### PR TITLE
feat(sync): implement complete sync engine — core, auth, conflict, queue, delta, iOS bindings (#447)

### DIFF
--- a/apps/android/src/main/kotlin/com/finance/android/di/SyncModule.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/di/SyncModule.kt
@@ -46,7 +46,7 @@ val syncModule = module {
     single<SequenceTracker> { InMemorySequenceTracker() }
 
     // ── Delta sync manager ──────────────────────────────────────────
-    single { DeltaSyncManager(get()) }
+    single { DeltaSyncManager(get(), get<SequenceTracker>(), get()) }
 
     // ── Token management ────────────────────────────────────────────
     single { TokenStorage() }

--- a/apps/android/src/main/kotlin/com/finance/android/sync/AndroidSyncManager.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/sync/AndroidSyncManager.kt
@@ -5,6 +5,9 @@ package com.finance.android.sync
 import android.content.Context
 import com.finance.sync.SyncEngine
 import com.finance.sync.SyncCredentials
+import com.finance.sync.SyncError
+import com.finance.sync.SyncPhase
+import com.finance.sync.SyncProgress
 import com.finance.sync.SyncStatus
 import com.finance.sync.queue.MutationQueue
 import kotlinx.coroutines.CoroutineScope
@@ -88,7 +91,9 @@ class AndroidSyncManager(
                 }
                 .catch { error ->
                     Timber.e(error, "Sync loop error")
-                    _syncStatus.value = SyncStatus.Error(error)
+                    _syncStatus.value = SyncStatus.Error(
+                        SyncError.NetworkError(error.message ?: "Unknown sync error"),
+                    )
                 }
                 .launchIn(this)
 
@@ -117,7 +122,9 @@ class AndroidSyncManager(
      */
     suspend fun syncNow(credentials: SyncCredentials) = withContext(Dispatchers.IO) {
         Timber.i("Running one-shot sync")
-        _syncStatus.value = SyncStatus.Syncing()
+        _syncStatus.value = SyncStatus.Syncing(
+            SyncProgress(phase = SyncPhase.PULLING, processedRecords = 0, totalRecords = null),
+        )
 
         try {
             if (!syncEngine.isConnected.value) {
@@ -131,7 +138,9 @@ class AndroidSyncManager(
                 }
                 .catch { error ->
                     Timber.e(error, "One-shot sync error")
-                    _syncStatus.value = SyncStatus.Error(error)
+                    _syncStatus.value = SyncStatus.Error(
+                        SyncError.NetworkError(error.message ?: "Unknown sync error"),
+                    )
                 }
                 .collect { /* consume until completed */ }
         } finally {

--- a/apps/android/src/main/kotlin/com/finance/android/ui/sync/SyncStatusViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/sync/SyncStatusViewModel.kt
@@ -89,6 +89,7 @@ class SyncStatusViewModel(
                 _syncStatus.value = status
 
                 when (status) {
+                    is SyncStatus.Connecting,
                     is SyncStatus.Connected,
                     is SyncStatus.Idle,
                     -> {

--- a/packages/sync/README.md
+++ b/packages/sync/README.md
@@ -1,28 +1,217 @@
 # Sync
 
-Data synchronization engine for the Finance app.
+Data synchronisation engine for the Finance app.
 
 ## Overview
 
-`packages/sync` will handle offline-first data synchronization between local SQLite databases and the remote backend. It depends on `packages/models` for entity definitions. This package is currently **scaffolded but not yet implemented** — the source directory contains only a `.gitkeep` placeholder.
+`packages/sync` implements offline-first data synchronisation between local
+SQLite databases and the remote backend. It depends on `packages/models` for
+entity definitions and is consumed by every platform client (iOS, Android,
+Web, Desktop).
 
-The planned approach uses PowerSync for conflict resolution and delta sync.
+The sync layer follows a **pull → conflict resolution → push** cycle:
 
-## Planned Components
+1. **Pull** — fetch remote changes via delta sync (only records newer than
+   the last-known sequence per table).
+2. **Conflict Resolution** — detect overlapping edits between local mutations
+   and server changes, then resolve them using a configurable strategy
+   (last-write-wins, merge, server-wins, or client-wins).
+3. **Push** — drain the local mutation queue by sending batched mutations to
+   the server.
 
-- **Sync client** — Manages connection to the PowerSync service and handles push/pull cycles
-- **Conflict resolution** — Deterministic strategy for resolving concurrent edits across devices
-- **Offline queue** — Buffers local mutations while offline for replay on reconnect
-- **Delta sync** — Transfers only changed records using `syncVersion` fields on each model
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        SyncClient                           │
+│  (high-level facade: auth + lifecycle + reactive state)     │
+├─────────────────────────────────────────────────────────────┤
+│                     DefaultSyncEngine                       │
+│  (orchestrator: connect / sync loop / credential refresh)   │
+├──────────────┬──────────────────────┬───────────────────────┤
+│ DeltaSyncManager │  ConflictResolver  │   MutationQueue      │
+│ (pull + push +   │  (LWW / merge /    │   (offline queue +   │
+│  seq tracking)   │  server/client wins)│   coalescing)        │
+├──────────────┴──────────────────────┴───────────────────────┤
+│                       SyncProvider                          │
+│  (backend abstraction — PowerSync or compatible service)    │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Components
+
+### Core Types
+- **`SyncConfig`** — connection parameters, intervals, retry policy
+- **`SyncStatus`** — sealed class for engine state (Idle, Connecting, Syncing, Connected, Error, Disconnected)
+- **`SyncCredentials`** — bearer token, user ID, expiry, refresh token
+- **`SyncMutation`** — pending local mutation (INSERT / UPDATE / DELETE)
+- **`SyncChange`** — server-originated change with sequence number and checksum
+- **`SyncResult`** — sealed outcome of a sync cycle (Success / Failure)
+
+### Auth Module (`auth/`)
+- **`AuthCredentials`** — sealed hierarchy (EmailPassword, OAuth+PKCE, Passkey, RefreshToken)
+- **`AuthSession`** — access + refresh tokens with expiry tracking
+- **`AuthManager`** — interface for sign-in / sign-out / token refresh
+- **`TokenManager`** — secure token storage and auto-refresh scheduling
+- **`PKCEHelper`** — code verifier / challenge generation for OAuth flows
+
+### Conflict Resolution (`conflict/`)
+- **`ConflictResolver`** — interface for resolving local vs. server conflicts
+- **`ConflictStrategy`** — per-table strategy mapping with four built-in resolvers:
+  - `LastWriteWinsResolver` — server timestamp comparison
+  - `MergeResolver` — field-level merge for complex entities
+  - `ServerWinsResolver` — always accept server version
+  - `ClientWinsResolver` — always keep local version
+
+### Offline Queue (`queue/`)
+- **`MutationQueue`** — interface with FIFO ordering and operation-aware coalescing
+- **`InMemoryMutationQueue`** — thread-safe in-memory implementation using `Mutex`
+- **`QueueProcessor`** — batch processing with exponential backoff and dead-letter support
+
+### Delta Sync (`delta/`)
+- **`DeltaSyncManager`** — incremental pull with pagination, conflict detection, batched push
+- **`SequenceTracker`** — persists per-table sync versions for resumable sync
+- **`SyncChecksum`** — CRC-32 integrity verification for pulled changes
+
+### Encryption (`crypto/`)
+- **`FieldEncryptor`** — field-level AES-256-GCM encryption for sensitive financial data
+- **`EnvelopeEncryption`** — envelope pattern with data encryption keys (DEKs)
+- **`HouseholdKeyManager`** — per-household key management and rotation
+- **`CryptoShredder`** — secure data deletion via key destruction
+
+### Public API
+- **`SyncEngine`** — interface for the sync lifecycle (connect / disconnect / sync)
+- **`DefaultSyncEngine`** — production orchestrator with periodic sync loop, credential refresh, exponential backoff, and health monitoring
+- **`SyncClient`** — high-level facade combining auth + sync engine + mutation queue
 
 ## Usage
 
-Once implemented, add the dependency in `build.gradle.kts`:
+### Add the dependency
 
 ```kotlin
 commonMain.dependencies {
     implementation(project(":packages:sync"))
 }
+```
+
+### Basic setup
+
+```kotlin
+// 1. Configure sync
+val config = SyncConfig(
+    endpoint = "https://sync.example.com",
+    databaseName = "finance.db",
+    syncIntervalMs = 30_000L,
+)
+
+// 2. Create components
+val provider: SyncProvider = // platform-specific implementation
+val mutationQueue = InMemoryMutationQueue()
+val sequenceTracker = InMemorySequenceTracker()
+
+val deltaSyncManager = DeltaSyncManager(provider, sequenceTracker, config)
+
+val syncEngine = DefaultSyncEngine(
+    config = config,
+    provider = provider,
+    mutationQueue = mutationQueue,
+    deltaSyncManager = deltaSyncManager,
+)
+
+// 3. Create the client
+val syncClient = SyncClient(
+    config = config,
+    authManager = authManager,
+    syncEngine = syncEngine,
+    mutationQueue = mutationQueue,
+)
+```
+
+### Sign in and start syncing
+
+```kotlin
+// Sign in with email/password and start the periodic sync loop
+val result = syncClient.signInAndSync(
+    AuthCredentials.EmailPassword(email, password),
+)
+
+result.onSuccess { println("Sync started") }
+result.onFailure { error -> println("Sign-in failed: $error") }
+```
+
+### Observe sync status
+
+```kotlin
+syncClient.syncStatus.collect { status ->
+    when (status) {
+        is SyncStatus.Idle -> showIdle()
+        is SyncStatus.Connecting -> showConnecting()
+        is SyncStatus.Syncing -> showProgress(status.progress)
+        is SyncStatus.Connected -> showConnected()
+        is SyncStatus.Error -> showError(status.error)
+        is SyncStatus.Disconnected -> showDisconnected()
+    }
+}
+```
+
+### Force an immediate sync
+
+```kotlin
+val result = syncClient.syncNow()
+when (result) {
+    is SyncResult.Success -> println(
+        "Synced: ${result.changesApplied} pulled, ${result.mutationsPushed} pushed"
+    )
+    is SyncResult.Failure -> println("Sync failed: ${result.error}")
+}
+```
+
+### Sign out
+
+```kotlin
+syncClient.signOut()  // stops sync, clears tokens, clears mutation queue
+```
+
+### Health monitoring integration
+
+```kotlin
+val healthMonitor = SyncHealthMonitor()
+
+val syncEngine = DefaultSyncEngine(
+    config = config,
+    provider = provider,
+    mutationQueue = mutationQueue,
+    deltaSyncManager = deltaSyncManager,
+    healthListener = object : SyncHealthListener {
+        override fun onSyncSuccess(durationMs: Long, pendingMutations: Int) {
+            healthMonitor.recordSyncSuccess(durationMs)
+            healthMonitor.updatePendingMutations(pendingMutations)
+        }
+
+        override fun onSyncFailure(error: SyncError) {
+            healthMonitor.recordSyncFailure()
+        }
+
+        override fun onPendingMutationsChanged(count: Int) {
+            healthMonitor.updatePendingMutations(count)
+        }
+    },
+)
+```
+
+### Automatic credential refresh
+
+```kotlin
+val syncEngine = DefaultSyncEngine(
+    config = config,
+    provider = provider,
+    mutationQueue = mutationQueue,
+    deltaSyncManager = deltaSyncManager,
+    credentialRefresher = {
+        val session = authManager.refreshToken().getOrThrow()
+        session.toSyncCredentials()
+    },
+)
 ```
 
 ## Development
@@ -37,4 +226,4 @@ node tools/gradle.js :packages:sync:allTests
 
 ## Status
 
-🚧 **Scaffolded** — no production code yet. See the project roadmap for timeline.
+✅ **Implemented** — all core modules are production-ready with comprehensive test coverage.

--- a/packages/sync/README.md
+++ b/packages/sync/README.md
@@ -41,6 +41,7 @@ The sync layer follows a **pull → conflict resolution → push** cycle:
 ## Components
 
 ### Core Types
+
 - **`SyncConfig`** — connection parameters, intervals, retry policy
 - **`SyncStatus`** — sealed class for engine state (Idle, Connecting, Syncing, Connected, Error, Disconnected)
 - **`SyncCredentials`** — bearer token, user ID, expiry, refresh token
@@ -49,6 +50,7 @@ The sync layer follows a **pull → conflict resolution → push** cycle:
 - **`SyncResult`** — sealed outcome of a sync cycle (Success / Failure)
 
 ### Auth Module (`auth/`)
+
 - **`AuthCredentials`** — sealed hierarchy (EmailPassword, OAuth+PKCE, Passkey, RefreshToken)
 - **`AuthSession`** — access + refresh tokens with expiry tracking
 - **`AuthManager`** — interface for sign-in / sign-out / token refresh
@@ -56,6 +58,7 @@ The sync layer follows a **pull → conflict resolution → push** cycle:
 - **`PKCEHelper`** — code verifier / challenge generation for OAuth flows
 
 ### Conflict Resolution (`conflict/`)
+
 - **`ConflictResolver`** — interface for resolving local vs. server conflicts
 - **`ConflictStrategy`** — per-table strategy mapping with four built-in resolvers:
   - `LastWriteWinsResolver` — server timestamp comparison
@@ -64,22 +67,26 @@ The sync layer follows a **pull → conflict resolution → push** cycle:
   - `ClientWinsResolver` — always keep local version
 
 ### Offline Queue (`queue/`)
+
 - **`MutationQueue`** — interface with FIFO ordering and operation-aware coalescing
 - **`InMemoryMutationQueue`** — thread-safe in-memory implementation using `Mutex`
 - **`QueueProcessor`** — batch processing with exponential backoff and dead-letter support
 
 ### Delta Sync (`delta/`)
+
 - **`DeltaSyncManager`** — incremental pull with pagination, conflict detection, batched push
 - **`SequenceTracker`** — persists per-table sync versions for resumable sync
 - **`SyncChecksum`** — CRC-32 integrity verification for pulled changes
 
 ### Encryption (`crypto/`)
+
 - **`FieldEncryptor`** — field-level AES-256-GCM encryption for sensitive financial data
 - **`EnvelopeEncryption`** — envelope pattern with data encryption keys (DEKs)
 - **`HouseholdKeyManager`** — per-household key management and rotation
 - **`CryptoShredder`** — secure data deletion via key destruction
 
 ### Public API
+
 - **`SyncEngine`** — interface for the sync lifecycle (connect / disconnect / sync)
 - **`DefaultSyncEngine`** — production orchestrator with periodic sync loop, credential refresh, exponential backoff, and health monitoring
 - **`SyncClient`** — high-level facade combining auth + sync engine + mutation queue

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/SyncChange.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/SyncChange.kt
@@ -6,14 +6,35 @@ import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 
 /**
+ * The type of operation in a server-originated [SyncChange].
+ *
+ * Distinct from [MutationOperation] because the server collapses
+ * INSERT and UPDATE into a single [UPSERT] semantic — the client
+ * applies an upsert regardless of whether the row existed locally.
+ */
+@Serializable
+enum class ChangeOperation {
+    /** Insert or update a record (server does not distinguish). */
+    UPSERT,
+
+    /** Soft-delete a record (sets `deleted_at`, does not physically remove). */
+    DELETE,
+}
+
+/**
  * A single change received from the sync backend during a pull cycle.
  *
  * @property tableName The database table affected.
  * @property operation The kind of DML operation that was applied server-side.
+ *   Uses [MutationOperation] for compatibility with conflict resolvers.
  * @property rowData Column name → serialised value map. `null` values represent SQL NULLs.
  * @property serverTimestamp The authoritative timestamp assigned by the server.
  * @property sequenceNumber A monotonically increasing number for ordering changes.
  *   Used by [com.finance.sync.delta.SequenceTracker] to implement delta sync.
+ * @property recordId The ID of the specific record that was changed.
+ *   Defaults to [rowData]`["id"]` when not explicitly set.
+ * @property syncVersion The sync version of the record after this change was applied.
+ * @property householdId The household scope for this change.
  */
 @Serializable
 data class SyncChange(
@@ -22,9 +43,33 @@ data class SyncChange(
     val rowData: Map<String, String?>,
     val serverTimestamp: Instant,
     val sequenceNumber: Long,
+    val recordId: String = "",
+    val syncVersion: Long = 0L,
+    val householdId: String = "",
 ) {
     init {
         require(tableName.isNotBlank()) { "Table name cannot be blank" }
         require(sequenceNumber >= 0) { "Sequence number must be non-negative, got $sequenceNumber" }
+        require(syncVersion >= 0) { "Sync version must be non-negative, got $syncVersion" }
     }
+
+    /**
+     * The effective record ID for this change, falling back to the `id`
+     * field in [rowData] if [recordId] was not explicitly set.
+     */
+    val effectiveRecordId: String
+        get() = recordId.ifBlank { rowData["id"] ?: "" }
+
+    /**
+     * Map this change's [MutationOperation] to the simpler [ChangeOperation].
+     *
+     * INSERT and UPDATE both map to [ChangeOperation.UPSERT] because the
+     * server-side semantic is always an upsert.
+     */
+    val changeOperation: ChangeOperation
+        get() = when (operation) {
+            MutationOperation.INSERT -> ChangeOperation.UPSERT
+            MutationOperation.UPDATE -> ChangeOperation.UPSERT
+            MutationOperation.DELETE -> ChangeOperation.DELETE
+        }
 }

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/SyncClient.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/SyncClient.kt
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.sync
+
+import com.finance.sync.auth.AuthCredentials
+import com.finance.sync.auth.AuthManager
+import com.finance.sync.queue.MutationQueue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+/**
+ * High-level sync client that ties together authentication and the sync engine.
+ *
+ * This is the main entry point for platform apps to interact with the
+ * sync subsystem. It manages the lifecycle of both authentication and
+ * the periodic sync loop, exposing reactive state for UI consumption.
+ *
+ * ```kotlin
+ * val client = SyncClient(
+ *     config = syncConfig,
+ *     authManager = authManager,
+ *     syncEngine = defaultSyncEngine,
+ *     mutationQueue = mutationQueue,
+ * )
+ *
+ * // Sign in and start syncing
+ * client.signInAndSync(AuthCredentials.EmailPassword(email, password))
+ *
+ * // Observe sync status
+ * client.syncStatus.collect { status -> updateUI(status) }
+ *
+ * // Force immediate sync
+ * val result = client.syncNow()
+ *
+ * // Sign out and stop syncing
+ * client.signOut()
+ *
+ * // Release resources when done
+ * client.destroy()
+ * ```
+ *
+ * @param config Sync configuration including endpoint and intervals.
+ * @param authManager Authentication manager for sign-in / sign-out / token refresh.
+ * @param syncEngine The sync engine that performs pull → resolve → push cycles.
+ * @param mutationQueue The queue of pending local mutations.
+ * @param coroutineContext Parent coroutine context for the client's internal scope.
+ *   Defaults to [EmptyCoroutineContext]; a [SupervisorJob] is always added
+ *   so that individual child failures do not cancel sibling coroutines.
+ */
+class SyncClient(
+    private val config: SyncConfig,
+    private val authManager: AuthManager,
+    private val syncEngine: DefaultSyncEngine,
+    private val mutationQueue: MutationQueue,
+    coroutineContext: CoroutineContext = EmptyCoroutineContext,
+) {
+
+    /**
+     * Internal [CoroutineScope] for the sync loop and lifecycle tasks.
+     *
+     * Uses a [SupervisorJob] so that individual failures (e.g., a failed
+     * sync cycle) do not cancel sibling coroutines (e.g., the pending-
+     * mutation observer).
+     */
+    private val scope = CoroutineScope(coroutineContext + SupervisorJob())
+
+    /** The running sync loop job, or `null` if sync is not active. */
+    private var syncLoopJob: Job? = null
+
+    // ── Reactive state ──────────────────────────────────────────────
+
+    /**
+     * Observable sync engine status.
+     *
+     * Mirrors [DefaultSyncEngine.status] for UI-layer consumption.
+     * Emits [SyncStatus] updates as the engine transitions through
+     * connection, syncing, error, and idle states.
+     */
+    val syncStatus: StateFlow<SyncStatus>
+        get() = syncEngine.status
+
+    /**
+     * Observable authentication state.
+     *
+     * `true` when the [AuthManager] has a valid session, `false` otherwise.
+     */
+    val isAuthenticated: StateFlow<Boolean>
+        get() = authManager.isAuthenticated
+
+    /**
+     * Observable count of local mutations waiting to be pushed to the server.
+     *
+     * Sourced from [MutationQueue.pendingCountFlow] and shared as a
+     * [StateFlow] for UI-layer consumption.
+     */
+    val pendingMutationCount: StateFlow<Int> = mutationQueue.pendingCountFlow
+        .stateIn(scope, SharingStarted.Eagerly, 0)
+
+    // ── Lifecycle ───────────────────────────────────────────────────
+
+    /**
+     * Start the periodic sync loop.
+     *
+     * Requires an active authentication session in [authManager]. If no
+     * session exists, this method returns without starting the loop.
+     *
+     * The loop runs until [stop] or [signOut] is called, or the client's
+     * coroutine scope is cancelled via [destroy].
+     */
+    suspend fun start() {
+        val session = authManager.currentSession.value ?: return
+        val credentials = session.toSyncCredentials()
+
+        syncLoopJob?.cancel()
+        syncLoopJob = scope.launch {
+            syncEngine.start(credentials)
+        }
+    }
+
+    /**
+     * Stop the sync loop and disconnect from the sync backend.
+     *
+     * Does **not** sign the user out — call [signOut] to clear the
+     * authentication session as well.
+     */
+    suspend fun stop() {
+        syncLoopJob?.cancel()
+        syncLoopJob = null
+        syncEngine.stop()
+    }
+
+    /**
+     * Force an immediate sync cycle outside the periodic schedule.
+     *
+     * Can be called while the periodic loop is running; the engine's
+     * internal mutex ensures only one cycle executes at a time.
+     *
+     * @return The [SyncResult] describing the outcome of the cycle.
+     */
+    suspend fun syncNow(): SyncResult {
+        return syncEngine.syncNow()
+    }
+
+    /**
+     * Authenticate with the given [credentials] and start syncing.
+     *
+     * Convenience method that combines [AuthManager.signIn] and [start]
+     * in a single call:
+     *
+     * 1. Signs in via [authManager].
+     * 2. Converts the resulting [com.finance.sync.auth.AuthSession] to
+     *    [SyncCredentials].
+     * 3. Launches the periodic sync loop with those credentials.
+     *
+     * @param credentials The authentication credentials (email/password, OAuth, etc.).
+     * @return [Result.success] if sign-in succeeded and sync started,
+     *   [Result.failure] if authentication failed. When authentication fails,
+     *   no sync loop is started and the previous state is preserved.
+     */
+    suspend fun signInAndSync(credentials: AuthCredentials): Result<Unit> {
+        val signInResult = authManager.signIn(credentials)
+        return signInResult.fold(
+            onSuccess = { session ->
+                val syncCredentials = session.toSyncCredentials()
+                syncLoopJob?.cancel()
+                syncLoopJob = scope.launch {
+                    syncEngine.start(syncCredentials)
+                }
+                Result.success(Unit)
+            },
+            onFailure = { error ->
+                Result.failure(error)
+            },
+        )
+    }
+
+    /**
+     * Sign out the current user and stop all sync activity.
+     *
+     * 1. Stops the sync loop and disconnects from the backend.
+     * 2. Signs out via [AuthManager] (invalidates tokens server-side).
+     * 3. Clears the local mutation queue.
+     *
+     * Safe to call multiple times; subsequent calls are no-ops.
+     */
+    suspend fun signOut() {
+        stop()
+        authManager.signOut()
+        mutationQueue.clear()
+    }
+
+    /**
+     * Release all resources held by this client.
+     *
+     * Cancels the internal [CoroutineScope], which terminates the sync loop
+     * and any background observers. After calling [destroy], this instance
+     * must not be reused.
+     *
+     * Platform DI containers should call this in their teardown lifecycle
+     * (e.g., `onCleared()` in Android ViewModel, `deinit` on iOS).
+     */
+    fun destroy() {
+        syncLoopJob?.cancel()
+        syncLoopJob = null
+        scope.cancel()
+    }
+}

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/SyncConfig.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/SyncConfig.kt
@@ -7,19 +7,48 @@ import kotlinx.serialization.Serializable
 /**
  * Configuration for initialising a [SyncProvider].
  *
+ * Combines connection parameters with operational tuning knobs for
+ * retry behaviour, batching, and timeouts. Immutable — use [copy] to
+ * create variants.
+ *
  * @property endpoint The base URL of the sync backend (e.g. PowerSync service).
  * @property databaseName Local database file name used by the sync provider.
  * @property syncRulesRef An opaque reference to the active sync-rules version on the backend.
  *   May be `null` when the provider discovers rules automatically.
+ * @property syncIntervalMs Milliseconds between automatic sync cycles. Default 30 000 (30 s).
+ * @property maxRetryAttempts Maximum number of retry attempts for a failed sync operation.
+ * @property retryBackoffBaseMs Base delay in milliseconds for exponential back-off. Default 1 000.
+ * @property retryBackoffMaxMs Ceiling for exponential back-off delay. Default 60 000 (1 min).
+ * @property batchSize Maximum number of records per push/pull batch. Default 100.
+ * @property enableCompression Whether to request compressed payloads from the server.
+ * @property connectionTimeoutMs TCP connection timeout in milliseconds. Default 10 000.
+ * @property requestTimeoutMs Per-request timeout in milliseconds. Default 30 000.
  */
 @Serializable
 data class SyncConfig(
     val endpoint: String,
     val databaseName: String,
     val syncRulesRef: String? = null,
+    val syncIntervalMs: Long = 30_000L,
+    val maxRetryAttempts: Int = 5,
+    val retryBackoffBaseMs: Long = 1_000L,
+    val retryBackoffMaxMs: Long = 60_000L,
+    val batchSize: Int = 100,
+    val enableCompression: Boolean = true,
+    val connectionTimeoutMs: Long = 10_000L,
+    val requestTimeoutMs: Long = 30_000L,
 ) {
     init {
         require(endpoint.isNotBlank()) { "Sync endpoint cannot be blank" }
         require(databaseName.isNotBlank()) { "Database name cannot be blank" }
+        require(syncIntervalMs > 0) { "Sync interval must be positive, got $syncIntervalMs" }
+        require(maxRetryAttempts >= 0) { "Max retry attempts must be non-negative, got $maxRetryAttempts" }
+        require(retryBackoffBaseMs > 0) { "Retry backoff base must be positive, got $retryBackoffBaseMs" }
+        require(retryBackoffMaxMs >= retryBackoffBaseMs) {
+            "Retry backoff max ($retryBackoffMaxMs) must be >= base ($retryBackoffBaseMs)"
+        }
+        require(batchSize > 0) { "Batch size must be positive, got $batchSize" }
+        require(connectionTimeoutMs > 0) { "Connection timeout must be positive, got $connectionTimeoutMs" }
+        require(requestTimeoutMs > 0) { "Request timeout must be positive, got $requestTimeoutMs" }
     }
 }

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/SyncCredentials.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/SyncCredentials.kt
@@ -2,27 +2,71 @@
 
 package com.finance.sync
 
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 
 /**
  * Credentials required to establish a connection with the sync backend.
  *
+ * Combines the bearer token for authenticating the sync session with
+ * optional refresh-token support for proactive token renewal.
+ *
  * @property endpointUrl The PowerSync (or compatible) service endpoint URL.
+ *   Defaults to an empty string when the URL is supplied via [SyncConfig.endpoint].
  * @property authToken A short-lived JWT or bearer token for authenticating the sync session.
  * @property userId The authenticated user's identifier, used for bucket-level data partitioning.
+ * @property refreshToken An opaque refresh token for obtaining new access tokens.
+ *   `null` when refresh is not supported or tokens are managed externally.
+ * @property expiresAt The instant at which [authToken] expires, or `null` if unknown.
  */
 @Serializable
 data class SyncCredentials(
-    val endpointUrl: String,
+    val endpointUrl: String = "",
     val authToken: String,
     val userId: String,
+    val refreshToken: String? = null,
+    val expiresAt: Instant? = null,
 ) {
     init {
-        require(endpointUrl.isNotBlank()) { "Sync endpoint URL cannot be blank" }
         require(authToken.isNotBlank()) { "Auth token cannot be blank" }
         require(userId.isNotBlank()) { "User ID cannot be blank" }
     }
 
+    // ── Security (S-8) ──────────────────────────────────────────────
     override fun toString(): String =
         "SyncCredentials(endpointUrl=$endpointUrl, authToken=*****, userId=$userId)"
+
+    // ── Token lifecycle helpers ─────────────────────────────────────
+
+    /**
+     * Check whether this credential's auth token has expired.
+     *
+     * Returns `false` when [expiresAt] is `null` (unknown expiry).
+     *
+     * @param now The current instant (injectable for testing).
+     * @return `true` if the auth token has expired.
+     */
+    fun isExpired(now: Instant = Clock.System.now()): Boolean {
+        return expiresAt != null && now >= expiresAt
+    }
+
+    /**
+     * Check whether the auth token is close enough to expiry that a
+     * proactive refresh should be triggered.
+     *
+     * Returns `false` when [expiresAt] is `null` (unknown expiry).
+     *
+     * @param bufferMs Milliseconds before expiry to consider "expiring soon".
+     *   Defaults to 60 000 (1 minute).
+     * @param now The current instant (injectable for testing).
+     * @return `true` if a refresh should be initiated.
+     */
+    fun isExpiringSoon(bufferMs: Long = 60_000L, now: Instant = Clock.System.now()): Boolean {
+        if (expiresAt == null) return false
+        val threshold = Instant.fromEpochMilliseconds(
+            expiresAt.toEpochMilliseconds() - bufferMs,
+        )
+        return now >= threshold
+    }
 }

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/SyncEngine.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/SyncEngine.kt
@@ -2,8 +2,27 @@
 
 package com.finance.sync
 
+import com.finance.sync.conflict.ConflictResolution
+import com.finance.sync.conflict.ConflictResolver
+import com.finance.sync.conflict.ConflictStrategy
+import com.finance.sync.conflict.SyncConflict
+import com.finance.sync.delta.DeltaSyncManager
+import com.finance.sync.queue.MutationQueue
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.datetime.Clock
+import kotlin.math.min
+import kotlin.math.pow
 
 /**
  * Main entry point for the Finance sync subsystem.
@@ -39,4 +58,455 @@ interface SyncEngine {
      * healthy connection to the sync backend.
      */
     val isConnected: StateFlow<Boolean>
+}
+
+// ── Sync result ─────────────────────────────────────────────────────
+
+/**
+ * Outcome of a single sync cycle (pull → resolve → push).
+ */
+sealed class SyncResult {
+
+    /**
+     * The sync cycle completed successfully.
+     *
+     * @property changesApplied Number of remote changes applied locally.
+     * @property mutationsPushed Number of local mutations pushed to the server.
+     * @property conflictsResolved Number of conflicts that were auto-resolved.
+     * @property durationMs Wall-clock duration of the sync cycle in milliseconds.
+     */
+    data class Success(
+        val changesApplied: Int,
+        val mutationsPushed: Int,
+        val conflictsResolved: Int,
+        val durationMs: Long,
+    ) : SyncResult()
+
+    /**
+     * The sync cycle failed.
+     *
+     * @property error Structured error describing the failure.
+     */
+    data class Failure(val error: SyncError) : SyncResult()
+}
+
+// ── Health monitoring ───────────────────────────────────────────────
+
+/**
+ * Callback interface for health monitoring integration.
+ *
+ * Allows the sync engine to report lifecycle metrics to an external
+ * monitor (e.g., `SyncHealthMonitor` in `packages/core`) without
+ * creating a compile-time dependency between the packages.
+ *
+ * All methods are called on the sync engine's coroutine context.
+ * Implementations must be fast and non-blocking.
+ */
+interface SyncHealthListener {
+
+    /**
+     * Called after a sync cycle completes successfully.
+     *
+     * @param durationMs Wall-clock duration of the sync cycle in milliseconds.
+     * @param pendingMutations Number of mutations still pending after the cycle.
+     */
+    fun onSyncSuccess(durationMs: Long, pendingMutations: Int)
+
+    /**
+     * Called after a sync cycle fails.
+     *
+     * @param error The structured sync error describing the failure.
+     */
+    fun onSyncFailure(error: SyncError)
+
+    /**
+     * Called when the pending mutation count changes.
+     *
+     * @param count Current number of pending mutations.
+     */
+    fun onPendingMutationsChanged(count: Int)
+}
+
+// ── Default implementation ──────────────────────────────────────────
+
+/**
+ * Default [SyncEngine] implementation that orchestrates the full sync lifecycle.
+ *
+ * Coordinates:
+ * 1. **Pull** — fetch remote changes via [SyncProvider.pullChanges] and validate
+ *    them through [DeltaSyncManager].
+ * 2. **Conflict resolution** — detect conflicts between pulled changes and
+ *    pending local mutations, resolving via [ConflictResolver].
+ * 3. **Push** — drain the [MutationQueue] by pushing mutations through the provider.
+ *
+ * The engine runs a periodic sync loop (configurable via [SyncConfig.syncIntervalMs])
+ * and supports on-demand sync via [syncNow]. All state is exposed through
+ * the reactive [status] flow.
+ *
+ * @param config Sync configuration including endpoint, intervals, and retry policy.
+ * @param provider The sync backend abstraction.
+ * @param conflictResolver Resolver for handling conflicts between local and remote changes.
+ * @param mutationQueue Queue of pending local mutations to push.
+ * @param deltaSyncManager Manager for incremental (delta) sync with sequence tracking.
+ * @param clock Time source (injectable for deterministic testing).
+ * @param healthListener Optional callback for reporting sync metrics to an external health
+ *   monitor. When `null`, health events are silently discarded.
+ * @param credentialRefresher Optional suspend function that returns fresh [SyncCredentials].
+ *   Called before each sync cycle when the current credentials are
+ *   [SyncCredentials.isExpiringSoon]. When `null`, no proactive refresh is attempted.
+ */
+class DefaultSyncEngine(
+    private val config: SyncConfig,
+    private val provider: SyncProvider,
+    private val conflictResolver: ConflictResolver = ConflictStrategy.LAST_WRITE_WINS.resolver,
+    private val mutationQueue: MutationQueue,
+    private val deltaSyncManager: DeltaSyncManager,
+    private val clock: Clock = Clock.System,
+    private val healthListener: SyncHealthListener? = null,
+    private val credentialRefresher: (suspend () -> SyncCredentials)? = null,
+) : SyncEngine {
+
+    private val _status = MutableStateFlow<SyncStatus>(SyncStatus.Idle)
+
+    /** Observable status of the sync engine. */
+    val status: StateFlow<SyncStatus> = _status.asStateFlow()
+
+    private val _isConnected = MutableStateFlow(false)
+    override val isConnected: StateFlow<Boolean> = _isConnected.asStateFlow()
+
+    private var syncJob: Job? = null
+    private var credentials: SyncCredentials? = null
+    private var consecutiveFailures: Int = 0
+
+    /**
+     * Mutex preventing concurrent [syncNow] cycles. Ensures that only
+     * one pull → resolve → push cycle runs at a time, even if [syncNow]
+     * is called while the periodic loop is mid-cycle.
+     */
+    private val syncMutex = Mutex()
+
+    override suspend fun connect(credentials: SyncCredentials) {
+        if (_isConnected.value) return
+
+        _status.value = SyncStatus.Connecting
+        this.credentials = credentials
+
+        try {
+            provider.connect(credentials, config)
+            _isConnected.value = true
+            _status.value = SyncStatus.Connected
+            consecutiveFailures = 0
+        } catch (e: Exception) {
+            _isConnected.value = false
+            _status.value = SyncStatus.Error(
+                SyncError.NetworkError(e.message ?: "Connection failed"),
+            )
+        }
+    }
+
+    override suspend fun disconnect() {
+        if (!_isConnected.value && syncJob == null) return
+
+        syncJob?.cancel()
+        syncJob = null
+
+        try {
+            provider.disconnect()
+        } catch (_: Exception) {
+            // Best-effort disconnect; swallow errors.
+        }
+
+        _isConnected.value = false
+        credentials = null
+        _status.value = SyncStatus.Disconnected
+    }
+
+    override fun sync(): Flow<SyncStatus> = _status
+
+    /**
+     * Start the sync engine: connect with the given [credentials] and begin
+     * a periodic sync loop.
+     *
+     * The sync loop runs within a [supervisorScope] so that individual sync
+     * cycle failures do not cancel the loop — errors are captured and
+     * reported via [status] and [healthListener]. The function suspends
+     * until [stop] is called or the caller's coroutine scope is cancelled.
+     *
+     * @param credentials Authentication credentials for the sync backend.
+     */
+    suspend fun start(credentials: SyncCredentials) {
+        connect(credentials)
+        if (!_isConnected.value) return
+
+        supervisorScope {
+            syncJob = launch {
+                while (isActive) {
+                    syncNow()
+                    delay(config.syncIntervalMs)
+                }
+            }
+        }
+    }
+
+    /**
+     * Stop the sync engine gracefully.
+     *
+     * 1. Cancels the periodic sync loop.
+     * 2. Waits for any in-flight sync cycle to complete (via [syncMutex]).
+     * 3. Disconnects from the sync backend.
+     *
+     * Safe to call multiple times; subsequent calls are no-ops.
+     */
+    suspend fun stop() {
+        syncJob?.cancel()
+        syncJob = null
+
+        // Wait for any in-flight sync cycle to finish before disconnecting.
+        syncMutex.withLock { /* barrier — ensures the active cycle completes */ }
+
+        disconnect()
+    }
+
+    /**
+     * Execute a single sync cycle immediately: pull → resolve conflicts → push.
+     *
+     * Can be called while the periodic loop is running to force an immediate
+     * sync, or standalone for manual sync control. Concurrent calls are
+     * serialised by [syncMutex] — only one cycle runs at a time.
+     *
+     * Before each cycle the engine checks whether the current credentials
+     * are close to expiry and, if a [credentialRefresher] was provided,
+     * obtains fresh credentials and reconnects transparently.
+     *
+     * @return A [SyncResult] describing the outcome of the cycle.
+     */
+    suspend fun syncNow(): SyncResult = syncMutex.withLock {
+        val startMs = clock.now().toEpochMilliseconds()
+
+        try {
+            // ── Phase 0: Credential Refresh ─────────────────────
+            refreshCredentialsIfNeeded()
+
+            // ── Phase 1: Pull + Conflict Detection ──────────────
+            _status.value = SyncStatus.Syncing(
+                SyncProgress(
+                    phase = SyncPhase.PULLING,
+                    processedRecords = 0,
+                    totalRecords = null,
+                ),
+            )
+
+            val pendingMutations = mutationQueue.allPending()
+            healthListener?.onPendingMutationsChanged(pendingMutations.size)
+
+            val pullCycleResult = deltaSyncManager.executePullCycle(pendingMutations)
+            val changes = pullCycleResult.changes
+
+            // Validate pulled changes for sequence continuity & checksums
+            if (changes.isNotEmpty()) {
+                deltaSyncManager.processChanges(changes)
+            }
+
+            // ── Phase 2: Conflict Resolution ────────────────────
+            var conflictsResolved = 0
+
+            if (pullCycleResult.conflicts.isNotEmpty()) {
+                _status.value = SyncStatus.Syncing(
+                    SyncProgress(
+                        phase = SyncPhase.RESOLVING_CONFLICTS,
+                        processedRecords = 0,
+                        totalRecords = null,
+                    ),
+                )
+
+                conflictsResolved = resolveDetectedConflicts(
+                    pullCycleResult.conflicts,
+                    pendingMutations,
+                )
+            }
+
+            // ── Phase 3: Push ───────────────────────────────────
+            val currentPending = mutationQueue.allPending()
+            var mutationsPushed = 0
+
+            if (currentPending.isNotEmpty()) {
+                _status.value = SyncStatus.Syncing(
+                    SyncProgress(
+                        phase = SyncPhase.PUSHING,
+                        processedRecords = 0,
+                        totalRecords = currentPending.size,
+                    ),
+                )
+
+                val pushResult = deltaSyncManager.pushMutations(currentPending)
+
+                for (succeededId in pushResult.succeeded) {
+                    mutationQueue.dequeue(succeededId)
+                    mutationsPushed++
+                }
+
+                _status.value = SyncStatus.Syncing(
+                    SyncProgress(
+                        phase = SyncPhase.PUSHING,
+                        processedRecords = mutationsPushed,
+                        totalRecords = currentPending.size,
+                    ),
+                )
+            }
+
+            val durationMs = clock.now().toEpochMilliseconds() - startMs
+            consecutiveFailures = 0
+            _status.value = SyncStatus.Connected
+
+            // Report success metrics to health monitor
+            val finalPending = mutationQueue.pendingCount()
+            healthListener?.onSyncSuccess(durationMs, finalPending)
+            healthListener?.onPendingMutationsChanged(finalPending)
+
+            SyncResult.Success(
+                changesApplied = changes.size,
+                mutationsPushed = mutationsPushed,
+                conflictsResolved = conflictsResolved,
+                durationMs = durationMs,
+            )
+        } catch (e: CancellationException) {
+            // Respect structured concurrency: never swallow cancellation.
+            throw e
+        } catch (e: Exception) {
+            consecutiveFailures++
+            val syncError = classifyError(e)
+            _status.value = SyncStatus.Error(syncError)
+
+            // Report failure to health monitor
+            healthListener?.onSyncFailure(syncError)
+
+            // Apply exponential back-off before returning
+            if (consecutiveFailures <= config.maxRetryAttempts) {
+                val backoffMs = computeBackoff(consecutiveFailures)
+                delay(backoffMs)
+            }
+
+            SyncResult.Failure(syncError)
+        }
+    }
+
+    /**
+     * Whether the sync loop is currently active.
+     */
+    fun isRunning(): Boolean = syncJob?.isActive == true
+
+    // ── Internal helpers ────────────────────────────────────────
+
+    /**
+     * Check whether the current credentials are expiring soon and, if a
+     * [credentialRefresher] was provided, obtain fresh credentials and
+     * reconnect to the sync backend.
+     *
+     * Called at the start of every sync cycle to ensure the auth token
+     * is valid for the duration of the pull → push round-trip.
+     *
+     * If the refresh fails, the engine proceeds with the current credentials.
+     * They may still be valid ([SyncCredentials.isExpiringSoon] fires before
+     * actual expiry). If they have truly expired, the pull/push will fail
+     * and the engine's error handling will classify it as an [SyncError.AuthError].
+     */
+    private suspend fun refreshCredentialsIfNeeded() {
+        val creds = credentials ?: return
+        if (!creds.isExpiringSoon()) return
+
+        val refresher = credentialRefresher ?: return
+
+        try {
+            val refreshed = refresher()
+            credentials = refreshed
+
+            // Reconnect with the fresh token so the provider uses it
+            // for subsequent pull/push calls in this cycle.
+            provider.disconnect()
+            provider.connect(refreshed, config)
+            _isConnected.value = true
+        } catch (_: Exception) {
+            // Refresh failed — proceed with current credentials.
+        }
+    }
+
+    /**
+     * Resolve previously detected [conflicts] against [pendingMutations].
+     *
+     * For each conflict, the appropriate [ConflictResolver] is selected via
+     * [ConflictStrategy.resolverFor] and the resolution determines whether
+     * the local mutation is kept, discarded, or replaced with merged data.
+     *
+     * @return Number of conflicts resolved.
+     */
+    private suspend fun resolveDetectedConflicts(
+        conflicts: List<SyncConflict>,
+        pendingMutations: List<SyncMutation>,
+    ): Int {
+        // Index pending mutations by "table:recordId" for O(1) lookup
+        val pendingByEntity = pendingMutations.associateBy { it.entityKey }
+        var resolved = 0
+
+        for (conflict in conflicts) {
+            val entityKey = "${conflict.tableName}:${conflict.recordId}"
+            val pending = pendingByEntity[entityKey] ?: continue
+
+            // Use table-specific resolver via ConflictStrategy
+            val tableResolver = ConflictStrategy.resolverFor(conflict.tableName)
+            val resolution = tableResolver.resolveConflict(conflict)
+
+            when (resolution) {
+                is ConflictResolution.AcceptServer,
+                is ConflictResolution.Delete,
+                -> {
+                    // Server wins or delete: discard the local mutation
+                    mutationQueue.dequeue(pending.id)
+                }
+
+                is ConflictResolution.AcceptLocal -> {
+                    // Local wins: keep the mutation in the queue for pushing
+                }
+
+                is ConflictResolution.Merged -> {
+                    // Merged: replace the mutation with merged data
+                    mutationQueue.dequeue(pending.id)
+                    mutationQueue.enqueue(pending.copy(rowData = resolution.data))
+                }
+            }
+
+            resolved++
+        }
+
+        return resolved
+    }
+
+    /**
+     * Classify an exception into a structured [SyncError].
+     */
+    private fun classifyError(e: Exception): SyncError {
+        val message = e.message ?: "Unknown error"
+        return when {
+            message.contains("auth", ignoreCase = true) ||
+                message.contains("401") ||
+                message.contains("403") -> SyncError.AuthError(message)
+
+            message.contains("timeout", ignoreCase = true) ||
+                message.contains("connect", ignoreCase = true) ||
+                message.contains("network", ignoreCase = true) -> SyncError.NetworkError(message)
+
+            message.contains("500") ||
+                message.contains("502") ||
+                message.contains("503") -> SyncError.ServerError(500, message)
+
+            else -> SyncError.Unknown(message)
+        }
+    }
+
+    /**
+     * Compute exponential back-off delay for the given [attempt] (1-based).
+     */
+    private fun computeBackoff(attempt: Int): Long {
+        val raw = config.retryBackoffBaseMs * 2.0.pow(attempt - 1)
+        return min(raw.toLong(), config.retryBackoffMaxMs)
+    }
 }

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/SyncMutation.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/SyncMutation.kt
@@ -23,6 +23,12 @@ enum class MutationOperation {
  * @property operation The kind of DML operation.
  * @property rowData A map of column name → serialised value. `null` values represent SQL NULLs.
  * @property timestamp When the mutation was created on the client.
+ * @property recordId The ID of the specific record being mutated. Falls back to
+ *   [rowData]`["id"]` or [id] via [entityKey] when not explicitly set.
+ * @property retryCount Number of times this mutation has been retried for push.
+ *   Incremented by the queue processor on transient failures.
+ * @property householdId The household scope for this mutation, used to partition
+ *   sync data and enforce row-level security.
  */
 @Serializable
 data class SyncMutation(
@@ -31,10 +37,14 @@ data class SyncMutation(
     val operation: MutationOperation,
     val rowData: Map<String, String?>,
     val timestamp: Instant,
+    val recordId: String = "",
+    val retryCount: Int = 0,
+    val householdId: String = "",
 ) {
     init {
         require(id.isNotBlank()) { "Mutation id cannot be blank" }
         require(tableName.isNotBlank()) { "Table name cannot be blank" }
+        require(retryCount >= 0) { "Retry count must be non-negative, got $retryCount" }
     }
 
     /**
@@ -42,5 +52,10 @@ data class SyncMutation(
      * in the same table are considered duplicates (latest wins).
      */
     val entityKey: String
-        get() = "$tableName:${rowData["id"] ?: id}"
+        get() = "$tableName:${recordId.ifBlank { rowData["id"] ?: id }}"
+
+    /**
+     * Create a copy of this mutation with the retry count incremented by one.
+     */
+    fun withIncrementedRetry(): SyncMutation = copy(retryCount = retryCount + 1)
 }

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/SyncProvider.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/SyncProvider.kt
@@ -3,6 +3,7 @@
 package com.finance.sync
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
 
 /**
  * Abstraction over the sync backend (PowerSync initially, but swappable).
@@ -37,4 +38,128 @@ interface SyncProvider {
      * Observe the sync provider's status in real time.
      */
     fun getStatus(): Flow<SyncStatus>
+
+    // ── Extended API ──────────────────────────────────────────────
+
+    /**
+     * Establish a connection to the sync backend using the given [credentials].
+     *
+     * This is an alternative to [initialize] that also handles authentication.
+     * Default implementation delegates to [initialize] using the [config].
+     *
+     * @param credentials Credentials for authenticating the sync session.
+     * @param config Sync configuration including endpoint and operational parameters.
+     */
+    suspend fun connect(credentials: SyncCredentials, config: SyncConfig) {
+        initialize(config)
+    }
+
+    /**
+     * Disconnect from the sync backend and release resources.
+     *
+     * Default implementation is a no-op; override for providers that
+     * maintain persistent connections.
+     */
+    suspend fun disconnect() {
+        // No-op by default.
+    }
+
+    /**
+     * Push a batch of local mutations with structured result reporting.
+     *
+     * Unlike [push], this returns a [PushResult] with per-mutation success/failure
+     * details. Default implementation delegates to [push] and reports all mutations
+     * as succeeded or all as failed.
+     *
+     * @param mutations The mutations to push.
+     * @return A [PushResult] with per-mutation outcomes.
+     */
+    suspend fun pushMutations(mutations: List<SyncMutation>): PushResult {
+        return try {
+            push(mutations).getOrThrow()
+            PushResult(
+                succeeded = mutations.map { it.id },
+                failed = emptyList(),
+            )
+        } catch (e: Exception) {
+            PushResult(
+                succeeded = emptyList(),
+                failed = mutations.map { m ->
+                    PushFailure(
+                        mutationId = m.id,
+                        error = e.message ?: "Unknown push error",
+                        retryable = true,
+                    )
+                },
+            )
+        }
+    }
+
+    /**
+     * Pull changes from the sync backend since the given version markers.
+     *
+     * @param since A map of table name → last known sync version. The server
+     *   returns only changes newer than these versions.
+     * @return A [PullResult] containing the changes and updated version markers.
+     */
+    suspend fun pullChanges(since: Map<String, Long>): PullResult {
+        return PullResult(
+            changes = emptyList(),
+            newVersions = since,
+            hasMore = false,
+        )
+    }
+
+    /**
+     * Observe the sync provider's status as a [Flow].
+     *
+     * Default implementation delegates to [getStatus].
+     */
+    fun observeStatus(): Flow<SyncStatus> = getStatus()
 }
+
+// ── Result types ────────────────────────────────────────────────────
+
+/**
+ * Outcome of pushing a batch of mutations to the sync backend.
+ *
+ * @property succeeded Mutation IDs that were accepted by the server.
+ * @property failed Mutations that failed, with per-mutation error details.
+ */
+data class PushResult(
+    val succeeded: List<String>,
+    val failed: List<PushFailure>,
+) {
+    /** `true` when every mutation in the batch succeeded. */
+    val isFullySuccessful: Boolean get() = failed.isEmpty()
+}
+
+/**
+ * Details about a single mutation that failed during push.
+ *
+ * @property mutationId The ID of the failed mutation.
+ * @property error Human-readable error description.
+ * @property retryable `true` if the failure is transient and the mutation
+ *   should be retried (e.g. timeout, 503). `false` for permanent failures
+ *   (e.g. constraint violation, 400).
+ */
+data class PushFailure(
+    val mutationId: String,
+    val error: String,
+    val retryable: Boolean,
+)
+
+/**
+ * Outcome of pulling changes from the sync backend.
+ *
+ * @property changes The list of changes received in this pull batch.
+ * @property newVersions Updated version markers per table. Callers should
+ *   persist these and pass them back on the next [SyncProvider.pullChanges] call.
+ * @property hasMore `true` when the server has additional changes beyond
+ *   this batch (pagination). The caller should issue another pull.
+ */
+data class PullResult(
+    val changes: List<SyncChange>,
+    val newVersions: Map<String, Long>,
+    val hasMore: Boolean,
+)

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/SyncStatus.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/SyncStatus.kt
@@ -13,28 +13,103 @@ sealed class SyncStatus {
     /** The engine is idle; no sync activity in progress. */
     data object Idle : SyncStatus()
 
+    /** The engine is establishing a connection to the sync backend. */
+    data object Connecting : SyncStatus()
+
     /**
      * A sync cycle is actively running.
      *
-     * @property progress A normalised value in `0.0..1.0` indicating completion,
-     *   or `null` when indeterminate.
+     * @property progress Structured progress information including phase,
+     *   processed records, and optional total record count.
      */
-    data class Syncing(val progress: Double? = null) : SyncStatus() {
-        init {
-            if (progress != null) {
-                require(progress in 0.0..1.0) {
-                    "Sync progress must be in 0.0..1.0, got $progress"
-                }
-            }
-        }
-    }
-
-    /** A non-recoverable (or not-yet-recovered) error occurred during sync. */
-    data class Error(val exception: Throwable) : SyncStatus()
+    data class Syncing(val progress: SyncProgress) : SyncStatus()
 
     /** The engine has an active, healthy connection to the sync backend. */
     data object Connected : SyncStatus()
 
+    /**
+     * A non-recoverable (or not-yet-recovered) error occurred during sync.
+     *
+     * @property error Structured error information. Uses [SyncError] sealed
+     *   hierarchy instead of raw [Throwable] for multiplatform safety and
+     *   exhaustive handling.
+     */
+    data class Error(val error: SyncError) : SyncStatus()
+
     /** The engine is not connected to the sync backend. */
     data object Disconnected : SyncStatus()
+}
+
+/**
+ * Structured progress information for an active sync cycle.
+ *
+ * @property phase The current phase of the sync cycle.
+ * @property processedRecords Number of records processed so far in this phase.
+ * @property totalRecords Total number of records expected in this phase,
+ *   or `null` when the total is indeterminate (e.g. streaming pull).
+ */
+data class SyncProgress(
+    val phase: SyncPhase,
+    val processedRecords: Int,
+    val totalRecords: Int?,
+) {
+    init {
+        require(processedRecords >= 0) {
+            "Processed records must be non-negative, got $processedRecords"
+        }
+        if (totalRecords != null) {
+            require(totalRecords >= 0) {
+                "Total records must be non-negative, got $totalRecords"
+            }
+        }
+    }
+
+    /**
+     * Normalised progress value in `0.0..1.0`, or `null` when indeterminate.
+     */
+    val fraction: Double?
+        get() = if (totalRecords != null && totalRecords > 0) {
+            (processedRecords.toDouble() / totalRecords).coerceIn(0.0, 1.0)
+        } else {
+            null
+        }
+}
+
+/**
+ * Phases within a single sync cycle, executed in order:
+ * pull → conflict resolution → push.
+ */
+enum class SyncPhase {
+    /** Pulling changes from the remote server. */
+    PULLING,
+
+    /** Pushing local mutations to the remote server. */
+    PUSHING,
+
+    /** Resolving conflicts between local and remote changes. */
+    RESOLVING_CONFLICTS,
+}
+
+/**
+ * Structured error types for sync failures.
+ *
+ * Uses a sealed class hierarchy instead of raw exceptions for
+ * multiplatform compatibility and exhaustive `when` handling.
+ */
+sealed class SyncError {
+
+    /** A network-level error (timeout, DNS, connection refused, etc.). */
+    data class NetworkError(val message: String) : SyncError()
+
+    /** An authentication or authorization error (expired token, revoked access). */
+    data class AuthError(val message: String) : SyncError()
+
+    /** One or more conflicts were detected that could not be auto-resolved. */
+    data class ConflictError(val conflicts: Int) : SyncError()
+
+    /** The server returned an error response. */
+    data class ServerError(val statusCode: Int, val message: String) : SyncError()
+
+    /** An unexpected or unclassified error. */
+    data class Unknown(val cause: String) : SyncError()
 }

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/auth/AuthCredentials.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/auth/AuthCredentials.kt
@@ -2,6 +2,20 @@
 
 package com.finance.sync.auth
 
+import kotlinx.serialization.Serializable
+
+/**
+ * Supported OAuth 2.0 providers for federated sign-in.
+ */
+@Serializable
+enum class OAuthProvider {
+    /** Sign in with Google. */
+    GOOGLE,
+
+    /** Sign in with Apple. */
+    APPLE,
+}
+
 /**
  * Sealed hierarchy of credential types for authentication (#70, #71).
  *
@@ -9,6 +23,7 @@ package com.finance.sync.auth
  * with Supabase Auth. The [AuthManager] implementation maps these to
  * the appropriate Supabase Auth API call.
  */
+@Serializable
 sealed class AuthCredentials {
 
     /**
@@ -17,6 +32,7 @@ sealed class AuthCredentials {
      * @property email    User's email address.
      * @property password User's password (plaintext — transmitted over TLS, never stored).
      */
+    @Serializable
     data class EmailPassword(
         val email: String,
         val password: String,
@@ -32,12 +48,13 @@ sealed class AuthCredentials {
      * authorization code plus the PKCE code verifier so the backend
      * can exchange them for tokens.
      *
-     * @property provider     OAuth provider identifier (e.g. "apple", "google").
+     * @property provider     OAuth provider identifier.
      * @property authCode     Authorization code returned by the provider.
      * @property codeVerifier PKCE code_verifier used when starting the flow.
      */
+    @Serializable
     data class OAuth(
-        val provider: String,
+        val provider: OAuthProvider,
         val authCode: String,
         val codeVerifier: String,
     ) : AuthCredentials() {
@@ -55,6 +72,7 @@ sealed class AuthCredentials {
      * @property credentialId  The credential identifier from the authenticator.
      * @property assertion     The signed assertion response (JSON-serialized).
      */
+    @Serializable
     data class Passkey(
         val credentialId: String,
         val assertion: String,
@@ -62,4 +80,18 @@ sealed class AuthCredentials {
         override fun toString(): String =
             "Passkey(credentialId=$credentialId, assertion=*****)"
     }
+
+    /**
+     * Refresh token sign-in.
+     *
+     * Used to obtain a new access token without user interaction when
+     * the current access token has expired but the refresh token is
+     * still valid.
+     *
+     * @property token The opaque refresh token.
+     */
+    @Serializable
+    data class RefreshToken(
+        val token: String,
+    ) : AuthCredentials()
 }

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/auth/AuthManager.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/auth/AuthManager.kt
@@ -44,9 +44,17 @@ interface AuthManager {
     val currentSession: StateFlow<AuthSession?>
 
     /**
+     * Observable stream of the current authentication state.
+     *
+     * Convenience flow derived from [currentSession] — emits `true`
+     * when a valid session exists, `false` otherwise.
+     */
+    val isAuthenticated: StateFlow<Boolean>
+
+    /**
      * Authenticate with the given [credentials].
      *
-     * Supports email/password, OAuth + PKCE, and passkey flows.
+     * Supports email/password, OAuth + PKCE, passkey, and refresh-token flows.
      * On success, stores tokens via [TokenManager] and updates
      * [currentSession].
      *
@@ -75,4 +83,17 @@ interface AuthManager {
      *         [Result.failure] if the refresh token is invalid.
      */
     suspend fun refreshToken(): Result<AuthSession>
+
+    /**
+     * Permanently delete the current user's account.
+     *
+     * This is a destructive operation that:
+     * 1. Deletes the user's account on the server
+     * 2. Clears all local tokens and cached data
+     * 3. Sets [currentSession] to `null`
+     *
+     * @return [Result.success] on successful deletion, or
+     *         [Result.failure] if the deletion failed (e.g. server error).
+     */
+    suspend fun deleteAccount(): Result<Unit>
 }

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/auth/AuthSession.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/auth/AuthSession.kt
@@ -2,6 +2,8 @@
 
 package com.finance.sync.auth
 
+import com.finance.sync.SyncCredentials
+import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 
 /**
@@ -20,12 +22,14 @@ import kotlinx.datetime.Instant
  * @property refreshToken Opaque refresh token for obtaining new access tokens.
  * @property expiresAt    Instant at which [accessToken] expires.
  * @property userId       The authenticated user's UUID (from the JWT `sub` claim).
+ * @property createdAt    Instant at which this session was created.
  */
 data class AuthSession(
     val accessToken: String,
     val refreshToken: String,
     val expiresAt: Instant,
     val userId: String,
+    val createdAt: Instant = Clock.System.now(),
 ) {
     override fun toString(): String =
         "AuthSession(userId=$userId, accessToken=*****, refreshToken=*****, expiresAt=$expiresAt)"
@@ -36,23 +40,41 @@ data class AuthSession(
      * @param now The current instant (injectable for testing).
      * @return `true` if the access token has not yet expired.
      */
-    fun isValid(now: Instant): Boolean = now < expiresAt
+    fun isValid(now: Instant = Clock.System.now()): Boolean = now < expiresAt
 
     /**
      * Check whether this session's access token is close enough to
      * expiry that a proactive refresh should be triggered.
      *
-     * The default threshold is 2 minutes before expiry, matching
-     * [TokenManager.REFRESH_THRESHOLD_SECONDS].
+     * The default threshold is 5 minutes before expiry, providing
+     * a comfortable window for the refresh round-trip.
      *
-     * @param now                The current instant.
-     * @param thresholdSeconds   Seconds before expiry to consider "needs refresh".
+     * @param bufferMs      Milliseconds before expiry to consider "needs refresh".
+     *   Defaults to 300 000 (5 minutes).
+     * @param now           The current instant.
      * @return `true` if a refresh should be initiated.
      */
-    fun needsRefresh(now: Instant, thresholdSeconds: Long = 120): Boolean {
+    fun needsRefresh(
+        bufferMs: Long = 300_000L,
+        now: Instant = Clock.System.now(),
+    ): Boolean {
         val thresholdInstant = Instant.fromEpochMilliseconds(
-            expiresAt.toEpochMilliseconds() - (thresholdSeconds * 1000),
+            expiresAt.toEpochMilliseconds() - bufferMs,
         )
         return now >= thresholdInstant
     }
+
+    /**
+     * Convert this auth session to [SyncCredentials] for use with the
+     * sync engine. The endpoint URL is not included — it should come
+     * from [com.finance.sync.SyncConfig.endpoint].
+     *
+     * @return A [SyncCredentials] instance populated from this session.
+     */
+    fun toSyncCredentials(): SyncCredentials = SyncCredentials(
+        authToken = accessToken,
+        userId = userId,
+        refreshToken = refreshToken,
+        expiresAt = expiresAt,
+    )
 }

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/auth/PKCEHelper.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/auth/PKCEHelper.kt
@@ -71,6 +71,22 @@ object PKCEHelper {
     }
 
     /**
+     * Generate a cryptographically random `state` parameter for OAuth flows.
+     *
+     * The state parameter is used to prevent CSRF attacks. It is a
+     * random string sent to the authorization server and echoed back
+     * in the callback, where the client verifies it matches.
+     *
+     * @param length Desired length of the state string. Defaults to 32.
+     * @return A random base64url-safe string.
+     */
+    fun generateState(length: Int = 32): String {
+        require(length > 0) { "State length must be positive, got $length" }
+        val randomBytes = PlatformSHA256.randomBytes(length)
+        return base64UrlEncode(randomBytes).take(length)
+    }
+
+    /**
      * Base64url encode without padding (RFC 4648 §5).
      *
      * Standard base64 with `+` → `-`, `/` → `_`, and trailing `=` removed.

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/auth/TokenManager.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/auth/TokenManager.kt
@@ -115,6 +115,41 @@ class TokenManager(
         val nowMillis = clock.now().toEpochMilliseconds()
         return maxOf(0L, refreshAtMillis - nowMillis)
     }
+
+    /**
+     * Retrieve a valid (non-expired) access token from storage.
+     *
+     * Returns `null` if no session is stored or the stored session's
+     * access token has expired.
+     *
+     * @return The access token string, or `null` if unavailable or expired.
+     */
+    suspend fun getValidToken(): String? {
+        val session = retrieveTokens() ?: return null
+        return if (!isTokenExpired(session)) session.accessToken else null
+    }
+
+    /**
+     * Persist an [AuthSession] to secure storage.
+     *
+     * Convenience suspend wrapper around [storeTokens] for use in
+     * coroutine-based auth flows.
+     *
+     * @param session The session to persist.
+     */
+    suspend fun storeSession(session: AuthSession) {
+        storeTokens(session)
+    }
+
+    /**
+     * Clear all stored session data.
+     *
+     * Convenience suspend wrapper around [clearTokens] for use in
+     * coroutine-based auth flows.
+     */
+    suspend fun clearSession() {
+        clearTokens()
+    }
 }
 
 /**

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/conflict/ClientWinsResolver.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/conflict/ClientWinsResolver.kt
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.sync.conflict
+
+import com.finance.sync.MutationOperation
+import com.finance.sync.SyncChange
+
+/**
+ * Client-always-wins conflict resolver.
+ *
+ * Unconditionally preserves the local (client) version of a record when a
+ * conflict is detected. The server's changes are discarded.
+ *
+ * Use cases:
+ * - Draft / unsaved data that the user is actively editing — the user's
+ *   intent should not be silently overwritten by a background sync.
+ * - Offline-first scenarios where the user explicitly chose to keep working
+ *   despite being disconnected, and expects their changes to "stick".
+ *
+ * **Caution:** this strategy can cause data loss on the server side if the
+ * server change carried important information. Prefer [LastWriteWinsResolver]
+ * or [MergeResolver] for shared entities.
+ */
+class ClientWinsResolver : ConflictResolver {
+
+    /**
+     * Always returns the [local] (client-originated) change.
+     */
+    override fun resolve(local: SyncChange, remote: SyncChange): SyncChange = local
+
+    /**
+     * Always accepts the local data.
+     *
+     * - Local DELETE → [ConflictResolution.Delete].
+     * - Local non-DELETE → [ConflictResolution.AcceptLocal] with the local data.
+     */
+    override fun resolveConflict(conflict: SyncConflict): ConflictResolution =
+        if (conflict.localOperation == MutationOperation.DELETE) {
+            ConflictResolution.Delete
+        } else {
+            ConflictResolution.AcceptLocal(conflict.localData)
+        }
+}

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/conflict/ConflictResolver.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/conflict/ConflictResolver.kt
@@ -2,6 +2,7 @@
 
 package com.finance.sync.conflict
 
+import com.finance.sync.MutationOperation
 import com.finance.sync.SyncChange
 
 /**
@@ -9,6 +10,15 @@ import com.finance.sync.SyncChange
  * the same entity (same table + row ID).
  *
  * Implementations decide which version wins, or produce a merged result.
+ *
+ * This interface exposes two resolution APIs:
+ * - [resolve]: the low-level API that works directly with [SyncChange] pairs.
+ * - [resolveConflict]: the high-level API that works with a [SyncConflict]
+ *   descriptor and returns a [ConflictResolution] sealed result.
+ *
+ * All implementations must be **deterministic** — given the same inputs they
+ * must always produce the same output regardless of call order — and
+ * **stateless** so they are safe to invoke from any coroutine.
  */
 interface ConflictResolver {
 
@@ -20,4 +30,55 @@ interface ConflictResolver {
      * @return The resolved [SyncChange] to apply.
      */
     fun resolve(local: SyncChange, remote: SyncChange): SyncChange
+
+    /**
+     * Resolve a conflict described by a [SyncConflict] descriptor.
+     *
+     * The default implementation bridges to [resolve] by constructing
+     * temporary [SyncChange] instances. Subclasses may override to provide
+     * richer resolution logic that leverages the additional metadata in
+     * [SyncConflict] (e.g., sync versions).
+     *
+     * @param conflict The detected conflict with both local and server data.
+     * @return The [ConflictResolution] decision.
+     */
+    fun resolveConflict(conflict: SyncConflict): ConflictResolution {
+        val local = SyncChange(
+            tableName = conflict.tableName,
+            operation = conflict.localOperation,
+            rowData = conflict.localData ?: emptyMap(),
+            serverTimestamp = conflict.localTimestamp,
+            sequenceNumber = conflict.localVersion,
+        )
+        val remote = SyncChange(
+            tableName = conflict.tableName,
+            operation = conflict.serverOperation,
+            rowData = conflict.serverData ?: emptyMap(),
+            serverTimestamp = conflict.serverTimestamp,
+            sequenceNumber = conflict.serverVersion,
+        )
+        val winner = resolve(local, remote)
+        return when {
+            winner.operation == MutationOperation.DELETE -> ConflictResolution.Delete
+            winner === remote -> ConflictResolution.AcceptServer(winner.rowData)
+            winner === local -> ConflictResolution.AcceptLocal(winner.rowData)
+            else -> ConflictResolution.Merged(winner.rowData)
+        }
+    }
+
+    /**
+     * Resolve a batch of conflicts, pairing each [SyncConflict] with its
+     * [ConflictResolution].
+     *
+     * The default implementation resolves each conflict individually via
+     * [resolveConflict]. Implementations may override to apply cross-record
+     * logic (e.g., ensuring referential integrity across related records).
+     *
+     * @param conflicts The list of detected conflicts.
+     * @return A list of pairs mapping each conflict to its resolution.
+     */
+    fun resolveAll(
+        conflicts: List<SyncConflict>,
+    ): List<Pair<SyncConflict, ConflictResolution>> =
+        conflicts.map { it to resolveConflict(it) }
 }

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/conflict/ConflictStrategy.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/conflict/ConflictStrategy.kt
@@ -2,7 +2,8 @@
 
 package com.finance.sync.conflict
 
-import com.finance.sync.SyncChange
+import com.finance.sync.MutationOperation
+import kotlinx.datetime.Instant
 
 /**
  * Determines which [ConflictResolver] to use for a given table.
@@ -17,7 +18,13 @@ enum class ConflictStrategy(val resolver: ConflictResolver) {
     LAST_WRITE_WINS(LastWriteWinsResolver()),
 
     /** Field-level merge — non-conflicting fields are combined. */
-    MERGE(MergeResolver());
+    MERGE(MergeResolver()),
+
+    /** Server always wins — discard local changes on conflict. */
+    SERVER_WINS(ServerWinsResolver()),
+
+    /** Client always wins — local changes override server. */
+    CLIENT_WINS(ClientWinsResolver());
 
     companion object {
         /**
@@ -37,4 +44,93 @@ enum class ConflictStrategy(val resolver: ConflictResolver) {
         fun resolverFor(tableName: String): ConflictResolver =
             (TABLE_STRATEGIES[tableName] ?: LAST_WRITE_WINS).resolver
     }
+}
+
+/**
+ * Represents a detected conflict between a local mutation and a server change
+ * targeting the same record.
+ *
+ * This type captures all the information needed by a [ConflictResolver] to
+ * decide how to reconcile the two versions.
+ *
+ * @property tableName The database table affected.
+ * @property recordId The primary key of the conflicting record.
+ * @property localData The locally-modified row data, or `null` for deletes.
+ * @property serverData The server-originated row data, or `null` for deletes.
+ * @property localVersion The sync version of the local mutation.
+ * @property serverVersion The sync version from the server.
+ * @property localTimestamp When the local mutation was created.
+ * @property serverTimestamp When the server change was applied.
+ * @property localOperation The type of local mutation (INSERT, UPDATE, DELETE).
+ * @property serverOperation The type of server mutation (INSERT, UPDATE, DELETE).
+ */
+data class SyncConflict(
+    val tableName: String,
+    val recordId: String,
+    val localData: Map<String, String?>?,
+    val serverData: Map<String, String?>?,
+    val localVersion: Long,
+    val serverVersion: Long,
+    val localTimestamp: Instant,
+    val serverTimestamp: Instant,
+    val localOperation: MutationOperation,
+    val serverOperation: MutationOperation,
+) {
+    init {
+        require(tableName.isNotBlank()) { "Table name cannot be blank" }
+        require(recordId.isNotBlank()) { "Record ID cannot be blank" }
+        require(localVersion >= 0) { "Local version must be non-negative, got $localVersion" }
+        require(serverVersion >= 0) { "Server version must be non-negative, got $serverVersion" }
+    }
+
+    /**
+     * `true` when both sides performed a DELETE — resolution is always [ConflictResolution.Delete].
+     */
+    val isBothDeleted: Boolean
+        get() = localOperation == MutationOperation.DELETE &&
+            serverOperation == MutationOperation.DELETE
+
+    /**
+     * `true` when at least one side performed a DELETE.
+     */
+    val involvesDelete: Boolean
+        get() = localOperation == MutationOperation.DELETE ||
+            serverOperation == MutationOperation.DELETE
+}
+
+/**
+ * The outcome of resolving a [SyncConflict].
+ *
+ * Every branch is exhaustively handleable in a `when` expression. Consumers
+ * inspect the resolution to decide which row data to persist locally.
+ */
+sealed class ConflictResolution {
+
+    /**
+     * Use the server's version of the record.
+     *
+     * @property data The server row data to apply, or `null` when the server deleted the record.
+     */
+    data class AcceptServer(val data: Map<String, String?>?) : ConflictResolution()
+
+    /**
+     * Use the local version of the record.
+     *
+     * @property data The local row data to keep, or `null` when the local side deleted the record.
+     */
+    data class AcceptLocal(val data: Map<String, String?>?) : ConflictResolution()
+
+    /**
+     * Use a merged version combining fields from both local and server.
+     *
+     * @property data The merged row data. Conflicting fields that were resolved via
+     *   fallback are annotated with `__conflict_<field>` keys containing the rejected value.
+     */
+    data class Merged(val data: Map<String, String?>) : ConflictResolution()
+
+    /**
+     * Delete the record. Used when at least one side issued a DELETE and the
+     * resolution strategy honours delete intent.
+     */
+    data object Delete : ConflictResolution()
 }

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/conflict/LastWriteWinsResolver.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/conflict/LastWriteWinsResolver.kt
@@ -2,6 +2,7 @@
 
 package com.finance.sync.conflict
 
+import com.finance.sync.MutationOperation
 import com.finance.sync.SyncChange
 
 /**
@@ -11,6 +12,16 @@ import com.finance.sync.SyncChange
  * If both timestamps are identical, the server timestamp ([SyncChange.serverTimestamp])
  * is used as a tiebreaker — the server-authoritative change wins because the
  * server timestamp is assigned after the client timestamp.
+ *
+ * ## Delete handling
+ *
+ * - If the server issued a DELETE, the delete is always honoured (intent to
+ *   remove is preserved).
+ * - If the local side issued a DELETE but the server did not, the version
+ *   comparison decides: a higher server version means the server "revived"
+ *   the record, so the server update wins; otherwise the local delete wins.
+ * - If both sides deleted, the higher-version delete is used (or the server's
+ *   on a tie).
  */
 class LastWriteWinsResolver : ConflictResolver {
 
@@ -37,6 +48,47 @@ class LastWriteWinsResolver : ConflictResolver {
                 // Absolute tie (extremely unlikely) → prefer remote (server authority).
                 else -> remote
             }
+        }
+    }
+
+    /**
+     * High-level conflict resolution using [SyncConflict] metadata.
+     *
+     * Resolution order:
+     * 1. If the server operation is DELETE → [ConflictResolution.Delete].
+     * 2. If the local operation is DELETE and server is not → compare versions.
+     *    Higher server version means the server revived the record; otherwise
+     *    the local delete intent wins.
+     * 3. Compare `syncVersion`: higher version wins.
+     * 4. On equal versions the server wins (tie-breaker — server is source of truth).
+     */
+    override fun resolveConflict(conflict: SyncConflict): ConflictResolution {
+        // 1. Server DELETE always wins — honour the intent to remove.
+        if (conflict.serverOperation == MutationOperation.DELETE) {
+            return ConflictResolution.Delete
+        }
+
+        // 2. Local DELETE vs. server non-DELETE.
+        if (conflict.localOperation == MutationOperation.DELETE) {
+            // If the server has a strictly higher version, the record was
+            // "revived" — accept the server's update.
+            return if (conflict.serverVersion > conflict.localVersion) {
+                ConflictResolution.AcceptServer(conflict.serverData)
+            } else {
+                ConflictResolution.Delete
+            }
+        }
+
+        // 3. Both are non-DELETE — compare sync versions.
+        return when {
+            conflict.serverVersion > conflict.localVersion ->
+                ConflictResolution.AcceptServer(conflict.serverData)
+
+            conflict.localVersion > conflict.serverVersion ->
+                ConflictResolution.AcceptLocal(conflict.localData)
+
+            // 4. Equal versions — server wins as tie-breaker.
+            else -> ConflictResolution.AcceptServer(conflict.serverData)
         }
     }
 }

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/conflict/MergeResolver.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/conflict/MergeResolver.kt
@@ -21,8 +21,19 @@ import com.finance.sync.SyncChange
  * we approximate: the *remote* row is treated as base for fields the *local*
  * change didn't touch, and vice-versa. Fields present in both are compared
  * directly.
+ *
+ * @param fallbackResolver Resolver used when field-level merge is impossible
+ *   (e.g., both sides delete, or a non-mergeable financial field is modified by
+ *   both sides). Defaults to [LastWriteWinsResolver].
+ * @param nonMergeableFields Field names that are considered indivisible — if
+ *   both sides modify one of these, the entire record is delegated to
+ *   [fallbackResolver] instead of doing per-field merge. Typical examples are
+ *   monetary fields (`amount`, `currency_code`) and record type discriminators.
  */
-class MergeResolver : ConflictResolver {
+class MergeResolver(
+    private val fallbackResolver: ConflictResolver = LastWriteWinsResolver(),
+    private val nonMergeableFields: Set<String> = setOf("amount", "currency_code", "type"),
+) : ConflictResolver {
 
     override fun resolve(local: SyncChange, remote: SyncChange): SyncChange {
         // DELETE always wins — if either side deleted, propagate the delete.
@@ -74,5 +85,90 @@ class MergeResolver : ConflictResolver {
             serverTimestamp = resolvedTimestamp,
             sequenceNumber = resolvedSequence,
         )
+    }
+
+    /**
+     * High-level conflict resolution using [SyncConflict] metadata.
+     *
+     * Resolution logic:
+     * 1. If either side is a DELETE → delegate to [fallbackResolver].
+     * 2. If both sides are `null` data → [ConflictResolution.Delete].
+     * 3. If only one side has data → accept that side.
+     * 4. Compute the set of fields changed by each side (fields present in
+     *    one side but not the other, or differing values).
+     * 5. Partition into non-conflicting (only one side touched) and
+     *    conflicting (both sides touched with different values).
+     * 6. If any conflicting field is in [nonMergeableFields] → delegate the
+     *    entire record to [fallbackResolver].
+     * 7. For non-conflicting fields take the changed value; for conflicting
+     *    fields use server value and tag `__conflict_<field>` with the
+     *    rejected local value.
+     * 8. Return [ConflictResolution.Merged].
+     */
+    override fun resolveConflict(conflict: SyncConflict): ConflictResolution {
+        // 1. Deletes cannot be field-merged.
+        if (conflict.involvesDelete) {
+            return fallbackResolver.resolveConflict(conflict)
+        }
+
+        val localData = conflict.localData
+        val serverData = conflict.serverData
+
+        // 2. Both sides null — effectively a double-delete / no data.
+        if (localData == null && serverData == null) {
+            return ConflictResolution.Delete
+        }
+
+        // 3. One side null — accept the non-null side.
+        if (localData == null) return ConflictResolution.AcceptServer(serverData)
+        if (serverData == null) return ConflictResolution.AcceptLocal(localData)
+
+        // 4. Compute per-field diffs.
+        val allKeys = localData.keys + serverData.keys
+
+        val merged = mutableMapOf<String, String?>()
+        var hasNonMergeableConflict = false
+
+        for (key in allKeys) {
+            // Skip conflict-marker keys from previous merges.
+            if (key.startsWith("__conflict_")) continue
+
+            val localValue = localData[key]
+            val remoteValue = serverData[key]
+            val localHas = key in localData
+            val remoteHas = key in serverData
+
+            when {
+                // Only one side has the field → take the present value.
+                localHas && !remoteHas -> merged[key] = localValue
+                remoteHas && !localHas -> merged[key] = remoteValue
+
+                // Same value → no conflict.
+                localValue == remoteValue -> merged[key] = localValue
+
+                // updated_at — always take the later one.
+                key == "updated_at" -> {
+                    merged[key] = maxOf(localValue ?: "", remoteValue ?: "")
+                }
+
+                // True field conflict.
+                else -> {
+                    // 6. Non-mergeable field conflict → bail out to fallback.
+                    if (key in nonMergeableFields) {
+                        hasNonMergeableConflict = true
+                        break
+                    }
+                    // 7. Mergeable field conflict — server wins, flag local.
+                    merged[key] = remoteValue
+                    merged["__conflict_$key"] = localValue
+                }
+            }
+        }
+
+        if (hasNonMergeableConflict) {
+            return fallbackResolver.resolveConflict(conflict)
+        }
+
+        return ConflictResolution.Merged(merged)
     }
 }

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/conflict/ServerWinsResolver.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/conflict/ServerWinsResolver.kt
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.sync.conflict
+
+import com.finance.sync.MutationOperation
+import com.finance.sync.SyncChange
+
+/**
+ * Server-always-wins conflict resolver.
+ *
+ * Unconditionally accepts the server's version of a record when a conflict is
+ * detected. This is the safest strategy when the server is the authoritative
+ * source of truth and local offline edits should be discarded on conflict.
+ *
+ * Use cases:
+ * - System-managed tables where server-side business rules are canonical
+ *   (e.g., household membership, user roles).
+ * - Initial sync bootstrapping where the server snapshot is guaranteed correct.
+ */
+class ServerWinsResolver : ConflictResolver {
+
+    /**
+     * Always returns the [remote] (server-originated) change.
+     */
+    override fun resolve(local: SyncChange, remote: SyncChange): SyncChange = remote
+
+    /**
+     * Always accepts the server's data.
+     *
+     * - Server DELETE → [ConflictResolution.Delete].
+     * - Server non-DELETE → [ConflictResolution.AcceptServer] with the server data.
+     */
+    override fun resolveConflict(conflict: SyncConflict): ConflictResolution =
+        if (conflict.serverOperation == MutationOperation.DELETE) {
+            ConflictResolution.Delete
+        } else {
+            ConflictResolution.AcceptServer(conflict.serverData)
+        }
+}

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/delta/DeltaSyncManager.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/delta/DeltaSyncManager.kt
@@ -2,18 +2,29 @@
 
 package com.finance.sync.delta
 
+import com.finance.sync.PushFailure
+import com.finance.sync.PushResult
 import com.finance.sync.SyncChange
+import com.finance.sync.SyncConfig
+import com.finance.sync.SyncMutation
+import com.finance.sync.SyncProvider
+import com.finance.sync.conflict.SyncConflict
+
+// ── Result types ────────────────────────────────────────────────────
 
 /**
- * Result of applying a batch of delta changes.
+ * Result of validating a batch of incoming changes for sequence continuity
+ * and data integrity.
+ *
+ * Returned by [DeltaSyncManager.processChanges] on a per-table basis.
  */
-sealed class DeltaSyncResult {
+sealed class ChangeValidationResult {
     /**
      * All changes were applied successfully.
      *
      * @property appliedCount Number of changes applied in this batch.
      */
-    data class Success(val appliedCount: Int) : DeltaSyncResult()
+    data class Success(val appliedCount: Int) : ChangeValidationResult()
 
     /**
      * A sequence gap was detected. The affected table requires a full resync.
@@ -26,7 +37,7 @@ sealed class DeltaSyncResult {
         val tableName: String,
         val expectedSequence: Long,
         val actualSequence: Long,
-    ) : DeltaSyncResult()
+    ) : ChangeValidationResult()
 
     /**
      * One or more rows failed checksum verification.
@@ -37,23 +48,231 @@ sealed class DeltaSyncResult {
     data class ChecksumMismatch(
         val tableName: String,
         val failedRowIds: List<String>,
-    ) : DeltaSyncResult()
+    ) : ChangeValidationResult()
 }
+
+/**
+ * Result of a delta sync pull cycle.
+ *
+ * Produced by [DeltaSyncManager.executePullCycle] and consumed by the
+ * sync engine to decide which changes to apply and which conflicts to
+ * resolve before pushing.
+ *
+ * @property changes All changes pulled from the server across all pages.
+ * @property conflicts Conflicts detected between pulled server changes and
+ *   pending local mutations (same `tableName` + `recordId`).
+ * @property newVersions Updated per-table sync versions after the pull.
+ *   Already persisted in the [SequenceTracker] by the time this result
+ *   is returned.
+ * @property checksum A hex-encoded CRC-32 checksum of all pulled changes,
+ *   or `null` when no changes were pulled. Useful for verifying that the
+ *   client and server agree on the same data set.
+ */
+data class DeltaSyncResult(
+    val changes: List<SyncChange>,
+    val conflicts: List<SyncConflict>,
+    val newVersions: Map<String, Long>,
+    val checksum: String?,
+)
+
+// ── Manager ─────────────────────────────────────────────────────────
 
 /**
  * Manages delta (incremental) synchronisation.
  *
- * Instead of pulling the full dataset on every sync, [DeltaSyncManager] tracks
- * the last sequence number per table and only requests changes after that point.
+ * Instead of pulling the full dataset on every sync, [DeltaSyncManager]
+ * tracks the last sequence number per table and only requests changes after
+ * that point.
  *
+ * Coordinates the pull → conflict detection → push cycle:
+ * 1. **Pull**: Request changes since last-known version per table, handling
+ *    pagination when the server indicates [com.finance.sync.PullResult.hasMore].
+ * 2. **Detect conflicts**: Compare pulled changes against pending local
+ *    mutations to find records modified on both sides.
+ * 3. **Push**: Send local mutations to the server in batches that respect
+ *    [SyncConfig.batchSize].
+ *
+ * Conflict *resolution* is intentionally left to the caller (typically the
+ * [com.finance.sync.SyncEngine]) so that the resolution strategy can vary
+ * per table or be overridden by the user.
+ *
+ * @property provider The sync backend provider (e.g. PowerSync).
  * @property sequenceTracker Persists per-table sequence numbers across sessions.
+ * @property config Sync configuration (batch size, retry policy, etc.).
  */
 class DeltaSyncManager(
+    private val provider: SyncProvider,
     private val sequenceTracker: SequenceTracker,
+    private val config: SyncConfig,
 ) {
 
+    // ── Pull ────────────────────────────────────────────────────────
+
     /**
-     * Process a batch of incoming [changes] from the sync backend.
+     * Pull changes from the server since last-known versions.
+     *
+     * Handles pagination: when the server sets
+     * [com.finance.sync.PullResult.hasMore] to `true`, additional pages are
+     * fetched until the server indicates all changes have been delivered.
+     *
+     * On success, the [SequenceTracker] is updated with the new per-table
+     * versions so the next pull starts from the correct point.
+     *
+     * @return All changes pulled across all pages.
+     */
+    suspend fun pullChanges(): List<SyncChange> {
+        val allChanges = mutableListOf<SyncChange>()
+        var hasMore = true
+
+        while (hasMore) {
+            val currentVersions = sequenceTracker.getAllVersions()
+            val result = provider.pullChanges(currentVersions)
+            allChanges.addAll(result.changes)
+            sequenceTracker.updateVersions(result.newVersions)
+            hasMore = result.hasMore
+        }
+
+        return allChanges
+    }
+
+    // ── Push ────────────────────────────────────────────────────────
+
+    /**
+     * Push local mutations to the server in batches.
+     *
+     * Mutations are chunked according to [SyncConfig.batchSize] and pushed
+     * sequentially. Results from all batches are aggregated into a single
+     * [PushResult].
+     *
+     * @param mutations The mutations to push.
+     * @return Aggregate push result across all batches.
+     */
+    suspend fun pushMutations(mutations: List<SyncMutation>): PushResult {
+        if (mutations.isEmpty()) {
+            return PushResult(succeeded = emptyList(), failed = emptyList())
+        }
+
+        val allSucceeded = mutableListOf<String>()
+        val allFailed = mutableListOf<PushFailure>()
+
+        val batches = mutations.chunked(config.batchSize)
+        for (batch in batches) {
+            val result = provider.pushMutations(batch)
+            allSucceeded.addAll(result.succeeded)
+            allFailed.addAll(result.failed)
+        }
+
+        return PushResult(succeeded = allSucceeded, failed = allFailed)
+    }
+
+    // ── Conflict detection ──────────────────────────────────────────
+
+    /**
+     * Detect conflicts between pulled server changes and pending local
+     * mutations.
+     *
+     * A conflict exists when a server change and a local mutation reference
+     * the same record (same `tableName` + `recordId`). For each such pair,
+     * a [SyncConflict] is created with both sides' data, versions, timestamps,
+     * and operations so that the caller can resolve the conflict using a
+     * [com.finance.sync.conflict.ConflictResolver].
+     *
+     * @param serverChanges Changes received from the server.
+     * @param localMutations Pending local mutations.
+     * @return List of detected conflicts; empty if there are no overlapping
+     *   records.
+     */
+    fun detectConflicts(
+        serverChanges: List<SyncChange>,
+        localMutations: List<SyncMutation>,
+    ): List<SyncConflict> {
+        if (serverChanges.isEmpty() || localMutations.isEmpty()) return emptyList()
+
+        // Index local mutations by "tableName:recordId" for O(1) lookup.
+        val localByKey = buildMap<String, SyncMutation> {
+            for (mutation in localMutations) {
+                val recordId = mutation.recordId.ifBlank {
+                    mutation.rowData["id"] ?: mutation.id
+                }
+                put("${mutation.tableName}:$recordId", mutation)
+            }
+        }
+
+        val conflicts = mutableListOf<SyncConflict>()
+
+        for (change in serverChanges) {
+            val key = "${change.tableName}:${change.effectiveRecordId}"
+            val localMutation = localByKey[key] ?: continue
+
+            conflicts.add(
+                SyncConflict(
+                    tableName = change.tableName,
+                    recordId = change.effectiveRecordId,
+                    localData = localMutation.rowData,
+                    serverData = change.rowData,
+                    // Local mutations haven't been synced yet → version 0
+                    localVersion = 0L,
+                    serverVersion = change.syncVersion,
+                    localTimestamp = localMutation.timestamp,
+                    serverTimestamp = change.serverTimestamp,
+                    localOperation = localMutation.operation,
+                    serverOperation = change.operation,
+                ),
+            )
+        }
+
+        return conflicts
+    }
+
+    // ── Full pull cycle ─────────────────────────────────────────────
+
+    /**
+     * Execute a full pull cycle: pull → detect conflicts → compute checksum.
+     *
+     * Does **NOT** push — pushing is the [com.finance.sync.SyncEngine]'s
+     * responsibility after conflict resolution.
+     *
+     * @param pendingMutations Current pending local mutations, used for
+     *   conflict detection against the pulled server changes.
+     * @return A [DeltaSyncResult] with all pulled changes, detected conflicts,
+     *   updated version markers, and an integrity checksum.
+     */
+    suspend fun executePullCycle(
+        pendingMutations: List<SyncMutation>,
+    ): DeltaSyncResult {
+        val changes = pullChanges()
+        val conflicts = detectConflicts(changes, pendingMutations)
+        val checksum = if (changes.isNotEmpty()) {
+            SyncChecksum.computeForChanges(changes)
+        } else {
+            null
+        }
+
+        return DeltaSyncResult(
+            changes = changes,
+            conflicts = conflicts,
+            newVersions = sequenceTracker.getAllVersions(),
+            checksum = checksum,
+        )
+    }
+
+    // ── Reset ───────────────────────────────────────────────────────
+
+    /**
+     * Force a full re-sync by resetting all sequence tracking.
+     *
+     * The next [pullChanges] or [executePullCycle] call will request all
+     * records from version 0 for every table.
+     */
+    suspend fun resetSync() {
+        sequenceTracker.resetAll()
+    }
+
+    // ── Change validation (sequence + checksum) ─────────────────────
+
+    /**
+     * Validate a batch of incoming [changes] for sequence continuity
+     * and checksum integrity.
      *
      * For each table represented in the batch:
      * 1. Verify that the first change's sequence number follows the last
@@ -61,13 +280,15 @@ class DeltaSyncManager(
      * 2. Optionally verify row checksums when a `__checksum` field is present.
      * 3. Update the sequence tracker with the highest sequence seen.
      *
-     * @return A [DeltaSyncResult] per table, keyed by table name.
+     * @return A [ChangeValidationResult] per table, keyed by table name.
      */
-    suspend fun processChanges(changes: List<SyncChange>): Map<String, DeltaSyncResult> {
+    suspend fun processChanges(
+        changes: List<SyncChange>,
+    ): Map<String, ChangeValidationResult> {
         if (changes.isEmpty()) return emptyMap()
 
         val byTable = changes.groupBy { it.tableName }
-        val results = mutableMapOf<String, DeltaSyncResult>()
+        val results = mutableMapOf<String, ChangeValidationResult>()
 
         for ((tableName, tableChanges) in byTable) {
             val sorted = tableChanges.sortedBy { it.sequenceNumber }
@@ -76,72 +297,6 @@ class DeltaSyncManager(
         }
 
         return results
-    }
-
-    /**
-     * Process changes for a single table, validating sequence continuity
-     * and checksums.
-     */
-    private suspend fun processTableChanges(
-        tableName: String,
-        sortedChanges: List<SyncChange>,
-    ): DeltaSyncResult {
-        val lastKnownSeq = sequenceTracker.getLastSequence(tableName)
-
-        // --- Sequence gap detection ---
-        val firstSeq = sortedChanges.first().sequenceNumber
-        val expectedFirstSeq = if (lastKnownSeq != null) lastKnownSeq + 1 else firstSeq
-
-        if (firstSeq != expectedFirstSeq) {
-            // Gap detected -- trigger a full resync for this table.
-            sequenceTracker.resetTable(tableName)
-            return DeltaSyncResult.SequenceGap(
-                tableName = tableName,
-                expectedSequence = expectedFirstSeq,
-                actualSequence = firstSeq,
-            )
-        }
-
-        // Verify intra-batch continuity.
-        for (i in 1 until sortedChanges.size) {
-            val prev = sortedChanges[i - 1].sequenceNumber
-            val curr = sortedChanges[i].sequenceNumber
-            if (curr != prev + 1) {
-                sequenceTracker.resetTable(tableName)
-                return DeltaSyncResult.SequenceGap(
-                    tableName = tableName,
-                    expectedSequence = prev + 1,
-                    actualSequence = curr,
-                )
-            }
-        }
-
-        // --- Checksum verification ---
-        val checksumFailures = mutableListOf<String>()
-        for (change in sortedChanges) {
-            val expectedChecksum = change.rowData["__checksum"]
-            if (expectedChecksum != null) {
-                val dataWithoutChecksum = change.rowData.filterKeys { it != "__checksum" }
-                val expected = expectedChecksum.toLongOrNull() ?: continue
-                if (!SyncChecksum.verifyRowChecksum(dataWithoutChecksum, expected)) {
-                    val rowId = change.rowData["id"] ?: change.sequenceNumber.toString()
-                    checksumFailures.add(rowId)
-                }
-            }
-        }
-
-        if (checksumFailures.isNotEmpty()) {
-            return DeltaSyncResult.ChecksumMismatch(
-                tableName = tableName,
-                failedRowIds = checksumFailures,
-            )
-        }
-
-        // --- Success: advance the sequence tracker ---
-        val highestSeq = sortedChanges.last().sequenceNumber
-        sequenceTracker.setLastSequence(tableName, highestSeq)
-
-        return DeltaSyncResult.Success(appliedCount = sortedChanges.size)
     }
 
     /**
@@ -165,4 +320,72 @@ class DeltaSyncManager(
      */
     suspend fun getLastSequence(tableName: String): Long? =
         sequenceTracker.getLastSequence(tableName)
+
+    // ── Internal helpers ────────────────────────────────────────────
+
+    /**
+     * Process changes for a single table, validating sequence continuity
+     * and checksums.
+     */
+    private suspend fun processTableChanges(
+        tableName: String,
+        sortedChanges: List<SyncChange>,
+    ): ChangeValidationResult {
+        val lastKnownSeq = sequenceTracker.getLastSequence(tableName)
+
+        // --- Sequence gap detection ---
+        val firstSeq = sortedChanges.first().sequenceNumber
+        val expectedFirstSeq = if (lastKnownSeq != null) lastKnownSeq + 1 else firstSeq
+
+        if (firstSeq != expectedFirstSeq) {
+            // Gap detected — trigger a full resync for this table.
+            sequenceTracker.resetTable(tableName)
+            return ChangeValidationResult.SequenceGap(
+                tableName = tableName,
+                expectedSequence = expectedFirstSeq,
+                actualSequence = firstSeq,
+            )
+        }
+
+        // Verify intra-batch continuity.
+        for (i in 1 until sortedChanges.size) {
+            val prev = sortedChanges[i - 1].sequenceNumber
+            val curr = sortedChanges[i].sequenceNumber
+            if (curr != prev + 1) {
+                sequenceTracker.resetTable(tableName)
+                return ChangeValidationResult.SequenceGap(
+                    tableName = tableName,
+                    expectedSequence = prev + 1,
+                    actualSequence = curr,
+                )
+            }
+        }
+
+        // --- Checksum verification ---
+        val checksumFailures = mutableListOf<String>()
+        for (change in sortedChanges) {
+            val expectedChecksum = change.rowData["__checksum"]
+            if (expectedChecksum != null) {
+                val dataWithoutChecksum = change.rowData.filterKeys { it != "__checksum" }
+                val expected = expectedChecksum.toLongOrNull() ?: continue
+                if (!SyncChecksum.verifyRowChecksum(dataWithoutChecksum, expected)) {
+                    val rowId = change.rowData["id"] ?: change.sequenceNumber.toString()
+                    checksumFailures.add(rowId)
+                }
+            }
+        }
+
+        if (checksumFailures.isNotEmpty()) {
+            return ChangeValidationResult.ChecksumMismatch(
+                tableName = tableName,
+                failedRowIds = checksumFailures,
+            )
+        }
+
+        // --- Success: advance the sequence tracker ---
+        val highestSeq = sortedChanges.last().sequenceNumber
+        sequenceTracker.setLastSequence(tableName, highestSeq)
+
+        return ChangeValidationResult.Success(appliedCount = sortedChanges.size)
+    }
 }

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/delta/SequenceTracker.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/delta/SequenceTracker.kt
@@ -3,10 +3,14 @@
 package com.finance.sync.delta
 
 /**
- * Persists the last-synced sequence number for each table.
+ * Persists the last-synced sequence number / sync version for each table.
  *
- * Backed by an interface so the storage mechanism is pluggable --
+ * Backed by an interface so the storage mechanism is pluggable —
  * in-memory for tests, SQLite or MMKV in production.
+ *
+ * The interface exposes `suspend` functions because production implementations
+ * (e.g. SQLite-backed) perform I/O. In-memory implementations can delegate to
+ * simple map operations.
  */
 interface SequenceTracker {
 
@@ -32,12 +36,97 @@ interface SequenceTracker {
      * for that table on next pull.
      */
     suspend fun resetTable(tableName: String)
+
+    // ── Extended API ────────────────────────────────────────────────
+
+    /**
+     * All table names that currently have a tracked version.
+     *
+     * Returns a snapshot; subsequent mutations do not affect the returned set.
+     * Default implementation returns an empty set — override in implementations
+     * that maintain an index of tracked tables.
+     */
+    suspend fun trackedTables(): Set<String> = emptySet()
+
+    /**
+     * Get the last-known sync version for [tableName].
+     *
+     * Convenience wrapper around [getLastSequence] that returns `0L` instead
+     * of `null` when the table has never been synced, matching the common
+     * pattern of "pull everything with `syncVersion > 0`" on first sync.
+     *
+     * @return The last synced version, or `0L` if the table has never been synced.
+     */
+    suspend fun getVersion(tableName: String): Long =
+        getLastSequence(tableName) ?: 0L
+
+    /**
+     * Get all tracked versions as a map suitable for passing directly to
+     * [com.finance.sync.SyncProvider.pullChanges].
+     *
+     * @return Map of table name → last synced version.
+     */
+    suspend fun getAllVersions(): Map<String, Long> = emptyMap()
+
+    /**
+     * Update the version for a single table after a successful pull.
+     *
+     * Only records forward progress — if [version] is not greater than the
+     * currently tracked value, the call is a no-op.
+     *
+     * @param tableName The table whose version to update.
+     * @param version The new sync version.
+     */
+    suspend fun updateVersion(tableName: String, version: Long) {
+        val current = getLastSequence(tableName)
+        if (current == null || version > current) {
+            setLastSequence(tableName, version)
+        }
+    }
+
+    /**
+     * Batch update versions, typically from
+     * [com.finance.sync.PullResult.newVersions].
+     *
+     * Each entry is applied via [updateVersion], so only forward progress
+     * is recorded.
+     *
+     * @param versions Map of table name → new sync version.
+     */
+    suspend fun updateVersions(versions: Map<String, Long>) {
+        for ((table, version) in versions) {
+            updateVersion(table, version)
+        }
+    }
+
+    /**
+     * Reset all tracked versions, forcing a full re-sync of every table.
+     *
+     * Alias for [reset] that follows the naming convention used by
+     * [DeltaSyncManager.resetSync].
+     */
+    suspend fun resetAll() {
+        reset()
+    }
+
+    /**
+     * Check if any table has been synced at least once.
+     *
+     * @return `true` if at least one table has a tracked version.
+     */
+    suspend fun hasEverSynced(): Boolean =
+        trackedTables().isNotEmpty()
 }
 
 /**
- * Simple in-memory implementation for testing and bootstrap scenarios.
+ * Simple in-memory [SequenceTracker] for testing and bootstrap scenarios.
+ *
+ * All state is held in a [MutableMap] and lost on process exit. For production
+ * use, the state should be persisted to SQLite (via SQLDelight) so that sync
+ * resumes from the correct point after app restart.
  */
 class InMemorySequenceTracker : SequenceTracker {
+
     private val sequences = mutableMapOf<String, Long>()
 
     override suspend fun getLastSequence(tableName: String): Long? =
@@ -54,4 +143,15 @@ class InMemorySequenceTracker : SequenceTracker {
     override suspend fun resetTable(tableName: String) {
         sequences.remove(tableName)
     }
+
+    // ── Extended overrides ──────────────────────────────────────────
+
+    override suspend fun trackedTables(): Set<String> =
+        sequences.keys.toSet()
+
+    override suspend fun getAllVersions(): Map<String, Long> =
+        sequences.toMap()
+
+    override suspend fun hasEverSynced(): Boolean =
+        sequences.isNotEmpty()
 }

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/delta/SyncChecksum.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/delta/SyncChecksum.kt
@@ -2,12 +2,14 @@
 
 package com.finance.sync.delta
 
+import com.finance.sync.SyncChange
+
 /**
- * Utility for computing and verifying row-level checksums.
+ * Utility for computing and verifying checksums for sync data integrity.
  *
- * Uses a simple CRC-style hash of the serialised row data to detect
- * data corruption during sync. This is intentionally *not* a cryptographic
- * hash -- it only needs to catch accidental corruption, not adversarial
+ * Uses a CRC-32 hash of canonically serialised data to detect accidental
+ * corruption during transmission. This is intentionally *not* a cryptographic
+ * hash — it only needs to catch accidental corruption, not adversarial
  * tampering (TLS handles that).
  *
  * The algorithm is a Kotlin-multiplatform-friendly implementation that
@@ -34,6 +36,8 @@ object SyncChecksum {
 
     /**
      * Compute a CRC-32 checksum of the given [data] bytes.
+     *
+     * @return The CRC-32 value as an unsigned [Long] in `0..0xFFFFFFFF`.
      */
     fun crc32(data: ByteArray): Long {
         var crc = 0xFFFFFFFF.toInt()
@@ -45,11 +49,13 @@ object SyncChecksum {
     }
 
     /**
-     * Compute a checksum for a row represented as a map of column -> value.
+     * Compute a checksum for a row represented as a map of column → value.
      *
      * The map keys are sorted to ensure deterministic ordering, then each
      * `key=value` pair is joined with `\n` and encoded to UTF-8 before
      * computing CRC-32.
+     *
+     * @return The CRC-32 value as an unsigned [Long].
      */
     fun computeRowChecksum(rowData: Map<String, String?>): Long {
         val canonical = rowData.keys
@@ -60,7 +66,69 @@ object SyncChecksum {
 
     /**
      * Verify that the [expected] checksum matches the actual checksum of [rowData].
+     *
+     * @return `true` if the checksums match.
      */
     fun verifyRowChecksum(rowData: Map<String, String?>, expected: Long): Boolean =
         computeRowChecksum(rowData) == expected
+
+    // ── Hex-string API (for DeltaSyncResult) ────────────────────────
+
+    /**
+     * Compute a checksum for a single record's data.
+     *
+     * Keys are sorted alphabetically for deterministic output, identical to
+     * [computeRowChecksum] but returning a zero-padded, 8-character hex string
+     * suitable for embedding in [DeltaSyncResult.checksum].
+     *
+     * @param data The record data as key-value pairs.
+     * @return A hex-encoded CRC-32 checksum string (e.g. `"a3f0bc12"`).
+     */
+    fun computeForRecord(data: Map<String, String?>): String =
+        computeRowChecksum(data).toHexString()
+
+    /**
+     * Compute a checksum for a collection of [SyncChange]s.
+     *
+     * Uses a stable ordering (sorted by `tableName`, then `effectiveRecordId`)
+     * to ensure deterministic checksums regardless of receive order. Each
+     * change contributes its table name, record ID, operation, and data
+     * checksum to the combined hash.
+     *
+     * @param changes The sync changes to checksum.
+     * @return A hex-encoded CRC-32 checksum string.
+     */
+    fun computeForChanges(changes: List<SyncChange>): String {
+        if (changes.isEmpty()) return EMPTY_CHECKSUM
+
+        val sorted = changes.sortedWith(
+            compareBy({ it.tableName }, { it.effectiveRecordId }),
+        )
+        val combined = sorted.joinToString(separator = "|") { change ->
+            "${change.tableName}:${change.effectiveRecordId}:" +
+                "${change.operation}:${computeForRecord(change.rowData)}"
+        }
+        return crc32(combined.encodeToByteArray()).toHexString()
+    }
+
+    /**
+     * Verify that a set of [changes] matches an [expectedChecksum].
+     *
+     * @return `true` if the computed checksum matches [expectedChecksum].
+     */
+    fun verify(changes: List<SyncChange>, expectedChecksum: String): Boolean =
+        computeForChanges(changes) == expectedChecksum
+
+    // ── Helpers ─────────────────────────────────────────────────────
+
+    /**
+     * Checksum value used for empty change sets.
+     */
+    private const val EMPTY_CHECKSUM = "00000000"
+
+    /**
+     * Format a CRC-32 [Long] value as a zero-padded, lower-case, 8-char hex string.
+     */
+    private fun Long.toHexString(): String =
+        this.toString(16).padStart(8, '0')
 }

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/queue/InMemoryMutationQueue.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/queue/InMemoryMutationQueue.kt
@@ -2,62 +2,250 @@
 
 package com.finance.sync.queue
 
+import com.finance.sync.MutationOperation
 import com.finance.sync.SyncMutation
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
 /**
  * Thread-safe, in-memory implementation of [MutationQueue].
  *
- * Uses a [Mutex] for coroutine-safe access -- no platform-specific concurrency
+ * Uses a [Mutex] for coroutine-safe access — no platform-specific concurrency
  * primitives required.
  *
- * When a mutation with a duplicate [SyncMutation.entityKey] is enqueued,
- * the older mutation is replaced with the newer one (latest mutation wins).
+ * Supports operation-aware coalescing when a mutation for the same
+ * [SyncMutation.entityKey] is already in the queue:
+ *
+ * | Existing | Incoming | Result                                   |
+ * |----------|----------|------------------------------------------|
+ * | INSERT   | UPDATE   | INSERT with merged `rowData`              |
+ * | INSERT   | DELETE   | **Both removed** (net no-op)              |
+ * | UPDATE   | UPDATE   | Single UPDATE with latest `rowData`       |
+ * | UPDATE   | DELETE   | DELETE                                    |
+ * | DELETE   | INSERT   | INSERT (re-creation)                      |
+ * | *other*  | *any*    | Latest mutation wins                      |
+ *
+ * Note: This implementation does **not** persist across app restarts.
+ * For production use, a persistent implementation backed by SQLite (via
+ * SQLDelight) should be used.
  */
 class InMemoryMutationQueue : MutationQueue {
 
     private val mutex = Mutex()
 
     /**
-     * Insertion-ordered map of mutation ID -> mutation.
-     * LinkedHashMap preserves insertion order for FIFO semantics.
+     * Insertion-ordered map of mutation ID → mutation.
+     * [LinkedHashMap] preserves insertion order for FIFO semantics.
      */
     private val queue = LinkedHashMap<String, SyncMutation>()
 
     /**
-     * Reverse index: entity key -> mutation ID.
-     * Used for O(1) deduplication lookups.
+     * Reverse index: entity key → mutation ID.
+     * Used for O(1) deduplication / coalescing lookups.
      */
     private val entityIndex = mutableMapOf<String, String>()
 
-    override suspend fun enqueue(mutation: SyncMutation) = mutex.withLock {
-        // Deduplicate: if a mutation for the same entity already exists, remove it.
-        val existingId = entityIndex[mutation.entityKey]
-        if (existingId != null) {
-            queue.remove(existingId)
-        }
+    /**
+     * Retry-count tracker: mutation ID → number of failed push attempts.
+     * Tracked separately from [SyncMutation] so the data class stays immutable
+     * and free of queue-management concerns.
+     */
+    private val retryCounts = mutableMapOf<String, Int>()
 
-        queue[mutation.id] = mutation
-        entityIndex[mutation.entityKey] = mutation.id
+    private val _pendingCount = MutableStateFlow(0)
+
+    // ── Reactive state ──────────────────────────────────────────────────
+
+    override val pendingCountFlow: Flow<Int>
+        get() = _pendingCount
+
+    override val hasPendingMutations: Flow<Boolean>
+        get() = _pendingCount.map { it > 0 }
+
+    // ── Core operations ─────────────────────────────────────────────────
+
+    override suspend fun enqueue(mutation: SyncMutation): Unit = mutex.withLock {
+        enqueueInternal(mutation)
+        _pendingCount.value = queue.size
     }
+
+    override suspend fun enqueueAll(mutations: List<SyncMutation>): Unit = mutex.withLock {
+        for (mutation in mutations) {
+            enqueueInternal(mutation)
+        }
+        _pendingCount.value = queue.size
+    }
+
+    // ── Peek / query ────────────────────────────────────────────────────
 
     override suspend fun peek(): SyncMutation? = mutex.withLock {
         queue.values.firstOrNull()
     }
 
-    override suspend fun dequeue(id: String) = mutex.withLock {
-        val removed = queue.remove(id)
-        if (removed != null) {
-            entityIndex.remove(removed.entityKey)
+    override suspend fun peekBatch(limit: Int): List<SyncMutation> = mutex.withLock {
+        require(limit > 0) { "Limit must be positive, got $limit" }
+        queue.values.take(limit)
+    }
+
+    override suspend fun allPending(): List<SyncMutation> = mutex.withLock {
+        queue.values.toList()
+    }
+
+    override suspend fun getMutationsForRecord(
+        tableName: String,
+        recordId: String,
+    ): List<SyncMutation> = mutex.withLock {
+        val targetKey = "$tableName:$recordId"
+        queue.values.filter { it.entityKey == targetKey }
+    }
+
+    // ── Acknowledge / dequeue ───────────────────────────────────────────
+
+    override suspend fun dequeue(id: String): Unit = mutex.withLock {
+        removeInternal(id)
+        _pendingCount.value = queue.size
+    }
+
+    override suspend fun acknowledge(mutationIds: List<String>): Unit = mutex.withLock {
+        for (id in mutationIds) {
+            removeInternal(id)
+        }
+        _pendingCount.value = queue.size
+    }
+
+    // ── Retry / failure tracking ────────────────────────────────────────
+
+    override suspend fun markFailed(mutationIds: List<String>): Unit = mutex.withLock {
+        for (id in mutationIds) {
+            if (queue.containsKey(id)) {
+                retryCounts[id] = (retryCounts[id] ?: 0) + 1
+            }
         }
     }
+
+    override suspend fun getDeadLetterMutations(maxRetries: Int): List<SyncMutation> = mutex.withLock {
+        require(maxRetries > 0) { "maxRetries must be positive, got $maxRetries" }
+        queue.values.filter { mutation ->
+            (retryCounts[mutation.id] ?: 0) >= maxRetries
+        }
+    }
+
+    override suspend fun getRetryCount(mutationId: String): Int = mutex.withLock {
+        retryCounts[mutationId] ?: 0
+    }
+
+    // ── Count ───────────────────────────────────────────────────────────
 
     override suspend fun pendingCount(): Int = mutex.withLock {
         queue.size
     }
 
-    override suspend fun allPending(): List<SyncMutation> = mutex.withLock {
-        queue.values.toList()
+    // ── Administration ──────────────────────────────────────────────────
+
+    override suspend fun clear(): Unit = mutex.withLock {
+        queue.clear()
+        entityIndex.clear()
+        retryCounts.clear()
+        _pendingCount.value = 0
+    }
+
+    // ── Internal helpers ────────────────────────────────────────────────
+
+    /**
+     * Enqueue a single mutation with operation-aware coalescing.
+     * **Must** be called while holding [mutex].
+     */
+    private fun enqueueInternal(mutation: SyncMutation) {
+        val existingId = entityIndex[mutation.entityKey]
+        if (existingId != null) {
+            val existing = queue[existingId]
+            if (existing != null) {
+                val coalesced = coalesce(existing, mutation)
+
+                // Remove the old entry regardless of coalescing outcome.
+                queue.remove(existingId)
+                entityIndex.remove(existing.entityKey)
+                retryCounts.remove(existingId)
+
+                if (coalesced != null) {
+                    // Re-insert at the tail so it gets the latest FIFO position.
+                    queue[coalesced.id] = coalesced
+                    entityIndex[coalesced.entityKey] = coalesced.id
+                }
+                // coalesced == null → INSERT + DELETE cancelled each other out.
+                return
+            }
+        }
+
+        // No prior mutation for this entity key — append to tail.
+        queue[mutation.id] = mutation
+        entityIndex[mutation.entityKey] = mutation.id
+    }
+
+    /**
+     * Remove a single mutation by ID and clean up associated indexes.
+     * **Must** be called while holding [mutex].
+     */
+    private fun removeInternal(id: String) {
+        val removed = queue.remove(id)
+        if (removed != null) {
+            entityIndex.remove(removed.entityKey)
+        }
+        retryCounts.remove(id)
+    }
+
+    /**
+     * Determine the result of coalescing two mutations that target the same
+     * entity key.
+     *
+     * @return The coalesced mutation, or `null` if the two mutations cancel
+     *   each other out (INSERT + DELETE → no-op).
+     */
+    private fun coalesce(existing: SyncMutation, incoming: SyncMutation): SyncMutation? {
+        return when (existing.operation) {
+            MutationOperation.INSERT -> when (incoming.operation) {
+                // Duplicate INSERT — shouldn't normally happen; latest wins.
+                MutationOperation.INSERT -> incoming
+
+                // INSERT + UPDATE → INSERT with merged data.
+                // The record hasn't been synced yet, so the server still needs
+                // an INSERT — but with the latest field values.
+                MutationOperation.UPDATE -> existing.copy(
+                    id = incoming.id,
+                    rowData = existing.rowData + incoming.rowData,
+                    timestamp = incoming.timestamp,
+                )
+
+                // INSERT + DELETE → net no-op. The record was created locally
+                // and deleted before syncing — nothing to push.
+                MutationOperation.DELETE -> null
+            }
+
+            MutationOperation.UPDATE -> when (incoming.operation) {
+                // UPDATE + INSERT — unusual but possible after conflict
+                // resolution; treat the INSERT as authoritative.
+                MutationOperation.INSERT -> incoming
+
+                // UPDATE + UPDATE → single UPDATE with latest data.
+                MutationOperation.UPDATE -> incoming
+
+                // UPDATE + DELETE → DELETE supersedes the UPDATE.
+                MutationOperation.DELETE -> incoming
+            }
+
+            MutationOperation.DELETE -> when (incoming.operation) {
+                // DELETE + INSERT → re-creation; treat as INSERT.
+                MutationOperation.INSERT -> incoming
+
+                // DELETE + UPDATE — unusual; latest wins.
+                MutationOperation.UPDATE -> incoming
+
+                // DELETE + DELETE → idempotent.
+                MutationOperation.DELETE -> incoming
+            }
+        }
     }
 }

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/queue/MutationQueue.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/queue/MutationQueue.kt
@@ -3,21 +3,60 @@
 package com.finance.sync.queue
 
 import com.finance.sync.SyncMutation
+import kotlinx.coroutines.flow.Flow
 
 /**
  * A FIFO queue of [SyncMutation]s awaiting push to the sync backend.
  *
  * Implementations must be safe for concurrent access from multiple coroutines.
+ *
+ * Provides FIFO ordering guarantees for mutations. Mutations for the same
+ * record are coalesced when possible:
+ * - INSERT + UPDATE → INSERT with merged data
+ * - INSERT + DELETE → both removed (net no-op)
+ * - UPDATE + UPDATE → single UPDATE with latest data
+ * - UPDATE + DELETE → DELETE
  */
 interface MutationQueue {
+
+    // ── Reactive state ──────────────────────────────────────────────────
+
+    /**
+     * Number of mutations currently in the queue, as a reactive [Flow].
+     *
+     * Emits a new value every time the queue size changes.
+     */
+    val pendingCountFlow: Flow<Int>
+
+    /**
+     * Whether the queue has any pending mutations, as a reactive [Flow].
+     *
+     * Convenience projection of [pendingCountFlow] — emits `true` when the
+     * queue is non-empty, `false` when empty.
+     */
+    val hasPendingMutations: Flow<Boolean>
+
+    // ── Core operations ─────────────────────────────────────────────────
 
     /**
      * Add a mutation to the tail of the queue.
      *
      * If a mutation for the same [SyncMutation.entityKey] is already enqueued,
-     * the implementation may (but is not required to) deduplicate.
+     * the implementation coalesces the mutations according to operation-aware
+     * rules (see class-level KDoc).
      */
     suspend fun enqueue(mutation: SyncMutation)
+
+    /**
+     * Add multiple mutations atomically.
+     *
+     * Coalescing rules apply to each mutation against the existing queue state
+     * and against earlier items in [mutations]. All insertions happen under a
+     * single lock acquisition.
+     */
+    suspend fun enqueueAll(mutations: List<SyncMutation>)
+
+    // ── Peek / query ────────────────────────────────────────────────────
 
     /**
      * Return the mutation at the head of the queue without removing it,
@@ -26,18 +65,95 @@ interface MutationQueue {
     suspend fun peek(): SyncMutation?
 
     /**
+     * Peek at the next batch of mutations to process.
+     * Does not remove them from the queue.
+     *
+     * @param limit Maximum number of mutations to return.
+     * @return Up to [limit] mutations in FIFO order; empty list if the queue
+     *   is empty.
+     */
+    suspend fun peekBatch(limit: Int = 100): List<SyncMutation>
+
+    /**
+     * Return a snapshot of all pending mutations in FIFO order.
+     */
+    suspend fun allPending(): List<SyncMutation>
+
+    /**
+     * Get all mutations for a specific record.
+     *
+     * Useful for checking if there are pending local changes for a record
+     * before applying a pull from the server.
+     *
+     * @param tableName The table the record belongs to.
+     * @param recordId The record's primary-key value (`rowData["id"]`).
+     * @return All queued mutations whose [SyncMutation.entityKey] matches
+     *   `"$tableName:$recordId"`.
+     */
+    suspend fun getMutationsForRecord(tableName: String, recordId: String): List<SyncMutation>
+
+    // ── Acknowledge / dequeue ───────────────────────────────────────────
+
+    /**
      * Remove the mutation with the given [id] from the queue.
      * No-op if the ID is not found.
      */
     suspend fun dequeue(id: String)
 
     /**
+     * Remove successfully processed mutations from the queue.
+     *
+     * This is the batch equivalent of [dequeue] — removes every mutation
+     * whose ID appears in [mutationIds] and cleans up associated retry state.
+     *
+     * @param mutationIds IDs of mutations that were successfully synced.
+     */
+    suspend fun acknowledge(mutationIds: List<String>)
+
+    // ── Retry / failure tracking ────────────────────────────────────────
+
+    /**
+     * Mark mutations as failed, incrementing their internal retry count.
+     *
+     * Mutations whose retry count reaches a configured maximum can be
+     * retrieved via [getDeadLetterMutations].
+     *
+     * @param mutationIds IDs of mutations that failed on this push attempt.
+     */
+    suspend fun markFailed(mutationIds: List<String>)
+
+    /**
+     * Get mutations that have exceeded the maximum retry threshold.
+     *
+     * These mutations need manual intervention or will be dropped.
+     *
+     * @param maxRetries The retry threshold. Mutations with a retry count
+     *   **≥** this value are considered dead-lettered.
+     * @return Dead-lettered mutations in FIFO order.
+     */
+    suspend fun getDeadLetterMutations(maxRetries: Int = 5): List<SyncMutation>
+
+    /**
+     * Get the current retry count for a mutation.
+     *
+     * @return The number of times [markFailed] has been called for this
+     *   mutation, or `0` if the mutation has never failed (or does not exist).
+     */
+    suspend fun getRetryCount(mutationId: String): Int
+
+    // ── Count ───────────────────────────────────────────────────────────
+
+    /**
      * The number of mutations currently waiting to be pushed.
      */
     suspend fun pendingCount(): Int
 
+    // ── Administration ──────────────────────────────────────────────────
+
     /**
-     * Return a snapshot of all pending mutations in FIFO order.
+     * Remove all mutations and associated retry state from the queue.
+     *
+     * Use with caution — typically only on user sign-out or full-resync.
      */
-    suspend fun allPending(): List<SyncMutation>
+    suspend fun clear()
 }

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/queue/QueueProcessor.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/queue/QueueProcessor.kt
@@ -2,15 +2,96 @@
 
 package com.finance.sync.queue
 
+import com.finance.sync.SyncMutation
 import com.finance.sync.SyncProvider
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.flow
 import kotlin.math.min
 import kotlin.math.pow
+import kotlin.random.Random
+
+// ── New batch-processing types ──────────────────────────────────────────
+
+/**
+ * Observable processing state for the queue processor.
+ */
+sealed class ProcessingState {
+    /** No processing activity. */
+    data object Idle : ProcessingState()
+
+    /**
+     * Currently processing a batch of mutations.
+     *
+     * @property batchSize Total mutations in the current batch.
+     * @property processed Number of mutations processed so far across all
+     *   batches in the current [QueueProcessor.processAll] invocation.
+     */
+    data class Processing(val batchSize: Int, val processed: Int) : ProcessingState()
+
+    /** Waiting before retrying a failed batch (backoff in progress). */
+    data object WaitingForRetry : ProcessingState()
+
+    /**
+     * A non-retryable or exhausted-retries error halted processing.
+     *
+     * @property error Human-readable description of the failure(s).
+     */
+    data class Failed(val error: String) : ProcessingState()
+}
+
+/**
+ * Aggregate result of processing one or more batches of mutations.
+ *
+ * @property succeeded Mutations that were pushed and acknowledged.
+ * @property failed Mutations that failed with non-retryable errors (removed).
+ * @property retryable Mutations that failed but are eligible for retry.
+ * @property deadLettered Mutations whose retry count reached the maximum.
+ */
+data class ProcessingResult(
+    val succeeded: Int,
+    val failed: Int,
+    val retryable: Int,
+    val deadLettered: Int,
+)
+
+/**
+ * Result from pushing a batch of mutations to the server.
+ *
+ * Allows partial success: some mutations may succeed while others fail.
+ *
+ * @property succeeded IDs of mutations the server accepted.
+ * @property failed Details about each mutation that the server rejected.
+ */
+data class PushResult(
+    val succeeded: List<String>,
+    val failed: List<PushFailure>,
+)
+
+/**
+ * Details about a single mutation push failure.
+ *
+ * @property mutationId The ID of the mutation that failed.
+ * @property error Human-readable error description.
+ * @property retryable `true` if the failure is transient and the mutation
+ *   should be retried; `false` if it is permanent (e.g., validation error).
+ */
+data class PushFailure(
+    val mutationId: String,
+    val error: String,
+    val retryable: Boolean,
+)
+
+// ── Legacy status (kept for backward compatibility) ─────────────────────
 
 /**
  * Status of the [QueueProcessor]'s push cycle.
+ *
+ * **Legacy API** — prefer observing [QueueProcessor.state] ([ProcessingState])
+ * for new code.
  */
 sealed class QueueProcessorStatus {
     /** No mutations to process. */
@@ -26,36 +107,332 @@ sealed class QueueProcessorStatus {
     data object Completed : QueueProcessorStatus()
 }
 
+// ── Processor ───────────────────────────────────────────────────────────
+
 /**
- * Drains the [MutationQueue] by pushing mutations through a [SyncProvider].
+ * Processes mutations from the [MutationQueue] and pushes them to the sync
+ * backend.
  *
  * Features:
- * - **Deduplication**: only the latest mutation per entity key is pushed.
- * - **Exponential back-off**: initial delay 1 s, factor 2, max 5 min.
- * - **Max retries**: 10 attempts per mutation before it is abandoned.
- * - **Status flow**: callers observe progress via [process].
+ * - **Batch processing**: pushes up to [batchSize] mutations per round-trip.
+ * - **Partial failure handling**: successfully pushed mutations are
+ *   acknowledged even when others in the same batch fail.
+ * - **Exponential backoff with jitter**: retries use
+ *   `min(baseMs × 2^retryCount, maxMs) × jitter` to avoid thundering herds.
+ * - **Dead-letter detection**: mutations exceeding [maxRetries] are skipped
+ *   and reported.
+ * - **Observable state**: callers observe progress via [state].
  *
- * @property queue     The mutation queue to drain.
- * @property provider  The sync backend to push mutations through.
- * @property maxRetries            Maximum push attempts per mutation (default 10).
- * @property initialBackoffMs      Initial back-off delay in milliseconds (default 1 000).
- * @property maxBackoffMs          Ceiling for back-off delay in milliseconds (default 300 000 = 5 min).
- * @property backoffFactor         Multiplier applied to the delay after each failure (default 2.0).
+ * Two constructor overloads are provided:
+ * 1. **Primary** — accepts a `pushFn` lambda for maximum flexibility.
+ * 2. **Legacy** — accepts a [SyncProvider] and wraps its `push()` method.
+ *
+ * @property queue         The mutation queue to drain.
+ * @property pushFn        Function that pushes a batch to the server and
+ *   returns a [PushResult] indicating per-mutation success/failure.
+ * @property batchSize     Number of mutations per push batch (default 50).
+ * @property maxRetries    Maximum retry attempts before dead-lettering
+ *   (default 5).
+ * @property baseBackoffMs Base delay for exponential backoff (default 1 000).
+ * @property maxBackoffMs  Ceiling for backoff delay (default 60 000).
  */
-class QueueProcessor(
+class QueueProcessor private constructor(
     private val queue: MutationQueue,
-    private val provider: SyncProvider,
-    private val maxRetries: Int = MAX_RETRIES,
-    private val initialBackoffMs: Long = INITIAL_BACKOFF_MS,
-    private val maxBackoffMs: Long = MAX_BACKOFF_MS,
-    private val backoffFactor: Double = BACKOFF_FACTOR,
+    private val pushFn: suspend (List<SyncMutation>) -> PushResult,
+    private val batchSize: Int,
+    private val maxRetries: Int,
+    private val baseBackoffMs: Long,
+    private val maxBackoffMs: Long,
+    private val backoffFactor: Double,
 ) {
 
+    // ── Public constructors ─────────────────────────────────────────────
+
     /**
-     * Start processing the queue.
+     * Primary constructor — uses a [pushFn] lambda to push mutations.
+     */
+    constructor(
+        queue: MutationQueue,
+        pushFn: suspend (List<SyncMutation>) -> PushResult,
+        batchSize: Int = DEFAULT_BATCH_SIZE,
+        maxRetries: Int = DEFAULT_MAX_RETRIES,
+        baseBackoffMs: Long = DEFAULT_BASE_BACKOFF_MS,
+        maxBackoffMs: Long = DEFAULT_MAX_BACKOFF_MS,
+    ) : this(
+        queue = queue,
+        pushFn = pushFn,
+        batchSize = batchSize,
+        maxRetries = maxRetries,
+        baseBackoffMs = baseBackoffMs,
+        maxBackoffMs = maxBackoffMs,
+        backoffFactor = BACKOFF_FACTOR,
+    )
+
+    /**
+     * Legacy constructor — wraps a [SyncProvider] into a [PushResult]-based
+     * push function.
+     *
+     * Maintained for backward compatibility with code that already uses
+     * [SyncProvider] directly.
+     */
+    constructor(
+        queue: MutationQueue,
+        provider: SyncProvider,
+        maxRetries: Int = MAX_RETRIES,
+        initialBackoffMs: Long = INITIAL_BACKOFF_MS,
+        maxBackoffMs: Long = MAX_BACKOFF_MS,
+        backoffFactor: Double = BACKOFF_FACTOR,
+    ) : this(
+        queue = queue,
+        pushFn = { mutations ->
+            val result = provider.push(mutations)
+            if (result.isSuccess) {
+                PushResult(
+                    succeeded = mutations.map { it.id },
+                    failed = emptyList(),
+                )
+            } else {
+                val error = result.exceptionOrNull()?.message ?: "Unknown error"
+                PushResult(
+                    succeeded = emptyList(),
+                    failed = mutations.map {
+                        PushFailure(it.id, error, retryable = true)
+                    },
+                )
+            }
+        },
+        batchSize = 1, // Legacy API processes one mutation at a time.
+        maxRetries = maxRetries,
+        baseBackoffMs = initialBackoffMs,
+        maxBackoffMs = maxBackoffMs,
+        backoffFactor = backoffFactor,
+    )
+
+    // ── Observable state ────────────────────────────────────────────────
+
+    private val _state = MutableStateFlow<ProcessingState>(ProcessingState.Idle)
+
+    /** Observable processing state. */
+    val state: StateFlow<ProcessingState> = _state.asStateFlow()
+
+    // ── New batch API ───────────────────────────────────────────────────
+
+    /**
+     * Process the next batch of mutations.
+     *
+     * Peeks at up to [batchSize] mutations, pushes them via [pushFn], then
+     * acknowledges successes and marks failures. Dead-lettered mutations
+     * (those at or above [maxRetries]) are counted but left in the queue
+     * for manual inspection via [MutationQueue.getDeadLetterMutations].
+     *
+     * @return The result of the processing attempt.
+     */
+    suspend fun processNextBatch(): ProcessingResult {
+        val batch = queue.peekBatch(batchSize)
+        if (batch.isEmpty()) {
+            _state.value = ProcessingState.Idle
+            return ProcessingResult(succeeded = 0, failed = 0, retryable = 0, deadLettered = 0)
+        }
+
+        _state.value = ProcessingState.Processing(batchSize = batch.size, processed = 0)
+
+        val result = pushFn(batch)
+
+        // Acknowledge successfully pushed mutations.
+        if (result.succeeded.isNotEmpty()) {
+            queue.acknowledge(result.succeeded)
+        }
+
+        // Categorise failures.
+        var retryable = 0
+        var deadLettered = 0
+        var permanentlyFailed = 0
+
+        val retryableIds = mutableListOf<String>()
+        val nonRetryableIds = mutableListOf<String>()
+
+        for (failure in result.failed) {
+            if (failure.retryable) {
+                retryableIds.add(failure.mutationId)
+            } else {
+                nonRetryableIds.add(failure.mutationId)
+            }
+        }
+
+        // Increment retry counts for retryable failures.
+        if (retryableIds.isNotEmpty()) {
+            queue.markFailed(retryableIds)
+            for (id in retryableIds) {
+                val count = queue.getRetryCount(id)
+                if (count >= maxRetries) {
+                    deadLettered++
+                } else {
+                    retryable++
+                }
+            }
+        }
+
+        // Non-retryable failures are removed from the queue immediately.
+        if (nonRetryableIds.isNotEmpty()) {
+            queue.acknowledge(nonRetryableIds)
+            permanentlyFailed = nonRetryableIds.size
+        }
+
+        val processingResult = ProcessingResult(
+            succeeded = result.succeeded.size,
+            failed = permanentlyFailed,
+            retryable = retryable,
+            deadLettered = deadLettered,
+        )
+
+        // Transition observable state.
+        _state.value = when {
+            retryable > 0 -> ProcessingState.WaitingForRetry
+            permanentlyFailed > 0 || deadLettered > 0 -> {
+                val errorMsgs = result.failed.joinToString("; ") { it.error }
+                ProcessingState.Failed(errorMsgs)
+            }
+            else -> ProcessingState.Idle
+        }
+
+        return processingResult
+    }
+
+    /**
+     * Process all pending mutations in the queue.
+     *
+     * Continues draining the queue in [batchSize]-sized chunks until:
+     * - The queue is empty, or
+     * - Only dead-lettered mutations remain, or
+     * - All mutations in a batch fail with non-retryable errors.
+     *
+     * Backoff delays are applied when retried mutations are present.
+     *
+     * @return Aggregate [ProcessingResult] covering all batches.
+     */
+    suspend fun processAll(): ProcessingResult {
+        var totalSucceeded = 0
+        var totalFailed = 0
+        var totalRetryable = 0
+        var totalDeadLettered = 0
+
+        while (true) {
+            val pending = queue.peekBatch(batchSize)
+            if (pending.isEmpty()) break
+
+            // Filter out dead-lettered mutations.
+            val processable = mutableListOf<SyncMutation>()
+            var skippedDead = 0
+            for (mutation in pending) {
+                if (queue.getRetryCount(mutation.id) >= maxRetries) {
+                    skippedDead++
+                } else {
+                    processable.add(mutation)
+                }
+            }
+
+            if (processable.isEmpty()) {
+                // Only dead-letter mutations remain — stop processing.
+                totalDeadLettered += skippedDead
+                break
+            }
+
+            // Apply backoff if any mutation has been retried.
+            val maxRetryCount = processable.maxOf { queue.getRetryCount(it.id) }
+            if (maxRetryCount > 0) {
+                _state.value = ProcessingState.WaitingForRetry
+                val backoff = calculateBackoff(maxRetryCount)
+                delay(backoff)
+            }
+
+            _state.value = ProcessingState.Processing(
+                batchSize = processable.size,
+                processed = totalSucceeded,
+            )
+
+            val result = pushFn(processable)
+
+            // Acknowledge successes.
+            if (result.succeeded.isNotEmpty()) {
+                queue.acknowledge(result.succeeded)
+                totalSucceeded += result.succeeded.size
+            }
+
+            // Handle failures.
+            val retryableIds = mutableListOf<String>()
+            val nonRetryableIds = mutableListOf<String>()
+
+            for (failure in result.failed) {
+                if (failure.retryable) {
+                    retryableIds.add(failure.mutationId)
+                } else {
+                    nonRetryableIds.add(failure.mutationId)
+                }
+            }
+
+            if (retryableIds.isNotEmpty()) {
+                queue.markFailed(retryableIds)
+                for (id in retryableIds) {
+                    val count = queue.getRetryCount(id)
+                    if (count >= maxRetries) {
+                        totalDeadLettered++
+                    } else {
+                        totalRetryable++
+                    }
+                }
+            }
+
+            if (nonRetryableIds.isNotEmpty()) {
+                queue.acknowledge(nonRetryableIds)
+                totalFailed += nonRetryableIds.size
+            }
+
+            // If nothing succeeded and nothing is retryable, stop.
+            if (result.succeeded.isEmpty() && retryableIds.isEmpty()) {
+                val errorMsgs = result.failed.joinToString("; ") { it.error }
+                _state.value = ProcessingState.Failed(errorMsgs)
+                totalFailed += nonRetryableIds.size - nonRetryableIds.size // already counted
+                break
+            }
+        }
+
+        _state.value = ProcessingState.Idle
+        return ProcessingResult(
+            succeeded = totalSucceeded,
+            failed = totalFailed,
+            retryable = totalRetryable,
+            deadLettered = totalDeadLettered,
+        )
+    }
+
+    /**
+     * Calculate backoff delay with jitter.
+     *
+     * Formula: `min(baseMs × 2^(retryCount−1), maxMs) × (0.5 + random(0, 0.5))`
+     *
+     * The jitter factor (0.5–1.0×) prevents thundering-herd problems when
+     * many clients retry simultaneously.
+     *
+     * @param retryCount The retry attempt number (1-based).
+     * @return Delay in milliseconds.
+     */
+    fun calculateBackoff(retryCount: Int): Long {
+        val exponential = baseBackoffMs * BACKOFF_FACTOR.pow(retryCount - 1)
+        val capped = min(exponential.toLong(), maxBackoffMs)
+        val jitter = 0.5 + Random.nextDouble() * 0.5
+        return (capped * jitter).toLong()
+    }
+
+    // ── Legacy API (backward compatible) ────────────────────────────────
+
+    /**
+     * Start processing the queue one mutation at a time.
      *
      * Returns a cold [Flow] that emits [QueueProcessorStatus] updates.
-     * The flow completes when the queue is empty or a mutation exhausts its retries.
+     * The flow completes when the queue is empty or a mutation exhausts its
+     * retries.
+     *
+     * **Legacy API** — prefer [processNextBatch] or [processAll] for new code.
      */
     fun process(): Flow<QueueProcessorStatus> = flow {
         emit(QueueProcessorStatus.Idle)
@@ -67,9 +444,9 @@ class QueueProcessor(
             var pushed = false
 
             while (attempt < maxRetries) {
-                val result = provider.push(listOf(mutation))
+                val result = pushFn(listOf(mutation))
 
-                if (result.isSuccess) {
+                if (result.succeeded.contains(mutation.id)) {
                     queue.dequeue(mutation.id)
                     pushed = true
                     break
@@ -78,10 +455,16 @@ class QueueProcessor(
                 attempt++
 
                 if (attempt >= maxRetries) {
-                    val error = result.exceptionOrNull()
-                        ?: RuntimeException("Push failed after $maxRetries attempts")
-                    emit(QueueProcessorStatus.Failed(mutation.id, error))
-                    // Remove the permanently-failed mutation so the queue isn't stuck.
+                    val errorMsg = result.failed.firstOrNull()?.error
+                        ?: "Push failed after $maxRetries attempts"
+                    emit(
+                        QueueProcessorStatus.Failed(
+                            mutation.id,
+                            RuntimeException(errorMsg),
+                        ),
+                    )
+                    // Remove the permanently-failed mutation so the queue
+                    // isn't stuck.
                     queue.dequeue(mutation.id)
                     break
                 }
@@ -103,16 +486,37 @@ class QueueProcessor(
 
     /**
      * Compute the back-off delay for the given [attempt] (1-based).
+     *
+     * **Legacy API** — prefer [calculateBackoff] for new code.
      */
     internal fun computeBackoff(attempt: Int): Long {
-        val raw = initialBackoffMs * backoffFactor.pow(attempt - 1)
+        val raw = baseBackoffMs * backoffFactor.pow(attempt - 1)
         return min(raw.toLong(), maxBackoffMs)
     }
 
     companion object {
+        /** @suppress Legacy constant — use [DEFAULT_MAX_RETRIES] for new code. */
         const val MAX_RETRIES = 10
+
+        /** @suppress Legacy constant — use [DEFAULT_BASE_BACKOFF_MS] for new code. */
         const val INITIAL_BACKOFF_MS = 1_000L
-        const val MAX_BACKOFF_MS = 300_000L // 5 minutes
+
+        /** Default maximum retries for the new batch API. */
+        const val DEFAULT_MAX_RETRIES = 5
+
+        /** Default batch size for [processNextBatch] / [processAll]. */
+        const val DEFAULT_BATCH_SIZE = 50
+
+        /** Default base backoff delay in milliseconds. */
+        const val DEFAULT_BASE_BACKOFF_MS = 1_000L
+
+        /** Maximum backoff delay in milliseconds (5 minutes). */
+        const val MAX_BACKOFF_MS = 300_000L
+
+        /** Default maximum backoff delay for the new batch API (60 seconds). */
+        const val DEFAULT_MAX_BACKOFF_MS = 60_000L
+
+        /** Backoff multiplier applied after each failed attempt. */
         const val BACKOFF_FACTOR = 2.0
     }
 }

--- a/packages/sync/src/commonTest/kotlin/com/finance/sync/DefaultSyncEngineTest.kt
+++ b/packages/sync/src/commonTest/kotlin/com/finance/sync/DefaultSyncEngineTest.kt
@@ -1,0 +1,414 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.sync
+
+import com.finance.sync.delta.DeltaSyncManager
+import com.finance.sync.delta.InMemorySequenceTracker
+import com.finance.sync.queue.InMemoryMutationQueue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DefaultSyncEngineTest {
+
+    private val config = SyncConfig(
+        endpoint = "https://sync.example.com",
+        databaseName = "test.db",
+        syncIntervalMs = 5_000L,
+        maxRetryAttempts = 3,
+        retryBackoffBaseMs = 100L,
+        retryBackoffMaxMs = 1_000L,
+    )
+
+    private val testCredentials = SyncCredentials(
+        authToken = "test-token",
+        userId = "user-123",
+    )
+
+    private fun createEngine(
+        provider: SyncProvider = FakeSyncProvider(),
+        healthListener: SyncHealthListener? = null,
+        credentialRefresher: (suspend () -> SyncCredentials)? = null,
+    ): DefaultSyncEngine {
+        val queue = InMemoryMutationQueue()
+        val tracker = InMemorySequenceTracker()
+        val deltaSyncManager = DeltaSyncManager(provider, tracker, config)
+        return DefaultSyncEngine(
+            config = config,
+            provider = provider,
+            mutationQueue = queue,
+            deltaSyncManager = deltaSyncManager,
+            healthListener = healthListener,
+            credentialRefresher = credentialRefresher,
+        )
+    }
+
+    // ── Connection lifecycle ────────────────────────────────────────
+
+    @Test
+    fun connectSetsStatusToConnected() = runTest {
+        val engine = createEngine()
+        engine.connect(testCredentials)
+
+        assertTrue(engine.isConnected.value)
+        assertEquals(SyncStatus.Connected, engine.status.value)
+    }
+
+    @Test
+    fun connectIsNoOpWhenAlreadyConnected() = runTest {
+        val provider = FakeSyncProvider()
+        val engine = createEngine(provider)
+
+        engine.connect(testCredentials)
+        engine.connect(testCredentials) // second call
+
+        assertEquals(1, provider.connectCount)
+    }
+
+    @Test
+    fun connectSetsErrorStatusOnFailure() = runTest {
+        val provider = FakeSyncProvider(connectShouldFail = true)
+        val engine = createEngine(provider)
+
+        engine.connect(testCredentials)
+
+        assertFalse(engine.isConnected.value)
+        assertIs<SyncStatus.Error>(engine.status.value)
+    }
+
+    @Test
+    fun disconnectSetsStatusToDisconnected() = runTest {
+        val engine = createEngine()
+        engine.connect(testCredentials)
+        engine.disconnect()
+
+        assertFalse(engine.isConnected.value)
+        assertEquals(SyncStatus.Disconnected, engine.status.value)
+    }
+
+    @Test
+    fun disconnectIsNoOpWhenNotConnected() = runTest {
+        val provider = FakeSyncProvider()
+        val engine = createEngine(provider)
+
+        engine.disconnect() // should not throw
+
+        assertEquals(0, provider.disconnectCount)
+    }
+
+    // ── Single sync cycle ───────────────────────────────────────────
+
+    @Test
+    fun syncNowReturnsSuccessOnCleanCycle() = runTest {
+        val engine = createEngine()
+        engine.connect(testCredentials)
+
+        val result = engine.syncNow()
+
+        assertIs<SyncResult.Success>(result)
+        assertEquals(0, result.changesApplied)
+        assertEquals(0, result.mutationsPushed)
+        assertEquals(0, result.conflictsResolved)
+    }
+
+    @Test
+    fun syncNowReturnsFailureOnProviderError() = runTest {
+        val provider = FakeSyncProvider(pullShouldFail = true)
+        val engine = createEngine(provider)
+        engine.connect(testCredentials)
+
+        val result = engine.syncNow()
+
+        assertIs<SyncResult.Failure>(result)
+    }
+
+    @Test
+    fun syncNowResetsConsecutiveFailuresOnSuccess() = runTest {
+        val provider = FakeSyncProvider()
+        val engine = createEngine(provider)
+        engine.connect(testCredentials)
+
+        // First call fails
+        provider.pullShouldFail = true
+        engine.syncNow()
+
+        // Second call succeeds
+        provider.pullShouldFail = false
+        val result = engine.syncNow()
+
+        assertIs<SyncResult.Success>(result)
+        assertEquals(SyncStatus.Connected, engine.status.value)
+    }
+
+    // ── Health listener ─────────────────────────────────────────────
+
+    @Test
+    fun syncNowReportsSuccessToHealthListener() = runTest {
+        val listener = RecordingHealthListener()
+        val engine = createEngine(healthListener = listener)
+        engine.connect(testCredentials)
+
+        engine.syncNow()
+
+        assertEquals(1, listener.successes.size)
+        assertTrue(listener.failures.isEmpty())
+    }
+
+    @Test
+    fun syncNowReportsFailureToHealthListener() = runTest {
+        val provider = FakeSyncProvider(pullShouldFail = true)
+        val listener = RecordingHealthListener()
+        val engine = createEngine(provider = provider, healthListener = listener)
+        engine.connect(testCredentials)
+
+        engine.syncNow()
+
+        assertEquals(1, listener.failures.size)
+        assertTrue(listener.successes.isEmpty())
+    }
+
+    @Test
+    fun syncNowReportsPendingMutationCount() = runTest {
+        val listener = RecordingHealthListener()
+        val engine = createEngine(healthListener = listener)
+        engine.connect(testCredentials)
+
+        engine.syncNow()
+
+        // Should have reported pending count at least once (at start of cycle)
+        assertTrue(listener.pendingChanges.isNotEmpty())
+    }
+
+    // ── Credential refresh ──────────────────────────────────────────
+
+    @Test
+    fun syncNowRefreshesExpiringCredentials() = runTest {
+        var refreshCalled = false
+        val now = Clock.System.now()
+
+        val refreshedCredentials = SyncCredentials(
+            authToken = "refreshed-token",
+            userId = "user-123",
+            expiresAt = Instant.fromEpochMilliseconds(
+                now.toEpochMilliseconds() + 3_600_000L,
+            ),
+        )
+
+        // Credentials that are about to expire (within 60s buffer)
+        val expiringCredentials = SyncCredentials(
+            authToken = "expiring-token",
+            userId = "user-123",
+            expiresAt = Instant.fromEpochMilliseconds(
+                now.toEpochMilliseconds() + 30_000L,
+            ),
+        )
+
+        val engine = createEngine(
+            credentialRefresher = {
+                refreshCalled = true
+                refreshedCredentials
+            },
+        )
+
+        engine.connect(expiringCredentials)
+        engine.syncNow()
+
+        assertTrue(refreshCalled)
+    }
+
+    @Test
+    fun syncNowSkipsRefreshWhenCredentialsAreValid() = runTest {
+        var refreshCalled = false
+        val now = Clock.System.now()
+
+        // Credentials that expire far in the future
+        val validCredentials = SyncCredentials(
+            authToken = "valid-token",
+            userId = "user-123",
+            expiresAt = Instant.fromEpochMilliseconds(
+                now.toEpochMilliseconds() + 3_600_000L,
+            ),
+        )
+
+        val engine = createEngine(
+            credentialRefresher = {
+                refreshCalled = true
+                validCredentials
+            },
+        )
+
+        engine.connect(validCredentials)
+        engine.syncNow()
+
+        assertFalse(refreshCalled)
+    }
+
+    @Test
+    fun syncNowContinuesWhenRefreshFails() = runTest {
+        val now = Clock.System.now()
+
+        val expiringCredentials = SyncCredentials(
+            authToken = "expiring-token",
+            userId = "user-123",
+            expiresAt = Instant.fromEpochMilliseconds(
+                now.toEpochMilliseconds() + 30_000L,
+            ),
+        )
+
+        val engine = createEngine(
+            credentialRefresher = {
+                throw RuntimeException("Refresh failed")
+            },
+        )
+
+        engine.connect(expiringCredentials)
+        val result = engine.syncNow()
+
+        // Should still complete the sync cycle (with existing credentials)
+        assertIs<SyncResult.Success>(result)
+    }
+
+    // ── Start / stop lifecycle ──────────────────────────────────────
+
+    @Test
+    fun isRunningReturnsFalseInitially() {
+        val engine = createEngine()
+        assertFalse(engine.isRunning())
+    }
+
+    @Test
+    fun stopCancelsRunningLoop() = runTest {
+        val engine = createEngine()
+
+        val startJob = async { engine.start(testCredentials) }
+        advanceTimeBy(100)
+
+        assertTrue(engine.isRunning())
+
+        engine.stop()
+        advanceUntilIdle()
+
+        assertFalse(engine.isRunning())
+        assertFalse(engine.isConnected.value)
+    }
+
+    @Test
+    fun stopIsIdempotent() = runTest {
+        val engine = createEngine()
+        engine.connect(testCredentials)
+
+        // Multiple stops should not throw
+        engine.stop()
+        engine.stop()
+        engine.stop()
+
+        assertFalse(engine.isConnected.value)
+    }
+
+    // ── Status flow ─────────────────────────────────────────────────
+
+    @Test
+    fun syncFlowReturnsStatusUpdates() = runTest {
+        val engine = createEngine()
+        val flow = engine.sync()
+
+        // Initially idle
+        engine.connect(testCredentials)
+
+        // After connect, should be Connected
+        assertEquals(SyncStatus.Connected, engine.status.value)
+    }
+}
+
+// ── Test helpers ────────────────────────────────────────────────────
+
+/**
+ * Recording implementation of [SyncHealthListener] for test assertions.
+ */
+class RecordingHealthListener : SyncHealthListener {
+    val successes = mutableListOf<Pair<Long, Int>>()
+    val failures = mutableListOf<SyncError>()
+    val pendingChanges = mutableListOf<Int>()
+
+    override fun onSyncSuccess(durationMs: Long, pendingMutations: Int) {
+        successes.add(durationMs to pendingMutations)
+    }
+
+    override fun onSyncFailure(error: SyncError) {
+        failures.add(error)
+    }
+
+    override fun onPendingMutationsChanged(count: Int) {
+        pendingChanges.add(count)
+    }
+}
+
+/**
+ * Minimal [SyncProvider] fake for unit testing.
+ *
+ * All operations succeed by default; individual operations can be configured
+ * to fail via constructor flags or mutable properties.
+ */
+class FakeSyncProvider(
+    var connectShouldFail: Boolean = false,
+    var pullShouldFail: Boolean = false,
+    var pushShouldFail: Boolean = false,
+) : SyncProvider {
+
+    var connectCount = 0
+        private set
+
+    var disconnectCount = 0
+        private set
+
+    var pushCount = 0
+        private set
+
+    override suspend fun initialize(config: SyncConfig) {
+        // No-op
+    }
+
+    override suspend fun connect(credentials: SyncCredentials, config: SyncConfig) {
+        if (connectShouldFail) throw RuntimeException("Simulated connect failure")
+        connectCount++
+    }
+
+    override suspend fun disconnect() {
+        disconnectCount++
+    }
+
+    override suspend fun push(mutations: List<SyncMutation>): Result<Unit> {
+        pushCount++
+        return if (pushShouldFail) {
+            Result.failure(RuntimeException("Simulated push failure"))
+        } else {
+            Result.success(Unit)
+        }
+    }
+
+    override fun pull(): Flow<List<SyncChange>> = emptyFlow()
+
+    override fun getStatus(): Flow<SyncStatus> = emptyFlow()
+
+    override suspend fun pullChanges(since: Map<String, Long>): PullResult {
+        if (pullShouldFail) throw RuntimeException("Simulated pull failure")
+        return PullResult(
+            changes = emptyList(),
+            newVersions = since,
+            hasMore = false,
+        )
+    }
+}

--- a/packages/sync/src/commonTest/kotlin/com/finance/sync/SyncClientTest.kt
+++ b/packages/sync/src/commonTest/kotlin/com/finance/sync/SyncClientTest.kt
@@ -1,0 +1,350 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.sync
+
+import com.finance.sync.auth.AuthCredentials
+import com.finance.sync.auth.AuthManager
+import com.finance.sync.auth.AuthSession
+import com.finance.sync.delta.DeltaSyncManager
+import com.finance.sync.delta.InMemorySequenceTracker
+import com.finance.sync.queue.InMemoryMutationQueue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SyncClientTest {
+
+    private val config = SyncConfig(
+        endpoint = "https://sync.example.com",
+        databaseName = "test.db",
+        syncIntervalMs = 5_000L,
+        maxRetryAttempts = 3,
+        retryBackoffBaseMs = 100L,
+        retryBackoffMaxMs = 1_000L,
+    )
+
+    private fun createTestComponents(
+        authManager: FakeAuthManager = FakeAuthManager(),
+        provider: FakeSyncProvider = FakeSyncProvider(),
+    ): TestComponents {
+        val queue = InMemoryMutationQueue()
+        val tracker = InMemorySequenceTracker()
+        val deltaSyncManager = DeltaSyncManager(provider, tracker, config)
+        val engine = DefaultSyncEngine(
+            config = config,
+            provider = provider,
+            mutationQueue = queue,
+            deltaSyncManager = deltaSyncManager,
+        )
+        return TestComponents(
+            authManager = authManager,
+            provider = provider,
+            queue = queue,
+            engine = engine,
+        )
+    }
+
+    private data class TestComponents(
+        val authManager: FakeAuthManager,
+        val provider: FakeSyncProvider,
+        val queue: InMemoryMutationQueue,
+        val engine: DefaultSyncEngine,
+    )
+
+    // ── signInAndSync ───────────────────────────────────────────────
+
+    @Test
+    fun signInAndSyncSucceedsWithValidCredentials() = runTest {
+        val components = createTestComponents()
+        val client = SyncClient(
+            config = config,
+            authManager = components.authManager,
+            syncEngine = components.engine,
+            mutationQueue = components.queue,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
+        )
+
+        val result = client.signInAndSync(
+            AuthCredentials.EmailPassword("test@example.com", "password"),
+        )
+
+        assertTrue(result.isSuccess)
+        assertTrue(components.authManager.isAuthenticated.value)
+
+        client.destroy()
+    }
+
+    @Test
+    fun signInAndSyncFailsWithInvalidCredentials() = runTest {
+        val authManager = FakeAuthManager(signInShouldFail = true)
+        val components = createTestComponents(authManager = authManager)
+        val client = SyncClient(
+            config = config,
+            authManager = components.authManager,
+            syncEngine = components.engine,
+            mutationQueue = components.queue,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
+        )
+
+        val result = client.signInAndSync(
+            AuthCredentials.EmailPassword("bad@example.com", "wrong"),
+        )
+
+        assertTrue(result.isFailure)
+        assertFalse(components.authManager.isAuthenticated.value)
+
+        client.destroy()
+    }
+
+    // ── signOut ─────────────────────────────────────────────────────
+
+    @Test
+    fun signOutClearsSessionAndQueue() = runTest {
+        val components = createTestComponents()
+        val client = SyncClient(
+            config = config,
+            authManager = components.authManager,
+            syncEngine = components.engine,
+            mutationQueue = components.queue,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
+        )
+
+        // Sign in first
+        client.signInAndSync(
+            AuthCredentials.EmailPassword("test@example.com", "password"),
+        )
+
+        // Enqueue a mutation
+        components.queue.enqueue(
+            SyncMutation(
+                id = "m-1",
+                tableName = "transactions",
+                operation = MutationOperation.INSERT,
+                rowData = mapOf("id" to "t-1", "amount" to "1000"),
+                timestamp = Clock.System.now(),
+            ),
+        )
+        assertEquals(1, components.queue.pendingCount())
+
+        // Sign out
+        client.signOut()
+
+        assertFalse(components.authManager.isAuthenticated.value)
+        assertEquals(0, components.queue.pendingCount())
+
+        client.destroy()
+    }
+
+    // ── syncNow ─────────────────────────────────────────────────────
+
+    @Test
+    fun syncNowDelegatesToEngine() = runTest {
+        val components = createTestComponents()
+        val client = SyncClient(
+            config = config,
+            authManager = components.authManager,
+            syncEngine = components.engine,
+            mutationQueue = components.queue,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
+        )
+
+        components.engine.connect(
+            SyncCredentials(authToken = "token", userId = "user-1"),
+        )
+
+        val result = client.syncNow()
+
+        assertIs<SyncResult.Success>(result)
+
+        client.destroy()
+    }
+
+    // ── Reactive state ──────────────────────────────────────────────
+
+    @Test
+    fun isAuthenticatedReflectsAuthManagerState() = runTest {
+        val components = createTestComponents()
+        val client = SyncClient(
+            config = config,
+            authManager = components.authManager,
+            syncEngine = components.engine,
+            mutationQueue = components.queue,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
+        )
+
+        assertFalse(client.isAuthenticated.value)
+
+        components.authManager.signIn(
+            AuthCredentials.EmailPassword("test@example.com", "password"),
+        )
+
+        assertTrue(client.isAuthenticated.value)
+
+        client.destroy()
+    }
+
+    @Test
+    fun pendingMutationCountReflectsQueue() = runTest {
+        val components = createTestComponents()
+        val client = SyncClient(
+            config = config,
+            authManager = components.authManager,
+            syncEngine = components.engine,
+            mutationQueue = components.queue,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
+        )
+
+        assertEquals(0, client.pendingMutationCount.value)
+
+        components.queue.enqueue(
+            SyncMutation(
+                id = "m-1",
+                tableName = "transactions",
+                operation = MutationOperation.INSERT,
+                rowData = mapOf("id" to "t-1"),
+                timestamp = Clock.System.now(),
+            ),
+        )
+
+        // Allow the stateIn collector to update
+        advanceUntilIdle()
+
+        assertEquals(1, client.pendingMutationCount.value)
+
+        client.destroy()
+    }
+
+    // ── Lifecycle ───────────────────────────────────────────────────
+
+    @Test
+    fun startRequiresActiveSession() = runTest {
+        val components = createTestComponents()
+        val client = SyncClient(
+            config = config,
+            authManager = components.authManager,
+            syncEngine = components.engine,
+            mutationQueue = components.queue,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
+        )
+
+        // No session — start should return without starting
+        client.start()
+
+        // Engine should not be connected
+        assertFalse(components.engine.isConnected.value)
+
+        client.destroy()
+    }
+
+    @Test
+    fun stopIsIdempotent() = runTest {
+        val components = createTestComponents()
+        val client = SyncClient(
+            config = config,
+            authManager = components.authManager,
+            syncEngine = components.engine,
+            mutationQueue = components.queue,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
+        )
+
+        // Multiple stops should not throw
+        client.stop()
+        client.stop()
+        client.stop()
+
+        client.destroy()
+    }
+
+    @Test
+    fun destroyCancelsScope() = runTest {
+        val components = createTestComponents()
+        val client = SyncClient(
+            config = config,
+            authManager = components.authManager,
+            syncEngine = components.engine,
+            mutationQueue = components.queue,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
+        )
+
+        client.destroy()
+
+        // After destroy, any operation on the scope should fail gracefully
+        // The client is no longer usable
+    }
+}
+
+// ── Fake AuthManager ────────────────────────────────────────────────
+
+/**
+ * Fake [AuthManager] implementation for testing.
+ *
+ * Simulates sign-in / sign-out flows with in-memory state.
+ */
+class FakeAuthManager(
+    private val signInShouldFail: Boolean = false,
+) : AuthManager {
+
+    private val _currentSession = MutableStateFlow<AuthSession?>(null)
+    override val currentSession: StateFlow<AuthSession?> = _currentSession.asStateFlow()
+
+    private val _isAuthenticated = MutableStateFlow(false)
+    override val isAuthenticated: StateFlow<Boolean> = _isAuthenticated.asStateFlow()
+
+    override suspend fun signIn(credentials: AuthCredentials): Result<AuthSession> {
+        if (signInShouldFail) {
+            return Result.failure(RuntimeException("Authentication failed"))
+        }
+
+        val session = AuthSession(
+            accessToken = "fake-access-token",
+            refreshToken = "fake-refresh-token",
+            expiresAt = Instant.fromEpochMilliseconds(
+                Clock.System.now().toEpochMilliseconds() + 3_600_000L,
+            ),
+            userId = "fake-user-id",
+        )
+
+        _currentSession.value = session
+        _isAuthenticated.value = true
+        return Result.success(session)
+    }
+
+    override suspend fun signOut() {
+        _currentSession.value = null
+        _isAuthenticated.value = false
+    }
+
+    override suspend fun refreshToken(): Result<AuthSession> {
+        val session = _currentSession.value
+            ?: return Result.failure(RuntimeException("No active session"))
+
+        val refreshed = session.copy(
+            accessToken = "refreshed-access-token",
+            expiresAt = Instant.fromEpochMilliseconds(
+                Clock.System.now().toEpochMilliseconds() + 3_600_000L,
+            ),
+        )
+
+        _currentSession.value = refreshed
+        return Result.success(refreshed)
+    }
+
+    override suspend fun deleteAccount(): Result<Unit> {
+        _currentSession.value = null
+        _isAuthenticated.value = false
+        return Result.success(Unit)
+    }
+}

--- a/packages/sync/src/commonTest/kotlin/com/finance/sync/auth/PKCEHelperTest.kt
+++ b/packages/sync/src/commonTest/kotlin/com/finance/sync/auth/PKCEHelperTest.kt
@@ -172,4 +172,103 @@ class PKCEHelperTest {
     private fun assertFalse(condition: Boolean, message: String) {
         assertTrue(!condition, message)
     }
+
+    // =========================================================================
+    // generateState tests
+    // =========================================================================
+
+    @Test
+    fun `generateState produces string of requested length`() {
+        val state = PKCEHelper.generateState(32)
+        assertEquals(32, state.length, "State should be exactly 32 characters")
+    }
+
+    @Test
+    fun `generateState with custom length`() {
+        val state = PKCEHelper.generateState(16)
+        assertEquals(16, state.length, "State should be exactly 16 characters")
+    }
+
+    @Test
+    fun `generateState produces only base64url-safe characters`() {
+        val base64urlPattern = Regex("^[A-Za-z0-9\\-_]+$")
+        repeat(10) {
+            val state = PKCEHelper.generateState()
+            assertTrue(
+                base64urlPattern.matches(state),
+                "State should contain only base64url-safe characters: $state",
+            )
+        }
+    }
+
+    @Test
+    fun `generateState produces different values each call`() {
+        val states = (1..5).map { PKCEHelper.generateState() }.toSet()
+        assertTrue(
+            states.size > 1,
+            "Expected unique state values but got duplicates",
+        )
+    }
+
+    @Test
+    fun `generateState rejects non-positive length`() {
+        assertFailsWith<IllegalArgumentException> {
+            PKCEHelper.generateState(0)
+        }
+    }
+
+    @Test
+    fun `generateState rejects negative length`() {
+        assertFailsWith<IllegalArgumentException> {
+            PKCEHelper.generateState(-1)
+        }
+    }
+
+    @Test
+    fun `generateState with length 1 produces single character`() {
+        val state = PKCEHelper.generateState(1)
+        assertEquals(1, state.length)
+    }
+
+    @Test
+    fun `generateState does not contain padding characters`() {
+        repeat(10) {
+            val state = PKCEHelper.generateState()
+            assertFalse(
+                state.contains("="),
+                "State must not contain base64 padding: $state",
+            )
+        }
+    }
+
+    // =========================================================================
+    // Code verifier + challenge integration
+    // =========================================================================
+
+    @Test
+    fun `verifier and challenge are always different`() {
+        val verifier = PKCEHelper.generateCodeVerifier()
+        val challenge = PKCEHelper.generateCodeChallenge(verifier)
+        assertTrue(
+            verifier != challenge,
+            "Verifier and challenge must differ (S256 transform)",
+        )
+    }
+
+    @Test
+    fun `different verifiers produce different challenges`() {
+        val verifier1 = PKCEHelper.generateCodeVerifier()
+        val verifier2 = PKCEHelper.generateCodeVerifier()
+        val challenge1 = PKCEHelper.generateCodeChallenge(verifier1)
+        val challenge2 = PKCEHelper.generateCodeChallenge(verifier2)
+        // With overwhelming probability different verifiers produce different challenges
+        assertTrue(
+            verifier1 != verifier2,
+            "Verifiers should differ (randomness)",
+        )
+        assertTrue(
+            challenge1 != challenge2,
+            "Challenges from different verifiers should differ",
+        )
+    }
 }

--- a/packages/sync/src/commonTest/kotlin/com/finance/sync/auth/ToStringSecurityTest.kt
+++ b/packages/sync/src/commonTest/kotlin/com/finance/sync/auth/ToStringSecurityTest.kt
@@ -3,6 +3,7 @@
 package com.finance.sync.auth
 
 import com.finance.sync.SyncCredentials
+import com.finance.sync.auth.OAuthProvider
 import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertFalse
@@ -71,7 +72,7 @@ class ToStringSecurityTest {
     @Test
     fun oauth_toString_masks_authCode_and_codeVerifier() {
         val creds = AuthCredentials.OAuth(
-            provider = "google",
+            provider = OAuthProvider.GOOGLE,
             authCode = "4/0AX4XfWjSecretAuthCode",
             codeVerifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
         )
@@ -80,7 +81,7 @@ class ToStringSecurityTest {
         assertFalse(str.contains("4/0AX4XfWjSecretAuthCode"), "authCode must not appear in toString()")
         assertFalse(str.contains("dBjftJeZ4CVP"), "codeVerifier must not appear in toString()")
         assertTrue(str.contains("*****"), "toString() must contain masked placeholder")
-        assertTrue(str.contains("google"), "provider must appear in toString()")
+        assertTrue(str.contains("GOOGLE"), "provider must appear in toString()")
     }
 
     // ── AuthCredentials.Passkey ─────────────────────────────────────

--- a/packages/sync/src/commonTest/kotlin/com/finance/sync/auth/TokenManagerTest.kt
+++ b/packages/sync/src/commonTest/kotlin/com/finance/sync/auth/TokenManagerTest.kt
@@ -2,6 +2,7 @@
 
 package com.finance.sync.auth
 
+import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlin.test.Test
@@ -189,6 +190,149 @@ class TokenManagerTest {
     @Test
     fun `millisUntilRefresh returns 0 for expired tokens`() {
         val session = createSession(expiresAtMillis = clock.nowMillis - 10_000L)
+        assertEquals(0L, tokenManager.millisUntilRefresh(session))
+    }
+
+    // =========================================================================
+    // getValidToken (suspend)
+    // =========================================================================
+
+    @Test
+    fun `getValidToken returns access token when stored and not expired`() = runTest {
+        val session = createSession(expiresAtMillis = clock.nowMillis + 3600_000L)
+        tokenManager.storeTokens(session)
+
+        val token = tokenManager.getValidToken()
+        assertNotNull(token)
+        assertEquals("access-token-123", token)
+    }
+
+    @Test
+    fun `getValidToken returns null when no token is stored`() = runTest {
+        val token = tokenManager.getValidToken()
+        assertNull(token, "Should return null when no session is stored")
+    }
+
+    @Test
+    fun `getValidToken returns null when stored token is expired`() = runTest {
+        val session = createSession(expiresAtMillis = clock.nowMillis - 1_000L)
+        tokenManager.storeTokens(session)
+
+        val token = tokenManager.getValidToken()
+        assertNull(token, "Should return null for an expired token")
+    }
+
+    @Test
+    fun `getValidToken returns null at exact expiry boundary`() = runTest {
+        val session = createSession(expiresAtMillis = clock.nowMillis)
+        tokenManager.storeTokens(session)
+
+        val token = tokenManager.getValidToken()
+        assertNull(token, "Should return null when token expires at exactly now")
+    }
+
+    @Test
+    fun `getValidToken reflects clock advancement`() = runTest {
+        val session = createSession(expiresAtMillis = clock.nowMillis + 5_000L)
+        tokenManager.storeTokens(session)
+
+        // Token is valid now
+        assertNotNull(tokenManager.getValidToken())
+
+        // Advance clock past expiry
+        clock.nowMillis += 6_000L
+        assertNull(tokenManager.getValidToken(), "Token should be invalid after clock advances past expiry")
+    }
+
+    // =========================================================================
+    // storeSession (suspend wrapper)
+    // =========================================================================
+
+    @Test
+    fun `storeSession persists tokens via TokenStorage`() = runTest {
+        val session = createSession(
+            accessToken = "suspend-access-token",
+            refreshToken = "suspend-refresh-token",
+            userId = "user-suspend",
+        )
+
+        tokenManager.storeSession(session)
+
+        val retrieved = tokenManager.retrieveTokens()
+        assertNotNull(retrieved)
+        assertEquals("suspend-access-token", retrieved.accessToken)
+        assertEquals("suspend-refresh-token", retrieved.refreshToken)
+        assertEquals("user-suspend", retrieved.userId)
+        assertEquals(session.expiresAt, retrieved.expiresAt)
+    }
+
+    @Test
+    fun `storeSession overwrites previously stored session`() = runTest {
+        tokenManager.storeSession(createSession(accessToken = "first"))
+        tokenManager.storeSession(createSession(accessToken = "second"))
+
+        val retrieved = tokenManager.retrieveTokens()
+        assertNotNull(retrieved)
+        assertEquals("second", retrieved.accessToken)
+    }
+
+    // =========================================================================
+    // clearSession (suspend wrapper)
+    // =========================================================================
+
+    @Test
+    fun `clearSession removes all tokens from storage`() = runTest {
+        tokenManager.storeSession(createSession())
+        assertNotNull(tokenManager.retrieveTokens(), "Token should exist before clearing")
+
+        tokenManager.clearSession()
+        assertNull(tokenManager.retrieveTokens(), "Token should be null after clearSession")
+    }
+
+    @Test
+    fun `clearSession is safe to call when nothing is stored`() = runTest {
+        // Should not throw
+        tokenManager.clearSession()
+        assertNull(tokenManager.retrieveTokens())
+    }
+
+    @Test
+    fun `clearSession then getValidToken returns null`() = runTest {
+        val session = createSession(expiresAtMillis = clock.nowMillis + 3600_000L)
+        tokenManager.storeSession(session)
+        assertNotNull(tokenManager.getValidToken(), "Should have a valid token")
+
+        tokenManager.clearSession()
+        assertNull(tokenManager.getValidToken(), "getValidToken should return null after clearSession")
+    }
+
+    // =========================================================================
+    // Edge cases
+    // =========================================================================
+
+    @Test
+    fun `multiple store-clear cycles work correctly`() = runTest {
+        repeat(3) { i ->
+            val session = createSession(accessToken = "token-$i")
+            tokenManager.storeSession(session)
+            assertEquals("token-$i", tokenManager.retrieveTokens()?.accessToken)
+            tokenManager.clearSession()
+            assertNull(tokenManager.retrieveTokens())
+        }
+    }
+
+    @Test
+    fun `isTokenExpired and shouldRefresh agree for already-expired token`() {
+        val session = createSession(expiresAtMillis = clock.nowMillis - 60_000L)
+        assertTrue(tokenManager.isTokenExpired(session), "Token should be expired")
+        assertTrue(tokenManager.shouldRefresh(session), "Should also need refresh")
+    }
+
+    @Test
+    fun `millisUntilRefresh matches shouldRefresh boundary`() {
+        // At exactly the threshold: shouldRefresh is true and delay is 0
+        val session = createSession(expiresAtMillis = clock.nowMillis + 120_000L)
+        assertTrue(tokenManager.shouldRefresh(session))
         assertEquals(0L, tokenManager.millisUntilRefresh(session))
     }
 }

--- a/packages/sync/src/commonTest/kotlin/com/finance/sync/conflict/ClientWinsResolverTest.kt
+++ b/packages/sync/src/commonTest/kotlin/com/finance/sync/conflict/ClientWinsResolverTest.kt
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.sync.conflict
+
+import com.finance.sync.MutationOperation
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class ClientWinsResolverTest {
+
+    private val resolver = ClientWinsResolver()
+
+    private fun conflict(
+        localOp: MutationOperation = MutationOperation.UPDATE,
+        serverOp: MutationOperation = MutationOperation.UPDATE,
+        localData: Map<String, String?>? = mapOf("id" to "1", "name" to "Local"),
+        serverData: Map<String, String?>? = mapOf("id" to "1", "name" to "Server"),
+        localVersion: Long = 1L,
+        serverVersion: Long = 2L,
+    ) = SyncConflict(
+        tableName = "accounts",
+        recordId = "1",
+        localData = localData,
+        serverData = serverData,
+        localVersion = localVersion,
+        serverVersion = serverVersion,
+        localTimestamp = Instant.parse("2024-01-01T10:00:00Z"),
+        serverTimestamp = Instant.parse("2024-01-01T12:00:00Z"),
+        localOperation = localOp,
+        serverOperation = serverOp,
+    )
+
+    @Test
+    fun localUpdateAlwaysWinsOverServerUpdate() {
+        val result = resolver.resolveConflict(conflict())
+        assertIs<ConflictResolution.AcceptLocal>(result)
+        assertEquals("Local", result.data?.get("name"))
+    }
+
+    @Test
+    fun localUpdateWinsEvenWhenServerVersionIsHigher() {
+        val result = resolver.resolveConflict(
+            conflict(localVersion = 1, serverVersion = 100),
+        )
+        assertIs<ConflictResolution.AcceptLocal>(result)
+    }
+
+    @Test
+    fun localDeleteWins() {
+        val result = resolver.resolveConflict(
+            conflict(localOp = MutationOperation.DELETE, localData = null),
+        )
+        assertIs<ConflictResolution.Delete>(result)
+    }
+
+    @Test
+    fun localInsertWinsOverServerInsert() {
+        val result = resolver.resolveConflict(
+            conflict(
+                localOp = MutationOperation.INSERT,
+                serverOp = MutationOperation.INSERT,
+            ),
+        )
+        assertIs<ConflictResolution.AcceptLocal>(result)
+    }
+
+    @Test
+    fun localUpdateWinsOverServerDelete() {
+        val result = resolver.resolveConflict(
+            conflict(
+                serverOp = MutationOperation.DELETE,
+                serverData = null,
+            ),
+        )
+        assertIs<ConflictResolution.AcceptLocal>(result)
+        assertEquals("Local", result.data?.get("name"))
+    }
+}

--- a/packages/sync/src/commonTest/kotlin/com/finance/sync/conflict/ConflictStrategyTest.kt
+++ b/packages/sync/src/commonTest/kotlin/com/finance/sync/conflict/ConflictStrategyTest.kt
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.sync.conflict
+
+import com.finance.sync.MutationOperation
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class ConflictStrategyTest {
+
+    // --- resolverFor mapping ---
+
+    @Test
+    fun budgetsUseMergeResolver() {
+        assertIs<MergeResolver>(ConflictStrategy.resolverFor("budgets"))
+    }
+
+    @Test
+    fun goalsUseMergeResolver() {
+        assertIs<MergeResolver>(ConflictStrategy.resolverFor("goals"))
+    }
+
+    @Test
+    fun householdsUseMergeResolver() {
+        assertIs<MergeResolver>(ConflictStrategy.resolverFor("households"))
+    }
+
+    @Test
+    fun unknownTableDefaultsToLastWriteWins() {
+        assertIs<LastWriteWinsResolver>(ConflictStrategy.resolverFor("transactions"))
+    }
+
+    @Test
+    fun accountsDefaultToLastWriteWins() {
+        assertIs<LastWriteWinsResolver>(ConflictStrategy.resolverFor("accounts"))
+    }
+
+    // --- Enum entries ---
+
+    @Test
+    fun allStrategiesHaveResolvers() {
+        ConflictStrategy.entries.forEach { strategy ->
+            // Just verify that the resolver is not null and is a ConflictResolver.
+            assertTrue(strategy.resolver is ConflictResolver, "${strategy.name} must have a resolver")
+        }
+    }
+
+    @Test
+    fun serverWinsStrategyUsesServerWinsResolver() {
+        assertIs<ServerWinsResolver>(ConflictStrategy.SERVER_WINS.resolver)
+    }
+
+    @Test
+    fun clientWinsStrategyUsesClientWinsResolver() {
+        assertIs<ClientWinsResolver>(ConflictStrategy.CLIENT_WINS.resolver)
+    }
+
+    // --- resolveAll batch ---
+
+    @Test
+    fun resolveAllProcessesAllConflicts() {
+        val resolver = LastWriteWinsResolver()
+        val conflicts = listOf(
+            SyncConflict(
+                tableName = "accounts",
+                recordId = "a1",
+                localData = mapOf("id" to "a1", "name" to "Local A"),
+                serverData = mapOf("id" to "a1", "name" to "Server A"),
+                localVersion = 1,
+                serverVersion = 2,
+                localTimestamp = Instant.parse("2024-01-01T10:00:00Z"),
+                serverTimestamp = Instant.parse("2024-01-01T12:00:00Z"),
+                localOperation = MutationOperation.UPDATE,
+                serverOperation = MutationOperation.UPDATE,
+            ),
+            SyncConflict(
+                tableName = "transactions",
+                recordId = "t1",
+                localData = null,
+                serverData = mapOf("id" to "t1", "amount" to "5000"),
+                localVersion = 3,
+                serverVersion = 5,
+                localTimestamp = Instant.parse("2024-01-01T10:00:00Z"),
+                serverTimestamp = Instant.parse("2024-01-01T12:00:00Z"),
+                localOperation = MutationOperation.DELETE,
+                serverOperation = MutationOperation.UPDATE,
+            ),
+        )
+
+        val results = resolver.resolveAll(conflicts)
+
+        assertEquals(2, results.size)
+
+        // First conflict: server version higher → AcceptServer.
+        val (firstConflict, firstResolution) = results[0]
+        assertEquals("a1", firstConflict.recordId)
+        assertIs<ConflictResolution.AcceptServer>(firstResolution)
+
+        // Second conflict: local delete but server has higher version → AcceptServer (revived).
+        val (secondConflict, secondResolution) = results[1]
+        assertEquals("t1", secondConflict.recordId)
+        assertIs<ConflictResolution.AcceptServer>(secondResolution)
+    }
+
+    @Test
+    fun resolveAllWithEmptyListReturnsEmpty() {
+        val resolver = ServerWinsResolver()
+        val results = resolver.resolveAll(emptyList())
+        assertTrue(results.isEmpty())
+    }
+}

--- a/packages/sync/src/commonTest/kotlin/com/finance/sync/conflict/LastWriteWinsResolverConflictTest.kt
+++ b/packages/sync/src/commonTest/kotlin/com/finance/sync/conflict/LastWriteWinsResolverConflictTest.kt
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.sync.conflict
+
+import com.finance.sync.MutationOperation
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for the [LastWriteWinsResolver.resolveConflict] high-level API.
+ *
+ * The low-level [LastWriteWinsResolver.resolve] tests remain in
+ * [LastWriteWinsResolverTest].
+ */
+class LastWriteWinsResolverConflictTest {
+
+    private val resolver = LastWriteWinsResolver()
+
+    private fun conflict(
+        localOp: MutationOperation = MutationOperation.UPDATE,
+        serverOp: MutationOperation = MutationOperation.UPDATE,
+        localData: Map<String, String?>? = mapOf("id" to "1", "name" to "Local"),
+        serverData: Map<String, String?>? = mapOf("id" to "1", "name" to "Server"),
+        localVersion: Long = 1L,
+        serverVersion: Long = 2L,
+        localTs: String = "2024-01-01T10:00:00Z",
+        serverTs: String = "2024-01-01T12:00:00Z",
+    ) = SyncConflict(
+        tableName = "transactions",
+        recordId = "1",
+        localData = localData,
+        serverData = serverData,
+        localVersion = localVersion,
+        serverVersion = serverVersion,
+        localTimestamp = Instant.parse(localTs),
+        serverTimestamp = Instant.parse(serverTs),
+        localOperation = localOp,
+        serverOperation = serverOp,
+    )
+
+    // --- DELETE handling ---
+
+    @Test
+    fun serverDeleteAlwaysWins() {
+        val result = resolver.resolveConflict(
+            conflict(serverOp = MutationOperation.DELETE, serverData = null),
+        )
+        assertIs<ConflictResolution.Delete>(result)
+    }
+
+    @Test
+    fun localDeleteWinsWhenLocalVersionHigherOrEqual() {
+        val result = resolver.resolveConflict(
+            conflict(
+                localOp = MutationOperation.DELETE,
+                localData = null,
+                localVersion = 5,
+                serverVersion = 3,
+            ),
+        )
+        assertIs<ConflictResolution.Delete>(result)
+    }
+
+    @Test
+    fun localDeleteLosesWhenServerVersionIsHigher() {
+        // Server "revived" the record with a higher version.
+        val result = resolver.resolveConflict(
+            conflict(
+                localOp = MutationOperation.DELETE,
+                localData = null,
+                localVersion = 3,
+                serverVersion = 5,
+            ),
+        )
+        assertIs<ConflictResolution.AcceptServer>(result)
+        assertEquals("Server", result.data?.get("name"))
+    }
+
+    @Test
+    fun localDeleteEqualVersionsResultsInDelete() {
+        val result = resolver.resolveConflict(
+            conflict(
+                localOp = MutationOperation.DELETE,
+                localData = null,
+                localVersion = 5,
+                serverVersion = 5,
+            ),
+        )
+        // Equal versions: local delete intent is preserved because server
+        // didn't exceed the local version.
+        assertIs<ConflictResolution.Delete>(result)
+    }
+
+    // --- Version comparison (non-DELETE) ---
+
+    @Test
+    fun higherServerVersionWins() {
+        val result = resolver.resolveConflict(
+            conflict(localVersion = 3, serverVersion = 5),
+        )
+        assertIs<ConflictResolution.AcceptServer>(result)
+        assertEquals("Server", result.data?.get("name"))
+    }
+
+    @Test
+    fun higherLocalVersionWins() {
+        val result = resolver.resolveConflict(
+            conflict(localVersion = 7, serverVersion = 5),
+        )
+        assertIs<ConflictResolution.AcceptLocal>(result)
+        assertEquals("Local", result.data?.get("name"))
+    }
+
+    @Test
+    fun equalVersionsServerWinsAsTieBreaker() {
+        val result = resolver.resolveConflict(
+            conflict(localVersion = 5, serverVersion = 5),
+        )
+        assertIs<ConflictResolution.AcceptServer>(result)
+    }
+
+    // --- Both DELETE ---
+
+    @Test
+    fun bothDeleteResultsInDelete() {
+        val result = resolver.resolveConflict(
+            conflict(
+                localOp = MutationOperation.DELETE,
+                serverOp = MutationOperation.DELETE,
+                localData = null,
+                serverData = null,
+            ),
+        )
+        assertIs<ConflictResolution.Delete>(result)
+    }
+}

--- a/packages/sync/src/commonTest/kotlin/com/finance/sync/conflict/MergeResolverConflictTest.kt
+++ b/packages/sync/src/commonTest/kotlin/com/finance/sync/conflict/MergeResolverConflictTest.kt
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.sync.conflict
+
+import com.finance.sync.MutationOperation
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [MergeResolver.resolveConflict] — the high-level SyncConflict API.
+ *
+ * The low-level [MergeResolver.resolve] tests remain in [MergeResolverTest].
+ */
+class MergeResolverConflictTest {
+
+    private val resolver = MergeResolver()
+
+    private fun conflict(
+        localOp: MutationOperation = MutationOperation.UPDATE,
+        serverOp: MutationOperation = MutationOperation.UPDATE,
+        localData: Map<String, String?>? = mapOf("id" to "1", "name" to "Local", "note" to "local note"),
+        serverData: Map<String, String?>? = mapOf("id" to "1", "name" to "Server", "icon" to "star"),
+        localVersion: Long = 1L,
+        serverVersion: Long = 2L,
+        localTs: String = "2024-01-01T10:00:00Z",
+        serverTs: String = "2024-01-01T12:00:00Z",
+    ) = SyncConflict(
+        tableName = "budgets",
+        recordId = "1",
+        localData = localData,
+        serverData = serverData,
+        localVersion = localVersion,
+        serverVersion = serverVersion,
+        localTimestamp = Instant.parse(localTs),
+        serverTimestamp = Instant.parse(serverTs),
+        localOperation = localOp,
+        serverOperation = serverOp,
+    )
+
+    // --- Non-conflicting field merge ---
+
+    @Test
+    fun nonConflictingFieldsAreMerged() {
+        val result = resolver.resolveConflict(
+            conflict(
+                localData = mapOf("id" to "1", "note" to "local note"),
+                serverData = mapOf("id" to "1", "icon" to "star"),
+            ),
+        )
+        assertIs<ConflictResolution.Merged>(result)
+        assertEquals("1", result.data["id"])
+        assertEquals("local note", result.data["note"])
+        assertEquals("star", result.data["icon"])
+    }
+
+    @Test
+    fun identicalFieldValuesDoNotConflict() {
+        val result = resolver.resolveConflict(
+            conflict(
+                localData = mapOf("id" to "1", "name" to "Same"),
+                serverData = mapOf("id" to "1", "name" to "Same"),
+            ),
+        )
+        assertIs<ConflictResolution.Merged>(result)
+        assertEquals("Same", result.data["name"])
+        assertNull(result.data["__conflict_name"])
+    }
+
+    @Test
+    fun conflictingMergeableFieldFlagsConflictMarker() {
+        val result = resolver.resolveConflict(
+            conflict(
+                localData = mapOf("id" to "1", "name" to "Local Name"),
+                serverData = mapOf("id" to "1", "name" to "Server Name"),
+            ),
+        )
+        assertIs<ConflictResolution.Merged>(result)
+        assertEquals("Server Name", result.data["name"])
+        assertEquals("Local Name", result.data["__conflict_name"])
+    }
+
+    @Test
+    fun updatedAtAlwaysUsesLaterValue() {
+        val result = resolver.resolveConflict(
+            conflict(
+                localData = mapOf("id" to "1", "updated_at" to "2024-01-01T14:00:00Z"),
+                serverData = mapOf("id" to "1", "updated_at" to "2024-01-01T10:00:00Z"),
+            ),
+        )
+        assertIs<ConflictResolution.Merged>(result)
+        assertEquals("2024-01-01T14:00:00Z", result.data["updated_at"])
+    }
+
+    // --- DELETE delegation ---
+
+    @Test
+    fun serverDeleteDelegatesToFallback() {
+        val result = resolver.resolveConflict(
+            conflict(
+                serverOp = MutationOperation.DELETE,
+                serverData = null,
+            ),
+        )
+        // Fallback (LWW) will produce Delete because server deleted.
+        assertIs<ConflictResolution.Delete>(result)
+    }
+
+    @Test
+    fun localDeleteDelegatesToFallback() {
+        val result = resolver.resolveConflict(
+            conflict(
+                localOp = MutationOperation.DELETE,
+                localData = null,
+            ),
+        )
+        // Fallback (LWW): local delete with lower version, server has higher
+        // version → server wins (revived).
+        assertIs<ConflictResolution.AcceptServer>(result)
+    }
+
+    @Test
+    fun localDeleteWithHigherVersionDelegatesToFallback() {
+        val result = resolver.resolveConflict(
+            conflict(
+                localOp = MutationOperation.DELETE,
+                localData = null,
+                localVersion = 10,
+                serverVersion = 5,
+            ),
+        )
+        // Fallback (LWW): local delete with higher version → delete wins.
+        assertIs<ConflictResolution.Delete>(result)
+    }
+
+    // --- Non-mergeable fields ---
+
+    @Test
+    fun nonMergeableFieldConflictDelegatesToFallback() {
+        // "amount" is in the default nonMergeableFields set.
+        val result = resolver.resolveConflict(
+            conflict(
+                localData = mapOf("id" to "1", "amount" to "5000"),
+                serverData = mapOf("id" to "1", "amount" to "7500"),
+            ),
+        )
+        // Should delegate to fallback (LWW) since "amount" conflict
+        // cannot be field-merged. Server version (2) > local version (1).
+        assertIs<ConflictResolution.AcceptServer>(result)
+    }
+
+    @Test
+    fun nonMergeableFieldWithSameValueDoesNotDelegateToFallback() {
+        // Same amount on both sides — no conflict, so no delegation.
+        val result = resolver.resolveConflict(
+            conflict(
+                localData = mapOf("id" to "1", "amount" to "5000", "note" to "local"),
+                serverData = mapOf("id" to "1", "amount" to "5000", "icon" to "cart"),
+            ),
+        )
+        assertIs<ConflictResolution.Merged>(result)
+        assertEquals("5000", result.data["amount"])
+        assertEquals("local", result.data["note"])
+        assertEquals("cart", result.data["icon"])
+    }
+
+    @Test
+    fun currencyCodeConflictDelegatesToFallback() {
+        // "currency_code" is in the default nonMergeableFields set.
+        val result = resolver.resolveConflict(
+            conflict(
+                localData = mapOf("id" to "1", "currency_code" to "USD"),
+                serverData = mapOf("id" to "1", "currency_code" to "EUR"),
+            ),
+        )
+        assertIs<ConflictResolution.AcceptServer>(result)
+    }
+
+    @Test
+    fun typeFieldConflictDelegatesToFallback() {
+        // "type" is in the default nonMergeableFields set.
+        val result = resolver.resolveConflict(
+            conflict(
+                localData = mapOf("id" to "1", "type" to "EXPENSE"),
+                serverData = mapOf("id" to "1", "type" to "INCOME"),
+            ),
+        )
+        assertIs<ConflictResolution.AcceptServer>(result)
+    }
+
+    @Test
+    fun customNonMergeableFieldsAreRespected() {
+        val customResolver = MergeResolver(
+            nonMergeableFields = setOf("status"),
+        )
+        val result = customResolver.resolveConflict(
+            conflict(
+                localData = mapOf("id" to "1", "status" to "PENDING"),
+                serverData = mapOf("id" to "1", "status" to "CLEARED"),
+            ),
+        )
+        // "status" is non-mergeable in this custom resolver.
+        assertIs<ConflictResolution.AcceptServer>(result)
+    }
+
+    @Test
+    fun customFallbackResolverIsUsed() {
+        val customResolver = MergeResolver(
+            fallbackResolver = ClientWinsResolver(),
+            nonMergeableFields = setOf("amount"),
+        )
+        val result = customResolver.resolveConflict(
+            conflict(
+                localData = mapOf("id" to "1", "amount" to "5000"),
+                serverData = mapOf("id" to "1", "amount" to "7500"),
+            ),
+        )
+        // Fallback is ClientWins, so local data should win.
+        assertIs<ConflictResolution.AcceptLocal>(result)
+        assertEquals("5000", result.data?.get("amount"))
+    }
+
+    // --- Null data edge cases ---
+
+    @Test
+    fun bothNullDataReturnsDelete() {
+        val result = resolver.resolveConflict(
+            conflict(localData = null, serverData = null),
+        )
+        assertIs<ConflictResolution.Delete>(result)
+    }
+
+    @Test
+    fun localNullDataReturnsAcceptServer() {
+        val result = resolver.resolveConflict(
+            conflict(localData = null, serverData = mapOf("id" to "1", "name" to "Server")),
+        )
+        assertIs<ConflictResolution.AcceptServer>(result)
+        assertEquals("Server", result.data?.get("name"))
+    }
+
+    @Test
+    fun serverNullDataReturnsAcceptLocal() {
+        val result = resolver.resolveConflict(
+            conflict(localData = mapOf("id" to "1", "name" to "Local"), serverData = null),
+        )
+        assertIs<ConflictResolution.AcceptLocal>(result)
+        assertEquals("Local", result.data?.get("name"))
+    }
+
+    // --- Multiple conflicting fields ---
+
+    @Test
+    fun multipleConflictingMergeableFieldsAllFlagged() {
+        val result = resolver.resolveConflict(
+            conflict(
+                localData = mapOf("id" to "1", "name" to "Local", "note" to "L", "icon" to "a"),
+                serverData = mapOf("id" to "1", "name" to "Server", "note" to "S", "icon" to "b"),
+            ),
+        )
+        assertIs<ConflictResolution.Merged>(result)
+        assertEquals("Server", result.data["name"])
+        assertEquals("Local", result.data["__conflict_name"])
+        assertEquals("S", result.data["note"])
+        assertEquals("L", result.data["__conflict_note"])
+        assertEquals("b", result.data["icon"])
+        assertEquals("a", result.data["__conflict_icon"])
+    }
+}

--- a/packages/sync/src/commonTest/kotlin/com/finance/sync/conflict/ServerWinsResolverTest.kt
+++ b/packages/sync/src/commonTest/kotlin/com/finance/sync/conflict/ServerWinsResolverTest.kt
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.sync.conflict
+
+import com.finance.sync.MutationOperation
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ServerWinsResolverTest {
+
+    private val resolver = ServerWinsResolver()
+
+    private fun conflict(
+        localOp: MutationOperation = MutationOperation.UPDATE,
+        serverOp: MutationOperation = MutationOperation.UPDATE,
+        localData: Map<String, String?>? = mapOf("id" to "1", "name" to "Local"),
+        serverData: Map<String, String?>? = mapOf("id" to "1", "name" to "Server"),
+        localVersion: Long = 1L,
+        serverVersion: Long = 2L,
+    ) = SyncConflict(
+        tableName = "accounts",
+        recordId = "1",
+        localData = localData,
+        serverData = serverData,
+        localVersion = localVersion,
+        serverVersion = serverVersion,
+        localTimestamp = Instant.parse("2024-01-01T10:00:00Z"),
+        serverTimestamp = Instant.parse("2024-01-01T12:00:00Z"),
+        localOperation = localOp,
+        serverOperation = serverOp,
+    )
+
+    @Test
+    fun serverUpdateAlwaysWinsOverLocalUpdate() {
+        val result = resolver.resolveConflict(conflict())
+        assertIs<ConflictResolution.AcceptServer>(result)
+        assertEquals("Server", result.data?.get("name"))
+    }
+
+    @Test
+    fun serverUpdateWinsEvenWhenLocalVersionIsHigher() {
+        val result = resolver.resolveConflict(
+            conflict(localVersion = 10, serverVersion = 1),
+        )
+        assertIs<ConflictResolution.AcceptServer>(result)
+    }
+
+    @Test
+    fun serverDeleteWins() {
+        val result = resolver.resolveConflict(
+            conflict(serverOp = MutationOperation.DELETE, serverData = null),
+        )
+        assertIs<ConflictResolution.Delete>(result)
+    }
+
+    @Test
+    fun serverInsertWinsOverLocalInsert() {
+        val result = resolver.resolveConflict(
+            conflict(
+                localOp = MutationOperation.INSERT,
+                serverOp = MutationOperation.INSERT,
+            ),
+        )
+        assertIs<ConflictResolution.AcceptServer>(result)
+    }
+
+    @Test
+    fun serverUpdateWinsOverLocalDelete() {
+        val result = resolver.resolveConflict(
+            conflict(
+                localOp = MutationOperation.DELETE,
+                localData = null,
+                serverOp = MutationOperation.UPDATE,
+            ),
+        )
+        assertIs<ConflictResolution.AcceptServer>(result)
+        assertEquals("Server", result.data?.get("name"))
+    }
+}

--- a/packages/sync/src/commonTest/kotlin/com/finance/sync/crypto/CryptoShredderTest.kt
+++ b/packages/sync/src/commonTest/kotlin/com/finance/sync/crypto/CryptoShredderTest.kt
@@ -2,6 +2,7 @@
 
 package com.finance.sync.crypto
 
+import com.finance.sync.integration.TestClock
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -129,5 +130,182 @@ class CryptoShredderTest {
         val cert = shredder.shredHouseholdData("empty-hh", requestedBy = "admin")
         assertTrue(cert.keyFingerprints.isEmpty())
         assertTrue(cert.verified)
+    }
+
+    // =========================================================================
+    // Deterministic clock for certificates
+    // =========================================================================
+
+    @Test
+    fun deletionCertificateUsesInjectedClock() {
+        val testClock = TestClock()
+        val keyStore = TestKeyStore()
+        keyStore.addHouseholdKey("hh-clock", "fp-1")
+
+        val shredder = CryptoShredder(keyStore, testClock)
+        val cert = shredder.shredHouseholdData("hh-clock", requestedBy = "system")
+
+        assertEquals(
+            testClock.now(),
+            cert.destroyedAt,
+            "Certificate timestamp should match the injected clock",
+        )
+    }
+
+    @Test
+    fun deletionCertificateIdContainsTimestamp() {
+        val testClock = TestClock()
+        val keyStore = TestKeyStore()
+        keyStore.addHouseholdKey("hh-id", "fp-1")
+
+        val shredder = CryptoShredder(keyStore, testClock)
+        val cert = shredder.shredHouseholdData("hh-id", requestedBy = "system")
+
+        assertTrue(cert.id.startsWith("cert-"), "Certificate ID should start with 'cert-'")
+        // The timestamp portion should be base-36 encoded
+        val timestampPart = cert.id.removePrefix("cert-")
+        assertTrue(timestampPart.isNotEmpty(), "Certificate ID should have a timestamp suffix")
+    }
+
+    // =========================================================================
+    // Multiple sequential shred operations
+    // =========================================================================
+
+    @Test
+    fun multipleShredOperationsProduceUniqueCertificates() {
+        val testClock = TestClock()
+        val keyStore = TestKeyStore()
+        keyStore.addHouseholdKey("hh-A", "fp-a")
+        keyStore.addHouseholdKey("hh-B", "fp-b")
+
+        val shredder = CryptoShredder(keyStore, testClock)
+
+        val certA = shredder.shredHouseholdData("hh-A", requestedBy = "admin")
+        testClock.advanceBy(1000)
+        val certB = shredder.shredHouseholdData("hh-B", requestedBy = "admin")
+
+        // Certificates should have different IDs (different timestamps)
+        assertTrue(certA.id != certB.id, "Sequential certificates should have different IDs")
+        assertEquals("hh-A", certA.subjectId)
+        assertEquals("hh-B", certB.subjectId)
+    }
+
+    @Test
+    fun shredSameHouseholdTwiceIsIdempotent() {
+        val keyStore = TestKeyStore()
+        keyStore.addHouseholdKey("hh-idem", "fp-1")
+
+        val shredder = CryptoShredder(keyStore)
+
+        // First shred should destroy keys
+        val cert1 = shredder.shredHouseholdData("hh-idem", requestedBy = "admin")
+        assertEquals(1, cert1.keyFingerprints.size)
+        assertTrue(cert1.verified)
+
+        // Second shred should be a no-op with empty fingerprints
+        val cert2 = shredder.shredHouseholdData("hh-idem", requestedBy = "admin")
+        assertTrue(cert2.keyFingerprints.isEmpty(), "No keys to destroy on second shred")
+        assertTrue(cert2.verified, "Still verified — no keys remain")
+    }
+
+    // =========================================================================
+    // Combined user + household shredding
+    // =========================================================================
+
+    @Test
+    fun shredUserThenHouseholdBothVerify() {
+        val keyStore = TestKeyStore()
+        keyStore.addUserKey("user-99", "fp-user-key")
+        keyStore.addHouseholdKey("hh-99", "fp-hh-kek")
+        keyStore.addHouseholdKey("hh-99", "fp-hh-dek")
+
+        val shredder = CryptoShredder(keyStore)
+
+        // Shred user first
+        val userCert = shredder.shredUserData("user-99", requestedBy = "user-99")
+        assertTrue(userCert.verified)
+        assertEquals(DeletionCertificate.SubjectType.USER, userCert.subjectType)
+        assertFalse(keyStore.hasKeysForUser("user-99"))
+
+        // Household keys should still exist
+        assertTrue(keyStore.hasKeysForHousehold("hh-99"))
+
+        // Shred household
+        val hhCert = shredder.shredHouseholdData("hh-99", requestedBy = "admin")
+        assertTrue(hhCert.verified)
+        assertEquals(DeletionCertificate.SubjectType.HOUSEHOLD, hhCert.subjectType)
+        assertEquals(2, hhCert.keyFingerprints.size)
+        assertFalse(keyStore.hasKeysForHousehold("hh-99"))
+    }
+
+    @Test
+    fun shredUserDataRecordsFingerprintsCorrectly() {
+        val keyStore = TestKeyStore()
+        keyStore.addUserKey("user-fp", "fingerprint-alpha")
+        keyStore.addUserKey("user-fp", "fingerprint-beta")
+        keyStore.addUserKey("user-fp", "fingerprint-gamma")
+
+        val shredder = CryptoShredder(keyStore)
+        val cert = shredder.shredUserData("user-fp", requestedBy = "user-fp")
+
+        assertEquals(3, cert.keyFingerprints.size, "All three fingerprints should be recorded")
+        assertTrue("fingerprint-alpha" in cert.keyFingerprints)
+        assertTrue("fingerprint-beta" in cert.keyFingerprints)
+        assertTrue("fingerprint-gamma" in cert.keyFingerprints)
+    }
+
+    // =========================================================================
+    // verifyShredding edge cases
+    // =========================================================================
+
+    @Test
+    fun verifyShredsReturnsTrueAfterDestroyingAllKeys() {
+        val keyStore = TestKeyStore()
+        keyStore.addHouseholdKey("hh-verify", "fp-1")
+        keyStore.addHouseholdKey("hh-verify", "fp-2")
+        keyStore.addHouseholdKey("hh-verify", "fp-3")
+
+        val shredder = CryptoShredder(keyStore)
+
+        assertFalse(shredder.verifyShredding("hh-verify"), "Before shredding: should not verify")
+
+        shredder.shredHouseholdData("hh-verify", requestedBy = "admin")
+
+        assertTrue(shredder.verifyShredding("hh-verify"), "After shredding: should verify")
+    }
+
+    @Test
+    fun shreddingDataWithMultipleSensitiveFields() {
+        // End-to-end: encrypt multiple fields, shred, verify data is unrecoverable
+        val crypto = TestCryptoProvider()
+        val random = TestRandomProvider()
+        val envelope = EnvelopeEncryption(crypto, random)
+        val encryptor = FieldEncryptor(crypto, envelope)
+
+        val kek = ByteArray(32) { (it + 1).toByte() }
+        val record = encryptor.encryptRecord(
+            fields = mapOf(
+                "payee" to "Very Secret Payee",
+                "note" to "Classified Note",
+                "account.name" to "Secret Account",
+                "amount_cents" to "999999",
+            ),
+            kek = kek,
+        )
+
+        // Before shredding: all fields decrypt correctly
+        val decrypted = encryptor.decryptRecord(record, kek)
+        assertEquals("Very Secret Payee", decrypted["payee"])
+        assertEquals("Classified Note", decrypted["note"])
+        assertEquals("Secret Account", decrypted["account.name"])
+
+        // After "shredding" (destroying the key): data is unrecoverable
+        val destroyedKek = ByteArray(32) { 0 }
+        val result = encryptor.decryptRecord(record, destroyedKek)
+        assertTrue(result["payee"] != "Very Secret Payee", "Payee should be unrecoverable")
+        assertTrue(result["note"] != "Classified Note", "Note should be unrecoverable")
+        assertTrue(result["account.name"] != "Secret Account", "Account name should be unrecoverable")
+        // amount_cents is cleartext, so it should still be readable
+        assertEquals("999999", result["amount_cents"])
     }
 }

--- a/packages/sync/src/commonTest/kotlin/com/finance/sync/crypto/EnvelopeEncryptionTest.kt
+++ b/packages/sync/src/commonTest/kotlin/com/finance/sync/crypto/EnvelopeEncryptionTest.kt
@@ -4,6 +4,8 @@ package com.finance.sync.crypto
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
 /**
@@ -79,5 +81,138 @@ class EnvelopeEncryptionTest {
                 "Wrap/unwrap round-trip it should succeed",
             )
         }
+    }
+
+    // =========================================================================
+    // Unwrapping with wrong KEK
+    // =========================================================================
+
+    @Test
+    fun unwrapWithWrongKekProducesIncorrectDek() {
+        val dek = envelope.generateDEK()
+        val wrapped = envelope.wrapDEK(dek, testKek)
+
+        val wrongKek = ByteArray(32) { 0xFF.toByte() }
+        // With XOR-based test crypto, wrong key produces different bytes
+        val unwrapped = envelope.unwrapDEK(wrapped, wrongKek)
+
+        assertTrue(
+            !dek.contentEquals(unwrapped),
+            "Unwrapping with wrong KEK should not produce original DEK",
+        )
+    }
+
+    @Test
+    fun unwrapWithSlightlyDifferentKekFails() {
+        val dek = envelope.generateDEK()
+        val wrapped = envelope.wrapDEK(dek, testKek)
+
+        // Change just one byte of the KEK
+        val alteredKek = testKek.copyOf()
+        alteredKek[0] = (alteredKek[0].toInt() xor 0x01).toByte()
+
+        val unwrapped = envelope.unwrapDEK(wrapped, alteredKek)
+        assertTrue(
+            !dek.contentEquals(unwrapped),
+            "Even a single-bit change in KEK should prevent correct unwrap",
+        )
+    }
+
+    // =========================================================================
+    // Wrapped DEK format
+    // =========================================================================
+
+    @Test
+    fun wrappedDekContainsNonceLengthPrefix() {
+        val dek = envelope.generateDEK()
+        val wrapped = envelope.wrapDEK(dek, testKek)
+
+        // First 4 bytes encode the nonce length as big-endian int
+        assertTrue(wrapped.size > 4, "Wrapped DEK must be longer than 4 bytes")
+
+        val nonceLen =
+            ((wrapped[0].toInt() and 0xFF) shl 24) or
+            ((wrapped[1].toInt() and 0xFF) shl 16) or
+            ((wrapped[2].toInt() and 0xFF) shl 8) or
+            (wrapped[3].toInt() and 0xFF)
+
+        assertTrue(nonceLen > 0, "Nonce length must be positive")
+        assertTrue(
+            wrapped.size > 4 + nonceLen,
+            "Wrapped DEK must contain nonce + ciphertext after length prefix",
+        )
+    }
+
+    @Test
+    fun wrappedDekIsTooShortThrows() {
+        assertFailsWith<IllegalArgumentException> {
+            envelope.unwrapDEK(byteArrayOf(0, 0, 0), testKek)
+        }
+    }
+
+    @Test
+    fun wrappedDekMalformedNonceLengthThrows() {
+        // Claim nonce is 255 bytes but provide only 5 total bytes
+        val malformed = byteArrayOf(0, 0, 0, 255.toByte(), 42)
+        assertFailsWith<IllegalArgumentException> {
+            envelope.unwrapDEK(malformed, testKek)
+        }
+    }
+
+    // =========================================================================
+    // DEK generation uniqueness
+    // =========================================================================
+
+    @Test
+    fun consecutiveDeksAreDifferent() {
+        val dek1 = envelope.generateDEK()
+        val dek2 = envelope.generateDEK()
+
+        assertTrue(
+            !dek1.contentEquals(dek2),
+            "Consecutive DEKs should be different",
+        )
+    }
+
+    @Test
+    fun dekLengthIsAlways32Bytes() {
+        repeat(10) {
+            val dek = envelope.generateDEK()
+            assertEquals(32, dek.size, "Every DEK must be 32 bytes")
+        }
+    }
+
+    // =========================================================================
+    // EncryptedPayload equality
+    // =========================================================================
+
+    @Test
+    fun encryptedPayloadEqualityByContent() {
+        val p1 = EncryptedPayload(
+            ciphertext = byteArrayOf(1, 2, 3),
+            nonce = byteArrayOf(4, 5, 6),
+            algorithm = "AES-256-GCM",
+        )
+        val p2 = EncryptedPayload(
+            ciphertext = byteArrayOf(1, 2, 3),
+            nonce = byteArrayOf(4, 5, 6),
+            algorithm = "AES-256-GCM",
+        )
+        assertEquals(p1, p2, "Payloads with same content should be equal")
+        assertEquals(p1.hashCode(), p2.hashCode(), "Equal payloads should have same hashCode")
+    }
+
+    @Test
+    fun encryptedPayloadInequalityOnCiphertext() {
+        val p1 = EncryptedPayload(byteArrayOf(1, 2, 3), byteArrayOf(4, 5, 6), "AES-256-GCM")
+        val p2 = EncryptedPayload(byteArrayOf(1, 2, 4), byteArrayOf(4, 5, 6), "AES-256-GCM")
+        assertNotEquals(p1, p2, "Different ciphertext should make payloads unequal")
+    }
+
+    @Test
+    fun encryptedPayloadInequalityOnAlgorithm() {
+        val p1 = EncryptedPayload(byteArrayOf(1), byteArrayOf(2), "AES-256-GCM")
+        val p2 = EncryptedPayload(byteArrayOf(1), byteArrayOf(2), "ChaCha20-Poly1305")
+        assertNotEquals(p1, p2, "Different algorithm should make payloads unequal")
     }
 }

--- a/packages/sync/src/commonTest/kotlin/com/finance/sync/crypto/FieldEncryptorTest.kt
+++ b/packages/sync/src/commonTest/kotlin/com/finance/sync/crypto/FieldEncryptorTest.kt
@@ -112,4 +112,144 @@ class FieldEncryptorTest {
             "Each record should have a unique DEK",
         )
     }
+
+    // =========================================================================
+    // Different inputs → different ciphertexts
+    // =========================================================================
+
+    @Test
+    fun differentInputsProduceDifferentCiphertexts() {
+        val record1 = mapOf("payee" to "Vendor Alpha", "amount_cents" to "100")
+        val record2 = mapOf("payee" to "Vendor Beta", "amount_cents" to "100")
+
+        val enc1 = FieldEncryptor(crypto, EnvelopeEncryption(crypto, TestRandomProvider(seed = 1)))
+        val enc2 = FieldEncryptor(crypto, EnvelopeEncryption(crypto, TestRandomProvider(seed = 1)))
+
+        val result1 = enc1.encryptRecord(record1, testKek)
+        val result2 = enc2.encryptRecord(record2, testKek)
+
+        val cipher1 = result1.encryptedFields["payee"]!!.ciphertext
+        val cipher2 = result2.encryptedFields["payee"]!!.ciphertext
+
+        assertTrue(
+            !cipher1.contentEquals(cipher2),
+            "Different plaintext inputs should produce different ciphertexts",
+        )
+    }
+
+    // =========================================================================
+    // Decryption with wrong key produces incorrect data
+    // =========================================================================
+
+    @Test
+    fun decryptionWithWrongKeyProducesGarbage() {
+        val encrypted = encryptor.encryptRecord(sampleRecord, testKek)
+        val wrongKek = ByteArray(32) { 0xFF.toByte() }
+
+        // With XOR-based test crypto, wrong key produces different (garbage) output
+        val result = encryptor.decryptRecord(encrypted, wrongKek)
+        assertNotEquals(
+            "Acme Corp",
+            result["payee"],
+            "Decryption with wrong key should not produce original plaintext",
+        )
+    }
+
+    @Test
+    fun decryptionWithWrongKeyDoesNotMatchAnyOriginalField() {
+        val encrypted = encryptor.encryptRecord(sampleRecord, testKek)
+        val wrongKek = ByteArray(32) { 0xAB.toByte() }
+
+        val result = encryptor.decryptRecord(encrypted, wrongKek)
+
+        // Every sensitive field should differ from original
+        for (fieldName in FieldEncryptor.DEFAULT_SENSITIVE_FIELDS) {
+            val original = sampleRecord[fieldName] ?: continue
+            assertNotEquals(
+                original,
+                result[fieldName],
+                "Field '$fieldName' should not match original when decrypted with wrong key",
+            )
+        }
+
+        // Non-sensitive fields should still be correct (they're in cleartext)
+        assertEquals("150000", result["amount_cents"])
+        assertEquals("2025-01-15", result["date"])
+    }
+
+    // =========================================================================
+    // Custom sensitive fields configuration
+    // =========================================================================
+
+    @Test
+    fun customSensitiveFieldsAreRespected() {
+        val customFields = setOf("amount_cents")
+        val customEncryptor = FieldEncryptor(crypto, envelope, customFields)
+
+        val result = customEncryptor.encryptRecord(sampleRecord, testKek)
+
+        // amount_cents should now be encrypted
+        assertTrue(
+            result.encryptedFields.containsKey("amount_cents"),
+            "Custom sensitive field 'amount_cents' should be encrypted",
+        )
+        // payee should now be in cleartext (not in custom set)
+        assertTrue(
+            result.cleartextFields.containsKey("payee"),
+            "Non-custom field 'payee' should be in cleartext",
+        )
+    }
+
+    @Test
+    fun emptyFieldsMapProducesEmptyResult() {
+        val result = encryptor.encryptRecord(emptyMap(), testKek)
+
+        assertTrue(result.encryptedFields.isEmpty(), "No encrypted fields for empty input")
+        assertTrue(result.cleartextFields.isEmpty(), "No cleartext fields for empty input")
+        assertTrue(result.wrappedDek.isNotEmpty(), "DEK should still be generated")
+    }
+
+    @Test
+    fun onlyNonSensitiveFieldsProducesNoCiphertexts() {
+        val nonSensitiveOnly = mapOf(
+            "amount_cents" to "5000",
+            "date" to "2025-06-15",
+        )
+
+        val result = encryptor.encryptRecord(nonSensitiveOnly, testKek)
+
+        assertTrue(result.encryptedFields.isEmpty(), "No sensitive fields to encrypt")
+        assertEquals(2, result.cleartextFields.size)
+        assertEquals("5000", result.cleartextFields["amount_cents"])
+    }
+
+    @Test
+    fun onlySensitiveFieldsProducesNoCleartext() {
+        val sensitiveOnly = mapOf(
+            "payee" to "Secret Corp",
+            "note" to "Confidential",
+        )
+
+        val result = encryptor.encryptRecord(sensitiveOnly, testKek)
+
+        assertTrue(result.cleartextFields.isEmpty(), "No cleartext fields")
+        assertEquals(2, result.encryptedFields.size)
+    }
+
+    @Test
+    fun encryptedRecordEquality() {
+        // Same inputs with same random provider should produce equal records
+        val r1 = TestRandomProvider(seed = 0)
+        val r2 = TestRandomProvider(seed = 0)
+        val c1 = TestCryptoProvider()
+        val c2 = TestCryptoProvider()
+
+        val enc1 = FieldEncryptor(c1, EnvelopeEncryption(c1, r1))
+        val enc2 = FieldEncryptor(c2, EnvelopeEncryption(c2, r2))
+
+        val result1 = enc1.encryptRecord(sampleRecord, testKek)
+        val result2 = enc2.encryptRecord(sampleRecord, testKek)
+
+        assertEquals(result1, result2, "Identical inputs and random state should produce equal records")
+    }
 }

--- a/packages/sync/src/commonTest/kotlin/com/finance/sync/crypto/HouseholdKeyManagerTest.kt
+++ b/packages/sync/src/commonTest/kotlin/com/finance/sync/crypto/HouseholdKeyManagerTest.kt
@@ -4,6 +4,7 @@ package com.finance.sync.crypto
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
@@ -138,5 +139,217 @@ class HouseholdKeyManagerTest {
             dek.contentEquals(unwrapped),
             "Re-wrapped DEK should unwrap to original",
         )
+    }
+
+    // =========================================================================
+    // Receiving key with wrong private key
+    // =========================================================================
+
+    @Test
+    fun receiveKeyWithWrongPrivateKeyProducesGarbage() {
+        val kek = random.nextBytes(HouseholdKeyManager.KEK_LENGTH_BYTES)
+        val shared = manager.shareKey(kek, bobKey)
+
+        // Try to receive with Alice's key instead of Bob's
+        val wrongReceived = manager.receiveKey(shared, aliceKey)
+        assertTrue(
+            !kek.contentEquals(wrongReceived),
+            "Receiving with wrong key should not produce original KEK",
+        )
+    }
+
+    @Test
+    fun receiveKeyWithCorrectKeyAfterWrongKeyStillWorks() {
+        val kek = random.nextBytes(HouseholdKeyManager.KEK_LENGTH_BYTES)
+        val shared = manager.shareKey(kek, bobKey)
+
+        // Wrong key first
+        val wrongResult = manager.receiveKey(shared, aliceKey)
+        assertTrue(!kek.contentEquals(wrongResult))
+
+        // Correct key still works
+        val correctResult = manager.receiveKey(shared, bobKey)
+        assertTrue(kek.contentEquals(correctResult), "Correct key should still work")
+    }
+
+    // =========================================================================
+    // receiveKey input validation
+    // =========================================================================
+
+    @Test
+    fun receiveKeyRejectsTooShortInput() {
+        // Encrypted KEK must be longer than NONCE_LENGTH (12 bytes)
+        val tooShort = ByteArray(HouseholdKeyManager.NONCE_LENGTH)
+        assertFailsWith<IllegalArgumentException> {
+            manager.receiveKey(tooShort, bobKey)
+        }
+    }
+
+    // =========================================================================
+    // Multiple members
+    // =========================================================================
+
+    @Test
+    fun shareKeyToMultipleMembersProducesUniqueShares() {
+        val kek = random.nextBytes(HouseholdKeyManager.KEK_LENGTH_BYTES)
+        val charlieKey = ByteArray(32) { (it + 90).toByte() }
+
+        val shareAlice = manager.shareKey(kek, aliceKey)
+        val shareBob = manager.shareKey(kek, bobKey)
+        val shareCharlie = manager.shareKey(kek, charlieKey)
+
+        // Each share should be different (encrypted to different keys)
+        assertTrue(!shareAlice.contentEquals(shareBob), "Alice and Bob shares should differ")
+        assertTrue(!shareBob.contentEquals(shareCharlie), "Bob and Charlie shares should differ")
+
+        // But each member can recover the same KEK
+        val aliceKek = manager.receiveKey(shareAlice, aliceKey)
+        val bobKek = manager.receiveKey(shareBob, bobKey)
+        val charlieKek = manager.receiveKey(shareCharlie, charlieKey)
+
+        assertTrue(kek.contentEquals(aliceKek), "Alice should receive correct KEK")
+        assertTrue(kek.contentEquals(bobKek), "Bob should receive correct KEK")
+        assertTrue(kek.contentEquals(charlieKek), "Charlie should receive correct KEK")
+    }
+
+    // =========================================================================
+    // Key rotation edge cases
+    // =========================================================================
+
+    @Test
+    fun keyRotationRequiresAtLeastOneMember() {
+        val rotation = KeyRotation(crypto, envelope, manager, random)
+        val oldKek = random.nextBytes(HouseholdKeyManager.KEK_LENGTH_BYTES)
+
+        assertFailsWith<IllegalArgumentException> {
+            rotation.rotateHouseholdKey(
+                householdId = "household-1",
+                oldKek = oldKek,
+                members = emptyList(),
+            )
+        }
+    }
+
+    @Test
+    fun keyRotationBundleHasCorrectHouseholdId() {
+        val rotation = KeyRotation(crypto, envelope, manager, random)
+        val oldKek = random.nextBytes(HouseholdKeyManager.KEK_LENGTH_BYTES)
+
+        val result = rotation.rotateHouseholdKey(
+            householdId = "household-xyz",
+            oldKek = oldKek,
+            members = listOf(aliceKey),
+        )
+
+        assertEquals("household-xyz", result.bundle.householdId)
+        assertEquals(HouseholdKeyManager.DEFAULT_ALGORITHM, result.bundle.algorithm)
+    }
+
+    @Test
+    fun keyRotationNewKekIs32Bytes() {
+        val rotation = KeyRotation(crypto, envelope, manager, random)
+        val oldKek = random.nextBytes(HouseholdKeyManager.KEK_LENGTH_BYTES)
+
+        val result = rotation.rotateHouseholdKey(
+            householdId = "household-1",
+            oldKek = oldKek,
+            members = listOf(aliceKey),
+        )
+
+        assertEquals(
+            HouseholdKeyManager.KEK_LENGTH_BYTES,
+            result.newKek.size,
+            "New KEK should be 32 bytes",
+        )
+    }
+
+    @Test
+    fun reWrapMultipleDeksPreservesAll() {
+        val rotation = KeyRotation(crypto, envelope, manager, random)
+        val oldKek = ByteArray(32) { 0x01 }
+        val newKek = ByteArray(32) { 0x02 }
+
+        // Generate and wrap 5 DEKs
+        val deks = List(5) { envelope.generateDEK() }
+        val wrappedOld = deks.map { envelope.wrapDEK(it, oldKek) }
+
+        val reWrapped = rotation.reWrapDeks(oldKek, newKek, wrappedOld)
+
+        assertEquals(5, reWrapped.size, "Should re-wrap all 5 DEKs")
+
+        // Each re-wrapped DEK should unwrap to its original
+        for (i in deks.indices) {
+            val unwrapped = envelope.unwrapDEK(reWrapped[i], newKek)
+            assertTrue(
+                deks[i].contentEquals(unwrapped),
+                "DEK $i should be recoverable after re-wrap",
+            )
+        }
+    }
+
+    @Test
+    fun reEncryptDataMultiplePayloadsRoundTrips() {
+        val rotation = KeyRotation(crypto, envelope, manager, random)
+        val oldKek = ByteArray(32) { 0x01 }
+        val newKek = ByteArray(32) { 0x02 }
+
+        val plaintexts = listOf("secret-1", "secret-2", "secret-3")
+        val originals = plaintexts.map {
+            crypto.encrypt(it.encodeToByteArray(), oldKek)
+        }
+
+        val reEncrypted = rotation.reEncryptData(oldKek, newKek, originals)
+
+        assertEquals(3, reEncrypted.size)
+        for (i in plaintexts.indices) {
+            val decrypted = crypto.decrypt(reEncrypted[i], newKek)
+            assertEquals(
+                plaintexts[i],
+                decrypted.decodeToString(),
+                "Payload $i should decrypt to original after re-encrypt",
+            )
+        }
+    }
+
+    // =========================================================================
+    // createHouseholdKey bundle structure
+    // =========================================================================
+
+    @Test
+    fun createHouseholdKeyBundleAlgorithmIsCorrect() {
+        val bundle = manager.createHouseholdKey("hh-test", aliceKey)
+        assertEquals(HouseholdKeyManager.DEFAULT_ALGORITHM, bundle.algorithm)
+    }
+
+    @Test
+    fun createHouseholdKeyEncryptedKekIsNotPlaintextKek() {
+        // The encrypted KEK should not be the raw KEK bytes
+        val bundle = manager.createHouseholdKey("hh-test", aliceKey)
+
+        // While we can't directly access the plaintext KEK (it's generated internally),
+        // we can verify the encrypted KEK is not empty and has reasonable size
+        assertTrue(
+            bundle.encryptedKek.size > HouseholdKeyManager.KEK_LENGTH_BYTES,
+            "Encrypted KEK should be larger than raw KEK (includes nonce)",
+        )
+    }
+
+    @Test
+    fun householdKeyBundleEqualityByContent() {
+        val bundle1 = HouseholdKeyBundle(
+            householdId = "hh-1",
+            encryptedKek = byteArrayOf(1, 2, 3),
+            publicKey = byteArrayOf(4, 5, 6),
+            algorithm = "X25519+AES-256-GCM",
+        )
+        val bundle2 = HouseholdKeyBundle(
+            householdId = "hh-1",
+            encryptedKek = byteArrayOf(1, 2, 3),
+            publicKey = byteArrayOf(4, 5, 6),
+            algorithm = "X25519+AES-256-GCM",
+        )
+
+        assertEquals(bundle1, bundle2, "Bundles with same content should be equal")
+        assertEquals(bundle1.hashCode(), bundle2.hashCode())
     }
 }

--- a/packages/sync/src/commonTest/kotlin/com/finance/sync/delta/DeltaSyncManagerTest.kt
+++ b/packages/sync/src/commonTest/kotlin/com/finance/sync/delta/DeltaSyncManagerTest.kt
@@ -3,14 +3,67 @@
 package com.finance.sync.delta
 
 import com.finance.sync.MutationOperation
+import com.finance.sync.PullResult
+import com.finance.sync.PushResult
 import com.finance.sync.SyncChange
+import com.finance.sync.SyncConfig
+import com.finance.sync.SyncMutation
+import com.finance.sync.SyncProvider
+import com.finance.sync.SyncStatus
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+
+/**
+ * A stub [SyncProvider] for unit-testing [DeltaSyncManager] without
+ * network I/O. Allows tests to configure responses for pull and push.
+ */
+private class StubSyncProvider : SyncProvider {
+
+    /** Responses to return from successive [pullChanges] calls. */
+    val pullResponses = ArrayDeque<PullResult>()
+
+    /** Accumulates mutations received via [pushMutations]. */
+    val pushedMutations = mutableListOf<SyncMutation>()
+
+    /** Response to return from [pushMutations]. */
+    var pushResponse: PushResult = PushResult(succeeded = emptyList(), failed = emptyList())
+
+    override suspend fun initialize(config: SyncConfig) {}
+    override suspend fun push(mutations: List<SyncMutation>): Result<Unit> = Result.success(Unit)
+    override fun pull(): Flow<List<SyncChange>> = emptyFlow()
+    override fun getStatus(): Flow<SyncStatus> = emptyFlow()
+
+    override suspend fun pullChanges(since: Map<String, Long>): PullResult {
+        return pullResponses.removeFirstOrNull()
+            ?: PullResult(changes = emptyList(), newVersions = since, hasMore = false)
+    }
+
+    override suspend fun pushMutations(mutations: List<SyncMutation>): PushResult {
+        pushedMutations.addAll(mutations)
+        return pushResponse.copy(
+            succeeded = if (pushResponse.succeeded.isEmpty()) {
+                mutations.map { it.id }
+            } else {
+                pushResponse.succeeded
+            },
+        )
+    }
+}
+
+/** Default [SyncConfig] for tests. */
+private val TEST_CONFIG = SyncConfig(
+    endpoint = "https://test.powersync.dev",
+    databaseName = "test.db",
+    batchSize = 2,
+)
 
 class DeltaSyncManagerTest {
 
@@ -19,6 +72,7 @@ class DeltaSyncManagerTest {
         seq: Long,
         rowId: String = "row-1",
         checksum: Long? = null,
+        syncVersion: Long = 0L,
     ): SyncChange {
         val rowData = buildMap {
             put("id", rowId)
@@ -31,18 +85,40 @@ class DeltaSyncManagerTest {
             rowData = rowData,
             serverTimestamp = Instant.parse("2024-01-01T00:00:00Z"),
             sequenceNumber = seq,
+            syncVersion = syncVersion,
         )
     }
+
+    private fun mutation(
+        id: String = "mut-1",
+        table: String = "accounts",
+        recordId: String = "row-1",
+        operation: MutationOperation = MutationOperation.UPDATE,
+    ): SyncMutation = SyncMutation(
+        id = id,
+        tableName = table,
+        operation = operation,
+        rowData = mapOf("id" to recordId, "name" to "Local"),
+        timestamp = Instant.parse("2024-01-01T00:00:00Z"),
+        recordId = recordId,
+    )
+
+    private fun createManager(
+        tracker: SequenceTracker = InMemorySequenceTracker(),
+        provider: SyncProvider = StubSyncProvider(),
+    ): DeltaSyncManager = DeltaSyncManager(provider, tracker, TEST_CONFIG)
+
+    // ── Sequence validation tests (processChanges) ──────────────
 
     @Test
     fun firstSyncAcceptsAnyStartingSequence() = runTest {
         val tracker = InMemorySequenceTracker()
-        val manager = DeltaSyncManager(tracker)
+        val manager = createManager(tracker)
         val result = manager.processChanges(listOf(
             change(seq = 1), change(seq = 2, rowId = "r2"), change(seq = 3, rowId = "r3"),
         ))
         val r = result["accounts"]
-        assertIs<DeltaSyncResult.Success>(r)
+        assertIs<ChangeValidationResult.Success>(r)
         assertEquals(3, r.appliedCount)
         assertEquals(3L, tracker.getLastSequence("accounts"))
     }
@@ -51,9 +127,9 @@ class DeltaSyncManagerTest {
     fun subsequentSyncContinuesFromLastSequence() = runTest {
         val tracker = InMemorySequenceTracker()
         tracker.setLastSequence("accounts", 5)
-        val manager = DeltaSyncManager(tracker)
+        val manager = createManager(tracker)
         val result = manager.processChanges(listOf(change(seq = 6, rowId = "r6"), change(seq = 7, rowId = "r7")))
-        assertIs<DeltaSyncResult.Success>(result["accounts"])
+        assertIs<ChangeValidationResult.Success>(result["accounts"])
         assertEquals(7L, tracker.getLastSequence("accounts"))
     }
 
@@ -61,10 +137,10 @@ class DeltaSyncManagerTest {
     fun sequenceGapDetectedBetweenBatches() = runTest {
         val tracker = InMemorySequenceTracker()
         tracker.setLastSequence("accounts", 5)
-        val manager = DeltaSyncManager(tracker)
+        val manager = createManager(tracker)
         val result = manager.processChanges(listOf(change(seq = 8, rowId = "r8")))
         val r = result["accounts"]
-        assertIs<DeltaSyncResult.SequenceGap>(r)
+        assertIs<ChangeValidationResult.SequenceGap>(r)
         assertEquals(6L, r.expectedSequence)
         assertEquals(8L, r.actualSequence)
         assertNull(tracker.getLastSequence("accounts"))
@@ -73,12 +149,12 @@ class DeltaSyncManagerTest {
     @Test
     fun sequenceGapDetectedWithinBatch() = runTest {
         val tracker = InMemorySequenceTracker()
-        val manager = DeltaSyncManager(tracker)
+        val manager = createManager(tracker)
         val result = manager.processChanges(listOf(
             change(seq = 1, rowId = "r1"), change(seq = 2, rowId = "r2"), change(seq = 4, rowId = "r4"),
         ))
         val r = result["accounts"]
-        assertIs<DeltaSyncResult.SequenceGap>(r)
+        assertIs<ChangeValidationResult.SequenceGap>(r)
         assertEquals(3L, r.expectedSequence)
         assertEquals(4L, r.actualSequence)
     }
@@ -86,14 +162,14 @@ class DeltaSyncManagerTest {
     @Test
     fun multipleTablesProcessedIndependently() = runTest {
         val tracker = InMemorySequenceTracker()
-        val manager = DeltaSyncManager(tracker)
+        val manager = createManager(tracker)
         val result = manager.processChanges(listOf(
             change(table = "accounts", seq = 1, rowId = "a1"),
             change(table = "accounts", seq = 2, rowId = "a2"),
             change(table = "transactions", seq = 1, rowId = "t1"),
         ))
-        assertIs<DeltaSyncResult.Success>(result["accounts"])
-        assertIs<DeltaSyncResult.Success>(result["transactions"])
+        assertIs<ChangeValidationResult.Success>(result["accounts"])
+        assertIs<ChangeValidationResult.Success>(result["transactions"])
         assertEquals(2L, tracker.getLastSequence("accounts"))
         assertEquals(1L, tracker.getLastSequence("transactions"))
     }
@@ -101,36 +177,36 @@ class DeltaSyncManagerTest {
     @Test
     fun validChecksumPasses() = runTest {
         val tracker = InMemorySequenceTracker()
-        val manager = DeltaSyncManager(tracker)
+        val manager = createManager(tracker)
         val rowData = mapOf("id" to "row-1", "name" to "Test")
         val checksum = SyncChecksum.computeRowChecksum(rowData)
         val result = manager.processChanges(listOf(change(seq = 1, checksum = checksum)))
-        assertIs<DeltaSyncResult.Success>(result["accounts"])
+        assertIs<ChangeValidationResult.Success>(result["accounts"])
     }
 
     @Test
     fun invalidChecksumDetected() = runTest {
         val tracker = InMemorySequenceTracker()
-        val manager = DeltaSyncManager(tracker)
+        val manager = createManager(tracker)
         val result = manager.processChanges(listOf(change(seq = 1, checksum = 999999L)))
         val r = result["accounts"]
-        assertIs<DeltaSyncResult.ChecksumMismatch>(r)
+        assertIs<ChangeValidationResult.ChecksumMismatch>(r)
         assertTrue(r.failedRowIds.contains("row-1"))
     }
 
     @Test
     fun changesWithoutChecksumFieldAreNotValidated() = runTest {
         val tracker = InMemorySequenceTracker()
-        val manager = DeltaSyncManager(tracker)
+        val manager = createManager(tracker)
         val result = manager.processChanges(listOf(change(seq = 1)))
-        assertIs<DeltaSyncResult.Success>(result["accounts"])
+        assertIs<ChangeValidationResult.Success>(result["accounts"])
     }
 
     @Test
     fun requestFullResyncClearsTableSequence() = runTest {
         val tracker = InMemorySequenceTracker()
         tracker.setLastSequence("accounts", 10)
-        val manager = DeltaSyncManager(tracker)
+        val manager = createManager(tracker)
         manager.requestFullResync("accounts")
         assertNull(tracker.getLastSequence("accounts"))
     }
@@ -140,7 +216,7 @@ class DeltaSyncManagerTest {
         val tracker = InMemorySequenceTracker()
         tracker.setLastSequence("accounts", 10)
         tracker.setLastSequence("transactions", 20)
-        val manager = DeltaSyncManager(tracker)
+        val manager = createManager(tracker)
         manager.requestFullResyncAll()
         assertNull(tracker.getLastSequence("accounts"))
         assertNull(tracker.getLastSequence("transactions"))
@@ -148,7 +224,7 @@ class DeltaSyncManagerTest {
 
     @Test
     fun emptyChangesListReturnsEmptyMap() = runTest {
-        val result = DeltaSyncManager(InMemorySequenceTracker()).processChanges(emptyList())
+        val result = createManager().processChanges(emptyList())
         assertTrue(result.isEmpty())
     }
 
@@ -156,10 +232,12 @@ class DeltaSyncManagerTest {
     fun getLastSequenceReturnsTrackedValue() = runTest {
         val tracker = InMemorySequenceTracker()
         tracker.setLastSequence("accounts", 42)
-        val manager = DeltaSyncManager(tracker)
+        val manager = createManager(tracker)
         assertEquals(42L, manager.getLastSequence("accounts"))
         assertNull(manager.getLastSequence("transactions"))
     }
+
+    // ── SyncChecksum tests ──────────────────────────────────────
 
     @Test
     fun checksumIsDeterministic() {
@@ -187,5 +265,327 @@ class DeltaSyncManagerTest {
         val checksum = SyncChecksum.computeRowChecksum(data)
         assertTrue(checksum >= 0L)
         assertTrue(SyncChecksum.verifyRowChecksum(data, checksum))
+    }
+
+    // ── Hex checksum API ────────────────────────────────────────
+
+    @Test
+    fun computeForRecordReturnsHexString() {
+        val data = mapOf("id" to "1", "name" to "Test")
+        val hex = SyncChecksum.computeForRecord(data)
+        assertEquals(8, hex.length, "Hex checksum should be 8 characters")
+        assertTrue(hex.all { it in '0'..'9' || it in 'a'..'f' }, "Should be lowercase hex")
+    }
+
+    @Test
+    fun computeForChangesIsDeterministic() {
+        val changes = listOf(
+            change(seq = 1, rowId = "r1"),
+            change(seq = 2, rowId = "r2"),
+        )
+        assertEquals(
+            SyncChecksum.computeForChanges(changes),
+            SyncChecksum.computeForChanges(changes),
+        )
+    }
+
+    @Test
+    fun computeForChangesIsOrderIndependent() {
+        val c1 = change(seq = 1, rowId = "r1")
+        val c2 = change(seq = 2, rowId = "r2")
+        // Reverse order should produce the same checksum (sorted internally)
+        assertEquals(
+            SyncChecksum.computeForChanges(listOf(c1, c2)),
+            SyncChecksum.computeForChanges(listOf(c2, c1)),
+        )
+    }
+
+    @Test
+    fun verifyMatchingChecksum() {
+        val changes = listOf(change(seq = 1, rowId = "r1"))
+        val checksum = SyncChecksum.computeForChanges(changes)
+        assertTrue(SyncChecksum.verify(changes, checksum))
+    }
+
+    @Test
+    fun verifyMismatchedChecksum() {
+        val changes = listOf(change(seq = 1, rowId = "r1"))
+        assertTrue(!SyncChecksum.verify(changes, "deadbeef"))
+    }
+
+    // ── pullChanges tests ───────────────────────────────────────
+
+    @Test
+    fun pullChangesFetchesFromProvider() = runTest {
+        val provider = StubSyncProvider()
+        val changes = listOf(change(seq = 1, rowId = "r1", syncVersion = 5))
+        provider.pullResponses.addLast(
+            PullResult(changes = changes, newVersions = mapOf("accounts" to 5L), hasMore = false),
+        )
+        val manager = DeltaSyncManager(provider, InMemorySequenceTracker(), TEST_CONFIG)
+
+        val result = manager.pullChanges()
+        assertEquals(1, result.size)
+        assertEquals("r1", result[0].effectiveRecordId)
+    }
+
+    @Test
+    fun pullChangesHandlesPagination() = runTest {
+        val provider = StubSyncProvider()
+        provider.pullResponses.addLast(
+            PullResult(
+                changes = listOf(change(seq = 1, rowId = "r1")),
+                newVersions = mapOf("accounts" to 1L),
+                hasMore = true,
+            ),
+        )
+        provider.pullResponses.addLast(
+            PullResult(
+                changes = listOf(change(seq = 2, rowId = "r2")),
+                newVersions = mapOf("accounts" to 2L),
+                hasMore = false,
+            ),
+        )
+        val tracker = InMemorySequenceTracker()
+        val manager = DeltaSyncManager(provider, tracker, TEST_CONFIG)
+
+        val result = manager.pullChanges()
+        assertEquals(2, result.size)
+        assertEquals(2L, tracker.getLastSequence("accounts"))
+    }
+
+    @Test
+    fun pullChangesUpdatesSequenceTracker() = runTest {
+        val provider = StubSyncProvider()
+        provider.pullResponses.addLast(
+            PullResult(
+                changes = listOf(change(seq = 1)),
+                newVersions = mapOf("accounts" to 10L),
+                hasMore = false,
+            ),
+        )
+        val tracker = InMemorySequenceTracker()
+        val manager = DeltaSyncManager(provider, tracker, TEST_CONFIG)
+
+        manager.pullChanges()
+        assertEquals(10L, tracker.getVersion("accounts"))
+    }
+
+    // ── pushMutations tests ─────────────────────────────────────
+
+    @Test
+    fun pushMutationsReturnsEmptyForEmptyList() = runTest {
+        val manager = createManager()
+        val result = manager.pushMutations(emptyList())
+        assertTrue(result.succeeded.isEmpty())
+        assertTrue(result.failed.isEmpty())
+    }
+
+    @Test
+    fun pushMutationsBatchesByConfig() = runTest {
+        // batchSize = 2 in TEST_CONFIG
+        val provider = StubSyncProvider()
+        val manager = DeltaSyncManager(provider, InMemorySequenceTracker(), TEST_CONFIG)
+
+        val mutations = listOf(
+            mutation(id = "m1", recordId = "r1"),
+            mutation(id = "m2", recordId = "r2"),
+            mutation(id = "m3", recordId = "r3"),
+        )
+        val result = manager.pushMutations(mutations)
+
+        // Provider should have received all 3 mutations across 2 batches
+        assertEquals(3, provider.pushedMutations.size)
+        assertEquals(3, result.succeeded.size)
+    }
+
+    // ── detectConflicts tests ───────────────────────────────────
+
+    @Test
+    fun detectConflictsReturnsEmptyWhenNoOverlap() {
+        val manager = createManager()
+        val serverChanges = listOf(change(seq = 1, rowId = "r1"))
+        val localMutations = listOf(mutation(recordId = "r2"))
+        val conflicts = manager.detectConflicts(serverChanges, localMutations)
+        assertTrue(conflicts.isEmpty())
+    }
+
+    @Test
+    fun detectConflictsFindsOverlappingRecords() {
+        val manager = createManager()
+        val serverChanges = listOf(
+            change(seq = 1, rowId = "r1", syncVersion = 5),
+        )
+        val localMutations = listOf(
+            mutation(id = "m1", recordId = "r1"),
+        )
+        val conflicts = manager.detectConflicts(serverChanges, localMutations)
+
+        assertEquals(1, conflicts.size)
+        assertEquals("accounts", conflicts[0].tableName)
+        assertEquals("r1", conflicts[0].recordId)
+        assertEquals(5L, conflicts[0].serverVersion)
+        assertEquals(0L, conflicts[0].localVersion)
+    }
+
+    @Test
+    fun detectConflictsIgnoresNonOverlappingTables() {
+        val manager = createManager()
+        val serverChanges = listOf(change(table = "accounts", seq = 1, rowId = "r1"))
+        val localMutations = listOf(mutation(table = "transactions", recordId = "r1"))
+        val conflicts = manager.detectConflicts(serverChanges, localMutations)
+        assertTrue(conflicts.isEmpty())
+    }
+
+    @Test
+    fun detectConflictsReturnsEmptyForEmptyInputs() {
+        val manager = createManager()
+        assertTrue(manager.detectConflicts(emptyList(), emptyList()).isEmpty())
+        assertTrue(manager.detectConflicts(listOf(change(seq = 1)), emptyList()).isEmpty())
+        assertTrue(manager.detectConflicts(emptyList(), listOf(mutation())).isEmpty())
+    }
+
+    // ── executePullCycle tests ──────────────────────────────────
+
+    @Test
+    fun executePullCycleReturnsChangesAndConflicts() = runTest {
+        val provider = StubSyncProvider()
+        provider.pullResponses.addLast(
+            PullResult(
+                changes = listOf(change(seq = 1, rowId = "r1", syncVersion = 3)),
+                newVersions = mapOf("accounts" to 3L),
+                hasMore = false,
+            ),
+        )
+        val manager = DeltaSyncManager(provider, InMemorySequenceTracker(), TEST_CONFIG)
+
+        val pendingMutations = listOf(mutation(id = "m1", recordId = "r1"))
+        val result = manager.executePullCycle(pendingMutations)
+
+        assertEquals(1, result.changes.size)
+        assertEquals(1, result.conflicts.size)
+        assertEquals(3L, result.newVersions["accounts"])
+        assertNotNull(result.checksum)
+    }
+
+    @Test
+    fun executePullCycleWithNoChangesReturnsNullChecksum() = runTest {
+        val provider = StubSyncProvider()
+        provider.pullResponses.addLast(
+            PullResult(changes = emptyList(), newVersions = emptyMap(), hasMore = false),
+        )
+        val manager = DeltaSyncManager(provider, InMemorySequenceTracker(), TEST_CONFIG)
+
+        val result = manager.executePullCycle(emptyList())
+        assertTrue(result.changes.isEmpty())
+        assertTrue(result.conflicts.isEmpty())
+        assertNull(result.checksum)
+    }
+
+    @Test
+    fun executePullCycleWithNoConflicts() = runTest {
+        val provider = StubSyncProvider()
+        provider.pullResponses.addLast(
+            PullResult(
+                changes = listOf(change(seq = 1, rowId = "r1")),
+                newVersions = mapOf("accounts" to 1L),
+                hasMore = false,
+            ),
+        )
+        val manager = DeltaSyncManager(provider, InMemorySequenceTracker(), TEST_CONFIG)
+
+        // Pending mutations for a different record
+        val pendingMutations = listOf(mutation(id = "m1", recordId = "r2"))
+        val result = manager.executePullCycle(pendingMutations)
+
+        assertEquals(1, result.changes.size)
+        assertTrue(result.conflicts.isEmpty())
+        assertNotNull(result.checksum)
+    }
+
+    // ── resetSync tests ─────────────────────────────────────────
+
+    @Test
+    fun resetSyncClearsAllVersions() = runTest {
+        val tracker = InMemorySequenceTracker()
+        tracker.setLastSequence("accounts", 10)
+        tracker.setLastSequence("transactions", 20)
+        val manager = createManager(tracker)
+
+        manager.resetSync()
+
+        assertNull(tracker.getLastSequence("accounts"))
+        assertNull(tracker.getLastSequence("transactions"))
+    }
+
+    // ── SequenceTracker extended API tests ───────────────────────
+
+    @Test
+    fun trackerGetVersionReturnsZeroForUnknownTable() = runTest {
+        val tracker = InMemorySequenceTracker()
+        assertEquals(0L, tracker.getVersion("unknown"))
+    }
+
+    @Test
+    fun trackerGetAllVersionsReturnsSnapshot() = runTest {
+        val tracker = InMemorySequenceTracker()
+        tracker.setLastSequence("accounts", 5)
+        tracker.setLastSequence("transactions", 10)
+        val versions = tracker.getAllVersions()
+        assertEquals(mapOf("accounts" to 5L, "transactions" to 10L), versions)
+    }
+
+    @Test
+    fun trackerUpdateVersionOnlyAdvances() = runTest {
+        val tracker = InMemorySequenceTracker()
+        tracker.updateVersion("accounts", 10)
+        assertEquals(10L, tracker.getVersion("accounts"))
+
+        // Trying to set a lower version should be a no-op
+        tracker.updateVersion("accounts", 5)
+        assertEquals(10L, tracker.getVersion("accounts"))
+
+        // Higher version should advance
+        tracker.updateVersion("accounts", 15)
+        assertEquals(15L, tracker.getVersion("accounts"))
+    }
+
+    @Test
+    fun trackerHasEverSynced() = runTest {
+        val tracker = InMemorySequenceTracker()
+        assertTrue(!tracker.hasEverSynced())
+
+        tracker.setLastSequence("accounts", 1)
+        assertTrue(tracker.hasEverSynced())
+    }
+
+    @Test
+    fun trackerTrackedTables() = runTest {
+        val tracker = InMemorySequenceTracker()
+        assertTrue(tracker.trackedTables().isEmpty())
+
+        tracker.setLastSequence("accounts", 1)
+        tracker.setLastSequence("transactions", 2)
+        assertEquals(setOf("accounts", "transactions"), tracker.trackedTables())
+    }
+
+    @Test
+    fun trackerResetAllClearsEverything() = runTest {
+        val tracker = InMemorySequenceTracker()
+        tracker.setLastSequence("accounts", 1)
+        tracker.setLastSequence("transactions", 2)
+
+        tracker.resetAll()
+
+        assertTrue(!tracker.hasEverSynced())
+        assertEquals(0L, tracker.getVersion("accounts"))
+    }
+
+    @Test
+    fun trackerUpdateVersionsBatch() = runTest {
+        val tracker = InMemorySequenceTracker()
+        tracker.updateVersions(mapOf("accounts" to 5L, "transactions" to 10L))
+        assertEquals(5L, tracker.getVersion("accounts"))
+        assertEquals(10L, tracker.getVersion("transactions"))
     }
 }

--- a/packages/sync/src/commonTest/kotlin/com/finance/sync/integration/OfflineResilienceTest.kt
+++ b/packages/sync/src/commonTest/kotlin/com/finance/sync/integration/OfflineResilienceTest.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 /**
@@ -156,5 +157,276 @@ class OfflineResilienceTest {
         val pushed3 = harness.deviceA.pushPendingMutations()
         assertEquals(1, pushed3, "Push should succeed when server recovers")
         assertEquals(0, harness.deviceA.offlineQueueSize, "Queue should be empty after successful push")
+    }
+
+    // ── Multiple offline periods → all mutations eventually sync ──
+
+    @Test
+    fun test_multiple_offline_periods_all_mutations_eventually_sync() = runTest {
+        val testClock = TestClock()
+        val multiHarness = SyncIntegrationTestHarness(clock = testClock)
+
+        // Period 1: Go offline, create mutations
+        multiHarness.networkA.goOffline()
+        repeat(3) { i ->
+            multiHarness.deviceA.put(
+                entityType = "transaction",
+                entityId = "txn-period1-$i",
+                payload = """{"amount":${(i + 1) * 100},"period":1}""",
+            )
+        }
+        assertEquals(3, multiHarness.deviceA.offlineQueueSize, "Period 1: 3 mutations queued")
+
+        // Come online, push period 1 mutations
+        multiHarness.networkA.goOnline()
+        testClock.advanceBy(1000)
+        val pushed1 = multiHarness.deviceA.pushPendingMutations()
+        assertEquals(3, pushed1, "Period 1: all 3 mutations should push")
+        assertEquals(0, multiHarness.deviceA.offlineQueueSize, "Queue should be empty")
+
+        // Period 2: Go offline again, create more mutations
+        multiHarness.networkA.goOffline()
+        testClock.advanceBy(5000)
+        repeat(4) { i ->
+            multiHarness.deviceA.put(
+                entityType = "transaction",
+                entityId = "txn-period2-$i",
+                payload = """{"amount":${(i + 1) * 200},"period":2}""",
+            )
+        }
+        assertEquals(4, multiHarness.deviceA.offlineQueueSize, "Period 2: 4 mutations queued")
+
+        // Come online, push period 2 mutations
+        multiHarness.networkA.goOnline()
+        testClock.advanceBy(1000)
+        val pushed2 = multiHarness.deviceA.pushPendingMutations()
+        assertEquals(4, pushed2, "Period 2: all 4 mutations should push")
+
+        // Period 3: Yet another offline period
+        multiHarness.networkA.goOffline()
+        testClock.advanceBy(10000)
+        repeat(2) { i ->
+            multiHarness.deviceA.put(
+                entityType = "account",
+                entityId = "acc-period3-$i",
+                payload = """{"name":"Account $i","period":3}""",
+            )
+        }
+
+        multiHarness.networkA.goOnline()
+        testClock.advanceBy(1000)
+        val pushed3 = multiHarness.deviceA.pushPendingMutations()
+        assertEquals(2, pushed3, "Period 3: all 2 mutations should push")
+
+        // Device B pulls all changes across all periods
+        val applied = multiHarness.deviceB.pullRemoteChanges()
+        assertEquals(9, applied.size, "Device B should receive all 9 mutations (3 + 4 + 2)")
+
+        // Verify Device B has all records
+        val transactions = multiHarness.deviceB.database.getAll("transaction")
+        assertEquals(7, transactions.size, "Device B should have 7 transactions")
+
+        val accounts = multiHarness.deviceB.database.getAll("account")
+        assertEquals(2, accounts.size, "Device B should have 2 accounts")
+    }
+
+    // ── Network drop mid-sync → retry on reconnect ──────────────
+
+    @Test
+    fun test_network_drop_during_push_retries_on_reconnect() = runTest {
+        // Device A goes offline and creates a mutation
+        harness.networkA.goOffline()
+        harness.deviceA.put(
+            entityType = "transaction",
+            entityId = "txn-drop",
+            payload = """{"amount":777}""",
+        )
+
+        // Try to push while offline — should fail silently
+        val pushedOffline = harness.deviceA.pushPendingMutations()
+        assertEquals(0, pushedOffline, "Push should fail while offline")
+        assertEquals(1, harness.deviceA.offlineQueueSize, "Mutation should remain queued")
+
+        // Come back online
+        harness.networkA.goOnline()
+
+        // Retry push — should succeed
+        val pushedOnline = harness.deviceA.pushPendingMutations()
+        assertEquals(1, pushedOnline, "Push should succeed after reconnect")
+        assertEquals(0, harness.deviceA.offlineQueueSize, "Queue should be empty after successful push")
+
+        // Device B should receive the mutation
+        val applied = harness.deviceB.pullRemoteChanges()
+        assertEquals(1, applied.size, "Device B should receive the mutation after retry")
+    }
+
+    @Test
+    fun test_server_error_mid_sync_does_not_lose_data() = runTest {
+        // Device A creates mutations while online
+        harness.deviceA.put(
+            entityType = "transaction",
+            entityId = "txn-server-err-1",
+            payload = """{"amount":100}""",
+        )
+
+        // Now go offline and create more
+        harness.networkA.goOffline()
+        harness.deviceA.put(
+            entityType = "transaction",
+            entityId = "txn-server-err-2",
+            payload = """{"amount":200}""",
+        )
+        harness.deviceA.put(
+            entityType = "transaction",
+            entityId = "txn-server-err-3",
+            payload = """{"amount":300}""",
+        )
+
+        // Come online but server will fail
+        harness.networkA.goOnline()
+        harness.server.shouldFailNext = true
+        val pushed1 = harness.deviceA.pushPendingMutations()
+        assertEquals(0, pushed1, "Push should fail due to server error")
+        assertEquals(2, harness.deviceA.offlineQueueSize, "Both mutations should remain queued")
+
+        // Server recovers
+        val pushed2 = harness.deviceA.pushPendingMutations()
+        assertEquals(2, pushed2, "Both mutations should push on retry")
+        assertEquals(0, harness.deviceA.offlineQueueSize)
+    }
+
+    // ── Pull while offline returns empty ─────────────────────────
+
+    @Test
+    fun test_pull_while_offline_returns_empty() = runTest {
+        // Device A creates a mutation
+        harness.deviceA.put(
+            entityType = "transaction",
+            entityId = "txn-pull-offline",
+            payload = """{"amount":500}""",
+        )
+
+        // Device B goes offline
+        harness.networkB.goOffline()
+
+        // Device B tries to pull — should get empty list (not crash)
+        val applied = harness.deviceB.pullRemoteChanges()
+        assertEquals(0, applied.size, "Pull while offline should return empty list")
+
+        // Device B comes back online and pulls successfully
+        harness.networkB.goOnline()
+        val appliedOnline = harness.deviceB.pullRemoteChanges()
+        assertEquals(1, appliedOnline.size, "Pull should succeed after coming online")
+    }
+
+    // ── Network state history tracking ──────────────────────────
+
+    @Test
+    fun test_network_state_history_is_tracked() = runTest {
+        // Initial state is ONLINE
+        assertEquals(
+            listOf(NetworkSimulator.State.ONLINE),
+            harness.networkA.stateHistory,
+        )
+
+        harness.networkA.goOffline()
+        harness.networkA.goOnline()
+        harness.networkA.goOffline()
+
+        assertEquals(
+            listOf(
+                NetworkSimulator.State.ONLINE,
+                NetworkSimulator.State.OFFLINE,
+                NetworkSimulator.State.ONLINE,
+                NetworkSimulator.State.OFFLINE,
+            ),
+            harness.networkA.stateHistory,
+        )
+    }
+
+    // ── Extended offline with data consistency ───────────────────
+
+    @Test
+    fun test_extended_offline_maintains_local_data_consistency() = runTest {
+        // Device A goes offline for an extended period
+        harness.networkA.goOffline()
+
+        // Create, update, then delete a record — all while offline
+        harness.deviceA.put(
+            entityType = "transaction",
+            entityId = "txn-lifecycle",
+            payload = """{"amount":100,"payee":"Initial"}""",
+        )
+        harness.deviceA.put(
+            entityType = "transaction",
+            entityId = "txn-lifecycle",
+            payload = """{"amount":200,"payee":"Updated"}""",
+            operation = MutationOperation.UPDATE,
+        )
+
+        // Local DB should have the latest version
+        val localRecord = harness.deviceA.database.get("transaction", "txn-lifecycle")
+        assertNotNull(localRecord)
+        assertTrue(localRecord.payload.contains("Updated"), "Local DB should reflect latest update")
+
+        // Come online and push
+        harness.networkA.goOnline()
+        harness.deviceA.pushPendingMutations()
+
+        // Device B should receive the mutations
+        val applied = harness.deviceB.pullRemoteChanges()
+        assertTrue(applied.isNotEmpty(), "Device B should receive mutations")
+
+        val bRecord = harness.deviceB.database.get("transaction", "txn-lifecycle")
+        assertNotNull(bRecord)
+    }
+
+    // ── Both devices offline simultaneously ─────────────────────
+
+    @Test
+    fun test_both_devices_offline_then_sync() = runTest {
+        val testClock = TestClock()
+        val dualOfflineHarness = SyncIntegrationTestHarness(clock = testClock)
+
+        // Both devices go offline
+        dualOfflineHarness.networkA.goOffline()
+        dualOfflineHarness.networkB.goOffline()
+
+        // Device A creates while offline
+        dualOfflineHarness.deviceA.put(
+            entityType = "transaction",
+            entityId = "txn-dual-a",
+            payload = """{"amount":111,"payee":"Device A Offline"}""",
+        )
+
+        testClock.advanceBy(500)
+
+        // Device B creates while offline
+        dualOfflineHarness.deviceB.put(
+            entityType = "transaction",
+            entityId = "txn-dual-b",
+            payload = """{"amount":222,"payee":"Device B Offline"}""",
+        )
+
+        // Both come online
+        dualOfflineHarness.networkA.goOnline()
+        dualOfflineHarness.networkB.goOnline()
+
+        testClock.advanceBy(100)
+
+        // Push queued mutations
+        dualOfflineHarness.deviceA.pushPendingMutations()
+        dualOfflineHarness.deviceB.pushPendingMutations()
+
+        // Pull to get each other's changes
+        dualOfflineHarness.deviceA.pullRemoteChanges()
+        dualOfflineHarness.deviceB.pullRemoteChanges()
+
+        // Both should have both transactions
+        val aRecord = dualOfflineHarness.deviceA.database.get("transaction", "txn-dual-b")
+        assertNotNull(aRecord, "Device A should have Device B's offline transaction")
+
+        val bRecord = dualOfflineHarness.deviceB.database.get("transaction", "txn-dual-a")
+        assertNotNull(bRecord, "Device B should have Device A's offline transaction")
     }
 }

--- a/packages/sync/src/commonTest/kotlin/com/finance/sync/integration/SyncScenarioTest.kt
+++ b/packages/sync/src/commonTest/kotlin/com/finance/sync/integration/SyncScenarioTest.kt
@@ -198,4 +198,157 @@ class SyncScenarioTest {
         val hasGap = harness.deviceB.detectSequenceGap()
         assertTrue(hasGap, "Device B should detect a sequence gap when sequence 2 is missing")
     }
+
+    // ── Multi-table sync ────────────────────────────────────────
+
+    @Test
+    fun test_multi_table_sync_transactions_accounts_categories() = runTest {
+        // Device A creates entities across three different tables
+        harness.deviceA.put(
+            entityType = "account",
+            entityId = "acc-001",
+            payload = """{"name":"Checking","balance_cents":500000}""",
+        )
+        harness.deviceA.put(
+            entityType = "category",
+            entityId = "cat-001",
+            payload = """{"name":"Groceries","icon":"cart"}""",
+        )
+        harness.deviceA.put(
+            entityType = "transaction",
+            entityId = "txn-001",
+            payload = """{"amount_cents":4200,"account_id":"acc-001","category_id":"cat-001","payee":"Supermarket"}""",
+        )
+        harness.deviceA.put(
+            entityType = "transaction",
+            entityId = "txn-002",
+            payload = """{"amount_cents":1500,"account_id":"acc-001","category_id":"cat-001","payee":"Corner Store"}""",
+        )
+
+        // Device B pulls all changes across all tables
+        val applied = harness.deviceB.pullRemoteChanges()
+
+        assertEquals(4, applied.size, "Device B should receive all 4 mutations across 3 tables")
+
+        // Verify each entity type is present in Device B's local DB
+        val accounts = harness.deviceB.database.getAll("account")
+        assertEquals(1, accounts.size, "Device B should have 1 account")
+        assertTrue(accounts[0].payload.contains("Checking"))
+
+        val categories = harness.deviceB.database.getAll("category")
+        assertEquals(1, categories.size, "Device B should have 1 category")
+        assertTrue(categories[0].payload.contains("Groceries"))
+
+        val transactions = harness.deviceB.database.getAll("transaction")
+        assertEquals(2, transactions.size, "Device B should have 2 transactions")
+    }
+
+    // ── Update after initial sync ───────────────────────────────
+
+    @Test
+    fun test_update_after_initial_sync_propagates() = runTest {
+        val testClock = TestClock()
+        val updateHarness = SyncIntegrationTestHarness(clock = testClock)
+
+        // Device A creates a transaction
+        updateHarness.deviceA.put(
+            entityType = "transaction",
+            entityId = "txn-update",
+            payload = """{"amount_cents":1000,"payee":"Original Payee"}""",
+        )
+
+        // Device B syncs it
+        updateHarness.deviceB.pullRemoteChanges()
+        val original = updateHarness.deviceB.database.get("transaction", "txn-update")
+        assertNotNull(original)
+        assertTrue(original.payload.contains("Original Payee"))
+
+        // Advance clock to ensure update has a later timestamp
+        testClock.advanceBy(1000)
+
+        // Device A updates the transaction
+        updateHarness.deviceA.put(
+            entityType = "transaction",
+            entityId = "txn-update",
+            payload = """{"amount_cents":2000,"payee":"Updated Payee"}""",
+            operation = MutationOperation.UPDATE,
+        )
+
+        // Device B pulls the update
+        val updates = updateHarness.deviceB.pullRemoteChanges()
+        assertEquals(1, updates.size, "Device B should receive the update")
+
+        val updated = updateHarness.deviceB.database.get("transaction", "txn-update")
+        assertNotNull(updated)
+        assertTrue(
+            updated.payload.contains("Updated Payee"),
+            "Device B should have the updated payee",
+        )
+    }
+
+    // ── Bi-directional sync ─────────────────────────────────────
+
+    @Test
+    fun test_bidirectional_sync_between_devices() = runTest {
+        // Device A creates a transaction
+        harness.deviceA.put(
+            entityType = "transaction",
+            entityId = "txn-from-a",
+            payload = """{"amount_cents":100,"payee":"From Device A"}""",
+        )
+
+        // Device B creates a different transaction
+        harness.deviceB.put(
+            entityType = "transaction",
+            entityId = "txn-from-b",
+            payload = """{"amount_cents":200,"payee":"From Device B"}""",
+        )
+
+        // Both pull changes
+        harness.deviceA.pullRemoteChanges()
+        harness.deviceB.pullRemoteChanges()
+
+        // Device A should now have both transactions
+        val aRecordFromB = harness.deviceA.database.get("transaction", "txn-from-b")
+        assertNotNull(aRecordFromB, "Device A should have Device B's transaction")
+        assertTrue(aRecordFromB.payload.contains("From Device B"))
+
+        // Device B should now have both transactions
+        val bRecordFromA = harness.deviceB.database.get("transaction", "txn-from-a")
+        assertNotNull(bRecordFromA, "Device B should have Device A's transaction")
+        assertTrue(bRecordFromA.payload.contains("From Device A"))
+    }
+
+    // ── Empty pull returns no changes ───────────────────────────
+
+    @Test
+    fun test_empty_pull_returns_no_changes() = runTest {
+        val applied = harness.deviceA.pullRemoteChanges()
+        assertEquals(0, applied.size, "Pull with no server changes should return empty list")
+    }
+
+    // ── Multiple records of same type ───────────────────────────
+
+    @Test
+    fun test_multiple_records_same_type_all_sync() = runTest {
+        // Device A creates 10 transactions
+        repeat(10) { i ->
+            harness.deviceA.put(
+                entityType = "transaction",
+                entityId = "txn-multi-$i",
+                payload = """{"amount_cents":${(i + 1) * 100},"payee":"Vendor $i"}""",
+            )
+        }
+
+        // Device B pulls all
+        val applied = harness.deviceB.pullRemoteChanges()
+        assertEquals(10, applied.size, "Device B should receive all 10 transactions")
+
+        // Verify each transaction exists in Device B's DB
+        repeat(10) { i ->
+            val record = harness.deviceB.database.get("transaction", "txn-multi-$i")
+            assertNotNull(record, "Transaction txn-multi-$i should exist on Device B")
+            assertTrue(record.payload.contains("Vendor $i"))
+        }
+    }
 }

--- a/packages/sync/src/commonTest/kotlin/com/finance/sync/queue/InMemoryMutationQueueTest.kt
+++ b/packages/sync/src/commonTest/kotlin/com/finance/sync/queue/InMemoryMutationQueueTest.kt
@@ -4,10 +4,12 @@ package com.finance.sync.queue
 
 import com.finance.sync.MutationOperation
 import com.finance.sync.SyncMutation
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -18,13 +20,17 @@ class InMemoryMutationQueueTest {
         table: String = "accounts",
         rowId: String = "row-1",
         op: MutationOperation = MutationOperation.INSERT,
+        data: Map<String, String?> = mapOf("id" to rowId, "name" to "Test"),
+        ts: Instant = Instant.parse("2024-01-01T00:00:00Z"),
     ): SyncMutation = SyncMutation(
         id = id,
         tableName = table,
         operation = op,
-        rowData = mapOf("id" to rowId, "name" to "Test"),
-        timestamp = Instant.parse("2024-01-01T00:00:00Z"),
+        rowData = data,
+        timestamp = ts,
     )
+
+    // ── Basic operations ────────────────────────────────────────────────
 
     @Test
     fun enqueueAndPeekReturnsSameItem() = runTest {
@@ -70,24 +76,6 @@ class InMemoryMutationQueueTest {
     }
 
     @Test
-    fun deduplication_sameEntityKeyReplacesOlder() = runTest {
-        val queue = InMemoryMutationQueue()
-        val older = mutation(id = "m-1", rowId = "row-1", op = MutationOperation.INSERT)
-        val newer = mutation(id = "m-2", rowId = "row-1", op = MutationOperation.UPDATE)
-        queue.enqueue(older); queue.enqueue(newer)
-        assertEquals(1, queue.pendingCount())
-        assertEquals(newer, queue.peek())
-    }
-
-    @Test
-    fun deduplication_differentTablesAreNotDeduplicated() = runTest {
-        val queue = InMemoryMutationQueue()
-        queue.enqueue(mutation(id = "m-1", table = "accounts", rowId = "row-1"))
-        queue.enqueue(mutation(id = "m-2", table = "transactions", rowId = "row-1"))
-        assertEquals(2, queue.pendingCount())
-    }
-
-    @Test
     fun allPendingReturnsEmptyListWhenEmpty() = runTest {
         assertTrue(InMemoryMutationQueue().allPending().isEmpty())
     }
@@ -104,16 +92,353 @@ class InMemoryMutationQueueTest {
         assertEquals(1, queue.pendingCount())
     }
 
+    // ── Deduplication / coalescing ──────────────────────────────────────
+
     @Test
-    fun deduplicationPreservesFifoOfRemainingItems() = runTest {
+    fun deduplication_differentTablesAreNotDeduplicated() = runTest {
         val queue = InMemoryMutationQueue()
-        val m1 = mutation(id = "m-1", rowId = "row-1")
-        val m2 = mutation(id = "m-2", rowId = "row-2")
+        queue.enqueue(mutation(id = "m-1", table = "accounts", rowId = "row-1"))
+        queue.enqueue(mutation(id = "m-2", table = "transactions", rowId = "row-1"))
+        assertEquals(2, queue.pendingCount())
+    }
+
+    @Test
+    fun coalesce_insertPlusUpdate_becomesInsertWithMergedData() = runTest {
+        val queue = InMemoryMutationQueue()
+        val insert = mutation(
+            id = "m-1", rowId = "row-1", op = MutationOperation.INSERT,
+            data = mapOf("id" to "row-1", "name" to "Original", "amount" to "100"),
+        )
+        val update = mutation(
+            id = "m-2", rowId = "row-1", op = MutationOperation.UPDATE,
+            data = mapOf("id" to "row-1", "name" to "Updated"),
+            ts = Instant.parse("2024-01-02T00:00:00Z"),
+        )
+        queue.enqueue(insert)
+        queue.enqueue(update)
+
+        assertEquals(1, queue.pendingCount())
+        val result = queue.peek()!!
+        assertEquals("m-2", result.id)
+        assertEquals(MutationOperation.INSERT, result.operation, "Should stay INSERT")
+        assertEquals("Updated", result.rowData["name"], "name should be merged from UPDATE")
+        assertEquals("100", result.rowData["amount"], "amount should be preserved from INSERT")
+        assertEquals(Instant.parse("2024-01-02T00:00:00Z"), result.timestamp)
+    }
+
+    @Test
+    fun coalesce_insertPlusDelete_removedFromQueue() = runTest {
+        val queue = InMemoryMutationQueue()
+        queue.enqueue(mutation(id = "m-1", rowId = "row-1", op = MutationOperation.INSERT))
+        queue.enqueue(mutation(id = "m-2", rowId = "row-1", op = MutationOperation.DELETE))
+        assertEquals(0, queue.pendingCount(), "INSERT + DELETE should cancel out")
+        assertNull(queue.peek())
+    }
+
+    @Test
+    fun coalesce_updatePlusUpdate_latestWins() = runTest {
+        val queue = InMemoryMutationQueue()
+        val u1 = mutation(id = "m-1", rowId = "row-1", op = MutationOperation.UPDATE)
+        val u2 = mutation(id = "m-2", rowId = "row-1", op = MutationOperation.UPDATE,
+            data = mapOf("id" to "row-1", "name" to "Latest"))
+        queue.enqueue(u1)
+        queue.enqueue(u2)
+        assertEquals(1, queue.pendingCount())
+        assertEquals(u2, queue.peek())
+    }
+
+    @Test
+    fun coalesce_updatePlusDelete_becomesDelete() = runTest {
+        val queue = InMemoryMutationQueue()
+        queue.enqueue(mutation(id = "m-1", rowId = "row-1", op = MutationOperation.UPDATE))
+        val del = mutation(id = "m-2", rowId = "row-1", op = MutationOperation.DELETE)
+        queue.enqueue(del)
+        assertEquals(1, queue.pendingCount())
+        assertEquals(del, queue.peek())
+    }
+
+    @Test
+    fun coalesce_deletePlusInsert_becomesInsert() = runTest {
+        val queue = InMemoryMutationQueue()
+        queue.enqueue(mutation(id = "m-1", rowId = "row-1", op = MutationOperation.DELETE))
+        val ins = mutation(id = "m-2", rowId = "row-1", op = MutationOperation.INSERT)
+        queue.enqueue(ins)
+        assertEquals(1, queue.pendingCount())
+        assertEquals(ins, queue.peek())
+    }
+
+    @Test
+    fun coalescingPreservesFifoOfRemainingItems() = runTest {
+        val queue = InMemoryMutationQueue()
+        val m1 = mutation(id = "m-1", rowId = "row-1", op = MutationOperation.INSERT)
+        val m2 = mutation(id = "m-2", rowId = "row-2", op = MutationOperation.INSERT)
         val m3 = mutation(id = "m-3", rowId = "row-1", op = MutationOperation.UPDATE)
         queue.enqueue(m1); queue.enqueue(m2); queue.enqueue(m3)
+
         val all = queue.allPending()
         assertEquals(2, all.size)
+        // m2 keeps its original position; the coalesced m1+m3 moves to the tail.
         assertEquals(m2, all[0])
-        assertEquals(m3, all[1])
+        // Coalesced result keeps INSERT operation and uses m3's ID.
+        assertEquals("m-3", all[1].id)
+        assertEquals(MutationOperation.INSERT, all[1].operation)
+    }
+
+    // ── enqueueAll ──────────────────────────────────────────────────────
+
+    @Test
+    fun enqueueAll_addsMultipleMutationsAtomically() = runTest {
+        val queue = InMemoryMutationQueue()
+        val mutations = listOf(
+            mutation(id = "m-1", rowId = "row-1"),
+            mutation(id = "m-2", rowId = "row-2"),
+            mutation(id = "m-3", rowId = "row-3"),
+        )
+        queue.enqueueAll(mutations)
+        assertEquals(3, queue.pendingCount())
+        assertEquals(mutations, queue.allPending())
+    }
+
+    @Test
+    fun enqueueAll_coalescesWithExistingQueue() = runTest {
+        val queue = InMemoryMutationQueue()
+        queue.enqueue(mutation(id = "m-1", rowId = "row-1", op = MutationOperation.INSERT))
+        queue.enqueueAll(listOf(
+            mutation(id = "m-2", rowId = "row-2", op = MutationOperation.INSERT),
+            mutation(id = "m-3", rowId = "row-1", op = MutationOperation.DELETE), // cancels m-1
+        ))
+        assertEquals(1, queue.pendingCount())
+        assertEquals("m-2", queue.peek()!!.id)
+    }
+
+    @Test
+    fun enqueueAll_coalescesWithinBatch() = runTest {
+        val queue = InMemoryMutationQueue()
+        queue.enqueueAll(listOf(
+            mutation(id = "m-1", rowId = "row-1", op = MutationOperation.INSERT),
+            mutation(id = "m-2", rowId = "row-1", op = MutationOperation.UPDATE,
+                data = mapOf("id" to "row-1", "name" to "Updated")),
+        ))
+        assertEquals(1, queue.pendingCount())
+        val result = queue.peek()!!
+        assertEquals(MutationOperation.INSERT, result.operation)
+        assertEquals("Updated", result.rowData["name"])
+    }
+
+    // ── peekBatch ───────────────────────────────────────────────────────
+
+    @Test
+    fun peekBatch_returnsUpToLimitItems() = runTest {
+        val queue = InMemoryMutationQueue()
+        for (i in 1..5) {
+            queue.enqueue(mutation(id = "m-$i", rowId = "row-$i"))
+        }
+        val batch = queue.peekBatch(3)
+        assertEquals(3, batch.size)
+        assertEquals("m-1", batch[0].id)
+        assertEquals("m-2", batch[1].id)
+        assertEquals("m-3", batch[2].id)
+        // Queue is unchanged.
+        assertEquals(5, queue.pendingCount())
+    }
+
+    @Test
+    fun peekBatch_returnsAllWhenLessThanLimit() = runTest {
+        val queue = InMemoryMutationQueue()
+        queue.enqueue(mutation(id = "m-1", rowId = "row-1"))
+        val batch = queue.peekBatch(100)
+        assertEquals(1, batch.size)
+    }
+
+    @Test
+    fun peekBatch_returnsEmptyListWhenEmpty() = runTest {
+        assertEquals(emptyList(), InMemoryMutationQueue().peekBatch(10))
+    }
+
+    // ── acknowledge ─────────────────────────────────────────────────────
+
+    @Test
+    fun acknowledge_removesMultipleMutations() = runTest {
+        val queue = InMemoryMutationQueue()
+        queue.enqueue(mutation(id = "m-1", rowId = "row-1"))
+        queue.enqueue(mutation(id = "m-2", rowId = "row-2"))
+        queue.enqueue(mutation(id = "m-3", rowId = "row-3"))
+        queue.acknowledge(listOf("m-1", "m-3"))
+        assertEquals(1, queue.pendingCount())
+        assertEquals("m-2", queue.peek()!!.id)
+    }
+
+    @Test
+    fun acknowledge_ignoresUnknownIds() = runTest {
+        val queue = InMemoryMutationQueue()
+        queue.enqueue(mutation(id = "m-1", rowId = "row-1"))
+        queue.acknowledge(listOf("m-1", "non-existent"))
+        assertEquals(0, queue.pendingCount())
+    }
+
+    @Test
+    fun acknowledge_clearsRetryCount() = runTest {
+        val queue = InMemoryMutationQueue()
+        queue.enqueue(mutation(id = "m-1", rowId = "row-1"))
+        queue.markFailed(listOf("m-1"))
+        assertEquals(1, queue.getRetryCount("m-1"))
+        queue.acknowledge(listOf("m-1"))
+        assertEquals(0, queue.getRetryCount("m-1"))
+    }
+
+    // ── Retry / dead-letter tracking ────────────────────────────────────
+
+    @Test
+    fun markFailed_incrementsRetryCount() = runTest {
+        val queue = InMemoryMutationQueue()
+        queue.enqueue(mutation(id = "m-1", rowId = "row-1"))
+        assertEquals(0, queue.getRetryCount("m-1"))
+        queue.markFailed(listOf("m-1"))
+        assertEquals(1, queue.getRetryCount("m-1"))
+        queue.markFailed(listOf("m-1"))
+        assertEquals(2, queue.getRetryCount("m-1"))
+    }
+
+    @Test
+    fun markFailed_ignoresUnknownIds() = runTest {
+        val queue = InMemoryMutationQueue()
+        queue.markFailed(listOf("non-existent")) // Should not throw.
+        assertEquals(0, queue.getRetryCount("non-existent"))
+    }
+
+    @Test
+    fun getDeadLetterMutations_returnsOnlyExceeded() = runTest {
+        val queue = InMemoryMutationQueue()
+        queue.enqueue(mutation(id = "m-1", rowId = "row-1"))
+        queue.enqueue(mutation(id = "m-2", rowId = "row-2"))
+        // m-1 fails 3 times, m-2 fails once.
+        repeat(3) { queue.markFailed(listOf("m-1")) }
+        queue.markFailed(listOf("m-2"))
+
+        val dead = queue.getDeadLetterMutations(maxRetries = 3)
+        assertEquals(1, dead.size)
+        assertEquals("m-1", dead[0].id)
+    }
+
+    @Test
+    fun getRetryCount_returnsZeroForUnknownMutation() = runTest {
+        assertEquals(0, InMemoryMutationQueue().getRetryCount("unknown"))
+    }
+
+    // ── getMutationsForRecord ───────────────────────────────────────────
+
+    @Test
+    fun getMutationsForRecord_findsMatchingMutations() = runTest {
+        val queue = InMemoryMutationQueue()
+        queue.enqueue(mutation(id = "m-1", table = "accounts", rowId = "row-1"))
+        queue.enqueue(mutation(id = "m-2", table = "accounts", rowId = "row-2"))
+        queue.enqueue(mutation(id = "m-3", table = "transactions", rowId = "row-1"))
+
+        val results = queue.getMutationsForRecord("accounts", "row-1")
+        assertEquals(1, results.size)
+        assertEquals("m-1", results[0].id)
+    }
+
+    @Test
+    fun getMutationsForRecord_returnsEmptyWhenNoMatch() = runTest {
+        val queue = InMemoryMutationQueue()
+        queue.enqueue(mutation(id = "m-1", table = "accounts", rowId = "row-1"))
+        assertTrue(queue.getMutationsForRecord("budgets", "row-1").isEmpty())
+    }
+
+    // ── clear ───────────────────────────────────────────────────────────
+
+    @Test
+    fun clear_removesAllMutationsAndRetryState() = runTest {
+        val queue = InMemoryMutationQueue()
+        queue.enqueue(mutation(id = "m-1", rowId = "row-1"))
+        queue.enqueue(mutation(id = "m-2", rowId = "row-2"))
+        queue.markFailed(listOf("m-1"))
+        queue.clear()
+        assertEquals(0, queue.pendingCount())
+        assertNull(queue.peek())
+        assertTrue(queue.allPending().isEmpty())
+        assertEquals(0, queue.getRetryCount("m-1"))
+    }
+
+    // ── Reactive flows ──────────────────────────────────────────────────
+
+    @Test
+    fun pendingCountFlow_emitsCurrentCount() = runTest {
+        val queue = InMemoryMutationQueue()
+        assertEquals(0, queue.pendingCountFlow.first())
+        queue.enqueue(mutation(id = "m-1", rowId = "row-1"))
+        assertEquals(1, queue.pendingCountFlow.first())
+        queue.enqueue(mutation(id = "m-2", rowId = "row-2"))
+        assertEquals(2, queue.pendingCountFlow.first())
+        queue.dequeue("m-1")
+        assertEquals(1, queue.pendingCountFlow.first())
+    }
+
+    @Test
+    fun hasPendingMutations_reflectsQueueState() = runTest {
+        val queue = InMemoryMutationQueue()
+        assertFalse(queue.hasPendingMutations.first())
+        queue.enqueue(mutation(id = "m-1", rowId = "row-1"))
+        assertTrue(queue.hasPendingMutations.first())
+        queue.dequeue("m-1")
+        assertFalse(queue.hasPendingMutations.first())
+    }
+
+    @Test
+    fun pendingCountFlow_updatesOnClear() = runTest {
+        val queue = InMemoryMutationQueue()
+        queue.enqueue(mutation(id = "m-1", rowId = "row-1"))
+        queue.enqueue(mutation(id = "m-2", rowId = "row-2"))
+        assertEquals(2, queue.pendingCountFlow.first())
+        queue.clear()
+        assertEquals(0, queue.pendingCountFlow.first())
+    }
+
+    @Test
+    fun pendingCountFlow_updatesOnAcknowledge() = runTest {
+        val queue = InMemoryMutationQueue()
+        queue.enqueue(mutation(id = "m-1", rowId = "row-1"))
+        queue.enqueue(mutation(id = "m-2", rowId = "row-2"))
+        queue.acknowledge(listOf("m-1"))
+        assertEquals(1, queue.pendingCountFlow.first())
+    }
+
+    // ── Edge cases ──────────────────────────────────────────────────────
+
+    @Test
+    fun coalesce_insertDeleteInsert_resultsInInsert() = runTest {
+        val queue = InMemoryMutationQueue()
+        queue.enqueue(mutation(id = "m-1", rowId = "row-1", op = MutationOperation.INSERT))
+        queue.enqueue(mutation(id = "m-2", rowId = "row-1", op = MutationOperation.DELETE))
+        // Queue is now empty (INSERT + DELETE = no-op).
+        assertEquals(0, queue.pendingCount())
+        // Now re-insert.
+        val reInsert = mutation(id = "m-3", rowId = "row-1", op = MutationOperation.INSERT)
+        queue.enqueue(reInsert)
+        assertEquals(1, queue.pendingCount())
+        assertEquals(reInsert, queue.peek())
+    }
+
+    @Test
+    fun dequeue_clearsRetryCount() = runTest {
+        val queue = InMemoryMutationQueue()
+        queue.enqueue(mutation(id = "m-1", rowId = "row-1"))
+        queue.markFailed(listOf("m-1"))
+        assertEquals(1, queue.getRetryCount("m-1"))
+        queue.dequeue("m-1")
+        assertEquals(0, queue.getRetryCount("m-1"))
+    }
+
+    @Test
+    fun coalesce_resetsRetryCountOfOldMutation() = runTest {
+        val queue = InMemoryMutationQueue()
+        queue.enqueue(mutation(id = "m-1", rowId = "row-1", op = MutationOperation.UPDATE))
+        queue.markFailed(listOf("m-1"))
+        assertEquals(1, queue.getRetryCount("m-1"))
+        // Coalescing replaces m-1 with m-2.
+        queue.enqueue(mutation(id = "m-2", rowId = "row-1", op = MutationOperation.UPDATE))
+        assertEquals(0, queue.getRetryCount("m-1"), "Old retry count should be cleared")
+        assertEquals(0, queue.getRetryCount("m-2"), "New mutation starts fresh")
     }
 }

--- a/packages/sync/src/commonTest/kotlin/com/finance/sync/queue/QueueProcessorTest.kt
+++ b/packages/sync/src/commonTest/kotlin/com/finance/sync/queue/QueueProcessorTest.kt
@@ -4,12 +4,13 @@ package com.finance.sync.queue
 
 import com.finance.sync.MutationOperation
 import com.finance.sync.SyncChange
+import com.finance.sync.SyncConfig
 import com.finance.sync.SyncMutation
 import com.finance.sync.SyncProvider
-import com.finance.sync.SyncConfig
 import com.finance.sync.SyncStatus
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
@@ -32,6 +33,8 @@ class QueueProcessorTest {
         timestamp = Instant.parse("2024-01-01T00:00:00Z"),
     )
 
+    // ── Helpers ─────────────────────────────────────────────────────────
+
     private class FakeSyncProvider(
         private val pushBehavior: (List<SyncMutation>) -> Result<Unit> = { Result.success(Unit) },
     ) : SyncProvider {
@@ -40,6 +43,30 @@ class QueueProcessorTest {
         override fun pull(): Flow<List<SyncChange>> = emptyFlow()
         override fun getStatus(): Flow<SyncStatus> = emptyFlow()
     }
+
+    /**
+     * Create a pushFn that always succeeds (acknowledges every mutation).
+     */
+    private fun alwaysSucceedPushFn(): suspend (List<SyncMutation>) -> PushResult = { mutations ->
+        PushResult(succeeded = mutations.map { it.id }, failed = emptyList())
+    }
+
+    /**
+     * Create a pushFn that always fails all mutations.
+     */
+    private fun alwaysFailPushFn(
+        error: String = "Server error",
+        retryable: Boolean = true,
+    ): suspend (List<SyncMutation>) -> PushResult = { mutations ->
+        PushResult(
+            succeeded = emptyList(),
+            failed = mutations.map { PushFailure(it.id, error, retryable) },
+        )
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Legacy API tests (process() flow with SyncProvider)
+    // ═══════════════════════════════════════════════════════════════════
 
     @Test
     fun emptyQueueEmitsIdleThenCompleted() = runTest {
@@ -133,5 +160,326 @@ class QueueProcessorTest {
         assertEquals(1, statuses.filterIsInstance<QueueProcessorStatus.Failed>().size)
         assertIs<QueueProcessorStatus.Completed>(statuses.last())
         assertEquals(0, queue.pendingCount())
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // New batch API tests (processNextBatch / processAll with pushFn)
+    // ═══════════════════════════════════════════════════════════════════
+
+    // ── processNextBatch ────────────────────────────────────────────────
+
+    @Test
+    fun processNextBatch_emptyQueue_returnsZeroResult() = runTest {
+        val processor = QueueProcessor(
+            queue = InMemoryMutationQueue(),
+            pushFn = alwaysSucceedPushFn(),
+        )
+        val result = processor.processNextBatch()
+        assertEquals(0, result.succeeded)
+        assertEquals(0, result.failed)
+        assertEquals(0, result.retryable)
+        assertEquals(0, result.deadLettered)
+        assertIs<ProcessingState.Idle>(processor.state.first())
+    }
+
+    @Test
+    fun processNextBatch_allSucceed() = runTest {
+        val queue = InMemoryMutationQueue()
+        queue.enqueue(mutation(id = "m-1", rowId = "row-1"))
+        queue.enqueue(mutation(id = "m-2", rowId = "row-2"))
+
+        val processor = QueueProcessor(
+            queue = queue,
+            pushFn = alwaysSucceedPushFn(),
+            batchSize = 10,
+        )
+        val result = processor.processNextBatch()
+        assertEquals(2, result.succeeded)
+        assertEquals(0, result.failed)
+        assertEquals(0, queue.pendingCount())
+    }
+
+    @Test
+    fun processNextBatch_respectsBatchSize() = runTest {
+        val queue = InMemoryMutationQueue()
+        for (i in 1..5) queue.enqueue(mutation(id = "m-$i", rowId = "row-$i"))
+
+        val pushed = mutableListOf<String>()
+        val processor = QueueProcessor(
+            queue = queue,
+            pushFn = { mutations ->
+                pushed.addAll(mutations.map { it.id })
+                PushResult(succeeded = mutations.map { it.id }, failed = emptyList())
+            },
+            batchSize = 2,
+        )
+        processor.processNextBatch()
+        assertEquals(listOf("m-1", "m-2"), pushed, "Should process only batchSize mutations")
+        assertEquals(3, queue.pendingCount())
+    }
+
+    @Test
+    fun processNextBatch_partialFailure() = runTest {
+        val queue = InMemoryMutationQueue()
+        queue.enqueue(mutation(id = "m-1", rowId = "row-1"))
+        queue.enqueue(mutation(id = "m-2", rowId = "row-2"))
+
+        val processor = QueueProcessor(
+            queue = queue,
+            pushFn = { _ ->
+                PushResult(
+                    succeeded = listOf("m-1"),
+                    failed = listOf(PushFailure("m-2", "Conflict", retryable = true)),
+                )
+            },
+            batchSize = 10,
+            maxRetries = 5,
+        )
+        val result = processor.processNextBatch()
+        assertEquals(1, result.succeeded)
+        assertEquals(1, result.retryable)
+        assertEquals(0, result.failed)
+        // m-1 removed, m-2 still in queue.
+        assertEquals(1, queue.pendingCount())
+        assertEquals(1, queue.getRetryCount("m-2"))
+    }
+
+    @Test
+    fun processNextBatch_nonRetryableFailure_removedFromQueue() = runTest {
+        val queue = InMemoryMutationQueue()
+        queue.enqueue(mutation(id = "m-1", rowId = "row-1"))
+
+        val processor = QueueProcessor(
+            queue = queue,
+            pushFn = { _ ->
+                PushResult(
+                    succeeded = emptyList(),
+                    failed = listOf(PushFailure("m-1", "Validation error", retryable = false)),
+                )
+            },
+        )
+        val result = processor.processNextBatch()
+        assertEquals(0, result.succeeded)
+        assertEquals(1, result.failed)
+        assertEquals(0, queue.pendingCount(), "Non-retryable failures should be removed")
+    }
+
+    @Test
+    fun processNextBatch_deadLetter_whenRetryCountExceedsMax() = runTest {
+        val queue = InMemoryMutationQueue()
+        queue.enqueue(mutation(id = "m-1", rowId = "row-1"))
+        // Pre-set retry count to maxRetries - 1.
+        repeat(4) { queue.markFailed(listOf("m-1")) }
+        assertEquals(4, queue.getRetryCount("m-1"))
+
+        val processor = QueueProcessor(
+            queue = queue,
+            pushFn = { _ ->
+                PushResult(
+                    succeeded = emptyList(),
+                    failed = listOf(PushFailure("m-1", "Timeout", retryable = true)),
+                )
+            },
+            maxRetries = 5,
+        )
+        val result = processor.processNextBatch()
+        assertEquals(0, result.succeeded)
+        assertEquals(1, result.deadLettered)
+        // Mutation is still in queue for inspection but marked as dead-lettered.
+        assertEquals(1, queue.pendingCount())
+        assertEquals(5, queue.getRetryCount("m-1"))
+    }
+
+    @Test
+    fun processNextBatch_updatesState() = runTest {
+        val queue = InMemoryMutationQueue()
+        queue.enqueue(mutation(id = "m-1", rowId = "row-1"))
+
+        val processor = QueueProcessor(
+            queue = queue,
+            pushFn = alwaysSucceedPushFn(),
+        )
+        assertIs<ProcessingState.Idle>(processor.state.value)
+        processor.processNextBatch()
+        // After successful processing, state returns to Idle.
+        assertIs<ProcessingState.Idle>(processor.state.value)
+    }
+
+    @Test
+    fun processNextBatch_failedState_onNonRetryable() = runTest {
+        val queue = InMemoryMutationQueue()
+        queue.enqueue(mutation(id = "m-1", rowId = "row-1"))
+
+        val processor = QueueProcessor(
+            queue = queue,
+            pushFn = alwaysFailPushFn(error = "Bad data", retryable = false),
+        )
+        processor.processNextBatch()
+        assertIs<ProcessingState.Failed>(processor.state.value)
+    }
+
+    @Test
+    fun processNextBatch_waitingForRetryState_onRetryable() = runTest {
+        val queue = InMemoryMutationQueue()
+        queue.enqueue(mutation(id = "m-1", rowId = "row-1"))
+
+        val processor = QueueProcessor(
+            queue = queue,
+            pushFn = alwaysFailPushFn(error = "Timeout", retryable = true),
+            maxRetries = 5,
+        )
+        processor.processNextBatch()
+        assertIs<ProcessingState.WaitingForRetry>(processor.state.value)
+    }
+
+    // ── processAll ──────────────────────────────────────────────────────
+
+    @Test
+    fun processAll_emptyQueue_returnsZeroResult() = runTest {
+        val processor = QueueProcessor(
+            queue = InMemoryMutationQueue(),
+            pushFn = alwaysSucceedPushFn(),
+        )
+        val result = processor.processAll()
+        assertEquals(0, result.succeeded)
+        assertEquals(0, result.failed)
+    }
+
+    @Test
+    fun processAll_drainsEntireQueue() = runTest {
+        val queue = InMemoryMutationQueue()
+        for (i in 1..7) queue.enqueue(mutation(id = "m-$i", rowId = "row-$i"))
+
+        val processor = QueueProcessor(
+            queue = queue,
+            pushFn = alwaysSucceedPushFn(),
+            batchSize = 3,
+        )
+        val result = processor.processAll()
+        assertEquals(7, result.succeeded)
+        assertEquals(0, result.failed)
+        assertEquals(0, queue.pendingCount())
+    }
+
+    @Test
+    fun processAll_stopsOnAllNonRetryableFailures() = runTest {
+        val queue = InMemoryMutationQueue()
+        queue.enqueue(mutation(id = "m-1", rowId = "row-1"))
+        queue.enqueue(mutation(id = "m-2", rowId = "row-2"))
+
+        val processor = QueueProcessor(
+            queue = queue,
+            pushFn = alwaysFailPushFn(error = "Permanent", retryable = false),
+            batchSize = 10,
+        )
+        val result = processor.processAll()
+        assertEquals(0, result.succeeded)
+        assertEquals(2, result.failed)
+        assertEquals(0, queue.pendingCount(), "Non-retryable failures removed")
+    }
+
+    @Test
+    fun processAll_partialSuccessAndContinues() = runTest {
+        val queue = InMemoryMutationQueue()
+        queue.enqueue(mutation(id = "m-1", rowId = "row-1"))
+        queue.enqueue(mutation(id = "m-2", rowId = "row-2"))
+        queue.enqueue(mutation(id = "m-3", rowId = "row-3"))
+
+        var callCount = 0
+        val processor = QueueProcessor(
+            queue = queue,
+            pushFn = { mutations ->
+                callCount++
+                if (callCount == 1) {
+                    // First batch: m-1 succeeds, m-2 fails retryably.
+                    PushResult(
+                        succeeded = listOf("m-1"),
+                        failed = listOf(PushFailure("m-2", "Timeout", retryable = true)),
+                    )
+                } else {
+                    // Subsequent batches: all succeed.
+                    PushResult(succeeded = mutations.map { it.id }, failed = emptyList())
+                }
+            },
+            batchSize = 2,
+            maxRetries = 5,
+            baseBackoffMs = 1L, // Minimal backoff for testing.
+            maxBackoffMs = 1L,
+        )
+        val result = processor.processAll()
+        assertEquals(3, result.succeeded) // m-1 + m-2 + m-3
+    }
+
+    @Test
+    fun processAll_stopsWhenOnlyDeadLetterRemain() = runTest {
+        val queue = InMemoryMutationQueue()
+        queue.enqueue(mutation(id = "m-1", rowId = "row-1"))
+        // Exhaust retries for m-1.
+        repeat(5) { queue.markFailed(listOf("m-1")) }
+
+        val processor = QueueProcessor(
+            queue = queue,
+            pushFn = alwaysSucceedPushFn(),
+            maxRetries = 5,
+        )
+        val result = processor.processAll()
+        assertEquals(0, result.succeeded)
+        assertTrue(result.deadLettered > 0)
+        // m-1 stays in queue for inspection.
+        assertEquals(1, queue.pendingCount())
+    }
+
+    @Test
+    fun processAll_stateIsIdleWhenDone() = runTest {
+        val queue = InMemoryMutationQueue()
+        queue.enqueue(mutation(id = "m-1", rowId = "row-1"))
+
+        val processor = QueueProcessor(
+            queue = queue,
+            pushFn = alwaysSucceedPushFn(),
+        )
+        processor.processAll()
+        assertIs<ProcessingState.Idle>(processor.state.value)
+    }
+
+    // ── calculateBackoff ────────────────────────────────────────────────
+
+    @Test
+    fun calculateBackoff_hasJitter() {
+        val processor = QueueProcessor(
+            queue = InMemoryMutationQueue(),
+            pushFn = alwaysSucceedPushFn(),
+            baseBackoffMs = 1_000L,
+            maxBackoffMs = 60_000L,
+        )
+        // With jitter factor (0.5-1.0), backoff for attempt 1 should be in [500, 1000].
+        val backoff = processor.calculateBackoff(1)
+        assertTrue(backoff in 500..1_000, "Backoff $backoff should be in [500, 1000]")
+    }
+
+    @Test
+    fun calculateBackoff_exponentialGrowth() {
+        val processor = QueueProcessor(
+            queue = InMemoryMutationQueue(),
+            pushFn = alwaysSucceedPushFn(),
+            baseBackoffMs = 1_000L,
+            maxBackoffMs = 60_000L,
+        )
+        // Attempt 3: base * 2^2 = 4000, with jitter → [2000, 4000].
+        val backoff = processor.calculateBackoff(3)
+        assertTrue(backoff in 2_000..4_000, "Backoff $backoff should be in [2000, 4000]")
+    }
+
+    @Test
+    fun calculateBackoff_cappedAtMax() {
+        val processor = QueueProcessor(
+            queue = InMemoryMutationQueue(),
+            pushFn = alwaysSucceedPushFn(),
+            baseBackoffMs = 1_000L,
+            maxBackoffMs = 5_000L,
+        )
+        // Attempt 10: 1000 * 2^9 = 512000, capped to 5000, jitter → [2500, 5000].
+        val backoff = processor.calculateBackoff(10)
+        assertTrue(backoff in 2_500..5_000, "Backoff $backoff should be in [2500, 5000]")
     }
 }

--- a/packages/sync/src/iosMain/kotlin/com/finance/sync/auth/PlatformSHA256.ios.kt
+++ b/packages/sync/src/iosMain/kotlin/com/finance/sync/auth/PlatformSHA256.ios.kt
@@ -2,10 +2,11 @@
 
 package com.finance.sync.auth
 
-import com.finance.sync.crypto.Sha256
-import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.reinterpret
 import kotlinx.cinterop.usePinned
+import platform.CoreCrypto.CC_SHA256
+import platform.CoreCrypto.CC_SHA256_DIGEST_LENGTH
 import platform.Security.SecRandomCopyBytes
 import platform.Security.errSecSuccess
 import platform.Security.kSecRandomDefault
@@ -13,24 +14,56 @@ import platform.Security.kSecRandomDefault
 /**
  * iOS actual for [PlatformSHA256].
  *
- * SHA-256 uses the shared pure-Kotlin implementation so the iOS source set can
- * hash synchronously without introducing a CommonCrypto cinterop. Secure random
- * bytes come from Security.framework's `SecRandomCopyBytes`.
+ * Uses CommonCrypto's `CC_SHA256` for hashing and the Security framework's
+ * `SecRandomCopyBytes` for cryptographically-secure random byte generation.
+ *
+ * Both APIs are available on all supported iOS versions (9.0+) and are
+ * FIPS 140-2 validated as part of Apple's corecrypto module.
  */
-@OptIn(ExperimentalForeignApi::class)
 actual object PlatformSHA256 {
-    actual fun sha256(input: ByteArray): ByteArray = Sha256.digest(input)
 
-    actual fun randomBytes(size: Int): ByteArray {
-        require(size >= 0) { "Random byte count must be non-negative, got $size" }
-        if (size == 0) {
-            return byteArrayOf()
+    /**
+     * Compute the SHA-256 digest of [input] using CommonCrypto.
+     *
+     * @param input The bytes to hash.
+     * @return 32-byte SHA-256 digest.
+     */
+    actual fun sha256(input: ByteArray): ByteArray {
+        val digest = UByteArray(CC_SHA256_DIGEST_LENGTH)
+        input.usePinned { pinnedInput ->
+            digest.usePinned { pinnedDigest ->
+                CC_SHA256(
+                    pinnedInput.addressOf(0),
+                    input.size.toUInt(),
+                    pinnedDigest.addressOf(0),
+                )
+            }
         }
+        return digest.toByteArray()
+    }
+
+    /**
+     * Generate [size] cryptographically-secure random bytes using
+     * the Security framework's `SecRandomCopyBytes`.
+     *
+     * @param size Number of random bytes to generate.
+     * @return Random byte array of the requested size.
+     * @throws IllegalStateException if the system CSPRNG fails.
+     */
+    actual fun randomBytes(size: Int): ByteArray {
+        require(size >= 0) { "Size must be non-negative, got $size" }
+        if (size == 0) return ByteArray(0)
 
         val bytes = ByteArray(size)
         bytes.usePinned { pinned ->
-            val status = SecRandomCopyBytes(kSecRandomDefault, size.toULong(), pinned.addressOf(0))
-            check(status == errSecSuccess) { "SecRandomCopyBytes failed with status: $status" }
+            val status = SecRandomCopyBytes(
+                kSecRandomDefault,
+                size.toULong(),
+                pinned.addressOf(0),
+            )
+            check(status == errSecSuccess) {
+                "SecRandomCopyBytes failed with status: $status"
+            }
         }
         return bytes
     }

--- a/packages/sync/src/iosMain/kotlin/com/finance/sync/auth/TokenStorage.ios.kt
+++ b/packages/sync/src/iosMain/kotlin/com/finance/sync/auth/TokenStorage.ios.kt
@@ -2,35 +2,184 @@
 
 package com.finance.sync.auth
 
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.value
+import platform.CoreFoundation.CFTypeRefVar
+import platform.Foundation.CFBridgingRelease
+import platform.Foundation.NSData
+import platform.Foundation.NSString
+import platform.Foundation.NSUTF8StringEncoding
+import platform.Foundation.create
+import platform.Foundation.dataUsingEncoding
+import platform.Security.SecItemAdd
+import platform.Security.SecItemCopyMatching
+import platform.Security.SecItemDelete
+import platform.Security.errSecSuccess
+import platform.Security.kSecAttrAccessible
+import platform.Security.kSecAttrAccessibleAfterFirstUnlock
+import platform.Security.kSecAttrAccount
+import platform.Security.kSecAttrService
+import platform.Security.kSecClass
+import platform.Security.kSecClassGenericPassword
+import platform.Security.kSecMatchLimit
+import platform.Security.kSecMatchLimitOne
+import platform.Security.kSecReturnData
+import platform.Security.kSecValueData
+import platform.darwin.kCFBooleanTrue
+
 /**
- * iOS actual for [TokenStorage].
+ * iOS actual for [TokenStorage] using Apple Keychain Services.
  *
- * This keeps token state in memory until the Swift Export bridge can delegate
- * directly to the app's KeychainManager-backed storage. That mirrors the current
- * Android, JVM, and JS development implementations while removing the iOS stub.
+ * Stores authentication tokens securely in the iOS Keychain with
+ * [kSecAttrAccessibleAfterFirstUnlock] protection class. This allows
+ * background sync operations to access tokens after the device has
+ * been unlocked at least once since boot.
+ *
+ * Each token field (access_token, refresh_token, expires_at, user_id)
+ * is stored as a separate Keychain item under the service name
+ * [SERVICE_NAME], keyed by a unique account identifier.
+ *
+ * **Error handling:** Keychain failures are handled gracefully —
+ * [save] silently fails (tokens become ephemeral), [load] returns `null`,
+ * and [clear] is best-effort. This prevents crashes when Keychain is
+ * unavailable (e.g., device in certain MDM configurations).
  */
 actual open class TokenStorage actual constructor() {
-    // TODO(#440): Replace this with direct Security.framework Keychain access
-    // when the Swift Export bridge is wired to the app's KeychainManager.
-    private var stored: StoredTokenData? = null
 
+    companion object {
+        /** Keychain service identifier for grouping all sync-related items. */
+        private const val SERVICE_NAME = "com.finance.sync.tokens"
+
+        /** Keychain account keys for each stored field. */
+        private const val KEY_ACCESS_TOKEN = "access_token"
+        private const val KEY_REFRESH_TOKEN = "refresh_token"
+        private const val KEY_EXPIRES_AT = "expires_at"
+        private const val KEY_USER_ID = "user_id"
+    }
+
+    /**
+     * Persist token data to the iOS Keychain.
+     *
+     * Saves each field as a separate Keychain item. If items already
+     * exist they are deleted first, then re-added to ensure atomicity.
+     */
     actual open fun save(
         accessToken: String,
         refreshToken: String,
         expiresAt: Long,
         userId: String,
     ) {
-        stored = StoredTokenData(
+        saveToKeychain(KEY_ACCESS_TOKEN, accessToken)
+        saveToKeychain(KEY_REFRESH_TOKEN, refreshToken)
+        saveToKeychain(KEY_EXPIRES_AT, expiresAt.toString())
+        saveToKeychain(KEY_USER_ID, userId)
+    }
+
+    /**
+     * Load token data from the iOS Keychain.
+     *
+     * @return The stored [StoredTokenData], or `null` if any required
+     *         field is missing or cannot be read.
+     */
+    actual open fun load(): StoredTokenData? {
+        val accessToken = readFromKeychain(KEY_ACCESS_TOKEN) ?: return null
+        val refreshToken = readFromKeychain(KEY_REFRESH_TOKEN) ?: return null
+        val expiresAtStr = readFromKeychain(KEY_EXPIRES_AT) ?: return null
+        val userId = readFromKeychain(KEY_USER_ID) ?: return null
+
+        val expiresAtMillis = expiresAtStr.toLongOrNull() ?: return null
+
+        return StoredTokenData(
             accessToken = accessToken,
             refreshToken = refreshToken,
-            expiresAtMillis = expiresAt,
+            expiresAtMillis = expiresAtMillis,
             userId = userId,
         )
     }
 
-    actual open fun load(): StoredTokenData? = stored
-
+    /**
+     * Remove all token data from the iOS Keychain.
+     *
+     * Best-effort: individual deletions that fail (e.g., item not found)
+     * are silently ignored.
+     */
     actual open fun clear() {
-        stored = null
+        deleteFromKeychain(KEY_ACCESS_TOKEN)
+        deleteFromKeychain(KEY_REFRESH_TOKEN)
+        deleteFromKeychain(KEY_EXPIRES_AT)
+        deleteFromKeychain(KEY_USER_ID)
+    }
+
+    /**
+     * Save a single key-value pair to the Keychain.
+     *
+     * Deletes any existing item with the same service+account first,
+     * then adds the new item with [kSecAttrAccessibleAfterFirstUnlock].
+     */
+    @OptIn(BetaInteropApi::class)
+    private fun saveToKeychain(key: String, value: String) {
+        // Delete existing entry first (ignore errors — may not exist)
+        deleteFromKeychain(key)
+
+        val valueData = (value as NSString).dataUsingEncoding(NSUTF8StringEncoding) ?: return
+
+        val query = mapOf<Any?, Any?>(
+            kSecClass to kSecClassGenericPassword,
+            kSecAttrService to SERVICE_NAME,
+            kSecAttrAccount to key,
+            kSecValueData to valueData,
+            kSecAttrAccessible to kSecAttrAccessibleAfterFirstUnlock,
+        )
+
+        @Suppress("UNCHECKED_CAST")
+        SecItemAdd(query as kotlinx.cinterop.CFDictionaryRef?, null)
+    }
+
+    /**
+     * Read a single value from the Keychain by key.
+     *
+     * @return The stored string value, or `null` if not found or on error.
+     */
+    @OptIn(BetaInteropApi::class, ExperimentalForeignApi::class)
+    private fun readFromKeychain(key: String): String? = memScoped {
+        val query = mapOf<Any?, Any?>(
+            kSecClass to kSecClassGenericPassword,
+            kSecAttrService to SERVICE_NAME,
+            kSecAttrAccount to key,
+            kSecReturnData to kCFBooleanTrue,
+            kSecMatchLimit to kSecMatchLimitOne,
+        )
+
+        val result = alloc<CFTypeRefVar>()
+
+        @Suppress("UNCHECKED_CAST")
+        val status = SecItemCopyMatching(query as kotlinx.cinterop.CFDictionaryRef?, result.ptr)
+
+        if (status != errSecSuccess) return@memScoped null
+
+        val data = CFBridgingRelease(result.value) as? NSData ?: return@memScoped null
+        NSString.create(data = data, encoding = NSUTF8StringEncoding) as? String
+    }
+
+    /**
+     * Delete a single Keychain item by key.
+     *
+     * Silently ignores [errSecItemNotFound] — item may have already
+     * been deleted or never existed.
+     */
+    @OptIn(BetaInteropApi::class)
+    private fun deleteFromKeychain(key: String) {
+        val query = mapOf<Any?, Any?>(
+            kSecClass to kSecClassGenericPassword,
+            kSecAttrService to SERVICE_NAME,
+            kSecAttrAccount to key,
+        )
+
+        @Suppress("UNCHECKED_CAST")
+        SecItemDelete(query as kotlinx.cinterop.CFDictionaryRef?)
     }
 }

--- a/packages/sync/src/iosMain/kotlin/com/finance/sync/crypto/KeyDerivation.ios.kt
+++ b/packages/sync/src/iosMain/kotlin/com/finance/sync/crypto/KeyDerivation.ios.kt
@@ -2,87 +2,82 @@
 
 package com.finance.sync.crypto
 
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.usePinned
+import platform.CoreCrypto.CCKeyDerivationPBKDF
+import platform.CoreCrypto.kCCPBKDF2
+import platform.CoreCrypto.kCCPRFHmacAlgSHA256
+import platform.CoreCrypto.kCCSuccess
+
 /**
- * iOS actual for [PlatformKeyDerivation].
+ * iOS actual for [PlatformKeyDerivation] using CommonCrypto's PBKDF2.
  *
- * Argon2id is not available through the Apple framework interop exposed to this
- * KMP module, so iOS uses PBKDF2-HMAC-SHA256 as a deterministic 32-byte fallback.
- * This keeps the iOS source set functional until a shared Argon2id binding lands.
+ * Derives a 256-bit key from a password and salt using PBKDF2-HMAC-SHA256.
+ * Uses 600,000 iterations per OWASP 2023 recommendations for PBKDF2-HMAC-SHA256.
+ *
+ * **Note:** The `expect` declaration documents Argon2id as the ideal KDF.
+ * iOS's CommonCrypto does not natively provide Argon2id, so we use PBKDF2
+ * with a high iteration count as the fallback. When a native Argon2id binding
+ * (e.g., via libsodium/Swift Crypto) is integrated, this implementation
+ * should be upgraded. The 600k-iteration PBKDF2 provides comparable
+ * resistance for the passphrase-based key derivation use case.
+ *
+ * @see <a href="https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html">OWASP Password Storage</a>
  */
 actual class PlatformKeyDerivation actual constructor() {
-    actual fun deriveKey(password: String, salt: ByteArray): ByteArray {
-        return pbkdf2HmacSha256(
-            password = password.encodeToByteArray(),
-            salt = salt,
-            iterations = PBKDF2_ITERATIONS,
-            outputLength = DERIVED_KEY_SIZE_BYTES,
-        )
+
+    companion object {
+        /** Derived key length in bytes (256 bits). */
+        private const val KEY_LENGTH = 32
+
+        /**
+         * PBKDF2 iteration count.
+         *
+         * 600,000 is the OWASP-recommended minimum for PBKDF2-HMAC-SHA256
+         * as of 2023. This provides adequate brute-force resistance for
+         * passphrase-derived keys on modern hardware.
+         */
+        private const val ITERATIONS = 600_000
     }
 
-    private fun pbkdf2HmacSha256(
-        password: ByteArray,
-        salt: ByteArray,
-        iterations: Int,
-        outputLength: Int,
-    ): ByteArray {
-        val blockCount = (outputLength + SHA256_DIGEST_SIZE - 1) / SHA256_DIGEST_SIZE
-        val derivedKey = ByteArray(blockCount * SHA256_DIGEST_SIZE)
+    /**
+     * Derive a 256-bit key from [password] and [salt] using PBKDF2-HMAC-SHA256.
+     *
+     * @param password The user-supplied passphrase.
+     * @param salt     A cryptographically-random salt (at least 16 bytes recommended).
+     * @return A 32-byte derived key.
+     * @throws IllegalArgumentException if [salt] is empty.
+     * @throws IllegalStateException if the native CCKeyDerivationPBKDF call fails.
+     */
+    actual fun deriveKey(password: String, salt: ByteArray): ByteArray {
+        require(salt.isNotEmpty()) { "Salt must not be empty" }
 
-        for (blockIndex in 1..blockCount) {
-            var u = hmacSha256(password, salt + intToBigEndian(blockIndex))
-            val accumulator = u.copyOf()
+        val derivedKey = ByteArray(KEY_LENGTH)
+        val passwordBytes = password.encodeToByteArray()
 
-            repeat(iterations - 1) {
-                u = hmacSha256(password, u)
-                for (byteIndex in accumulator.indices) {
-                    accumulator[byteIndex] =
-                        (accumulator[byteIndex].toInt() xor u[byteIndex].toInt()).toByte()
+        passwordBytes.usePinned { pinnedPassword ->
+            salt.usePinned { pinnedSalt ->
+                derivedKey.usePinned { pinnedKey ->
+                    val result = CCKeyDerivationPBKDF(
+                        kCCPBKDF2,
+                        pinnedPassword.addressOf(0).reinterpret(),
+                        passwordBytes.size.convert(),
+                        pinnedSalt.addressOf(0).reinterpret(),
+                        salt.size.convert(),
+                        kCCPRFHmacAlgSHA256,
+                        ITERATIONS.toUInt(),
+                        pinnedKey.addressOf(0).reinterpret(),
+                        KEY_LENGTH.convert(),
+                    )
+                    check(result == kCCSuccess) {
+                        "PBKDF2 key derivation failed with error code: $result"
+                    }
                 }
             }
-
-            accumulator.copyInto(
-                destination = derivedKey,
-                destinationOffset = (blockIndex - 1) * SHA256_DIGEST_SIZE,
-            )
         }
 
-        return derivedKey.copyOf(outputLength)
-    }
-
-    private fun hmacSha256(key: ByteArray, message: ByteArray): ByteArray {
-        val normalizedKey = if (key.size > HMAC_BLOCK_SIZE_BYTES) {
-            Sha256.digest(key)
-        } else {
-            key
-        }
-
-        val keyBlock = ByteArray(HMAC_BLOCK_SIZE_BYTES)
-        normalizedKey.copyInto(keyBlock)
-
-        val innerPad = ByteArray(HMAC_BLOCK_SIZE_BYTES) { index ->
-            (keyBlock[index].toInt() xor INNER_PAD_BYTE).toByte()
-        }
-        val outerPad = ByteArray(HMAC_BLOCK_SIZE_BYTES) { index ->
-            (keyBlock[index].toInt() xor OUTER_PAD_BYTE).toByte()
-        }
-
-        val innerHash = Sha256.digest(innerPad + message)
-        return Sha256.digest(outerPad + innerHash)
-    }
-
-    private fun intToBigEndian(value: Int): ByteArray = byteArrayOf(
-        (value ushr 24).toByte(),
-        (value ushr 16).toByte(),
-        (value ushr 8).toByte(),
-        value.toByte(),
-    )
-
-    private companion object {
-        const val PBKDF2_ITERATIONS: Int = 100_000
-        const val DERIVED_KEY_SIZE_BYTES: Int = 32
-        const val SHA256_DIGEST_SIZE: Int = 32
-        const val HMAC_BLOCK_SIZE_BYTES: Int = 64
-        const val INNER_PAD_BYTE: Int = 0x36
-        const val OUTER_PAD_BYTE: Int = 0x5C
+        return derivedKey
     }
 }


### PR DESCRIPTION
## Summary
Full implementation of the \packages/sync/\ module — previously scaffolded with empty files, now a complete offline-first sync engine with 330 passing tests.

## Changes

### Core Types & Auth (#447, #448)
- SyncConfig, SyncStatus (sealed class), SyncCredentials, SyncMutation, SyncChange, SyncProvider
- AuthCredentials, AuthSession, AuthManager, TokenManager, PKCEHelper
- SyncEngine orchestrator with periodic sync, credential refresh, health monitoring
- SyncClient high-level facade

### Conflict Resolution (#449)
- ConflictResolver interface + 4 strategies: LastWriteWins, FieldMerge, ServerWins, ClientWins
- Deterministic resolution, financial field protection, field-level merge

### Offline Queue (#450)
- MutationQueue with FIFO ordering and 6 coalescing rules (INSERT+DELETE→no-op, etc.)
- QueueProcessor with exponential backoff and jitter

### Delta Sync (#451)
- DeltaSyncManager with paginated pull/push cycles
- SequenceTracker for per-table version tracking
- SyncChecksum for data integrity verification

### Encryption & Crypto (#452)
- Envelope encryption (DEK/KEK), field-level encryption, crypto shredding

### iOS Platform Bindings (#440)
- PlatformSHA256 (CommonCrypto CC_SHA256)
- TokenStorage (Apple Keychain with kSecAttrAccessibleAfterFirstUnlock)
- KeyDerivation (PBKDF2-HMAC-SHA256, 600K iterations)

### Tests (#453)
- 330 total passing tests: conflict (62), queue (63), delta (27+), auth (26), crypto (30), integration (12), engine (23)

## Architecture
\\\
SyncClient (facade)
  └── SyncEngine (orchestrator)
        ├── DeltaSyncManager (pull/push)
        ├── ConflictResolver (strategies)
        ├── MutationQueue (offline buffer)
        └── QueueProcessor (retry/backoff)
\\\

Closes #447
Closes #448
Closes #449
Closes #450
Closes #451
Closes #452
Closes #453
Closes #440