### PR TITLE
refactor(ios): MVVM ViewModel architecture and biometric auth (#441, #442)

### DIFF
--- a/apps/ios/Finance/FinanceApp.swift
+++ b/apps/ios/Finance/FinanceApp.swift
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
+import os
 import SwiftUI
 
 /// Finance — a cross-platform financial tracking application.
@@ -7,11 +8,71 @@ import SwiftUI
 /// This is the SwiftUI entry point for iOS, iPadOS, and macOS (Catalyst).
 /// The app consumes shared business logic from the KMP `core` module and
 /// renders a native Apple experience using SwiftUI exclusively.
+///
+/// When biometric app lock is enabled in settings, the app shows a
+/// full-screen lock overlay on launch and when returning from background.
 @main
 struct FinanceApp: App {
+    @State private var biometricManager = BiometricAuthManager()
+    @State private var isLocked = true
+    @Environment(\.scenePhase) private var scenePhase
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
+        category: "FinanceApp"
+    )
+
+    /// Whether the user has enabled biometric app lock in settings.
+    private var biometricLockEnabled: Bool {
+        UserDefaults.standard.bool(forKey: BiometricAuthManager.appLockEnabledKey)
+    }
+
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ZStack {
+                ContentView()
+                    .environment(biometricManager)
+                    .accessibilityHidden(biometricLockEnabled && isLocked)
+
+                if biometricLockEnabled && isLocked {
+                    LockScreenView(
+                        biometricManager: biometricManager,
+                        onUnlock: { isLocked = false }
+                    )
+                    .transition(.opacity)
+                }
+            }
+            .onChange(of: scenePhase) { _, newPhase in
+                handleScenePhaseChange(newPhase)
+            }
+            .task {
+                if !biometricLockEnabled {
+                    isLocked = false
+                }
+            }
+        }
+    }
+
+    /// Handles scene phase transitions for biometric lock management.
+    ///
+    /// - `.active`: refreshes biometric availability (e.g. user enrolled
+    ///   Face ID while the app was backgrounded).
+    /// - `.background`: re-locks the app when biometric lock is enabled so
+    ///   the next foreground activation requires authentication.
+    private func handleScenePhaseChange(_ phase: ScenePhase) {
+        switch phase {
+        case .active:
+            Self.logger.debug("Scene became active")
+            biometricManager.refreshAvailability()
+        case .background:
+            Self.logger.debug("Scene entered background")
+            if biometricLockEnabled {
+                isLocked = true
+            }
+        case .inactive:
+            Self.logger.debug("Scene became inactive")
+        @unknown default:
+            break
         }
     }
 }

--- a/apps/ios/Finance/Models/AccountItem.swift
+++ b/apps/ios/Finance/Models/AccountItem.swift
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// AccountItem.swift
+// Finance
+//
+// Data models for financial accounts, extracted from view-level definitions
+// to enable protocol-based repository sourcing and KMP integration.
+
+import SwiftUI
+
+// MARK: - Account Type
+
+/// Visual representation of account types used across the app.
+enum AccountTypeUI: String, CaseIterable, Hashable, Sendable {
+    case checking, savings, creditCard, cash, investment, loan, other
+
+    var displayName: String {
+        switch self {
+        case .checking: String(localized: "Checking")
+        case .savings: String(localized: "Savings")
+        case .creditCard: String(localized: "Credit Cards")
+        case .cash: String(localized: "Cash")
+        case .investment: String(localized: "Investments")
+        case .loan: String(localized: "Loans")
+        case .other: String(localized: "Other")
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .checking: "building.columns"
+        case .savings: "banknote"
+        case .creditCard: "creditcard"
+        case .cash: "dollarsign.circle"
+        case .investment: "chart.line.uptrend.xyaxis"
+        case .loan: "percent"
+        case .other: "ellipsis.circle"
+        }
+    }
+}
+
+// MARK: - Account Item
+
+/// A single financial account (checking, savings, credit card, etc.).
+///
+/// Conforms to `Hashable` for use as a `NavigationLink` value type.
+struct AccountItem: Identifiable, Hashable, Sendable {
+    let id: String
+    let name: String
+    let balanceMinorUnits: Int64
+    let currencyCode: String
+    let type: AccountTypeUI
+    let icon: String
+    let isArchived: Bool
+}
+
+// MARK: - Account Group
+
+/// Groups accounts by type for sectioned list display.
+struct AccountGroup: Identifiable, Sendable {
+    let id: String
+    let type: AccountTypeUI
+    let accounts: [AccountItem]
+
+    var totalBalance: Int64 { accounts.reduce(0) { $0 + $1.balanceMinorUnits } }
+}

--- a/apps/ios/Finance/Models/BudgetItem.swift
+++ b/apps/ios/Finance/Models/BudgetItem.swift
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// BudgetItem.swift
+// Finance
+//
+// Budget data model used by Dashboard and Budgets screens.
+// Extracted to enable repository-based sourcing and KMP integration.
+
+import SwiftUI
+
+// MARK: - Budget Item
+
+/// A single budget category with spending progress.
+///
+/// Used by both the Budgets screen (full detail) and the Dashboard
+/// (summary cards). All monetary values are in minor units (cents).
+struct BudgetItem: Identifiable, Sendable {
+    let id: String
+    let name: String
+    let categoryName: String
+    let spentMinorUnits: Int64
+    let limitMinorUnits: Int64
+    let currencyCode: String
+    let period: String
+    let icon: String
+
+    /// Fraction of budget consumed (0.0–1.0+).
+    var progress: Double {
+        guard limitMinorUnits > 0 else { return 0 }
+        return Double(spentMinorUnits) / Double(limitMinorUnits)
+    }
+
+    /// Amount remaining before hitting the limit.
+    var remainingMinorUnits: Int64 { limitMinorUnits - spentMinorUnits }
+
+    /// Color indicating budget health: green → orange → red.
+    var progressColor: Color {
+        if progress >= 1.0 { return .red }
+        if progress >= 0.75 { return .orange }
+        return .green
+    }
+
+    /// Human-readable status text.
+    var statusText: String {
+        progress >= 1.0 ? String(localized: "Over budget") : String(localized: "On track")
+    }
+}

--- a/apps/ios/Finance/Models/GoalItem.swift
+++ b/apps/ios/Finance/Models/GoalItem.swift
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// GoalItem.swift
+// Finance
+//
+// Goal data model used by the Goals screen.
+// Extracted to enable repository-based sourcing and KMP integration.
+
+import SwiftUI
+
+// MARK: - Goal Status
+
+/// Visual status of a financial goal.
+enum GoalStatusUI: String, CaseIterable, Hashable, Sendable {
+    case active, paused, completed, cancelled
+
+    var displayName: String {
+        switch self {
+        case .active: String(localized: "Active")
+        case .paused: String(localized: "Paused")
+        case .completed: String(localized: "Completed")
+        case .cancelled: String(localized: "Cancelled")
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .active: .blue
+        case .paused: .orange
+        case .completed: .green
+        case .cancelled: .gray
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .active: "flame"
+        case .paused: "pause.circle"
+        case .completed: "checkmark.circle.fill"
+        case .cancelled: "xmark.circle"
+        }
+    }
+}
+
+// MARK: - Goal Item
+
+/// A single financial goal with progress tracking.
+struct GoalItem: Identifiable, Sendable {
+    let id: String
+    let name: String
+    let currentMinorUnits: Int64
+    let targetMinorUnits: Int64
+    let currencyCode: String
+    let targetDate: Date?
+    let status: GoalStatusUI
+    let icon: String
+    let color: Color
+
+    /// Fraction of goal achieved (0.0–1.0+).
+    var progress: Double {
+        guard targetMinorUnits > 0 else { return 0 }
+        return Double(currentMinorUnits) / Double(targetMinorUnits)
+    }
+
+    /// Whether the saved amount meets or exceeds the target.
+    var isComplete: Bool { currentMinorUnits >= targetMinorUnits }
+
+    /// Amount still needed to reach the target.
+    var remainingMinorUnits: Int64 { max(0, targetMinorUnits - currentMinorUnits) }
+}

--- a/apps/ios/Finance/Models/PickerOption.swift
+++ b/apps/ios/Finance/Models/PickerOption.swift
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// PickerOption.swift
+// Finance
+//
+// Lightweight model for populating picker controls (account picker,
+// category picker) in transaction creation and similar flows.
+
+import Foundation
+
+/// A generic option for use in `Picker` and selection lists.
+struct PickerOption: Identifiable, Hashable, Sendable {
+    let id: String
+    let name: String
+    let icon: String
+}

--- a/apps/ios/Finance/Models/TransactionItem.swift
+++ b/apps/ios/Finance/Models/TransactionItem.swift
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// TransactionItem.swift
+// Finance
+//
+// Unified transaction data model used by Dashboard, Accounts, Transactions,
+// and TransactionCreate screens. Extracted to enable repository-based sourcing.
+
+import SwiftUI
+
+// MARK: - Transaction Type
+
+/// Visual representation of transaction direction.
+enum TransactionTypeUI: String, CaseIterable, Hashable, Sendable {
+    case expense, income, transfer
+
+    var displayName: String {
+        switch self {
+        case .expense: String(localized: "Expense")
+        case .income: String(localized: "Income")
+        case .transfer: String(localized: "Transfer")
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .expense: "arrow.up.right"
+        case .income: "arrow.down.left"
+        case .transfer: "arrow.left.arrow.right"
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .expense: .red
+        case .income: .green
+        case .transfer: .blue
+        }
+    }
+}
+
+// MARK: - Transaction Status
+
+/// Clearance status of a transaction.
+enum TransactionStatusUI: String, CaseIterable, Hashable, Sendable {
+    case pending, cleared, reconciled, voided
+
+    var displayName: String {
+        switch self {
+        case .pending: String(localized: "Pending")
+        case .cleared: String(localized: "Cleared")
+        case .reconciled: String(localized: "Reconciled")
+        case .voided: String(localized: "Void")
+        }
+    }
+}
+
+// MARK: - Transaction Item
+
+/// A single financial transaction.
+///
+/// This is the unified model used across all screens. Views that need fewer
+/// fields (e.g., Dashboard) use default values for `accountName`, `type`, and `status`.
+struct TransactionItem: Identifiable, Hashable, Sendable {
+    let id: String
+    let payee: String
+    let category: String
+    let accountName: String
+    let amountMinorUnits: Int64
+    let currencyCode: String
+    let date: Date
+    let type: TransactionTypeUI
+    let status: TransactionStatusUI
+
+    /// Convenience: `true` when the transaction type is `.expense`.
+    var isExpense: Bool { type == .expense }
+
+    init(
+        id: String,
+        payee: String,
+        category: String,
+        accountName: String = "",
+        amountMinorUnits: Int64,
+        currencyCode: String,
+        date: Date,
+        type: TransactionTypeUI = .expense,
+        status: TransactionStatusUI = .cleared
+    ) {
+        self.id = id
+        self.payee = payee
+        self.category = category
+        self.accountName = accountName
+        self.amountMinorUnits = amountMinorUnits
+        self.currencyCode = currencyCode
+        self.date = date
+        self.type = type
+        self.status = status
+    }
+}

--- a/apps/ios/Finance/Repositories/AccountRepository.swift
+++ b/apps/ios/Finance/Repositories/AccountRepository.swift
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// AccountRepository.swift
+// Finance
+//
+// Protocol defining the data-access contract for financial accounts.
+// Swap the concrete implementation to move from mock data to a
+// KMP-backed repository without changing any ViewModel or View code.
+
+import Foundation
+
+/// Data-access contract for financial accounts.
+///
+/// All methods are `async throws` so implementations can perform
+/// network, database, or KMP bridge calls transparently.
+protocol AccountRepository: Sendable {
+
+    /// Returns every non-archived account.
+    func getAccounts() async throws -> [AccountItem]
+
+    /// Returns a single account by its identifier, or `nil` if not found.
+    func getAccount(id: String) async throws -> AccountItem?
+
+    /// Permanently deletes the account with the given identifier.
+    func deleteAccount(id: String) async throws
+}

--- a/apps/ios/Finance/Repositories/BudgetRepository.swift
+++ b/apps/ios/Finance/Repositories/BudgetRepository.swift
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// BudgetRepository.swift
+// Finance
+//
+// Protocol defining the data-access contract for budgets.
+// Swap the concrete implementation to move from mock data to a
+// KMP-backed repository without changing any ViewModel or View code.
+
+import Foundation
+
+/// Data-access contract for budget categories.
+///
+/// All methods are `async throws` so implementations can perform
+/// network, database, or KMP bridge calls transparently.
+protocol BudgetRepository: Sendable {
+
+    /// Returns all budgets for the current or specified period.
+    func getBudgets() async throws -> [BudgetItem]
+}

--- a/apps/ios/Finance/Repositories/GoalRepository.swift
+++ b/apps/ios/Finance/Repositories/GoalRepository.swift
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// GoalRepository.swift
+// Finance
+//
+// Protocol defining the data-access contract for financial goals.
+// Swap the concrete implementation to move from mock data to a
+// KMP-backed repository without changing any ViewModel or View code.
+
+import Foundation
+
+/// Data-access contract for financial goals.
+///
+/// All methods are `async throws` so implementations can perform
+/// network, database, or KMP bridge calls transparently.
+protocol GoalRepository: Sendable {
+
+    /// Returns all goals regardless of status.
+    func getGoals() async throws -> [GoalItem]
+}

--- a/apps/ios/Finance/Repositories/Mocks/MockAccountRepository.swift
+++ b/apps/ios/Finance/Repositories/Mocks/MockAccountRepository.swift
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// MockAccountRepository.swift
+// Finance
+//
+// In-memory mock implementation of AccountRepository.
+// TODO: Replace MockAccountRepository with KMP-backed repository
+// that reads from SQLDelight via the Swift Export bridge.
+
+import Foundation
+
+/// Returns hardcoded sample accounts for development and SwiftUI previews.
+struct MockAccountRepository: AccountRepository {
+
+    func getAccounts() async throws -> [AccountItem] {
+        [
+            AccountItem(
+                id: "a1", name: "Main Checking",
+                balanceMinorUnits: 12_450_00, currencyCode: "USD",
+                type: .checking, icon: "building.columns", isArchived: false
+            ),
+            AccountItem(
+                id: "a2", name: "Savings",
+                balanceMinorUnits: 25_000_00, currencyCode: "USD",
+                type: .savings, icon: "banknote", isArchived: false
+            ),
+            AccountItem(
+                id: "a3", name: "Travel Card",
+                balanceMinorUnits: -1_200_00, currencyCode: "USD",
+                type: .creditCard, icon: "creditcard", isArchived: false
+            ),
+            AccountItem(
+                id: "a4", name: "Brokerage",
+                balanceMinorUnits: 18_500_00, currencyCode: "USD",
+                type: .investment, icon: "chart.line.uptrend.xyaxis", isArchived: false
+            ),
+            AccountItem(
+                id: "a5", name: "Emergency Fund",
+                balanceMinorUnits: 10_000_00, currencyCode: "USD",
+                type: .savings, icon: "banknote", isArchived: false
+            ),
+        ]
+    }
+
+    func getAccount(id: String) async throws -> AccountItem? {
+        try await getAccounts().first { $0.id == id }
+    }
+
+    func deleteAccount(id: String) async throws {
+        // No-op for mock — ViewModel manages local state removal.
+    }
+}

--- a/apps/ios/Finance/Repositories/Mocks/MockBudgetRepository.swift
+++ b/apps/ios/Finance/Repositories/Mocks/MockBudgetRepository.swift
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// MockBudgetRepository.swift
+// Finance
+//
+// In-memory mock implementation of BudgetRepository.
+// TODO: Replace MockBudgetRepository with KMP-backed repository
+// that reads from SQLDelight via the Swift Export bridge.
+
+import Foundation
+
+/// Returns hardcoded sample budgets for development and SwiftUI previews.
+struct MockBudgetRepository: BudgetRepository {
+
+    func getBudgets() async throws -> [BudgetItem] {
+        [
+            BudgetItem(
+                id: "b1", name: String(localized: "Groceries"),
+                categoryName: String(localized: "Groceries"),
+                spentMinorUnits: 320_00, limitMinorUnits: 500_00,
+                currencyCode: "USD", period: String(localized: "Monthly"), icon: "cart"
+            ),
+            BudgetItem(
+                id: "b2", name: String(localized: "Dining Out"),
+                categoryName: String(localized: "Dining Out"),
+                spentMinorUnits: 180_00, limitMinorUnits: 200_00,
+                currencyCode: "USD", period: String(localized: "Monthly"), icon: "fork.knife"
+            ),
+            BudgetItem(
+                id: "b3", name: String(localized: "Transport"),
+                categoryName: String(localized: "Transport"),
+                spentMinorUnits: 95_00, limitMinorUnits: 150_00,
+                currencyCode: "USD", period: String(localized: "Monthly"), icon: "car"
+            ),
+            BudgetItem(
+                id: "b4", name: String(localized: "Entertainment"),
+                categoryName: String(localized: "Entertainment"),
+                spentMinorUnits: 210_00, limitMinorUnits: 200_00,
+                currencyCode: "USD", period: String(localized: "Monthly"), icon: "film"
+            ),
+            BudgetItem(
+                id: "b5", name: String(localized: "Shopping"),
+                categoryName: String(localized: "Shopping"),
+                spentMinorUnits: 75_00, limitMinorUnits: 300_00,
+                currencyCode: "USD", period: String(localized: "Monthly"), icon: "bag"
+            ),
+        ]
+    }
+}

--- a/apps/ios/Finance/Repositories/Mocks/MockGoalRepository.swift
+++ b/apps/ios/Finance/Repositories/Mocks/MockGoalRepository.swift
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// MockGoalRepository.swift
+// Finance
+//
+// In-memory mock implementation of GoalRepository.
+// TODO: Replace MockGoalRepository with KMP-backed repository
+// that reads from SQLDelight via the Swift Export bridge.
+
+import Foundation
+import SwiftUI
+
+/// Returns hardcoded sample goals for development and SwiftUI previews.
+struct MockGoalRepository: GoalRepository {
+
+    func getGoals() async throws -> [GoalItem] {
+        [
+            GoalItem(
+                id: "g1", name: String(localized: "Emergency Fund"),
+                currentMinorUnits: 7_500_00, targetMinorUnits: 10_000_00,
+                currencyCode: "USD",
+                targetDate: Calendar.current.date(byAdding: .month, value: 6, to: .now),
+                status: .active, icon: "shield", color: .blue
+            ),
+            GoalItem(
+                id: "g2", name: String(localized: "Vacation"),
+                currentMinorUnits: 1_200_00, targetMinorUnits: 5_000_00,
+                currencyCode: "USD",
+                targetDate: Calendar.current.date(byAdding: .month, value: 12, to: .now),
+                status: .active, icon: "airplane", color: .teal
+            ),
+            GoalItem(
+                id: "g3", name: String(localized: "New Laptop"),
+                currentMinorUnits: 2_000_00, targetMinorUnits: 2_000_00,
+                currencyCode: "USD",
+                targetDate: nil,
+                status: .completed, icon: "laptopcomputer", color: .green
+            ),
+            GoalItem(
+                id: "g4", name: String(localized: "Home Down Payment"),
+                currentMinorUnits: 15_000_00, targetMinorUnits: 60_000_00,
+                currencyCode: "USD",
+                targetDate: Calendar.current.date(byAdding: .year, value: 3, to: .now),
+                status: .active, icon: "house", color: .purple
+            ),
+        ]
+    }
+}

--- a/apps/ios/Finance/Repositories/Mocks/MockTransactionRepository.swift
+++ b/apps/ios/Finance/Repositories/Mocks/MockTransactionRepository.swift
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// MockTransactionRepository.swift
+// Finance
+//
+// In-memory mock implementation of TransactionRepository.
+// TODO: Replace MockTransactionRepository with KMP-backed repository
+// that reads from SQLDelight via the Swift Export bridge.
+
+import Foundation
+
+/// Returns hardcoded sample transactions for development and SwiftUI previews.
+struct MockTransactionRepository: TransactionRepository {
+
+    func getTransactions() async throws -> [TransactionItem] {
+        [
+            TransactionItem(
+                id: "t1", payee: "Whole Foods",
+                category: String(localized: "Groceries"),
+                accountName: "Main Checking",
+                amountMinorUnits: -85_40, currencyCode: "USD",
+                date: .now, type: .expense, status: .cleared
+            ),
+            TransactionItem(
+                id: "t2", payee: "Payroll",
+                category: String(localized: "Income"),
+                accountName: "Main Checking",
+                amountMinorUnits: 4_250_00, currencyCode: "USD",
+                date: .now, type: .income, status: .cleared
+            ),
+            TransactionItem(
+                id: "t3", payee: "Netflix",
+                category: String(localized: "Entertainment"),
+                accountName: "Travel Card",
+                amountMinorUnits: -15_99, currencyCode: "USD",
+                date: Calendar.current.date(byAdding: .day, value: -1, to: .now)!,
+                type: .expense, status: .cleared
+            ),
+            TransactionItem(
+                id: "t4", payee: "Transfer to Savings",
+                category: String(localized: "Transfer"),
+                accountName: "Main Checking",
+                amountMinorUnits: -500_00, currencyCode: "USD",
+                date: Calendar.current.date(byAdding: .day, value: -1, to: .now)!,
+                type: .transfer, status: .cleared
+            ),
+            TransactionItem(
+                id: "t5", payee: "Shell Gas",
+                category: String(localized: "Transport"),
+                accountName: "Travel Card",
+                amountMinorUnits: -45_00, currencyCode: "USD",
+                date: Calendar.current.date(byAdding: .day, value: -2, to: .now)!,
+                type: .expense, status: .pending
+            ),
+            TransactionItem(
+                id: "t6", payee: "Starbucks",
+                category: String(localized: "Dining Out"),
+                accountName: "Main Checking",
+                amountMinorUnits: -6_75, currencyCode: "USD",
+                date: Calendar.current.date(byAdding: .day, value: -3, to: .now)!,
+                type: .expense, status: .cleared
+            ),
+            TransactionItem(
+                id: "t7", payee: "Amazon",
+                category: String(localized: "Shopping"),
+                accountName: "Travel Card",
+                amountMinorUnits: -129_99, currencyCode: "USD",
+                date: Calendar.current.date(byAdding: .day, value: -4, to: .now)!,
+                type: .expense, status: .reconciled
+            ),
+        ]
+    }
+
+    func getTransactions(forAccountId accountId: String) async throws -> [TransactionItem] {
+        try await getTransactions().filter { $0.accountName.isEmpty || !accountId.isEmpty }
+    }
+
+    func getRecentTransactions(limit: Int) async throws -> [TransactionItem] {
+        let all = try await getTransactions()
+        return Array(all.sorted { $0.date > $1.date }.prefix(limit))
+    }
+
+    func createTransaction(_ transaction: TransactionItem) async throws {
+        // No-op for mock — simulates a successful save.
+        try? await Task.sleep(for: .milliseconds(300))
+    }
+
+    func deleteTransaction(id: String) async throws {
+        // No-op for mock — ViewModel manages local state removal.
+    }
+}

--- a/apps/ios/Finance/Repositories/TransactionRepository.swift
+++ b/apps/ios/Finance/Repositories/TransactionRepository.swift
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// TransactionRepository.swift
+// Finance
+//
+// Protocol defining the data-access contract for transactions.
+// Swap the concrete implementation to move from mock data to a
+// KMP-backed repository without changing any ViewModel or View code.
+
+import Foundation
+
+/// Data-access contract for financial transactions.
+///
+/// All methods are `async throws` so implementations can perform
+/// network, database, or KMP bridge calls transparently.
+protocol TransactionRepository: Sendable {
+
+    /// Returns all transactions, most recent first.
+    func getTransactions() async throws -> [TransactionItem]
+
+    /// Returns transactions belonging to the given account.
+    func getTransactions(forAccountId accountId: String) async throws -> [TransactionItem]
+
+    /// Returns the most recent transactions, limited to `limit` items.
+    func getRecentTransactions(limit: Int) async throws -> [TransactionItem]
+
+    /// Persists a new transaction.
+    func createTransaction(_ transaction: TransactionItem) async throws
+
+    /// Permanently deletes the transaction with the given identifier.
+    func deleteTransaction(id: String) async throws
+}

--- a/apps/ios/Finance/Screens/AccountDetailView.swift
+++ b/apps/ios/Finance/Screens/AccountDetailView.swift
@@ -5,64 +5,36 @@
 //
 // Account detail screen showing balance, info, and transaction history.
 
+import os
 import SwiftUI
-
-// MARK: - View Model
-
-@Observable
-@MainActor
-final class AccountDetailViewModel {
-    var transactions: [TransactionRow] = []
-    var isLoading = false
-
-    struct TransactionRow: Identifiable {
-        let id: String
-        let payee: String
-        let category: String
-        let amountMinorUnits: Int64
-        let currencyCode: String
-        let date: Date
-        let isExpense: Bool
-    }
-
-    struct DateGroup: Identifiable {
-        let id: String
-        let date: Date
-        let transactions: [TransactionRow]
-    }
-
-    var groupedTransactions: [DateGroup] {
-        let calendar = Calendar.current
-        let grouped = Dictionary(grouping: transactions) { calendar.startOfDay(for: $0.date) }
-        return grouped
-            .sorted { $0.key > $1.key }
-            .map { DateGroup(id: $0.key.ISO8601Format(), date: $0.key, transactions: $0.value) }
-    }
-
-    func loadTransactions(accountId: String) async {
-        isLoading = true
-        defer { isLoading = false }
-
-        // TODO: Replace with KMP shared logic via Swift Export bridge
-        transactions = [
-            TransactionRow(id: "t1", payee: "Whole Foods", category: String(localized: "Groceries"), amountMinorUnits: -85_40, currencyCode: "USD", date: .now, isExpense: true),
-            TransactionRow(id: "t2", payee: "Shell Gas", category: String(localized: "Transport"), amountMinorUnits: -45_00, currencyCode: "USD", date: .now, isExpense: true),
-            TransactionRow(id: "t3", payee: "Direct Deposit", category: String(localized: "Income"), amountMinorUnits: 4_250_00, currencyCode: "USD", date: Calendar.current.date(byAdding: .day, value: -1, to: .now)!, isExpense: false),
-            TransactionRow(id: "t4", payee: "Amazon", category: String(localized: "Shopping"), amountMinorUnits: -129_99, currencyCode: "USD", date: Calendar.current.date(byAdding: .day, value: -2, to: .now)!, isExpense: true),
-            TransactionRow(id: "t5", payee: "Starbucks", category: String(localized: "Dining Out"), amountMinorUnits: -6_75, currencyCode: "USD", date: Calendar.current.date(byAdding: .day, value: -2, to: .now)!, isExpense: true),
-        ]
-    }
-}
 
 // MARK: - View
 
 struct AccountDetailView: View {
-    let account: AccountsViewModel.AccountItem
-    @State private var viewModel = AccountDetailViewModel()
+    let account: AccountItem
+    @Environment(BiometricAuthManager.self) private var biometricManager
+    @State private var viewModel: AccountDetailViewModel
+    @State private var showAccountNumber = false
+    @State private var biometricError: BiometricError?
+    @State private var showingBiometricError = false
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
+        category: "AccountDetailView"
+    )
+
+    init(
+        account: AccountItem,
+        viewModel: AccountDetailViewModel = AccountDetailViewModel(repository: MockTransactionRepository())
+    ) {
+        self.account = account
+        _viewModel = State(initialValue: viewModel)
+    }
 
     var body: some View {
         List {
             accountHeader
+            accountActions
             ForEach(viewModel.groupedTransactions) { group in
                 Section {
                     ForEach(group.transactions) { transaction in
@@ -87,6 +59,16 @@ struct AccountDetailView: View {
         .navigationBarTitleDisplayMode(.large)
         .refreshable { await viewModel.loadTransactions(accountId: account.id) }
         .task { await viewModel.loadTransactions(accountId: account.id) }
+        .alert(
+            String(localized: "Authentication Error"),
+            isPresented: $showingBiometricError,
+            presenting: biometricError
+        ) { _ in
+            Button(String(localized: "OK"), role: .cancel) {}
+                .accessibilityLabel(String(localized: "Dismiss error"))
+        } message: { error in
+            Text(error.localizedDescription)
+        }
     }
 
     private var accountHeader: some View {
@@ -111,7 +93,81 @@ struct AccountDetailView: View {
         }
     }
 
-    private func transactionRow(_ transaction: AccountDetailViewModel.TransactionRow) -> some View {
+    // MARK: - Account Actions
+
+    /// Section with sensitive account operations gated behind biometric
+    /// authentication.  Viewing the account number requires Face ID /
+    /// Touch ID (with passcode fallback) before the value is revealed.
+    private var accountActions: some View {
+        Section {
+            Button {
+                Task { await toggleAccountNumber() }
+            } label: {
+                Label(
+                    showAccountNumber
+                        ? String(localized: "Hide Account Number")
+                        : String(localized: "View Account Number"),
+                    systemImage: showAccountNumber ? "eye.slash" : "eye"
+                )
+            }
+            .accessibilityLabel(
+                showAccountNumber
+                    ? String(localized: "Hide account number")
+                    : String(localized: "View account number")
+            )
+            .accessibilityHint(
+                showAccountNumber
+                    ? String(localized: "Hides the account number")
+                    : String(localized: "Requires authentication to reveal the account number")
+            )
+
+            if showAccountNumber {
+                LabeledContent(String(localized: "Account Number")) {
+                    Text("•••• •••• •••• 4242")
+                        .font(.body.monospaced())
+                        .foregroundStyle(.secondary)
+                }
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(String(localized: "Account number ending in 4242"))
+            }
+        }
+    }
+
+    // MARK: - Biometric Authentication
+
+    /// Toggles the visibility of the masked account number.
+    ///
+    /// Showing the number requires biometric / passcode authentication;
+    /// hiding is immediate and does not require re-authentication.
+    private func toggleAccountNumber() async {
+        if showAccountNumber {
+            showAccountNumber = false
+            Self.logger.debug("Account number hidden")
+            return
+        }
+        do {
+            try await biometricManager.authenticate(
+                reason: String(localized: "Authenticate to view account number")
+            )
+            showAccountNumber = true
+            Self.logger.info("Account number revealed after authentication")
+        } catch let error as BiometricError {
+            Self.logger.warning(
+                "Account number auth failed: \(error.localizedDescription, privacy: .public)"
+            )
+            if case .cancelled = error { return }
+            biometricError = error
+            showingBiometricError = true
+        } catch {
+            Self.logger.error(
+                "Account number auth error: \(error.localizedDescription, privacy: .public)"
+            )
+            biometricError = .unknown(underlying: error)
+            showingBiometricError = true
+        }
+    }
+
+    private func transactionRow(_ transaction: TransactionItem) -> some View {
         HStack(spacing: 12) {
             Image(systemName: transaction.isExpense ? "arrow.up.right" : "arrow.down.left")
                 .font(.caption)
@@ -133,9 +189,10 @@ struct AccountDetailView: View {
 
 #Preview {
     NavigationStack {
-        AccountDetailView(account: AccountsViewModel.AccountItem(
+        AccountDetailView(account: AccountItem(
             id: "preview-1", name: "Main Checking", balanceMinorUnits: 12_450_00,
             currencyCode: "USD", type: .checking, icon: "building.columns", isArchived: false
         ))
     }
+    .environment(BiometricAuthManager())
 }

--- a/apps/ios/Finance/Screens/AccountsView.swift
+++ b/apps/ios/Finance/Screens/AccountsView.swift
@@ -7,94 +7,14 @@
 
 import SwiftUI
 
-// MARK: - View Model
-
-@Observable
-@MainActor
-final class AccountsViewModel {
-    var accountGroups: [AccountGroup] = []
-    var isLoading = false
-    var showingAddAccount = false
-
-    struct AccountGroup: Identifiable {
-        let id: String
-        let type: AccountTypeUI
-        let accounts: [AccountItem]
-        var totalBalance: Int64 { accounts.reduce(0) { $0 + $1.balanceMinorUnits } }
-    }
-
-    struct AccountItem: Identifiable, Hashable {
-        let id: String
-        let name: String
-        let balanceMinorUnits: Int64
-        let currencyCode: String
-        let type: AccountTypeUI
-        let icon: String
-        let isArchived: Bool
-    }
-
-    enum AccountTypeUI: String, CaseIterable, Hashable {
-        case checking, savings, creditCard, cash, investment, loan, other
-
-        var displayName: String {
-            switch self {
-            case .checking: String(localized: "Checking")
-            case .savings: String(localized: "Savings")
-            case .creditCard: String(localized: "Credit Cards")
-            case .cash: String(localized: "Cash")
-            case .investment: String(localized: "Investments")
-            case .loan: String(localized: "Loans")
-            case .other: String(localized: "Other")
-            }
-        }
-
-        var systemImage: String {
-            switch self {
-            case .checking: "building.columns"
-            case .savings: "banknote"
-            case .creditCard: "creditcard"
-            case .cash: "dollarsign.circle"
-            case .investment: "chart.line.uptrend.xyaxis"
-            case .loan: "percent"
-            case .other: "ellipsis.circle"
-            }
-        }
-    }
-
-    func loadAccounts() async {
-        isLoading = true
-        defer { isLoading = false }
-
-        // TODO: Replace with KMP shared logic via Swift Export bridge
-        let sampleAccounts: [AccountItem] = [
-            AccountItem(id: "a1", name: "Main Checking", balanceMinorUnits: 12_450_00, currencyCode: "USD", type: .checking, icon: "building.columns", isArchived: false),
-            AccountItem(id: "a2", name: "Savings", balanceMinorUnits: 25_000_00, currencyCode: "USD", type: .savings, icon: "banknote", isArchived: false),
-            AccountItem(id: "a3", name: "Travel Card", balanceMinorUnits: -1_200_00, currencyCode: "USD", type: .creditCard, icon: "creditcard", isArchived: false),
-            AccountItem(id: "a4", name: "Brokerage", balanceMinorUnits: 18_500_00, currencyCode: "USD", type: .investment, icon: "chart.line.uptrend.xyaxis", isArchived: false),
-            AccountItem(id: "a5", name: "Emergency Fund", balanceMinorUnits: 10_000_00, currencyCode: "USD", type: .savings, icon: "banknote", isArchived: false),
-        ]
-
-        let grouped = Dictionary(grouping: sampleAccounts) { $0.type }
-        accountGroups = AccountTypeUI.allCases.compactMap { type in
-            guard let accounts = grouped[type], !accounts.isEmpty else { return nil }
-            return AccountGroup(id: type.rawValue, type: type, accounts: accounts)
-        }
-    }
-
-    func deleteAccount(id: String) async {
-        // TODO: Implement via KMP shared logic
-        accountGroups = accountGroups.compactMap { group in
-            let filtered = group.accounts.filter { $0.id != id }
-            guard !filtered.isEmpty else { return nil }
-            return AccountGroup(id: group.id, type: group.type, accounts: filtered)
-        }
-    }
-}
-
 // MARK: - View
 
 struct AccountsView: View {
-    @State private var viewModel = AccountsViewModel()
+    @State private var viewModel: AccountsViewModel
+
+    init(viewModel: AccountsViewModel = AccountsViewModel(repository: MockAccountRepository())) {
+        _viewModel = State(initialValue: viewModel)
+    }
 
     var body: some View {
         NavigationStack {
@@ -152,12 +72,12 @@ struct AccountsView: View {
             }
         }
         .listStyle(.insetGrouped)
-        .navigationDestination(for: AccountsViewModel.AccountItem.self) { account in
+        .navigationDestination(for: AccountItem.self) { account in
             AccountDetailView(account: account)
         }
     }
 
-    private func accountRow(_ account: AccountsViewModel.AccountItem) -> some View {
+    private func accountRow(_ account: AccountItem) -> some View {
         HStack {
             Image(systemName: account.icon)
                 .font(.title3).foregroundStyle(.blue)
@@ -194,4 +114,4 @@ struct AccountsView: View {
     }
 }
 
-#Preview { AccountsView() }
+#Preview { AccountsView(viewModel: AccountsViewModel(repository: MockAccountRepository())) }

--- a/apps/ios/Finance/Screens/BudgetsView.swift
+++ b/apps/ios/Finance/Screens/BudgetsView.swift
@@ -7,86 +7,14 @@
 
 import SwiftUI
 
-// MARK: - View Model
-
-@Observable
-@MainActor
-final class BudgetsViewModel {
-    var budgets: [BudgetItem] = []
-    var isLoading = false
-    var selectedMonth = Date()
-    var showingCreateBudget = false
-
-    struct BudgetItem: Identifiable, Sendable {
-        let id: String
-        let name: String
-        let categoryName: String
-        let spentMinorUnits: Int64
-        let limitMinorUnits: Int64
-        let currencyCode: String
-        let period: String
-        let icon: String
-
-        var progress: Double {
-            guard limitMinorUnits > 0 else { return 0 }
-            return Double(spentMinorUnits) / Double(limitMinorUnits)
-        }
-
-        var remainingMinorUnits: Int64 { limitMinorUnits - spentMinorUnits }
-
-        var progressColor: Color {
-            if progress >= 1.0 { return .red }
-            if progress >= 0.75 { return .orange }
-            return .green
-        }
-
-        var statusText: String {
-            progress >= 1.0 ? String(localized: "Over budget") : String(localized: "On track")
-        }
-    }
-
-    var totalBudgeted: Int64 { budgets.reduce(0) { $0 + $1.limitMinorUnits } }
-    var totalSpent: Int64 { budgets.reduce(0) { $0 + $1.spentMinorUnits } }
-
-    var monthDisplayText: String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "MMMM yyyy"
-        return formatter.string(from: selectedMonth)
-    }
-
-    func previousMonth() {
-        if let d = Calendar.current.date(byAdding: .month, value: -1, to: selectedMonth) {
-            selectedMonth = d
-            Task { await loadBudgets() }
-        }
-    }
-
-    func nextMonth() {
-        if let d = Calendar.current.date(byAdding: .month, value: 1, to: selectedMonth) {
-            selectedMonth = d
-            Task { await loadBudgets() }
-        }
-    }
-
-    func loadBudgets() async {
-        isLoading = true
-        defer { isLoading = false }
-
-        // TODO: Replace with KMP shared logic via Swift Export bridge
-        budgets = [
-            BudgetItem(id: "b1", name: String(localized: "Groceries"), categoryName: String(localized: "Groceries"), spentMinorUnits: 320_00, limitMinorUnits: 500_00, currencyCode: "USD", period: String(localized: "Monthly"), icon: "cart"),
-            BudgetItem(id: "b2", name: String(localized: "Dining Out"), categoryName: String(localized: "Dining Out"), spentMinorUnits: 180_00, limitMinorUnits: 200_00, currencyCode: "USD", period: String(localized: "Monthly"), icon: "fork.knife"),
-            BudgetItem(id: "b3", name: String(localized: "Transport"), categoryName: String(localized: "Transport"), spentMinorUnits: 95_00, limitMinorUnits: 150_00, currencyCode: "USD", period: String(localized: "Monthly"), icon: "car"),
-            BudgetItem(id: "b4", name: String(localized: "Entertainment"), categoryName: String(localized: "Entertainment"), spentMinorUnits: 210_00, limitMinorUnits: 200_00, currencyCode: "USD", period: String(localized: "Monthly"), icon: "film"),
-            BudgetItem(id: "b5", name: String(localized: "Shopping"), categoryName: String(localized: "Shopping"), spentMinorUnits: 75_00, limitMinorUnits: 300_00, currencyCode: "USD", period: String(localized: "Monthly"), icon: "bag"),
-        ]
-    }
-}
-
 // MARK: - View
 
 struct BudgetsView: View {
-    @State private var viewModel = BudgetsViewModel()
+    @State private var viewModel: BudgetsViewModel
+
+    init(viewModel: BudgetsViewModel = BudgetsViewModel(repository: MockBudgetRepository())) {
+        _viewModel = State(initialValue: viewModel)
+    }
 
     var body: some View {
         NavigationStack {
@@ -183,7 +111,7 @@ struct BudgetsView: View {
         }
     }
 
-    private func budgetCard(_ budget: BudgetsViewModel.BudgetItem) -> some View {
+    private func budgetCard(_ budget: BudgetItem) -> some View {
         HStack(spacing: 16) {
             ProgressRing(progress: budget.progress, lineWidth: 6, progressColor: budget.progressColor, size: 56)
             VStack(alignment: .leading, spacing: 4) {
@@ -232,4 +160,4 @@ struct BudgetsView: View {
     }
 }
 
-#Preview { BudgetsView() }
+#Preview { BudgetsView(viewModel: BudgetsViewModel(repository: MockBudgetRepository())) }

--- a/apps/ios/Finance/Screens/DashboardView.swift
+++ b/apps/ios/Finance/Screens/DashboardView.swift
@@ -8,77 +8,18 @@
 
 import SwiftUI
 
-// MARK: - View Model
-
-@Observable
-@MainActor
-final class DashboardViewModel {
-    var netWorth: Int64 = 0
-    var monthlyIncome: Int64 = 0
-    var monthlyExpenses: Int64 = 0
-    var budgetSummaries: [BudgetSummaryItem] = []
-    var recentTransactions: [TransactionItem] = []
-    var isLoading = false
-    var currencyCode: String = "USD"
-
-    struct BudgetSummaryItem: Identifiable, Sendable {
-        let id: String
-        let name: String
-        let spentMinorUnits: Int64
-        let limitMinorUnits: Int64
-        let currencyCode: String
-
-        var progress: Double {
-            guard limitMinorUnits > 0 else { return 0 }
-            return Double(spentMinorUnits) / Double(limitMinorUnits)
-        }
-
-        var progressColor: Color {
-            if progress >= 1.0 { return .red }
-            if progress >= 0.75 { return .orange }
-            return .green
-        }
-    }
-
-    struct TransactionItem: Identifiable, Sendable {
-        let id: String
-        let payee: String
-        let category: String
-        let amountMinorUnits: Int64
-        let currencyCode: String
-        let date: Date
-        let isExpense: Bool
-    }
-
-    func loadDashboard() async {
-        isLoading = true
-        defer { isLoading = false }
-
-        // TODO: Replace with KMP shared logic calls via Swift Export bridge
-        netWorth = 42_750_00
-        monthlyIncome = 8_500_00
-        monthlyExpenses = 5_230_00
-        currencyCode = "USD"
-
-        budgetSummaries = [
-            BudgetSummaryItem(id: "1", name: String(localized: "Groceries"), spentMinorUnits: 320_00, limitMinorUnits: 500_00, currencyCode: "USD"),
-            BudgetSummaryItem(id: "2", name: String(localized: "Dining Out"), spentMinorUnits: 180_00, limitMinorUnits: 200_00, currencyCode: "USD"),
-            BudgetSummaryItem(id: "3", name: String(localized: "Transport"), spentMinorUnits: 95_00, limitMinorUnits: 150_00, currencyCode: "USD"),
-            BudgetSummaryItem(id: "4", name: String(localized: "Entertainment"), spentMinorUnits: 210_00, limitMinorUnits: 200_00, currencyCode: "USD"),
-        ]
-
-        recentTransactions = [
-            TransactionItem(id: "t1", payee: "Whole Foods", category: String(localized: "Groceries"), amountMinorUnits: -85_40, currencyCode: "USD", date: .now, isExpense: true),
-            TransactionItem(id: "t2", payee: "Payroll", category: String(localized: "Income"), amountMinorUnits: 4_250_00, currencyCode: "USD", date: Calendar.current.date(byAdding: .day, value: -1, to: .now)!, isExpense: false),
-            TransactionItem(id: "t3", payee: "Netflix", category: String(localized: "Entertainment"), amountMinorUnits: -15_99, currencyCode: "USD", date: Calendar.current.date(byAdding: .day, value: -2, to: .now)!, isExpense: true),
-        ]
-    }
-}
-
 // MARK: - View
 
 struct DashboardView: View {
-    @State private var viewModel = DashboardViewModel()
+    @State private var viewModel: DashboardViewModel
+
+    init(viewModel: DashboardViewModel = DashboardViewModel(
+        accountRepository: MockAccountRepository(),
+        transactionRepository: MockTransactionRepository(),
+        budgetRepository: MockBudgetRepository()
+    )) {
+        _viewModel = State(initialValue: viewModel)
+    }
 
     var body: some View {
         NavigationStack {
@@ -155,7 +96,7 @@ struct DashboardView: View {
             Text(String(localized: "Budget Health")).font(.headline)
             ScrollView(.horizontal, showsIndicators: false) {
                 LazyHStack(spacing: 16) {
-                    ForEach(viewModel.budgetSummaries) { budget in
+                    ForEach(viewModel.budgets) { budget in
                         budgetHealthCard(budget)
                     }
                 }
@@ -164,7 +105,7 @@ struct DashboardView: View {
         }
     }
 
-    private func budgetHealthCard(_ budget: DashboardViewModel.BudgetSummaryItem) -> some View {
+    private func budgetHealthCard(_ budget: BudgetItem) -> some View {
         VStack(spacing: 8) {
             ProgressRing(progress: budget.progress, lineWidth: 6, progressColor: budget.progressColor, size: 60)
             Text(budget.name).font(.caption).foregroundStyle(.secondary).lineLimit(1)
@@ -213,7 +154,7 @@ struct DashboardView: View {
         }
     }
 
-    private func transactionRow(_ transaction: DashboardViewModel.TransactionItem) -> some View {
+    private func transactionRow(_ transaction: TransactionItem) -> some View {
         HStack(spacing: 12) {
             Image(systemName: transaction.isExpense ? "arrow.up.right" : "arrow.down.left")
                 .font(.body)
@@ -233,4 +174,10 @@ struct DashboardView: View {
     }
 }
 
-#Preview { DashboardView() }
+#Preview {
+    DashboardView(viewModel: DashboardViewModel(
+        accountRepository: MockAccountRepository(),
+        transactionRepository: MockTransactionRepository(),
+        budgetRepository: MockBudgetRepository()
+    ))
+}

--- a/apps/ios/Finance/Screens/GoalsView.swift
+++ b/apps/ios/Finance/Screens/GoalsView.swift
@@ -7,81 +7,14 @@
 
 import SwiftUI
 
-// MARK: - View Model
-
-@Observable
-@MainActor
-final class GoalsViewModel {
-    var goals: [GoalItem] = []
-    var isLoading = false
-    var showingCreateGoal = false
-
-    struct GoalItem: Identifiable, Sendable {
-        let id: String
-        let name: String
-        let currentMinorUnits: Int64
-        let targetMinorUnits: Int64
-        let currencyCode: String
-        let targetDate: Date?
-        let status: GoalStatusUI
-        let icon: String
-        let color: Color
-
-        var progress: Double {
-            guard targetMinorUnits > 0 else { return 0 }
-            return Double(currentMinorUnits) / Double(targetMinorUnits)
-        }
-
-        var isComplete: Bool { currentMinorUnits >= targetMinorUnits }
-        var remainingMinorUnits: Int64 { max(0, targetMinorUnits - currentMinorUnits) }
-    }
-
-    enum GoalStatusUI: String, Sendable {
-        case active, paused, completed, cancelled
-        var displayName: String {
-            switch self {
-            case .active: String(localized: "Active")
-            case .paused: String(localized: "Paused")
-            case .completed: String(localized: "Completed")
-            case .cancelled: String(localized: "Cancelled")
-            }
-        }
-        var color: Color {
-            switch self {
-            case .active: .blue
-            case .paused: .orange
-            case .completed: .green
-            case .cancelled: .gray
-            }
-        }
-        var systemImage: String {
-            switch self {
-            case .active: "flame"
-            case .paused: "pause.circle"
-            case .completed: "checkmark.circle.fill"
-            case .cancelled: "xmark.circle"
-            }
-        }
-    }
-
-    func loadGoals() async {
-        isLoading = true
-        defer { isLoading = false }
-
-        // TODO: Replace with KMP shared logic via Swift Export bridge
-        goals = [
-            GoalItem(id: "g1", name: String(localized: "Emergency Fund"), currentMinorUnits: 7_500_00, targetMinorUnits: 10_000_00, currencyCode: "USD", targetDate: Calendar.current.date(byAdding: .month, value: 6, to: .now), status: .active, icon: "shield", color: .blue),
-            GoalItem(id: "g2", name: String(localized: "Vacation"), currentMinorUnits: 1_200_00, targetMinorUnits: 5_000_00, currencyCode: "USD", targetDate: Calendar.current.date(byAdding: .month, value: 12, to: .now), status: .active, icon: "airplane", color: .teal),
-            GoalItem(id: "g3", name: String(localized: "New Laptop"), currentMinorUnits: 2_000_00, targetMinorUnits: 2_000_00, currencyCode: "USD", targetDate: nil, status: .completed, icon: "laptopcomputer", color: .green),
-            GoalItem(id: "g4", name: String(localized: "Home Down Payment"), currentMinorUnits: 15_000_00, targetMinorUnits: 60_000_00, currencyCode: "USD", targetDate: Calendar.current.date(byAdding: .year, value: 3, to: .now), status: .active, icon: "house", color: .purple),
-        ]
-    }
-}
-
 // MARK: - View
 
 struct GoalsView: View {
-    @State private var viewModel = GoalsViewModel()
+    @State private var viewModel: GoalsViewModel
+
+    init(viewModel: GoalsViewModel = GoalsViewModel(repository: MockGoalRepository())) {
+        _viewModel = State(initialValue: viewModel)
+    }
 
     var body: some View {
         NavigationStack {
@@ -124,7 +57,7 @@ struct GoalsView: View {
         .padding(.bottom, 20)
     }
 
-    private func goalCard(_ goal: GoalsViewModel.GoalItem) -> some View {
+    private func goalCard(_ goal: GoalItem) -> some View {
         VStack(alignment: .leading, spacing: 12) {
             // Header
             HStack(spacing: 12) {
@@ -212,4 +145,4 @@ struct GoalsView: View {
     }
 }
 
-#Preview { GoalsView() }
+#Preview { GoalsView(viewModel: GoalsViewModel(repository: MockGoalRepository())) }

--- a/apps/ios/Finance/Screens/LockScreenView.swift
+++ b/apps/ios/Finance/Screens/LockScreenView.swift
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// LockScreenView.swift
+// Finance
+//
+// Full-screen biometric authentication gate displayed when the app
+// is locked and the user has enabled biometric app lock in settings.
+// References: #442
+
+import os
+import SwiftUI
+
+// MARK: - Lock Screen View
+
+/// A full-screen overlay that gates access to the app behind biometric
+/// authentication (Face ID / Touch ID / Optic ID with passcode fallback).
+///
+/// Shown when:
+/// - The app launches with biometric lock enabled
+/// - The app returns from background with biometric lock enabled
+///
+/// The view automatically triggers authentication on appear and provides
+/// a manual retry button if the initial attempt fails or is cancelled.
+struct LockScreenView: View {
+    let biometricManager: BiometricAuthManager
+    let onUnlock: () -> Void
+
+    @State private var authError: BiometricError?
+    @State private var showingError = false
+    @State private var isAuthenticating = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
+        category: "LockScreenView"
+    )
+
+    var body: some View {
+        ZStack {
+            FinanceColors.backgroundPrimary
+                .ignoresSafeArea()
+
+            VStack(spacing: FinanceSpacing.lg) {
+                Spacer()
+
+                Image(systemName: biometricManager.biometricType.systemImage)
+                    .font(.system(size: 64))
+                    .foregroundStyle(FinanceColors.interactive)
+                    .symbolEffect(
+                        .pulse,
+                        isActive: isAuthenticating && !reduceMotion
+                    )
+                    .accessibilityHidden(true)
+
+                Text(String(localized: "Finance is Locked"))
+                    .font(.title2)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(FinanceColors.textPrimary)
+                    .accessibilityAddTraits(.isHeader)
+
+                Text(String(localized: "Authenticate to access your financial data."))
+                    .font(.body)
+                    .foregroundStyle(FinanceColors.textSecondary)
+                    .multilineTextAlignment(.center)
+
+                Spacer()
+
+                Button {
+                    Task { await authenticate() }
+                } label: {
+                    Label(
+                        unlockButtonTitle,
+                        systemImage: biometricManager.biometricType.systemImage
+                    )
+                    .font(.headline)
+                    .frame(maxWidth: .infinity, minHeight: FinanceSpacing.minTapTarget)
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(isAuthenticating)
+                .accessibilityLabel(unlockButtonTitle)
+                .accessibilityHint(String(localized: "Authenticates to unlock the app"))
+                .padding(.bottom, FinanceSpacing.xl)
+            }
+            .padding(.horizontal, FinanceSpacing.xl)
+        }
+        .alert(
+            String(localized: "Authentication Failed"),
+            isPresented: $showingError,
+            presenting: authError
+        ) { _ in
+            Button(String(localized: "Try Again")) {
+                Task { await authenticate() }
+            }
+            .accessibilityLabel(String(localized: "Try again"))
+            Button(String(localized: "Cancel"), role: .cancel) {}
+        } message: { error in
+            Text(error.localizedDescription)
+        }
+        .task {
+            await authenticate()
+        }
+        .accessibilityLabel(String(localized: "App lock screen"))
+    }
+
+    // MARK: - Private Helpers
+
+    /// Localized button title matching the current biometric type.
+    private var unlockButtonTitle: String {
+        switch biometricManager.biometricType {
+        case .faceID: String(localized: "Unlock with Face ID")
+        case .touchID: String(localized: "Unlock with Touch ID")
+        case .opticID: String(localized: "Unlock with Optic ID")
+        case .none: String(localized: "Unlock")
+        }
+    }
+
+    /// Triggers biometric (or passcode-fallback) authentication.
+    ///
+    /// On success the `onUnlock` closure is called — optionally wrapped
+    /// in an animation when Reduce Motion is off.  On cancellation the
+    /// user stays on the lock screen and can retry manually.
+    private func authenticate() async {
+        guard !isAuthenticating else { return }
+        isAuthenticating = true
+        defer { isAuthenticating = false }
+
+        do {
+            try await biometricManager.authenticate(
+                reason: String(localized: "Authenticate to unlock Finance")
+            )
+            Self.logger.info("App unlock authentication succeeded")
+            if reduceMotion {
+                onUnlock()
+            } else {
+                withAnimation(.easeOut(duration: 0.25)) {
+                    onUnlock()
+                }
+            }
+        } catch let error as BiometricError {
+            Self.logger.warning(
+                "App unlock failed: \(error.localizedDescription, privacy: .public)"
+            )
+            if case .cancelled = error {
+                // User cancelled — stay on lock screen, let them retry
+                return
+            }
+            authError = error
+            showingError = true
+        } catch {
+            Self.logger.error(
+                "App unlock unexpected error: \(error.localizedDescription, privacy: .public)"
+            )
+            authError = .unknown(underlying: error)
+            showingError = true
+        }
+    }
+}
+
+#Preview {
+    LockScreenView(
+        biometricManager: BiometricAuthManager(),
+        onUnlock: {}
+    )
+}

--- a/apps/ios/Finance/Screens/SettingsView.swift
+++ b/apps/ios/Finance/Screens/SettingsView.swift
@@ -6,69 +6,13 @@
 // Form-style settings with large navigation title. Covers currency,
 // notifications, biometric auth, data export, and about.
 
+import os
 import SwiftUI
-
-// MARK: - View Model
-
-@Observable
-@MainActor
-final class SettingsViewModel {
-    var selectedCurrency = "USD"
-    var notificationsEnabled = true
-    var budgetAlerts = true
-    var goalMilestones = true
-    var biometricEnabled = false
-    var biometricType: BiometricType = .faceID
-    var appVersion = "1.0.0"
-    var buildNumber = "1"
-    var showingExportConfirmation = false
-    var isExporting = false
-    var showingDeleteConfirmation = false
-
-    enum BiometricType {
-        case faceID, touchID, none
-        var displayName: String {
-            switch self {
-            case .faceID: String(localized: "Face ID")
-            case .touchID: String(localized: "Touch ID")
-            case .none: String(localized: "Biometric Authentication")
-            }
-        }
-        var systemImage: String {
-            switch self {
-            case .faceID: "faceid"
-            case .touchID: "touchid"
-            case .none: "lock"
-            }
-        }
-    }
-
-    let supportedCurrencies = [
-        ("USD", "US Dollar"), ("EUR", "Euro"), ("GBP", "British Pound"),
-        ("CAD", "Canadian Dollar"), ("JPY", "Japanese Yen"),
-        ("AUD", "Australian Dollar"), ("CHF", "Swiss Franc"),
-    ]
-
-    func loadSettings() async {
-        // TODO: Replace with KMP shared logic and Keychain reads
-    }
-
-    func exportData() async {
-        isExporting = true
-        defer { isExporting = false }
-        // TODO: Implement data export via KMP shared logic
-        try? await Task.sleep(for: .seconds(1))
-    }
-
-    func toggleBiometric() async {
-        // TODO: Implement via LAContext biometric evaluation
-        biometricEnabled.toggle()
-    }
-}
 
 // MARK: - View
 
 struct SettingsView: View {
+    @Environment(BiometricAuthManager.self) private var biometricManager
     @State private var viewModel = SettingsViewModel()
 
     var body: some View {
@@ -83,6 +27,16 @@ struct SettingsView: View {
             .navigationTitle(String(localized: "Settings"))
             .navigationBarTitleDisplayMode(.large)
             .task { await viewModel.loadSettings() }
+            .alert(
+                String(localized: "Authentication Error"),
+                isPresented: $viewModel.showingBiometricError,
+                presenting: viewModel.biometricError
+            ) { _ in
+                Button(String(localized: "OK"), role: .cancel) {}
+                    .accessibilityLabel(String(localized: "Dismiss error"))
+            } message: { error in
+                Text(error.localizedDescription)
+            }
         }
     }
 
@@ -132,12 +86,34 @@ struct SettingsView: View {
         Section(String(localized: "Security")) {
             Toggle(isOn: Binding(
                 get: { viewModel.biometricEnabled },
-                set: { _ in Task { await viewModel.toggleBiometric() } }
+                set: { _ in
+                    Task { await viewModel.toggleBiometric(using: biometricManager) }
+                }
             )) {
-                Label(viewModel.biometricType.displayName, systemImage: viewModel.biometricType.systemImage)
+                Label(
+                    biometricManager.biometricType.displayName,
+                    systemImage: biometricManager.biometricType.systemImage
+                )
             }
-            .accessibilityLabel(viewModel.biometricType.displayName)
-            .accessibilityHint(String(localized: "Require biometric authentication to open the app"))
+            .disabled(!biometricManager.isAvailable)
+            .accessibilityLabel(biometricManager.biometricType.displayName)
+            .accessibilityHint(
+                biometricManager.isAvailable
+                    ? String(localized: "Require biometric authentication to open the app")
+                    : String(localized: "Biometric authentication is not available on this device")
+            )
+            .accessibilityValue(
+                viewModel.biometricEnabled
+                    ? String(localized: "Enabled")
+                    : String(localized: "Disabled")
+            )
+
+            if !biometricManager.isAvailable {
+                Text(String(localized: "Biometric authentication is not available. Enroll Face ID or Touch ID in device Settings."))
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .accessibilityLabel(String(localized: "Biometric authentication is not available. Enroll Face ID or Touch ID in device Settings."))
+            }
 
             NavigationLink {
                 ScrollView {
@@ -159,7 +135,14 @@ struct SettingsView: View {
     private var dataSection: some View {
         Section(String(localized: "Data")) {
             Button {
-                viewModel.showingExportConfirmation = true
+                Task {
+                    let authorized = await viewModel.authenticateForExport(
+                        using: biometricManager
+                    )
+                    if authorized {
+                        viewModel.showingExportConfirmation = true
+                    }
+                }
             } label: {
                 Label {
                     if viewModel.isExporting {
@@ -204,7 +187,7 @@ struct SettingsView: View {
                 titleVisibility: .visible
             ) {
                 Button(String(localized: "Delete Everything"), role: .destructive) {
-                    // TODO: Implement via KMP shared logic
+                    // TODO: Replace MockRepository with KMP-backed repository
                 }
                 Button(String(localized: "Cancel"), role: .cancel) {}
             } message: {
@@ -238,4 +221,7 @@ struct SettingsView: View {
     }
 }
 
-#Preview { SettingsView() }
+#Preview {
+    SettingsView()
+        .environment(BiometricAuthManager())
+}

--- a/apps/ios/Finance/Screens/TransactionCreateView.swift
+++ b/apps/ios/Finance/Screens/TransactionCreateView.swift
@@ -7,136 +7,18 @@
 
 import SwiftUI
 
-// MARK: - View Model
-
-@Observable
-@MainActor
-final class TransactionCreateViewModel {
-    var currentStep: Step = .type
-
-    enum Step: Int, CaseIterable {
-        case type = 0, details = 1, review = 2
-        var title: String {
-            switch self {
-            case .type: String(localized: "Type")
-            case .details: String(localized: "Details")
-            case .review: String(localized: "Review")
-            }
-        }
-    }
-
-    var transactionType: TransactionType = .expense
-    var amountText = ""
-    var payee = ""
-    var selectedAccountId: String?
-    var selectedCategoryId: String?
-    var date = Date()
-    var note = ""
-    var currencyCode = "USD"
-    var isSaving = false
-    var showingValidationError = false
-    var validationMessage = ""
-
-    enum TransactionType: String, CaseIterable {
-        case expense, income, transfer
-        var displayName: String {
-            switch self {
-            case .expense: String(localized: "Expense")
-            case .income: String(localized: "Income")
-            case .transfer: String(localized: "Transfer")
-            }
-        }
-        var systemImage: String {
-            switch self {
-            case .expense: "arrow.up.right"
-            case .income: "arrow.down.left"
-            case .transfer: "arrow.left.arrow.right"
-            }
-        }
-        var color: Color {
-            switch self {
-            case .expense: .red
-            case .income: .green
-            case .transfer: .blue
-            }
-        }
-    }
-
-    struct PickerOption: Identifiable {
-        let id: String
-        let name: String
-        let icon: String
-    }
-
-    var accounts: [PickerOption] = [
-        PickerOption(id: "a1", name: "Main Checking", icon: "building.columns"),
-        PickerOption(id: "a2", name: "Savings", icon: "banknote"),
-        PickerOption(id: "a3", name: "Travel Card", icon: "creditcard"),
-    ]
-
-    var categories: [PickerOption] = [
-        PickerOption(id: "c1", name: "Groceries", icon: "cart"),
-        PickerOption(id: "c2", name: "Dining Out", icon: "fork.knife"),
-        PickerOption(id: "c3", name: "Transport", icon: "car"),
-        PickerOption(id: "c4", name: "Entertainment", icon: "film"),
-        PickerOption(id: "c5", name: "Shopping", icon: "bag"),
-        PickerOption(id: "c6", name: "Income", icon: "dollarsign.circle"),
-    ]
-
-    var canAdvance: Bool {
-        switch currentStep {
-        case .type: true
-        case .details: !amountText.isEmpty && selectedAccountId != nil && !payee.isEmpty
-        case .review: true
-        }
-    }
-
-    var amountMinorUnits: Int64 { Int64((Double(amountText) ?? 0) * 100) }
-
-    func advance() {
-        guard let next = Step(rawValue: currentStep.rawValue + 1) else { return }
-        currentStep = next
-    }
-
-    func goBack() {
-        guard let prev = Step(rawValue: currentStep.rawValue - 1) else { return }
-        currentStep = prev
-    }
-
-    func save() async -> Bool {
-        guard validate() else { return false }
-        isSaving = true
-        defer { isSaving = false }
-        // TODO: Replace with KMP shared logic
-        try? await Task.sleep(for: .milliseconds(500))
-        return true
-    }
-
-    private func validate() -> Bool {
-        if amountText.isEmpty || (Double(amountText) ?? 0) <= 0 {
-            validationMessage = String(localized: "Please enter a valid amount.")
-            showingValidationError = true
-            return false
-        }
-        if payee.isEmpty {
-            validationMessage = String(localized: "Please enter a payee.")
-            showingValidationError = true
-            return false
-        }
-        if selectedAccountId == nil {
-            validationMessage = String(localized: "Please select an account.")
-            showingValidationError = true
-            return false
-        }
-        return true
-    }
-}
-
 // MARK: - View
 
 struct TransactionCreateView: View {
     @Environment(\.dismiss) private var dismiss
-    @State private var viewModel = TransactionCreateViewModel()
+    @State private var viewModel: TransactionCreateViewModel
+
+    init(viewModel: TransactionCreateViewModel = TransactionCreateViewModel(
+        transactionRepository: MockTransactionRepository(),
+        accountRepository: MockAccountRepository()
+    )) {
+        _viewModel = State(initialValue: viewModel)
+    }
 
     var body: some View {
         NavigationStack {
@@ -167,6 +49,7 @@ struct TransactionCreateView: View {
             } message: {
                 Text(viewModel.validationMessage)
             }
+            .task { await viewModel.loadData() }
         }
     }
 
@@ -209,7 +92,7 @@ struct TransactionCreateView: View {
             VStack(spacing: 16) {
                 Text(String(localized: "What type of transaction?"))
                     .font(.title3).fontWeight(.semibold).padding(.top, 24)
-                ForEach(TransactionCreateViewModel.TransactionType.allCases, id: \.rawValue) { type in
+                ForEach(TransactionTypeUI.allCases, id: \.rawValue) { type in
                     Button {
                         viewModel.transactionType = type
                     } label: {
@@ -357,4 +240,9 @@ struct TransactionCreateView: View {
     }
 }
 
-#Preview { TransactionCreateView() }
+#Preview {
+    TransactionCreateView(viewModel: TransactionCreateViewModel(
+        transactionRepository: MockTransactionRepository(),
+        accountRepository: MockAccountRepository()
+    ))
+}

--- a/apps/ios/Finance/Screens/TransactionsView.swift
+++ b/apps/ios/Finance/Screens/TransactionsView.swift
@@ -7,105 +7,14 @@
 
 import SwiftUI
 
-// MARK: - View Model
-
-@Observable
-@MainActor
-final class TransactionsViewModel {
-    var transactions: [TransactionListItem] = []
-    var isLoading = false
-    var searchText = ""
-    var showingCreateTransaction = false
-
-    struct TransactionListItem: Identifiable, Sendable {
-        let id: String
-        let payee: String
-        let category: String
-        let accountName: String
-        let amountMinorUnits: Int64
-        let currencyCode: String
-        let date: Date
-        let type: TransactionTypeUI
-        let status: TransactionStatusUI
-    }
-
-    enum TransactionTypeUI: String, Sendable {
-        case expense, income, transfer
-        var systemImage: String {
-            switch self {
-            case .expense: "arrow.up.right"
-            case .income: "arrow.down.left"
-            case .transfer: "arrow.left.arrow.right"
-            }
-        }
-        var color: Color {
-            switch self {
-            case .expense: .red
-            case .income: .green
-            case .transfer: .blue
-            }
-        }
-    }
-
-    enum TransactionStatusUI: String, Sendable {
-        case pending, cleared, reconciled, voided
-        var displayName: String {
-            switch self {
-            case .pending: String(localized: "Pending")
-            case .cleared: String(localized: "Cleared")
-            case .reconciled: String(localized: "Reconciled")
-            case .voided: String(localized: "Void")
-            }
-        }
-    }
-
-    struct DateGroup: Identifiable {
-        let id: String
-        let date: Date
-        let transactions: [TransactionListItem]
-    }
-
-    var filteredTransactions: [TransactionListItem] {
-        guard !searchText.isEmpty else { return transactions }
-        return transactions.filter {
-            $0.payee.localizedCaseInsensitiveContains(searchText) ||
-            $0.category.localizedCaseInsensitiveContains(searchText) ||
-            $0.accountName.localizedCaseInsensitiveContains(searchText)
-        }
-    }
-
-    var groupedTransactions: [DateGroup] {
-        let calendar = Calendar.current
-        let grouped = Dictionary(grouping: filteredTransactions) { calendar.startOfDay(for: $0.date) }
-        return grouped.sorted { $0.key > $1.key }
-            .map { DateGroup(id: $0.key.ISO8601Format(), date: $0.key, transactions: $0.value) }
-    }
-
-    func loadTransactions() async {
-        isLoading = true
-        defer { isLoading = false }
-
-        // TODO: Replace with KMP shared logic via Swift Export bridge
-        transactions = [
-            TransactionListItem(id: "t1", payee: "Whole Foods", category: String(localized: "Groceries"), accountName: "Main Checking", amountMinorUnits: -85_40, currencyCode: "USD", date: .now, type: .expense, status: .cleared),
-            TransactionListItem(id: "t2", payee: "Payroll", category: String(localized: "Income"), accountName: "Main Checking", amountMinorUnits: 4_250_00, currencyCode: "USD", date: .now, type: .income, status: .cleared),
-            TransactionListItem(id: "t3", payee: "Netflix", category: String(localized: "Entertainment"), accountName: "Travel Card", amountMinorUnits: -15_99, currencyCode: "USD", date: Calendar.current.date(byAdding: .day, value: -1, to: .now)!, type: .expense, status: .cleared),
-            TransactionListItem(id: "t4", payee: "Transfer to Savings", category: String(localized: "Transfer"), accountName: "Main Checking", amountMinorUnits: -500_00, currencyCode: "USD", date: Calendar.current.date(byAdding: .day, value: -1, to: .now)!, type: .transfer, status: .cleared),
-            TransactionListItem(id: "t5", payee: "Shell Gas", category: String(localized: "Transport"), accountName: "Travel Card", amountMinorUnits: -45_00, currencyCode: "USD", date: Calendar.current.date(byAdding: .day, value: -2, to: .now)!, type: .expense, status: .pending),
-            TransactionListItem(id: "t6", payee: "Starbucks", category: String(localized: "Dining Out"), accountName: "Main Checking", amountMinorUnits: -6_75, currencyCode: "USD", date: Calendar.current.date(byAdding: .day, value: -3, to: .now)!, type: .expense, status: .cleared),
-            TransactionListItem(id: "t7", payee: "Amazon", category: String(localized: "Shopping"), accountName: "Travel Card", amountMinorUnits: -129_99, currencyCode: "USD", date: Calendar.current.date(byAdding: .day, value: -4, to: .now)!, type: .expense, status: .reconciled),
-        ]
-    }
-
-    func deleteTransaction(id: String) async {
-        transactions.removeAll { $0.id == id }
-    }
-}
-
 // MARK: - View
 
 struct TransactionsView: View {
-    @State private var viewModel = TransactionsViewModel()
+    @State private var viewModel: TransactionsViewModel
+
+    init(viewModel: TransactionsViewModel = TransactionsViewModel(repository: MockTransactionRepository())) {
+        _viewModel = State(initialValue: viewModel)
+    }
 
     var body: some View {
         NavigationStack {
@@ -175,7 +84,7 @@ struct TransactionsView: View {
         .listStyle(.insetGrouped)
     }
 
-    private func transactionRow(_ transaction: TransactionsViewModel.TransactionListItem) -> some View {
+    private func transactionRow(_ transaction: TransactionItem) -> some View {
         HStack(spacing: 12) {
             Image(systemName: transaction.type.systemImage)
                 .font(.caption).foregroundStyle(transaction.type.color)
@@ -208,4 +117,4 @@ struct TransactionsView: View {
     }
 }
 
-#Preview { TransactionsView() }
+#Preview { TransactionsView(viewModel: TransactionsViewModel(repository: MockTransactionRepository())) }

--- a/apps/ios/Finance/Security/BiometricAuthManager.swift
+++ b/apps/ios/Finance/Security/BiometricAuthManager.swift
@@ -48,6 +48,30 @@ enum BiometricType: Sendable {
     case opticID
 }
 
+// MARK: - BiometricType Display Properties
+
+extension BiometricType {
+    /// Localized display name for use in UI labels and settings.
+    var displayName: String {
+        switch self {
+        case .faceID: String(localized: "Face ID")
+        case .touchID: String(localized: "Touch ID")
+        case .opticID: String(localized: "Optic ID")
+        case .none: String(localized: "Biometric Authentication")
+        }
+    }
+
+    /// SF Symbol name matching the biometric type.
+    var systemImage: String {
+        switch self {
+        case .faceID: "faceid"
+        case .touchID: "touchid"
+        case .opticID: "opticid"
+        case .none: "lock"
+        }
+    }
+}
+
 // MARK: - BiometricAuthManaging Protocol
 
 /// Abstraction over biometric authentication for testability.
@@ -80,6 +104,13 @@ final class BiometricAuthManager: BiometricAuthManaging {
 
     /// Default localized reason shown in the system biometric prompt.
     static let defaultReason = String(localized: "Verify your identity to access Finance")
+
+    /// UserDefaults key for the biometric app lock preference.
+    ///
+    /// Used by `SettingsViewModel` and `FinanceApp` to persist/read the
+    /// user's choice to enable biometric app lock. This is a non-sensitive
+    /// boolean preference — not a secret.
+    static let appLockEnabledKey = "biometricAuthEnabled"
 
     // MARK: - Initialization
 

--- a/apps/ios/Finance/ViewModels/AccountDetailViewModel.swift
+++ b/apps/ios/Finance/ViewModels/AccountDetailViewModel.swift
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// AccountDetailViewModel.swift
+// Finance
+//
+// ViewModel for the account detail screen. Loads transactions for a
+// specific account and groups them by date for sectioned display.
+
+import Observation
+import Foundation
+
+@Observable
+@MainActor
+final class AccountDetailViewModel {
+    private let repository: TransactionRepository
+
+    var transactions: [TransactionItem] = []
+    var isLoading = false
+    var errorMessage: String?
+
+    /// Transactions grouped by calendar day, most recent first.
+    struct DateGroup: Identifiable {
+        let id: String
+        let date: Date
+        let transactions: [TransactionItem]
+    }
+
+    var groupedTransactions: [DateGroup] {
+        let calendar = Calendar.current
+        let grouped = Dictionary(grouping: transactions) { calendar.startOfDay(for: $0.date) }
+        return grouped
+            .sorted { $0.key > $1.key }
+            .map { DateGroup(id: $0.key.ISO8601Format(), date: $0.key, transactions: $0.value) }
+    }
+
+    init(repository: TransactionRepository) {
+        self.repository = repository
+    }
+
+    func loadTransactions(accountId: String) async {
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            transactions = try await repository.getTransactions(forAccountId: accountId)
+        } catch {
+            errorMessage = error.localizedDescription
+            transactions = []
+        }
+    }
+}

--- a/apps/ios/Finance/ViewModels/AccountsViewModel.swift
+++ b/apps/ios/Finance/ViewModels/AccountsViewModel.swift
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// AccountsViewModel.swift
+// Finance
+//
+// ViewModel for the accounts list screen. Loads accounts from a
+// repository and groups them by account type for sectioned display.
+
+import Observation
+import Foundation
+
+@Observable
+@MainActor
+final class AccountsViewModel {
+    private let repository: AccountRepository
+
+    var accountGroups: [AccountGroup] = []
+    var isLoading = false
+    var showingAddAccount = false
+
+    init(repository: AccountRepository) {
+        self.repository = repository
+    }
+
+    func loadAccounts() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            let accounts = try await repository.getAccounts()
+            let grouped = Dictionary(grouping: accounts) { $0.type }
+            accountGroups = AccountTypeUI.allCases.compactMap { type in
+                guard let items = grouped[type], !items.isEmpty else { return nil }
+                return AccountGroup(id: type.rawValue, type: type, accounts: items)
+            }
+        } catch {
+            // Error handling will be enhanced with KMP-backed repository
+            accountGroups = []
+        }
+    }
+
+    func deleteAccount(id: String) async {
+        do {
+            try await repository.deleteAccount(id: id)
+        } catch {
+            // Deletion error handling will be enhanced with KMP-backed repository
+        }
+        // Remove from local state for immediate UI feedback
+        accountGroups = accountGroups.compactMap { group in
+            let filtered = group.accounts.filter { $0.id != id }
+            guard !filtered.isEmpty else { return nil }
+            return AccountGroup(id: group.id, type: group.type, accounts: filtered)
+        }
+    }
+}

--- a/apps/ios/Finance/ViewModels/BudgetsViewModel.swift
+++ b/apps/ios/Finance/ViewModels/BudgetsViewModel.swift
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// BudgetsViewModel.swift
+// Finance
+//
+// ViewModel for the budgets screen. Loads budget categories from a
+// repository, supports month navigation, and computes aggregate totals.
+
+import Observation
+import Foundation
+
+@Observable
+@MainActor
+final class BudgetsViewModel {
+    private let repository: BudgetRepository
+
+    var budgets: [BudgetItem] = []
+    var isLoading = false
+    var selectedMonth = Date()
+    var showingCreateBudget = false
+
+    var totalBudgeted: Int64 { budgets.reduce(0) { $0 + $1.limitMinorUnits } }
+    var totalSpent: Int64 { budgets.reduce(0) { $0 + $1.spentMinorUnits } }
+
+    var monthDisplayText: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMMM yyyy"
+        return formatter.string(from: selectedMonth)
+    }
+
+    init(repository: BudgetRepository) {
+        self.repository = repository
+    }
+
+    func previousMonth() {
+        if let d = Calendar.current.date(byAdding: .month, value: -1, to: selectedMonth) {
+            selectedMonth = d
+            Task { await loadBudgets() }
+        }
+    }
+
+    func nextMonth() {
+        if let d = Calendar.current.date(byAdding: .month, value: 1, to: selectedMonth) {
+            selectedMonth = d
+            Task { await loadBudgets() }
+        }
+    }
+
+    func loadBudgets() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            budgets = try await repository.getBudgets()
+        } catch {
+            // Error handling will be enhanced with KMP-backed repository
+            budgets = []
+        }
+    }
+}

--- a/apps/ios/Finance/ViewModels/DashboardViewModel.swift
+++ b/apps/ios/Finance/ViewModels/DashboardViewModel.swift
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// DashboardViewModel.swift
+// Finance
+//
+// ViewModel for the main dashboard screen. Aggregates data from account,
+// transaction, and budget repositories to present net worth, monthly
+// spending, budget health, and recent transactions.
+
+import Observation
+import SwiftUI
+
+@Observable
+@MainActor
+final class DashboardViewModel {
+    private let accountRepository: AccountRepository
+    private let transactionRepository: TransactionRepository
+    private let budgetRepository: BudgetRepository
+
+    var accounts: [AccountItem] = []
+    var budgets: [BudgetItem] = []
+    var recentTransactions: [TransactionItem] = []
+    var isLoading = false
+    var errorMessage: String?
+    var currencyCode: String = "USD"
+
+    /// Computed from the sum of all account balances.
+    var netWorth: Int64 { accounts.reduce(0) { $0 + $1.balanceMinorUnits } }
+
+    /// Sum of income transactions in the current dataset.
+    var monthlyIncome: Int64 {
+        recentTransactions
+            .filter { $0.type == .income }
+            .reduce(0) { $0 + $1.amountMinorUnits }
+    }
+
+    /// Sum of expense transactions in the current dataset (as a positive value).
+    var monthlyExpenses: Int64 {
+        recentTransactions
+            .filter { $0.isExpense }
+            .reduce(0) { $0 + abs($1.amountMinorUnits) }
+    }
+
+    init(
+        accountRepository: AccountRepository,
+        transactionRepository: TransactionRepository,
+        budgetRepository: BudgetRepository
+    ) {
+        self.accountRepository = accountRepository
+        self.transactionRepository = transactionRepository
+        self.budgetRepository = budgetRepository
+    }
+
+    func loadDashboard() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            async let accountsResult = accountRepository.getAccounts()
+            async let transactionsResult = transactionRepository.getRecentTransactions(limit: 5)
+            async let budgetsResult = budgetRepository.getBudgets()
+
+            accounts = try await accountsResult
+            recentTransactions = try await transactionsResult
+            budgets = try await budgetsResult
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/apps/ios/Finance/ViewModels/GoalsViewModel.swift
+++ b/apps/ios/Finance/ViewModels/GoalsViewModel.swift
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// GoalsViewModel.swift
+// Finance
+//
+// ViewModel for the goals screen. Loads financial goals from a
+// repository and exposes them for card-based display.
+
+import Observation
+import Foundation
+
+@Observable
+@MainActor
+final class GoalsViewModel {
+    private let repository: GoalRepository
+
+    var goals: [GoalItem] = []
+    var isLoading = false
+    var showingCreateGoal = false
+
+    init(repository: GoalRepository) {
+        self.repository = repository
+    }
+
+    func loadGoals() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            goals = try await repository.getGoals()
+        } catch {
+            // Error handling will be enhanced with KMP-backed repository
+            goals = []
+        }
+    }
+}

--- a/apps/ios/Finance/ViewModels/SettingsViewModel.swift
+++ b/apps/ios/Finance/ViewModels/SettingsViewModel.swift
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// SettingsViewModel.swift
+// Finance
+//
+// ViewModel for the settings screen. Manages user preferences for
+// currency, notifications, biometric auth, and data management.
+
+import Foundation
+import Observation
+import os
+
+@Observable
+@MainActor
+final class SettingsViewModel {
+    var selectedCurrency = "USD"
+    var notificationsEnabled = true
+    var budgetAlerts = true
+    var goalMilestones = true
+    var biometricEnabled: Bool = UserDefaults.standard.bool(
+        forKey: BiometricAuthManager.appLockEnabledKey
+    )
+    var appVersion = "1.0.0"
+    var buildNumber = "1"
+    var showingExportConfirmation = false
+    var isExporting = false
+    var showingDeleteConfirmation = false
+    var biometricError: BiometricError?
+    var showingBiometricError = false
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
+        category: "SettingsViewModel"
+    )
+
+    let supportedCurrencies = [
+        ("USD", "US Dollar"), ("EUR", "Euro"), ("GBP", "British Pound"),
+        ("CAD", "Canadian Dollar"), ("JPY", "Japanese Yen"),
+        ("AUD", "Australian Dollar"), ("CHF", "Swiss Franc"),
+    ]
+
+    func loadSettings() async {
+        biometricEnabled = UserDefaults.standard.bool(
+            forKey: BiometricAuthManager.appLockEnabledKey
+        )
+        // TODO: Load settings from KMP shared preferences and Keychain
+    }
+
+    /// Toggles biometric app lock, requiring authentication to confirm
+    /// the change in both directions (enable and disable).
+    func toggleBiometric(using manager: BiometricAuthManager) async {
+        let newValue = !biometricEnabled
+        let reason = newValue
+            ? String(localized: "Verify your identity to enable biometric lock")
+            : String(localized: "Verify your identity to disable biometric lock")
+
+        do {
+            try await manager.authenticate(reason: reason)
+            biometricEnabled = newValue
+            UserDefaults.standard.set(
+                newValue,
+                forKey: BiometricAuthManager.appLockEnabledKey
+            )
+            Self.logger.info(
+                "Biometric app lock \(newValue ? "enabled" : "disabled", privacy: .public)"
+            )
+        } catch let error as BiometricError {
+            Self.logger.warning(
+                "Biometric toggle failed: \(error.localizedDescription, privacy: .public)"
+            )
+            if case .cancelled = error { return }
+            biometricError = error
+            showingBiometricError = true
+        } catch {
+            Self.logger.error(
+                "Biometric toggle unexpected error: \(error.localizedDescription, privacy: .public)"
+            )
+            biometricError = .unknown(underlying: error)
+            showingBiometricError = true
+        }
+    }
+
+    /// Authenticates the user before allowing data export.
+    ///
+    /// Export contains sensitive financial data and is gated behind
+    /// biometric / passcode authentication regardless of whether
+    /// biometric app lock is enabled.
+    ///
+    /// - Returns: `true` if the user was successfully authenticated.
+    func authenticateForExport(using manager: BiometricAuthManager) async -> Bool {
+        do {
+            try await manager.authenticate(
+                reason: String(localized: "Verify your identity to export financial data")
+            )
+            Self.logger.info("Export data authentication succeeded")
+            return true
+        } catch let error as BiometricError {
+            Self.logger.warning(
+                "Export auth failed: \(error.localizedDescription, privacy: .public)"
+            )
+            if case .cancelled = error { return false }
+            biometricError = error
+            showingBiometricError = true
+            return false
+        } catch {
+            Self.logger.error(
+                "Export auth unexpected error: \(error.localizedDescription, privacy: .public)"
+            )
+            biometricError = .unknown(underlying: error)
+            showingBiometricError = true
+            return false
+        }
+    }
+
+    func exportData() async {
+        isExporting = true
+        defer { isExporting = false }
+        // TODO: Implement data export via KMP shared logic
+        try? await Task.sleep(for: .seconds(1))
+    }
+}

--- a/apps/ios/Finance/ViewModels/TransactionCreateViewModel.swift
+++ b/apps/ios/Finance/ViewModels/TransactionCreateViewModel.swift
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// TransactionCreateViewModel.swift
+// Finance
+//
+// ViewModel for the multi-step transaction creation sheet. Loads accounts
+// from AccountRepository for the picker and saves via TransactionRepository.
+
+import Observation
+import SwiftUI
+
+@Observable
+@MainActor
+final class TransactionCreateViewModel {
+    private let transactionRepository: TransactionRepository
+    private let accountRepository: AccountRepository
+
+    var currentStep: Step = .type
+
+    enum Step: Int, CaseIterable {
+        case type = 0, details = 1, review = 2
+        var title: String {
+            switch self {
+            case .type: String(localized: "Type")
+            case .details: String(localized: "Details")
+            case .review: String(localized: "Review")
+            }
+        }
+    }
+
+    var transactionType: TransactionTypeUI = .expense
+    var amountText = ""
+    var payee = ""
+    var selectedAccountId: String?
+    var selectedCategoryId: String?
+    var date = Date()
+    var note = ""
+    var currencyCode = "USD"
+    var isSaving = false
+    var showingValidationError = false
+    var validationMessage = ""
+
+    var accounts: [PickerOption] = []
+
+    var categories: [PickerOption] = [
+        PickerOption(id: "c1", name: "Groceries", icon: "cart"),
+        PickerOption(id: "c2", name: "Dining Out", icon: "fork.knife"),
+        PickerOption(id: "c3", name: "Transport", icon: "car"),
+        PickerOption(id: "c4", name: "Entertainment", icon: "film"),
+        PickerOption(id: "c5", name: "Shopping", icon: "bag"),
+        PickerOption(id: "c6", name: "Income", icon: "dollarsign.circle"),
+    ]
+
+    var canAdvance: Bool {
+        switch currentStep {
+        case .type: true
+        case .details: !amountText.isEmpty && selectedAccountId != nil && !payee.isEmpty
+        case .review: true
+        }
+    }
+
+    var amountMinorUnits: Int64 { Int64((Double(amountText) ?? 0) * 100) }
+
+    init(
+        transactionRepository: TransactionRepository,
+        accountRepository: AccountRepository
+    ) {
+        self.transactionRepository = transactionRepository
+        self.accountRepository = accountRepository
+    }
+
+    /// Loads accounts for the account picker.
+    func loadData() async {
+        do {
+            let accountItems = try await accountRepository.getAccounts()
+            accounts = accountItems.map { PickerOption(id: $0.id, name: $0.name, icon: $0.icon) }
+        } catch {
+            // Fall back to empty accounts; user will see "Select Account" prompt
+            accounts = []
+        }
+    }
+
+    func advance() {
+        guard let next = Step(rawValue: currentStep.rawValue + 1) else { return }
+        currentStep = next
+    }
+
+    func goBack() {
+        guard let prev = Step(rawValue: currentStep.rawValue - 1) else { return }
+        currentStep = prev
+    }
+
+    func save() async -> Bool {
+        guard validate() else { return false }
+        isSaving = true
+        defer { isSaving = false }
+
+        let categoryName = categories.first { $0.id == selectedCategoryId }?.name ?? ""
+        let accountName = accounts.first { $0.id == selectedAccountId }?.name ?? ""
+
+        let transaction = TransactionItem(
+            id: UUID().uuidString,
+            payee: payee,
+            category: categoryName,
+            accountName: accountName,
+            amountMinorUnits: transactionType == .income ? amountMinorUnits : -amountMinorUnits,
+            currencyCode: currencyCode,
+            date: date,
+            type: transactionType,
+            status: .pending
+        )
+
+        do {
+            try await transactionRepository.createTransaction(transaction)
+            return true
+        } catch {
+            validationMessage = error.localizedDescription
+            showingValidationError = true
+            return false
+        }
+    }
+
+    private func validate() -> Bool {
+        if amountText.isEmpty || (Double(amountText) ?? 0) <= 0 {
+            validationMessage = String(localized: "Please enter a valid amount.")
+            showingValidationError = true
+            return false
+        }
+        if payee.isEmpty {
+            validationMessage = String(localized: "Please enter a payee.")
+            showingValidationError = true
+            return false
+        }
+        if selectedAccountId == nil {
+            validationMessage = String(localized: "Please select an account.")
+            showingValidationError = true
+            return false
+        }
+        return true
+    }
+}

--- a/apps/ios/Finance/ViewModels/TransactionsViewModel.swift
+++ b/apps/ios/Finance/ViewModels/TransactionsViewModel.swift
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// TransactionsViewModel.swift
+// Finance
+//
+// ViewModel for the full transaction list screen. Loads all transactions,
+// supports search filtering, date grouping, and swipe-to-delete.
+
+import Observation
+import SwiftUI
+
+@Observable
+@MainActor
+final class TransactionsViewModel {
+    private let repository: TransactionRepository
+
+    var transactions: [TransactionItem] = []
+    var isLoading = false
+    var searchText = ""
+    var showingCreateTransaction = false
+
+    /// Transactions grouped by calendar day, most recent first.
+    struct DateGroup: Identifiable {
+        let id: String
+        let date: Date
+        let transactions: [TransactionItem]
+    }
+
+    var filteredTransactions: [TransactionItem] {
+        guard !searchText.isEmpty else { return transactions }
+        return transactions.filter {
+            $0.payee.localizedCaseInsensitiveContains(searchText) ||
+            $0.category.localizedCaseInsensitiveContains(searchText) ||
+            $0.accountName.localizedCaseInsensitiveContains(searchText)
+        }
+    }
+
+    var groupedTransactions: [DateGroup] {
+        let calendar = Calendar.current
+        let grouped = Dictionary(grouping: filteredTransactions) { calendar.startOfDay(for: $0.date) }
+        return grouped.sorted { $0.key > $1.key }
+            .map { DateGroup(id: $0.key.ISO8601Format(), date: $0.key, transactions: $0.value) }
+    }
+
+    init(repository: TransactionRepository) {
+        self.repository = repository
+    }
+
+    func loadTransactions() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            transactions = try await repository.getTransactions()
+        } catch {
+            // Error handling will be enhanced with KMP-backed repository
+            transactions = []
+        }
+    }
+
+    func deleteTransaction(id: String) async {
+        do {
+            try await repository.deleteTransaction(id: id)
+        } catch {
+            // Deletion error handling will be enhanced with KMP-backed repository
+        }
+        // Remove from local state for immediate UI feedback
+        transactions.removeAll { $0.id == id }
+    }
+}


### PR DESCRIPTION
Core iOS architecture overhaul:

**ViewModel Architecture (#441):**
- Extract 10 model types into Models/ directory
- Create 4 repository protocols with mock implementations
- Create 8 @Observable ViewModels for all screens
- Refactor 7 screens to use ViewModel injection

**Biometric Auth Integration (#442):**
- Wire BiometricAuthManager into SettingsView toggle
- Add app launch biometric lock gate (LockScreenView)
- Gate sensitive operations (export data, view account numbers)
- Handle all error cases with graceful fallback

Closes #441
Closes #442