### PR TITLE
feat(android): initialize Koin DI, Timber logging, and crash reporting (#291)

### DIFF
--- a/apps/android/build.gradle.kts
+++ b/apps/android/build.gradle.kts
@@ -60,6 +60,13 @@ dependencies {
     // AndroidX Core
     implementation(libs.core.ktx)
 
+    // DI — Koin
+    implementation(libs.koin.android)
+    implementation(libs.koin.compose.viewmodel)
+
+    // Logging
+    implementation(libs.timber)
+
     // Security & Biometric
     implementation(libs.biometric)
     implementation(libs.security.crypto)

--- a/apps/android/src/main/kotlin/com/finance/android/FinanceApplication.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/FinanceApplication.kt
@@ -3,17 +3,40 @@
 package com.finance.android
 
 import android.app.Application
+import com.finance.android.di.appModule
+import org.koin.android.ext.koin.androidContext
+import org.koin.android.ext.koin.androidLogger
+import org.koin.core.context.startKoin
+import org.koin.core.logger.Level
+import timber.log.Timber
 
 /**
  * Finance application entry point.
  *
- * Initializes application-level dependencies and configuration.
- * DI framework (e.g. Koin) can be set up here in a future iteration.
+ * Initializes Koin DI, Timber logging, and crash reporting
+ * before any Activity is created.
  */
 class FinanceApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
-        // TODO: Initialize DI (Koin), logging, crash reporting
+        initLogging()
+        initDependencyInjection()
+    }
+
+    private fun initLogging() {
+        if (BuildConfig.DEBUG) {
+            Timber.plant(Timber.DebugTree())
+        }
+        Timber.i("Finance app starting")
+    }
+
+    private fun initDependencyInjection() {
+        startKoin {
+            androidLogger(if (BuildConfig.DEBUG) Level.DEBUG else Level.NONE)
+            androidContext(this@FinanceApplication)
+            modules(appModule)
+        }
+        Timber.i("Koin DI initialized")
     }
 }

--- a/apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.di
+
+import com.finance.android.logging.TimberCrashReporter
+import com.finance.core.monitoring.CrashReporter
+import com.finance.core.monitoring.MetricsCollector
+import org.koin.dsl.module
+
+/**
+ * Root Koin module for the Finance Android app.
+ *
+ * Provides application-scoped singletons for monitoring, logging,
+ * and shared services consumed by ViewModels and UI layers.
+ */
+val appModule = module {
+
+    /** Crash reporting — backed by Timber for on-device logging. */
+    single<CrashReporter> {
+        TimberCrashReporter(consentProvider = { false })
+    }
+
+    /**
+     * Anonymous usage metrics — consent defaults to off.
+     * When consent UI is implemented, wire [consentProvider]
+     * to the user's preference in Settings.
+     */
+    single {
+        MetricsCollector(consentProvider = { false })
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/logging/TimberCrashReporter.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/logging/TimberCrashReporter.kt
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.logging
+
+import com.finance.core.monitoring.CrashReporter
+import timber.log.Timber
+
+/**
+ * [CrashReporter] implementation backed by Timber.
+ *
+ * Logs errors and breadcrumbs through Timber's structured logging.
+ * No crash reports are transmitted to external services — all data
+ * stays on-device. When a third-party crash service (e.g., Sentry)
+ * is integrated in a future iteration, this class should be updated
+ * to forward reports to that service.
+ *
+ * Consent is checked on every call; when disabled all methods are no-ops.
+ *
+ * @param consentProvider Returns true when the user has opted in to crash reporting.
+ */
+class TimberCrashReporter(
+    private val consentProvider: () -> Boolean,
+) : CrashReporter {
+
+    override fun reportError(exception: Throwable, context: Map<String, String>) {
+        if (!consentProvider()) return
+        if (context.isNotEmpty()) {
+            Timber.e(exception, "Crash context: %s", context)
+        } else {
+            Timber.e(exception)
+        }
+    }
+
+    override fun setUserId(id: String?) {
+        if (!consentProvider()) return
+        Timber.tag("CrashReporter").i("User ID set: %s", id ?: "<cleared>")
+    }
+
+    override fun log(message: String) {
+        if (!consentProvider()) return
+        Timber.tag("CrashReporter").d(message)
+    }
+
+    override fun isEnabled(): Boolean = consentProvider()
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/onboarding/OnboardingNavigation.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/onboarding/OnboardingNavigation.kt
@@ -2,20 +2,13 @@
 
 package com.finance.android.ui.onboarding
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.finance.android.FinanceApp
 
 /**
  * Navigation route constants for the onboarding / main-app boundary.
@@ -41,7 +34,7 @@ private object OnboardingRoutes {
  *
  * The navigation graph contains two destinations:
  * - **onboarding** — the multi-step [OnboardingScreen]
- * - **main** — placeholder for the real [FinanceNavHost] (to be wired up by the main-app module)
+ * - **main** — the full [FinanceApp] with bottom bar, FAB, and all screens
  *
  * After the user completes or skips onboarding the graph navigates to "main"
  * and removes the onboarding back-stack entry so pressing Back does not return
@@ -78,30 +71,7 @@ fun OnboardingNavigation() {
         }
 
         composable(OnboardingRoutes.MAIN_APP) {
-            // TODO: Replace with actual FinanceNavHost once the main app shell is built.
-            FinanceNavHostPlaceholder()
+            FinanceApp()
         }
-    }
-}
-
-/**
- * Temporary placeholder for the main application navigation host.
- *
- * Replace this with the real `FinanceNavHost` composable once the dashboard,
- * accounts, budgets, and settings screens are implemented.
- */
-@Composable
-private fun FinanceNavHostPlaceholder() {
-    Box(
-        contentAlignment = Alignment.Center,
-        modifier = Modifier.fillMaxSize(),
-    ) {
-        Text(
-            text = "Finance — Home",
-            style = MaterialTheme.typography.headlineMedium,
-            modifier = Modifier.semantics {
-                contentDescription = "Finance app home screen placeholder"
-            },
-        )
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ detekt = "1.23.7"
 sqlcipher-android = "4.6.1"
 ktor = "3.0.3"
 koin = "4.0.1"
+timber = "5.0.1"
 turbine = "1.2.0"
 kover = "0.9.1"
 compose-multiplatform = "1.7.3"
@@ -46,6 +47,9 @@ ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "kto
 ktor-client-js = { module = "io.ktor:ktor-client-js", version.ref = "ktor" }
 ktor-serialization-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
+koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
+koin-compose-viewmodel = { module = "io.insert-koin:koin-compose-viewmodel", version.ref = "koin" }
+timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 


### PR DESCRIPTION
Closes #291

## Summary
- Initialize Koin dependency injection and Timber-based crash reporting during Android app startup.
- Add the Android DI module and crash reporter integration used by the application layer.
- Update onboarding navigation wiring and Android dependency configuration to support the new setup.