### PR TITLE
feat(windows): desktop screens, sidebar navigation, keyboard shortcuts

### DIFF
--- a/apps/windows/build.gradle.kts
+++ b/apps/windows/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.compose.multiplatform)
+}
+
+dependencies {
+    implementation(compose.desktop.currentOs)
+    implementation(compose.material3)
+    implementation(compose.materialIconsExtended)
+}
+
+compose.desktop {
+    application {
+        mainClass = "com.finance.desktop.MainKt"
+        nativeDistributions {
+            targetFormats(org.jetbrains.compose.desktop.application.dsl.TargetFormat.Msi)
+            packageName = "Finance"
+            packageVersion = "1.0.0"
+        }
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/FinanceApp.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/FinanceApp.kt
@@ -1,0 +1,51 @@
+package com.finance.desktop
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import com.finance.desktop.components.ShortcutHandler
+import com.finance.desktop.navigation.Screen
+import com.finance.desktop.navigation.SidebarNavigation
+import com.finance.desktop.screens.AccountsScreen
+import com.finance.desktop.screens.BudgetsScreen
+import com.finance.desktop.screens.DashboardScreen
+import com.finance.desktop.screens.GoalsScreen
+import com.finance.desktop.screens.SettingsScreen
+import com.finance.desktop.screens.TransactionsScreen
+import com.finance.desktop.theme.FinanceDesktopTheme
+
+/**
+ * Root composable for the Finance Windows desktop application.
+ *
+ * Applies [FinanceDesktopTheme] (Material 3 with design-token colors) and
+ * renders the sidebar navigation shell with all core screens.
+ *
+ * @param shortcutHandler The [ShortcutHandler] wired to the application
+ *   window's [onPreviewKeyEvent], enabling Ctrl+1 through Ctrl+6 shortcuts.
+ */
+@Composable
+fun FinanceApp(shortcutHandler: ShortcutHandler) {
+    FinanceDesktopTheme {
+        Surface(
+            modifier = Modifier
+                .fillMaxSize()
+                .semantics { contentDescription = "Finance application" },
+            color = MaterialTheme.colorScheme.background,
+        ) {
+            SidebarNavigation(shortcutHandler = shortcutHandler) { screen ->
+                when (screen) {
+                    Screen.Dashboard -> DashboardScreen()
+                    Screen.Accounts -> AccountsScreen()
+                    Screen.Transactions -> TransactionsScreen()
+                    Screen.Budgets -> BudgetsScreen()
+                    Screen.Goals -> GoalsScreen()
+                    Screen.Settings -> SettingsScreen()
+                }
+            }
+        }
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/Main.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/Main.kt
@@ -1,0 +1,35 @@
+package com.finance.desktop
+
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.WindowPosition
+import androidx.compose.ui.window.application
+import androidx.compose.ui.window.rememberWindowState
+import com.finance.desktop.components.rememberShortcutHandler
+
+/**
+ * Entry point for the Finance desktop application.
+ *
+ * Launches a Compose Desktop window sized for a typical desktop viewport
+ * with the [FinanceApp] root composable wrapped in the Finance design-token
+ * theme. Keyboard shortcuts are wired via [onPreviewKeyEvent] on the window.
+ */
+fun main() = application {
+    val windowState = rememberWindowState(
+        size = DpSize(width = 1280.dp, height = 800.dp),
+        position = WindowPosition(Alignment.Center),
+    )
+
+    val shortcutHandler = rememberShortcutHandler()
+
+    Window(
+        onCloseRequest = ::exitApplication,
+        title = "Finance",
+        state = windowState,
+        onPreviewKeyEvent = { shortcutHandler.onKeyEvent(it) },
+    ) {
+        FinanceApp(shortcutHandler)
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/components/KeyboardShortcuts.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/components/KeyboardShortcuts.kt
@@ -1,0 +1,127 @@
+package com.finance.desktop.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isShiftPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.type
+
+/**
+ * Represents a keyboard shortcut binding.
+ *
+ * @param key The [Key] to match.
+ * @param ctrl Whether Ctrl must be held. Defaults to `true` (most desktop shortcuts use Ctrl).
+ * @param shift Whether Shift must be held. Defaults to `false`.
+ * @param description Human-readable label for accessibility and tooltip display.
+ * @param action The callback to invoke when the shortcut is triggered.
+ */
+@Stable
+data class KeyboardShortcut(
+    val key: Key,
+    val ctrl: Boolean = true,
+    val shift: Boolean = false,
+    val description: String,
+    val action: () -> Unit,
+)
+
+/**
+ * Registry that collects [KeyboardShortcut]s and dispatches incoming [KeyEvent]s.
+ *
+ * Create an instance via [rememberShortcutHandler] inside a composable scope,
+ * then wire [onKeyEvent] into a window or root modifier `onPreviewKeyEvent`.
+ */
+@Stable
+class ShortcutHandler {
+    private val shortcuts = mutableListOf<KeyboardShortcut>()
+
+    /** Register a shortcut. Duplicates (same key combo) are replaced. */
+    fun register(shortcut: KeyboardShortcut) {
+        shortcuts.removeAll {
+            it.key == shortcut.key && it.ctrl == shortcut.ctrl && it.shift == shortcut.shift
+        }
+        shortcuts.add(shortcut)
+    }
+
+    /** Unregister all shortcuts with the given [key]. */
+    fun unregister(key: Key) {
+        shortcuts.removeAll { it.key == key }
+    }
+
+    /** Clear every registered shortcut. */
+    fun clear() {
+        shortcuts.clear()
+    }
+
+    /** Returns all currently-registered shortcuts (for tooltip / help display). */
+    fun allShortcuts(): List<KeyboardShortcut> = shortcuts.toList()
+
+    /**
+     * Attempt to handle a [KeyEvent]. Returns `true` if the event was consumed.
+     *
+     * Call this from `onPreviewKeyEvent` on the application [Window] so that
+     * shortcuts fire before any child composable consumes the event.
+     */
+    fun onKeyEvent(event: KeyEvent): Boolean {
+        if (event.type != KeyEventType.KeyDown) return false
+        val match = shortcuts.firstOrNull { shortcut ->
+            event.key == shortcut.key &&
+                event.isCtrlPressed == shortcut.ctrl &&
+                event.isShiftPressed == shortcut.shift
+        }
+        if (match != null) {
+            match.action()
+            return true
+        }
+        return false
+    }
+}
+
+/**
+ * Creates and remembers a [ShortcutHandler] that is cleared when the
+ * composable leaves the composition.
+ */
+@Composable
+fun rememberShortcutHandler(): ShortcutHandler {
+    val handler = remember { ShortcutHandler() }
+    DisposableEffect(Unit) {
+        onDispose { handler.clear() }
+    }
+    return handler
+}
+
+/**
+ * Composable that registers a set of [KeyboardShortcut]s on the provided
+ * [ShortcutHandler] for the lifetime of the composition.
+ *
+ * Place this inside the composable tree — shortcuts are automatically
+ * unregistered when the composable is removed.
+ *
+ * Usage:
+ * ```
+ * KeyboardShortcutEffect(handler) {
+ *     listOf(
+ *         KeyboardShortcut(Key.One, description = "Dashboard") { navigateTo(Screen.Dashboard) },
+ *         KeyboardShortcut(Key.Two, description = "Accounts") { navigateTo(Screen.Accounts) },
+ *     )
+ * }
+ * ```
+ */
+@Composable
+fun KeyboardShortcutEffect(
+    handler: ShortcutHandler,
+    shortcuts: () -> List<KeyboardShortcut>,
+) {
+    val bindings = remember(shortcuts) { shortcuts() }
+    DisposableEffect(bindings) {
+        bindings.forEach { handler.register(it) }
+        onDispose {
+            bindings.forEach { handler.unregister(it.key) }
+        }
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/navigation/SidebarNavigation.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/navigation/SidebarNavigation.kt
@@ -1,0 +1,295 @@
+package com.finance.desktop.navigation
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountBalance
+import androidx.compose.material.icons.filled.Dashboard
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.PieChart
+import androidx.compose.material.icons.filled.Receipt
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.ripple
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.finance.desktop.components.KeyboardShortcut
+import com.finance.desktop.components.KeyboardShortcutEffect
+import com.finance.desktop.components.ShortcutHandler
+import com.finance.desktop.theme.FinanceDesktopTheme
+
+/**
+ * Desktop navigation destinations.
+ *
+ * Each entry carries its icon, label, and keyboard shortcut key (Ctrl+1 … Ctrl+6).
+ */
+enum class Screen(
+    val label: String,
+    val icon: ImageVector,
+    val shortcutKey: Key,
+    val shortcutLabel: String,
+) {
+    Dashboard("Dashboard", Icons.Filled.Dashboard, Key.One, "Ctrl+1"),
+    Accounts("Accounts", Icons.Filled.AccountBalance, Key.Two, "Ctrl+2"),
+    Transactions("Transactions", Icons.Filled.Receipt, Key.Three, "Ctrl+3"),
+    Budgets("Budgets", Icons.Filled.PieChart, Key.Four, "Ctrl+4"),
+    Goals("Goals", Icons.Filled.Star, Key.Five, "Ctrl+5"),
+    Settings("Settings", Icons.Filled.Settings, Key.Six, "Ctrl+6"),
+}
+
+/** Width of the sidebar when expanded. */
+private val SIDEBAR_EXPANDED_WIDTH = 240.dp
+
+/** Width of the sidebar when collapsed (icon-only rail). */
+private val SIDEBAR_COLLAPSED_WIDTH = 64.dp
+
+/**
+ * Root layout composable that renders a collapsible sidebar together with
+ * the currently-selected screen content.
+ *
+ * Keyboard shortcuts Ctrl+1 through Ctrl+6 navigate between screens.
+ * The sidebar can be collapsed via the hamburger button to give more
+ * horizontal space to the content area.
+ *
+ * @param shortcutHandler The [ShortcutHandler] from the application window,
+ *   used to register navigation shortcuts.
+ * @param content Composable lambda receiving the currently selected [Screen].
+ */
+@Composable
+fun SidebarNavigation(
+    shortcutHandler: ShortcutHandler,
+    content: @Composable (Screen) -> Unit,
+) {
+    var currentScreen by rememberSaveable { mutableStateOf(Screen.Dashboard) }
+    var isExpanded by rememberSaveable { mutableStateOf(true) }
+
+    // Register keyboard shortcuts (Ctrl+1 … Ctrl+6)
+    KeyboardShortcutEffect(shortcutHandler) {
+        Screen.entries.map { screen ->
+            KeyboardShortcut(
+                key = screen.shortcutKey,
+                description = "Navigate to ${screen.label}",
+            ) { currentScreen = screen }
+        }
+    }
+
+    Row(modifier = Modifier.fillMaxSize()) {
+        SidebarPanel(
+            currentScreen = currentScreen,
+            isExpanded = isExpanded,
+            onScreenSelected = { currentScreen = it },
+            onToggleExpanded = { isExpanded = !isExpanded },
+        )
+
+        // Content area
+        Box(modifier = Modifier.weight(1f).fillMaxHeight()) {
+            content(currentScreen)
+        }
+    }
+}
+
+/**
+ * The sidebar panel itself — a vertical rail with icons, and optionally labels.
+ */
+@Composable
+private fun SidebarPanel(
+    currentScreen: Screen,
+    isExpanded: Boolean,
+    onScreenSelected: (Screen) -> Unit,
+    onToggleExpanded: () -> Unit,
+) {
+    val sidebarWidth by animateDpAsState(
+        targetValue = if (isExpanded) SIDEBAR_EXPANDED_WIDTH else SIDEBAR_COLLAPSED_WIDTH,
+        animationSpec = tween(durationMillis = 200),
+        label = "sidebar-width",
+    )
+
+    Surface(
+        modifier = Modifier
+            .width(sidebarWidth)
+            .fillMaxHeight(),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        tonalElevation = 1.dp,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxHeight()
+                .padding(vertical = FinanceDesktopTheme.spacing.sm),
+        ) {
+            // Collapse / expand toggle
+            Row(
+                modifier = Modifier
+                    .padding(horizontal = FinanceDesktopTheme.spacing.sm)
+                    .height(48.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                IconButton(
+                    onClick = onToggleExpanded,
+                    modifier = Modifier.semantics {
+                        contentDescription =
+                            if (isExpanded) "Collapse sidebar" else "Expand sidebar"
+                    },
+                ) {
+                    Icon(Icons.Filled.Menu, contentDescription = null)
+                }
+                AnimatedVisibility(visible = isExpanded, enter = fadeIn(), exit = fadeOut()) {
+                    Text(
+                        text = "Finance",
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.padding(start = FinanceDesktopTheme.spacing.sm),
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
+            HorizontalDivider(
+                modifier = Modifier.padding(horizontal = FinanceDesktopTheme.spacing.sm),
+                color = MaterialTheme.colorScheme.outlineVariant,
+            )
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
+
+            // Navigation items — all except Settings
+            Screen.entries
+                .filter { it != Screen.Settings }
+                .forEach { screen ->
+                    SidebarItem(
+                        screen = screen,
+                        isSelected = currentScreen == screen,
+                        isExpanded = isExpanded,
+                        onClick = { onScreenSelected(screen) },
+                    )
+                }
+
+            Spacer(Modifier.weight(1f))
+
+            // Settings at bottom
+            HorizontalDivider(
+                modifier = Modifier.padding(horizontal = FinanceDesktopTheme.spacing.sm),
+                color = MaterialTheme.colorScheme.outlineVariant,
+            )
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.xs))
+            SidebarItem(
+                screen = Screen.Settings,
+                isSelected = currentScreen == Screen.Settings,
+                isExpanded = isExpanded,
+                onClick = { onScreenSelected(Screen.Settings) },
+            )
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
+        }
+    }
+}
+
+/**
+ * Single sidebar navigation item. Shows icon + optional label when expanded.
+ *
+ * Accessibility: exposes [Role.Tab], selection state, and shortcut hint via
+ * content description so Narrator reads e.g. "Dashboard, selected, Ctrl+1".
+ */
+@Composable
+private fun SidebarItem(
+    screen: Screen,
+    isSelected: Boolean,
+    isExpanded: Boolean,
+    onClick: () -> Unit,
+) {
+    val backgroundColor = if (isSelected) {
+        MaterialTheme.colorScheme.primaryContainer
+    } else {
+        MaterialTheme.colorScheme.surfaceVariant
+    }
+
+    val contentColor = if (isSelected) {
+        MaterialTheme.colorScheme.onPrimaryContainer
+    } else {
+        MaterialTheme.colorScheme.onSurfaceVariant
+    }
+
+    val accessibilityLabel = buildString {
+        append(screen.label)
+        if (isSelected) append(", selected")
+        append(", ${screen.shortcutLabel}")
+    }
+
+    Row(
+        modifier = Modifier
+            .padding(horizontal = FinanceDesktopTheme.spacing.sm, vertical = 2.dp)
+            .height(44.dp)
+            .then(
+                if (isExpanded) Modifier.width(SIDEBAR_EXPANDED_WIDTH - FinanceDesktopTheme.spacing.lg)
+                else Modifier.width(SIDEBAR_COLLAPSED_WIDTH - FinanceDesktopTheme.spacing.lg),
+            )
+            .background(backgroundColor, RoundedCornerShape(8.dp))
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = ripple(),
+                onClick = onClick,
+            )
+            .semantics {
+                role = Role.Tab
+                selected = isSelected
+                contentDescription = accessibilityLabel
+            }
+            .padding(horizontal = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Start,
+    ) {
+        Icon(
+            imageVector = screen.icon,
+            contentDescription = null, // described by Row semantics
+            tint = contentColor,
+            modifier = Modifier.size(22.dp),
+        )
+        AnimatedVisibility(visible = isExpanded, enter = fadeIn(), exit = fadeOut()) {
+            Text(
+                text = screen.label,
+                style = MaterialTheme.typography.labelLarge,
+                color = contentColor,
+                fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.padding(start = 12.dp),
+            )
+        }
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/AccountsScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/AccountsScreen.kt
@@ -1,0 +1,488 @@
+package com.finance.desktop.screens
+
+import androidx.compose.foundation.ContextMenuArea
+import androidx.compose.foundation.ContextMenuItem
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountBalance
+import androidx.compose.material.icons.filled.CreditCard
+import androidx.compose.material.icons.filled.Savings
+import androidx.compose.material.icons.filled.ShowChart
+import androidx.compose.material.icons.filled.TrendingDown
+import androidx.compose.material.icons.filled.TrendingUp
+import androidx.compose.material.icons.filled.Wallet
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.VerticalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.finance.desktop.theme.FinanceDesktopTheme
+
+// =============================================================================
+// Sample data (UI-layer placeholders)
+// =============================================================================
+
+private data class AccountItem(
+    val id: String,
+    val name: String,
+    val type: String,
+    val typeIcon: ImageVector,
+    val balance: String,
+    val transactions: List<AccountTransaction>,
+)
+
+private data class AccountTransaction(
+    val id: String,
+    val payee: String,
+    val amount: String,
+    val isExpense: Boolean,
+    val date: String,
+    val category: String,
+)
+
+private val sampleAccounts = listOf(
+    AccountItem(
+        "1", "Main Checking", "Checking", Icons.Filled.AccountBalance, "\$5,247.30",
+        listOf(
+            AccountTransaction("t1", "Whole Foods", "-\$52.30", true, "Mar 6", "Groceries"),
+            AccountTransaction("t2", "Salary", "+\$4,200.00", false, "Mar 5", "Income"),
+            AccountTransaction("t3", "Electric Bill", "-\$125.00", true, "Mar 3", "Utilities"),
+            AccountTransaction("t4", "Gas Station", "-\$45.00", true, "Mar 2", "Transport"),
+        ),
+    ),
+    AccountItem(
+        "2", "Savings Account", "Savings", Icons.Filled.Savings, "\$18,670.00",
+        listOf(
+            AccountTransaction("t5", "Interest", "+\$12.50", false, "Mar 1", "Income"),
+            AccountTransaction("t6", "Transfer In", "+\$500.00", false, "Feb 28", "Transfer"),
+        ),
+    ),
+    AccountItem(
+        "3", "Visa Card", "Credit Card", Icons.Filled.CreditCard, "-\$1,284.50",
+        listOf(
+            AccountTransaction("t7", "Netflix", "-\$15.99", true, "Mar 5", "Entertainment"),
+            AccountTransaction("t8", "Restaurant", "-\$68.00", true, "Mar 4", "Dining"),
+            AccountTransaction("t9", "Amazon", "-\$42.99", true, "Mar 3", "Shopping"),
+        ),
+    ),
+    AccountItem(
+        "4", "Investment Portfolio", "Investment", Icons.Filled.ShowChart, "\$92,500.00",
+        listOf(
+            AccountTransaction("t10", "Dividend", "+\$125.00", false, "Mar 1", "Investment"),
+        ),
+    ),
+    AccountItem(
+        "5", "Cash Wallet", "Cash", Icons.Filled.Wallet, "\$185.42",
+        listOf(),
+    ),
+)
+
+// =============================================================================
+// Accounts Screen — Master-Detail Layout
+// =============================================================================
+
+/**
+ * Master-detail accounts screen for the desktop Finance application.
+ *
+ * Layout:
+ * ```
+ * ┌─────────────────┬────────────────────────────────┐
+ * │  Account List    │  Account Detail                │
+ * │  (scrollable)   │  + Transaction History          │
+ * │                 │  (scrollable)                   │
+ * └─────────────────┴────────────────────────────────┘
+ * ```
+ *
+ * Right-click context menus on accounts and transactions for desktop UX.
+ * Narrator reads account type, name, and balance for each item.
+ */
+@Composable
+fun AccountsScreen(modifier: Modifier = Modifier) {
+    var selectedAccountId by remember { mutableStateOf(sampleAccounts.first().id) }
+    val selectedAccount = sampleAccounts.find { it.id == selectedAccountId }
+        ?: sampleAccounts.first()
+
+    Row(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(FinanceDesktopTheme.spacing.xxl)
+            .semantics { contentDescription = "Accounts screen" },
+    ) {
+        // ── Master: Account list ──
+        AccountListPanel(
+            accounts = sampleAccounts,
+            selectedId = selectedAccount.id,
+            onSelect = { selectedAccountId = it.id },
+            modifier = Modifier
+                .width(320.dp)
+                .fillMaxHeight(),
+        )
+
+        VerticalDivider(
+            modifier = Modifier
+                .fillMaxHeight()
+                .padding(horizontal = FinanceDesktopTheme.spacing.sm),
+            color = MaterialTheme.colorScheme.outlineVariant,
+        )
+
+        // ── Detail: selected account info + transaction history ──
+        AccountDetailPanel(
+            account = selectedAccount,
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxHeight(),
+        )
+    }
+}
+
+// =============================================================================
+// Master panel — account list
+// =============================================================================
+
+@Composable
+private fun AccountListPanel(
+    accounts: List<AccountItem>,
+    selectedId: String,
+    onSelect: (AccountItem) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier,
+        shape = MaterialTheme.shapes.medium,
+        tonalElevation = 1.dp,
+    ) {
+        Column(modifier = Modifier.padding(FinanceDesktopTheme.spacing.lg)) {
+            Text(
+                text = "Accounts",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.semantics {
+                    heading()
+                    contentDescription = "Accounts list"
+                },
+            )
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.md))
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
+
+            LazyColumn(
+                verticalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.sm),
+            ) {
+                items(accounts, key = { it.id }) { account ->
+                    AccountListItem(
+                        account = account,
+                        isSelected = account.id == selectedId,
+                        onClick = { onSelect(account) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AccountListItem(
+    account: AccountItem,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+) {
+    val containerColor = if (isSelected) {
+        MaterialTheme.colorScheme.primaryContainer
+    } else {
+        MaterialTheme.colorScheme.surface
+    }
+    val contentColor = if (isSelected) {
+        MaterialTheme.colorScheme.onPrimaryContainer
+    } else {
+        MaterialTheme.colorScheme.onSurface
+    }
+
+    ContextMenuArea(
+        items = {
+            listOf(
+                ContextMenuItem("View Account") { onClick() },
+                ContextMenuItem("Edit Account") { /* edit */ },
+                ContextMenuItem("Archive Account") { /* archive */ },
+            )
+        },
+    ) {
+        ElevatedCard(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .semantics {
+                    contentDescription =
+                        "${account.name}, ${account.type}, balance: ${account.balance}"
+                    selected = isSelected
+                },
+            colors = CardDefaults.elevatedCardColors(containerColor = containerColor),
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(FinanceDesktopTheme.spacing.md),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = account.typeIcon,
+                    contentDescription = null,
+                    tint = contentColor,
+                    modifier = Modifier.size(28.dp),
+                )
+                Spacer(Modifier.width(FinanceDesktopTheme.spacing.md))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = account.name,
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.Medium,
+                        color = contentColor,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        text = account.type,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = contentColor.copy(alpha = 0.7f),
+                    )
+                }
+                Text(
+                    text = account.balance,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = contentColor,
+                )
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Detail panel — account info + transaction history
+// =============================================================================
+
+@Composable
+private fun AccountDetailPanel(
+    account: AccountItem,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.padding(start = FinanceDesktopTheme.spacing.lg),
+    ) {
+        // Account info header
+        ElevatedCard(
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics {
+                    contentDescription = "${account.name}, balance: ${account.balance}"
+                },
+            colors = CardDefaults.elevatedCardColors(
+                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            ),
+        ) {
+            Column(modifier = Modifier.padding(FinanceDesktopTheme.spacing.xxl)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = account.typeIcon,
+                        contentDescription = null,
+                        modifier = Modifier.size(32.dp),
+                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                    )
+                    Spacer(Modifier.width(FinanceDesktopTheme.spacing.md))
+                    Text(
+                        text = account.name,
+                        style = MaterialTheme.typography.titleLarge,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer,
+                        modifier = Modifier.semantics { heading() },
+                    )
+                }
+                Spacer(Modifier.height(FinanceDesktopTheme.spacing.lg))
+                Text(
+                    text = "Current Balance",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f),
+                )
+                Text(
+                    text = account.balance,
+                    style = MaterialTheme.typography.headlineLarge,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+                Spacer(Modifier.height(FinanceDesktopTheme.spacing.md))
+                HorizontalDivider(
+                    color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.2f),
+                )
+                Spacer(Modifier.height(FinanceDesktopTheme.spacing.md))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    DetailChip("Type", account.type)
+                    DetailChip("Status", "Active")
+                    DetailChip("Transactions", "${account.transactions.size}")
+                }
+            }
+        }
+
+        Spacer(Modifier.height(FinanceDesktopTheme.spacing.xxl))
+
+        // Transaction history
+        Text(
+            text = "Transaction History",
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.semantics {
+                heading()
+                contentDescription = "Transaction History for ${account.name}"
+            },
+        )
+        Spacer(Modifier.height(FinanceDesktopTheme.spacing.md))
+
+        if (account.transactions.isEmpty()) {
+            Box(
+                modifier = Modifier.fillMaxWidth().weight(1f),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = "No transactions for this account",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.semantics {
+                        contentDescription = "No transactions for this account"
+                    },
+                )
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.sm),
+            ) {
+                items(account.transactions, key = { it.id }) { txn ->
+                    AccountTransactionRow(txn)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DetailChip(label: String, value: String) {
+    Column(
+        modifier = Modifier.semantics { contentDescription = "$label: $value" },
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f),
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+        )
+    }
+}
+
+@Composable
+private fun AccountTransactionRow(txn: AccountTransaction) {
+    val amountColor = if (txn.isExpense) MaterialTheme.colorScheme.error else Color(0xFF2E7D32)
+
+    ContextMenuArea(
+        items = {
+            listOf(
+                ContextMenuItem("View Details") { /* view */ },
+                ContextMenuItem("Edit Transaction") { /* edit */ },
+                ContextMenuItem("Copy Amount") { /* copy */ },
+                ContextMenuItem("Delete Transaction") { /* delete */ },
+            )
+        },
+    ) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics {
+                    contentDescription =
+                        "Transaction: ${txn.amount} at ${txn.payee}, ${txn.category}, ${txn.date}"
+                },
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        horizontal = FinanceDesktopTheme.spacing.md,
+                        vertical = FinanceDesktopTheme.spacing.sm,
+                    ),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Icon(
+                        imageVector = if (txn.isExpense) Icons.Filled.TrendingDown
+                        else Icons.Filled.TrendingUp,
+                        contentDescription = null,
+                        tint = amountColor,
+                        modifier = Modifier.size(20.dp),
+                    )
+                    Spacer(Modifier.width(FinanceDesktopTheme.spacing.md))
+                    Column {
+                        Text(
+                            text = txn.payee,
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.Medium,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        Text(
+                            text = "${txn.category} • ${txn.date}",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+                Text(
+                    text = txn.amount,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = amountColor,
+                )
+            }
+        }
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/BudgetsScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/BudgetsScreen.kt
@@ -1,0 +1,271 @@
+package com.finance.desktop.screens
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.ContextMenuArea
+import androidx.compose.foundation.ContextMenuItem
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PieChart
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.finance.desktop.theme.FinanceDesktopTheme
+
+// =============================================================================
+// Sample data
+// =============================================================================
+
+private data class BudgetItem(
+    val id: String,
+    val name: String,
+    val spent: String,
+    val limit: String,
+    val remaining: String,
+    val utilization: Float,
+    val isOver: Boolean,
+    val period: String,
+)
+
+private val sampleBudgetItems = listOf(
+    BudgetItem("1", "Groceries", "\$248", "\$600", "\$352 left", 0.41f, false, "Monthly"),
+    BudgetItem("2", "Dining Out", "\$245", "\$300", "\$55 left", 0.82f, false, "Monthly"),
+    BudgetItem("3", "Transport", "\$89", "\$200", "\$111 left", 0.45f, false, "Monthly"),
+    BudgetItem("4", "Entertainment", "\$180", "\$150", "\$30 over", 1.2f, true, "Monthly"),
+    BudgetItem("5", "Shopping", "\$320", "\$400", "\$80 left", 0.80f, false, "Monthly"),
+    BudgetItem("6", "Utilities", "\$125", "\$200", "\$75 left", 0.625f, false, "Monthly"),
+    BudgetItem("7", "Healthcare", "\$45", "\$150", "\$105 left", 0.30f, false, "Monthly"),
+    BudgetItem("8", "Subscriptions", "\$78", "\$100", "\$22 left", 0.78f, false, "Monthly"),
+)
+
+// =============================================================================
+// Budgets Screen — Grid of Budget Cards
+// =============================================================================
+
+/**
+ * Budget overview screen for the desktop Finance application.
+ *
+ * Displays a responsive grid of budget cards, each showing:
+ * - Category name and period
+ * - Animated progress ring with utilization percentage
+ * - Spent / limit amounts and remaining balance
+ * - Color-coded health indicator (green/amber/red)
+ *
+ * Right-click context menus provide Edit and Delete actions.
+ * Narrator reads category, amounts, and health status.
+ */
+@Composable
+fun BudgetsScreen(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(FinanceDesktopTheme.spacing.xxl)
+            .semantics { contentDescription = "Budgets screen" },
+    ) {
+        Text(
+            text = "Budgets",
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.semantics {
+                heading()
+                contentDescription = "Budgets heading"
+            },
+        )
+        Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
+        Text(
+            text = "Track your spending against budget limits",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Spacer(Modifier.height(FinanceDesktopTheme.spacing.xxl))
+
+        if (sampleBudgetItems.isEmpty()) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center,
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Icon(
+                        imageVector = Icons.Filled.PieChart,
+                        contentDescription = null,
+                        modifier = Modifier.size(64.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(Modifier.height(FinanceDesktopTheme.spacing.lg))
+                    Text(
+                        text = "No budgets yet",
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier.semantics {
+                            contentDescription = "No budgets yet"
+                        },
+                    )
+                    Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
+                    Text(
+                        text = "Create your first budget to start tracking",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        } else {
+            LazyVerticalGrid(
+                columns = GridCells.Adaptive(minSize = 240.dp),
+                horizontalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.lg),
+                verticalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.lg),
+            ) {
+                items(sampleBudgetItems, key = { it.id }) { budget ->
+                    BudgetCard(budget)
+                }
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Budget Card with Progress Ring
+// =============================================================================
+
+@Composable
+private fun BudgetCard(budget: BudgetItem) {
+    val healthColor = when {
+        budget.isOver -> MaterialTheme.colorScheme.error
+        budget.utilization > 0.75f -> Color(0xFFFF9800)
+        else -> MaterialTheme.colorScheme.primary
+    }
+    val healthLabel = when {
+        budget.isOver -> "over budget"
+        budget.utilization > 0.75f -> "approaching limit"
+        else -> "on track"
+    }
+
+    val animatedProgress by animateFloatAsState(
+        targetValue = budget.utilization.coerceIn(0f, 1f),
+        animationSpec = tween(800),
+        label = "budget-ring-progress",
+    )
+
+    ContextMenuArea(
+        items = {
+            listOf(
+                ContextMenuItem("Edit Budget") { /* edit */ },
+                ContextMenuItem("View Transactions") { /* view transactions for category */ },
+                ContextMenuItem("Reset Budget") { /* reset */ },
+                ContextMenuItem("Delete Budget") { /* delete */ },
+            )
+        },
+    ) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics {
+                    contentDescription =
+                        "${budget.name}: ${budget.spent} of ${budget.limit}, ${budget.remaining}, $healthLabel"
+                },
+            colors = CardDefaults.cardColors(
+                containerColor = if (budget.isOver) {
+                    MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.3f)
+                } else {
+                    MaterialTheme.colorScheme.surface
+                },
+            ),
+        ) {
+            Column(
+                modifier = Modifier.padding(FinanceDesktopTheme.spacing.xxl),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                // Category name + period
+                Text(
+                    text = budget.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = budget.period,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+
+                Spacer(Modifier.height(FinanceDesktopTheme.spacing.lg))
+
+                // Progress ring
+                Box(
+                    modifier = Modifier.size(96.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    val trackColor = MaterialTheme.colorScheme.surfaceVariant
+                    Canvas(Modifier.size(96.dp)) {
+                        val strokeWidth = 8.dp.toPx()
+                        val arcSize = Size(size.width - strokeWidth, size.height - strokeWidth)
+                        val topLeft = Offset(strokeWidth / 2, strokeWidth / 2)
+                        drawArc(
+                            trackColor, -90f, 360f, false,
+                            topLeft, arcSize,
+                            style = Stroke(strokeWidth, cap = StrokeCap.Round),
+                        )
+                        drawArc(
+                            healthColor, -90f, animatedProgress * 360f, false,
+                            topLeft, arcSize,
+                            style = Stroke(strokeWidth, cap = StrokeCap.Round),
+                        )
+                    }
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(
+                            text = "${(budget.utilization * 100).toInt()}%",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = healthColor,
+                        )
+                    }
+                }
+
+                Spacer(Modifier.height(FinanceDesktopTheme.spacing.lg))
+
+                // Amounts
+                Text(
+                    text = "${budget.spent} / ${budget.limit}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                )
+                Spacer(Modifier.height(FinanceDesktopTheme.spacing.xs))
+                Text(
+                    text = budget.remaining,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = healthColor,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+        }
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/DashboardScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/DashboardScreen.kt
@@ -1,0 +1,493 @@
+package com.finance.desktop.screens
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.ContextMenuArea
+import androidx.compose.foundation.ContextMenuItem
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountBalance
+import androidx.compose.material.icons.filled.AttachMoney
+import androidx.compose.material.icons.filled.TrendingDown
+import androidx.compose.material.icons.filled.TrendingUp
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.finance.desktop.theme.FinanceDesktopTheme
+
+// =============================================================================
+// Sample data models for the desktop dashboard (UI-layer placeholders)
+// =============================================================================
+
+private data class DashboardState(
+    val netWorth: String = "$116,899.22",
+    val todaySpending: String = "$28.78",
+    val monthlySpending: String = "$1,247.63",
+    val recentTransactions: List<SampleTransaction> = sampleTransactions,
+    val budgetItems: List<SampleBudget> = sampleBudgets,
+)
+
+private data class SampleTransaction(
+    val id: String,
+    val payee: String,
+    val category: String,
+    val amount: String,
+    val isExpense: Boolean,
+    val date: String,
+)
+
+private data class SampleBudget(
+    val name: String,
+    val spent: String,
+    val limit: String,
+    val utilization: Float,
+    val isOver: Boolean,
+)
+
+private val sampleTransactions = listOf(
+    SampleTransaction("1", "Whole Foods", "Groceries", "-\$52.30", true, "Today"),
+    SampleTransaction("2", "Salary Deposit", "Income", "+\$4,200.00", false, "Today"),
+    SampleTransaction("3", "Netflix", "Entertainment", "-\$15.99", true, "Yesterday"),
+    SampleTransaction("4", "Gas Station", "Transport", "-\$45.00", true, "Yesterday"),
+    SampleTransaction("5", "Freelance Payment", "Income", "+\$800.00", false, "Mar 3"),
+)
+
+private val sampleBudgets = listOf(
+    SampleBudget("Groceries", "\$248", "\$600", 0.41f, false),
+    SampleBudget("Dining", "\$245", "\$300", 0.82f, false),
+    SampleBudget("Transport", "\$89", "\$200", 0.45f, false),
+    SampleBudget("Entertainment", "\$180", "\$150", 1.2f, true),
+)
+
+// =============================================================================
+// Dashboard Screen
+// =============================================================================
+
+/**
+ * Multi-panel dashboard for the desktop Finance application.
+ *
+ * Layout (Fluent Design, mouse-optimized spacing):
+ * ```
+ * ┌───────────────────────┬──────────────────┐
+ * │  Net Worth Card       │  Recent          │
+ * │  Spending Summary     │  Transactions    │
+ * │                       │  (scrollable)    │
+ * ├───────────────────────┴──────────────────┤
+ * │  Budget Health (horizontal cards)         │
+ * └──────────────────────────────────────────┘
+ * ```
+ *
+ * Context menus on transaction items provide right-click actions.
+ * Narrator reads every card via semantic content descriptions.
+ */
+@Composable
+fun DashboardScreen(modifier: Modifier = Modifier) {
+    val state = DashboardState()
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(FinanceDesktopTheme.spacing.xxl)
+            .semantics { contentDescription = "Dashboard screen" },
+    ) {
+        // ── Top half: summary (left) + recent transactions (right) ──
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            horizontalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.xxl),
+        ) {
+            // Left column: net worth + spending summary
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight(),
+                verticalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.lg),
+            ) {
+                NetWorthCard(state.netWorth)
+                SpendingSummaryRow(state.todaySpending, state.monthlySpending)
+            }
+
+            // Right column: recent transactions
+            RecentTransactionsPanel(
+                transactions = state.recentTransactions,
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight(),
+            )
+        }
+
+        Spacer(Modifier.height(FinanceDesktopTheme.spacing.xxl))
+
+        // ── Bottom: budget health cards ──
+        BudgetHealthSection(state.budgetItems)
+    }
+}
+
+// =============================================================================
+// Sub-composables
+// =============================================================================
+
+@Composable
+private fun NetWorthCard(formatted: String) {
+    ElevatedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics { contentDescription = "Net worth: $formatted" },
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+        ),
+    ) {
+        Column(
+            modifier = Modifier.padding(FinanceDesktopTheme.spacing.xxl),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Icon(
+                imageVector = Icons.Filled.AccountBalance,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                modifier = Modifier.size(32.dp),
+            )
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
+            Text(
+                text = "Net Worth",
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.xs))
+            Text(
+                text = formatted,
+                style = MaterialTheme.typography.headlineLarge,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+                modifier = Modifier.semantics { heading() },
+            )
+        }
+    }
+}
+
+@Composable
+private fun SpendingSummaryRow(today: String, monthly: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.lg),
+    ) {
+        SpendingCard(
+            label = "Today",
+            amount = today,
+            icon = Icons.Filled.TrendingDown,
+            modifier = Modifier.weight(1f),
+        )
+        SpendingCard(
+            label = "This Month",
+            amount = monthly,
+            icon = Icons.Filled.AttachMoney,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+@Composable
+private fun SpendingCard(
+    label: String,
+    amount: String,
+    icon: ImageVector,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.semantics { contentDescription = "$label spending: $amount" },
+    ) {
+        Row(
+            modifier = Modifier.padding(FinanceDesktopTheme.spacing.lg),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(24.dp),
+            )
+            Spacer(Modifier.width(FinanceDesktopTheme.spacing.md))
+            Column {
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    text = amount,
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RecentTransactionsPanel(
+    transactions: List<SampleTransaction>,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier,
+        shape = MaterialTheme.shapes.medium,
+        tonalElevation = 1.dp,
+    ) {
+        Column(modifier = Modifier.padding(FinanceDesktopTheme.spacing.lg)) {
+            Text(
+                text = "Recent Transactions",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.semantics {
+                    heading()
+                    contentDescription = "Recent Transactions section"
+                },
+            )
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.md))
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
+
+            if (transactions.isEmpty()) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = "No recent transactions",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.semantics {
+                            contentDescription = "No recent transactions"
+                        },
+                    )
+                }
+            } else {
+                LazyColumn(
+                    verticalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.sm),
+                ) {
+                    items(transactions, key = { it.id }) { txn ->
+                        TransactionRow(txn)
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Single transaction row with right-click context menu.
+ */
+@Composable
+private fun TransactionRow(transaction: SampleTransaction) {
+    val amountColor = if (transaction.isExpense) {
+        MaterialTheme.colorScheme.error
+    } else {
+        Color(0xFF2E7D32)
+    }
+
+    ContextMenuArea(
+        items = {
+            listOf(
+                ContextMenuItem("View Details") { /* navigate to detail */ },
+                ContextMenuItem("Edit Transaction") { /* open edit */ },
+                ContextMenuItem("Copy Amount") { /* copy to clipboard */ },
+            )
+        },
+    ) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics {
+                    contentDescription =
+                        "Transaction: ${transaction.amount} at ${transaction.payee}, ${transaction.category}, ${transaction.date}"
+                },
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        horizontal = FinanceDesktopTheme.spacing.md,
+                        vertical = FinanceDesktopTheme.spacing.sm,
+                    ),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Icon(
+                        imageVector = if (transaction.isExpense) Icons.Filled.TrendingDown
+                        else Icons.Filled.TrendingUp,
+                        contentDescription = null,
+                        tint = amountColor,
+                        modifier = Modifier.size(20.dp),
+                    )
+                    Spacer(Modifier.width(FinanceDesktopTheme.spacing.md))
+                    Column {
+                        Text(
+                            text = transaction.payee,
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.Medium,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        Text(
+                            text = "${transaction.category} • ${transaction.date}",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+                Text(
+                    text = transaction.amount,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = amountColor,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun BudgetHealthSection(budgets: List<SampleBudget>) {
+    Column {
+        Text(
+            text = "Budget Health",
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.semantics {
+                heading()
+                contentDescription = "Budget Health section"
+            },
+        )
+        Spacer(Modifier.height(FinanceDesktopTheme.spacing.md))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.lg),
+        ) {
+            budgets.forEach { budget ->
+                DashboardBudgetCard(budget, modifier = Modifier.weight(1f))
+            }
+        }
+    }
+}
+
+@Composable
+private fun DashboardBudgetCard(budget: SampleBudget, modifier: Modifier = Modifier) {
+    val healthColor = when {
+        budget.isOver -> MaterialTheme.colorScheme.error
+        budget.utilization > 0.75f -> Color(0xFFFF9800)
+        else -> MaterialTheme.colorScheme.primary
+    }
+    val healthLabel = when {
+        budget.isOver -> "over budget"
+        budget.utilization > 0.75f -> "warning"
+        else -> "healthy"
+    }
+
+    val animatedProgress by animateFloatAsState(
+        targetValue = budget.utilization.coerceIn(0f, 1f),
+        animationSpec = tween(800),
+        label = "budget-progress",
+    )
+
+    ContextMenuArea(
+        items = {
+            listOf(
+                ContextMenuItem("View Budget Details") { /* navigate */ },
+                ContextMenuItem("Edit Budget") { /* open edit */ },
+            )
+        },
+    ) {
+        Card(
+            modifier = modifier.semantics {
+                contentDescription =
+                    "${budget.name}: ${budget.spent} of ${budget.limit}, $healthLabel"
+            },
+        ) {
+            Column(
+                modifier = Modifier.padding(FinanceDesktopTheme.spacing.lg),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                // Progress ring
+                Box(
+                    modifier = Modifier.size(72.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    val trackColor = MaterialTheme.colorScheme.surfaceVariant
+                    Canvas(Modifier.size(72.dp)) {
+                        val strokeWidth = 6.dp.toPx()
+                        val arcSize = Size(size.width - strokeWidth, size.height - strokeWidth)
+                        val topLeft = Offset(strokeWidth / 2, strokeWidth / 2)
+                        drawArc(
+                            trackColor, -90f, 360f, false,
+                            topLeft, arcSize,
+                            style = Stroke(strokeWidth, cap = StrokeCap.Round),
+                        )
+                        drawArc(
+                            healthColor, -90f, animatedProgress * 360f, false,
+                            topLeft, arcSize,
+                            style = Stroke(strokeWidth, cap = StrokeCap.Round),
+                        )
+                    }
+                    Text(
+                        text = "${(budget.utilization * 100).toInt()}%",
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.Bold,
+                    )
+                }
+                Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
+                Text(
+                    text = budget.name,
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.Medium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = "${budget.spent} / ${budget.limit}",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/GoalsScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/GoalsScreen.kt
@@ -1,0 +1,300 @@
+package com.finance.desktop.screens
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.ContextMenuArea
+import androidx.compose.foundation.ContextMenuItem
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DirectionsCar
+import androidx.compose.material.icons.filled.Flight
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.PhoneAndroid
+import androidx.compose.material.icons.filled.School
+import androidx.compose.material.icons.filled.Shield
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.finance.desktop.theme.FinanceDesktopTheme
+
+// =============================================================================
+// Sample data
+// =============================================================================
+
+private data class GoalItem(
+    val id: String,
+    val name: String,
+    val icon: ImageVector,
+    val currentAmount: String,
+    val targetAmount: String,
+    val progress: Float,
+    val deadline: String,
+    val monthlyContribution: String,
+)
+
+private val sampleGoals = listOf(
+    GoalItem("1", "Emergency Fund", Icons.Filled.Shield, "\$8,500", "\$10,000", 0.85f, "Jun 2025", "\$375/mo"),
+    GoalItem("2", "Vacation Fund", Icons.Filled.Flight, "\$1,200", "\$3,000", 0.40f, "Dec 2025", "\$200/mo"),
+    GoalItem("3", "New Car", Icons.Filled.DirectionsCar, "\$5,000", "\$25,000", 0.20f, "Mar 2027", "\$500/mo"),
+    GoalItem("4", "Home Down Payment", Icons.Filled.Home, "\$32,000", "\$80,000", 0.40f, "Jan 2028", "\$1,200/mo"),
+    GoalItem("5", "New Phone", Icons.Filled.PhoneAndroid, "\$800", "\$1,200", 0.67f, "Aug 2025", "\$100/mo"),
+    GoalItem("6", "Education Fund", Icons.Filled.School, "\$4,500", "\$15,000", 0.30f, "Sep 2026", "\$350/mo"),
+)
+
+// =============================================================================
+// Goals Screen — Card Grid with Progress Bars
+// =============================================================================
+
+/**
+ * Savings goals screen for the desktop Finance application.
+ *
+ * Displays a responsive grid of goal cards, each showing:
+ * - Goal name and icon
+ * - Animated horizontal progress bar
+ * - Current / target amounts
+ * - Deadline and monthly contribution info
+ *
+ * Right-click context menus provide Edit, Contribute, and Delete actions.
+ * Narrator reads goal name, progress percentage, amounts, and deadline.
+ */
+@Composable
+fun GoalsScreen(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(FinanceDesktopTheme.spacing.xxl)
+            .semantics { contentDescription = "Goals screen" },
+    ) {
+        Text(
+            text = "Savings Goals",
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.semantics {
+                heading()
+                contentDescription = "Savings Goals heading"
+            },
+        )
+        Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
+        Text(
+            text = "Track progress toward your financial goals",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Spacer(Modifier.height(FinanceDesktopTheme.spacing.xxl))
+
+        if (sampleGoals.isEmpty()) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center,
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Icon(
+                        imageVector = Icons.Filled.Star,
+                        contentDescription = null,
+                        modifier = Modifier.size(64.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(Modifier.height(FinanceDesktopTheme.spacing.lg))
+                    Text(
+                        text = "No savings goals yet",
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier.semantics {
+                            contentDescription = "No savings goals yet"
+                        },
+                    )
+                    Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
+                    Text(
+                        text = "Create a goal to start saving toward something",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        } else {
+            LazyVerticalGrid(
+                columns = GridCells.Adaptive(minSize = 320.dp),
+                horizontalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.lg),
+                verticalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.lg),
+            ) {
+                items(sampleGoals, key = { it.id }) { goal ->
+                    GoalCard(goal)
+                }
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Goal Card with Progress Bar
+// =============================================================================
+
+@Composable
+private fun GoalCard(goal: GoalItem) {
+    val progressColor = when {
+        goal.progress >= 0.75f -> Color(0xFF2E7D32)
+        goal.progress >= 0.40f -> MaterialTheme.colorScheme.primary
+        else -> Color(0xFFFF9800)
+    }
+    val progressPercent = (goal.progress * 100).toInt()
+
+    val animatedProgress by animateFloatAsState(
+        targetValue = goal.progress.coerceIn(0f, 1f),
+        animationSpec = tween(800),
+        label = "goal-progress",
+    )
+
+    ContextMenuArea(
+        items = {
+            listOf(
+                ContextMenuItem("Add Contribution") { /* contribute */ },
+                ContextMenuItem("Edit Goal") { /* edit */ },
+                ContextMenuItem("View History") { /* history */ },
+                ContextMenuItem("Delete Goal") { /* delete */ },
+            )
+        },
+    ) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics {
+                    contentDescription =
+                        "${goal.name}: $progressPercent% complete, ${goal.currentAmount} of ${goal.targetAmount}, deadline ${goal.deadline}"
+                },
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surface,
+            ),
+            elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+        ) {
+            Column(
+                modifier = Modifier.padding(FinanceDesktopTheme.spacing.xxl),
+            ) {
+                // Header row: icon + name + percentage
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector = goal.icon,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(28.dp),
+                        )
+                        Spacer(Modifier.width(FinanceDesktopTheme.spacing.md))
+                        Text(
+                            text = goal.name,
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                    Text(
+                        text = "$progressPercent%",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = progressColor,
+                    )
+                }
+
+                Spacer(Modifier.height(FinanceDesktopTheme.spacing.lg))
+
+                // Progress bar
+                LinearProgressIndicator(
+                    progress = { animatedProgress },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(8.dp),
+                    color = progressColor,
+                    trackColor = MaterialTheme.colorScheme.surfaceVariant,
+                    strokeCap = StrokeCap.Round,
+                )
+
+                Spacer(Modifier.height(FinanceDesktopTheme.spacing.lg))
+
+                // Amounts row
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Column {
+                        Text(
+                            text = "Saved",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Text(
+                            text = goal.currentAmount,
+                            style = MaterialTheme.typography.bodyLarge,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                    }
+                    Column(horizontalAlignment = Alignment.End) {
+                        Text(
+                            text = "Target",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Text(
+                            text = goal.targetAmount,
+                            style = MaterialTheme.typography.bodyLarge,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                    }
+                }
+
+                Spacer(Modifier.height(FinanceDesktopTheme.spacing.md))
+
+                // Footer: deadline + monthly contribution
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Text(
+                        text = "Deadline: ${goal.deadline}",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(
+                        text = goal.monthlyContribution,
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.Medium,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/SettingsScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/SettingsScreen.kt
@@ -1,0 +1,397 @@
+package com.finance.desktop.screens
+
+import androidx.compose.foundation.ContextMenuArea
+import androidx.compose.foundation.ContextMenuItem
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ColorLens
+import androidx.compose.material.icons.filled.CurrencyExchange
+import androidx.compose.material.icons.filled.DarkMode
+import androidx.compose.material.icons.filled.Fingerprint
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Language
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.Sync
+import androidx.compose.material3.Card
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import com.finance.desktop.theme.FinanceDesktopTheme
+
+// =============================================================================
+// Settings Screen — Form-style layout
+// =============================================================================
+
+/**
+ * Form-style settings screen for the desktop Finance application.
+ *
+ * Groups settings into labelled sections:
+ * - **Appearance**: Dark mode, accent color, language
+ * - **Security**: Windows Hello toggle, auto-lock
+ * - **Notifications**: Desktop notification toggles
+ * - **Data & Sync**: Currency, sync, export
+ * - **About**: Version info
+ *
+ * Each setting row carries a semantic content description for Narrator.
+ * Right-click context menus on dropdowns offer "Reset to default".
+ */
+@Composable
+fun SettingsScreen(modifier: Modifier = Modifier) {
+    // Local state for toggles/dropdowns (UI-layer placeholders)
+    var darkMode by remember { mutableStateOf(false) }
+    var windowsHello by remember { mutableStateOf(true) }
+    var autoLock by remember { mutableStateOf(true) }
+    var budgetNotifications by remember { mutableStateOf(true) }
+    var goalNotifications by remember { mutableStateOf(true) }
+    var syncEnabled by remember { mutableStateOf(true) }
+    var selectedCurrency by remember { mutableStateOf("USD") }
+    var selectedLanguage by remember { mutableStateOf("English") }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(FinanceDesktopTheme.spacing.xxl)
+            .verticalScroll(rememberScrollState())
+            .semantics { contentDescription = "Settings screen" },
+    ) {
+        Text(
+            text = "Settings",
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.semantics {
+                heading()
+                contentDescription = "Settings heading"
+            },
+        )
+
+        Spacer(Modifier.height(FinanceDesktopTheme.spacing.xxl))
+
+        // ── Appearance ──────────────────────────────────────────────
+        SettingsSection("Appearance") {
+            ToggleSetting(
+                icon = Icons.Filled.DarkMode,
+                label = "Dark Mode",
+                description = "Use dark color scheme",
+                checked = darkMode,
+                onCheckedChange = { darkMode = it },
+            )
+            DropdownSetting(
+                icon = Icons.Filled.Language,
+                label = "Language",
+                currentValue = selectedLanguage,
+                options = listOf("English", "Spanish", "French", "German", "Japanese"),
+                onValueChange = { selectedLanguage = it },
+            )
+            DropdownSetting(
+                icon = Icons.Filled.ColorLens,
+                label = "Accent Color",
+                currentValue = "Blue",
+                options = listOf("Blue", "Teal", "Purple", "Green", "Orange"),
+                onValueChange = { /* update accent */ },
+            )
+        }
+
+        Spacer(Modifier.height(FinanceDesktopTheme.spacing.xxl))
+
+        // ── Security ────────────────────────────────────────────────
+        SettingsSection("Security") {
+            ToggleSetting(
+                icon = Icons.Filled.Fingerprint,
+                label = "Windows Hello",
+                description = "Use biometric or PIN authentication",
+                checked = windowsHello,
+                onCheckedChange = { windowsHello = it },
+            )
+            ToggleSetting(
+                icon = Icons.Filled.Lock,
+                label = "Auto-Lock",
+                description = "Lock app after 5 minutes of inactivity",
+                checked = autoLock,
+                onCheckedChange = { autoLock = it },
+            )
+        }
+
+        Spacer(Modifier.height(FinanceDesktopTheme.spacing.xxl))
+
+        // ── Notifications ───────────────────────────────────────────
+        SettingsSection("Notifications") {
+            ToggleSetting(
+                icon = Icons.Filled.Notifications,
+                label = "Budget Alerts",
+                description = "Notify when approaching budget limits",
+                checked = budgetNotifications,
+                onCheckedChange = { budgetNotifications = it },
+            )
+            ToggleSetting(
+                icon = Icons.Filled.Notifications,
+                label = "Goal Milestones",
+                description = "Notify when reaching savings milestones",
+                checked = goalNotifications,
+                onCheckedChange = { goalNotifications = it },
+            )
+        }
+
+        Spacer(Modifier.height(FinanceDesktopTheme.spacing.xxl))
+
+        // ── Data & Sync ─────────────────────────────────────────────
+        SettingsSection("Data & Sync") {
+            DropdownSetting(
+                icon = Icons.Filled.CurrencyExchange,
+                label = "Default Currency",
+                currentValue = selectedCurrency,
+                options = listOf("USD", "EUR", "GBP", "JPY", "CAD", "AUD"),
+                onValueChange = { selectedCurrency = it },
+            )
+            ToggleSetting(
+                icon = Icons.Filled.Sync,
+                label = "Cloud Sync",
+                description = "Sync data across devices",
+                checked = syncEnabled,
+                onCheckedChange = { syncEnabled = it },
+            )
+        }
+
+        Spacer(Modifier.height(FinanceDesktopTheme.spacing.xxl))
+
+        // ── About ───────────────────────────────────────────────────
+        SettingsSection("About") {
+            InfoSetting(
+                icon = Icons.Filled.Info,
+                label = "Version",
+                value = "1.0.0",
+            )
+            InfoSetting(
+                icon = Icons.Filled.Info,
+                label = "Build",
+                value = "2025.03.06",
+            )
+        }
+
+        Spacer(Modifier.height(FinanceDesktopTheme.spacing.massive))
+    }
+}
+
+// =============================================================================
+// Section composable
+// =============================================================================
+
+@Composable
+private fun SettingsSection(
+    title: String,
+    content: @Composable () -> Unit,
+) {
+    Column {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier
+                .padding(bottom = FinanceDesktopTheme.spacing.sm)
+                .semantics {
+                    heading()
+                    contentDescription = "$title settings section"
+                },
+        )
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Column(
+                modifier = Modifier.padding(FinanceDesktopTheme.spacing.lg),
+            ) {
+                content()
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Setting row types
+// =============================================================================
+
+/**
+ * Toggle setting row: icon + label + description + switch.
+ */
+@Composable
+private fun ToggleSetting(
+    icon: ImageVector,
+    label: String,
+    description: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    val stateLabel = if (checked) "enabled" else "disabled"
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = FinanceDesktopTheme.spacing.sm)
+            .semantics {
+                contentDescription = "$label, $stateLabel. $description"
+                role = Role.Switch
+            },
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(end = FinanceDesktopTheme.spacing.md),
+        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+            )
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Switch(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+        )
+    }
+    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+}
+
+/**
+ * Dropdown setting row: icon + label + button that opens a dropdown menu.
+ */
+@Composable
+private fun DropdownSetting(
+    icon: ImageVector,
+    label: String,
+    currentValue: String,
+    options: List<String>,
+    onValueChange: (String) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    ContextMenuArea(
+        items = {
+            listOf(ContextMenuItem("Reset to Default") { onValueChange(options.first()) })
+        },
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = FinanceDesktopTheme.spacing.sm)
+                .semantics {
+                    contentDescription = "$label: $currentValue"
+                },
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(end = FinanceDesktopTheme.spacing.md),
+            )
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+                modifier = Modifier.weight(1f),
+            )
+            TextButton(
+                onClick = { expanded = true },
+                modifier = Modifier.semantics {
+                    contentDescription = "$label selector, current value: $currentValue"
+                },
+            ) {
+                Text(currentValue)
+            }
+            DropdownMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false },
+            ) {
+                options.forEach { option ->
+                    DropdownMenuItem(
+                        text = { Text(option) },
+                        onClick = {
+                            onValueChange(option)
+                            expanded = false
+                        },
+                        modifier = Modifier.semantics {
+                            contentDescription = "Select $option for $label"
+                        },
+                    )
+                }
+            }
+        }
+    }
+    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+}
+
+/**
+ * Read-only info row: icon + label + value.
+ */
+@Composable
+private fun InfoSetting(
+    icon: ImageVector,
+    label: String,
+    value: String,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = FinanceDesktopTheme.spacing.sm)
+            .semantics {
+                contentDescription = "$label: $value"
+            },
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(end = FinanceDesktopTheme.spacing.md),
+            )
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+            )
+        }
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/TransactionsScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/TransactionsScreen.kt
@@ -1,0 +1,534 @@
+package com.finance.desktop.screens
+
+import androidx.compose.foundation.ContextMenuArea
+import androidx.compose.foundation.ContextMenuItem
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDownward
+import androidx.compose.material.icons.filled.ArrowUpward
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.FilterList
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.SwapHoriz
+import androidx.compose.material.icons.filled.TrendingDown
+import androidx.compose.material.icons.filled.TrendingUp
+import androidx.compose.material3.Card
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.finance.desktop.theme.FinanceDesktopTheme
+
+// =============================================================================
+// Sample data (UI-layer placeholders)
+// =============================================================================
+
+private data class TransactionItem(
+    val id: String,
+    val date: String,
+    val payee: String,
+    val category: String,
+    val account: String,
+    val amount: String,
+    val rawAmount: Double,
+    val type: TransactionTypeUi,
+)
+
+private enum class TransactionTypeUi { EXPENSE, INCOME, TRANSFER }
+
+private enum class SortColumn { DATE, PAYEE, CATEGORY, ACCOUNT, AMOUNT }
+private enum class SortDirection { ASC, DESC }
+
+private val sampleTransactionItems = listOf(
+    TransactionItem("1", "2025-03-06", "Whole Foods", "Groceries", "Checking", "-\$52.30", -52.30, TransactionTypeUi.EXPENSE),
+    TransactionItem("2", "2025-03-06", "Salary Deposit", "Income", "Checking", "+\$4,200.00", 4200.0, TransactionTypeUi.INCOME),
+    TransactionItem("3", "2025-03-05", "Netflix", "Entertainment", "Visa Card", "-\$15.99", -15.99, TransactionTypeUi.EXPENSE),
+    TransactionItem("4", "2025-03-05", "Gas Station", "Transport", "Checking", "-\$45.00", -45.0, TransactionTypeUi.EXPENSE),
+    TransactionItem("5", "2025-03-04", "Freelance Payment", "Income", "Checking", "+\$800.00", 800.0, TransactionTypeUi.INCOME),
+    TransactionItem("6", "2025-03-04", "Restaurant", "Dining", "Visa Card", "-\$68.00", -68.0, TransactionTypeUi.EXPENSE),
+    TransactionItem("7", "2025-03-03", "Electric Bill", "Utilities", "Checking", "-\$125.00", -125.0, TransactionTypeUi.EXPENSE),
+    TransactionItem("8", "2025-03-03", "Transfer to Savings", "Transfer", "Checking", "-\$500.00", -500.0, TransactionTypeUi.TRANSFER),
+    TransactionItem("9", "2025-03-02", "Amazon", "Shopping", "Visa Card", "-\$42.99", -42.99, TransactionTypeUi.EXPENSE),
+    TransactionItem("10", "2025-03-01", "Interest", "Income", "Savings", "+\$12.50", 12.50, TransactionTypeUi.INCOME),
+)
+
+// =============================================================================
+// Transactions Screen — Full-width Table
+// =============================================================================
+
+/**
+ * Full-width transaction table for the desktop Finance application.
+ *
+ * Features:
+ * - Search bar for filtering by payee or category
+ * - Type filter chips (All / Expenses / Income / Transfers)
+ * - Sortable columns (click header to sort ascending/descending)
+ * - Right-click context menus on each row
+ * - Mouse-friendly row spacing and hover-ready layout
+ *
+ * Narrator: Every row is described as "Transaction: amount at payee, category, date".
+ * Sort controls announce column name and direction.
+ */
+@Composable
+fun TransactionsScreen(modifier: Modifier = Modifier) {
+    var searchQuery by remember { mutableStateOf("") }
+    var typeFilter by remember { mutableStateOf<TransactionTypeUi?>(null) }
+    var sortColumn by remember { mutableStateOf(SortColumn.DATE) }
+    var sortDirection by remember { mutableStateOf(SortDirection.DESC) }
+
+    val filteredAndSorted by remember(searchQuery, typeFilter, sortColumn, sortDirection) {
+        derivedStateOf {
+            sampleTransactionItems
+                .filter { txn ->
+                    val matchesSearch = searchQuery.isBlank() ||
+                        txn.payee.contains(searchQuery, ignoreCase = true) ||
+                        txn.category.contains(searchQuery, ignoreCase = true)
+                    val matchesType = typeFilter == null || txn.type == typeFilter
+                    matchesSearch && matchesType
+                }
+                .sortedWith(
+                    compareBy<TransactionItem> { txn ->
+                        when (sortColumn) {
+                            SortColumn.DATE -> txn.date
+                            SortColumn.PAYEE -> txn.payee.lowercase()
+                            SortColumn.CATEGORY -> txn.category.lowercase()
+                            SortColumn.ACCOUNT -> txn.account.lowercase()
+                            SortColumn.AMOUNT -> txn.rawAmount.toString().padStart(20)
+                        }
+                    }.let { if (sortDirection == SortDirection.DESC) it.reversed() else it },
+                )
+        }
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(FinanceDesktopTheme.spacing.xxl)
+            .semantics { contentDescription = "Transactions screen" },
+    ) {
+        // Header
+        Text(
+            text = "Transactions",
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.semantics {
+                heading()
+                contentDescription = "Transactions heading"
+            },
+        )
+
+        Spacer(Modifier.height(FinanceDesktopTheme.spacing.lg))
+
+        // Search + filters bar
+        SearchAndFilterBar(
+            searchQuery = searchQuery,
+            onSearchChange = { searchQuery = it },
+            typeFilter = typeFilter,
+            onTypeFilterChange = { typeFilter = it },
+        )
+
+        Spacer(Modifier.height(FinanceDesktopTheme.spacing.lg))
+
+        // Table
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            shape = MaterialTheme.shapes.medium,
+            tonalElevation = 1.dp,
+        ) {
+            Column {
+                // Table header
+                TableHeader(
+                    sortColumn = sortColumn,
+                    sortDirection = sortDirection,
+                    onSort = { column ->
+                        if (sortColumn == column) {
+                            sortDirection =
+                                if (sortDirection == SortDirection.ASC) SortDirection.DESC
+                                else SortDirection.ASC
+                        } else {
+                            sortColumn = column
+                            sortDirection = SortDirection.ASC
+                        }
+                    },
+                )
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+
+                // Table body
+                if (filteredAndSorted.isEmpty()) {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Icon(
+                                imageVector = if (searchQuery.isNotBlank() || typeFilter != null)
+                                    Icons.Filled.FilterList else Icons.Filled.SwapHoriz,
+                                contentDescription = null,
+                                modifier = Modifier.size(48.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            Spacer(Modifier.height(FinanceDesktopTheme.spacing.md))
+                            Text(
+                                text = if (searchQuery.isNotBlank() || typeFilter != null)
+                                    "No matching transactions" else "No transactions yet",
+                                style = MaterialTheme.typography.titleMedium,
+                                modifier = Modifier.semantics {
+                                    contentDescription = "No matching transactions"
+                                },
+                            )
+                        }
+                    }
+                } else {
+                    LazyColumn {
+                        items(filteredAndSorted, key = { it.id }) { txn ->
+                            TransactionTableRow(txn)
+                            HorizontalDivider(
+                                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Search & Filter Bar
+// =============================================================================
+
+@Composable
+private fun SearchAndFilterBar(
+    searchQuery: String,
+    onSearchChange: (String) -> Unit,
+    typeFilter: TransactionTypeUi?,
+    onTypeFilterChange: (TransactionTypeUi?) -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.lg),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        // Search field
+        OutlinedTextField(
+            value = searchQuery,
+            onValueChange = onSearchChange,
+            modifier = Modifier
+                .weight(1f)
+                .semantics {
+                    contentDescription = "Search transactions by payee or category"
+                },
+            placeholder = { Text("Search payees, categories\u2026") },
+            leadingIcon = { Icon(Icons.Filled.Search, contentDescription = null) },
+            trailingIcon = {
+                if (searchQuery.isNotEmpty()) {
+                    IconButton(
+                        onClick = { onSearchChange("") },
+                        modifier = Modifier.semantics {
+                            contentDescription = "Clear search"
+                        },
+                    ) {
+                        Icon(Icons.Filled.Clear, contentDescription = null)
+                    }
+                }
+            },
+            singleLine = true,
+            shape = RoundedCornerShape(8.dp),
+        )
+
+        // Filter chips
+        Row(horizontalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.sm)) {
+            FilterChip(
+                selected = typeFilter == null,
+                onClick = { onTypeFilterChange(null) },
+                label = { Text("All") },
+                modifier = Modifier.semantics {
+                    contentDescription = "Filter: All types"
+                },
+            )
+            FilterChip(
+                selected = typeFilter == TransactionTypeUi.EXPENSE,
+                onClick = {
+                    onTypeFilterChange(
+                        if (typeFilter == TransactionTypeUi.EXPENSE) null
+                        else TransactionTypeUi.EXPENSE,
+                    )
+                },
+                label = { Text("Expenses") },
+                leadingIcon = {
+                    Icon(
+                        Icons.Filled.TrendingDown,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                    )
+                },
+                modifier = Modifier.semantics {
+                    contentDescription = "Filter: Expenses"
+                },
+            )
+            FilterChip(
+                selected = typeFilter == TransactionTypeUi.INCOME,
+                onClick = {
+                    onTypeFilterChange(
+                        if (typeFilter == TransactionTypeUi.INCOME) null
+                        else TransactionTypeUi.INCOME,
+                    )
+                },
+                label = { Text("Income") },
+                leadingIcon = {
+                    Icon(
+                        Icons.Filled.TrendingUp,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                    )
+                },
+                modifier = Modifier.semantics {
+                    contentDescription = "Filter: Income"
+                },
+            )
+            FilterChip(
+                selected = typeFilter == TransactionTypeUi.TRANSFER,
+                onClick = {
+                    onTypeFilterChange(
+                        if (typeFilter == TransactionTypeUi.TRANSFER) null
+                        else TransactionTypeUi.TRANSFER,
+                    )
+                },
+                label = { Text("Transfers") },
+                leadingIcon = {
+                    Icon(
+                        Icons.Filled.SwapHoriz,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                    )
+                },
+                modifier = Modifier.semantics {
+                    contentDescription = "Filter: Transfers"
+                },
+            )
+        }
+    }
+}
+
+// =============================================================================
+// Table Header — sortable columns
+// =============================================================================
+
+@Composable
+private fun TableHeader(
+    sortColumn: SortColumn,
+    sortDirection: SortDirection,
+    onSort: (SortColumn) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+            .padding(
+                horizontal = FinanceDesktopTheme.spacing.lg,
+                vertical = FinanceDesktopTheme.spacing.md,
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        SortableColumnHeader(
+            "Date", SortColumn.DATE, sortColumn, sortDirection, onSort, Modifier.width(120.dp),
+        )
+        SortableColumnHeader(
+            "Payee", SortColumn.PAYEE, sortColumn, sortDirection, onSort, Modifier.weight(1f),
+        )
+        SortableColumnHeader(
+            "Category", SortColumn.CATEGORY, sortColumn, sortDirection, onSort,
+            Modifier.width(140.dp),
+        )
+        SortableColumnHeader(
+            "Account", SortColumn.ACCOUNT, sortColumn, sortDirection, onSort,
+            Modifier.width(140.dp),
+        )
+        SortableColumnHeader(
+            "Amount", SortColumn.AMOUNT, sortColumn, sortDirection, onSort,
+            Modifier.width(130.dp),
+        )
+    }
+}
+
+@Composable
+private fun SortableColumnHeader(
+    label: String,
+    column: SortColumn,
+    currentSort: SortColumn,
+    direction: SortDirection,
+    onSort: (SortColumn) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val isActive = currentSort == column
+    val dirLabel = if (isActive) {
+        if (direction == SortDirection.ASC) "ascending" else "descending"
+    } else {
+        "not sorted"
+    }
+
+    Row(
+        modifier = modifier
+            .clickable { onSort(column) }
+            .padding(vertical = FinanceDesktopTheme.spacing.xs)
+            .semantics {
+                contentDescription = "$label column, $dirLabel. Click to sort."
+            },
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = if (isActive) FontWeight.Bold else FontWeight.Medium,
+            color = if (isActive) MaterialTheme.colorScheme.primary
+            else MaterialTheme.colorScheme.onSurface,
+        )
+        if (isActive) {
+            Spacer(Modifier.width(4.dp))
+            Icon(
+                imageVector = if (direction == SortDirection.ASC) Icons.Filled.ArrowUpward
+                else Icons.Filled.ArrowDownward,
+                contentDescription = null,
+                modifier = Modifier.size(16.dp),
+                tint = MaterialTheme.colorScheme.primary,
+            )
+        }
+    }
+}
+
+// =============================================================================
+// Table Row
+// =============================================================================
+
+@Composable
+private fun TransactionTableRow(txn: TransactionItem) {
+    val amountColor = when (txn.type) {
+        TransactionTypeUi.EXPENSE -> MaterialTheme.colorScheme.error
+        TransactionTypeUi.INCOME -> Color(0xFF2E7D32)
+        TransactionTypeUi.TRANSFER -> MaterialTheme.colorScheme.tertiary
+    }
+    val typeIcon = when (txn.type) {
+        TransactionTypeUi.EXPENSE -> Icons.Filled.TrendingDown
+        TransactionTypeUi.INCOME -> Icons.Filled.TrendingUp
+        TransactionTypeUi.TRANSFER -> Icons.Filled.SwapHoriz
+    }
+
+    ContextMenuArea(
+        items = {
+            listOf(
+                ContextMenuItem("View Details") { /* view */ },
+                ContextMenuItem("Edit Transaction") { /* edit */ },
+                ContextMenuItem("Duplicate") { /* duplicate */ },
+                ContextMenuItem("Copy Amount") { /* copy */ },
+                ContextMenuItem("Delete") { /* delete */ },
+            )
+        },
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { /* navigate to detail */ }
+                .padding(
+                    horizontal = FinanceDesktopTheme.spacing.lg,
+                    vertical = FinanceDesktopTheme.spacing.md,
+                )
+                .semantics {
+                    contentDescription =
+                        "Transaction: ${txn.amount} at ${txn.payee}, ${txn.category}, ${txn.date}"
+                },
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // Date
+            Text(
+                text = txn.date,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.width(120.dp),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            // Payee (with type icon)
+            Row(
+                modifier = Modifier.weight(1f),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = typeIcon,
+                    contentDescription = null,
+                    tint = amountColor,
+                    modifier = Modifier.size(18.dp),
+                )
+                Spacer(Modifier.width(FinanceDesktopTheme.spacing.sm))
+                Text(
+                    text = txn.payee,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+
+            // Category
+            Text(
+                text = txn.category,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.width(140.dp),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+
+            // Account
+            Text(
+                text = txn.account,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.width(140.dp),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+
+            // Amount
+            Text(
+                text = txn.amount,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = amountColor,
+                modifier = Modifier.width(130.dp),
+            )
+        }
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/theme/FinanceDesktopTheme.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/theme/FinanceDesktopTheme.kt
@@ -1,0 +1,251 @@
+package com.finance.desktop.theme
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Typography
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+// =============================================================================
+// Primitive colors — packages/design-tokens/tokens/primitive/colors.json
+// =============================================================================
+
+// region Blue
+private val Blue50 = Color(0xFFEFF6FF)
+private val Blue100 = Color(0xFFDBEAFE)
+private val Blue200 = Color(0xFFBFDBFE)
+private val Blue300 = Color(0xFF93C5FD)
+private val Blue400 = Color(0xFF60A5FA)
+private val Blue500 = Color(0xFF3B82F6)
+private val Blue600 = Color(0xFF2563EB)
+private val Blue700 = Color(0xFF1D4ED8)
+private val Blue800 = Color(0xFF1E40AF)
+private val Blue900 = Color(0xFF1E3A8A)
+// endregion
+
+// region Teal
+private val Teal50 = Color(0xFFF0FDFA)
+private val Teal100 = Color(0xFFCCFBF1)
+private val Teal400 = Color(0xFF2DD4BF)
+private val Teal600 = Color(0xFF0D9488)
+private val Teal800 = Color(0xFF115E59)
+private val Teal900 = Color(0xFF134E4A)
+// endregion
+
+// region Green
+private val Green500 = Color(0xFF22C55E)
+private val Green600 = Color(0xFF16A34A)
+private val Green700 = Color(0xFF15803D)
+// endregion
+
+// region Amber
+private val Amber50 = Color(0xFFFFFBEB)
+private val Amber500 = Color(0xFFF59E0B)
+private val Amber600 = Color(0xFFD97706)
+private val Amber700 = Color(0xFFB45309)
+// endregion
+
+// region Red
+private val Red50 = Color(0xFFFEF2F2)
+private val Red400 = Color(0xFFF87171)
+private val Red500 = Color(0xFFEF4444)
+private val Red600 = Color(0xFFDC2626)
+private val Red700 = Color(0xFFB91C1C)
+private val Red900 = Color(0xFF7F1D1D)
+// endregion
+
+// region Neutral
+private val Neutral0 = Color(0xFFFFFFFF)
+private val Neutral50 = Color(0xFFF9FAFB)
+private val Neutral100 = Color(0xFFF3F4F6)
+private val Neutral200 = Color(0xFFE5E7EB)
+private val Neutral300 = Color(0xFFD1D5DB)
+private val Neutral400 = Color(0xFF9CA3AF)
+private val Neutral500 = Color(0xFF6B7280)
+private val Neutral600 = Color(0xFF4B5563)
+private val Neutral700 = Color(0xFF374151)
+private val Neutral800 = Color(0xFF1F2937)
+private val Neutral900 = Color(0xFF111827)
+private val Neutral950 = Color(0xFF030712)
+// endregion
+
+// =============================================================================
+// Material 3 color schemes — mapped from design-token semantic layer
+// =============================================================================
+
+private val LightColorScheme = lightColorScheme(
+    primary = Blue600,
+    onPrimary = Neutral0,
+    primaryContainer = Blue100,
+    onPrimaryContainer = Blue900,
+    secondary = Teal600,
+    onSecondary = Neutral0,
+    secondaryContainer = Teal100,
+    onSecondaryContainer = Teal900,
+    tertiary = Amber600,
+    onTertiary = Neutral0,
+    tertiaryContainer = Amber50,
+    onTertiaryContainer = Amber700,
+    error = Red600,
+    onError = Neutral0,
+    errorContainer = Red50,
+    onErrorContainer = Red700,
+    background = Neutral0,
+    onBackground = Neutral900,
+    surface = Neutral0,
+    onSurface = Neutral900,
+    surfaceVariant = Neutral100,
+    onSurfaceVariant = Neutral600,
+    outline = Neutral300,
+    outlineVariant = Neutral200,
+)
+
+private val DarkColorScheme = darkColorScheme(
+    primary = Blue400,
+    onPrimary = Blue900,
+    primaryContainer = Blue800,
+    onPrimaryContainer = Blue100,
+    secondary = Teal400,
+    onSecondary = Teal900,
+    secondaryContainer = Teal800,
+    onSecondaryContainer = Teal100,
+    tertiary = Amber500,
+    onTertiary = Amber700,
+    tertiaryContainer = Amber700,
+    onTertiaryContainer = Amber50,
+    error = Red400,
+    onError = Red900,
+    errorContainer = Red700,
+    onErrorContainer = Red50,
+    background = Neutral950,
+    onBackground = Neutral50,
+    surface = Neutral950,
+    onSurface = Neutral50,
+    surfaceVariant = Neutral800,
+    onSurfaceVariant = Neutral400,
+    outline = Neutral700,
+    outlineVariant = Neutral700,
+)
+
+// =============================================================================
+// Typography — Fluent Design uses Segoe UI (platform default on Windows)
+// =============================================================================
+
+private val FinanceTypography = Typography(
+    displayLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Bold,
+        fontSize = 48.sp,
+        lineHeight = 60.sp,
+    ),
+    headlineLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 30.sp,
+        lineHeight = 38.sp,
+    ),
+    titleLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 20.sp,
+        lineHeight = 30.sp,
+    ),
+    bodyLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 16.sp,
+        lineHeight = 24.sp,
+    ),
+    bodyMedium = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 14.sp,
+        lineHeight = 21.sp,
+    ),
+    labelLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 14.sp,
+        lineHeight = 21.sp,
+    ),
+    labelSmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 12.sp,
+        lineHeight = 18.sp,
+    ),
+)
+
+// =============================================================================
+// Spacing — packages/design-tokens/tokens/primitive/spacing.json
+// =============================================================================
+
+@Immutable
+data class Spacing(
+    val none: Dp = 0.dp,
+    val xs: Dp = 4.dp,
+    val sm: Dp = 8.dp,
+    val md: Dp = 12.dp,
+    val lg: Dp = 16.dp,
+    val xl: Dp = 20.dp,
+    val xxl: Dp = 24.dp,
+    val xxxl: Dp = 32.dp,
+    val huge: Dp = 40.dp,
+    val massive: Dp = 48.dp,
+    val colossal: Dp = 64.dp,
+    val epic: Dp = 80.dp,
+)
+
+val LocalSpacing = staticCompositionLocalOf { Spacing() }
+
+// =============================================================================
+// Theme composable
+// =============================================================================
+
+/**
+ * Material 3 theme for the Finance Windows desktop application.
+ *
+ * Provides color scheme (light/dark based on system setting), typography
+ * derived from the shared design tokens, and a custom [Spacing] composition
+ * local accessible via [FinanceDesktopTheme.spacing].
+ *
+ * Typography uses [FontFamily.Default] which resolves to Segoe UI on Windows,
+ * aligning with Fluent Design system conventions.
+ */
+@Composable
+fun FinanceDesktopTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable () -> Unit,
+) {
+    val colorScheme = if (darkTheme) DarkColorScheme else LightColorScheme
+
+    CompositionLocalProvider(LocalSpacing provides Spacing()) {
+        MaterialTheme(
+            colorScheme = colorScheme,
+            typography = FinanceTypography,
+            content = content,
+        )
+    }
+}
+
+/**
+ * Convenience accessor for Finance desktop design tokens.
+ */
+object FinanceDesktopTheme {
+    val spacing: Spacing
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalSpacing.current
+}


### PR DESCRIPTION
Closes #36
Closes #35

Implement core desktop UI screens for the Windows Compose Desktop application:
- SidebarNavigation with collapsible sidebar and Ctrl+1-6 shortcuts
- DashboardScreen with multi-panel layout
- AccountsScreen with master-detail layout
- TransactionsScreen with sortable table, search, and filters
- BudgetsScreen with progress ring grid
- GoalsScreen with progress bar grid
- SettingsScreen with form-style sections
- KeyboardShortcuts handler composable

All screens use desktop patterns: multi-panel layouts, context menus, keyboard shortcuts, and Narrator accessibility.