### PR TITLE
fix(sync): inject controllable clock into sync test harness

### DIFF
--- a/packages/sync/src/commonTest/kotlin/com/finance/sync/integration/SyncIntegrationTestHarness.kt
+++ b/packages/sync/src/commonTest/kotlin/com/finance/sync/integration/SyncIntegrationTestHarness.kt
@@ -20,15 +20,15 @@ import kotlinx.datetime.Instant
  * - A [SyncClient] that reads/writes to the local DB and communicates with the
  *   shared [MockSyncServer].
  */
-class SyncIntegrationTestHarness {
+class SyncIntegrationTestHarness(clock: Clock = Clock.System) {
 
     val server = MockSyncServer()
 
     val networkA = NetworkSimulator()
     val networkB = NetworkSimulator()
 
-    val deviceA = SyncClient(clientId = "device-a", database = InMemoryDatabase(), network = networkA, server = server)
-    val deviceB = SyncClient(clientId = "device-b", database = InMemoryDatabase(), network = networkB, server = server)
+    val deviceA = SyncClient(clientId = "device-a", database = InMemoryDatabase(clock), network = networkA, server = server, clock = clock)
+    val deviceB = SyncClient(clientId = "device-b", database = InMemoryDatabase(clock), network = networkB, server = server, clock = clock)
 
     /** Reset all components to a clean state. */
     suspend fun reset() {
@@ -49,7 +49,7 @@ class SyncIntegrationTestHarness {
  * so that these integration tests run on all KMP targets without native
  * database dependencies.
  */
-class InMemoryDatabase {
+class InMemoryDatabase(private val clock: Clock = Clock.System) {
 
     private val mutex = Mutex()
 
@@ -86,7 +86,7 @@ class InMemoryDatabase {
         if (existing != null) {
             store[key(entityType, entityId)] = existing.copy(
                 isDeleted = true,
-                updatedAt = Clock.System.now(),
+                updatedAt = clock.now(),
             )
         }
     }
@@ -115,6 +115,7 @@ class SyncClient(
     val database: InMemoryDatabase,
     private val network: NetworkSimulator,
     private val server: MockSyncServer,
+    private val clock: Clock = Clock.System,
 ) {
     private val mutex = Mutex()
 
@@ -141,7 +142,7 @@ class SyncClient(
         payload: String,
         operation: MutationOperation = MutationOperation.INSERT,
     ) {
-        val now = Clock.System.now()
+        val now = clock.now()
 
         database.upsert(
             InMemoryDatabase.EntityRecord(
@@ -168,7 +169,7 @@ class SyncClient(
      * Soft-delete an entity locally and queue the delete mutation.
      */
     suspend fun softDelete(entityType: String, entityId: String) {
-        val now = Clock.System.now()
+        val now = clock.now()
         database.delete(entityType, entityId)
 
         val mutation = SyncMutation(

--- a/packages/sync/src/commonTest/kotlin/com/finance/sync/integration/SyncScenarioTest.kt
+++ b/packages/sync/src/commonTest/kotlin/com/finance/sync/integration/SyncScenarioTest.kt
@@ -77,30 +77,31 @@ class SyncScenarioTest {
     }
 
     // ── Concurrent edits (LWW) ──────────────────────────────────
-    // Note: This test uses Clock.System.now() for LWW ordering and requires
-    // multi-millisecond resolution. Skipped on JS browser where timing can be
-    // unreliable in the single-threaded event loop.
 
     @Test
     fun test_concurrent_edits_resolve_with_lww() = runTest {
+        // Use a controllable clock so LWW ordering is deterministic
+        // and does not depend on wall-clock resolution (fixes ChromeHeadless flakes).
+        val testClock = TestClock()
+        val lwwHarness = SyncIntegrationTestHarness(clock = testClock)
+
         // Both devices go offline
-        harness.networkA.goOffline()
-        harness.networkB.goOffline()
+        lwwHarness.networkA.goOffline()
+        lwwHarness.networkB.goOffline()
 
         // Device A edits the transaction first (earlier timestamp)
-        harness.deviceA.put(
+        lwwHarness.deviceA.put(
             entityType = "transaction",
             entityId = "txn-conflict",
             payload = """{"amount":1000,"payee":"Device A Edit"}""",
             operation = MutationOperation.UPDATE,
         )
 
-        // Small delay to ensure Device B's timestamp is strictly later
-        // (Clock.System.now() has at least millisecond resolution)
-        kotlinx.coroutines.delay(50)
+        // Advance the test clock by 1 second to guarantee LWW ordering.
+        testClock.advanceBy(1000)
 
         // Device B edits the same transaction (later timestamp → wins LWW)
-        harness.deviceB.put(
+        lwwHarness.deviceB.put(
             entityType = "transaction",
             entityId = "txn-conflict",
             payload = """{"amount":2000,"payee":"Device B Edit"}""",
@@ -108,17 +109,17 @@ class SyncScenarioTest {
         )
 
         // Both come online and push
-        harness.networkA.goOnline()
-        harness.networkB.goOnline()
+        lwwHarness.networkA.goOnline()
+        lwwHarness.networkB.goOnline()
 
-        harness.deviceA.pushPendingMutations()
-        harness.deviceB.pushPendingMutations()
+        lwwHarness.deviceA.pushPendingMutations()
+        lwwHarness.deviceB.pushPendingMutations()
 
         // Device A pulls — should get Device B's version (later timestamp)
-        val appliedOnA = harness.deviceA.pullRemoteChanges()
+        val appliedOnA = lwwHarness.deviceA.pullRemoteChanges()
         assertEquals(1, appliedOnA.size, "Device A should receive Device B's mutation")
 
-        val recordOnA = harness.deviceA.database.get("transaction", "txn-conflict")
+        val recordOnA = lwwHarness.deviceA.database.get("transaction", "txn-conflict")
         assertNotNull(recordOnA)
         assertTrue(
             recordOnA.payload.contains("Device B Edit"),
@@ -126,10 +127,10 @@ class SyncScenarioTest {
         )
 
         // Device B pulls — Device A's mutation should NOT overwrite (older timestamp)
-        val appliedOnB = harness.deviceB.pullRemoteChanges()
+        val appliedOnB = lwwHarness.deviceB.pullRemoteChanges()
         assertEquals(0, appliedOnB.size, "Device B should ignore Device A's older mutation")
 
-        val recordOnB = harness.deviceB.database.get("transaction", "txn-conflict")
+        val recordOnB = lwwHarness.deviceB.database.get("transaction", "txn-conflict")
         assertNotNull(recordOnB)
         assertTrue(
             recordOnB.payload.contains("Device B Edit"),
@@ -141,28 +142,36 @@ class SyncScenarioTest {
 
     @Test
     fun test_delete_syncs_as_soft_delete() = runTest {
+        // Use a controllable clock so the delete timestamp is guaranteed
+        // to be strictly later than the insert (fixes potential ChromeHeadless flakes).
+        val testClock = TestClock()
+        val deleteHarness = SyncIntegrationTestHarness(clock = testClock)
+
         // Device A creates a transaction
-        harness.deviceA.put(
+        deleteHarness.deviceA.put(
             entityType = "transaction",
             entityId = "txn-delete",
             payload = """{"amount":500,"payee":"To Be Deleted"}""",
         )
 
         // Device B receives it
-        harness.deviceB.pullRemoteChanges()
-        val beforeDelete = harness.deviceB.database.get("transaction", "txn-delete")
+        deleteHarness.deviceB.pullRemoteChanges()
+        val beforeDelete = deleteHarness.deviceB.database.get("transaction", "txn-delete")
         assertNotNull(beforeDelete, "Device B should have the transaction")
 
+        // Advance clock so the soft-delete timestamp is strictly later than the insert
+        testClock.advanceBy(1000)
+
         // Device A soft-deletes
-        harness.deviceA.softDelete("transaction", "txn-delete")
+        deleteHarness.deviceA.softDelete("transaction", "txn-delete")
 
         // Device B pulls the delete
-        val applied = harness.deviceB.pullRemoteChanges()
+        val applied = deleteHarness.deviceB.pullRemoteChanges()
         assertEquals(1, applied.size, "Device B should receive the delete mutation")
         assertEquals(MutationOperation.DELETE, applied.first().operation)
 
         // Verify soft-delete on Device B
-        val afterDelete = harness.deviceB.database.get("transaction", "txn-delete")
+        val afterDelete = deleteHarness.deviceB.database.get("transaction", "txn-delete")
         assertNotNull(afterDelete, "Record should still exist (soft delete)")
         assertTrue(afterDelete.isDeleted, "Record should be marked as deleted")
     }

--- a/packages/sync/src/commonTest/kotlin/com/finance/sync/integration/TestClock.kt
+++ b/packages/sync/src/commonTest/kotlin/com/finance/sync/integration/TestClock.kt
@@ -1,0 +1,35 @@
+package com.finance.sync.integration
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * A controllable [Clock] for deterministic testing.
+ *
+ * Starts at a fixed epoch instant and only advances when [advanceBy] is
+ * called explicitly, removing all dependency on real wall-clock timing
+ * and eliminating flaky assertions in CI environments (e.g. ChromeHeadless)
+ * where system-clock resolution may be insufficient.
+ */
+class TestClock(
+    startInstant: Instant = Instant.fromEpochMilliseconds(1_700_000_000_000L),
+) : Clock {
+
+    private var _now: Instant = startInstant
+
+    override fun now(): Instant = _now
+
+    /** Advance the clock by [millis] milliseconds. */
+    fun advanceBy(millis: Long) {
+        require(millis >= 0) { "Cannot advance clock by negative millis: $millis" }
+        _now = _now + millis.milliseconds
+    }
+
+    /** Advance the clock by [duration]. */
+    fun advanceBy(duration: Duration) {
+        require(!duration.isNegative()) { "Cannot advance clock by negative duration: $duration" }
+        _now = _now + duration
+    }
+}


### PR DESCRIPTION
## Summary

Fix Phase 2 sync tests that use timing-sensitive assertions.

### Problem

SyncScenarioTest.test_concurrent_edits_resolve_with_lww relies on Clock.System.now() with a delay(50) to create earlier vs later timestamps. In ChromeHeadless, system-clock resolution is insufficient, causing flaky test failures.

	est_delete_syncs_as_soft_delete has a similar implicit dependency on wall-clock advancement between put() and softDelete().

### Fix

1. **Created TestClock** — a controllable kotlinx.datetime.Clock implementation with dvanceBy(millis) method. Starts at a fixed epoch instant and only advances when explicitly told to.

2. **Injected Clock into the test infrastructure:**
   - SyncIntegrationTestHarness(clock: Clock = Clock.System) — passes clock to all components
   - SyncClient(clock: Clock) — uses injected clock in put() and softDelete()
   - InMemoryDatabase(clock: Clock) — uses injected clock in delete()

3. **Updated timing-sensitive tests:**
   - 	est_concurrent_edits_resolve_with_lww: replaced delay(50) with 	estClock.advanceBy(1000) for deterministic LWW ordering
   - 	est_delete_syncs_as_soft_delete: added 	estClock.advanceBy(1000) before soft-delete to guarantee timestamp ordering

4. **Non-timing tests unchanged** — 	est_online_sync_propagates_changes, 	est_offline_queue_replays_on_reconnect, and 	est_sequence_gap_triggers_resync continue using Clock.System via the default harness.

Closes #173