### PR TITLE
fix(api): harden Edge Functions — constant-time auth, atomic invites, idempotent webhook (#375)

### DIFF
--- a/services/api/supabase/functions/auth-webhook/index.ts
+++ b/services/api/supabase/functions/auth-webhook/index.ts
@@ -36,6 +36,30 @@ interface WebhookPayload {
 }
 
 /**
+ * Constant-time string comparison to prevent timing attacks (A-6).
+ *
+ * Uses TextEncoder for proper byte-level encoding and XOR accumulation
+ * so that the comparison time depends only on the string length, not on
+ * where the first mismatch occurs.
+ *
+ * Note: the early return on length mismatch is an accepted trade-off —
+ * leaking the *length* of the secret is not exploitable in practice.
+ */
+function constantTimeEqual(a: string, b: string): boolean {
+  const encoder = new TextEncoder();
+  const bufA = encoder.encode(a);
+  const bufB = encoder.encode(b);
+
+  if (bufA.length !== bufB.length) return false;
+
+  let result = 0;
+  for (let i = 0; i < bufA.length; i++) {
+    result |= bufA[i] ^ bufB[i];
+  }
+  return result === 0;
+}
+
+/**
  * Verify that the webhook request is authentic using the shared secret.
  */
 function verifyWebhookSecret(req: Request): boolean {
@@ -50,17 +74,8 @@ function verifyWebhookSecret(req: Request): boolean {
     return false;
   }
 
-  // Bearer token comparison using constant-time-like approach
   const token = authHeader.replace('Bearer ', '');
-  if (token.length !== secret.length) {
-    return false;
-  }
-
-  let mismatch = 0;
-  for (let i = 0; i < token.length; i++) {
-    mismatch |= token.charCodeAt(i) ^ secret.charCodeAt(i);
-  }
-  return mismatch === 0;
+  return constantTimeEqual(token, secret);
 }
 
 serve(async (req: Request): Promise<Response> => {
@@ -116,8 +131,10 @@ serve(async (req: Request): Promise<Response> => {
     const displayName =
       record.raw_user_meta_data?.full_name ?? record.raw_user_meta_data?.name ?? null;
 
-    // Call the database function to create user, household, and membership
-    const { error } = await supabaseAdmin.rpc('handle_new_user_signup', {
+    // Call the database function to create user, household, and membership.
+    // The RPC is idempotent (M-6): duplicate webhook fires return
+    // { already_provisioned: true } instead of creating duplicate households.
+    const { data, error } = await supabaseAdmin.rpc('handle_new_user_signup', {
       p_user_id: record.id,
       p_email: record.email,
       p_name: displayName,
@@ -129,6 +146,28 @@ serve(async (req: Request): Promise<Response> => {
         status: 500,
         headers: { 'Content-Type': 'application/json' },
       });
+    }
+
+    const result = data as {
+      user_id: string;
+      household_id: string;
+      display_name: string;
+      already_provisioned?: boolean;
+    };
+
+    // Idempotent re-fire: user was already provisioned on a previous webhook
+    if (result?.already_provisioned) {
+      console.log('User already provisioned (idempotent re-fire):', record.id);
+      return new Response(
+        JSON.stringify({
+          message: 'User already provisioned',
+          user_id: record.id,
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
     }
 
     // Log success without exposing user data

--- a/services/api/supabase/functions/household-invite/index.ts
+++ b/services/api/supabase/functions/household-invite/index.ts
@@ -219,14 +219,11 @@ serve(async (req: Request): Promise<Response> => {
           return errorResponse(req, 'invite_code is required');
         }
 
-        const { data, error: rpcError } = await supabase.rpc(
-          'accept_household_invitation',
-          {
-            p_invite_code: invite_code,
-            p_user_id: user.id,
-            p_user_email: user.email,
-          },
-        );
+        const { data, error: rpcError } = await supabase.rpc('accept_household_invitation', {
+          p_invite_code: invite_code,
+          p_user_id: user.id,
+          p_user_email: user.email,
+        });
 
         if (rpcError) {
           console.error('accept_household_invitation RPC failed:', rpcError.message);

--- a/services/api/supabase/functions/household-invite/index.ts
+++ b/services/api/supabase/functions/household-invite/index.ts
@@ -204,7 +204,13 @@ serve(async (req: Request): Promise<Response> => {
 
       case 'PUT': {
         // ===================================================================
-        // ACCEPT INVITATION
+        // ACCEPT INVITATION (API-8: atomic via database RPC)
+        // ===================================================================
+        // The entire check → insert membership → mark accepted flow runs
+        // inside a single PostgreSQL transaction with a SELECT ... FOR UPDATE
+        // lock on the invitation row, preventing race conditions such as:
+        //   • Two users accepting the same single-use invite concurrently
+        //   • The same user accepting twice (race past the membership check)
         // ===================================================================
         const body = await req.json();
         const { invite_code } = body;
@@ -213,84 +219,51 @@ serve(async (req: Request): Promise<Response> => {
           return errorResponse(req, 'invite_code is required');
         }
 
-        // Look up the invitation
-        const { data: invitation, error: lookupError } = await supabase
-          .from('household_invitations')
-          .select('*')
-          .eq('invite_code', invite_code)
-          .is('deleted_at', null)
-          .single();
+        const { data, error: rpcError } = await supabase.rpc(
+          'accept_household_invitation',
+          {
+            p_invite_code: invite_code,
+            p_user_id: user.id,
+            p_user_email: user.email,
+          },
+        );
 
-        if (lookupError || !invitation) {
-          return errorResponse(req, 'Invalid invitation code', 404);
-        }
-
-        // Validate invitation state
-        if (invitation.accepted_at) {
-          return errorResponse(req, 'This invitation has already been accepted', 410);
-        }
-
-        if (new Date(invitation.expires_at) < new Date()) {
-          return errorResponse(req, 'This invitation has expired', 410);
-        }
-
-        if (invitation.invited_email && invitation.invited_email !== user.email) {
-          return errorResponse(req, 'This invitation is for a different email address', 403);
-        }
-
-        // Check if user is already a member
-        const { data: existingMember } = await supabase
-          .from('household_members')
-          .select('id')
-          .eq('household_id', invitation.household_id)
-          .eq('user_id', user.id)
-          .is('deleted_at', null)
-          .single();
-
-        if (existingMember) {
-          return errorResponse(req, 'You are already a member of this household', 409);
-        }
-
-        // Add user to household in a transaction-like sequence
-        // 1. Create household membership
-        const { error: memberError } = await supabase.from('household_members').insert({
-          household_id: invitation.household_id,
-          user_id: user.id,
-          role: invitation.role,
-        });
-
-        if (memberError) {
-          console.error('Failed to add member:', memberError.message);
+        if (rpcError) {
+          console.error('accept_household_invitation RPC failed:', rpcError.message);
           return internalErrorResponse(req);
         }
 
-        // 2. Mark invitation as accepted
-        const { error: acceptError } = await supabase
-          .from('household_invitations')
-          .update({
-            accepted_at: new Date().toISOString(),
-            accepted_by: user.id,
-          })
-          .eq('id', invitation.id);
+        // The RPC returns { error: "<CODE>" } for application-level errors,
+        // or { household_id, household_name, role } on success.
+        const result = data as {
+          error?: string;
+          household_id?: string;
+          household_name?: string;
+          role?: string;
+        };
 
-        if (acceptError) {
-          console.error('Failed to mark invitation as accepted:', acceptError.message);
-          // Membership was already created, so this is a partial failure
-          // The invitation can be cleaned up later
+        if (result.error) {
+          switch (result.error) {
+            case 'INVITE_NOT_FOUND':
+              return errorResponse(req, 'Invalid invitation code', 404);
+            case 'INVITE_ALREADY_ACCEPTED':
+              return errorResponse(req, 'This invitation has already been accepted', 410);
+            case 'INVITE_EXPIRED':
+              return errorResponse(req, 'This invitation has expired', 410);
+            case 'INVITE_EMAIL_MISMATCH':
+              return errorResponse(req, 'This invitation is for a different email address', 403);
+            case 'ALREADY_MEMBER':
+              return errorResponse(req, 'You are already a member of this household', 409);
+            default:
+              return internalErrorResponse(req);
+          }
         }
-
-        // Get household name for response
-        const { data: household } = await supabase
-          .from('households')
-          .select('name')
-          .eq('id', invitation.household_id)
-          .single();
 
         return jsonResponse(req, {
           message: 'Invitation accepted',
-          household_id: invitation.household_id,
-          household_name: household?.name ?? 'Unknown',
-          role: invitation.role,
+          household_id: result.household_id,
+          household_name: result.household_name,
+          role: result.role,
         });
       }
 

--- a/services/api/supabase/migrations/20260316000001_edge_function_security.sql
+++ b/services/api/supabase/migrations/20260316000001_edge_function_security.sql
@@ -1,0 +1,185 @@
+-- SPDX-License-Identifier: BUSL-1.1
+
+-- Migration: 20260316000001_edge_function_security
+-- Description: Security hardening for Edge Function database operations
+-- Issues: #375
+--
+-- Changes:
+--   1. Make handle_new_user_signup idempotent (M-6): guard against duplicate
+--      webhook fires creating duplicate households.
+--   2. Add accept_household_invitation atomic RPC (API-8): wrap invitation
+--      acceptance in a single transaction with row-level locking to prevent
+--      race conditions (duplicate memberships, double-acceptance).
+
+-- =============================================================================
+-- 1. Idempotent handle_new_user_signup (M-6)
+-- =============================================================================
+-- If the auth webhook fires twice for the same signup event, the second call
+-- must be a no-op. The original function had ON CONFLICT DO NOTHING for the
+-- user INSERT but unconditionally created a new household + membership on
+-- every invocation. This version checks for an existing membership first.
+
+CREATE OR REPLACE FUNCTION public.handle_new_user_signup(
+    p_user_id   uuid,
+    p_email     text,
+    p_name      text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    display     text;
+    hh_id       uuid;
+BEGIN
+    -- Derive display name from email if not provided
+    display := COALESCE(NULLIF(p_name, ''), split_part(p_email, '@', 1));
+
+    -- Upsert the user row (idempotent)
+    INSERT INTO users (id, email, display_name)
+    VALUES (p_user_id, p_email, display)
+    ON CONFLICT (id) DO NOTHING;
+
+    -- =========================================================================
+    -- Idempotency guard (M-6): If the user already has an active household
+    -- membership, this is a duplicate webhook fire — return existing data
+    -- without creating a second household.
+    -- =========================================================================
+    SELECT hm.household_id INTO hh_id
+    FROM household_members hm
+    WHERE hm.user_id = p_user_id
+      AND hm.deleted_at IS NULL
+    ORDER BY hm.created_at ASC
+    LIMIT 1;
+
+    IF hh_id IS NOT NULL THEN
+        -- Re-read the display name in case it was set on the first run
+        SELECT u.display_name INTO display
+        FROM users u
+        WHERE u.id = p_user_id;
+
+        RETURN jsonb_build_object(
+            'user_id',              p_user_id,
+            'household_id',         hh_id,
+            'display_name',         COALESCE(display, split_part(p_email, '@', 1)),
+            'already_provisioned',  true
+        );
+    END IF;
+
+    -- Create a default personal household
+    INSERT INTO households (name, created_by)
+    VALUES (display || '''s Household', p_user_id)
+    RETURNING id INTO hh_id;
+
+    -- Add user as owner of the household
+    INSERT INTO household_members (household_id, user_id, role)
+    VALUES (hh_id, p_user_id, 'owner');
+
+    RETURN jsonb_build_object(
+        'user_id',        p_user_id,
+        'household_id',   hh_id,
+        'display_name',   display
+    );
+END;
+$$;
+
+-- Permissions unchanged from the original migration — service_role only
+GRANT EXECUTE ON FUNCTION public.handle_new_user_signup(uuid, text, text) TO service_role;
+REVOKE EXECUTE ON FUNCTION public.handle_new_user_signup(uuid, text, text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.handle_new_user_signup(uuid, text, text) FROM anon;
+
+-- =============================================================================
+-- 2. Atomic accept_household_invitation RPC (API-8)
+-- =============================================================================
+-- Replaces the multi-step check → insert → update sequence in the Edge
+-- Function with a single atomic transaction.  SELECT ... FOR UPDATE on the
+-- invitation row serialises concurrent acceptance attempts, preventing:
+--   • Two different users accepting a single-use invite simultaneously
+--   • The same user accepting twice (race past the membership check)
+--
+-- Error signalling: application-level errors are returned as
+-- jsonb { "error": "<CODE>" } so the Edge Function can map them to the
+-- appropriate HTTP status without parsing PostgreSQL exception messages.
+
+CREATE OR REPLACE FUNCTION public.accept_household_invitation(
+    p_invite_code   text,
+    p_user_id       uuid,
+    p_user_email    text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_invitation    RECORD;
+    v_household_name text;
+BEGIN
+    -- Lock the invitation row to serialise concurrent acceptance attempts.
+    -- Any competing transaction blocks here until this one commits.
+    SELECT *
+    INTO v_invitation
+    FROM household_invitations
+    WHERE invite_code = p_invite_code
+      AND deleted_at IS NULL
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RETURN jsonb_build_object('error', 'INVITE_NOT_FOUND');
+    END IF;
+
+    -- Already accepted?
+    IF v_invitation.accepted_at IS NOT NULL THEN
+        RETURN jsonb_build_object('error', 'INVITE_ALREADY_ACCEPTED');
+    END IF;
+
+    -- Expired?
+    IF v_invitation.expires_at < now() THEN
+        RETURN jsonb_build_object('error', 'INVITE_EXPIRED');
+    END IF;
+
+    -- Email-restricted invite sent to a different address?
+    IF v_invitation.invited_email IS NOT NULL
+       AND v_invitation.invited_email <> p_user_email THEN
+        RETURN jsonb_build_object('error', 'INVITE_EMAIL_MISMATCH');
+    END IF;
+
+    -- Already a member of this household?
+    IF EXISTS (
+        SELECT 1 FROM household_members
+        WHERE household_id = v_invitation.household_id
+          AND user_id = p_user_id
+          AND deleted_at IS NULL
+    ) THEN
+        RETURN jsonb_build_object('error', 'ALREADY_MEMBER');
+    END IF;
+
+    -- =========================================================================
+    -- Atomic mutation: insert membership + mark invitation accepted
+    -- =========================================================================
+    INSERT INTO household_members (household_id, user_id, role)
+    VALUES (v_invitation.household_id, p_user_id, v_invitation.role);
+
+    UPDATE household_invitations
+    SET accepted_at = now(),
+        accepted_by = p_user_id
+    WHERE id = v_invitation.id;
+
+    -- Fetch household name for the response
+    SELECT name INTO v_household_name
+    FROM households
+    WHERE id = v_invitation.household_id;
+
+    RETURN jsonb_build_object(
+        'household_id',   v_invitation.household_id,
+        'household_name', COALESCE(v_household_name, 'Unknown'),
+        'role',           v_invitation.role
+    );
+END;
+$$;
+
+-- Edge Functions call this via service role
+GRANT EXECUTE ON FUNCTION public.accept_household_invitation(text, uuid, text) TO service_role;
+REVOKE EXECUTE ON FUNCTION public.accept_household_invitation(text, uuid, text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.accept_household_invitation(text, uuid, text) FROM anon;


### PR DESCRIPTION
## Summary
Bundle of security hardening fixes for Supabase Edge Functions.

## Changes
1. **auth-webhook**: Constant-time comparison for webhook secret validation (byte-level XOR)
2. **household-invite**: Atomic invitation acceptance via PostgreSQL RPC with \FOR UPDATE\ row locking — prevents race conditions
3. **auth-webhook**: Idempotent signup webhook — checks for existing memberships before provisioning

## New Migration
\20260316000001_edge_function_security.sql\ — Creates two PostgreSQL functions:
- \handle_new_user_signup\: Idempotent user provisioning
- \ccept_household_invitation\: Atomic acceptance with row-level locking

## Security Findings Addressed
- A-6 (Medium): Timing-safe secret comparison
- API-8 (High): Race condition in invitation acceptance
- M-6 (Medium): Webhook idempotency

Refs #375