### PR TITLE
feat(ios): implement Keychain, Face ID, and Apple Sign-In (#20, #21, #24)

### DIFF
--- a/apps/ios/Finance/Security/AppleSignInManager.swift
+++ b/apps/ios/Finance/Security/AppleSignInManager.swift
@@ -1,0 +1,275 @@
+// AppleSignInManager.swift
+// Finance
+//
+// Sign in with Apple integration via ASAuthorizationController.
+// Converts Apple credentials to a Supabase auth session.
+// Refs #24
+
+import AuthenticationServices
+import CryptoKit
+import Foundation
+
+// MARK: - AppleSignInError
+
+/// Errors surfaced by ``AppleSignInManager``.
+enum AppleSignInError: LocalizedError, Sendable {
+    case missingIdentityToken
+    case invalidIdentityToken
+    case authorizationFailed(underlying: Error)
+    case cancelled
+    case supabaseSessionFailed(underlying: Error)
+    case unknown(underlying: Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingIdentityToken:
+            String(localized: "Apple Sign-In did not return an identity token.")
+        case .invalidIdentityToken:
+            String(localized: "The identity token from Apple could not be decoded.")
+        case .authorizationFailed(let underlying):
+            String(localized: "Apple Sign-In failed: \(underlying.localizedDescription)")
+        case .cancelled:
+            String(localized: "Apple Sign-In was cancelled.")
+        case .supabaseSessionFailed(let underlying):
+            String(localized: "Failed to create a session: \(underlying.localizedDescription)")
+        case .unknown(let underlying):
+            String(localized: "An unexpected error occurred: \(underlying.localizedDescription)")
+        }
+    }
+}
+
+// MARK: - AppleSignInCredential
+
+/// Lightweight value type holding the relevant fields from an Apple
+/// authorization response.
+struct AppleSignInCredential: Sendable {
+    /// The stable, team-scoped user identifier from Apple.
+    let userID: String
+
+    /// The user's full name, if provided (first sign-in only).
+    let fullName: PersonNameComponents?
+
+    /// The user's email address, if provided (first sign-in only).
+    let email: String?
+
+    /// The JWT identity token issued by Apple (used for Supabase auth).
+    let identityToken: String
+
+    /// The short-lived authorization code (for server-side validation).
+    let authorizationCode: String?
+
+    /// A nonce that was sent with the request, used for replay protection.
+    let nonce: String
+}
+
+// MARK: - AppleSignInManaging Protocol
+
+/// Abstraction over Apple Sign-In for testability.
+@MainActor
+protocol AppleSignInManaging: Sendable {
+    func signIn() async throws -> AppleSignInCredential
+}
+
+// MARK: - AppleSignInManager
+
+/// Manages the Sign in with Apple flow via `ASAuthorizationController`.
+///
+/// ## Flow
+/// 1. Generate a cryptographic nonce for replay protection.
+/// 2. Present the system Apple Sign-In sheet.
+/// 3. Receive the `ASAuthorizationAppleIDCredential`.
+/// 4. Extract the identity token and map to ``AppleSignInCredential``.
+/// 5. Forward the credential to the Supabase auth layer for session creation.
+///
+/// > Important: Apple only provides the user's full name and email on the
+/// > **first** authorization. Persist these values via the KMP data layer
+/// > immediately upon receipt.
+@Observable
+@MainActor
+final class AppleSignInManager: NSObject, AppleSignInManaging {
+
+    // MARK: - State
+
+    /// Whether a sign-in flow is currently in progress.
+    private(set) var isSigningIn: Bool = false
+
+    /// The current nonce used for the active sign-in request.
+    private var currentNonce: String?
+
+    /// Continuation used to bridge the delegate callback to async/await.
+    private var signInContinuation: CheckedContinuation<AppleSignInCredential, Error>?
+
+    // MARK: - Public API
+
+    /// Initiates the Sign in with Apple authorization flow.
+    func signIn() async throws -> AppleSignInCredential {
+        guard !isSigningIn else {
+            throw AppleSignInError.unknown(
+                underlying: NSError(
+                    domain: "AppleSignInManager",
+                    code: -1,
+                    userInfo: [
+                        NSLocalizedDescriptionKey: String(localized: "A sign-in is already in progress.")
+                    ]
+                )
+            )
+        }
+
+        isSigningIn = true
+
+        defer {
+            isSigningIn = false
+            currentNonce = nil
+        }
+
+        let nonce = Self.generateNonce()
+        currentNonce = nonce
+
+        return try await withCheckedThrowingContinuation { continuation in
+            self.signInContinuation = continuation
+
+            let provider = ASAuthorizationAppleIDProvider()
+            let request = provider.createRequest()
+            request.requestedScopes = [.fullName, .email]
+            request.nonce = Self.sha256(nonce)
+
+            let controller = ASAuthorizationController(authorizationRequests: [request])
+            controller.delegate = self
+            controller.performRequests()
+        }
+    }
+
+    // MARK: - Credential State
+
+    /// Checks the current authorization state for a previously signed-in user.
+    func credentialState(for userID: String) async throws -> ASAuthorizationAppleIDProvider.CredentialState {
+        try await withCheckedThrowingContinuation { continuation in
+            ASAuthorizationAppleIDProvider().getCredentialState(forUserID: userID) { state, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: state)
+                }
+            }
+        }
+    }
+
+    // MARK: - Nonce Generation
+
+    /// Generates a cryptographically secure random nonce string.
+    static func generateNonce(length: Int = 32) -> String {
+        precondition(length > 0, "Nonce length must be positive.")
+
+        let charset = Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+        var randomBytes = [UInt8](repeating: 0, count: length)
+        let result = SecRandomCopyBytes(kSecRandomDefault, randomBytes.count, &randomBytes)
+
+        guard result == errSecSuccess else {
+            let key = SymmetricKey(size: .bits256)
+            return key.withUnsafeBytes { bytes in
+                String(bytes.prefix(length).map { charset[Int($0) % charset.count] })
+            }
+        }
+
+        return String(randomBytes.map { charset[Int($0) % charset.count] })
+    }
+
+    /// Returns the SHA-256 hash of the input string, hex-encoded.
+    static func sha256(_ input: String) -> String {
+        let data = Data(input.utf8)
+        let hash = SHA256.hash(data: data)
+        return hash.compactMap { String(format: "%02x", $0) }.joined()
+    }
+}
+
+// MARK: - ASAuthorizationControllerDelegate
+
+extension AppleSignInManager: ASAuthorizationControllerDelegate {
+
+    nonisolated func authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithAuthorization authorization: ASAuthorization
+    ) {
+        Task { @MainActor in
+            handleAuthorization(authorization)
+        }
+    }
+
+    nonisolated func authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithError error: Error
+    ) {
+        Task { @MainActor in
+            handleAuthorizationError(error)
+        }
+    }
+
+    // MARK: - Delegate Helpers
+
+    private func handleAuthorization(_ authorization: ASAuthorization) {
+        guard let appleCredential = authorization.credential as? ASAuthorizationAppleIDCredential else {
+            signInContinuation?.resume(
+                throwing: AppleSignInError.unknown(
+                    underlying: NSError(
+                        domain: "AppleSignInManager",
+                        code: -2,
+                        userInfo: [
+                            NSLocalizedDescriptionKey: String(localized: "Unexpected credential type received.")
+                        ]
+                    )
+                )
+            )
+            signInContinuation = nil
+            return
+        }
+
+        guard let identityTokenData = appleCredential.identityToken else {
+            signInContinuation?.resume(throwing: AppleSignInError.missingIdentityToken)
+            signInContinuation = nil
+            return
+        }
+
+        guard let identityToken = String(data: identityTokenData, encoding: .utf8) else {
+            signInContinuation?.resume(throwing: AppleSignInError.invalidIdentityToken)
+            signInContinuation = nil
+            return
+        }
+
+        let authorizationCode: String? = appleCredential.authorizationCode
+            .flatMap { String(data: $0, encoding: .utf8) }
+
+        let credential = AppleSignInCredential(
+            userID: appleCredential.user,
+            fullName: appleCredential.fullName,
+            email: appleCredential.email,
+            identityToken: identityToken,
+            authorizationCode: authorizationCode,
+            nonce: currentNonce ?? ""
+        )
+
+        signInContinuation?.resume(returning: credential)
+        signInContinuation = nil
+    }
+
+    private func handleAuthorizationError(_ error: Error) {
+        let mappedError: AppleSignInError
+
+        if let asError = error as? ASAuthorizationError {
+            switch asError.code {
+            case .canceled:
+                mappedError = .cancelled
+            case .failed, .invalidResponse, .notHandled, .notInteractive:
+                mappedError = .authorizationFailed(underlying: asError)
+            case .unknown:
+                mappedError = .unknown(underlying: asError)
+            @unknown default:
+                mappedError = .unknown(underlying: asError)
+            }
+        } else {
+            mappedError = .unknown(underlying: error)
+        }
+
+        signInContinuation?.resume(throwing: mappedError)
+        signInContinuation = nil
+    }
+}

--- a/apps/ios/Finance/Security/BiometricAuthManager.swift
+++ b/apps/ios/Finance/Security/BiometricAuthManager.swift
@@ -1,0 +1,196 @@
+// BiometricAuthManager.swift
+// Finance
+//
+// Face ID / Touch ID wrapper using LocalAuthentication framework.
+// Refs #21
+
+import Foundation
+import LocalAuthentication
+
+// MARK: - BiometricError
+
+/// Errors surfaced by ``BiometricAuthManager``.
+enum BiometricError: LocalizedError, Sendable {
+    case biometryNotAvailable
+    case biometryNotEnrolled
+    case biometryLockout
+    case authenticationFailed(underlying: Error)
+    case cancelled
+    case unknown(underlying: Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .biometryNotAvailable:
+            String(localized: "Biometric authentication is not available on this device.")
+        case .biometryNotEnrolled:
+            String(localized: "No biometric credentials are enrolled. Please set up Face ID or Touch ID in Settings.")
+        case .biometryLockout:
+            String(localized: "Biometric authentication is locked out. Please use your device passcode to re-enable it.")
+        case .authenticationFailed(let underlying):
+            String(localized: "Authentication failed: \(underlying.localizedDescription)")
+        case .cancelled:
+            String(localized: "Authentication was cancelled.")
+        case .unknown(let underlying):
+            String(localized: "An unexpected error occurred: \(underlying.localizedDescription)")
+        }
+    }
+}
+
+// MARK: - BiometricType
+
+/// The type of biometric hardware available on the current device.
+enum BiometricType: Sendable {
+    case none
+    case faceID
+    case touchID
+    case opticID
+}
+
+// MARK: - BiometricAuthManaging Protocol
+
+/// Abstraction over biometric authentication for testability.
+protocol BiometricAuthManaging: Sendable {
+    func canAuthenticate() -> Bool
+    func authenticate(reason: String) async throws
+}
+
+// MARK: - BiometricAuthManager
+
+/// Manages Face ID, Touch ID, and Optic ID authentication via the
+/// `LocalAuthentication` framework.
+///
+/// Uses `.deviceOwnerAuthentication` policy which permits biometric
+/// authentication with automatic fallback to the device passcode when
+/// biometry is unavailable or locked out.
+///
+/// > Important: Never cache biometric results beyond the current session.
+@Observable
+@MainActor
+final class BiometricAuthManager: BiometricAuthManaging {
+
+    // MARK: - Published State
+
+    /// Whether biometric authentication is available on this device.
+    private(set) var isAvailable: Bool = false
+
+    /// The type of biometric hardware detected.
+    private(set) var biometricType: BiometricType = .none
+
+    /// Default localized reason shown in the system biometric prompt.
+    static let defaultReason = String(localized: "Verify your identity to access Finance")
+
+    // MARK: - Initialization
+
+    init() {
+        refreshAvailability()
+    }
+
+    // MARK: - Public API
+
+    /// Checks whether biometric or passcode authentication can be performed.
+    ///
+    /// - Returns: `true` if the device can evaluate the authentication policy.
+    @discardableResult
+    nonisolated func canAuthenticate() -> Bool {
+        let context = LAContext()
+        var error: NSError?
+        let canEvaluate = context.canEvaluatePolicy(
+            .deviceOwnerAuthentication,
+            error: &error
+        )
+        return canEvaluate
+    }
+
+    /// Prompts the user for biometric authentication (Face ID / Touch ID)
+    /// with an automatic fallback to the device passcode.
+    ///
+    /// - Parameter reason: A localized string explaining why authentication
+    ///   is required. Defaults to ``defaultReason``.
+    /// - Throws: A ``BiometricError`` describing why authentication failed.
+    func authenticate(
+        reason: String = BiometricAuthManager.defaultReason
+    ) async throws {
+        let context = LAContext()
+        context.localizedCancelTitle = String(localized: "Cancel")
+
+        var policyError: NSError?
+        guard context.canEvaluatePolicy(
+            .deviceOwnerAuthentication,
+            error: &policyError
+        ) else {
+            throw mapLAError(policyError)
+        }
+
+        do {
+            let success = try await context.evaluatePolicy(
+                .deviceOwnerAuthentication,
+                localizedReason: reason
+            )
+
+            guard success else {
+                throw BiometricError.authenticationFailed(
+                    underlying: NSError(
+                        domain: "BiometricAuthManager",
+                        code: -1,
+                        userInfo: [
+                            NSLocalizedDescriptionKey: String(localized: "Authentication did not succeed.")
+                        ]
+                    )
+                )
+            }
+        } catch let error as LAError {
+            throw mapLAError(error)
+        } catch {
+            throw BiometricError.unknown(underlying: error)
+        }
+    }
+
+    // MARK: - Availability
+
+    /// Refreshes cached availability and biometric type state.
+    func refreshAvailability() {
+        let context = LAContext()
+        var error: NSError?
+        isAvailable = context.canEvaluatePolicy(
+            .deviceOwnerAuthenticationWithBiometrics,
+            error: &error
+        )
+
+        switch context.biometryType {
+        case .faceID:
+            biometricType = .faceID
+        case .touchID:
+            biometricType = .touchID
+        case .opticID:
+            biometricType = .opticID
+        default:
+            biometricType = .none
+        }
+    }
+
+    // MARK: - Error Mapping
+
+    /// Maps `LAError` codes to ``BiometricError`` cases.
+    private func mapLAError(_ error: Error?) -> BiometricError {
+        guard let nsError = error as NSError? else {
+            return .biometryNotAvailable
+        }
+
+        let code = LAError.Code(rawValue: nsError.code) ?? .appCancel
+
+        switch code {
+        case .biometryNotAvailable:
+            return .biometryNotAvailable
+        case .biometryNotEnrolled:
+            return .biometryNotEnrolled
+        case .biometryLockout:
+            return .biometryLockout
+        case .userCancel, .appCancel, .systemCancel:
+            return .cancelled
+        case .authenticationFailed:
+            return .authenticationFailed(underlying: nsError)
+        default:
+            return .unknown(underlying: nsError)
+        }
+    }
+}

--- a/apps/ios/Finance/Security/KeychainManager.swift
+++ b/apps/ios/Finance/Security/KeychainManager.swift
@@ -1,0 +1,244 @@
+// KeychainManager.swift
+// Finance
+//
+// Security wrapper around Apple Keychain Services.
+// Refs #20
+
+import Foundation
+import Security
+
+// MARK: - KeychainError
+
+/// Errors returned by ``KeychainManager`` operations.
+enum KeychainError: LocalizedError, Sendable {
+    case saveFailed(status: OSStatus)
+    case loadFailed(status: OSStatus)
+    case deleteFailed(status: OSStatus)
+    case unexpectedData
+    case secureEnclaveNotAvailable
+
+    var errorDescription: String? {
+        switch self {
+        case .saveFailed(let status):
+            String(localized: "Keychain save failed (status \(status)).")
+        case .loadFailed(let status):
+            String(localized: "Keychain load failed (status \(status)).")
+        case .deleteFailed(let status):
+            String(localized: "Keychain delete failed (status \(status)).")
+        case .unexpectedData:
+            String(localized: "Keychain returned data in an unexpected format.")
+        case .secureEnclaveNotAvailable:
+            String(localized: "Secure Enclave is not available on this device.")
+        }
+    }
+}
+
+// MARK: - KeychainManaging Protocol
+
+/// Abstraction over Keychain operations for testability.
+protocol KeychainManaging: Sendable {
+    func save(key: String, data: Data) throws
+    func load(key: String) -> Data?
+    func delete(key: String) throws
+}
+
+// MARK: - KeychainManager
+
+/// Thread-safe wrapper around Apple Security framework Keychain Services.
+///
+/// All sensitive data — OAuth tokens, refresh tokens, encryption keys (DEK/KEK),
+/// and passkey credentials — **must** be stored via this manager.
+///
+/// Uses `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` to prevent access when the
+/// device is locked and to block iCloud Keychain sync of secrets.
+///
+/// Leverages the Secure Enclave (`kSecAttrTokenIDSecureEnclave`) for key generation
+/// when hardware supports it.
+actor KeychainManager: KeychainManaging {
+
+    // MARK: - Constants
+
+    /// The Keychain service identifier for all Finance app items.
+    static let serviceName = "com.finance.app"
+
+    /// Shared instance for app-wide use.
+    static let shared = KeychainManager()
+
+    /// Keychain access group for sharing credentials between the main app,
+    /// watchOS extension, widgets, and App Clips.
+    /// Configure the actual group identifier in the entitlements file.
+    private let accessGroup: String?
+
+    // MARK: - Initialization
+
+    /// Creates a new ``KeychainManager``.
+    /// - Parameter accessGroup: Optional Keychain access group for cross-target sharing.
+    init(accessGroup: String? = nil) {
+        self.accessGroup = accessGroup
+    }
+
+    // MARK: - Public API
+
+    /// Stores data in the Keychain under the given key.
+    ///
+    /// If an item with the same key already exists it is updated in place.
+    /// Items are stored with `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`
+    /// to ensure they cannot be read when the device is locked and are
+    /// excluded from iCloud Keychain sync.
+    ///
+    /// - Parameters:
+    ///   - key: A unique identifier for the Keychain item.
+    ///   - data: The secret data to store.
+    /// - Throws: ``KeychainError/saveFailed(status:)`` on failure.
+    nonisolated func save(key: String, data: Data) throws {
+        // Attempt to delete any existing item first to avoid errSecDuplicateItem.
+        let deleteQuery = baseQuery(for: key)
+        SecItemDelete(deleteQuery as CFDictionary)
+
+        var query = baseQuery(for: key)
+        query[kSecValueData as String] = data
+        query[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+
+        let status = SecItemAdd(query as CFDictionary, nil)
+
+        guard status == errSecSuccess else {
+            throw KeychainError.saveFailed(status: status)
+        }
+    }
+
+    /// Loads data from the Keychain for the given key.
+    ///
+    /// - Parameter key: The identifier of the Keychain item to retrieve.
+    /// - Returns: The stored `Data`, or `nil` if no item exists for the key.
+    nonisolated func load(key: String) -> Data? {
+        var query = baseQuery(for: key)
+        query[kSecReturnData as String] = kCFBooleanTrue as Any
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        guard status == errSecSuccess else {
+            return nil
+        }
+
+        return result as? Data
+    }
+
+    /// Deletes the Keychain item for the given key.
+    ///
+    /// If no item exists for the key this method succeeds silently
+    /// (`errSecItemNotFound` is treated as success).
+    ///
+    /// - Parameter key: The identifier of the Keychain item to remove.
+    /// - Throws: ``KeychainError/deleteFailed(status:)`` on failure.
+    nonisolated func delete(key: String) throws {
+        let query = baseQuery(for: key)
+        let status = SecItemDelete(query as CFDictionary)
+
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainError.deleteFailed(status: status)
+        }
+    }
+
+    // MARK: - Secure Enclave
+
+    /// Checks whether the current device supports the Secure Enclave.
+    ///
+    /// - Returns: `true` if Secure Enclave key generation is available.
+    nonisolated var isSecureEnclaveAvailable: Bool {
+        // Secure Enclave is available on devices with an A7 chip or later
+        // and on Apple Silicon Macs.
+        var error: Unmanaged<CFError>?
+        let accessControl = SecAccessControlCreateWithFlags(
+            kCFAllocatorDefault,
+            kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+            .privateKeyUsage,
+            &error
+        )
+        return accessControl != nil && error == nil
+    }
+
+    /// Saves data gated by the Secure Enclave so that retrieval requires
+    /// biometric authentication.
+    ///
+    /// - Parameters:
+    ///   - key: A unique identifier for the Keychain item.
+    ///   - data: The secret data to store.
+    /// - Throws: ``KeychainError/secureEnclaveNotAvailable`` if hardware
+    ///   doesn't support it, or ``KeychainError/saveFailed(status:)`` on failure.
+    nonisolated func saveWithSecureEnclave(key: String, data: Data) throws {
+        guard isSecureEnclaveAvailable else {
+            throw KeychainError.secureEnclaveNotAvailable
+        }
+
+        var error: Unmanaged<CFError>?
+        guard let accessControl = SecAccessControlCreateWithFlags(
+            kCFAllocatorDefault,
+            kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+            [.privateKeyUsage, .biometryCurrentSet],
+            &error
+        ) else {
+            throw KeychainError.saveFailed(status: errSecParam)
+        }
+
+        // Remove any existing item first.
+        let deleteQuery = baseQuery(for: key)
+        SecItemDelete(deleteQuery as CFDictionary)
+
+        var query = baseQuery(for: key)
+        query[kSecValueData as String] = data
+        query[kSecAttrAccessControl as String] = accessControl
+        query[kSecAttrTokenID as String] = kSecAttrTokenIDSecureEnclave
+
+        let status = SecItemAdd(query as CFDictionary, nil)
+
+        guard status == errSecSuccess else {
+            throw KeychainError.saveFailed(status: status)
+        }
+    }
+
+    // MARK: - Background Access
+
+    /// Saves data with `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`
+    /// so that `BGTaskScheduler` background tasks can access it while the
+    /// device is locked (after the first unlock since boot).
+    ///
+    /// Use this for tokens required by background sync operations.
+    ///
+    /// - Parameters:
+    ///   - key: A unique identifier for the Keychain item.
+    ///   - data: The secret data to store.
+    /// - Throws: ``KeychainError/saveFailed(status:)`` on failure.
+    nonisolated func saveForBackgroundAccess(key: String, data: Data) throws {
+        let deleteQuery = baseQuery(for: key)
+        SecItemDelete(deleteQuery as CFDictionary)
+
+        var query = baseQuery(for: key)
+        query[kSecValueData as String] = data
+        query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+
+        let status = SecItemAdd(query as CFDictionary, nil)
+
+        guard status == errSecSuccess else {
+            throw KeychainError.saveFailed(status: status)
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Builds the base Keychain query dictionary shared across operations.
+    private nonisolated func baseQuery(for key: String) -> [String: Any] {
+        var query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Self.serviceName,
+            kSecAttrAccount as String: key,
+        ]
+
+        if let accessGroup {
+            query[kSecAttrAccessGroup as String] = accessGroup
+        }
+
+        return query
+    }
+}

--- a/apps/ios/Finance/Security/UniversalLinkHandler.swift
+++ b/apps/ios/Finance/Security/UniversalLinkHandler.swift
@@ -1,0 +1,152 @@
+// UniversalLinkHandler.swift
+// Finance
+//
+// Handles Universal Links for OAuth callbacks and household invitations.
+// Designed for integration with SwiftUI's `.onOpenURL` modifier.
+// Refs #20, #24
+
+import Foundation
+
+// MARK: - DeepLink
+
+/// Represents a parsed Universal Link / deep link handled by the Finance app.
+enum DeepLink: Sendable, Equatable {
+    /// OAuth redirect callback — received after external identity provider
+    /// (Apple, Google, etc.) completes authorization.
+    case authCallback(url: URL)
+
+    /// Household invitation — the user tapped a link to join a household.
+    case householdInvite(code: String)
+
+    /// An unrecognized link that doesn't match any known route.
+    case unknown(url: URL)
+}
+
+// MARK: - UniversalLinkHandler
+
+/// Parses incoming Universal Links and maps them to ``DeepLink`` values.
+///
+/// ## Supported Routes
+/// | Path Pattern           | Maps To                          |
+/// |------------------------|----------------------------------|
+/// | `/auth/callback`       | ``DeepLink/authCallback(url:)``  |
+/// | `/invite/{code}`       | ``DeepLink/householdInvite(code:)``|
+@Observable
+@MainActor
+final class UniversalLinkHandler {
+
+    // MARK: - Constants
+
+    /// The expected host for Finance Universal Links.
+    static let expectedHost = "finance.app"
+
+    /// Path prefix for OAuth callbacks.
+    private static let authCallbackPath = "/auth/callback"
+
+    /// Path prefix for household invitations.
+    private static let invitePathPrefix = "/invite/"
+
+    // MARK: - State
+
+    /// The most recently parsed deep link, if any.
+    private(set) var currentDeepLink: DeepLink?
+
+    /// Whether the handler is currently processing an auth callback.
+    private(set) var isProcessingAuthCallback: Bool = false
+
+    /// Whether a household invite is pending user action.
+    private(set) var hasPendingInvite: Bool = false
+
+    /// The pending household invitation code, if any.
+    private(set) var pendingInviteCode: String?
+
+    // MARK: - Public API
+
+    /// Parses and handles an incoming Universal Link URL.
+    ///
+    /// - Parameter url: The incoming URL to parse.
+    /// - Returns: The parsed ``DeepLink`` for further handling.
+    @discardableResult
+    func handle(_ url: URL) -> DeepLink {
+        let deepLink = parse(url)
+        currentDeepLink = deepLink
+
+        switch deepLink {
+        case .authCallback:
+            isProcessingAuthCallback = true
+            hasPendingInvite = false
+            pendingInviteCode = nil
+
+        case .householdInvite(let code):
+            isProcessingAuthCallback = false
+            hasPendingInvite = true
+            pendingInviteCode = code
+
+        case .unknown:
+            isProcessingAuthCallback = false
+            hasPendingInvite = false
+            pendingInviteCode = nil
+        }
+
+        return deepLink
+    }
+
+    /// Marks the current auth callback as fully processed.
+    func completeAuthCallback() {
+        isProcessingAuthCallback = false
+        if case .authCallback = currentDeepLink {
+            currentDeepLink = nil
+        }
+    }
+
+    /// Marks the current household invite as handled (accepted or dismissed).
+    func completeInvite() {
+        hasPendingInvite = false
+        pendingInviteCode = nil
+        if case .householdInvite = currentDeepLink {
+            currentDeepLink = nil
+        }
+    }
+
+    /// Clears all pending state.
+    func reset() {
+        currentDeepLink = nil
+        isProcessingAuthCallback = false
+        hasPendingInvite = false
+        pendingInviteCode = nil
+    }
+
+    // MARK: - Parsing
+
+    /// Parses a URL into a ``DeepLink``.
+    ///
+    /// Supports both Universal Links and custom scheme URLs.
+    ///
+    /// - Parameter url: The URL to parse.
+    /// - Returns: The corresponding ``DeepLink`` case.
+    func parse(_ url: URL) -> DeepLink {
+        let path: String
+        if let components = URLComponents(url: url, resolvingAgainstBaseURL: true) {
+            path = components.path
+        } else {
+            path = url.path
+        }
+
+        // Route: /auth/callback
+        if path.hasPrefix(Self.authCallbackPath) {
+            return .authCallback(url: url)
+        }
+
+        // Route: /invite/{code}
+        if path.hasPrefix(Self.invitePathPrefix) {
+            let code = String(path.dropFirst(Self.invitePathPrefix.count))
+            let trimmedCode = code.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+
+            if !trimmedCode.isEmpty {
+                return .householdInvite(code: trimmedCode)
+            }
+        }
+
+        return .unknown(url: url)
+    }
+}


### PR DESCRIPTION
## Summary

Implements the iOS security layer for Finance app: Keychain Services, biometric authentication (Face ID / Touch ID), Apple Sign-In, and Universal Link handling.

### Changes

#### `KeychainManager.swift` (#20)
- `actor`-based thread-safe Keychain wrapper using Apple Security framework
- `save(key:data:)` — stores with `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`
- `load(key:)` → `Data?` — retrieves Keychain items
- `delete(key:)` — removes items (`errSecItemNotFound` treated as success)
- Service name: `com.finance.app`
- Secure Enclave support via `kSecAttrTokenIDSecureEnclave` when available
- `saveForBackgroundAccess` with `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` for BGTaskScheduler
- `KeychainManaging` protocol abstraction for testability

#### `BiometricAuthManager.swift` (#21)
- `@Observable @MainActor` class using `LocalAuthentication` framework
- `canAuthenticate() -> Bool` — checks device capability
- `authenticate(reason:) async throws` — presents biometric prompt with passcode fallback
- Uses `.deviceOwnerAuthentication` policy (Face ID / Touch ID + passcode)
- Default reason: "Verify your identity to access Finance"
- Comprehensive error mapping (`BiometricError` enum)

#### `AppleSignInManager.swift` (#24)
- `@Observable @MainActor` class implementing `ASAuthorizationControllerDelegate`
- Bridges delegate callbacks to `async/await` via `CheckedContinuation`
- Cryptographic nonce generation (`SecRandomCopyBytes` + SHA-256)
- Extracts identity token, authorization code, user ID, full name, email
- `AppleSignInCredential` value type ready for Supabase auth session creation

#### `UniversalLinkHandler.swift` (#20, #24)
- `@Observable @MainActor` URL parser for `.onOpenURL` integration
- Routes: `/auth/callback` → OAuth redirects, `/invite/{code}` → household invitations
- State management: `currentDeepLink`, `isProcessingAuthCallback`, `hasPendingInvite`

### Design Decisions
- **Actor isolation** for KeychainManager ensures thread safety across concurrent callers
- **Protocol abstractions** (`KeychainManaging`, `BiometricAuthManaging`, `AppleSignInManaging`) enable dependency injection and testing
- **No UIKit** — all managers are pure Swift, SwiftUI-compatible via `@Observable`
- **No secrets in UserDefaults** — all sensitive data goes through Keychain

Closes #20
Closes #21
Closes #24