### PR TITLE
fix(ci): skip add-to-project when PAT not configured (#427)

### DIFF
--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -8,16 +8,19 @@ on:
 
 jobs:
   add-to-project:
+    # Projects V2 requires a PAT with `project` scope — GITHUB_TOKEN is insufficient.
+    # This job is skipped when the ADD_TO_PROJECT_PAT secret is not configured.
+    # Setup: create a PAT (classic) with `project` scope, add it as a repository
+    # secret named ADD_TO_PROJECT_PAT.
+    if: ${{ secrets.ADD_TO_PROJECT_PAT != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    continue-on-error: true
     permissions:
       issues: write
       pull-requests: write
-      repository-projects: write
     steps:
       - name: Add to project
         uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: https://github.com/users/jrmoulckers/projects/2
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
## Summary

Fix the add-to-project CI check that fails on every PR with `Could not resolve to a ProjectV2 with the number 2`.

## Root Cause

`GITHUB_TOKEN` lacks the `project` scope required by GitHub Projects V2. The `actions/add-to-project` action needs a PAT.

## Changes

- Gate the job on `ADD_TO_PROJECT_PAT` secret being configured
- Use `ADD_TO_PROJECT_PAT` instead of `GITHUB_TOKEN`
- Remove `continue-on-error` (job now skips cleanly instead of failing)
- Remove `repository-projects` permission (PAT provides its own scope)

## After Merge

Create a PAT (classic) with `project` scope and add as repo secret `ADD_TO_PROJECT_PAT` to activate project board automation.

Closes #427
