### PR TITLE
feat(monitoring): crash reporting, sync health monitoring, metrics collection

### DIFF
--- a/docs/guides/monitoring.md
+++ b/docs/guides/monitoring.md
@@ -1,0 +1,164 @@
+# Monitoring Strategy
+
+> Privacy-respecting observability for the Finance application.
+> Covers crash reporting, sync health, API monitoring, and alerting.
+
+## Principles
+
+1. **Privacy first** — No PII in crash reports or metrics. All telemetry is anonymous.
+2. **User consent required** — Crash reporting and usage metrics are opt-in. The app must function fully without them.
+3. **Edge-first** — Monitor client-side health (sync, offline queue) as the primary signal. Server metrics are secondary.
+4. **Minimal data** — Collect only what is needed to diagnose issues. Never log financial data, account numbers, or balances.
+
+---
+
+## Crash Reporting
+
+### Requirements
+
+- All crash reports must be **PII-free** — strip user identifiers, file paths, and device-unique IDs before submission.
+- Users must **explicitly opt in** via a consent flow at onboarding or in settings.
+- Crash context includes: app version, OS version, device model (generalized), locale, and a sanitized stack trace.
+- A pseudonymous user ID (rotatable, not tied to real identity) may be attached to correlate crashes per session.
+
+### Recommended Tools
+
+| Tool | Deployment | Privacy Notes |
+|------|-----------|---------------|
+| **Sentry (self-hosted)** | On-premise or private cloud | Full data sovereignty. Recommended for production. |
+| **Firebase Crashlytics** | Google Cloud | Acceptable if data residency requirements are met. Disable user ID tracking. |
+
+### Self-Hosted Sentry Setup
+
+- Deploy Sentry via Docker Compose on private infrastructure.
+- Configure data scrubbing rules to strip PII from stack traces.
+- Set retention policy to 90 days maximum.
+- Disable session replay and user feedback attachments.
+
+### Integration Points
+
+- `CrashReporter` interface in `packages/core` provides a platform-agnostic API.
+- Each platform app (`apps/ios`, `apps/android`, `apps/web`, `apps/windows`) implements the interface with the native SDK.
+- Unhandled exceptions are caught at the platform layer and forwarded through `CrashReporter.reportError()`.
+
+---
+
+## Sync Health Monitoring
+
+### Metrics
+
+| Metric | Description | Collection Point |
+|--------|-------------|-----------------|
+| `sync_latency_ms` | Time from sync initiation to completion | Client (SyncHealthMonitor) |
+| `pending_mutations` | Number of unsynced local changes | Client (SyncHealthMonitor) |
+| `sync_failure_count` | Consecutive sync failures | Client (SyncHealthMonitor) |
+| `conflict_rate` | Conflicts per sync cycle | Client + Server |
+| `last_successful_sync` | Timestamp of last successful sync | Client (SyncHealthMonitor) |
+| `average_sync_duration_ms` | Rolling average of sync duration | Client (SyncHealthMonitor) |
+
+### Health Status
+
+The `HealthStatus` sealed class evaluates sync state:
+
+- **Healthy** — Last sync < 5 minutes ago, no pending failures, pending mutations < 50.
+- **Degraded** — Last sync 5–30 minutes ago, or 1–3 consecutive failures, or pending mutations 50–200.
+- **Unhealthy** — Last sync > 30 minutes ago, or > 3 consecutive failures, or pending mutations > 200.
+
+### Server-Side Sync Logs
+
+The `sync_health_logs` table in Supabase records sync events server-side:
+
+- Tracks sync duration, record counts, and error codes per user per device.
+- RLS enforced: users can read only their own logs; writes are restricted to the system (service role).
+- Retained for 30 days, then automatically purged.
+
+---
+
+## API Monitoring
+
+### Metrics
+
+| Metric | Target | Alert Threshold |
+|--------|--------|----------------|
+| Response time (p50) | < 200 ms | > 500 ms |
+| Response time (p99) | < 1000 ms | > 3000 ms |
+| Error rate (5xx) | < 0.1% | > 1% |
+| Auth failure rate | < 1% | > 5% |
+| Sync endpoint latency | < 500 ms | > 2000 ms |
+
+### Implementation
+
+- Supabase Edge Functions emit structured JSON logs with request duration and status code.
+- Use Supabase’s built-in observability dashboard for PostgreSQL query performance.
+- Monitor RLS policy evaluation time — complex policies can degrade query performance.
+
+---
+
+## Alert Thresholds and Escalation
+
+### Severity Levels
+
+| Level | Condition | Response Time | Action |
+|-------|-----------|--------------|--------|
+| **P1 — Critical** | Sync completely broken for all users, data loss risk | 15 minutes | Page on-call, all hands |
+| **P2 — High** | Sync degraded (> 50% failure rate), auth outage | 1 hour | Notify on-call, begin investigation |
+| **P3 — Medium** | Elevated error rates, slow API responses | 4 hours | Create issue, investigate next business day |
+| **P4 — Low** | Minor anomalies, single-user reports | 24 hours | Log and monitor |
+
+### Escalation Flow
+
+1. Automated alert fires based on threshold breach.
+2. On-call engineer acknowledges within response time SLA.
+3. If not acknowledged, escalate to secondary on-call.
+4. Post-incident review for all P1 and P2 incidents.
+
+### Alert Channels
+
+- **P1/P2**: PagerDuty (or equivalent) — SMS + push notification.
+- **P3**: Slack/Teams channel notification.
+- **P4**: Dashboard annotation only.
+
+---
+
+## Usage Metrics (Anonymous)
+
+### What We Collect (with consent)
+
+- Screen view counts (which features are used, not what data is viewed).
+- Feature adoption rates (e.g., "budget created" event, not budget details).
+- App session duration (generalized to buckets: < 1 min, 1–5 min, 5–15 min, > 15 min).
+- Sync performance metrics (latency, success rate).
+
+### What We Never Collect
+
+- Financial data (transactions, balances, account names, amounts).
+- Personal information (name, email, phone, location).
+- Browsing or navigation patterns that could identify individuals.
+- Device-unique identifiers (use rotatable pseudonymous IDs only).
+
+### Consent Management
+
+- `MetricsCollector` in `packages/core` checks consent status before recording any metric.
+- Consent is stored locally and can be revoked at any time.
+- Revoking consent stops all future collection and deletes locally buffered metrics.
+
+---
+
+## Architecture Diagram
+
+```
++---------------+     +------------------+     +-----------------+
+|  Client App   |---->|  CrashReporter   |---->|  Sentry (self-  |
+|  (per plat.)  |     |  (interface)     |     |  hosted)        |
++------+--------+     +------------------+     +-----------------+
+       |
+       |             +------------------+     +-----------------+
+       +------------>| SyncHealthMonitor|---->|  sync_health_   |
+       |             | (client metrics) |     |  logs (Supabase) |
+       |             +------------------+     +-----------------+
+       |
+       |             +------------------+
+       +------------>| MetricsCollector |---->  Local buffer
+                     | (consent-gated)  |     (anonymous only)
+                     +------------------+
+```

--- a/packages/core/src/commonMain/kotlin/com/finance/core/monitoring/CrashReporter.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/monitoring/CrashReporter.kt
@@ -1,0 +1,70 @@
+package com.finance.core.monitoring
+
+/**
+ * Platform-agnostic interface for crash and error reporting.
+ *
+ * Implementations must ensure that:
+ * - No PII is included in crash reports (strip user names, emails, file paths).
+ * - Reporting only occurs when the user has granted consent.
+ * - Financial data (amounts, account numbers, balances) is never attached to reports.
+ *
+ * Each platform app provides a concrete implementation backed by the
+ * chosen crash reporting service (e.g., Sentry, Firebase Crashlytics).
+ */
+interface CrashReporter {
+
+    /**
+     * Report a caught or uncaught exception with optional context.
+     *
+     * @param exception The exception to report. Stack traces are sanitized
+     *   by the implementation before transmission.
+     * @param context Free-form key-value pairs providing diagnostic context.
+     *   Keys and values must not contain PII or financial data.
+     *   Example: `mapOf("screen" to "budget_list", "action" to "sync")`.
+     */
+    fun reportError(exception: Throwable, context: Map<String, String> = emptyMap())
+
+    /**
+     * Associate a pseudonymous user ID with subsequent crash reports.
+     *
+     * The ID must be a rotatable, non-reversible identifier that cannot
+     * be linked back to the user's real identity. Implementations should
+     * use a hash or random UUID, never an email or account ID.
+     *
+     * @param id Pseudonymous user identifier, or null to clear.
+     */
+    fun setUserId(id: String?)
+
+    /**
+     * Record a breadcrumb log message for diagnostic context.
+     *
+     * Breadcrumbs are attached to subsequent crash reports to help
+     * reconstruct the sequence of events leading to a crash.
+     * Messages must not contain PII or financial data.
+     *
+     * @param message Descriptive log message (e.g., "Sync started", "Budget screen opened").
+     */
+    fun log(message: String)
+
+    /**
+     * Check whether the user has granted consent for crash reporting.
+     *
+     * Implementations must return false if consent has not been
+     * explicitly granted. When false, [reportError], [setUserId],
+     * and [log] must be no-ops.
+     *
+     * @return true if crash reporting is enabled and consented.
+     */
+    fun isEnabled(): Boolean
+}
+
+/**
+ * No-op [CrashReporter] used when crash reporting is disabled or
+ * no platform implementation is available.
+ */
+object NoOpCrashReporter : CrashReporter {
+    override fun reportError(exception: Throwable, context: Map<String, String>) = Unit
+    override fun setUserId(id: String?) = Unit
+    override fun log(message: String) = Unit
+    override fun isEnabled(): Boolean = false
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/monitoring/HealthStatus.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/monitoring/HealthStatus.kt
@@ -1,0 +1,96 @@
+package com.finance.core.monitoring
+
+import kotlinx.datetime.Instant
+
+/**
+ * Represents the overall health of the sync subsystem.
+ *
+ * Health is determined by evaluating sync recency, failure count,
+ * and pending mutation queue depth. Platform layers can map these
+ * states to user-facing indicators (e.g., status icons, banners).
+ */
+sealed class HealthStatus {
+
+    /** Sync is operating normally with no issues detected. */
+    data object Healthy : HealthStatus()
+
+    /**
+     * Sync is functional but showing signs of stress.
+     *
+     * @property reason Human-readable description of the degradation cause.
+     */
+    data class Degraded(val reason: String) : HealthStatus()
+
+    /**
+     * Sync is non-functional or critically impaired.
+     *
+     * @property reason Human-readable description of the failure cause.
+     */
+    data class Unhealthy(val reason: String) : HealthStatus()
+
+    companion object {
+        /** Maximum age of last sync before status degrades (5 minutes). */
+        internal const val DEGRADED_SYNC_AGE_MS: Long = 5 * 60 * 1000L
+
+        /** Maximum age of last sync before status becomes unhealthy (30 minutes). */
+        internal const val UNHEALTHY_SYNC_AGE_MS: Long = 30 * 60 * 1000L
+
+        /** Pending mutation count threshold for degraded status. */
+        internal const val DEGRADED_PENDING_THRESHOLD: Int = 50
+
+        /** Pending mutation count threshold for unhealthy status. */
+        internal const val UNHEALTHY_PENDING_THRESHOLD: Int = 200
+
+        /** Consecutive failure count threshold for degraded status. */
+        internal const val DEGRADED_FAILURE_THRESHOLD: Int = 1
+
+        /** Consecutive failure count threshold for unhealthy status. */
+        internal const val UNHEALTHY_FAILURE_THRESHOLD: Int = 3
+
+        /**
+         * Evaluate sync health from current metrics.
+         *
+         * @param lastSyncTime Timestamp of the last successful sync, or null if never synced.
+         * @param currentTime Current timestamp for age calculation.
+         * @param failureCount Number of consecutive sync failures.
+         * @param pendingMutations Number of unsynced local mutations.
+         * @return The computed [HealthStatus].
+         */
+        fun evaluate(
+            lastSyncTime: Instant?,
+            currentTime: Instant,
+            failureCount: Int,
+            pendingMutations: Int,
+        ): HealthStatus {
+            if (lastSyncTime == null) {
+                return Unhealthy("No successful sync recorded")
+            }
+
+            val syncAgeMs = (currentTime - lastSyncTime).inWholeMilliseconds
+
+            // Check unhealthy conditions first (most severe)
+            if (syncAgeMs > UNHEALTHY_SYNC_AGE_MS) {
+                return Unhealthy("Last sync was over 30 minutes ago")
+            }
+            if (failureCount > UNHEALTHY_FAILURE_THRESHOLD) {
+                return Unhealthy("$failureCount consecutive sync failures")
+            }
+            if (pendingMutations > UNHEALTHY_PENDING_THRESHOLD) {
+                return Unhealthy("$pendingMutations mutations pending sync")
+            }
+
+            // Check degraded conditions
+            if (syncAgeMs > DEGRADED_SYNC_AGE_MS) {
+                return Degraded("Last sync was over 5 minutes ago")
+            }
+            if (failureCount >= DEGRADED_FAILURE_THRESHOLD) {
+                return Degraded("$failureCount consecutive sync failure(s)")
+            }
+            if (pendingMutations >= DEGRADED_PENDING_THRESHOLD) {
+                return Degraded("$pendingMutations mutations pending sync")
+            }
+
+            return Healthy
+        }
+    }
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/monitoring/MetricsCollector.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/monitoring/MetricsCollector.kt
@@ -1,0 +1,119 @@
+package com.finance.core.monitoring
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+
+/**
+ * Collects anonymous usage metrics with explicit consent gating.
+ *
+ * Every public method checks [consentProvider] before recording data.
+ * If consent is not granted, calls are silent no-ops. Metrics never
+ * contain PII, financial data, or device-unique identifiers.
+ *
+ * Recorded events are buffered locally and flushed by platform-specific
+ * transport implementations. Call [flushEvents] to retrieve and clear
+ * the buffer for transmission.
+ *
+ * @param consentProvider Returns true when the user has opted in to analytics.
+ * @param clock Clock source for timestamps (injectable for testing).
+ */
+class MetricsCollector(
+    private val consentProvider: () -> Boolean,
+    private val clock: Clock = Clock.System,
+) {
+
+    private val eventBuffer = mutableListOf<MetricEvent>()
+
+    /**
+     * Record a screen view event.
+     *
+     * @param screenName Identifier for the screen (e.g., "budget_list", "settings").
+     *   Must not contain user-specific data.
+     */
+    fun recordScreenView(screenName: String) {
+        recordEvent("screen_view", mapOf("screen" to screenName))
+    }
+
+    /**
+     * Record a feature usage event.
+     *
+     * @param featureName Identifier for the feature (e.g., "create_budget", "export_data").
+     *   Must not contain user-specific or financial data.
+     * @param properties Optional metadata about the usage. Values must be anonymous.
+     */
+    fun recordFeatureUsage(featureName: String, properties: Map<String, String> = emptyMap()) {
+        recordEvent("feature_usage", properties + ("feature" to featureName))
+    }
+
+    /**
+     * Record a sync performance event.
+     *
+     * @param durationMs Sync duration in milliseconds.
+     * @param recordCount Number of records synced.
+     * @param success Whether the sync completed successfully.
+     */
+    fun recordSyncPerformance(durationMs: Long, recordCount: Int, success: Boolean) {
+        recordEvent(
+            "sync_performance",
+            mapOf(
+                "duration_ms" to durationMs.toString(),
+                "record_count" to recordCount.toString(),
+                "success" to success.toString(),
+            ),
+        )
+    }
+
+    /**
+     * Retrieve and clear all buffered metric events.
+     *
+     * Platform transport layers call this to collect events for
+     * batch transmission to the analytics backend.
+     *
+     * @return List of buffered events. Empty if no events or consent not granted.
+     */
+    fun flushEvents(): List<MetricEvent> {
+        if (!consentProvider()) return emptyList()
+
+        val flushed = eventBuffer.toList()
+        eventBuffer.clear()
+        return flushed
+    }
+
+    /**
+     * Discard all buffered events without transmitting.
+     *
+     * Called when the user revokes analytics consent.
+     */
+    fun clearEvents() {
+        eventBuffer.clear()
+    }
+
+    /** Number of events currently buffered. */
+    val bufferedEventCount: Int
+        get() = eventBuffer.size
+
+    private fun recordEvent(name: String, properties: Map<String, String>) {
+        if (!consentProvider()) return
+
+        eventBuffer.add(
+            MetricEvent(
+                name = name,
+                timestamp = clock.now(),
+                properties = properties,
+            ),
+        )
+    }
+}
+
+/**
+ * A single anonymous metric event.
+ *
+ * @property name Event type identifier (e.g., "screen_view", "feature_usage").
+ * @property timestamp When the event occurred.
+ * @property properties Key-value metadata. Must not contain PII or financial data.
+ */
+data class MetricEvent(
+    val name: String,
+    val timestamp: Instant,
+    val properties: Map<String, String>,
+)

--- a/packages/core/src/commonMain/kotlin/com/finance/core/monitoring/SyncHealthMonitor.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/monitoring/SyncHealthMonitor.kt
@@ -1,0 +1,130 @@
+package com.finance.core.monitoring
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+
+/**
+ * Tracks sync subsystem health metrics on the client.
+ *
+ * Maintains a rolling window of sync performance data and exposes
+ * the current [HealthStatus] as a reactive [StateFlow]. Platform UI
+ * layers observe [healthStatus] to display sync indicators.
+ *
+ * This class is not thread-safe — callers must synchronize access
+ * or confine usage to a single coroutine dispatcher.
+ *
+ * @param clock Clock source for timestamps (injectable for testing).
+ * @param maxDurationSamples Maximum number of sync duration samples
+ *   retained for average calculation.
+ */
+class SyncHealthMonitor(
+    private val clock: Clock = Clock.System,
+    private val maxDurationSamples: Int = 100,
+) {
+
+    private val _lastSyncTime = MutableStateFlow<Instant?>(null)
+
+    /** Timestamp of the last successful sync, or null if never synced. */
+    val lastSyncTime: StateFlow<Instant?> = _lastSyncTime.asStateFlow()
+
+    private val _pendingMutations = MutableStateFlow(0)
+
+    /** Number of local mutations waiting to be synced to the server. */
+    val pendingMutations: StateFlow<Int> = _pendingMutations.asStateFlow()
+
+    private val _failureCount = MutableStateFlow(0)
+
+    /** Number of consecutive sync failures since the last success. */
+    val failureCount: StateFlow<Int> = _failureCount.asStateFlow()
+
+    private val _averageSyncDurationMs = MutableStateFlow(0L)
+
+    /** Rolling average sync duration in milliseconds. */
+    val averageSyncDurationMs: StateFlow<Long> = _averageSyncDurationMs.asStateFlow()
+
+    private val _healthStatus = MutableStateFlow<HealthStatus>(HealthStatus.Healthy)
+
+    /** Current computed health status of the sync subsystem. */
+    val healthStatus: StateFlow<HealthStatus> = _healthStatus.asStateFlow()
+
+    private val durationSamples = mutableListOf<Long>()
+
+    /**
+     * Record a successful sync completion.
+     *
+     * Resets the failure counter, updates the last sync timestamp,
+     * and adds the sync duration to the rolling average.
+     *
+     * @param durationMs Time taken for the sync operation in milliseconds.
+     */
+    fun recordSyncSuccess(durationMs: Long) {
+        require(durationMs >= 0) { "Sync duration must be non-negative, got $durationMs" }
+
+        _lastSyncTime.value = clock.now()
+        _failureCount.value = 0
+        addDurationSample(durationMs)
+        refreshHealthStatus()
+    }
+
+    /**
+     * Record a sync failure.
+     *
+     * Increments the consecutive failure counter and re-evaluates health.
+     */
+    fun recordSyncFailure() {
+        _failureCount.value += 1
+        refreshHealthStatus()
+    }
+
+    /**
+     * Update the count of pending local mutations.
+     *
+     * @param count Current number of unsynced mutations.
+     */
+    fun updatePendingMutations(count: Int) {
+        require(count >= 0) { "Pending mutation count must be non-negative, got $count" }
+
+        _pendingMutations.value = count
+        refreshHealthStatus()
+    }
+
+    /**
+     * Force a re-evaluation of the health status.
+     *
+     * Call this periodically (e.g., every minute) to detect staleness
+     * even when no sync events are occurring.
+     */
+    fun refreshHealthStatus() {
+        _healthStatus.value = HealthStatus.evaluate(
+            lastSyncTime = _lastSyncTime.value,
+            currentTime = clock.now(),
+            failureCount = _failureCount.value,
+            pendingMutations = _pendingMutations.value,
+        )
+    }
+
+    /**
+     * Reset all metrics to their initial state.
+     *
+     * Useful when the user signs out or switches accounts.
+     */
+    fun reset() {
+        _lastSyncTime.value = null
+        _pendingMutations.value = 0
+        _failureCount.value = 0
+        _averageSyncDurationMs.value = 0L
+        durationSamples.clear()
+        _healthStatus.value = HealthStatus.Healthy
+    }
+
+    private fun addDurationSample(durationMs: Long) {
+        durationSamples.add(durationMs)
+        if (durationSamples.size > maxDurationSamples) {
+            durationSamples.removeAt(0)
+        }
+        _averageSyncDurationMs.value = durationSamples.average().toLong()
+    }
+}

--- a/services/api/supabase/migrations/20260307000001_monitoring.sql
+++ b/services/api/supabase/migrations/20260307000001_monitoring.sql
@@ -1,0 +1,54 @@
+-- Monitoring: server-side sync health logging
+-- Refs: #84, #85
+-- Records sync health metrics reported by clients, enabling server-side
+-- analysis of sync performance and reliability across the user base.
+
+-- Sync health logs table
+CREATE TABLE IF NOT EXISTS public.sync_health_logs (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id         UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    device_id       TEXT NOT NULL,
+    sync_duration_ms BIGINT NOT NULL,
+    record_count    INTEGER NOT NULL DEFAULT 0,
+    error_code      TEXT,
+    error_message   TEXT,
+    sync_status     TEXT NOT NULL CHECK (sync_status IN ('success', 'failure', 'partial')),
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.sync_health_logs IS 'Server-side sync performance metrics reported by clients.';
+COMMENT ON COLUMN public.sync_health_logs.device_id IS 'Pseudonymous device identifier (rotatable, not a hardware ID).';
+COMMENT ON COLUMN public.sync_health_logs.sync_duration_ms IS 'Total sync round-trip time in milliseconds.';
+COMMENT ON COLUMN public.sync_health_logs.error_code IS 'Machine-readable error code for failed syncs (null on success).';
+COMMENT ON COLUMN public.sync_health_logs.error_message IS 'Sanitized error description -- must not contain PII or financial data.';
+COMMENT ON COLUMN public.sync_health_logs.sync_status IS 'Outcome of the sync operation: success, failure, or partial.';
+
+-- Index for querying a user's recent sync history
+CREATE INDEX idx_sync_health_logs_user_created
+    ON public.sync_health_logs (user_id, created_at DESC);
+
+-- Index for server-side aggregate queries (overall health dashboard)
+CREATE INDEX idx_sync_health_logs_status_created
+    ON public.sync_health_logs (sync_status, created_at DESC);
+
+-- Enable Row-Level Security
+ALTER TABLE public.sync_health_logs ENABLE ROW LEVEL SECURITY;
+
+-- RLS policy: users can read their own sync health logs
+CREATE POLICY sync_health_logs_select_own
+    ON public.sync_health_logs
+    FOR SELECT
+    USING (user_id = auth.uid());
+
+-- RLS policy: only the service role (system) can insert sync health logs.
+-- Client writes go through an Edge Function that validates and inserts
+-- using the service role, preventing clients from spoofing metrics.
+CREATE POLICY sync_health_logs_insert_service
+    ON public.sync_health_logs
+    FOR INSERT
+    WITH CHECK (
+        (current_setting('role', true)) = 'service_role'
+    );
+
+-- RLS policy: no direct updates -- logs are append-only
+-- (No UPDATE or DELETE policies are defined, making logs immutable via RLS.)


### PR DESCRIPTION
Add privacy-respecting monitoring infrastructure:

- **Monitoring strategy document** (docs/guides/monitoring.md): Privacy-first principles, crash reporting with Sentry/Crashlytics recommendations, sync health metrics, API monitoring targets, alert thresholds and escalation
- **CrashReporter interface** (CrashReporter.kt): PII-free, consent-gated crash reporting with NoOp fallback
- **SyncHealthMonitor** (SyncHealthMonitor.kt): Reactive sync health tracking with rolling averages via StateFlow
- **HealthStatus sealed class** (HealthStatus.kt): Healthy/Degraded/Unhealthy states with configurable thresholds
- **MetricsCollector** (MetricsCollector.kt): Anonymous usage metrics with consent check on every operation
- **sync_health_logs migration** (20260307000001_monitoring.sql): Server-side sync metrics table with RLS (users read own, system writes only)

Closes #84
Closes #85