### PR TITLE
fix(sync): use platform CSPRNG in RandomProvider (#359)

### DIFF
--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/crypto/RandomProvider.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/crypto/RandomProvider.kt
@@ -2,6 +2,8 @@
 
 package com.finance.sync.crypto
 
+import com.finance.sync.auth.PlatformSHA256
+
 /**
  * Abstraction for cryptographically-secure random byte generation.
  *
@@ -14,13 +16,15 @@ interface RandomProvider {
 }
 
 /**
- * Default [RandomProvider] using [kotlin.random.Random].
+ * Default [RandomProvider] backed by the platform CSPRNG.
  *
- * **WARNING:** This is NOT cryptographically secure and exists only as a
- * fallback / compilation placeholder. Platform `actual` implementations
- * MUST supply a CSPRNG-backed provider for production use.
+ * Delegates to [PlatformSHA256.randomBytes] which uses the platform-native
+ * cryptographically-secure random number generator on each target:
+ * - **JVM/Android:** `java.security.SecureRandom`
+ * - **iOS:** `SecRandomCopyBytes` (via CryptoKit)
+ * - **JS:** `crypto.getRandomValues` (Web Crypto API)
  */
 internal object DefaultRandomProvider : RandomProvider {
     override fun nextBytes(size: Int): ByteArray =
-        kotlin.random.Random.nextBytes(size)
+        PlatformSHA256.randomBytes(size)
 }


### PR DESCRIPTION
## Summary
Replace non-cryptographic kotlin.random.Random with platform CSPRNG.

## Security Finding
C-1 (Critical): DefaultRandomProvider uses predictable randomness for generating DEKs, KEKs, and nonces, making all encryption breakable.

## Fix
Delegate to existing PlatformSHA256.randomBytes() expect/actual, which uses platform-specific CSPRNG implementations (SecureRandom on JVM/Android, SecRandomCopyBytes on iOS, crypto.getRandomValues on JS).

Single-file change. No interface changes. All 25 crypto tests pass.

Closes #359