### PR TITLE
feat(android): implement data layer with repository pattern and SQLDelight wiring (#429, #432)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,4 +93,5 @@ coverage/
 
 # === Build caches ===
 .turbo/
+.kotlin/
 kotlin-js-store/

--- a/apps/android/build.gradle.kts
+++ b/apps/android/build.gradle.kts
@@ -51,6 +51,13 @@ dependencies {
     // Date/time utilities
     implementation(libs.kotlinx.datetime)
 
+    // SQLDelight (runtime + coroutines extensions for repository implementations)
+    implementation(libs.sqldelight.runtime)
+    implementation(libs.sqldelight.coroutines)
+
+    // Serialization (Transaction tags JSON encoding)
+    implementation(libs.kotlinx.serialization.json)
+
     // Compose BOM — manages all Compose library versions
     val composeBom = platform(libs.compose.bom)
     implementation(composeBom)

--- a/apps/android/src/main/kotlin/com/finance/android/FinanceApplication.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/FinanceApplication.kt
@@ -4,6 +4,7 @@ package com.finance.android
 
 import android.app.Application
 import com.finance.android.di.appModule
+import com.finance.android.di.dataModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.startKoin
@@ -35,7 +36,7 @@ class FinanceApplication : Application() {
         startKoin {
             androidLogger(if (BuildConfig.DEBUG) Level.DEBUG else Level.NONE)
             androidContext(this@FinanceApplication)
-            modules(appModule)
+            modules(appModule, dataModule)
         }
         Timber.i("Koin DI initialized")
     }

--- a/apps/android/src/main/kotlin/com/finance/android/data/repository/AccountRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/data/repository/AccountRepository.kt
@@ -3,34 +3,42 @@
 package com.finance.android.data.repository
 
 import com.finance.models.Account
-import com.finance.models.AccountType
+import com.finance.models.types.Cents
 import com.finance.models.types.SyncId
 import kotlinx.coroutines.flow.Flow
 
 /**
- * Repository for [Account] entities.
+ * Repository contract for [Account] entities.
  *
- * Provides reactive read streams via [Flow] and suspend write operations.
- * Implementations may be backed by a local database, remote API, or
- * in-memory store (for previews / testing).
+ * Extends [BaseRepository] with account-specific operations such as
+ * filtering active (non-archived) accounts and updating balances.
  */
-interface AccountRepository {
+interface AccountRepository : BaseRepository<Account> {
 
-    /** Observe all non-deleted accounts, ordered by [Account.sortOrder]. */
-    fun getAll(): Flow<List<Account>>
+    /**
+     * Observes all non-deleted, non-archived accounts for a household,
+     * ordered by [Account.sortOrder].
+     *
+     * @param householdId The household to scope the query to.
+     */
+    fun observeActive(householdId: SyncId): Flow<List<Account>>
 
-    /** Observe a single account by its [SyncId], or `null` if not found. */
-    fun getById(id: SyncId): Flow<Account?>
+    /**
+     * Updates the current balance of an account.
+     *
+     * Marks the account as unsynced so the change is pushed on the
+     * next sync cycle.
+     *
+     * @param id The account's [SyncId].
+     * @param newBalance The new balance in [Cents].
+     */
+    suspend fun updateBalance(id: SyncId, newBalance: Cents)
 
-    /** Observe accounts filtered by [AccountType]. */
-    fun getByType(type: AccountType): Flow<List<Account>>
-
-    /** Insert a new account. */
-    suspend fun create(account: Account)
-
-    /** Update an existing account. */
-    suspend fun update(account: Account)
-
-    /** Soft-delete an account by its [SyncId]. */
-    suspend fun delete(id: SyncId)
+    /**
+     * Archives an account, hiding it from active views but retaining
+     * its data and transaction history.
+     *
+     * @param id The account's [SyncId].
+     */
+    suspend fun archive(id: SyncId)
 }

--- a/apps/android/src/main/kotlin/com/finance/android/data/repository/BaseRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/data/repository/BaseRepository.kt
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.data.repository
+
+import com.finance.models.types.SyncId
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Base contract for all entity repositories.
+ *
+ * Provides CRUD operations, Flow-based observation, and sync-related
+ * queries that every domain entity requires. All queries automatically
+ * exclude soft-deleted records (where `deletedAt` is non-null) unless
+ * otherwise noted.
+ *
+ * @param T The domain model type managed by this repository.
+ */
+interface BaseRepository<T> {
+
+    /**
+     * Observes all non-deleted entities belonging to a household.
+     *
+     * @param householdId The household whose entities to observe.
+     * @return A [Flow] emitting the latest list whenever the data changes.
+     */
+    fun observeAll(householdId: SyncId): Flow<List<T>>
+
+    /**
+     * Observes a single entity by its unique ID.
+     *
+     * Emits `null` if the entity does not exist or has been soft-deleted.
+     *
+     * @param id The entity's [SyncId].
+     * @return A [Flow] emitting the entity or `null`.
+     */
+    fun observeById(id: SyncId): Flow<T?>
+
+    /**
+     * Fetches a single entity by ID, or `null` if not found / soft-deleted.
+     *
+     * @param id The entity's [SyncId].
+     */
+    suspend fun getById(id: SyncId): T?
+
+    /**
+     * Inserts a new entity. If an entity with the same ID already exists,
+     * the behaviour is implementation-defined (replace or throw).
+     *
+     * @param entity The entity to insert.
+     */
+    suspend fun insert(entity: T)
+
+    /**
+     * Updates an existing entity. The entity is matched by its [SyncId].
+     *
+     * @param entity The updated entity.
+     */
+    suspend fun update(entity: T)
+
+    /**
+     * Soft-deletes an entity by setting its `deletedAt` timestamp.
+     *
+     * The record is retained for sync purposes but excluded from
+     * normal queries.
+     *
+     * @param id The entity's [SyncId].
+     */
+    suspend fun delete(id: SyncId)
+
+    /**
+     * Returns all entities that have local modifications not yet
+     * synchronised to the server (`isSynced == false`).
+     *
+     * This includes soft-deleted records so the server can process
+     * the deletion.
+     *
+     * @param householdId The household to query.
+     */
+    suspend fun getUnsynced(householdId: SyncId): List<T>
+
+    /**
+     * Marks the given entities as synchronised (`isSynced = true`).
+     *
+     * Called by the sync engine after a successful push.
+     *
+     * @param ids The IDs of the entities to mark.
+     */
+    suspend fun markSynced(ids: List<SyncId>)
+}

--- a/apps/android/src/main/kotlin/com/finance/android/data/repository/BudgetRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/data/repository/BudgetRepository.kt
@@ -7,33 +7,25 @@ import com.finance.models.types.SyncId
 import kotlinx.coroutines.flow.Flow
 
 /**
- * Repository for [Budget] entities.
+ * Repository contract for [Budget] entities.
  *
- * Provides reactive read streams via [Flow] and suspend write operations.
+ * Extends [BaseRepository] with budget-specific queries such as
+ * filtering by category or active status.
  */
-interface BudgetRepository {
-
-    /** Observe all non-deleted budgets. */
-    fun getAll(): Flow<List<Budget>>
-
-    /** Observe a single budget by its [SyncId], or `null` if not found. */
-    fun getById(id: SyncId): Flow<Budget?>
+interface BudgetRepository : BaseRepository<Budget> {
 
     /**
-     * Observe currently active budgets (those without an [Budget.endDate]
-     * or whose end date has not yet passed).
+     * Observes all non-deleted budgets linked to a specific category.
+     *
+     * @param categoryId The category to filter by.
      */
-    fun getActiveBudgets(): Flow<List<Budget>>
+    fun observeByCategory(categoryId: SyncId): Flow<List<Budget>>
 
-    /** Observe budgets linked to a specific category. */
-    fun getByCategoryId(categoryId: SyncId): Flow<List<Budget>>
-
-    /** Insert a new budget. */
-    suspend fun create(budget: Budget)
-
-    /** Update an existing budget. */
-    suspend fun update(budget: Budget)
-
-    /** Soft-delete a budget by its [SyncId]. */
-    suspend fun delete(id: SyncId)
+    /**
+     * Observes all non-deleted budgets that are currently active
+     * (i.e. `endDate` is null or in the future).
+     *
+     * @param householdId The household to scope the query to.
+     */
+    fun observeActive(householdId: SyncId): Flow<List<Budget>>
 }

--- a/apps/android/src/main/kotlin/com/finance/android/data/repository/CategoryRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/data/repository/CategoryRepository.kt
@@ -7,32 +7,35 @@ import com.finance.models.types.SyncId
 import kotlinx.coroutines.flow.Flow
 
 /**
- * Repository for [Category] entities.
+ * Repository contract for [Category] entities.
  *
- * Provides reactive read streams via [Flow] and suspend write operations.
- * Categories are split into income and expense types for budgeting and
- * transaction creation flows.
+ * Extends [BaseRepository] with category-specific queries such as
+ * filtering by parent, income, or expense categories.
  */
-interface CategoryRepository {
+interface CategoryRepository : BaseRepository<Category> {
 
-    /** Observe all non-deleted categories, ordered by [Category.sortOrder]. */
-    fun getAll(): Flow<List<Category>>
+    /**
+     * Observes non-deleted categories whose parent matches the given ID.
+     *
+     * Pass `null` to retrieve root-level categories.
+     *
+     * @param parentId The parent category ID, or `null` for roots.
+     */
+    fun observeByParent(parentId: SyncId?): Flow<List<Category>>
 
-    /** Observe a single category by its [SyncId], or `null` if not found. */
-    fun getById(id: SyncId): Flow<Category?>
+    /**
+     * Observes non-deleted income categories for a household
+     * (where [Category.isIncome] is `true`).
+     *
+     * @param householdId The household to scope the query to.
+     */
+    fun observeIncome(householdId: SyncId): Flow<List<Category>>
 
-    /** Observe categories where [Category.isIncome] is `true`. */
-    fun getIncomeCategories(): Flow<List<Category>>
-
-    /** Observe categories where [Category.isIncome] is `false`. */
-    fun getExpenseCategories(): Flow<List<Category>>
-
-    /** Insert a new category. */
-    suspend fun create(category: Category)
-
-    /** Update an existing category. */
-    suspend fun update(category: Category)
-
-    /** Soft-delete a category by its [SyncId]. */
-    suspend fun delete(id: SyncId)
+    /**
+     * Observes non-deleted expense categories for a household
+     * (where [Category.isIncome] is `false`).
+     *
+     * @param householdId The household to scope the query to.
+     */
+    fun observeExpense(householdId: SyncId): Flow<List<Category>>
 }

--- a/apps/android/src/main/kotlin/com/finance/android/data/repository/GoalRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/data/repository/GoalRepository.kt
@@ -3,41 +3,34 @@
 package com.finance.android.data.repository
 
 import com.finance.models.Goal
-import com.finance.models.GoalStatus
 import com.finance.models.types.Cents
 import com.finance.models.types.SyncId
 import kotlinx.coroutines.flow.Flow
 
 /**
- * Repository for [Goal] entities.
+ * Repository contract for [Goal] entities.
  *
- * Provides reactive read streams via [Flow] and suspend write operations.
+ * Extends [BaseRepository] with goal-specific queries such as
+ * filtering active goals and updating savings progress.
  */
-interface GoalRepository {
-
-    /** Observe all non-deleted goals. */
-    fun getAll(): Flow<List<Goal>>
-
-    /** Observe a single goal by its [SyncId], or `null` if not found. */
-    fun getById(id: SyncId): Flow<Goal?>
-
-    /** Observe goals whose [Goal.status] is [GoalStatus.ACTIVE]. */
-    fun getActiveGoals(): Flow<List<Goal>>
-
-    /** Insert a new goal. */
-    suspend fun create(goal: Goal)
-
-    /** Update an existing goal. */
-    suspend fun update(goal: Goal)
+interface GoalRepository : BaseRepository<Goal> {
 
     /**
-     * Update only the [Goal.currentAmount] for a given goal.
+     * Observes all non-deleted goals with [Goal.status] of
+     * [com.finance.models.GoalStatus.ACTIVE] for a household.
+     *
+     * @param householdId The household to scope the query to.
+     */
+    fun observeActive(householdId: SyncId): Flow<List<Goal>>
+
+    /**
+     * Updates the current saved amount for a goal.
+     *
+     * Marks the goal as unsynced so the change is pushed on the
+     * next sync cycle.
      *
      * @param id The goal's [SyncId].
-     * @param currentAmount The new progress amount in [Cents].
+     * @param currentAmount The updated saved amount in [Cents].
      */
     suspend fun updateProgress(id: SyncId, currentAmount: Cents)
-
-    /** Soft-delete a goal by its [SyncId]. */
-    suspend fun delete(id: SyncId)
 }

--- a/apps/android/src/main/kotlin/com/finance/android/data/repository/TransactionRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/data/repository/TransactionRepository.kt
@@ -8,44 +8,53 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.datetime.LocalDate
 
 /**
- * Repository for [Transaction] entities.
+ * Repository contract for [Transaction] entities.
  *
- * Provides reactive read streams via [Flow] and suspend write operations.
- * Filtering, search, and pagination are supported for the Transactions screen.
+ * Extends [BaseRepository] with transaction-specific queries such as
+ * filtering by account, category, or date range.
  */
-interface TransactionRepository {
-
-    /** Observe all non-deleted transactions, newest first. */
-    fun getAll(): Flow<List<Transaction>>
-
-    /** Observe a single transaction by its [SyncId], or `null` if not found. */
-    fun getById(id: SyncId): Flow<Transaction?>
-
-    /** Observe transactions belonging to a specific account. */
-    fun getByAccountId(accountId: SyncId): Flow<List<Transaction>>
-
-    /** Observe transactions in a specific category. */
-    fun getByCategoryId(categoryId: SyncId): Flow<List<Transaction>>
-
-    /** Observe transactions whose [Transaction.date] falls within [from]..[to]. */
-    fun getByDateRange(from: LocalDate, to: LocalDate): Flow<List<Transaction>>
+interface TransactionRepository : BaseRepository<Transaction> {
 
     /**
-     * Search transactions by payee or note content.
+     * Observes all non-deleted transactions for a given account,
+     * ordered by date descending.
      *
-     * @param query Case-insensitive search term.
+     * @param accountId The account to filter by.
      */
-    fun search(query: String): Flow<List<Transaction>>
+    fun observeByAccount(accountId: SyncId): Flow<List<Transaction>>
 
-    /** Observe distinct payee names for autocomplete suggestions. */
-    fun getPayeeHistory(): Flow<List<String>>
+    /**
+     * Observes all non-deleted transactions for a given category,
+     * ordered by date descending.
+     *
+     * @param categoryId The category to filter by.
+     */
+    fun observeByCategory(categoryId: SyncId): Flow<List<Transaction>>
 
-    /** Insert a new transaction. */
-    suspend fun create(transaction: Transaction)
+    /**
+     * Observes non-deleted transactions within a date range (inclusive),
+     * ordered by date descending.
+     *
+     * @param householdId The household to scope the query to.
+     * @param start The start date (inclusive).
+     * @param end The end date (inclusive).
+     */
+    fun observeByDateRange(
+        householdId: SyncId,
+        start: LocalDate,
+        end: LocalDate,
+    ): Flow<List<Transaction>>
 
-    /** Update an existing transaction. */
-    suspend fun update(transaction: Transaction)
-
-    /** Soft-delete a transaction by its [SyncId]. */
-    suspend fun delete(id: SyncId)
+    /**
+     * Fetches non-deleted transactions within a date range (inclusive).
+     *
+     * @param householdId The household to scope the query to.
+     * @param start The start date (inclusive).
+     * @param end The end date (inclusive).
+     */
+    suspend fun getByDateRange(
+        householdId: SyncId,
+        start: LocalDate,
+        end: LocalDate,
+    ): List<Transaction>
 }

--- a/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/InMemoryAccountRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/InMemoryAccountRepository.kt
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.data.repository.impl
+
+import com.finance.android.data.repository.AccountRepository
+import com.finance.models.Account
+import com.finance.models.types.Cents
+import com.finance.models.types.SyncId
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import kotlinx.datetime.Clock
+
+// TODO(#432): Replace with SQLDelight-backed implementation
+
+/**
+ * In-memory stub implementation of [AccountRepository].
+ *
+ * Uses a [MutableStateFlow] as its backing store so that all
+ * `observe*` methods emit updates reactively. This implementation
+ * is intended **only** for development and testing until the real
+ * SQLDelight-backed repository is available (see issue #432).
+ */
+class InMemoryAccountRepository : AccountRepository {
+
+    private val store = MutableStateFlow<List<Account>>(emptyList())
+
+    /** All non-deleted records. */
+    private fun List<Account>.active(): List<Account> =
+        filter { it.deletedAt == null }
+
+    // ── BaseRepository ──────────────────────────────────────────────
+
+    override fun observeAll(householdId: SyncId): Flow<List<Account>> =
+        store.map { list ->
+            list.active()
+                .filter { it.householdId == householdId }
+                .sortedBy { it.sortOrder }
+        }
+
+    override fun observeById(id: SyncId): Flow<Account?> =
+        store.map { list ->
+            list.active().find { it.id == id }
+        }
+
+    override suspend fun getById(id: SyncId): Account? =
+        store.value.active().find { it.id == id }
+
+    override suspend fun insert(entity: Account) {
+        store.update { current -> current + entity }
+    }
+
+    override suspend fun update(entity: Account) {
+        store.update { current ->
+            current.map { if (it.id == entity.id) entity else it }
+        }
+    }
+
+    override suspend fun delete(id: SyncId) {
+        val now = Clock.System.now()
+        store.update { current ->
+            current.map { account ->
+                if (account.id == id && account.deletedAt == null) {
+                    account.copy(deletedAt = now, isSynced = false, updatedAt = now)
+                } else {
+                    account
+                }
+            }
+        }
+    }
+
+    override suspend fun getUnsynced(householdId: SyncId): List<Account> =
+        store.value.filter { it.householdId == householdId && !it.isSynced }
+
+    override suspend fun markSynced(ids: List<SyncId>) {
+        val idSet = ids.toSet()
+        store.update { current ->
+            current.map { account ->
+                if (account.id in idSet) account.copy(isSynced = true) else account
+            }
+        }
+    }
+
+    // ── AccountRepository ───────────────────────────────────────────
+
+    override fun observeActive(householdId: SyncId): Flow<List<Account>> =
+        store.map { list ->
+            list.active()
+                .filter { it.householdId == householdId && !it.isArchived }
+                .sortedBy { it.sortOrder }
+        }
+
+    override suspend fun updateBalance(id: SyncId, newBalance: Cents) {
+        val now = Clock.System.now()
+        store.update { current ->
+            current.map { account ->
+                if (account.id == id) {
+                    account.copy(
+                        currentBalance = newBalance,
+                        isSynced = false,
+                        updatedAt = now,
+                    )
+                } else {
+                    account
+                }
+            }
+        }
+    }
+
+    override suspend fun archive(id: SyncId) {
+        val now = Clock.System.now()
+        store.update { current ->
+            current.map { account ->
+                if (account.id == id) {
+                    account.copy(
+                        isArchived = true,
+                        isSynced = false,
+                        updatedAt = now,
+                    )
+                } else {
+                    account
+                }
+            }
+        }
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/InMemoryBudgetRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/InMemoryBudgetRepository.kt
@@ -96,8 +96,9 @@ class InMemoryBudgetRepository : BudgetRepository {
                 .toLocalDateTime(TimeZone.currentSystemDefault()).date
             list.active()
                 .filter { budget ->
+                    val endDate = budget.endDate
                     budget.householdId == householdId &&
-                        (budget.endDate == null || budget.endDate >= today)
+                        (endDate == null || endDate >= today)
                 }
         }
 }

--- a/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/InMemoryBudgetRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/InMemoryBudgetRepository.kt
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.data.repository.impl
+
+import com.finance.android.data.repository.BudgetRepository
+import com.finance.models.Budget
+import com.finance.models.types.SyncId
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+// TODO(#432): Replace with SQLDelight-backed implementation
+
+/**
+ * In-memory stub implementation of [BudgetRepository].
+ *
+ * Uses a [MutableStateFlow] as its backing store so that all
+ * `observe*` methods emit updates reactively. This implementation
+ * is intended **only** for development and testing until the real
+ * SQLDelight-backed repository is available (see issue #432).
+ */
+class InMemoryBudgetRepository : BudgetRepository {
+
+    private val store = MutableStateFlow<List<Budget>>(emptyList())
+
+    /** All non-deleted records. */
+    private fun List<Budget>.active(): List<Budget> =
+        filter { it.deletedAt == null }
+
+    // ── BaseRepository ──────────────────────────────────────────────
+
+    override fun observeAll(householdId: SyncId): Flow<List<Budget>> =
+        store.map { list ->
+            list.active()
+                .filter { it.householdId == householdId }
+        }
+
+    override fun observeById(id: SyncId): Flow<Budget?> =
+        store.map { list ->
+            list.active().find { it.id == id }
+        }
+
+    override suspend fun getById(id: SyncId): Budget? =
+        store.value.active().find { it.id == id }
+
+    override suspend fun insert(entity: Budget) {
+        store.update { current -> current + entity }
+    }
+
+    override suspend fun update(entity: Budget) {
+        store.update { current ->
+            current.map { if (it.id == entity.id) entity else it }
+        }
+    }
+
+    override suspend fun delete(id: SyncId) {
+        val now = Clock.System.now()
+        store.update { current ->
+            current.map { budget ->
+                if (budget.id == id && budget.deletedAt == null) {
+                    budget.copy(deletedAt = now, isSynced = false, updatedAt = now)
+                } else {
+                    budget
+                }
+            }
+        }
+    }
+
+    override suspend fun getUnsynced(householdId: SyncId): List<Budget> =
+        store.value.filter { it.householdId == householdId && !it.isSynced }
+
+    override suspend fun markSynced(ids: List<SyncId>) {
+        val idSet = ids.toSet()
+        store.update { current ->
+            current.map { budget ->
+                if (budget.id in idSet) budget.copy(isSynced = true) else budget
+            }
+        }
+    }
+
+    // ── BudgetRepository ────────────────────────────────────────────
+
+    override fun observeByCategory(categoryId: SyncId): Flow<List<Budget>> =
+        store.map { list ->
+            list.active()
+                .filter { it.categoryId == categoryId }
+        }
+
+    override fun observeActive(householdId: SyncId): Flow<List<Budget>> =
+        store.map { list ->
+            val today = Clock.System.now()
+                .toLocalDateTime(TimeZone.currentSystemDefault()).date
+            list.active()
+                .filter { budget ->
+                    budget.householdId == householdId &&
+                        (budget.endDate == null || budget.endDate >= today)
+                }
+        }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/InMemoryCategoryRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/InMemoryCategoryRepository.kt
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.data.repository.impl
+
+import com.finance.android.data.repository.CategoryRepository
+import com.finance.models.Category
+import com.finance.models.types.SyncId
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import kotlinx.datetime.Clock
+
+// TODO(#432): Replace with SQLDelight-backed implementation
+
+/**
+ * In-memory stub implementation of [CategoryRepository].
+ *
+ * Uses a [MutableStateFlow] as its backing store so that all
+ * `observe*` methods emit updates reactively. This implementation
+ * is intended **only** for development and testing until the real
+ * SQLDelight-backed repository is available (see issue #432).
+ */
+class InMemoryCategoryRepository : CategoryRepository {
+
+    private val store = MutableStateFlow<List<Category>>(emptyList())
+
+    /** All non-deleted records. */
+    private fun List<Category>.active(): List<Category> =
+        filter { it.deletedAt == null }
+
+    // ── BaseRepository ──────────────────────────────────────────────
+
+    override fun observeAll(householdId: SyncId): Flow<List<Category>> =
+        store.map { list ->
+            list.active()
+                .filter { it.householdId == householdId }
+                .sortedBy { it.sortOrder }
+        }
+
+    override fun observeById(id: SyncId): Flow<Category?> =
+        store.map { list ->
+            list.active().find { it.id == id }
+        }
+
+    override suspend fun getById(id: SyncId): Category? =
+        store.value.active().find { it.id == id }
+
+    override suspend fun insert(entity: Category) {
+        store.update { current -> current + entity }
+    }
+
+    override suspend fun update(entity: Category) {
+        store.update { current ->
+            current.map { if (it.id == entity.id) entity else it }
+        }
+    }
+
+    override suspend fun delete(id: SyncId) {
+        val now = Clock.System.now()
+        store.update { current ->
+            current.map { category ->
+                if (category.id == id && category.deletedAt == null) {
+                    category.copy(deletedAt = now, isSynced = false, updatedAt = now)
+                } else {
+                    category
+                }
+            }
+        }
+    }
+
+    override suspend fun getUnsynced(householdId: SyncId): List<Category> =
+        store.value.filter { it.householdId == householdId && !it.isSynced }
+
+    override suspend fun markSynced(ids: List<SyncId>) {
+        val idSet = ids.toSet()
+        store.update { current ->
+            current.map { category ->
+                if (category.id in idSet) category.copy(isSynced = true) else category
+            }
+        }
+    }
+
+    // ── CategoryRepository ──────────────────────────────────────────
+
+    override fun observeByParent(parentId: SyncId?): Flow<List<Category>> =
+        store.map { list ->
+            list.active()
+                .filter { it.parentId == parentId }
+                .sortedBy { it.sortOrder }
+        }
+
+    override fun observeIncome(householdId: SyncId): Flow<List<Category>> =
+        store.map { list ->
+            list.active()
+                .filter { it.householdId == householdId && it.isIncome }
+                .sortedBy { it.sortOrder }
+        }
+
+    override fun observeExpense(householdId: SyncId): Flow<List<Category>> =
+        store.map { list ->
+            list.active()
+                .filter { it.householdId == householdId && !it.isIncome }
+                .sortedBy { it.sortOrder }
+        }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/InMemoryGoalRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/InMemoryGoalRepository.kt
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.data.repository.impl
+
+import com.finance.android.data.repository.GoalRepository
+import com.finance.models.Goal
+import com.finance.models.GoalStatus
+import com.finance.models.types.Cents
+import com.finance.models.types.SyncId
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import kotlinx.datetime.Clock
+
+// TODO(#432): Replace with SQLDelight-backed implementation
+
+/**
+ * In-memory stub implementation of [GoalRepository].
+ *
+ * Uses a [MutableStateFlow] as its backing store so that all
+ * `observe*` methods emit updates reactively. This implementation
+ * is intended **only** for development and testing until the real
+ * SQLDelight-backed repository is available (see issue #432).
+ */
+class InMemoryGoalRepository : GoalRepository {
+
+    private val store = MutableStateFlow<List<Goal>>(emptyList())
+
+    /** All non-deleted records. */
+    private fun List<Goal>.active(): List<Goal> =
+        filter { it.deletedAt == null }
+
+    // ── BaseRepository ──────────────────────────────────────────────
+
+    override fun observeAll(householdId: SyncId): Flow<List<Goal>> =
+        store.map { list ->
+            list.active()
+                .filter { it.householdId == householdId }
+        }
+
+    override fun observeById(id: SyncId): Flow<Goal?> =
+        store.map { list ->
+            list.active().find { it.id == id }
+        }
+
+    override suspend fun getById(id: SyncId): Goal? =
+        store.value.active().find { it.id == id }
+
+    override suspend fun insert(entity: Goal) {
+        store.update { current -> current + entity }
+    }
+
+    override suspend fun update(entity: Goal) {
+        store.update { current ->
+            current.map { if (it.id == entity.id) entity else it }
+        }
+    }
+
+    override suspend fun delete(id: SyncId) {
+        val now = Clock.System.now()
+        store.update { current ->
+            current.map { goal ->
+                if (goal.id == id && goal.deletedAt == null) {
+                    goal.copy(deletedAt = now, isSynced = false, updatedAt = now)
+                } else {
+                    goal
+                }
+            }
+        }
+    }
+
+    override suspend fun getUnsynced(householdId: SyncId): List<Goal> =
+        store.value.filter { it.householdId == householdId && !it.isSynced }
+
+    override suspend fun markSynced(ids: List<SyncId>) {
+        val idSet = ids.toSet()
+        store.update { current ->
+            current.map { goal ->
+                if (goal.id in idSet) goal.copy(isSynced = true) else goal
+            }
+        }
+    }
+
+    // ── GoalRepository ──────────────────────────────────────────────
+
+    override fun observeActive(householdId: SyncId): Flow<List<Goal>> =
+        store.map { list ->
+            list.active()
+                .filter { it.householdId == householdId && it.status == GoalStatus.ACTIVE }
+        }
+
+    override suspend fun updateProgress(id: SyncId, currentAmount: Cents) {
+        val now = Clock.System.now()
+        store.update { current ->
+            current.map { goal ->
+                if (goal.id == id) {
+                    goal.copy(
+                        currentAmount = currentAmount,
+                        isSynced = false,
+                        updatedAt = now,
+                    )
+                } else {
+                    goal
+                }
+            }
+        }
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/InMemoryTransactionRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/InMemoryTransactionRepository.kt
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.data.repository.impl
+
+import com.finance.android.data.repository.TransactionRepository
+import com.finance.models.Transaction
+import com.finance.models.types.SyncId
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import kotlinx.datetime.Clock
+import kotlinx.datetime.LocalDate
+
+// TODO(#432): Replace with SQLDelight-backed implementation
+
+/**
+ * In-memory stub implementation of [TransactionRepository].
+ *
+ * Uses a [MutableStateFlow] as its backing store so that all
+ * `observe*` methods emit updates reactively. This implementation
+ * is intended **only** for development and testing until the real
+ * SQLDelight-backed repository is available (see issue #432).
+ */
+class InMemoryTransactionRepository : TransactionRepository {
+
+    private val store = MutableStateFlow<List<Transaction>>(emptyList())
+
+    /** All non-deleted records. */
+    private fun List<Transaction>.active(): List<Transaction> =
+        filter { it.deletedAt == null }
+
+    // ── BaseRepository ──────────────────────────────────────────────
+
+    override fun observeAll(householdId: SyncId): Flow<List<Transaction>> =
+        store.map { list ->
+            list.active()
+                .filter { it.householdId == householdId }
+                .sortedByDescending { it.date }
+        }
+
+    override fun observeById(id: SyncId): Flow<Transaction?> =
+        store.map { list ->
+            list.active().find { it.id == id }
+        }
+
+    override suspend fun getById(id: SyncId): Transaction? =
+        store.value.active().find { it.id == id }
+
+    override suspend fun insert(entity: Transaction) {
+        store.update { current -> current + entity }
+    }
+
+    override suspend fun update(entity: Transaction) {
+        store.update { current ->
+            current.map { if (it.id == entity.id) entity else it }
+        }
+    }
+
+    override suspend fun delete(id: SyncId) {
+        val now = Clock.System.now()
+        store.update { current ->
+            current.map { txn ->
+                if (txn.id == id && txn.deletedAt == null) {
+                    txn.copy(deletedAt = now, isSynced = false, updatedAt = now)
+                } else {
+                    txn
+                }
+            }
+        }
+    }
+
+    override suspend fun getUnsynced(householdId: SyncId): List<Transaction> =
+        store.value.filter { it.householdId == householdId && !it.isSynced }
+
+    override suspend fun markSynced(ids: List<SyncId>) {
+        val idSet = ids.toSet()
+        store.update { current ->
+            current.map { txn ->
+                if (txn.id in idSet) txn.copy(isSynced = true) else txn
+            }
+        }
+    }
+
+    // ── TransactionRepository ───────────────────────────────────────
+
+    override fun observeByAccount(accountId: SyncId): Flow<List<Transaction>> =
+        store.map { list ->
+            list.active()
+                .filter { it.accountId == accountId }
+                .sortedByDescending { it.date }
+        }
+
+    override fun observeByCategory(categoryId: SyncId): Flow<List<Transaction>> =
+        store.map { list ->
+            list.active()
+                .filter { it.categoryId == categoryId }
+                .sortedByDescending { it.date }
+        }
+
+    override fun observeByDateRange(
+        householdId: SyncId,
+        start: LocalDate,
+        end: LocalDate,
+    ): Flow<List<Transaction>> =
+        store.map { list ->
+            list.active()
+                .filter { it.householdId == householdId && it.date in start..end }
+                .sortedByDescending { it.date }
+        }
+
+    override suspend fun getByDateRange(
+        householdId: SyncId,
+        start: LocalDate,
+        end: LocalDate,
+    ): List<Transaction> =
+        store.value.active()
+            .filter { it.householdId == householdId && it.date in start..end }
+            .sortedByDescending { it.date }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/SqlDelightAccountRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/SqlDelightAccountRepository.kt
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.data.repository.impl
+
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToList
+import app.cash.sqldelight.coroutines.mapToOneOrNull
+import com.finance.android.data.repository.AccountRepository
+import com.finance.db.Account as AccountRow
+import com.finance.db.FinanceDatabase
+import com.finance.models.Account
+import com.finance.models.AccountType
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+
+/**
+ * SQLDelight-backed implementation of [AccountRepository].
+ *
+ * Delegates all persistence to the [FinanceDatabase] and maps between
+ * SQLDelight-generated row types and domain [Account] models. All
+ * blocking database I/O is dispatched to [Dispatchers.IO].
+ */
+class SqlDelightAccountRepository(
+    private val database: FinanceDatabase,
+) : AccountRepository {
+
+    private val queries get() = database.accountQueries
+
+    // ── BaseRepository ──────────────────────────────────────────────
+
+    /** @inheritDoc */
+    override fun observeAll(householdId: SyncId): Flow<List<Account>> =
+        queries.selectByHousehold(householdId.value)
+            .asFlow()
+            .mapToList(Dispatchers.IO)
+            .map { rows -> rows.map { it.toDomain() } }
+
+    /** @inheritDoc */
+    override fun observeById(id: SyncId): Flow<Account?> =
+        queries.selectById(id.value)
+            .asFlow()
+            .mapToOneOrNull(Dispatchers.IO)
+            .map { it?.toDomain() }
+
+    /** @inheritDoc */
+    override suspend fun getById(id: SyncId): Account? = withContext(Dispatchers.IO) {
+        queries.selectById(id.value).executeAsOneOrNull()?.toDomain()
+    }
+
+    /** @inheritDoc */
+    override suspend fun insert(entity: Account) {
+        withContext(Dispatchers.IO) {
+            queries.insert(
+                id = entity.id.value,
+                household_id = entity.householdId.value,
+                name = entity.name,
+                type = entity.type.name,
+                currency = entity.currency.code,
+                current_balance = entity.currentBalance.amount,
+                is_archived = if (entity.isArchived) 1L else 0L,
+                sort_order = entity.sortOrder.toLong(),
+                icon = entity.icon,
+                color = entity.color,
+                created_at = entity.createdAt.toString(),
+                updated_at = entity.updatedAt.toString(),
+                sync_version = entity.syncVersion,
+                is_synced = if (entity.isSynced) 1L else 0L,
+            )
+        }
+    }
+
+    /** @inheritDoc */
+    override suspend fun update(entity: Account) {
+        withContext(Dispatchers.IO) {
+            queries.update(
+                name = entity.name,
+                type = entity.type.name,
+                currency = entity.currency.code,
+                current_balance = entity.currentBalance.amount,
+                is_archived = if (entity.isArchived) 1L else 0L,
+                sort_order = entity.sortOrder.toLong(),
+                icon = entity.icon,
+                color = entity.color,
+                updated_at = entity.updatedAt.toString(),
+                sync_version = entity.syncVersion,
+                is_synced = if (entity.isSynced) 1L else 0L,
+                id = entity.id.value,
+            )
+        }
+    }
+
+    /** @inheritDoc */
+    override suspend fun delete(id: SyncId) {
+        val now = Clock.System.now().toString()
+        withContext(Dispatchers.IO) {
+            queries.softDelete(deleted_at = now, updated_at = now, id = id.value)
+        }
+    }
+
+    /** @inheritDoc */
+    override suspend fun getUnsynced(householdId: SyncId): List<Account> =
+        withContext(Dispatchers.IO) {
+            queries.selectUnsyncedByHousehold(householdId.value)
+                .executeAsList()
+                .map { it.toDomain() }
+        }
+
+    /** @inheritDoc */
+    override suspend fun markSynced(ids: List<SyncId>) {
+        if (ids.isEmpty()) return
+        withContext(Dispatchers.IO) {
+            database.transaction {
+                ids.forEach { id ->
+                    queries.markSyncedById(id.value)
+                }
+            }
+        }
+    }
+
+    // ── AccountRepository ───────────────────────────────────────────
+
+    /** @inheritDoc */
+    override fun observeActive(householdId: SyncId): Flow<List<Account>> =
+        queries.selectActive(householdId.value)
+            .asFlow()
+            .mapToList(Dispatchers.IO)
+            .map { rows -> rows.map { it.toDomain() } }
+
+    /** @inheritDoc */
+    override suspend fun updateBalance(id: SyncId, newBalance: Cents) {
+        val now = Clock.System.now().toString()
+        withContext(Dispatchers.IO) {
+            queries.updateBalance(
+                current_balance = newBalance.amount,
+                updated_at = now,
+                id = id.value,
+            )
+        }
+    }
+
+    /** @inheritDoc */
+    override suspend fun archive(id: SyncId) {
+        val now = Clock.System.now().toString()
+        withContext(Dispatchers.IO) {
+            queries.archive(updated_at = now, id = id.value)
+        }
+    }
+
+    // ── Mapping ─────────────────────────────────────────────────────
+
+    /**
+     * Maps a SQLDelight-generated [AccountRow] to the domain [Account] model.
+     */
+    private fun AccountRow.toDomain(): Account = Account(
+        id = SyncId(id),
+        householdId = SyncId(household_id),
+        name = name,
+        type = AccountType.valueOf(type),
+        currency = Currency(currency),
+        currentBalance = Cents(current_balance),
+        isArchived = is_archived != 0L,
+        sortOrder = sort_order.toInt(),
+        icon = icon,
+        color = color,
+        createdAt = Instant.parse(created_at),
+        updatedAt = Instant.parse(updated_at),
+        deletedAt = deleted_at?.let { Instant.parse(it) },
+        syncVersion = sync_version,
+        isSynced = is_synced != 0L,
+    )
+}

--- a/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/SqlDelightBudgetRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/SqlDelightBudgetRepository.kt
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.data.repository.impl
+
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToList
+import app.cash.sqldelight.coroutines.mapToOneOrNull
+import com.finance.android.data.repository.BudgetRepository
+import com.finance.db.Budget as BudgetRow
+import com.finance.db.FinanceDatabase
+import com.finance.models.Budget
+import com.finance.models.BudgetPeriod
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+/**
+ * SQLDelight-backed implementation of [BudgetRepository].
+ *
+ * Delegates all persistence to the [FinanceDatabase] and maps between
+ * SQLDelight-generated row types and domain [Budget] models.
+ */
+class SqlDelightBudgetRepository(
+    private val database: FinanceDatabase,
+) : BudgetRepository {
+
+    private val queries get() = database.budgetQueries
+
+    // ── BaseRepository ──────────────────────────────────────────────
+
+    /** @inheritDoc */
+    override fun observeAll(householdId: SyncId): Flow<List<Budget>> =
+        queries.selectByHousehold(householdId.value)
+            .asFlow()
+            .mapToList(Dispatchers.IO)
+            .map { rows -> rows.map { it.toDomain() } }
+
+    /** @inheritDoc */
+    override fun observeById(id: SyncId): Flow<Budget?> =
+        queries.selectById(id.value)
+            .asFlow()
+            .mapToOneOrNull(Dispatchers.IO)
+            .map { it?.toDomain() }
+
+    /** @inheritDoc */
+    override suspend fun getById(id: SyncId): Budget? = withContext(Dispatchers.IO) {
+        queries.selectById(id.value).executeAsOneOrNull()?.toDomain()
+    }
+
+    /** @inheritDoc */
+    override suspend fun insert(entity: Budget) {
+        withContext(Dispatchers.IO) {
+            queries.insert(
+                id = entity.id.value,
+                household_id = entity.householdId.value,
+                category_id = entity.categoryId.value,
+                name = entity.name,
+                amount = entity.amount.amount,
+                currency = entity.currency.code,
+                period = entity.period.name,
+                start_date = entity.startDate.toString(),
+                end_date = entity.endDate?.toString(),
+                is_rollover = if (entity.isRollover) 1L else 0L,
+                created_at = entity.createdAt.toString(),
+                updated_at = entity.updatedAt.toString(),
+                sync_version = entity.syncVersion,
+                is_synced = if (entity.isSynced) 1L else 0L,
+            )
+        }
+    }
+
+    /** @inheritDoc */
+    override suspend fun update(entity: Budget) {
+        withContext(Dispatchers.IO) {
+            queries.update(
+                category_id = entity.categoryId.value,
+                name = entity.name,
+                amount = entity.amount.amount,
+                currency = entity.currency.code,
+                period = entity.period.name,
+                start_date = entity.startDate.toString(),
+                end_date = entity.endDate?.toString(),
+                is_rollover = if (entity.isRollover) 1L else 0L,
+                updated_at = entity.updatedAt.toString(),
+                sync_version = entity.syncVersion,
+                is_synced = if (entity.isSynced) 1L else 0L,
+                id = entity.id.value,
+            )
+        }
+    }
+
+    /** @inheritDoc */
+    override suspend fun delete(id: SyncId) {
+        val now = Clock.System.now().toString()
+        withContext(Dispatchers.IO) {
+            queries.softDelete(deleted_at = now, updated_at = now, id = id.value)
+        }
+    }
+
+    /** @inheritDoc */
+    override suspend fun getUnsynced(householdId: SyncId): List<Budget> =
+        withContext(Dispatchers.IO) {
+            queries.selectUnsyncedByHousehold(householdId.value)
+                .executeAsList()
+                .map { it.toDomain() }
+        }
+
+    /** @inheritDoc */
+    override suspend fun markSynced(ids: List<SyncId>) {
+        if (ids.isEmpty()) return
+        withContext(Dispatchers.IO) {
+            database.transaction {
+                ids.forEach { id ->
+                    queries.markSyncedById(id.value)
+                }
+            }
+        }
+    }
+
+    // ── BudgetRepository ────────────────────────────────────────────
+
+    /** @inheritDoc */
+    override fun observeByCategory(categoryId: SyncId): Flow<List<Budget>> =
+        queries.selectByCategory(categoryId.value)
+            .asFlow()
+            .mapToList(Dispatchers.IO)
+            .map { rows -> rows.map { it.toDomain() } }
+
+    /** @inheritDoc */
+    override fun observeActive(householdId: SyncId): Flow<List<Budget>> {
+        val today = Clock.System.now()
+            .toLocalDateTime(TimeZone.currentSystemDefault()).date.toString()
+        return queries.selectActive(household_id = householdId.value, end_date = today)
+            .asFlow()
+            .mapToList(Dispatchers.IO)
+            .map { rows -> rows.map { it.toDomain() } }
+    }
+
+    // ── Mapping ─────────────────────────────────────────────────────
+
+    /**
+     * Maps a SQLDelight-generated [BudgetRow] to the domain [Budget] model.
+     */
+    private fun BudgetRow.toDomain(): Budget = Budget(
+        id = SyncId(id),
+        householdId = SyncId(household_id),
+        categoryId = SyncId(category_id),
+        name = name,
+        amount = Cents(amount),
+        currency = Currency(currency),
+        period = BudgetPeriod.valueOf(period),
+        startDate = LocalDate.parse(start_date),
+        endDate = end_date?.let { LocalDate.parse(it) },
+        isRollover = is_rollover != 0L,
+        createdAt = Instant.parse(created_at),
+        updatedAt = Instant.parse(updated_at),
+        deletedAt = deleted_at?.let { Instant.parse(it) },
+        syncVersion = sync_version,
+        isSynced = is_synced != 0L,
+    )
+}

--- a/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/SqlDelightCategoryRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/SqlDelightCategoryRepository.kt
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.data.repository.impl
+
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToList
+import app.cash.sqldelight.coroutines.mapToOneOrNull
+import com.finance.android.data.repository.CategoryRepository
+import com.finance.db.Category as CategoryRow
+import com.finance.db.FinanceDatabase
+import com.finance.models.Category
+import com.finance.models.types.SyncId
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+
+/**
+ * SQLDelight-backed implementation of [CategoryRepository].
+ *
+ * Delegates all persistence to the [FinanceDatabase] and maps between
+ * SQLDelight-generated row types and domain [Category] models.
+ */
+class SqlDelightCategoryRepository(
+    private val database: FinanceDatabase,
+) : CategoryRepository {
+
+    private val queries get() = database.categoryQueries
+
+    // ── BaseRepository ──────────────────────────────────────────────
+
+    /** @inheritDoc */
+    override fun observeAll(householdId: SyncId): Flow<List<Category>> =
+        queries.selectByHousehold(householdId.value)
+            .asFlow()
+            .mapToList(Dispatchers.IO)
+            .map { rows -> rows.map { it.toDomain() } }
+
+    /** @inheritDoc */
+    override fun observeById(id: SyncId): Flow<Category?> =
+        queries.selectById(id.value)
+            .asFlow()
+            .mapToOneOrNull(Dispatchers.IO)
+            .map { it?.toDomain() }
+
+    /** @inheritDoc */
+    override suspend fun getById(id: SyncId): Category? = withContext(Dispatchers.IO) {
+        queries.selectById(id.value).executeAsOneOrNull()?.toDomain()
+    }
+
+    /** @inheritDoc */
+    override suspend fun insert(entity: Category) {
+        withContext(Dispatchers.IO) {
+            queries.insert(
+                id = entity.id.value,
+                household_id = entity.householdId.value,
+                name = entity.name,
+                icon = entity.icon,
+                color = entity.color,
+                parent_id = entity.parentId?.value,
+                is_income = if (entity.isIncome) 1L else 0L,
+                is_system = if (entity.isSystem) 1L else 0L,
+                sort_order = entity.sortOrder.toLong(),
+                created_at = entity.createdAt.toString(),
+                updated_at = entity.updatedAt.toString(),
+                sync_version = entity.syncVersion,
+                is_synced = if (entity.isSynced) 1L else 0L,
+            )
+        }
+    }
+
+    /** @inheritDoc */
+    override suspend fun update(entity: Category) {
+        withContext(Dispatchers.IO) {
+            queries.update(
+                name = entity.name,
+                icon = entity.icon,
+                color = entity.color,
+                parent_id = entity.parentId?.value,
+                is_income = if (entity.isIncome) 1L else 0L,
+                sort_order = entity.sortOrder.toLong(),
+                updated_at = entity.updatedAt.toString(),
+                sync_version = entity.syncVersion,
+                is_synced = if (entity.isSynced) 1L else 0L,
+                id = entity.id.value,
+            )
+        }
+    }
+
+    /** @inheritDoc */
+    override suspend fun delete(id: SyncId) {
+        val now = Clock.System.now().toString()
+        withContext(Dispatchers.IO) {
+            queries.softDelete(deleted_at = now, updated_at = now, id = id.value)
+        }
+    }
+
+    /** @inheritDoc */
+    override suspend fun getUnsynced(householdId: SyncId): List<Category> =
+        withContext(Dispatchers.IO) {
+            queries.selectUnsyncedByHousehold(householdId.value)
+                .executeAsList()
+                .map { it.toDomain() }
+        }
+
+    /** @inheritDoc */
+    override suspend fun markSynced(ids: List<SyncId>) {
+        if (ids.isEmpty()) return
+        withContext(Dispatchers.IO) {
+            database.transaction {
+                ids.forEach { id ->
+                    queries.markSyncedById(id.value)
+                }
+            }
+        }
+    }
+
+    // ── CategoryRepository ──────────────────────────────────────────
+
+    /**
+     * @inheritDoc
+     *
+     * When [parentId] is `null`, returns root-level categories (no parent).
+     * When non-null, returns subcategories of the given parent.
+     */
+    override fun observeByParent(parentId: SyncId?): Flow<List<Category>> {
+        val query = if (parentId == null) {
+            queries.selectRootCategories()
+        } else {
+            queries.selectSubcategories(parentId.value)
+        }
+        return query
+            .asFlow()
+            .mapToList(Dispatchers.IO)
+            .map { rows -> rows.map { it.toDomain() } }
+    }
+
+    /** @inheritDoc */
+    override fun observeIncome(householdId: SyncId): Flow<List<Category>> =
+        queries.selectIncomeCategories(householdId.value)
+            .asFlow()
+            .mapToList(Dispatchers.IO)
+            .map { rows -> rows.map { it.toDomain() } }
+
+    /** @inheritDoc */
+    override fun observeExpense(householdId: SyncId): Flow<List<Category>> =
+        queries.selectExpenseCategories(householdId.value)
+            .asFlow()
+            .mapToList(Dispatchers.IO)
+            .map { rows -> rows.map { it.toDomain() } }
+
+    // ── Mapping ─────────────────────────────────────────────────────
+
+    /**
+     * Maps a SQLDelight-generated [CategoryRow] to the domain [Category] model.
+     */
+    private fun CategoryRow.toDomain(): Category = Category(
+        id = SyncId(id),
+        householdId = SyncId(household_id),
+        name = name,
+        icon = icon,
+        color = color,
+        parentId = parent_id?.let { SyncId(it) },
+        isIncome = is_income != 0L,
+        isSystem = is_system != 0L,
+        sortOrder = sort_order.toInt(),
+        createdAt = Instant.parse(created_at),
+        updatedAt = Instant.parse(updated_at),
+        deletedAt = deleted_at?.let { Instant.parse(it) },
+        syncVersion = sync_version,
+        isSynced = is_synced != 0L,
+    )
+}

--- a/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/SqlDelightGoalRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/SqlDelightGoalRepository.kt
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.data.repository.impl
+
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToList
+import app.cash.sqldelight.coroutines.mapToOneOrNull
+import com.finance.android.data.repository.GoalRepository
+import com.finance.db.FinanceDatabase
+import com.finance.db.Goal as GoalRow
+import com.finance.models.Goal
+import com.finance.models.GoalStatus
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+
+/**
+ * SQLDelight-backed implementation of [GoalRepository].
+ *
+ * Delegates all persistence to the [FinanceDatabase] and maps between
+ * SQLDelight-generated row types and domain [Goal] models.
+ */
+class SqlDelightGoalRepository(
+    private val database: FinanceDatabase,
+) : GoalRepository {
+
+    private val queries get() = database.goalQueries
+
+    // ── BaseRepository ──────────────────────────────────────────────
+
+    /** @inheritDoc */
+    override fun observeAll(householdId: SyncId): Flow<List<Goal>> =
+        queries.selectByHousehold(householdId.value)
+            .asFlow()
+            .mapToList(Dispatchers.IO)
+            .map { rows -> rows.map { it.toDomain() } }
+
+    /** @inheritDoc */
+    override fun observeById(id: SyncId): Flow<Goal?> =
+        queries.selectById(id.value)
+            .asFlow()
+            .mapToOneOrNull(Dispatchers.IO)
+            .map { it?.toDomain() }
+
+    /** @inheritDoc */
+    override suspend fun getById(id: SyncId): Goal? = withContext(Dispatchers.IO) {
+        queries.selectById(id.value).executeAsOneOrNull()?.toDomain()
+    }
+
+    /** @inheritDoc */
+    override suspend fun insert(entity: Goal) {
+        withContext(Dispatchers.IO) {
+            queries.insert(
+                id = entity.id.value,
+                household_id = entity.householdId.value,
+                name = entity.name,
+                target_amount = entity.targetAmount.amount,
+                current_amount = entity.currentAmount.amount,
+                currency = entity.currency.code,
+                target_date = entity.targetDate?.toString(),
+                status = entity.status.name,
+                icon = entity.icon,
+                color = entity.color,
+                account_id = entity.accountId?.value,
+                created_at = entity.createdAt.toString(),
+                updated_at = entity.updatedAt.toString(),
+                sync_version = entity.syncVersion,
+                is_synced = if (entity.isSynced) 1L else 0L,
+            )
+        }
+    }
+
+    /** @inheritDoc */
+    override suspend fun update(entity: Goal) {
+        withContext(Dispatchers.IO) {
+            queries.update(
+                name = entity.name,
+                target_amount = entity.targetAmount.amount,
+                current_amount = entity.currentAmount.amount,
+                currency = entity.currency.code,
+                target_date = entity.targetDate?.toString(),
+                status = entity.status.name,
+                icon = entity.icon,
+                color = entity.color,
+                account_id = entity.accountId?.value,
+                updated_at = entity.updatedAt.toString(),
+                sync_version = entity.syncVersion,
+                is_synced = if (entity.isSynced) 1L else 0L,
+                id = entity.id.value,
+            )
+        }
+    }
+
+    /** @inheritDoc */
+    override suspend fun delete(id: SyncId) {
+        val now = Clock.System.now().toString()
+        withContext(Dispatchers.IO) {
+            queries.softDelete(deleted_at = now, updated_at = now, id = id.value)
+        }
+    }
+
+    /** @inheritDoc */
+    override suspend fun getUnsynced(householdId: SyncId): List<Goal> =
+        withContext(Dispatchers.IO) {
+            queries.selectUnsyncedByHousehold(householdId.value)
+                .executeAsList()
+                .map { it.toDomain() }
+        }
+
+    /** @inheritDoc */
+    override suspend fun markSynced(ids: List<SyncId>) {
+        if (ids.isEmpty()) return
+        withContext(Dispatchers.IO) {
+            database.transaction {
+                ids.forEach { id ->
+                    queries.markSyncedById(id.value)
+                }
+            }
+        }
+    }
+
+    // ── GoalRepository ──────────────────────────────────────────────
+
+    /** @inheritDoc */
+    override fun observeActive(householdId: SyncId): Flow<List<Goal>> =
+        queries.selectActive(householdId.value)
+            .asFlow()
+            .mapToList(Dispatchers.IO)
+            .map { rows -> rows.map { it.toDomain() } }
+
+    /** @inheritDoc */
+    override suspend fun updateProgress(id: SyncId, currentAmount: Cents) {
+        val now = Clock.System.now().toString()
+        withContext(Dispatchers.IO) {
+            queries.updateProgress(
+                current_amount = currentAmount.amount,
+                updated_at = now,
+                id = id.value,
+            )
+        }
+    }
+
+    // ── Mapping ─────────────────────────────────────────────────────
+
+    /**
+     * Maps a SQLDelight-generated [GoalRow] to the domain [Goal] model.
+     */
+    private fun GoalRow.toDomain(): Goal = Goal(
+        id = SyncId(id),
+        householdId = SyncId(household_id),
+        name = name,
+        targetAmount = Cents(target_amount),
+        currentAmount = Cents(current_amount),
+        currency = Currency(currency),
+        targetDate = target_date?.let { LocalDate.parse(it) },
+        status = GoalStatus.valueOf(status),
+        icon = icon,
+        color = color,
+        accountId = account_id?.let { SyncId(it) },
+        createdAt = Instant.parse(created_at),
+        updatedAt = Instant.parse(updated_at),
+        deletedAt = deleted_at?.let { Instant.parse(it) },
+        syncVersion = sync_version,
+        isSynced = is_synced != 0L,
+    )
+}

--- a/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/SqlDelightTransactionRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/SqlDelightTransactionRepository.kt
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.data.repository.impl
+
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToList
+import app.cash.sqldelight.coroutines.mapToOneOrNull
+import com.finance.android.data.repository.TransactionRepository
+import com.finance.db.FinanceDatabase
+import com.finance.db.Transaction as TransactionRow
+import com.finance.models.Transaction
+import com.finance.models.TransactionStatus
+import com.finance.models.TransactionType
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+
+/**
+ * SQLDelight-backed implementation of [TransactionRepository].
+ *
+ * Delegates all persistence to the [FinanceDatabase] and maps between
+ * SQLDelight-generated row types and domain [Transaction] models. Tags
+ * are serialized as a JSON array in the `tags` TEXT column.
+ */
+class SqlDelightTransactionRepository(
+    private val database: FinanceDatabase,
+) : TransactionRepository {
+
+    private val queries get() = database.transactionQueries
+
+    private val tagsSerializer = ListSerializer(String.serializer())
+
+    // ── BaseRepository ──────────────────────────────────────────────
+
+    /** @inheritDoc */
+    override fun observeAll(householdId: SyncId): Flow<List<Transaction>> =
+        queries.selectByHousehold(householdId.value)
+            .asFlow()
+            .mapToList(Dispatchers.IO)
+            .map { rows -> rows.map { it.toDomain() } }
+
+    /** @inheritDoc */
+    override fun observeById(id: SyncId): Flow<Transaction?> =
+        queries.selectById(id.value)
+            .asFlow()
+            .mapToOneOrNull(Dispatchers.IO)
+            .map { it?.toDomain() }
+
+    /** @inheritDoc */
+    override suspend fun getById(id: SyncId): Transaction? = withContext(Dispatchers.IO) {
+        queries.selectById(id.value).executeAsOneOrNull()?.toDomain()
+    }
+
+    /** @inheritDoc */
+    override suspend fun insert(entity: Transaction) {
+        withContext(Dispatchers.IO) {
+            queries.insert(
+                id = entity.id.value,
+                household_id = entity.householdId.value,
+                account_id = entity.accountId.value,
+                category_id = entity.categoryId?.value,
+                type = entity.type.name,
+                status = entity.status.name,
+                amount = entity.amount.amount,
+                currency = entity.currency.code,
+                payee = entity.payee,
+                note = entity.note,
+                date = entity.date.toString(),
+                transfer_account_id = entity.transferAccountId?.value,
+                transfer_transaction_id = entity.transferTransactionId?.value,
+                is_recurring = if (entity.isRecurring) 1L else 0L,
+                recurring_rule_id = entity.recurringRuleId?.value,
+                tags = Json.encodeToString(tagsSerializer, entity.tags),
+                created_at = entity.createdAt.toString(),
+                updated_at = entity.updatedAt.toString(),
+                sync_version = entity.syncVersion,
+                is_synced = if (entity.isSynced) 1L else 0L,
+            )
+        }
+    }
+
+    /** @inheritDoc */
+    override suspend fun update(entity: Transaction) {
+        withContext(Dispatchers.IO) {
+            queries.update(
+                account_id = entity.accountId.value,
+                category_id = entity.categoryId?.value,
+                type = entity.type.name,
+                status = entity.status.name,
+                amount = entity.amount.amount,
+                currency = entity.currency.code,
+                payee = entity.payee,
+                note = entity.note,
+                date = entity.date.toString(),
+                transfer_account_id = entity.transferAccountId?.value,
+                transfer_transaction_id = entity.transferTransactionId?.value,
+                is_recurring = if (entity.isRecurring) 1L else 0L,
+                recurring_rule_id = entity.recurringRuleId?.value,
+                tags = Json.encodeToString(tagsSerializer, entity.tags),
+                updated_at = entity.updatedAt.toString(),
+                sync_version = entity.syncVersion,
+                is_synced = if (entity.isSynced) 1L else 0L,
+                id = entity.id.value,
+            )
+        }
+    }
+
+    /** @inheritDoc */
+    override suspend fun delete(id: SyncId) {
+        val now = Clock.System.now().toString()
+        withContext(Dispatchers.IO) {
+            queries.softDelete(deleted_at = now, updated_at = now, id = id.value)
+        }
+    }
+
+    /** @inheritDoc */
+    override suspend fun getUnsynced(householdId: SyncId): List<Transaction> =
+        withContext(Dispatchers.IO) {
+            queries.selectUnsyncedByHousehold(householdId.value)
+                .executeAsList()
+                .map { it.toDomain() }
+        }
+
+    /** @inheritDoc */
+    override suspend fun markSynced(ids: List<SyncId>) {
+        if (ids.isEmpty()) return
+        withContext(Dispatchers.IO) {
+            database.transaction {
+                ids.forEach { id ->
+                    queries.markSyncedById(id.value)
+                }
+            }
+        }
+    }
+
+    // ── TransactionRepository ───────────────────────────────────────
+
+    /** @inheritDoc */
+    override fun observeByAccount(accountId: SyncId): Flow<List<Transaction>> =
+        queries.selectByAccount(accountId.value)
+            .asFlow()
+            .mapToList(Dispatchers.IO)
+            .map { rows -> rows.map { it.toDomain() } }
+
+    /** @inheritDoc */
+    override fun observeByCategory(categoryId: SyncId): Flow<List<Transaction>> =
+        queries.selectByCategory(categoryId.value)
+            .asFlow()
+            .mapToList(Dispatchers.IO)
+            .map { rows -> rows.map { it.toDomain() } }
+
+    /** @inheritDoc */
+    override fun observeByDateRange(
+        householdId: SyncId,
+        start: LocalDate,
+        end: LocalDate,
+    ): Flow<List<Transaction>> =
+        queries.selectByDateRange(
+            household_id = householdId.value,
+            date = start.toString(),
+            date_ = end.toString(),
+        )
+            .asFlow()
+            .mapToList(Dispatchers.IO)
+            .map { rows -> rows.map { it.toDomain() } }
+
+    /** @inheritDoc */
+    override suspend fun getByDateRange(
+        householdId: SyncId,
+        start: LocalDate,
+        end: LocalDate,
+    ): List<Transaction> = withContext(Dispatchers.IO) {
+        queries.selectByDateRange(
+            household_id = householdId.value,
+            date = start.toString(),
+            date_ = end.toString(),
+        )
+            .executeAsList()
+            .map { it.toDomain() }
+    }
+
+    // ── Mapping ─────────────────────────────────────────────────────
+
+    /**
+     * Maps a SQLDelight-generated [TransactionRow] to the domain [Transaction] model.
+     */
+    private fun TransactionRow.toDomain(): Transaction = Transaction(
+        id = SyncId(id),
+        householdId = SyncId(household_id),
+        accountId = SyncId(account_id),
+        categoryId = category_id?.let { SyncId(it) },
+        type = TransactionType.valueOf(type),
+        status = TransactionStatus.valueOf(status),
+        amount = Cents(amount),
+        currency = Currency(currency),
+        payee = payee,
+        note = note,
+        date = LocalDate.parse(date),
+        transferAccountId = transfer_account_id?.let { SyncId(it) },
+        transferTransactionId = transfer_transaction_id?.let { SyncId(it) },
+        isRecurring = is_recurring != 0L,
+        recurringRuleId = recurring_rule_id?.let { SyncId(it) },
+        tags = Json.decodeFromString(tagsSerializer, tags),
+        createdAt = Instant.parse(created_at),
+        updatedAt = Instant.parse(updated_at),
+        deletedAt = deleted_at?.let { Instant.parse(it) },
+        syncVersion = sync_version,
+        isSynced = is_synced != 0L,
+    )
+}

--- a/apps/android/src/main/kotlin/com/finance/android/data/repository/mock/MockAccountRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/data/repository/mock/MockAccountRepository.kt
@@ -5,7 +5,7 @@ package com.finance.android.data.repository.mock
 import com.finance.android.data.repository.AccountRepository
 import com.finance.android.ui.data.SampleData
 import com.finance.models.Account
-import com.finance.models.AccountType
+import com.finance.models.types.Cents
 import com.finance.models.types.SyncId
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -24,18 +24,28 @@ class MockAccountRepository : AccountRepository {
 
     private val _accounts = MutableStateFlow(SampleData.accounts.toList())
 
-    override fun getAll(): Flow<List<Account>> =
-        _accounts.map { list -> list.filter { it.deletedAt == null }.sortedBy { it.sortOrder } }
-
-    override fun getById(id: SyncId): Flow<Account?> =
-        _accounts.map { list -> list.find { it.id == id && it.deletedAt == null } }
-
-    override fun getByType(type: AccountType): Flow<List<Account>> =
+    override fun observeAll(householdId: SyncId): Flow<List<Account>> =
         _accounts.map { list ->
-            list.filter { it.type == type && it.deletedAt == null }.sortedBy { it.sortOrder }
+            list.filter { it.householdId == householdId && it.deletedAt == null }
+                .sortedBy { it.sortOrder }
         }
 
-    override suspend fun create(account: Account) {
+    override fun observeById(id: SyncId): Flow<Account?> =
+        _accounts.map { list -> list.find { it.id == id && it.deletedAt == null } }
+
+    override suspend fun getById(id: SyncId): Account? =
+        _accounts.value.find { it.id == id && it.deletedAt == null }
+
+    override fun observeActive(householdId: SyncId): Flow<List<Account>> =
+        _accounts.map { list ->
+            list.filter {
+                it.householdId == householdId &&
+                    !it.isArchived &&
+                    it.deletedAt == null
+            }.sortedBy { it.sortOrder }
+        }
+
+    override suspend fun insert(account: Account) {
         _accounts.update { it + account }
     }
 
@@ -45,9 +55,53 @@ class MockAccountRepository : AccountRepository {
         }
     }
 
-    override suspend fun delete(id: SyncId) {
+    override suspend fun updateBalance(id: SyncId, newBalance: Cents) {
+        val now = Clock.System.now()
         _accounts.update { list ->
-            list.map { if (it.id == id) it.copy(deletedAt = Clock.System.now()) else it }
+            list.map { account ->
+                if (account.id == id) account.copy(
+                    currentBalance = newBalance,
+                    updatedAt = now,
+                    isSynced = false,
+                ) else account
+            }
+        }
+    }
+
+    override suspend fun archive(id: SyncId) {
+        val now = Clock.System.now()
+        _accounts.update { list ->
+            list.map { account ->
+                if (account.id == id) account.copy(
+                    isArchived = true,
+                    updatedAt = now,
+                    isSynced = false,
+                ) else account
+            }
+        }
+    }
+
+    override suspend fun delete(id: SyncId) {
+        val now = Clock.System.now()
+        _accounts.update { list ->
+            list.map { account ->
+                if (account.id == id) account.copy(
+                    deletedAt = now,
+                    updatedAt = now,
+                    isSynced = false,
+                ) else account
+            }
+        }
+    }
+
+    override suspend fun getUnsynced(householdId: SyncId): List<Account> =
+        _accounts.value.filter { it.householdId == householdId && !it.isSynced }
+
+    override suspend fun markSynced(ids: List<SyncId>) {
+        _accounts.update { list ->
+            list.map { account ->
+                if (account.id in ids) account.copy(isSynced = true) else account
+            }
         }
     }
 }

--- a/apps/android/src/main/kotlin/com/finance/android/data/repository/mock/MockBudgetRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/data/repository/mock/MockBudgetRepository.kt
@@ -25,28 +25,34 @@ class MockBudgetRepository : BudgetRepository {
 
     private val _budgets = MutableStateFlow(SampleData.budgets.toList())
 
-    override fun getAll(): Flow<List<Budget>> =
-        _budgets.map { list -> list.filter { it.deletedAt == null } }
+    override fun observeAll(householdId: SyncId): Flow<List<Budget>> =
+        _budgets.map { list ->
+            list.filter { it.householdId == householdId && it.deletedAt == null }
+        }
 
-    override fun getById(id: SyncId): Flow<Budget?> =
+    override fun observeById(id: SyncId): Flow<Budget?> =
         _budgets.map { list -> list.find { it.id == id && it.deletedAt == null } }
 
-    override fun getActiveBudgets(): Flow<List<Budget>> =
+    override suspend fun getById(id: SyncId): Budget? =
+        _budgets.value.find { it.id == id && it.deletedAt == null }
+
+    override fun observeActive(householdId: SyncId): Flow<List<Budget>> =
         _budgets.map { list ->
             val today = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
             list.filter { budget ->
                 val end = budget.endDate
-                budget.deletedAt == null &&
+                budget.householdId == householdId &&
+                    budget.deletedAt == null &&
                     (end == null || end >= today)
             }
         }
 
-    override fun getByCategoryId(categoryId: SyncId): Flow<List<Budget>> =
+    override fun observeByCategory(categoryId: SyncId): Flow<List<Budget>> =
         _budgets.map { list ->
             list.filter { it.categoryId == categoryId && it.deletedAt == null }
         }
 
-    override suspend fun create(budget: Budget) {
+    override suspend fun insert(budget: Budget) {
         _budgets.update { it + budget }
     }
 
@@ -57,8 +63,26 @@ class MockBudgetRepository : BudgetRepository {
     }
 
     override suspend fun delete(id: SyncId) {
+        val now = Clock.System.now()
         _budgets.update { list ->
-            list.map { if (it.id == id) it.copy(deletedAt = Clock.System.now()) else it }
+            list.map { budget ->
+                if (budget.id == id) budget.copy(
+                    deletedAt = now,
+                    updatedAt = now,
+                    isSynced = false,
+                ) else budget
+            }
+        }
+    }
+
+    override suspend fun getUnsynced(householdId: SyncId): List<Budget> =
+        _budgets.value.filter { it.householdId == householdId && !it.isSynced }
+
+    override suspend fun markSynced(ids: List<SyncId>) {
+        _budgets.update { list ->
+            list.map { budget ->
+                if (budget.id in ids) budget.copy(isSynced = true) else budget
+            }
         }
     }
 }

--- a/apps/android/src/main/kotlin/com/finance/android/data/repository/mock/MockCategoryRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/data/repository/mock/MockCategoryRepository.kt
@@ -23,25 +23,43 @@ class MockCategoryRepository : CategoryRepository {
 
     private val _categories = MutableStateFlow(SampleData.categories.toList())
 
-    override fun getAll(): Flow<List<Category>> =
+    override fun observeAll(householdId: SyncId): Flow<List<Category>> =
         _categories.map { list ->
-            list.filter { it.deletedAt == null }.sortedBy { it.sortOrder }
+            list.filter { it.householdId == householdId && it.deletedAt == null }
+                .sortedBy { it.sortOrder }
         }
 
-    override fun getById(id: SyncId): Flow<Category?> =
+    override fun observeById(id: SyncId): Flow<Category?> =
         _categories.map { list -> list.find { it.id == id && it.deletedAt == null } }
 
-    override fun getIncomeCategories(): Flow<List<Category>> =
+    override suspend fun getById(id: SyncId): Category? =
+        _categories.value.find { it.id == id && it.deletedAt == null }
+
+    override fun observeByParent(parentId: SyncId?): Flow<List<Category>> =
         _categories.map { list ->
-            list.filter { it.isIncome && it.deletedAt == null }.sortedBy { it.sortOrder }
+            list.filter { it.parentId == parentId && it.deletedAt == null }
+                .sortedBy { it.sortOrder }
         }
 
-    override fun getExpenseCategories(): Flow<List<Category>> =
+    override fun observeIncome(householdId: SyncId): Flow<List<Category>> =
         _categories.map { list ->
-            list.filter { !it.isIncome && it.deletedAt == null }.sortedBy { it.sortOrder }
+            list.filter {
+                it.householdId == householdId &&
+                    it.isIncome &&
+                    it.deletedAt == null
+            }.sortedBy { it.sortOrder }
         }
 
-    override suspend fun create(category: Category) {
+    override fun observeExpense(householdId: SyncId): Flow<List<Category>> =
+        _categories.map { list ->
+            list.filter {
+                it.householdId == householdId &&
+                    !it.isIncome &&
+                    it.deletedAt == null
+            }.sortedBy { it.sortOrder }
+        }
+
+    override suspend fun insert(category: Category) {
         _categories.update { it + category }
     }
 
@@ -52,8 +70,26 @@ class MockCategoryRepository : CategoryRepository {
     }
 
     override suspend fun delete(id: SyncId) {
+        val now = Clock.System.now()
         _categories.update { list ->
-            list.map { if (it.id == id) it.copy(deletedAt = Clock.System.now()) else it }
+            list.map { category ->
+                if (category.id == id) category.copy(
+                    deletedAt = now,
+                    updatedAt = now,
+                    isSynced = false,
+                ) else category
+            }
+        }
+    }
+
+    override suspend fun getUnsynced(householdId: SyncId): List<Category> =
+        _categories.value.filter { it.householdId == householdId && !it.isSynced }
+
+    override suspend fun markSynced(ids: List<SyncId>) {
+        _categories.update { list ->
+            list.map { category ->
+                if (category.id in ids) category.copy(isSynced = true) else category
+            }
         }
     }
 }

--- a/apps/android/src/main/kotlin/com/finance/android/data/repository/mock/MockGoalRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/data/repository/mock/MockGoalRepository.kt
@@ -3,7 +3,6 @@
 package com.finance.android.data.repository.mock
 
 import com.finance.android.data.repository.GoalRepository
-import com.finance.android.ui.data.SampleData
 import com.finance.models.Goal
 import com.finance.models.GoalStatus
 import com.finance.models.types.Cents
@@ -23,20 +22,29 @@ import kotlinx.datetime.Clock
  */
 class MockGoalRepository : GoalRepository {
 
-    private val _goals = MutableStateFlow(SampleData.goals)
+    private val _goals = MutableStateFlow<List<Goal>>(emptyList())
 
-    override fun getAll(): Flow<List<Goal>> =
-        _goals.map { list -> list.filter { it.deletedAt == null } }
-
-    override fun getById(id: SyncId): Flow<Goal?> =
-        _goals.map { list -> list.find { it.id == id && it.deletedAt == null } }
-
-    override fun getActiveGoals(): Flow<List<Goal>> =
+    override fun observeAll(householdId: SyncId): Flow<List<Goal>> =
         _goals.map { list ->
-            list.filter { it.deletedAt == null && it.status == GoalStatus.ACTIVE }
+            list.filter { it.householdId == householdId && it.deletedAt == null }
         }
 
-    override suspend fun create(goal: Goal) {
+    override fun observeById(id: SyncId): Flow<Goal?> =
+        _goals.map { list -> list.find { it.id == id && it.deletedAt == null } }
+
+    override suspend fun getById(id: SyncId): Goal? =
+        _goals.value.find { it.id == id && it.deletedAt == null }
+
+    override fun observeActive(householdId: SyncId): Flow<List<Goal>> =
+        _goals.map { list ->
+            list.filter {
+                it.householdId == householdId &&
+                    it.deletedAt == null &&
+                    it.status == GoalStatus.ACTIVE
+            }
+        }
+
+    override suspend fun insert(goal: Goal) {
         _goals.update { it + goal }
     }
 
@@ -47,19 +55,39 @@ class MockGoalRepository : GoalRepository {
     }
 
     override suspend fun updateProgress(id: SyncId, currentAmount: Cents) {
+        val now = Clock.System.now()
         _goals.update { list ->
             list.map { goal ->
                 if (goal.id == id) goal.copy(
                     currentAmount = currentAmount,
-                    updatedAt = Clock.System.now(),
+                    updatedAt = now,
+                    isSynced = false,
                 ) else goal
             }
         }
     }
 
     override suspend fun delete(id: SyncId) {
+        val now = Clock.System.now()
         _goals.update { list ->
-            list.map { if (it.id == id) it.copy(deletedAt = Clock.System.now()) else it }
+            list.map { goal ->
+                if (goal.id == id) goal.copy(
+                    deletedAt = now,
+                    updatedAt = now,
+                    isSynced = false,
+                ) else goal
+            }
+        }
+    }
+
+    override suspend fun getUnsynced(householdId: SyncId): List<Goal> =
+        _goals.value.filter { it.householdId == householdId && !it.isSynced }
+
+    override suspend fun markSynced(ids: List<SyncId>) {
+        _goals.update { list ->
+            list.map { goal ->
+                if (goal.id in ids) goal.copy(isSynced = true) else goal
+            }
         }
     }
 }

--- a/apps/android/src/main/kotlin/com/finance/android/data/repository/mock/MockTransactionRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/data/repository/mock/MockTransactionRepository.kt
@@ -24,52 +24,55 @@ class MockTransactionRepository : TransactionRepository {
 
     private val _transactions = MutableStateFlow(SampleData.transactions.toList())
 
-    override fun getAll(): Flow<List<Transaction>> =
+    override fun observeAll(householdId: SyncId): Flow<List<Transaction>> =
         _transactions.map { list ->
-            list.filter { it.deletedAt == null }.sortedByDescending { it.date }
+            list.filter { it.householdId == householdId && it.deletedAt == null }
+                .sortedByDescending { it.date }
         }
 
-    override fun getById(id: SyncId): Flow<Transaction?> =
+    override fun observeById(id: SyncId): Flow<Transaction?> =
         _transactions.map { list -> list.find { it.id == id && it.deletedAt == null } }
 
-    override fun getByAccountId(accountId: SyncId): Flow<List<Transaction>> =
+    override suspend fun getById(id: SyncId): Transaction? =
+        _transactions.value.find { it.id == id && it.deletedAt == null }
+
+    override fun observeByAccount(accountId: SyncId): Flow<List<Transaction>> =
         _transactions.map { list ->
             list.filter { it.accountId == accountId && it.deletedAt == null }
                 .sortedByDescending { it.date }
         }
 
-    override fun getByCategoryId(categoryId: SyncId): Flow<List<Transaction>> =
+    override fun observeByCategory(categoryId: SyncId): Flow<List<Transaction>> =
         _transactions.map { list ->
             list.filter { it.categoryId == categoryId && it.deletedAt == null }
                 .sortedByDescending { it.date }
         }
 
-    override fun getByDateRange(from: LocalDate, to: LocalDate): Flow<List<Transaction>> =
+    override fun observeByDateRange(
+        householdId: SyncId,
+        start: LocalDate,
+        end: LocalDate,
+    ): Flow<List<Transaction>> =
         _transactions.map { list ->
-            list.filter { it.deletedAt == null && it.date in from..to }
-                .sortedByDescending { it.date }
-        }
-
-    override fun search(query: String): Flow<List<Transaction>> =
-        _transactions.map { list ->
-            val q = query.lowercase()
-            list.filter { txn ->
-                txn.deletedAt == null && (
-                    txn.payee?.lowercase()?.contains(q) == true ||
-                    txn.note?.lowercase()?.contains(q) == true
-                )
+            list.filter {
+                it.householdId == householdId &&
+                    it.deletedAt == null &&
+                    it.date in start..end
             }.sortedByDescending { it.date }
         }
 
-    override fun getPayeeHistory(): Flow<List<String>> =
-        _transactions.map { list ->
-            list.filter { it.deletedAt == null }
-                .mapNotNull { it.payee }
-                .distinct()
-                .sorted()
-        }
+    override suspend fun getByDateRange(
+        householdId: SyncId,
+        start: LocalDate,
+        end: LocalDate,
+    ): List<Transaction> =
+        _transactions.value.filter {
+            it.householdId == householdId &&
+                it.deletedAt == null &&
+                it.date in start..end
+        }.sortedByDescending { it.date }
 
-    override suspend fun create(transaction: Transaction) {
+    override suspend fun insert(transaction: Transaction) {
         _transactions.update { it + transaction }
     }
 
@@ -80,8 +83,26 @@ class MockTransactionRepository : TransactionRepository {
     }
 
     override suspend fun delete(id: SyncId) {
+        val now = Clock.System.now()
         _transactions.update { list ->
-            list.map { if (it.id == id) it.copy(deletedAt = Clock.System.now()) else it }
+            list.map { transaction ->
+                if (transaction.id == id) transaction.copy(
+                    deletedAt = now,
+                    updatedAt = now,
+                    isSynced = false,
+                ) else transaction
+            }
+        }
+    }
+
+    override suspend fun getUnsynced(householdId: SyncId): List<Transaction> =
+        _transactions.value.filter { it.householdId == householdId && !it.isSynced }
+
+    override suspend fun markSynced(ids: List<SyncId>) {
+        _transactions.update { list ->
+            list.map { transaction ->
+                if (transaction.id in ids) transaction.copy(isSynced = true) else transaction
+            }
         }
     }
 }

--- a/apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt
@@ -7,11 +7,11 @@ import com.finance.android.data.repository.BudgetRepository
 import com.finance.android.data.repository.CategoryRepository
 import com.finance.android.data.repository.GoalRepository
 import com.finance.android.data.repository.TransactionRepository
-import com.finance.android.data.repository.mock.MockAccountRepository
-import com.finance.android.data.repository.mock.MockBudgetRepository
-import com.finance.android.data.repository.mock.MockCategoryRepository
-import com.finance.android.data.repository.mock.MockGoalRepository
-import com.finance.android.data.repository.mock.MockTransactionRepository
+import com.finance.android.data.repository.impl.InMemoryAccountRepository
+import com.finance.android.data.repository.impl.InMemoryBudgetRepository
+import com.finance.android.data.repository.impl.InMemoryCategoryRepository
+import com.finance.android.data.repository.impl.InMemoryGoalRepository
+import com.finance.android.data.repository.impl.InMemoryTransactionRepository
 import com.finance.android.logging.TimberCrashReporter
 import com.finance.android.ui.screens.BiometricAvailabilityChecker
 import com.finance.android.ui.screens.DefaultBiometricAvailabilityChecker
@@ -55,14 +55,14 @@ val appModule = module {
     }
 
     // ── Repositories ────────────────────────────────────────────────
-    // Mock implementations backed by SampleData.
+    // Temporary in-memory implementations.
     // Swap these to real SQLDelight-backed implementations later.
 
-    singleOf(::MockAccountRepository) bind AccountRepository::class
-    singleOf(::MockTransactionRepository) bind TransactionRepository::class
-    singleOf(::MockBudgetRepository) bind BudgetRepository::class
-    singleOf(::MockGoalRepository) bind GoalRepository::class
-    singleOf(::MockCategoryRepository) bind CategoryRepository::class
+    singleOf(::InMemoryAccountRepository) bind AccountRepository::class
+    singleOf(::InMemoryTransactionRepository) bind TransactionRepository::class
+    singleOf(::InMemoryBudgetRepository) bind BudgetRepository::class
+    singleOf(::InMemoryGoalRepository) bind GoalRepository::class
+    singleOf(::InMemoryCategoryRepository) bind CategoryRepository::class
 
     // ── Settings dependencies ───────────────────────────────────────
 

--- a/apps/android/src/main/kotlin/com/finance/android/di/DataModule.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/di/DataModule.kt
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.di
+
+import com.finance.android.data.repository.AccountRepository
+import com.finance.android.data.repository.BudgetRepository
+import com.finance.android.data.repository.CategoryRepository
+import com.finance.android.data.repository.GoalRepository
+import com.finance.android.data.repository.TransactionRepository
+import com.finance.android.data.repository.impl.InMemoryAccountRepository
+import com.finance.android.data.repository.impl.InMemoryBudgetRepository
+import com.finance.android.data.repository.impl.InMemoryCategoryRepository
+import com.finance.android.data.repository.impl.InMemoryGoalRepository
+import com.finance.android.data.repository.impl.InMemoryTransactionRepository
+import org.koin.dsl.module
+
+// TODO(#432): Replace in-memory implementations with SQLDelight-backed repositories
+
+/**
+ * Koin module providing the data layer (repositories).
+ *
+ * Each repository is bound as a singleton so that all consumers
+ * (ViewModels, sync engine, etc.) share the same instance and
+ * observe a single source of truth.
+ *
+ * The current bindings use in-memory stub implementations. Once
+ * issue #432 is complete, swap each `InMemory*` class for the
+ * corresponding SQLDelight-backed implementation.
+ */
+val dataModule = module {
+
+    /** Transaction repository — manages income, expense, and transfer records. */
+    single<TransactionRepository> { InMemoryTransactionRepository() }
+
+    /** Account repository — manages bank, credit, cash, and investment accounts. */
+    single<AccountRepository> { InMemoryAccountRepository() }
+
+    /** Budget repository — manages spending budgets linked to categories. */
+    single<BudgetRepository> { InMemoryBudgetRepository() }
+
+    /** Category repository — manages income and expense categories. */
+    single<CategoryRepository> { InMemoryCategoryRepository() }
+
+    /** Goal repository — manages savings goals and progress tracking. */
+    single<GoalRepository> { InMemoryGoalRepository() }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/di/DataModule.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/di/DataModule.kt
@@ -7,40 +7,53 @@ import com.finance.android.data.repository.BudgetRepository
 import com.finance.android.data.repository.CategoryRepository
 import com.finance.android.data.repository.GoalRepository
 import com.finance.android.data.repository.TransactionRepository
-import com.finance.android.data.repository.impl.InMemoryAccountRepository
-import com.finance.android.data.repository.impl.InMemoryBudgetRepository
-import com.finance.android.data.repository.impl.InMemoryCategoryRepository
-import com.finance.android.data.repository.impl.InMemoryGoalRepository
-import com.finance.android.data.repository.impl.InMemoryTransactionRepository
+import com.finance.android.data.repository.impl.SqlDelightAccountRepository
+import com.finance.android.data.repository.impl.SqlDelightBudgetRepository
+import com.finance.android.data.repository.impl.SqlDelightCategoryRepository
+import com.finance.android.data.repository.impl.SqlDelightGoalRepository
+import com.finance.android.data.repository.impl.SqlDelightTransactionRepository
+import com.finance.android.security.KeystoreEncryptionKeyProvider
+import com.finance.db.DatabaseFactory
+import com.finance.db.EncryptionKeyProvider
+import com.finance.db.FinanceDatabase
+import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
 
-// TODO(#432): Replace in-memory implementations with SQLDelight-backed repositories
-
 /**
- * Koin module providing the data layer (repositories).
+ * Koin module providing the data layer (database + repositories).
  *
  * Each repository is bound as a singleton so that all consumers
  * (ViewModels, sync engine, etc.) share the same instance and
- * observe a single source of truth.
- *
- * The current bindings use in-memory stub implementations. Once
- * issue #432 is complete, swap each `InMemory*` class for the
- * corresponding SQLDelight-backed implementation.
+ * observe a single source of truth backed by the SQLDelight
+ * [FinanceDatabase].
  */
 val dataModule = module {
 
+    // ── Database ────────────────────────────────────────────────────
+
+    /** Encryption key provider — stores the SQLCipher passphrase in Android Keystore. */
+    single<EncryptionKeyProvider> { KeystoreEncryptionKeyProvider(androidContext()) }
+
+    /** Database factory — creates the encrypted SQLDelight database driver. */
+    single { DatabaseFactory(androidContext(), get()) }
+
+    /** SQLDelight database — single source of truth for all local data. */
+    single<FinanceDatabase> { get<DatabaseFactory>().createDatabase() }
+
+    // ── Repositories ────────────────────────────────────────────────
+
     /** Transaction repository — manages income, expense, and transfer records. */
-    single<TransactionRepository> { InMemoryTransactionRepository() }
+    single<TransactionRepository> { SqlDelightTransactionRepository(get()) }
 
     /** Account repository — manages bank, credit, cash, and investment accounts. */
-    single<AccountRepository> { InMemoryAccountRepository() }
+    single<AccountRepository> { SqlDelightAccountRepository(get()) }
 
     /** Budget repository — manages spending budgets linked to categories. */
-    single<BudgetRepository> { InMemoryBudgetRepository() }
+    single<BudgetRepository> { SqlDelightBudgetRepository(get()) }
 
     /** Category repository — manages income and expense categories. */
-    single<CategoryRepository> { InMemoryCategoryRepository() }
+    single<CategoryRepository> { SqlDelightCategoryRepository(get()) }
 
     /** Goal repository — manages savings goals and progress tracking. */
-    single<GoalRepository> { InMemoryGoalRepository() }
+    single<GoalRepository> { SqlDelightGoalRepository(get()) }
 }

--- a/apps/android/src/main/kotlin/com/finance/android/security/KeystoreEncryptionKeyProvider.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/security/KeystoreEncryptionKeyProvider.kt
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.security
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
+import com.finance.db.EncryptionKeyProvider
+import java.util.UUID
+
+/**
+ * Android [EncryptionKeyProvider] implementation backed by
+ * [EncryptedSharedPreferences] and Android Keystore.
+ *
+ * Generates a random SQLCipher passphrase on first use and stores it
+ * in an AES-256-GCM encrypted SharedPreferences file. The encryption
+ * master key is managed by Android Keystore (hardware-backed where
+ * available).
+ *
+ * @param context Application context used to create the encrypted prefs.
+ */
+class KeystoreEncryptionKeyProvider(
+    private val context: Context,
+) : EncryptionKeyProvider {
+
+    private val masterKeyAlias: String by lazy {
+        MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
+    }
+
+    private val prefs: SharedPreferences by lazy {
+        EncryptedSharedPreferences.create(
+            PREFS_FILE_NAME,
+            masterKeyAlias,
+            context,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+        )
+    }
+
+    /** Retrieves existing key or generates a new one via Android Keystore. */
+    override fun getOrCreateKey(): String {
+        return prefs.getString(KEY_PREF, null) ?: run {
+            val key = UUID.randomUUID().toString()
+            prefs.edit().putString(KEY_PREF, key).apply()
+            key
+        }
+    }
+
+    /** Checks if a key already exists in Android Keystore. */
+    override fun hasKey(): Boolean = prefs.contains(KEY_PREF)
+
+    /** Deletes the stored key (for crypto-shredding / account deletion). */
+    override fun deleteKey() {
+        prefs.edit().remove(KEY_PREF).apply()
+    }
+
+    private companion object {
+        /** File name for the encrypted preferences storing the DB key. */
+        const val PREFS_FILE_NAME = "finance_db_encryption"
+        /** Preference key under which the SQLCipher passphrase is stored. */
+        const val KEY_PREF = "db_encryption_key"
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/SettingsViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/SettingsViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.finance.android.data.repository.CategoryRepository
 import com.finance.android.data.repository.TransactionRepository
+import com.finance.models.types.SyncId
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -106,6 +107,9 @@ data class SettingsUiState(
 // ---------------------------------------------------------------------------
 // Preferences keys
 // ---------------------------------------------------------------------------
+
+// TODO(#434): Replace with authenticated user's household ID
+private val PLACEHOLDER_HOUSEHOLD_ID = SyncId("household-1")
 
 private object PrefKeys {
     const val FILE_NAME = "finance_settings"
@@ -273,8 +277,8 @@ class SettingsViewModel(
      * to avoid leaking financial data.
      */
     private suspend fun buildExportContent(format: ExportFormat): String {
-        val transactions = transactionRepository.getAll().first()
-        val categories = categoryRepository.getAll().first()
+        val transactions = transactionRepository.observeAll(PLACEHOLDER_HOUSEHOLD_ID).first()
+        val categories = categoryRepository.observeAll(PLACEHOLDER_HOUSEHOLD_ID).first()
         val categoryMap = categories.associateBy { it.id }
 
         return when (format) {

--- a/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/AccountsViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/AccountsViewModel.kt
@@ -12,6 +12,7 @@ import com.finance.models.AccountType
 import com.finance.models.Transaction
 import com.finance.models.types.Cents
 import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -19,6 +20,9 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+
+// TODO(#434): Replace with authenticated user's household ID
+private val PLACEHOLDER_HOUSEHOLD_ID = SyncId("household-1")
 
 data class AccountGroup(
     val type: AccountType,
@@ -54,7 +58,7 @@ class AccountsViewModel(
     private fun loadAccounts() {
         viewModelScope.launch {
             delay(200)
-            val accounts = accountRepository.getAll().first()
+            val accounts = accountRepository.observeAll(PLACEHOLDER_HOUSEHOLD_ID).first()
             val currency = Currency.USD
             if (accounts.isEmpty()) {
                 _uiState.update { it.copy(isLoading = false, isEmpty = true) }
@@ -76,7 +80,7 @@ class AccountsViewModel(
 
     fun selectAccount(account: Account) {
         viewModelScope.launch {
-            val txns = transactionRepository.getByAccountId(account.id).first()
+            val txns = transactionRepository.observeByAccount(account.id).first()
                 .sortedByDescending { it.date }
             _uiState.update { it.copy(selectedAccount = account, selectedAccountTransactions = txns) }
         }

--- a/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/BudgetsViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/BudgetsViewModel.kt
@@ -25,6 +25,9 @@ import kotlinx.datetime.Clock
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 
+// TODO(#434): Replace with authenticated user's household ID
+private val PLACEHOLDER_HOUSEHOLD_ID = SyncId("household-1")
+
 /**
  * UI state for the Budgets screen.
  *
@@ -122,9 +125,9 @@ class BudgetsViewModel(
 
     private suspend fun loadData() {
         try {
-            val budgets = budgetRepository.getAll().first()
-            val transactions = transactionRepository.getAll().first()
-            val categories = categoryRepository.getAll().first()
+            val budgets = budgetRepository.observeAll(PLACEHOLDER_HOUSEHOLD_ID).first()
+            val transactions = transactionRepository.observeAll(PLACEHOLDER_HOUSEHOLD_ID).first()
+            val categories = categoryRepository.observeAll(PLACEHOLDER_HOUSEHOLD_ID).first()
             val categoryMap = categories.associateBy { it.id }
 
             val currency = Currency.USD

--- a/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/DashboardViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/DashboardViewModel.kt
@@ -15,6 +15,7 @@ import com.finance.core.currency.CurrencyFormatter
 import com.finance.models.Transaction
 import com.finance.models.types.Cents
 import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -26,6 +27,9 @@ import kotlinx.datetime.Clock
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
+
+// TODO(#434): Replace with authenticated user's household ID
+private val PLACEHOLDER_HOUSEHOLD_ID = SyncId("household-1")
 
 data class DashboardUiState(
     val isLoading: Boolean = true,
@@ -91,10 +95,10 @@ class DashboardViewModel(
     }
 
     private suspend fun loadData() {
-        val accounts = accountRepository.getAll().first()
-        val transactions = transactionRepository.getAll().first()
-        val budgets = budgetRepository.getAll().first()
-        val categories = categoryRepository.getAll().first()
+        val accounts = accountRepository.observeAll(PLACEHOLDER_HOUSEHOLD_ID).first()
+        val transactions = transactionRepository.observeAll(PLACEHOLDER_HOUSEHOLD_ID).first()
+        val budgets = budgetRepository.observeAll(PLACEHOLDER_HOUSEHOLD_ID).first()
+        val categories = categoryRepository.observeAll(PLACEHOLDER_HOUSEHOLD_ID).first()
         val categoryMap = categories.associateBy { it.id }
 
         val currency = Currency.USD

--- a/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/GoalsViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/GoalsViewModel.kt
@@ -18,6 +18,9 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
+// TODO(#434): Replace with authenticated user's household ID
+private val PLACEHOLDER_HOUSEHOLD_ID = SyncId("household-1")
+
 /**
  * UI state for the Goals screen.
  *
@@ -103,7 +106,7 @@ class GoalsViewModel(
 
     private suspend fun loadData() {
         try {
-            val goals = goalRepository.getAll().first()
+            val goals = goalRepository.observeAll(PLACEHOLDER_HOUSEHOLD_ID).first()
             val currency = Currency.USD
 
             val goalItems = goals.map { goal ->

--- a/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/TransactionCreateViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/TransactionCreateViewModel.kt
@@ -28,6 +28,9 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 
+// TODO(#434): Replace with authenticated user's household ID
+private val PLACEHOLDER_HOUSEHOLD_ID = SyncId("household-1")
+
 enum class CreateStep(val index: Int, val label: String) {
     AMOUNT(0, "Amount & Payee"),
     CATEGORY(1, "Category & Account"),
@@ -83,9 +86,11 @@ class TransactionCreateViewModel(
 
     init {
         viewModelScope.launch {
-            val cats = categoryRepository.getAll().first()
-            val accts = accountRepository.getAll().first()
-            payeeHistory = transactionRepository.getPayeeHistory().first()
+            val cats = categoryRepository.observeAll(PLACEHOLDER_HOUSEHOLD_ID).first()
+            val accts = accountRepository.observeAll(PLACEHOLDER_HOUSEHOLD_ID).first()
+            payeeHistory = transactionRepository.observeAll(PLACEHOLDER_HOUSEHOLD_ID).first()
+                .mapNotNull { it.payee }
+                .distinct()
             categoryMap = cats.associateBy { it.id }
             accountMap = accts.associateBy { it.id }
             _uiState.update { it.copy(categories = cats, accounts = accts,
@@ -176,7 +181,7 @@ class TransactionCreateViewModel(
                 Cents(s.amountCents) else Cents(-s.amountCents)
             val transaction = Transaction(
                 id = SyncId("txn-${now.toEpochMilliseconds()}"),
-                householdId = SyncId("household-1"),
+                householdId = PLACEHOLDER_HOUSEHOLD_ID,
                 accountId = s.selectedAccountId!!,
                 categoryId = s.selectedCategoryId,
                 type = s.transactionType,
@@ -190,7 +195,7 @@ class TransactionCreateViewModel(
                 createdAt = now,
                 updatedAt = now,
             )
-            transactionRepository.create(transaction)
+            transactionRepository.insert(transaction)
             _uiState.update { it.copy(isSaving = false, isSaved = true) }
         }
     }

--- a/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/TransactionsViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/TransactionsViewModel.kt
@@ -23,6 +23,9 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.minus
 import kotlinx.datetime.toLocalDateTime
 
+// TODO(#434): Replace with authenticated user's household ID
+private val PLACEHOLDER_HOUSEHOLD_ID = SyncId("household-1")
+
 data class TransactionFilter(
     val searchQuery: String = "",
     val type: TransactionType? = null,
@@ -126,8 +129,8 @@ class TransactionsViewModel(
         val filter = _uiState.value.filter
         val today = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
 
-        val allTransactions = transactionRepository.getAll().first()
-        val categories = categoryRepository.getAll().first()
+        val allTransactions = transactionRepository.observeAll(PLACEHOLDER_HOUSEHOLD_ID).first()
+        val categories = categoryRepository.observeAll(PLACEHOLDER_HOUSEHOLD_ID).first()
         val categoryMap = categories.associateBy { it.id }
 
         var filtered = allTransactions

--- a/apps/android/src/test/kotlin/com/finance/android/data/repository/mock/MockAccountRepositoryTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/data/repository/mock/MockAccountRepositoryTest.kt
@@ -54,9 +54,9 @@ class MockAccountRepositoryTest {
     // -- Tests ----------------------------------------------------------------
 
     @Test
-    fun `getAll returns non-deleted accounts sorted by sortOrder`() = runTest {
+    fun `observeAll returns non-deleted accounts sorted by sortOrder`() = runTest {
         val repo = createRepo()
-        val accounts = repo.getAll()
+        val accounts = repo.observeAll(SyncId("household-1"))
 
         accounts.test {
             val list = awaitItem()
@@ -71,11 +71,11 @@ class MockAccountRepositoryTest {
     }
 
     @Test
-    fun `getById returns matching account`() = runTest {
+    fun `observeById returns matching account`() = runTest {
         val repo = createRepo()
         val knownId = SyncId("acc-checking")
 
-        repo.getById(knownId).test {
+        repo.observeById(knownId).test {
             val account = awaitItem()
             assertNotNull(account, "Should find the checking account from SampleData")
             assertEquals(knownId, account.id)
@@ -85,10 +85,10 @@ class MockAccountRepositoryTest {
     }
 
     @Test
-    fun `getById returns null for unknown id`() = runTest {
+    fun `observeById returns null for unknown id`() = runTest {
         val repo = createRepo()
 
-        repo.getById(SyncId("nonexistent-id")).test {
+        repo.observeById(SyncId("nonexistent-id")).test {
             val account = awaitItem()
             assertNull(account, "Unknown ID should return null")
             cancelAndIgnoreRemainingEvents()
@@ -96,38 +96,40 @@ class MockAccountRepositoryTest {
     }
 
     @Test
-    fun `getByType filters by account type`() = runTest {
+    fun `observeAll contains savings accounts`() = runTest {
         val repo = createRepo()
 
-        repo.getByType(AccountType.SAVINGS).test {
+        repo.observeAll(SyncId("household-1")).test {
             val list = awaitItem()
-            assertTrue(list.isNotEmpty(), "SampleData has savings accounts")
-            assertTrue(list.all { it.type == AccountType.SAVINGS })
+            val savings = list.filter { it.type == AccountType.SAVINGS }
+            assertTrue(savings.isNotEmpty(), "SampleData has savings accounts")
+            assertTrue(savings.all { it.type == AccountType.SAVINGS })
             cancelAndIgnoreRemainingEvents()
         }
     }
 
     @Test
-    fun `getByType returns empty for type with no accounts`() = runTest {
+    fun `observeAll contains no loan accounts`() = runTest {
         val repo = createRepo()
 
-        repo.getByType(AccountType.LOAN).test {
+        repo.observeAll(SyncId("household-1")).test {
             val list = awaitItem()
-            assertTrue(list.isEmpty(), "SampleData has no loan accounts")
+            val loans = list.filter { it.type == AccountType.LOAN }
+            assertTrue(loans.isEmpty(), "SampleData has no loan accounts")
             cancelAndIgnoreRemainingEvents()
         }
     }
 
     @Test
-    fun `create adds account to list`() = runTest {
+    fun `insert adds account to list`() = runTest {
         val repo = createRepo()
         val newAccount = account("acc-new", name = "New Savings", type = AccountType.SAVINGS)
 
-        repo.getAll().test {
+        repo.observeAll(SyncId("household-1")).test {
             val before = awaitItem()
             val sizeBefore = before.size
 
-            repo.create(newAccount)
+            repo.insert(newAccount)
 
             val after = awaitItem()
             assertEquals(sizeBefore + 1, after.size, "List should grow by 1")
@@ -141,7 +143,7 @@ class MockAccountRepositoryTest {
         val repo = createRepo()
         val knownId = SyncId("acc-checking")
 
-        repo.getById(knownId).test {
+        repo.observeById(knownId).test {
             val original = awaitItem()
             assertNotNull(original)
 
@@ -162,18 +164,18 @@ class MockAccountRepositoryTest {
 
         repo.delete(targetId)
 
-        repo.getById(targetId).test {
+        repo.observeById(targetId).test {
             val result = awaitItem()
-            assertNull(result, "Soft-deleted account should not appear via getById")
+            assertNull(result, "Soft-deleted account should not appear via observeById")
             cancelAndIgnoreRemainingEvents()
         }
     }
 
     @Test
-    fun `deleted accounts excluded from getAll`() = runTest {
+    fun `deleted accounts excluded from observeAll`() = runTest {
         val repo = createRepo()
 
-        repo.getAll().test {
+        repo.observeAll(SyncId("household-1")).test {
             val before = awaitItem()
             val sizeBefore = before.size
             val targetId = before.first().id
@@ -181,7 +183,7 @@ class MockAccountRepositoryTest {
             repo.delete(targetId)
 
             val after = awaitItem()
-            assertEquals(sizeBefore - 1, after.size, "Deleted account should be excluded from getAll")
+            assertEquals(sizeBefore - 1, after.size, "Deleted account should be excluded from observeAll")
             assertNull(after.find { it.id == targetId }, "Deleted account ID should not appear")
             cancelAndIgnoreRemainingEvents()
         }
@@ -191,14 +193,14 @@ class MockAccountRepositoryTest {
     fun `Flow re-emits on mutations`() = runTest {
         val repo = createRepo()
 
-        repo.getAll().test {
+        repo.observeAll(SyncId("household-1")).test {
             // Initial emission
             val initial = awaitItem()
             val initialSize = initial.size
 
             // Create → new emission
             val newAccount = account("acc-flow-test", name = "Flow Test")
-            repo.create(newAccount)
+            repo.insert(newAccount)
             val afterCreate = awaitItem()
             assertEquals(initialSize + 1, afterCreate.size)
 

--- a/apps/android/src/test/kotlin/com/finance/android/data/repository/mock/MockBudgetRepositoryTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/data/repository/mock/MockBudgetRepositoryTest.kt
@@ -61,10 +61,10 @@ class MockBudgetRepositoryTest {
     // -- Tests ----------------------------------------------------------------
 
     @Test
-    fun `getAll returns non-deleted budgets`() = runTest {
+    fun `observeAll returns non-deleted budgets`() = runTest {
         val repo = createRepo()
 
-        repo.getAll().test {
+        repo.observeAll(SyncId("household-1")).test {
             val list = awaitItem()
             assertTrue(list.isNotEmpty(), "SampleData should provide budgets")
             assertTrue(list.all { it.deletedAt == null })
@@ -73,10 +73,10 @@ class MockBudgetRepositoryTest {
     }
 
     @Test
-    fun `getById returns matching budget`() = runTest {
+    fun `observeById returns matching budget`() = runTest {
         val repo = createRepo()
 
-        repo.getById(SyncId("bud-groceries")).test {
+        repo.observeById(SyncId("bud-groceries")).test {
             val budget = awaitItem()
             assertNotNull(budget)
             assertEquals("Groceries", budget.name)
@@ -85,10 +85,10 @@ class MockBudgetRepositoryTest {
     }
 
     @Test
-    fun `getById returns null for unknown id`() = runTest {
+    fun `observeById returns null for unknown id`() = runTest {
         val repo = createRepo()
 
-        repo.getById(SyncId("nonexistent")).test {
+        repo.observeById(SyncId("nonexistent")).test {
             val budget = awaitItem()
             assertNull(budget)
             cancelAndIgnoreRemainingEvents()
@@ -96,11 +96,11 @@ class MockBudgetRepositoryTest {
     }
 
     @Test
-    fun `getActiveBudgets filters by active status`() = runTest {
+    fun `observeActive filters by active status`() = runTest {
         val repo = createRepo()
 
         // SampleData budgets have no endDate → all should be active
-        repo.getActiveBudgets().test {
+        repo.observeActive(SyncId("household-1")).test {
             val list = awaitItem()
             assertTrue(list.isNotEmpty(), "SampleData budgets with no endDate should be active")
             cancelAndIgnoreRemainingEvents()
@@ -108,7 +108,7 @@ class MockBudgetRepositoryTest {
     }
 
     @Test
-    fun `getActiveBudgets excludes budgets with past endDate`() = runTest {
+    fun `observeActive excludes budgets with past endDate`() = runTest {
         val repo = createRepo()
 
         // Create a budget that has already ended
@@ -118,9 +118,9 @@ class MockBudgetRepositoryTest {
             name = "Expired Budget",
             endDate = pastEnd,
         )
-        repo.create(expiredBudget)
+        repo.insert(expiredBudget)
 
-        repo.getActiveBudgets().test {
+        repo.observeActive(SyncId("household-1")).test {
             val list = awaitItem()
             assertNull(
                 list.find { it.id == SyncId("bud-expired") },
@@ -131,7 +131,7 @@ class MockBudgetRepositoryTest {
     }
 
     @Test
-    fun `getActiveBudgets includes budgets with future endDate`() = runTest {
+    fun `observeActive includes budgets with future endDate`() = runTest {
         val repo = createRepo()
 
         val futureEnd = LocalDate(2099, 12, 31)
@@ -140,9 +140,9 @@ class MockBudgetRepositoryTest {
             name = "Future Budget",
             endDate = futureEnd,
         )
-        repo.create(futureBudget)
+        repo.insert(futureBudget)
 
-        repo.getActiveBudgets().test {
+        repo.observeActive(SyncId("household-1")).test {
             val list = awaitItem()
             assertNotNull(
                 list.find { it.id == SyncId("bud-future") },
@@ -153,11 +153,11 @@ class MockBudgetRepositoryTest {
     }
 
     @Test
-    fun `getByCategoryId filters correctly`() = runTest {
+    fun `observeByCategory filters correctly`() = runTest {
         val repo = createRepo()
         val categoryId = SyncId("cat-groceries")
 
-        repo.getByCategoryId(categoryId).test {
+        repo.observeByCategory(categoryId).test {
             val list = awaitItem()
             assertTrue(list.isNotEmpty(), "SampleData has a groceries budget")
             assertTrue(list.all { it.categoryId == categoryId })
@@ -166,15 +166,15 @@ class MockBudgetRepositoryTest {
     }
 
     @Test
-    fun `create adds budget to list`() = runTest {
+    fun `insert adds budget to list`() = runTest {
         val repo = createRepo()
         val newBudget = budget("bud-new", name = "New Budget")
 
-        repo.getAll().test {
+        repo.observeAll(SyncId("household-1")).test {
             val before = awaitItem()
             val sizeBefore = before.size
 
-            repo.create(newBudget)
+            repo.insert(newBudget)
 
             val after = awaitItem()
             assertEquals(sizeBefore + 1, after.size)
@@ -188,7 +188,7 @@ class MockBudgetRepositoryTest {
         val repo = createRepo()
         val knownId = SyncId("bud-groceries")
 
-        repo.getById(knownId).test {
+        repo.observeById(knownId).test {
             val original = awaitItem()
             assertNotNull(original)
 
@@ -209,18 +209,18 @@ class MockBudgetRepositoryTest {
 
         repo.delete(targetId)
 
-        repo.getById(targetId).test {
+        repo.observeById(targetId).test {
             val result = awaitItem()
-            assertNull(result, "Soft-deleted budget should not appear via getById")
+            assertNull(result, "Soft-deleted budget should not appear via observeById")
             cancelAndIgnoreRemainingEvents()
         }
     }
 
     @Test
-    fun `deleted budgets excluded from getAll`() = runTest {
+    fun `deleted budgets excluded from observeAll`() = runTest {
         val repo = createRepo()
 
-        repo.getAll().test {
+        repo.observeAll(SyncId("household-1")).test {
             val before = awaitItem()
             val sizeBefore = before.size
 
@@ -236,13 +236,13 @@ class MockBudgetRepositoryTest {
     fun `Flow re-emits on mutations`() = runTest {
         val repo = createRepo()
 
-        repo.getAll().test {
+        repo.observeAll(SyncId("household-1")).test {
             val initial = awaitItem()
             val initialSize = initial.size
 
             // Create
             val newBudget = budget("bud-flow-test", name = "Flow Test Budget")
-            repo.create(newBudget)
+            repo.insert(newBudget)
             val afterCreate = awaitItem()
             assertEquals(initialSize + 1, afterCreate.size)
 

--- a/apps/android/src/test/kotlin/com/finance/android/data/repository/mock/MockCategoryRepositoryTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/data/repository/mock/MockCategoryRepositoryTest.kt
@@ -49,10 +49,10 @@ class MockCategoryRepositoryTest {
     // -- Tests ----------------------------------------------------------------
 
     @Test
-    fun `getAll returns all non-deleted categories`() = runTest {
+    fun `observeAll returns all non-deleted categories`() = runTest {
         val repo = createRepo()
 
-        repo.getAll().test {
+        repo.observeAll(SyncId("household-1")).test {
             val list = awaitItem()
             assertTrue(list.isNotEmpty(), "SampleData should provide categories")
             assertTrue(list.all { it.deletedAt == null })
@@ -61,10 +61,10 @@ class MockCategoryRepositoryTest {
     }
 
     @Test
-    fun `getAll returns categories sorted by sortOrder`() = runTest {
+    fun `observeAll returns categories sorted by sortOrder`() = runTest {
         val repo = createRepo()
 
-        repo.getAll().test {
+        repo.observeAll(SyncId("household-1")).test {
             val list = awaitItem()
             val sortOrders = list.map { it.sortOrder }
             assertEquals(sortOrders.sorted(), sortOrders, "Categories should be sorted by sortOrder")
@@ -73,10 +73,10 @@ class MockCategoryRepositoryTest {
     }
 
     @Test
-    fun `getIncomeCategories filters correctly`() = runTest {
+    fun `observeIncome filters correctly`() = runTest {
         val repo = createRepo()
 
-        repo.getIncomeCategories().test {
+        repo.observeIncome(SyncId("household-1")).test {
             val list = awaitItem()
             assertTrue(list.isNotEmpty(), "SampleData has income categories")
             assertTrue(list.all { it.isIncome }, "All returned categories should be income")
@@ -85,10 +85,10 @@ class MockCategoryRepositoryTest {
     }
 
     @Test
-    fun `getExpenseCategories filters correctly`() = runTest {
+    fun `observeExpense filters correctly`() = runTest {
         val repo = createRepo()
 
-        repo.getExpenseCategories().test {
+        repo.observeExpense(SyncId("household-1")).test {
             val list = awaitItem()
             assertTrue(list.isNotEmpty(), "SampleData has expense categories")
             assertTrue(list.none { it.isIncome }, "No returned categories should be income")
@@ -100,10 +100,10 @@ class MockCategoryRepositoryTest {
     fun `income and expense categories are disjoint`() = runTest {
         val repo = createRepo()
 
-        repo.getIncomeCategories().test {
+        repo.observeIncome(SyncId("household-1")).test {
             val incomeIds = awaitItem().map { it.id }.toSet()
 
-            repo.getExpenseCategories().test {
+            repo.observeExpense(SyncId("household-1")).test {
                 val expenseIds = awaitItem().map { it.id }.toSet()
 
                 assertTrue(
@@ -117,10 +117,10 @@ class MockCategoryRepositoryTest {
     }
 
     @Test
-    fun `getById returns matching category`() = runTest {
+    fun `observeById returns matching category`() = runTest {
         val repo = createRepo()
 
-        repo.getById(SyncId("cat-groceries")).test {
+        repo.observeById(SyncId("cat-groceries")).test {
             val category = awaitItem()
             assertNotNull(category)
             assertEquals("Groceries", category.name)
@@ -129,10 +129,10 @@ class MockCategoryRepositoryTest {
     }
 
     @Test
-    fun `getById returns null for unknown id`() = runTest {
+    fun `observeById returns null for unknown id`() = runTest {
         val repo = createRepo()
 
-        repo.getById(SyncId("nonexistent")).test {
+        repo.observeById(SyncId("nonexistent")).test {
             val category = awaitItem()
             assertNull(category)
             cancelAndIgnoreRemainingEvents()
@@ -140,28 +140,28 @@ class MockCategoryRepositoryTest {
     }
 
     @Test
-    fun `getById returns null for deleted category`() = runTest {
+    fun `observeById returns null for deleted category`() = runTest {
         val repo = createRepo()
 
         repo.delete(SyncId("cat-groceries"))
 
-        repo.getById(SyncId("cat-groceries")).test {
+        repo.observeById(SyncId("cat-groceries")).test {
             val category = awaitItem()
-            assertNull(category, "Soft-deleted category should not appear via getById")
+            assertNull(category, "Soft-deleted category should not appear via observeById")
             cancelAndIgnoreRemainingEvents()
         }
     }
 
     @Test
-    fun `create adds category`() = runTest {
+    fun `insert adds category`() = runTest {
         val repo = createRepo()
         val newCategory = category("cat-new", name = "New Category")
 
-        repo.getAll().test {
+        repo.observeAll(SyncId("household-1")).test {
             val before = awaitItem()
             val sizeBefore = before.size
 
-            repo.create(newCategory)
+            repo.insert(newCategory)
 
             val after = awaitItem()
             assertEquals(sizeBefore + 1, after.size)
@@ -175,7 +175,7 @@ class MockCategoryRepositoryTest {
         val repo = createRepo()
         val knownId = SyncId("cat-groceries")
 
-        repo.getById(knownId).test {
+        repo.observeById(knownId).test {
             val original = awaitItem()
             assertNotNull(original)
 
@@ -193,7 +193,7 @@ class MockCategoryRepositoryTest {
     fun `delete soft-deletes category`() = runTest {
         val repo = createRepo()
 
-        repo.getAll().test {
+        repo.observeAll(SyncId("household-1")).test {
             val before = awaitItem()
             val sizeBefore = before.size
 
@@ -206,11 +206,11 @@ class MockCategoryRepositoryTest {
     }
 
     @Test
-    fun `deleted categories excluded from getIncomeCategories`() = runTest {
+    fun `deleted categories excluded from observeIncome`() = runTest {
         val repo = createRepo()
         val salaryId = SyncId("cat-salary")
 
-        repo.getIncomeCategories().test {
+        repo.observeIncome(SyncId("household-1")).test {
             val before = awaitItem()
             assertTrue(before.any { it.id == salaryId }, "Salary should exist initially")
 
@@ -226,13 +226,13 @@ class MockCategoryRepositoryTest {
     fun `Flow re-emits on mutations`() = runTest {
         val repo = createRepo()
 
-        repo.getAll().test {
+        repo.observeAll(SyncId("household-1")).test {
             val initial = awaitItem()
             val initialSize = initial.size
 
             // Create
             val newCat = category("cat-flow-test", name = "Flow Test")
-            repo.create(newCat)
+            repo.insert(newCat)
             val afterCreate = awaitItem()
             assertEquals(initialSize + 1, afterCreate.size)
 

--- a/apps/android/src/test/kotlin/com/finance/android/data/repository/mock/MockGoalRepositoryTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/data/repository/mock/MockGoalRepositoryTest.kt
@@ -57,10 +57,10 @@ class MockGoalRepositoryTest {
     // -- Tests ----------------------------------------------------------------
 
     @Test
-    fun `getAll returns empty initially`() = runTest {
+    fun `observeAll returns empty initially`() = runTest {
         val repo = createRepo()
 
-        repo.getAll().test {
+        repo.observeAll(SyncId("household-1")).test {
             val list = awaitItem()
             assertTrue(list.isEmpty(), "GoalRepository starts with no data")
             cancelAndIgnoreRemainingEvents()
@@ -68,12 +68,12 @@ class MockGoalRepositoryTest {
     }
 
     @Test
-    fun `getAll returns non-deleted goals`() = runTest {
+    fun `observeAll returns non-deleted goals`() = runTest {
         val repo = createRepo()
-        repo.create(goal("goal-1", name = "Vacation"))
-        repo.create(goal("goal-2", name = "Car"))
+        repo.insert(goal("goal-1", name = "Vacation"))
+        repo.insert(goal("goal-2", name = "Car"))
 
-        repo.getAll().test {
+        repo.observeAll(SyncId("household-1")).test {
             val list = awaitItem()
             assertEquals(2, list.size)
             assertTrue(list.all { it.deletedAt == null })
@@ -82,11 +82,11 @@ class MockGoalRepositoryTest {
     }
 
     @Test
-    fun `getById returns matching goal`() = runTest {
+    fun `observeById returns matching goal`() = runTest {
         val repo = createRepo()
-        repo.create(goal("goal-1", name = "Emergency Fund"))
+        repo.insert(goal("goal-1", name = "Emergency Fund"))
 
-        repo.getById(SyncId("goal-1")).test {
+        repo.observeById(SyncId("goal-1")).test {
             val result = awaitItem()
             assertNotNull(result)
             assertEquals("Emergency Fund", result.name)
@@ -95,10 +95,10 @@ class MockGoalRepositoryTest {
     }
 
     @Test
-    fun `getById returns null for unknown id`() = runTest {
+    fun `observeById returns null for unknown id`() = runTest {
         val repo = createRepo()
 
-        repo.getById(SyncId("nonexistent")).test {
+        repo.observeById(SyncId("nonexistent")).test {
             val result = awaitItem()
             assertNull(result)
             cancelAndIgnoreRemainingEvents()
@@ -106,14 +106,14 @@ class MockGoalRepositoryTest {
     }
 
     @Test
-    fun `getActiveGoals filters by active status`() = runTest {
+    fun `observeActive filters by active status`() = runTest {
         val repo = createRepo()
-        repo.create(goal("goal-active", name = "Active Goal", status = GoalStatus.ACTIVE))
-        repo.create(goal("goal-paused", name = "Paused Goal", status = GoalStatus.PAUSED))
-        repo.create(goal("goal-completed", name = "Completed Goal", status = GoalStatus.COMPLETED))
-        repo.create(goal("goal-cancelled", name = "Cancelled Goal", status = GoalStatus.CANCELLED))
+        repo.insert(goal("goal-active", name = "Active Goal", status = GoalStatus.ACTIVE))
+        repo.insert(goal("goal-paused", name = "Paused Goal", status = GoalStatus.PAUSED))
+        repo.insert(goal("goal-completed", name = "Completed Goal", status = GoalStatus.COMPLETED))
+        repo.insert(goal("goal-cancelled", name = "Cancelled Goal", status = GoalStatus.CANCELLED))
 
-        repo.getActiveGoals().test {
+        repo.observeActive(SyncId("household-1")).test {
             val list = awaitItem()
             assertEquals(1, list.size, "Only ACTIVE goals should be returned")
             assertEquals(SyncId("goal-active"), list.first().id)
@@ -122,12 +122,12 @@ class MockGoalRepositoryTest {
     }
 
     @Test
-    fun `getActiveGoals excludes deleted goals even if status is ACTIVE`() = runTest {
+    fun `observeActive excludes deleted goals even if status is ACTIVE`() = runTest {
         val repo = createRepo()
-        repo.create(goal("goal-1", name = "Active Goal", status = GoalStatus.ACTIVE))
+        repo.insert(goal("goal-1", name = "Active Goal", status = GoalStatus.ACTIVE))
         repo.delete(SyncId("goal-1"))
 
-        repo.getActiveGoals().test {
+        repo.observeActive(SyncId("household-1")).test {
             val list = awaitItem()
             assertTrue(list.isEmpty(), "Soft-deleted active goals should not appear")
             cancelAndIgnoreRemainingEvents()
@@ -137,11 +137,11 @@ class MockGoalRepositoryTest {
     @Test
     fun `updateProgress modifies goal currentAmount`() = runTest {
         val repo = createRepo()
-        repo.create(goal("goal-1", name = "Savings Goal", targetCents = 500_000L, currentCents = 0L))
+        repo.insert(goal("goal-1", name = "Savings Goal", targetCents = 500_000L, currentCents = 0L))
 
         repo.updateProgress(SyncId("goal-1"), Cents(150_000L))
 
-        repo.getById(SyncId("goal-1")).test {
+        repo.observeById(SyncId("goal-1")).test {
             val result = awaitItem()
             assertNotNull(result)
             assertEquals(Cents(150_000L), result.currentAmount)
@@ -153,12 +153,12 @@ class MockGoalRepositoryTest {
     fun `updateProgress updates updatedAt timestamp`() = runTest {
         val repo = createRepo()
         val originalGoal = goal("goal-1", name = "Timestamp Goal")
-        repo.create(originalGoal)
+        repo.insert(originalGoal)
         val originalUpdatedAt = originalGoal.updatedAt
 
         repo.updateProgress(SyncId("goal-1"), Cents(25_000L))
 
-        repo.getById(SyncId("goal-1")).test {
+        repo.observeById(SyncId("goal-1")).test {
             val result = awaitItem()
             assertNotNull(result)
             assertTrue(
@@ -170,14 +170,14 @@ class MockGoalRepositoryTest {
     }
 
     @Test
-    fun `create adds goal`() = runTest {
+    fun `insert adds goal`() = runTest {
         val repo = createRepo()
 
-        repo.getAll().test {
+        repo.observeAll(SyncId("household-1")).test {
             val before = awaitItem()
             assertTrue(before.isEmpty())
 
-            repo.create(goal("goal-new", name = "New Goal"))
+            repo.insert(goal("goal-new", name = "New Goal"))
 
             val after = awaitItem()
             assertEquals(1, after.size)
@@ -189,9 +189,9 @@ class MockGoalRepositoryTest {
     @Test
     fun `update replaces existing goal`() = runTest {
         val repo = createRepo()
-        repo.create(goal("goal-1", name = "Original Name"))
+        repo.insert(goal("goal-1", name = "Original Name"))
 
-        repo.getById(SyncId("goal-1")).test {
+        repo.observeById(SyncId("goal-1")).test {
             val original = awaitItem()
             assertNotNull(original)
 
@@ -208,26 +208,26 @@ class MockGoalRepositoryTest {
     @Test
     fun `delete soft-deletes goal`() = runTest {
         val repo = createRepo()
-        repo.create(goal("goal-1", name = "To Delete"))
+        repo.insert(goal("goal-1", name = "To Delete"))
 
         repo.delete(SyncId("goal-1"))
 
-        repo.getById(SyncId("goal-1")).test {
+        repo.observeById(SyncId("goal-1")).test {
             val result = awaitItem()
-            assertNull(result, "Soft-deleted goal should not appear via getById")
+            assertNull(result, "Soft-deleted goal should not appear via observeById")
             cancelAndIgnoreRemainingEvents()
         }
     }
 
     @Test
-    fun `deleted goals excluded from getAll`() = runTest {
+    fun `deleted goals excluded from observeAll`() = runTest {
         val repo = createRepo()
-        repo.create(goal("goal-1", name = "Keep"))
-        repo.create(goal("goal-2", name = "Remove"))
+        repo.insert(goal("goal-1", name = "Keep"))
+        repo.insert(goal("goal-2", name = "Remove"))
 
         repo.delete(SyncId("goal-2"))
 
-        repo.getAll().test {
+        repo.observeAll(SyncId("household-1")).test {
             val list = awaitItem()
             assertEquals(1, list.size)
             assertEquals(SyncId("goal-1"), list.first().id)
@@ -239,13 +239,13 @@ class MockGoalRepositoryTest {
     fun `Flow re-emits on create and delete`() = runTest {
         val repo = createRepo()
 
-        repo.getAll().test {
+        repo.observeAll(SyncId("household-1")).test {
             // Initial → empty
             val initial = awaitItem()
             assertTrue(initial.isEmpty())
 
             // Create → 1 goal
-            repo.create(goal("goal-flow", name = "Flow Goal"))
+            repo.insert(goal("goal-flow", name = "Flow Goal"))
             val afterCreate = awaitItem()
             assertEquals(1, afterCreate.size)
 

--- a/apps/android/src/test/kotlin/com/finance/android/data/repository/mock/MockTransactionRepositoryTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/data/repository/mock/MockTransactionRepositoryTest.kt
@@ -4,6 +4,7 @@ package com.finance.android.data.repository.mock
 
 import app.cash.turbine.test
 import com.finance.models.Transaction
+import kotlinx.coroutines.flow.first
 import com.finance.models.TransactionStatus
 import com.finance.models.TransactionType
 import com.finance.models.types.Cents
@@ -65,10 +66,10 @@ class MockTransactionRepositoryTest {
     // -- Tests ----------------------------------------------------------------
 
     @Test
-    fun `getAll returns non-deleted transactions`() = runTest {
+    fun `observeAll returns non-deleted transactions`() = runTest {
         val repo = createRepo()
 
-        repo.getAll().test {
+        repo.observeAll(SyncId("household-1")).test {
             val list = awaitItem()
             assertTrue(list.isNotEmpty(), "SampleData should provide transactions")
             assertTrue(list.all { it.deletedAt == null })
@@ -77,10 +78,10 @@ class MockTransactionRepositoryTest {
     }
 
     @Test
-    fun `getAll returns transactions sorted by date descending`() = runTest {
+    fun `observeAll returns transactions sorted by date descending`() = runTest {
         val repo = createRepo()
 
-        repo.getAll().test {
+        repo.observeAll(SyncId("household-1")).test {
             val list = awaitItem()
             val dates = list.map { it.date }
             assertEquals(dates.sortedDescending(), dates, "Transactions should be newest first")
@@ -89,11 +90,11 @@ class MockTransactionRepositoryTest {
     }
 
     @Test
-    fun `getByAccountId filters correctly`() = runTest {
+    fun `observeByAccount filters correctly`() = runTest {
         val repo = createRepo()
         val accountId = SyncId("acc-checking")
 
-        repo.getByAccountId(accountId).test {
+        repo.observeByAccount(accountId).test {
             val list = awaitItem()
             assertTrue(list.isNotEmpty(), "SampleData has checking transactions")
             assertTrue(list.all { it.accountId == accountId })
@@ -102,10 +103,10 @@ class MockTransactionRepositoryTest {
     }
 
     @Test
-    fun `getByAccountId returns empty for unknown account`() = runTest {
+    fun `observeByAccount returns empty for unknown account`() = runTest {
         val repo = createRepo()
 
-        repo.getByAccountId(SyncId("acc-nonexistent")).test {
+        repo.observeByAccount(SyncId("acc-nonexistent")).test {
             val list = awaitItem()
             assertTrue(list.isEmpty())
             cancelAndIgnoreRemainingEvents()
@@ -113,11 +114,11 @@ class MockTransactionRepositoryTest {
     }
 
     @Test
-    fun `getByCategoryId filters correctly`() = runTest {
+    fun `observeByCategory filters correctly`() = runTest {
         val repo = createRepo()
         val categoryId = SyncId("cat-groceries")
 
-        repo.getByCategoryId(categoryId).test {
+        repo.observeByCategory(categoryId).test {
             val list = awaitItem()
             assertTrue(list.isNotEmpty(), "SampleData has grocery transactions")
             assertTrue(list.all { it.categoryId == categoryId })
@@ -126,12 +127,12 @@ class MockTransactionRepositoryTest {
     }
 
     @Test
-    fun `getByDateRange returns transactions within range`() = runTest {
+    fun `observeByDateRange returns transactions within range`() = runTest {
         val repo = createRepo()
         val from = today.minus(2, DateTimeUnit.DAY)
         val to = today
 
-        repo.getByDateRange(from, to).test {
+        repo.observeByDateRange(SyncId("household-1"), from, to).test {
             val list = awaitItem()
             assertTrue(list.isNotEmpty(), "Should have transactions in the last 2 days")
             assertTrue(list.all { it.date in from..to }, "All dates should be within range")
@@ -140,12 +141,12 @@ class MockTransactionRepositoryTest {
     }
 
     @Test
-    fun `getByDateRange returns empty for future range`() = runTest {
+    fun `observeByDateRange returns empty for future range`() = runTest {
         val repo = createRepo()
         val futureStart = LocalDate(2099, 1, 1)
         val futureEnd = LocalDate(2099, 12, 31)
 
-        repo.getByDateRange(futureStart, futureEnd).test {
+        repo.observeByDateRange(SyncId("household-1"), futureStart, futureEnd).test {
             val list = awaitItem()
             assertTrue(list.isEmpty(), "No transactions should exist in the far future")
             cancelAndIgnoreRemainingEvents()
@@ -153,54 +154,58 @@ class MockTransactionRepositoryTest {
     }
 
     @Test
-    fun `search matches payee text case-insensitively`() = runTest {
+    fun `observeAll contains Starbucks transaction`() = runTest {
         val repo = createRepo()
 
-        repo.search("starbucks").test {
+        repo.observeAll(SyncId("household-1")).test {
             val list = awaitItem()
-            assertTrue(list.isNotEmpty(), "SampleData contains a Starbucks transaction")
-            assertTrue(list.all { it.payee?.contains("Starbucks", ignoreCase = true) == true })
+            val matches = list.filter { it.payee?.contains("Starbucks", ignoreCase = true) == true }
+            assertTrue(matches.isNotEmpty(), "SampleData contains a Starbucks transaction")
             cancelAndIgnoreRemainingEvents()
         }
     }
 
     @Test
-    fun `search matches note text`() = runTest {
+    fun `observeAll contains transaction with note`() = runTest {
         val repo = createRepo()
 
-        // Create a transaction with a note, then search for it
         val txn = transaction("txn-note-test", payee = "SomePayee", note = "Birthday dinner")
-        repo.create(txn)
+        repo.insert(txn)
 
-        repo.search("birthday").test {
+        repo.observeAll(SyncId("household-1")).test {
             val list = awaitItem()
-            assertTrue(list.isNotEmpty(), "Should find transaction by note text")
-            assertTrue(list.any { it.id == SyncId("txn-note-test") })
+            val matches = list.filter { it.note?.contains("Birthday", ignoreCase = true) == true }
+            assertTrue(matches.isNotEmpty(), "Should find transaction by note text")
+            assertTrue(matches.any { it.id == SyncId("txn-note-test") })
             cancelAndIgnoreRemainingEvents()
         }
     }
 
     @Test
-    fun `search returns empty for no matches`() = runTest {
+    fun `observeAll has no transactions matching gibberish`() = runTest {
         val repo = createRepo()
 
-        repo.search("zzz-no-match-zzz").test {
+        repo.observeAll(SyncId("household-1")).test {
             val list = awaitItem()
-            assertTrue(list.isEmpty(), "No transactions should match gibberish query")
+            val matches = list.filter {
+                it.payee?.contains("zzz-no-match-zzz", ignoreCase = true) == true ||
+                    it.note?.contains("zzz-no-match-zzz", ignoreCase = true) == true
+            }
+            assertTrue(matches.isEmpty(), "No transactions should match gibberish query")
             cancelAndIgnoreRemainingEvents()
         }
     }
 
     @Test
-    fun `create adds transaction`() = runTest {
+    fun `insert adds transaction`() = runTest {
         val repo = createRepo()
         val newTxn = transaction("txn-new", payee = "New Store")
 
-        repo.getAll().test {
+        repo.observeAll(SyncId("household-1")).test {
             val before = awaitItem()
             val sizeBefore = before.size
 
-            repo.create(newTxn)
+            repo.insert(newTxn)
 
             val after = awaitItem()
             assertEquals(sizeBefore + 1, after.size)
@@ -216,18 +221,18 @@ class MockTransactionRepositoryTest {
 
         repo.delete(targetId)
 
-        repo.getById(targetId).test {
+        repo.observeById(targetId).test {
             val result = awaitItem()
-            assertNull(result, "Soft-deleted transaction should not appear via getById")
+            assertNull(result, "Soft-deleted transaction should not appear via observeById")
             cancelAndIgnoreRemainingEvents()
         }
     }
 
     @Test
-    fun `deleted transactions excluded from getAll`() = runTest {
+    fun `deleted transactions excluded from observeAll`() = runTest {
         val repo = createRepo()
 
-        repo.getAll().test {
+        repo.observeAll(SyncId("household-1")).test {
             val before = awaitItem()
             val sizeBefore = before.size
             val targetId = before.first().id
@@ -241,30 +246,28 @@ class MockTransactionRepositoryTest {
     }
 
     @Test
-    fun `getPayeeHistory returns distinct sorted payees`() = runTest {
+    fun `observeAll provides distinct payees`() = runTest {
         val repo = createRepo()
 
-        repo.getPayeeHistory().test {
-            val payees = awaitItem()
-            assertTrue(payees.isNotEmpty())
-            assertEquals(payees.sorted(), payees, "Payees should be alphabetically sorted")
-            assertEquals(payees.distinct(), payees, "Payees should be distinct")
-            cancelAndIgnoreRemainingEvents()
-        }
+        val payees = repo.observeAll(SyncId("household-1")).first()
+            .mapNotNull { it.payee }
+            .distinct()
+        assertTrue(payees.isNotEmpty())
+        assertEquals(payees.distinct(), payees, "Payees should be distinct")
     }
 
     @Test
     fun `Flow re-emits on mutations`() = runTest {
         val repo = createRepo()
 
-        repo.getAll().test {
+        repo.observeAll(SyncId("household-1")).test {
             // Initial emission
             val initial = awaitItem()
             val initialSize = initial.size
 
             // Create → new emission
             val newTxn = transaction("txn-flow-test", payee = "Flow Test Payee")
-            repo.create(newTxn)
+            repo.insert(newTxn)
             val afterCreate = awaitItem()
             assertEquals(initialSize + 1, afterCreate.size)
 

--- a/apps/android/src/test/kotlin/com/finance/android/ui/viewmodel/BudgetsViewModelTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/ui/viewmodel/BudgetsViewModelTest.kt
@@ -132,25 +132,28 @@ class BudgetsViewModelTest {
     ) : BudgetRepository {
         private val _budgets = MutableStateFlow(initial)
 
-        override fun getAll(): Flow<List<Budget>> =
+        override fun observeAll(householdId: SyncId): Flow<List<Budget>> =
             _budgets.map { list -> list.filter { it.deletedAt == null } }
 
-        override fun getById(id: SyncId): Flow<Budget?> =
+        override fun observeById(id: SyncId): Flow<Budget?> =
             _budgets.map { list -> list.find { it.id == id && it.deletedAt == null } }
 
-        override fun getActiveBudgets(): Flow<List<Budget>> = getAll()
+        override suspend fun getById(id: SyncId): Budget? =
+            _budgets.value.find { it.id == id && it.deletedAt == null }
 
-        override fun getByCategoryId(categoryId: SyncId): Flow<List<Budget>> =
+        override fun observeActive(householdId: SyncId): Flow<List<Budget>> = observeAll(householdId)
+
+        override fun observeByCategory(categoryId: SyncId): Flow<List<Budget>> =
             _budgets.map { list ->
                 list.filter { it.categoryId == categoryId && it.deletedAt == null }
             }
 
-        override suspend fun create(budget: Budget) {
-            _budgets.value = _budgets.value + budget
+        override suspend fun insert(entity: Budget) {
+            _budgets.value = _budgets.value + entity
         }
 
-        override suspend fun update(budget: Budget) {
-            _budgets.value = _budgets.value.map { if (it.id == budget.id) budget else it }
+        override suspend fun update(entity: Budget) {
+            _budgets.value = _budgets.value.map { if (it.id == entity.id) entity else it }
         }
 
         override suspend fun delete(id: SyncId) {
@@ -158,6 +161,10 @@ class BudgetsViewModelTest {
                 if (it.id == id) it.copy(deletedAt = Clock.System.now()) else it
             }
         }
+
+        override suspend fun getUnsynced(householdId: SyncId): List<Budget> = emptyList()
+
+        override suspend fun markSynced(ids: List<SyncId>) {}
     }
 
     /**
@@ -168,34 +175,42 @@ class BudgetsViewModelTest {
     ) : TransactionRepository {
         private val _transactions = MutableStateFlow(initial)
 
-        override fun getAll(): Flow<List<Transaction>> =
+        override fun observeAll(householdId: SyncId): Flow<List<Transaction>> =
             _transactions.map { list -> list.filter { it.deletedAt == null } }
 
-        override fun getById(id: SyncId): Flow<Transaction?> =
+        override fun observeById(id: SyncId): Flow<Transaction?> =
             _transactions.map { list -> list.find { it.id == id } }
 
-        override fun getByAccountId(accountId: SyncId): Flow<List<Transaction>> =
+        override suspend fun getById(id: SyncId): Transaction? =
+            _transactions.value.find { it.id == id }
+
+        override fun observeByAccount(accountId: SyncId): Flow<List<Transaction>> =
             _transactions.map { list -> list.filter { it.accountId == accountId } }
 
-        override fun getByCategoryId(categoryId: SyncId): Flow<List<Transaction>> =
+        override fun observeByCategory(categoryId: SyncId): Flow<List<Transaction>> =
             _transactions.map { list -> list.filter { it.categoryId == categoryId } }
 
-        override fun getByDateRange(from: LocalDate, to: LocalDate): Flow<List<Transaction>> =
-            _transactions.map { list -> list.filter { it.date in from..to } }
+        override fun observeByDateRange(
+            householdId: SyncId,
+            start: LocalDate,
+            end: LocalDate,
+        ): Flow<List<Transaction>> =
+            _transactions.map { list -> list.filter { it.date in start..end } }
 
-        override fun search(query: String): Flow<List<Transaction>> =
-            _transactions.map { emptyList() }
+        override suspend fun getByDateRange(
+            householdId: SyncId,
+            start: LocalDate,
+            end: LocalDate,
+        ): List<Transaction> =
+            _transactions.value.filter { it.date in start..end }
 
-        override fun getPayeeHistory(): Flow<List<String>> =
-            _transactions.map { emptyList() }
-
-        override suspend fun create(transaction: Transaction) {
-            _transactions.value = _transactions.value + transaction
+        override suspend fun insert(entity: Transaction) {
+            _transactions.value = _transactions.value + entity
         }
 
-        override suspend fun update(transaction: Transaction) {
+        override suspend fun update(entity: Transaction) {
             _transactions.value =
-                _transactions.value.map { if (it.id == transaction.id) transaction else it }
+                _transactions.value.map { if (it.id == entity.id) entity else it }
         }
 
         override suspend fun delete(id: SyncId) {
@@ -203,6 +218,10 @@ class BudgetsViewModelTest {
                 if (it.id == id) it.copy(deletedAt = Clock.System.now()) else it
             }
         }
+
+        override suspend fun getUnsynced(householdId: SyncId): List<Transaction> = emptyList()
+
+        override suspend fun markSynced(ids: List<SyncId>) {}
     }
 
     /**
@@ -213,25 +232,31 @@ class BudgetsViewModelTest {
     ) : CategoryRepository {
         private val _categories = MutableStateFlow(initial)
 
-        override fun getAll(): Flow<List<Category>> =
+        override fun observeAll(householdId: SyncId): Flow<List<Category>> =
             _categories.map { list -> list.filter { it.deletedAt == null } }
 
-        override fun getById(id: SyncId): Flow<Category?> =
+        override fun observeById(id: SyncId): Flow<Category?> =
             _categories.map { list -> list.find { it.id == id } }
 
-        override fun getIncomeCategories(): Flow<List<Category>> =
+        override suspend fun getById(id: SyncId): Category? =
+            _categories.value.find { it.id == id }
+
+        override fun observeByParent(parentId: SyncId?): Flow<List<Category>> =
+            _categories.map { list -> list.filter { it.parentId == parentId && it.deletedAt == null } }
+
+        override fun observeIncome(householdId: SyncId): Flow<List<Category>> =
             _categories.map { list -> list.filter { it.isIncome } }
 
-        override fun getExpenseCategories(): Flow<List<Category>> =
+        override fun observeExpense(householdId: SyncId): Flow<List<Category>> =
             _categories.map { list -> list.filter { !it.isIncome } }
 
-        override suspend fun create(category: Category) {
-            _categories.value = _categories.value + category
+        override suspend fun insert(entity: Category) {
+            _categories.value = _categories.value + entity
         }
 
-        override suspend fun update(category: Category) {
+        override suspend fun update(entity: Category) {
             _categories.value =
-                _categories.value.map { if (it.id == category.id) category else it }
+                _categories.value.map { if (it.id == entity.id) entity else it }
         }
 
         override suspend fun delete(id: SyncId) {
@@ -239,6 +264,10 @@ class BudgetsViewModelTest {
                 if (it.id == id) it.copy(deletedAt = Clock.System.now()) else it
             }
         }
+
+        override suspend fun getUnsynced(householdId: SyncId): List<Category> = emptyList()
+
+        override suspend fun markSynced(ids: List<SyncId>) {}
     }
 
     // ═══════════════════════════════════════════════════════════════════

--- a/apps/android/src/test/kotlin/com/finance/android/ui/viewmodel/GoalsViewModelTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/ui/viewmodel/GoalsViewModelTest.kt
@@ -92,23 +92,26 @@ class GoalsViewModelTest {
     ) : GoalRepository {
         private val _goals = MutableStateFlow(initial)
 
-        override fun getAll(): Flow<List<Goal>> =
+        override fun observeAll(householdId: SyncId): Flow<List<Goal>> =
             _goals.map { list -> list.filter { it.deletedAt == null } }
 
-        override fun getById(id: SyncId): Flow<Goal?> =
+        override fun observeById(id: SyncId): Flow<Goal?> =
             _goals.map { list -> list.find { it.id == id && it.deletedAt == null } }
 
-        override fun getActiveGoals(): Flow<List<Goal>> =
+        override suspend fun getById(id: SyncId): Goal? =
+            _goals.value.find { it.id == id && it.deletedAt == null }
+
+        override fun observeActive(householdId: SyncId): Flow<List<Goal>> =
             _goals.map { list ->
                 list.filter { it.deletedAt == null && it.status == GoalStatus.ACTIVE }
             }
 
-        override suspend fun create(goal: Goal) {
-            _goals.value = _goals.value + goal
+        override suspend fun insert(entity: Goal) {
+            _goals.value = _goals.value + entity
         }
 
-        override suspend fun update(goal: Goal) {
-            _goals.value = _goals.value.map { if (it.id == goal.id) goal else it }
+        override suspend fun update(entity: Goal) {
+            _goals.value = _goals.value.map { if (it.id == entity.id) entity else it }
         }
 
         override suspend fun updateProgress(id: SyncId, currentAmount: Cents) {
@@ -125,6 +128,10 @@ class GoalsViewModelTest {
                 if (it.id == id) it.copy(deletedAt = Clock.System.now()) else it
             }
         }
+
+        override suspend fun getUnsynced(householdId: SyncId): List<Goal> = emptyList()
+
+        override suspend fun markSynced(ids: List<SyncId>) {}
     }
 
     // ═══════════════════════════════════════════════════════════════════

--- a/packages/models/src/commonMain/sqldelight/com/finance/db/Account.sq
+++ b/packages/models/src/commonMain/sqldelight/com/finance/db/Account.sq
@@ -71,3 +71,12 @@ SELECT * FROM account WHERE is_synced = 0;
 
 markSynced:
 UPDATE account SET is_synced = 1, sync_version = ? WHERE id = ?;
+
+selectUnsyncedByHousehold:
+SELECT * FROM account WHERE household_id = ? AND is_synced = 0;
+
+markSyncedById:
+UPDATE account SET is_synced = 1 WHERE id = ?;
+
+archive:
+UPDATE account SET is_archived = 1, updated_at = ?, sync_version = sync_version + 1, is_synced = 0 WHERE id = ?;

--- a/packages/models/src/commonMain/sqldelight/com/finance/db/Budget.sq
+++ b/packages/models/src/commonMain/sqldelight/com/finance/db/Budget.sq
@@ -75,3 +75,9 @@ SELECT * FROM budget WHERE is_synced = 0;
 
 markSynced:
 UPDATE budget SET is_synced = 1, sync_version = ? WHERE id = ?;
+
+selectUnsyncedByHousehold:
+SELECT * FROM budget WHERE household_id = ? AND is_synced = 0;
+
+markSyncedById:
+UPDATE budget SET is_synced = 1 WHERE id = ?;

--- a/packages/models/src/commonMain/sqldelight/com/finance/db/Category.sq
+++ b/packages/models/src/commonMain/sqldelight/com/finance/db/Category.sq
@@ -72,3 +72,12 @@ SELECT * FROM category WHERE is_synced = 0;
 
 markSynced:
 UPDATE category SET is_synced = 1, sync_version = ? WHERE id = ?;
+
+selectUnsyncedByHousehold:
+SELECT * FROM category WHERE household_id = ? AND is_synced = 0;
+
+markSyncedById:
+UPDATE category SET is_synced = 1 WHERE id = ?;
+
+selectRootCategories:
+SELECT * FROM category WHERE parent_id IS NULL AND deleted_at IS NULL ORDER BY sort_order ASC;

--- a/packages/models/src/commonMain/sqldelight/com/finance/db/Goal.sq
+++ b/packages/models/src/commonMain/sqldelight/com/finance/db/Goal.sq
@@ -81,3 +81,9 @@ SELECT * FROM goal WHERE is_synced = 0;
 
 markSynced:
 UPDATE goal SET is_synced = 1, sync_version = ? WHERE id = ?;
+
+selectUnsyncedByHousehold:
+SELECT * FROM goal WHERE household_id = ? AND is_synced = 0;
+
+markSyncedById:
+UPDATE goal SET is_synced = 1 WHERE id = ?;

--- a/packages/models/src/commonMain/sqldelight/com/finance/db/Transaction.sq
+++ b/packages/models/src/commonMain/sqldelight/com/finance/db/Transaction.sq
@@ -114,3 +114,9 @@ SELECT * FROM "transaction" WHERE is_synced = 0;
 
 markSynced:
 UPDATE "transaction" SET is_synced = 1, sync_version = ? WHERE id = ?;
+
+selectUnsyncedByHousehold:
+SELECT * FROM "transaction" WHERE household_id = ? AND is_synced = 0;
+
+markSyncedById:
+UPDATE "transaction" SET is_synced = 1 WHERE id = ?;


### PR DESCRIPTION
## Summary
Implement the Android data layer with repository pattern abstraction and SQLDelight database integration.

## Changes

### Repository Pattern (#429)
- 6 repository interfaces: \BaseRepository<T>\, \TransactionRepository\, \AccountRepository\, \BudgetRepository\, \CategoryRepository\, \GoalRepository\
- 5 in-memory stub implementations for testing
- Koin DI module (\DataModule.kt\)

### SQLDelight Wiring (#432)
- 5 SQLDelight-backed repository implementations (\SqlDelight*Repository\)
- \KeystoreEncryptionKeyProvider\ for SQLCipher passphrase via Android Keystore
- New SQLDelight queries (\selectUnsyncedByHousehold\, \markSyncedById\, \rchive\, \selectRootCategories\)
- Koin DI updated to use SQLDelight implementations in production

## Testing
- In-memory implementations retained for unit testing
- All repositories use \kotlinx.datetime\, \Cents\, \SyncId\ value types

Closes #429
Closes #432