### PR TITLE
feat(ios): implement Swift Charts and watchOS companion (#28, #30)

### DIFF
--- a/apps/ios/Finance/Charts/BudgetProgressChart.swift
+++ b/apps/ios/Finance/Charts/BudgetProgressChart.swift
@@ -1,0 +1,130 @@
+// BudgetProgressChart.swift
+// Finance
+//
+// Gauge / ring chart showing budget utilisation for a single budget.
+// Uses the IBM CVD-safe palette for colour-blind accessibility.
+// Refs #28
+
+import SwiftUI
+
+// MARK: - Data Model
+
+/// Represents the current utilisation state for one budget.
+struct BudgetProgress: Identifiable, Sendable {
+    let id = UUID()
+    let name: String
+    /// Amount spent so far (dollars, not cents).
+    let spent: Double
+    /// Total budgeted amount (dollars, not cents).
+    let budgeted: Double
+    /// Zero-based index used for CVD-safe colour assignment.
+    let colorIndex: Int
+
+    /// Fraction spent (clamped to 0...1 for the gauge).
+    var fraction: Double {
+        guard budgeted > 0 else { return 0 }
+        return min(max(spent / budgeted, 0), 1)
+    }
+
+    /// True when spending exceeds the budget.
+    var isOverBudget: Bool { spent > budgeted }
+}
+
+// MARK: - Single Ring View
+
+/// A single budget ring rendered as a Gauge.
+struct BudgetRing: View {
+    let progress: BudgetProgress
+    let currencyCode: String
+
+    var body: some View {
+        Gauge(value: progress.fraction) {
+            Text(progress.name)
+                .font(.caption)
+        } currentValueLabel: {
+            Text(percentText)
+                .font(.caption2)
+                .fontWeight(.semibold)
+        } minimumValueLabel: {
+            Text("0")
+                .font(.caption2)
+        } maximumValueLabel: {
+            Text(formattedCurrency(progress.budgeted))
+                .font(.caption2)
+        }
+        .gaugeStyle(.accessoryCircular)
+        .tint(ringGradient)
+        .accessibilityLabel(progress.name)
+        .accessibilityValue(
+            String(localized: "\(percentText) spent, \(formattedCurrency(progress.spent)) of \(formattedCurrency(progress.budgeted))")
+        )
+    }
+
+    // MARK: - Helpers
+
+    private var percentText: String {
+        let pct = Int((progress.fraction * 100).rounded())
+        return "\(pct)%"
+    }
+
+    private var ringGradient: some ShapeStyle {
+        if progress.isOverBudget {
+            return AnyShapeStyle(Color.red)
+        }
+        return AnyShapeStyle(
+            ChartColorPalette.color(at: progress.colorIndex)
+        )
+    }
+
+    private func formattedCurrency(_ value: Double) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = currencyCode
+        formatter.maximumFractionDigits = 0
+        return formatter.string(from: NSNumber(value: value))
+            ?? "\(currencyCode) \(Int(value))"
+    }
+}
+
+// MARK: - Collection View
+
+/// Displays multiple budget rings in a responsive grid.
+struct BudgetProgressChart: View {
+    let budgets: [BudgetProgress]
+    let currencyCode: String
+
+    private let columns = [
+        GridItem(.adaptive(minimum: 100, maximum: 160), spacing: 16)
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(String(localized: "Budget Progress"))
+                .font(.headline)
+                .accessibilityAddTraits(.isHeader)
+
+            LazyVGrid(columns: columns, spacing: 16) {
+                ForEach(budgets) { budget in
+                    BudgetRing(progress: budget, currencyCode: currencyCode)
+                }
+            }
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel(String(localized: "Budget utilisation gauges"))
+        }
+        .padding()
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Budget Progress") {
+    BudgetProgressChart(
+        budgets: [
+            BudgetProgress(name: "Food", spent: 420, budgeted: 600, colorIndex: 0),
+            BudgetProgress(name: "Transport", spent: 290, budgeted: 300, colorIndex: 1),
+            BudgetProgress(name: "Entertainment", spent: 200, budgeted: 150, colorIndex: 2),
+            BudgetProgress(name: "Utilities", spent: 110, budgeted: 250, colorIndex: 3),
+        ],
+        currencyCode: "USD"
+    )
+}

--- a/apps/ios/Finance/Charts/CategoryBreakdownChart.swift
+++ b/apps/ios/Finance/Charts/CategoryBreakdownChart.swift
@@ -1,0 +1,155 @@
+// CategoryBreakdownChart.swift
+// Finance
+//
+// Donut / pie chart showing the proportional breakdown of spending by category.
+// Uses the IBM CVD-safe palette for colour-blind accessibility.
+// Refs #28
+
+import Charts
+import SwiftUI
+
+// MARK: - Data Model
+
+/// A single slice in the category breakdown chart.
+struct CategorySlice: Identifiable, Sendable {
+    let id = UUID()
+    let category: String
+    /// Amount in the user's display currency (dollars).
+    let amount: Double
+    /// Zero-based index for CVD-safe colour assignment.
+    let colorIndex: Int
+}
+
+// MARK: - View
+
+/// A donut chart showing proportional spending per category.
+///
+/// Tapping a slice highlights it and shows a detail callout.
+struct CategoryBreakdownChart: View {
+    let data: [CategorySlice]
+    let currencyCode: String
+
+    @State private var selectedCategory: String?
+
+    private var totalSpending: Double {
+        data.reduce(0) { $0 + $1.amount }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(String(localized: "Category Breakdown"))
+                .font(.headline)
+                .accessibilityAddTraits(.isHeader)
+
+            Chart(data) { slice in
+                SectorMark(
+                    angle: .value(String(localized: "Amount"), slice.amount),
+                    innerRadius: .ratio(0.6),
+                    angularInset: 1.5
+                )
+                .cornerRadius(4)
+                .foregroundStyle(ChartColorPalette.color(at: slice.colorIndex))
+                .opacity(selectedCategory == nil || selectedCategory == slice.category ? 1 : 0.4)
+                .accessibilityLabel(slice.category)
+                .accessibilityValue(
+                    "\(formattedCurrency(slice.amount)), \(percentageText(for: slice))"
+                )
+            }
+            .chartAngleSelection(value: $selectedAngle)
+            .frame(minHeight: 240)
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel(String(localized: "Category breakdown donut chart"))
+
+            // Legend
+            legendView
+        }
+        .padding()
+        .onChange(of: selectedAngle) { _, newValue in
+            withAnimation(.easeInOut(duration: 0.15)) {
+                selectedCategory = categoryForAngle(newValue)
+            }
+        }
+    }
+
+    // MARK: - Angle Selection
+
+    @State private var selectedAngle: Double?
+
+    private func categoryForAngle(_ angle: Double?) -> String? {
+        guard let angle else { return nil }
+        var cumulative: Double = 0
+        for slice in data {
+            cumulative += slice.amount
+            if angle <= cumulative {
+                return slice.category
+            }
+        }
+        return data.last?.category
+    }
+
+    // MARK: - Legend
+
+    private var legendView: some View {
+        LazyVGrid(
+            columns: [GridItem(.adaptive(minimum: 130, maximum: 200))],
+            alignment: .leading,
+            spacing: 6
+        ) {
+            ForEach(data) { slice in
+                HStack(spacing: 6) {
+                    Circle()
+                        .fill(ChartColorPalette.color(at: slice.colorIndex))
+                        .frame(width: 10, height: 10)
+                        .accessibilityHidden(true)
+
+                    Text(slice.category)
+                        .font(.caption)
+                        .lineLimit(1)
+
+                    Spacer()
+
+                    Text(percentageText(for: slice))
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(
+                    "\(slice.category), \(formattedCurrency(slice.amount)), \(percentageText(for: slice))"
+                )
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func percentageText(for slice: CategorySlice) -> String {
+        guard totalSpending > 0 else { return "0%" }
+        let pct = Int(((slice.amount / totalSpending) * 100).rounded())
+        return "\(pct)%"
+    }
+
+    private func formattedCurrency(_ value: Double) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = currencyCode
+        formatter.maximumFractionDigits = 0
+        return formatter.string(from: NSNumber(value: value))
+            ?? "\(currencyCode) \(Int(value))"
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Category Breakdown") {
+    CategoryBreakdownChart(
+        data: [
+            CategorySlice(category: "Food & Dining", amount: 520, colorIndex: 0),
+            CategorySlice(category: "Transport", amount: 310, colorIndex: 1),
+            CategorySlice(category: "Entertainment", amount: 180, colorIndex: 2),
+            CategorySlice(category: "Utilities", amount: 275, colorIndex: 3),
+            CategorySlice(category: "Shopping", amount: 430, colorIndex: 4),
+            CategorySlice(category: "Health", amount: 140, colorIndex: 5),
+        ],
+        currencyCode: "USD"
+    )
+}

--- a/apps/ios/Finance/Charts/ChartColorPalette.swift
+++ b/apps/ios/Finance/Charts/ChartColorPalette.swift
@@ -1,0 +1,37 @@
+// ChartColorPalette.swift
+// Finance
+//
+// IBM CVD-safe color palette from design tokens for accessible chart rendering.
+// Refs #28
+
+import SwiftUI
+
+/// Color-blind safe palette derived from the IBM CVD-safe design tokens
+/// (packages/design-tokens/tokens/primitive/colors.json -> color.chart.*).
+///
+/// Every chart in the app **must** use these colors so that users with
+/// colour-vision deficiency can distinguish data series.
+enum ChartColorPalette {
+    // MARK: - IBM CVD-Safe Series Colors
+
+    /// IBM CVD-safe blue  (#648FFF)
+    static let blue = Color(red: 0x64 / 255.0, green: 0x8F / 255.0, blue: 0xFF / 255.0)
+    /// IBM CVD-safe purple (#785EF0)
+    static let purple = Color(red: 0x78 / 255.0, green: 0x5E / 255.0, blue: 0xF0 / 255.0)
+    /// IBM CVD-safe magenta (#DC267F)
+    static let magenta = Color(red: 0xDC / 255.0, green: 0x26 / 255.0, blue: 0x7F / 255.0)
+    /// IBM CVD-safe orange (#FE6100)
+    static let orange = Color(red: 0xFE / 255.0, green: 0x61 / 255.0, blue: 0x00 / 255.0)
+    /// IBM CVD-safe gold (#FFB000)
+    static let gold = Color(red: 0xFF / 255.0, green: 0xB0 / 255.0, blue: 0x00 / 255.0)
+    /// CVD-safe teal (#009E73)
+    static let teal = Color(red: 0x00 / 255.0, green: 0x9E / 255.0, blue: 0x73 / 255.0)
+
+    /// Ordered series array - use palette[index % palette.count] to cycle.
+    static let ordered: [Color] = [blue, purple, magenta, orange, gold, teal]
+
+    /// Returns a color for the given zero-based series index, cycling if needed.
+    static func color(at index: Int) -> Color {
+        ordered[index % ordered.count]
+    }
+}

--- a/apps/ios/Finance/Charts/SpendingChart.swift
+++ b/apps/ios/Finance/Charts/SpendingChart.swift
@@ -1,0 +1,100 @@
+// SpendingChart.swift
+// Finance
+//
+// Bar chart showing spending by category using Swift Charts.
+// Uses the IBM CVD-safe palette for colour-blind accessibility.
+// Refs #28
+
+import Charts
+import SwiftUI
+
+// MARK: - Data Model
+
+/// A single spending entry for one category in a given period.
+struct CategorySpending: Identifiable, Sendable {
+    let id = UUID()
+    let category: String
+    /// Amount in the user's display currency (dollars, not cents).
+    let amount: Double
+    /// Zero-based index used to pick a CVD-safe color.
+    let colorIndex: Int
+}
+
+// MARK: - View
+
+/// A bar chart that visualises spending by category.
+///
+/// Bars are coloured using ChartColorPalette (IBM CVD-safe) and each bar
+/// carries an accessibility label so VoiceOver can announce the data.
+struct SpendingChart: View {
+    let data: [CategorySpending]
+    let currencyCode: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(String(localized: "Spending by Category"))
+                .font(.headline)
+                .accessibilityAddTraits(.isHeader)
+
+            Chart(data) { item in
+                BarMark(
+                    x: .value(String(localized: "Category"), item.category),
+                    y: .value(String(localized: "Amount"), item.amount)
+                )
+                .foregroundStyle(ChartColorPalette.color(at: item.colorIndex))
+                .accessibilityLabel(item.category)
+                .accessibilityValue(
+                    formattedCurrency(item.amount)
+                )
+            }
+            .chartYAxis {
+                AxisMarks(position: .leading) { value in
+                    AxisValueLabel {
+                        if let doubleValue = value.as(Double.self) {
+                            Text(formattedCurrency(doubleValue))
+                                .font(.caption2)
+                        }
+                    }
+                    AxisGridLine()
+                }
+            }
+            .chartXAxis {
+                AxisMarks { _ in
+                    AxisValueLabel()
+                        .font(.caption)
+                }
+            }
+            .frame(minHeight: 220)
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel(String(localized: "Spending by category bar chart"))
+        }
+        .padding()
+    }
+
+    // MARK: - Helpers
+
+    private func formattedCurrency(_ value: Double) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = currencyCode
+        formatter.maximumFractionDigits = 0
+        return formatter.string(from: NSNumber(value: value))
+            ?? "\(currencyCode) \(Int(value))"
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Spending Chart") {
+    SpendingChart(
+        data: [
+            CategorySpending(category: "Food", amount: 520, colorIndex: 0),
+            CategorySpending(category: "Transport", amount: 310, colorIndex: 1),
+            CategorySpending(category: "Entertainment", amount: 180, colorIndex: 2),
+            CategorySpending(category: "Utilities", amount: 275, colorIndex: 3),
+            CategorySpending(category: "Shopping", amount: 430, colorIndex: 4),
+            CategorySpending(category: "Health", amount: 140, colorIndex: 5),
+        ],
+        currencyCode: "USD"
+    )
+}

--- a/apps/ios/Finance/Charts/TrendChart.swift
+++ b/apps/ios/Finance/Charts/TrendChart.swift
@@ -1,0 +1,197 @@
+// TrendChart.swift
+// Finance
+//
+// Line chart for net-worth or spending trends over time.
+// Uses the IBM CVD-safe palette for colour-blind accessibility.
+// Refs #28
+
+import Charts
+import SwiftUI
+
+// MARK: - Data Model
+
+/// A single data point on a trend line.
+struct TrendDataPoint: Identifiable, Sendable {
+    let id = UUID()
+    let date: Date
+    /// Value in the user's display currency (dollars).
+    let value: Double
+    /// The name of the series this point belongs to (e.g. "Net Worth", "Spending").
+    let series: String
+}
+
+// MARK: - View
+
+/// A line chart that renders one or more financial trend series over time.
+///
+/// Each series is assigned a colour from ChartColorPalette.
+/// Interactive selection via chartOverlay lets users tap/drag to inspect values.
+struct TrendChart: View {
+    let data: [TrendDataPoint]
+    let currencyCode: String
+
+    @State private var selectedDate: Date?
+
+    /// Unique series names, preserving first-occurrence order.
+    private var seriesNames: [String] {
+        var seen = Set<String>()
+        return data.compactMap { point in
+            if seen.insert(point.series).inserted {
+                return point.series
+            }
+            return nil
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(String(localized: "Trend"))
+                .font(.headline)
+                .accessibilityAddTraits(.isHeader)
+
+            Chart(data) { point in
+                LineMark(
+                    x: .value(String(localized: "Date"), point.date),
+                    y: .value(String(localized: "Amount"), point.value)
+                )
+                .foregroundStyle(
+                    colorForSeries(point.series)
+                )
+                .symbol(by: .value(String(localized: "Series"), point.series))
+                .interpolationMethod(.catmullRom)
+                .accessibilityLabel(point.series)
+                .accessibilityValue(
+                    "\(formattedDate(point.date)), \(formattedCurrency(point.value))"
+                )
+
+                AreaMark(
+                    x: .value(String(localized: "Date"), point.date),
+                    y: .value(String(localized: "Amount"), point.value)
+                )
+                .foregroundStyle(
+                    colorForSeries(point.series).opacity(0.1)
+                )
+
+                if let selectedDate,
+                   Calendar.current.isDate(point.date, inSameDayAs: selectedDate),
+                   point.series == seriesNames.first {
+                    RuleMark(x: .value(String(localized: "Selected"), selectedDate))
+                        .foregroundStyle(.secondary)
+                        .lineStyle(StrokeStyle(lineWidth: 1, dash: [4, 4]))
+                        .accessibilityHidden(true)
+
+                    PointMark(
+                        x: .value(String(localized: "Date"), point.date),
+                        y: .value(String(localized: "Amount"), point.value)
+                    )
+                    .symbolSize(60)
+                    .foregroundStyle(colorForSeries(point.series))
+                    .accessibilityLabel(
+                        String(localized: "Selected: \(point.series)")
+                    )
+                    .accessibilityValue(formattedCurrency(point.value))
+                }
+            }
+            .chartYAxis {
+                AxisMarks(position: .leading) { value in
+                    AxisValueLabel {
+                        if let doubleValue = value.as(Double.self) {
+                            Text(formattedCurrency(doubleValue))
+                                .font(.caption2)
+                        }
+                    }
+                    AxisGridLine()
+                }
+            }
+            .chartXAxis {
+                AxisMarks(values: .stride(by: .month)) { _ in
+                    AxisValueLabel(format: .dateTime.month(.abbreviated))
+                        .font(.caption2)
+                    AxisGridLine()
+                }
+            }
+            .chartOverlay { proxy in
+                GeometryReader { geometry in
+                    Rectangle()
+                        .fill(.clear)
+                        .contentShape(Rectangle())
+                        .gesture(
+                            DragGesture(minimumDistance: 0)
+                                .onChanged { drag in
+                                    let origin = geometry[proxy.plotFrame!].origin
+                                    let x = drag.location.x - origin.x
+                                    if let date: Date = proxy.value(atX: x) {
+                                        selectedDate = date
+                                    }
+                                }
+                                .onEnded { _ in
+                                    selectedDate = nil
+                                }
+                        )
+                }
+            }
+            .frame(minHeight: 220)
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel(String(localized: "Financial trend line chart"))
+        }
+        .padding()
+    }
+
+    // MARK: - Helpers
+
+    private func colorForSeries(_ series: String) -> Color {
+        let index = seriesNames.firstIndex(of: series) ?? 0
+        return ChartColorPalette.color(at: index)
+    }
+
+    private func formattedCurrency(_ value: Double) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = currencyCode
+        formatter.maximumFractionDigits = 0
+        return formatter.string(from: NSNumber(value: value))
+            ?? "\(currencyCode) \(Int(value))"
+    }
+
+    private func formattedDate(_ date: Date) -> String {
+        date.formatted(.dateTime.month(.abbreviated).day())
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Trend Chart - Net Worth") {
+    let calendar = Calendar.current
+    let today = Date.now
+    let points: [TrendDataPoint] = (0..<12).map { monthOffset in
+        let date = calendar.date(byAdding: .month, value: -11 + monthOffset, to: today)!
+        return TrendDataPoint(
+            date: date,
+            value: 12_000 + Double(monthOffset) * 850 + Double.random(in: -200...200),
+            series: "Net Worth"
+        )
+    }
+
+    TrendChart(data: points, currencyCode: "USD")
+}
+
+#Preview("Trend Chart - Multi-Series") {
+    let calendar = Calendar.current
+    let today = Date.now
+    let income: [TrendDataPoint] = (0..<6).map { i in
+        TrendDataPoint(
+            date: calendar.date(byAdding: .month, value: -5 + i, to: today)!,
+            value: 5_000 + Double.random(in: -300...300),
+            series: "Income"
+        )
+    }
+    let spending: [TrendDataPoint] = (0..<6).map { i in
+        TrendDataPoint(
+            date: calendar.date(byAdding: .month, value: -5 + i, to: today)!,
+            value: 3_500 + Double.random(in: -400...400),
+            series: "Spending"
+        )
+    }
+
+    TrendChart(data: income + spending, currencyCode: "USD")
+}

--- a/apps/ios/FinanceWatch/BalanceView.swift
+++ b/apps/ios/FinanceWatch/BalanceView.swift
@@ -1,0 +1,58 @@
+// BalanceView.swift
+// FinanceWatch
+//
+// Displays the total account balance at a glance on Apple Watch.
+// Data is provided by the WatchConnectivityManager from the paired iPhone.
+// Refs #30
+
+import SwiftUI
+
+struct BalanceView: View {
+    let manager: WatchConnectivityManager
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "banknote")
+                .font(.title2)
+                .foregroundStyle(.teal)
+                .accessibilityHidden(true)
+
+            Text(String(localized: "Total Balance"))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .accessibilityAddTraits(.isHeader)
+
+            Text(formattedBalance)
+                .font(.title2)
+                .fontWeight(.bold)
+                .minimumScaleFactor(0.5)
+                .lineLimit(1)
+                .accessibilityLabel(
+                    String(localized: "Total balance: \(formattedBalance)")
+                )
+
+            if !manager.hasReceivedData {
+                Text(String(localized: "Waiting for data from iPhone..."))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityElement(children: .combine)
+    }
+
+    private var formattedBalance: String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = manager.currencyCode
+        formatter.maximumFractionDigits = 2
+        return formatter.string(from: NSNumber(value: manager.totalBalance))
+            ?? "\(manager.currencyCode) \(manager.totalBalance)"
+    }
+}
+
+#Preview("Balance View") {
+    let manager = WatchConnectivityManager()
+    BalanceView(manager: manager)
+}

--- a/apps/ios/FinanceWatch/BudgetStatusView.swift
+++ b/apps/ios/FinanceWatch/BudgetStatusView.swift
@@ -1,0 +1,120 @@
+// BudgetStatusView.swift
+// FinanceWatch
+//
+// Top-3 budget utilisation rings displayed on Apple Watch.
+// Uses compact Gauge views with haptic alerts for over-budget items.
+// Refs #30
+
+import SwiftUI
+import WatchKit
+
+struct BudgetStatusView: View {
+    let manager: WatchConnectivityManager
+
+    @State private var hasPlayedHaptic = false
+
+    var body: some View {
+        Group {
+            if manager.budgetStatuses.isEmpty {
+                emptyState
+            } else {
+                budgetRings
+            }
+        }
+        .navigationTitle(String(localized: "Budgets"))
+        .task {
+            await playOverBudgetHaptic()
+        }
+    }
+
+    private var budgetRings: some View {
+        VStack(spacing: 12) {
+            Text(String(localized: "Budget Status"))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .accessibilityAddTraits(.isHeader)
+
+            HStack(spacing: 8) {
+                ForEach(
+                    Array(manager.budgetStatuses.prefix(3).enumerated()),
+                    id: \.element.id
+                ) { index, status in
+                    budgetGauge(status: status, colorIndex: index)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func budgetGauge(status: WatchBudgetStatus, colorIndex: Int) -> some View {
+        VStack(spacing: 4) {
+            Gauge(value: status.fraction) {
+                // Intentionally empty - label below
+            } currentValueLabel: {
+                Text(percentText(status))
+                    .font(.system(.caption2, design: .rounded))
+                    .fontWeight(.bold)
+            }
+            .gaugeStyle(.accessoryCircular)
+            .tint(status.isOverBudget ? .red : tintColor(for: colorIndex))
+
+            Text(status.name)
+                .font(.system(.caption2))
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(status.name)
+        .accessibilityValue(
+            String(localized: "\(percentText(status)) spent, \(formattedCurrency(status.spent)) of \(formattedCurrency(status.budgeted))")
+        )
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "chart.pie")
+                .font(.title3)
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+            Text(String(localized: "No budgets set"))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityLabel(String(localized: "No budgets set"))
+    }
+
+    private func playOverBudgetHaptic() async {
+        guard !hasPlayedHaptic else { return }
+        let hasOverBudget = manager.budgetStatuses.contains { $0.isOverBudget }
+        if hasOverBudget {
+            WKInterfaceDevice.current().play(.notification)
+            hasPlayedHaptic = true
+        }
+    }
+
+    private func tintColor(for index: Int) -> Color {
+        let colors: [Color] = [.blue, .purple, .teal]
+        return colors[index % colors.count]
+    }
+
+    private func percentText(_ status: WatchBudgetStatus) -> String {
+        let pct = Int((status.fraction * 100).rounded())
+        return "\(pct)%"
+    }
+
+    private func formattedCurrency(_ value: Double) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = manager.currencyCode
+        formatter.maximumFractionDigits = 0
+        return formatter.string(from: NSNumber(value: value))
+            ?? "\(manager.currencyCode) \(Int(value))"
+    }
+}
+
+#Preview("Budget Status") {
+    let manager = WatchConnectivityManager()
+    BudgetStatusView(manager: manager)
+}

--- a/apps/ios/FinanceWatch/ComplicationProvider.swift
+++ b/apps/ios/FinanceWatch/ComplicationProvider.swift
@@ -1,0 +1,180 @@
+// ComplicationProvider.swift
+// FinanceWatch
+//
+// WidgetKit complication showing the user's current balance on the watch face.
+// Updates via a timeline provider that reads from the WatchConnectivity context.
+// Refs #30
+
+import SwiftUI
+import WidgetKit
+
+// MARK: - Timeline Entry
+
+struct BalanceTimelineEntry: TimelineEntry {
+    let date: Date
+    let balance: Double
+    let currencyCode: String
+}
+
+// MARK: - Timeline Provider
+
+/// Reads the latest balance from shared UserDefaults (App Group).
+/// Note: Only non-sensitive display data (formatted balance) is stored here.
+/// Tokens and credentials remain in Keychain access groups.
+struct BalanceComplicationProvider: TimelineProvider {
+    private static let suiteName = "group.com.finance.watch"
+    private static let balanceKey = "complication.totalBalance"
+    private static let currencyKey = "complication.currencyCode"
+
+    func placeholder(in context: Context) -> BalanceTimelineEntry {
+        BalanceTimelineEntry(date: .now, balance: 0, currencyCode: "USD")
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (BalanceTimelineEntry) -> Void) {
+        completion(currentEntry())
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<BalanceTimelineEntry>) -> Void) {
+        let entry = currentEntry()
+        let nextUpdate = Calendar.current.date(byAdding: .minute, value: 30, to: .now)!
+        completion(Timeline(entries: [entry], policy: .after(nextUpdate)))
+    }
+
+    private func currentEntry() -> BalanceTimelineEntry {
+        let defaults = UserDefaults(suiteName: Self.suiteName)
+        let balance = defaults?.double(forKey: Self.balanceKey) ?? 0
+        let currency = defaults?.string(forKey: Self.currencyKey) ?? "USD"
+        return BalanceTimelineEntry(date: .now, balance: balance, currencyCode: currency)
+    }
+}
+
+// MARK: - Widget
+
+struct BalanceComplication: Widget {
+    let kind = "BalanceComplication"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: BalanceComplicationProvider()) { entry in
+            BalanceComplicationView(entry: entry)
+                .containerBackground(.fill.tertiary, for: .widget)
+        }
+        .configurationDisplayName(Text("Balance"))
+        .description(Text("Shows your current total balance."))
+        .supportedFamilies([
+            .accessoryCircular,
+            .accessoryRectangular,
+            .accessoryInline,
+            .accessoryCorner,
+        ])
+    }
+}
+
+struct BalanceComplicationView: View {
+    @Environment(\.widgetFamily) var family
+    let entry: BalanceTimelineEntry
+
+    var body: some View {
+        switch family {
+        case .accessoryCircular: circularView
+        case .accessoryRectangular: rectangularView
+        case .accessoryInline: inlineView
+        case .accessoryCorner: cornerView
+        default: circularView
+        }
+    }
+
+    private var circularView: some View {
+        VStack(spacing: 1) {
+            Image(systemName: "dollarsign.circle")
+                .font(.caption)
+                .accessibilityHidden(true)
+            Text(compactBalance)
+                .font(.caption2)
+                .fontWeight(.semibold)
+                .minimumScaleFactor(0.6)
+        }
+        .accessibilityLabel(String(localized: "Balance: \(formattedBalance)"))
+    }
+
+    private var rectangularView: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(String(localized: "Balance"))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Text(formattedBalance)
+                    .font(.caption)
+                    .fontWeight(.bold)
+                    .minimumScaleFactor(0.6)
+                    .lineLimit(1)
+            }
+            Spacer()
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(String(localized: "Balance: \(formattedBalance)"))
+    }
+
+    private var inlineView: some View {
+        Text("\(formattedBalance)")
+            .accessibilityLabel(String(localized: "Balance: \(formattedBalance)"))
+    }
+
+    private var cornerView: some View {
+        Text(compactBalance)
+            .font(.caption)
+            .fontWeight(.semibold)
+            .widgetLabel {
+                Text(String(localized: "Balance"))
+            }
+            .accessibilityLabel(String(localized: "Balance: \(formattedBalance)"))
+    }
+
+    private var formattedBalance: String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = entry.currencyCode
+        formatter.maximumFractionDigits = 0
+        return formatter.string(from: NSNumber(value: entry.balance))
+            ?? "\(entry.currencyCode) \(Int(entry.balance))"
+    }
+
+    private var compactBalance: String {
+        let absVal = Swift.abs(entry.balance)
+        let sign = entry.balance < 0 ? "-" : ""
+        let symbol = currencySymbol
+        if absVal >= 1_000_000 {
+            return "\(sign)\(symbol)\(String(format: "%.1fM", absVal / 1_000_000))"
+        } else if absVal >= 1_000 {
+            return "\(sign)\(symbol)\(String(format: "%.1fK", absVal / 1_000))"
+        } else {
+            return "\(sign)\(symbol)\(Int(absVal))"
+        }
+    }
+
+    private var currencySymbol: String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = entry.currencyCode
+        formatter.locale = .current
+        return formatter.currencySymbol ?? "$"
+    }
+}
+
+#Preview("Circular", as: .accessoryCircular) {
+    BalanceComplication()
+} timeline: {
+    BalanceTimelineEntry(date: .now, balance: 24_850, currencyCode: "USD")
+    BalanceTimelineEntry(date: .now, balance: 1_250_000, currencyCode: "USD")
+}
+
+#Preview("Rectangular", as: .accessoryRectangular) {
+    BalanceComplication()
+} timeline: {
+    BalanceTimelineEntry(date: .now, balance: 24_850, currencyCode: "USD")
+}
+
+#Preview("Inline", as: .accessoryInline) {
+    BalanceComplication()
+} timeline: {
+    BalanceTimelineEntry(date: .now, balance: 24_850, currencyCode: "USD")
+}

--- a/apps/ios/FinanceWatch/FinanceWatchApp.swift
+++ b/apps/ios/FinanceWatch/FinanceWatchApp.swift
@@ -1,0 +1,157 @@
+// FinanceWatchApp.swift
+// FinanceWatch
+//
+// watchOS companion app entry point for the Finance app.
+// Displays account balances, recent transactions, and budget status
+// using data transferred from the iPhone app via WatchConnectivity.
+// Refs #30
+
+import SwiftUI
+import WatchConnectivity
+
+/// The main entry point for the Finance watchOS companion app.
+@main
+struct FinanceWatchApp: App {
+    @State private var connectivityManager = WatchConnectivityManager()
+
+    var body: some Scene {
+        WindowGroup {
+            NavigationStack {
+                TabView {
+                    BalanceView(manager: connectivityManager)
+                    RecentTransactionsView(manager: connectivityManager)
+                    BudgetStatusView(manager: connectivityManager)
+                }
+                .tabViewStyle(.verticalPage)
+            }
+        }
+    }
+}
+
+// MARK: - WatchConnectivity Manager
+
+/// Manages the WCSession connection with the paired iPhone app.
+///
+/// Receives pre-computed financial data via applicationContext or
+/// userInfo transfers - the watchOS app never imports the KMP framework
+/// directly.
+@Observable
+@MainActor
+final class WatchConnectivityManager: NSObject, Sendable {
+    var totalBalance: Double = 0
+    var currencyCode: String = "USD"
+    var recentTransactions: [WatchTransaction] = []
+    var budgetStatuses: [WatchBudgetStatus] = []
+    var hasReceivedData: Bool = false
+
+    override init() {
+        super.init()
+        activateSession()
+    }
+
+    private func activateSession() {
+        guard WCSession.isSupported() else { return }
+        let session = WCSession.default
+        session.delegate = self
+        session.activate()
+    }
+
+    nonisolated func applyContext(_ context: [String: Any]) {
+        Task { @MainActor in
+            if let balance = context["totalBalance"] as? Double {
+                self.totalBalance = balance
+            }
+            if let code = context["currencyCode"] as? String {
+                self.currencyCode = code
+            }
+            if let txData = context["recentTransactions"] as? [[String: Any]] {
+                self.recentTransactions = txData.compactMap(WatchTransaction.init)
+            }
+            if let budgetData = context["budgetStatuses"] as? [[String: Any]] {
+                self.budgetStatuses = budgetData.compactMap(WatchBudgetStatus.init)
+            }
+            self.hasReceivedData = true
+        }
+    }
+}
+
+// MARK: - WCSessionDelegate
+
+extension WatchConnectivityManager: WCSessionDelegate {
+    nonisolated func session(
+        _ session: WCSession,
+        activationDidCompleteWith activationState: WCSessionActivationState,
+        error: Error?
+    ) {
+        if activationState == .activated {
+            let context = session.receivedApplicationContext
+            if !context.isEmpty { applyContext(context) }
+        }
+    }
+
+    nonisolated func session(
+        _ session: WCSession,
+        didReceiveApplicationContext applicationContext: [String: Any]
+    ) {
+        applyContext(applicationContext)
+    }
+
+    nonisolated func session(
+        _ session: WCSession,
+        didReceiveUserInfo userInfo: [String: Any] = [:]
+    ) {
+        applyContext(userInfo)
+    }
+}
+
+// MARK: - Lightweight Watch Models
+
+struct WatchTransaction: Identifiable, Sendable {
+    let id: String
+    let payee: String
+    let amount: Double
+    let category: String
+    let date: Date
+    let isExpense: Bool
+
+    init?(dictionary: [String: Any]) {
+        guard let id = dictionary["id"] as? String,
+              let payee = dictionary["payee"] as? String,
+              let amount = dictionary["amount"] as? Double,
+              let category = dictionary["category"] as? String,
+              let timestamp = dictionary["date"] as? TimeInterval
+        else { return nil }
+        self.id = id
+        self.payee = payee
+        self.amount = amount
+        self.category = category
+        self.date = Date(timeIntervalSince1970: timestamp)
+        self.isExpense = dictionary["isExpense"] as? Bool ?? true
+    }
+}
+
+struct WatchBudgetStatus: Identifiable, Sendable {
+    let id: String
+    let name: String
+    let spent: Double
+    let budgeted: Double
+
+    var fraction: Double {
+        guard budgeted > 0 else { return 0 }
+        return min(max(spent / budgeted, 0), 1)
+    }
+
+    var isOverBudget: Bool { spent > budgeted }
+
+    init?(dictionary: [String: Any]) {
+        guard let id = dictionary["id"] as? String,
+              let name = dictionary["name"] as? String,
+              let spent = dictionary["spent"] as? Double,
+              let budgeted = dictionary["budgeted"] as? Double
+        else { return nil }
+        self.id = id
+        self.name = name
+        self.spent = spent
+        self.budgeted = budgeted
+    }
+}

--- a/apps/ios/FinanceWatch/RecentTransactionsView.swift
+++ b/apps/ios/FinanceWatch/RecentTransactionsView.swift
@@ -1,0 +1,88 @@
+// RecentTransactionsView.swift
+// FinanceWatch
+//
+// Compact list of the 5 most recent transactions on Apple Watch.
+// Refs #30
+
+import SwiftUI
+
+struct RecentTransactionsView: View {
+    let manager: WatchConnectivityManager
+
+    var body: some View {
+        Group {
+            if manager.recentTransactions.isEmpty {
+                emptyState
+            } else {
+                transactionList
+            }
+        }
+        .navigationTitle(String(localized: "Recent"))
+    }
+
+    private var transactionList: some View {
+        List(manager.recentTransactions.prefix(5)) { tx in
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(tx.payee)
+                        .font(.caption)
+                        .fontWeight(.medium)
+                        .lineLimit(1)
+                    Text(tx.category)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                Spacer()
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text(formattedAmount(tx))
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(tx.isExpense ? .red : .green)
+                    Text(tx.date, style: .relative)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(
+                "\(tx.payee), \(tx.category), \(formattedAmount(tx)), \(formattedDate(tx.date))"
+            )
+        }
+        .listStyle(.carousel)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "tray")
+                .font(.title3)
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+            Text(String(localized: "No recent transactions"))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityLabel(String(localized: "No recent transactions"))
+    }
+
+    private func formattedAmount(_ tx: WatchTransaction) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = manager.currencyCode
+        formatter.maximumFractionDigits = 2
+        let value = tx.isExpense ? -abs(tx.amount) : abs(tx.amount)
+        return formatter.string(from: NSNumber(value: value))
+            ?? "\(manager.currencyCode) \(value)"
+    }
+
+    private func formattedDate(_ date: Date) -> String {
+        date.formatted(.relative(presentation: .named))
+    }
+}
+
+#Preview("Recent Transactions") {
+    let manager = WatchConnectivityManager()
+    RecentTransactionsView(manager: manager)
+}

--- a/apps/ios/Package.swift
+++ b/apps/ios/Package.swift
@@ -1,21 +1,47 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 5.10
+// Package.swift
+//
+// Swift Package Manager manifest for the Finance iOS & watchOS targets.
+// The iOS app uses Swift Charts for financial data visualisation (#28).
+// The watchOS companion app displays balance, transactions, and budgets (#30).
+
 import PackageDescription
 
 let package = Package(
     name: "Finance",
     platforms: [
         .iOS(.v17),
-        .macOS(.v14),
         .watchOS(.v10),
+        .macOS(.v14),
     ],
     products: [
         .library(name: "FinanceApp", targets: ["FinanceApp"]),
+        .library(name: "FinanceWatch", targets: ["FinanceWatch"]),
     ],
-    dependencies: [],
     targets: [
         .target(
             name: "FinanceApp",
-            path: "Finance"
+            dependencies: [],
+            path: "Finance",
+            sources: [
+                "Charts/ChartColorPalette.swift",
+                "Charts/SpendingChart.swift",
+                "Charts/TrendChart.swift",
+                "Charts/BudgetProgressChart.swift",
+                "Charts/CategoryBreakdownChart.swift",
+            ]
+        ),
+        .target(
+            name: "FinanceWatch",
+            dependencies: [],
+            path: "FinanceWatch",
+            sources: [
+                "FinanceWatchApp.swift",
+                "BalanceView.swift",
+                "RecentTransactionsView.swift",
+                "BudgetStatusView.swift",
+                "ComplicationProvider.swift",
+            ]
         ),
     ]
 )


### PR DESCRIPTION
## Summary

Implement Swift Charts for financial data visualisation and watchOS companion app for the Finance iOS platform.

### Swift Charts (`apps/ios/Finance/Charts/`) — Refs #28

- **ChartColorPalette.swift** — IBM CVD-safe (color-blind accessible) 6-color palette derived from design tokens
- **SpendingChart.swift** — Bar chart showing spending by category with VoiceOver labels
- **TrendChart.swift** — Line chart for net worth/spending over time with interactive drag-to-inspect
- **BudgetProgressChart.swift** — Gauge/ring chart for budget utilisation with over-budget detection
- **CategoryBreakdownChart.swift** — Donut chart with angle selection, legend, and proportional breakdown

### watchOS Companion (`apps/ios/FinanceWatch/`) — Refs #30

- **FinanceWatchApp.swift** — @main entry, WatchConnectivityManager (@Observable), lightweight watch models
- **BalanceView.swift** — Total balance at-a-glance with Dynamic Type
- **RecentTransactionsView.swift** — Last 5 transactions in compact list
- **BudgetStatusView.swift** — Top 3 budget rings with haptic over-budget alerts
- **ComplicationProvider.swift** — WidgetKit complication (circular, rectangular, inline, corner) via App Group

### Package.swift

- SPM manifest defining FinanceApp (iOS 17+) and FinanceWatch (watchOS 10+) targets

### Design Principles

- All charts use the IBM CVD-safe palette from `packages/design-tokens`
- Every interactive element has `.accessibilityLabel()` / `.accessibilityValue()`
- All text uses Dynamic Type system fonts (no hardcoded sizes)
- watchOS app receives pre-computed data via WCSession — no KMP dependency
- Non-sensitive display data in App Group UserDefaults; credentials in Keychain
- `#Preview` macros for every view

Closes #28
Closes #30