### PR TITLE
feat(models): implement JS platform DatabaseFactory (#297)

### DIFF
--- a/packages/models/build.gradle.kts
+++ b/packages/models/build.gradle.kts
@@ -30,6 +30,13 @@ kotlin {
                 implementation(libs.sqlcipher.android)
             }
         }
+        val jsMain by getting {
+            dependencies {
+                implementation(libs.sqldelight.js.driver)
+                implementation(npm("@cashapp/sqldelight-sqljs-worker", "2.0.2"))
+                implementation(devNpm("copy-webpack-plugin", "9.1.0"))
+            }
+        }
     }
 }
 

--- a/packages/models/src/jsMain/kotlin/com/finance/db/DatabaseFactory.js.kt
+++ b/packages/models/src/jsMain/kotlin/com/finance/db/DatabaseFactory.js.kt
@@ -2,16 +2,37 @@
 
 package com.finance.db
 
+import app.cash.sqldelight.driver.worker.WebWorkerDriver
+import org.w3c.dom.Worker
+
 /**
- * JS/Web DatabaseFactory using SQLite-WASM with OPFS persistence.
- * Encryption handled at the WASM level or via Web Crypto API.
+ * JS/Web DatabaseFactory using SQLDelight's web-worker-driver.
+ *
+ * The database runs inside a Web Worker via sql.js (SQLite compiled to WASM),
+ * keeping all SQL execution off the main thread. Data is currently held
+ * in-memory; OPFS-backed persistence is a planned follow-up.
+ *
+ * Encryption is accepted via [EncryptionKeyProvider] but not yet applied.
+ * A concrete Web Crypto API implementation of [EncryptionKeyProvider] is
+ * required before encryption can be wired in (tracked separately).
  */
 actual class DatabaseFactory(
+    @Suppress("unused")
     private val keyProvider: EncryptionKeyProvider,
 ) {
+    /**
+     * Creates a [FinanceDatabase] backed by a [WebWorkerDriver].
+     *
+     * The returned database is ready for use; schema creation and
+     * migrations are handled separately by [MigrationExecutor].
+     */
     actual fun createDatabase(): FinanceDatabase {
-        // Web implementation will use sql.js-httpvfs or wa-sqlite with OPFS
-        // SQLCipher-WASM provides encryption at the WASM level
-        TODO("Web database factory implementation requires WASM SQLite setup")
+        val worker = Worker(
+            js(
+                """new URL("@cashapp/sqldelight-sqljs-worker/sqljs.worker.js", import.meta.url)"""
+            )
+        )
+        val driver = WebWorkerDriver(worker)
+        return FinanceDatabase(driver)
     }
 }

--- a/packages/models/src/jsTest/kotlin/com/finance/db/DatabaseFactoryJsTest.kt
+++ b/packages/models/src/jsTest/kotlin/com/finance/db/DatabaseFactoryJsTest.kt
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.db
+
+import app.cash.sqldelight.driver.worker.WebWorkerDriver
+import kotlinx.coroutines.test.runTest
+import org.w3c.dom.Worker
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+/**
+ * Integration tests for the JS platform [DatabaseFactory].
+ *
+ * These tests run in a browser environment (Karma) and require the
+ * sql.js Web Worker to be available. The webpack config in
+ * `webpack.config.d/sqljs.js` copies the worker file into the test output.
+ */
+class DatabaseFactoryJsTest {
+
+    private fun createTestKeyProvider(): EncryptionKeyProvider = object : EncryptionKeyProvider {
+        override fun getOrCreateKey(): String = "test-key-not-real"
+        override fun hasKey(): Boolean = true
+        override fun deleteKey() {}
+    }
+
+    private fun createWorker(): Worker = Worker(
+        js("""new URL("@cashapp/sqldelight-sqljs-worker/sqljs.worker.js", import.meta.url)""")
+    )
+
+    @Test
+    fun factory_creates_database_without_throwing() {
+        val factory = DatabaseFactory(createTestKeyProvider())
+        val db = factory.createDatabase()
+        assertNotNull(db, "DatabaseFactory should return a non-null FinanceDatabase")
+    }
+
+    @Test
+    fun schema_creates_all_tables() = runTest {
+        val driver = WebWorkerDriver(createWorker())
+        FinanceDatabase.Schema.create(driver).await()
+        val db = FinanceDatabase(driver)
+
+        assertNotNull(db.userQueries, "userQueries should be accessible")
+        assertNotNull(db.accountQueries, "accountQueries should be accessible")
+        assertNotNull(db.transactionQueries, "transactionQueries should be accessible")
+        assertNotNull(db.budgetQueries, "budgetQueries should be accessible")
+        assertNotNull(db.goalQueries, "goalQueries should be accessible")
+        assertNotNull(db.categoryQueries, "categoryQueries should be accessible")
+        assertNotNull(db.householdQueries, "householdQueries should be accessible")
+        assertNotNull(db.householdMemberQueries, "householdMemberQueries should be accessible")
+    }
+}

--- a/packages/models/webpack.config.d/README.md
+++ b/packages/models/webpack.config.d/README.md
@@ -1,0 +1,7 @@
+# Webpack Configuration
+
+This directory contains Webpack configuration fragments that are automatically
+merged by Kotlin/JS when running browser tests.
+
+- `sqljs.js` — Copies the `@cashapp/sqldelight-sqljs-worker` file so that
+  `WebWorkerDriver` can locate it during test execution.

--- a/packages/models/webpack.config.d/sqljs.js
+++ b/packages/models/webpack.config.d/sqljs.js
@@ -1,0 +1,16 @@
+// Copy the SQLDelight sql.js worker file so the Karma test runner can load it.
+// KMP's JS browser test runner uses Webpack, which needs this plugin to
+// make the worker script available at the expected URL.
+
+const CopyWebpackPlugin = require("copy-webpack-plugin");
+
+config.plugins.push(
+  new CopyWebpackPlugin({
+    patterns: [
+      {
+        from: "../../node_modules/@cashapp/sqldelight-sqljs-worker/sqljs.worker.js",
+        to: "sqljs.worker.js",
+      },
+    ],
+  })
+);


### PR DESCRIPTION
Closes #297

## Summary
- Implement the JS platform DatabaseFactory for the shared models package.
- Add Gradle and webpack sql.js configuration needed by the JS database implementation.
- Add JS-specific tests that verify DatabaseFactory behavior on the JS target.