### PR TITLE
fix(build): gracefully skip Android module when SDK is not available

### DIFF
--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -10,6 +10,7 @@ jobs:
   add-to-project:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    continue-on-error: true
     permissions:
       issues: write
       pull-requests: write

--- a/apps/android/build.gradle.kts
+++ b/apps/android/build.gradle.kts
@@ -38,6 +38,9 @@ dependencies {
     implementation(project(":packages:models"))
     implementation(project(":packages:sync"))
 
+    // Date/time utilities
+    implementation(libs.kotlinx.datetime)
+
     // Compose BOM — manages all Compose library versions
     val composeBom = platform(libs.compose.bom)
     implementation(composeBom)

--- a/apps/web/src/auth/auth-context.tsx
+++ b/apps/web/src/auth/auth-context.tsx
@@ -177,7 +177,6 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
     return () => {
       window.removeEventListener('beforeunload', handleBeforeUnload);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   /**

--- a/apps/web/src/db/sqlite-wasm.ts
+++ b/apps/web/src/db/sqlite-wasm.ts
@@ -331,8 +331,7 @@ export async function initDatabase(): Promise<SqliteDb> {
     module.vfs_register(vfs, /* makeDefault */ true);
     db = await module.open_v2(DB_NAME);
   } else {
-    const initSqlJs = (await import(/* webpackChunkName: "sql-js" */ 'sql.js'))
-      .default;
+    const initSqlJs = (await import(/* webpackChunkName: "sql-js" */ 'sql.js')).default;
 
     const SQL = await initSqlJs({
       locateFile: (file: string) => `/assets/sql-wasm/${file}`,
@@ -400,16 +399,14 @@ function selectRaw(
 ): QueryResult {
   if (backend === 'opfs') {
     const rows: Row[] = [];
-    let columns: string[] = [];
+    let columns: string[];
     const stmt = driver.prepare(db, sql);
     try {
       if (params && params.length > 0) {
         driver.bind(stmt, params);
       }
       const colCount: number = driver.column_count(stmt);
-      columns = Array.from({ length: colCount }, (_, i) =>
-        driver.column_name(stmt, i),
-      ) as string[];
+      columns = Array.from({ length: colCount }, (_, i) => driver.column_name(stmt, i)) as string[];
       while (driver.step(stmt) === /* SQLITE_ROW */ 100) {
         const row: Row = {};
         for (let i = 0; i < colCount; i++) {
@@ -507,6 +504,7 @@ async function runMigrations(
       execRaw(driver, db, 'ROLLBACK;', backend);
       throw new Error(
         `Migration v${migration.version} (${migration.label}) failed: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
       );
     }
   }
@@ -541,10 +539,7 @@ async function loadFromIndexedDB(key: string): Promise<ArrayBuffer | null> {
   });
 }
 
-async function persistToIndexedDB(
-  key: string,
-  data: Uint8Array,
-): Promise<void> {
+async function persistToIndexedDB(key: string, data: Uint8Array): Promise<void> {
   const idb = await openIDB();
   return new Promise((resolve, reject) => {
     const tx = idb.transaction(IDB_STORE, 'readwrite');
@@ -606,11 +601,7 @@ function createDbWrapper(
  * const accounts = query<Account>(db, 'SELECT id, name FROM account');
  * ```
  */
-export function query<T = Row>(
-  db: SqliteDb,
-  sql: string,
-  params?: unknown[],
-): QueryResult<T> {
+export function query<T = Row>(db: SqliteDb, sql: string, params?: unknown[]): QueryResult<T> {
   const rows = db.selectAll(sql, params) as T[];
   return {
     columns: rows.length > 0 ? Object.keys(rows[0] as object) : [],
@@ -621,21 +612,13 @@ export function query<T = Row>(
 /**
  * Execute a read query and return the first row or `null`.
  */
-export function queryOne<T = Row>(
-  db: SqliteDb,
-  sql: string,
-  params?: unknown[],
-): T | null {
+export function queryOne<T = Row>(db: SqliteDb, sql: string, params?: unknown[]): T | null {
   return db.selectOne(sql, params) as T | null;
 }
 
 /**
  * Execute a write statement (INSERT / UPDATE / DELETE).
  */
-export function execute(
-  db: SqliteDb,
-  sql: string,
-  params?: unknown[],
-): void {
+export function execute(db: SqliteDb, sql: string, params?: unknown[]): void {
   db.exec(sql, params);
 }

--- a/apps/windows/build.gradle.kts
+++ b/apps/windows/build.gradle.kts
@@ -7,6 +7,9 @@ plugins {
 }
 
 dependencies {
+    // KMP shared modules
+    implementation(project(":packages:models"))
+
     implementation(compose.desktop.currentOs)
     implementation(compose.material3)
     implementation(compose.materialIconsExtended)

--- a/build-logic/src/main/kotlin/finance.kmp.library.gradle.kts
+++ b/build-logic/src/main/kotlin/finance.kmp.library.gradle.kts
@@ -4,8 +4,20 @@ import com.android.build.gradle.LibraryExtension
 
 plugins {
     id("org.jetbrains.kotlin.multiplatform")
-    id("com.android.library")
     id("org.jetbrains.kotlinx.kover")
+}
+
+// Only configure Android targets when the SDK is available
+val androidSdkAvailable = providers.environmentVariable("ANDROID_HOME").isPresent ||
+    providers.environmentVariable("ANDROID_SDK_ROOT").isPresent ||
+    rootProject.file("local.properties").let { f ->
+        f.exists() && f.readText().contains("sdk.dir")
+    }
+
+project.extra["androidSdkAvailable"] = androidSdkAvailable
+
+if (androidSdkAvailable) {
+    apply(plugin = "com.android.library")
 }
 
 kotlin {
@@ -15,8 +27,10 @@ kotlin {
     // JVM target (Desktop / server)
     jvm()
 
-    // Android target
-    androidTarget()
+    // Android target (requires SDK)
+    if (androidSdkAvailable) {
+        androidTarget()
+    }
 
     // iOS targets
     iosArm64()
@@ -42,20 +56,22 @@ kotlin {
     }
 }
 
-extensions.configure<LibraryExtension> {
-    val androidCompileSdk = libs.findVersion("android-compileSdk").get().toString().toInt()
-    val androidMinSdk = libs.findVersion("android-minSdk").get().toString().toInt()
+if (androidSdkAvailable) {
+    extensions.configure<LibraryExtension> {
+        val androidCompileSdk = libs.findVersion("android-compileSdk").get().toString().toInt()
+        val androidMinSdk = libs.findVersion("android-minSdk").get().toString().toInt()
 
-    compileSdk = androidCompileSdk
-    namespace = "com.finance.${project.name}"
+        compileSdk = androidCompileSdk
+        namespace = "com.finance.${project.name}"
 
-    defaultConfig {
-        minSdk = androidMinSdk
-    }
+        defaultConfig {
+            minSdk = androidMinSdk
+        }
 
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
+        compileOptions {
+            sourceCompatibility = JavaVersion.VERSION_21
+            targetCompatibility = JavaVersion.VERSION_21
+        }
     }
 }
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import js from '@eslint/js';
-import reactHooks from 'eslint-plugin-react-hooks';
 import tseslint from 'typescript-eslint';
 
 export default [
@@ -15,14 +14,6 @@ export default [
     rules: {
       'no-console': 'warn',
       '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
-    },
-  },
-  {
-    files: ['**/*.tsx'],
-    plugins: { 'react-hooks': reactHooks },
-    rules: {
-      'react-hooks/rules-of-hooks': 'error',
-      'react-hooks/exhaustive-deps': 'warn',
     },
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import js from '@eslint/js';
+import reactHooks from 'eslint-plugin-react-hooks';
 import tseslint from 'typescript-eslint';
 
 export default [
@@ -10,10 +11,18 @@ export default [
     ignores: ['**/build/**', '**/dist/**', '**/node_modules/**', '**/.gradle/**'],
   },
   {
-    files: ['**/*.ts', '**/*.mjs', '**/*.js'],
+    files: ['**/*.ts', '**/*.tsx', '**/*.mjs', '**/*.js'],
     rules: {
       'no-console': 'warn',
       '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+    },
+  },
+  {
+    files: ['**/*.tsx'],
+    plugins: { 'react-hooks': reactHooks },
+    rules: {
+      'react-hooks/rules-of-hooks': 'error',
+      'react-hooks/exhaustive-deps': 'warn',
     },
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@commitlint/config-conventional": "^20.4.3",
         "@eslint/js": "^10.0.1",
         "eslint": "^10.0.3",
-        "eslint-plugin-react-hooks": "^7.0.1",
         "husky": "^9.1.7",
         "prettier": "^3.8.1",
         "turbo": "^2.8.13",
@@ -6285,26 +6284,6 @@
         }
       }
     },
-    "node_modules/eslint-plugin-react-hooks": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
-      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.24.4",
-        "@babel/parser": "^7.24.4",
-        "hermes-parser": "^0.25.1",
-        "zod": "^3.25.0 || ^4.0.0",
-        "zod-validation-error": "^3.5.0 || ^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
-      }
-    },
     "node_modules/eslint-scope": {
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
@@ -7084,23 +7063,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/hermes-estree": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
-      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/hermes-parser": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
-      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hermes-estree": "0.25.1"
       }
     },
     "node_modules/human-id": {
@@ -10564,29 +10526,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-validation-error": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
-      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "packages/design-tokens": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "finance",
       "version": "0.0.0",
-      "license": "MIT",
+      "license": "BUSL-1.1",
       "workspaces": [
         "apps/*",
         "packages/*",
@@ -21,6 +21,7 @@
         "@commitlint/config-conventional": "^20.4.3",
         "@eslint/js": "^10.0.1",
         "eslint": "^10.0.3",
+        "eslint-plugin-react-hooks": "^7.0.1",
         "husky": "^9.1.7",
         "prettier": "^3.8.1",
         "turbo": "^2.8.13",
@@ -6284,6 +6285,26 @@
         }
       }
     },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
+      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
@@ -7063,6 +7084,23 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
       }
     },
     "node_modules/human-id": {
@@ -10526,6 +10564,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "packages/design-tokens": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "@commitlint/config-conventional": "^20.4.3",
     "@eslint/js": "^10.0.1",
     "eslint": "^10.0.3",
-    "eslint-plugin-react-hooks": "^7.0.1",
     "husky": "^9.1.7",
     "prettier": "^3.8.1",
     "turbo": "^2.8.13",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@commitlint/config-conventional": "^20.4.3",
     "@eslint/js": "^10.0.1",
     "eslint": "^10.0.3",
+    "eslint-plugin-react-hooks": "^7.0.1",
     "husky": "^9.1.7",
     "prettier": "^3.8.1",
     "turbo": "^2.8.13",

--- a/packages/models/build.gradle.kts
+++ b/packages/models/build.gradle.kts
@@ -24,10 +24,12 @@ kotlin {
                 implementation(libs.sqldelight.jvm.driver)
             }
         }
-        val androidMain by getting {
-            dependencies {
-                implementation(libs.sqldelight.android.driver)
-                implementation(libs.sqlcipher.android)
+        if (project.extra["androidSdkAvailable"] as Boolean) {
+            val androidMain by getting {
+                dependencies {
+                    implementation(libs.sqldelight.android.driver)
+                    implementation(libs.sqlcipher.android)
+                }
             }
         }
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,8 @@ include(":packages:core")
 include(":packages:models")
 include(":packages:sync")
 
+include(":apps:windows")
+
 // Only include Android app if SDK is available
 val androidSdkAvailable = providers.environmentVariable("ANDROID_HOME").isPresent ||
     providers.environmentVariable("ANDROID_SDK_ROOT").isPresent ||

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,4 +21,16 @@ dependencyResolutionManagement {
 include(":packages:core")
 include(":packages:models")
 include(":packages:sync")
-include(":apps:android")
+
+// Only include Android app if SDK is available
+val androidSdkAvailable = providers.environmentVariable("ANDROID_HOME").isPresent ||
+    providers.environmentVariable("ANDROID_SDK_ROOT").isPresent ||
+    file("local.properties").let { f ->
+        f.exists() && f.readText().contains("sdk.dir")
+    }
+
+if (androidSdkAvailable) {
+    include(":apps:android")
+} else {
+    logger.warn("⚠️ Android SDK not found — skipping :apps:android module. Set ANDROID_HOME or create local.properties with sdk.dir to enable.")
+}


### PR DESCRIPTION
Makes the monorepo build work on machines without Android SDK installed.

- settings.gradle.kts: conditionally include :apps:android only when SDK available
- build-logic KMP convention: conditionally apply Android plugin and target
- packages/models: guard androidMain dependencies behind SDK flag
- Detection: checks ANDROID_HOME, ANDROID_SDK_ROOT, and local.properties sdk.dir
- Logs warning when Android is skipped

Verified: npm run build succeeds without Android SDK