### PR TITLE
feat(web): wire CRUD forms to all pages and add dashboard charts (#461, #462)

### DIFF
--- a/apps/web/src/components/forms/BudgetForm.tsx
+++ b/apps/web/src/components/forms/BudgetForm.tsx
@@ -1,0 +1,381 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Accessible budget creation form.
+ *
+ * Renders a modal dialog with fields for creating a new budget:
+ * category (required select), amount (required, dollars → cents),
+ * period (select, default Monthly), and start date (default first of current
+ * month).
+ *
+ * Validates input client-side with accessible error messages using
+ * `aria-invalid` and `aria-describedby`. The `householdId` and budget `name`
+ * are derived from the selected category, so no separate household prop is
+ * needed. Amount is stored as integer cents — never as a float.
+ *
+ * Keyboard support: Tab navigation, Enter submits via the form element,
+ * Escape cancels. Focus is trapped within the dialog and the first field
+ * is autofocused when the dialog opens.
+ *
+ * @module components/forms/BudgetForm
+ * @see {@link CreateBudgetInput} from db/repositories/budgets
+ * References: issue #461
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type FormEvent,
+  type KeyboardEvent,
+} from 'react';
+
+import { useFocusTrap } from '../../accessibility/aria';
+import type { CreateBudgetInput } from '../../db/repositories/budgets';
+import type { BudgetPeriod, Category } from '../../kmp/bridge';
+
+import './forms.css';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Period options for the budget period select, ordered by display preference. */
+const BUDGET_PERIODS: readonly { value: BudgetPeriod; label: string }[] = [
+  { value: 'MONTHLY', label: 'Monthly' },
+  { value: 'WEEKLY', label: 'Weekly' },
+  { value: 'BIWEEKLY', label: 'Biweekly' },
+  { value: 'QUARTERLY', label: 'Quarterly' },
+  { value: 'YEARLY', label: 'Yearly' },
+] as const;
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+/** Props for {@link BudgetForm}. */
+export interface BudgetFormProps {
+  /** Whether the form dialog is open. */
+  isOpen: boolean;
+  /** Callback invoked when the user cancels or presses Escape. */
+  onCancel: () => void;
+  /**
+   * Callback invoked with validated form data when the user submits.
+   * The `amount` field is already in integer cents.
+   */
+  onSubmit: (data: CreateBudgetInput) => Promise<void>;
+  /** Available categories to assign the budget to. */
+  categories: Category[];
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Return the first day of the current month as an ISO local-date string (YYYY-MM-01). */
+function firstOfCurrentMonthISO(): string {
+  const d = new Date();
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  return `${year}-${month}-01`;
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+interface FormErrors {
+  categoryId?: string;
+  amount?: string;
+}
+
+function validate(categoryId: string, amountStr: string): FormErrors {
+  const errors: FormErrors = {};
+
+  if (!categoryId) {
+    errors.categoryId = 'Please select a category.';
+  }
+
+  const parsed = parseFloat(amountStr);
+  if (!amountStr.trim() || Number.isNaN(parsed) || parsed <= 0) {
+    errors.amount = 'Amount must be greater than zero.';
+  }
+
+  return errors;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/**
+ * Accessible modal form for creating a new budget.
+ *
+ * Provides fields for category, amount (dollars, converted to integer cents
+ * before submission), period, and start date. Validates input and surfaces
+ * errors with ARIA attributes. Traps focus within the dialog while open.
+ */
+export function BudgetForm({ isOpen, onCancel, onSubmit, categories }: BudgetFormProps) {
+  // -- refs ----------------------------------------------------------------
+  const panelRef = useRef<HTMLDivElement>(null);
+  const firstInputRef = useRef<HTMLSelectElement>(null);
+
+  // -- state ---------------------------------------------------------------
+  const [categoryId, setCategoryId] = useState('');
+  const [amount, setAmount] = useState('');
+  const [period, setPeriod] = useState<BudgetPeriod>('MONTHLY');
+  const [startDate, setStartDate] = useState(firstOfCurrentMonthISO);
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // -- focus trap -----------------------------------------------------------
+  useFocusTrap(panelRef, { active: isOpen, restoreFocus: true });
+
+  // -- autofocus first field ------------------------------------------------
+  useEffect(() => {
+    if (isOpen) {
+      const id = requestAnimationFrame(() => {
+        firstInputRef.current?.focus();
+      });
+      return () => cancelAnimationFrame(id);
+    }
+  }, [isOpen]);
+
+  // -- reset on open -------------------------------------------------------
+  useEffect(() => {
+    if (isOpen) {
+      setCategoryId('');
+      setAmount('');
+      setPeriod('MONTHLY');
+      setStartDate(firstOfCurrentMonthISO());
+      setErrors({});
+      setSubmitting(false);
+      setSubmitError(null);
+    }
+  }, [isOpen]);
+
+  // -- handlers ------------------------------------------------------------
+
+  const handleCancel = useCallback(() => {
+    onCancel();
+  }, [onCancel]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        handleCancel();
+      }
+    },
+    [handleCancel],
+  );
+
+  const handleSubmit = useCallback(
+    async (e: FormEvent) => {
+      e.preventDefault();
+
+      const fieldErrors = validate(categoryId, amount);
+      setErrors(fieldErrors);
+
+      if (Object.keys(fieldErrors).length > 0) {
+        return;
+      }
+
+      // Derive householdId and name from the selected category.
+      const selectedCategory = categories.find((c) => c.id === categoryId);
+      if (!selectedCategory) {
+        setSubmitError('Selected category not found.');
+        return;
+      }
+
+      // Convert dollars to integer cents — never store floats as money.
+      const amountCents = Math.round(parseFloat(amount) * 100);
+
+      const input: CreateBudgetInput = {
+        householdId: selectedCategory.householdId,
+        categoryId,
+        name: selectedCategory.name,
+        amount: { amount: amountCents },
+        period,
+        startDate,
+        endDate: null,
+        isRollover: false,
+      };
+
+      setSubmitting(true);
+      setSubmitError(null);
+
+      try {
+        await onSubmit(input);
+        // Reset form on success
+        setCategoryId('');
+        setAmount('');
+        setPeriod('MONTHLY');
+        setStartDate(firstOfCurrentMonthISO());
+        setErrors({});
+      } catch (err) {
+        setSubmitError(err instanceof Error ? err.message : 'Failed to create budget.');
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [categoryId, amount, period, startDate, categories, onSubmit],
+  );
+
+  // -- render --------------------------------------------------------------
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const hasCategoryError = Boolean(errors.categoryId);
+  const hasAmountError = Boolean(errors.amount);
+
+  return (
+    <div className="form-dialog" role="presentation" onKeyDown={handleKeyDown}>
+      {/* Backdrop */}
+      <div className="form-dialog__backdrop" aria-hidden="true" onClick={handleCancel} />
+
+      {/* Dialog panel */}
+      <div
+        ref={panelRef}
+        className="form-dialog__panel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="budget-form-title"
+      >
+        <h2 id="budget-form-title" className="form-dialog__title">
+          Create Budget
+        </h2>
+
+        {/* Form-level error */}
+        {submitError && (
+          <div className="form-banner-error" role="alert">
+            {submitError}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} noValidate>
+          <div className="form-fields">
+            {/* Category */}
+            <div className="form-group">
+              <label
+                htmlFor="budget-category"
+                className="form-group__label form-group__label--required"
+              >
+                Category
+              </label>
+              <select
+                ref={firstInputRef}
+                id="budget-category"
+                className={`form-select${hasCategoryError ? ' form-select--error' : ''}`}
+                value={categoryId}
+                onChange={(e) => setCategoryId(e.target.value)}
+                aria-invalid={hasCategoryError}
+                aria-describedby={hasCategoryError ? 'budget-category-error' : undefined}
+                aria-required="true"
+              >
+                <option value="">Select a category</option>
+                {categories.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.name}
+                  </option>
+                ))}
+              </select>
+              {hasCategoryError && (
+                <span id="budget-category-error" className="form-error" role="alert">
+                  {errors.categoryId}
+                </span>
+              )}
+            </div>
+
+            {/* Amount (dollars — converted to cents on submit) */}
+            <div className="form-group">
+              <label
+                htmlFor="budget-amount"
+                className="form-group__label form-group__label--required"
+              >
+                Amount
+              </label>
+              <input
+                id="budget-amount"
+                className={`form-input${hasAmountError ? ' form-input--error' : ''}`}
+                type="number"
+                step="0.01"
+                min="0.01"
+                inputMode="decimal"
+                value={amount}
+                onChange={(e) => setAmount(e.target.value)}
+                placeholder="0.00"
+                aria-invalid={hasAmountError}
+                aria-describedby={hasAmountError ? 'budget-amount-error' : undefined}
+                aria-required="true"
+                autoComplete="off"
+              />
+              {hasAmountError && (
+                <span id="budget-amount-error" className="form-error" role="alert">
+                  {errors.amount}
+                </span>
+              )}
+            </div>
+
+            {/* Period */}
+            <div className="form-group">
+              <label htmlFor="budget-period" className="form-group__label">
+                Period
+              </label>
+              <select
+                id="budget-period"
+                className="form-select"
+                value={period}
+                onChange={(e) => setPeriod(e.target.value as BudgetPeriod)}
+              >
+                {BUDGET_PERIODS.map((p) => (
+                  <option key={p.value} value={p.value}>
+                    {p.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* Start Date */}
+            <div className="form-group">
+              <label htmlFor="budget-start-date" className="form-group__label">
+                Start Date
+              </label>
+              <input
+                id="budget-start-date"
+                className="form-input"
+                type="date"
+                value={startDate}
+                onChange={(e) => setStartDate(e.target.value)}
+              />
+            </div>
+          </div>
+
+          {/* Actions */}
+          <div className="form-actions">
+            <button
+              type="button"
+              className="form-button form-button--secondary"
+              onClick={handleCancel}
+              disabled={submitting}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="form-button form-button--primary"
+              disabled={submitting}
+              aria-busy={submitting}
+            >
+              {submitting ? 'Creating…' : 'Create Budget'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/forms/GoalForm.tsx
+++ b/apps/web/src/components/forms/GoalForm.tsx
@@ -1,0 +1,399 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Accessible goal creation form.
+ *
+ * Renders a modal dialog with fields for creating a new savings goal:
+ * name (required), target amount (required), current amount (defaults to zero),
+ * target date (optional, must be in the future), and description (optional).
+ *
+ * Validates input client-side with accessible error messages using
+ * `aria-invalid` and `aria-describedby`. The household ID is resolved from the
+ * local database so callers only need to handle the repository input contract.
+ *
+ * Keyboard support: Tab navigation, Enter submits, Escape cancels.
+ * Focus is trapped within the dialog and the first field is autofocused.
+ *
+ * @module components/forms/GoalForm
+ * @see {@link CreateGoalInput} from db/repositories/goals
+ * References: issue #444
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type FormEvent,
+  type KeyboardEvent,
+} from 'react';
+
+import { useFocusTrap } from '../../accessibility/aria';
+import { useDatabase } from '../../db/DatabaseProvider';
+import type { CreateGoalInput } from '../../db/repositories/goals';
+import { queryOne, type Row } from '../../db/sqlite-wasm';
+import type { GoalStatus, SyncId } from '../../kmp/bridge';
+
+import './forms.css';
+
+const DEFAULT_GOAL_STATUS: GoalStatus = 'ACTIVE';
+
+/** Props for {@link GoalForm}. */
+export interface GoalFormProps {
+  /** Whether the form dialog is open. */
+  isOpen: boolean;
+  /** Callback invoked when the user cancels or presses Escape. */
+  onCancel: () => void;
+  /** Callback invoked with validated form data when the user submits. */
+  onSubmit: (data: CreateGoalInput) => Promise<void>;
+}
+
+interface FormErrors {
+  name?: string;
+  targetAmount?: string;
+  currentAmount?: string;
+  targetDate?: string;
+}
+
+/** Return today's date as an ISO local-date string (YYYY-MM-DD). */
+function todayISO(): string {
+  const date = new Date();
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/** Return tomorrow's date as an ISO local-date string (YYYY-MM-DD). */
+function tomorrowISO(): string {
+  const date = new Date();
+  date.setDate(date.getDate() + 1);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function validate(
+  name: string,
+  targetAmountStr: string,
+  currentAmountStr: string,
+  targetDate: string,
+): FormErrors {
+  const errors: FormErrors = {};
+
+  if (!name.trim()) {
+    errors.name = 'Goal name is required.';
+  }
+
+  const parsedTargetAmount = parseFloat(targetAmountStr);
+  if (!targetAmountStr.trim() || Number.isNaN(parsedTargetAmount) || parsedTargetAmount <= 0) {
+    errors.targetAmount = 'Target amount must be greater than zero.';
+  }
+
+  if (currentAmountStr.trim() !== '') {
+    const parsedCurrentAmount = parseFloat(currentAmountStr);
+    if (Number.isNaN(parsedCurrentAmount) || parsedCurrentAmount < 0) {
+      errors.currentAmount = 'Current amount must be zero or greater.';
+    }
+  }
+
+  if (targetDate && targetDate <= todayISO()) {
+    errors.targetDate = 'Target date must be in the future.';
+  }
+
+  return errors;
+}
+
+/**
+ * Query the first household ID from the local SQLite database.
+ *
+ * @returns The household SyncId or `null` if none exists.
+ */
+function getFirstHouseholdId(db: ReturnType<typeof useDatabase>): SyncId | null {
+  const row = queryOne<Row>(
+    db,
+    'SELECT id FROM household WHERE deleted_at IS NULL ORDER BY created_at ASC LIMIT 1',
+  );
+  if (row && typeof row.id === 'string') {
+    return row.id;
+  }
+  return null;
+}
+
+/**
+ * Accessible modal form for creating a new financial goal.
+ *
+ * Provides fields for name, target amount, current amount, target date, and
+ * description. Validates input and surfaces errors with ARIA attributes.
+ * Traps focus within the dialog while open.
+ */
+export function GoalForm({ isOpen, onCancel, onSubmit }: GoalFormProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const firstInputRef = useRef<HTMLInputElement>(null);
+
+  const [name, setName] = useState('');
+  const [targetAmount, setTargetAmount] = useState('');
+  const [currentAmount, setCurrentAmount] = useState('0.00');
+  const [targetDate, setTargetDate] = useState('');
+  const [description, setDescription] = useState('');
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const db = useDatabase();
+
+  useFocusTrap(panelRef, { active: isOpen, restoreFocus: true });
+
+  useEffect(() => {
+    if (isOpen) {
+      const id = requestAnimationFrame(() => {
+        firstInputRef.current?.focus();
+      });
+      return () => cancelAnimationFrame(id);
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (isOpen) {
+      setName('');
+      setTargetAmount('');
+      setCurrentAmount('0.00');
+      setTargetDate('');
+      setDescription('');
+      setErrors({});
+      setSubmitting(false);
+      setSubmitError(null);
+    }
+  }, [isOpen]);
+
+  const handleCancel = useCallback(() => {
+    onCancel();
+  }, [onCancel]);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        handleCancel();
+      }
+    },
+    [handleCancel],
+  );
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent) => {
+      event.preventDefault();
+
+      const fieldErrors = validate(name, targetAmount, currentAmount, targetDate);
+      setErrors(fieldErrors);
+
+      if (Object.keys(fieldErrors).length > 0) {
+        return;
+      }
+
+      const householdId = getFirstHouseholdId(db);
+      if (!householdId) {
+        setSubmitError('No household found. Please create a household before adding goals.');
+        return;
+      }
+
+      const input: CreateGoalInput = {
+        householdId,
+        name: name.trim(),
+        targetAmount: { amount: Math.round(parseFloat(targetAmount) * 100) },
+        currentAmount: { amount: Math.round(parseFloat(currentAmount || '0') * 100) },
+        targetDate: targetDate || null,
+        status: DEFAULT_GOAL_STATUS,
+      };
+
+      setSubmitting(true);
+      setSubmitError(null);
+
+      try {
+        await onSubmit(input);
+        setName('');
+        setTargetAmount('');
+        setCurrentAmount('0.00');
+        setTargetDate('');
+        setDescription('');
+        setErrors({});
+      } catch (err) {
+        setSubmitError(err instanceof Error ? err.message : 'Failed to create goal.');
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [name, targetAmount, currentAmount, targetDate, db, onSubmit],
+  );
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const hasNameError = Boolean(errors.name);
+  const hasTargetAmountError = Boolean(errors.targetAmount);
+  const hasCurrentAmountError = Boolean(errors.currentAmount);
+  const hasTargetDateError = Boolean(errors.targetDate);
+  const minimumTargetDate = tomorrowISO();
+
+  return (
+    <div className="form-dialog" role="presentation" onKeyDown={handleKeyDown}>
+      <div className="form-dialog__backdrop" aria-hidden="true" onClick={handleCancel} />
+
+      <div
+        ref={panelRef}
+        className="form-dialog__panel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="goal-form-title"
+      >
+        <h2 id="goal-form-title" className="form-dialog__title">
+          Create Goal
+        </h2>
+
+        {submitError && (
+          <div className="form-banner-error" role="alert">
+            {submitError}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} noValidate>
+          <div className="form-fields">
+            <div className="form-group">
+              <label htmlFor="goal-name" className="form-group__label form-group__label--required">
+                Name
+              </label>
+              <input
+                ref={firstInputRef}
+                id="goal-name"
+                className={`form-input${hasNameError ? ' form-input--error' : ''}`}
+                type="text"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                placeholder="Emergency Fund"
+                aria-invalid={hasNameError}
+                aria-describedby={hasNameError ? 'goal-name-error' : undefined}
+                aria-required="true"
+                autoComplete="off"
+              />
+              {hasNameError && (
+                <span id="goal-name-error" className="form-error" role="alert">
+                  {errors.name}
+                </span>
+              )}
+            </div>
+
+            <div className="form-group">
+              <label
+                htmlFor="goal-target-amount"
+                className="form-group__label form-group__label--required"
+              >
+                Target Amount
+              </label>
+              <input
+                id="goal-target-amount"
+                className={`form-input${hasTargetAmountError ? ' form-input--error' : ''}`}
+                type="number"
+                step="0.01"
+                min="0.01"
+                inputMode="decimal"
+                value={targetAmount}
+                onChange={(event) => setTargetAmount(event.target.value)}
+                placeholder="0.00"
+                aria-invalid={hasTargetAmountError}
+                aria-describedby={hasTargetAmountError ? 'goal-target-amount-error' : undefined}
+                aria-required="true"
+                autoComplete="off"
+              />
+              {hasTargetAmountError && (
+                <span id="goal-target-amount-error" className="form-error" role="alert">
+                  {errors.targetAmount}
+                </span>
+              )}
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="goal-current-amount" className="form-group__label">
+                Current Amount
+              </label>
+              <input
+                id="goal-current-amount"
+                className={`form-input${hasCurrentAmountError ? ' form-input--error' : ''}`}
+                type="number"
+                step="0.01"
+                min="0"
+                inputMode="decimal"
+                value={currentAmount}
+                onChange={(event) => setCurrentAmount(event.target.value)}
+                placeholder="0.00"
+                aria-invalid={hasCurrentAmountError}
+                aria-describedby={hasCurrentAmountError ? 'goal-current-amount-error' : undefined}
+                autoComplete="off"
+              />
+              {hasCurrentAmountError && (
+                <span id="goal-current-amount-error" className="form-error" role="alert">
+                  {errors.currentAmount}
+                </span>
+              )}
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="goal-target-date" className="form-group__label">
+                Target Date
+              </label>
+              <input
+                id="goal-target-date"
+                className={`form-input${hasTargetDateError ? ' form-input--error' : ''}`}
+                type="date"
+                min={minimumTargetDate}
+                value={targetDate}
+                onChange={(event) => setTargetDate(event.target.value)}
+                aria-invalid={hasTargetDateError}
+                aria-describedby={hasTargetDateError ? 'goal-target-date-error' : undefined}
+              />
+              {hasTargetDateError && (
+                <span id="goal-target-date-error" className="form-error" role="alert">
+                  {errors.targetDate}
+                </span>
+              )}
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="goal-description" className="form-group__label">
+                Description
+              </label>
+              <textarea
+                id="goal-description"
+                className="form-textarea"
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+                rows={3}
+                placeholder="Optional notes about this goal"
+              />
+            </div>
+          </div>
+
+          <div className="form-actions">
+            <button
+              type="button"
+              className="form-button form-button--secondary"
+              onClick={handleCancel}
+              disabled={submitting}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="form-button form-button--primary"
+              disabled={submitting}
+              aria-busy={submitting}
+            >
+              {submitting ? 'Creating…' : 'Create Goal'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/forms/index.ts
+++ b/apps/web/src/components/forms/index.ts
@@ -8,5 +8,9 @@
 
 export { AccountForm } from './AccountForm';
 export type { AccountFormProps } from './AccountForm';
+export { BudgetForm } from './BudgetForm';
+export type { BudgetFormProps } from './BudgetForm';
+export { GoalForm } from './GoalForm';
+export type { GoalFormProps } from './GoalForm';
 export { TransactionForm } from './TransactionForm';
 export type { TransactionFormProps } from './TransactionForm';

--- a/apps/web/src/pages/AccountsPage.test.tsx
+++ b/apps/web/src/pages/AccountsPage.test.tsx
@@ -9,6 +9,12 @@ vi.mock('../hooks', () => ({
   useAccounts: vi.fn(),
 }));
 
+// AccountForm renders unconditionally and calls useDatabase internally.
+// Stub it out so the test has no provider dependency.
+vi.mock('../components/forms', () => ({
+  AccountForm: () => null,
+}));
+
 const mockedUseAccounts = vi.mocked(useAccounts);
 const syncMetadata = {
   createdAt: '2025-01-01T00:00:00Z',

--- a/apps/web/src/pages/AccountsPage.tsx
+++ b/apps/web/src/pages/AccountsPage.tsx
@@ -2,6 +2,7 @@
 
 import React, { useMemo, useState } from 'react';
 import { CurrencyDisplay, EmptyState, ErrorBanner, LoadingSpinner } from '../components/common';
+import { AccountForm } from '../components/forms';
 import { useAccounts } from '../hooks';
 import type { AccountType } from '../kmp/bridge';
 
@@ -27,7 +28,8 @@ const ACCOUNT_TYPE_ORDER: AccountType[] = [
 
 export const AccountsPage: React.FC = () => {
   const [selectedAccountId, setSelectedAccountId] = useState<string | null>(null);
-  const { accounts, loading, error, refresh } = useAccounts();
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const { accounts, loading, error, refresh, createAccount } = useAccounts();
 
   const accountGroups = useMemo(
     () =>
@@ -44,6 +46,47 @@ export const AccountsPage: React.FC = () => {
       ? (accounts.find((account) => account.id === selectedAccountId) ?? null)
       : null;
   const netWorth = accounts.reduce((sum, account) => sum + account.currentBalance.amount, 0);
+  const headingStyle = {
+    fontSize: 'var(--type-scale-headline-font-size)',
+    fontWeight: 'var(--type-scale-headline-font-weight)',
+    margin: 0,
+  } as const;
+  const pageHeader = (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 'var(--spacing-3)',
+        flexWrap: 'wrap',
+        marginBottom: 'var(--spacing-4)',
+      }}
+    >
+      <h2 style={headingStyle}>Accounts</h2>
+      <button
+        type="button"
+        className="add-button"
+        onClick={() => setIsFormOpen(true)}
+        aria-label="Add new account"
+      >
+        + Add Account
+      </button>
+    </div>
+  );
+  const accountForm = (
+    <AccountForm
+      isOpen={isFormOpen}
+      onCancel={() => setIsFormOpen(false)}
+      onSubmit={async (data) => {
+        const createdAccount = createAccount(data);
+        if (createdAccount === null) {
+          throw new Error('Failed to create account.');
+        }
+        setIsFormOpen(false);
+        refresh();
+      }}
+    />
+  );
 
   if (loading) {
     return (
@@ -84,19 +127,12 @@ export const AccountsPage: React.FC = () => {
   if (accounts.length === 0) {
     return (
       <>
-        <h2
-          style={{
-            fontSize: 'var(--type-scale-headline-font-size)',
-            fontWeight: 'var(--type-scale-headline-font-weight)',
-            marginBottom: 'var(--spacing-2)',
-          }}
-        >
-          Accounts
-        </h2>
+        {pageHeader}
         <EmptyState
           title="No accounts yet"
           description="Add your first account to start tracking your balances."
         />
+        {accountForm}
       </>
     );
   }
@@ -139,15 +175,7 @@ export const AccountsPage: React.FC = () => {
 
   return (
     <>
-      <h2
-        style={{
-          fontSize: 'var(--type-scale-headline-font-size)',
-          fontWeight: 'var(--type-scale-headline-font-weight)',
-          marginBottom: 'var(--spacing-2)',
-        }}
-      >
-        Accounts
-      </h2>
+      {pageHeader}
       <p
         style={{ marginBottom: 'var(--spacing-6)', color: 'var(--semantic-text-secondary)' }}
         aria-live="polite"
@@ -206,6 +234,7 @@ export const AccountsPage: React.FC = () => {
           </section>
         );
       })}
+      {accountForm}
     </>
   );
 };

--- a/apps/web/src/pages/BudgetsPage.tsx
+++ b/apps/web/src/pages/BudgetsPage.tsx
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { CurrencyDisplay, EmptyState, ErrorBanner, LoadingSpinner } from '../components/common';
+import { BudgetForm } from '../components/forms';
+import type { CreateBudgetInput } from '../db/repositories/budgets';
 import { useBudgets, useCategories } from '../hooks';
 
 function getBudgetIcon(iconName: string | null | undefined): string {
@@ -22,13 +24,15 @@ function getBudgetIcon(iconName: string | null | undefined): string {
 }
 
 export const BudgetsPage: React.FC = () => {
-  const { budgets, loading, error, refresh } = useBudgets();
+  const { budgets, loading, error, refresh, createBudget } = useBudgets();
   const {
     categories,
     loading: categoriesLoading,
     error: categoriesError,
     refresh: refreshCategories,
   } = useCategories();
+
+  const [isFormOpen, setIsFormOpen] = useState(false);
 
   const categoriesById = useMemo(
     () => new Map(categories.map((category) => [category.id, category])),
@@ -42,21 +46,73 @@ export const BudgetsPage: React.FC = () => {
     refreshCategories();
   };
 
+  /** Open the Create Budget dialog. */
+  const handleAddBudget = useCallback(() => {
+    setIsFormOpen(true);
+  }, []);
+
+  /** Close the Create Budget dialog without saving. */
+  const handleFormCancel = useCallback(() => {
+    setIsFormOpen(false);
+  }, []);
+
+  /**
+   * Submit a new budget.  `createBudget` from the hook is synchronous and
+   * already triggers an internal refresh on success, so we only need to close
+   * the form here.
+   */
+  const handleFormSubmit = useCallback(
+    async (data: CreateBudgetInput) => {
+      const result = createBudget(data);
+      if (result === null) {
+        throw new Error('Failed to create budget.');
+      }
+      setIsFormOpen(false);
+      refresh();
+    },
+    [createBudget, refresh],
+  );
+
   const totalBudgeted = budgets.reduce((sum, budget) => sum + budget.amount.amount, 0);
   const totalSpent = budgets.reduce((sum, budget) => sum + budget.spentAmount.amount, 0);
   const totalRemaining = budgets.reduce((sum, budget) => sum + budget.remainingAmount.amount, 0);
 
   return (
     <>
-      <h2
+      <div
         style={{
-          fontSize: 'var(--type-scale-headline-font-size)',
-          fontWeight: 'var(--type-scale-headline-font-weight)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
           marginBottom: 'var(--spacing-6)',
+          gap: 'var(--spacing-4)',
+          flexWrap: 'wrap',
         }}
       >
-        Budgets
-      </h2>
+        <h2
+          style={{
+            fontSize: 'var(--type-scale-headline-font-size)',
+            fontWeight: 'var(--type-scale-headline-font-weight)',
+          }}
+        >
+          Budgets
+        </h2>
+        <button
+          type="button"
+          className="form-button form-button--primary"
+          onClick={handleAddBudget}
+          aria-label="Add budget"
+        >
+          + Add Budget
+        </button>
+      </div>
+
+      <BudgetForm
+        isOpen={isFormOpen}
+        onCancel={handleFormCancel}
+        onSubmit={handleFormSubmit}
+        categories={categories}
+      />
       {isLoading ? (
         <div style={{ display: 'flex', justifyContent: 'center', padding: 'var(--spacing-8) 0' }}>
           <LoadingSpinner label="Loading budgets" />

--- a/apps/web/src/pages/DashboardPage.test.tsx
+++ b/apps/web/src/pages/DashboardPage.test.tsx
@@ -2,16 +2,27 @@
 
 import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { useCategories, useDashboardData } from '../hooks';
+import { useCategories, useDashboardData, useTransactions } from '../hooks';
 import { DashboardPage } from './DashboardPage';
 
 vi.mock('../hooks', () => ({
   useDashboardData: vi.fn(),
   useCategories: vi.fn(),
+  // DashboardPage now calls useTransactions to feed chart components.
+  useTransactions: vi.fn(),
+}));
+
+// Chart components depend on Recharts canvas APIs unavailable in jsdom.
+// Stub them so the render test stays provider/canvas-free.
+vi.mock('../components/charts', () => ({
+  TrendLineChart: () => null,
+  SpendingBarChart: () => null,
+  CategoryPieChart: () => null,
 }));
 
 const mockedUseDashboardData = vi.mocked(useDashboardData);
 const mockedUseCategories = vi.mocked(useCategories);
+const mockedUseTransactions = vi.mocked(useTransactions);
 const syncMetadata = {
   createdAt: '2025-01-01T00:00:00Z',
   updatedAt: '2025-01-01T00:00:00Z',
@@ -108,6 +119,17 @@ describe('DashboardPage', () => {
       createCategory: vi.fn(),
       updateCategory: vi.fn(),
       deleteCategory: vi.fn(),
+    });
+    // useTransactions is called by DashboardPage to supply chart data.
+    // Return an empty list — charts are stubbed, so no data is needed.
+    mockedUseTransactions.mockReturnValue({
+      transactions: [],
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+      createTransaction: vi.fn(),
+      updateTransaction: vi.fn(),
+      deleteTransaction: vi.fn(),
     });
   });
 

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -1,10 +1,32 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { useMemo } from 'react';
+import { CategoryPieChart, SpendingBarChart, TrendLineChart } from '../components/charts';
 import { CurrencyDisplay, EmptyState, ErrorBanner, LoadingSpinner } from '../components/common';
-import { useCategories, useDashboardData } from '../hooks';
+import { useCategories, useDashboardData, useTransactions } from '../hooks';
 import type { DashboardData } from '../hooks/useDashboardData';
 import type { Transaction } from '../kmp/bridge';
+
+const CHART_LOOKBACK_DAYS = 30;
+
+function formatLocalDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+}
+
+function getLastNDaysBounds(days: number): { startDate: string; endDate: string } {
+  const endDate = new Date();
+  const startDate = new Date(endDate);
+  startDate.setDate(endDate.getDate() - (days - 1));
+
+  return {
+    startDate: formatLocalDate(startDate),
+    endDate: formatLocalDate(endDate),
+  };
+}
 
 function getTransactionDisplayAmount(transaction: Transaction): number {
   if (transaction.type === 'EXPENSE') {
@@ -26,6 +48,53 @@ function isDashboardDataEmpty(data: DashboardData): boolean {
   );
 }
 
+function buildTrendData(transactions: Transaction[], days: number) {
+  const dailySpending = new Map<string, number>();
+
+  for (const transaction of transactions) {
+    dailySpending.set(
+      transaction.date,
+      (dailySpending.get(transaction.date) ?? 0) + Math.abs(transaction.amount.amount) / 100,
+    );
+  }
+
+  const endDate = new Date();
+
+  return Array.from({ length: days }, (_value, index) => {
+    const pointDate = new Date(endDate);
+    pointDate.setDate(endDate.getDate() - (days - index - 1));
+    const dateKey = formatLocalDate(pointDate);
+
+    return {
+      label: pointDate.toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+      }),
+      spending: dailySpending.get(dateKey) ?? 0,
+    };
+  });
+}
+
+function buildCategoryData(transactions: Transaction[], categoryNames: Map<string, string>) {
+  const totalsByCategory = new Map<string, number>();
+
+  for (const transaction of transactions) {
+    const categoryName =
+      transaction.categoryId !== null
+        ? (categoryNames.get(transaction.categoryId) ?? 'Uncategorized')
+        : 'Uncategorized';
+
+    totalsByCategory.set(
+      categoryName,
+      (totalsByCategory.get(categoryName) ?? 0) + Math.abs(transaction.amount.amount) / 100,
+    );
+  }
+
+  return Array.from(totalsByCategory, ([name, value]) => ({ name, value })).sort(
+    (left, right) => right.value - left.value,
+  );
+}
+
 export const DashboardPage: React.FC = () => {
   const { data, loading, error, refresh } = useDashboardData();
   const {
@@ -34,14 +103,41 @@ export const DashboardPage: React.FC = () => {
     error: categoriesError,
     refresh: refreshCategories,
   } = useCategories();
+  const chartDateRange = useMemo(() => getLastNDaysBounds(CHART_LOOKBACK_DAYS), []);
+  const chartFilters = useMemo(
+    () => ({
+      type: 'EXPENSE' as const,
+      startDate: chartDateRange.startDate,
+      endDate: chartDateRange.endDate,
+    }),
+    [chartDateRange],
+  );
+  const {
+    transactions: chartTransactions,
+    loading: chartTransactionsLoading,
+    error: chartTransactionsError,
+    refresh: refreshChartTransactions,
+  } = useTransactions(chartFilters);
 
   const categoryNames = useMemo(
     () => new Map(categories.map((category) => [category.id, category.name])),
     [categories],
   );
+  const chartCurrency =
+    chartTransactions[0]?.currency.code ?? data?.recentTransactions[0]?.currency.code ?? 'USD';
+  const { trendData, barData, categoryData, hasChartData } = useMemo(() => {
+    const transformedCategoryData = buildCategoryData(chartTransactions, categoryNames);
 
-  const isLoading = loading || categoriesLoading;
-  const resolvedError = error ?? categoriesError;
+    return {
+      trendData: buildTrendData(chartTransactions, CHART_LOOKBACK_DAYS),
+      barData: transformedCategoryData.map(({ name, value }) => ({ name, amount: value })),
+      categoryData: transformedCategoryData,
+      hasChartData: transformedCategoryData.length > 0,
+    };
+  }, [chartTransactions, categoryNames]);
+
+  const isLoading = loading || categoriesLoading || chartTransactionsLoading;
+  const resolvedError = error ?? categoriesError ?? chartTransactionsError;
   const budgetPercentage =
     data !== null && data.monthlyBudget > 0
       ? Math.round((data.budgetSpent / data.monthlyBudget) * 100)
@@ -51,6 +147,7 @@ export const DashboardPage: React.FC = () => {
   const handleRetry = () => {
     refresh();
     refreshCategories();
+    refreshChartTransactions();
   };
 
   return (
@@ -118,6 +215,34 @@ export const DashboardPage: React.FC = () => {
               </article>
             </div>
           </section>
+          {hasChartData ? (
+            <section className="page-section dashboard-charts" aria-label="Financial charts">
+              <div className="chart-container" aria-label="Spending trend chart">
+                <TrendLineChart
+                  data={trendData}
+                  series={[{ dataKey: 'spending', name: 'Spending' }]}
+                  currency={chartCurrency}
+                  title="Spending Trend"
+                />
+              </div>
+              <div className="chart-container" aria-label="Category spending bar chart">
+                <SpendingBarChart
+                  data={barData}
+                  currency={chartCurrency}
+                  title="Spending by Category"
+                />
+              </div>
+              <div className="chart-container" aria-label="Category share pie chart">
+                <CategoryPieChart
+                  data={categoryData}
+                  currency={chartCurrency}
+                  width={280}
+                  height={280}
+                  title="Category Share"
+                />
+              </div>
+            </section>
+          ) : null}
           <section className="page-section" aria-label="Recent transactions">
             <h3 className="page-section__title">Recent Transactions</h3>
             <div className="card">

--- a/apps/web/src/pages/GoalsPage.test.tsx
+++ b/apps/web/src/pages/GoalsPage.test.tsx
@@ -9,6 +9,12 @@ vi.mock('../hooks', () => ({
   useGoals: vi.fn(),
 }));
 
+// GoalForm renders unconditionally and calls useDatabase internally.
+// Stub it out so the test has no provider dependency.
+vi.mock('../components/forms', () => ({
+  GoalForm: () => null,
+}));
+
 const mockedUseGoals = vi.mocked(useGoals);
 const syncMetadata = {
   createdAt: '2025-01-01T00:00:00Z',

--- a/apps/web/src/pages/GoalsPage.tsx
+++ b/apps/web/src/pages/GoalsPage.tsx
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { CurrencyDisplay, EmptyState, ErrorBanner, LoadingSpinner } from '../components/common';
+import { GoalForm } from '../components/forms';
+import type { CreateGoalInput } from '../db/repositories/goals';
 import { useGoals } from '../hooks';
 
 function getGoalIcon(iconName: string | null | undefined): string {
@@ -20,21 +22,53 @@ function getGoalIcon(iconName: string | null | undefined): string {
 }
 
 export const GoalsPage: React.FC = () => {
-  const { goals, loading, error, refresh } = useGoals();
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const { goals, loading, error, refresh, createGoal } = useGoals();
   const totalTarget = goals.reduce((sum, goal) => sum + goal.targetAmount.amount, 0);
   const totalSaved = goals.reduce((sum, goal) => sum + goal.currentAmount.amount, 0);
 
+  const handleOpenForm = useCallback(() => {
+    setIsFormOpen(true);
+  }, []);
+
+  const handleCloseForm = useCallback(() => {
+    setIsFormOpen(false);
+  }, []);
+
+  const handleSubmitGoal = useCallback(
+    async (data: CreateGoalInput) => {
+      const createdGoal = createGoal(data);
+      if (createdGoal === null) {
+        throw new Error('Failed to create goal.');
+      }
+
+      setIsFormOpen(false);
+      refresh();
+    },
+    [createGoal, refresh],
+  );
+
   return (
     <>
-      <h2
-        style={{
-          fontSize: 'var(--type-scale-headline-font-size)',
-          fontWeight: 'var(--type-scale-headline-font-weight)',
-          marginBottom: 'var(--spacing-6)',
-        }}
-      >
-        Goals
-      </h2>
+      <div className="page-section__header" style={{ marginBottom: 'var(--spacing-6)' }}>
+        <h2
+          style={{
+            fontSize: 'var(--type-scale-headline-font-size)',
+            fontWeight: 'var(--type-scale-headline-font-weight)',
+            marginBottom: 0,
+          }}
+        >
+          Goals
+        </h2>
+        <button
+          type="button"
+          className="form-button form-button--primary"
+          onClick={handleOpenForm}
+          aria-label="Add a new goal"
+        >
+          Add Goal
+        </button>
+      </div>
       {loading ? (
         <div style={{ display: 'flex', justifyContent: 'center', padding: 'var(--spacing-8) 0' }}>
           <LoadingSpinner label="Loading goals" />
@@ -197,6 +231,7 @@ export const GoalsPage: React.FC = () => {
           </section>
         </>
       )}
+      <GoalForm isOpen={isFormOpen} onCancel={handleCloseForm} onSubmit={handleSubmitGoal} />
     </>
   );
 };

--- a/apps/web/src/pages/TransactionsPage.test.tsx
+++ b/apps/web/src/pages/TransactionsPage.test.tsx
@@ -2,13 +2,21 @@
 
 import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { useAccounts, useCategories, useTransactions } from '../hooks';
+import { useAccounts } from '../hooks/useAccounts';
+import { useCategories } from '../hooks/useCategories';
+import { useTransactions } from '../hooks/useTransactions';
 import { TransactionsPage } from './TransactionsPage';
 
-vi.mock('../hooks', () => ({
-  useTransactions: vi.fn(),
-  useCategories: vi.fn(),
-  useAccounts: vi.fn(),
+// Mock each hook file individually — the page imports from the individual
+// paths, not the barrel, so the barrel mock would not intercept them.
+vi.mock('../hooks/useTransactions', () => ({ useTransactions: vi.fn() }));
+vi.mock('../hooks/useCategories', () => ({ useCategories: vi.fn() }));
+vi.mock('../hooks/useAccounts', () => ({ useAccounts: vi.fn() }));
+
+// TransactionForm renders unconditionally and calls useDatabase internally.
+// Stub it out so the test has no provider dependency.
+vi.mock('../components/forms', () => ({
+  TransactionForm: () => null,
 }));
 
 const mockedUseTransactions = vi.mocked(useTransactions);

--- a/apps/web/src/pages/TransactionsPage.tsx
+++ b/apps/web/src/pages/TransactionsPage.tsx
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { CurrencyDisplay, EmptyState, ErrorBanner, LoadingSpinner } from '../components/common';
-import { useAccounts, useCategories, useTransactions } from '../hooks';
+import { TransactionForm } from '../components/forms';
+import type { CreateTransactionInput } from '../db/repositories/transactions';
+import { useAccounts } from '../hooks/useAccounts';
+import { useCategories } from '../hooks/useCategories';
+import { useTransactions } from '../hooks/useTransactions';
 import type { Transaction } from '../kmp/bridge';
 
 const ALL_CATEGORIES_FILTER = '__all__';
@@ -18,6 +22,7 @@ function getTransactionDisplayAmount(transaction: Transaction): number {
 export const TransactionsPage: React.FC = () => {
   const [query, setQuery] = useState('');
   const [selectedCategoryId, setSelectedCategoryId] = useState(ALL_CATEGORIES_FILTER);
+  const [isFormOpen, setIsFormOpen] = useState(false);
 
   const filters = useMemo(
     () => ({
@@ -27,7 +32,13 @@ export const TransactionsPage: React.FC = () => {
     [query, selectedCategoryId],
   );
 
-  const { transactions, loading, error, refresh: refreshTransactions } = useTransactions(filters);
+  const {
+    transactions,
+    loading,
+    error,
+    refresh: refreshTransactions,
+    createTransaction,
+  } = useTransactions(filters);
   const {
     categories,
     loading: categoriesLoading,
@@ -48,6 +59,18 @@ export const TransactionsPage: React.FC = () => {
     refreshCategories();
     refreshAccounts();
   };
+
+  const handleTransactionSubmit = useCallback(
+    async (data: CreateTransactionInput): Promise<void> => {
+      const result = createTransaction(data);
+      if (result === null) {
+        throw new Error('Failed to create transaction. Please try again.');
+      }
+      setIsFormOpen(false);
+      refreshTransactions();
+    },
+    [createTransaction, refreshTransactions],
+  );
 
   const categoryFilters = useMemo(
     () => [
@@ -93,15 +116,24 @@ export const TransactionsPage: React.FC = () => {
 
   return (
     <>
-      <h2
-        style={{
-          fontSize: 'var(--type-scale-headline-font-size)',
-          fontWeight: 'var(--type-scale-headline-font-weight)',
-          marginBottom: 'var(--spacing-4)',
-        }}
-      >
-        Transactions
-      </h2>
+      <div className="transactions-page-header">
+        <h2
+          style={{
+            fontSize: 'var(--type-scale-headline-font-size)',
+            fontWeight: 'var(--type-scale-headline-font-weight)',
+          }}
+        >
+          Transactions
+        </h2>
+        <button
+          type="button"
+          className="add-button"
+          onClick={() => setIsFormOpen(true)}
+          aria-label="Add new transaction"
+        >
+          <span aria-hidden="true">+</span> Add Transaction
+        </button>
+      </div>
       <div className="search-bar" role="search">
         <input
           type="search"
@@ -183,6 +215,13 @@ export const TransactionsPage: React.FC = () => {
           ))}
         </div>
       )}
+      <TransactionForm
+        isOpen={isFormOpen}
+        accounts={accounts}
+        categories={categories}
+        onSubmit={handleTransactionSubmit}
+        onCancel={() => setIsFormOpen(false)}
+      />
     </>
   );
 };

--- a/apps/web/src/styles/responsive.css
+++ b/apps/web/src/styles/responsive.css
@@ -220,6 +220,32 @@
   font-weight: var(--type-scale-title-font-weight);
   color: var(--semantic-text-primary);
 }
+.add-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-2);
+  min-height: 40px;
+  padding: var(--spacing-2) var(--spacing-4);
+  border: 1px solid var(--semantic-interactive-default);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-interactive-default);
+  color: var(--semantic-text-inverse);
+  font: inherit;
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  transition:
+    background-color var(--duration-fast, 100ms) ease,
+    border-color var(--duration-fast, 100ms) ease;
+}
+.add-button:hover:not(:disabled) {
+  background: var(--semantic-interactive-hover);
+  border-color: var(--semantic-interactive-hover);
+}
+.add-button:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+}
 .list-group {
   display: flex;
   flex-direction: column;
@@ -483,6 +509,41 @@
 .settings-item--destructive .settings-item__value {
   color: var(--semantic-status-negative);
 }
+.dashboard-charts {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--spacing-6, 1.5rem);
+  margin-top: var(--spacing-6, 1.5rem);
+}
+.chart-container {
+  min-width: 0;
+  min-height: 300px;
+  padding: var(--spacing-4, 1rem);
+  background: var(--semantic-surface-primary, var(--card-background));
+  border: 1px solid var(--card-border);
+  border-radius: var(--border-radius-lg, 12px);
+  box-shadow: var(--card-shadow);
+}
+.chart-container > div {
+  height: 100%;
+}
+.chart-container [aria-roledescription='pie chart'] svg {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin-inline: auto;
+}
+.chart-title {
+  margin-bottom: var(--spacing-4);
+  font-size: var(--type-scale-title-font-size);
+  font-weight: var(--type-scale-title-font-weight);
+  color: var(--semantic-text-primary);
+}
+@media (min-width: 640px) {
+  .dashboard-charts {
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  }
+}
 @media (min-width: 768px) {
   .app-layout {
     flex-direction: row;
@@ -539,12 +600,28 @@
     grid-template-columns: repeat(3, 1fr);
   }
 }
+@media (min-width: 1024px) {
+  .dashboard-charts {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
 @media (min-width: 1200px) {
   :root {
     --layout-sidebar-width: 280px;
   }
 }
+/* ─── Transactions page ──────────────────────────────────────────────────── */
+.transactions-page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--spacing-3);
+  margin-bottom: var(--spacing-4);
+}
+/* ─── End Transactions page ──────────────────────────────────────────────── */
 @media (prefers-reduced-motion: reduce) {
+  .add-button,
   .progress-bar__fill,
   .progress-ring__fill {
     transition: none;


### PR DESCRIPTION
## Summary

Connects all CRUD form components to their pages and adds financial charts to the Dashboard, making the web app fully interactive for creating transactions, accounts, budgets, and goals.

## Changes

### CRUD Forms Wired to Pages
- **TransactionsPage** — \+ Add Transaction\ button opens TransactionForm modal, wired to \createTransaction\ hook, list refreshes on success
- **AccountsPage** — \+ Add Account\ button opens AccountForm modal, wired to \createAccount\ hook, list refreshes on success
- **BudgetsPage** — New \BudgetForm\ component (category, amount, period, start date) + \+ Add Budget\ button, wired to \createBudget\
- **GoalsPage** — New \GoalForm\ component (name, target/current amount, target date, description) + \+ Add Goal\ button, wired to \createGoal\

### New Components
- \BudgetForm.tsx\ — Accessible modal form with category selector, dollar→cents conversion, period picker
- \GoalForm.tsx\ — Accessible modal form with future-date validation, dollar→cents conversion

### Dashboard Charts
- Added \TrendLineChart\ — 30-day daily spending trend
- Added \SpendingBarChart\ — Spending by category bars
- Added \CategoryPieChart\ — Category spending distribution
- Charts hidden when no transaction data exists
- Responsive grid layout (stacked mobile, side-by-side desktop)

### Accessibility
- All form modals: focus trap, Escape to close, aria-invalid, aria-describedby
- All Add buttons: proper aria-labels
- Charts: aria-labels on containers, prefers-reduced-motion support

## Validation
- ✅ TypeScript strict — zero errors
- ✅ ESLint — zero warnings
- ✅ Prettier — all clean
- ✅ 34/34 tests passing

Closes #461
Closes #462
Refs #445
