### PR TITLE
chore(github): add CODEOWNERS for automated review routing (#200)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,25 +1,35 @@
-# Default
+# Finance Monorepo — Code Owners
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default — catch-all
 * @jrmoulckers
 
-# Shared packages
-packages/core/ @jrmoulckers
-packages/models/ @jrmoulckers
-packages/sync/ @jrmoulckers
-packages/design-tokens/ @jrmoulckers
+# Platform applications
+/apps/android/          @jrmoulckers
+/apps/ios/              @jrmoulckers
+/apps/web/              @jrmoulckers
+/apps/windows/          @jrmoulckers
 
-# Platform apps
-apps/android/ @jrmoulckers
-apps/ios/ @jrmoulckers
-apps/web/ @jrmoulckers
-apps/windows/ @jrmoulckers
+# Shared packages (critical — changes affect all platforms)
+/packages/core/         @jrmoulckers
+/packages/models/       @jrmoulckers
+/packages/sync/         @jrmoulckers
+/packages/design-tokens/ @jrmoulckers
 
-# Backend
-services/api/ @jrmoulckers
-
-# Infrastructure
-.github/ @jrmoulckers
-build-logic/ @jrmoulckers
-gradle/ @jrmoulckers
+# Backend services
+/services/api/          @jrmoulckers
 
 # Documentation
-docs/ @jrmoulckers
+/docs/                  @jrmoulckers
+
+# Build infrastructure
+/build-logic/           @jrmoulckers
+/tools/                 @jrmoulckers
+/.github/               @jrmoulckers
+
+# Configuration files (high impact)
+/gradle/                @jrmoulckers
+/*.gradle.kts           @jrmoulckers
+/gradle.properties      @jrmoulckers
+/turbo.json             @jrmoulckers
+/package.json           @jrmoulckers

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -170,6 +170,12 @@ finance/
 └── .vscode/        # VS Code workspace config (MCP, settings)
 ```
 
+## Review Routing
+
+GitHub uses [`.github/CODEOWNERS`](./CODEOWNERS) to automatically request review from the repository owner for changes in high-impact areas such as shared packages, platform apps, backend services, build infrastructure, and repository configuration.
+
+If your pull request spans multiple areas, GitHub will apply the most specific matching rule for each changed path. Update `CODEOWNERS` in the same pull request whenever ownership changes so review routing stays accurate.
+
 ## Need Help?
 
 - Read `docs/ai/` for full AI workflow documentation


### PR DESCRIPTION
## Summary
Add \.github/CODEOWNERS\ file for automated review assignment, mapping all major paths to \@jrmoulckers\.

## Changes
- Created \.github/CODEOWNERS\ covering apps/, packages/, services/, docs/, tools/, build-logic/, and config files
- Updated \.github/CONTRIBUTING.md\ with Review Routing section

Closes #200