### PR TITLE
fix(sync): mask sensitive fields in toString() to prevent token leaking (#357)

### DIFF
--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/SyncCredentials.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/SyncCredentials.kt
@@ -22,4 +22,7 @@ data class SyncCredentials(
         require(authToken.isNotBlank()) { "Auth token cannot be blank" }
         require(userId.isNotBlank()) { "User ID cannot be blank" }
     }
+
+    override fun toString(): String =
+        "SyncCredentials(endpointUrl=$endpointUrl, authToken=*****, userId=$userId)"
 }

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/auth/AuthCredentials.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/auth/AuthCredentials.kt
@@ -20,7 +20,10 @@ sealed class AuthCredentials {
     data class EmailPassword(
         val email: String,
         val password: String,
-    ) : AuthCredentials()
+    ) : AuthCredentials() {
+        override fun toString(): String =
+            "EmailPassword(email=$email, password=*****)"
+    }
 
     /**
      * OAuth 2.0 + PKCE sign-in (Apple, Google, etc.) (#71).
@@ -37,7 +40,10 @@ sealed class AuthCredentials {
         val provider: String,
         val authCode: String,
         val codeVerifier: String,
-    ) : AuthCredentials()
+    ) : AuthCredentials() {
+        override fun toString(): String =
+            "OAuth(provider=$provider, authCode=*****, codeVerifier=*****)"
+    }
 
     /**
      * Passkey / WebAuthn sign-in (#69).
@@ -52,5 +58,8 @@ sealed class AuthCredentials {
     data class Passkey(
         val credentialId: String,
         val assertion: String,
-    ) : AuthCredentials()
+    ) : AuthCredentials() {
+        override fun toString(): String =
+            "Passkey(credentialId=$credentialId, assertion=*****)"
+    }
 }

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/auth/AuthSession.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/auth/AuthSession.kt
@@ -27,6 +27,9 @@ data class AuthSession(
     val expiresAt: Instant,
     val userId: String,
 ) {
+    override fun toString(): String =
+        "AuthSession(userId=$userId, accessToken=*****, refreshToken=*****, expiresAt=$expiresAt)"
+
     /**
      * Check whether this session's access token is still valid.
      *

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/auth/TokenManager.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/auth/TokenManager.kt
@@ -156,4 +156,7 @@ data class StoredTokenData(
     val refreshToken: String,
     val expiresAtMillis: Long,
     val userId: String,
-)
+) {
+    override fun toString(): String =
+        "StoredTokenData(userId=$userId, accessToken=*****, refreshToken=*****, expiresAtMillis=$expiresAtMillis)"
+}

--- a/packages/sync/src/commonTest/kotlin/com/finance/sync/auth/ToStringSecurityTest.kt
+++ b/packages/sync/src/commonTest/kotlin/com/finance/sync/auth/ToStringSecurityTest.kt
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.sync.auth
+
+import com.finance.sync.SyncCredentials
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Verifies that toString() overrides on security-sensitive data classes
+ * mask tokens, passwords, and other secret fields to prevent accidental
+ * leakage in logs, exception messages, or crash reports (#357, S-8).
+ */
+class ToStringSecurityTest {
+
+    // ── SyncCredentials ─────────────────────────────────────────────
+
+    @Test
+    fun syncCredentials_toString_masks_authToken() {
+        val creds = SyncCredentials(
+            endpointUrl = "https://sync.example.com",
+            authToken = "super-secret-jwt-token",
+            userId = "user-42",
+        )
+        val str = creds.toString()
+
+        assertFalse(str.contains("super-secret-jwt-token"), "authToken must not appear in toString()")
+        assertTrue(str.contains("*****"), "toString() must contain masked placeholder")
+        assertTrue(str.contains("user-42"), "userId must appear in toString()")
+        assertTrue(str.contains("https://sync.example.com"), "endpointUrl must appear in toString()")
+    }
+
+    // ── AuthSession ─────────────────────────────────────────────────
+
+    @Test
+    fun authSession_toString_masks_tokens() {
+        val session = AuthSession(
+            accessToken = "eyJhbGciOiJIUzI1NiJ9.access",
+            refreshToken = "opaque-refresh-token-abc",
+            expiresAt = Instant.fromEpochMilliseconds(1_700_000_000_000),
+            userId = "user-99",
+        )
+        val str = session.toString()
+
+        assertFalse(str.contains("eyJhbGciOiJIUzI1NiJ9"), "accessToken must not appear in toString()")
+        assertFalse(str.contains("opaque-refresh-token-abc"), "refreshToken must not appear in toString()")
+        assertTrue(str.contains("*****"), "toString() must contain masked placeholder")
+        assertTrue(str.contains("user-99"), "userId must appear in toString()")
+        assertTrue(str.contains("expiresAt"), "expiresAt label must appear in toString()")
+    }
+
+    // ── AuthCredentials.EmailPassword ───────────────────────────────
+
+    @Test
+    fun emailPassword_toString_masks_password() {
+        val creds = AuthCredentials.EmailPassword(
+            email = "alice@example.com",
+            password = "P@ssw0rd!Secret",
+        )
+        val str = creds.toString()
+
+        assertFalse(str.contains("P@ssw0rd!Secret"), "password must not appear in toString()")
+        assertTrue(str.contains("*****"), "toString() must contain masked placeholder")
+        assertTrue(str.contains("alice@example.com"), "email must appear in toString()")
+    }
+
+    // ── AuthCredentials.OAuth ───────────────────────────────────────
+
+    @Test
+    fun oauth_toString_masks_authCode_and_codeVerifier() {
+        val creds = AuthCredentials.OAuth(
+            provider = "google",
+            authCode = "4/0AX4XfWjSecretAuthCode",
+            codeVerifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+        )
+        val str = creds.toString()
+
+        assertFalse(str.contains("4/0AX4XfWjSecretAuthCode"), "authCode must not appear in toString()")
+        assertFalse(str.contains("dBjftJeZ4CVP"), "codeVerifier must not appear in toString()")
+        assertTrue(str.contains("*****"), "toString() must contain masked placeholder")
+        assertTrue(str.contains("google"), "provider must appear in toString()")
+    }
+
+    // ── AuthCredentials.Passkey ─────────────────────────────────────
+
+    @Test
+    fun passkey_toString_masks_assertion() {
+        val creds = AuthCredentials.Passkey(
+            credentialId = "cred-id-123",
+            assertion = "{\"authenticatorData\":\"secret-bytes\"}",
+        )
+        val str = creds.toString()
+
+        assertFalse(str.contains("secret-bytes"), "assertion must not appear in toString()")
+        assertTrue(str.contains("*****"), "toString() must contain masked placeholder")
+        assertTrue(str.contains("cred-id-123"), "credentialId must appear in toString()")
+    }
+
+    // ── StoredTokenData ─────────────────────────────────────────────
+
+    @Test
+    fun storedTokenData_toString_masks_tokens() {
+        val data = StoredTokenData(
+            accessToken = "stored-access-token-xyz",
+            refreshToken = "stored-refresh-token-abc",
+            expiresAtMillis = 1_700_000_000_000,
+            userId = "user-77",
+        )
+        val str = data.toString()
+
+        assertFalse(str.contains("stored-access-token-xyz"), "accessToken must not appear in toString()")
+        assertFalse(str.contains("stored-refresh-token-abc"), "refreshToken must not appear in toString()")
+        assertTrue(str.contains("*****"), "toString() must contain masked placeholder")
+        assertTrue(str.contains("user-77"), "userId must appear in toString()")
+        assertTrue(str.contains("1700000000000"), "expiresAtMillis must appear in toString()")
+    }
+}


### PR DESCRIPTION
## Summary
Override toString() on all data classes holding secrets, replacing sensitive values with \*****\.

## Security Finding
S-8 (High): Kotlin data class auto-generates toString() including accessToken, refreshToken, passwords, and auth codes — leaks to logs, exceptions, and crash reports.

## Changes (5 files)
- \SyncCredentials.kt\ — masks \uthToken\
- \AuthSession.kt\ — masks \ccessToken\, \efreshToken\
- \AuthCredentials.kt\ — masks \password\ (EmailPassword), \uthCode\+\codeVerifier\ (OAuth), \ssertion\ (Passkey)
- \TokenManager.kt\ — masks \ccessToken\, \efreshToken\ on StoredTokenData
- **New:** \ToStringSecurityTest.kt\ — 6 tests verifying no sensitive values leak

## Testing
- 6 new tests + 121 existing tests all pass

Refs #357