### PR TITLE
docs: add user-facing guides and platform documentation (#346-#360)

### DIFF
--- a/docs/guides/accessibility.md
+++ b/docs/guides/accessibility.md
@@ -1,0 +1,327 @@
+# Accessibility Guide
+
+Finance is designed to be usable by everyone, regardless of ability. Accessibility isn't an afterthought — it's a design principle woven into every screen, feature, and interaction.
+
+This guide covers the accessibility features available in Finance and how to use them.
+
+---
+
+## Table of Contents
+
+- [Screen reader support](#screen-reader-support)
+- [Dynamic type and font scaling](#dynamic-type-and-font-scaling)
+- [High contrast mode](#high-contrast-mode)
+- [Reduced motion](#reduced-motion)
+- [Keyboard navigation](#keyboard-navigation)
+- [Color-blind friendly design](#color-blind-friendly-design)
+- [Cognitive accessibility](#cognitive-accessibility)
+- [Simplified view mode](#simplified-view-mode)
+- [How to enable accessibility features](#how-to-enable-accessibility-features)
+
+---
+
+## Screen reader support
+
+Finance works with the screen reader on every platform:
+
+| Platform | Screen reader |
+| --- | --- |
+| **iOS** | VoiceOver |
+| **Android** | TalkBack |
+| **Windows** | Narrator |
+| **Web** | Any screen reader (ARIA landmarks and roles) |
+
+### What's announced
+
+Finance provides meaningful announcements for all financial data:
+
+- **Account balances** are announced with the currency (e.g., "Chase Checking: two thousand four hundred fifty dollars")
+- **Transaction rows** include full context: date, payee, category, and amount
+- **Budget progress** is announced as a percentage (e.g., "Food budget: seventy-five percent used, one hundred fifty dollars remaining")
+- **Goal milestones** are announced with progress
+- **Sync status** is announced when it changes (synced, syncing, pending, offline)
+
+### Charts and reports
+
+All charts have an **accessible table alternative**. Screen reader users can switch from a visual chart to a data table that conveys the same information in a linear, readable format.
+
+- Pie/donut charts → category list with amounts and percentages
+- Line/bar charts → monthly data table with trend indicators
+- Progress bars → percentage and absolute values
+
+### Navigation
+
+- All interactive elements have descriptive labels
+- Heading hierarchy is consistent (H1 for screen title, H2 for sections, H3 for items)
+- Focus order follows logical reading order
+- Dialogs trap focus appropriately and can be dismissed with Escape
+
+---
+
+## Dynamic type and font scaling
+
+Finance respects your system font size preferences on all platforms.
+
+### How it works
+
+- **iOS**: Finance follows your Dynamic Type setting. Text scales from the smallest to the largest accessibility sizes, including AX sizes.
+- **Android**: Finance follows your system font scale. Go to device Settings → Display → Font size.
+- **Windows**: Finance follows your system text scaling. Go to Settings → Accessibility → Text size.
+- **Web**: Finance uses relative font units (rem) that scale with your browser's font size setting.
+
+### What scales
+
+- All text content — labels, amounts, descriptions, buttons
+- Spacing adjusts proportionally so content doesn't overlap
+- Touch targets grow to maintain usability at larger sizes
+
+> 💡 Finance is tested at 200% font scale to ensure everything remains usable and readable.
+
+---
+
+## High contrast mode
+
+For users who need stronger visual distinction between elements, Finance supports high contrast display.
+
+### How to enable
+
+- **iOS**: Go to device Settings → Accessibility → Display & Text Size → Increase Contrast
+- **Android**: Go to device Settings → Accessibility → High contrast text
+- **Windows**: Go to Settings → Accessibility → Contrast themes → select a high contrast theme
+- **Web**: Finance respects the `prefers-contrast: high` CSS media query. Enable high contrast in your operating system or browser settings.
+
+### What changes
+
+- Borders become more visible around buttons, cards, and input fields
+- Text contrast increases to meet and exceed WCAG AAA contrast ratios
+- Budget progress bars use solid, high-contrast fills
+- Icons gain stronger outlines
+- Focus indicators become more prominent
+
+---
+
+## Reduced motion
+
+If animations and transitions cause discomfort, Finance can minimize or eliminate them.
+
+### How to enable
+
+- **iOS**: Go to device Settings → Accessibility → Motion → Reduce Motion
+- **Android**: Go to device Settings → Accessibility → Remove animations
+- **Windows**: Go to Settings → Accessibility → Visual effects → Animation effects → Off
+- **Web**: Finance respects the `prefers-reduced-motion` CSS media query
+
+### What changes
+
+When reduced motion is enabled:
+
+- Screen transitions switch from animated slides to simple fades or instant swaps
+- Progress bars don't animate when they fill — they appear at the correct position
+- The sync status indicator doesn't animate — it changes state directly
+- Celebration effects (goal milestones) use a simple text acknowledgment instead of confetti or motion
+- Haptic feedback continues to work (it's tactile, not visual motion)
+
+---
+
+## Keyboard navigation
+
+Finance is fully keyboard-accessible, especially on web and Windows where keyboard use is most common.
+
+### General keyboard shortcuts
+
+| Shortcut | Action |
+| --- | --- |
+| `Tab` | Move to the next interactive element |
+| `Shift+Tab` | Move to the previous interactive element |
+| `Enter` or `Space` | Activate a button or select an option |
+| `Escape` | Close a dialog, cancel an action, or dismiss a popup |
+| `Arrow keys` | Navigate within lists, menus, and date pickers |
+
+### App shortcuts (Web and Windows)
+
+| Shortcut | Action |
+| --- | --- |
+| `Ctrl+N` (or `⌘+N`) | New transaction |
+| `/` | Open search |
+| `Ctrl+E` | Export data |
+
+### Focus indicators
+
+When navigating with a keyboard, a clear **focus ring** shows which element is currently selected. The ring is:
+
+- High contrast and visible on all backgrounds
+- Consistent in style across the app
+- Visible on buttons, links, form fields, and all interactive elements
+
+### Category reordering
+
+In the category management screen, drag-and-drop has a keyboard alternative:
+
+1. Focus on a category item.
+2. Press `Space` to pick it up.
+3. Use `Arrow Up` / `Arrow Down` to move it.
+4. Press `Space` to drop it in the new position.
+
+---
+
+## Color-blind friendly design
+
+Finance uses the **IBM Carbon CVD-safe color palette** — a set of colors designed to be distinguishable by people with all types of color vision deficiency (CVD), including protanopia, deuteranopia, and tritanopia.
+
+### Where this matters most
+
+- **Charts and reports**: Each category in a pie chart or bar chart uses a distinct CVD-safe color. No two adjacent categories share colors that could be confused.
+- **Budget status**: Progress indicators don't rely on color alone — they also use labels and icons:
+  - Under 80%: labeled "On track"
+  - 80–100%: labeled "Getting close"
+  - Over 100%: labeled with the percentage
+- **Transaction types**: Income and expenses are distinguished by direction indicators (↑ / ↓) and labels, not just green and red.
+
+### Design principle
+
+Finance follows the WCAG 2.2 guideline of **never relying on color alone** to convey information. Every piece of color-coded information also has a text label, icon, or pattern that communicates the same meaning.
+
+---
+
+## Cognitive accessibility
+
+Finance is designed with cognitive accessibility in mind, inspired by apps like Tiimo that support users with ADHD, anxiety, and other cognitive differences.
+
+### Non-judgmental language
+
+The app never shames or criticizes. All language is factual and encouraging:
+
+- ✅ _"You've used 110% of your Food plan — want to adjust?"_
+- ❌ ~~"You overspent on food!"~~
+- ✅ _"Welcome back! Pick up where you left off."_
+- ❌ ~~"You broke your streak!"~~
+
+### Reduced cognitive load
+
+- **3-tap transaction entry** — the most common action is simple and fast
+- **Progressive disclosure** — advanced options are hidden behind "More details" so the default view isn't overwhelming
+- **Experience levels** — the 🌱 Getting Started tier hides complexity until you're ready
+- **Gentle nudges** — task cards are non-nagging and easily dismissed
+- **Consistent layout** — screens follow the same structure so you always know where things are
+
+### Contextual education
+
+Every financial concept in the app has an **info button** (ℹ️) that explains:
+
+- What it is (in plain language)
+- How it's calculated
+- Why it matters
+
+This means you never need to leave the app to understand what you're looking at.
+
+### Streaks without guilt
+
+Finance tracks consecutive days of logging, but treats breaks with grace:
+
+- Positive framing for active streaks
+- No guilt, no loss aversion, no "you lost your streak" messaging
+- Just a warm welcome back when you return
+
+---
+
+## Simplified view mode
+
+For times when the full interface is too much, Finance offers a **Simplified View Mode** that shows only the essentials.
+
+### What it shows
+
+- Your total balance
+- Today's spending
+- Top 3 budget categories
+- Next goal milestone
+
+### What it hides
+
+- Detailed charts and analytics
+- Transaction history (still accessible via menu)
+- Advanced settings and options
+
+### Additional simplifications
+
+- Larger text with more whitespace
+- Fewer numbers on screen at once
+- Reduced motion (no animations)
+
+### How to enable
+
+1. Go to **Settings → Accessibility → Simplified View**.
+2. Toggle it on.
+
+Finance also respects your system accessibility settings — if your device is set to larger text or reduced motion, Finance adapts automatically.
+
+---
+
+## How to enable accessibility features
+
+Most accessibility features in Finance activate automatically based on your device settings. Here's a quick reference:
+
+### iOS
+
+| Feature | Where to enable |
+| --- | --- |
+| VoiceOver | Settings → Accessibility → VoiceOver |
+| Dynamic Type | Settings → Accessibility → Display & Text Size → Larger Text |
+| Reduce Motion | Settings → Accessibility → Motion → Reduce Motion |
+| Increase Contrast | Settings → Accessibility → Display & Text Size → Increase Contrast |
+| Bold Text | Settings → Accessibility → Display & Text Size → Bold Text |
+
+### Android
+
+| Feature | Where to enable |
+| --- | --- |
+| TalkBack | Settings → Accessibility → TalkBack |
+| Font size | Settings → Display → Font size |
+| Remove animations | Settings → Accessibility → Remove animations |
+| High contrast text | Settings → Accessibility → High contrast text |
+| Color correction | Settings → Accessibility → Color correction |
+
+### Windows
+
+| Feature | Where to enable |
+| --- | --- |
+| Narrator | Settings → Accessibility → Narrator |
+| Text size | Settings → Accessibility → Text size |
+| Contrast themes | Settings → Accessibility → Contrast themes |
+| Animation effects | Settings → Accessibility → Visual effects → Animation effects |
+
+### Web
+
+| Feature | How to enable |
+| --- | --- |
+| Screen reader | Use your operating system's screen reader (VoiceOver, NVDA, JAWS, Narrator) |
+| Font size | Browser settings → Font size (Finance uses relative units) |
+| High contrast | OS-level high contrast settings or browser extension |
+| Reduced motion | OS-level reduced motion setting (Finance reads `prefers-reduced-motion`) |
+
+### In Finance
+
+| Feature | Where to find it |
+| --- | --- |
+| Experience level | Settings → Experience Level (🌱 Getting Started for simplified UI) |
+| Simplified view | Settings → Accessibility → Simplified View |
+| Biometric lock | Settings → Security → Biometric Lock |
+
+---
+
+## Accessibility standards
+
+Finance targets **WCAG 2.2 Level AA** compliance across all platforms. This includes:
+
+- Minimum 4.5:1 contrast ratio for normal text
+- Minimum 3:1 contrast ratio for large text and UI components
+- All functionality available via keyboard
+- No content that flashes more than 3 times per second
+- Clear focus indicators on all interactive elements
+- Meaningful labels for all form fields and buttons
+- Consistent navigation structure across the app
+
+---
+
+_If you encounter an accessibility barrier in Finance, please report it. Go to **Settings → Help → Report a Bug** and describe the issue. Accessibility bugs are treated as high-priority._
+
+_For general help, see the [FAQ](./faq.md). For platform-specific features, see the [Platform Guides](./platforms.md)._

--- a/docs/guides/accessibility.md
+++ b/docs/guides/accessibility.md
@@ -24,12 +24,12 @@ This guide covers the accessibility features available in Finance and how to use
 
 Finance works with the screen reader on every platform:
 
-| Platform | Screen reader |
-| --- | --- |
-| **iOS** | VoiceOver |
-| **Android** | TalkBack |
-| **Windows** | Narrator |
-| **Web** | Any screen reader (ARIA landmarks and roles) |
+| Platform    | Screen reader                                |
+| ----------- | -------------------------------------------- |
+| **iOS**     | VoiceOver                                    |
+| **Android** | TalkBack                                     |
+| **Windows** | Narrator                                     |
+| **Web**     | Any screen reader (ARIA landmarks and roles) |
 
 ### What's announced
 
@@ -129,21 +129,21 @@ Finance is fully keyboard-accessible, especially on web and Windows where keyboa
 
 ### General keyboard shortcuts
 
-| Shortcut | Action |
-| --- | --- |
-| `Tab` | Move to the next interactive element |
-| `Shift+Tab` | Move to the previous interactive element |
-| `Enter` or `Space` | Activate a button or select an option |
-| `Escape` | Close a dialog, cancel an action, or dismiss a popup |
-| `Arrow keys` | Navigate within lists, menus, and date pickers |
+| Shortcut           | Action                                               |
+| ------------------ | ---------------------------------------------------- |
+| `Tab`              | Move to the next interactive element                 |
+| `Shift+Tab`        | Move to the previous interactive element             |
+| `Enter` or `Space` | Activate a button or select an option                |
+| `Escape`           | Close a dialog, cancel an action, or dismiss a popup |
+| `Arrow keys`       | Navigate within lists, menus, and date pickers       |
 
 ### App shortcuts (Web and Windows)
 
-| Shortcut | Action |
-| --- | --- |
+| Shortcut            | Action          |
+| ------------------- | --------------- |
 | `Ctrl+N` (or `⌘+N`) | New transaction |
-| `/` | Open search |
-| `Ctrl+E` | Export data |
+| `/`                 | Open search     |
+| `Ctrl+E`            | Export data     |
 
 ### Focus indicators
 
@@ -262,49 +262,49 @@ Most accessibility features in Finance activate automatically based on your devi
 
 ### iOS
 
-| Feature | Where to enable |
-| --- | --- |
-| VoiceOver | Settings → Accessibility → VoiceOver |
-| Dynamic Type | Settings → Accessibility → Display & Text Size → Larger Text |
-| Reduce Motion | Settings → Accessibility → Motion → Reduce Motion |
+| Feature           | Where to enable                                                    |
+| ----------------- | ------------------------------------------------------------------ |
+| VoiceOver         | Settings → Accessibility → VoiceOver                               |
+| Dynamic Type      | Settings → Accessibility → Display & Text Size → Larger Text       |
+| Reduce Motion     | Settings → Accessibility → Motion → Reduce Motion                  |
 | Increase Contrast | Settings → Accessibility → Display & Text Size → Increase Contrast |
-| Bold Text | Settings → Accessibility → Display & Text Size → Bold Text |
+| Bold Text         | Settings → Accessibility → Display & Text Size → Bold Text         |
 
 ### Android
 
-| Feature | Where to enable |
-| --- | --- |
-| TalkBack | Settings → Accessibility → TalkBack |
-| Font size | Settings → Display → Font size |
-| Remove animations | Settings → Accessibility → Remove animations |
+| Feature            | Where to enable                               |
+| ------------------ | --------------------------------------------- |
+| TalkBack           | Settings → Accessibility → TalkBack           |
+| Font size          | Settings → Display → Font size                |
+| Remove animations  | Settings → Accessibility → Remove animations  |
 | High contrast text | Settings → Accessibility → High contrast text |
-| Color correction | Settings → Accessibility → Color correction |
+| Color correction   | Settings → Accessibility → Color correction   |
 
 ### Windows
 
-| Feature | Where to enable |
-| --- | --- |
-| Narrator | Settings → Accessibility → Narrator |
-| Text size | Settings → Accessibility → Text size |
-| Contrast themes | Settings → Accessibility → Contrast themes |
+| Feature           | Where to enable                                               |
+| ----------------- | ------------------------------------------------------------- |
+| Narrator          | Settings → Accessibility → Narrator                           |
+| Text size         | Settings → Accessibility → Text size                          |
+| Contrast themes   | Settings → Accessibility → Contrast themes                    |
 | Animation effects | Settings → Accessibility → Visual effects → Animation effects |
 
 ### Web
 
-| Feature | How to enable |
-| --- | --- |
-| Screen reader | Use your operating system's screen reader (VoiceOver, NVDA, JAWS, Narrator) |
-| Font size | Browser settings → Font size (Finance uses relative units) |
-| High contrast | OS-level high contrast settings or browser extension |
-| Reduced motion | OS-level reduced motion setting (Finance reads `prefers-reduced-motion`) |
+| Feature        | How to enable                                                               |
+| -------------- | --------------------------------------------------------------------------- |
+| Screen reader  | Use your operating system's screen reader (VoiceOver, NVDA, JAWS, Narrator) |
+| Font size      | Browser settings → Font size (Finance uses relative units)                  |
+| High contrast  | OS-level high contrast settings or browser extension                        |
+| Reduced motion | OS-level reduced motion setting (Finance reads `prefers-reduced-motion`)    |
 
 ### In Finance
 
-| Feature | Where to find it |
-| --- | --- |
+| Feature          | Where to find it                                                   |
+| ---------------- | ------------------------------------------------------------------ |
 | Experience level | Settings → Experience Level (🌱 Getting Started for simplified UI) |
-| Simplified view | Settings → Accessibility → Simplified View |
-| Biometric lock | Settings → Security → Biometric Lock |
+| Simplified view  | Settings → Accessibility → Simplified View                         |
+| Biometric lock   | Settings → Security → Biometric Lock                               |
 
 ---
 

--- a/docs/guides/faq.md
+++ b/docs/guides/faq.md
@@ -1,0 +1,338 @@
+# FAQ & Troubleshooting
+
+Answers to the most common questions about Finance. Can't find what you're looking for? See the [Getting Started Guide](./getting-started.md) or the [Feature Guide](./features.md).
+
+---
+
+## Table of Contents
+
+- [General Questions](#general-questions)
+- [Privacy & Data](#privacy--data)
+- [Sync & Multi-Device](#sync--multi-device)
+- [Account & Login](#account--login)
+- [Features](#features)
+- [Platforms](#platforms)
+- [Billing](#billing)
+- [Troubleshooting](#troubleshooting)
+- [Getting Help](#getting-help)
+
+---
+
+## General Questions
+
+### What is Finance?
+
+Finance is a personal and family finance tracker that helps you manage accounts, budgets, goals, and spending. It's built around three principles: privacy-first, offline-first, and simplicity-first. The app works natively on iOS, Android, Web, and Windows.
+
+### What makes Finance different from other finance apps?
+
+- **Your data stays on your device** — encrypted, offline-first, no bank connections required
+- **It adapts to you** — three experience levels so the app matches your comfort with finance
+- **30 seconds a day** — quick-entry transactions, widgets, and at-a-glance budgets
+- **No judgment** — the app informs and empowers, never shames
+- **Native on every platform** — not a web wrapper, but a real native app on iOS, Android, Web, and Windows
+
+### Do I need a bank connection to use Finance?
+
+No. Finance is a **manual tracking app**. You enter transactions yourself — which takes about 3 taps and under 10 seconds. This is a deliberate choice: it keeps your bank credentials off the internet and helps you build awareness of your spending habits.
+
+### Is Finance open source?
+
+Finance is **source-available** under the Business Source License 1.1 (BSL). You can view, fork, and learn from the code. Personal and non-commercial use is always allowed. The code converts to Apache License 2.0 (fully open source) on March 8, 2030.
+
+---
+
+## Privacy & Data
+
+### How is my data stored?
+
+All your financial data is stored **locally on your device**, encrypted at rest using SQLCipher (an industry-standard encrypted database). Nothing leaves your device unless you opt in to cross-device sync.
+
+For more details, see the [Privacy & Security Guide](./privacy-security.md).
+
+### Is my financial data shared with anyone?
+
+**No.** Finance does not sell, share, or monetize your data. Period.
+
+- No ads
+- No data brokers
+- No third-party analytics tracking your financial behavior
+- Analytics and crash reporting are opt-in and contain no personal or financial data
+
+### What happens to my data when I'm offline?
+
+Everything works normally. Finance is built **offline-first**, which means:
+
+- ✅ Add transactions
+- ✅ Check budgets and balances
+- ✅ Search your history
+- ✅ View reports
+- ✅ Do literally everything
+
+If you have sync enabled, changes queue up and sync automatically when you're back online.
+
+### How do I export my data?
+
+1. Go to **Settings → Export**.
+2. Choose **JSON** (complete export) or **CSV** (spreadsheet-friendly transactions).
+3. Tap **Export**.
+4. The file saves to your device or your platform's share sheet opens.
+
+Export happens instantly on your device — no waiting for an email. This is available on the free tier.
+
+### How do I delete my account and all my data?
+
+1. Go to **Settings → Delete Account**.
+2. Type the confirmation phrase ("DELETE MY DATA").
+3. Confirm.
+
+This deletes:
+- All local data on the current device
+- All synced data on the server (if you used sync)
+- Your account credentials
+
+The deletion is permanent after a 30-day grace period. A confirmation email is sent. Finance uses a process called **crypto-shredding** — the encryption keys for your data are destroyed, making the data unreadable even if any encrypted fragments remain.
+
+> 💡 We recommend exporting your data before deleting your account, just in case.
+
+---
+
+## Sync & Multi-Device
+
+### How does sync work?
+
+When you enable sync:
+
+1. You create a Finance account (email or passkey).
+2. Sign in on each device.
+3. Your data syncs automatically in the background.
+
+Your data is **end-to-end encrypted** before it leaves your device. The sync server stores only encrypted data — it can't read your transactions, balances, or any financial information.
+
+### Sync isn't working — what should I do?
+
+Try these steps in order:
+
+1. **Check your internet connection** — sync requires connectivity.
+2. **Check the sync indicator** — look for the small status icon (usually in the top corner or on the Settings screen):
+   - 🟢 Green dot = synced
+   - 🟡 Yellow dot = changes pending
+   - ⚫ Grey dot = offline
+   - 🔄 Animated = syncing in progress
+3. **Pull to refresh** — on the Accounts or main screen, pull down to trigger a manual sync.
+4. **Sign out and back in** — go to **Settings → Account → Sign Out**, then sign in again.
+5. **Check for app updates** — make sure you're on the latest version on all devices.
+
+If sync still isn't working after trying these steps, see [Getting Help](#getting-help) below.
+
+### What happens if I edit the same thing on two devices while offline?
+
+Finance handles this automatically in most cases using a "last write wins" approach. If the conflict is ambiguous (for example, you changed the amount on both devices), Finance shows both versions and lets you choose which one to keep. No data is ever silently discarded.
+
+### Can I use Finance without sync?
+
+Absolutely. The free tier is a complete financial tracker on a single device — no account or internet required.
+
+---
+
+## Account & Login
+
+### I forgot my password — how do I recover?
+
+1. On the sign-in screen, tap **Forgot Password**.
+2. Enter your email address.
+3. Check your email for a password reset link.
+4. Follow the link to set a new password.
+
+> ⚠️ Your local data on the current device is unaffected by a password reset. But if you used sync, you'll need to sign in again to resume syncing.
+
+### What is a passkey?
+
+A **passkey** is a modern, password-free way to sign in. Instead of typing a password, you authenticate with your device's biometrics (Face ID, fingerprint, Windows Hello) or a security key.
+
+Passkeys are:
+
+- More secure than passwords (can't be phished or leaked in a data breach)
+- Faster to use (just a biometric scan)
+- Supported on all Finance platforms
+
+You can set up a passkey in **Settings → Account → Passkey**.
+
+### Do I need to create an account to use Finance?
+
+No. You can use Finance without any account. An account is only needed if you want to sync across multiple devices (a premium feature).
+
+---
+
+## Features
+
+### Can I track accounts in different currencies?
+
+Yes. Each account can have its own currency. Finance supports all ISO 4217 currencies. Reports and summaries convert totals to your default currency.
+
+Set your default currency in **Settings → Currency**.
+
+### Can I share finances with my partner or family?
+
+Yes — with the **Household Sharing** feature (premium). You can:
+
+- Create a shared household
+- Invite family members
+- Set roles (owner, partner, member, viewer)
+- Share specific accounts and budgets while keeping others private
+
+See [Features → Household Sharing](./features.md#household-sharing) for details.
+
+### How do recurring transactions work?
+
+1. Create a transaction as usual.
+2. Tap **Make Recurring**.
+3. Choose a schedule (daily, weekly, bi-weekly, monthly, yearly, or custom).
+
+Future instances generate automatically. You can skip, edit, or cancel individual occurrences or the whole series. You'll get a notification before upcoming bills.
+
+### What's the difference between archiving and deleting an account?
+
+- **Archive**: Hides the account from your main list but keeps all history. The balance is excluded from net worth. You can un-archive later.
+- **Delete transactions**: Individual transactions can be deleted (with undo). The account itself is archived rather than destroyed.
+
+Archiving is recommended for closed accounts so you keep your financial history intact.
+
+---
+
+## Platforms
+
+### Which platforms are supported?
+
+| Platform | Status |
+| --- | --- |
+| iOS (iPhone, iPad, Mac) | ✅ Available |
+| Android (phones, tablets) | ✅ Available |
+| Web (any modern browser) | ✅ Available |
+| Windows 11 | ✅ Available |
+
+Companion apps for Apple Watch and Wear OS are planned for a future release.
+
+### Can I install the web version as an app?
+
+Yes! The web version is a **Progressive Web App (PWA)**, which means you can install it like a native app:
+
+- **Chrome/Edge**: Click the install icon in the address bar (or the browser menu → "Install app")
+- **Safari (macOS)**: Go to File → Add to Dock
+- **Mobile browsers**: Use your browser's "Add to Home Screen" option
+
+Once installed, it works offline and launches in its own window.
+
+### Are there keyboard shortcuts on the web and desktop?
+
+Yes! On the web and Windows:
+
+| Shortcut | Action |
+| --- | --- |
+| `Ctrl+N` | New transaction |
+| `/` | Search |
+| `Tab` | Navigate through fields and categories |
+
+See [Platform Guides → Web](./platforms.md#web-pwa) and [Platform Guides → Windows](./platforms.md#windows) for more.
+
+---
+
+## Billing
+
+### Is there a free version?
+
+Yes. The **free tier** includes everything you need to track finances on a single device:
+
+- All account types, transactions, budgets, goals, and categories
+- All three experience levels
+- Contextual help and financial education
+- Offline operation
+- Data export (JSON and CSV)
+- Basic reports (spending by category, monthly trends)
+- "Can I Afford This?" budget check widget
+
+### What does premium include?
+
+The premium tier adds:
+
+- **Multi-device cloud sync** (end-to-end encrypted)
+- **Household sharing** (partner/family finances with role-based access)
+- **AI-powered features**: auto-categorization, suggested budgets, spending forecasts
+- **Advanced reports** and custom visualizations
+- **Learning paths** (guided financial education modules)
+- Priority support
+
+### How much does premium cost?
+
+| Plan | Price |
+| --- | --- |
+| Monthly | ~$4.99/month |
+| Annual | ~$39.99/year (save ~33%) |
+| Family | Household sharing (pricing TBD) |
+
+---
+
+## Troubleshooting
+
+### The app is slow or unresponsive
+
+1. **Close and reopen the app** — this clears temporary state.
+2. **Check for updates** — make sure you're on the latest version.
+3. **Restart your device** — sometimes the simplest fix works.
+4. **Check your storage** — if your device is nearly full, performance can suffer.
+
+### A transaction isn't showing up
+
+- **Check the account filter** — are you viewing the right account?
+- **Check the date filter** — is the date range set correctly?
+- **Pull to refresh** — if you use sync, new transactions from other devices may need a moment.
+- **Search for it** — use the search function to find by amount, payee, or notes.
+
+### My budget numbers look wrong
+
+- **Check rollover settings** — if rollover is enabled, last month's balance is included.
+- **Check for moved money** — someone may have covered an overspent category by moving budget from another one.
+- **Check the budget period** — make sure you're looking at the right month.
+
+### I can't sign in
+
+- **Check your internet connection** — sign-in requires connectivity.
+- **Check your email** — make sure you're using the right email address.
+- **Try "Forgot Password"** — reset your password via email.
+- **Try a passkey** — if you set up a passkey, try biometric sign-in instead.
+- **Clear the app cache** — on Android, go to device Settings → Apps → Finance → Clear Cache. On iOS, try reinstalling.
+
+### The app won't install (Web PWA)
+
+- **Use a supported browser** — Chrome, Edge, or another Chromium-based browser works best. Firefox has limited PWA support.
+- **Use HTTPS** — PWA installation requires a secure (HTTPS) connection.
+- **Try incognito mode** — a browser extension might be interfering.
+
+---
+
+## Getting Help
+
+### How do I report a bug?
+
+If you've found something that isn't working right:
+
+1. Go to **Settings → Help → Report a Bug**.
+2. Describe what happened, what you expected to happen, and any steps to reproduce.
+3. Finance may include non-sensitive diagnostic info (app version, platform, error code) — no personal or financial data is included.
+
+You can also file an issue on the [GitHub repository](https://github.com/jrmoulckers/finance/issues) if you're comfortable with that.
+
+### How do I request a feature?
+
+We love hearing ideas! You can:
+
+1. Go to **Settings → Help → Feature Request**.
+2. Or open a feature request on [GitHub](https://github.com/jrmoulckers/finance/issues).
+
+### How do I contact support?
+
+For questions that aren't answered here, reach out through **Settings → Help → Contact Us**.
+
+---
+
+_Still stuck? The [Getting Started Guide](./getting-started.md) covers the basics, and the [Feature Guide](./features.md) goes deep on every capability._

--- a/docs/guides/faq.md
+++ b/docs/guides/faq.md
@@ -87,6 +87,7 @@ Export happens instantly on your device — no waiting for an email. This is ava
 3. Confirm.
 
 This deletes:
+
 - All local data on the current device
 - All synced data on the server (if you used sync)
 - Your account credentials
@@ -204,12 +205,12 @@ Archiving is recommended for closed accounts so you keep your financial history 
 
 ### Which platforms are supported?
 
-| Platform | Status |
-| --- | --- |
-| iOS (iPhone, iPad, Mac) | ✅ Available |
+| Platform                  | Status       |
+| ------------------------- | ------------ |
+| iOS (iPhone, iPad, Mac)   | ✅ Available |
 | Android (phones, tablets) | ✅ Available |
-| Web (any modern browser) | ✅ Available |
-| Windows 11 | ✅ Available |
+| Web (any modern browser)  | ✅ Available |
+| Windows 11                | ✅ Available |
 
 Companion apps for Apple Watch and Wear OS are planned for a future release.
 
@@ -227,11 +228,11 @@ Once installed, it works offline and launches in its own window.
 
 Yes! On the web and Windows:
 
-| Shortcut | Action |
-| --- | --- |
-| `Ctrl+N` | New transaction |
-| `/` | Search |
-| `Tab` | Navigate through fields and categories |
+| Shortcut | Action                                 |
+| -------- | -------------------------------------- |
+| `Ctrl+N` | New transaction                        |
+| `/`      | Search                                 |
+| `Tab`    | Navigate through fields and categories |
 
 See [Platform Guides → Web](./platforms.md#web-pwa) and [Platform Guides → Windows](./platforms.md#windows) for more.
 
@@ -264,11 +265,11 @@ The premium tier adds:
 
 ### How much does premium cost?
 
-| Plan | Price |
-| --- | --- |
-| Monthly | ~$4.99/month |
-| Annual | ~$39.99/year (save ~33%) |
-| Family | Household sharing (pricing TBD) |
+| Plan    | Price                           |
+| ------- | ------------------------------- |
+| Monthly | ~$4.99/month                    |
+| Annual  | ~$39.99/year (save ~33%)        |
+| Family  | Household sharing (pricing TBD) |
 
 ---
 

--- a/docs/guides/features.md
+++ b/docs/guides/features.md
@@ -25,14 +25,14 @@ An account represents any place you keep or owe money. Your accounts form the fo
 
 ### Account types
 
-| Type | What it's for | Examples |
-| --- | --- | --- |
-| **Checking** | Everyday spending | Chase Checking, Bank of America |
-| **Savings** | Money set aside | Emergency fund, vacation savings |
-| **Credit Card** | What you owe on cards | Visa, Amex, store cards |
-| **Cash** | Physical money on hand | Wallet, cash jar |
-| **Investment** | Brokerage and retirement | 401(k), Robinhood, Vanguard |
-| **Loan** | Debt you're paying down | Mortgage, student loans, car payment |
+| Type            | What it's for            | Examples                             |
+| --------------- | ------------------------ | ------------------------------------ |
+| **Checking**    | Everyday spending        | Chase Checking, Bank of America      |
+| **Savings**     | Money set aside          | Emergency fund, vacation savings     |
+| **Credit Card** | What you owe on cards    | Visa, Amex, store cards              |
+| **Cash**        | Physical money on hand   | Wallet, cash jar                     |
+| **Investment**  | Brokerage and retirement | 401(k), Robinhood, Vanguard          |
+| **Loan**        | Debt you're paying down  | Mortgage, student loans, car payment |
 
 ### Adding an account
 
@@ -397,10 +397,10 @@ You own your data. Finance makes it easy to take it with you.
 
 ### What's included
 
-| Format | Includes |
-| --- | --- |
-| JSON | Accounts, transactions, categories, budgets, goals, plus metadata (export date, record counts, integrity check) |
-| CSV | Transaction history with dates, amounts, payees, categories, and notes |
+| Format | Includes                                                                                                        |
+| ------ | --------------------------------------------------------------------------------------------------------------- |
+| JSON   | Accounts, transactions, categories, budgets, goals, plus metadata (export date, record counts, integrity check) |
+| CSV    | Transaction history with dates, amounts, payees, categories, and notes                                          |
 
 Export is instant — no waiting for an email. The file is generated on your device from your local data.
 
@@ -432,12 +432,12 @@ Invitations expire after 72 hours for security.
 
 ### Roles and permissions
 
-| Role | Can do |
-| --- | --- |
-| **Owner** | Full control — manage members, edit everything, delete the household |
-| **Partner** | Edit shared accounts and budgets, view everything |
-| **Member** | Edit their own entries, view shared items |
-| **Viewer** | Read-only access to shared items |
+| Role        | Can do                                                               |
+| ----------- | -------------------------------------------------------------------- |
+| **Owner**   | Full control — manage members, edit everything, delete the household |
+| **Partner** | Edit shared accounts and budgets, view everything                    |
+| **Member**  | Edit their own entries, view shared items                            |
+| **Viewer**  | Read-only access to shared items                                     |
 
 The owner can change anyone's role. No one can escalate their own permissions.
 
@@ -463,11 +463,11 @@ Finance adapts to your comfort level with financial concepts.
 
 ### Three levels
 
-| Level | What it means |
-| --- | --- |
+| Level                  | What it means                                                                                                                                       |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 🌱 **Getting Started** | Plain language everywhere. Guided prompts walk you through actions. Advanced features are hidden until you're ready. Proactive tips help you learn. |
-| 📊 **Comfortable** | Standard financial terms with plain-language descriptions available on tap. All features visible. This is the default. |
-| 🧠 **Advanced** | Traditional finance terminology. Detailed breakdowns. Power-user shortcuts. Raw data access. |
+| 📊 **Comfortable**     | Standard financial terms with plain-language descriptions available on tap. All features visible. This is the default.                              |
+| 🧠 **Advanced**        | Traditional finance terminology. Detailed breakdowns. Power-user shortcuts. Raw data access.                                                        |
 
 ### What changes between levels
 

--- a/docs/guides/features.md
+++ b/docs/guides/features.md
@@ -1,0 +1,496 @@
+# Feature Guide
+
+A complete guide to everything Finance can do. Each section explains what the feature is, why it's useful, and how to use it.
+
+---
+
+## Table of Contents
+
+- [Accounts](#accounts)
+- [Transactions](#transactions)
+- [Categories](#categories)
+- [Budgets](#budgets)
+- [Goals](#goals)
+- [Reports & Analytics](#reports--analytics)
+- [Multi-Currency](#multi-currency)
+- [Data Export](#data-export)
+- [Household Sharing](#household-sharing)
+- [Experience Levels](#experience-levels)
+
+---
+
+## Accounts
+
+An account represents any place you keep or owe money. Your accounts form the foundation of your financial picture.
+
+### Account types
+
+| Type | What it's for | Examples |
+| --- | --- | --- |
+| **Checking** | Everyday spending | Chase Checking, Bank of America |
+| **Savings** | Money set aside | Emergency fund, vacation savings |
+| **Credit Card** | What you owe on cards | Visa, Amex, store cards |
+| **Cash** | Physical money on hand | Wallet, cash jar |
+| **Investment** | Brokerage and retirement | 401(k), Robinhood, Vanguard |
+| **Loan** | Debt you're paying down | Mortgage, student loans, car payment |
+
+### Adding an account
+
+1. Go to **Accounts**.
+2. Tap **Add Account**.
+3. Enter a name, choose the type, and set the current balance.
+4. Tap **Save**.
+
+The account appears in your list, grouped by type: assets (things you own) on top, liabilities (things you owe) below. Your **net worth** — total assets minus total liabilities — appears at the top.
+
+### Managing accounts
+
+- **Edit**: Tap an account to change its name, type, or icon.
+- **Archive**: No longer using an account? Archive it instead of deleting it. The history stays searchable, but it's hidden from your main list and excluded from net worth. You can un-archive anytime.
+- **Balance adjustments**: You can't directly edit a balance (that would break your history). Instead, Finance creates an "adjustment" transaction to correct it, keeping your records accurate.
+
+> 💡 Each account gets an auto-selected icon based on its type, but you can customize it.
+
+---
+
+## Transactions
+
+Transactions record every time money moves — spending, income, transfers, and everything in between.
+
+### Quick entry (the everyday flow)
+
+This is the action you'll use most — and it's designed for speed:
+
+1. Tap **+** (available from any screen).
+2. Enter the amount.
+3. Pick a category.
+4. Tap **Save**.
+
+Three taps, under 10 seconds. You'll feel a subtle haptic confirmation when it saves.
+
+> 💡 Finance suggests categories based on your recent entries. The more you use it, the smarter the suggestions get.
+
+### Adding more detail
+
+Before saving, tap **More details** to add:
+
+- **Payee** — who you paid or who paid you (e.g., "Amazon", "Employer")
+- **Date** — defaults to today; change it for past transactions
+- **Notes** — any context (e.g., "Birthday gift for Mom")
+- **Tags** — custom labels like "vacation" or "tax-deductible"
+- **Account** — which account this transaction belongs to (defaults to your last-used account)
+
+### Editing and deleting
+
+- **Edit**: Tap any transaction to change the amount, category, payee, date, or notes. Budgets and balances recalculate automatically.
+- **Delete**: Swipe to delete (with confirmation). An undo option appears for 10 seconds.
+
+### Transfers
+
+To move money between your own accounts:
+
+1. Tap **+** → select **Transfer**.
+2. Choose the **from** and **to** accounts.
+3. Enter the amount.
+4. Tap **Save**.
+
+Transfers create two linked records (one debit, one credit) and don't affect any budget category. They show up in both account histories with a distinct transfer icon.
+
+**Example:** Moving $500 from Checking ($3,000) to Savings ($20,000) → Checking becomes $2,500, Savings becomes $20,500.
+
+### Split transactions
+
+Bought multiple categories of things in one purchase? Split it:
+
+1. Enter the total amount (e.g., $125 at Costco).
+2. Tap **Split**.
+3. Assign amounts to categories:
+   - Groceries: $80
+   - Household: $30
+   - Personal Care: $15
+4. The split must add up to the total.
+
+Split transactions appear as a single entry that expands to show each category's portion.
+
+### Recurring transactions
+
+Set up transactions that repeat on a schedule — subscriptions, bills, paychecks:
+
+1. Create a transaction as usual.
+2. Tap **Make Recurring**.
+3. Choose a schedule: daily, weekly, bi-weekly, monthly, yearly, or custom.
+4. Finance generates future instances automatically.
+
+You can:
+
+- Skip a single instance
+- Modify just one occurrence or the entire series
+- Set a variable amount (enter the actual amount when it hits)
+- Get a notification before upcoming bills
+
+**Example:** A $15/month Netflix subscription on the 1st → it appears automatically each month.
+
+### Search and filter
+
+Find any transaction quickly:
+
+- **Search** by payee name, notes, or amount
+- **Filter** by account, category, date range, or amount range
+- Search results show matching transactions with a total sum
+
+Search works entirely offline — it queries your local database directly.
+
+---
+
+## Categories
+
+Categories organize your transactions into spending and income groups.
+
+### Default categories
+
+Finance ships with sensible defaults arranged in a hierarchy:
+
+- **Food** → Groceries, Dining Out, Coffee & Tea
+- **Transport** → Gas, Public Transit, Ride Share
+- **Housing** → Rent/Mortgage, Insurance, Maintenance
+- **Utilities** → Electric, Water, Internet, Phone
+- **Health** → Medical, Pharmacy, Fitness
+- **Personal** → Clothing, Haircare, Personal Care
+- **Entertainment** → Streaming, Events, Hobbies
+- **Shopping** → General, Electronics, Gifts
+- **Education** → Courses, Books, Supplies
+- **Income** → Salary, Freelance, Investments
+
+Plus an "Uncategorized" catch-all.
+
+### Custom categories
+
+Create your own categories:
+
+1. Go to **Settings → Categories** (or long-press a category picker).
+2. Tap **Add Category**.
+3. Enter a name, choose an icon and color, and pick a parent category (or make it top-level).
+4. Tap **Save**.
+
+You can nest up to 3 levels deep.
+
+### Editing and organizing
+
+- **Rename or restyle**: Change a category's name, icon, or color anytime.
+- **Reorder**: Drag categories to put your most-used ones at the top. A keyboard alternative is available for accessibility.
+- **Move**: Reassign a sub-category to a different parent.
+- **Delete**: You'll need to reassign any existing transactions to another category first.
+
+### Auto-categorization rules
+
+Finance can learn from your patterns:
+
+- If you categorize a "Starbucks" transaction as "Coffee & Tea," Finance will suggest that category next time you enter a Starbucks transaction.
+- Suggestions always ask for confirmation — nothing is silently auto-assigned.
+- You can view and edit these rules in **Settings → Category Rules**.
+
+---
+
+## Budgets
+
+Finance uses **envelope budgeting** — a method where every dollar of income gets assigned to a specific category. It's like putting cash into labeled envelopes for each spending area.
+
+### Creating a budget
+
+1. Go to **Budget**.
+2. Tap **Set Up Budget** (or Finance prompts you after your first income entry).
+3. Enter your monthly income.
+4. Assign amounts to each category.
+5. The **"To Budget"** counter counts down to $0 — when every dollar has a job, you're set.
+
+> 💡 If you're new to budgeting, Finance suggests a **50/30/20** split as a starting point: 50% needs, 30% wants, 20% savings.
+
+### Tracking progress
+
+Each budget category shows:
+
+- **Budgeted** — how much you assigned
+- **Spent** — how much you've used
+- **Remaining** — what's left
+
+A progress bar fills as you spend:
+
+- 🟢 **Under 80%** — on track
+- 🟡 **80–100%** — getting close
+- Past 100% the bar continues — no alarm, just information
+
+Finance uses non-judgmental language. You'll never see "You overspent!" Instead:
+
+> _"You've used 110% of your Food plan — want to adjust?"_
+
+### Budget periods
+
+Monthly is the default, but you can set budgets for different time periods:
+
+- Weekly
+- Bi-weekly
+- Monthly
+- Yearly
+- Custom date range
+
+### Rollover
+
+What happens to unspent money at the end of the period?
+
+- **Rollover on** (per category): Unspent money carries forward. If you budgeted $600 for food and only spent $400, next month starts with that $200 plus your new allocation.
+- **Rollover off**: Each period starts fresh.
+- **Negative rollover**: If you overspend, the debt carries to next month (so you can make up for it).
+
+To enable rollover: tap a budget category → toggle **Rollover**.
+
+### Covering overspending
+
+Went over in one category? Move money from another:
+
+1. Tap the overspent category.
+2. Tap **Cover**.
+3. Choose a category that has remaining budget.
+4. Enter the amount to move.
+
+**Example:** Entertainment has $100 left. Dining is $50 over. Move $50 from Entertainment → both categories balanced.
+
+### Budget alerts
+
+Get a gentle heads-up when you're approaching a limit:
+
+- Configurable thresholds: 50%, 80%, 100%
+- Notifications are opt-in and use friendly language:
+
+> _"You've used 80% of your Food budget this month."_
+
+---
+
+## Goals
+
+Goals help you save toward specific targets — whether it's a rainy day fund, a vacation, or a major purchase.
+
+### Setting a goal
+
+1. Go to **Goals**.
+2. Tap **Add Goal**.
+3. Enter:
+   - **Name** — what you're saving for (e.g., "Emergency Fund")
+   - **Target amount** — how much you need (e.g., $10,000)
+   - **Deadline** (optional) — when you want to reach it
+4. Tap **Save**.
+
+If you set a deadline, Finance calculates how much you need to save each month to stay on track.
+
+### Tracking progress
+
+Each goal shows:
+
+- A visual progress bar with percentage
+- Amount saved vs. target
+- On-track / behind / ahead status (if you set a deadline)
+- A projection: _"At this pace, you'll reach your goal by [date]."_
+
+### Funding a goal
+
+Put money toward a goal in two ways:
+
+- **From unbudgeted income**: Assign money from your "To Budget" balance directly to a goal.
+- **From budget categories**: Move allocation from a budget category to a goal.
+
+Each contribution appears in the goal's history.
+
+### Milestone celebrations 🎉
+
+Finance celebrates your progress:
+
+- **25%** — "Great start!"
+- **50%** — "Halfway there!"
+- **75%** — "Almost there!"
+- **100%** — "You did it! 🎉"
+
+Milestones are positive and encouraging — never pressuring.
+
+---
+
+## Reports & Analytics
+
+Finance turns your data into clear, actionable insights. All reports are available offline and work with your local data.
+
+### Spending by category
+
+See where your money goes with a visual breakdown:
+
+- A donut chart shows each category's share of spending
+- Tap any category to see the individual transactions
+- Switch between time periods: this month, last month, or a custom date range
+- Total spending for the period appears at the top
+
+The chart uses a **color-blind safe palette** so it's readable for everyone. An accessible list view is also available.
+
+### Spending trends
+
+Track how your spending changes over time:
+
+- A bar or line chart shows monthly totals
+- Filter by a specific category or view all spending
+- Choose a time range: 3, 6, or 12 months
+- A trend indicator shows if spending is going up or down compared to the previous period
+
+**Example:** _"Dining spending is down 12% compared to last month."_
+
+### Income vs. expenses
+
+Compare what comes in to what goes out:
+
+- Side-by-side view of income and expenses
+- **Savings rate** — the percentage of income you keep
+- Monthly trend over time
+- Breakdown by income source
+
+**Example:** Income: $5,000. Expenses: $3,800. Savings: $1,200 (24% savings rate).
+
+### Net worth
+
+Track your overall financial position over time:
+
+- **Net worth** = total assets − total liabilities
+- A line chart shows the trend over months and years
+- Breakdown by individual account
+- Archived accounts are excluded
+
+All report data is also available as tables (not just charts) for accessibility.
+
+---
+
+## Multi-Currency
+
+Finance supports multiple currencies for people who earn, spend, or save in more than one currency.
+
+### Setting your default currency
+
+During setup (or anytime in Settings), choose your primary currency. Finance supports all ISO 4217 currencies and formats amounts with the correct symbol, decimal places, and position.
+
+### Using multiple currencies
+
+- Each account can have its own currency.
+- Transactions are recorded in the account's currency.
+- Reports and summaries show totals converted to your default currency.
+
+### Exchange rates
+
+Finance handles currency display so you always know what you have in each currency. Multi-currency balances are shown alongside converted values in your default currency.
+
+---
+
+## Data Export
+
+You own your data. Finance makes it easy to take it with you.
+
+### How to export
+
+1. Go to **Settings → Export**.
+2. Choose a format:
+   - **JSON** — complete export, includes all data (accounts, transactions, categories, budgets, goals)
+   - **CSV** — spreadsheet-friendly export of transactions
+3. Tap **Export**.
+4. The file saves to your device or opens your platform's share sheet.
+
+### What's included
+
+| Format | Includes |
+| --- | --- |
+| JSON | Accounts, transactions, categories, budgets, goals, plus metadata (export date, record counts, integrity check) |
+| CSV | Transaction history with dates, amounts, payees, categories, and notes |
+
+Export is instant — no waiting for an email. The file is generated on your device from your local data.
+
+> 💡 Data export is available on the free tier. It's also how Finance satisfies your legal right to data portability under GDPR and CCPA.
+
+---
+
+## Household Sharing
+
+Share your financial picture with a partner or family — while keeping personal finances private.
+
+> ⚠️ Household sharing is a **premium feature** available with a paid subscription.
+
+### Creating a household
+
+1. Go to **Settings → Household**.
+2. Tap **Create Household**.
+3. Give it a name (e.g., "Smith Family Finances").
+
+You're the **owner** of the household.
+
+### Inviting members
+
+1. From your household screen, tap **Invite Member**.
+2. Enter their email address or share an invite link.
+3. They accept the invitation from their Finance app.
+
+Invitations expire after 72 hours for security.
+
+### Roles and permissions
+
+| Role | Can do |
+| --- | --- |
+| **Owner** | Full control — manage members, edit everything, delete the household |
+| **Partner** | Edit shared accounts and budgets, view everything |
+| **Member** | Edit their own entries, view shared items |
+| **Viewer** | Read-only access to shared items |
+
+The owner can change anyone's role. No one can escalate their own permissions.
+
+### Shared vs. personal
+
+- **Shared accounts and budgets** are visible to all household members
+- **Personal accounts** remain private — only you can see them
+- Budget categories can be flagged as "shared" (like rent) or "personal" (like hobbies)
+- Shared spending rolls up into shared reports
+
+### How it works technically
+
+- Household data syncs through the same encrypted sync system
+- Each household has its own encryption key
+- Access is enforced server-side — permissions can't be bypassed
+- If a member leaves, their access is revoked immediately
+
+---
+
+## Experience Levels
+
+Finance adapts to your comfort level with financial concepts.
+
+### Three levels
+
+| Level | What it means |
+| --- | --- |
+| 🌱 **Getting Started** | Plain language everywhere. Guided prompts walk you through actions. Advanced features are hidden until you're ready. Proactive tips help you learn. |
+| 📊 **Comfortable** | Standard financial terms with plain-language descriptions available on tap. All features visible. This is the default. |
+| 🧠 **Advanced** | Traditional finance terminology. Detailed breakdowns. Power-user shortcuts. Raw data access. |
+
+### What changes between levels
+
+- **Terminology** — "Spending plan" vs. "Budget" vs. "Envelope allocation"
+- **Visible features** — progressive disclosure based on your level
+- **Default views** — simplified summaries vs. detailed breakdowns
+- **Notifications** — gentle nudges vs. data-rich alerts
+- **Charts** — simple bar charts vs. multi-axis visualizations
+
+### Changing your level
+
+Go to **Settings → Experience Level** and choose a new tier. The change takes effect immediately. You can switch as often as you like.
+
+### Contextual help
+
+No matter which level you choose, every financial concept in the app has an **info tap** (ℹ️). Tap it to see:
+
+- What the concept is
+- How it's calculated
+- Why it matters
+
+Finance believes in education without condescension. You should never feel lost.
+
+---
+
+_For more help, see the [FAQ](./faq.md) or the [Privacy & Security Guide](./privacy-security.md)._

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -38,12 +38,12 @@ Finance tracks your accounts, transactions, budgets, goals, and spending — all
 
 Finance runs natively on four platforms:
 
-| Platform | Details |
-| --- | --- |
-| 📱 **iOS** | iPhone, iPad, and Mac (native SwiftUI) |
-| 🤖 **Android** | Phones and tablets (Jetpack Compose) |
-| 🌐 **Web** | Any modern browser — installable as an app (PWA) |
-| 🖥️ **Windows** | Windows 11 desktop app |
+| Platform       | Details                                          |
+| -------------- | ------------------------------------------------ |
+| 📱 **iOS**     | iPhone, iPad, and Mac (native SwiftUI)           |
+| 🤖 **Android** | Phones and tablets (Jetpack Compose)             |
+| 🌐 **Web**     | Any modern browser — installable as an app (PWA) |
+| 🖥️ **Windows** | Windows 11 desktop app                           |
 
 All platforms share the same core features. Your data syncs seamlessly between them if you choose to enable sync (it's optional).
 
@@ -74,11 +74,11 @@ A quick 30-second setup (skippable at any point):
 
 Finance offers three experience tiers — you pick the one that fits you best, and you can change it anytime in Settings:
 
-| Level | Best for | What changes |
-| --- | --- | --- |
-| 🌱 **Getting Started** | New to budgeting or personal finance | Simpler language, guided prompts, fewer numbers on screen |
-| 📊 **Comfortable** | You've tracked finances before | Standard view with all features visible (this is the default) |
-| 🧠 **Advanced** | You love spreadsheets and data | Detailed breakdowns, technical terms, power-user shortcuts |
+| Level                  | Best for                             | What changes                                                  |
+| ---------------------- | ------------------------------------ | ------------------------------------------------------------- |
+| 🌱 **Getting Started** | New to budgeting or personal finance | Simpler language, guided prompts, fewer numbers on screen     |
+| 📊 **Comfortable**     | You've tracked finances before       | Standard view with all features visible (this is the default) |
+| 🧠 **Advanced**        | You love spreadsheets and data       | Detailed breakdowns, technical terms, power-user shortcuts    |
 
 ---
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -1,0 +1,298 @@
+# Getting Started with Finance
+
+Welcome to Finance — a personal finance tracker that respects your privacy, works offline, and takes less than 30 seconds a day to use. 🎉
+
+Whether you want to track spending, build a budget, save for a goal, or just see where your money goes, this guide will walk you through everything you need to get up and running.
+
+---
+
+## Table of Contents
+
+- [What is Finance?](#what-is-finance)
+- [Where can I use Finance?](#where-can-i-use-finance)
+- [Setting up your account](#setting-up-your-account)
+- [Adding your first account](#adding-your-first-account)
+- [Creating your first transaction](#creating-your-first-transaction)
+- [Setting up a budget](#setting-up-a-budget)
+- [Setting a savings goal](#setting-a-savings-goal)
+- [Working offline](#working-offline)
+- [Syncing across devices](#syncing-across-devices)
+- [Tips for daily use](#tips-for-daily-use)
+- [Next steps](#next-steps)
+
+---
+
+## What is Finance?
+
+Finance is a personal and family finance tracker built around three ideas:
+
+1. **Your data stays private.** Everything is stored on your device, encrypted. No bank connections required. No one sees your data but you.
+2. **It works with your brain.** The app adapts to your comfort level with financial concepts — whether you're just starting out or you're a spreadsheet expert.
+3. **30 seconds or less.** Recording a purchase takes three taps. Checking your budget takes a glance. The app fits into your life — not the other way around.
+
+Finance tracks your accounts, transactions, budgets, goals, and spending — all in one place, across all your devices.
+
+---
+
+## Where can I use Finance?
+
+Finance runs natively on four platforms:
+
+| Platform | Details |
+| --- | --- |
+| 📱 **iOS** | iPhone, iPad, and Mac (native SwiftUI) |
+| 🤖 **Android** | Phones and tablets (Jetpack Compose) |
+| 🌐 **Web** | Any modern browser — installable as an app (PWA) |
+| 🖥️ **Windows** | Windows 11 desktop app |
+
+All platforms share the same core features. Your data syncs seamlessly between them if you choose to enable sync (it's optional).
+
+For platform-specific tips like setting up Face ID or Windows Hello, see the [Platform Guides](./platforms.md).
+
+---
+
+## Setting up your account
+
+When you first open Finance, you'll choose one of two paths:
+
+### Path A: "Just let me in"
+
+One tap and you're in. Finance auto-detects your currency and drops you into a ready-to-use dashboard. No sign-up required — you can start tracking immediately.
+
+> 💡 You can always create an account later when you want to sync across devices.
+
+### Path B: "Personalize my experience"
+
+A quick 30-second setup (skippable at any point):
+
+1. **"How do you feel about your money?"** — This helps Finance choose the right level of detail for you.
+2. **Currency + First account** — Set your currency and add your first account in one step.
+3. **"What matters most?"** — Pick your top priority (save more, track spending, build a budget, or reduce debt).
+4. **"You're ready."** — Your personalized dashboard appears.
+
+### Choosing your experience level
+
+Finance offers three experience tiers — you pick the one that fits you best, and you can change it anytime in Settings:
+
+| Level | Best for | What changes |
+| --- | --- | --- |
+| 🌱 **Getting Started** | New to budgeting or personal finance | Simpler language, guided prompts, fewer numbers on screen |
+| 📊 **Comfortable** | You've tracked finances before | Standard view with all features visible (this is the default) |
+| 🧠 **Advanced** | You love spreadsheets and data | Detailed breakdowns, technical terms, power-user shortcuts |
+
+---
+
+## Adding your first account
+
+An "account" in Finance represents any place you keep money — a bank account, a credit card, your wallet, even an investment account.
+
+**To add your first account:**
+
+1. Go to the **Accounts** screen.
+2. Tap **Add Account**.
+3. Enter a name (e.g., "Chase Checking").
+4. Choose the account type:
+   - **Checking** — everyday spending account
+   - **Savings** — money set aside
+   - **Credit Card** — tracks what you owe
+   - **Cash** — physical cash on hand
+   - **Investment** — brokerage, retirement, etc.
+   - **Loan** — mortgage, student loan, car payment
+5. Enter your current balance.
+6. Tap **Save**.
+
+That's it! Your account appears in your list with its balance. You can add more accounts anytime.
+
+> 💡 Your balance updates automatically as you add transactions. If you need to correct a balance later, Finance creates an "adjustment" transaction so your history stays accurate.
+
+---
+
+## Creating your first transaction
+
+Transactions are the heart of Finance — they record every time money comes in or goes out. The quick-entry feature is designed to take **three taps or less**.
+
+**To add a transaction:**
+
+1. Tap the **+** button (available from any screen).
+2. Type the amount (e.g., `4.50`).
+3. Choose a category (e.g., "Coffee & Tea").
+4. Tap **Save**.
+
+Done! Your account balance and budget update instantly.
+
+**Want to add more detail?** Tap "More details" before saving to add:
+
+- **Payee** — who you paid (e.g., "Starbucks")
+- **Date** — defaults to today, but you can change it
+- **Notes** — any context you want to remember
+- **Tags** — custom labels for extra organization
+- **Account** — if you have multiple accounts
+
+> 💡 Finance learns from your habits. After a few entries, it suggests categories based on your recent transactions.
+
+### Other things you can do with transactions
+
+- **Transfer money** between your own accounts (e.g., checking → savings)
+- **Split a transaction** across multiple categories (e.g., a grocery run that includes household items)
+- **Search and filter** your transaction history by payee, category, date, or amount
+- **Edit or delete** any transaction — budgets and balances recalculate automatically
+
+For the full guide, see [Features → Transactions](./features.md#transactions).
+
+---
+
+## Setting up a budget
+
+Finance uses **envelope budgeting** — a method where you give every dollar a job. Think of it like dividing your income into labeled envelopes for different spending categories.
+
+**To create your first budget:**
+
+1. Go to the **Budget** screen.
+2. Tap **Set Up Budget** (or Finance will prompt you after your first income entry).
+3. Enter your total monthly income.
+4. Assign amounts to categories:
+   - Food: $600
+   - Housing: $1,200
+   - Transport: $400
+   - Entertainment: $200
+   - ...and so on
+5. The "To Budget" counter counts down as you assign money. The goal is $0 remaining — every dollar has a job.
+
+**Tracking your budget:**
+
+Each category shows a progress bar:
+
+- 🟢 **Green** — you've used less than 80% of the budget
+- 🟡 **Yellow** — you're between 80% and 100%
+- The bar keeps going past 100% if you go over — no judgment, just information
+
+> 💡 Finance uses encouraging language, never shaming. Instead of "You overspent!", you'll see something like: _"You've used 110% of your Food plan — want to adjust?"_
+
+**Budget tips:**
+
+- **Rollover**: Unspent money can carry forward to next month (enable per category).
+- **Cover overspending**: Move money between categories if one runs over. Go to the overspent category → tap **Cover** → choose a category to move money from.
+- **Budget periods**: Monthly is the default. Weekly, bi-weekly, and yearly options are also available.
+
+For the full guide, see [Features → Budgets](./features.md#budgets).
+
+---
+
+## Setting a savings goal
+
+Goals help you save toward something specific — an emergency fund, a vacation, a house down payment, or anything else.
+
+**To set a goal:**
+
+1. Go to the **Goals** screen.
+2. Tap **Add Goal**.
+3. Enter a name (e.g., "House Down Payment").
+4. Set your target amount (e.g., $50,000).
+5. Optionally, set a deadline (e.g., December 2028).
+6. Tap **Save**.
+
+Finance shows your progress with a visual bar and tells you how much you need to save each month to stay on track.
+
+**Funding your goal:**
+
+- Assign money from your unbudgeted income directly to a goal.
+- Move money from budget categories to your goal.
+- Each contribution is tracked in your goal's history.
+
+**Milestone celebrations:**
+
+Finance celebrates your progress at 25%, 50%, 75%, and 100%. 🎉
+
+For the full guide, see [Features → Goals](./features.md#goals).
+
+---
+
+## Working offline
+
+Finance is **offline-first**. That means:
+
+- ✅ You can add transactions without internet
+- ✅ You can check budgets and balances without internet
+- ✅ You can search your history without internet
+- ✅ You can do everything the app offers without internet
+
+Your data lives on your device. The internet is only needed if you choose to sync across multiple devices — and even then, everything queues up and syncs automatically when you're back online.
+
+> 💡 This also means your financial data never has to leave your device if you don't want it to.
+
+---
+
+## Syncing across devices
+
+If you use Finance on more than one device (like your phone and your laptop), you can enable cloud sync to keep everything in sync.
+
+**How it works:**
+
+1. Create a Finance account (email or passkey).
+2. Sign in on each device.
+3. Sync happens automatically in the background.
+
+**What you should know:**
+
+- Sync is **opt-in** — you don't have to use it.
+- Your data is **end-to-end encrypted** before it leaves your device. The sync server can't read your financial data.
+- If you edit the same transaction on two devices while offline, Finance handles the conflict — usually automatically, but it'll ask you if there's ambiguity.
+- A small sync indicator shows the current state: synced, syncing, pending changes, or offline.
+
+Sync is a **premium feature** — the free tier gives you a complete financial tracker on a single device.
+
+---
+
+## Tips for daily use
+
+Finance is designed around a **30-second daily habit**. Here's how people use it:
+
+### ☀️ Morning: Check your snapshot
+
+An optional daily notification tells you yesterday's spending and how your week is going:
+
+> _"Yesterday you spent $47. Your week is on track. ✅"_
+
+### 🏃 During the day: Quick capture
+
+When you buy something, open Finance → tap **+** → enter amount → pick category → done. Three taps, under 10 seconds.
+
+Or use the **home screen widget** to check your remaining budget at a glance.
+
+### 🤔 "Can I afford this?"
+
+Standing in a store? Tap a budget category on the widget to see what's left:
+
+> _"Dining: $67 left this month."_
+
+### 📊 Weekly: Review your spending
+
+An optional weekly summary arrives each week:
+
+> _"This week: $312 spent. Biggest category: Dining ($89). You're $43 under budget."_
+
+### 📅 Monthly: Reflect
+
+A dashboard card shows your monthly picture: income, spending, savings rate, and how things compare to last month.
+
+### 🔥 Streaks
+
+Finance tracks how many days in a row you log something. It's a gentle motivator — and if you skip a day, there's no guilt. Just:
+
+> _"Welcome back! Pick up where you left off."_
+
+---
+
+## Next steps
+
+You're all set! Here are some things to explore next:
+
+- 📖 **[Feature Guide](./features.md)** — Deep dive into every feature: accounts, transactions, budgets, goals, reports, multi-currency, sharing, and more.
+- 🔒 **[Privacy & Security](./privacy-security.md)** — Learn how your data is protected.
+- 📱 **[Platform Guides](./platforms.md)** — Get the most out of Finance on your specific device.
+- ♿ **[Accessibility](./accessibility.md)** — Screen reader support, high contrast, keyboard navigation, and more.
+- ❓ **[FAQ & Troubleshooting](./faq.md)** — Answers to common questions.
+
+---
+
+_Finance is non-judgmental, private, and built to fit your life. Welcome aboard._

--- a/docs/guides/in-app-help-plan.md
+++ b/docs/guides/in-app-help-plan.md
@@ -1,0 +1,359 @@
+# In-App Help Integration Plan
+
+> **Status:** Planning  
+> **Purpose:** Define how contextual help, tooltips, FAQ, and documentation integrate into the Finance app experience across all platforms.
+
+---
+
+## Table of Contents
+
+- [Goals](#goals)
+- [Strategy overview](#strategy-overview)
+- [Tooltip system for financial concepts](#tooltip-system-for-financial-concepts)
+- [Link structure: app to docs](#link-structure-app-to-docs)
+- [FAQ integration](#faq-integration)
+- [Contextual help triggers](#contextual-help-triggers)
+- [Feedback mechanism](#feedback-mechanism)
+- [Implementation guidance](#implementation-guidance)
+
+---
+
+## Goals
+
+1. **No user should feel lost.** Every financial concept in the app should be explainable in context, without leaving the current screen.
+2. **Help should match the user's level.** Content adapts to the user's experience tier (🌱 Getting Started, 📊 Comfortable, 🧠 Advanced).
+3. **Help should not be intrusive.** Tooltips and guidance appear when invited, never forced.
+4. **External docs are a fallback, not the primary path.** The app should answer 90% of questions in context. External documentation handles the remaining 10% (deep dives, legal details, troubleshooting edge cases).
+
+---
+
+## Strategy overview
+
+In-app help operates in three layers:
+
+```
+Layer 1: Contextual tooltips (inline, on-screen)
+   ↓ need more?
+Layer 2: Help panel / bottom sheet (in-app, deeper explanation)
+   ↓ need more?
+Layer 3: External documentation (docs site, linked from app)
+```
+
+### Layer 1 — Contextual tooltips
+
+Small info icons (ℹ️) next to financial terms and concepts. Tapping opens a brief, plain-language tooltip.
+
+**Examples:**
+- Next to "Net Worth": _"Your net worth is everything you own minus everything you owe. It's the big-picture number that shows your overall financial health."_
+- Next to "Rollover": _"When rollover is on, any money you didn't spend this month carries forward to next month."_
+- Next to "Savings Rate": _"Your savings rate is the percentage of your income that you keep. A higher number means you're saving more."_
+
+### Layer 2 — Help panel
+
+A slide-up panel or bottom sheet with a fuller explanation, examples, and a "Learn more" link to external docs. Triggered by:
+- Tapping "Learn more" on a tooltip
+- Tapping a "?" icon in the section header
+- The help entry in the navigation/settings menu
+
+### Layer 3 — External documentation
+
+Links to the hosted documentation site (or in-app WebView) for:
+- Complete feature guides
+- Privacy and security details
+- FAQ and troubleshooting
+- Legal documents (privacy policy, terms of service)
+
+---
+
+## Tooltip system for financial concepts
+
+### Content structure
+
+Each tooltip has a consistent structure:
+
+```
+┌─────────────────────────────────────┐
+│ [Term]                              │
+│                                     │
+│ [Plain-language definition]         │
+│ [One-sentence "why it matters"]     │
+│                                     │
+│ [Learn more →]  (optional link)     │
+└─────────────────────────────────────┘
+```
+
+### Content by experience tier
+
+Tooltips adapt to the user's selected experience level:
+
+| Concept | 🌱 Getting Started | 📊 Comfortable | 🧠 Advanced |
+| --- | --- | --- | --- |
+| **Net Worth** | "Everything you own minus everything you owe." | "Total assets minus total liabilities." | "Sum of asset account balances less liability account balances, excluding archived accounts." |
+| **Savings Rate** | "How much of your income you keep." | "Percentage of income not spent." | "Net savings ÷ gross income × 100, calculated per period." |
+| **Rollover** | "Unspent budget money carries to next month." | "Positive or negative balance rolls to the next budget period." | "Residual allocation propagated to the subsequent period as a signed carryforward." |
+
+### Tooltip inventory (initial set)
+
+Financial concepts that need tooltips at launch:
+
+| Screen | Concept | Tooltip needed |
+| --- | --- | --- |
+| Accounts | Net worth | ✅ |
+| Accounts | Assets vs. liabilities | ✅ |
+| Transactions | Split transaction | ✅ |
+| Transactions | Transfer vs. transaction | ✅ |
+| Transactions | Recurring transaction | ✅ |
+| Budget | Envelope budgeting | ✅ |
+| Budget | To Budget (remaining) | ✅ |
+| Budget | Rollover | ✅ |
+| Budget | Cover overspending | ✅ |
+| Goals | Target amount | ✅ |
+| Goals | Monthly contribution | ✅ |
+| Goals | Projected completion | ✅ |
+| Reports | Spending breakdown | ✅ |
+| Reports | Savings rate | ✅ |
+| Reports | Spending trend | ✅ |
+| Reports | Income vs. expenses | ✅ |
+| Settings | Biometric lock | ✅ |
+| Settings | Data export | ✅ |
+| Settings | Crypto-shredding (in delete flow) | ✅ |
+| Sync | End-to-end encryption | ✅ |
+| Sync | Conflict resolution | ✅ |
+
+### Implementation notes
+
+- Tooltips are stored as structured data (JSON or resource files) so they can be:
+  - Updated without app releases (via sync or remote config)
+  - Localized for different languages
+  - A/B tested for clarity
+- Each tooltip has an ID, concept key, and tier-specific content
+- The tooltip component is shared across platforms via the KMP design system
+
+---
+
+## Link structure: app to docs
+
+### URL scheme
+
+All in-app links to external documentation follow a consistent pattern:
+
+```
+https://docs.finance.example.com/guides/{page}#{section}
+```
+
+**Examples:**
+- `https://docs.finance.example.com/guides/features#budgets`
+- `https://docs.finance.example.com/guides/faq#sync-isnt-working`
+- `https://docs.finance.example.com/guides/privacy-security#your-rights`
+
+### Link mapping
+
+| In-app location | Link target |
+| --- | --- |
+| Settings → Help → Getting Started | `guides/getting-started` |
+| Settings → Help → Feature Guide | `guides/features` |
+| Settings → Help → FAQ | `guides/faq` |
+| Settings → Help → Privacy & Security | `guides/privacy-security` |
+| Settings → Help → Accessibility | `guides/accessibility` |
+| Tooltip "Learn more" → Budgets | `guides/features#budgets` |
+| Tooltip "Learn more" → Goals | `guides/features#goals` |
+| Tooltip "Learn more" → Sync | `guides/getting-started#syncing-across-devices` |
+| Delete account confirmation | `guides/privacy-security#how-to-exercise-your-rights` |
+| Privacy policy link | `legal/privacy-policy` |
+
+### Opening behavior
+
+- **iOS**: Opens in `SFSafariViewController` (in-app browser) — user stays in the app context
+- **Android**: Opens in a Custom Tab (Chrome Custom Tab) — stays in the app context
+- **Windows**: Opens in the system default browser
+- **Web**: Opens in a new tab (or same-origin navigation for internal docs)
+
+---
+
+## FAQ integration
+
+### In-app FAQ screen
+
+A searchable FAQ screen accessible from **Settings → Help → FAQ** that:
+
+1. Displays the most common questions from [`docs/guides/faq.md`](./faq.md)
+2. Lets users search by keyword
+3. Groups questions by category (General, Privacy, Sync, Billing, Troubleshooting)
+4. Links to the full web FAQ for the complete list
+
+### Contextual FAQ suggestions
+
+Certain screens surface relevant FAQ items proactively:
+
+| Screen / State | Suggested FAQ |
+| --- | --- |
+| Sync settings (first visit) | "How does sync work?" |
+| Sync error state | "Sync isn't working — what should I do?" |
+| Export screen | "How do I export my data?" |
+| Delete account screen | "How do I delete my account?" |
+| Offline state (badge visible) | "What happens when I'm offline?" |
+| Premium feature (locked) | "Is there a free version?" / "What does premium include?" |
+| Login screen | "I forgot my password" |
+
+### FAQ content management
+
+- FAQ content is authored in `docs/guides/faq.md` (the single source of truth)
+- A subset is bundled into the app for offline access
+- The full FAQ is available online via the docs site
+- FAQ entries have unique IDs for deep linking (e.g., `faq#sync-isnt-working`)
+
+---
+
+## Contextual help triggers
+
+### When help appears
+
+Help is offered — never forced — at specific moments:
+
+| Trigger | Help type | Content |
+| --- | --- | --- |
+| First time viewing budget screen | Coach mark / spotlight | "This is your budget. Each category is like an envelope of money." |
+| First time using quick entry | Guided highlight | "Tap +, enter amount, pick category. That's it!" |
+| Overspent a budget category | Non-judgmental nudge | "You've used 110% of Food. You can cover it from another category." |
+| Goal milestone reached | Celebration + tip | "🎉 50% of your goal! At this pace, you'll reach it by [date]." |
+| First time in settings | Task card | "Tip: Set up biometric lock to keep your finances private." |
+| After 7 days of use | Achievement card | "You've tracked for a week! Here's your first weekly summary." |
+
+### Dismissal behavior
+
+- All coach marks and tips can be dismissed with a single tap
+- Dismissed tips don't reappear
+- A "Show tips" toggle in Settings re-enables them
+- Tips that have been dismissed are stored locally (per device)
+
+### Onboarding task cards
+
+After onboarding, gentle task cards appear on the dashboard:
+
+- "Add your first account" (if none exist)
+- "Set a spending plan" (if no budget exists)
+- "Try the quick-entry button"
+- "Complete your setup (3/6 done)"
+
+Cards are:
+- Non-nagging (appear once, can be dismissed permanently)
+- Progress-tracked (show completion state)
+- Experience-tier-aware (🌱 users see more guidance)
+
+---
+
+## Feedback mechanism
+
+### In-app feedback flow
+
+Users can provide feedback from any screen:
+
+1. **Settings → Help → Send Feedback** — general feedback form
+2. **Settings → Help → Report a Bug** — structured bug report
+3. **Settings → Help → Feature Request** — structured feature request
+4. **Tooltip → "Was this helpful?"** — quick yes/no on tooltips
+
+### Bug report structure
+
+The bug report form collects:
+
+| Field | Required | Contains personal data? |
+| --- | --- | --- |
+| Description of the problem | Yes | Potentially (user-written) |
+| Steps to reproduce | No | No |
+| Expected vs. actual behavior | No | No |
+| App version | Auto-filled | No |
+| Platform and OS version | Auto-filled | No |
+| Experience tier | Auto-filled | No |
+| Screenshot (opt-in) | No | Potentially |
+
+**What is NOT collected:**
+- ❌ Financial data (accounts, transactions, balances)
+- ❌ Personal identifiers (email, name) unless the user provides them for follow-up
+- ❌ Device identifiers or advertising IDs
+- ❌ Location data
+
+### Tooltip feedback loop
+
+Each tooltip has an optional "Was this helpful?" prompt:
+
+```
+┌─────────────────────────────────────┐
+│ Net Worth                           │
+│                                     │
+│ Everything you own minus everything │
+│ you owe.                            │
+│                                     │
+│ Was this helpful?  👍  👎           │
+│ [Learn more →]                      │
+└─────────────────────────────────────┘
+```
+
+Feedback is aggregated anonymously to identify tooltips that need improvement. No personal data is attached to tooltip feedback.
+
+---
+
+## Implementation guidance
+
+### Priority order
+
+1. **Phase 1** (launch): Tooltip system with initial 20 concepts, Settings → Help links, in-app FAQ screen
+2. **Phase 2** (v1.1): Contextual FAQ suggestions, onboarding task cards, coach marks
+3. **Phase 3** (v1.2): Feedback mechanism, tooltip feedback loop, remote tooltip content updates
+
+### Technical architecture
+
+```
+┌──────────────────────────────────────────────┐
+│  KMP Shared Layer                            │
+│  ┌──────────────────────────────────────┐    │
+│  │  HelpContentProvider                  │    │
+│  │  - getTooltip(conceptId, tier) → Tip  │    │
+│  │  - getFAQItems(category) → List<FAQ>  │    │
+│  │  - getDocLink(topic) → URL            │    │
+│  └──────────────────────────────────────┘    │
+│                                              │
+│  ┌──────────────────────────────────────┐    │
+│  │  Tooltip Content (JSON resources)     │    │
+│  │  - Tiered content per concept         │    │
+│  │  - Localizable strings                │    │
+│  └──────────────────────────────────────┘    │
+└──────────────────────────────────────────────┘
+         │
+         │ expect/actual
+         ▼
+┌──────────────┐ ┌──────────────┐ ┌──────────────┐ ┌──────────────┐
+│ iOS Tooltip  │ │ Android      │ │ Web Tooltip  │ │ Windows      │
+│ Component    │ │ Tooltip      │ │ Component    │ │ Tooltip      │
+│ (SwiftUI)    │ │ (Compose)    │ │ (React)      │ │ (Compose)    │
+└──────────────┘ └──────────────┘ └──────────────┘ └──────────────┘
+```
+
+### Content guidelines
+
+All help content should follow the product voice:
+
+- **Non-judgmental**: Never make the user feel bad about not knowing something
+- **Plain language**: Explain like a knowledgeable friend, not a textbook
+- **Actionable**: Tell users what they can do, not just what something is
+- **Brief**: Tooltips are 1–2 sentences. Help panels are 2–3 paragraphs max.
+- **Tier-appropriate**: Language matches the user's chosen experience level
+
+### Metrics to track
+
+| Metric | What it tells us |
+| --- | --- |
+| Tooltip open rate (per concept) | Which concepts need more explanation |
+| Tooltip "not helpful" rate | Which explanations need rewriting |
+| FAQ search queries with no results | What topics are missing from FAQ |
+| Help link tap-through rate | Whether users need deeper content |
+| Coach mark dismissal rate | Whether guidance is useful or annoying |
+| Time to dismiss onboarding cards | Whether cards are valuable or ignored |
+
+All metrics are privacy-safe (aggregated counts, no personal data) and only collected if the user has opted in to analytics.
+
+---
+
+_This plan aligns with Finance's product identity: educational without condescension, helpful without being pushy, and respectful of the user's time and autonomy._
+
+_Related documentation: [Feature Guide](./features.md) · [FAQ](./faq.md) · [Product Identity](../design/product-identity.md)_

--- a/docs/guides/in-app-help-plan.md
+++ b/docs/guides/in-app-help-plan.md
@@ -44,6 +44,7 @@ Layer 3: External documentation (docs site, linked from app)
 Small info icons (ℹ️) next to financial terms and concepts. Tapping opens a brief, plain-language tooltip.
 
 **Examples:**
+
 - Next to "Net Worth": _"Your net worth is everything you own minus everything you owe. It's the big-picture number that shows your overall financial health."_
 - Next to "Rollover": _"When rollover is on, any money you didn't spend this month carries forward to next month."_
 - Next to "Savings Rate": _"Your savings rate is the percentage of your income that you keep. A higher number means you're saving more."_
@@ -51,6 +52,7 @@ Small info icons (ℹ️) next to financial terms and concepts. Tapping opens a 
 ### Layer 2 — Help panel
 
 A slide-up panel or bottom sheet with a fuller explanation, examples, and a "Learn more" link to external docs. Triggered by:
+
 - Tapping "Learn more" on a tooltip
 - Tapping a "?" icon in the section header
 - The help entry in the navigation/settings menu
@@ -58,6 +60,7 @@ A slide-up panel or bottom sheet with a fuller explanation, examples, and a "Lea
 ### Layer 3 — External documentation
 
 Links to the hosted documentation site (or in-app WebView) for:
+
 - Complete feature guides
 - Privacy and security details
 - FAQ and troubleshooting
@@ -86,39 +89,39 @@ Each tooltip has a consistent structure:
 
 Tooltips adapt to the user's selected experience level:
 
-| Concept | 🌱 Getting Started | 📊 Comfortable | 🧠 Advanced |
-| --- | --- | --- | --- |
-| **Net Worth** | "Everything you own minus everything you owe." | "Total assets minus total liabilities." | "Sum of asset account balances less liability account balances, excluding archived accounts." |
-| **Savings Rate** | "How much of your income you keep." | "Percentage of income not spent." | "Net savings ÷ gross income × 100, calculated per period." |
-| **Rollover** | "Unspent budget money carries to next month." | "Positive or negative balance rolls to the next budget period." | "Residual allocation propagated to the subsequent period as a signed carryforward." |
+| Concept          | 🌱 Getting Started                             | 📊 Comfortable                                                  | 🧠 Advanced                                                                                   |
+| ---------------- | ---------------------------------------------- | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| **Net Worth**    | "Everything you own minus everything you owe." | "Total assets minus total liabilities."                         | "Sum of asset account balances less liability account balances, excluding archived accounts." |
+| **Savings Rate** | "How much of your income you keep."            | "Percentage of income not spent."                               | "Net savings ÷ gross income × 100, calculated per period."                                    |
+| **Rollover**     | "Unspent budget money carries to next month."  | "Positive or negative balance rolls to the next budget period." | "Residual allocation propagated to the subsequent period as a signed carryforward."           |
 
 ### Tooltip inventory (initial set)
 
 Financial concepts that need tooltips at launch:
 
-| Screen | Concept | Tooltip needed |
-| --- | --- | --- |
-| Accounts | Net worth | ✅ |
-| Accounts | Assets vs. liabilities | ✅ |
-| Transactions | Split transaction | ✅ |
-| Transactions | Transfer vs. transaction | ✅ |
-| Transactions | Recurring transaction | ✅ |
-| Budget | Envelope budgeting | ✅ |
-| Budget | To Budget (remaining) | ✅ |
-| Budget | Rollover | ✅ |
-| Budget | Cover overspending | ✅ |
-| Goals | Target amount | ✅ |
-| Goals | Monthly contribution | ✅ |
-| Goals | Projected completion | ✅ |
-| Reports | Spending breakdown | ✅ |
-| Reports | Savings rate | ✅ |
-| Reports | Spending trend | ✅ |
-| Reports | Income vs. expenses | ✅ |
-| Settings | Biometric lock | ✅ |
-| Settings | Data export | ✅ |
-| Settings | Crypto-shredding (in delete flow) | ✅ |
-| Sync | End-to-end encryption | ✅ |
-| Sync | Conflict resolution | ✅ |
+| Screen       | Concept                           | Tooltip needed |
+| ------------ | --------------------------------- | -------------- |
+| Accounts     | Net worth                         | ✅             |
+| Accounts     | Assets vs. liabilities            | ✅             |
+| Transactions | Split transaction                 | ✅             |
+| Transactions | Transfer vs. transaction          | ✅             |
+| Transactions | Recurring transaction             | ✅             |
+| Budget       | Envelope budgeting                | ✅             |
+| Budget       | To Budget (remaining)             | ✅             |
+| Budget       | Rollover                          | ✅             |
+| Budget       | Cover overspending                | ✅             |
+| Goals        | Target amount                     | ✅             |
+| Goals        | Monthly contribution              | ✅             |
+| Goals        | Projected completion              | ✅             |
+| Reports      | Spending breakdown                | ✅             |
+| Reports      | Savings rate                      | ✅             |
+| Reports      | Spending trend                    | ✅             |
+| Reports      | Income vs. expenses               | ✅             |
+| Settings     | Biometric lock                    | ✅             |
+| Settings     | Data export                       | ✅             |
+| Settings     | Crypto-shredding (in delete flow) | ✅             |
+| Sync         | End-to-end encryption             | ✅             |
+| Sync         | Conflict resolution               | ✅             |
 
 ### Implementation notes
 
@@ -142,24 +145,25 @@ https://docs.finance.example.com/guides/{page}#{section}
 ```
 
 **Examples:**
+
 - `https://docs.finance.example.com/guides/features#budgets`
 - `https://docs.finance.example.com/guides/faq#sync-isnt-working`
 - `https://docs.finance.example.com/guides/privacy-security#your-rights`
 
 ### Link mapping
 
-| In-app location | Link target |
-| --- | --- |
-| Settings → Help → Getting Started | `guides/getting-started` |
-| Settings → Help → Feature Guide | `guides/features` |
-| Settings → Help → FAQ | `guides/faq` |
-| Settings → Help → Privacy & Security | `guides/privacy-security` |
-| Settings → Help → Accessibility | `guides/accessibility` |
-| Tooltip "Learn more" → Budgets | `guides/features#budgets` |
-| Tooltip "Learn more" → Goals | `guides/features#goals` |
-| Tooltip "Learn more" → Sync | `guides/getting-started#syncing-across-devices` |
-| Delete account confirmation | `guides/privacy-security#how-to-exercise-your-rights` |
-| Privacy policy link | `legal/privacy-policy` |
+| In-app location                      | Link target                                           |
+| ------------------------------------ | ----------------------------------------------------- |
+| Settings → Help → Getting Started    | `guides/getting-started`                              |
+| Settings → Help → Feature Guide      | `guides/features`                                     |
+| Settings → Help → FAQ                | `guides/faq`                                          |
+| Settings → Help → Privacy & Security | `guides/privacy-security`                             |
+| Settings → Help → Accessibility      | `guides/accessibility`                                |
+| Tooltip "Learn more" → Budgets       | `guides/features#budgets`                             |
+| Tooltip "Learn more" → Goals         | `guides/features#goals`                               |
+| Tooltip "Learn more" → Sync          | `guides/getting-started#syncing-across-devices`       |
+| Delete account confirmation          | `guides/privacy-security#how-to-exercise-your-rights` |
+| Privacy policy link                  | `legal/privacy-policy`                                |
 
 ### Opening behavior
 
@@ -185,15 +189,15 @@ A searchable FAQ screen accessible from **Settings → Help → FAQ** that:
 
 Certain screens surface relevant FAQ items proactively:
 
-| Screen / State | Suggested FAQ |
-| --- | --- |
-| Sync settings (first visit) | "How does sync work?" |
-| Sync error state | "Sync isn't working — what should I do?" |
-| Export screen | "How do I export my data?" |
-| Delete account screen | "How do I delete my account?" |
-| Offline state (badge visible) | "What happens when I'm offline?" |
-| Premium feature (locked) | "Is there a free version?" / "What does premium include?" |
-| Login screen | "I forgot my password" |
+| Screen / State                | Suggested FAQ                                             |
+| ----------------------------- | --------------------------------------------------------- |
+| Sync settings (first visit)   | "How does sync work?"                                     |
+| Sync error state              | "Sync isn't working — what should I do?"                  |
+| Export screen                 | "How do I export my data?"                                |
+| Delete account screen         | "How do I delete my account?"                             |
+| Offline state (badge visible) | "What happens when I'm offline?"                          |
+| Premium feature (locked)      | "Is there a free version?" / "What does premium include?" |
+| Login screen                  | "I forgot my password"                                    |
 
 ### FAQ content management
 
@@ -210,14 +214,14 @@ Certain screens surface relevant FAQ items proactively:
 
 Help is offered — never forced — at specific moments:
 
-| Trigger | Help type | Content |
-| --- | --- | --- |
-| First time viewing budget screen | Coach mark / spotlight | "This is your budget. Each category is like an envelope of money." |
-| First time using quick entry | Guided highlight | "Tap +, enter amount, pick category. That's it!" |
-| Overspent a budget category | Non-judgmental nudge | "You've used 110% of Food. You can cover it from another category." |
-| Goal milestone reached | Celebration + tip | "🎉 50% of your goal! At this pace, you'll reach it by [date]." |
-| First time in settings | Task card | "Tip: Set up biometric lock to keep your finances private." |
-| After 7 days of use | Achievement card | "You've tracked for a week! Here's your first weekly summary." |
+| Trigger                          | Help type              | Content                                                             |
+| -------------------------------- | ---------------------- | ------------------------------------------------------------------- |
+| First time viewing budget screen | Coach mark / spotlight | "This is your budget. Each category is like an envelope of money."  |
+| First time using quick entry     | Guided highlight       | "Tap +, enter amount, pick category. That's it!"                    |
+| Overspent a budget category      | Non-judgmental nudge   | "You've used 110% of Food. You can cover it from another category." |
+| Goal milestone reached           | Celebration + tip      | "🎉 50% of your goal! At this pace, you'll reach it by [date]."     |
+| First time in settings           | Task card              | "Tip: Set up biometric lock to keep your finances private."         |
+| After 7 days of use              | Achievement card       | "You've tracked for a week! Here's your first weekly summary."      |
 
 ### Dismissal behavior
 
@@ -236,6 +240,7 @@ After onboarding, gentle task cards appear on the dashboard:
 - "Complete your setup (3/6 done)"
 
 Cards are:
+
 - Non-nagging (appear once, can be dismissed permanently)
 - Progress-tracked (show completion state)
 - Experience-tier-aware (🌱 users see more guidance)
@@ -257,17 +262,18 @@ Users can provide feedback from any screen:
 
 The bug report form collects:
 
-| Field | Required | Contains personal data? |
-| --- | --- | --- |
-| Description of the problem | Yes | Potentially (user-written) |
-| Steps to reproduce | No | No |
-| Expected vs. actual behavior | No | No |
-| App version | Auto-filled | No |
-| Platform and OS version | Auto-filled | No |
-| Experience tier | Auto-filled | No |
-| Screenshot (opt-in) | No | Potentially |
+| Field                        | Required    | Contains personal data?    |
+| ---------------------------- | ----------- | -------------------------- |
+| Description of the problem   | Yes         | Potentially (user-written) |
+| Steps to reproduce           | No          | No                         |
+| Expected vs. actual behavior | No          | No                         |
+| App version                  | Auto-filled | No                         |
+| Platform and OS version      | Auto-filled | No                         |
+| Experience tier              | Auto-filled | No                         |
+| Screenshot (opt-in)          | No          | Potentially                |
 
 **What is NOT collected:**
+
 - ❌ Financial data (accounts, transactions, balances)
 - ❌ Personal identifiers (email, name) unless the user provides them for follow-up
 - ❌ Device identifiers or advertising IDs
@@ -341,14 +347,14 @@ All help content should follow the product voice:
 
 ### Metrics to track
 
-| Metric | What it tells us |
-| --- | --- |
-| Tooltip open rate (per concept) | Which concepts need more explanation |
-| Tooltip "not helpful" rate | Which explanations need rewriting |
-| FAQ search queries with no results | What topics are missing from FAQ |
-| Help link tap-through rate | Whether users need deeper content |
-| Coach mark dismissal rate | Whether guidance is useful or annoying |
-| Time to dismiss onboarding cards | Whether cards are valuable or ignored |
+| Metric                             | What it tells us                       |
+| ---------------------------------- | -------------------------------------- |
+| Tooltip open rate (per concept)    | Which concepts need more explanation   |
+| Tooltip "not helpful" rate         | Which explanations need rewriting      |
+| FAQ search queries with no results | What topics are missing from FAQ       |
+| Help link tap-through rate         | Whether users need deeper content      |
+| Coach mark dismissal rate          | Whether guidance is useful or annoying |
+| Time to dismiss onboarding cards   | Whether cards are valuable or ignored  |
 
 All metrics are privacy-safe (aggregated counts, no personal data) and only collected if the user has opted in to analytics.
 

--- a/docs/guides/platforms.md
+++ b/docs/guides/platforms.md
@@ -1,0 +1,312 @@
+# Platform Guides
+
+Finance runs natively on iOS, Android, Web, and Windows. While the core features are the same everywhere, each platform has its own strengths. This guide covers platform-specific features and setup.
+
+---
+
+## Table of Contents
+
+- [iOS](#ios)
+- [Android](#android)
+- [Web PWA](#web-pwa)
+- [Windows](#windows)
+- [Cross-platform sync](#cross-platform-sync)
+
+---
+
+## iOS
+
+Finance on iOS is built with SwiftUI for a native Apple experience on iPhone, iPad, and Mac.
+
+### Face ID & Touch ID
+
+Lock Finance with your biometrics so only you can see your finances.
+
+**To set up:**
+
+1. Go to **Settings → Security → Biometric Lock**.
+2. Toggle **Face ID** (or **Touch ID** on older devices) on.
+3. Authenticate to confirm.
+
+**Options:**
+- Require biometric every time you open the app
+- Require biometric after a period of inactivity
+
+Your biometric data stays entirely on your device — Finance asks iOS to verify your identity, but the app never sees your actual Face ID or Touch ID data.
+
+> 💡 Finance uses Apple's **Secure Enclave** for storing encryption keys. This is the same hardware security chip that protects Apple Pay.
+
+### Apple Keychain integration
+
+Your Finance authentication credentials are stored in the Apple Keychain with the highest security level:
+
+- **Accessible only when your device is unlocked** — no background access to sensitive data
+- **Not synced to iCloud** — your credentials stay on this device
+- **Biometric-protected** — access requires Face ID or Touch ID confirmation
+
+Background sync tokens use a slightly less restrictive level (`AfterFirstUnlock`) so sync can happen while the app is in the background.
+
+### Widgets
+
+Finance offers home screen and Lock Screen widgets so you can check your finances without opening the app:
+
+- **Budget remaining** — see how much is left in your spending categories
+- **Goal progress** — track how close you are to your savings goals
+- **"Can I Afford This?"** — tap a category to see remaining budget
+
+On iOS 17+, widgets are **interactive** — tap the **+** button on a widget to open quick-entry without launching the full app.
+
+### Haptic feedback
+
+Finance uses Apple's custom haptic engine for subtle, satisfying feedback:
+
+- A confirmation tap when you save a transaction
+- A gentle pulse when you approach a budget threshold
+- A celebratory pattern when you hit a goal milestone
+
+### watchOS companion app
+
+> ⚠️ The Apple Watch companion app is **planned for a future release**. It will include quick transaction entry and budget glances from your wrist.
+
+### iPad & Mac
+
+Finance adapts to larger screens:
+
+- **iPad**: Multi-column layout, Split View and Slide Over support
+- **Mac** (via Catalyst/native): Full desktop experience with keyboard shortcuts
+
+---
+
+## Android
+
+Finance on Android is built with Jetpack Compose and Material You for a modern, customizable experience.
+
+### Biometric setup
+
+Lock Finance with your fingerprint or face recognition.
+
+**To set up:**
+
+1. Go to **Settings → Security → Biometric Lock**.
+2. Toggle **Biometric Lock** on.
+3. Authenticate with your fingerprint or face to confirm.
+
+Finance uses **BIOMETRIC_STRONG** (Class 3 biometrics) for maximum security, with a device PIN/pattern/password as fallback.
+
+> 💡 On devices with **StrongBox** hardware (like Google Pixel), your encryption keys are stored in a dedicated security chip — the same level of protection as hardware security keys.
+
+### Material You theming
+
+Finance automatically adapts to your Android 12+ **dynamic color** palette:
+
+- The app's color scheme follows your wallpaper colors
+- Widgets match your home screen's theme
+- All colors remain accessible (WCAG 2.2 AA contrast ratios are maintained)
+
+No setup needed — dynamic theming is automatic. You can override it in **Settings → Appearance** if you prefer a specific theme.
+
+### Home screen widgets
+
+Add Finance widgets to your home screen for at-a-glance information:
+
+- **Budget remaining** — see your spending categories with progress bars
+- **Goal progress** — visual tracker for savings goals
+
+Widgets use Material You dynamic colors to blend with your home screen.
+
+### Quick access shortcuts
+
+Long-press the Finance app icon for shortcuts:
+
+- **Quick Transaction** — jump straight to transaction entry
+- **Check Budget** — go directly to your budget screen
+
+### Quick Settings tile
+
+Add Finance to your Quick Settings panel for instant access:
+
+1. Pull down your notification shade.
+2. Tap the ✏️ **Edit** button on your Quick Settings tiles.
+3. Find **Finance Quick Entry** and drag it to your active tiles.
+4. Tap the tile anytime to open a quick transaction overlay — even from other apps.
+
+### Notifications
+
+Finance uses Android's notification system for:
+
+- Daily spending snapshots (optional)
+- Weekly summaries (optional)
+- Budget threshold alerts (when you approach or reach a limit)
+- Upcoming bill reminders
+
+All notifications are opt-in. Customize them in **Settings → Notifications** or through Android's system notification settings for Finance.
+
+### Predictive Back gesture
+
+Finance supports Android 14+'s Predictive Back gesture — you'll see a preview of where you're going when you start a back swipe.
+
+---
+
+## Web PWA
+
+Finance on the web is a **Progressive Web App (PWA)** — a full-featured app that runs in your browser and can be installed like a native app.
+
+### Installing as an app
+
+You don't have to use Finance in a browser tab. Install it for a native-like experience:
+
+**Chrome or Edge:**
+1. Visit Finance in your browser.
+2. Click the **install icon** (⊕) in the address bar, or open the browser menu → **Install app**.
+3. Finance opens in its own window with its own icon — just like a regular app.
+
+**Safari (macOS):**
+1. Visit Finance in Safari.
+2. Go to **File → Add to Dock**.
+
+**Mobile browsers:**
+1. Visit Finance in your mobile browser.
+2. Tap the browser menu → **Add to Home Screen**.
+
+Once installed, Finance launches in its own window, has its own taskbar/dock icon, and works offline.
+
+### Offline capabilities
+
+The web version works offline thanks to a service worker that caches the app:
+
+- ✅ Full app works without internet
+- ✅ All your data is stored locally in the browser (using OPFS or IndexedDB)
+- ✅ Transactions, budgets, and reports all work offline
+- ✅ Changes sync when you're back online (if sync is enabled)
+
+### Browser requirements
+
+Finance works best in modern browsers:
+
+| Browser | Support |
+| --- | --- |
+| **Chrome** (90+) | ✅ Full support, installable |
+| **Edge** (90+) | ✅ Full support, installable |
+| **Safari** (16+) | ✅ Supported (limited PWA install on macOS) |
+| **Firefox** (90+) | ✅ Supported (limited PWA install) |
+
+For the best experience, use Chrome or Edge — they have the most complete PWA support.
+
+### Keyboard shortcuts
+
+The web version is built with a **keyboard-first workflow** for efficient desktop use:
+
+| Shortcut | Action |
+| --- | --- |
+| `Ctrl+N` (or `⌘+N`) | New transaction |
+| `/` | Open search |
+| `Tab` | Navigate through fields and categories |
+| `Enter` | Confirm / save |
+| `Escape` | Cancel / close dialog |
+
+### Desktop layout
+
+At desktop widths (1200px and wider), Finance uses a **multi-panel layout** — you can see your accounts, transactions, and budget side-by-side without navigating between screens.
+
+### Printing reports
+
+Monthly reports are print-optimized. Go to any report → use your browser's print function (`Ctrl+P`) to get a clean, formatted printout.
+
+---
+
+## Windows
+
+Finance on Windows is built with Compose Desktop for a native Windows 11 experience.
+
+### Windows Hello
+
+Lock Finance with Windows Hello biometrics or PIN.
+
+**To set up:**
+
+1. Make sure **Windows Hello** is configured on your device (Settings → Accounts → Sign-in options).
+2. Open Finance → go to **Settings → Security → Biometric Lock**.
+3. Toggle **Windows Hello** on.
+4. Authenticate to confirm.
+
+Windows Hello supports:
+- Fingerprint readers
+- IR face recognition cameras
+- Security keys
+- PIN fallback
+
+### Desktop features
+
+Finance takes advantage of the Windows desktop environment:
+
+**Snap Layouts:**
+- Snap Finance to half your screen alongside a browser or spreadsheet
+- Finance adapts its layout to the snap size
+
+**System notifications:**
+- Budget alerts appear as Windows toast notifications
+- Click a notification to jump directly to the relevant screen
+- Notifications integrate with Focus Assist (they won't interrupt when you're in Do Not Disturb mode)
+
+### Keyboard shortcuts
+
+Finance supports keyboard shortcuts for efficient use:
+
+| Shortcut | Action |
+| --- | --- |
+| `Ctrl+N` | New transaction |
+| `Ctrl+F` or `/` | Search |
+| `Ctrl+E` | Export data |
+| `Tab` / `Shift+Tab` | Navigate forward / backward |
+| `Enter` | Confirm / save |
+| `Escape` | Cancel / close |
+
+### Accessibility on Windows
+
+- **Narrator** screen reader is fully supported
+- **High Contrast** themes are respected
+- All controls are keyboard-accessible
+- Focus indicators are clearly visible
+
+See the [Accessibility Guide](./accessibility.md) for more.
+
+### Data storage
+
+Your encrypted database is stored in `%LOCALAPPDATA%\Finance\` — per-user, not cloud-synced. Authentication tokens are protected with Windows DPAPI (Data Protection API), which ties encryption to your Windows user account.
+
+---
+
+## Cross-platform sync
+
+If you use Finance on multiple platforms, sync keeps everything consistent.
+
+### What syncs
+
+- ✅ Accounts and balances
+- ✅ Transactions
+- ✅ Categories (including custom ones)
+- ✅ Budgets and allocations
+- ✅ Goals and progress
+- ✅ Preferences and settings
+
+### How it works
+
+1. Changes you make are saved locally first (instantly).
+2. In the background, the sync engine sends encrypted changes to the server.
+3. Other devices pull the changes and merge them.
+4. Everything is end-to-end encrypted — the server never sees your actual data.
+
+### Sync status
+
+A small indicator shows the current state:
+
+- 🟢 **Synced** — everything is up to date
+- 🔄 **Syncing** — data transfer in progress
+- 🟡 **Pending** — you have local changes waiting to sync
+- ⚫ **Offline** — no internet connection (everything still works locally)
+
+Tap the indicator to see the last sync time and how many changes are pending.
+
+---
+
+_For general help, see the [FAQ](./faq.md). For security details, see the [Privacy & Security Guide](./privacy-security.md)._

--- a/docs/guides/platforms.md
+++ b/docs/guides/platforms.md
@@ -29,6 +29,7 @@ Lock Finance with your biometrics so only you can see your finances.
 3. Authenticate to confirm.
 
 **Options:**
+
 - Require biometric every time you open the app
 - Require biometric after a period of inactivity
 
@@ -156,15 +157,18 @@ Finance on the web is a **Progressive Web App (PWA)** — a full-featured app th
 You don't have to use Finance in a browser tab. Install it for a native-like experience:
 
 **Chrome or Edge:**
+
 1. Visit Finance in your browser.
 2. Click the **install icon** (⊕) in the address bar, or open the browser menu → **Install app**.
 3. Finance opens in its own window with its own icon — just like a regular app.
 
 **Safari (macOS):**
+
 1. Visit Finance in Safari.
 2. Go to **File → Add to Dock**.
 
 **Mobile browsers:**
+
 1. Visit Finance in your mobile browser.
 2. Tap the browser menu → **Add to Home Screen**.
 
@@ -183,12 +187,12 @@ The web version works offline thanks to a service worker that caches the app:
 
 Finance works best in modern browsers:
 
-| Browser | Support |
-| --- | --- |
-| **Chrome** (90+) | ✅ Full support, installable |
-| **Edge** (90+) | ✅ Full support, installable |
-| **Safari** (16+) | ✅ Supported (limited PWA install on macOS) |
-| **Firefox** (90+) | ✅ Supported (limited PWA install) |
+| Browser           | Support                                     |
+| ----------------- | ------------------------------------------- |
+| **Chrome** (90+)  | ✅ Full support, installable                |
+| **Edge** (90+)    | ✅ Full support, installable                |
+| **Safari** (16+)  | ✅ Supported (limited PWA install on macOS) |
+| **Firefox** (90+) | ✅ Supported (limited PWA install)          |
 
 For the best experience, use Chrome or Edge — they have the most complete PWA support.
 
@@ -196,13 +200,13 @@ For the best experience, use Chrome or Edge — they have the most complete PWA 
 
 The web version is built with a **keyboard-first workflow** for efficient desktop use:
 
-| Shortcut | Action |
-| --- | --- |
-| `Ctrl+N` (or `⌘+N`) | New transaction |
-| `/` | Open search |
-| `Tab` | Navigate through fields and categories |
-| `Enter` | Confirm / save |
-| `Escape` | Cancel / close dialog |
+| Shortcut            | Action                                 |
+| ------------------- | -------------------------------------- |
+| `Ctrl+N` (or `⌘+N`) | New transaction                        |
+| `/`                 | Open search                            |
+| `Tab`               | Navigate through fields and categories |
+| `Enter`             | Confirm / save                         |
+| `Escape`            | Cancel / close dialog                  |
 
 ### Desktop layout
 
@@ -230,6 +234,7 @@ Lock Finance with Windows Hello biometrics or PIN.
 4. Authenticate to confirm.
 
 Windows Hello supports:
+
 - Fingerprint readers
 - IR face recognition cameras
 - Security keys
@@ -240,10 +245,12 @@ Windows Hello supports:
 Finance takes advantage of the Windows desktop environment:
 
 **Snap Layouts:**
+
 - Snap Finance to half your screen alongside a browser or spreadsheet
 - Finance adapts its layout to the snap size
 
 **System notifications:**
+
 - Budget alerts appear as Windows toast notifications
 - Click a notification to jump directly to the relevant screen
 - Notifications integrate with Focus Assist (they won't interrupt when you're in Do Not Disturb mode)
@@ -252,14 +259,14 @@ Finance takes advantage of the Windows desktop environment:
 
 Finance supports keyboard shortcuts for efficient use:
 
-| Shortcut | Action |
-| --- | --- |
-| `Ctrl+N` | New transaction |
-| `Ctrl+F` or `/` | Search |
-| `Ctrl+E` | Export data |
+| Shortcut            | Action                      |
+| ------------------- | --------------------------- |
+| `Ctrl+N`            | New transaction             |
+| `Ctrl+F` or `/`     | Search                      |
+| `Ctrl+E`            | Export data                 |
 | `Tab` / `Shift+Tab` | Navigate forward / backward |
-| `Enter` | Confirm / save |
-| `Escape` | Cancel / close |
+| `Enter`             | Confirm / save              |
+| `Escape`            | Cancel / close              |
 
 ### Accessibility on Windows
 

--- a/docs/guides/privacy-security.md
+++ b/docs/guides/privacy-security.md
@@ -29,12 +29,12 @@ Your local database is encrypted using **SQLCipher** — the same encryption sta
 
 The encryption key itself is stored in your device's secure hardware:
 
-| Platform | Where the key lives |
-| --- | --- |
-| iOS | Apple Keychain (Secure Enclave) |
-| Android | Android Keystore (StrongBox when available) |
-| Windows | DPAPI (per-user, not cloud-synced) |
-| Web | In-memory only (for auth tokens) |
+| Platform | Where the key lives                         |
+| -------- | ------------------------------------------- |
+| iOS      | Apple Keychain (Secure Enclave)             |
+| Android  | Android Keystore (StrongBox when available) |
+| Windows  | DPAPI (per-user, not cloud-synced)          |
+| Web      | In-memory only (for auth tokens)            |
 
 ### Encrypted in transit
 
@@ -60,12 +60,12 @@ Because your data is stored locally:
 
 Finance supports biometric unlock so only you can open the app.
 
-| Platform | Methods |
-| --- | --- |
-| **iOS** | Face ID, Touch ID |
-| **Android** | Fingerprint, face recognition |
+| Platform    | Methods                                |
+| ----------- | -------------------------------------- |
+| **iOS**     | Face ID, Touch ID                      |
+| **Android** | Fingerprint, face recognition          |
 | **Windows** | Windows Hello (fingerprint, face, PIN) |
-| **Web** | WebAuthn-compatible biometrics |
+| **Web**     | WebAuthn-compatible biometrics         |
 
 All platforms use **strong biometric authentication** (Class 3 on Android) with a device PIN/passcode fallback.
 
@@ -109,25 +109,25 @@ Finance follows a **data minimization** principle — we collect only what's nee
 
 ### Data stored on your device
 
-| Data | Why it's needed |
-| --- | --- |
-| Account names, types, and balances | To display and track your financial accounts |
+| Data                                                           | Why it's needed                                  |
+| -------------------------------------------------------------- | ------------------------------------------------ |
+| Account names, types, and balances                             | To display and track your financial accounts     |
 | Transactions (amounts, dates, payees, notes, categories, tags) | To record and categorize your financial activity |
-| Budgets and spending plans | To track spending against your budget |
-| Goals and progress | To track savings goal progress |
-| Categories and rules | To organize transactions |
-| App preferences (currency, theme, experience level) | To personalize your experience |
+| Budgets and spending plans                                     | To track spending against your budget            |
+| Goals and progress                                             | To track savings goal progress                   |
+| Categories and rules                                           | To organize transactions                         |
+| App preferences (currency, theme, experience level)            | To personalize your experience                   |
 
 This data is stored in your encrypted local database and never leaves your device unless you enable sync.
 
 ### Data stored on the sync server (only if you enable sync)
 
-| Data | Why it's needed |
-| --- | --- |
-| Email address | To identify your account and send critical notifications (e.g., password reset) |
-| Encrypted financial data | To sync between your devices (the server can't read this data) |
-| Household memberships | To manage shared finance access |
-| Sync metadata (timestamps, device IDs) | To coordinate sync between devices |
+| Data                                   | Why it's needed                                                                 |
+| -------------------------------------- | ------------------------------------------------------------------------------- |
+| Email address                          | To identify your account and send critical notifications (e.g., password reset) |
+| Encrypted financial data               | To sync between your devices (the server can't read this data)                  |
+| Household memberships                  | To manage shared finance access                                                 |
+| Sync metadata (timestamps, device IDs) | To coordinate sync between devices                                              |
 
 ### What is NOT collected
 
@@ -172,11 +172,13 @@ Finance uses a minimal set of third-party services for sync and authentication. 
 **What it does:** Provides the backend database and authentication system for cross-device sync.
 
 **What it can see:**
+
 - Your email address (for authentication)
 - Encrypted financial data (it stores this but cannot decrypt it — the encryption keys never leave your device)
 - Sync metadata (timestamps, record counts)
 
 **What it cannot see:**
+
 - Your transaction amounts, payees, or notes
 - Your account names or balances
 - Your budget or goal details
@@ -198,23 +200,23 @@ You have legal rights over your personal data. Here's what they are and how Fina
 
 If you're in the EU or EEA, you have the right to:
 
-| Right | What it means | How Finance supports it |
-| --- | --- | --- |
-| **Access** | See what personal data we have | Export your data anytime (Settings → Export) |
-| **Erasure** | Have your data deleted | Delete your account and all data (Settings → Delete Account) |
-| **Portability** | Get your data in a standard format | Export as JSON or CSV |
-| **Rectification** | Correct inaccurate data | Edit any account, transaction, or profile information directly in the app |
-| **Objection** | Object to certain processing | Analytics/crash reporting are opt-in; you can turn them off anytime |
+| Right             | What it means                      | How Finance supports it                                                   |
+| ----------------- | ---------------------------------- | ------------------------------------------------------------------------- |
+| **Access**        | See what personal data we have     | Export your data anytime (Settings → Export)                              |
+| **Erasure**       | Have your data deleted             | Delete your account and all data (Settings → Delete Account)              |
+| **Portability**   | Get your data in a standard format | Export as JSON or CSV                                                     |
+| **Rectification** | Correct inaccurate data            | Edit any account, transaction, or profile information directly in the app |
+| **Objection**     | Object to certain processing       | Analytics/crash reporting are opt-in; you can turn them off anytime       |
 
 ### Under CCPA/CPRA (California)
 
 If you're a California resident, you have the right to:
 
-| Right | What it means | How Finance supports it |
-| --- | --- | --- |
-| **Know** | Know what personal data is collected | This guide documents everything collected |
-| **Delete** | Request deletion of your data | Delete your account (Settings → Delete Account) |
-| **Opt-out of sale** | Opt out of data selling | Finance **does not sell** your personal data. Ever. |
+| Right                  | What it means                                | How Finance supports it                                        |
+| ---------------------- | -------------------------------------------- | -------------------------------------------------------------- |
+| **Know**               | Know what personal data is collected         | This guide documents everything collected                      |
+| **Delete**             | Request deletion of your data                | Delete your account (Settings → Delete Account)                |
+| **Opt-out of sale**    | Opt out of data selling                      | Finance **does not sell** your personal data. Ever.            |
 | **Non-discrimination** | Equal service regardless of rights exercised | Exercising your rights has no effect on your access to Finance |
 
 ---
@@ -235,6 +237,7 @@ If you're a California resident, you have the right to:
 3. Confirm.
 
 What happens next:
+
 - All local data on the current device is deleted.
 - If you used sync, all server-side data is deleted through **crypto-shredding** — the encryption keys are destroyed, making any remaining encrypted data permanently unreadable.
 - A deletion confirmation is sent to your email.
@@ -273,12 +276,12 @@ When you delete your account, Finance doesn't just delete the encrypted data —
 
 Authentication tokens (the credentials that prove you're signed in) are stored using each platform's most secure storage mechanism:
 
-| Platform | Storage | Protection |
-| --- | --- | --- |
-| iOS | Keychain with Secure Enclave | Accessible only when device is unlocked; biometric access control |
-| Android | EncryptedSharedPreferences with Android Keystore | AES-256 encryption backed by hardware security |
-| Windows | DPAPI-encrypted files | Per-user encryption, not cloud-synced |
-| Web | In-memory only (access token); HttpOnly cookie (refresh token) | Tokens never touch localStorage or IndexedDB |
+| Platform | Storage                                                        | Protection                                                        |
+| -------- | -------------------------------------------------------------- | ----------------------------------------------------------------- |
+| iOS      | Keychain with Secure Enclave                                   | Accessible only when device is unlocked; biometric access control |
+| Android  | EncryptedSharedPreferences with Android Keystore               | AES-256 encryption backed by hardware security                    |
+| Windows  | DPAPI-encrypted files                                          | Per-user encryption, not cloud-synced                             |
+| Web      | In-memory only (access token); HttpOnly cookie (refresh token) | Tokens never touch localStorage or IndexedDB                      |
 
 ### Row-Level Security (RLS)
 

--- a/docs/guides/privacy-security.md
+++ b/docs/guides/privacy-security.md
@@ -1,0 +1,313 @@
+# Privacy & Security Guide
+
+Finance is built on a simple belief: **your financial data is yours and no one else's**. This guide explains exactly how your data is protected, what's collected, and what rights you have.
+
+---
+
+## Table of Contents
+
+- [How your data is protected](#how-your-data-is-protected)
+- [Biometric authentication](#biometric-authentication)
+- [Passkey authentication](#passkey-authentication)
+- [What data is collected and why](#what-data-is-collected-and-why)
+- [Data minimization — what we don't collect](#data-minimization--what-we-dont-collect)
+- [Third-party services](#third-party-services)
+- [Your rights](#your-rights)
+- [How to exercise your rights](#how-to-exercise-your-rights)
+- [Security features in detail](#security-features-in-detail)
+- [Reporting security issues](#reporting-security-issues)
+
+---
+
+## How your data is protected
+
+Finance uses a **local-first architecture**. That means your financial data lives on your device, not on a server somewhere. Here's what that looks like in practice:
+
+### Encrypted at rest
+
+Your local database is encrypted using **SQLCipher** — the same encryption standard used by governments and enterprises. Even if someone physically accessed your device's storage, they couldn't read your data without the encryption key.
+
+The encryption key itself is stored in your device's secure hardware:
+
+| Platform | Where the key lives |
+| --- | --- |
+| iOS | Apple Keychain (Secure Enclave) |
+| Android | Android Keystore (StrongBox when available) |
+| Windows | DPAPI (per-user, not cloud-synced) |
+| Web | In-memory only (for auth tokens) |
+
+### Encrypted in transit
+
+If you choose to enable sync, your data is **end-to-end encrypted** before it leaves your device. Finance uses an **envelope encryption** system:
+
+- Each record gets its own encryption key (called a DEK — Data Encryption Key)
+- Those keys are wrapped with a master key (called a KEK — Key Encryption Key)
+- The encryption uses **AES-256-GCM**, an industry-standard authenticated encryption algorithm
+- The sync server only ever sees encrypted data — it cannot read your transactions, balances, or any financial information
+
+### Local-first means offline-first
+
+Because your data is stored locally:
+
+- ✅ The app works without internet
+- ✅ Your data exists even if the server goes down
+- ✅ No one can access your data remotely without your device
+- ✅ You always have your full financial history available
+
+---
+
+## Biometric authentication
+
+Finance supports biometric unlock so only you can open the app.
+
+| Platform | Methods |
+| --- | --- |
+| **iOS** | Face ID, Touch ID |
+| **Android** | Fingerprint, face recognition |
+| **Windows** | Windows Hello (fingerprint, face, PIN) |
+| **Web** | WebAuthn-compatible biometrics |
+
+All platforms use **strong biometric authentication** (Class 3 on Android) with a device PIN/passcode fallback.
+
+### How to enable biometric lock
+
+1. Go to **Settings → Security → Biometric Lock**.
+2. Toggle it on.
+3. Authenticate with your biometric to confirm.
+
+You can configure when the lock activates:
+
+- **Every time** you open the app
+- **After inactivity** (e.g., after 5 minutes)
+
+> 💡 Biometric data never leaves your device. Finance asks your device's operating system to verify your identity — the app itself never sees or stores your fingerprint, face scan, or other biometric data.
+
+---
+
+## Passkey authentication
+
+Finance supports **passkeys** — a modern, phishing-resistant alternative to passwords.
+
+### What's a passkey?
+
+A passkey replaces your password with a cryptographic key pair stored on your device. To sign in, you just use your biometrics (Face ID, fingerprint, Windows Hello) or a security key. There's nothing to type, nothing to remember, and nothing that can be phished or leaked in a data breach.
+
+### How to set up a passkey
+
+1. Go to **Settings → Account → Passkey**.
+2. Tap **Set Up Passkey**.
+3. Follow your device's prompt to create the passkey (usually a biometric scan).
+4. Done — next time you sign in, just use your biometric.
+
+Passkeys can be backed up to your platform's credential manager (iCloud Keychain, Google Password Manager, etc.), so they work across your devices.
+
+---
+
+## What data is collected and why
+
+Finance follows a **data minimization** principle — we collect only what's needed to make the app work, and nothing more.
+
+### Data stored on your device
+
+| Data | Why it's needed |
+| --- | --- |
+| Account names, types, and balances | To display and track your financial accounts |
+| Transactions (amounts, dates, payees, notes, categories, tags) | To record and categorize your financial activity |
+| Budgets and spending plans | To track spending against your budget |
+| Goals and progress | To track savings goal progress |
+| Categories and rules | To organize transactions |
+| App preferences (currency, theme, experience level) | To personalize your experience |
+
+This data is stored in your encrypted local database and never leaves your device unless you enable sync.
+
+### Data stored on the sync server (only if you enable sync)
+
+| Data | Why it's needed |
+| --- | --- |
+| Email address | To identify your account and send critical notifications (e.g., password reset) |
+| Encrypted financial data | To sync between your devices (the server can't read this data) |
+| Household memberships | To manage shared finance access |
+| Sync metadata (timestamps, device IDs) | To coordinate sync between devices |
+
+### What is NOT collected
+
+- ❌ Bank account numbers or routing numbers
+- ❌ Credit card numbers
+- ❌ Social Security numbers or government IDs
+- ❌ Location data
+- ❌ Contacts or phone data
+- ❌ Browsing history
+- ❌ Usage analytics (unless you opt in)
+
+### Analytics and crash reporting
+
+Analytics and crash reporting are:
+
+- **Off by default** — they only activate if you explicitly opt in
+- **Free of personal data** — no financial data, no account details, no transaction information
+- **Free of device identifiers** — pseudonymous, non-reversible identifiers only
+
+You can control these in **Settings → Privacy**.
+
+---
+
+## Data minimization — what we don't collect
+
+Finance deliberately avoids collecting data that other finance apps require:
+
+- **No bank connections** — we never ask for your bank login credentials
+- **No payment card data** — we don't store card numbers
+- **No location tracking** — we don't know where you made a purchase
+- **No social graph** — we don't access your contacts
+- **No behavioral profiling** — we don't build advertising profiles from your spending
+
+---
+
+## Third-party services
+
+Finance uses a minimal set of third-party services for sync and authentication. Here's what they are and what they can see:
+
+### Supabase (sync and authentication)
+
+**What it does:** Provides the backend database and authentication system for cross-device sync.
+
+**What it can see:**
+- Your email address (for authentication)
+- Encrypted financial data (it stores this but cannot decrypt it — the encryption keys never leave your device)
+- Sync metadata (timestamps, record counts)
+
+**What it cannot see:**
+- Your transaction amounts, payees, or notes
+- Your account names or balances
+- Your budget or goal details
+- Anything meaningful about your finances
+
+### PowerSync (offline sync coordination)
+
+**What it does:** Coordinates the sync of data between your devices and the server.
+
+**What it handles:** Encrypted data in transit. Like Supabase, it cannot decrypt your financial data.
+
+---
+
+## Your rights
+
+You have legal rights over your personal data. Here's what they are and how Finance supports them.
+
+### Under GDPR (European Union)
+
+If you're in the EU or EEA, you have the right to:
+
+| Right | What it means | How Finance supports it |
+| --- | --- | --- |
+| **Access** | See what personal data we have | Export your data anytime (Settings → Export) |
+| **Erasure** | Have your data deleted | Delete your account and all data (Settings → Delete Account) |
+| **Portability** | Get your data in a standard format | Export as JSON or CSV |
+| **Rectification** | Correct inaccurate data | Edit any account, transaction, or profile information directly in the app |
+| **Objection** | Object to certain processing | Analytics/crash reporting are opt-in; you can turn them off anytime |
+
+### Under CCPA/CPRA (California)
+
+If you're a California resident, you have the right to:
+
+| Right | What it means | How Finance supports it |
+| --- | --- | --- |
+| **Know** | Know what personal data is collected | This guide documents everything collected |
+| **Delete** | Request deletion of your data | Delete your account (Settings → Delete Account) |
+| **Opt-out of sale** | Opt out of data selling | Finance **does not sell** your personal data. Ever. |
+| **Non-discrimination** | Equal service regardless of rights exercised | Exercising your rights has no effect on your access to Finance |
+
+---
+
+## How to exercise your rights
+
+### Export your data
+
+1. Go to **Settings → Export**.
+2. Choose JSON (complete) or CSV (transactions).
+3. Tap **Export**.
+4. The file is generated on your device and ready to download or share.
+
+### Delete your account
+
+1. Go to **Settings → Delete Account**.
+2. Type the confirmation phrase: `DELETE MY DATA`.
+3. Confirm.
+
+What happens next:
+- All local data on the current device is deleted.
+- If you used sync, all server-side data is deleted through **crypto-shredding** — the encryption keys are destroyed, making any remaining encrypted data permanently unreadable.
+- A deletion confirmation is sent to your email.
+- The deletion is permanent after a 30-day grace period.
+
+### Contact us about your data
+
+For any privacy-related request that can't be handled through the app, reach out via **Settings → Help → Contact Us**.
+
+---
+
+## Security features in detail
+
+### SQLCipher database encryption
+
+Every Finance database on your device is encrypted with SQLCipher, which uses 256-bit AES encryption. The database is unreadable without the encryption key, which is stored in your platform's secure hardware (Keychain, Keystore, DPAPI).
+
+### Envelope encryption (for sync)
+
+When you sync data, Finance uses a two-layer encryption system:
+
+1. **Data Encryption Key (DEK)** — a unique key generated for each record. Your transaction is encrypted with this key.
+2. **Key Encryption Key (KEK)** — a master key that encrypts (wraps) the DEKs. Only you (and household members you've authorized) have the KEK.
+
+This means: even if someone obtained the encrypted data and one DEK, they could only read one record — not your entire history. And without the KEK, they can't unwrap any DEKs at all.
+
+### Key derivation
+
+Your encryption keys are derived using **Argon2id** — a modern, memory-hard key derivation function designed to resist brute-force attacks. It's the winner of the Password Hashing Competition and is recommended by OWASP.
+
+### Crypto-shredding
+
+When you delete your account, Finance doesn't just delete the encrypted data — it destroys the encryption keys. This is called **crypto-shredding**. Even if encrypted data fragments remain on a server somewhere, they're permanently unreadable because the keys no longer exist. A verifiable deletion certificate is generated.
+
+### Secure token storage
+
+Authentication tokens (the credentials that prove you're signed in) are stored using each platform's most secure storage mechanism:
+
+| Platform | Storage | Protection |
+| --- | --- | --- |
+| iOS | Keychain with Secure Enclave | Accessible only when device is unlocked; biometric access control |
+| Android | EncryptedSharedPreferences with Android Keystore | AES-256 encryption backed by hardware security |
+| Windows | DPAPI-encrypted files | Per-user encryption, not cloud-synced |
+| Web | In-memory only (access token); HttpOnly cookie (refresh token) | Tokens never touch localStorage or IndexedDB |
+
+### Row-Level Security (RLS)
+
+On the server side, every database table has **Row-Level Security** enabled. This means the database itself enforces that you can only access your own data — even if there were a bug in the application code, the database would prevent unauthorized access.
+
+### Input validation
+
+All data entered into Finance is validated before being stored:
+
+- Parameterized database queries prevent SQL injection
+- Transaction amounts, dates, payee names, and notes are all validated for format and length
+- Error handling uses a type-safe system that prevents data from being stored in an invalid state
+
+---
+
+## Reporting security issues
+
+If you discover a security vulnerability in Finance, please report it responsibly:
+
+1. **Do not** post the vulnerability publicly (on GitHub issues, social media, etc.).
+2. Contact us through **Settings → Help → Security Report** or email the security contact listed in the repository.
+3. Include:
+   - A description of the vulnerability
+   - Steps to reproduce it
+   - The potential impact
+4. We'll acknowledge your report and work on a fix.
+
+We take security issues seriously and appreciate responsible disclosure.
+
+---
+
+_For general questions, see the [FAQ](./faq.md). For platform-specific security features, see the [Platform Guides](./platforms.md)._


### PR DESCRIPTION
## Summary
7 user-facing documentation guides totaling ~15,300 words.

## Documents Created
- **Getting Started Guide (#346)**: First launch, accounts, transactions, budgets, goals
- **Feature Documentation (#347)**: All features with user-friendly explanations
- **FAQ & Troubleshooting (#348)**: Common questions and solutions
- **Privacy & Security Guide (#349)**: Data protection, user rights, security features
- **Platform-Specific Guides (#356)**: iOS, Android, Web, Windows details
- **Accessibility Features Guide (#360)**: Screen readers, high contrast, keyboard nav
- **In-App Help Integration Plan (#358)**: Contextual help strategy and tooltip system

Written for end users with warm, non-judgmental tone matching product identity.
All documents are cross-linked for discoverability.

Closes #346
Closes #347
Closes #348
Closes #349
Closes #356
Closes #358
Closes #360

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>