### PR TITLE
Phase 2: E2E encryption, household key sharing, and crypto-shredding

### DIFF
--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/crypto/CryptoShredder.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/crypto/CryptoShredder.kt
@@ -1,0 +1,117 @@
+package com.finance.sync.crypto
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+
+/**
+ * Crypto-shredding service for GDPR-compliant data deletion (#96).
+ *
+ * Instead of attempting to locate and scrub every copy of personal data
+ * (which is error-prone in distributed systems), crypto-shredding destroys
+ * the encryption keys. Without the keys the ciphertext is computationally
+ * indistinguishable from random noise, satisfying GDPR Art. 17 ("right
+ * to erasure").
+ *
+ * This class coordinates with a [KeyStore] abstraction to destroy keys and
+ * issues [DeletionCertificate]s as an auditable record of the operation.
+ *
+ * @property keyStore  Persistent store of encryption keys.
+ * @property clock     Time source (injectable for testing).
+ */
+class CryptoShredder(
+    private val keyStore: KeyStore,
+    private val clock: Clock = Clock.System,
+) {
+
+    /**
+     * Destroy all KEKs and DEKs associated with [householdId].
+     *
+     * After this operation, every record encrypted under the household's KEK
+     * is permanently unreadable.
+     *
+     * @param householdId The household to shred.
+     * @param requestedBy The principal requesting deletion (for audit trail).
+     * @return A [DeletionCertificate] recording the event.
+     */
+    fun shredHouseholdData(householdId: String, requestedBy: String): DeletionCertificate {
+        val fingerprints = keyStore.destroyHouseholdKeys(householdId)
+        val now = clock.now()
+        val verified = verifyShredding(householdId)
+
+        return DeletionCertificate(
+            id = generateCertificateId(now),
+            subjectType = DeletionCertificate.SubjectType.HOUSEHOLD,
+            subjectId = householdId,
+            destroyedAt = now,
+            requestedBy = requestedBy,
+            keyFingerprints = fingerprints,
+            verified = verified,
+        )
+    }
+
+    /**
+     * Destroy all personal encryption keys for [userId].
+     *
+     * This covers the user's personal key-pair and any key material
+     * that is exclusively theirs (not shared household keys, which
+     * are handled by [shredHouseholdData]).
+     *
+     * @param userId      The user whose keys should be destroyed.
+     * @param requestedBy The principal requesting deletion.
+     * @return A [DeletionCertificate] recording the event.
+     */
+    fun shredUserData(userId: String, requestedBy: String): DeletionCertificate {
+        val fingerprints = keyStore.destroyUserKeys(userId)
+        val now = clock.now()
+        val verified = !keyStore.hasKeysForUser(userId)
+
+        return DeletionCertificate(
+            id = generateCertificateId(now),
+            subjectType = DeletionCertificate.SubjectType.USER,
+            subjectId = userId,
+            destroyedAt = now,
+            requestedBy = requestedBy,
+            keyFingerprints = fingerprints,
+            verified = verified,
+        )
+    }
+
+    /**
+     * Verify that all keys for [householdId] have been destroyed
+     * and encrypted data is unrecoverable.
+     *
+     * @return `true` if no keys remain for the household.
+     */
+    fun verifyShredding(householdId: String): Boolean =
+        !keyStore.hasKeysForHousehold(householdId)
+
+    private fun generateCertificateId(timestamp: Instant): String =
+        "cert-" + timestamp.toEpochMilliseconds().toString(36)
+}
+
+/**
+ * Abstraction over the persistent key storage layer.
+ *
+ * Implementations are platform-specific (Keychain on iOS, KeyStore on Android/JVM,
+ * IndexedDB + WebCrypto on JS) and are responsible for secure storage and
+ * irrecoverable deletion of key material.
+ */
+interface KeyStore {
+    /**
+     * Destroy all keys associated with [householdId].
+     * @return Fingerprints (hex-encoded hashes) of the destroyed keys.
+     */
+    fun destroyHouseholdKeys(householdId: String): List<String>
+
+    /**
+     * Destroy all keys associated with [userId].
+     * @return Fingerprints of the destroyed keys.
+     */
+    fun destroyUserKeys(userId: String): List<String>
+
+    /** @return `true` if any keys for [householdId] still exist. */
+    fun hasKeysForHousehold(householdId: String): Boolean
+
+    /** @return `true` if any keys for [userId] still exist. */
+    fun hasKeysForUser(userId: String): Boolean
+}

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/crypto/DeletionCertificate.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/crypto/DeletionCertificate.kt
@@ -1,0 +1,37 @@
+package com.finance.sync.crypto
+
+import kotlinx.datetime.Instant
+
+/**
+ * Immutable certificate recording a crypto-shredding event (#96).
+ *
+ * Stored as part of the GDPR audit trail to prove that encryption keys
+ * were destroyed, rendering the associated data permanently unreadable.
+ * The certificate itself contains NO sensitive data -- only identifiers
+ * and timestamps.
+ *
+ * @property id              Unique certificate identifier.
+ * @property subjectType     What was shredded ("household" or "user").
+ * @property subjectId       The household or user ID whose keys were destroyed.
+ * @property destroyedAt     UTC timestamp of key destruction.
+ * @property requestedBy     The user or system principal that initiated deletion.
+ * @property keyFingerprints Fingerprints (hashes) of the destroyed keys, for
+ *                           verification without revealing key material.
+ * @property verified        Whether [CryptoShredder.verifyShredding] confirmed
+ *                           that data is unrecoverable.
+ */
+data class DeletionCertificate(
+    val id: String,
+    val subjectType: SubjectType,
+    val subjectId: String,
+    val destroyedAt: Instant,
+    val requestedBy: String,
+    val keyFingerprints: List<String>,
+    val verified: Boolean,
+) {
+    /** The type of entity whose keys were shredded. */
+    enum class SubjectType {
+        HOUSEHOLD,
+        USER,
+    }
+}

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/crypto/EncryptedPayload.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/crypto/EncryptedPayload.kt
@@ -1,0 +1,31 @@
+package com.finance.sync.crypto
+
+/**
+ * Represents an encrypted payload containing the ciphertext and all metadata
+ * needed to decrypt it.
+ *
+ * Part of the E2E encryption layer for sensitive financial fields (#92).
+ */
+data class EncryptedPayload(
+    /** The encrypted data. */
+    val ciphertext: ByteArray,
+    /** The nonce/initialization vector used during encryption. */
+    val nonce: ByteArray,
+    /** The algorithm identifier (e.g. "AES-256-GCM"). */
+    val algorithm: String,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || other !is EncryptedPayload) return false
+        return ciphertext.contentEquals(other.ciphertext) &&
+            nonce.contentEquals(other.nonce) &&
+            algorithm == other.algorithm
+    }
+
+    override fun hashCode(): Int {
+        var result = ciphertext.contentHashCode()
+        result = 31 * result + nonce.contentHashCode()
+        result = 31 * result + algorithm.hashCode()
+        return result
+    }
+}

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/crypto/EncryptionService.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/crypto/EncryptionService.kt
@@ -1,0 +1,38 @@
+package com.finance.sync.crypto
+
+/**
+ * Core encryption service interface for E2E encryption of financial data (#92).
+ *
+ * Implementations must use authenticated encryption (e.g. AES-256-GCM) to ensure
+ * both confidentiality and integrity of sensitive financial fields.
+ *
+ * Platform-specific implementations are provided via expect/actual for
+ * [PlatformKeyDerivation]; this interface is consumed by [FieldEncryptor] and
+ * [EnvelopeEncryption] to encrypt/decrypt individual data fields.
+ */
+interface EncryptionService {
+
+    /**
+     * Encrypt [plaintext] with the given symmetric [key].
+     *
+     * Implementations must generate a fresh, cryptographically-random nonce
+     * for every call and include it in the returned [EncryptedPayload].
+     *
+     * @param plaintext Raw bytes to encrypt.
+     * @param key       Symmetric key (e.g. a DEK). Length must match the algorithm requirement.
+     * @return An [EncryptedPayload] containing ciphertext, nonce, and algorithm identifier.
+     * @throws IllegalArgumentException if [key] length is invalid.
+     */
+    fun encrypt(plaintext: ByteArray, key: ByteArray): EncryptedPayload
+
+    /**
+     * Decrypt an [EncryptedPayload] using the given symmetric [key].
+     *
+     * @param payload The [EncryptedPayload] produced by [encrypt].
+     * @param key     The same symmetric key that was used to encrypt.
+     * @return The original plaintext bytes.
+     * @throws IllegalArgumentException if [key] length is invalid.
+     * @throws IllegalStateException    if decryption or authentication fails.
+     */
+    fun decrypt(payload: EncryptedPayload, key: ByteArray): ByteArray
+}

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/crypto/EnvelopeEncryption.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/crypto/EnvelopeEncryption.kt
@@ -1,0 +1,73 @@
+package com.finance.sync.crypto
+
+/**
+ * Envelope encryption utilities for the DEK/KEK pattern (#92).
+ *
+ * Each sync record is encrypted with its own random Data Encryption Key (DEK).
+ * The DEK is then "wrapped" (encrypted) with the household's Key Encryption Key
+ * (KEK) so that:
+ *  - Compromising one record's DEK does not expose other records.
+ *  - Key rotation only requires re-wrapping DEKs, not re-encrypting all data.
+ *
+ * @property encryptionService The [EncryptionService] used for wrap/unwrap operations.
+ */
+class EnvelopeEncryption(
+    private val encryptionService: EncryptionService,
+    private val randomProvider: RandomProvider = DefaultRandomProvider,
+) {
+
+    companion object {
+        /** DEK length in bytes (256-bit). */
+        const val DEK_LENGTH_BYTES: Int = 32
+    }
+
+    /**
+     * Generate a cryptographically random Data Encryption Key.
+     *
+     * @return A new [DEK_LENGTH_BYTES]-byte random key.
+     */
+    fun generateDEK(): ByteArray = randomProvider.nextBytes(DEK_LENGTH_BYTES)
+
+    /**
+     * Wrap (encrypt) a [dek] with the household [kek].
+     *
+     * @param dek The Data Encryption Key to protect.
+     * @param kek The Key Encryption Key (household KEK).
+     * @return The encrypted DEK bytes (serialized as `[4-byte nonce length][nonce][ciphertext]`).
+     */
+    fun wrapDEK(dek: ByteArray, kek: ByteArray): ByteArray {
+        val payload = encryptionService.encrypt(dek, kek)
+        val nonceLen = payload.nonce.size
+        return byteArrayOf(
+            (nonceLen shr 24 and 0xFF).toByte(),
+            (nonceLen shr 16 and 0xFF).toByte(),
+            (nonceLen shr 8 and 0xFF).toByte(),
+            (nonceLen and 0xFF).toByte(),
+        ) + payload.nonce + payload.ciphertext
+    }
+
+    /**
+     * Unwrap (decrypt) a previously wrapped DEK.
+     *
+     * @param wrappedDek The output of [wrapDEK].
+     * @param kek        The same household KEK used to wrap.
+     * @return The original DEK bytes.
+     */
+    fun unwrapDEK(wrappedDek: ByteArray, kek: ByteArray): ByteArray {
+        require(wrappedDek.size > 4) { "Wrapped DEK too short" }
+        val nonceLen =
+            ((wrappedDek[0].toInt() and 0xFF) shl 24) or
+            ((wrappedDek[1].toInt() and 0xFF) shl 16) or
+            ((wrappedDek[2].toInt() and 0xFF) shl 8) or
+            (wrappedDek[3].toInt() and 0xFF)
+        require(wrappedDek.size > 4 + nonceLen) { "Wrapped DEK is malformed" }
+        val nonce = wrappedDek.copyOfRange(4, 4 + nonceLen)
+        val ciphertext = wrappedDek.copyOfRange(4 + nonceLen, wrappedDek.size)
+        val payload = EncryptedPayload(
+            ciphertext = ciphertext,
+            nonce = nonce,
+            algorithm = "AES-256-GCM",
+        )
+        return encryptionService.decrypt(payload, kek)
+    }
+}

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/crypto/FieldEncryptor.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/crypto/FieldEncryptor.kt
@@ -1,0 +1,126 @@
+package com.finance.sync.crypto
+
+/**
+ * Encrypts and decrypts specific fields on sync entities (#92).
+ *
+ * Only sensitive fields are encrypted; non-sensitive fields (needed for queries
+ * such as `amount_cents`, `date`, `category_id`) are left in the clear so the
+ * backend can index and filter them without accessing plaintext PII.
+ *
+ * Uses **envelope encryption**: each record gets its own random DEK, which is
+ * wrapped with the household KEK. This allows key rotation without re-encrypting
+ * every record's data -- only the DEK wrappers need to be updated.
+ *
+ * @property encryptionService The symmetric encryption primitive.
+ * @property envelopeEncryption The DEK/KEK envelope helper.
+ * @property sensitiveFields The set of field names that must be encrypted.
+ */
+class FieldEncryptor(
+    private val encryptionService: EncryptionService,
+    private val envelopeEncryption: EnvelopeEncryption,
+    private val sensitiveFields: Set<String> = DEFAULT_SENSITIVE_FIELDS,
+) {
+
+    companion object {
+        /**
+         * Default set of fields classified as sensitive PII / financial data.
+         * These are encrypted at rest; everything else remains queryable.
+         */
+        val DEFAULT_SENSITIVE_FIELDS: Set<String> = setOf(
+            "payee",
+            "note",
+            "account.name",
+        )
+
+        /**
+         * Fields that are explicitly left in the clear for server-side queries.
+         * Listed here for documentation / audit purposes.
+         */
+        val QUERYABLE_FIELDS: Set<String> = setOf(
+            "amount_cents",
+            "date",
+            "category_id",
+        )
+    }
+
+    /**
+     * Result of encrypting a record's sensitive fields.
+     *
+     * @property encryptedFields Map of field name to [EncryptedPayload] for sensitive fields.
+     * @property cleartextFields Map of field name to original value for non-sensitive fields.
+     * @property wrappedDek      The per-record DEK, wrapped with the household KEK.
+     */
+    data class EncryptedRecord(
+        val encryptedFields: Map<String, EncryptedPayload>,
+        val cleartextFields: Map<String, String>,
+        val wrappedDek: ByteArray,
+    ) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other == null || other !is EncryptedRecord) return false
+            return encryptedFields == other.encryptedFields &&
+                cleartextFields == other.cleartextFields &&
+                wrappedDek.contentEquals(other.wrappedDek)
+        }
+
+        override fun hashCode(): Int {
+            var result = encryptedFields.hashCode()
+            result = 31 * result + cleartextFields.hashCode()
+            result = 31 * result + wrappedDek.contentHashCode()
+            return result
+        }
+    }
+
+    /**
+     * Encrypt a record's fields using envelope encryption.
+     *
+     * @param fields Map of field name to plaintext value.
+     * @param kek    The household Key Encryption Key.
+     * @return An [EncryptedRecord] with sensitive fields encrypted and a wrapped DEK.
+     */
+    fun encryptRecord(fields: Map<String, String>, kek: ByteArray): EncryptedRecord {
+        val dek = envelopeEncryption.generateDEK()
+        val wrappedDek = envelopeEncryption.wrapDEK(dek, kek)
+
+        val encrypted = mutableMapOf<String, EncryptedPayload>()
+        val cleartext = mutableMapOf<String, String>()
+
+        for ((name, value) in fields) {
+            if (name in sensitiveFields) {
+                encrypted[name] = encryptionService.encrypt(
+                    plaintext = value.encodeToByteArray(),
+                    key = dek,
+                )
+            } else {
+                cleartext[name] = value
+            }
+        }
+
+        return EncryptedRecord(
+            encryptedFields = encrypted,
+            cleartextFields = cleartext,
+            wrappedDek = wrappedDek,
+        )
+    }
+
+    /**
+     * Decrypt a previously encrypted record.
+     *
+     * @param record The [EncryptedRecord] to decrypt.
+     * @param kek    The household KEK that was used to wrap the DEK.
+     * @return A flat map of field name to plaintext value (all fields merged).
+     */
+    fun decryptRecord(record: EncryptedRecord, kek: ByteArray): Map<String, String> {
+        val dek = envelopeEncryption.unwrapDEK(record.wrappedDek, kek)
+
+        val result = mutableMapOf<String, String>()
+        result.putAll(record.cleartextFields)
+
+        for ((name, payload) in record.encryptedFields) {
+            val plainBytes = encryptionService.decrypt(payload, dek)
+            result[name] = plainBytes.decodeToString()
+        }
+
+        return result
+    }
+}

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/crypto/HouseholdKeyBundle.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/crypto/HouseholdKeyBundle.kt
@@ -1,0 +1,38 @@
+package com.finance.sync.crypto
+
+/**
+ * Bundle representing a household's encryption key material (#94).
+ *
+ * Created when a new household is provisioned or when keys are rotated.
+ * The [encryptedKek] is encrypted to the creating member's public key
+ * so only they can unwrap it; additional members receive their own copy
+ * via [HouseholdKeyManager.shareKey].
+ *
+ * @property householdId  Unique identifier for the household.
+ * @property encryptedKek The KEK encrypted to the creator's public key.
+ * @property publicKey    The creator's public key (for key-agreement / verification).
+ * @property algorithm    The asymmetric algorithm used (e.g. "X25519+AES-256-GCM").
+ */
+data class HouseholdKeyBundle(
+    val householdId: String,
+    val encryptedKek: ByteArray,
+    val publicKey: ByteArray,
+    val algorithm: String,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || other !is HouseholdKeyBundle) return false
+        return householdId == other.householdId &&
+            encryptedKek.contentEquals(other.encryptedKek) &&
+            publicKey.contentEquals(other.publicKey) &&
+            algorithm == other.algorithm
+    }
+
+    override fun hashCode(): Int {
+        var result = householdId.hashCode()
+        result = 31 * result + encryptedKek.contentHashCode()
+        result = 31 * result + publicKey.contentHashCode()
+        result = 31 * result + algorithm.hashCode()
+        return result
+    }
+}

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/crypto/HouseholdKeyManager.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/crypto/HouseholdKeyManager.kt
@@ -1,0 +1,91 @@
+package com.finance.sync.crypto
+
+/**
+ * Manages household Key Encryption Keys (KEKs) for multi-member households (#94).
+ *
+ * Each household has a single symmetric KEK that protects all per-record DEKs.
+ * When a new member joins, the KEK is asymmetrically encrypted to their public
+ * key so they can decrypt it locally. This avoids transmitting the KEK in the
+ * clear and ensures only authorised members can access household data.
+ *
+ * NOTE: In this initial implementation the asymmetric layer is modelled with
+ * symmetric encryption (using the public/private key material as a symmetric key).
+ * Platform-specific asymmetric crypto (X25519 + sealed box) will replace this
+ * when the platform app modules are implemented.
+ *
+ * @property encryptionService Symmetric encryption for KEK generation and wrapping.
+ * @property randomProvider    CSPRNG for key generation.
+ */
+class HouseholdKeyManager(
+    private val encryptionService: EncryptionService,
+    private val randomProvider: RandomProvider = DefaultRandomProvider,
+) {
+
+    companion object {
+        /** KEK length in bytes (256-bit). */
+        const val KEK_LENGTH_BYTES: Int = 32
+
+        /** Default asymmetric algorithm identifier. */
+        const val DEFAULT_ALGORITHM: String = "X25519+AES-256-GCM"
+
+        /** Standard nonce length for AES-256-GCM in bytes. */
+        const val NONCE_LENGTH: Int = 12
+    }
+
+    /**
+     * Create a new household KEK and bundle it for the founding member.
+     *
+     * In a production implementation the KEK would be asymmetrically encrypted
+     * to the creator's public key. Here we model the intent and use the
+     * symmetric [EncryptionService] as a stand-in until platform asymmetric
+     * primitives are available.
+     *
+     * @param householdId      A unique household identifier.
+     * @param creatorPublicKey The founding member's public key material.
+     * @return A [HouseholdKeyBundle] containing the encrypted KEK.
+     */
+    fun createHouseholdKey(
+        householdId: String,
+        creatorPublicKey: ByteArray,
+    ): HouseholdKeyBundle {
+        val kek = randomProvider.nextBytes(KEK_LENGTH_BYTES)
+        val encryptedKek = encryptionService.encrypt(kek, creatorPublicKey)
+        return HouseholdKeyBundle(
+            householdId = householdId,
+            encryptedKek = encryptedKek.nonce + encryptedKek.ciphertext,
+            publicKey = creatorPublicKey,
+            algorithm = DEFAULT_ALGORITHM,
+        )
+    }
+
+    /**
+     * Encrypt an existing household KEK for a new member.
+     *
+     * @param kek               The plaintext household KEK.
+     * @param recipientPublicKey The new member's public key.
+     * @return Opaque bytes that only the recipient can decrypt with their private key.
+     */
+    fun shareKey(kek: ByteArray, recipientPublicKey: ByteArray): ByteArray {
+        val payload = encryptionService.encrypt(kek, recipientPublicKey)
+        return payload.nonce + payload.ciphertext
+    }
+
+    /**
+     * Decrypt a shared household KEK using the recipient's private key.
+     *
+     * @param encryptedKek The bytes produced by [shareKey].
+     * @param privateKey   The recipient's private key material.
+     * @return The plaintext household KEK.
+     */
+    fun receiveKey(encryptedKek: ByteArray, privateKey: ByteArray): ByteArray {
+        require(encryptedKek.size > NONCE_LENGTH) { "Encrypted KEK too short" }
+        val nonce = encryptedKek.copyOfRange(0, NONCE_LENGTH)
+        val ciphertext = encryptedKek.copyOfRange(NONCE_LENGTH, encryptedKek.size)
+        val payload = EncryptedPayload(
+            ciphertext = ciphertext,
+            nonce = nonce,
+            algorithm = DEFAULT_ALGORITHM,
+        )
+        return encryptionService.decrypt(payload, privateKey)
+    }
+}

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/crypto/KeyDerivation.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/crypto/KeyDerivation.kt
@@ -1,0 +1,27 @@
+package com.finance.sync.crypto
+
+/**
+ * Interface for password-based key derivation (#92).
+ *
+ * Declared as `expect` so each platform can supply its own `actual`
+ * implementation backed by a native Argon2id library (or fallback KDF).
+ *
+ * The derived key is used as the household KEK seed when a user first
+ * creates or joins a household.
+ */
+expect class PlatformKeyDerivation() {
+    /**
+     * Derive a 256-bit key from [password] and [salt] using Argon2id.
+     *
+     * Recommended parameters (tunable per platform):
+     *  - Memory: 64 MiB
+     *  - Iterations: 3
+     *  - Parallelism: 1
+     *  - Output length: 32 bytes
+     *
+     * @param password The user-supplied passphrase.
+     * @param salt     A cryptographically-random salt (at least 16 bytes).
+     * @return A 32-byte derived key.
+     */
+    fun deriveKey(password: String, salt: ByteArray): ByteArray
+}

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/crypto/KeyRotation.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/crypto/KeyRotation.kt
@@ -1,0 +1,134 @@
+package com.finance.sync.crypto
+
+/**
+ * Key rotation support for household KEKs (#94).
+ *
+ * When a member leaves a household, or on a periodic schedule, the household
+ * KEK is rotated. This involves:
+ *  1. Generating a new KEK.
+ *  2. Re-encrypting (re-sharing) the new KEK to every remaining member.
+ *  3. Re-wrapping all existing per-record DEKs with the new KEK.
+ *
+ * Note: re-wrapping DEKs does NOT require re-encrypting the underlying data,
+ * because the DEKs themselves remain unchanged -- only their wrappers change.
+ *
+ * @property encryptionService Symmetric encryption primitive.
+ * @property envelopeEncryption Envelope (DEK/KEK) helper.
+ * @property householdKeyManager Household key manager for key sharing.
+ */
+class KeyRotation(
+    private val encryptionService: EncryptionService,
+    private val envelopeEncryption: EnvelopeEncryption,
+    private val householdKeyManager: HouseholdKeyManager,
+    private val randomProvider: RandomProvider = DefaultRandomProvider,
+) {
+
+    /**
+     * Rotate the household KEK.
+     *
+     * Generates a new KEK, encrypts it for every member, and returns a
+     * new [HouseholdKeyBundle].
+     *
+     * @param householdId The household whose key is being rotated.
+     * @param oldKek      The current (outgoing) KEK -- needed to re-wrap existing DEKs.
+     * @param members     List of member public keys who should receive the new KEK.
+     * @return A pair of the new [HouseholdKeyBundle] and a list of per-member encrypted KEKs.
+     */
+    fun rotateHouseholdKey(
+        householdId: String,
+        oldKek: ByteArray,
+        members: List<ByteArray>,
+    ): RotationResult {
+        require(members.isNotEmpty()) { "At least one member is required" }
+
+        val newKek = randomProvider.nextBytes(HouseholdKeyManager.KEK_LENGTH_BYTES)
+
+        // Encrypt the new KEK for each member
+        val memberShares = members.map { memberPublicKey ->
+            householdKeyManager.shareKey(newKek, memberPublicKey)
+        }
+
+        val bundle = HouseholdKeyBundle(
+            householdId = householdId,
+            encryptedKek = memberShares.first(),
+            publicKey = members.first(),
+            algorithm = HouseholdKeyManager.DEFAULT_ALGORITHM,
+        )
+
+        return RotationResult(
+            newKek = newKek,
+            bundle = bundle,
+            memberShares = memberShares,
+        )
+    }
+
+    /**
+     * Re-encrypt (re-wrap) existing data with a new KEK.
+     *
+     * This unwraps each record's DEK with the old KEK and re-wraps it with the
+     * new KEK. The underlying ciphertext is untouched -- only the DEK wrapper changes.
+     *
+     * @param oldKek The outgoing KEK.
+     * @param newKek The incoming KEK.
+     * @param wrappedDeks List of currently wrapped DEKs.
+     * @return List of re-wrapped DEKs in the same order.
+     */
+    fun reWrapDeks(
+        oldKek: ByteArray,
+        newKek: ByteArray,
+        wrappedDeks: List<ByteArray>,
+    ): List<ByteArray> = wrappedDeks.map { wrappedDek ->
+        val dek = envelopeEncryption.unwrapDEK(wrappedDek, oldKek)
+        envelopeEncryption.wrapDEK(dek, newKek)
+    }
+
+    /**
+     * Re-encrypt existing encrypted payloads with a new KEK.
+     *
+     * Decrypts each payload with [oldKek] and re-encrypts with [newKek].
+     * This is the full-data re-encryption path used when the DEK/KEK separation
+     * is not applicable (e.g. for directly-KEK-encrypted metadata).
+     *
+     * @param oldKek The outgoing KEK.
+     * @param newKek The incoming KEK.
+     * @param data   List of payloads encrypted with [oldKek].
+     * @return List of payloads re-encrypted with [newKek].
+     */
+    fun reEncryptData(
+        oldKek: ByteArray,
+        newKek: ByteArray,
+        data: List<EncryptedPayload>,
+    ): List<EncryptedPayload> = data.map { payload ->
+        val plaintext = encryptionService.decrypt(payload, oldKek)
+        encryptionService.encrypt(plaintext, newKek)
+    }
+
+    /**
+     * Result of a key rotation operation.
+     *
+     * @property newKek       The new plaintext KEK (handle securely!).
+     * @property bundle       The [HouseholdKeyBundle] for the primary member.
+     * @property memberShares Per-member encrypted copies of the new KEK.
+     */
+    data class RotationResult(
+        val newKek: ByteArray,
+        val bundle: HouseholdKeyBundle,
+        val memberShares: List<ByteArray>,
+    ) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other == null || other !is RotationResult) return false
+            return newKek.contentEquals(other.newKek) &&
+                bundle == other.bundle &&
+                memberShares.size == other.memberShares.size &&
+                memberShares.zip(other.memberShares).all { (a, b) -> a.contentEquals(b) }
+        }
+
+        override fun hashCode(): Int {
+            var result = newKek.contentHashCode()
+            result = 31 * result + bundle.hashCode()
+            result = 31 * result + memberShares.hashCode()
+            return result
+        }
+    }
+}

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/crypto/RandomProvider.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/crypto/RandomProvider.kt
@@ -1,0 +1,24 @@
+package com.finance.sync.crypto
+
+/**
+ * Abstraction for cryptographically-secure random byte generation.
+ *
+ * Platform implementations should delegate to their native CSPRNG
+ * (e.g. SecureRandom on JVM, crypto.getRandomValues on JS, SecRandomCopyBytes on iOS).
+ */
+interface RandomProvider {
+    /** Generate [size] cryptographically-random bytes. */
+    fun nextBytes(size: Int): ByteArray
+}
+
+/**
+ * Default [RandomProvider] using [kotlin.random.Random].
+ *
+ * **WARNING:** This is NOT cryptographically secure and exists only as a
+ * fallback / compilation placeholder. Platform `actual` implementations
+ * MUST supply a CSPRNG-backed provider for production use.
+ */
+internal object DefaultRandomProvider : RandomProvider {
+    override fun nextBytes(size: Int): ByteArray =
+        kotlin.random.Random.nextBytes(size)
+}

--- a/packages/sync/src/commonTest/kotlin/com/finance/sync/crypto/CryptoShredderTest.kt
+++ b/packages/sync/src/commonTest/kotlin/com/finance/sync/crypto/CryptoShredderTest.kt
@@ -1,0 +1,131 @@
+package com.finance.sync.crypto
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [CryptoShredder] (#96).
+ *
+ * Verifies that crypto-shredding:
+ *  - Destroys keys and produces a deletion certificate.
+ *  - Makes data unrecoverable after shredding.
+ *  - Passes verification checks.
+ */
+class CryptoShredderTest {
+
+    @Test
+    fun shredHouseholdDataDestroysKeys() {
+        val keyStore = TestKeyStore()
+        keyStore.addHouseholdKey("hh-1", "fingerprint-kek-1")
+        keyStore.addHouseholdKey("hh-1", "fingerprint-dek-1")
+
+        val shredder = CryptoShredder(keyStore)
+
+        assertTrue(keyStore.hasKeysForHousehold("hh-1"), "Keys should exist before shredding")
+
+        val cert = shredder.shredHouseholdData("hh-1", requestedBy = "admin@example.com")
+
+        assertFalse(keyStore.hasKeysForHousehold("hh-1"), "Keys should be gone after shredding")
+        assertEquals(DeletionCertificate.SubjectType.HOUSEHOLD, cert.subjectType)
+        assertEquals("hh-1", cert.subjectId)
+        assertEquals("admin@example.com", cert.requestedBy)
+        assertTrue(cert.verified, "Shredding should be verified")
+        assertEquals(2, cert.keyFingerprints.size, "Both key fingerprints should be recorded")
+    }
+
+    @Test
+    fun shredUserDataDestroysKeys() {
+        val keyStore = TestKeyStore()
+        keyStore.addUserKey("user-42", "fingerprint-pk-42")
+
+        val shredder = CryptoShredder(keyStore)
+
+        assertTrue(keyStore.hasKeysForUser("user-42"), "Keys should exist before shredding")
+
+        val cert = shredder.shredUserData("user-42", requestedBy = "user-42")
+
+        assertFalse(keyStore.hasKeysForUser("user-42"), "Keys should be gone")
+        assertEquals(DeletionCertificate.SubjectType.USER, cert.subjectType)
+        assertEquals("user-42", cert.subjectId)
+        assertTrue(cert.verified)
+    }
+
+    @Test
+    fun verifyShredsReturnsTrue_whenNoKeysExist() {
+        val keyStore = TestKeyStore()
+        val shredder = CryptoShredder(keyStore)
+
+        assertTrue(
+            shredder.verifyShredding("non-existent"),
+            "No keys == successfully shredded",
+        )
+    }
+
+    @Test
+    fun verifyShredsReturnsFalse_whenKeysStillExist() {
+        val keyStore = TestKeyStore()
+        keyStore.addHouseholdKey("hh-2", "fingerprint-still-here")
+
+        val shredder = CryptoShredder(keyStore)
+
+        assertFalse(
+            shredder.verifyShredding("hh-2"),
+            "Keys still exist, shredding not verified",
+        )
+    }
+
+    @Test
+    fun deletionCertificateContainsTimestamp() {
+        val keyStore = TestKeyStore()
+        keyStore.addHouseholdKey("hh-3", "fp-1")
+
+        val shredder = CryptoShredder(keyStore)
+        val cert = shredder.shredHouseholdData("hh-3", requestedBy = "system")
+
+        assertNotNull(cert.destroyedAt, "Certificate must include a timestamp")
+        assertTrue(cert.id.startsWith("cert-"), "Certificate ID should have expected prefix")
+    }
+
+    @Test
+    fun shreddingMakesDataUnrecoverable() {
+        // Simulate: encrypt data, then shred keys, then attempt to decrypt
+        val crypto = TestCryptoProvider()
+        val random = TestRandomProvider()
+        val envelope = EnvelopeEncryption(crypto, random)
+        val encryptor = FieldEncryptor(crypto, envelope)
+
+        val kek = ByteArray(32) { (it + 1).toByte() }
+        val record = encryptor.encryptRecord(
+            fields = mapOf("payee" to "Secret Payee", "amount_cents" to "5000"),
+            kek = kek,
+        )
+
+        // Before shredding, decryption works
+        val decrypted = encryptor.decryptRecord(record, kek)
+        assertEquals("Secret Payee", decrypted["payee"])
+
+        // After shredding, the KEK is gone -- simulate by zeroing it
+        val destroyedKek = ByteArray(32) { 0 }
+
+        // Attempting decryption with destroyed key should produce garbage
+        val result = encryptor.decryptRecord(record, destroyedKek)
+        assertTrue(
+            result["payee"] != "Secret Payee",
+            "Data should be unrecoverable with destroyed key",
+        )
+    }
+
+    @Test
+    fun shredHouseholdDataWithNoKeys() {
+        val keyStore = TestKeyStore()
+        val shredder = CryptoShredder(keyStore)
+
+        // Should not throw; just produces an empty certificate
+        val cert = shredder.shredHouseholdData("empty-hh", requestedBy = "admin")
+        assertTrue(cert.keyFingerprints.isEmpty())
+        assertTrue(cert.verified)
+    }
+}

--- a/packages/sync/src/commonTest/kotlin/com/finance/sync/crypto/EnvelopeEncryptionTest.kt
+++ b/packages/sync/src/commonTest/kotlin/com/finance/sync/crypto/EnvelopeEncryptionTest.kt
@@ -1,0 +1,81 @@
+package com.finance.sync.crypto
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [EnvelopeEncryption] (#92).
+ *
+ * Verifies DEK generation, wrap/unwrap round-trips, and key isolation.
+ */
+class EnvelopeEncryptionTest {
+
+    private val crypto = TestCryptoProvider()
+    private val random = TestRandomProvider()
+    private val envelope = EnvelopeEncryption(crypto, random)
+
+    /** A 32-byte test KEK. */
+    private val testKek = ByteArray(32) { (it + 1).toByte() }
+
+    @Test
+    fun generateDekReturnsCorrectLength() {
+        val dek = envelope.generateDEK()
+        assertEquals(
+            EnvelopeEncryption.DEK_LENGTH_BYTES,
+            dek.size,
+            "DEK should be {EnvelopeEncryption.DEK_LENGTH_BYTES} bytes",
+        )
+    }
+
+    @Test
+    fun wrapUnwrapDekRoundTrips() {
+        val dek = envelope.generateDEK()
+        val wrapped = envelope.wrapDEK(dek, testKek)
+        val unwrapped = envelope.unwrapDEK(wrapped, testKek)
+
+        assertTrue(
+            dek.contentEquals(unwrapped),
+            "Unwrapped DEK must match original",
+        )
+    }
+
+    @Test
+    fun wrappedDekDiffersFromOriginal() {
+        val dek = envelope.generateDEK()
+        val wrapped = envelope.wrapDEK(dek, testKek)
+
+        assertTrue(
+            !dek.contentEquals(wrapped),
+            "Wrapped DEK should not equal plaintext DEK",
+        )
+    }
+
+    @Test
+    fun differentKeksProduceDifferentWrappings() {
+        val dek = envelope.generateDEK()
+        val kek1 = ByteArray(32) { 0x01 }
+        val kek2 = ByteArray(32) { 0x02 }
+
+        val wrapped1 = envelope.wrapDEK(dek, kek1)
+        val wrapped2 = envelope.wrapDEK(dek, kek2)
+
+        assertTrue(
+            !wrapped1.contentEquals(wrapped2),
+            "Different KEKs should produce different wrapped DEKs",
+        )
+    }
+
+    @Test
+    fun multipleWrapsCanAllUnwrap() {
+        val dek = envelope.generateDEK()
+        repeat(5) {
+            val wrapped = envelope.wrapDEK(dek, testKek)
+            val unwrapped = envelope.unwrapDEK(wrapped, testKek)
+            assertTrue(
+                dek.contentEquals(unwrapped),
+                "Wrap/unwrap round-trip it should succeed",
+            )
+        }
+    }
+}

--- a/packages/sync/src/commonTest/kotlin/com/finance/sync/crypto/FieldEncryptorTest.kt
+++ b/packages/sync/src/commonTest/kotlin/com/finance/sync/crypto/FieldEncryptorTest.kt
@@ -1,0 +1,113 @@
+package com.finance.sync.crypto
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [FieldEncryptor] (#92).
+ *
+ * Verifies that:
+ *  - Sensitive fields (payee, note, account.name) are encrypted.
+ *  - Non-sensitive fields (amount_cents, date, category_id) remain readable.
+ *  - Encrypt-then-decrypt round-trips correctly.
+ */
+class FieldEncryptorTest {
+
+    private val crypto = TestCryptoProvider()
+    private val random = TestRandomProvider()
+    private val envelope = EnvelopeEncryption(crypto, random)
+    private val encryptor = FieldEncryptor(crypto, envelope)
+
+    /** A 32-byte test KEK. */
+    private val testKek = ByteArray(32) { (it + 1).toByte() }
+
+    private val sampleRecord = mapOf(
+        "payee" to "Acme Corp",
+        "note" to "Invoice #1234",
+        "account.name" to "Checking Account",
+        "amount_cents" to "150000",
+        "date" to "2025-01-15",
+        "category_id" to "cat-groceries",
+    )
+
+    @Test
+    fun sensitiveFieldsAreEncrypted() {
+        val result = encryptor.encryptRecord(sampleRecord, testKek)
+
+        // Sensitive fields must appear in encryptedFields, not cleartextFields
+        assertTrue(result.encryptedFields.containsKey("payee"))
+        assertTrue(result.encryptedFields.containsKey("note"))
+        assertTrue(result.encryptedFields.containsKey("account.name"))
+
+        // Their ciphertext must differ from plaintext
+        val payeeCipher = result.encryptedFields["payee"]!!.ciphertext
+        assertNotEquals(
+            "Acme Corp",
+            payeeCipher.decodeToString(),
+            "payee should be encrypted",
+        )
+    }
+
+    @Test
+    fun nonSensitiveFieldsRemainReadable() {
+        val result = encryptor.encryptRecord(sampleRecord, testKek)
+
+        assertEquals("150000", result.cleartextFields["amount_cents"])
+        assertEquals("2025-01-15", result.cleartextFields["date"])
+        assertEquals("cat-groceries", result.cleartextFields["category_id"])
+    }
+
+    @Test
+    fun encryptThenDecryptRoundTrips() {
+        val encrypted = encryptor.encryptRecord(sampleRecord, testKek)
+        val decrypted = encryptor.decryptRecord(encrypted, testKek)
+
+        for ((key, value) in sampleRecord) {
+            assertEquals(value, decrypted[key], "Field 'key' should round-trip")
+        }
+    }
+
+    @Test
+    fun sensitiveFieldsNotInCleartext() {
+        val result = encryptor.encryptRecord(sampleRecord, testKek)
+
+        assertTrue(
+            "payee" !in result.cleartextFields,
+            "payee must not appear in cleartext",
+        )
+        assertTrue(
+            "note" !in result.cleartextFields,
+            "note must not appear in cleartext",
+        )
+        assertTrue(
+            "account.name" !in result.cleartextFields,
+            "account.name must not appear in cleartext",
+        )
+    }
+
+    @Test
+    fun encryptedRecordContainsWrappedDek() {
+        val result = encryptor.encryptRecord(sampleRecord, testKek)
+        assertTrue(result.wrappedDek.isNotEmpty(), "wrappedDek must be present")
+    }
+
+    @Test
+    fun differentRecordsGetDifferentDeks() {
+        val random1 = TestRandomProvider(seed = 100)
+        val random2 = TestRandomProvider(seed = 200)
+        val env1 = EnvelopeEncryption(crypto, random1)
+        val env2 = EnvelopeEncryption(crypto, random2)
+        val enc1 = FieldEncryptor(crypto, env1)
+        val enc2 = FieldEncryptor(crypto, env2)
+
+        val result1 = enc1.encryptRecord(sampleRecord, testKek)
+        val result2 = enc2.encryptRecord(sampleRecord, testKek)
+
+        assertTrue(
+            !result1.wrappedDek.contentEquals(result2.wrappedDek),
+            "Each record should have a unique DEK",
+        )
+    }
+}

--- a/packages/sync/src/commonTest/kotlin/com/finance/sync/crypto/HouseholdKeyManagerTest.kt
+++ b/packages/sync/src/commonTest/kotlin/com/finance/sync/crypto/HouseholdKeyManagerTest.kt
@@ -1,0 +1,140 @@
+package com.finance.sync.crypto
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [HouseholdKeyManager] and [KeyRotation] (#94).
+ *
+ * Verifies key creation, sharing between members, and key rotation.
+ */
+class HouseholdKeyManagerTest {
+
+    private val crypto = TestCryptoProvider()
+    private val random = TestRandomProvider()
+    private val envelope = EnvelopeEncryption(crypto, random)
+    private val manager = HouseholdKeyManager(crypto, random)
+
+    /** Simulated 32-byte key pair (in test, public == private for simplicity). */
+    private val aliceKey = ByteArray(32) { (it + 10).toByte() }
+    private val bobKey = ByteArray(32) { (it + 50).toByte() }
+
+    @Test
+    fun createHouseholdKeyReturnsBundle() {
+        val bundle = manager.createHouseholdKey("household-1", aliceKey)
+
+        assertEquals("household-1", bundle.householdId)
+        assertEquals(HouseholdKeyManager.DEFAULT_ALGORITHM, bundle.algorithm)
+        assertTrue(bundle.encryptedKek.isNotEmpty(), "Encrypted KEK must not be empty")
+        assertTrue(bundle.publicKey.contentEquals(aliceKey), "Public key should be creator's key")
+    }
+
+    @Test
+    fun shareAndReceiveKeyRoundTrips() {
+        // Generate a KEK
+        val kek = random.nextBytes(HouseholdKeyManager.KEK_LENGTH_BYTES)
+
+        // Alice shares with Bob
+        val sharedBlob = manager.shareKey(kek, bobKey)
+
+        // Bob receives with his key (in test, public == private)
+        val received = manager.receiveKey(sharedBlob, bobKey)
+
+        assertTrue(
+            kek.contentEquals(received),
+            "Bob should receive the same KEK Alice shared",
+        )
+    }
+
+    @Test
+    fun sharedKeyDiffersFromPlaintextKek() {
+        val kek = random.nextBytes(HouseholdKeyManager.KEK_LENGTH_BYTES)
+        val shared = manager.shareKey(kek, bobKey)
+
+        assertTrue(
+            !kek.contentEquals(shared),
+            "Shared blob should differ from plaintext KEK",
+        )
+    }
+
+    @Test
+    fun keyRotationGeneratesNewKek() {
+        val rotation = KeyRotation(crypto, envelope, manager, random)
+        val oldKek = random.nextBytes(HouseholdKeyManager.KEK_LENGTH_BYTES)
+
+        val result = rotation.rotateHouseholdKey(
+            householdId = "household-1",
+            oldKek = oldKek,
+            members = listOf(aliceKey, bobKey),
+        )
+
+        assertTrue(
+            !oldKek.contentEquals(result.newKek),
+            "New KEK should differ from old KEK",
+        )
+        assertEquals(2, result.memberShares.size, "Should have share for each member")
+    }
+
+    @Test
+    fun rotatedKeyCanBeReceivedByAllMembers() {
+        val rotation = KeyRotation(crypto, envelope, manager, random)
+        val oldKek = random.nextBytes(HouseholdKeyManager.KEK_LENGTH_BYTES)
+
+        val result = rotation.rotateHouseholdKey(
+            householdId = "household-1",
+            oldKek = oldKek,
+            members = listOf(aliceKey, bobKey),
+        )
+
+        // Each member should be able to decrypt the new KEK
+        val aliceReceived = manager.receiveKey(result.memberShares[0], aliceKey)
+        val bobReceived = manager.receiveKey(result.memberShares[1], bobKey)
+
+        assertTrue(result.newKek.contentEquals(aliceReceived), "Alice should receive new KEK")
+        assertTrue(result.newKek.contentEquals(bobReceived), "Bob should receive new KEK")
+    }
+
+    @Test
+    fun reEncryptDataChangesPayloads() {
+        val rotation = KeyRotation(crypto, envelope, manager, random)
+        val oldKek = ByteArray(32) { 0x01 }
+        val newKek = ByteArray(32) { 0x02 }
+
+        val original = listOf(
+            crypto.encrypt("secret-data".encodeToByteArray(), oldKek),
+        )
+
+        val reEncrypted = rotation.reEncryptData(oldKek, newKek, original)
+
+        // Re-encrypted ciphertext should differ
+        assertTrue(
+            !original[0].ciphertext.contentEquals(reEncrypted[0].ciphertext),
+            "Re-encrypted ciphertext should differ",
+        )
+
+        // Decrypting with new key should recover original
+        val decrypted = crypto.decrypt(reEncrypted[0], newKek)
+        assertEquals("secret-data", decrypted.decodeToString())
+    }
+
+    @Test
+    fun reWrapDeksPreservesUnderlyingDeks() {
+        val rotation = KeyRotation(crypto, envelope, manager, random)
+        val oldKek = ByteArray(32) { 0x01 }
+        val newKek = ByteArray(32) { 0x02 }
+
+        val dek = envelope.generateDEK()
+        val wrappedOld = envelope.wrapDEK(dek, oldKek)
+
+        val reWrapped = rotation.reWrapDeks(oldKek, newKek, listOf(wrappedOld))
+
+        // Unwrap with new KEK should yield original DEK
+        val unwrapped = envelope.unwrapDEK(reWrapped[0], newKek)
+        assertTrue(
+            dek.contentEquals(unwrapped),
+            "Re-wrapped DEK should unwrap to original",
+        )
+    }
+}

--- a/packages/sync/src/commonTest/kotlin/com/finance/sync/crypto/TestCryptoProvider.kt
+++ b/packages/sync/src/commonTest/kotlin/com/finance/sync/crypto/TestCryptoProvider.kt
@@ -1,0 +1,101 @@
+package com.finance.sync.crypto
+
+/**
+ * Test-only crypto provider that uses a simple XOR cipher.
+ *
+ * This is intentionally NOT secure -- it exists solely to exercise the
+ * encryption interfaces in unit tests without depending on platform crypto.
+ * Every method is deterministic given the same inputs, making assertions easy.
+ *
+ * The "nonce" is a fixed-length random byte array stored alongside the ciphertext
+ * to validate round-trip nonce handling. The XOR cipher XORs plaintext with the
+ * key (repeating the key as needed).
+ */
+class TestCryptoProvider(
+    private val nonceLength: Int = 12,
+) : EncryptionService {
+
+    /** Counter used to generate unique (but predictable) nonces in tests. */
+    private var nonceCounter: Int = 0
+
+    override fun encrypt(plaintext: ByteArray, key: ByteArray): EncryptedPayload {
+        require(key.isNotEmpty()) { "Key must not be empty" }
+        val nonce = generateTestNonce()
+        val ciphertext = xor(plaintext, key)
+        return EncryptedPayload(
+            ciphertext = ciphertext,
+            nonce = nonce,
+            algorithm = "TEST-XOR",
+        )
+    }
+
+    override fun decrypt(payload: EncryptedPayload, key: ByteArray): ByteArray {
+        require(key.isNotEmpty()) { "Key must not be empty" }
+        return xor(payload.ciphertext, key)
+    }
+
+    /**
+     * Generate a deterministic nonce for testing.
+     * Each call produces a unique nonce within the same test run.
+     */
+    private fun generateTestNonce(): ByteArray {
+        val counter = nonceCounter++
+        return ByteArray(nonceLength) { i ->
+            (counter xor i).toByte()
+        }
+    }
+
+    companion object {
+        /** XOR [data] with [key], repeating the key as needed. */
+        fun xor(data: ByteArray, key: ByteArray): ByteArray =
+            ByteArray(data.size) { i ->
+                (data[i].toInt() xor key[i % key.size].toInt()).toByte()
+            }
+    }
+}
+
+/**
+ * Test-only [RandomProvider] that returns predictable bytes.
+ *
+ * Uses a simple counter-based scheme so that tests are deterministic
+ * while still producing distinct byte arrays on each call.
+ */
+class TestRandomProvider(private var seed: Int = 42) : RandomProvider {
+    override fun nextBytes(size: Int): ByteArray {
+        val current = seed
+        seed += size
+        return ByteArray(size) { i -> ((current + i) and 0xFF).toByte() }
+    }
+}
+
+/**
+ * Test-only [KeyStore] backed by in-memory maps.
+ */
+class TestKeyStore : KeyStore {
+    private val householdKeys = mutableMapOf<String, MutableList<String>>()
+    private val userKeys = mutableMapOf<String, MutableList<String>>()
+
+    /** Register a key fingerprint for a household (test setup helper). */
+    fun addHouseholdKey(householdId: String, fingerprint: String) {
+        householdKeys.getOrPut(householdId) { mutableListOf() }.add(fingerprint)
+    }
+
+    /** Register a key fingerprint for a user (test setup helper). */
+    fun addUserKey(userId: String, fingerprint: String) {
+        userKeys.getOrPut(userId) { mutableListOf() }.add(fingerprint)
+    }
+
+    override fun destroyHouseholdKeys(householdId: String): List<String> {
+        return householdKeys.remove(householdId) ?: emptyList()
+    }
+
+    override fun destroyUserKeys(userId: String): List<String> {
+        return userKeys.remove(userId) ?: emptyList()
+    }
+
+    override fun hasKeysForHousehold(householdId: String): Boolean =
+        householdKeys.containsKey(householdId) && householdKeys[householdId]!!.isNotEmpty()
+
+    override fun hasKeysForUser(userId: String): Boolean =
+        userKeys.containsKey(userId) && userKeys[userId]!!.isNotEmpty()
+}

--- a/packages/sync/src/iosMain/kotlin/com/finance/sync/crypto/KeyDerivation.ios.kt
+++ b/packages/sync/src/iosMain/kotlin/com/finance/sync/crypto/KeyDerivation.ios.kt
@@ -1,0 +1,13 @@
+package com.finance.sync.crypto
+
+/**
+ * iOS actual for [PlatformKeyDerivation].
+ *
+ * Stub -- real implementation will use CryptoKit / libsodium
+ * when the iOS app module is built.
+ */
+actual class PlatformKeyDerivation actual constructor() {
+    actual fun deriveKey(password: String, salt: ByteArray): ByteArray {
+        throw NotImplementedError("Platform crypto not yet implemented -- iOS Argon2id binding required")
+    }
+}

--- a/packages/sync/src/jsMain/kotlin/com/finance/sync/crypto/KeyDerivation.js.kt
+++ b/packages/sync/src/jsMain/kotlin/com/finance/sync/crypto/KeyDerivation.js.kt
@@ -1,0 +1,13 @@
+package com.finance.sync.crypto
+
+/**
+ * JS actual for [PlatformKeyDerivation].
+ *
+ * Stub -- real implementation will use a WebCrypto / wasm-argon2 binding
+ * when the web app module is built.
+ */
+actual class PlatformKeyDerivation actual constructor() {
+    actual fun deriveKey(password: String, salt: ByteArray): ByteArray {
+        throw NotImplementedError("Platform crypto not yet implemented -- JS Argon2id binding required")
+    }
+}

--- a/packages/sync/src/jvmMain/kotlin/com/finance/sync/crypto/KeyDerivation.jvm.kt
+++ b/packages/sync/src/jvmMain/kotlin/com/finance/sync/crypto/KeyDerivation.jvm.kt
@@ -1,0 +1,13 @@
+package com.finance.sync.crypto
+
+/**
+ * JVM actual for [PlatformKeyDerivation].
+ *
+ * Stub -- real implementation will use Bouncy Castle or similar
+ * Argon2id binding when the JVM app module is built.
+ */
+actual class PlatformKeyDerivation actual constructor() {
+    actual fun deriveKey(password: String, salt: ByteArray): ByteArray {
+        throw NotImplementedError("Platform crypto not yet implemented -- JVM Argon2id binding required")
+    }
+}


### PR DESCRIPTION
## Summary
Implement encryption infrastructure for sensitive financial data (KMP).

### What's included
- Envelope encryption: per-record DEK wrapped with household KEK
- FieldEncryptor for selective field encryption (payee, note, account.name)
- Household key sharing with key rotation support
- Crypto-shredding for GDPR-compliant data deletion with audit certificates
- Platform crypto interfaces (expect/actual) with test-only XOR provider
- 4 test suites covering all encryption flows

Closes #92
Closes #94
Closes #96