### PR TITLE
docs: add launch preparation guides (#409, #411, #412)

### DIFF
--- a/docs/guides/app-store-submission.md
+++ b/docs/guides/app-store-submission.md
@@ -29,12 +29,12 @@ For background on developer account setup, build requirements, and review guidel
 
 ### Distribution Summary
 
-| Channel         | Format  | Developer Account       | Fee             |
-| --------------- | ------- | ----------------------- | --------------- |
-| Apple App Store | IPA     | Apple Developer Program | $99 USD/year    |
-| Google Play     | AAB     | Google Play Console     | $25 USD one-time |
-| Microsoft Store | MSIX    | Partner Center          | $19 USD one-time |
-| Web (PWA)       | Hosted  | N/A                     | Hosting costs   |
+| Channel         | Format | Developer Account       | Fee              |
+| --------------- | ------ | ----------------------- | ---------------- |
+| Apple App Store | IPA    | Apple Developer Program | $99 USD/year     |
+| Google Play     | AAB    | Google Play Console     | $25 USD one-time |
+| Microsoft Store | MSIX   | Partner Center          | $19 USD one-time |
+| Web (PWA)       | Hosted | N/A                     | Hosting costs    |
 
 ---
 
@@ -44,14 +44,14 @@ These values are shared across all stores. Platform-specific adjustments are not
 
 ### App Identity
 
-| Field          | Value                                                                                      |
-| -------------- | ------------------------------------------------------------------------------------------ |
-| App name       | **Finance**                                                                                |
-| Bundle ID      | `com.finance.app`                                                                          |
-| Category       | Finance / Personal Finance                                                                 |
-| Content rating | Everyone / PEGI 3 (no objectionable content)                                               |
-| Pricing        | Free (with in-app purchases for premium tier)                                              |
-| Default locale | English (US)                                                                               |
+| Field          | Value                                         |
+| -------------- | --------------------------------------------- |
+| App name       | **Finance**                                   |
+| Bundle ID      | `com.finance.app`                             |
+| Category       | Finance / Personal Finance                    |
+| Content rating | Everyone / PEGI 3 (no objectionable content)  |
+| Pricing        | Free (with in-app purchases for premium tier) |
+| Default locale | English (US)                                  |
 
 ### Short Description
 
@@ -110,34 +110,34 @@ Character count: ~1,900 ✅ (well within 4,000 limit)
 
 > iOS: max 100 characters, comma-separated · Play Store: up to 5 tags · Microsoft: up to 7 keywords
 
-| Platform  | Value                                                                                       |
-| --------- | ------------------------------------------------------------------------------------------- |
-| iOS       | `budget,expense,tracker,money,finance,savings,offline,privacy,spending,goals`               |
-| Android   | `budgeting`, `expense tracker`, `personal finance`, `offline`, `privacy`                    |
+| Platform  | Value                                                                                        |
+| --------- | -------------------------------------------------------------------------------------------- |
+| iOS       | `budget,expense,tracker,money,finance,savings,offline,privacy,spending,goals`                |
+| Android   | `budgeting`, `expense tracker`, `personal finance`, `offline`, `privacy`                     |
 | Microsoft | `budgeting`, `expense tracker`, `personal finance`, `offline`, `privacy`, `money`, `savings` |
 
 iOS keyword character count: 74 ✅ (under 100)
 
 ### Contact Information
 
-| Field              | Value                     | Notes                                              |
-| ------------------ | ------------------------- | -------------------------------------------------- |
-| Contact email      | `{{SUPPORT_EMAIL}}`       | Must be monitored — app stores forward user issues |
-| Support URL        | `{{SUPPORT_URL}}`         | Linked from store listings and in-app Settings     |
-| Privacy policy URL | `{{PRIVACY_POLICY_URL}}`  | Must be publicly accessible (no auth wall)         |
-| Terms of service   | `{{TERMS_OF_SERVICE_URL}}`| Required by Apple; recommended for all stores      |
-| Marketing website  | `{{WEBSITE_URL}}`         | Landing page with download links                   |
+| Field              | Value                      | Notes                                              |
+| ------------------ | -------------------------- | -------------------------------------------------- |
+| Contact email      | `{{SUPPORT_EMAIL}}`        | Must be monitored — app stores forward user issues |
+| Support URL        | `{{SUPPORT_URL}}`          | Linked from store listings and in-app Settings     |
+| Privacy policy URL | `{{PRIVACY_POLICY_URL}}`   | Must be publicly accessible (no auth wall)         |
+| Terms of service   | `{{TERMS_OF_SERVICE_URL}}` | Required by Apple; recommended for all stores      |
+| Marketing website  | `{{WEBSITE_URL}}`          | Landing page with download links                   |
 
 > **⚠️ Action required:** Replace all `{{PLACEHOLDER}}` values with real URLs before submission. Privacy policy and terms of service must be live and accessible at the time of submission.
 
 ### App Icon
 
-| Platform  | Size          | Format               | Notes                              |
-| --------- | ------------- | -------------------- | ---------------------------------- |
-| iOS       | 1024 × 1024   | PNG, no transparency | Single icon; system applies masks  |
+| Platform  | Size          | Format               | Notes                                           |
+| --------- | ------------- | -------------------- | ----------------------------------------------- |
+| iOS       | 1024 × 1024   | PNG, no transparency | Single icon; system applies masks               |
 | Android   | 512 × 512     | PNG, 32-bit          | Adaptive icon with foreground/background layers |
-| Microsoft | 300 × 300 min | PNG                  | Recommended 512 × 512             |
-| Web (PWA) | 512 × 512     | PNG                  | Also provide 192 × 192 for manifest |
+| Microsoft | 300 × 300 min | PNG                  | Recommended 512 × 512                           |
+| Web (PWA) | 512 × 512     | PNG                  | Also provide 192 × 192 for manifest             |
 
 Source icon: generate from design tokens / brand assets pipeline.
 
@@ -165,22 +165,22 @@ Complete these steps before the first public submission. TestFlight beta testing
 
 ### App Store Listing Fields
 
-| Field                     | Limit                   | Value                                                              |
-| ------------------------- | ----------------------- | ------------------------------------------------------------------ |
-| App name                  | 30 chars                | `Finance`                                                          |
-| Subtitle                  | 30 chars                | `Private financial tracking`                                       |
-| Promotional text          | 170 chars, no review    | `Track every dollar privately. Offline-first budgeting for individuals, couples, and families.` |
-| Description               | 4,000 chars             | See [Full Description](#full-description)                          |
-| Keywords                  | 100 chars               | See [Keywords / Tags](#keywords--tags)                             |
-| Primary category          | —                       | Finance                                                            |
-| Secondary category        | —                       | Productivity                                                       |
-| Bundle ID                 | —                       | `com.finance.app`                                                  |
-| SKU                       | —                       | `finance-ios-001`                                                  |
-| Support URL               | Required                | `{{SUPPORT_URL}}`                                                  |
-| Marketing URL             | Optional                | `{{WEBSITE_URL}}`                                                  |
-| Privacy policy URL        | Required                | `{{PRIVACY_POLICY_URL}}`                                           |
-| Copyright                 | —                       | `© {{YEAR}} Finance`                                               |
-| Version                   | Semver                  | Current release version from Changesets                            |
+| Field              | Limit                | Value                                                                                           |
+| ------------------ | -------------------- | ----------------------------------------------------------------------------------------------- |
+| App name           | 30 chars             | `Finance`                                                                                       |
+| Subtitle           | 30 chars             | `Private financial tracking`                                                                    |
+| Promotional text   | 170 chars, no review | `Track every dollar privately. Offline-first budgeting for individuals, couples, and families.` |
+| Description        | 4,000 chars          | See [Full Description](#full-description)                                                       |
+| Keywords           | 100 chars            | See [Keywords / Tags](#keywords--tags)                                                          |
+| Primary category   | —                    | Finance                                                                                         |
+| Secondary category | —                    | Productivity                                                                                    |
+| Bundle ID          | —                    | `com.finance.app`                                                                               |
+| SKU                | —                    | `finance-ios-001`                                                                               |
+| Support URL        | Required             | `{{SUPPORT_URL}}`                                                                               |
+| Marketing URL      | Optional             | `{{WEBSITE_URL}}`                                                                               |
+| Privacy policy URL | Required             | `{{PRIVACY_POLICY_URL}}`                                                                        |
+| Copyright          | —                    | `© {{YEAR}} Finance`                                                                            |
+| Version            | Semver               | Current release version from Changesets                                                         |
 
 ### Privacy Nutrition Labels
 
@@ -276,17 +276,17 @@ The app uses encryption: Yes
 
 ### Age Rating Questionnaire
 
-| Question                                 | Answer |
-| ---------------------------------------- | ------ |
-| Made for Kids                            | No     |
-| Violence (cartoon, realistic, etc.)      | None   |
-| Sexual content or nudity                 | None   |
-| Profanity or crude humor                 | None   |
-| Alcohol, tobacco, or drugs               | None   |
-| Medical/treatment information            | None   |
-| Gambling or contests                     | None   |
-| Horror or fear themes                    | None   |
-| Unrestricted web access                  | No     |
+| Question                            | Answer |
+| ----------------------------------- | ------ |
+| Made for Kids                       | No     |
+| Violence (cartoon, realistic, etc.) | None   |
+| Sexual content or nudity            | None   |
+| Profanity or crude humor            | None   |
+| Alcohol, tobacco, or drugs          | None   |
+| Medical/treatment information       | None   |
+| Gambling or contests                | None   |
+| Horror or fear themes               | None   |
+| Unrestricted web access             | No     |
 
 **Expected rating:** 4+ (appropriate for all ages).
 
@@ -311,19 +311,19 @@ The app uses encryption: Yes
 
 ### Store Listing Fields
 
-| Field              | Limit         | Value                                                              |
-| ------------------ | ------------- | ------------------------------------------------------------------ |
-| App name           | 30 chars      | `Finance`                                                          |
-| Short description  | 80 chars      | `Track your money privately. Offline-first budgeting and expense tracking.` |
-| Full description   | 4,000 chars   | See [Full Description](#full-description)                          |
-| App icon           | 512 × 512     | PNG, 32-bit, no transparency                                      |
-| Feature graphic    | 1024 × 500    | PNG or JPEG — hero image for store listing                         |
-| App category       | —             | Finance                                                            |
-| Tags               | Up to 5       | See [Keywords / Tags](#keywords--tags)                             |
-| Contact email      | Required      | `{{SUPPORT_EMAIL}}`                                                |
-| Contact phone      | Optional      | —                                                                  |
-| Contact website    | Optional      | `{{WEBSITE_URL}}`                                                  |
-| Privacy policy URL | Required      | `{{PRIVACY_POLICY_URL}}`                                           |
+| Field              | Limit       | Value                                                                       |
+| ------------------ | ----------- | --------------------------------------------------------------------------- |
+| App name           | 30 chars    | `Finance`                                                                   |
+| Short description  | 80 chars    | `Track your money privately. Offline-first budgeting and expense tracking.` |
+| Full description   | 4,000 chars | See [Full Description](#full-description)                                   |
+| App icon           | 512 × 512   | PNG, 32-bit, no transparency                                                |
+| Feature graphic    | 1024 × 500  | PNG or JPEG — hero image for store listing                                  |
+| App category       | —           | Finance                                                                     |
+| Tags               | Up to 5     | See [Keywords / Tags](#keywords--tags)                                      |
+| Contact email      | Required    | `{{SUPPORT_EMAIL}}`                                                         |
+| Contact phone      | Optional    | —                                                                           |
+| Contact website    | Optional    | `{{WEBSITE_URL}}`                                                           |
+| Privacy policy URL | Required    | `{{PRIVACY_POLICY_URL}}`                                                    |
 
 Short description character count: 73 ✅ (under 80)
 
@@ -333,32 +333,32 @@ Google Play's Data Safety form maps to the app's actual data practices. See the 
 
 #### Data Types Declaration
 
-| Data Type                               | Collected         | Shared | Purpose                         | Optional |
-| --------------------------------------- | ----------------- | ------ | ------------------------------- | -------- |
+| Data Type                               | Collected         | Shared | Purpose                         | Optional        |
+| --------------------------------------- | ----------------- | ------ | ------------------------------- | --------------- |
 | Email address                           | ✅                | ❌     | Account authentication          | Yes (sync only) |
-| Financial info (transactions, balances) | ✅                | ❌     | App functionality               | No       |
-| App activity (screens viewed)           | ✅ (with consent) | ❌     | Analytics — funnel optimization | Yes      |
-| Crash logs                              | ✅ (with consent) | ❌     | Stability monitoring            | Yes      |
-| Device identifiers                      | ❌                | ❌     | Not collected                   | —        |
-| Location                                | ❌                | ❌     | Not collected                   | —        |
+| Financial info (transactions, balances) | ✅                | ❌     | App functionality               | No              |
+| App activity (screens viewed)           | ✅ (with consent) | ❌     | Analytics — funnel optimization | Yes             |
+| Crash logs                              | ✅ (with consent) | ❌     | Stability monitoring            | Yes             |
+| Device identifiers                      | ❌                | ❌     | Not collected                   | —               |
+| Location                                | ❌                | ❌     | Not collected                   | —               |
 
 #### Key Data Safety Declarations
 
-| Declaration                            | Value                                                      |
-| -------------------------------------- | ---------------------------------------------------------- |
-| Data encrypted in transit              | ✅ Yes (TLS 1.3)                                           |
-| Data encrypted at rest                 | ✅ Yes (SQLCipher AES-256)                                 |
-| Users can request data deletion        | ✅ Yes (Settings > Account > Delete Account)               |
-| Data not sold to third parties         | ✅ Confirmed                                               |
-| Committed to Play Families policy      | N/A — app is not targeted at children                      |
-| Independent security review            | TBD — recommended post-launch                              |
+| Declaration                       | Value                                        |
+| --------------------------------- | -------------------------------------------- |
+| Data encrypted in transit         | ✅ Yes (TLS 1.3)                             |
+| Data encrypted at rest            | ✅ Yes (SQLCipher AES-256)                   |
+| Users can request data deletion   | ✅ Yes (Settings > Account > Delete Account) |
+| Data not sold to third parties    | ✅ Confirmed                                 |
+| Committed to Play Families policy | N/A — app is not targeted at children        |
+| Independent security review       | TBD — recommended post-launch                |
 
 ### Screenshot Requirements
 
 Provide **2–8 screenshots** per device type. All screenshots must reflect actual in-app UI.
 
-| Device Type | Dimensions (px)          | Required           |
-| ----------- | ------------------------ | ------------------ |
+| Device Type | Dimensions (px)         | Required           |
+| ----------- | ----------------------- | ------------------ |
 | Phone       | 1080 × 1920 (16:9)      | ✅ Yes (minimum 2) |
 | 7" Tablet   | 1200 × 1920             | Recommended        |
 | 10" Tablet  | 1600 × 2560             | Recommended        |
@@ -390,13 +390,13 @@ Google Play uses the **IARC (International Age Rating Coalition)** system. Answe
 
 ### Android-Specific Build Requirements
 
-| Requirement           | Detail                                                                     |
-| --------------------- | -------------------------------------------------------------------------- |
-| Target API level      | Latest stable (currently API 35 / Android 15)                              |
-| App bundle format     | AAB required (not APK) for Play Store                                      |
-| App signing           | Enroll in Google Play App Signing                                          |
-| 64-bit support        | Required for all native code                                               |
-| Deobfuscation file    | Upload ProGuard/R8 mapping file for crash reports                          |
+| Requirement        | Detail                                            |
+| ------------------ | ------------------------------------------------- |
+| Target API level   | Latest stable (currently API 35 / Android 15)     |
+| App bundle format  | AAB required (not APK) for Play Store             |
+| App signing        | Enroll in Google Play App Signing                 |
+| 64-bit support     | Required for all native code                      |
+| Deobfuscation file | Upload ProGuard/R8 mapping file for crash reports |
 
 ---
 
@@ -423,17 +423,17 @@ For step-by-step MSIX packaging, see the [Windows Store Guide](windows-store.md)
 
 ### Store Listing Fields
 
-| Field              | Limit           | Value                                                                  |
-| ------------------ | --------------- | ---------------------------------------------------------------------- |
-| App name           | 256 chars       | `Finance`                                                              |
-| Short description  | 1,000 chars     | See [Full Description](#full-description) (first two paragraphs)       |
-| Full description   | 10,000 chars    | See [Full Description](#full-description) — expand with desktop-specific notes |
-| App icon           | 300 × 300 min   | PNG (recommended 512 × 512)                                           |
-| Category           | —               | Personal Finance                                                       |
-| Support contact    | Required        | `{{SUPPORT_EMAIL}}`                                                    |
-| Privacy policy URL | Required        | `{{PRIVACY_POLICY_URL}}`                                               |
-| Website            | Optional        | `{{WEBSITE_URL}}`                                                      |
-| Keywords           | Up to 7         | See [Keywords / Tags](#keywords--tags)                                 |
+| Field              | Limit         | Value                                                                          |
+| ------------------ | ------------- | ------------------------------------------------------------------------------ |
+| App name           | 256 chars     | `Finance`                                                                      |
+| Short description  | 1,000 chars   | See [Full Description](#full-description) (first two paragraphs)               |
+| Full description   | 10,000 chars  | See [Full Description](#full-description) — expand with desktop-specific notes |
+| App icon           | 300 × 300 min | PNG (recommended 512 × 512)                                                    |
+| Category           | —             | Personal Finance                                                               |
+| Support contact    | Required      | `{{SUPPORT_EMAIL}}`                                                            |
+| Privacy policy URL | Required      | `{{PRIVACY_POLICY_URL}}`                                                       |
+| Website            | Optional      | `{{WEBSITE_URL}}`                                                              |
+| Keywords           | Up to 7       | See [Keywords / Tags](#keywords--tags)                                         |
 
 ### Privacy Statement Requirements
 
@@ -449,10 +449,10 @@ Microsoft requires a privacy policy that meets these criteria:
 
 ### Screenshot Requirements
 
-| Type        | Dimensions (px)                        | Count         |
-| ----------- | -------------------------------------- | ------------- |
-| Desktop     | 1366 × 768 minimum, 3840 × 2160 max   | 1–10 required |
-| Recommended | 1920 × 1080 (Full HD)                  | Best practice |
+| Type        | Dimensions (px)                     | Count         |
+| ----------- | ----------------------------------- | ------------- |
+| Desktop     | 1366 × 768 minimum, 3840 × 2160 max | 1–10 required |
+| Recommended | 1920 × 1080 (Full HD)               | Best practice |
 
 **Desktop screenshots should show:**
 
@@ -472,15 +472,15 @@ Microsoft Store uses the same **IARC** questionnaire as Google Play. Answers are
 
 ### Windows-Specific Compliance
 
-| Requirement         | Detail                                                                          |
-| ------------------- | ------------------------------------------------------------------------------- |
-| Accessibility       | Windows Narrator, High Contrast, keyboard-only navigation supported            |
-| System integration  | Respects system theme (light/dark), DPI scaling, Snap Layouts                  |
-| Offline capability  | Core financial features work without network                                    |
-| Clean uninstall     | No residual files outside `%LOCALAPPDATA%`                                     |
-| Capabilities        | Declared in manifest: `internetClient`, `localStorage`                         |
-| Min OS version      | Windows 10 version 1809 (build 17763)                                          |
-| Architecture        | x64 required, ARM64 recommended                                                |
+| Requirement        | Detail                                                              |
+| ------------------ | ------------------------------------------------------------------- |
+| Accessibility      | Windows Narrator, High Contrast, keyboard-only navigation supported |
+| System integration | Respects system theme (light/dark), DPI scaling, Snap Layouts       |
+| Offline capability | Core financial features work without network                        |
+| Clean uninstall    | No residual files outside `%LOCALAPPDATA%`                          |
+| Capabilities       | Declared in manifest: `internetClient`, `localStorage`              |
+| Min OS version     | Windows 10 version 1809 (build 17763)                               |
+| Architecture       | x64 required, ARM64 recommended                                     |
 
 ---
 
@@ -519,32 +519,44 @@ Add these tags to `apps/web/index.html` `<head>` for rich link previews when the
 
 ```html
 <!-- Primary Meta Tags -->
-<meta name="title" content="Finance — Private Financial Tracking">
-<meta name="description" content="Track your money privately. Offline-first budgeting and expense tracking across all your devices.">
+<meta name="title" content="Finance — Private Financial Tracking" />
+<meta
+  name="description"
+  content="Track your money privately. Offline-first budgeting and expense tracking across all your devices."
+/>
 
 <!-- Open Graph / Facebook -->
-<meta property="og:type" content="website">
-<meta property="og:url" content="{{APP_URL}}">
-<meta property="og:title" content="Finance — Private Financial Tracking">
-<meta property="og:description" content="Track your money privately. Offline-first budgeting and expense tracking across all your devices.">
-<meta property="og:image" content="{{APP_URL}}/og-image.png">
-<meta property="og:image:width" content="1200">
-<meta property="og:image:height" content="630">
-<meta property="og:image:alt" content="Finance app dashboard showing budget overview and recent transactions">
+<meta property="og:type" content="website" />
+<meta property="og:url" content="{{APP_URL}}" />
+<meta property="og:title" content="Finance — Private Financial Tracking" />
+<meta
+  property="og:description"
+  content="Track your money privately. Offline-first budgeting and expense tracking across all your devices."
+/>
+<meta property="og:image" content="{{APP_URL}}/og-image.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta
+  property="og:image:alt"
+  content="Finance app dashboard showing budget overview and recent transactions"
+/>
 
 <!-- Twitter -->
-<meta property="twitter:card" content="summary_large_image">
-<meta property="twitter:url" content="{{APP_URL}}">
-<meta property="twitter:title" content="Finance — Private Financial Tracking">
-<meta property="twitter:description" content="Track your money privately. Offline-first budgeting and expense tracking across all your devices.">
-<meta property="twitter:image" content="{{APP_URL}}/og-image.png">
+<meta property="twitter:card" content="summary_large_image" />
+<meta property="twitter:url" content="{{APP_URL}}" />
+<meta property="twitter:title" content="Finance — Private Financial Tracking" />
+<meta
+  property="twitter:description"
+  content="Track your money privately. Offline-first budgeting and expense tracking across all your devices."
+/>
+<meta property="twitter:image" content="{{APP_URL}}/og-image.png" />
 
 <!-- PWA / Mobile -->
-<meta name="theme-color" content="#1a1a2e">
-<meta name="apple-mobile-web-app-capable" content="yes">
-<meta name="apple-mobile-web-app-status-bar-style" content="default">
-<meta name="apple-mobile-web-app-title" content="Finance">
-<link rel="apple-touch-icon" href="/icons/icon-192.png">
+<meta name="theme-color" content="#1a1a2e" />
+<meta name="apple-mobile-web-app-capable" content="yes" />
+<meta name="apple-mobile-web-app-status-bar-style" content="default" />
+<meta name="apple-mobile-web-app-title" content="Finance" />
+<link rel="apple-touch-icon" href="/icons/icon-192.png" />
 ```
 
 **OG image:** Create a 1200 × 630 px image (`og-image.png`) showing the app dashboard with the tagline. Store in `apps/web/public/`.
@@ -591,13 +603,13 @@ window.addEventListener('appinstalled', () => {
 
 ### Lighthouse Score Targets
 
-| Category       | Target | Key Metrics                                              |
-| -------------- | ------ | -------------------------------------------------------- |
-| Performance    | ≥ 90   | LCP < 2.5 s, FID < 100 ms, CLS < 0.1                   |
-| Accessibility  | ≥ 95   | WCAG 2.2 AA, ARIA landmarks, focus management           |
-| Best Practices | ≥ 95   | HTTPS, no console errors, CSP headers                    |
-| SEO            | ≥ 90   | Meta tags, canonical URL, robots.txt, structured data    |
-| PWA            | ✅ Pass | Installable, offline-capable, fast loading               |
+| Category       | Target  | Key Metrics                                           |
+| -------------- | ------- | ----------------------------------------------------- |
+| Performance    | ≥ 90    | LCP < 2.5 s, FID < 100 ms, CLS < 0.1                  |
+| Accessibility  | ≥ 95    | WCAG 2.2 AA, ARIA landmarks, focus management         |
+| Best Practices | ≥ 95    | HTTPS, no console errors, CSP headers                 |
+| SEO            | ≥ 90    | Meta tags, canonical URL, robots.txt, structured data |
+| PWA            | ✅ Pass | Installable, offline-capable, fast loading            |
 
 ---
 
@@ -669,12 +681,12 @@ After submitting to each store, follow this runbook to track review progress and
 
 ### Expected Review Times
 
-| Store          | Typical Review Time  | Expedited Review Available |
-| -------------- | -------------------- | -------------------------- |
-| Apple          | 24–48 hours          | Yes (limited, request via App Store Connect) |
-| Google Play    | Hours to 7 days      | No                         |
-| Microsoft      | 1–5 business days    | No                         |
-| Web (PWA)      | No review required   | N/A                        |
+| Store       | Typical Review Time | Expedited Review Available                   |
+| ----------- | ------------------- | -------------------------------------------- |
+| Apple       | 24–48 hours         | Yes (limited, request via App Store Connect) |
+| Google Play | Hours to 7 days     | No                                           |
+| Microsoft   | 1–5 business days   | No                                           |
+| Web (PWA)   | No review required  | N/A                                          |
 
 ### If Rejected
 

--- a/docs/guides/app-store-submission.md
+++ b/docs/guides/app-store-submission.md
@@ -1,0 +1,720 @@
+# App Store Submission Guide — Finance
+
+> **Status:** DRAFT — Pending human review
+> **Last Updated:** 2025-07-22
+> **Purpose:** Ready-to-use metadata, checklists, and step-by-step instructions for submitting Finance to every distribution channel
+> **Related:** [App Store Preparation](app-store-preparation.md) · [Launch Checklist](launch-checklist.md) · [Release Process](release-process.md) · [Beta Testing](beta-testing.md)
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [App Metadata (Shared)](#app-metadata-shared)
+- [iOS — Apple App Store](#ios--apple-app-store)
+- [Android — Google Play Store](#android--google-play-store)
+- [Windows — Microsoft Store](#windows--microsoft-store)
+- [Web — Progressive Web App (PWA)](#web--progressive-web-app-pwa)
+- [Pre-Submission Checklist](#pre-submission-checklist)
+- [Post-Submission Runbook](#post-submission-runbook)
+- [References](#references)
+
+---
+
+## Overview
+
+This document contains the **final submission metadata and checklists** for publishing Finance to all four distribution channels. It is designed to be used on submission day — every field value, character count, and asset requirement is specified so that submissions are predictable and error-free.
+
+For background on developer account setup, build requirements, and review guidelines, see the [App Store Preparation Guide](app-store-preparation.md).
+
+### Distribution Summary
+
+| Channel         | Format  | Developer Account       | Fee             |
+| --------------- | ------- | ----------------------- | --------------- |
+| Apple App Store | IPA     | Apple Developer Program | $99 USD/year    |
+| Google Play     | AAB     | Google Play Console     | $25 USD one-time |
+| Microsoft Store | MSIX    | Partner Center          | $19 USD one-time |
+| Web (PWA)       | Hosted  | N/A                     | Hosting costs   |
+
+---
+
+## App Metadata (Shared)
+
+These values are shared across all stores. Platform-specific adjustments are noted in each store's section.
+
+### App Identity
+
+| Field          | Value                                                                                      |
+| -------------- | ------------------------------------------------------------------------------------------ |
+| App name       | **Finance**                                                                                |
+| Bundle ID      | `com.finance.app`                                                                          |
+| Category       | Finance / Personal Finance                                                                 |
+| Content rating | Everyone / PEGI 3 (no objectionable content)                                               |
+| Pricing        | Free (with in-app purchases for premium tier)                                              |
+| Default locale | English (US)                                                                               |
+
+### Short Description
+
+> 30 characters · Used as App Store subtitle, Play Store short description
+
+```
+Private financial tracking
+```
+
+Character count: 26 ✅
+
+### Full Description
+
+> Max 4,000 characters · Adapt per-store as needed
+
+```
+Take control of your money — privately, on every device.
+
+Finance is a personal finance tracker built for clarity, privacy, and speed. Track accounts, transactions, budgets, and goals across iOS, Android, Windows, and the web — all from a single, beautifully native app on each platform.
+
+YOUR DATA STAYS YOURS
+Finance is offline-first. Your financial data is encrypted at rest with SQLCipher (AES-256) and never leaves your device unless you choose to sync. No bank connections required. No third-party data sharing. Signal-level privacy for your finances.
+
+30 SECONDS OR LESS
+Add transactions in 3 taps. Widgets show your remaining budget at a glance. Quick-check "Can I Afford This?" from your home screen. Finance is designed around a daily habit that takes less than 30 seconds.
+
+WORKS WITH YOUR BRAIN
+Choose your expertise level — Getting Started, Comfortable, or Advanced — and the entire app adapts. Terminology, visible features, chart complexity, and notifications all adjust to your comfort level. Contextual education explains every financial concept with a single tap.
+
+FEATURES
+• Account management — Checking, savings, credit cards, cash, investments, loans
+• Transaction tracking — Quick entry, recurring transactions, multi-currency support
+• Envelope budgeting — Give every dollar a job with flexible spending plans
+• Goal tracking — Set savings goals with visual progress and milestone celebrations
+• Reports & analytics — Spending trends, category breakdowns, monthly comparisons
+• Multi-device sync — Optional encrypted cloud sync across all your devices
+• Partner & family sharing — Shared budgets with role-based access (Premium)
+• Data export — Export all your data in CSV or JSON at any time
+
+DESIGNED FOR EVERYONE
+Finance meets WCAG 2.2 AA accessibility standards. Screen reader support (VoiceOver, TalkBack, Narrator, NVDA), dynamic text sizing, high contrast mode, reduced motion support, and cognitive accessibility (ADHD-friendly design) are built in — not bolted on.
+
+FACTS, NOT JUDGMENTS
+Finance observes and informs — it never shames. Over budget? The app offers to help you adjust, not scold. Missed a day of logging? "Welcome back! Pick up where you left off."
+
+FREE FOREVER (CORE)
+All core financial tracking features are free, forever. Premium unlocks AI-powered insights, multi-device sync, and household sharing.
+
+Privacy policy: {{PRIVACY_POLICY_URL}}
+Terms of service: {{TERMS_OF_SERVICE_URL}}
+```
+
+Character count: ~1,900 ✅ (well within 4,000 limit)
+
+### Keywords / Tags
+
+> iOS: max 100 characters, comma-separated · Play Store: up to 5 tags · Microsoft: up to 7 keywords
+
+| Platform  | Value                                                                                       |
+| --------- | ------------------------------------------------------------------------------------------- |
+| iOS       | `budget,expense,tracker,money,finance,savings,offline,privacy,spending,goals`               |
+| Android   | `budgeting`, `expense tracker`, `personal finance`, `offline`, `privacy`                    |
+| Microsoft | `budgeting`, `expense tracker`, `personal finance`, `offline`, `privacy`, `money`, `savings` |
+
+iOS keyword character count: 74 ✅ (under 100)
+
+### Contact Information
+
+| Field              | Value                     | Notes                                              |
+| ------------------ | ------------------------- | -------------------------------------------------- |
+| Contact email      | `{{SUPPORT_EMAIL}}`       | Must be monitored — app stores forward user issues |
+| Support URL        | `{{SUPPORT_URL}}`         | Linked from store listings and in-app Settings     |
+| Privacy policy URL | `{{PRIVACY_POLICY_URL}}`  | Must be publicly accessible (no auth wall)         |
+| Terms of service   | `{{TERMS_OF_SERVICE_URL}}`| Required by Apple; recommended for all stores      |
+| Marketing website  | `{{WEBSITE_URL}}`         | Landing page with download links                   |
+
+> **⚠️ Action required:** Replace all `{{PLACEHOLDER}}` values with real URLs before submission. Privacy policy and terms of service must be live and accessible at the time of submission.
+
+### App Icon
+
+| Platform  | Size          | Format               | Notes                              |
+| --------- | ------------- | -------------------- | ---------------------------------- |
+| iOS       | 1024 × 1024   | PNG, no transparency | Single icon; system applies masks  |
+| Android   | 512 × 512     | PNG, 32-bit          | Adaptive icon with foreground/background layers |
+| Microsoft | 300 × 300 min | PNG                  | Recommended 512 × 512             |
+| Web (PWA) | 512 × 512     | PNG                  | Also provide 192 × 192 for manifest |
+
+Source icon: generate from design tokens / brand assets pipeline.
+
+---
+
+## iOS — Apple App Store
+
+### TestFlight Setup Checklist
+
+Complete these steps before the first public submission. TestFlight beta testing validates the build and review process.
+
+- [ ] Apple Developer Program enrollment complete ($99/year)
+- [ ] App registered in [App Store Connect](https://appstoreconnect.apple.com)
+- [ ] Bundle ID `com.finance.app` registered in Certificates, Identifiers & Profiles
+- [ ] Signing certificates (Development + Distribution) generated
+- [ ] Provisioning profiles (Development + App Store) created
+- [ ] Fastlane `deliver` configured in `apps/ios/fastlane/`
+- [ ] First build uploaded to App Store Connect (via Xcode or Fastlane)
+- [ ] Build processed by Apple (15–30 min)
+- [ ] Internal testers added (up to 100, immediate access)
+- [ ] External beta group created with beta description and "What to Test" notes
+- [ ] External build submitted for TestFlight review (lightweight, usually < 24 hours)
+- [ ] At least 10 external testers invited and active for ≥ 2 weeks
+- [ ] Critical beta feedback triaged and resolved
+
+### App Store Listing Fields
+
+| Field                     | Limit                   | Value                                                              |
+| ------------------------- | ----------------------- | ------------------------------------------------------------------ |
+| App name                  | 30 chars                | `Finance`                                                          |
+| Subtitle                  | 30 chars                | `Private financial tracking`                                       |
+| Promotional text          | 170 chars, no review    | `Track every dollar privately. Offline-first budgeting for individuals, couples, and families.` |
+| Description               | 4,000 chars             | See [Full Description](#full-description)                          |
+| Keywords                  | 100 chars               | See [Keywords / Tags](#keywords--tags)                             |
+| Primary category          | —                       | Finance                                                            |
+| Secondary category        | —                       | Productivity                                                       |
+| Bundle ID                 | —                       | `com.finance.app`                                                  |
+| SKU                       | —                       | `finance-ios-001`                                                  |
+| Support URL               | Required                | `{{SUPPORT_URL}}`                                                  |
+| Marketing URL             | Optional                | `{{WEBSITE_URL}}`                                                  |
+| Privacy policy URL        | Required                | `{{PRIVACY_POLICY_URL}}`                                           |
+| Copyright                 | —                       | `© {{YEAR}} Finance`                                               |
+| Version                   | Semver                  | Current release version from Changesets                            |
+
+### Privacy Nutrition Labels
+
+Apple requires disclosure of all data collection via privacy "nutrition labels" in App Store Connect. This must accurately reflect what the app and any third-party SDKs collect.
+
+#### Data Types Collected
+
+| Data Type                | Collected         | Linked to Identity | Used for Tracking |
+| ------------------------ | ----------------- | ------------------ | ----------------- |
+| Email address            | ✅                | ✅                 | ❌                |
+| Name                     | ❌                | —                  | —                 |
+| Financial info           | ✅                | ✅                 | ❌                |
+| Usage data               | ✅ (with consent) | ❌                 | ❌                |
+| Diagnostics (crash data) | ✅ (with consent) | ❌                 | ❌                |
+| Identifiers              | ❌                | —                  | —                 |
+| Location                 | ❌                | —                  | —                 |
+| Contacts                 | ❌                | —                  | —                 |
+| Health & Fitness         | ❌                | —                  | —                 |
+
+#### Data Use Purposes
+
+| Data Type      | Purpose                                        |
+| -------------- | ---------------------------------------------- |
+| Email address  | App Functionality (authentication, recovery)   |
+| Financial info | App Functionality (core feature)               |
+| Usage data     | Analytics (opt-in only, PII-free)              |
+| Diagnostics    | App Functionality (crash reporting, stability) |
+
+#### Key Declarations
+
+- **"Data Not Used to Track You"** — Finance does NOT track users across other apps or websites
+- **"Data Not Sold"** — Finance does NOT sell any user data
+- **App Tracking Transparency (ATT):** Not required — Finance does not track. No ATT prompt needed
+
+> **⚠️ Important:** If you integrate any third-party SDKs (analytics, crash reporting), their data collection must also be declared in the nutrition labels.
+
+### Screenshot Requirements
+
+Apple requires screenshots for **each device size** supported. Missing sizes means the app won't appear on those devices.
+
+| Device                | Screen Size | Dimensions (px)    | Required              |
+| --------------------- | ----------- | ------------------ | --------------------- |
+| iPhone 16 Pro Max     | 6.9"        | 1320 × 2868        | ✅ Required           |
+| iPhone 16 Pro         | 6.3"        | 1206 × 2622        | Recommended           |
+| iPhone SE (3rd gen)   | 4.7"        | 750 × 1334         | ✅ If supporting SE   |
+| iPad Pro 13" (M4)     | 13"         | 2064 × 2752        | ✅ If supporting iPad |
+| iPad Pro 11" (M4)     | 11"         | 1668 × 2420        | Falls back to 13"     |
+| Apple Watch Series 10 | 46mm        | 416 × 496          | If watchOS app        |
+| Mac (Apple Silicon)   | —           | 1280 × 800 minimum | If Mac Catalyst       |
+
+**Per device size:** 2–10 screenshots. Recommended: 5 screens in this order:
+
+1. **Dashboard** — "See your finances at a glance"
+2. **Quick Entry** — "Add transactions in 3 taps"
+3. **Budget** — "Give every dollar a job"
+4. **Reports** — "Understand your spending trends"
+5. **Goals** — "Track progress toward what matters"
+
+**Format:** PNG or JPEG, no alpha channel, portrait orientation preferred, consistent across sets.
+
+**Automation:** Fastlane `snapshot` or Xcode UI tests. Store generated screenshots in `apps/ios/Screenshots/`.
+
+### App Review Notes
+
+Provide these notes in the "App Review Information" section of App Store Connect so the reviewer can test the app effectively.
+
+```
+DEMO ACCOUNT
+Email: {{REVIEW_ACCOUNT_EMAIL}}
+Password: {{REVIEW_ACCOUNT_PASSWORD}}
+
+NOTES FOR REVIEWER
+- Finance works fully offline. No internet connection is required for core features
+  (accounts, transactions, budgets, goals, reports).
+- Cloud sync is an optional feature that requires sign-in. The demo account above
+  has sync enabled with sample data.
+- The app uses a freemium model. Premium features (AI insights, multi-device sync,
+  household sharing) require an in-app subscription. A sandbox test account is
+  configured for IAP testing.
+- Biometric authentication (Face ID / Touch ID) is optional and can be enabled in
+  Settings > Security.
+- The app uses SQLCipher (AES-256) for local database encryption. This is
+  declarable under export compliance as mass-market encryption (ECCN 5D992).
+
+EXPORT COMPLIANCE
+The app uses encryption: Yes
+- SQLCipher (AES-256-CBC) for local database encryption
+- TLS 1.3 for network communication
+- Exempt under mass-market encryption exemption (ECCN 5D992)
+```
+
+> **⚠️ Action required:** Create a dedicated App Review test account with sample data before submission. Replace `{{REVIEW_ACCOUNT_EMAIL}}` and `{{REVIEW_ACCOUNT_PASSWORD}}` with real credentials.
+
+### Age Rating Questionnaire
+
+| Question                                 | Answer |
+| ---------------------------------------- | ------ |
+| Made for Kids                            | No     |
+| Violence (cartoon, realistic, etc.)      | None   |
+| Sexual content or nudity                 | None   |
+| Profanity or crude humor                 | None   |
+| Alcohol, tobacco, or drugs               | None   |
+| Medical/treatment information            | None   |
+| Gambling or contests                     | None   |
+| Horror or fear themes                    | None   |
+| Unrestricted web access                  | No     |
+
+**Expected rating:** 4+ (appropriate for all ages).
+
+---
+
+## Android — Google Play Store
+
+### Internal Testing Track Setup Checklist
+
+- [ ] Google Play Console account registered ($25 one-time fee)
+- [ ] App created in Play Console with package name `com.finance.app`
+- [ ] App signing enrolled (Google Play App Signing — recommended)
+- [ ] Upload key generated and stored securely
+- [ ] First AAB uploaded to **Internal testing** track
+- [ ] Internal testers email list created (`core-team` group)
+- [ ] Opt-in link shared with internal testers
+- [ ] Internal testing validated (install, launch, core flows)
+- [ ] Promoted to **Closed testing** with `alpha-circle` tester group
+- [ ] 20+ testers active for 14 consecutive days (Google Play production requirement)
+- [ ] Critical feedback triaged and resolved
+- [ ] Promoted to **Production** with staged rollout (5% → 20% → 50% → 100%)
+
+### Store Listing Fields
+
+| Field              | Limit         | Value                                                              |
+| ------------------ | ------------- | ------------------------------------------------------------------ |
+| App name           | 30 chars      | `Finance`                                                          |
+| Short description  | 80 chars      | `Track your money privately. Offline-first budgeting and expense tracking.` |
+| Full description   | 4,000 chars   | See [Full Description](#full-description)                          |
+| App icon           | 512 × 512     | PNG, 32-bit, no transparency                                      |
+| Feature graphic    | 1024 × 500    | PNG or JPEG — hero image for store listing                         |
+| App category       | —             | Finance                                                            |
+| Tags               | Up to 5       | See [Keywords / Tags](#keywords--tags)                             |
+| Contact email      | Required      | `{{SUPPORT_EMAIL}}`                                                |
+| Contact phone      | Optional      | —                                                                  |
+| Contact website    | Optional      | `{{WEBSITE_URL}}`                                                  |
+| Privacy policy URL | Required      | `{{PRIVACY_POLICY_URL}}`                                           |
+
+Short description character count: 73 ✅ (under 80)
+
+### Data Safety Section
+
+Google Play's Data Safety form maps to the app's actual data practices. See the [Privacy Audit](../audits/security-checklist.md) for the full data inventory.
+
+#### Data Types Declaration
+
+| Data Type                               | Collected         | Shared | Purpose                         | Optional |
+| --------------------------------------- | ----------------- | ------ | ------------------------------- | -------- |
+| Email address                           | ✅                | ❌     | Account authentication          | Yes (sync only) |
+| Financial info (transactions, balances) | ✅                | ❌     | App functionality               | No       |
+| App activity (screens viewed)           | ✅ (with consent) | ❌     | Analytics — funnel optimization | Yes      |
+| Crash logs                              | ✅ (with consent) | ❌     | Stability monitoring            | Yes      |
+| Device identifiers                      | ❌                | ❌     | Not collected                   | —        |
+| Location                                | ❌                | ❌     | Not collected                   | —        |
+
+#### Key Data Safety Declarations
+
+| Declaration                            | Value                                                      |
+| -------------------------------------- | ---------------------------------------------------------- |
+| Data encrypted in transit              | ✅ Yes (TLS 1.3)                                           |
+| Data encrypted at rest                 | ✅ Yes (SQLCipher AES-256)                                 |
+| Users can request data deletion        | ✅ Yes (Settings > Account > Delete Account)               |
+| Data not sold to third parties         | ✅ Confirmed                                               |
+| Committed to Play Families policy      | N/A — app is not targeted at children                      |
+| Independent security review            | TBD — recommended post-launch                              |
+
+### Screenshot Requirements
+
+Provide **2–8 screenshots** per device type. All screenshots must reflect actual in-app UI.
+
+| Device Type | Dimensions (px)          | Required           |
+| ----------- | ------------------------ | ------------------ |
+| Phone       | 1080 × 1920 (16:9)      | ✅ Yes (minimum 2) |
+| 7" Tablet   | 1200 × 1920             | Recommended        |
+| 10" Tablet  | 1600 × 2560             | Recommended        |
+| Chromebook  | 1920 × 1080 (landscape) | Optional           |
+
+**Format:** PNG or JPEG, no alpha/transparency, max 8 MB each.
+
+**Feature graphic:** 1024 × 500 px, PNG or JPEG. This hero image appears at the top of the store listing and in search results. Design with the app name and a clear visual — avoid text-heavy designs (they scale poorly on small screens).
+
+**Automation:** Fastlane `screengrab` or Compose Screenshot Testing. Store in `apps/android/screenshots/`.
+
+### Content Rating (IARC Questionnaire)
+
+Google Play uses the **IARC (International Age Rating Coalition)** system. Answer the questionnaire in Play Console under **Policy > App content > Content rating**.
+
+| Question Area                   | Answer                                            |
+| ------------------------------- | ------------------------------------------------- |
+| Violence                        | None                                              |
+| Sexual content                  | None                                              |
+| Language                        | None                                              |
+| Controlled substances           | None                                              |
+| User-generated content          | No (V1) — revisit if household comments are added |
+| Personal information collection | Yes — financial data, email (for sync)            |
+| Location data                   | No                                                |
+| Ads                             | No                                                |
+| In-app purchases                | Yes (freemium model)                              |
+
+**Expected rating:** PEGI 3 / Everyone (ESRB). Finance apps with no objectionable content receive the lowest age rating.
+
+### Android-Specific Build Requirements
+
+| Requirement           | Detail                                                                     |
+| --------------------- | -------------------------------------------------------------------------- |
+| Target API level      | Latest stable (currently API 35 / Android 15)                              |
+| App bundle format     | AAB required (not APK) for Play Store                                      |
+| App signing           | Enroll in Google Play App Signing                                          |
+| 64-bit support        | Required for all native code                                               |
+| Deobfuscation file    | Upload ProGuard/R8 mapping file for crash reports                          |
+
+---
+
+## Windows — Microsoft Store
+
+### MSIX Package Signing Checklist
+
+For step-by-step MSIX packaging, see the [Windows Store Guide](windows-store.md).
+
+- [ ] Partner Center account registered ($19 individual / $99 company)
+- [ ] App name **Finance** reserved in Partner Center
+- [ ] Package Identity Name and Publisher Identity copied into `AppxManifest.xml`
+- [ ] Code-signing certificate obtained (Partner Center or trusted CA)
+- [ ] Application built: `node tools/gradle.js :apps:windows:build`
+- [ ] MSIX package created (via MSIX Packaging Tool or `makeappx.exe`)
+- [ ] MSIX signed with `signtool.exe` using the code-signing certificate
+- [ ] Package passes [Windows App Certification Kit (WACK)](https://learn.microsoft.com/windows/uwp/debug-test-perf/windows-app-certification-kit) tests
+  - [ ] Security test (no malware, valid signing)
+  - [ ] Technical compliance (proper MSIX structure, capability declarations)
+  - [ ] Performance test (reasonable launch time, no hangs)
+  - [ ] Accessibility test (basic Narrator compatibility)
+- [ ] Package uploaded to Partner Center
+- [ ] Submission passes Microsoft certification review
+
+### Store Listing Fields
+
+| Field              | Limit           | Value                                                                  |
+| ------------------ | --------------- | ---------------------------------------------------------------------- |
+| App name           | 256 chars       | `Finance`                                                              |
+| Short description  | 1,000 chars     | See [Full Description](#full-description) (first two paragraphs)       |
+| Full description   | 10,000 chars    | See [Full Description](#full-description) — expand with desktop-specific notes |
+| App icon           | 300 × 300 min   | PNG (recommended 512 × 512)                                           |
+| Category           | —               | Personal Finance                                                       |
+| Support contact    | Required        | `{{SUPPORT_EMAIL}}`                                                    |
+| Privacy policy URL | Required        | `{{PRIVACY_POLICY_URL}}`                                               |
+| Website            | Optional        | `{{WEBSITE_URL}}`                                                      |
+| Keywords           | Up to 7         | See [Keywords / Tags](#keywords--tags)                                 |
+
+### Privacy Statement Requirements
+
+Microsoft requires a privacy policy that meets these criteria:
+
+- [ ] Hosted at a publicly accessible URL (not behind authentication)
+- [ ] Discloses all data types collected and their purposes
+- [ ] Describes how data is stored (local SQLCipher encryption, optional cloud sync)
+- [ ] Covers data retention and deletion policies
+- [ ] Includes contact information for privacy inquiries
+- [ ] Accessible from within the app (Settings > Privacy)
+- [ ] URL provided in Partner Center and in-app
+
+### Screenshot Requirements
+
+| Type        | Dimensions (px)                        | Count         |
+| ----------- | -------------------------------------- | ------------- |
+| Desktop     | 1366 × 768 minimum, 3840 × 2160 max   | 1–10 required |
+| Recommended | 1920 × 1080 (Full HD)                  | Best practice |
+
+**Desktop screenshots should show:**
+
+1. Dashboard with sidebar navigation visible
+2. Multi-panel transaction view
+3. Budget overview with keyboard shortcuts visible
+4. Reports with full-width charts
+5. Settings / preferences panel
+
+**Format:** PNG, landscape orientation, showing the app in a typical desktop window.
+
+Store screenshots in `apps/windows/screenshots/desktop/`.
+
+### Age Rating
+
+Microsoft Store uses the same **IARC** questionnaire as Google Play. Answers are identical — see [Content Rating (IARC Questionnaire)](#content-rating-iarc-questionnaire). Expected rating: PEGI 3 / Everyone.
+
+### Windows-Specific Compliance
+
+| Requirement         | Detail                                                                          |
+| ------------------- | ------------------------------------------------------------------------------- |
+| Accessibility       | Windows Narrator, High Contrast, keyboard-only navigation supported            |
+| System integration  | Respects system theme (light/dark), DPI scaling, Snap Layouts                  |
+| Offline capability  | Core financial features work without network                                    |
+| Clean uninstall     | No residual files outside `%LOCALAPPDATA%`                                     |
+| Capabilities        | Declared in manifest: `internetClient`, `localStorage`                         |
+| Min OS version      | Windows 10 version 1809 (build 17763)                                          |
+| Architecture        | x64 required, ARM64 recommended                                                |
+
+---
+
+## Web — Progressive Web App (PWA)
+
+### manifest.json Verification Checklist
+
+The web app manifest controls PWA installability and appearance. Verify all fields before launch.
+
+- [ ] `manifest.json` exists at `apps/web/public/manifest.json`
+- [ ] `<link rel="manifest" href="/manifest.json">` present in `index.html`
+- [ ] `name` field set: `"Finance"`
+- [ ] `short_name` field set: `"Finance"`
+- [ ] `description` field set with value prop
+- [ ] `start_url` set to `/` or `/dashboard`
+- [ ] `display` set to `"standalone"`
+- [ ] `background_color` set (matches app background)
+- [ ] `theme_color` set (matches brand primary color)
+- [ ] `orientation` set to `"any"`
+- [ ] `categories` includes `["finance", "productivity"]`
+- [ ] Icons provided:
+  - [ ] 192 × 192 PNG with `purpose: "any maskable"`
+  - [ ] 512 × 512 PNG with `purpose: "any maskable"`
+- [ ] Screenshots provided (at least one `wide` and one `narrow` form factor)
+- [ ] Service worker registered with `fetch` event handler
+- [ ] Offline fallback page configured
+- [ ] Chrome DevTools > Application > Manifest shows no errors
+- [ ] [PWA Builder](https://www.pwabuilder.com/) validation passes
+- [ ] Lighthouse PWA audit passes (✅ Installable)
+
+**Reference manifest:** See [App Store Preparation](app-store-preparation.md#manifest-validation) for the full `manifest.json` template.
+
+### Open Graph Meta Tags
+
+Add these tags to `apps/web/index.html` `<head>` for rich link previews when the app URL is shared on social media, messaging apps, and search results.
+
+```html
+<!-- Primary Meta Tags -->
+<meta name="title" content="Finance — Private Financial Tracking">
+<meta name="description" content="Track your money privately. Offline-first budgeting and expense tracking across all your devices.">
+
+<!-- Open Graph / Facebook -->
+<meta property="og:type" content="website">
+<meta property="og:url" content="{{APP_URL}}">
+<meta property="og:title" content="Finance — Private Financial Tracking">
+<meta property="og:description" content="Track your money privately. Offline-first budgeting and expense tracking across all your devices.">
+<meta property="og:image" content="{{APP_URL}}/og-image.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:alt" content="Finance app dashboard showing budget overview and recent transactions">
+
+<!-- Twitter -->
+<meta property="twitter:card" content="summary_large_image">
+<meta property="twitter:url" content="{{APP_URL}}">
+<meta property="twitter:title" content="Finance — Private Financial Tracking">
+<meta property="twitter:description" content="Track your money privately. Offline-first budgeting and expense tracking across all your devices.">
+<meta property="twitter:image" content="{{APP_URL}}/og-image.png">
+
+<!-- PWA / Mobile -->
+<meta name="theme-color" content="#1a1a2e">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="default">
+<meta name="apple-mobile-web-app-title" content="Finance">
+<link rel="apple-touch-icon" href="/icons/icon-192.png">
+```
+
+**OG image:** Create a 1200 × 630 px image (`og-image.png`) showing the app dashboard with the tagline. Store in `apps/web/public/`.
+
+### PWA Install Prompt Configuration
+
+The browser's install prompt triggers automatically when PWA criteria are met. To customize the experience:
+
+```typescript
+// apps/web/src/pwa-install.ts
+
+let deferredPrompt: BeforeInstallPromptEvent | null = null;
+
+window.addEventListener('beforeinstallprompt', (e: Event) => {
+  // Prevent the default browser prompt
+  e.preventDefault();
+  deferredPrompt = e as BeforeInstallPromptEvent;
+  // Show your custom install UI (e.g., banner or button)
+  showInstallPromotion();
+});
+
+async function installApp(): Promise<void> {
+  if (!deferredPrompt) return;
+  deferredPrompt.prompt();
+  const { outcome } = await deferredPrompt.userChoice;
+  console.log(`Install prompt outcome: ${outcome}`);
+  deferredPrompt = null;
+  hideInstallPromotion();
+}
+
+window.addEventListener('appinstalled', () => {
+  // Hide install promotion — app is installed
+  hideInstallPromotion();
+  deferredPrompt = null;
+});
+```
+
+**Install prompt UX guidelines:**
+
+- Show the custom install prompt only after the user has engaged with the app (e.g., after 2+ sessions or 30+ seconds)
+- Provide a clear value proposition: "Install Finance for offline access and a native experience"
+- Allow dismissal without penalty — don't re-prompt for at least 2 weeks
+- Never block app usage behind an install prompt
+
+### Lighthouse Score Targets
+
+| Category       | Target | Key Metrics                                              |
+| -------------- | ------ | -------------------------------------------------------- |
+| Performance    | ≥ 90   | LCP < 2.5 s, FID < 100 ms, CLS < 0.1                   |
+| Accessibility  | ≥ 95   | WCAG 2.2 AA, ARIA landmarks, focus management           |
+| Best Practices | ≥ 95   | HTTPS, no console errors, CSP headers                    |
+| SEO            | ≥ 90   | Meta tags, canonical URL, robots.txt, structured data    |
+| PWA            | ✅ Pass | Installable, offline-capable, fast loading               |
+
+---
+
+## Pre-Submission Checklist
+
+Complete **every item** before submitting to any store. This checklist is the final gate between development and public release.
+
+### Legal & Compliance
+
+- [ ] Privacy policy published at `{{PRIVACY_POLICY_URL}}` and accessible without authentication
+- [ ] Terms of service published at `{{TERMS_OF_SERVICE_URL}}`
+- [ ] Privacy policy linked from in-app Settings > Privacy on all platforms
+- [ ] Terms of service linked from in-app Settings on all platforms
+- [ ] Data collection inventory verified — every collected data type is documented
+- [ ] GDPR compliance: right to access, erasure, portability, and consent management
+- [ ] Export compliance documentation ready (SQLCipher AES-256 = mass-market encryption)
+
+### Accounts & Infrastructure
+
+- [ ] Support email `{{SUPPORT_EMAIL}}` configured and monitored
+- [ ] Support URL `{{SUPPORT_URL}}` live with help content or contact form
+- [ ] Test accounts prepared for app review (Apple, Google — with sample data)
+- [ ] Analytics consent flow implemented (opt-in, not opt-out)
+- [ ] Crash reporting configured with user consent (Sentry or equivalent)
+- [ ] Error tracking dashboard accessible to the team
+
+### Visual Assets
+
+- [ ] App icon exported at all required platform sizes (see [App Icon](#app-icon))
+- [ ] All screenshots captured on the **latest release build** (not dev builds or mockups)
+  - [ ] iOS: iPhone 16 Pro Max (6.9") and iPad Pro 13" at minimum
+  - [ ] Android: Phone (1080 × 1920) at minimum; 7" and 10" tablet recommended
+  - [ ] Windows: Desktop (1920 × 1080 recommended)
+  - [ ] Web: OG image (1200 × 630)
+- [ ] Feature graphic created (1024 × 500) for Google Play
+- [ ] All screenshots show actual app UI with realistic sample data
+
+### Store Metadata
+
+- [ ] App name, descriptions, and keywords finalized (see [App Metadata](#app-metadata-shared))
+- [ ] Data safety / privacy labels completed accurately on all platforms
+  - [ ] Apple: Privacy nutrition labels in App Store Connect
+  - [ ] Google: Data safety section in Play Console
+  - [ ] Microsoft: Privacy statement URL in Partner Center
+- [ ] Content rating / age rating questionnaires completed on all platforms
+- [ ] Release notes written for v1.0.0
+
+### Technical Readiness
+
+- [ ] Release builds compile without warnings on all platforms
+- [ ] All automated tests pass on CI (`npm test`)
+- [ ] Performance benchmarks met (cold start < 2 s, scroll 60 fps, memory < 150 MB)
+- [ ] Offline functionality verified — core features work without network
+- [ ] Cross-device sync tested (iOS ↔ Android, Android ↔ Web, etc.)
+- [ ] In-app purchases tested in sandbox environments (StoreKit 2, Google Play Billing)
+- [ ] Crash-free rate > 99% in beta testing
+
+### Marketing & Launch
+
+- [ ] Release notes written (concise, user-facing language)
+- [ ] Marketing website / landing page ready with download links
+- [ ] OG image and social sharing metadata configured (see [Open Graph Meta Tags](#open-graph-meta-tags))
+
+---
+
+## Post-Submission Runbook
+
+After submitting to each store, follow this runbook to track review progress and handle issues.
+
+### Expected Review Times
+
+| Store          | Typical Review Time  | Expedited Review Available |
+| -------------- | -------------------- | -------------------------- |
+| Apple          | 24–48 hours          | Yes (limited, request via App Store Connect) |
+| Google Play    | Hours to 7 days      | No                         |
+| Microsoft      | 1–5 business days    | No                         |
+| Web (PWA)      | No review required   | N/A                        |
+
+### If Rejected
+
+1. **Read the rejection reason carefully** — store review teams provide specific guideline references
+2. **Fix the issue** — address the exact violation cited
+3. **Reply to the reviewer** (Apple: Resolution Center; Google: Play Console appeals) with a clear explanation of what was changed
+4. **Resubmit** — the re-review is usually faster than the initial review
+5. **Document the rejection** — add a note to this guide so future submissions avoid the same issue
+
+### Post-Approval Actions
+
+- [ ] Enable staged rollout (Google Play: start at 5%)
+- [ ] Monitor crash reporting dashboard for the first 48 hours
+- [ ] Check store listing renders correctly (screenshots, description, icon)
+- [ ] Verify download and install flow on a clean device
+- [ ] Confirm in-app purchases work in production
+- [ ] Monitor user reviews and respond to feedback within 48 hours
+
+---
+
+## References
+
+### Store Documentation
+
+- [Apple App Store Review Guidelines](https://developer.apple.com/app-store/review/guidelines/)
+- [App Store Connect Help](https://developer.apple.com/help/app-store-connect/)
+- [Google Play Console Help](https://support.google.com/googleplay/android-developer)
+- [Google Play Data Safety](https://support.google.com/googleplay/android-developer/answer/10787469)
+- [Microsoft Store Policies](https://learn.microsoft.com/windows/apps/publish/store-policies)
+- [MSIX Packaging](https://learn.microsoft.com/windows/msix/)
+- [Web App Manifest — MDN](https://developer.mozilla.org/en-US/docs/Web/Manifest)
+- [IARC Rating System](https://www.globalratings.com/)
+
+### Project Documentation
+
+- [App Store Preparation Guide](app-store-preparation.md) — Developer account setup, build requirements, review guidelines
+- [Windows Store Guide](windows-store.md) — MSIX packaging step-by-step
+- [Launch Checklist](launch-checklist.md) — Full pre-launch verification
+- [Release Process](release-process.md) — Versioning, pipelines, rollback
+- [Beta Testing](beta-testing.md) — Beta distribution and feedback collection
+- [Security Checklist](../audits/security-checklist.md) — OWASP MASVS L1 audit
+- [Product Identity](../design/product-identity.md) — App description, value prop, differentiators
+- [Feature Specification](../design/features.md) — Full feature list with acceptance criteria

--- a/docs/guides/beta-testing.md
+++ b/docs/guides/beta-testing.md
@@ -1,294 +1,309 @@
 # Beta Testing Program
 
-> End-to-end guide for running Finance's beta testing program across Android,
-> iOS, Web, and Windows. Covers distribution, tester management, feedback
-> collection, and exit criteria.
+> Complete guide for planning and running Finance's pre-launch beta. Covers
+> goals, tester recruitment, platform distribution, test scenarios, feedback
+> collection, triage, and exit criteria.
+>
+> **Related docs:**
+> [Beta Test Plan — Detailed Scenarios](./beta-test-plan.md) ·
+> [Pre-Launch Checklist](./launch-checklist.md) ·
+> [Release Process](./release-process.md)
 
 ---
 
-## 1. Platform-Specific Beta Distribution
+## Table of Contents
 
-### 1.1 Android — Google Play Internal Testing
+1. [Beta Program Overview](#1-beta-program-overview)
+2. [Tester Recruitment](#2-tester-recruitment)
+3. [Distribution Setup](#3-distribution-setup)
+4. [Test Scenarios Checklist](#4-test-scenarios-checklist)
+5. [Feedback Collection](#5-feedback-collection)
+6. [Triage Process](#6-triage-process)
+7. [Exit Criteria](#7-exit-criteria)
 
-**Track setup:**
+---
 
-1. Open [Google Play Console](https://play.google.com/console) → **Release** →
-   **Testing** → **Internal testing**.
-2. Create a new internal testing release.
-3. Upload the signed AAB produced by the CI `release-android` workflow.
-4. Set the release name to the current version (e.g., `1.2.0-beta.1`).
+## 1. Beta Program Overview
 
-**Tester groups:**
+### Goals
 
-| Group          | Purpose                           | Max Testers |
-| -------------- | --------------------------------- | ----------- |
-| `core-team`    | Internal developers and designers | 20          |
-| `alpha-circle` | Trusted external volunteers       | 50          |
-| `beta-public`  | Open beta (promoted later)        | 1,000       |
+| Goal                         | What We Learn                                                                                                                           |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| **Validate core flows**      | Onboarding → accounts → transactions → budgets → goals → reports work end-to-end on every platform.                                     |
+| **Find bugs**                | Surface crashes, data-loss scenarios, and edge cases before general availability (GA).                                                  |
+| **Assess UX**                | Verify that the expertise-tiered UI (🌱 Getting Started, 📊 Comfortable, 🧠 Advanced) feels intuitive across financial-literacy levels. |
+| **Test sync across devices** | Confirm offline-first architecture + PowerSync replication keeps data consistent when users move between platforms.                     |
 
-**Steps:**
+### Duration
 
-1. Navigate to **Internal testing** → **Testers** → **Create email list**.
-2. Add tester email addresses (Google accounts required).
-3. Share the opt-in link with each group.
-4. Testers accept the invite and install via the Play Store.
+**Minimum 2 weeks** of active testing. Extend if exit criteria (§ 7) are not
+met. The [Pre-Launch Checklist](./launch-checklist.md) requires a minimum
+2-week beta period per platform before sign-off.
+
+### Target Coverage
+
+| Platform  | Minimum Testers |
+| --------- | --------------- |
+| Android   | 10              |
+| iOS       | 10              |
+| Web       | 10              |
+| Windows   | 10              |
+| **Total** | **40+**         |
+
+Aim for diversity within each group — see § 2 for recruitment criteria.
+
+---
+
+## 2. Tester Recruitment
+
+Finance is a **privacy-first, offline-first personal finance app** that adapts
+to three expertise tiers. Effective beta testing requires testers who mirror
+the real audience described in [Product Identity](../design/product-identity.md)
+and the personas in our design docs (Alex, Jordan, Casey).
+
+### Who to Recruit
+
+| Category                              | Why                                                                                                              | Example Profile                                                                                                                    |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| **Internal team members**             | Fast feedback loop; familiar with expected behavior.                                                             | Developers, designers, QA on the Finance team.                                                                                     |
+| **Friends & family (early adopters)** | Real-world usage patterns; less filtered feedback.                                                               | A friend who tracks spending in a spreadsheet today.                                                                               |
+| **Accessibility testers**             | Validate screen-reader flows, large-text layouts, and motor-accessibility. Must include users with disabilities. | A VoiceOver or TalkBack daily user; someone who relies on high-contrast or switch control.                                         |
+| **Financial literacy range**          | Exercise all three expertise tiers (🌱 / 📊 / 🧠).                                                               | Casey-like persona (beginner, cognitive-accessibility needs) through Jordan-like persona (confident, power-user budgeting).        |
+| **Platform diversity**                | Catch device-specific bugs and OS-version regressions.                                                           | Pixel 7 + Samsung Galaxy S23 (Android); iPhone 15 + iPhone SE (iOS); Chrome + Safari (Web); Surface Pro + budget laptop (Windows). |
+
+### Recruitment Messaging Template
+
+Copy and personalize the message below when inviting testers:
+
+```text
+Subject: Help us beta test Finance — a private, multi-platform money tracker
+
+Hi {name},
+
+We're looking for beta testers for Finance, a personal finance app that
+keeps your data private and encrypted on your device.
+
+What we need from you:
+• Install the app on your {platform} device.
+• Use it for at least 2 weeks — track real or sample transactions,
+  set up a budget, and try the features listed in the test guide.
+• Report anything confusing, broken, or delightful via the in-app
+  feedback form (Settings → Send Feedback, or shake your phone).
+
+Your data stays on your device. Nothing is shared with third parties.
+
+Interested? Reply to this message and I'll send your install link.
+
+Thanks!
+— The Finance Team
+```
+
+---
+
+## 3. Distribution Setup
+
+Each platform has its own beta channel. Set up all four before inviting
+testers.
+
+### 3.1 iOS — TestFlight
+
+1. In [App Store Connect](https://appstoreconnect.apple.com), select
+   **Finance → TestFlight**.
+2. Upload the IPA built by the CI `release-ios` workflow (via Fastlane).
+3. Create a beta group called **Finance Beta** and add testers by email
+   (any Apple ID works).
+4. Fill in _Beta App Description_ and _What to Test_ (use the 13 scenarios
+   from § 4).
+5. Submit the first build for **Beta App Review** (subsequent builds to the
+   same group auto-approve).
+6. Testers receive a TestFlight invite and install via the TestFlight app.
+
+**Tip:** Internal testers (Apple Developer account holders, up to 100) get
+builds immediately with no review delay — use this for the core team.
+
+### 3.2 Android — Google Play Internal Testing Track
+
+1. Open [Google Play Console](https://play.google.com/console) → **Release →
+   Testing → Internal testing**.
+2. Create a release and upload the signed AAB from the CI `release-android`
+   workflow.
+3. Under **Testers**, create email lists:
+
+   | List           | Purpose                     |
+   | -------------- | --------------------------- |
+   | `core-team`    | Internal developers / QA    |
+   | `alpha-circle` | Trusted external volunteers |
+
+4. Share the opt-in link with each list. Testers accept and install via the
+   Play Store.
 
 **Promotion path:** Internal → Closed beta → Open beta → Production.
 
----
+### 3.3 Web — Staging Environment
 
-### 1.2 iOS — TestFlight
+1. Every push to a `release/*` branch generates a **Vercel Preview
+   Deployment** at a URL like
+   `https://finance-<branch>-<team>.vercel.app`.
+2. Gate access with **Vercel Authentication** or a `BETA_ACCESS_CODE`
+   environment variable.
+3. Share the preview URL and access code with testers via a secure channel.
 
-**Configuration:**
+### 3.4 Windows — MSIX Sideloading or Flight Ring
 
-1. In [App Store Connect](https://appstoreconnect.apple.com), select the
-   Finance app → **TestFlight** tab.
-2. Upload the IPA built by the CI `release-ios` workflow (via Fastlane
-   `deliver`).
-3. Apple processes the build (typically 15–30 minutes).
-
-**Internal testers (up to 100):**
-
-- Add via **App Store Connect Users** (must have an Apple Developer account
-  role).
-- Builds are available immediately — no review required.
-
-**External testers (up to 10,000):**
-
-1. Create a **beta group** (e.g., `Finance Beta`).
-2. Add testers by email (any Apple ID).
-3. Fill in the _Beta App Description_ and _What to Test_ fields.
-4. Submit for **Beta App Review** (first build only; subsequent builds to the
-   same group auto-approve unless metadata changes).
-5. Testers receive a TestFlight invite email and install via the TestFlight app.
-
-**TestFlight metadata:**
-
-```
-Beta App Description:
-  Finance helps you track spending, set budgets, and reach savings goals.
-  This beta build may contain bugs — please report them via the in-app
-  feedback form.
-
-What to Test:
-  - Account creation and sign-in
-  - Adding and editing transactions
-  - Budget and goal features
-  - Offline mode and sync
-  - Dark mode and accessibility
-```
-
----
-
-### 1.3 Web — Staging Environment (Vercel Preview)
-
-**Setup:**
-
-1. Every push to `phase-*/beta` or `release/*` branches generates a **Vercel
-   Preview Deployment** automatically.
-2. The preview URL follows the pattern:
-   `https://finance-<branch>-<team>.vercel.app`
-
-**Restricted access:**
-
-- Enable **Vercel Authentication** on the preview deployment so only invited
-  team members can access it.
-- Alternatively, gate access with an environment variable
-  `BETA_ACCESS_CODE` — users must enter the code on first visit.
-
-**Tester instructions:**
-
-1. Navigate to the preview URL provided in the release communication.
-2. Enter the beta access code (shared via secure channel).
-3. Use the app as normal; report issues via the in-app feedback form.
-
----
-
-### 1.4 Windows — MSIX Sideloading & Flight Rings
-
-**MSIX sideloading (internal beta):**
+**Sideloading (recommended for initial beta):**
 
 1. Build the MSIX package via the CI `release-windows` workflow.
-2. Sign the package with the development certificate (stored in CI secrets).
-3. Distribute the `.msix` file via a shared internal link (e.g., SharePoint or
-   GitHub Release asset marked as pre-release).
-4. Testers install by double-clicking the MSIX and accepting the prompt.
-   - Prerequisite: **Developer mode** or the signing certificate must be in the
-     Trusted People store.
+2. Sign with the development certificate (stored in CI secrets).
+3. Distribute the `.msix` via a shared link (e.g., GitHub Release marked
+   _pre-release_).
+4. Testers install by double-clicking the MSIX.
+   - Prerequisite: **Developer mode** enabled, or the signing certificate
+     is in the Trusted People store.
 
-**Microsoft Store flight rings (future):**
+**Microsoft Store flight ring (when Store-published):**
 
-| Ring              | Audience         | Purpose                   |
-| ----------------- | ---------------- | ------------------------- |
-| `Dev`             | Core team        | Daily builds              |
-| `Beta`            | Invited testers  | Feature-complete previews |
-| `Release Preview` | Broader audience | Final validation          |
-| `Production`      | All users        | General availability      |
-
-**Flight ring configuration (when Store-published):**
-
-1. In **Partner Center**, create a package flight.
-2. Assign the flight to a known user group (Microsoft accounts).
+1. In **Partner Center**, create a package flight for a `Beta` ring.
+2. Assign to a known-user group (Microsoft accounts).
 3. Upload the MSIX and submit for certification.
 4. Testers in the flight group receive the update via the Store.
 
 ---
 
-## 2. Test Plan
+## 4. Test Scenarios Checklist
 
-### 2.1 Critical User Journeys (10)
-
-Every beta tester should exercise these flows. Detailed scenarios are in
+Every beta tester should complete as many of these scenarios as possible.
+Detailed step-by-step instructions for each are in
 [`beta-test-plan.md`](./beta-test-plan.md).
 
-| #   | Journey                                 | Priority |
-| --- | --------------------------------------- | -------- |
-| 1   | Account creation and sign-in            | P0       |
-| 2   | Transaction CRUD (create, edit, delete) | P0       |
-| 3   | Transaction search and filter           | P1       |
-| 4   | Budget creation and tracking            | P0       |
-| 5   | Goal setting and milestone celebrations | P1       |
-| 6   | Offline usage → reconnect → sync        | P0       |
-| 7   | Multi-device sync                       | P1       |
-| 8   | Data export (JSON, CSV)                 | P1       |
-| 9   | Settings persistence across sessions    | P1       |
-| 10  | Accessibility — screen reader full flow | P0       |
-
-### 2.2 Device Matrix
-
-| Platform | Primary Device         | Secondary Device       |
-| -------- | ---------------------- | ---------------------- |
-| Android  | Pixel 7 (API 34)       | Samsung Galaxy S23     |
-| iOS      | iPhone 15 (iOS 17)     | iPhone SE 3 (iOS 16)   |
-| Web      | Chrome 120+ (desktop)  | Safari 17 (mobile)     |
-| Windows  | Surface Pro 9 (Win 11) | Budget laptop (Win 10) |
-
-### 2.3 Bug Severity Definitions
-
-| Severity | Label | Definition                                   | SLA                     |
-| -------- | ----- | -------------------------------------------- | ----------------------- |
-| P0       | 🔴    | App crash, data loss, security vulnerability | Fix before release      |
-| P1       | 🟠    | Feature broken, no workaround                | Fix before release      |
-| P2       | 🟡    | Feature broken, workaround exists            | Fix within next release |
-| P3       | 🟢    | Cosmetic issue, minor UX friction            | Backlog                 |
+- [ ] **1. Create account and complete onboarding** — Sign up (email, social, or passkey), choose an expertise tier (🌱 / 📊 / 🧠), and land on the dashboard.
+- [ ] **2. Add a checking account** — Create a "Checking" account with an initial balance. Verify it appears in the account list with the correct balance.
+- [ ] **3. Create 5+ transactions (mix of expense/income)** — Use quick-entry (< 10 s per transaction). Include at least one expense and one income entry across different categories.
+- [ ] **4. Set up a monthly budget for a category** — Allocate money to at least one category (e.g., Food $600). Confirm the progress bar and remaining amount update after adding transactions.
+- [ ] **5. Create a savings goal** — Set a goal with a name, target amount, and optional deadline. Fund it and verify progress and milestone celebrations.
+- [ ] **6. View reports and analytics** — Open spending-by-category, spending-trends, and income-vs-expenses reports. Verify charts render correctly and data matches entered transactions.
+- [ ] **7. Export data as JSON** — Settings → Export → JSON. Verify the file downloads and contains accounts, transactions, categories, budgets, and goals.
+- [ ] **8. Export data as CSV** — Settings → Export → CSV. Open the file in a spreadsheet and confirm transactions are present and amounts are correct.
+- [ ] **9. Test offline mode (disable network, make changes, reconnect)** — Enable airplane mode. Add a transaction and edit a budget. Re-enable network. Verify changes sync without data loss.
+- [ ] **10. Sync across two devices (if applicable)** — Sign in on a second device (any platform). Confirm all data appears. Make a change on each device and verify bidirectional sync.
+- [ ] **11. Test biometric authentication** — Enable biometric lock (Face ID, fingerprint, or Windows Hello) in Settings. Close and reopen the app. Verify the biometric prompt appears and grants access.
+- [ ] **12. Navigate with screen reader enabled** — Turn on TalkBack (Android), VoiceOver (iOS), NVDA (Web), or Narrator (Windows). Complete onboarding and add a transaction using only the screen reader. Note any unlabeled elements or confusing announcements.
+- [ ] **13. Test with large font / high contrast settings** — Set the device to maximum font size and enable high-contrast mode. Navigate through accounts, transactions, budgets, and reports. Verify no text is clipped and contrast is sufficient.
 
 ---
 
-## 3. Beta Exit Criteria
+## 5. Feedback Collection
 
-All of the following must be met before promoting a beta build to production:
+### 5.1 In-App Feedback Mechanism
 
-| Criterion                       | Target                            |
-| ------------------------------- | --------------------------------- |
-| Crash-free rate                 | ≥ 99.5%                           |
-| P0 bugs open                    | 0                                 |
-| P1 bugs open                    | 0                                 |
-| P2 bugs open                    | ≤ 3 (with workarounds documented) |
-| Unique testers per platform     | ≥ 10                              |
-| All 10 critical journeys passed | ✅ on every platform              |
-| Performance benchmarks met      | See § 2.1 #10 in test plan        |
-| Accessibility audit passed      | No P0/P1 a11y issues              |
-| Beta duration                   | ≥ 5 business days                 |
+Every platform includes two entry points:
 
-**Sign-off process:**
+| Trigger               | Platform     | How                                                                          |
+| --------------------- | ------------ | ---------------------------------------------------------------------------- |
+| **Shake to report**   | Android, iOS | Shake the device to open the feedback form with an auto-attached screenshot. |
+| **Feedback button**   | All          | Settings → **Send Feedback** (always visible).                               |
+| **Keyboard shortcut** | Web, Windows | `Ctrl+Shift+F` opens the feedback form.                                      |
 
-1. QA lead compiles the beta summary report.
-2. Engineering lead reviews open issues and crash reports.
+### 5.2 Structured Feedback Form Template
+
+The in-app form collects the following:
+
+| Field         | Type                                                                  | Required | Notes                                                 |
+| ------------- | --------------------------------------------------------------------- | -------- | ----------------------------------------------------- |
+| Category      | Dropdown: Bug · Feature Request · Performance · Accessibility · Other | Yes      | Determines triage label.                              |
+| Summary       | Short text (≤ 120 chars)                                              | Yes      | One-line description.                                 |
+| Description   | Text area                                                             | Yes      | What happened, what you expected, steps to reproduce. |
+| Screenshot    | Auto-attached on shake; manual attach otherwise                       | No       |                                                       |
+| Device info   | Auto-collected (OS, model, app version)                               | Yes      |                                                       |
+| Contact email | Text                                                                  | No       | Only if the tester wants a follow-up.                 |
+
+### 5.3 Bug Report Template for Testers
+
+Share this template with testers who prefer to report via email or a shared
+channel:
+
+```markdown
+### Bug Report
+
+**Summary:** (one line — what went wrong)
+
+**Steps to reproduce:**
+
+1.
+2.
+3.
+
+**Expected result:**
+
+**Actual result:**
+
+**Platform / Device / OS version:**
+
+**App version:** (Settings → About)
+
+**Screenshot or screen recording:** (attach if possible)
+
+**Does this happen every time?** Yes / No / Sometimes
+```
+
+### 5.4 Weekly Feedback Summary Process
+
+Every Friday during the beta period:
+
+1. QA lead compiles all new feedback from the in-app form and GitHub
+   Discussions into a single summary.
+2. Group feedback by theme: bugs, UX friction, accessibility gaps, feature
+   requests.
+3. Note top 3 issues by frequency.
+4. Post the summary to GitHub Discussions (category: `Beta Feedback`).
+5. Include: current crash-free rate, count of open P0/P1 bugs, and
+   under-tested scenarios that need more coverage.
+
+---
+
+## 6. Triage Process
+
+Every reported issue is assigned a priority level. Triage happens daily during
+the beta period.
+
+| Priority | Label                | Definition                                                                          | Action                                                                     |
+| -------- | -------------------- | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| **P0**   | 🔴 Crash / data loss | App crash, data loss, data corruption, or security vulnerability.                   | Fix immediately. Push a hotfix build to all beta channels within 24 hours. |
+| **P1**   | 🟠 Broken core flow  | A core flow (onboarding, transactions, budgets, sync) is broken with no workaround. | Fix before GA. Must not remain open for more than 48 hours.                |
+| **P2**   | 🟡 UX issue          | Feature works but is confusing, slow, or visually broken. Workaround exists.        | Prioritize for GA if time permits. Document the workaround for testers.    |
+| **P3**   | 🟢 Enhancement       | Cosmetic polish, minor friction, or a feature request.                              | Add to backlog. Revisit after GA.                                          |
+
+**Triage flow:**
+
+```
+New feedback arrives
+       ↓
+QA assigns priority (P0–P3) + platform label
+       ↓
+P0/P1 → GitHub Issue created immediately → assigned to engineer
+P2    → GitHub Issue created → added to current sprint if capacity allows
+P3    → GitHub Issue created → added to backlog
+```
+
+---
+
+## 7. Exit Criteria
+
+All of the following must be satisfied before the beta is closed and the build
+is promoted to production. See also the Testing section of the
+[Pre-Launch Checklist](./launch-checklist.md).
+
+- [ ] **Zero P0 bugs open** — no crashes, data loss, or security issues remain unresolved.
+- [ ] **Zero P1 bugs open for > 48 hours** — every broken core flow has been fixed or a hotfix is deployed.
+- [ ] **All 13 test scenarios validated by 3+ testers per platform** — each row in the § 4 checklist has been completed and confirmed working by at least 3 different testers on each target platform.
+- [ ] **Sync tested across at least 2 platform combinations** — e.g., iOS ↔ Android, Web ↔ Windows. Data round-trips without loss or conflict.
+- [ ] **Accessibility tested by 2+ testers with disabilities** — real users who rely on assistive technology (screen reader, switch control, magnification) have completed core flows and reported no blocking issues.
+- [ ] **Net Promoter Score ≥ 7 (if surveyed)** — if a post-beta survey is sent, the average score meets this threshold.
+- [ ] **Beta duration ≥ 2 weeks** — calendar time from first tester install to exit-criteria review.
+
+### Sign-Off Process
+
+1. QA lead compiles the **beta summary report** covering all criteria above.
+2. Engineering lead reviews open issues and crash-free rate.
 3. Product owner gives explicit **GO / NO-GO** approval.
-4. Release manager promotes the build to production tracks.
-
----
-
-## 4. Feedback Collection
-
-### 4.1 In-App Feedback Form
-
-Every platform includes a **"Send Feedback"** entry point in the Settings
-screen and a persistent **shake-to-report** gesture (mobile) or
-**Ctrl+Shift+F** shortcut (desktop/web).
-
-**Form fields:**
-
-| Field         | Type           | Required |
-| ------------- | -------------- | -------- |
-| Category      | Dropdown       | Yes      |
-| Description   | Text area      | Yes      |
-| Screenshot    | Auto-attached  | No       |
-| Device info   | Auto-collected | Yes      |
-| App version   | Auto-collected | Yes      |
-| Contact email | Text           | No       |
-
-**Categories:** Bug, Feature Request, Performance, Accessibility, Other.
-
-### 4.2 GitHub Discussions Integration
-
-All beta feedback is routed to **GitHub Discussions** in the `finance` repo:
-
-- **Category:** `Beta Feedback`
-- **Labels:** auto-applied based on form category
-  (`beta-bug`, `beta-feature`, `beta-perf`, `beta-a11y`).
-- **Triage:** The QA team reviews new discussions daily and converts
-  actionable items into GitHub Issues.
-
-**Flow:**
-
-```
-In-app form  →  Backend API  →  GitHub Discussions (via GitHub API)
-                                    ↓
-                              QA triage (daily)
-                                    ↓
-                              GitHub Issue (if actionable)
-```
-
-### 4.3 Crash Reporting
-
-| Platform | Tool                 | Dashboard        |
-| -------- | -------------------- | ---------------- |
-| Android  | Firebase Crashlytics | Firebase Console |
-| iOS      | Firebase Crashlytics | Firebase Console |
-| Web      | Sentry               | Sentry Dashboard |
-| Windows  | Sentry               | Sentry Dashboard |
-
-Crash-free rate is monitored continuously and included in the beta exit
-criteria check.
-
----
-
-## 5. Beta Communication
-
-### 5.1 Tester Onboarding Email
-
-```
-Subject: Welcome to the Finance Beta! 🎉
-
-Hi {name},
-
-You've been invited to beta test Finance — a multi-platform financial
-tracking app. Here's how to get started:
-
-1. Install the app using the link for your platform:
-   - Android: {play_store_link}
-   - iOS: {testflight_link}
-   - Web: {vercel_preview_link}
-   - Windows: {msix_download_link}
-
-2. Sign in or create an account.
-
-3. Try the 10 critical user journeys listed in the test plan.
-
-4. Report any issues via the in-app feedback form (Settings → Send Feedback).
-
-Thank you for helping us build a better Finance!
-
-— The Finance Team
-```
-
-### 5.2 Weekly Beta Update
-
-Every Friday during the beta period, post a summary to GitHub Discussions:
-
-- New features / fixes in this build
-- Known issues
-- Top feedback themes
-- Updated crash-free rate
-- Call to action for under-tested areas
+4. Release manager promotes the build to production tracks (see
+   [Release Process](./release-process.md)).

--- a/docs/guides/launch-checklist.md
+++ b/docs/guides/launch-checklist.md
@@ -77,7 +77,7 @@ All accessibility audit items must pass on every platform before release.
 
 ## App Store Listings
 
-- [ ] **App store listings ready** — all metadata prepared and validated for each distribution channel.
+- [ ] **App store listings ready** — all metadata prepared and validated for each distribution channel. See the [App Store Submission Guide](app-store-submission.md) for exact field values, character counts, and asset specs.
   - [ ] **Google Play Store**
     - [ ] App title, short description, full description finalized
     - [ ] Feature graphic (1024×500), icon (512×512), screenshots for phone and tablet
@@ -171,6 +171,8 @@ All accessibility audit items must pass on every platform before release.
 
 - [User Guide](../user-guide/README.md) — End-user documentation
 - [Release Process](release-process.md) — Release workflows, versioning, hotfix, and rollback
+- [App Store Submission Guide](app-store-submission.md) — Submission metadata, checklists, and field values
+- [App Store Preparation Guide](app-store-preparation.md) — Developer account setup and store requirements
 - [Performance Guide](performance.md) — Performance targets and benchmarking
 - [Security Checklist](../audits/security-checklist.md) — OWASP MASVS L1 audit
 - [Accessibility Checklist](../audits/accessibility-checklist.md) — WCAG 2.2 AA audit

--- a/docs/guides/release-process.md
+++ b/docs/guides/release-process.md
@@ -10,7 +10,8 @@ This document describes how Finance releases are versioned, built, and distribut
 - [Per-Platform Release Pipelines](#per-platform-release-pipelines)
 - [Hotfix Process](#hotfix-process)
 - [Rollback Procedures](#rollback-procedures)
-- [Release Checklist](#release-checklist)
+- [Pre-Release Checklist](#pre-release-checklist)
+- [Post-Release Verification](#post-release-verification)
 
 ---
 
@@ -298,6 +299,8 @@ Use the hotfix process when:
 
 If a released version introduces a regression that wasn't caught in testing, you may need to roll back.
 
+> **📖 For detailed, step-by-step rollback instructions** — including database migration rollback and PowerSync conflict handling — see the dedicated [Rollback Procedures Guide](rollback-procedures.md).
+
 ### Web Rollback
 
 Web rollbacks are the simplest because Vercel keeps previous deployments:
@@ -335,28 +338,146 @@ Apple does not support rollbacks in the App Store:
 
 ---
 
-## Release Checklist
+## Pre-Release Checklist
 
-Before triggering any platform release, verify:
+Before triggering any platform release, every item below must be verified. A single unchecked item blocks the release unless the project lead grants a documented exception.
 
-- [ ] All CI checks pass on `main` (lint, test, build, security scans)
+### CI & Code Quality
+
+- [ ] All CI checks pass on `main` (lint, test, build, type-check)
 - [ ] Changeset version PR has been merged
 - [ ] `CHANGELOG.md` accurately describes user-facing changes
 - [ ] No `FIXME` or `TODO` items in the code being released
+- [ ] Version number confirmed — follows [semver rules](#semver-rules) and matches the platform format in [Version Format by Platform](#version-format-by-platform)
+
+### Security
+
+- [ ] Security audit critical items resolved — no FAIL items in the [OWASP MASVS L1 Security Checklist](../audits/security-checklist.md)
+- [ ] CodeQL scan passing — no high or critical findings ([`security.yml`](../../.github/workflows/security.yml))
+- [ ] Dependency audit clean — no critical or high CVEs in production dependencies (Dependabot / `dependency-review.yml`)
+- [ ] Secret scanning — no alerts in GitHub Advanced Security push protection
+- [ ] Security checklist reviewed for any auth/data changes
+
+### Privacy
+
+- [ ] Privacy audit critical items addressed — data practices verified per [Privacy & Compliance checklist](launch-checklist.md#privacy--compliance)
+- [ ] No PII, financial data, or credentials in logs, crash reports, or telemetry
+- [ ] Sentry `beforeSend` scrubbing rules verified (see [monitoring architecture](../architecture/monitoring.md#52-scrubbing-implementation))
+- [ ] Data collection inventory up to date — every metric collected is documented with purpose and legal basis
+
+### Monitoring & Alerting
+
+- [ ] Error tracking configured for the releasing platform (Sentry integration, consent-gated)
+- [ ] Sync health monitoring operational — `SyncHealthMonitor` thresholds reviewed (see [monitoring strategy](monitoring.md#sync-health-monitoring))
+- [ ] Alerting rules configured — team is notified when error rates or latency exceed thresholds (see [alert thresholds](monitoring.md#alert-thresholds-and-escalation))
+- [ ] Uptime monitoring active for API and web endpoints
+- [ ] Operational and client health dashboards accessible (see [monitoring architecture § dashboards](../architecture/monitoring.md#7-dashboards))
+
+### Performance
+
+- [ ] Performance baselines measured — cold start, scroll FPS, SQLite aggregation, memory usage (see [performance guide](performance.md))
+- [ ] Performance benchmarks show no regressions vs. previous release
+- [ ] Lighthouse CI passing for web releases (see [`web-ci.yml`](../../.github/workflows/web-ci.yml))
+- [ ] Bundle size within budget (no unexpected increases)
+
+### Testing & Beta
+
+- [ ] Beta testing completed with feedback addressed:
+  - iOS: TestFlight beta with ≥ 10 testers, ≥ 2-week testing period
+  - Android: Internal/closed track with ≥ 10 testers, ≥ 2-week testing period
+  - Web: Preview deployment shared with testers, feedback collected
+  - Windows: Flight ring with testers, feedback collected
+- [ ] Critical user flows validated by beta testers (onboarding, transactions, budgets, sync, export)
+- [ ] Bug reports from beta triaged — all critical and high-severity bugs resolved
 - [ ] Accessibility audit passes for any UI changes (see [accessibility checklist](../audits/accessibility-checklist.md))
-- [ ] Security checklist reviewed for any auth/data changes (see [security checklist](../audits/security-checklist.md))
-- [ ] Release notes written for the app store listing (plain language, user-facing)
-- [ ] Beta testing completed (TestFlight for iOS, internal track for Android, preview deploy for web, flight ring for Windows)
-- [ ] Performance benchmarks show no regressions (see [performance guide](performance.md))
+
+### Release Artifacts
+
+- [ ] Release notes drafted for the app store listing (plain language, user-facing)
+- [ ] App store metadata updated (screenshots, descriptions) if UI changed
 - [ ] Team notified in the release channel
+
+---
+
+## Post-Release Verification
+
+After a release reaches users, verify that everything is working as expected. Do not promote from internal/beta to production until these checks pass.
+
+### Smoke Test Checklist
+
+Run these critical user flows on the released build within 1 hour of deployment:
+
+| # | Test | iOS | Android | Web | Windows |
+|---|------|-----|---------|-----|---------|
+| 1 | App launches without crash | ☐ | ☐ | ☐ | ☐ |
+| 2 | User can sign in (existing account) | ☐ | ☐ | ☐ | ☐ |
+| 3 | User can create a new account | ☐ | ☐ | ☐ | ☐ |
+| 4 | Sync completes successfully (online) | ☐ | ☐ | ☐ | ☐ |
+| 5 | Add a transaction (< 10 s quick-entry) | ☐ | ☐ | ☐ | ☐ |
+| 6 | View budget overview | ☐ | ☐ | ☐ | ☐ |
+| 7 | View reports / charts | ☐ | ☐ | ☐ | ☐ |
+| 8 | Offline mode — make changes while offline | ☐ | ☐ | ☐ | ☐ |
+| 9 | Reconnect — offline changes sync correctly | ☐ | ☐ | ☐ | ☐ |
+| 10 | Export data (CSV / JSON) | ☐ | ☐ | ☐ | ☐ |
+| 11 | Screen reader announces key elements | ☐ | ☐ | ☐ | ☐ |
+| 12 | Settings / preferences load correctly | ☐ | ☐ | ☐ | ☐ |
+
+### Monitoring Dashboard Checks
+
+Within the first 30 minutes after users start receiving the update:
+
+- [ ] **Crash-free session rate** — verify ≥ 99.5% (check Sentry → Releases → new version)
+- [ ] **Error rate** — no spike compared to the previous version baseline
+- [ ] **Sync success rate** — remains above 95% (`sync_health_logs` aggregate)
+- [ ] **Sync latency P95** — remains below 5 s threshold
+- [ ] **API response time P95** — remains below 1 s
+- [ ] **Auth failure rate** — remains below 1%
+- [ ] **PowerSync queue depth** — no unexpected growth (< 1000 pending)
+- [ ] **Uptime monitors** — all green (API, web, PowerSync endpoints)
+
+### Error Rate Baseline Comparison
+
+Compare the new release's error metrics against the previous version during the same time window (first 24 hours):
+
+| Metric | Previous Release Baseline | New Release (24 h) | Status |
+|--------|---------------------------|---------------------|--------|
+| Crash-free sessions | __%% | __%% | ☐ |
+| Unhandled exceptions / 1k sessions | __ | __ | ☐ |
+| Sync failure rate | __%% | __%% | ☐ |
+| API 5xx error rate | __%% | __%% | ☐ |
+| Client `Unhealthy` sync status count | __ | __ | ☐ |
+
+**Action thresholds:**
+
+- **≤ 10% regression** — monitor for 24 more hours, no action needed.
+- **10–25% regression** — investigate root cause, consider halting staged rollout.
+- **> 25% regression or new P0/P1 errors** — halt rollout immediately, begin [rollback procedures](rollback-procedures.md).
+
+### Staged Rollout Progression
+
+For mobile platforms, follow this promotion schedule (adjust based on monitoring):
+
+| Stage | Audience | Duration | Gate |
+|-------|----------|----------|------|
+| Internal testing | Team only | 1–2 days | Smoke tests pass |
+| Beta / TestFlight | Beta testers | 3–7 days | No critical bugs reported |
+| Staged rollout 10% | 10% of production users | 2–3 days | Error rates within baseline |
+| Staged rollout 50% | 50% of production users | 1–2 days | Error rates within baseline |
+| Full rollout 100% | All users | — | No regressions detected |
+
+> **Never skip the staged rollout for mobile releases.** The blast radius of a broken mobile update is much larger than web because users cannot be instantly rolled back.
 
 ---
 
 ## References
 
+- [Rollback Procedures](rollback-procedures.md) — Detailed rollback instructions for every platform, database, and sync
 - [ADR-0006: CI/CD Strategy](../architecture/0006-cicd-strategy.md) — Architectural decisions for the CI/CD pipeline
+- [Monitoring Architecture](../architecture/monitoring.md) — Error tracking, sync health, dashboards, and alerting
+- [Monitoring Strategy](monitoring.md) — Privacy-respecting observability setup
 - [Changesets documentation](https://github.com/changesets/changesets) — Upstream docs for the versioning tool
 - [Fastlane documentation](https://docs.fastlane.tools/) — Mobile build and release automation
 - [Performance Guide](performance.md) — Performance targets and benchmarking
 - [Security Checklist](../audits/security-checklist.md) — OWASP MASVS L1 audit items
 - [Accessibility Checklist](../audits/accessibility-checklist.md) — WCAG 2.2 AA audit items
+- [Launch Checklist](launch-checklist.md) — Complete pre-launch verification

--- a/docs/guides/release-process.md
+++ b/docs/guides/release-process.md
@@ -407,20 +407,20 @@ After a release reaches users, verify that everything is working as expected. Do
 
 Run these critical user flows on the released build within 1 hour of deployment:
 
-| # | Test | iOS | Android | Web | Windows |
-|---|------|-----|---------|-----|---------|
-| 1 | App launches without crash | ☐ | ☐ | ☐ | ☐ |
-| 2 | User can sign in (existing account) | ☐ | ☐ | ☐ | ☐ |
-| 3 | User can create a new account | ☐ | ☐ | ☐ | ☐ |
-| 4 | Sync completes successfully (online) | ☐ | ☐ | ☐ | ☐ |
-| 5 | Add a transaction (< 10 s quick-entry) | ☐ | ☐ | ☐ | ☐ |
-| 6 | View budget overview | ☐ | ☐ | ☐ | ☐ |
-| 7 | View reports / charts | ☐ | ☐ | ☐ | ☐ |
-| 8 | Offline mode — make changes while offline | ☐ | ☐ | ☐ | ☐ |
-| 9 | Reconnect — offline changes sync correctly | ☐ | ☐ | ☐ | ☐ |
-| 10 | Export data (CSV / JSON) | ☐ | ☐ | ☐ | ☐ |
-| 11 | Screen reader announces key elements | ☐ | ☐ | ☐ | ☐ |
-| 12 | Settings / preferences load correctly | ☐ | ☐ | ☐ | ☐ |
+| #   | Test                                       | iOS | Android | Web | Windows |
+| --- | ------------------------------------------ | --- | ------- | --- | ------- |
+| 1   | App launches without crash                 | ☐   | ☐       | ☐   | ☐       |
+| 2   | User can sign in (existing account)        | ☐   | ☐       | ☐   | ☐       |
+| 3   | User can create a new account              | ☐   | ☐       | ☐   | ☐       |
+| 4   | Sync completes successfully (online)       | ☐   | ☐       | ☐   | ☐       |
+| 5   | Add a transaction (< 10 s quick-entry)     | ☐   | ☐       | ☐   | ☐       |
+| 6   | View budget overview                       | ☐   | ☐       | ☐   | ☐       |
+| 7   | View reports / charts                      | ☐   | ☐       | ☐   | ☐       |
+| 8   | Offline mode — make changes while offline  | ☐   | ☐       | ☐   | ☐       |
+| 9   | Reconnect — offline changes sync correctly | ☐   | ☐       | ☐   | ☐       |
+| 10  | Export data (CSV / JSON)                   | ☐   | ☐       | ☐   | ☐       |
+| 11  | Screen reader announces key elements       | ☐   | ☐       | ☐   | ☐       |
+| 12  | Settings / preferences load correctly      | ☐   | ☐       | ☐   | ☐       |
 
 ### Monitoring Dashboard Checks
 
@@ -439,13 +439,13 @@ Within the first 30 minutes after users start receiving the update:
 
 Compare the new release's error metrics against the previous version during the same time window (first 24 hours):
 
-| Metric | Previous Release Baseline | New Release (24 h) | Status |
-|--------|---------------------------|---------------------|--------|
-| Crash-free sessions | __%% | __%% | ☐ |
-| Unhandled exceptions / 1k sessions | __ | __ | ☐ |
-| Sync failure rate | __%% | __%% | ☐ |
-| API 5xx error rate | __%% | __%% | ☐ |
-| Client `Unhealthy` sync status count | __ | __ | ☐ |
+| Metric                               | Previous Release Baseline | New Release (24 h) | Status |
+| ------------------------------------ | ------------------------- | ------------------ | ------ |
+| Crash-free sessions                  | \_\_%%                    | \_\_%%             | ☐      |
+| Unhandled exceptions / 1k sessions   | \_\_                      | \_\_               | ☐      |
+| Sync failure rate                    | \_\_%%                    | \_\_%%             | ☐      |
+| API 5xx error rate                   | \_\_%%                    | \_\_%%             | ☐      |
+| Client `Unhealthy` sync status count | \_\_                      | \_\_               | ☐      |
 
 **Action thresholds:**
 
@@ -457,13 +457,13 @@ Compare the new release's error metrics against the previous version during the 
 
 For mobile platforms, follow this promotion schedule (adjust based on monitoring):
 
-| Stage | Audience | Duration | Gate |
-|-------|----------|----------|------|
-| Internal testing | Team only | 1–2 days | Smoke tests pass |
-| Beta / TestFlight | Beta testers | 3–7 days | No critical bugs reported |
+| Stage              | Audience                | Duration | Gate                        |
+| ------------------ | ----------------------- | -------- | --------------------------- |
+| Internal testing   | Team only               | 1–2 days | Smoke tests pass            |
+| Beta / TestFlight  | Beta testers            | 3–7 days | No critical bugs reported   |
 | Staged rollout 10% | 10% of production users | 2–3 days | Error rates within baseline |
 | Staged rollout 50% | 50% of production users | 1–2 days | Error rates within baseline |
-| Full rollout 100% | All users | — | No regressions detected |
+| Full rollout 100%  | All users               | —        | No regressions detected     |
 
 > **Never skip the staged rollout for mobile releases.** The blast radius of a broken mobile update is much larger than web because users cannot be instantly rolled back.
 

--- a/docs/guides/rollback-procedures.md
+++ b/docs/guides/rollback-procedures.md
@@ -24,12 +24,12 @@ Detailed rollback instructions for every platform, database migration, and sync 
 
 Before initiating a rollback, assess the situation using these criteria:
 
-| Severity | Symptoms | Action |
-|----------|----------|--------|
-| **P0 — Data loss or corruption** | Users report missing or garbled data; sync writes incorrect values | Immediate rollback on all affected platforms. Halt all staged rollouts. |
-| **P1 — Crash on launch** | Crash-free rate drops below 95%; app unusable for a significant portion of users | Immediate rollback. Use hotfix process in parallel. |
-| **P2 — Feature broken** | A core feature (transactions, budgets, sync) is broken but app launches | Halt staged rollout. Ship hotfix within 24 hours. Rollback if hotfix timeline exceeds 48 hours. |
-| **P3 — Minor regression** | UI glitch, non-critical feature affected | Do NOT roll back. Ship fix in next regular release. |
+| Severity                         | Symptoms                                                                         | Action                                                                                          |
+| -------------------------------- | -------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| **P0 — Data loss or corruption** | Users report missing or garbled data; sync writes incorrect values               | Immediate rollback on all affected platforms. Halt all staged rollouts.                         |
+| **P1 — Crash on launch**         | Crash-free rate drops below 95%; app unusable for a significant portion of users | Immediate rollback. Use hotfix process in parallel.                                             |
+| **P2 — Feature broken**          | A core feature (transactions, budgets, sync) is broken but app launches          | Halt staged rollout. Ship hotfix within 24 hours. Rollback if hotfix timeline exceeds 48 hours. |
+| **P3 — Minor regression**        | UI glitch, non-critical feature affected                                         | Do NOT roll back. Ship fix in next regular release.                                             |
 
 > **Rule of thumb:** Roll back if the issue affects > 5% of users AND the hotfix cannot ship within 24 hours. For data integrity issues, always roll back immediately regardless of hotfix timeline.
 
@@ -176,6 +176,7 @@ Apple does not support rollbacks in the App Store. Users who have updated cannot
 ### Prevention Strategy
 
 > **For iOS, prevention is the best rollback strategy.** Always:
+>
 > - Use TestFlight with a meaningful beta period (minimum 3–7 days) before promoting to App Store.
 > - Use phased release (automatic 7-day rollout) rather than immediate release to all users.
 > - Enable **Phased Release** in App Store Connect: this distributes the update to 1%, 2%, 5%, 10%, 20%, 50%, 100% over 7 days, giving time to catch issues.
@@ -285,14 +286,14 @@ Every migration file in `services/api/supabase/migrations/` SHOULD have a corres
 
 ### Common Rollback Patterns
 
-| Migration Type | Rollback Approach | Risk Level |
-|----------------|-------------------|------------|
-| **Add new table** | `DROP TABLE IF EXISTS <table>` (safe if table is unused) | Low |
-| **Add new column** | `ALTER TABLE <table> DROP COLUMN <column>` (safe if column is unused) | Low |
-| **Alter column type** | `ALTER TABLE <table> ALTER COLUMN <column> TYPE <old_type>` | Medium — may fail if data doesn't fit old type |
-| **Add RLS policy** | `DROP POLICY <policy> ON <table>` | Medium — verify no security gap |
-| **Drop column** | **Cannot roll back** — data is gone. Must restore from backup. | Critical |
-| **Data migration** | **Cannot roll back** — must restore from backup or run reverse data migration. | Critical |
+| Migration Type        | Rollback Approach                                                              | Risk Level                                     |
+| --------------------- | ------------------------------------------------------------------------------ | ---------------------------------------------- |
+| **Add new table**     | `DROP TABLE IF EXISTS <table>` (safe if table is unused)                       | Low                                            |
+| **Add new column**    | `ALTER TABLE <table> DROP COLUMN <column>` (safe if column is unused)          | Low                                            |
+| **Alter column type** | `ALTER TABLE <table> ALTER COLUMN <column> TYPE <old_type>`                    | Medium — may fail if data doesn't fit old type |
+| **Add RLS policy**    | `DROP POLICY <policy> ON <table>`                                              | Medium — verify no security gap                |
+| **Drop column**       | **Cannot roll back** — data is gone. Must restore from backup.                 | Critical                                       |
+| **Data migration**    | **Cannot roll back** — must restore from backup or run reverse data migration. | Critical                                       |
 
 ### Backup Verification
 
@@ -347,12 +348,12 @@ If the broken release did NOT change the database schema (pure UI/logic bug):
 
 During any rollback, expect a period where multiple client versions are active:
 
-| Client State | Action |
-|-------------|--------|
-| Never updated (still on v1.3.0) | No action — working normally |
-| Updated to v1.3.1 (broken) | Will receive v1.3.2 via auto-update |
+| Client State                                     | Action                                                         |
+| ------------------------------------------------ | -------------------------------------------------------------- |
+| Never updated (still on v1.3.0)                  | No action — working normally                                   |
+| Updated to v1.3.1 (broken)                       | Will receive v1.3.2 via auto-update                            |
 | Updated to v1.3.1, has pending offline mutations | Mutations will upload when online — ensure server accepts them |
-| Updated to v1.3.2 (fix) | Working normally |
+| Updated to v1.3.2 (fix)                          | Working normally                                               |
 
 **Key principle:** The server must accept writes from ALL active client versions during the transition period. Use versioned API endpoints or schema-tolerant sync rules.
 

--- a/docs/guides/rollback-procedures.md
+++ b/docs/guides/rollback-procedures.md
@@ -1,0 +1,465 @@
+# Rollback Procedures
+
+Detailed rollback instructions for every platform, database migration, and sync layer. Use this guide when a released version introduces a regression that requires reverting to a previous version.
+
+**Related:** [Release Process](release-process.md) · [Monitoring Strategy](monitoring.md) · [Monitoring Architecture](../architecture/monitoring.md)
+
+---
+
+## Table of Contents
+
+- [Decision Framework](#decision-framework)
+- [Web — Vercel Rollback](#web--vercel-rollback)
+- [Android — Google Play Store Rollback](#android--google-play-store-rollback)
+- [iOS — App Store Rollback](#ios--app-store-rollback)
+- [Windows — Microsoft Store Rollback](#windows--microsoft-store-rollback)
+- [Database — Migration Rollback](#database--migration-rollback)
+- [Sync — PowerSync Conflict Handling During Rollback](#sync--powersync-conflict-handling-during-rollback)
+- [Communication Templates](#communication-templates)
+- [Post-Rollback Checklist](#post-rollback-checklist)
+
+---
+
+## Decision Framework
+
+Before initiating a rollback, assess the situation using these criteria:
+
+| Severity | Symptoms | Action |
+|----------|----------|--------|
+| **P0 — Data loss or corruption** | Users report missing or garbled data; sync writes incorrect values | Immediate rollback on all affected platforms. Halt all staged rollouts. |
+| **P1 — Crash on launch** | Crash-free rate drops below 95%; app unusable for a significant portion of users | Immediate rollback. Use hotfix process in parallel. |
+| **P2 — Feature broken** | A core feature (transactions, budgets, sync) is broken but app launches | Halt staged rollout. Ship hotfix within 24 hours. Rollback if hotfix timeline exceeds 48 hours. |
+| **P3 — Minor regression** | UI glitch, non-critical feature affected | Do NOT roll back. Ship fix in next regular release. |
+
+> **Rule of thumb:** Roll back if the issue affects > 5% of users AND the hotfix cannot ship within 24 hours. For data integrity issues, always roll back immediately regardless of hotfix timeline.
+
+---
+
+## Web — Vercel Rollback
+
+**Time to restore:** < 1 minute (instant redeployment)
+
+Web rollbacks are the simplest because Vercel retains every previous deployment as an immutable artifact.
+
+### Option 1: Vercel Dashboard (Recommended)
+
+1. Open the [Vercel dashboard](https://vercel.com) → select the Finance web project.
+2. Navigate to **Deployments**.
+3. Find the last known-good production deployment (look for the ✅ marker on the previous version).
+4. Click the **⋯** menu → **Promote to Production**.
+5. Confirm the promotion. The previous version is live within seconds.
+6. Verify by loading the production URL and checking the app version in the footer or console.
+
+### Option 2: Git Revert
+
+If Vercel auto-deploys from `main`, you can revert the commit:
+
+```bash
+# Identify the merge commit that introduced the regression
+git log --oneline -10
+
+# Revert it
+git revert <commit-sha> --no-edit
+
+# Push to main — Vercel auto-deploys the reverted state
+git push origin main
+```
+
+> ⚠️ **The `git push` above is a remote operation.** Do not execute it without human approval. Prepare the revert commit locally and request approval to push.
+
+### Post-Rollback
+
+- [ ] Verify production URL serves the previous version
+- [ ] Check Lighthouse CI scores haven't degraded
+- [ ] Confirm service worker cache is invalidated (users may need a hard refresh)
+- [ ] Monitor error rates in Sentry for the web platform
+
+---
+
+## Android — Google Play Store Rollback
+
+**Time to restore:** Minutes to hours (depending on rollout stage)
+
+Google Play does not support "reverting" to a previous version. You must publish a new release with a higher `versionCode`.
+
+### If in Staged Rollout (< 100%)
+
+1. Open [Google Play Console](https://play.google.com/console) → select Finance.
+2. Navigate to **Release** → **Production** (or the affected track).
+3. Click **Halt rollout** to stop the broken version from reaching additional users.
+4. Users who already updated will keep the broken version until a fix ships.
+5. To restore the previous behavior:
+   - Build the previous release source with an **incremented `versionCode`** (e.g., if broken = `10301`, new = `10302`).
+   - Upload the AAB and resume rollout with the fix.
+
+### If Fully Rolled Out (100%)
+
+1. **Immediately** begin the [hotfix process](release-process.md#hotfix-process):
+
+   ```bash
+   git checkout -b hotfix/android-v1.3.1 android/v1.3.0
+   ```
+
+2. Apply the revert/fix, increment `versionCode`, build a signed AAB.
+3. Upload to Play Console → **Internal testing** track first.
+4. Smoke test on the internal track.
+5. Promote directly to **Production** (skip staged rollout for hotfixes if severity is P0/P1).
+
+### Emergency: Managed Publishing
+
+If the broken version has not yet gone live (Play Console shows "In review" or "Pending publication"):
+
+1. Go to **Publishing overview** → enable **Managed publishing** if not already enabled.
+2. Find the pending release and **unpublish** it before it goes live.
+3. This prevents the broken version from reaching any users.
+
+### Build Number Rules
+
+Android `versionCode` must always increase. When rolling back code to a previous version, you must still increment the `versionCode`:
+
+```
+v1.3.0 (versionCode 10300) — working
+v1.3.1 (versionCode 10301) — broken ← users got this
+v1.3.2 (versionCode 10302) — rollback (same code as v1.3.0, new versionCode)
+```
+
+### Post-Rollback
+
+- [ ] Verify the fix build is live on Play Console
+- [ ] Monitor crash-free rate in Sentry → Releases → new version
+- [ ] Check `sync_health_logs` for Android devices — sync success rate recovering
+- [ ] Monitor Play Console → **Android vitals** for ANR rate and crash rate
+
+---
+
+## iOS — App Store Rollback
+
+**Time to restore:** 24–48 hours (App Store review required)
+
+Apple does not support rollbacks in the App Store. Users who have updated cannot downgrade. The only path is to ship a new version with the fix.
+
+### If in TestFlight Only (Not Live in App Store)
+
+1. Open [App Store Connect](https://appstoreconnect.apple.com) → select Finance.
+2. Navigate to **TestFlight** → find the broken build.
+3. Click the build → **Expire Build**. This removes it from TestFlight and testers revert to the previous available build.
+4. If no previous build is available on TestFlight, upload a known-good build:
+
+   ```bash
+   git checkout ios/v1.2.0  # previous good tag
+   # Build and upload via Fastlane
+   ```
+
+### If Live in App Store
+
+1. **Begin the [hotfix process](release-process.md#hotfix-process) immediately:**
+
+   ```bash
+   git checkout -b hotfix/ios-v1.3.1 ios/v1.3.0
+   ```
+
+2. Apply the revert/fix, bump `CFBundleShortVersionString` to `1.3.1`, increment build number.
+3. Build via Fastlane `gym` and upload to TestFlight via `pilot`.
+4. Run a rapid smoke test on TestFlight (15–30 min minimum).
+5. Submit to App Store for review.
+
+6. **Request Expedited Review:**
+   - In App Store Connect, after submitting the build, click **Contact Us** or use the **Request Expedited Review** option.
+   - Explain this is a critical bug fix (crash, data loss, security issue).
+   - Apple typically processes expedited reviews within 24 hours.
+
+7. **While waiting for review**, communicate to users via:
+   - In-app message (if the app still launches) suggesting workarounds.
+   - Support channels (email, social media).
+   - Status page update (if configured).
+
+### Prevention Strategy
+
+> **For iOS, prevention is the best rollback strategy.** Always:
+> - Use TestFlight with a meaningful beta period (minimum 3–7 days) before promoting to App Store.
+> - Use phased release (automatic 7-day rollout) rather than immediate release to all users.
+> - Enable **Phased Release** in App Store Connect: this distributes the update to 1%, 2%, 5%, 10%, 20%, 50%, 100% over 7 days, giving time to catch issues.
+
+### Post-Rollback
+
+- [ ] Verify the fix build is approved and live in the App Store
+- [ ] Monitor Sentry → Releases → new iOS version for crash reports
+- [ ] Check TestFlight crash logs for any lingering issues
+- [ ] Verify sync health on iOS devices via `sync_health_logs`
+- [ ] Update the App Store "What's New" text to mention the fix
+
+---
+
+## Windows — Microsoft Store Rollback
+
+**Time to restore:** 24–48 hours (Store certification required)
+
+### If in Flight Ring Only (Not Live in Store)
+
+1. Open [Partner Center](https://partner.microsoft.com/dashboard) → select Finance.
+2. Navigate to **Packages** → **Package flights**.
+3. Find the flight ring containing the broken build.
+4. Remove the broken MSIX package from the flight and save.
+5. Upload a known-good MSIX if testers need a working version.
+
+### If Live in Microsoft Store
+
+1. **Begin the [hotfix process](release-process.md#hotfix-process):**
+
+   ```bash
+   git checkout -b hotfix/windows-v1.3.1 windows/v1.3.0
+   ```
+
+2. Apply the revert/fix, bump the MSIX version to `1.3.1.0`.
+3. Build the MSIX package (`./gradlew :apps:windows:packageMsi`).
+4. Submit via Partner Center or the MS Store Submission API.
+5. Request **expedited certification** in the submission notes (explain the severity).
+
+### Gradual Rollout
+
+Use Partner Center's **gradual rollout** feature to limit exposure:
+
+1. In the submission, enable **gradual rollout**.
+2. Set the initial percentage (e.g., 10%).
+3. Monitor error rates before increasing to 50%, then 100%.
+4. If issues are detected, **Halt** the rollout from Partner Center.
+
+### MSIX Version Rules
+
+MSIX versions must be four-part (`Major.Minor.Patch.Revision`) and must always increase:
+
+```
+1.3.0.0 — working
+1.3.1.0 — broken
+1.3.2.0 — rollback (same code as 1.3.0.0, higher version number)
+```
+
+The fourth segment is reserved by the Store and must be `0`.
+
+### Post-Rollback
+
+- [ ] Verify the fix package passed Store certification
+- [ ] Monitor Sentry → Releases → new Windows version
+- [ ] Check Windows App Certification Kit (WACK) results
+- [ ] Verify auto-update picks up the fix version on test devices
+
+---
+
+## Database — Migration Rollback
+
+Database rollback is the most dangerous operation. Supabase migrations are forward-only by default. Rolling back requires explicit down-migration scripts.
+
+### Prerequisites
+
+Every migration file in `services/api/supabase/migrations/` SHOULD have a corresponding rollback script documented in the migration's header comment or in a `rollback/` companion directory.
+
+### Rollback Steps
+
+1. **Identify the problematic migration:**
+
+   ```bash
+   # List recent migrations applied to the database
+   ls -la services/api/supabase/migrations/
+   ```
+
+2. **Verify the rollback script exists and is safe:**
+   - Read the migration file to understand what it changed (new tables, altered columns, new RLS policies).
+   - Confirm the rollback script reverses the changes without data loss.
+   - **NEVER run `DROP TABLE` or `TRUNCATE` without verifying that no user data will be lost.**
+
+3. **Test the rollback on a staging/local environment first:**
+
+   ```bash
+   # Reset local Supabase and apply migrations up to the target version
+   npx supabase db reset  # local only
+   ```
+
+4. **Apply the rollback to production:**
+
+   > ⚠️ **This is a destructive operation.** Do NOT execute rollback SQL on production without explicit human approval from the project lead. Prepare the SQL, explain its impact, and request approval.
+
+5. **Verify data integrity after rollback:**
+   - Run validation queries to confirm row counts and data consistency.
+   - Verify RLS policies are intact (run as both `anon` and `authenticated` roles).
+   - Check that Edge Functions still work with the rolled-back schema.
+
+### Common Rollback Patterns
+
+| Migration Type | Rollback Approach | Risk Level |
+|----------------|-------------------|------------|
+| **Add new table** | `DROP TABLE IF EXISTS <table>` (safe if table is unused) | Low |
+| **Add new column** | `ALTER TABLE <table> DROP COLUMN <column>` (safe if column is unused) | Low |
+| **Alter column type** | `ALTER TABLE <table> ALTER COLUMN <column> TYPE <old_type>` | Medium — may fail if data doesn't fit old type |
+| **Add RLS policy** | `DROP POLICY <policy> ON <table>` | Medium — verify no security gap |
+| **Drop column** | **Cannot roll back** — data is gone. Must restore from backup. | Critical |
+| **Data migration** | **Cannot roll back** — must restore from backup or run reverse data migration. | Critical |
+
+### Backup Verification
+
+Before any database rollback:
+
+- [ ] Confirm Supabase point-in-time recovery (PITR) is enabled
+- [ ] Note the current timestamp for potential PITR restore
+- [ ] Verify the most recent backup is healthy (Supabase Dashboard → Database → Backups)
+
+---
+
+## Sync — PowerSync Conflict Handling During Rollback
+
+Rolling back a client app version while the sync layer is active creates potential conflicts. Different client versions may have different schemas, different write rules, or different data expectations.
+
+### Scenario: Client Rollback with Schema Change
+
+If the broken release included a database schema change (new column, new table) AND clients already synced data using the new schema:
+
+```
+Timeline:
+  v1.3.0 (old schema)  →  v1.3.1 (new schema, broken)  →  v1.3.2 (rolled back to old schema)
+                              ↑
+                     Some clients synced data with new columns
+```
+
+**Resolution steps:**
+
+1. **PowerSync sync rules must handle both schemas.** Ensure the PowerSync sync rules (`services/api/powersync/`) accept writes from both old and new schema versions gracefully.
+
+2. **Server-side schema must remain backward-compatible:**
+   - Do NOT drop the new columns/tables from the server database during rollback — old-version clients that haven't updated yet will still send data with the old schema, and clients that briefly ran the new version may have writes in the PowerSync upload queue.
+   - Instead, make the new columns nullable or add default values so old-version clients don't break.
+
+3. **Handle orphaned data:**
+   - Data written to new columns by v1.3.1 clients may be meaningless after rollback. Mark it for cleanup but do not delete it immediately.
+   - Add a migration in the next release to clean up orphaned data if needed.
+
+4. **Monitor the PowerSync queue:**
+   - Watch for upload failures in `sync_health_logs` — these indicate schema mismatches.
+   - Check the PowerSync dashboard for elevated conflict rates.
+
+### Scenario: Client Rollback Without Schema Change
+
+If the broken release did NOT change the database schema (pure UI/logic bug):
+
+- Rollback is safe from a sync perspective.
+- Pending mutations from the broken version will still sync correctly because the schema hasn't changed.
+- No special PowerSync handling required.
+
+### Scenario: Multiple Client Versions Active Simultaneously
+
+During any rollback, expect a period where multiple client versions are active:
+
+| Client State | Action |
+|-------------|--------|
+| Never updated (still on v1.3.0) | No action — working normally |
+| Updated to v1.3.1 (broken) | Will receive v1.3.2 via auto-update |
+| Updated to v1.3.1, has pending offline mutations | Mutations will upload when online — ensure server accepts them |
+| Updated to v1.3.2 (fix) | Working normally |
+
+**Key principle:** The server must accept writes from ALL active client versions during the transition period. Use versioned API endpoints or schema-tolerant sync rules.
+
+### PowerSync Conflict Resolution During Rollback
+
+Finance uses PowerSync's CRDT-based conflict resolution. During a rollback:
+
+1. **Last-write-wins (LWW)** applies to most fields — the most recent write wins regardless of client version.
+2. **Delete conflicts** — if a rolled-back client doesn't know about a record created by the broken version, it won't delete it. The record persists on the server. Clean up in the next release if needed.
+3. **Queue depth monitoring** — watch `pending_mutations` on clients. If it grows unexpectedly, investigate whether the server is rejecting writes from old-schema clients.
+
+### Post-Rollback Sync Verification
+
+- [ ] PowerSync dashboard shows no elevated error rates
+- [ ] `sync_health_logs` shows sync success rate recovering to baseline
+- [ ] No clients stuck in `Unhealthy` sync status for > 30 minutes
+- [ ] Conflict rate returns to baseline (< 5% of syncs)
+- [ ] Upload queue depth is stable or decreasing across all platforms
+
+---
+
+## Communication Templates
+
+Use these templates to notify stakeholders during a rollback.
+
+### Internal Team Notification (Slack / Teams)
+
+```
+🚨 ROLLBACK IN PROGRESS — [Platform] v[X.Y.Z]
+
+Issue: [Brief description of the regression]
+Severity: [P0/P1/P2]
+Affected users: [Estimated count or percentage]
+Action: Rolling back to v[X.Y.Z-1]. Hotfix branch created.
+ETA for fix: [Estimated time]
+
+Tracking: [Link to GitHub issue]
+Dashboard: [Link to monitoring dashboard]
+
+Please hold off on any [platform] releases until the all-clear.
+```
+
+### User-Facing Status Update (Status Page / Social)
+
+```
+We're aware of an issue with the latest [Platform] update (v[X.Y.Z])
+that may cause [brief user-visible symptom].
+
+We're rolling out a fix now. Most users will receive the update
+automatically within [timeframe].
+
+Your data is safe — [platform]'s offline storage ensures no data
+is lost during this process.
+
+We apologize for the inconvenience. Updates will be posted here.
+```
+
+### Post-Rollback All-Clear
+
+```
+✅ ROLLBACK COMPLETE — [Platform] v[X.Y.Z]
+
+The fix (v[X.Y.Z+1]) is now live. Monitoring confirms:
+- Crash-free rate: [XX]%
+- Sync success rate: [XX]%
+- Error rate: back to baseline
+
+Root cause: [One-line summary]
+Post-incident review scheduled: [Date/time]
+```
+
+---
+
+## Post-Rollback Checklist
+
+After completing a rollback on any platform:
+
+### Immediate (Within 1 Hour)
+
+- [ ] Rollback version is live and accessible to users
+- [ ] Smoke tests pass on the rolled-back version (see [Post-Release Verification](release-process.md#post-release-verification))
+- [ ] Monitoring dashboards confirm error rates returning to baseline
+- [ ] Internal team notified of rollback status
+- [ ] User-facing communication sent (if applicable)
+
+### Short-Term (Within 24 Hours)
+
+- [ ] Root cause identified and documented in the GitHub issue
+- [ ] Hotfix PR opened with regression test that covers the bug
+- [ ] Post-incident review scheduled (blameless retrospective)
+- [ ] Staged rollout percentages reset for the next release
+- [ ] Release checklist updated if the regression could have been caught earlier
+
+### Follow-Up (Within 1 Week)
+
+- [ ] Post-incident review completed — action items documented
+- [ ] Regression test added to CI to prevent recurrence
+- [ ] Release process improvements implemented (if any identified)
+- [ ] Monitoring thresholds adjusted if the issue wasn't caught fast enough
+- [ ] Updated this runbook if the rollback process revealed gaps
+
+---
+
+## References
+
+- [Release Process](release-process.md) — Full release workflow, changesets, and hotfix process
+- [Monitoring Strategy](monitoring.md) — Sync health, API metrics, and alert thresholds
+- [Monitoring Architecture](../architecture/monitoring.md) — Sentry integration, dashboards, and privacy guardrails
+- [Performance Guide](performance.md) — Performance baselines for comparison
+- [Launch Checklist](launch-checklist.md) — Pre-launch verification including incident response readiness


### PR DESCRIPTION
## Summary
Launch preparation documentation for app store submission, beta testing, and release validation.

## App Store Submission (#409)
- iOS, Android, Windows, Web store listing guides with metadata templates
- Privacy labels, screenshot specs, content rating guidance
- 27-item pre-submission checklist and post-submission runbook

## Beta Testing Program (#411)
- Recruitment across personas and accessibility needs
- 13-scenario test checklist, feedback templates, GA exit criteria

## Release Process (#412)
- Enhanced pre-release checklist, post-release smoke tests
- Staged rollout schedule, rollback procedures per platform
- Database migration and PowerSync conflict handling

Closes #409
Closes #411
Closes #412
