### PR TITLE
docs(api): add OpenAPI 3.0 specification and API documentation (#212)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1930,6 +1930,30 @@
         "node": ">=20.19.0"
       }
     },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
@@ -2518,6 +2542,28 @@
         }
       }
     },
+    "node_modules/@exodus/schemasafe": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.3.0.tgz",
+      "integrity": "sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.6.0.tgz",
+      "integrity": "sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/@finance/api": {
+      "resolved": "services/api",
+      "link": true
+    },
     "node_modules/@finance/design-tokens": {
       "resolved": "packages/design-tokens",
       "link": true
@@ -2564,6 +2610,16 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@humanwhocodes/momoa": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.4.tgz",
+      "integrity": "sha512-RE815I4arJFtt+FVeU1Tgp9/Xvecacji8w/V6XtXsWWH/wz/eNkNbhb+ny/+PlVZjV0rxQpRSQKNKE3lcktHEA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
     "node_modules/@humanwhocodes/retry": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
@@ -2598,6 +2654,19 @@
         "@types/node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@joshwooding/vite-plugin-react-docgen-typescript": {
@@ -2668,6 +2737,32 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
       }
     },
     "node_modules/@jsonjoy.com/base64": {
@@ -3210,6 +3305,656 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz",
+      "integrity": "sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.26.0.tgz",
+      "integrity": "sha512-HedpXXYzzbaoutw6DFLWLDket2FwLkLpil4hGCZ1xYEIMTcivdfwEOISgdbLEWyG3HW52gTq2V9mOVJrONgiwg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.26.0.tgz",
+      "integrity": "sha512-1iKxXXE8415Cdv0yjG3G6hQnB5eVEsJce3QaawX8SjDn0mAS0ZM8fAbZZJD4ajvhC15cePvosSCut404KrIIvQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.53.0.tgz",
+      "integrity": "sha512-m7F5ZTq+V9mKGWYpX8EnZ7NjoqAU7VemQ1E2HAG+W/u0wpY1x0OmbxAXfGKFHCspdJk8UKlwPGrpcB8nay3P8A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/otlp-exporter-base": "0.53.0",
+        "@opentelemetry/otlp-transformer": "0.53.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.53.0.tgz",
+      "integrity": "sha512-UCWPreGQEhD6FjBaeDuXhiMf6kkBODF0ZQzrk/tuQcaVDJ+dDQ/xhJp192H9yWnKxVpEjFrSSLnpqmX4VwX+eA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/otlp-transformer": "0.53.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.53.0.tgz",
+      "integrity": "sha512-rM0sDA9HD8dluwuBxLetUmoqGJKSAbWenwD65KY9iZhUxdBHRLrIdrABfNDP7aiTjcgK8XFyTn5fhDz7N+W6DA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.53.0",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-logs": "0.53.0",
+        "@opentelemetry/sdk-metrics": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "protobufjs": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-b3": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.26.0.tgz",
+      "integrity": "sha512-vvVkQLQ/lGGyEy9GT8uFnI047pajSOVnZI2poJqVGD3nJ+B9sFGdlHNnQKophE3lHfnIH0pw2ubrCTjZCgIj+Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.26.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-jaeger": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.26.0.tgz",
+      "integrity": "sha512-DelFGkCdaxA1C/QA0Xilszfr0t4YbGd3DjxiCDPh34lfnFr+VkkrjV9S8ZTJvAzfdKERXhfOxIKBoGPJwoSz7Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.26.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.26.0.tgz",
+      "integrity": "sha512-CPNYchBE7MBecCSVy0HKpUISEeJOniWqcHaAHpmasZ3j9o6V3AyBzhRc90jdmemq0HOxDr6ylhUbDhBqqPpeNw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.53.0.tgz",
+      "integrity": "sha512-dhSisnEgIj/vJZXZV6f6KcTnyLDx/VuQ6l3ejuZpMpPlh9S1qMHiZU9NMmOkVkwwHkMy3G6mEBwdP23vUZVr4g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.53.0",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/resources": "1.26.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.26.0.tgz",
+      "integrity": "sha512-0SvDXmou/JjzSDOjUmetAAvcKQW6ZrvosU0rkbDGpXvvZN+pQF6JbK/Kd4hNdK4q/22yeruqvukXEJyySTzyTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/resources": "1.26.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.26.0.tgz",
+      "integrity": "sha512-olWQldtvbK4v22ymrKLbIcBi9L2SpMO84sCPY54IVsJhP9fRsxJT194C/AVaAuJzLE30EdhhM1VmvVYR7az+cw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.26.0.tgz",
+      "integrity": "sha512-Fj5IVKrj0yeUwlewCRwzOVcr5avTuNnMHWf7GPc1t6WaT78J6CJyF3saZ/0RkZfdeNO8IcBl/bNcWMVZBMRW8Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "1.26.0",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/propagator-b3": "1.26.0",
+        "@opentelemetry/propagator-jaeger": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "semver": "^7.5.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
+      "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@redocly/ajv": {
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.2.tgz",
+      "integrity": "sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js-replace": "^1.0.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@redocly/cli": {
+      "version": "1.34.10",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-1.34.10.tgz",
+      "integrity": "sha512-L/uc382Y+9CUrohDLXqWjjw5VspYP310nf4nd6BJBZ99igZK0Fi4HRtgz9uA5ROFKLbaKDnn/AoWxOAxjv5A/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.53.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-trace-node": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.27.0",
+        "@redocly/config": "0.22.0",
+        "@redocly/openapi-core": "1.34.10",
+        "@redocly/respect-core": "1.34.10",
+        "abort-controller": "3.0.0",
+        "chokidar": "3.5.3",
+        "colorette": "1.4.0",
+        "core-js": "3.32.1",
+        "dotenv": "16.4.7",
+        "form-data": "4.0.4",
+        "get-port-please": "3.0.1",
+        "glob": "7.2.3",
+        "handlebars": "4.7.8",
+        "mobx": "6.12.3",
+        "pluralize": "8.0.0",
+        "react": "^17.0.0 || ^18.2.0 || ^19.2.1",
+        "react-dom": "^17.0.0 || ^18.2.0 || ^19.2.1",
+        "redoc": "2.5.0",
+        "semver": "7.7.4",
+        "simple-websocket": "9.1.0",
+        "styled-components": "6.3.9",
+        "yargs": "17.0.1"
+      },
+      "bin": {
+        "openapi": "bin/cli.js",
+        "redocly": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18.17.0",
+        "npm": ">=9.5.0"
+      }
+    },
+    "node_modules/@redocly/cli/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@redocly/cli/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@redocly/cli/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/@redocly/cli/node_modules/colorette": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@redocly/cli/node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/@redocly/cli/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@redocly/cli/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@redocly/cli/node_modules/yargs": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.0.1.tgz",
+      "integrity": "sha512-xBBulfCc8Y6gLFcrPvtqKz9hz8SO0l1Ni8GgDekvBX2ro0HRQImDGnikfc33cgzcYUSncapnNcZDjVFIH3f6KQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@redocly/cli/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@redocly/config": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.22.0.tgz",
+      "integrity": "sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@redocly/openapi-core": {
+      "version": "1.34.10",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.10.tgz",
+      "integrity": "sha512-XCBR/9WHJ0cpezuunHMZjuFMl4KqUo7eiFwzrQrvm7lTXt0EBd3No8UY+9OyzXpDfreGEMMtxmaLZ+ksVw378g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/ajv": "8.11.2",
+        "@redocly/config": "0.22.0",
+        "colorette": "1.4.0",
+        "https-proxy-agent": "7.0.6",
+        "js-levenshtein": "1.1.6",
+        "js-yaml": "4.1.1",
+        "minimatch": "5.1.9",
+        "pluralize": "8.0.0",
+        "yaml-ast-parser": "0.0.43"
+      },
+      "engines": {
+        "node": ">=18.17.0",
+        "npm": ">=9.5.0"
+      }
+    },
+    "node_modules/@redocly/openapi-core/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@redocly/openapi-core/node_modules/colorette": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@redocly/openapi-core/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@redocly/respect-core": {
+      "version": "1.34.10",
+      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-1.34.10.tgz",
+      "integrity": "sha512-z0ZclPGO45a/Ba0BxD+DuGnOh+TCPBdJid3leDCjHuJ4DPzF8T4BI7d7bKJDlGyZuSQAcgIPjNNY+1xr9x5yIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@faker-js/faker": "7.6.0",
+        "@redocly/ajv": "8.11.2",
+        "@redocly/openapi-core": "1.34.10",
+        "better-ajv-errors": "1.2.0",
+        "colorette": "2.0.20",
+        "concat-stream": "2.0.0",
+        "cookie": "0.7.2",
+        "dotenv": "16.4.7",
+        "form-data": "4.0.4",
+        "jest-diff": "29.7.0",
+        "jest-matcher-utils": "29.7.0",
+        "js-yaml": "4.1.0",
+        "json-pointer": "0.6.2",
+        "jsonpath-plus": "10.3.0",
+        "open": "10.1.0",
+        "openapi-sampler": "1.7.0",
+        "outdent": "0.8.0",
+        "set-cookie-parser": "2.7.1",
+        "undici": "6.23.0"
+      },
+      "engines": {
+        "node": ">=18.17.0",
+        "npm": ">=9.5.0"
+      }
+    },
+    "node_modules/@redocly/respect-core/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@redocly/respect-core/node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/@redocly/respect-core/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@redocly/respect-core/node_modules/outdent": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.8.0.tgz",
+      "integrity": "sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@redocly/respect-core/node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@redocly/respect-core/node_modules/undici": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
+      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.11.2",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
@@ -3667,6 +4412,13 @@
       "funding": {
         "url": "https://ko-fi.com/dangreen"
       }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -4409,6 +5161,21 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/stylis": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.7.tgz",
+      "integrity": "sha512-VgDNokpBoKF+wrdvhAAfS55OMQpL6QRglwTwNC3kIgBrzZxA4WsFj+2eLfEA/uMUDzBcEhYmjSbwQakn/i3ajA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
@@ -4858,6 +5625,19 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -4960,6 +5740,20 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -5031,6 +5825,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -5101,6 +5902,43 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/better-ajv-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/better-ajv-errors/-/better-ajv-errors-1.2.0.tgz",
+      "integrity": "sha512-UW+IsFycygIo7bclP9h5ugkNH8EjCSgqyFB/yQ4Hqqa1OEYDtb0uFIkYE0b6+CjkgJYVM5UKI/pJPxjYe9EZlA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/code-frame": "^7.16.0",
+        "@humanwhocodes/momoa": "^2.0.2",
+        "chalk": "^4.1.2",
+        "jsonpointer": "^5.0.0",
+        "leven": "^3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "peerDependencies": {
+        "ajv": "4.11.8 - 8"
+      }
+    },
+    "node_modules/better-ajv-errors/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/better-opn": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/better-opn/-/better-opn-3.0.2.tgz",
@@ -5155,6 +5993,19 @@
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/brace-expansion": {
@@ -5249,6 +6100,13 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/bundle-name": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
@@ -5315,6 +6173,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -5323,6 +6188,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/caniuse-lite": {
@@ -5399,6 +6274,54 @@
       "engines": {
         "node": ">= 16"
       }
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
@@ -5537,6 +6460,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
@@ -5569,6 +6505,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "dev": true,
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
       }
     },
     "node_modules/conventional-changelog-angular": {
@@ -5634,6 +6593,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.32.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.32.1.tgz",
+      "integrity": "sha512-lqufgNn9NLnESg5mQeYsxQP5w7wrViSj0jr/kv6ECQiByzQkrn1MKvV0L3acttpDqfQrHLwr2KCMgX5b8X+lyQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
@@ -5692,6 +6663,28 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
       }
     },
     "node_modules/css-tree": {
@@ -6260,6 +7253,12 @@
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
+    "node_modules/decko": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decko/-/decko-1.2.0.tgz",
+      "integrity": "sha512-m8FnyHXV1QX+S1cl+KPFDIl6NMkxtKsy6+U/aYyjrOqWMuwAwYWu7ePqrsUHtDR5Y8Yk2pi/KIDSgF+vT4cPOQ==",
+      "dev": true
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -6373,6 +7372,16 @@
         "robust-predicates": "^3.0.2"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -6391,6 +7400,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/dir-glob": {
@@ -6425,6 +7444,16 @@
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "dev": true,
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",
@@ -6588,6 +7617,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-toolkit": {
       "version": "1.45.1",
       "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
@@ -6597,6 +7642,13 @@
         "docs",
         "benchmarks"
       ]
+    },
+    "node_modules/es6-promise": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+      "integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -6942,6 +7994,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
@@ -7036,6 +8098,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -7052,6 +8121,43 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.3.tgz",
+      "integrity": "sha512-1o60KoFw2+LWKQu3IdcfcFlGTW4dpqEWmjhYec6H82AYZU2TVBXep6tMl8Z1Y+wM+ZrzCwe3BZ9Vyd9N2rIvmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.5.tgz",
+      "integrity": "sha512-NLY+V5NNbdmiEszx9n14mZBseJTC50bRq1VHsaxOmR72JDuZt+5J1Co+dC/4JPnyq+WrIHNM69r0sqf7BMb3Mg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.3",
+        "path-expression-matcher": "^1.1.3",
+        "strnum": "^2.1.2"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -7140,6 +8246,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/foreach": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.6.tgz",
+      "integrity": "sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fs-extra": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -7154,6 +8284,13 @@
       "engines": {
         "node": ">=6 <7 || >=8"
       }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -7247,6 +8384,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/get-port-please": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.0.1.tgz",
+      "integrity": "sha512-R5pcVO8Z1+pVDu8Ml3xaJCEkBiiy1VQN9za0YqH8GIi1nIqD4IzQhzY6dDzMRtdS1lyiGlucRzm8IN8wtLIXng==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
@@ -7384,13 +8528,34 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7476,6 +8641,13 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/http2-client": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/http2-client/-/http2-client-1.3.5.tgz",
+      "integrity": "sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
@@ -7643,6 +8815,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -7692,6 +8876,19 @@
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
@@ -7963,6 +9160,152 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -7971,6 +9314,16 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/js-tokens": {
@@ -8083,6 +9436,16 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -8109,6 +9472,16 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-pointer": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/json-pointer/-/json-pointer-0.6.2.tgz",
+      "integrity": "sha512-vLWcKbOaXlO+jvRy4qNd+TI1QUPZzfJj1tpJ3vAXDych5XJf93ftpUKe5pKCrzyIIwgBJcOcCVRUfqQP25afBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "foreach": "^2.0.4"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -8147,6 +9520,35 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonpath-plus": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.3.0.tgz",
+      "integrity": "sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -8155,6 +9557,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/levn": {
@@ -8521,6 +9933,26 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -8537,6 +9969,13 @@
       "dependencies": {
         "yallist": "^3.0.2"
       }
+    },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lz-string": {
       "version": "1.5.0",
@@ -8556,6 +9995,26 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/math-intrinsics": {
@@ -8642,6 +10101,29 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mimic-function": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
@@ -8701,6 +10183,69 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mobx": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.12.3.tgz",
+      "integrity": "sha512-c8NKkO4R2lShkSXZ2Ongj1ycjugjzFFo/UswHBnS62y07DMcTc9Rvo03/3nRyszIvwPNljlkd4S828zIBv/piw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mobx"
+      }
+    },
+    "node_modules/mobx-react": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/mobx-react/-/mobx-react-9.2.1.tgz",
+      "integrity": "sha512-WJNNm0FB2n0Z0u+jS1QHmmWyV8l2WiAj8V8I/96kbUEN2YbYCoKW+hbbqKKRUBqElu0llxM7nWKehvRIkhBVJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mobx-react-lite": "^4.1.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mobx"
+      },
+      "peerDependencies": {
+        "mobx": "^6.9.0",
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mobx-react-lite": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-4.1.1.tgz",
+      "integrity": "sha512-iUxiMpsvNraCKXU+yPotsOncNNmyeS2B5DKL+TL6Tar/xm+wwNJAubJmtRSeAoYawdZqwv8Z/+5nPRHeQxTiXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.4.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mobx"
+      },
+      "peerDependencies": {
+        "mobx": "^6.9.0",
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -8744,6 +10289,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -8765,12 +10317,160 @@
         }
       }
     },
+    "node_modules/node-fetch-h2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch-h2/-/node-fetch-h2-2.3.0.tgz",
+      "integrity": "sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "http2-client": "^1.2.5"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/node-readfiles": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/node-readfiles/-/node-readfiles-0.2.0.tgz",
+      "integrity": "sha512-SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es6-promise": "^3.2.1"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/oas-kit-common": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/oas-kit-common/-/oas-kit-common-1.0.8.tgz",
+      "integrity": "sha512-pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "fast-safe-stringify": "^2.0.7"
+      }
+    },
+    "node_modules/oas-linter": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/oas-linter/-/oas-linter-3.2.2.tgz",
+      "integrity": "sha512-KEGjPDVoU5K6swgo9hJVA/qYGlwfbFx+Kg2QB/kd7rzV5N8N5Mg6PlsoCMohVnQmo+pzJap/F610qTodKzecGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@exodus/schemasafe": "^1.0.0-rc.2",
+        "should": "^13.2.1",
+        "yaml": "^1.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/oas-linter/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/oas-resolver": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/oas-resolver/-/oas-resolver-2.5.6.tgz",
+      "integrity": "sha512-Yx5PWQNZomfEhPPOphFbZKi9W93CocQj18NlD2Pa4GWZzdZpSJvYwoiuurRI7m3SpcChrnO08hkuQDL3FGsVFQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "node-fetch-h2": "^2.3.0",
+        "oas-kit-common": "^1.0.8",
+        "reftools": "^1.1.9",
+        "yaml": "^1.10.0",
+        "yargs": "^17.0.1"
+      },
+      "bin": {
+        "resolve": "resolve.js"
+      },
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/oas-resolver/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/oas-schema-walker": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/oas-schema-walker/-/oas-schema-walker-1.1.5.tgz",
+      "integrity": "sha512-2yucenq1a9YPmeNExoUa9Qwrt9RFkjqaMAA1X+U7sbb0AqBeTIdMHky9SQQ6iN94bO5NW0W4TRYXerG+BdAvAQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/oas-validator": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/oas-validator/-/oas-validator-5.0.8.tgz",
+      "integrity": "sha512-cu20/HE5N5HKqVygs3dt94eYJfBi0TsZvPVXDhbXQHiEityDN+RROTleefoKRKKJ9dFAF2JBkDHgvWj0sjKGmw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "call-me-maybe": "^1.0.1",
+        "oas-kit-common": "^1.0.8",
+        "oas-linter": "^3.2.2",
+        "oas-resolver": "^2.5.6",
+        "oas-schema-walker": "^1.1.5",
+        "reftools": "^1.1.9",
+        "should": "^13.2.1",
+        "yaml": "^1.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/oas-validator/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
@@ -8844,6 +10544,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/onetime": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
@@ -8858,6 +10568,66 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
+      "integrity": "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open/node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open/node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openapi-sampler": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.7.0.tgz",
+      "integrity": "sha512-fWq32F5vqGpgRJYIarC/9Y1wC9tKnRDcCOjsDJ7MIcSv2HsE7kNifcXIZ8FVtNStBUWxYrEk/MKqVF0SwZ5gog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.7",
+        "fast-xml-parser": "^5.3.4",
+        "json-pointer": "0.6.2"
       }
     },
     "node_modules/optionator": {
@@ -9013,6 +10783,13 @@
         "util": "^0.10.3"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -9021,6 +10798,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz",
+      "integrity": "sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -9118,6 +10921,13 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/perfect-scrollbar": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/perfect-scrollbar/-/perfect-scrollbar-1.5.6.tgz",
+      "integrity": "sha512-rixgxw3SxyJbCaSpo1n35A/fwI1r2rdwMKOTCg/AcG+xOEyZcE8UHVjpZMFCVImzsFoCZeJTT+M/rdEIQYO2nw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -9146,6 +10956,29 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/polished": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-4.3.1.tgz",
+      "integrity": "sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -9186,6 +11019,13 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -9241,6 +11081,16 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -9249,6 +11099,50 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/punycode": {
@@ -9314,6 +11208,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
     },
     "node_modules/react": {
       "version": "19.2.4",
@@ -9445,6 +11349,20 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/react-tabs": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-6.1.0.tgz",
+      "integrity": "sha512-6QtbTRDKM+jA/MZTTefvigNxo0zz+gnBTVFw2CFVvq+f2BuH0nF0vDLNClL045nuTAdOoK/IL1vTP0ZLX0DAyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "prop-types": "^15.5.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/read-yaml-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-yaml-file/-/read-yaml-file-1.1.0.tgz",
@@ -9483,6 +11401,34 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/recast": {
@@ -9559,6 +11505,47 @@
         "node": ">=8"
       }
     },
+    "node_modules/redoc": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.5.0.tgz",
+      "integrity": "sha512-NpYsOZ1PD9qFdjbLVBZJWptqE+4Y6TkUuvEOqPUmoH7AKOmPcE+hYjotLxQNTqVoWL4z0T2uxILmcc8JGDci+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/openapi-core": "^1.4.0",
+        "classnames": "^2.3.2",
+        "decko": "^1.2.0",
+        "dompurify": "^3.2.4",
+        "eventemitter3": "^5.0.1",
+        "json-pointer": "^0.6.2",
+        "lunr": "^2.3.9",
+        "mark.js": "^8.11.1",
+        "marked": "^4.3.0",
+        "mobx-react": "^9.1.1",
+        "openapi-sampler": "^1.5.0",
+        "path-browserify": "^1.0.1",
+        "perfect-scrollbar": "^1.5.5",
+        "polished": "^4.2.2",
+        "prismjs": "^1.29.0",
+        "prop-types": "^15.8.1",
+        "react-tabs": "^6.0.2",
+        "slugify": "~1.4.7",
+        "stickyfill": "^1.1.1",
+        "swagger2openapi": "^7.0.8",
+        "url-template": "^2.0.8"
+      },
+      "engines": {
+        "node": ">=6.9",
+        "npm": ">=3.0.0"
+      },
+      "peerDependencies": {
+        "core-js": "^3.1.4",
+        "mobx": "^6.0.4",
+        "react": "^16.8.4 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "styled-components": "^4.1.1 || ^5.1.1 || ^6.0.5"
+      }
+    },
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -9572,6 +11559,16 @@
       "license": "MIT",
       "peerDependencies": {
         "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reftools": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/reftools/-/reftools-1.1.9.tgz",
+      "integrity": "sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
       }
     },
     "node_modules/require-directory": {
@@ -9861,6 +11858,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -9883,6 +11887,66 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/should": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
+      "integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "should-equal": "^2.0.0",
+        "should-format": "^3.0.3",
+        "should-type": "^1.4.0",
+        "should-type-adaptors": "^1.0.1",
+        "should-util": "^1.0.0"
+      }
+    },
+    "node_modules/should-equal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
+      "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "should-type": "^1.4.0"
+      }
+    },
+    "node_modules/should-format": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
+      "integrity": "sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "should-type": "^1.3.0",
+        "should-type-adaptors": "^1.0.1"
+      }
+    },
+    "node_modules/should-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+      "integrity": "sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/should-type-adaptors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+      "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "should-type": "^1.3.0",
+        "should-util": "^1.0.0"
+      }
+    },
+    "node_modules/should-util": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
+      "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -9980,6 +12044,56 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-websocket": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/simple-websocket/-/simple-websocket-9.1.0.tgz",
+      "integrity": "sha512-8MJPnjRN6A8UCp1I+H/dSFyjwJhp6wta4hsVRhjf8w9qBHRzxYt14RaOcjvQnhD1N4yKOddEjflwMnQM4VtXjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "queue-microtask": "^1.2.2",
+        "randombytes": "^2.1.0",
+        "readable-stream": "^3.6.0",
+        "ws": "^7.4.2"
+      }
+    },
+    "node_modules/simple-websocket/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -10034,6 +12148,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/slugify": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.7.tgz",
+      "integrity": "sha512-tf+h5W1IrjNm/9rKKj0JU2MDMruiopx0jjVA5zCdBtcGjfp0+c5rHw/zADLC3IeKlGHtVbHtpfzvYA0OYT+HKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/source-map": {
@@ -10093,6 +12217,12 @@
       "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stickyfill": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stickyfill/-/stickyfill-1.1.1.tgz",
+      "integrity": "sha512-GCp7vHAfpao+Qh/3Flh9DXEJ/qSi0KJwJw6zYlZOtRYXWUIpMM6mC2rIep/dK8RQqwW0KxGJIllmjPIBOGN8AA==",
+      "dev": true
     },
     "node_modules/storybook": {
       "version": "8.6.18",
@@ -10203,6 +12333,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
+      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/style-dictionary": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-5.3.3.tgz",
@@ -10231,13 +12374,82 @@
         "node": ">=22.0.0"
       }
     },
+    "node_modules/styled-components": {
+      "version": "6.3.9",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.3.9.tgz",
+      "integrity": "sha512-J72R4ltw0UBVUlEjTzI0gg2STOqlI9JBhQOL4Dxt7aJOnnSesy0qJDn4PYfMCafk9cWOaVg129Pesl5o+DIh0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/is-prop-valid": "1.4.0",
+        "@emotion/unitless": "0.10.0",
+        "@types/stylis": "4.2.7",
+        "css-to-react-native": "3.2.0",
+        "csstype": "3.2.3",
+        "postcss": "8.4.49",
+        "shallowequal": "1.1.0",
+        "stylis": "4.3.6",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/styled-components"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0",
+        "react-dom": ">= 16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/styled-components/node_modules/postcss": {
+      "version": "8.4.49",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/stylis": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -10256,6 +12468,44 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger2openapi": {
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/swagger2openapi/-/swagger2openapi-7.0.8.tgz",
+      "integrity": "sha512-upi/0ZGkYgEcLeGieoz8gT74oWHA0E7JivX7aN9mAf+Tc7BQoRBvnIGHoPDw+f9TXTW4s6kGYCZJtauP6OYp7g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "call-me-maybe": "^1.0.1",
+        "node-fetch": "^2.6.1",
+        "node-fetch-h2": "^2.3.0",
+        "node-readfiles": "^0.2.0",
+        "oas-kit-common": "^1.0.8",
+        "oas-resolver": "^2.5.6",
+        "oas-schema-walker": "^1.1.5",
+        "oas-validator": "^5.0.8",
+        "reftools": "^1.1.9",
+        "yaml": "^1.10.0",
+        "yargs": "^17.0.1"
+      },
+      "bin": {
+        "boast": "boast.js",
+        "oas-validate": "oas-validate.js",
+        "swagger2openapi": "swagger2openapi.js"
+      },
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/swagger2openapi/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/symbol-tree": {
@@ -10623,6 +12873,13 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -10659,6 +12916,20 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/undici": {
@@ -10729,6 +13000,13 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/uri-js-replace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uri-js-replace/-/uri-js-replace-1.0.1.tgz",
+      "integrity": "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/url": {
       "version": "0.11.4",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
@@ -10742,6 +13020,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "dev": true,
+      "license": "BSD"
     },
     "node_modules/url/node_modules/punycode": {
       "version": "1.4.1",
@@ -10772,6 +13057,13 @@
         "is-typed-array": "^1.1.3",
         "which-typed-array": "^1.1.2"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/victory-vendor": {
       "version": "37.3.6",
@@ -11190,6 +13482,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -11207,6 +13506,13 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.19.0",
@@ -11312,6 +13618,13 @@
         "url": "https://github.com/sponsors/eemeli"
       }
     },
+    "node_modules/yaml-ast-parser": {
+      "version": "0.0.43",
+      "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
+      "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -11359,6 +13672,15 @@
       "version": "0.1.0",
       "devDependencies": {
         "style-dictionary": "^5.3.3"
+      }
+    },
+    "services/api": {
+      "name": "@finance/api",
+      "version": "0.0.0",
+      "license": "BUSL-1.1",
+      "devDependencies": {
+        "@redocly/cli": "^1.34.3",
+        "yaml": "^2.8.2"
       }
     }
   }

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -1,14 +1,42 @@
 # Finance — Supabase Backend (`services/api/`)
 
-This directory contains the Supabase project configuration and PostgreSQL migrations for the Finance app backend.
+This directory contains the Supabase project configuration, PostgreSQL migrations, and Edge Functions for the Finance app backend.
+
+## API Documentation
+
+Interactive API docs are generated from the [OpenAPI 3.0 specification](openapi.yaml).
+
+```bash
+cd services/api
+npm install
+npm run docs:api        # Preview at http://localhost:8080
+npm run docs:api:lint   # Validate the spec
+```
+
+See [`docs/README.md`](docs/README.md) for full details on viewing and updating the API documentation.
 
 ## Project Structure
 
 ```
 services/api/
 ├── README.md
+├── openapi.yaml                             # OpenAPI 3.0 API specification
+├── package.json                             # npm scripts (docs:api, etc.)
+├── docs/
+│   └── README.md                            # API documentation guide
+├── powersync/
+│   └── sync-rules.yaml                      # PowerSync selective replication rules
 └── supabase/
     ├── config.toml                          # Supabase CLI project config
+    ├── functions/                           # Edge Functions (Deno/TypeScript)
+    │   ├── _shared/                         # Shared utilities (CORS, auth, response)
+    │   ├── health-check/                    # GET  — System health status
+    │   ├── auth-webhook/                    # POST — Auth user-creation webhook
+    │   ├── passkey-register/                # POST — WebAuthn registration ceremony
+    │   ├── passkey-authenticate/            # POST — WebAuthn authentication ceremony
+    │   ├── household-invite/                # POST/GET/PUT — Invitation lifecycle
+    │   ├── account-deletion/                # DELETE — GDPR account erasure
+    │   └── data-export/                     # GET  — GDPR data portability
     └── migrations/
         ├── 20260306000001_initial_schema.sql # Tables, indexes, triggers
         └── 20260306000002_rls_policies.sql   # Row-Level Security policies

--- a/services/api/docs/README.md
+++ b/services/api/docs/README.md
@@ -1,0 +1,76 @@
+<!-- SPDX-License-Identifier: BUSL-1.1 -->
+
+# Finance — API Documentation
+
+Interactive reference documentation for the Finance app's Supabase Edge Functions API.
+
+## Quick Start
+
+### View the API docs locally
+
+```bash
+cd services/api
+npm install
+npm run docs:api
+```
+
+This starts a local [Redoc](https://redocly.com/redoc) preview server (default: `http://localhost:8080`) that renders the OpenAPI 3.0 specification with an interactive explorer.
+
+### Lint the OpenAPI spec
+
+```bash
+npm run docs:api:lint
+```
+
+Validates the `openapi.yaml` file against the OpenAPI 3.0 specification and Redocly's recommended rules.
+
+### Bundle for distribution
+
+```bash
+npm run docs:api:bundle
+```
+
+Produces a self-contained `docs/openapi-bundled.yaml` with all `$ref`s resolved — useful for importing into Postman, Insomnia, or CI pipelines.
+
+## OpenAPI Specification
+
+The canonical spec lives at [`services/api/openapi.yaml`](../openapi.yaml).
+
+### Endpoints
+
+| Tag              | Method   | Path                     | Auth          | Description                              |
+| ---------------- | -------- | ------------------------ | ------------- | ---------------------------------------- |
+| System           | `GET`    | `/health-check`          | None          | Uptime / service health                  |
+| Auth             | `POST`   | `/auth-webhook`          | Webhook secret| Internal user-creation webhook           |
+| Auth             | `POST`   | `/passkey-register`      | Bearer JWT    | WebAuthn registration ceremony           |
+| Auth             | `POST`   | `/passkey-authenticate`  | None          | WebAuthn authentication ceremony         |
+| Households       | `POST`   | `/household-invite`      | Bearer JWT    | Create a household invitation            |
+| Households       | `GET`    | `/household-invite`      | Bearer JWT    | Validate an invite code                  |
+| Households       | `PUT`    | `/household-invite`      | Bearer JWT    | Accept an invitation                     |
+| Data Management  | `DELETE` | `/account-deletion`      | Bearer JWT    | GDPR Article 17 — account erasure        |
+| Data Management  | `GET`    | `/data-export`           | Bearer JWT    | GDPR Article 20 — data portability       |
+
+### Security Schemes
+
+| Scheme         | Type          | Used By                          |
+| -------------- | ------------- | -------------------------------- |
+| `BearerJWT`    | HTTP Bearer   | Most endpoints                   |
+| `WebhookSecret`| HTTP Bearer   | `auth-webhook` only (internal)   |
+
+### Conventions
+
+- **Monetary values** are stored as `BIGINT` (cents). For example, `$12.34` → `1234`.
+- **Currency** is an ISO 4217 code (e.g. `"USD"`) alongside every monetary column.
+- **Timestamps** are ISO 8601 in UTC.
+- **UUIDs** are v4 random.
+- **Soft deletes**: a `deleted_at` timestamp marks deleted records; they are never physically removed.
+
+## Updating the Docs
+
+1. Make your changes to the Edge Function source in `supabase/functions/`.
+2. Update `openapi.yaml` to reflect the new or modified endpoints.
+3. Run `npm run docs:api:lint` to validate.
+4. Preview with `npm run docs:api` to verify rendering.
+5. Commit both the function changes and the spec update together.
+
+> **Tip:** Keep request/response examples realistic. Use integer cents for monetary values and placeholder tokens (`YOUR_JWT_TOKEN_HERE`) — never real secrets.

--- a/services/api/docs/README.md
+++ b/services/api/docs/README.md
@@ -38,24 +38,24 @@ The canonical spec lives at [`services/api/openapi.yaml`](../openapi.yaml).
 
 ### Endpoints
 
-| Tag              | Method   | Path                     | Auth          | Description                              |
-| ---------------- | -------- | ------------------------ | ------------- | ---------------------------------------- |
-| System           | `GET`    | `/health-check`          | None          | Uptime / service health                  |
-| Auth             | `POST`   | `/auth-webhook`          | Webhook secret| Internal user-creation webhook           |
-| Auth             | `POST`   | `/passkey-register`      | Bearer JWT    | WebAuthn registration ceremony           |
-| Auth             | `POST`   | `/passkey-authenticate`  | None          | WebAuthn authentication ceremony         |
-| Households       | `POST`   | `/household-invite`      | Bearer JWT    | Create a household invitation            |
-| Households       | `GET`    | `/household-invite`      | Bearer JWT    | Validate an invite code                  |
-| Households       | `PUT`    | `/household-invite`      | Bearer JWT    | Accept an invitation                     |
-| Data Management  | `DELETE` | `/account-deletion`      | Bearer JWT    | GDPR Article 17 — account erasure        |
-| Data Management  | `GET`    | `/data-export`           | Bearer JWT    | GDPR Article 20 — data portability       |
+| Tag             | Method   | Path                    | Auth           | Description                        |
+| --------------- | -------- | ----------------------- | -------------- | ---------------------------------- |
+| System          | `GET`    | `/health-check`         | None           | Uptime / service health            |
+| Auth            | `POST`   | `/auth-webhook`         | Webhook secret | Internal user-creation webhook     |
+| Auth            | `POST`   | `/passkey-register`     | Bearer JWT     | WebAuthn registration ceremony     |
+| Auth            | `POST`   | `/passkey-authenticate` | None           | WebAuthn authentication ceremony   |
+| Households      | `POST`   | `/household-invite`     | Bearer JWT     | Create a household invitation      |
+| Households      | `GET`    | `/household-invite`     | Bearer JWT     | Validate an invite code            |
+| Households      | `PUT`    | `/household-invite`     | Bearer JWT     | Accept an invitation               |
+| Data Management | `DELETE` | `/account-deletion`     | Bearer JWT     | GDPR Article 17 — account erasure  |
+| Data Management | `GET`    | `/data-export`          | Bearer JWT     | GDPR Article 20 — data portability |
 
 ### Security Schemes
 
-| Scheme         | Type          | Used By                          |
-| -------------- | ------------- | -------------------------------- |
-| `BearerJWT`    | HTTP Bearer   | Most endpoints                   |
-| `WebhookSecret`| HTTP Bearer   | `auth-webhook` only (internal)   |
+| Scheme          | Type        | Used By                        |
+| --------------- | ----------- | ------------------------------ |
+| `BearerJWT`     | HTTP Bearer | Most endpoints                 |
+| `WebhookSecret` | HTTP Bearer | `auth-webhook` only (internal) |
 
 ### Conventions
 

--- a/services/api/openapi.yaml
+++ b/services/api/openapi.yaml
@@ -1,0 +1,1483 @@
+# SPDX-License-Identifier: BUSL-1.1
+#
+# OpenAPI 3.0 specification for the Finance app Supabase Edge Functions.
+# Generated from the actual Edge Function implementations in
+# services/api/supabase/functions/.
+#
+# See: services/api/docs/README.md for usage instructions.
+
+openapi: "3.0.3"
+
+info:
+  title: Finance — Supabase Edge Functions API
+  version: 1.0.0
+  description: |
+    REST API for the Finance app backend, powered by Supabase Edge Functions
+    (Deno runtime). This API provides authentication (WebAuthn passkeys),
+    household management, GDPR data-portability, and system health monitoring.
+
+    ## Conventions
+
+    - **Monetary values** are always integers in **cents** (`BIGINT`), never
+      floating-point.
+    - **Currency** is expressed as an ISO 4217 code (`"USD"`, `"EUR"`, etc.)
+      alongside every monetary column.
+    - **Timestamps** are ISO 8601 strings in UTC (`2025-07-15T10:30:00.000Z`).
+    - **UUIDs** are v4 random UUIDs.
+    - **Soft deletes**: records are never physically removed — a `deleted_at`
+      timestamp is set instead.
+  contact:
+    name: Finance Backend Team
+  license:
+    name: BUSL-1.1
+    url: https://spdx.org/licenses/BUSL-1.1.html
+
+servers:
+  - url: http://localhost:54321/functions/v1
+    description: Local Supabase development (supabase start)
+  - url: https://{project_ref}.supabase.co/functions/v1
+    description: Supabase hosted project
+    variables:
+      project_ref:
+        default: your-project-ref
+        description: Supabase project reference ID
+
+tags:
+  - name: System
+    description: Health and operational status endpoints
+  - name: Auth
+    description: >-
+      Authentication endpoints — WebAuthn passkey registration and
+      authentication ceremonies, and the internal auth webhook
+  - name: Households
+    description: Household invitation lifecycle (create, validate, accept)
+  - name: Data Management
+    description: GDPR data portability — export and account deletion
+
+# ---------------------------------------------------------------------------
+# Security Schemes
+# ---------------------------------------------------------------------------
+
+components:
+  securitySchemes:
+    BearerJWT:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: >-
+        Supabase Auth JWT obtained after sign-in.  Pass as
+        `Authorization: Bearer <token>`.
+    WebhookSecret:
+      type: http
+      scheme: bearer
+      description: >-
+        Shared secret configured in `AUTH_WEBHOOK_SECRET`.  Used exclusively
+        by the Supabase Auth webhook; not intended for end-user clients.
+
+  # -------------------------------------------------------------------------
+  # Reusable Schemas
+  # -------------------------------------------------------------------------
+  schemas:
+    # -- Common ---------------------------------------------------------------
+    Error:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: string
+          description: Human-readable error message.
+      example:
+        error: "Method not allowed"
+
+    StructuredError:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: object
+          required: [code, message]
+          properties:
+            code:
+              type: string
+              description: Machine-readable error code.
+            message:
+              type: string
+              description: Human-readable error message.
+      example:
+        error:
+          code: "INVALID_FORMAT"
+          message: 'Export format must be "json" or "csv". Use ?format=json or ?format=csv.'
+
+    # -- Health Check ---------------------------------------------------------
+    HealthCheckResponse:
+      type: object
+      required: [status, timestamp, services, version]
+      properties:
+        status:
+          type: string
+          enum: [healthy, degraded]
+          description: Overall system status.
+        timestamp:
+          type: string
+          format: date-time
+          description: ISO 8601 timestamp of the health check.
+        services:
+          type: object
+          required: [database, auth]
+          properties:
+            database:
+              type: string
+              enum: [connected, operational, unavailable, error]
+              description: Database connectivity status.
+            auth:
+              type: string
+              enum: [connected, operational, unavailable, error]
+              description: Auth service status.
+        version:
+          type: string
+          description: API version string.
+      example:
+        status: healthy
+        timestamp: "2025-07-15T10:30:00.000Z"
+        services:
+          database: connected
+          auth: operational
+        version: "1.0.0"
+
+    # -- Auth Webhook ---------------------------------------------------------
+    AuthWebhookPayload:
+      type: object
+      required: [type, table, record]
+      properties:
+        type:
+          type: string
+          description: >-
+            Event type (`INSERT`, `UPDATE`, `DELETE`).
+            Only `INSERT` is processed; other types are acknowledged and ignored.
+          example: INSERT
+        table:
+          type: string
+          description: Source table name.
+          example: users
+        record:
+          type: object
+          required: [id, email, created_at]
+          properties:
+            id:
+              type: string
+              format: uuid
+              description: Auth user UUID.
+            email:
+              type: string
+              format: email
+            raw_user_meta_data:
+              type: object
+              nullable: true
+              properties:
+                full_name:
+                  type: string
+                  nullable: true
+                name:
+                  type: string
+                  nullable: true
+                avatar_url:
+                  type: string
+                  format: uri
+                  nullable: true
+            created_at:
+              type: string
+              format: date-time
+        old_record:
+          type: object
+          nullable: true
+          description: Previous row state (null for INSERT).
+
+    AuthWebhookCreatedResponse:
+      type: object
+      required: [message, user_id]
+      properties:
+        message:
+          type: string
+          example: User provisioned
+        user_id:
+          type: string
+          format: uuid
+          example: "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d"
+
+    AuthWebhookIgnoredResponse:
+      type: object
+      required: [message]
+      properties:
+        message:
+          type: string
+          example: Event ignored
+
+    # -- Passkey Registration -------------------------------------------------
+    PasskeyRegistrationOptionsResponse:
+      type: object
+      description: >-
+        WebAuthn `PublicKeyCredentialCreationOptions` as defined by
+        the Web Authentication specification. The exact shape is
+        produced by `@simplewebauthn/server` `generateRegistrationOptions`.
+      properties:
+        rp:
+          type: object
+          properties:
+            name:
+              type: string
+              example: Finance App
+            id:
+              type: string
+              example: finance.example.com
+        user:
+          type: object
+          properties:
+            id:
+              type: string
+              description: Base64url-encoded user UUID.
+            name:
+              type: string
+              example: user@example.com
+            displayName:
+              type: string
+              example: user@example.com
+        challenge:
+          type: string
+          description: Base64url-encoded challenge.
+          example: "dGhpcyBpcyBhIHNhbXBsZSBjaGFsbGVuZ2U"
+        pubKeyCredParams:
+          type: array
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+                example: public-key
+              alg:
+                type: integer
+                description: COSE algorithm identifier (-7 = ES256, -257 = RS256).
+                example: -7
+        timeout:
+          type: integer
+          example: 60000
+        attestation:
+          type: string
+          example: none
+        excludeCredentials:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              type:
+                type: string
+                example: public-key
+        authenticatorSelection:
+          type: object
+          properties:
+            residentKey:
+              type: string
+              example: preferred
+            userVerification:
+              type: string
+              example: preferred
+            authenticatorAttachment:
+              type: string
+              example: platform
+
+    PasskeyRegistrationVerifyResponse:
+      type: object
+      required: [verified, credential_id, device_type]
+      properties:
+        verified:
+          type: boolean
+          example: true
+        credential_id:
+          type: string
+          description: Base64url-encoded credential ID.
+          example: "Y3JlZGVudGlhbC1pZC1leGFtcGxl"
+        device_type:
+          type: string
+          description: Authenticator device type.
+          example: singleDevice
+
+    # -- Passkey Authentication -----------------------------------------------
+    PasskeyAuthOptionsResponse:
+      type: object
+      description: >-
+        WebAuthn `PublicKeyCredentialRequestOptions` as defined by
+        the Web Authentication specification.
+      properties:
+        challenge:
+          type: string
+          description: Base64url-encoded challenge.
+          example: "dGhpcyBpcyBhIHNhbXBsZSBjaGFsbGVuZ2U"
+        timeout:
+          type: integer
+          example: 60000
+        rpId:
+          type: string
+          example: finance.example.com
+        userVerification:
+          type: string
+          example: preferred
+        allowCredentials:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              type:
+                type: string
+                example: public-key
+              transports:
+                type: array
+                items:
+                  type: string
+                  example: internal
+
+    PasskeyAuthVerifyResponse:
+      type: object
+      required: [verified, user_id, message]
+      properties:
+        verified:
+          type: boolean
+          example: true
+        user_id:
+          type: string
+          format: uuid
+          description: The authenticated user's UUID.
+          example: "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d"
+        message:
+          type: string
+          example: "Passkey authentication successful. Exchange for session."
+
+    # -- Household Invite -----------------------------------------------------
+    HouseholdInviteCreateRequest:
+      type: object
+      required: [household_id]
+      properties:
+        household_id:
+          type: string
+          format: uuid
+          description: The household to invite the user to.
+          example: "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+        invited_email:
+          type: string
+          format: email
+          nullable: true
+          description: >-
+            Optional email to restrict the invitation to a specific user.
+            If omitted, anyone with the invite code can accept.
+          example: friend@example.com
+        role:
+          type: string
+          default: member
+          description: Role assigned to the invitee upon acceptance.
+          example: member
+        expires_in_hours:
+          type: integer
+          default: 72
+          minimum: 1
+          description: Hours until the invitation expires.
+          example: 72
+
+    HouseholdInviteCreateResponse:
+      type: object
+      required: [id, invite_code, expires_at, role, household_name]
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e"
+        invite_code:
+          type: string
+          description: >-
+            Cryptographically random 24-character uppercase invite code.
+          example: "01A2B3C4D5E6F7G8H9I0J1K2"
+        expires_at:
+          type: string
+          format: date-time
+          example: "2025-07-18T10:30:00.000Z"
+        role:
+          type: string
+          example: member
+        household_name:
+          type: string
+          example: "Smith Family"
+
+    HouseholdInviteValidateResponse:
+      type: object
+      required: [valid, household_id, household_name, role, expires_at]
+      properties:
+        valid:
+          type: boolean
+          example: true
+        household_id:
+          type: string
+          format: uuid
+          example: "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+        household_name:
+          type: string
+          example: "Smith Family"
+        role:
+          type: string
+          example: member
+        expires_at:
+          type: string
+          format: date-time
+          example: "2025-07-18T10:30:00.000Z"
+
+    HouseholdInviteAcceptRequest:
+      type: object
+      required: [invite_code]
+      properties:
+        invite_code:
+          type: string
+          description: Invite code received from the household owner.
+          example: "01A2B3C4D5E6F7G8H9I0J1K2"
+
+    HouseholdInviteAcceptResponse:
+      type: object
+      required: [message, household_id, household_name, role]
+      properties:
+        message:
+          type: string
+          example: Invitation accepted
+        household_id:
+          type: string
+          format: uuid
+          example: "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+        household_name:
+          type: string
+          example: "Smith Family"
+        role:
+          type: string
+          example: member
+
+    # -- Account Deletion -----------------------------------------------------
+    AccountDeletionRequest:
+      type: object
+      required: [confirm]
+      properties:
+        confirm:
+          oneOf:
+            - type: boolean
+              example: true
+            - type: string
+              example: DELETE_MY_ACCOUNT
+          description: >-
+            Explicit confirmation to prevent accidental deletion.
+            Must be `true` or the string `"DELETE_MY_ACCOUNT"`.
+
+    DeletionCertificate:
+      type: object
+      required:
+        - deletion_certificate
+      properties:
+        deletion_certificate:
+          type: object
+          required:
+            - certificate_id
+            - subject_type
+            - subject_id
+            - deleted_at
+            - households_affected
+            - keys_shredded
+            - key_fingerprints
+            - verified
+            - message
+          properties:
+            certificate_id:
+              type: string
+              description: Unique deletion certificate identifier.
+              example: "cert-m1abc2d-0011aabb22cc33dd44ee55ff"
+            subject_type:
+              type: string
+              enum: [USER]
+              example: USER
+            subject_id:
+              type: string
+              format: uuid
+              example: "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d"
+            deleted_at:
+              type: string
+              format: date-time
+              example: "2025-07-15T10:30:00.000Z"
+            households_affected:
+              type: integer
+              example: 2
+            keys_shredded:
+              type: integer
+              example: 3
+            key_fingerprints:
+              type: array
+              items:
+                type: string
+              example:
+                - "shredded:household:f47ac10b-58cc-4372-a567-0e02b2c3d479:m1abc2d"
+                - "revoked:user-key:b8c9d0e1-f2a3-4b5c-6d7e-8f9a0b1c2d3e:a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d:m1abc2e"
+                - "shredded:user:a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d:m1abc2f"
+            verified:
+              type: boolean
+              example: true
+            message:
+              type: string
+              example: >-
+                Your account and associated data have been permanently deleted.
+                Encrypted data has been rendered unrecoverable via
+                crypto-shredding. This certificate serves as proof of deletion
+                per GDPR Article 17.
+
+    # -- Data Export -----------------------------------------------------------
+    DataExportJsonResponse:
+      type: object
+      required: [export_date, user_id, format_version, data]
+      properties:
+        export_date:
+          type: string
+          format: date-time
+          example: "2025-07-15T10:30:00.000Z"
+        user_id:
+          type: string
+          format: uuid
+          example: "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d"
+        format_version:
+          type: string
+          example: "1.0"
+        data:
+          type: object
+          description: >-
+            Keyed by table name. Each value is an array of records belonging
+            to the authenticated user (user-scoped tables) or to households
+            the user belongs to (household-scoped tables).  Sensitive columns
+            such as `public_key` are redacted.
+          properties:
+            users:
+              type: array
+              items:
+                type: object
+            households:
+              type: array
+              items:
+                type: object
+            household_members:
+              type: array
+              items:
+                type: object
+            accounts:
+              type: array
+              items:
+                type: object
+                description: >-
+                  Financial account record.  Monetary values (e.g.
+                  `balance`) are in **cents** (integer).
+            categories:
+              type: array
+              items:
+                type: object
+            transactions:
+              type: array
+              items:
+                type: object
+                description: >-
+                  Transaction record.  `amount` is in **cents** (integer).
+            budgets:
+              type: array
+              items:
+                type: object
+                description: >-
+                  Budget record.  `amount` is in **cents** (integer).
+            goals:
+              type: array
+              items:
+                type: object
+                description: >-
+                  Goal record.  `target_amount` and `current_amount` are
+                  in **cents** (integer).
+            passkey_credentials:
+              type: array
+              items:
+                type: object
+                description: >-
+                  Passkey credential metadata.  The `public_key` column
+                  is redacted to `[REDACTED]`.
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+paths:
+  # =========================================================================
+  # Health Check
+  # =========================================================================
+  /health-check:
+    get:
+      operationId: getHealthCheck
+      summary: System health check
+      description: >-
+        Public endpoint for uptime monitoring.  Returns the operational
+        status of core backend services (database, auth) without exposing
+        any internal details.  No authentication required.
+      tags: [System]
+      security: []
+      responses:
+        "200":
+          description: All services are healthy.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthCheckResponse"
+              example:
+                status: healthy
+                timestamp: "2025-07-15T10:30:00.000Z"
+                services:
+                  database: connected
+                  auth: operational
+                version: "1.0.0"
+        "405":
+          description: Method not allowed (non-GET request).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "Method not allowed"
+        "503":
+          description: One or more services are degraded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthCheckResponse"
+              example:
+                status: degraded
+                timestamp: "2025-07-15T10:30:00.000Z"
+                services:
+                  database: unavailable
+                  auth: operational
+                version: "1.0.0"
+
+  # =========================================================================
+  # Auth Webhook
+  # =========================================================================
+  /auth-webhook:
+    post:
+      operationId: handleAuthWebhook
+      summary: Auth user-creation webhook
+      description: >-
+        Internal endpoint invoked by Supabase Auth on `auth.users` INSERT
+        events.  Provisions a new user row, a default personal household,
+        and an owner membership.  Non-INSERT events are acknowledged and
+        ignored.
+
+        **This endpoint is not intended for client applications.**
+        It is secured with a shared secret (`AUTH_WEBHOOK_SECRET`).
+      tags: [Auth]
+      security:
+        - WebhookSecret: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AuthWebhookPayload"
+            example:
+              type: INSERT
+              table: users
+              record:
+                id: "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d"
+                email: user@example.com
+                raw_user_meta_data:
+                  full_name: "Jane Doe"
+                created_at: "2025-07-15T10:30:00.000Z"
+              old_record: null
+      responses:
+        "201":
+          description: User provisioned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthWebhookCreatedResponse"
+        "200":
+          description: Event type other than INSERT — acknowledged and ignored.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthWebhookIgnoredResponse"
+        "401":
+          description: Webhook secret missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: Unauthorized
+        "405":
+          description: Method not allowed (non-POST request).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "Method not allowed"
+        "500":
+          description: Internal server error during user provisioning.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "Internal server error"
+
+  # =========================================================================
+  # Passkey Registration
+  # =========================================================================
+  /passkey-register:
+    post:
+      operationId: passkeyRegister
+      summary: WebAuthn passkey registration ceremony
+      description: >-
+        Two-step WebAuthn registration flow controlled by the `step` query
+        parameter:
+
+        1. `?step=options` — Generate `PublicKeyCredentialCreationOptions`
+           (challenge) for the client.
+        2. `?step=verify` — Validate the attestation response from the
+           authenticator and store the new credential.
+
+        Both steps require a valid Supabase Auth JWT.
+      tags: [Auth]
+      security:
+        - BearerJWT: []
+      parameters:
+        - name: step
+          in: query
+          required: true
+          schema:
+            type: string
+            enum: [options, verify]
+          description: >-
+            Ceremony step.  `options` generates the challenge;
+            `verify` validates the authenticator response.
+      requestBody:
+        required: false
+        description: >-
+          Required only for `?step=verify`.  The body is the
+          `AuthenticatorAttestationResponse` produced by the browser's
+          `navigator.credentials.create()` call.
+        content:
+          application/json:
+            schema:
+              type: object
+              description: >-
+                WebAuthn `AuthenticatorAttestationResponse` —
+                shape defined by the Web Authentication specification.
+            example:
+              id: "Y3JlZGVudGlhbC1pZC1leGFtcGxl"
+              rawId: "Y3JlZGVudGlhbC1pZC1leGFtcGxl"
+              response:
+                clientDataJSON: "eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiZEdobGN5QnBjeUJoSUhOaGJYQnNaU0JqYUdGc2JHVnVaMlUiLCJvcmlnaW4iOiJodHRwczovL2FwcC5maW5hbmNlLmV4YW1wbGUuY29tIn0"
+                attestationObject: "o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YQ"
+              type: "public-key"
+              clientExtensionResults: {}
+              authenticatorAttachment: "platform"
+      responses:
+        "200":
+          description: >-
+            Registration options generated (`?step=options`), or
+            authentication options generated.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PasskeyRegistrationOptionsResponse"
+        "201":
+          description: >-
+            Credential verified and stored (`?step=verify`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PasskeyRegistrationVerifyResponse"
+              example:
+                verified: true
+                credential_id: "Y3JlZGVudGlhbC1pZC1leGFtcGxl"
+                device_type: singleDevice
+        "400":
+          description: >-
+            Invalid step parameter, no valid challenge found, or
+            registration verification failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                invalidStep:
+                  summary: Missing or invalid step parameter
+                  value:
+                    error: "Invalid step. Use ?step=options or ?step=verify"
+                noChallenge:
+                  summary: Challenge expired or not found
+                  value:
+                    error: "No valid challenge found"
+                verificationFailed:
+                  summary: Attestation verification failed
+                  value:
+                    error: "Registration verification failed"
+        "401":
+          description: Missing or invalid JWT.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: Unauthorized
+        "405":
+          description: Method not allowed (non-POST request).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "Internal server error"
+
+  # =========================================================================
+  # Passkey Authentication
+  # =========================================================================
+  /passkey-authenticate:
+    post:
+      operationId: passkeyAuthenticate
+      summary: WebAuthn passkey authentication ceremony
+      description: >-
+        Two-step WebAuthn authentication flow controlled by the `step`
+        query parameter:
+
+        1. `?step=options` — Generate `PublicKeyCredentialRequestOptions`
+           (challenge).  Optionally accepts `{ "email": "..." }` to
+           scope `allowCredentials` to a known user; omit for a
+           usernameless / discoverable-credential flow.
+        2. `?step=verify` — Validate the assertion response from the
+           authenticator and return a verification result.
+
+        **No JWT is required** — this endpoint is used to *establish*
+        authentication, not to guard an already-authenticated resource.
+      tags: [Auth]
+      security: []
+      parameters:
+        - name: step
+          in: query
+          required: true
+          schema:
+            type: string
+            enum: [options, verify]
+          description: >-
+            Ceremony step.  `options` generates the challenge;
+            `verify` validates the authenticator assertion.
+      requestBody:
+        required: false
+        description: >-
+          For `?step=options`: optional JSON body with `email` to scope
+          allowed credentials.
+
+          For `?step=verify`: the `AuthenticatorAssertionResponse`
+          produced by `navigator.credentials.get()`.
+        content:
+          application/json:
+            schema:
+              type: object
+              description: >-
+                For `?step=options`: optional object with `email` to scope
+                allowed credentials (see `PasskeyAuthOptionsRequest`).
+
+                For `?step=verify`: `AuthenticatorAssertionResponse` as
+                defined by the Web Authentication specification.
+              properties:
+                email:
+                  type: string
+                  format: email
+                  description: >-
+                    (options step only) Scope `allowCredentials` to a
+                    known user.  Omit for a usernameless flow.
+                id:
+                  type: string
+                  description: (verify step only) Credential ID.
+                rawId:
+                  type: string
+                  description: (verify step only) Raw credential ID.
+                response:
+                  type: object
+                  description: (verify step only) Authenticator response.
+                type:
+                  type: string
+                  description: (verify step only) Credential type.
+                clientExtensionResults:
+                  type: object
+                  description: (verify step only) Client extension results.
+            examples:
+              optionsWithEmail:
+                summary: Request options scoped to a user
+                value:
+                  email: user@example.com
+              optionsUsernameless:
+                summary: Usernameless discoverable-credential flow
+                value: {}
+              verify:
+                summary: Authenticator assertion response
+                value:
+                  id: "Y3JlZGVudGlhbC1pZC1leGFtcGxl"
+                  rawId: "Y3JlZGVudGlhbC1pZC1leGFtcGxl"
+                  response:
+                    clientDataJSON: "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0In0"
+                    authenticatorData: "SZYN5YgOjGh0NBcPZHZgW4"
+                    signature: "MEUCIQDNrG..."
+                  type: "public-key"
+                  clientExtensionResults: {}
+      responses:
+        "200":
+          description: >-
+            For `?step=options`: authentication options with challenge.
+
+            For `?step=verify`: passkey verified successfully.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/PasskeyAuthOptionsResponse"
+                  - $ref: "#/components/schemas/PasskeyAuthVerifyResponse"
+              examples:
+                options:
+                  summary: Authentication options response
+                  value:
+                    challenge: "dGhpcyBpcyBhIHNhbXBsZSBjaGFsbGVuZ2U"
+                    timeout: 60000
+                    rpId: finance.example.com
+                    userVerification: preferred
+                    allowCredentials:
+                      - id: "Y3JlZGVudGlhbC1pZC1leGFtcGxl"
+                        type: public-key
+                        transports: [internal]
+                verified:
+                  summary: Successful verification
+                  value:
+                    verified: true
+                    user_id: "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d"
+                    message: "Passkey authentication successful. Exchange for session."
+        "400":
+          description: >-
+            Invalid step, missing credential ID, credential not found,
+            or no valid challenge.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                invalidStep:
+                  summary: Invalid step parameter
+                  value:
+                    error: "Invalid step. Use ?step=options or ?step=verify"
+                missingId:
+                  summary: Missing credential ID in verify body
+                  value:
+                    error: "Missing credential ID"
+                credentialNotFound:
+                  summary: Credential not in database
+                  value:
+                    error: "Credential not found"
+                noChallenge:
+                  summary: Challenge expired or not found
+                  value:
+                    error: "No valid challenge found"
+        "401":
+          description: Authentication assertion verification failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "Authentication verification failed"
+        "405":
+          description: Method not allowed (non-POST request).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "Internal server error"
+
+  # =========================================================================
+  # Household Invite
+  # =========================================================================
+  /household-invite:
+    post:
+      operationId: createHouseholdInvite
+      summary: Create a household invitation
+      description: >-
+        Generates a cryptographically random invite code for a household.
+        Only the household **owner** (`created_by`) may create invitations.
+        Optionally restricts the invitation to a specific email address.
+      tags: [Households]
+      security:
+        - BearerJWT: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/HouseholdInviteCreateRequest"
+            example:
+              household_id: "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+              invited_email: friend@example.com
+              role: member
+              expires_in_hours: 72
+      responses:
+        "201":
+          description: Invitation created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HouseholdInviteCreateResponse"
+        "400":
+          description: Missing required field (`household_id`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "household_id is required"
+        "401":
+          description: Missing or invalid JWT.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "Authentication required"
+        "403":
+          description: Authenticated user is not the household owner.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "Only the household owner can create invitations"
+        "404":
+          description: Household not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "Household not found"
+        "409":
+          description: Invited user is already a household member.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "User is already a member of this household"
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "Internal server error"
+
+    get:
+      operationId: validateHouseholdInvite
+      summary: Validate an invite code
+      description: >-
+        Validates a household invitation code and returns household
+        metadata.  Returns an error if the code is invalid, expired,
+        already accepted, or restricted to a different email.
+      tags: [Households]
+      security:
+        - BearerJWT: []
+      parameters:
+        - name: code
+          in: query
+          required: true
+          schema:
+            type: string
+          description: The invitation code to validate.
+          example: "01A2B3C4D5E6F7G8H9I0J1K2"
+      responses:
+        "200":
+          description: Invitation is valid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HouseholdInviteValidateResponse"
+        "400":
+          description: Missing `code` query parameter.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "code query parameter is required"
+        "401":
+          description: Missing or invalid JWT.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "Authentication required"
+        "403":
+          description: Invitation is restricted to a different email.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "This invitation is for a different email address"
+        "404":
+          description: Invitation code not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "Invalid invitation code"
+        "410":
+          description: Invitation expired or already accepted.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                expired:
+                  summary: Invitation expired
+                  value:
+                    error: "This invitation has expired"
+                alreadyAccepted:
+                  summary: Already accepted
+                  value:
+                    error: "This invitation has already been accepted"
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "Internal server error"
+
+    put:
+      operationId: acceptHouseholdInvite
+      summary: Accept a household invitation
+      description: >-
+        Accepts a valid invitation and adds the authenticated user to the
+        household as a member.  The invitation is marked as accepted and
+        cannot be reused.
+      tags: [Households]
+      security:
+        - BearerJWT: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/HouseholdInviteAcceptRequest"
+            example:
+              invite_code: "01A2B3C4D5E6F7G8H9I0J1K2"
+      responses:
+        "200":
+          description: Invitation accepted — user added to the household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HouseholdInviteAcceptResponse"
+        "400":
+          description: Missing `invite_code` in request body.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "invite_code is required"
+        "401":
+          description: Missing or invalid JWT.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "Authentication required"
+        "403":
+          description: Invitation is restricted to a different email.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "This invitation is for a different email address"
+        "404":
+          description: Invitation code not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "Invalid invitation code"
+        "409":
+          description: User is already a member of the household.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "You are already a member of this household"
+        "410":
+          description: Invitation expired or already accepted.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                expired:
+                  summary: Invitation expired
+                  value:
+                    error: "This invitation has expired"
+                alreadyAccepted:
+                  summary: Already accepted
+                  value:
+                    error: "This invitation has already been accepted"
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "Internal server error"
+
+  # =========================================================================
+  # Account Deletion
+  # =========================================================================
+  /account-deletion:
+    delete:
+      operationId: deleteAccount
+      summary: Delete user account (GDPR Article 17)
+      description: >-
+        Permanently deletes the authenticated user's account.  This
+        triggers:
+
+        1. **Audit log** of the deletion request.
+        2. **Crypto-shredding** — encryption keys are destroyed so that
+           encrypted data becomes unrecoverable.
+        3. **Household cleanup** — the user is removed from all
+           households; sole-member households are soft-deleted entirely.
+        4. **Soft-delete** of the user record and passkey credentials.
+        5. **Auth user removal** — the Supabase Auth identity is deleted.
+
+        Returns a **deletion certificate** (per GDPR Article 17) that
+        the client should store locally as proof of erasure.
+
+        **This action is irreversible.**
+      tags: [Data Management]
+      security:
+        - BearerJWT: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AccountDeletionRequest"
+            examples:
+              confirmBoolean:
+                summary: Confirm with boolean
+                value:
+                  confirm: true
+              confirmString:
+                summary: Confirm with string
+                value:
+                  confirm: DELETE_MY_ACCOUNT
+      responses:
+        "200":
+          description: Account deleted — deletion certificate returned.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeletionCertificate"
+        "400":
+          description: Missing or invalid confirmation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: >-
+                  Account deletion requires confirmation. Send
+                  { "confirm": "DELETE_MY_ACCOUNT" } in the request body.
+        "401":
+          description: Missing or invalid JWT.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "Authentication required"
+        "405":
+          description: Method not allowed (non-DELETE request).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "Method not allowed"
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "Internal server error"
+
+  # =========================================================================
+  # Data Export
+  # =========================================================================
+  /data-export:
+    get:
+      operationId: exportData
+      summary: Export user data (GDPR Article 20)
+      description: >-
+        Exports all of the authenticated user's data across all their
+        households in either **JSON** or **CSV** format.  The response is
+        streamed as a file download.
+
+        ### Exported tables
+
+        | Table                | Scope       |
+        | -------------------- | ----------- |
+        | `users`              | Own row     |
+        | `households`         | Member of   |
+        | `household_members`  | Member of   |
+        | `accounts`           | Household   |
+        | `categories`         | Household   |
+        | `transactions`       | Household   |
+        | `budgets`            | Household   |
+        | `goals`              | Household   |
+        | `passkey_credentials`| Own rows    |
+
+        Sensitive columns (e.g. `public_key`) are redacted to
+        `[REDACTED]`.
+
+        ### Rate limiting
+
+        Maximum **10 exports per user per hour** (tracked in
+        `data_export_audit_log`).
+
+        ### Monetary values
+
+        All monetary values in the export are integers in **cents**.
+        For example, `$12.34` is represented as `1234`.
+      tags: [Data Management]
+      security:
+        - BearerJWT: []
+      parameters:
+        - name: format
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [json, csv]
+            default: json
+          description: >-
+            Export format.  Defaults to `json`.  Alternatively, set the
+            `Accept` header to `text/csv` to receive CSV.
+      responses:
+        "200":
+          description: >-
+            Data export file.  Delivered as a streaming download with
+            `Content-Disposition: attachment`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DataExportJsonResponse"
+            text/csv:
+              schema:
+                type: string
+                description: >-
+                  CSV output with sections separated by `# Table: <name>`
+                  comment headers.
+          headers:
+            Content-Disposition:
+              schema:
+                type: string
+              description: >-
+                Suggested filename, e.g.
+                `attachment; filename="finance-export-2025-07-15T10-30-00-000Z.json"`.
+              example: 'attachment; filename="finance-export-2025-07-15T10-30-00-000Z.json"'
+        "400":
+          description: Invalid export format.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StructuredError"
+              example:
+                error:
+                  code: INVALID_FORMAT
+                  message: 'Export format must be "json" or "csv". Use ?format=json or ?format=csv.'
+        "401":
+          description: Missing or invalid JWT.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "Authentication required"
+        "405":
+          description: Method not allowed (non-GET request).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "Method not allowed"
+        "413":
+          description: Request entity too large (Content-Length exceeds 1 KB).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StructuredError"
+              example:
+                error:
+                  code: REQUEST_TOO_LARGE
+                  message: "Request exceeds maximum allowed size."
+        "429":
+          description: Rate limit exceeded (10 exports per hour).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StructuredError"
+              example:
+                error:
+                  code: RATE_LIMITED
+                  message: "Export limit exceeded. Maximum 10 exports per hour."
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StructuredError"
+              example:
+                error:
+                  code: INTERNAL_ERROR
+                  message: "An unexpected error occurred."

--- a/services/api/openapi.yaml
+++ b/services/api/openapi.yaml
@@ -6,7 +6,7 @@
 #
 # See: services/api/docs/README.md for usage instructions.
 
-openapi: "3.0.3"
+openapi: '3.0.3'
 
 info:
   title: Finance — Supabase Edge Functions API
@@ -87,7 +87,7 @@ components:
           type: string
           description: Human-readable error message.
       example:
-        error: "Method not allowed"
+        error: 'Method not allowed'
 
     StructuredError:
       type: object
@@ -105,7 +105,7 @@ components:
               description: Human-readable error message.
       example:
         error:
-          code: "INVALID_FORMAT"
+          code: 'INVALID_FORMAT'
           message: 'Export format must be "json" or "csv". Use ?format=json or ?format=csv.'
 
     # -- Health Check ---------------------------------------------------------
@@ -138,11 +138,11 @@ components:
           description: API version string.
       example:
         status: healthy
-        timestamp: "2025-07-15T10:30:00.000Z"
+        timestamp: '2025-07-15T10:30:00.000Z'
         services:
           database: connected
           auth: operational
-        version: "1.0.0"
+        version: '1.0.0'
 
     # -- Auth Webhook ---------------------------------------------------------
     AuthWebhookPayload:
@@ -202,7 +202,7 @@ components:
         user_id:
           type: string
           format: uuid
-          example: "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d"
+          example: 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d'
 
     AuthWebhookIgnoredResponse:
       type: object
@@ -244,7 +244,7 @@ components:
         challenge:
           type: string
           description: Base64url-encoded challenge.
-          example: "dGhpcyBpcyBhIHNhbXBsZSBjaGFsbGVuZ2U"
+          example: 'dGhpcyBpcyBhIHNhbXBsZSBjaGFsbGVuZ2U'
         pubKeyCredParams:
           type: array
           items:
@@ -296,7 +296,7 @@ components:
         credential_id:
           type: string
           description: Base64url-encoded credential ID.
-          example: "Y3JlZGVudGlhbC1pZC1leGFtcGxl"
+          example: 'Y3JlZGVudGlhbC1pZC1leGFtcGxl'
         device_type:
           type: string
           description: Authenticator device type.
@@ -312,7 +312,7 @@ components:
         challenge:
           type: string
           description: Base64url-encoded challenge.
-          example: "dGhpcyBpcyBhIHNhbXBsZSBjaGFsbGVuZ2U"
+          example: 'dGhpcyBpcyBhIHNhbXBsZSBjaGFsbGVuZ2U'
         timeout:
           type: integer
           example: 60000
@@ -349,10 +349,10 @@ components:
           type: string
           format: uuid
           description: The authenticated user's UUID.
-          example: "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d"
+          example: 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d'
         message:
           type: string
-          example: "Passkey authentication successful. Exchange for session."
+          example: 'Passkey authentication successful. Exchange for session.'
 
     # -- Household Invite -----------------------------------------------------
     HouseholdInviteCreateRequest:
@@ -363,7 +363,7 @@ components:
           type: string
           format: uuid
           description: The household to invite the user to.
-          example: "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+          example: 'f47ac10b-58cc-4372-a567-0e02b2c3d479'
         invited_email:
           type: string
           format: email
@@ -391,22 +391,22 @@ components:
         id:
           type: string
           format: uuid
-          example: "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e"
+          example: 'b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e'
         invite_code:
           type: string
           description: >-
             Cryptographically random 24-character uppercase invite code.
-          example: "01A2B3C4D5E6F7G8H9I0J1K2"
+          example: '01A2B3C4D5E6F7G8H9I0J1K2'
         expires_at:
           type: string
           format: date-time
-          example: "2025-07-18T10:30:00.000Z"
+          example: '2025-07-18T10:30:00.000Z'
         role:
           type: string
           example: member
         household_name:
           type: string
-          example: "Smith Family"
+          example: 'Smith Family'
 
     HouseholdInviteValidateResponse:
       type: object
@@ -418,17 +418,17 @@ components:
         household_id:
           type: string
           format: uuid
-          example: "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+          example: 'f47ac10b-58cc-4372-a567-0e02b2c3d479'
         household_name:
           type: string
-          example: "Smith Family"
+          example: 'Smith Family'
         role:
           type: string
           example: member
         expires_at:
           type: string
           format: date-time
-          example: "2025-07-18T10:30:00.000Z"
+          example: '2025-07-18T10:30:00.000Z'
 
     HouseholdInviteAcceptRequest:
       type: object
@@ -437,7 +437,7 @@ components:
         invite_code:
           type: string
           description: Invite code received from the household owner.
-          example: "01A2B3C4D5E6F7G8H9I0J1K2"
+          example: '01A2B3C4D5E6F7G8H9I0J1K2'
 
     HouseholdInviteAcceptResponse:
       type: object
@@ -449,10 +449,10 @@ components:
         household_id:
           type: string
           format: uuid
-          example: "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+          example: 'f47ac10b-58cc-4372-a567-0e02b2c3d479'
         household_name:
           type: string
-          example: "Smith Family"
+          example: 'Smith Family'
         role:
           type: string
           example: member
@@ -493,7 +493,7 @@ components:
             certificate_id:
               type: string
               description: Unique deletion certificate identifier.
-              example: "cert-m1abc2d-0011aabb22cc33dd44ee55ff"
+              example: 'cert-m1abc2d-0011aabb22cc33dd44ee55ff'
             subject_type:
               type: string
               enum: [USER]
@@ -501,11 +501,11 @@ components:
             subject_id:
               type: string
               format: uuid
-              example: "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d"
+              example: 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d'
             deleted_at:
               type: string
               format: date-time
-              example: "2025-07-15T10:30:00.000Z"
+              example: '2025-07-15T10:30:00.000Z'
             households_affected:
               type: integer
               example: 2
@@ -517,9 +517,9 @@ components:
               items:
                 type: string
               example:
-                - "shredded:household:f47ac10b-58cc-4372-a567-0e02b2c3d479:m1abc2d"
-                - "revoked:user-key:b8c9d0e1-f2a3-4b5c-6d7e-8f9a0b1c2d3e:a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d:m1abc2e"
-                - "shredded:user:a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d:m1abc2f"
+                - 'shredded:household:f47ac10b-58cc-4372-a567-0e02b2c3d479:m1abc2d'
+                - 'revoked:user-key:b8c9d0e1-f2a3-4b5c-6d7e-8f9a0b1c2d3e:a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d:m1abc2e'
+                - 'shredded:user:a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d:m1abc2f'
             verified:
               type: boolean
               example: true
@@ -539,14 +539,14 @@ components:
         export_date:
           type: string
           format: date-time
-          example: "2025-07-15T10:30:00.000Z"
+          example: '2025-07-15T10:30:00.000Z'
         user_id:
           type: string
           format: uuid
-          example: "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d"
+          example: 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d'
         format_version:
           type: string
-          example: "1.0"
+          example: '1.0'
         data:
           type: object
           description: >-
@@ -624,40 +624,40 @@ paths:
       tags: [System]
       security: []
       responses:
-        "200":
+        '200':
           description: All services are healthy.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HealthCheckResponse"
+                $ref: '#/components/schemas/HealthCheckResponse'
               example:
                 status: healthy
-                timestamp: "2025-07-15T10:30:00.000Z"
+                timestamp: '2025-07-15T10:30:00.000Z'
                 services:
                   database: connected
                   auth: operational
-                version: "1.0.0"
-        "405":
+                version: '1.0.0'
+        '405':
           description: Method not allowed (non-GET request).
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               example:
-                error: "Method not allowed"
-        "503":
+                error: 'Method not allowed'
+        '503':
           description: One or more services are degraded.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HealthCheckResponse"
+                $ref: '#/components/schemas/HealthCheckResponse'
               example:
                 status: degraded
-                timestamp: "2025-07-15T10:30:00.000Z"
+                timestamp: '2025-07-15T10:30:00.000Z'
                 services:
                   database: unavailable
                   auth: operational
-                version: "1.0.0"
+                version: '1.0.0'
 
   # =========================================================================
   # Auth Webhook
@@ -682,54 +682,54 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AuthWebhookPayload"
+              $ref: '#/components/schemas/AuthWebhookPayload'
             example:
               type: INSERT
               table: users
               record:
-                id: "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d"
+                id: 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d'
                 email: user@example.com
                 raw_user_meta_data:
-                  full_name: "Jane Doe"
-                created_at: "2025-07-15T10:30:00.000Z"
+                  full_name: 'Jane Doe'
+                created_at: '2025-07-15T10:30:00.000Z'
               old_record: null
       responses:
-        "201":
+        '201':
           description: User provisioned successfully.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AuthWebhookCreatedResponse"
-        "200":
+                $ref: '#/components/schemas/AuthWebhookCreatedResponse'
+        '200':
           description: Event type other than INSERT — acknowledged and ignored.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AuthWebhookIgnoredResponse"
-        "401":
+                $ref: '#/components/schemas/AuthWebhookIgnoredResponse'
+        '401':
           description: Webhook secret missing or invalid.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               example:
                 error: Unauthorized
-        "405":
+        '405':
           description: Method not allowed (non-POST request).
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               example:
-                error: "Method not allowed"
-        "500":
+                error: 'Method not allowed'
+        '500':
           description: Internal server error during user provisioning.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               example:
-                error: "Internal server error"
+                error: 'Internal server error'
 
   # =========================================================================
   # Passkey Registration
@@ -775,77 +775,77 @@ paths:
                 WebAuthn `AuthenticatorAttestationResponse` —
                 shape defined by the Web Authentication specification.
             example:
-              id: "Y3JlZGVudGlhbC1pZC1leGFtcGxl"
-              rawId: "Y3JlZGVudGlhbC1pZC1leGFtcGxl"
+              id: 'Y3JlZGVudGlhbC1pZC1leGFtcGxl'
+              rawId: 'Y3JlZGVudGlhbC1pZC1leGFtcGxl'
               response:
-                clientDataJSON: "eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiZEdobGN5QnBjeUJoSUhOaGJYQnNaU0JqYUdGc2JHVnVaMlUiLCJvcmlnaW4iOiJodHRwczovL2FwcC5maW5hbmNlLmV4YW1wbGUuY29tIn0"
-                attestationObject: "o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YQ"
-              type: "public-key"
+                clientDataJSON: 'eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiZEdobGN5QnBjeUJoSUhOaGJYQnNaU0JqYUdGc2JHVnVaMlUiLCJvcmlnaW4iOiJodHRwczovL2FwcC5maW5hbmNlLmV4YW1wbGUuY29tIn0'
+                attestationObject: 'o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YQ'
+              type: 'public-key'
               clientExtensionResults: {}
-              authenticatorAttachment: "platform"
+              authenticatorAttachment: 'platform'
       responses:
-        "200":
+        '200':
           description: >-
             Registration options generated (`?step=options`), or
             authentication options generated.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PasskeyRegistrationOptionsResponse"
-        "201":
+                $ref: '#/components/schemas/PasskeyRegistrationOptionsResponse'
+        '201':
           description: >-
             Credential verified and stored (`?step=verify`).
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PasskeyRegistrationVerifyResponse"
+                $ref: '#/components/schemas/PasskeyRegistrationVerifyResponse'
               example:
                 verified: true
-                credential_id: "Y3JlZGVudGlhbC1pZC1leGFtcGxl"
+                credential_id: 'Y3JlZGVudGlhbC1pZC1leGFtcGxl'
                 device_type: singleDevice
-        "400":
+        '400':
           description: >-
             Invalid step parameter, no valid challenge found, or
             registration verification failed.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               examples:
                 invalidStep:
                   summary: Missing or invalid step parameter
                   value:
-                    error: "Invalid step. Use ?step=options or ?step=verify"
+                    error: 'Invalid step. Use ?step=options or ?step=verify'
                 noChallenge:
                   summary: Challenge expired or not found
                   value:
-                    error: "No valid challenge found"
+                    error: 'No valid challenge found'
                 verificationFailed:
                   summary: Attestation verification failed
                   value:
-                    error: "Registration verification failed"
-        "401":
+                    error: 'Registration verification failed'
+        '401':
           description: Missing or invalid JWT.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               example:
                 error: Unauthorized
-        "405":
+        '405':
           description: Method not allowed (non-POST request).
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
-        "500":
+                $ref: '#/components/schemas/Error'
+        '500':
           description: Internal server error.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               example:
-                error: "Internal server error"
+                error: 'Internal server error'
 
   # =========================================================================
   # Passkey Authentication
@@ -930,16 +930,16 @@ paths:
               verify:
                 summary: Authenticator assertion response
                 value:
-                  id: "Y3JlZGVudGlhbC1pZC1leGFtcGxl"
-                  rawId: "Y3JlZGVudGlhbC1pZC1leGFtcGxl"
+                  id: 'Y3JlZGVudGlhbC1pZC1leGFtcGxl'
+                  rawId: 'Y3JlZGVudGlhbC1pZC1leGFtcGxl'
                   response:
-                    clientDataJSON: "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0In0"
-                    authenticatorData: "SZYN5YgOjGh0NBcPZHZgW4"
-                    signature: "MEUCIQDNrG..."
-                  type: "public-key"
+                    clientDataJSON: 'eyJ0eXBlIjoid2ViYXV0aG4uZ2V0In0'
+                    authenticatorData: 'SZYN5YgOjGh0NBcPZHZgW4'
+                    signature: 'MEUCIQDNrG...'
+                  type: 'public-key'
                   clientExtensionResults: {}
       responses:
-        "200":
+        '200':
           description: >-
             For `?step=options`: authentication options with challenge.
 
@@ -948,73 +948,73 @@ paths:
             application/json:
               schema:
                 oneOf:
-                  - $ref: "#/components/schemas/PasskeyAuthOptionsResponse"
-                  - $ref: "#/components/schemas/PasskeyAuthVerifyResponse"
+                  - $ref: '#/components/schemas/PasskeyAuthOptionsResponse'
+                  - $ref: '#/components/schemas/PasskeyAuthVerifyResponse'
               examples:
                 options:
                   summary: Authentication options response
                   value:
-                    challenge: "dGhpcyBpcyBhIHNhbXBsZSBjaGFsbGVuZ2U"
+                    challenge: 'dGhpcyBpcyBhIHNhbXBsZSBjaGFsbGVuZ2U'
                     timeout: 60000
                     rpId: finance.example.com
                     userVerification: preferred
                     allowCredentials:
-                      - id: "Y3JlZGVudGlhbC1pZC1leGFtcGxl"
+                      - id: 'Y3JlZGVudGlhbC1pZC1leGFtcGxl'
                         type: public-key
                         transports: [internal]
                 verified:
                   summary: Successful verification
                   value:
                     verified: true
-                    user_id: "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d"
-                    message: "Passkey authentication successful. Exchange for session."
-        "400":
+                    user_id: 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d'
+                    message: 'Passkey authentication successful. Exchange for session.'
+        '400':
           description: >-
             Invalid step, missing credential ID, credential not found,
             or no valid challenge.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               examples:
                 invalidStep:
                   summary: Invalid step parameter
                   value:
-                    error: "Invalid step. Use ?step=options or ?step=verify"
+                    error: 'Invalid step. Use ?step=options or ?step=verify'
                 missingId:
                   summary: Missing credential ID in verify body
                   value:
-                    error: "Missing credential ID"
+                    error: 'Missing credential ID'
                 credentialNotFound:
                   summary: Credential not in database
                   value:
-                    error: "Credential not found"
+                    error: 'Credential not found'
                 noChallenge:
                   summary: Challenge expired or not found
                   value:
-                    error: "No valid challenge found"
-        "401":
+                    error: 'No valid challenge found'
+        '401':
           description: Authentication assertion verification failed.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               example:
-                error: "Authentication verification failed"
-        "405":
+                error: 'Authentication verification failed'
+        '405':
           description: Method not allowed (non-POST request).
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
-        "500":
+                $ref: '#/components/schemas/Error'
+        '500':
           description: Internal server error.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               example:
-                error: "Internal server error"
+                error: 'Internal server error'
 
   # =========================================================================
   # Household Invite
@@ -1035,67 +1035,67 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/HouseholdInviteCreateRequest"
+              $ref: '#/components/schemas/HouseholdInviteCreateRequest'
             example:
-              household_id: "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+              household_id: 'f47ac10b-58cc-4372-a567-0e02b2c3d479'
               invited_email: friend@example.com
               role: member
               expires_in_hours: 72
       responses:
-        "201":
+        '201':
           description: Invitation created.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HouseholdInviteCreateResponse"
-        "400":
+                $ref: '#/components/schemas/HouseholdInviteCreateResponse'
+        '400':
           description: Missing required field (`household_id`).
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               example:
-                error: "household_id is required"
-        "401":
+                error: 'household_id is required'
+        '401':
           description: Missing or invalid JWT.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               example:
-                error: "Authentication required"
-        "403":
+                error: 'Authentication required'
+        '403':
           description: Authenticated user is not the household owner.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               example:
-                error: "Only the household owner can create invitations"
-        "404":
+                error: 'Only the household owner can create invitations'
+        '404':
           description: Household not found.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               example:
-                error: "Household not found"
-        "409":
+                error: 'Household not found'
+        '409':
           description: Invited user is already a household member.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               example:
-                error: "User is already a member of this household"
-        "500":
+                error: 'User is already a member of this household'
+        '500':
           description: Internal server error.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               example:
-                error: "Internal server error"
+                error: 'Internal server error'
 
     get:
       operationId: validateHouseholdInvite
@@ -1114,69 +1114,69 @@ paths:
           schema:
             type: string
           description: The invitation code to validate.
-          example: "01A2B3C4D5E6F7G8H9I0J1K2"
+          example: '01A2B3C4D5E6F7G8H9I0J1K2'
       responses:
-        "200":
+        '200':
           description: Invitation is valid.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HouseholdInviteValidateResponse"
-        "400":
+                $ref: '#/components/schemas/HouseholdInviteValidateResponse'
+        '400':
           description: Missing `code` query parameter.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               example:
-                error: "code query parameter is required"
-        "401":
+                error: 'code query parameter is required'
+        '401':
           description: Missing or invalid JWT.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               example:
-                error: "Authentication required"
-        "403":
+                error: 'Authentication required'
+        '403':
           description: Invitation is restricted to a different email.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               example:
-                error: "This invitation is for a different email address"
-        "404":
+                error: 'This invitation is for a different email address'
+        '404':
           description: Invitation code not found.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               example:
-                error: "Invalid invitation code"
-        "410":
+                error: 'Invalid invitation code'
+        '410':
           description: Invitation expired or already accepted.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               examples:
                 expired:
                   summary: Invitation expired
                   value:
-                    error: "This invitation has expired"
+                    error: 'This invitation has expired'
                 alreadyAccepted:
                   summary: Already accepted
                   value:
-                    error: "This invitation has already been accepted"
-        "500":
+                    error: 'This invitation has already been accepted'
+        '500':
           description: Internal server error.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               example:
-                error: "Internal server error"
+                error: 'Internal server error'
 
     put:
       operationId: acceptHouseholdInvite
@@ -1193,79 +1193,79 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/HouseholdInviteAcceptRequest"
+              $ref: '#/components/schemas/HouseholdInviteAcceptRequest'
             example:
-              invite_code: "01A2B3C4D5E6F7G8H9I0J1K2"
+              invite_code: '01A2B3C4D5E6F7G8H9I0J1K2'
       responses:
-        "200":
+        '200':
           description: Invitation accepted — user added to the household.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HouseholdInviteAcceptResponse"
-        "400":
+                $ref: '#/components/schemas/HouseholdInviteAcceptResponse'
+        '400':
           description: Missing `invite_code` in request body.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               example:
-                error: "invite_code is required"
-        "401":
+                error: 'invite_code is required'
+        '401':
           description: Missing or invalid JWT.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               example:
-                error: "Authentication required"
-        "403":
+                error: 'Authentication required'
+        '403':
           description: Invitation is restricted to a different email.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               example:
-                error: "This invitation is for a different email address"
-        "404":
+                error: 'This invitation is for a different email address'
+        '404':
           description: Invitation code not found.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               example:
-                error: "Invalid invitation code"
-        "409":
+                error: 'Invalid invitation code'
+        '409':
           description: User is already a member of the household.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               example:
-                error: "You are already a member of this household"
-        "410":
+                error: 'You are already a member of this household'
+        '410':
           description: Invitation expired or already accepted.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               examples:
                 expired:
                   summary: Invitation expired
                   value:
-                    error: "This invitation has expired"
+                    error: 'This invitation has expired'
                 alreadyAccepted:
                   summary: Already accepted
                   value:
-                    error: "This invitation has already been accepted"
-        "500":
+                    error: 'This invitation has already been accepted'
+        '500':
           description: Internal server error.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               example:
-                error: "Internal server error"
+                error: 'Internal server error'
 
   # =========================================================================
   # Account Deletion
@@ -1298,7 +1298,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AccountDeletionRequest"
+              $ref: '#/components/schemas/AccountDeletionRequest'
             examples:
               confirmBoolean:
                 summary: Confirm with boolean
@@ -1309,46 +1309,46 @@ paths:
                 value:
                   confirm: DELETE_MY_ACCOUNT
       responses:
-        "200":
+        '200':
           description: Account deleted — deletion certificate returned.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DeletionCertificate"
-        "400":
+                $ref: '#/components/schemas/DeletionCertificate'
+        '400':
           description: Missing or invalid confirmation.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               example:
                 error: >-
                   Account deletion requires confirmation. Send
                   { "confirm": "DELETE_MY_ACCOUNT" } in the request body.
-        "401":
+        '401':
           description: Missing or invalid JWT.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               example:
-                error: "Authentication required"
-        "405":
+                error: 'Authentication required'
+        '405':
           description: Method not allowed (non-DELETE request).
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               example:
-                error: "Method not allowed"
-        "500":
+                error: 'Method not allowed'
+        '500':
           description: Internal server error.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               example:
-                error: "Internal server error"
+                error: 'Internal server error'
 
   # =========================================================================
   # Data Export
@@ -1403,14 +1403,14 @@ paths:
             Export format.  Defaults to `json`.  Alternatively, set the
             `Accept` header to `text/csv` to receive CSV.
       responses:
-        "200":
+        '200':
           description: >-
             Data export file.  Delivered as a streaming download with
             `Content-Disposition: attachment`.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DataExportJsonResponse"
+                $ref: '#/components/schemas/DataExportJsonResponse'
             text/csv:
               schema:
                 type: string
@@ -1425,59 +1425,59 @@ paths:
                 Suggested filename, e.g.
                 `attachment; filename="finance-export-2025-07-15T10-30-00-000Z.json"`.
               example: 'attachment; filename="finance-export-2025-07-15T10-30-00-000Z.json"'
-        "400":
+        '400':
           description: Invalid export format.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/StructuredError"
+                $ref: '#/components/schemas/StructuredError'
               example:
                 error:
                   code: INVALID_FORMAT
                   message: 'Export format must be "json" or "csv". Use ?format=json or ?format=csv.'
-        "401":
+        '401':
           description: Missing or invalid JWT.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               example:
-                error: "Authentication required"
-        "405":
+                error: 'Authentication required'
+        '405':
           description: Method not allowed (non-GET request).
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
               example:
-                error: "Method not allowed"
-        "413":
+                error: 'Method not allowed'
+        '413':
           description: Request entity too large (Content-Length exceeds 1 KB).
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/StructuredError"
+                $ref: '#/components/schemas/StructuredError'
               example:
                 error:
                   code: REQUEST_TOO_LARGE
-                  message: "Request exceeds maximum allowed size."
-        "429":
+                  message: 'Request exceeds maximum allowed size.'
+        '429':
           description: Rate limit exceeded (10 exports per hour).
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/StructuredError"
+                $ref: '#/components/schemas/StructuredError'
               example:
                 error:
                   code: RATE_LIMITED
-                  message: "Export limit exceeded. Maximum 10 exports per hour."
-        "500":
+                  message: 'Export limit exceeded. Maximum 10 exports per hour.'
+        '500':
           description: Internal server error.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/StructuredError"
+                $ref: '#/components/schemas/StructuredError'
               example:
                 error:
                   code: INTERNAL_ERROR
-                  message: "An unexpected error occurred."
+                  message: 'An unexpected error occurred.'

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@finance/api",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Finance app — Supabase Edge Functions API and documentation",
+  "license": "BUSL-1.1",
+  "scripts": {
+    "docs:api": "npx @redocly/cli preview-docs openapi.yaml",
+    "docs:api:lint": "npx @redocly/cli lint openapi.yaml",
+    "docs:api:bundle": "npx @redocly/cli bundle openapi.yaml -o docs/openapi-bundled.yaml"
+  },
+  "devDependencies": {
+    "@redocly/cli": "^1.34.3",
+    "yaml": "^2.8.2"
+  }
+}


### PR DESCRIPTION
## Summary
Generate OpenAPI 3.0 specification documenting all Supabase Edge Functions with interactive viewer.

## Changes
- \services/api/openapi.yaml\ — ~1,600 line OpenAPI 3.0.3 spec covering all 7 Edge Functions (9 operations)
- \services/api/package.json\ — npm scripts: \docs:api\ (preview), \docs:api:lint\ (validate), \docs:api:bundle\
- \services/api/docs/README.md\ — API documentation guide
- Updated \services/api/README.md\ with API docs section

## Endpoints Documented
| Tag | Endpoints |
|-----|-----------|
| System | GET /health-check |
| Auth | POST /auth-webhook, /passkey-register, /passkey-authenticate |
| Households | POST/GET/PUT /household-invite |
| Data Management | DELETE /account-deletion, GET /data-export |

Closes #212