### PR TITLE
feat(core): implement data export service with JSON and CSV serializers (#351, #350, #355)

### DIFF
--- a/packages/core/src/commonMain/kotlin/com/finance/core/export/CsvExportSerializer.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/export/CsvExportSerializer.kt
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.export
+
+import com.finance.models.*
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+
+/**
+ * Serializes [ExportData] into a concatenated multi-section CSV string.
+ *
+ * Each entity type is written as a separate section with a header comment
+ * (e.g., `# ACCOUNTS`) followed by RFC 4180-compliant column headers and
+ * data rows. Sections are separated by blank lines. A metadata section
+ * precedes the entity data.
+ *
+ * RFC 4180 compliance:
+ * - CRLF (`\r\n`) line endings throughout.
+ * - Fields containing commas, double-quotes, or newlines are enclosed in
+ *   double-quotes.
+ * - Double-quote characters within a field are escaped by doubling them
+ *   (`"` → `""`).
+ *
+ * Sync-internal fields (`syncVersion`, `isSynced`) are excluded from output.
+ * Monetary [Cents] values are formatted as decimal strings using the currency's
+ * [Currency.decimalPlaces] (e.g., `1250` → `"12.50"` for USD).
+ * Tags lists are serialized as semicolon-separated values within a single field.
+ * Dates and timestamps are ISO 8601 strings.
+ *
+ * @see ExportSerializer
+ * @see DataExportService
+ */
+class CsvExportSerializer : ExportSerializer {
+
+    override val format: ExportFormat = ExportFormat.CSV
+
+    override fun serialize(data: ExportData, metadata: ExportMetadata): String {
+        val sb = StringBuilder()
+
+        // ── Metadata section ─────────────────────────────────────────
+        appendMetadataSection(sb, metadata)
+
+        // ── Entity sections ──────────────────────────────────────────
+        appendAccountsSection(sb, data.accounts)
+        appendTransactionsSection(sb, data.transactions)
+        appendCategoriesSection(sb, data.categories)
+        appendBudgetsSection(sb, data.budgets)
+        appendGoalsSection(sb, data.goals)
+
+        return sb.toString()
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // Section builders
+    // ═════════════════════════════════════════════════════════════════
+
+    private fun appendMetadataSection(sb: StringBuilder, metadata: ExportMetadata) {
+        sb.appendLine("# METADATA")
+        sb.appendRow("key", "value")
+        sb.appendRow("export_date", metadata.exportDate.toString())
+        sb.appendRow("app_version", metadata.appVersion)
+        sb.appendRow("schema_version", metadata.schemaVersion)
+        sb.appendRow("user_id_hash", metadata.userIdHash)
+        sb.appendRow("accounts_count", metadata.entityCounts.accounts.toString())
+        sb.appendRow("transactions_count", metadata.entityCounts.transactions.toString())
+        sb.appendRow("categories_count", metadata.entityCounts.categories.toString())
+        sb.appendRow("budgets_count", metadata.entityCounts.budgets.toString())
+        sb.appendRow("goals_count", metadata.entityCounts.goals.toString())
+        sb.appendCrlf()
+    }
+
+    private fun appendAccountsSection(sb: StringBuilder, accounts: List<Account>) {
+        sb.appendLine("# ACCOUNTS")
+        val headers = listOf(
+            "id", "household_id", "name", "type", "currency",
+            "current_balance", "is_archived", "sort_order",
+            "icon", "color", "created_at", "updated_at", "deleted_at",
+        )
+        sb.appendRow(*headers.toTypedArray())
+        for (account in accounts) {
+            sb.appendRow(
+                account.id.value,
+                account.householdId.value,
+                account.name,
+                account.type.name,
+                account.currency.code,
+                formatCentsDisplay(account.currentBalance, account.currency),
+                account.isArchived.toString(),
+                account.sortOrder.toString(),
+                account.icon ?: "",
+                account.color ?: "",
+                account.createdAt.toString(),
+                account.updatedAt.toString(),
+                account.deletedAt?.toString() ?: "",
+            )
+        }
+        sb.appendCrlf()
+    }
+
+    private fun appendTransactionsSection(sb: StringBuilder, transactions: List<Transaction>) {
+        sb.appendLine("# TRANSACTIONS")
+        val headers = listOf(
+            "id", "household_id", "account_id", "category_id",
+            "type", "status", "amount", "currency",
+            "payee", "note", "date",
+            "transfer_account_id", "transfer_transaction_id",
+            "is_recurring", "recurring_rule_id", "tags",
+            "created_at", "updated_at", "deleted_at",
+        )
+        sb.appendRow(*headers.toTypedArray())
+        for (txn in transactions) {
+            sb.appendRow(
+                txn.id.value,
+                txn.householdId.value,
+                txn.accountId.value,
+                txn.categoryId?.value ?: "",
+                txn.type.name,
+                txn.status.name,
+                formatCentsDisplay(txn.amount, txn.currency),
+                txn.currency.code,
+                txn.payee ?: "",
+                txn.note ?: "",
+                txn.date.toString(),
+                txn.transferAccountId?.value ?: "",
+                txn.transferTransactionId?.value ?: "",
+                txn.isRecurring.toString(),
+                txn.recurringRuleId?.value ?: "",
+                txn.tags.joinToString(";"),
+                txn.createdAt.toString(),
+                txn.updatedAt.toString(),
+                txn.deletedAt?.toString() ?: "",
+            )
+        }
+        sb.appendCrlf()
+    }
+
+    private fun appendCategoriesSection(sb: StringBuilder, categories: List<Category>) {
+        sb.appendLine("# CATEGORIES")
+        val headers = listOf(
+            "id", "household_id", "name", "icon", "color",
+            "parent_id", "is_income", "is_system", "sort_order",
+            "created_at", "updated_at", "deleted_at",
+        )
+        sb.appendRow(*headers.toTypedArray())
+        for (category in categories) {
+            sb.appendRow(
+                category.id.value,
+                category.householdId.value,
+                category.name,
+                category.icon ?: "",
+                category.color ?: "",
+                category.parentId?.value ?: "",
+                category.isIncome.toString(),
+                category.isSystem.toString(),
+                category.sortOrder.toString(),
+                category.createdAt.toString(),
+                category.updatedAt.toString(),
+                category.deletedAt?.toString() ?: "",
+            )
+        }
+        sb.appendCrlf()
+    }
+
+    private fun appendBudgetsSection(sb: StringBuilder, budgets: List<Budget>) {
+        sb.appendLine("# BUDGETS")
+        val headers = listOf(
+            "id", "household_id", "category_id", "name",
+            "amount", "currency", "period",
+            "start_date", "end_date", "is_rollover",
+            "created_at", "updated_at", "deleted_at",
+        )
+        sb.appendRow(*headers.toTypedArray())
+        for (budget in budgets) {
+            sb.appendRow(
+                budget.id.value,
+                budget.householdId.value,
+                budget.categoryId.value,
+                budget.name,
+                formatCentsDisplay(budget.amount, budget.currency),
+                budget.currency.code,
+                budget.period.name,
+                budget.startDate.toString(),
+                budget.endDate?.toString() ?: "",
+                budget.isRollover.toString(),
+                budget.createdAt.toString(),
+                budget.updatedAt.toString(),
+                budget.deletedAt?.toString() ?: "",
+            )
+        }
+        sb.appendCrlf()
+    }
+
+    private fun appendGoalsSection(sb: StringBuilder, goals: List<Goal>) {
+        sb.appendLine("# GOALS")
+        val headers = listOf(
+            "id", "household_id", "name",
+            "target_amount", "current_amount", "currency",
+            "target_date", "status", "icon", "color", "account_id",
+            "created_at", "updated_at", "deleted_at",
+        )
+        sb.appendRow(*headers.toTypedArray())
+        for (goal in goals) {
+            sb.appendRow(
+                goal.id.value,
+                goal.householdId.value,
+                goal.name,
+                formatCentsDisplay(goal.targetAmount, goal.currency),
+                formatCentsDisplay(goal.currentAmount, goal.currency),
+                goal.currency.code,
+                goal.targetDate?.toString() ?: "",
+                goal.status.name,
+                goal.icon ?: "",
+                goal.color ?: "",
+                goal.accountId?.value ?: "",
+                goal.createdAt.toString(),
+                goal.updatedAt.toString(),
+                goal.deletedAt?.toString() ?: "",
+            )
+        }
+        sb.appendCrlf()
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // RFC 4180 formatting helpers
+    // ═════════════════════════════════════════════════════════════════
+
+    /**
+     * Appends a comment/section-header line with CRLF ending.
+     *
+     * Comment lines (starting with `#`) are outside the RFC 4180 spec but are
+     * a widely-supported convention for multi-section CSV files.
+     */
+    private fun StringBuilder.appendLine(line: String) {
+        append(line)
+        append(CRLF)
+    }
+
+    /** Appends a bare CRLF (blank line separator between sections). */
+    private fun StringBuilder.appendCrlf() {
+        append(CRLF)
+    }
+
+    /**
+     * Appends a single CSV row with proper RFC 4180 escaping.
+     *
+     * Each field is escaped individually, fields are joined with commas,
+     * and the row is terminated with CRLF.
+     */
+    private fun StringBuilder.appendRow(vararg fields: String) {
+        append(fields.joinToString(",") { escapeField(it) })
+        append(CRLF)
+    }
+
+    companion object {
+        /** RFC 4180 line terminator. */
+        private const val CRLF = "\r\n"
+
+        /**
+         * Escapes a single CSV field per RFC 4180.
+         *
+         * A field must be enclosed in double-quotes if it contains:
+         * - A comma (`,`)
+         * - A double-quote (`"`)
+         * - A newline (`\n` or `\r`)
+         *
+         * Any double-quote characters inside the field are doubled (`"` → `""`).
+         */
+        internal fun escapeField(field: String): String {
+            val needsQuoting = field.contains(',') ||
+                field.contains('"') ||
+                field.contains('\n') ||
+                field.contains('\r')
+            return if (needsQuoting) {
+                "\"${field.replace("\"", "\"\"")}\""
+            } else {
+                field
+            }
+        }
+    }
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/export/DataExportService.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/export/DataExportService.kt
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.export
+
+import com.finance.models.types.SyncId
+import kotlinx.datetime.*
+
+/**
+ * Orchestrates financial data export from local storage to portable formats.
+ *
+ * This service coordinates validating data, delegating to format-specific
+ * [ExportSerializer] implementations, and computing integrity checksums.
+ *
+ * Exports run entirely client-side from local SQLite — no server round-trip.
+ * Internal sync fields (`syncVersion`, `isSynced`) are never included in output;
+ * the [ExportSerializer] implementation is responsible for stripping them.
+ * Soft-deleted records (`deletedAt != null`) must be pre-filtered by the caller.
+ *
+ * Usage:
+ * ```
+ * val result = DataExportService.export(
+ *     data = ExportData(accounts, transactions, categories, budgets, goals),
+ *     serializer = jsonSerializer,
+ *     userId = currentUserId,
+ *     appVersion = "1.0.0",
+ * )
+ * when (result) {
+ *     is ExportOutcome.Success -> handleExport(result.export)
+ *     is ExportOutcome.Failure -> showError(result.error)
+ * }
+ * ```
+ *
+ * @see ExportSerializer for format-specific serialization
+ * @see ExportData for the input data container
+ * @see ExportOutcome for the result type
+ */
+object DataExportService {
+
+    /** Current export schema version. Increment on breaking changes to the export format. */
+    const val SCHEMA_VERSION = "1.0"
+
+    /**
+     * Exports all financial data using the specified serializer.
+     *
+     * The export pipeline proceeds in four phases:
+     * 1. **GATHERING_DATA** — validates that [data] is non-empty and builds metadata.
+     * 2. **SERIALIZING** — delegates to [serializer] to produce the content string.
+     * 3. **COMPUTING_CHECKSUM** — computes SHA-256 hex digest of the content.
+     * 4. **COMPLETE** — packages everything into [ExportResult].
+     *
+     * Progress is reported via [onProgress] at each phase boundary.
+     *
+     * @param data All financial data to export (pre-filtered, no deleted records).
+     * @param serializer Format-specific serializer implementation.
+     * @param userId The authenticated user's ID (will be SHA-256 hashed in metadata).
+     * @param appVersion Current application version string.
+     * @param exportInstant Override for the export timestamp. Defaults to [Clock.System.now].
+     *                      Exposed for deterministic testing.
+     * @param onProgress Optional callback for progress updates.
+     * @return [ExportOutcome.Success] with the export result, or [ExportOutcome.Failure]
+     *         with error details.
+     */
+    fun export(
+        data: ExportData,
+        serializer: ExportSerializer,
+        userId: SyncId,
+        appVersion: String,
+        exportInstant: Instant = Clock.System.now(),
+        onProgress: ((ExportProgress) -> Unit)? = null,
+    ): ExportOutcome {
+        // Phase 1: Validate data
+        if (data.isEmpty) {
+            return ExportOutcome.Failure(ExportError.NoData())
+        }
+
+        val totalPhases = ExportPhase.entries.size
+
+        onProgress?.invoke(ExportProgress(ExportPhase.GATHERING_DATA, 1, totalPhases))
+
+        // Build metadata
+        val metadata = ExportMetadata(
+            exportDate = exportInstant,
+            appVersion = appVersion,
+            schemaVersion = SCHEMA_VERSION,
+            userIdHash = hashUserId(userId),
+            entityCounts = ExportEntityCounts(
+                accounts = data.accounts.size,
+                transactions = data.transactions.size,
+                categories = data.categories.size,
+                budgets = data.budgets.size,
+                goals = data.goals.size,
+            ),
+        )
+
+        // Phase 2: Serialize
+        onProgress?.invoke(ExportProgress(ExportPhase.SERIALIZING, 2, totalPhases))
+
+        val content: String = try {
+            serializer.serialize(data, metadata)
+        } catch (e: Exception) {
+            return ExportOutcome.Failure(
+                ExportError.SerializationFailed(e.message ?: "Unknown serialization error"),
+            )
+        }
+
+        // Phase 3: Compute checksum
+        onProgress?.invoke(ExportProgress(ExportPhase.COMPUTING_CHECKSUM, 3, totalPhases))
+
+        val checksum: String = try {
+            computeChecksum(content)
+        } catch (e: Exception) {
+            return ExportOutcome.Failure(
+                ExportError.ChecksumFailed(e.message ?: "Unknown checksum error"),
+            )
+        }
+
+        // Phase 4: Complete
+        val result = ExportResult(
+            content = content,
+            format = serializer.format,
+            filename = generateFilename(serializer.format, exportInstant),
+            metadata = metadata,
+            checksum = checksum,
+            sizeBytes = content.encodeToByteArray().size.toLong(),
+        )
+
+        onProgress?.invoke(ExportProgress(ExportPhase.COMPLETE, totalPhases, totalPhases))
+
+        return ExportOutcome.Success(result)
+    }
+
+    /**
+     * Generates a timestamped filename for the export.
+     *
+     * Format: `finance-export-{yyyy-MM-dd}.{extension}`
+     *
+     * Uses the UTC date from [exportDate] to ensure consistent filenames
+     * regardless of the user's time zone.
+     *
+     * @param format The export format (determines the file extension).
+     * @param exportDate The instant to derive the date from.
+     * @return A filename string, e.g., "finance-export-2026-03-15.json".
+     */
+    internal fun generateFilename(format: ExportFormat, exportDate: Instant): String {
+        val date = exportDate.toLocalDateTime(TimeZone.UTC).date
+        return "finance-export-${date}.${format.extension}"
+    }
+
+    /**
+     * Creates an anonymised user identifier by SHA-256 hashing the raw user ID.
+     *
+     * The result is prefixed with `"sha256:"` for clarity and self-documentation
+     * when inspecting export files.
+     *
+     * @param userId The raw user ID to hash.
+     * @return A string like `"sha256:e3b0c44298fc1c149afbf4c8996fb924..."`.
+     */
+    internal fun hashUserId(userId: SyncId): String {
+        return "sha256:${Sha256.hexDigest(userId.value)}"
+    }
+
+    /**
+     * Computes the SHA-256 hex digest of the given content string.
+     *
+     * The content is UTF-8 encoded before hashing.
+     *
+     * @param content The string to hash.
+     * @return 64-character lowercase hexadecimal digest.
+     */
+    internal fun computeChecksum(content: String): String {
+        return Sha256.hexDigest(content)
+    }
+}
+
+/**
+ * Outcome of an export operation — either [Success] with the result or [Failure] with an error.
+ *
+ * Follows the project-wide pattern of sealed class outcomes for exhaustive `when` handling,
+ * avoiding exceptions for business-logic errors.
+ */
+sealed class ExportOutcome {
+    /** Export completed successfully. */
+    data class Success(val export: ExportResult) : ExportOutcome()
+
+    /** Export failed with a domain-specific error. */
+    data class Failure(val error: ExportError) : ExportOutcome()
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/export/ExportData.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/export/ExportData.kt
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.export
+
+import com.finance.models.*
+
+/**
+ * Container for all financial data to be exported.
+ *
+ * Callers construct this by querying SQLDelight DAOs for each entity type.
+ * All records should already be filtered (`deleted_at IS NULL`) by the queries —
+ * the export pipeline does **not** perform soft-delete filtering.
+ *
+ * Sync-internal fields (`syncVersion`, `isSynced`) are present on the domain
+ * models but must be stripped by the [ExportSerializer] implementation during
+ * serialization — callers pass the full domain objects unchanged.
+ *
+ * Usage:
+ * ```
+ * val data = ExportData(
+ *     accounts = accountDao.selectActive(),
+ *     transactions = transactionDao.selectAll(),
+ *     categories = categoryDao.selectAll(),
+ *     budgets = budgetDao.selectActive(),
+ *     goals = goalDao.selectActive(),
+ * )
+ * ```
+ */
+data class ExportData(
+    /** Active (non-deleted) accounts to include in the export. */
+    val accounts: List<Account>,
+    /** Non-deleted transactions to include in the export. */
+    val transactions: List<Transaction>,
+    /** Non-deleted categories to include in the export. */
+    val categories: List<Category>,
+    /** Active (non-deleted) budgets to include in the export. */
+    val budgets: List<Budget>,
+    /** Active (non-deleted) goals to include in the export. */
+    val goals: List<Goal>,
+) {
+    /** `true` when every entity list is empty — nothing to export. */
+    val isEmpty: Boolean
+        get() = accounts.isEmpty() &&
+            transactions.isEmpty() &&
+            categories.isEmpty() &&
+            budgets.isEmpty() &&
+            goals.isEmpty()
+
+    /** Total number of records across all entity types. */
+    val totalRecords: Int
+        get() = accounts.size + transactions.size + categories.size +
+            budgets.size + goals.size
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/export/ExportSerializer.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/export/ExportSerializer.kt
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.export
+
+/**
+ * Format-specific serializer for financial data export.
+ *
+ * Implementations handle the actual conversion of [ExportData] to a string
+ * representation in a specific format (JSON, CSV, etc.).
+ *
+ * Sync-internal fields (`syncVersion`, `isSynced`) on the domain models
+ * **must not** appear in the serialized output. Implementations are responsible
+ * for stripping or mapping these fields during serialization.
+ *
+ * Implementations:
+ * - JSON serializer (issue #350) — produces a formatted JSON string.
+ * - CSV serializer (issue #355) — produces a base64-encoded ZIP containing
+ *   individual CSVs per entity type.
+ *
+ * @see DataExportService for orchestration
+ */
+interface ExportSerializer {
+
+    /** The format this serializer produces. */
+    val format: ExportFormat
+
+    /**
+     * Serializes export data with metadata into a string representation.
+     *
+     * For [ExportFormat.JSON]: produces a pretty-printed JSON string.
+     * For [ExportFormat.CSV]: produces a base64-encoded ZIP containing individual CSVs.
+     *
+     * @param data The financial data to serialize (pre-filtered, no deleted records).
+     * @param metadata Export metadata to include in the output.
+     * @return The serialized content as a string.
+     * @throws IllegalStateException if the data cannot be serialized.
+     */
+    fun serialize(data: ExportData, metadata: ExportMetadata): String
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/export/ExportTypes.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/export/ExportTypes.kt
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.export
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.Serializable
+
+/**
+ * Supported export file formats.
+ *
+ * Each format specifies its file extension and MIME type for downstream
+ * consumers (e.g., share-sheet integration, file pickers).
+ */
+enum class ExportFormat(val extension: String, val mimeType: String) {
+    /** Full-fidelity JSON export containing all entities and metadata. */
+    JSON("json", "application/json"),
+
+    /**
+     * CSV export — actually produces a ZIP archive containing one CSV per entity type.
+     * The [extension] is "zip" to reflect the real file format.
+     */
+    CSV("zip", "text/csv"),
+}
+
+/**
+ * Metadata included in every export, providing provenance and integrity information.
+ *
+ * The [userIdHash] is a SHA-256 hex digest of the raw user ID, ensuring the export
+ * does not contain PII while still allowing correlation across exports by the same user.
+ */
+@Serializable
+data class ExportMetadata(
+    /** Timestamp when the export was generated. */
+    val exportDate: Instant,
+    /** Application version that produced the export (e.g., "1.0.0"). */
+    val appVersion: String,
+    /** Schema version for the export format. Increment on breaking changes. */
+    val schemaVersion: String,
+    /** SHA-256 hex digest of the user's ID, prefixed with "sha256:". */
+    val userIdHash: String,
+    /** Counts of each entity type included in the export. */
+    val entityCounts: ExportEntityCounts,
+)
+
+/**
+ * Per-entity-type record counts included in [ExportMetadata].
+ */
+@Serializable
+data class ExportEntityCounts(
+    val accounts: Int,
+    val transactions: Int,
+    val categories: Int,
+    val budgets: Int,
+    val goals: Int,
+) {
+    /** Total number of records across all entity types. */
+    val total: Int get() = accounts + transactions + categories + budgets + goals
+}
+
+/**
+ * Successful export result containing the serialized content and integrity data.
+ *
+ * @property content The serialized data — a JSON string for [ExportFormat.JSON],
+ *                   or a base64-encoded ZIP for [ExportFormat.CSV].
+ * @property format  The format that produced [content].
+ * @property filename Suggested filename (e.g., "finance-export-2026-03-15.json").
+ * @property metadata Provenance and entity-count metadata.
+ * @property checksum SHA-256 hex digest of [content] for integrity verification.
+ * @property sizeBytes Length of [content] in bytes (UTF-8 encoded).
+ */
+data class ExportResult(
+    val content: String,
+    val format: ExportFormat,
+    val filename: String,
+    val metadata: ExportMetadata,
+    val checksum: String,
+    val sizeBytes: Long,
+)
+
+/**
+ * Progress update emitted during an export operation.
+ *
+ * @property phase   The current phase of the export pipeline.
+ * @property current Number of completed steps within this phase.
+ * @property total   Total steps expected in this phase.
+ */
+data class ExportProgress(
+    val phase: ExportPhase,
+    val current: Int,
+    val total: Int,
+) {
+    /** Completion fraction in [0.0, 1.0]. Returns 0 when [total] is zero. */
+    val fraction: Float get() = if (total > 0) current.toFloat() / total else 0f
+}
+
+/**
+ * Phases of the export pipeline, reported via [ExportProgress].
+ */
+enum class ExportPhase {
+    /** Validating and gathering data for export. */
+    GATHERING_DATA,
+    /** Converting data to the target format (JSON, CSV, etc.). */
+    SERIALIZING,
+    /** Computing SHA-256 checksum of the serialized content. */
+    COMPUTING_CHECKSUM,
+    /** Export completed successfully. */
+    COMPLETE,
+}
+
+/**
+ * Sealed hierarchy of export errors for exhaustive `when` handling.
+ *
+ * Follows the project-wide pattern established by [com.finance.core.validation.ValidationError]:
+ * sealed base class with a human-readable [message] and concrete data subclasses.
+ */
+sealed class ExportError(val message: String) {
+    /** No exportable data was found — all entity lists are empty. */
+    data class NoData(
+        val detail: String = "No exportable data found",
+    ) : ExportError(detail)
+
+    /** The [ExportSerializer] failed to serialize the data. */
+    data class SerializationFailed(
+        val cause: String,
+    ) : ExportError("Serialization failed: $cause")
+
+    /** SHA-256 checksum computation failed unexpectedly. */
+    data class ChecksumFailed(
+        val cause: String,
+    ) : ExportError("Checksum computation failed: $cause")
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/export/JsonExportSerializer.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/export/JsonExportSerializer.kt
@@ -1,0 +1,381 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.export
+
+import com.finance.models.*
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * Serializes [ExportData] into a pretty-printed JSON string.
+ *
+ * Produces a self-describing JSON document containing export metadata and all
+ * financial entities. Sync-internal fields (`syncVersion`, `isSynced`) are
+ * excluded by mapping domain models to private DTOs before serialization.
+ *
+ * Monetary values are represented as objects with three fields:
+ * - `amount` — the raw value in minor currency units (e.g., cents).
+ * - `display` — human-readable decimal string (e.g., `"12.50"`).
+ * - `currency` — ISO 4217 currency code.
+ *
+ * Dates and timestamps are serialized as ISO 8601 strings.
+ *
+ * Example output structure:
+ * ```json
+ * {
+ *   "export_version": "1.0",
+ *   "metadata": { ... },
+ *   "data": {
+ *     "accounts": [ ... ],
+ *     "transactions": [ ... ],
+ *     "categories": [ ... ],
+ *     "budgets": [ ... ],
+ *     "goals": [ ... ]
+ *   }
+ * }
+ * ```
+ *
+ * @see ExportSerializer
+ * @see DataExportService
+ */
+class JsonExportSerializer : ExportSerializer {
+
+    override val format: ExportFormat = ExportFormat.JSON
+
+    /**
+     * JSON encoder configured for human-readable export output.
+     *
+     * - Pretty-printed with 2-space indentation for readability.
+     * - `encodeDefaults = true` ensures optional fields (nulls, empty lists)
+     *   are always present so consumers can rely on a stable schema.
+     */
+    private val json = Json {
+        prettyPrint = true
+        prettyPrintIndent = "  "
+        encodeDefaults = true
+    }
+
+    override fun serialize(data: ExportData, metadata: ExportMetadata): String {
+        val envelope = ExportEnvelope(
+            exportVersion = DataExportService.SCHEMA_VERSION,
+            metadata = MetadataDto.from(metadata),
+            data = ExportDataDto.from(data),
+        )
+        return json.encodeToString(envelope)
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // DTOs — private @Serializable classes that mirror domain models
+    // minus sync-internal fields (syncVersion, isSynced).
+    // ═════════════════════════════════════════════════════════════════
+
+    /**
+     * Top-level envelope for the JSON export.
+     */
+    @Serializable
+    private data class ExportEnvelope(
+        @SerialName("export_version") val exportVersion: String,
+        val metadata: MetadataDto,
+        val data: ExportDataDto,
+    )
+
+    /**
+     * DTO for [ExportMetadata].
+     */
+    @Serializable
+    private data class MetadataDto(
+        @SerialName("export_date") val exportDate: String,
+        @SerialName("app_version") val appVersion: String,
+        @SerialName("schema_version") val schemaVersion: String,
+        @SerialName("user_id_hash") val userIdHash: String,
+        @SerialName("entity_counts") val entityCounts: EntityCountsDto,
+    ) {
+        companion object {
+            fun from(metadata: ExportMetadata): MetadataDto = MetadataDto(
+                exportDate = metadata.exportDate.toString(),
+                appVersion = metadata.appVersion,
+                schemaVersion = metadata.schemaVersion,
+                userIdHash = metadata.userIdHash,
+                entityCounts = EntityCountsDto(
+                    accounts = metadata.entityCounts.accounts,
+                    transactions = metadata.entityCounts.transactions,
+                    categories = metadata.entityCounts.categories,
+                    budgets = metadata.entityCounts.budgets,
+                    goals = metadata.entityCounts.goals,
+                ),
+            )
+        }
+    }
+
+    @Serializable
+    private data class EntityCountsDto(
+        val accounts: Int,
+        val transactions: Int,
+        val categories: Int,
+        val budgets: Int,
+        val goals: Int,
+    )
+
+    /**
+     * DTO for the `"data"` section of the export.
+     */
+    @Serializable
+    private data class ExportDataDto(
+        val accounts: List<AccountDto>,
+        val transactions: List<TransactionDto>,
+        val categories: List<CategoryDto>,
+        val budgets: List<BudgetDto>,
+        val goals: List<GoalDto>,
+    ) {
+        companion object {
+            fun from(data: ExportData): ExportDataDto = ExportDataDto(
+                accounts = data.accounts.map { AccountDto.from(it) },
+                transactions = data.transactions.map { TransactionDto.from(it) },
+                categories = data.categories.map { CategoryDto.from(it) },
+                budgets = data.budgets.map { BudgetDto.from(it) },
+                goals = data.goals.map { GoalDto.from(it) },
+            )
+        }
+    }
+
+    // ── Monetary value DTO ───────────────────────────────────────────
+
+    /**
+     * Monetary value represented with raw cents, display string, and currency.
+     *
+     * Example: `{ "amount": 1250, "display": "12.50", "currency": "USD" }`
+     */
+    @Serializable
+    private data class MoneyDto(
+        val amount: Long,
+        val display: String,
+        val currency: String,
+    ) {
+        companion object {
+            fun from(cents: Cents, currency: Currency): MoneyDto = MoneyDto(
+                amount = cents.amount,
+                display = formatCentsDisplay(cents, currency),
+                currency = currency.code,
+            )
+        }
+    }
+
+    // ── Entity DTOs ──────────────────────────────────────────────────
+
+    @Serializable
+    private data class AccountDto(
+        val id: String,
+        @SerialName("household_id") val householdId: String,
+        val name: String,
+        val type: String,
+        val currency: String,
+        @SerialName("current_balance") val currentBalance: MoneyDto,
+        @SerialName("is_archived") val isArchived: Boolean,
+        @SerialName("sort_order") val sortOrder: Int,
+        val icon: String?,
+        val color: String?,
+        @SerialName("created_at") val createdAt: String,
+        @SerialName("updated_at") val updatedAt: String,
+        @SerialName("deleted_at") val deletedAt: String?,
+    ) {
+        companion object {
+            fun from(account: Account): AccountDto = AccountDto(
+                id = account.id.value,
+                householdId = account.householdId.value,
+                name = account.name,
+                type = account.type.name,
+                currency = account.currency.code,
+                currentBalance = MoneyDto.from(account.currentBalance, account.currency),
+                isArchived = account.isArchived,
+                sortOrder = account.sortOrder,
+                icon = account.icon,
+                color = account.color,
+                createdAt = account.createdAt.toString(),
+                updatedAt = account.updatedAt.toString(),
+                deletedAt = account.deletedAt?.toString(),
+            )
+        }
+    }
+
+    @Serializable
+    private data class TransactionDto(
+        val id: String,
+        @SerialName("household_id") val householdId: String,
+        @SerialName("account_id") val accountId: String,
+        @SerialName("category_id") val categoryId: String?,
+        val type: String,
+        val status: String,
+        val amount: MoneyDto,
+        val payee: String?,
+        val note: String?,
+        val date: String,
+        @SerialName("transfer_account_id") val transferAccountId: String?,
+        @SerialName("transfer_transaction_id") val transferTransactionId: String?,
+        @SerialName("is_recurring") val isRecurring: Boolean,
+        @SerialName("recurring_rule_id") val recurringRuleId: String?,
+        val tags: List<String>,
+        @SerialName("created_at") val createdAt: String,
+        @SerialName("updated_at") val updatedAt: String,
+        @SerialName("deleted_at") val deletedAt: String?,
+    ) {
+        companion object {
+            fun from(transaction: Transaction): TransactionDto = TransactionDto(
+                id = transaction.id.value,
+                householdId = transaction.householdId.value,
+                accountId = transaction.accountId.value,
+                categoryId = transaction.categoryId?.value,
+                type = transaction.type.name,
+                status = transaction.status.name,
+                amount = MoneyDto.from(transaction.amount, transaction.currency),
+                payee = transaction.payee,
+                note = transaction.note,
+                date = transaction.date.toString(),
+                transferAccountId = transaction.transferAccountId?.value,
+                transferTransactionId = transaction.transferTransactionId?.value,
+                isRecurring = transaction.isRecurring,
+                recurringRuleId = transaction.recurringRuleId?.value,
+                tags = transaction.tags,
+                createdAt = transaction.createdAt.toString(),
+                updatedAt = transaction.updatedAt.toString(),
+                deletedAt = transaction.deletedAt?.toString(),
+            )
+        }
+    }
+
+    @Serializable
+    private data class CategoryDto(
+        val id: String,
+        @SerialName("household_id") val householdId: String,
+        val name: String,
+        val icon: String?,
+        val color: String?,
+        @SerialName("parent_id") val parentId: String?,
+        @SerialName("is_income") val isIncome: Boolean,
+        @SerialName("is_system") val isSystem: Boolean,
+        @SerialName("sort_order") val sortOrder: Int,
+        @SerialName("created_at") val createdAt: String,
+        @SerialName("updated_at") val updatedAt: String,
+        @SerialName("deleted_at") val deletedAt: String?,
+    ) {
+        companion object {
+            fun from(category: Category): CategoryDto = CategoryDto(
+                id = category.id.value,
+                householdId = category.householdId.value,
+                name = category.name,
+                icon = category.icon,
+                color = category.color,
+                parentId = category.parentId?.value,
+                isIncome = category.isIncome,
+                isSystem = category.isSystem,
+                sortOrder = category.sortOrder,
+                createdAt = category.createdAt.toString(),
+                updatedAt = category.updatedAt.toString(),
+                deletedAt = category.deletedAt?.toString(),
+            )
+        }
+    }
+
+    @Serializable
+    private data class BudgetDto(
+        val id: String,
+        @SerialName("household_id") val householdId: String,
+        @SerialName("category_id") val categoryId: String,
+        val name: String,
+        val amount: MoneyDto,
+        val period: String,
+        @SerialName("start_date") val startDate: String,
+        @SerialName("end_date") val endDate: String?,
+        @SerialName("is_rollover") val isRollover: Boolean,
+        @SerialName("created_at") val createdAt: String,
+        @SerialName("updated_at") val updatedAt: String,
+        @SerialName("deleted_at") val deletedAt: String?,
+    ) {
+        companion object {
+            fun from(budget: Budget): BudgetDto = BudgetDto(
+                id = budget.id.value,
+                householdId = budget.householdId.value,
+                categoryId = budget.categoryId.value,
+                name = budget.name,
+                amount = MoneyDto.from(budget.amount, budget.currency),
+                period = budget.period.name,
+                startDate = budget.startDate.toString(),
+                endDate = budget.endDate?.toString(),
+                isRollover = budget.isRollover,
+                createdAt = budget.createdAt.toString(),
+                updatedAt = budget.updatedAt.toString(),
+                deletedAt = budget.deletedAt?.toString(),
+            )
+        }
+    }
+
+    @Serializable
+    private data class GoalDto(
+        val id: String,
+        @SerialName("household_id") val householdId: String,
+        val name: String,
+        @SerialName("target_amount") val targetAmount: MoneyDto,
+        @SerialName("current_amount") val currentAmount: MoneyDto,
+        @SerialName("target_date") val targetDate: String?,
+        val status: String,
+        val icon: String?,
+        val color: String?,
+        @SerialName("account_id") val accountId: String?,
+        @SerialName("created_at") val createdAt: String,
+        @SerialName("updated_at") val updatedAt: String,
+        @SerialName("deleted_at") val deletedAt: String?,
+    ) {
+        companion object {
+            fun from(goal: Goal): GoalDto = GoalDto(
+                id = goal.id.value,
+                householdId = goal.householdId.value,
+                name = goal.name,
+                targetAmount = MoneyDto.from(goal.targetAmount, goal.currency),
+                currentAmount = MoneyDto.from(goal.currentAmount, goal.currency),
+                targetDate = goal.targetDate?.toString(),
+                status = goal.status.name,
+                icon = goal.icon,
+                color = goal.color,
+                accountId = goal.accountId?.value,
+                createdAt = goal.createdAt.toString(),
+                updatedAt = goal.updatedAt.toString(),
+                deletedAt = goal.deletedAt?.toString(),
+            )
+        }
+    }
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// Shared formatting — used by both JSON and CSV serializers.
+// ═════════════════════════════════════════════════════════════════════
+
+/**
+ * Formats a [Cents] value as a decimal display string using the currency's
+ * [Currency.decimalPlaces].
+ *
+ * Examples:
+ * - `Cents(1250)` with USD (2 decimals) → `"12.50"`
+ * - `Cents(-350)` with USD (2 decimals) → `"-3.50"`
+ * - `Cents(1000)` with JPY (0 decimals) → `"1000"`
+ * - `Cents(12345)` with BHD (3 decimals) → `"12.345"`
+ */
+internal fun formatCentsDisplay(cents: Cents, currency: Currency): String {
+    val decimals = currency.decimalPlaces
+    if (decimals == 0) return cents.amount.toString()
+
+    val isNegative = cents.amount < 0
+    val absAmount = if (isNegative) -cents.amount else cents.amount
+    var divisor = 1L
+    repeat(decimals) { divisor *= 10 }
+    val wholePart = absAmount / divisor
+    val fractionalPart = absAmount % divisor
+
+    val sign = if (isNegative) "-" else ""
+    return "$sign$wholePart.${fractionalPart.toString().padStart(decimals, '0')}"
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/export/Sha256.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/export/Sha256.kt
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.export
+
+/**
+ * Pure-Kotlin SHA-256 implementation for multiplatform use.
+ *
+ * Used for export checksums and user-ID anonymisation. This is **not** intended
+ * for security-critical cryptographic operations — for those, use the platform-
+ * specific implementations in `packages/sync` (e.g., [com.finance.sync.auth.PlatformSHA256]).
+ *
+ * Implements the SHA-256 algorithm per FIPS 180-4.
+ */
+internal object Sha256 {
+
+    private val K = intArrayOf(
+        0x428a2f98.toInt(), 0x71374491, 0xb5c0fbcf.toInt(), 0xe9b5dba5.toInt(),
+        0x3956c25b, 0x59f111f1, 0x923f82a4.toInt(), 0xab1c5ed5.toInt(),
+        0xd807aa98.toInt(), 0x12835b01, 0x243185be, 0x550c7dc3,
+        0x72be5d74, 0x80deb1fe.toInt(), 0x9bdc06a7.toInt(), 0xc19bf174.toInt(),
+        0xe49b69c1.toInt(), 0xefbe4786.toInt(), 0x0fc19dc6, 0x240ca1cc,
+        0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+        0x983e5152.toInt(), 0xa831c66d.toInt(), 0xb00327c8.toInt(), 0xbf597fc7.toInt(),
+        0xc6e00bf3.toInt(), 0xd5a79147.toInt(), 0x06ca6351, 0x14292967,
+        0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+        0x650a7354, 0x766a0abb, 0x81c2c92e.toInt(), 0x92722c85.toInt(),
+        0xa2bfe8a1.toInt(), 0xa81a664b.toInt(), 0xc24b8b70.toInt(), 0xc76c51a3.toInt(),
+        0xd192e819.toInt(), 0xd6990624.toInt(), 0xf40e3585.toInt(), 0x106aa070,
+        0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5,
+        0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814.toInt(), 0x8cc70208.toInt(),
+        0x90befffa.toInt(), 0xa4506ceb.toInt(), 0xbef9a3f7.toInt(), 0xc67178f2.toInt(),
+    )
+
+    /**
+     * Computes the SHA-256 digest of [input] and returns the result as a
+     * lowercase hexadecimal string (64 characters).
+     */
+    fun hexDigest(input: ByteArray): String {
+        val hash = digest(input)
+        return hash.joinToString("") { byte ->
+            (byte.toInt() and 0xFF).toString(16).padStart(2, '0')
+        }
+    }
+
+    /**
+     * Convenience overload that hashes a UTF-8 encoded string.
+     */
+    fun hexDigest(input: String): String = hexDigest(input.encodeToByteArray())
+
+    /**
+     * Computes the raw 32-byte SHA-256 digest of [message].
+     */
+    fun digest(message: ByteArray): ByteArray {
+        val padded = pad(message)
+        var h0 = 0x6a09e667
+        var h1 = 0xbb67ae85.toInt()
+        var h2 = 0x3c6ef372
+        var h3 = 0xa54ff53a.toInt()
+        var h4 = 0x510e527f
+        var h5 = 0x9b05688c.toInt()
+        var h6 = 0x1f83d9ab
+        var h7 = 0x5be0cd19
+
+        for (i in padded.indices step 64) {
+            val w = IntArray(64)
+            for (j in 0 until 16) {
+                w[j] = ((padded[i + j * 4].toInt() and 0xFF) shl 24) or
+                    ((padded[i + j * 4 + 1].toInt() and 0xFF) shl 16) or
+                    ((padded[i + j * 4 + 2].toInt() and 0xFF) shl 8) or
+                    (padded[i + j * 4 + 3].toInt() and 0xFF)
+            }
+            for (j in 16 until 64) {
+                val s0 = rightRotate(w[j - 15], 7) xor rightRotate(w[j - 15], 18) xor (w[j - 15] ushr 3)
+                val s1 = rightRotate(w[j - 2], 17) xor rightRotate(w[j - 2], 19) xor (w[j - 2] ushr 10)
+                w[j] = w[j - 16] + s0 + w[j - 7] + s1
+            }
+
+            var a = h0; var b = h1; var c = h2; var d = h3
+            var e = h4; var f = h5; var g = h6; var h = h7
+
+            for (j in 0 until 64) {
+                val s1 = rightRotate(e, 6) xor rightRotate(e, 11) xor rightRotate(e, 25)
+                val ch = (e and f) xor (e.inv() and g)
+                val temp1 = h + s1 + ch + K[j] + w[j]
+                val s0 = rightRotate(a, 2) xor rightRotate(a, 13) xor rightRotate(a, 22)
+                val maj = (a and b) xor (a and c) xor (b and c)
+                val temp2 = s0 + maj
+
+                h = g; g = f; f = e; e = d + temp1
+                d = c; c = b; b = a; a = temp1 + temp2
+            }
+
+            h0 += a; h1 += b; h2 += c; h3 += d
+            h4 += e; h5 += f; h6 += g; h7 += h
+        }
+
+        return intToBytes(h0) + intToBytes(h1) + intToBytes(h2) + intToBytes(h3) +
+            intToBytes(h4) + intToBytes(h5) + intToBytes(h6) + intToBytes(h7)
+    }
+
+    private fun pad(message: ByteArray): ByteArray {
+        val bitLen = message.size.toLong() * 8
+        val padLen = (56 - (message.size + 1) % 64 + 64) % 64
+        val padded = ByteArray(message.size + 1 + padLen + 8)
+        message.copyInto(padded)
+        padded[message.size] = 0x80.toByte()
+        for (i in 0 until 8) {
+            padded[padded.size - 8 + i] = (bitLen ushr (56 - i * 8)).toByte()
+        }
+        return padded
+    }
+
+    private fun rightRotate(value: Int, bits: Int): Int =
+        (value ushr bits) or (value shl (32 - bits))
+
+    private fun intToBytes(value: Int): ByteArray = byteArrayOf(
+        (value ushr 24).toByte(), (value ushr 16).toByte(),
+        (value ushr 8).toByte(), value.toByte(),
+    )
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/export/CsvExportSerializerTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/export/CsvExportSerializerTest.kt
@@ -1,0 +1,488 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.export
+
+import com.finance.core.TestFixtures
+import com.finance.models.*
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlin.test.*
+
+class CsvExportSerializerTest {
+
+    private val serializer = CsvExportSerializer()
+
+    private val fixedInstant = Instant.parse("2024-06-15T12:00:00Z")
+    private val fixedDate = LocalDate(2024, 6, 15)
+
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    private fun sampleMetadata() = ExportMetadata(
+        exportDate = fixedInstant,
+        appVersion = "2.1.0",
+        schemaVersion = "1.0",
+        userIdHash = "sha256:abc123",
+        entityCounts = ExportEntityCounts(
+            accounts = 1,
+            transactions = 1,
+            categories = 1,
+            budgets = 1,
+            goals = 1,
+        ),
+    )
+
+    private fun sampleData(): ExportData {
+        TestFixtures.reset()
+        return ExportData(
+            accounts = listOf(
+                TestFixtures.createAccount(name = "Checking"),
+            ),
+            transactions = listOf(
+                TestFixtures.createExpense(amount = Cents(1250)),
+            ),
+            categories = listOf(
+                Category(
+                    id = TestFixtures.nextId(),
+                    householdId = SyncId("household-1"),
+                    name = "Groceries",
+                    createdAt = fixedInstant,
+                    updatedAt = fixedInstant,
+                ),
+            ),
+            budgets = listOf(
+                TestFixtures.createBudget(name = "Food Budget"),
+            ),
+            goals = listOf(
+                Goal(
+                    id = TestFixtures.nextId(),
+                    householdId = SyncId("household-1"),
+                    name = "Emergency Fund",
+                    targetAmount = Cents(100000),
+                    currentAmount = Cents(25000),
+                    currency = Currency.USD,
+                    createdAt = fixedInstant,
+                    updatedAt = fixedInstant,
+                ),
+            ),
+        )
+    }
+
+    /**
+     * Splits CSV output into lines using CRLF, keeping empty lines for
+     * section boundaries.
+     */
+    private fun csvLines(content: String): List<String> =
+        content.split("\r\n")
+
+    // ═════════════════════════════════════════════════════════════════
+    // Format property
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun format_isCsv() {
+        assertEquals(ExportFormat.CSV, serializer.format)
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // RFC 4180 — CRLF line endings
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun serialize_usesCrlfLineEndings() {
+        val content = serializer.serialize(sampleData(), sampleMetadata())
+        // Every \n should be preceded by \r (CRLF), unless it's inside a quoted field.
+        // Check that non-quoted line boundaries use CRLF.
+        assertTrue(content.contains("\r\n"), "Output should contain CRLF line endings")
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // RFC 4180 — fields with commas are quoted
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun serialize_fieldsWithCommas_areQuoted() {
+        TestFixtures.reset()
+        val data = ExportData(
+            accounts = listOf(
+                TestFixtures.createAccount(name = "Savings, Joint"),
+            ),
+            transactions = emptyList(),
+            categories = emptyList(),
+            budgets = emptyList(),
+            goals = emptyList(),
+        )
+        val content = serializer.serialize(data, sampleMetadata())
+        assertTrue(
+            content.contains("\"Savings, Joint\""),
+            "Field with comma should be enclosed in double-quotes",
+        )
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // RFC 4180 — fields with double-quotes are escaped
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun serialize_fieldsWithDoubleQuotes_areEscaped() {
+        TestFixtures.reset()
+        val data = ExportData(
+            accounts = emptyList(),
+            transactions = listOf(
+                TestFixtures.createTransaction(
+                    payee = "McDonald's \"Big Mac\" Deal",
+                ),
+            ),
+            categories = emptyList(),
+            budgets = emptyList(),
+            goals = emptyList(),
+        )
+        val content = serializer.serialize(data, sampleMetadata())
+        // The double-quotes inside the field should be doubled per RFC 4180
+        assertTrue(
+            content.contains("\"McDonald's \"\"Big Mac\"\" Deal\""),
+            "Double-quotes within a field should be escaped by doubling them",
+        )
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // RFC 4180 — fields with newlines are quoted
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun serialize_fieldsWithNewlines_areQuoted() {
+        TestFixtures.reset()
+        val data = ExportData(
+            accounts = emptyList(),
+            transactions = listOf(
+                TestFixtures.createTransaction(
+                    note = "Line 1\nLine 2",
+                ),
+            ),
+            categories = emptyList(),
+            budgets = emptyList(),
+            goals = emptyList(),
+        )
+        val content = serializer.serialize(data, sampleMetadata())
+        // The field containing a newline should be wrapped in double-quotes
+        assertTrue(
+            content.contains("\"Line 1\nLine 2\""),
+            "Field with newline should be enclosed in double-quotes",
+        )
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // Monetary values formatted as decimal strings
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun serialize_monetaryValues_formattedAsDecimal() {
+        val content = serializer.serialize(sampleData(), sampleMetadata())
+        // Account balance: Cents(10000) with USD → "100.00"
+        assertTrue(content.contains("100.00"), "Account balance should be formatted as 100.00")
+        // Transaction amount: Cents(1250) with USD → "12.50"
+        assertTrue(content.contains("12.50"), "Transaction amount should be formatted as 12.50")
+    }
+
+    @Test
+    fun serialize_jpyCurrency_noDecimalPlaces() {
+        TestFixtures.reset()
+        val data = ExportData(
+            accounts = listOf(
+                TestFixtures.createAccount(
+                    name = "JPY Account",
+                    currency = Currency.JPY,
+                    currentBalance = Cents(1000),
+                ),
+            ),
+            transactions = emptyList(),
+            categories = emptyList(),
+            budgets = emptyList(),
+            goals = emptyList(),
+        )
+        val content = serializer.serialize(data, sampleMetadata())
+        val lines = csvLines(content)
+        // Find the accounts data line (after headers)
+        val accountDataLine = lines.first { it.startsWith("test-") }
+        // JPY has 0 decimal places, so Cents(1000) → "1000" (no decimal point)
+        assertTrue(
+            accountDataLine.contains(",1000,") || accountDataLine.contains(",1000\r"),
+            "JPY amounts should have no decimal places",
+        )
+    }
+
+    @Test
+    fun serialize_negativeAmount_formattedCorrectly() {
+        TestFixtures.reset()
+        val data = ExportData(
+            accounts = listOf(
+                TestFixtures.createAccount(
+                    name = "Credit Card",
+                    type = AccountType.CREDIT_CARD,
+                    currentBalance = Cents(-15075),
+                ),
+            ),
+            transactions = emptyList(),
+            categories = emptyList(),
+            budgets = emptyList(),
+            goals = emptyList(),
+        )
+        val content = serializer.serialize(data, sampleMetadata())
+        assertTrue(content.contains("-150.75"), "Negative balance should be formatted as -150.75")
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // Dates as ISO 8601
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun serialize_datesAsIso8601() {
+        val content = serializer.serialize(sampleData(), sampleMetadata())
+        assertTrue(
+            content.contains("2024-06-15T12:00:00Z"),
+            "Timestamps should be ISO 8601 format",
+        )
+        assertTrue(
+            content.contains("2024-06-15"),
+            "Dates should be ISO 8601 format",
+        )
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // Tags serialized as semicolon-separated
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun serialize_tags_semicolonSeparated() {
+        TestFixtures.reset()
+        val data = ExportData(
+            accounts = emptyList(),
+            transactions = listOf(
+                Transaction(
+                    id = TestFixtures.nextId(),
+                    householdId = SyncId("household-1"),
+                    accountId = SyncId("account-1"),
+                    type = TransactionType.EXPENSE,
+                    amount = Cents(500),
+                    currency = Currency.USD,
+                    date = fixedDate,
+                    tags = listOf("groceries", "essential", "weekly"),
+                    createdAt = fixedInstant,
+                    updatedAt = fixedInstant,
+                ),
+            ),
+            categories = emptyList(),
+            budgets = emptyList(),
+            goals = emptyList(),
+        )
+        val content = serializer.serialize(data, sampleMetadata())
+        assertTrue(
+            content.contains("groceries;essential;weekly"),
+            "Tags should be semicolon-separated",
+        )
+    }
+
+    @Test
+    fun serialize_emptyTags_producesEmptyField() {
+        TestFixtures.reset()
+        val data = ExportData(
+            accounts = emptyList(),
+            transactions = listOf(
+                TestFixtures.createExpense(), // no tags by default
+            ),
+            categories = emptyList(),
+            budgets = emptyList(),
+            goals = emptyList(),
+        )
+        val content = serializer.serialize(data, sampleMetadata())
+        // The tags field should be empty (two consecutive commas or comma before timestamp)
+        val lines = csvLines(content)
+        val txnDataLine = lines.first { it.startsWith("test-") && lines.indexOf(it) > lines.indexOf("# TRANSACTIONS") }
+        // Tags column is followed by created_at — empty tags means ",," somewhere
+        assertTrue(
+            txnDataLine.contains(",,") || txnDataLine.contains(",2024"),
+            "Empty tags should produce an empty field",
+        )
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // syncVersion and isSynced excluded
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun serialize_excludesSyncVersion() {
+        val content = serializer.serialize(sampleData(), sampleMetadata())
+        assertFalse(
+            content.contains("syncVersion") || content.contains("sync_version"),
+            "syncVersion should not appear in CSV output",
+        )
+    }
+
+    @Test
+    fun serialize_excludesIsSynced() {
+        val content = serializer.serialize(sampleData(), sampleMetadata())
+        assertFalse(
+            content.contains("isSynced") || content.contains("is_synced"),
+            "isSynced should not appear in CSV output",
+        )
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // Empty collections produce header-only sections
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun serialize_emptyCollections_produceHeaderOnlySections() {
+        TestFixtures.reset()
+        val data = ExportData(
+            accounts = listOf(TestFixtures.createAccount()), // at least one entity
+            transactions = emptyList(),
+            categories = emptyList(),
+            budgets = emptyList(),
+            goals = emptyList(),
+        )
+        val content = serializer.serialize(data, sampleMetadata())
+        val lines = csvLines(content)
+
+        // Find TRANSACTIONS section — should have header comment + column headers but no data rows
+        val txnHeaderIdx = lines.indexOf("# TRANSACTIONS")
+        assertTrue(txnHeaderIdx >= 0, "TRANSACTIONS section header should be present")
+        // Next line is column headers
+        val txnColumnsLine = lines[txnHeaderIdx + 1]
+        assertTrue(txnColumnsLine.startsWith("id,"), "Column headers should follow section comment")
+        // Line after column headers should be empty (section separator)
+        val lineAfterHeaders = lines[txnHeaderIdx + 2]
+        assertTrue(
+            lineAfterHeaders.isEmpty() || lineAfterHeaders.startsWith("#"),
+            "Empty collection should have no data rows after headers",
+        )
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // Unicode characters preserved
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun serialize_unicodeCharacters_preserved() {
+        TestFixtures.reset()
+        val data = ExportData(
+            accounts = listOf(
+                TestFixtures.createAccount(name = "Café Übermensch 日本語"),
+            ),
+            transactions = emptyList(),
+            categories = emptyList(),
+            budgets = emptyList(),
+            goals = emptyList(),
+        )
+        val content = serializer.serialize(data, sampleMetadata())
+        assertTrue(
+            content.contains("Café Übermensch 日本語"),
+            "Unicode characters should be preserved in output",
+        )
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // Metadata section
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun serialize_containsMetadataSection() {
+        val content = serializer.serialize(sampleData(), sampleMetadata())
+        assertTrue(content.contains("# METADATA"), "Output should contain metadata section")
+        assertTrue(content.contains("export_date"), "Metadata should contain export_date")
+        assertTrue(content.contains("app_version"), "Metadata should contain app_version")
+        assertTrue(content.contains("schema_version"), "Metadata should contain schema_version")
+        assertTrue(content.contains("user_id_hash"), "Metadata should contain user_id_hash")
+    }
+
+    @Test
+    fun serialize_metadataContainsCorrectValues() {
+        val content = serializer.serialize(sampleData(), sampleMetadata())
+        assertTrue(content.contains("2024-06-15T12:00:00Z"), "Should contain export date")
+        assertTrue(content.contains("2.1.0"), "Should contain app version")
+        assertTrue(content.contains("sha256:abc123"), "Should contain user ID hash")
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // Section headers present
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun serialize_containsAllSectionHeaders() {
+        val content = serializer.serialize(sampleData(), sampleMetadata())
+        assertTrue(content.contains("# ACCOUNTS"), "Should contain ACCOUNTS section")
+        assertTrue(content.contains("# TRANSACTIONS"), "Should contain TRANSACTIONS section")
+        assertTrue(content.contains("# CATEGORIES"), "Should contain CATEGORIES section")
+        assertTrue(content.contains("# BUDGETS"), "Should contain BUDGETS section")
+        assertTrue(content.contains("# GOALS"), "Should contain GOALS section")
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // escapeField unit tests (via companion)
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun escapeField_plainText_unchanged() {
+        assertEquals("hello", CsvExportSerializer.escapeField("hello"))
+    }
+
+    @Test
+    fun escapeField_withComma_quoted() {
+        assertEquals("\"hello, world\"", CsvExportSerializer.escapeField("hello, world"))
+    }
+
+    @Test
+    fun escapeField_withDoubleQuote_quotedAndEscaped() {
+        assertEquals("\"say \"\"hi\"\"\"", CsvExportSerializer.escapeField("say \"hi\""))
+    }
+
+    @Test
+    fun escapeField_withNewline_quoted() {
+        assertEquals("\"line1\nline2\"", CsvExportSerializer.escapeField("line1\nline2"))
+    }
+
+    @Test
+    fun escapeField_withCarriageReturn_quoted() {
+        assertEquals("\"line1\rline2\"", CsvExportSerializer.escapeField("line1\rline2"))
+    }
+
+    @Test
+    fun escapeField_emptyString_unchanged() {
+        assertEquals("", CsvExportSerializer.escapeField(""))
+    }
+
+    @Test
+    fun escapeField_commaAndQuote_quotedAndEscaped() {
+        assertEquals(
+            "\"He said, \"\"hello\"\"\"",
+            CsvExportSerializer.escapeField("He said, \"hello\""),
+        )
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // Budget fields present
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun serialize_budgetFieldsCorrect() {
+        val content = serializer.serialize(sampleData(), sampleMetadata())
+        assertTrue(content.contains("Food Budget"), "Budget name should be present")
+        assertTrue(content.contains("MONTHLY"), "Budget period should be present")
+        assertTrue(content.contains("500.00"), "Budget amount should be formatted as decimal")
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // Goal fields present
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun serialize_goalFieldsCorrect() {
+        val content = serializer.serialize(sampleData(), sampleMetadata())
+        assertTrue(content.contains("Emergency Fund"), "Goal name should be present")
+        assertTrue(content.contains("1000.00"), "Goal target amount should be formatted")
+        assertTrue(content.contains("250.00"), "Goal current amount should be formatted")
+        assertTrue(content.contains("ACTIVE"), "Goal status should be present")
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/export/DataExportServiceTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/export/DataExportServiceTest.kt
@@ -1,0 +1,678 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.export
+
+import com.finance.core.TestFixtures
+import com.finance.models.types.SyncId
+import kotlinx.datetime.*
+import kotlin.test.*
+
+class DataExportServiceTest {
+
+    // ── Test helpers ──────────────────────────────────────────────────
+
+    /** Minimal mock serializer that concatenates entity counts as its "serialized" output. */
+    private class MockSerializer(
+        override val format: ExportFormat = ExportFormat.JSON,
+    ) : ExportSerializer {
+        var serializeCalled = false
+            private set
+        var lastData: ExportData? = null
+            private set
+        var lastMetadata: ExportMetadata? = null
+            private set
+
+        override fun serialize(data: ExportData, metadata: ExportMetadata): String {
+            serializeCalled = true
+            lastData = data
+            lastMetadata = metadata
+            return """{"accounts":${data.accounts.size},"transactions":${data.transactions.size}}"""
+        }
+    }
+
+    /** A serializer that always throws, for error-path testing. */
+    private class FailingSerializer(
+        override val format: ExportFormat = ExportFormat.JSON,
+        private val errorMessage: String = "serialization boom",
+    ) : ExportSerializer {
+        override fun serialize(data: ExportData, metadata: ExportMetadata): String {
+            throw IllegalStateException(errorMessage)
+        }
+    }
+
+    private val fixedInstant = Instant.parse("2026-03-15T10:30:00Z")
+    private val testUserId = SyncId("user-abc-123")
+    private val testAppVersion = "2.1.0"
+
+    private fun createSampleData(): ExportData {
+        TestFixtures.reset()
+        return ExportData(
+            accounts = listOf(
+                TestFixtures.createAccount(name = "Checking"),
+                TestFixtures.createAccount(name = "Savings"),
+            ),
+            transactions = listOf(
+                TestFixtures.createExpense(),
+                TestFixtures.createIncome(),
+                TestFixtures.createExpense(),
+            ),
+            categories = listOf(
+                // Create minimal categories via the model directly
+                com.finance.models.Category(
+                    id = TestFixtures.nextId(),
+                    householdId = SyncId("household-1"),
+                    name = "Food",
+                    createdAt = TestFixtures.fixedInstant,
+                    updatedAt = TestFixtures.fixedInstant,
+                ),
+            ),
+            budgets = listOf(
+                TestFixtures.createBudget(),
+            ),
+            goals = listOf(
+                com.finance.models.Goal(
+                    id = TestFixtures.nextId(),
+                    householdId = SyncId("household-1"),
+                    name = "Emergency Fund",
+                    targetAmount = com.finance.models.types.Cents(100000),
+                    currency = com.finance.models.types.Currency.USD,
+                    createdAt = TestFixtures.fixedInstant,
+                    updatedAt = TestFixtures.fixedInstant,
+                ),
+            ),
+        )
+    }
+
+    private fun createEmptyData(): ExportData = ExportData(
+        accounts = emptyList(),
+        transactions = emptyList(),
+        categories = emptyList(),
+        budgets = emptyList(),
+        goals = emptyList(),
+    )
+
+    // ═══════════════════════════════════════════════════════════════════
+    // export() — success cases
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    fun export_withValidData_returnsSuccess() {
+        val data = createSampleData()
+        val serializer = MockSerializer()
+
+        val outcome = DataExportService.export(
+            data = data,
+            serializer = serializer,
+            userId = testUserId,
+            appVersion = testAppVersion,
+            exportInstant = fixedInstant,
+        )
+
+        assertIs<ExportOutcome.Success>(outcome)
+        assertTrue(serializer.serializeCalled)
+    }
+
+    @Test
+    fun export_returnsCorrectFormat() {
+        val data = createSampleData()
+        val serializer = MockSerializer(format = ExportFormat.CSV)
+
+        val outcome = DataExportService.export(
+            data = data,
+            serializer = serializer,
+            userId = testUserId,
+            appVersion = testAppVersion,
+            exportInstant = fixedInstant,
+        )
+
+        assertIs<ExportOutcome.Success>(outcome)
+        assertEquals(ExportFormat.CSV, outcome.export.format)
+    }
+
+    @Test
+    fun export_contentMatchesSerializerOutput() {
+        val data = createSampleData()
+        val serializer = MockSerializer()
+
+        val outcome = DataExportService.export(
+            data = data,
+            serializer = serializer,
+            userId = testUserId,
+            appVersion = testAppVersion,
+            exportInstant = fixedInstant,
+        )
+
+        assertIs<ExportOutcome.Success>(outcome)
+        assertEquals("""{"accounts":2,"transactions":3}""", outcome.export.content)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // export() — empty data
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    fun export_withEmptyData_returnsNoDataError() {
+        val data = createEmptyData()
+        val serializer = MockSerializer()
+
+        val outcome = DataExportService.export(
+            data = data,
+            serializer = serializer,
+            userId = testUserId,
+            appVersion = testAppVersion,
+        )
+
+        assertIs<ExportOutcome.Failure>(outcome)
+        assertIs<ExportError.NoData>(outcome.error)
+        assertFalse(serializer.serializeCalled)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // export() — metadata
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    fun export_metadataContainsCorrectEntityCounts() {
+        val data = createSampleData()
+        val serializer = MockSerializer()
+
+        val outcome = DataExportService.export(
+            data = data,
+            serializer = serializer,
+            userId = testUserId,
+            appVersion = testAppVersion,
+            exportInstant = fixedInstant,
+        )
+
+        assertIs<ExportOutcome.Success>(outcome)
+        val counts = outcome.export.metadata.entityCounts
+        assertEquals(2, counts.accounts)
+        assertEquals(3, counts.transactions)
+        assertEquals(1, counts.categories)
+        assertEquals(1, counts.budgets)
+        assertEquals(1, counts.goals)
+        assertEquals(8, counts.total)
+    }
+
+    @Test
+    fun export_metadataContainsSchemaVersion() {
+        val data = createSampleData()
+        val serializer = MockSerializer()
+
+        val outcome = DataExportService.export(
+            data = data,
+            serializer = serializer,
+            userId = testUserId,
+            appVersion = testAppVersion,
+            exportInstant = fixedInstant,
+        )
+
+        assertIs<ExportOutcome.Success>(outcome)
+        assertEquals(DataExportService.SCHEMA_VERSION, outcome.export.metadata.schemaVersion)
+        assertEquals("1.0", outcome.export.metadata.schemaVersion)
+    }
+
+    @Test
+    fun export_metadataContainsAppVersion() {
+        val data = createSampleData()
+        val serializer = MockSerializer()
+
+        val outcome = DataExportService.export(
+            data = data,
+            serializer = serializer,
+            userId = testUserId,
+            appVersion = testAppVersion,
+            exportInstant = fixedInstant,
+        )
+
+        assertIs<ExportOutcome.Success>(outcome)
+        assertEquals(testAppVersion, outcome.export.metadata.appVersion)
+    }
+
+    @Test
+    fun export_metadataContainsExportDate() {
+        val data = createSampleData()
+        val serializer = MockSerializer()
+
+        val outcome = DataExportService.export(
+            data = data,
+            serializer = serializer,
+            userId = testUserId,
+            appVersion = testAppVersion,
+            exportInstant = fixedInstant,
+        )
+
+        assertIs<ExportOutcome.Success>(outcome)
+        assertEquals(fixedInstant, outcome.export.metadata.exportDate)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // export() — user ID hashing
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    fun export_hashesUserId_prefixedWithSha256() {
+        val data = createSampleData()
+        val serializer = MockSerializer()
+
+        val outcome = DataExportService.export(
+            data = data,
+            serializer = serializer,
+            userId = testUserId,
+            appVersion = testAppVersion,
+            exportInstant = fixedInstant,
+        )
+
+        assertIs<ExportOutcome.Success>(outcome)
+        assertTrue(outcome.export.metadata.userIdHash.startsWith("sha256:"))
+    }
+
+    @Test
+    fun export_userIdHashIsNotRawUserId() {
+        val data = createSampleData()
+        val serializer = MockSerializer()
+
+        val outcome = DataExportService.export(
+            data = data,
+            serializer = serializer,
+            userId = testUserId,
+            appVersion = testAppVersion,
+            exportInstant = fixedInstant,
+        )
+
+        assertIs<ExportOutcome.Success>(outcome)
+        assertFalse(outcome.export.metadata.userIdHash.contains(testUserId.value))
+    }
+
+    @Test
+    fun export_userIdHashIs64HexCharsAfterPrefix() {
+        val data = createSampleData()
+        val serializer = MockSerializer()
+
+        val outcome = DataExportService.export(
+            data = data,
+            serializer = serializer,
+            userId = testUserId,
+            appVersion = testAppVersion,
+            exportInstant = fixedInstant,
+        )
+
+        assertIs<ExportOutcome.Success>(outcome)
+        val hashPart = outcome.export.metadata.userIdHash.removePrefix("sha256:")
+        assertEquals(64, hashPart.length)
+        assertTrue(hashPart.all { it in '0'..'9' || it in 'a'..'f' })
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // export() — checksum
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    fun export_checksumIsSha256Hex() {
+        val data = createSampleData()
+        val serializer = MockSerializer()
+
+        val outcome = DataExportService.export(
+            data = data,
+            serializer = serializer,
+            userId = testUserId,
+            appVersion = testAppVersion,
+            exportInstant = fixedInstant,
+        )
+
+        assertIs<ExportOutcome.Success>(outcome)
+        assertEquals(64, outcome.export.checksum.length)
+        assertTrue(outcome.export.checksum.all { it in '0'..'9' || it in 'a'..'f' })
+    }
+
+    @Test
+    fun export_checksumIsDeterministic() {
+        val data = createSampleData()
+
+        val outcome1 = DataExportService.export(
+            data = data,
+            serializer = MockSerializer(),
+            userId = testUserId,
+            appVersion = testAppVersion,
+            exportInstant = fixedInstant,
+        )
+        val outcome2 = DataExportService.export(
+            data = data,
+            serializer = MockSerializer(),
+            userId = testUserId,
+            appVersion = testAppVersion,
+            exportInstant = fixedInstant,
+        )
+
+        assertIs<ExportOutcome.Success>(outcome1)
+        assertIs<ExportOutcome.Success>(outcome2)
+        assertEquals(outcome1.export.checksum, outcome2.export.checksum)
+    }
+
+    @Test
+    fun export_sizeMatchesContentByteLength() {
+        val data = createSampleData()
+        val serializer = MockSerializer()
+
+        val outcome = DataExportService.export(
+            data = data,
+            serializer = serializer,
+            userId = testUserId,
+            appVersion = testAppVersion,
+            exportInstant = fixedInstant,
+        )
+
+        assertIs<ExportOutcome.Success>(outcome)
+        val expectedSize = outcome.export.content.encodeToByteArray().size.toLong()
+        assertEquals(expectedSize, outcome.export.sizeBytes)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // export() — filename
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    fun export_generatesCorrectFilenameForJson() {
+        val data = createSampleData()
+        val serializer = MockSerializer(format = ExportFormat.JSON)
+
+        val outcome = DataExportService.export(
+            data = data,
+            serializer = serializer,
+            userId = testUserId,
+            appVersion = testAppVersion,
+            exportInstant = fixedInstant,
+        )
+
+        assertIs<ExportOutcome.Success>(outcome)
+        assertEquals("finance-export-2026-03-15.json", outcome.export.filename)
+    }
+
+    @Test
+    fun export_generatesCorrectFilenameForCsv() {
+        val data = createSampleData()
+        val serializer = MockSerializer(format = ExportFormat.CSV)
+
+        val outcome = DataExportService.export(
+            data = data,
+            serializer = serializer,
+            userId = testUserId,
+            appVersion = testAppVersion,
+            exportInstant = fixedInstant,
+        )
+
+        assertIs<ExportOutcome.Success>(outcome)
+        assertEquals("finance-export-2026-03-15.zip", outcome.export.filename)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // export() — progress callback
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    fun export_callsProgressInCorrectOrder() {
+        val data = createSampleData()
+        val serializer = MockSerializer()
+        val phases = mutableListOf<ExportPhase>()
+
+        DataExportService.export(
+            data = data,
+            serializer = serializer,
+            userId = testUserId,
+            appVersion = testAppVersion,
+            exportInstant = fixedInstant,
+            onProgress = { phases.add(it.phase) },
+        )
+
+        assertEquals(
+            listOf(
+                ExportPhase.GATHERING_DATA,
+                ExportPhase.SERIALIZING,
+                ExportPhase.COMPUTING_CHECKSUM,
+                ExportPhase.COMPLETE,
+            ),
+            phases,
+        )
+    }
+
+    @Test
+    fun export_progressFractionIncreasesMonotonically() {
+        val data = createSampleData()
+        val serializer = MockSerializer()
+        val fractions = mutableListOf<Float>()
+
+        DataExportService.export(
+            data = data,
+            serializer = serializer,
+            userId = testUserId,
+            appVersion = testAppVersion,
+            exportInstant = fixedInstant,
+            onProgress = { fractions.add(it.fraction) },
+        )
+
+        // Fractions should be strictly increasing
+        for (i in 1 until fractions.size) {
+            assertTrue(
+                fractions[i] > fractions[i - 1],
+                "Expected fraction[${i}] (${fractions[i]}) > fraction[${i - 1}] (${fractions[i - 1]})",
+            )
+        }
+        // Last fraction should be 1.0
+        assertEquals(1.0f, fractions.last())
+    }
+
+    @Test
+    fun export_noProgressCallbackDoesNotCrash() {
+        val data = createSampleData()
+        val serializer = MockSerializer()
+
+        // Just verify it doesn't throw when onProgress is null
+        val outcome = DataExportService.export(
+            data = data,
+            serializer = serializer,
+            userId = testUserId,
+            appVersion = testAppVersion,
+            exportInstant = fixedInstant,
+            onProgress = null,
+        )
+
+        assertIs<ExportOutcome.Success>(outcome)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // export() — serializer failure
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    fun export_serializerThrows_returnsSerializationFailed() {
+        val data = createSampleData()
+        val serializer = FailingSerializer(errorMessage = "unexpected format error")
+
+        val outcome = DataExportService.export(
+            data = data,
+            serializer = serializer,
+            userId = testUserId,
+            appVersion = testAppVersion,
+            exportInstant = fixedInstant,
+        )
+
+        assertIs<ExportOutcome.Failure>(outcome)
+        assertIs<ExportError.SerializationFailed>(outcome.error)
+        assertTrue(outcome.error.message.contains("unexpected format error"))
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // export() — serializer receives correct data
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    fun export_passesDataAndMetadataToSerializer() {
+        val data = createSampleData()
+        val serializer = MockSerializer()
+
+        DataExportService.export(
+            data = data,
+            serializer = serializer,
+            userId = testUserId,
+            appVersion = testAppVersion,
+            exportInstant = fixedInstant,
+        )
+
+        assertNotNull(serializer.lastData)
+        assertNotNull(serializer.lastMetadata)
+        assertEquals(2, serializer.lastData!!.accounts.size)
+        assertEquals(3, serializer.lastData!!.transactions.size)
+        assertEquals(testAppVersion, serializer.lastMetadata!!.appVersion)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // generateFilename()
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    fun generateFilename_jsonFormat() {
+        val filename = DataExportService.generateFilename(ExportFormat.JSON, fixedInstant)
+        assertEquals("finance-export-2026-03-15.json", filename)
+    }
+
+    @Test
+    fun generateFilename_csvFormat() {
+        val filename = DataExportService.generateFilename(ExportFormat.CSV, fixedInstant)
+        assertEquals("finance-export-2026-03-15.zip", filename)
+    }
+
+    @Test
+    fun generateFilename_usesUtcDate() {
+        // 2026-03-15T23:30:00Z is March 15 in UTC but could be March 16 in UTC+2
+        val lateNight = Instant.parse("2026-03-15T23:30:00Z")
+        val filename = DataExportService.generateFilename(ExportFormat.JSON, lateNight)
+        assertEquals("finance-export-2026-03-15.json", filename)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // hashUserId()
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    fun hashUserId_startsWithPrefix() {
+        val hash = DataExportService.hashUserId(SyncId("test-user"))
+        assertTrue(hash.startsWith("sha256:"))
+    }
+
+    @Test
+    fun hashUserId_producesValidHex() {
+        val hash = DataExportService.hashUserId(SyncId("test-user"))
+        val hexPart = hash.removePrefix("sha256:")
+        assertEquals(64, hexPart.length)
+        assertTrue(hexPart.all { it in '0'..'9' || it in 'a'..'f' })
+    }
+
+    @Test
+    fun hashUserId_deterministicForSameInput() {
+        val hash1 = DataExportService.hashUserId(SyncId("same-user"))
+        val hash2 = DataExportService.hashUserId(SyncId("same-user"))
+        assertEquals(hash1, hash2)
+    }
+
+    @Test
+    fun hashUserId_differentForDifferentInput() {
+        val hash1 = DataExportService.hashUserId(SyncId("user-a"))
+        val hash2 = DataExportService.hashUserId(SyncId("user-b"))
+        assertNotEquals(hash1, hash2)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // computeChecksum()
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    fun computeChecksum_returnsValidHex() {
+        val checksum = DataExportService.computeChecksum("hello world")
+        assertEquals(64, checksum.length)
+        assertTrue(checksum.all { it in '0'..'9' || it in 'a'..'f' })
+    }
+
+    @Test
+    fun computeChecksum_deterministicForSameInput() {
+        val c1 = DataExportService.computeChecksum("same content")
+        val c2 = DataExportService.computeChecksum("same content")
+        assertEquals(c1, c2)
+    }
+
+    @Test
+    fun computeChecksum_differentForDifferentInput() {
+        val c1 = DataExportService.computeChecksum("content A")
+        val c2 = DataExportService.computeChecksum("content B")
+        assertNotEquals(c1, c2)
+    }
+
+    @Test
+    fun computeChecksum_knownTestVector() {
+        // SHA-256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        val checksum = DataExportService.computeChecksum("")
+        assertEquals("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", checksum)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // ExportData
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    fun exportData_isEmpty_allEmpty() {
+        val data = createEmptyData()
+        assertTrue(data.isEmpty)
+        assertEquals(0, data.totalRecords)
+    }
+
+    @Test
+    fun exportData_isNotEmpty_whenHasAccounts() {
+        TestFixtures.reset()
+        val data = ExportData(
+            accounts = listOf(TestFixtures.createAccount()),
+            transactions = emptyList(),
+            categories = emptyList(),
+            budgets = emptyList(),
+            goals = emptyList(),
+        )
+        assertFalse(data.isEmpty)
+        assertEquals(1, data.totalRecords)
+    }
+
+    @Test
+    fun exportData_totalRecords_sumsAllEntities() {
+        val data = createSampleData()
+        assertEquals(8, data.totalRecords)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // ExportProgress
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    fun exportProgress_fractionComputation() {
+        val progress = ExportProgress(ExportPhase.SERIALIZING, 2, 4)
+        assertEquals(0.5f, progress.fraction)
+    }
+
+    @Test
+    fun exportProgress_fractionZeroWhenTotalZero() {
+        val progress = ExportProgress(ExportPhase.GATHERING_DATA, 0, 0)
+        assertEquals(0f, progress.fraction)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // ExportEntityCounts
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    fun exportEntityCounts_totalSumsAll() {
+        val counts = ExportEntityCounts(
+            accounts = 2,
+            transactions = 10,
+            categories = 5,
+            budgets = 3,
+            goals = 1,
+        )
+        assertEquals(21, counts.total)
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/export/JsonExportSerializerTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/export/JsonExportSerializerTest.kt
@@ -1,0 +1,498 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.export
+
+import com.finance.core.TestFixtures
+import com.finance.models.*
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.serialization.json.*
+import kotlin.test.*
+
+class JsonExportSerializerTest {
+
+    private val serializer = JsonExportSerializer()
+
+    /** Lenient parser for round-trip validation of serializer output. */
+    private val jsonParser = Json { ignoreUnknownKeys = true }
+
+    private val fixedInstant = Instant.parse("2024-06-15T12:00:00Z")
+    private val fixedDate = LocalDate(2024, 6, 15)
+
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    private fun sampleMetadata() = ExportMetadata(
+        exportDate = fixedInstant,
+        appVersion = "2.1.0",
+        schemaVersion = "1.0",
+        userIdHash = "sha256:abc123",
+        entityCounts = ExportEntityCounts(
+            accounts = 1,
+            transactions = 1,
+            categories = 1,
+            budgets = 1,
+            goals = 1,
+        ),
+    )
+
+    private fun sampleData(): ExportData {
+        TestFixtures.reset()
+        return ExportData(
+            accounts = listOf(
+                TestFixtures.createAccount(name = "Checking"),
+            ),
+            transactions = listOf(
+                TestFixtures.createExpense(amount = Cents(1250)),
+            ),
+            categories = listOf(
+                Category(
+                    id = TestFixtures.nextId(),
+                    householdId = SyncId("household-1"),
+                    name = "Groceries",
+                    createdAt = fixedInstant,
+                    updatedAt = fixedInstant,
+                ),
+            ),
+            budgets = listOf(
+                TestFixtures.createBudget(name = "Food Budget"),
+            ),
+            goals = listOf(
+                Goal(
+                    id = TestFixtures.nextId(),
+                    householdId = SyncId("household-1"),
+                    name = "Emergency Fund",
+                    targetAmount = Cents(100000),
+                    currentAmount = Cents(25000),
+                    currency = Currency.USD,
+                    createdAt = fixedInstant,
+                    updatedAt = fixedInstant,
+                ),
+            ),
+        )
+    }
+
+    private fun emptyData(): ExportData = ExportData(
+        accounts = emptyList(),
+        transactions = emptyList(),
+        categories = emptyList(),
+        budgets = emptyList(),
+        goals = emptyList(),
+    )
+
+    /** Parses the serializer output into a [JsonObject] for assertions. */
+    private fun serializeAndParse(
+        data: ExportData = sampleData(),
+        metadata: ExportMetadata = sampleMetadata(),
+    ): JsonObject {
+        val content = serializer.serialize(data, metadata)
+        return jsonParser.parseToJsonElement(content).jsonObject
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // Output is valid JSON (round-trip parse test)
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun serialize_producesValidJson() {
+        val content = serializer.serialize(sampleData(), sampleMetadata())
+        // Should not throw — valid JSON
+        val parsed = jsonParser.parseToJsonElement(content)
+        assertIs<JsonObject>(parsed)
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // Schema version and metadata
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun serialize_containsExportVersion() {
+        val root = serializeAndParse()
+        assertEquals("1.0", root["export_version"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun serialize_metadataContainsExportDate() {
+        val root = serializeAndParse()
+        val metadata = root["metadata"]!!.jsonObject
+        assertEquals(fixedInstant.toString(), metadata["export_date"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun serialize_metadataContainsAppVersion() {
+        val root = serializeAndParse()
+        val metadata = root["metadata"]!!.jsonObject
+        assertEquals("2.1.0", metadata["app_version"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun serialize_metadataContainsSchemaVersion() {
+        val root = serializeAndParse()
+        val metadata = root["metadata"]!!.jsonObject
+        assertEquals("1.0", metadata["schema_version"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun serialize_metadataContainsUserIdHash() {
+        val root = serializeAndParse()
+        val metadata = root["metadata"]!!.jsonObject
+        assertEquals("sha256:abc123", metadata["user_id_hash"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun serialize_metadataContainsEntityCounts() {
+        val root = serializeAndParse()
+        val counts = root["metadata"]!!.jsonObject["entity_counts"]!!.jsonObject
+        assertEquals(1, counts["accounts"]?.jsonPrimitive?.int)
+        assertEquals(1, counts["transactions"]?.jsonPrimitive?.int)
+        assertEquals(1, counts["categories"]?.jsonPrimitive?.int)
+        assertEquals(1, counts["budgets"]?.jsonPrimitive?.int)
+        assertEquals(1, counts["goals"]?.jsonPrimitive?.int)
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // All entity types serialized correctly
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun serialize_containsDataSection() {
+        val root = serializeAndParse()
+        assertNotNull(root["data"])
+        val data = root["data"]!!.jsonObject
+        assertNotNull(data["accounts"])
+        assertNotNull(data["transactions"])
+        assertNotNull(data["categories"])
+        assertNotNull(data["budgets"])
+        assertNotNull(data["goals"])
+    }
+
+    @Test
+    fun serialize_accountsHaveCorrectFields() {
+        val root = serializeAndParse()
+        val account = root["data"]!!.jsonObject["accounts"]!!.jsonArray[0].jsonObject
+        assertEquals("Checking", account["name"]?.jsonPrimitive?.content)
+        assertEquals("CHECKING", account["type"]?.jsonPrimitive?.content)
+        assertEquals("USD", account["currency"]?.jsonPrimitive?.content)
+        assertNotNull(account["id"])
+        assertNotNull(account["household_id"])
+        assertNotNull(account["created_at"])
+        assertNotNull(account["updated_at"])
+    }
+
+    @Test
+    fun serialize_transactionsHaveCorrectFields() {
+        val root = serializeAndParse()
+        val txn = root["data"]!!.jsonObject["transactions"]!!.jsonArray[0].jsonObject
+        assertEquals("EXPENSE", txn["type"]?.jsonPrimitive?.content)
+        assertEquals("CLEARED", txn["status"]?.jsonPrimitive?.content)
+        assertNotNull(txn["account_id"])
+        assertNotNull(txn["date"])
+        assertNotNull(txn["tags"])
+    }
+
+    @Test
+    fun serialize_categoriesHaveCorrectFields() {
+        val root = serializeAndParse()
+        val category = root["data"]!!.jsonObject["categories"]!!.jsonArray[0].jsonObject
+        assertEquals("Groceries", category["name"]?.jsonPrimitive?.content)
+        assertNotNull(category["is_income"])
+        assertNotNull(category["is_system"])
+    }
+
+    @Test
+    fun serialize_budgetsHaveCorrectFields() {
+        val root = serializeAndParse()
+        val budget = root["data"]!!.jsonObject["budgets"]!!.jsonArray[0].jsonObject
+        assertEquals("Food Budget", budget["name"]?.jsonPrimitive?.content)
+        assertEquals("MONTHLY", budget["period"]?.jsonPrimitive?.content)
+        assertNotNull(budget["category_id"])
+        assertNotNull(budget["start_date"])
+    }
+
+    @Test
+    fun serialize_goalsHaveCorrectFields() {
+        val root = serializeAndParse()
+        val goal = root["data"]!!.jsonObject["goals"]!!.jsonArray[0].jsonObject
+        assertEquals("Emergency Fund", goal["name"]?.jsonPrimitive?.content)
+        assertEquals("ACTIVE", goal["status"]?.jsonPrimitive?.content)
+        assertNotNull(goal["target_amount"])
+        assertNotNull(goal["current_amount"])
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // Monetary values include amount, display, and currency
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun serialize_monetaryValuesContainAmountDisplayCurrency() {
+        val root = serializeAndParse()
+        val balance = root["data"]!!.jsonObject["accounts"]!!.jsonArray[0]
+            .jsonObject["current_balance"]!!.jsonObject
+
+        assertEquals(10000L, balance["amount"]?.jsonPrimitive?.long)
+        assertEquals("100.00", balance["display"]?.jsonPrimitive?.content)
+        assertEquals("USD", balance["currency"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun serialize_transactionAmountFormattedCorrectly() {
+        val root = serializeAndParse()
+        val amount = root["data"]!!.jsonObject["transactions"]!!.jsonArray[0]
+            .jsonObject["amount"]!!.jsonObject
+
+        assertEquals(1250L, amount["amount"]?.jsonPrimitive?.long)
+        assertEquals("12.50", amount["display"]?.jsonPrimitive?.content)
+        assertEquals("USD", amount["currency"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun serialize_goalAmountsFormattedCorrectly() {
+        val root = serializeAndParse()
+        val goal = root["data"]!!.jsonObject["goals"]!!.jsonArray[0].jsonObject
+
+        val targetAmount = goal["target_amount"]!!.jsonObject
+        assertEquals(100000L, targetAmount["amount"]?.jsonPrimitive?.long)
+        assertEquals("1000.00", targetAmount["display"]?.jsonPrimitive?.content)
+
+        val currentAmount = goal["current_amount"]!!.jsonObject
+        assertEquals(25000L, currentAmount["amount"]?.jsonPrimitive?.long)
+        assertEquals("250.00", currentAmount["display"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun serialize_zeroCurrencyDecimalPlaces_formatsCorrectly() {
+        TestFixtures.reset()
+        val data = ExportData(
+            accounts = listOf(
+                TestFixtures.createAccount(
+                    name = "JPY Account",
+                    currency = Currency.JPY,
+                    currentBalance = Cents(1000),
+                ),
+            ),
+            transactions = emptyList(),
+            categories = emptyList(),
+            budgets = emptyList(),
+            goals = emptyList(),
+        )
+        val root = serializeAndParse(data = data)
+        val balance = root["data"]!!.jsonObject["accounts"]!!.jsonArray[0]
+            .jsonObject["current_balance"]!!.jsonObject
+
+        assertEquals(1000L, balance["amount"]?.jsonPrimitive?.long)
+        assertEquals("1000", balance["display"]?.jsonPrimitive?.content)
+        assertEquals("JPY", balance["currency"]?.jsonPrimitive?.content)
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // Dates formatted as ISO 8601
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun serialize_datesAsIso8601() {
+        val root = serializeAndParse()
+        val account = root["data"]!!.jsonObject["accounts"]!!.jsonArray[0].jsonObject
+        assertEquals("2024-06-15T12:00:00Z", account["created_at"]?.jsonPrimitive?.content)
+        assertEquals("2024-06-15T12:00:00Z", account["updated_at"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun serialize_transactionDateAsIso8601() {
+        val root = serializeAndParse()
+        val txn = root["data"]!!.jsonObject["transactions"]!!.jsonArray[0].jsonObject
+        assertEquals("2024-06-15", txn["date"]?.jsonPrimitive?.content)
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // syncVersion and isSynced excluded
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun serialize_excludesSyncVersionFromAllEntities() {
+        val content = serializer.serialize(sampleData(), sampleMetadata())
+        assertFalse(content.contains("syncVersion"), "syncVersion should not appear in output")
+        assertFalse(content.contains("sync_version"), "sync_version should not appear in output")
+    }
+
+    @Test
+    fun serialize_excludesIsSyncedFromAllEntities() {
+        val content = serializer.serialize(sampleData(), sampleMetadata())
+        assertFalse(content.contains("isSynced"), "isSynced should not appear in output")
+        assertFalse(content.contains("is_synced"), "is_synced should not appear in output")
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // Empty collections produce empty arrays
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun serialize_emptyCollections_produceEmptyArrays() {
+        TestFixtures.reset()
+        val data = ExportData(
+            accounts = listOf(TestFixtures.createAccount()), // need at least 1 entity total
+            transactions = emptyList(),
+            categories = emptyList(),
+            budgets = emptyList(),
+            goals = emptyList(),
+        )
+        val root = serializeAndParse(data = data)
+        val dataSection = root["data"]!!.jsonObject
+        assertEquals(1, dataSection["accounts"]!!.jsonArray.size)
+        assertEquals(0, dataSection["transactions"]!!.jsonArray.size)
+        assertEquals(0, dataSection["categories"]!!.jsonArray.size)
+        assertEquals(0, dataSection["budgets"]!!.jsonArray.size)
+        assertEquals(0, dataSection["goals"]!!.jsonArray.size)
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // Special characters in strings
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun serialize_handlesQuotesInPayeeName() {
+        TestFixtures.reset()
+        val data = ExportData(
+            accounts = emptyList(),
+            transactions = listOf(
+                TestFixtures.createTransaction(
+                    payee = "McDonald's \"Big Mac\" Deal",
+                    note = "Lunch with \"friends\"",
+                ),
+            ),
+            categories = emptyList(),
+            budgets = emptyList(),
+            goals = emptyList(),
+        )
+        val content = serializer.serialize(data, sampleMetadata())
+        // Round-trip parse should succeed
+        val parsed = jsonParser.parseToJsonElement(content).jsonObject
+        val txn = parsed["data"]!!.jsonObject["transactions"]!!.jsonArray[0].jsonObject
+        assertEquals("McDonald's \"Big Mac\" Deal", txn["payee"]?.jsonPrimitive?.content)
+        assertEquals("Lunch with \"friends\"", txn["note"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun serialize_handlesUnicodeCharacters() {
+        TestFixtures.reset()
+        val data = ExportData(
+            accounts = listOf(
+                TestFixtures.createAccount(name = "Café Übermensch 日本語"),
+            ),
+            transactions = emptyList(),
+            categories = emptyList(),
+            budgets = emptyList(),
+            goals = emptyList(),
+        )
+        val content = serializer.serialize(data, sampleMetadata())
+        val parsed = jsonParser.parseToJsonElement(content).jsonObject
+        val account = parsed["data"]!!.jsonObject["accounts"]!!.jsonArray[0].jsonObject
+        assertEquals("Café Übermensch 日本語", account["name"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun serialize_handlesNewlinesInNotes() {
+        TestFixtures.reset()
+        val data = ExportData(
+            accounts = emptyList(),
+            transactions = listOf(
+                TestFixtures.createTransaction(
+                    note = "Line 1\nLine 2\nLine 3",
+                ),
+            ),
+            categories = emptyList(),
+            budgets = emptyList(),
+            goals = emptyList(),
+        )
+        val content = serializer.serialize(data, sampleMetadata())
+        val parsed = jsonParser.parseToJsonElement(content).jsonObject
+        val txn = parsed["data"]!!.jsonObject["transactions"]!!.jsonArray[0].jsonObject
+        assertEquals("Line 1\nLine 2\nLine 3", txn["note"]?.jsonPrimitive?.content)
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // Format property
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun format_isJson() {
+        assertEquals(ExportFormat.JSON, serializer.format)
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // Negative monetary values
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun serialize_negativeAmountFormattedCorrectly() {
+        TestFixtures.reset()
+        val data = ExportData(
+            accounts = listOf(
+                TestFixtures.createAccount(
+                    name = "Credit Card",
+                    type = AccountType.CREDIT_CARD,
+                    currentBalance = Cents(-15075),
+                ),
+            ),
+            transactions = emptyList(),
+            categories = emptyList(),
+            budgets = emptyList(),
+            goals = emptyList(),
+        )
+        val root = serializeAndParse(data = data)
+        val balance = root["data"]!!.jsonObject["accounts"]!!.jsonArray[0]
+            .jsonObject["current_balance"]!!.jsonObject
+        assertEquals(-15075L, balance["amount"]?.jsonPrimitive?.long)
+        assertEquals("-150.75", balance["display"]?.jsonPrimitive?.content)
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // Transaction tags
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun serialize_transactionTagsAsArray() {
+        TestFixtures.reset()
+        val data = ExportData(
+            accounts = emptyList(),
+            transactions = listOf(
+                Transaction(
+                    id = TestFixtures.nextId(),
+                    householdId = SyncId("household-1"),
+                    accountId = SyncId("account-1"),
+                    type = TransactionType.EXPENSE,
+                    amount = Cents(500),
+                    currency = Currency.USD,
+                    date = fixedDate,
+                    tags = listOf("groceries", "essential", "weekly"),
+                    createdAt = fixedInstant,
+                    updatedAt = fixedInstant,
+                ),
+            ),
+            categories = emptyList(),
+            budgets = emptyList(),
+            goals = emptyList(),
+        )
+        val root = serializeAndParse(data = data)
+        val tags = root["data"]!!.jsonObject["transactions"]!!.jsonArray[0]
+            .jsonObject["tags"]!!.jsonArray
+        assertEquals(3, tags.size)
+        assertEquals("groceries", tags[0].jsonPrimitive.content)
+        assertEquals("essential", tags[1].jsonPrimitive.content)
+        assertEquals("weekly", tags[2].jsonPrimitive.content)
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // Null optional fields
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun serialize_nullFieldsSerializedAsJsonNull() {
+        val root = serializeAndParse()
+        val account = root["data"]!!.jsonObject["accounts"]!!.jsonArray[0].jsonObject
+        // icon and color default to null
+        assertTrue(account["icon"] is JsonNull || account["icon"]?.jsonPrimitive?.contentOrNull == null)
+        assertTrue(account["color"] is JsonNull || account["color"]?.jsonPrimitive?.contentOrNull == null)
+    }
+}


### PR DESCRIPTION
## Summary
Implement the KMP DataExporter foundation and format-specific serializers for GDPR data portability compliance.

## DataExporter Service (#351)
- DataExportService object singleton orchestrating the export pipeline
- ExportSerializer interface for pluggable format implementations
- ExportData, ExportResult, ExportMetadata, ExportProgress types
- ExportOutcome/ExportError sealed classes for error handling
- Pure-Kotlin SHA-256 for checksums and user ID anonymization

## JSON Serializer (#355)
- DTO pattern excluding syncVersion/isSynced at compile time
- Monetary values as amount/display/currency objects
- Versioned schema with export_version 1.0

## CSV Serializer (#350)
- RFC 4180 compliant with CRLF line endings and proper escaping
- Multi-section format with comment headers per entity type

## Testing
- 94 total tests passing (JVM build successful)

Closes #351
Closes #350
Closes #355
