### PR TITLE
feat(core): household sharing manager and RBAC permissions

### DIFF
--- a/packages/core/src/commonMain/kotlin/com/finance/core/household/HouseholdManager.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/household/HouseholdManager.kt
@@ -1,0 +1,71 @@
+package com.finance.core.household
+
+import com.finance.models.Household
+import com.finance.models.HouseholdMember
+import com.finance.models.HouseholdRole
+import com.finance.models.types.SyncId
+
+/**
+ * Core interface for household lifecycle and membership management.
+ *
+ * Implementations are responsible for persistence, invite-code generation,
+ * and enforcing household-level invariants (e.g. max members, single owner).
+ * All operations are suspend because they may involve database or network I/O.
+ *
+ * RBAC enforcement is **not** baked into this interface; callers should check
+ * [RbacPermissions] before invoking mutation methods.
+ */
+interface HouseholdManager {
+
+    /**
+     * Create a new household and add [ownerId] as the [HouseholdRole.OWNER].
+     *
+     * @param name   Display name for the household.
+     * @param ownerId  [SyncId] of the user who will own the household.
+     * @return The newly created [Household].
+     */
+    suspend fun createHousehold(name: String, ownerId: SyncId): Household
+
+    /**
+     * Generate an invite for [email] to join [householdId] with the given [role].
+     *
+     * @return An [InviteResult] indicating success (with code) or failure reason.
+     */
+    suspend fun inviteMember(
+        householdId: SyncId,
+        email: String,
+        role: HouseholdRole,
+    ): InviteResult
+
+    /**
+     * Accept a pending invite using the single-use [inviteCode].
+     *
+     * @param inviteCode  The invite code received by the invitee.
+     * @param userId      [SyncId] of the accepting user.
+     * @return [Result.success] with the new [HouseholdMember] on success,
+     *         or [Result.failure] with a descriptive exception on error
+     *         (e.g. expired code, already redeemed).
+     */
+    suspend fun acceptInvite(inviteCode: String, userId: SyncId): Result<HouseholdMember>
+
+    /**
+     * Remove a member from the household.
+     *
+     * Owners cannot be removed — transfer ownership first.
+     *
+     * @param householdId  The household to remove the member from.
+     * @param memberId     [SyncId] of the [HouseholdMember] to remove.
+     */
+    suspend fun removeMember(householdId: SyncId, memberId: SyncId)
+
+    /**
+     * Change the role of an existing member.
+     *
+     * Cannot demote the sole owner — there must always be exactly one.
+     *
+     * @param householdId  The household that the member belongs to.
+     * @param memberId     [SyncId] of the [HouseholdMember] to update.
+     * @param role         The new [HouseholdRole] to assign.
+     */
+    suspend fun updateRole(householdId: SyncId, memberId: SyncId, role: HouseholdRole)
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/household/HouseholdRole.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/household/HouseholdRole.kt
@@ -1,0 +1,10 @@
+package com.finance.core.household
+
+/**
+ * Re-export [com.finance.models.HouseholdRole] so that callers working within
+ * the `core.household` package don't need a separate models import.
+ *
+ * Canonical definition: [com.finance.models.HouseholdRole]
+ * Values: OWNER, PARTNER, MEMBER, VIEWER
+ */
+typealias HouseholdRole = com.finance.models.HouseholdRole

--- a/packages/core/src/commonMain/kotlin/com/finance/core/household/InviteResult.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/household/InviteResult.kt
@@ -1,0 +1,23 @@
+package com.finance.core.household
+
+/**
+ * Outcome of a household member invitation attempt.
+ * Modelled as a sealed hierarchy for exhaustive `when` handling.
+ */
+sealed class InviteResult {
+
+    /**
+     * Invitation was created successfully.
+     * @param code Single-use invite code to share with the invitee.
+     */
+    data class Success(val code: String) : InviteResult()
+
+    /** The invited email is already a member of this household. */
+    data object AlreadyMember : InviteResult()
+
+    /** The household has reached its maximum member count. */
+    data object HouseholdFull : InviteResult()
+
+    /** The provided email address failed validation. */
+    data object InvalidEmail : InviteResult()
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/household/RbacPermissions.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/household/RbacPermissions.kt
@@ -1,0 +1,91 @@
+package com.finance.core.household
+
+import com.finance.models.HouseholdRole
+
+/**
+ * Role-Based Access Control (RBAC) permission enforcement for households.
+ *
+ * Permission matrix:
+ * ```
+ * Permission            | OWNER | PARTNER | MEMBER | VIEWER
+ * ----------------------|-------|---------|--------|-------
+ * viewTransactions      |  Yes  |   Yes   |   Yes  |   Yes
+ * createTransactions    |  Yes  |   Yes   |   Yes  |   No
+ * editBudgets           |  Yes  |   Yes   |   No   |   No
+ * manageMembers         |  Yes  |   No    |   No   |   No
+ * deleteHousehold       |  Yes  |   No    |   No   |   No
+ * ```
+ */
+object RbacPermissions {
+
+    /**
+     * Complete set of permissions that can be granted to a role.
+     * Immutable — use [permissionMatrix] to look up a role's grants.
+     */
+    data class PermissionSet(
+        val viewTransactions: Boolean,
+        val createTransactions: Boolean,
+        val editBudgets: Boolean,
+        val manageMembers: Boolean,
+        val deleteHousehold: Boolean,
+    )
+
+    /**
+     * Exhaustive mapping from every [HouseholdRole] to its [PermissionSet].
+     * This is the single source of truth for all permission checks.
+     */
+    val permissionMatrix: Map<HouseholdRole, PermissionSet> = mapOf(
+        HouseholdRole.OWNER to PermissionSet(
+            viewTransactions = true,
+            createTransactions = true,
+            editBudgets = true,
+            manageMembers = true,
+            deleteHousehold = true,
+        ),
+        HouseholdRole.PARTNER to PermissionSet(
+            viewTransactions = true,
+            createTransactions = true,
+            editBudgets = true,
+            manageMembers = false,
+            deleteHousehold = false,
+        ),
+        HouseholdRole.MEMBER to PermissionSet(
+            viewTransactions = true,
+            createTransactions = true,
+            editBudgets = false,
+            manageMembers = false,
+            deleteHousehold = false,
+        ),
+        HouseholdRole.VIEWER to PermissionSet(
+            viewTransactions = true,
+            createTransactions = false,
+            editBudgets = false,
+            manageMembers = false,
+            deleteHousehold = false,
+        ),
+    )
+
+    // -- Convenience query functions --
+
+    fun canViewTransactions(role: HouseholdRole): Boolean =
+        permissionMatrix.getValue(role).viewTransactions
+
+    fun canCreateTransactions(role: HouseholdRole): Boolean =
+        permissionMatrix.getValue(role).createTransactions
+
+    fun canEditBudgets(role: HouseholdRole): Boolean =
+        permissionMatrix.getValue(role).editBudgets
+
+    fun canManageMembers(role: HouseholdRole): Boolean =
+        permissionMatrix.getValue(role).manageMembers
+
+    fun canDeleteHousehold(role: HouseholdRole): Boolean =
+        permissionMatrix.getValue(role).deleteHousehold
+
+    /**
+     * Return the full [PermissionSet] for the given role.
+     * Useful when a caller needs to check multiple permissions at once.
+     */
+    fun permissionsFor(role: HouseholdRole): PermissionSet =
+        permissionMatrix.getValue(role)
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/household/HouseholdManagerTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/household/HouseholdManagerTest.kt
@@ -1,0 +1,351 @@
+package com.finance.core.household
+
+import com.finance.core.TestFixtures
+import com.finance.models.Household
+import com.finance.models.HouseholdMember
+import com.finance.models.HouseholdRole
+import com.finance.models.types.SyncId
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlin.test.*
+
+/**
+ * Tests for [HouseholdManager] contract using an in-memory fake.
+ * Verifies create -> invite -> accept -> remove -> updateRole flows.
+ */
+class HouseholdManagerTest {
+
+    private lateinit var manager: FakeHouseholdManager
+
+    @BeforeTest
+    fun setup() {
+        TestFixtures.reset()
+        manager = FakeHouseholdManager()
+    }
+
+    // -- createHousehold --
+
+    @Test
+    fun createHousehold_returnsHouseholdWithOwner() = runTest {
+        val ownerId = TestFixtures.nextId()
+        val household = manager.createHousehold("Test Family", ownerId)
+
+        assertEquals("Test Family", household.name)
+        assertEquals(ownerId, household.ownerId)
+
+        // Owner should be added as a member automatically
+        val members = manager.membersOf(household.id)
+        assertEquals(1, members.size)
+        assertEquals(HouseholdRole.OWNER, members.first().role)
+        assertEquals(ownerId, members.first().userId)
+    }
+
+    @Test
+    fun createHousehold_generatesUniqueSyncIds() = runTest {
+        val h1 = manager.createHousehold("Family A", TestFixtures.nextId())
+        val h2 = manager.createHousehold("Family B", TestFixtures.nextId())
+        assertNotEquals(h1.id, h2.id)
+    }
+
+    // -- inviteMember --
+
+    @Test
+    fun inviteMember_success_returnsCode() = runTest {
+        val household = manager.createHousehold("Family", TestFixtures.nextId())
+        val result = manager.inviteMember(household.id, "partner@test.com", HouseholdRole.PARTNER)
+
+        assertIs<InviteResult.Success>(result)
+        assertTrue(result.code.isNotBlank())
+    }
+
+    @Test
+    fun inviteMember_invalidEmail_returnsInvalidEmail() = runTest {
+        val household = manager.createHousehold("Family", TestFixtures.nextId())
+        val result = manager.inviteMember(household.id, "not-an-email", HouseholdRole.MEMBER)
+
+        assertIs<InviteResult.InvalidEmail>(result)
+    }
+
+    @Test
+    fun inviteMember_alreadyMember_returnsAlreadyMember() = runTest {
+        val ownerId = TestFixtures.nextId()
+        val household = manager.createHousehold("Family", ownerId)
+
+        // Accept an invite first
+        val invite = manager.inviteMember(household.id, "user@test.com", HouseholdRole.MEMBER)
+        assertIs<InviteResult.Success>(invite)
+        val userId = TestFixtures.nextId()
+        manager.acceptInvite(invite.code, userId)
+
+        // Mark user email in the fake so duplicate detection works
+        manager.setUserEmail(userId, "user@test.com")
+
+        // Try inviting the same email again
+        val duplicate = manager.inviteMember(household.id, "user@test.com", HouseholdRole.MEMBER)
+        assertIs<InviteResult.AlreadyMember>(duplicate)
+    }
+
+    @Test
+    fun inviteMember_householdFull_returnsHouseholdFull() = runTest {
+        val household = manager.createHousehold("Tiny Family", TestFixtures.nextId())
+
+        // Fill up the household to max capacity (fake uses max = 6)
+        repeat(FakeHouseholdManager.MAX_MEMBERS - 1) { i ->
+            val invite = manager.inviteMember(household.id, "user$i@test.com", HouseholdRole.MEMBER)
+            assertIs<InviteResult.Success>(invite)
+            manager.acceptInvite(invite.code, TestFixtures.nextId())
+        }
+
+        // One more should fail
+        val result = manager.inviteMember(household.id, "overflow@test.com", HouseholdRole.MEMBER)
+        assertIs<InviteResult.HouseholdFull>(result)
+    }
+
+    // -- acceptInvite --
+
+    @Test
+    fun acceptInvite_validCode_addsMember() = runTest {
+        val household = manager.createHousehold("Family", TestFixtures.nextId())
+        val invite = manager.inviteMember(household.id, "new@test.com", HouseholdRole.PARTNER)
+        assertIs<InviteResult.Success>(invite)
+
+        val userId = TestFixtures.nextId()
+        val result = manager.acceptInvite(invite.code, userId)
+
+        assertTrue(result.isSuccess)
+        val member = result.getOrThrow()
+        assertEquals(HouseholdRole.PARTNER, member.role)
+        assertEquals(userId, member.userId)
+        assertEquals(household.id, member.householdId)
+    }
+
+    @Test
+    fun acceptInvite_invalidCode_returnsFailure() = runTest {
+        val result = manager.acceptInvite("bogus-code", TestFixtures.nextId())
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun acceptInvite_codeCannotBeReusedTwice() = runTest {
+        val household = manager.createHousehold("Family", TestFixtures.nextId())
+        val invite = manager.inviteMember(household.id, "new@test.com", HouseholdRole.MEMBER)
+        assertIs<InviteResult.Success>(invite)
+
+        // First use succeeds
+        val first = manager.acceptInvite(invite.code, TestFixtures.nextId())
+        assertTrue(first.isSuccess)
+
+        // Second use fails
+        val second = manager.acceptInvite(invite.code, TestFixtures.nextId())
+        assertTrue(second.isFailure)
+    }
+
+    // -- removeMember --
+
+    @Test
+    fun removeMember_removesMemberFromHousehold() = runTest {
+        val household = manager.createHousehold("Family", TestFixtures.nextId())
+        val invite = manager.inviteMember(household.id, "doomed@test.com", HouseholdRole.MEMBER)
+        assertIs<InviteResult.Success>(invite)
+
+        val memberId = TestFixtures.nextId()
+        val result = manager.acceptInvite(invite.code, memberId)
+        assertTrue(result.isSuccess)
+        val member = result.getOrThrow()
+
+        assertEquals(2, manager.membersOf(household.id).size)
+
+        manager.removeMember(household.id, member.id)
+
+        assertEquals(1, manager.membersOf(household.id).size)
+    }
+
+    @Test
+    fun removeMember_ownerCannotBeRemoved() = runTest {
+        val ownerId = TestFixtures.nextId()
+        val household = manager.createHousehold("Family", ownerId)
+        val ownerMember = manager.membersOf(household.id).first { it.role == HouseholdRole.OWNER }
+
+        assertFailsWith<IllegalStateException> {
+            manager.removeMember(household.id, ownerMember.id)
+        }
+    }
+
+    // -- updateRole --
+
+    @Test
+    fun updateRole_changeMemberRole() = runTest {
+        val household = manager.createHousehold("Family", TestFixtures.nextId())
+        val invite = manager.inviteMember(household.id, "member@test.com", HouseholdRole.MEMBER)
+        assertIs<InviteResult.Success>(invite)
+
+        val result = manager.acceptInvite(invite.code, TestFixtures.nextId())
+        assertTrue(result.isSuccess)
+        val member = result.getOrThrow()
+
+        assertEquals(HouseholdRole.MEMBER, member.role)
+
+        manager.updateRole(household.id, member.id, HouseholdRole.PARTNER)
+
+        val updated = manager.membersOf(household.id).first { it.id == member.id }
+        assertEquals(HouseholdRole.PARTNER, updated.role)
+    }
+
+    @Test
+    fun updateRole_cannotDemoteOnlyOwner() = runTest {
+        val ownerId = TestFixtures.nextId()
+        val household = manager.createHousehold("Family", ownerId)
+        val ownerMember = manager.membersOf(household.id).first { it.role == HouseholdRole.OWNER }
+
+        assertFailsWith<IllegalStateException> {
+            manager.updateRole(household.id, ownerMember.id, HouseholdRole.MEMBER)
+        }
+    }
+}
+
+// -- In-memory fake implementing HouseholdManager for test purposes --
+
+/**
+ * Minimal in-memory implementation of [HouseholdManager] used only in tests.
+ * Keeps all state in-memory maps — no persistence, no I/O.
+ */
+internal class FakeHouseholdManager : HouseholdManager {
+
+    companion object {
+        const val MAX_MEMBERS = 6
+    }
+
+    private var idCounter = 1000
+
+    private val households = mutableMapOf<SyncId, Household>()
+    private val members = mutableMapOf<SyncId, MutableList<HouseholdMember>>()
+    private val userEmails = mutableMapOf<SyncId, String>()
+
+    /** Pending invites: code -> (householdId, email, role) */
+    private data class PendingInvite(
+        val householdId: SyncId,
+        val email: String,
+        val role: HouseholdRole,
+    )
+
+    private val pendingInvites = mutableMapOf<String, PendingInvite>()
+
+    private fun nextId(): SyncId = SyncId("fake-${++idCounter}")
+    private fun now(): Instant = Clock.System.now()
+
+    /** Expose members for test assertions. */
+    fun membersOf(householdId: SyncId): List<HouseholdMember> =
+        members[householdId].orEmpty()
+
+    /** Associate a userId with an email for duplicate-member detection. */
+    fun setUserEmail(userId: SyncId, email: String) {
+        userEmails[userId] = email
+    }
+
+    override suspend fun createHousehold(name: String, ownerId: SyncId): Household {
+        val id = nextId()
+        val timestamp = now()
+        val household = Household(
+            id = id,
+            name = name,
+            ownerId = ownerId,
+            createdAt = timestamp,
+            updatedAt = timestamp,
+        )
+        households[id] = household
+
+        val ownerMember = HouseholdMember(
+            id = nextId(),
+            householdId = id,
+            userId = ownerId,
+            role = HouseholdRole.OWNER,
+            joinedAt = timestamp,
+            createdAt = timestamp,
+            updatedAt = timestamp,
+        )
+        members[id] = mutableListOf(ownerMember)
+        return household
+    }
+
+    override suspend fun inviteMember(
+        householdId: SyncId,
+        email: String,
+        role: HouseholdRole,
+    ): InviteResult {
+        // Basic email validation
+        if (!email.contains("@") || !email.contains(".")) {
+            return InviteResult.InvalidEmail
+        }
+
+        val currentMembers = members[householdId] ?: return InviteResult.InvalidEmail
+
+        // Check if email already belongs to an existing member
+        val memberUserIds = currentMembers.map { it.userId }.toSet()
+        val emailAlreadyMember = memberUserIds.any { uid -> userEmails[uid] == email }
+        if (emailAlreadyMember) {
+            return InviteResult.AlreadyMember
+        }
+
+        // Check capacity
+        if (currentMembers.size >= MAX_MEMBERS) {
+            return InviteResult.HouseholdFull
+        }
+
+        val code = "invite-${++idCounter}"
+        pendingInvites[code] = PendingInvite(householdId, email, role)
+        return InviteResult.Success(code)
+    }
+
+    override suspend fun acceptInvite(inviteCode: String, userId: SyncId): Result<HouseholdMember> {
+        val invite = pendingInvites.remove(inviteCode)
+            ?: return Result.failure(IllegalArgumentException("Invalid or expired invite code"))
+
+        val timestamp = now()
+        val member = HouseholdMember(
+            id = nextId(),
+            householdId = invite.householdId,
+            userId = userId,
+            role = invite.role,
+            joinedAt = timestamp,
+            createdAt = timestamp,
+            updatedAt = timestamp,
+        )
+        members.getOrPut(invite.householdId) { mutableListOf() }.add(member)
+        return Result.success(member)
+    }
+
+    override suspend fun removeMember(householdId: SyncId, memberId: SyncId) {
+        val memberList = members[householdId]
+            ?: error("Household not found: ${householdId.value}")
+
+        val target = memberList.firstOrNull { it.id == memberId }
+            ?: error("Member not found: ${memberId.value}")
+
+        if (target.role == HouseholdRole.OWNER) {
+            error("Cannot remove the owner from the household")
+        }
+
+        memberList.removeAll { it.id == memberId }
+    }
+
+    override suspend fun updateRole(householdId: SyncId, memberId: SyncId, role: HouseholdRole) {
+        val memberList = members[householdId]
+            ?: error("Household not found: ${householdId.value}")
+
+        val index = memberList.indexOfFirst { it.id == memberId }
+        if (index == -1) error("Member not found: ${memberId.value}")
+
+        val target = memberList[index]
+
+        // Cannot demote the sole owner
+        if (target.role == HouseholdRole.OWNER && role != HouseholdRole.OWNER) {
+            val ownerCount = memberList.count { it.role == HouseholdRole.OWNER }
+            if (ownerCount <= 1) {
+                error("Cannot demote the only owner of the household")
+            }
+        }
+
+        memberList[index] = target.copy(role = role, updatedAt = now())
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/household/RbacPermissionsTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/household/RbacPermissionsTest.kt
@@ -1,0 +1,210 @@
+package com.finance.core.household
+
+import com.finance.models.HouseholdRole
+import kotlin.test.*
+
+/**
+ * Verifies the RBAC permission matrix for every [HouseholdRole].
+ * Each test makes assertions against both the convenience functions
+ * and the underlying [RbacPermissions.permissionMatrix] data structure.
+ */
+class RbacPermissionsTest {
+
+    // Owner -- full access
+
+    @Test
+    fun owner_canViewTransactions() {
+        assertTrue(RbacPermissions.canViewTransactions(HouseholdRole.OWNER))
+    }
+
+    @Test
+    fun owner_canCreateTransactions() {
+        assertTrue(RbacPermissions.canCreateTransactions(HouseholdRole.OWNER))
+    }
+
+    @Test
+    fun owner_canEditBudgets() {
+        assertTrue(RbacPermissions.canEditBudgets(HouseholdRole.OWNER))
+    }
+
+    @Test
+    fun owner_canManageMembers() {
+        assertTrue(RbacPermissions.canManageMembers(HouseholdRole.OWNER))
+    }
+
+    @Test
+    fun owner_canDeleteHousehold() {
+        assertTrue(RbacPermissions.canDeleteHousehold(HouseholdRole.OWNER))
+    }
+
+    // Partner -- finances yes, admin no
+
+    @Test
+    fun partner_canViewTransactions() {
+        assertTrue(RbacPermissions.canViewTransactions(HouseholdRole.PARTNER))
+    }
+
+    @Test
+    fun partner_canCreateTransactions() {
+        assertTrue(RbacPermissions.canCreateTransactions(HouseholdRole.PARTNER))
+    }
+
+    @Test
+    fun partner_canEditBudgets() {
+        assertTrue(RbacPermissions.canEditBudgets(HouseholdRole.PARTNER))
+    }
+
+    @Test
+    fun partner_cannotManageMembers() {
+        assertFalse(RbacPermissions.canManageMembers(HouseholdRole.PARTNER))
+    }
+
+    @Test
+    fun partner_cannotDeleteHousehold() {
+        assertFalse(RbacPermissions.canDeleteHousehold(HouseholdRole.PARTNER))
+    }
+
+    // Member -- create and view, but not edit budgets or admin
+
+    @Test
+    fun member_canViewTransactions() {
+        assertTrue(RbacPermissions.canViewTransactions(HouseholdRole.MEMBER))
+    }
+
+    @Test
+    fun member_canCreateTransactions() {
+        assertTrue(RbacPermissions.canCreateTransactions(HouseholdRole.MEMBER))
+    }
+
+    @Test
+    fun member_cannotEditBudgets() {
+        assertFalse(RbacPermissions.canEditBudgets(HouseholdRole.MEMBER))
+    }
+
+    @Test
+    fun member_cannotManageMembers() {
+        assertFalse(RbacPermissions.canManageMembers(HouseholdRole.MEMBER))
+    }
+
+    @Test
+    fun member_cannotDeleteHousehold() {
+        assertFalse(RbacPermissions.canDeleteHousehold(HouseholdRole.MEMBER))
+    }
+
+    // Viewer -- read-only
+
+    @Test
+    fun viewer_canViewTransactions() {
+        assertTrue(RbacPermissions.canViewTransactions(HouseholdRole.VIEWER))
+    }
+
+    @Test
+    fun viewer_cannotCreateTransactions() {
+        assertFalse(RbacPermissions.canCreateTransactions(HouseholdRole.VIEWER))
+    }
+
+    @Test
+    fun viewer_cannotEditBudgets() {
+        assertFalse(RbacPermissions.canEditBudgets(HouseholdRole.VIEWER))
+    }
+
+    @Test
+    fun viewer_cannotManageMembers() {
+        assertFalse(RbacPermissions.canManageMembers(HouseholdRole.VIEWER))
+    }
+
+    @Test
+    fun viewer_cannotDeleteHousehold() {
+        assertFalse(RbacPermissions.canDeleteHousehold(HouseholdRole.VIEWER))
+    }
+
+    // Matrix structural integrity
+
+    @Test
+    fun permissionMatrix_coversAllRoles() {
+        val matrixRoles = RbacPermissions.permissionMatrix.keys
+        HouseholdRole.entries.forEach { role ->
+            assertTrue(
+                role in matrixRoles,
+                "permissionMatrix is missing role: $role",
+            )
+        }
+    }
+
+    @Test
+    fun permissionsFor_returnsMatchingPermissionSet() {
+        val ownerPerms = RbacPermissions.permissionsFor(HouseholdRole.OWNER)
+        assertTrue(ownerPerms.viewTransactions)
+        assertTrue(ownerPerms.createTransactions)
+        assertTrue(ownerPerms.editBudgets)
+        assertTrue(ownerPerms.manageMembers)
+        assertTrue(ownerPerms.deleteHousehold)
+    }
+
+    @Test
+    fun permissionMatrix_hasExactlyFourEntries() {
+        assertEquals(
+            HouseholdRole.entries.size,
+            RbacPermissions.permissionMatrix.size,
+            "permissionMatrix should have exactly one entry per HouseholdRole",
+        )
+    }
+
+    // Role hierarchy -- permissions are strictly decreasing
+
+    @Test
+    fun permissions_decreaseFromOwnerToViewer() {
+        fun permCount(role: HouseholdRole): Int {
+            val p = RbacPermissions.permissionsFor(role)
+            return listOf(
+                p.viewTransactions,
+                p.createTransactions,
+                p.editBudgets,
+                p.manageMembers,
+                p.deleteHousehold,
+            ).count { it }
+        }
+
+        assertTrue(permCount(HouseholdRole.OWNER) >= permCount(HouseholdRole.PARTNER))
+        assertTrue(permCount(HouseholdRole.PARTNER) >= permCount(HouseholdRole.MEMBER))
+        assertTrue(permCount(HouseholdRole.MEMBER) >= permCount(HouseholdRole.VIEWER))
+    }
+
+    @Test
+    fun allRoles_canViewTransactions() {
+        HouseholdRole.entries.forEach { role ->
+            assertTrue(
+                RbacPermissions.canViewTransactions(role),
+                "$role should be able to view transactions",
+            )
+        }
+    }
+
+    @Test
+    fun onlyOwner_canDeleteHousehold() {
+        HouseholdRole.entries.forEach { role ->
+            if (role == HouseholdRole.OWNER) {
+                assertTrue(RbacPermissions.canDeleteHousehold(role))
+            } else {
+                assertFalse(
+                    RbacPermissions.canDeleteHousehold(role),
+                    "$role should NOT be able to delete household",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun onlyOwner_canManageMembers() {
+        HouseholdRole.entries.forEach { role ->
+            if (role == HouseholdRole.OWNER) {
+                assertTrue(RbacPermissions.canManageMembers(role))
+            } else {
+                assertFalse(
+                    RbacPermissions.canManageMembers(role),
+                    "$role should NOT be able to manage members",
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Household Sharing & RBAC Permissions

### Summary
Adds the core household sharing infrastructure and role-based access control (RBAC) system to `packages/core` commonMain. This enables multi-user household management with proper permission enforcement across all platforms.

### Changes

#### Source (`packages/core/src/commonMain/kotlin/com/finance/core/household/`)

- **`HouseholdManager.kt`** — Interface defining household lifecycle operations:
  - `createHousehold(name, ownerId)` — creates household + owner member
  - `inviteMember(householdId, email, role)` — generates single-use invite codes
  - `acceptInvite(inviteCode, userId)` — redeems invite, returns `Result<HouseholdMember>`
  - `removeMember(householdId, memberId)` — removes non-owner members
  - `updateRole(householdId, memberId, role)` — changes member roles with owner protection

- **`HouseholdRole.kt`** — Typealias re-exporting `com.finance.models.HouseholdRole` (OWNER, PARTNER, MEMBER, VIEWER) for package-local convenience

- **`InviteResult.kt`** — Sealed class for invite outcomes:
  - `Success(code)` — invite created with single-use code
  - `AlreadyMember` — email already in household
  - `HouseholdFull` — max member count reached
  - `InvalidEmail` — email validation failed

- **`RbacPermissions.kt`** — Permission enforcement object with:
  - `PermissionSet` data class (viewTransactions, createTransactions, editBudgets, manageMembers, deleteHousehold)
  - `permissionMatrix: Map<HouseholdRole, PermissionSet>` — single source of truth
  - Convenience query functions: `canViewTransactions()`, `canCreateTransactions()`, etc.

#### Tests (`packages/core/src/commonTest/kotlin/com/finance/core/household/`)

- **`RbacPermissionsTest.kt`** — 27 tests:
  - Per-role permission checks (Owner=5/5, Partner=3/5, Member=3/5, Viewer=1/5)
  - Matrix structural integrity (covers all roles, correct count)
  - Role hierarchy validation (permissions strictly decrease Owner→Viewer)

- **`HouseholdManagerTest.kt`** — 12 tests with `FakeHouseholdManager`:
  - Create household with auto-owner membership
  - Invite flows (success, invalid email, already member, household full)
  - Accept invite (valid code, invalid code, single-use enforcement)
  - Remove member (success, owner protection)
  - Update role (success, sole-owner demotion protection)

### Permission Matrix

| Permission | OWNER | PARTNER | MEMBER | VIEWER |
|---|---|---|---|---|
| viewTransactions | ✅ | ✅ | ✅ | ✅ |
| createTransactions | ✅ | ✅ | ✅ | ❌ |
| editBudgets | ✅ | ✅ | ❌ | ❌ |
| manageMembers | ✅ | ❌ | ❌ | ❌ |
| deleteHousehold | ✅ | ❌ | ❌ | ❌ |

### Design Decisions
- **No duplicate enum**: `HouseholdRole` already exists in `packages/models`, so core re-exports it via typealias
- **Interface, not implementation**: `HouseholdManager` is an interface — concrete implementations will live in platform modules with actual persistence
- **RBAC decoupled from manager**: Permission checks are in `RbacPermissions` (pure functions), not baked into `HouseholdManager`, for flexibility
- **Sealed class for InviteResult**: Enables exhaustive `when` handling at call sites
- **Result type for acceptInvite**: Uses Kotlin `Result` instead of exceptions for expected failure cases

Closes #232
Closes #233
