### PR TITLE
feat(ios): data export, transaction edit, privacy screens (#472, #473, #474)

### DIFF
--- a/apps/ios/Finance/Models/TransactionItem.swift
+++ b/apps/ios/Finance/Models/TransactionItem.swift
@@ -71,6 +71,7 @@ struct TransactionItem: Identifiable, Hashable, Sendable {
     let date: Date
     let type: TransactionTypeUI
     let status: TransactionStatusUI
+    let note: String?
 
     /// Convenience: `true` when the transaction type is `.expense`.
     var isExpense: Bool { type == .expense }
@@ -84,7 +85,8 @@ struct TransactionItem: Identifiable, Hashable, Sendable {
         currencyCode: String,
         date: Date,
         type: TransactionTypeUI = .expense,
-        status: TransactionStatusUI = .cleared
+        status: TransactionStatusUI = .cleared,
+        note: String? = nil
     ) {
         self.id = id
         self.payee = payee
@@ -95,5 +97,6 @@ struct TransactionItem: Identifiable, Hashable, Sendable {
         self.date = date
         self.type = type
         self.status = status
+        self.note = note
     }
 }

--- a/apps/ios/Finance/Repositories/Mocks/MockTransactionRepository.swift
+++ b/apps/ios/Finance/Repositories/Mocks/MockTransactionRepository.swift
@@ -88,4 +88,9 @@ struct MockTransactionRepository: TransactionRepository {
     func deleteTransaction(id: String) async throws {
         // No-op for mock — ViewModel manages local state removal.
     }
+
+    func updateTransaction(_ transaction: TransactionItem) async throws {
+        // No-op for mock — simulates a successful update.
+        try? await Task.sleep(for: .milliseconds(300))
+    }
 }

--- a/apps/ios/Finance/Repositories/TransactionRepository.swift
+++ b/apps/ios/Finance/Repositories/TransactionRepository.swift
@@ -29,4 +29,7 @@ protocol TransactionRepository: Sendable {
 
     /// Permanently deletes the transaction with the given identifier.
     func deleteTransaction(id: String) async throws
+
+    /// Updates an existing transaction with new values.
+    func updateTransaction(_ transaction: TransactionItem) async throws
 }

--- a/apps/ios/Finance/Screens/AboutView.swift
+++ b/apps/ios/Finance/Screens/AboutView.swift
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// AboutView.swift
+// Finance
+//
+// About screen showing app identity, version information,
+// description, and links to privacy policy, terms, and
+// open-source license acknowledgments.
+
+import os
+import SwiftUI
+
+// MARK: - View
+
+struct AboutView: View {
+    @ScaledMetric private var appIconSize: CGFloat = 80
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
+        category: "AboutView"
+    )
+
+    private var appVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0"
+    }
+
+    private var buildNumber: String {
+        Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
+    }
+
+    var body: some View {
+        List {
+            appIdentitySection
+            descriptionSection
+            linksSection
+            creditsSection
+        }
+        .navigationTitle(String(localized: "About"))
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            Self.logger.debug("About screen viewed")
+        }
+    }
+
+    // MARK: - App Identity
+
+    private var appIdentitySection: some View {
+        Section {
+            VStack(spacing: 12) {
+                Image(systemName: "banknote")
+                    .font(.system(size: appIconSize * 0.5))
+                    .foregroundStyle(Color.accentColor)
+                    .frame(width: appIconSize, height: appIconSize)
+                    .background(
+                        RoundedRectangle(cornerRadius: appIconSize * 0.2, style: .continuous)
+                            .fill(Color.accentColor.opacity(0.12))
+                    )
+                    .accessibilityHidden(true)
+
+                Text(String(localized: "Finance"))
+                    .font(.title2)
+                    .fontWeight(.bold)
+                    .accessibilityAddTraits(.isHeader)
+
+                Text(String(localized: "Version %@ (%@)", defaultValue: "Version \(appVersion) (\(buildNumber))"))
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .accessibilityLabel(
+                        String(localized: "App version \(appVersion), build \(buildNumber)")
+                    )
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 8)
+        }
+    }
+
+    // MARK: - Description
+
+    private var descriptionSection: some View {
+        Section {
+            Text(String(localized: "Finance is a privacy-first personal financial tracking app. Your data is encrypted locally and synced end-to-end across your devices. We never sell or share your financial information."))
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .accessibilityLabel(
+                    String(localized: "Finance is a privacy-first personal financial tracking app. Your data is encrypted locally and synced end-to-end across your devices. We never sell or share your financial information.")
+                )
+        }
+    }
+
+    // MARK: - Links
+
+    private var linksSection: some View {
+        Section {
+            NavigationLink {
+                PrivacyPolicyView()
+            } label: {
+                Label(String(localized: "Privacy Policy"), systemImage: "hand.raised")
+            }
+            .accessibilityLabel(String(localized: "Privacy Policy"))
+            .accessibilityHint(String(localized: "Opens the privacy policy"))
+
+            NavigationLink {
+                PrivacyPolicyView()
+            } label: {
+                Label(String(localized: "Terms of Service"), systemImage: "doc.text")
+            }
+            .accessibilityLabel(String(localized: "Terms of Service"))
+            .accessibilityHint(String(localized: "Opens the terms of service"))
+
+            NavigationLink {
+                LicensesView()
+            } label: {
+                Label(String(localized: "Open Source Licenses"), systemImage: "chevron.left.forwardslash.chevron.right")
+            }
+            .accessibilityLabel(String(localized: "Open Source Licenses"))
+            .accessibilityHint(String(localized: "Opens the open source license attributions"))
+        } header: {
+            Text(String(localized: "Legal"))
+        }
+    }
+
+    // MARK: - Credits
+
+    private var creditsSection: some View {
+        Section {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(String(localized: "Built with SwiftUI and Kotlin Multiplatform"))
+                    .font(.body)
+
+                Text(String(localized: "Designed and developed by the Finance team."))
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(
+                String(localized: "Built with SwiftUI and Kotlin Multiplatform. Designed and developed by the Finance team.")
+            )
+
+            LabeledContent(String(localized: "Copyright")) {
+                Text("© 2026 Jeffrey Moulckers")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+            .accessibilityLabel(String(localized: "Copyright 2026 Jeffrey Moulckers"))
+        } header: {
+            Text(String(localized: "Credits"))
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        AboutView()
+    }
+}

--- a/apps/ios/Finance/Screens/LicensesView.swift
+++ b/apps/ios/Finance/Screens/LicensesView.swift
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// LicensesView.swift
+// Finance
+//
+// Displays third-party open-source license attributions using
+// collapsible DisclosureGroups. Each library shows its name,
+// license type, and the full license text when expanded.
+
+import os
+import SwiftUI
+
+// MARK: - License Model
+
+/// Represents a third-party library and its license information.
+private struct LicenseEntry: Identifiable {
+    let id = UUID()
+    let name: String
+    let version: String
+    let licenseType: String
+    let url: String
+    let copyright: String
+    let licenseText: String
+}
+
+// MARK: - View
+
+struct LicensesView: View {
+    @ScaledMetric private var iconSize: CGFloat = 20
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
+        category: "LicensesView"
+    )
+
+    private let licenses: [LicenseEntry] = [
+        LicenseEntry(
+            name: "SQLDelight",
+            version: "2.0.2",
+            licenseType: "Apache License 2.0",
+            url: "https://github.com/cashapp/sqldelight",
+            copyright: "Copyright (C) Cash App (Block, Inc.)",
+            licenseText: LicenseTexts.apache2
+        ),
+        LicenseEntry(
+            name: "Kotlin",
+            version: "2.1.0",
+            licenseType: "Apache License 2.0",
+            url: "https://github.com/JetBrains/kotlin",
+            copyright: "Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.",
+            licenseText: LicenseTexts.apache2
+        ),
+        LicenseEntry(
+            name: "kotlinx-coroutines",
+            version: "1.9.0",
+            licenseType: "Apache License 2.0",
+            url: "https://github.com/Kotlin/kotlinx.coroutines",
+            copyright: "Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.",
+            licenseText: LicenseTexts.apache2
+        ),
+        LicenseEntry(
+            name: "kotlinx-serialization",
+            version: "1.7.3",
+            licenseType: "Apache License 2.0",
+            url: "https://github.com/Kotlin/kotlinx.serialization",
+            copyright: "Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.",
+            licenseText: LicenseTexts.apache2
+        ),
+        LicenseEntry(
+            name: "kotlinx-datetime",
+            version: "0.6.1",
+            licenseType: "Apache License 2.0",
+            url: "https://github.com/Kotlin/kotlinx-datetime",
+            copyright: "Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.",
+            licenseText: LicenseTexts.apache2
+        ),
+        LicenseEntry(
+            name: "Ktor",
+            version: "3.0.3",
+            licenseType: "Apache License 2.0",
+            url: "https://github.com/ktorio/ktor",
+            copyright: "Copyright 2014-2024 JetBrains s.r.o. and contributors.",
+            licenseText: LicenseTexts.apache2
+        ),
+        LicenseEntry(
+            name: "Koin",
+            version: "4.0.1",
+            licenseType: "Apache License 2.0",
+            url: "https://github.com/InsertKoinIO/koin",
+            copyright: "Copyright 2017-2024 Koin contributors.",
+            licenseText: LicenseTexts.apache2
+        ),
+        LicenseEntry(
+            name: "SQLCipher",
+            version: "4.6.1",
+            licenseType: "BSD 3-Clause",
+            url: "https://www.zetetic.net/sqlcipher/",
+            copyright: "Copyright (c) 2008-2024 Zetetic LLC. All rights reserved.",
+            licenseText: LicenseTexts.bsd3Clause
+        ),
+    ]
+
+    var body: some View {
+        List {
+            headerSection
+
+            ForEach(licenses) { license in
+                licenseDisclosureGroup(for: license)
+            }
+        }
+        .navigationTitle(String(localized: "Open Source Licenses"))
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            Self.logger.debug("Licenses screen viewed")
+        }
+    }
+
+    // MARK: - Header
+
+    private var headerSection: some View {
+        Section {
+            Text(String(localized: "Finance uses the following open-source libraries. We are grateful to the developers and communities behind these projects."))
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .accessibilityLabel(
+                    String(localized: "Finance uses the following open-source libraries. We are grateful to the developers and communities behind these projects.")
+                )
+        }
+    }
+
+    // MARK: - License Row
+
+    private func licenseDisclosureGroup(for license: LicenseEntry) -> some View {
+        Section {
+            DisclosureGroup {
+                VStack(alignment: .leading, spacing: 12) {
+                    LabeledContent(String(localized: "Version")) {
+                        Text(license.version)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    LabeledContent(String(localized: "License")) {
+                        Text(license.licenseType)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Divider()
+
+                    Text(license.copyright)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    Text(license.licenseText)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(
+                    String(localized: "\(license.name) version \(license.version), \(license.licenseType). \(license.copyright)")
+                )
+            } label: {
+                Label {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(license.name)
+                            .font(.body)
+                        Text(license.licenseType)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                } icon: {
+                    Image(systemName: "book.closed")
+                        .frame(width: iconSize)
+                        .foregroundStyle(Color.accentColor)
+                }
+            }
+            .accessibilityLabel(String(localized: "\(license.name), \(license.licenseType)"))
+            .accessibilityHint(String(localized: "Expands to show the full license text"))
+        }
+    }
+}
+
+// MARK: - License Texts
+
+/// Contains the reusable full text of common open-source licenses.
+private enum LicenseTexts {
+    static let apache2 = """
+    Licensed under the Apache License, Version 2.0 (the "License"); \
+    you may not use this file except in compliance with the License. \
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software \
+    distributed under the License is distributed on an "AS IS" BASIS, \
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. \
+    See the License for the specific language governing permissions and \
+    limitations under the License.
+    """
+
+    static let bsd3Clause = """
+    Redistribution and use in source and binary forms, with or without \
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, \
+    this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright notice, \
+    this list of conditions and the following disclaimer in the documentation \
+    and/or other materials provided with the distribution.
+
+    3. Neither the name of the copyright holder nor the names of its \
+    contributors may be used to endorse or promote products derived from this \
+    software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER "AS IS" AND ANY EXPRESS \
+    OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES \
+    OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO \
+    EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, \
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, \
+    PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; \
+    OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, \
+    WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR \
+    OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF \
+    ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+    """
+}
+
+#Preview {
+    NavigationStack {
+        LicensesView()
+    }
+}

--- a/apps/ios/Finance/Screens/PrivacyPolicyView.swift
+++ b/apps/ios/Finance/Screens/PrivacyPolicyView.swift
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// PrivacyPolicyView.swift
+// Finance
+//
+// Structured privacy policy screen for App Store compliance.
+// Describes data collection, storage, third-party services,
+// user rights, and retention policies in a scrollable List.
+
+import os
+import SwiftUI
+
+// MARK: - View
+
+struct PrivacyPolicyView: View {
+    @ScaledMetric private var iconSize: CGFloat = 20
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
+        category: "PrivacyPolicyView"
+    )
+
+    private static let effectiveDate = "January 1, 2026"
+    private static let contactEmail = "privacy@finance-app.example.com"
+
+    var body: some View {
+        List {
+            effectiveDateSection
+            dataWeCollectSection
+            howWeUseDataSection
+            dataStorageSection
+            thirdPartyServicesSection
+            yourRightsSection
+            dataRetentionSection
+            contactSection
+            updatesSection
+        }
+        .navigationTitle(String(localized: "Privacy Policy"))
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            Self.logger.debug("Privacy policy viewed")
+        }
+    }
+
+    // MARK: - Effective Date
+
+    private var effectiveDateSection: some View {
+        Section {
+            Label {
+                Text(String(localized: "Effective: \(Self.effectiveDate)"))
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            } icon: {
+                Image(systemName: "calendar")
+                    .frame(width: iconSize)
+                    .foregroundStyle(.secondary)
+            }
+            .accessibilityLabel(
+                String(localized: "Policy effective date: \(Self.effectiveDate)")
+            )
+        }
+    }
+
+    // MARK: - Data We Collect
+
+    private var dataWeCollectSection: some View {
+        Section {
+            policyRow(
+                icon: "dollarsign.circle",
+                title: String(localized: "Financial Transactions"),
+                detail: String(localized: "Amounts, payees, categories, dates, and notes for each transaction you enter.")
+            )
+            policyRow(
+                icon: "building.columns",
+                title: String(localized: "Account Information"),
+                detail: String(localized: "Account names, types, and balances that you create within the app.")
+            )
+            policyRow(
+                icon: "chart.pie",
+                title: String(localized: "Budget & Goal Data"),
+                detail: String(localized: "Budget categories, spending limits, goal targets, and progress you configure.")
+            )
+            policyRow(
+                icon: "iphone",
+                title: String(localized: "Device Identifiers"),
+                detail: String(localized: "An anonymous device identifier for sync purposes only. No advertising identifiers are collected.")
+            )
+        } header: {
+            Text(String(localized: "Data We Collect"))
+        } footer: {
+            Text(String(localized: "All financial data is entered by you and stored locally on your device first. We do not access your bank accounts or import data automatically."))
+                .font(.footnote)
+        }
+    }
+
+    // MARK: - How We Use Your Data
+
+    private var howWeUseDataSection: some View {
+        Section {
+            policyRow(
+                icon: "person.fill",
+                title: String(localized: "Personal Financial Tracking"),
+                detail: String(localized: "Your data is used exclusively to provide you with financial tracking, budgeting, and goal progress features.")
+            )
+            policyRow(
+                icon: "nosign",
+                title: String(localized: "Never Sold or Shared"),
+                detail: String(localized: "We never sell, rent, or share your financial data with third parties for advertising or marketing purposes.")
+            )
+            policyRow(
+                icon: "chart.bar.xaxis",
+                title: String(localized: "No Profiling"),
+                detail: String(localized: "We do not build advertising profiles or perform behavioral analysis on your financial data.")
+            )
+        } header: {
+            Text(String(localized: "How We Use Your Data"))
+        }
+    }
+
+    // MARK: - Data Storage
+
+    private var dataStorageSection: some View {
+        Section {
+            policyRow(
+                icon: "lock.shield",
+                title: String(localized: "Local Encryption"),
+                detail: String(localized: "All data is encrypted on your device using SQLCipher with AES-256 encryption. Your data is protected even if the device is compromised.")
+            )
+            policyRow(
+                icon: "key.fill",
+                title: String(localized: "Keychain Protected Secrets"),
+                detail: String(localized: "Authentication tokens and encryption keys are stored in the Apple Keychain, protected by the Secure Enclave when available.")
+            )
+            policyRow(
+                icon: "arrow.triangle.2.circlepath",
+                title: String(localized: "End-to-End Encrypted Sync"),
+                detail: String(localized: "When sync is enabled, data is encrypted on your device before transmission. The server cannot read your financial data.")
+            )
+        } header: {
+            Text(String(localized: "Data Storage & Security"))
+        }
+    }
+
+    // MARK: - Third-Party Services
+
+    private var thirdPartyServicesSection: some View {
+        Section {
+            policyRow(
+                icon: "cloud",
+                title: String(localized: "Supabase"),
+                detail: String(localized: "Used for authenticated data sync between your devices. Data is end-to-end encrypted before reaching Supabase servers.")
+            )
+            policyRow(
+                icon: "arrow.clockwise.circle",
+                title: String(localized: "PowerSync"),
+                detail: String(localized: "Provides offline-first sync capability. Ensures your data is available without an internet connection and syncs when connectivity is restored.")
+            )
+            policyRow(
+                icon: "xmark.circle",
+                title: String(localized: "No Analytics or Advertising"),
+                detail: String(localized: "We do not use any analytics tracking, advertising networks, or third-party SDKs that collect your personal information.")
+            )
+        } header: {
+            Text(String(localized: "Third-Party Services"))
+        }
+    }
+
+    // MARK: - Your Rights
+
+    private var yourRightsSection: some View {
+        Section {
+            policyRow(
+                icon: "square.and.arrow.up",
+                title: String(localized: "Export Your Data"),
+                detail: String(localized: "Export all your financial data at any time in CSV or JSON format from Settings > Data > Export Data.")
+            )
+            policyRow(
+                icon: "trash",
+                title: String(localized: "Delete Your Data"),
+                detail: String(localized: "Delete all data from your device and our servers at any time from Settings > Data > Delete All Data.")
+            )
+            policyRow(
+                icon: "externaldrive",
+                title: String(localized: "Data Portability"),
+                detail: String(localized: "Your exported data is in standard formats (CSV, JSON) that can be imported into other financial applications.")
+            )
+        } header: {
+            Text(String(localized: "Your Rights"))
+        }
+    }
+
+    // MARK: - Data Retention
+
+    private var dataRetentionSection: some View {
+        Section {
+            policyRow(
+                icon: "clock",
+                title: String(localized: "Retained Until Deleted"),
+                detail: String(localized: "Your data is kept on your device and sync server until you choose to delete it. We do not impose automatic data expiration.")
+            )
+            policyRow(
+                icon: "person.badge.minus",
+                title: String(localized: "Account Deletion"),
+                detail: String(localized: "When you delete your account, all data is removed from our sync servers within 30 days. Local data is deleted immediately from your device.")
+            )
+        } header: {
+            Text(String(localized: "Data Retention"))
+        }
+    }
+
+    // MARK: - Contact
+
+    private var contactSection: some View {
+        Section {
+            Label {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(String(localized: "Privacy Inquiries"))
+                        .font(.body)
+                    Text(Self.contactEmail)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            } icon: {
+                Image(systemName: "envelope")
+                    .frame(width: iconSize)
+                    .foregroundStyle(Color.accentColor)
+            }
+            .accessibilityLabel(String(localized: "Privacy inquiries"))
+            .accessibilityValue(Self.contactEmail)
+            .accessibilityHint(String(localized: "Contact email for privacy questions"))
+        } header: {
+            Text(String(localized: "Contact"))
+        } footer: {
+            Text(String(localized: "For questions about this privacy policy or your data, contact us at the email above."))
+                .font(.footnote)
+        }
+    }
+
+    // MARK: - Updates
+
+    private var updatesSection: some View {
+        Section {
+            policyRow(
+                icon: "bell.badge",
+                title: String(localized: "Policy Changes"),
+                detail: String(localized: "We will notify you of significant changes to this privacy policy through an in-app notification. Continued use of the app after changes constitutes acceptance.")
+            )
+        } header: {
+            Text(String(localized: "Policy Updates"))
+        }
+    }
+
+    // MARK: - Helper
+
+    private func policyRow(icon: String, title: String, detail: String) -> some View {
+        Label {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.body)
+                Text(detail)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+        } icon: {
+            Image(systemName: icon)
+                .frame(width: iconSize)
+                .foregroundStyle(Color.accentColor)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(title). \(detail)")
+    }
+}
+
+#Preview {
+    NavigationStack {
+        PrivacyPolicyView()
+    }
+}

--- a/apps/ios/Finance/Screens/SettingsView.swift
+++ b/apps/ios/Finance/Screens/SettingsView.swift
@@ -37,6 +37,22 @@ struct SettingsView: View {
             } message: { error in
                 Text(error.localizedDescription)
             }
+            .alert(
+                String(localized: "Export Error"),
+                isPresented: $viewModel.showingExportError
+            ) {
+                Button(String(localized: "OK"), role: .cancel) {}
+                    .accessibilityLabel(String(localized: "Dismiss export error"))
+            } message: {
+                if let errorMessage = viewModel.exportError {
+                    Text(errorMessage)
+                }
+            }
+            .sheet(isPresented: $viewModel.showExportSheet) {
+                if let fileURL = viewModel.exportFileURL {
+                    ShareSheet(activityItems: [fileURL])
+                }
+            }
         }
     }
 
@@ -116,12 +132,7 @@ struct SettingsView: View {
             }
 
             NavigationLink {
-                ScrollView {
-                    Text(String(localized: "Privacy policy content will be loaded here."))
-                        .font(.body).foregroundStyle(.secondary).padding()
-                }
-                .navigationTitle(String(localized: "Privacy Policy"))
-                .navigationBarTitleDisplayMode(.inline)
+                PrivacyPolicyView()
             } label: {
                 Label(String(localized: "Privacy Policy"), systemImage: "hand.raised")
             }
@@ -134,13 +145,21 @@ struct SettingsView: View {
 
     private var dataSection: some View {
         Section(String(localized: "Data")) {
+            Picker(String(localized: "Export Format"), selection: $viewModel.exportFormat) {
+                ForEach(DataExportService.ExportFormat.allCases, id: \.self) { format in
+                    Text(format.displayName).tag(format)
+                }
+            }
+            .accessibilityLabel(String(localized: "Export format"))
+            .accessibilityHint(String(localized: "Select CSV or JSON format for data export"))
+
             Button {
                 Task {
                     let authorized = await viewModel.authenticateForExport(
                         using: biometricManager
                     )
                     if authorized {
-                        viewModel.showingExportConfirmation = true
+                        await viewModel.exportData()
                     }
                 }
             } label: {
@@ -160,19 +179,6 @@ struct SettingsView: View {
             .disabled(viewModel.isExporting)
             .accessibilityLabel(String(localized: "Export data"))
             .accessibilityHint(String(localized: "Exports all your financial data as a file"))
-            .confirmationDialog(
-                String(localized: "Export Data"),
-                isPresented: $viewModel.showingExportConfirmation,
-                titleVisibility: .visible
-            ) {
-                Button(String(localized: "Export as CSV")) { Task { await viewModel.exportData() } }
-                    .accessibilityLabel(String(localized: "Export as CSV"))
-                Button(String(localized: "Export as JSON")) { Task { await viewModel.exportData() } }
-                    .accessibilityLabel(String(localized: "Export as JSON"))
-                Button(String(localized: "Cancel"), role: .cancel) {}
-            } message: {
-                Text(String(localized: "Choose your preferred export format."))
-            }
 
             Button(role: .destructive) {
                 viewModel.showingDeleteConfirmation = true
@@ -200,24 +206,51 @@ struct SettingsView: View {
 
     private var aboutSection: some View {
         Section(String(localized: "About")) {
+            NavigationLink {
+                AboutView()
+            } label: {
+                Label(String(localized: "About Finance"), systemImage: "info.circle")
+            }
+            .accessibilityLabel(String(localized: "About Finance"))
+            .accessibilityHint(String(localized: "Opens the about screen with app information"))
+
             LabeledContent(String(localized: "Version")) {
                 Text("\(viewModel.appVersion) (\(viewModel.buildNumber))").foregroundStyle(.secondary)
             }
             .accessibilityLabel(String(localized: "App version \(viewModel.appVersion), build \(viewModel.buildNumber)"))
 
             NavigationLink {
-                ScrollView {
-                    Text(String(localized: "Open source licenses and acknowledgments will be listed here."))
-                        .font(.body).foregroundStyle(.secondary).padding()
-                }
-                .navigationTitle(String(localized: "Acknowledgments"))
-                .navigationBarTitleDisplayMode(.inline)
+                LicensesView()
             } label: {
-                Label(String(localized: "Acknowledgments"), systemImage: "heart")
+                Label(String(localized: "Open Source Licenses"), systemImage: "chevron.left.forwardslash.chevron.right")
             }
-            .accessibilityLabel(String(localized: "Acknowledgments"))
-            .accessibilityHint(String(localized: "Opens the open source acknowledgments"))
+            .accessibilityLabel(String(localized: "Open Source Licenses"))
+            .accessibilityHint(String(localized: "Opens the open source license attributions"))
         }
+    }
+}
+
+// MARK: - ShareSheet
+
+/// UIKit wrapper for `UIActivityViewController` used to share exported files.
+///
+/// UIKit is required here because SwiftUI does not provide a built-in
+/// equivalent for presenting a system share sheet with arbitrary file URLs.
+struct ShareSheet: UIViewControllerRepresentable {
+    let activityItems: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(
+            activityItems: activityItems,
+            applicationActivities: nil
+        )
+    }
+
+    func updateUIViewController(
+        _ uiViewController: UIActivityViewController,
+        context: Context
+    ) {
+        // No updates needed — the share sheet is presented once and dismissed by the user.
     }
 }
 

--- a/apps/ios/Finance/Screens/TransactionEditView.swift
+++ b/apps/ios/Finance/Screens/TransactionEditView.swift
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// TransactionEditView.swift
+// Finance
+//
+// Multi-step sheet for editing an existing transaction.
+// Mirrors the wizard pattern of TransactionCreateView with
+// pre-populated fields and a discard-changes confirmation.
+
+import SwiftUI
+
+// MARK: - View
+
+struct TransactionEditView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var viewModel: TransactionEditViewModel
+    @State private var showingDiscardConfirmation = false
+
+    init(viewModel: TransactionEditViewModel) {
+        _viewModel = State(initialValue: viewModel)
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                stepIndicator.padding(.horizontal).padding(.top, 8)
+                Divider().padding(.top, 12)
+                Group {
+                    switch viewModel.currentStep {
+                    case .type: typeStep
+                    case .details: detailsStep
+                    case .review: reviewStep
+                    }
+                }
+                .frame(maxHeight: .infinity)
+                bottomBar
+            }
+            .navigationTitle(String(localized: "Edit Transaction"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(String(localized: "Cancel")) {
+                        if viewModel.hasChanges {
+                            showingDiscardConfirmation = true
+                        } else {
+                            dismiss()
+                        }
+                    }
+                    .accessibilityLabel(String(localized: "Cancel"))
+                    .accessibilityHint(String(localized: "Dismisses the edit form"))
+                }
+            }
+            .confirmationDialog(
+                String(localized: "Discard Changes?"),
+                isPresented: $showingDiscardConfirmation,
+                titleVisibility: .visible
+            ) {
+                Button(String(localized: "Discard Changes"), role: .destructive) {
+                    dismiss()
+                }
+                Button(String(localized: "Keep Editing"), role: .cancel) {}
+            } message: {
+                Text(String(localized: "You have unsaved changes. Are you sure you want to discard them?"))
+            }
+            .alert(String(localized: "Validation Error"), isPresented: $viewModel.showingValidationError) {
+                Button(String(localized: "OK"), role: .cancel) {}
+            } message: {
+                Text(viewModel.validationMessage)
+            }
+            .task { await viewModel.loadData() }
+        }
+    }
+
+    // MARK: - Step Indicator
+
+    private var stepIndicator: some View {
+        HStack(spacing: 0) {
+            ForEach(TransactionEditViewModel.Step.allCases, id: \.rawValue) { step in
+                VStack(spacing: 4) {
+                    Circle()
+                        .fill(step.rawValue <= viewModel.currentStep.rawValue ? Color.blue : Color.gray.opacity(0.3))
+                        .frame(width: 12, height: 12)
+                        .overlay {
+                            if step.rawValue < viewModel.currentStep.rawValue {
+                                Image(systemName: "checkmark")
+                                    .font(.system(size: 7, weight: .bold)).foregroundStyle(.white)
+                            }
+                        }
+                    Text(step.title).font(.caption2)
+                        .foregroundStyle(step.rawValue <= viewModel.currentStep.rawValue ? .primary : .secondary)
+                }
+                .frame(maxWidth: .infinity)
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(String(localized: "Step \(step.rawValue + 1): \(step.title)"))
+                .accessibilityValue(step == viewModel.currentStep ? String(localized: "Current step") : "")
+
+                if step.rawValue < TransactionEditViewModel.Step.allCases.count - 1 {
+                    Rectangle()
+                        .fill(step.rawValue < viewModel.currentStep.rawValue ? Color.blue : Color.gray.opacity(0.3))
+                        .frame(height: 2).padding(.bottom, 16)
+                }
+            }
+        }
+    }
+
+    // MARK: - Step 1: Type
+
+    private var typeStep: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                Text(String(localized: "What type of transaction?"))
+                    .font(.title3).fontWeight(.semibold).padding(.top, 24)
+                ForEach(TransactionTypeUI.allCases, id: \.rawValue) { type in
+                    Button {
+                        viewModel.transactionType = type
+                    } label: {
+                        HStack(spacing: 16) {
+                            Image(systemName: type.systemImage)
+                                .font(.title3).foregroundStyle(type.color)
+                                .frame(width: 44, height: 44)
+                                .background(type.color.opacity(0.1), in: RoundedRectangle(cornerRadius: 10))
+                            Text(type.displayName).font(.body).foregroundStyle(.primary)
+                            Spacer()
+                            if viewModel.transactionType == type {
+                                Image(systemName: "checkmark.circle.fill").foregroundStyle(.blue).font(.title3)
+                            }
+                        }
+                        .padding()
+                        .background(
+                            RoundedRectangle(cornerRadius: 12)
+                                .stroke(viewModel.transactionType == type ? Color.blue : Color.gray.opacity(0.2),
+                                        lineWidth: viewModel.transactionType == type ? 2 : 1)
+                        )
+                    }
+                    .accessibilityLabel(type.displayName)
+                    .accessibilityValue(viewModel.transactionType == type ? String(localized: "Selected") : "")
+                    .accessibilityHint(String(localized: "Selects \(type.displayName) as the transaction type"))
+                }
+            }
+            .padding(.horizontal)
+        }
+    }
+
+    // MARK: - Step 2: Details
+
+    private var detailsStep: some View {
+        Form {
+            Section(String(localized: "Amount")) {
+                HStack {
+                    Text(currencySymbol).font(.title2).foregroundStyle(.secondary)
+                    TextField(String(localized: "0.00"), text: $viewModel.amountText)
+                        .font(.title2).keyboardType(.decimalPad)
+                        .accessibilityLabel(String(localized: "Transaction amount"))
+                        .accessibilityHint(String(localized: "Enter the amount in dollars"))
+                }
+            }
+            Section(String(localized: "Payee")) {
+                TextField(String(localized: "Who was this payment to?"), text: $viewModel.payee)
+                    .accessibilityLabel(String(localized: "Payee name"))
+                    .accessibilityHint(String(localized: "Enter the name of the payee"))
+            }
+            Section(String(localized: "Account")) {
+                Picker(String(localized: "Account"), selection: $viewModel.selectedAccountId) {
+                    Text(String(localized: "Select Account")).tag(nil as String?)
+                    ForEach(viewModel.accounts) { account in
+                        Label(account.name, systemImage: account.icon).tag(account.id as String?)
+                    }
+                }
+                .accessibilityLabel(String(localized: "Account"))
+                .accessibilityHint(String(localized: "Select the account for this transaction"))
+            }
+            Section(String(localized: "Category")) {
+                Picker(String(localized: "Category"), selection: $viewModel.selectedCategoryId) {
+                    Text(String(localized: "Select Category")).tag(nil as String?)
+                    ForEach(viewModel.categories) { category in
+                        Label(category.name, systemImage: category.icon).tag(category.id as String?)
+                    }
+                }
+                .accessibilityLabel(String(localized: "Category"))
+                .accessibilityHint(String(localized: "Select the category for this transaction"))
+            }
+            Section(String(localized: "Date")) {
+                DatePicker(String(localized: "Date"), selection: $viewModel.date, displayedComponents: .date)
+                    .accessibilityLabel(String(localized: "Transaction date"))
+                    .accessibilityHint(String(localized: "Select the date of this transaction"))
+            }
+            Section(String(localized: "Note (optional)")) {
+                TextField(String(localized: "Add a note..."), text: $viewModel.note, axis: .vertical)
+                    .lineLimit(3)
+                    .accessibilityLabel(String(localized: "Note"))
+                    .accessibilityHint(String(localized: "Add an optional note for this transaction"))
+            }
+        }
+    }
+
+    // MARK: - Step 3: Review
+
+    private var reviewStep: some View {
+        Form {
+            Section(String(localized: "Transaction Summary")) {
+                LabeledContent(String(localized: "Type")) {
+                    Label(viewModel.transactionType.displayName, systemImage: viewModel.transactionType.systemImage)
+                }
+                LabeledContent(String(localized: "Amount")) {
+                    CurrencyLabel(amountInMinorUnits: viewModel.amountMinorUnits, currencyCode: viewModel.currencyCode, showSign: false, font: .body.bold())
+                }
+                LabeledContent(String(localized: "Payee")) { Text(viewModel.payee) }
+                if let accountId = viewModel.selectedAccountId,
+                   let account = viewModel.accounts.first(where: { $0.id == accountId }) {
+                    LabeledContent(String(localized: "Account")) { Text(account.name) }
+                }
+                if let categoryId = viewModel.selectedCategoryId,
+                   let category = viewModel.categories.first(where: { $0.id == categoryId }) {
+                    LabeledContent(String(localized: "Category")) { Text(category.name) }
+                }
+                LabeledContent(String(localized: "Date")) { Text(viewModel.date, style: .date) }
+                if !viewModel.note.isEmpty {
+                    LabeledContent(String(localized: "Note")) { Text(viewModel.note).foregroundStyle(.secondary) }
+                }
+            }
+        }
+    }
+
+    // MARK: - Bottom Bar
+
+    private var bottomBar: some View {
+        HStack(spacing: 12) {
+            if viewModel.currentStep != .type {
+                Button { viewModel.goBack() } label: {
+                    Text(String(localized: "Back")).frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .accessibilityLabel(String(localized: "Back"))
+                .accessibilityHint(String(localized: "Goes to the previous step"))
+            }
+            if viewModel.currentStep == .review {
+                Button {
+                    Task { if await viewModel.save() { dismiss() } }
+                } label: {
+                    if viewModel.isSaving { ProgressView().frame(maxWidth: .infinity) }
+                    else { Text(String(localized: "Save Changes")).frame(maxWidth: .infinity) }
+                }
+                .buttonStyle(.borderedProminent).disabled(viewModel.isSaving)
+                .accessibilityLabel(String(localized: "Save Changes"))
+                .accessibilityHint(String(localized: "Saves the edited transaction and closes the form"))
+            } else {
+                Button { viewModel.advance() } label: {
+                    Text(String(localized: "Next")).frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent).disabled(!viewModel.canAdvance)
+                .accessibilityLabel(String(localized: "Next"))
+                .accessibilityHint(String(localized: "Advances to the next step"))
+            }
+        }
+        .padding()
+    }
+
+    private var currencySymbol: String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = viewModel.currencyCode
+        return formatter.currencySymbol ?? "$"
+    }
+}
+
+#Preview {
+    TransactionEditView(viewModel: TransactionEditViewModel(
+        transaction: TransactionItem(
+            id: "preview-1", payee: "Whole Foods",
+            category: "Groceries", accountName: "Main Checking",
+            amountMinorUnits: -85_40, currencyCode: "USD",
+            date: .now, type: .expense, status: .cleared,
+            note: "Weekly shop"
+        ),
+        repository: MockTransactionRepository(),
+        accountRepository: MockAccountRepository()
+    ))
+}

--- a/apps/ios/Finance/Screens/TransactionsView.swift
+++ b/apps/ios/Finance/Screens/TransactionsView.swift
@@ -3,7 +3,9 @@
 // TransactionsView.swift
 // Finance
 //
-// Date-grouped transaction list with search, swipe actions, and pull-to-refresh.
+// Date-grouped transaction list with search, advanced filtering,
+// swipe actions, and pull-to-refresh.
+// NavigationStack is provided by MainTabView for deep-link support (#470).
 
 import SwiftUI
 
@@ -11,46 +13,156 @@ import SwiftUI
 
 struct TransactionsView: View {
     @State private var viewModel: TransactionsViewModel
+    @State private var transactionToEdit: TransactionItem?
 
     init(viewModel: TransactionsViewModel = TransactionsViewModel(repository: MockTransactionRepository())) {
         _viewModel = State(initialValue: viewModel)
     }
 
     var body: some View {
-        NavigationStack {
-            Group {
-                if viewModel.filteredTransactions.isEmpty && !viewModel.isLoading {
-                    if viewModel.searchText.isEmpty {
-                        EmptyStateView(
-                            systemImage: "arrow.left.arrow.right",
-                            title: String(localized: "No Transactions"),
-                            message: String(localized: "Add your first transaction to start tracking your spending."),
-                            actionLabel: String(localized: "Add Transaction"),
-                            action: { viewModel.showingCreateTransaction = true }
-                        )
-                    } else {
-                        ContentUnavailableView.search(text: viewModel.searchText)
+        ZStack {
+            if viewModel.isLoading && viewModel.transactions.isEmpty {
+                ProgressView(String(localized: "Loading..."))
+                    .accessibilityLabel(String(localized: "Loading data"))
+            } else if let error = viewModel.errorMessage, viewModel.transactions.isEmpty {
+                ContentUnavailableView {
+                    Label(String(localized: "Something Went Wrong"), systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(error)
+                } actions: {
+                    Button(String(localized: "Try Again")) {
+                        Task { await viewModel.loadTransactions() }
                     }
+                }
+            } else if viewModel.filteredTransactions.isEmpty && !viewModel.isLoading {
+                if viewModel.searchText.isEmpty && !viewModel.filters.isActive {
+                    EmptyStateView(
+                        systemImage: "arrow.left.arrow.right",
+                        title: String(localized: "No Transactions"),
+                        message: String(localized: "Add your first transaction to start tracking your spending."),
+                        actionLabel: String(localized: "Add Transaction"),
+                        action: { viewModel.showingCreateTransaction = true }
+                    )
+                } else if viewModel.filters.isActive {
+                    ContentUnavailableView(
+                        String(localized: "No Matching Transactions"),
+                        systemImage: "line.3.horizontal.decrease.circle",
+                        description: Text(String(localized: "Try adjusting your filters to see more transactions."))
+                    )
                 } else {
-                    transactionsList
+                    ContentUnavailableView.search(text: viewModel.searchText)
+                }
+            } else {
+                transactionsList
+            }
+        }
+        .overlay(alignment: .top) {
+            if let error = viewModel.errorMessage, !viewModel.transactions.isEmpty {
+                ErrorBannerView(message: error) {
+                    await viewModel.loadTransactions()
                 }
             }
-            .navigationTitle(String(localized: "Transactions"))
-            .searchable(text: $viewModel.searchText, prompt: String(localized: "Search by payee, category, or account"))
-            .toolbar {
-                ToolbarItem(placement: .primaryAction) {
-                    Button { viewModel.showingCreateTransaction = true } label: {
-                        Image(systemName: "plus")
-                    }
-                    .accessibilityLabel(String(localized: "Add transaction"))
-                    .accessibilityHint(String(localized: "Opens a form to create a new transaction"))
-                }
+        }
+        .safeAreaInset(edge: .top) {
+            if viewModel.filters.isActive {
+                filterChipBar
             }
-            .sheet(isPresented: $viewModel.showingCreateTransaction) { TransactionCreateView() }
-            .refreshable { await viewModel.loadTransactions() }
-            .task { await viewModel.loadTransactions() }
+        }
+        .navigationTitle(String(localized: "Transactions"))
+        .searchable(text: $viewModel.searchText, prompt: String(localized: "Search by payee, category, or account"))
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button { viewModel.showingCreateTransaction = true } label: {
+                    Image(systemName: "plus")
+                }
+                .accessibilityLabel(String(localized: "Add transaction"))
+                .accessibilityHint(String(localized: "Opens a form to create a new transaction"))
+            }
+            ToolbarItem(placement: .secondaryAction) {
+                Button { viewModel.showFilterSheet = true } label: {
+                    filterButtonLabel
+                }
+                .accessibilityLabel(String(localized: "Filter transactions"))
+                .accessibilityHint(String(localized: "Opens the filter sheet to refine the transaction list"))
+            }
+        }
+        .sheet(isPresented: $viewModel.showingCreateTransaction) { TransactionCreateView() }
+        .sheet(isPresented: $viewModel.showFilterSheet) {
+            TransactionFilterView(
+                filters: $viewModel.filters,
+                availableCategories: viewModel.availableCategories
+            )
+        }
+        .sheet(item: $transactionToEdit, onDismiss: {
+            Task { await viewModel.loadTransactions() }
+        }) { transaction in
+            TransactionEditView(viewModel: TransactionEditViewModel(
+                transaction: transaction,
+                repository: MockTransactionRepository(),
+                accountRepository: MockAccountRepository()
+            ))
+        }
+        .refreshable { await viewModel.loadTransactions() }
+        .task { await viewModel.loadTransactions() }
+    }
+
+    // MARK: - Filter Button Label
+
+    @ViewBuilder
+    private var filterButtonLabel: some View {
+        if viewModel.activeFilterCount > 0 {
+            Image(systemName: "line.3.horizontal.decrease.circle.fill")
+                .symbolRenderingMode(.hierarchical)
+                .overlay(alignment: .topTrailing) {
+                    Text("\(viewModel.activeFilterCount)")
+                        .font(.caption2.bold())
+                        .foregroundStyle(.white)
+                        .frame(minWidth: 16, minHeight: 16)
+                        .background(.red, in: Circle())
+                        .offset(x: 6, y: -6)
+                        .accessibilityHidden(true)
+                }
+                .accessibilityValue(String(localized: "\(viewModel.activeFilterCount) active filters"))
+        } else {
+            Image(systemName: "line.3.horizontal.decrease.circle")
         }
     }
+
+    // MARK: - Filter Chip Bar
+
+    private var filterChipBar: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(viewModel.filters.activeChipLabels) { chip in
+                    FilterChipView(label: chip.label) {
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            viewModel.removeFilterChip(chip)
+                        }
+                    }
+                }
+
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        viewModel.clearAllFilters()
+                    }
+                } label: {
+                    Text(String(localized: "Clear All"))
+                        .font(.caption)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .frame(minHeight: 44)
+                        .foregroundStyle(.red)
+                }
+                .accessibilityLabel(String(localized: "Clear all filters"))
+                .accessibilityHint(String(localized: "Removes all active filters"))
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 4)
+        }
+        .background(.bar)
+    }
+
+    // MARK: - Transactions List
 
     private var transactionsList: some View {
         List {
@@ -68,12 +180,13 @@ struct TransactionsView: View {
                             }
                             .swipeActions(edge: .leading, allowsFullSwipe: false) {
                                 Button {
-                                    // TODO: Navigate to edit flow
+                                    transactionToEdit = transaction
                                 } label: {
                                     Label(String(localized: "Edit"), systemImage: "pencil")
                                 }
                                 .tint(.blue)
                                 .accessibilityLabel(String(localized: "Edit transaction"))
+                                .accessibilityHint(String(localized: "Opens the edit form for this transaction"))
                             }
                     }
                 } header: {
@@ -117,4 +230,8 @@ struct TransactionsView: View {
     }
 }
 
-#Preview { TransactionsView(viewModel: TransactionsViewModel(repository: MockTransactionRepository())) }
+#Preview {
+    NavigationStack {
+        TransactionsView(viewModel: TransactionsViewModel(repository: MockTransactionRepository()))
+    }
+}

--- a/apps/ios/Finance/Services/DataExportService.swift
+++ b/apps/ios/Finance/Services/DataExportService.swift
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// DataExportService.swift
+// Finance
+//
+// Exports user financial data as CSV or JSON for GDPR compliance.
+// All monetary values are converted from minor units (cents) to major
+// units (dollars) for human-readable output. Sensitive financial values
+// are never logged — only metadata (format, filename) is recorded.
+
+import Foundation
+import os
+
+/// Thread-safe service that exports user financial data to temporary files.
+///
+/// Uses `actor` isolation to ensure safe concurrent access. All exported
+/// files are written to the system temporary directory and should be
+/// cleaned up by the caller after sharing.
+actor DataExportService {
+
+    // MARK: - Types
+
+    /// Supported export file formats.
+    enum ExportFormat: String, CaseIterable, Sendable {
+        case csv, json
+
+        var fileExtension: String { rawValue }
+
+        var mimeType: String {
+            switch self {
+            case .csv: return "text/csv"
+            case .json: return "application/json"
+            }
+        }
+
+        var displayName: String {
+            switch self {
+            case .csv: return "CSV"
+            case .json: return "JSON"
+            }
+        }
+    }
+
+    /// Container for all user data to be exported.
+    struct ExportData: Sendable {
+        let accounts: [AccountItem]
+        let transactions: [TransactionItem]
+        let budgets: [BudgetItem]
+        let goals: [GoalItem]
+    }
+
+    /// Errors specific to the export process.
+    enum ExportError: LocalizedError, Sendable {
+        case encodingFailed
+        case writeFailed(underlying: String)
+
+        var errorDescription: String? {
+            switch self {
+            case .encodingFailed:
+                return String(localized: "Failed to encode export data.")
+            case .writeFailed(let detail):
+                return String(localized: "Failed to write export file: \(detail)")
+            }
+        }
+    }
+
+    // MARK: - Private Properties
+
+    private let logger = Logger(subsystem: "com.finance.app", category: "DataExportService")
+
+    /// ISO 8601 formatter used for all date output in exports.
+    private let iso8601Formatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
+    // MARK: - Public API
+
+    /// Exports all user data to a temporary file in the specified format.
+    ///
+    /// - Parameters:
+    ///   - data: The complete user data to export.
+    ///   - format: The desired output format (CSV or JSON).
+    /// - Returns: A file URL pointing to the generated export file.
+    /// - Throws: `ExportError` if encoding or file writing fails.
+    func export(data: ExportData, format: ExportFormat) throws -> URL {
+        let timestamp = iso8601Formatter.string(from: Date())
+            .replacingOccurrences(of: ":", with: "-")
+        let filename = "finance-export-\(timestamp).\(format.fileExtension)"
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(filename)
+
+        switch format {
+        case .csv:
+            let csvContent = generateCSV(data: data)
+            try csvContent.write(to: tempURL, atomically: true, encoding: .utf8)
+        case .json:
+            let jsonData = try generateJSON(data: data)
+            try jsonData.write(to: tempURL)
+        }
+
+        logger.info(
+            "Exported data as \(format.rawValue, privacy: .public) to \(tempURL.lastPathComponent, privacy: .public)"
+        )
+        return tempURL
+    }
+
+    // MARK: - CSV Generation
+
+    /// Generates a complete CSV string with sections for accounts,
+    /// transactions, budgets, and goals.
+    ///
+    /// Each section starts with a comment header (`# SectionName`),
+    /// followed by a column header row and data rows. Fields containing
+    /// commas, quotes, or newlines are properly escaped per RFC 4180.
+    private func generateCSV(data: ExportData) -> String {
+        var lines: [String] = []
+
+        // — Accounts —
+        lines.append("# Accounts")
+        lines.append("Name,Type,Balance,Currency,Archived")
+        for account in data.accounts {
+            let row = [
+                csvEscape(account.name),
+                csvEscape(account.type.rawValue),
+                formatAmount(account.balanceMinorUnits),
+                csvEscape(account.currencyCode),
+                String(account.isArchived),
+            ]
+            lines.append(row.joined(separator: ","))
+        }
+
+        lines.append("")
+
+        // — Transactions —
+        lines.append("# Transactions")
+        lines.append("Date,Payee,Amount,Currency,Category,Type,Status,Account")
+        for transaction in data.transactions {
+            let row = [
+                csvEscape(iso8601Formatter.string(from: transaction.date)),
+                csvEscape(transaction.payee),
+                formatAmount(transaction.amountMinorUnits),
+                csvEscape(transaction.currencyCode),
+                csvEscape(transaction.category),
+                csvEscape(transaction.type.rawValue),
+                csvEscape(transaction.status.rawValue),
+                csvEscape(transaction.accountName),
+            ]
+            lines.append(row.joined(separator: ","))
+        }
+
+        lines.append("")
+
+        // — Budgets —
+        lines.append("# Budgets")
+        lines.append("Name,Category,Spent,Limit,Currency,Period")
+        for budget in data.budgets {
+            let row = [
+                csvEscape(budget.name),
+                csvEscape(budget.categoryName),
+                formatAmount(budget.spentMinorUnits),
+                formatAmount(budget.limitMinorUnits),
+                csvEscape(budget.currencyCode),
+                csvEscape(budget.period),
+            ]
+            lines.append(row.joined(separator: ","))
+        }
+
+        lines.append("")
+
+        // — Goals —
+        lines.append("# Goals")
+        lines.append("Name,Current,Target,Currency,Status,Target Date")
+        for goal in data.goals {
+            let targetDateStr = goal.targetDate
+                .map { iso8601Formatter.string(from: $0) } ?? ""
+            let row = [
+                csvEscape(goal.name),
+                formatAmount(goal.currentMinorUnits),
+                formatAmount(goal.targetMinorUnits),
+                csvEscape(goal.currencyCode),
+                csvEscape(goal.status.rawValue),
+                csvEscape(targetDateStr),
+            ]
+            lines.append(row.joined(separator: ","))
+        }
+
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    /// Escapes a CSV field per RFC 4180.
+    ///
+    /// If the field contains a comma, double-quote, or newline, the
+    /// entire field is wrapped in double-quotes and any existing
+    /// double-quotes are doubled.
+    private func csvEscape(_ field: String) -> String {
+        let needsEscaping = field.contains(",")
+            || field.contains("\"")
+            || field.contains("\n")
+            || field.contains("\r")
+        guard needsEscaping else { return field }
+        let escaped = field.replacingOccurrences(of: "\"", with: "\"\"")
+        return "\"\(escaped)\""
+    }
+
+    // MARK: - JSON Generation
+
+    /// Generates a structured JSON representation of all user data.
+    ///
+    /// The output includes an `exportDate` timestamp and arrays for
+    /// accounts, transactions, budgets, and goals.
+    private func generateJSON(data: ExportData) throws -> Data {
+        let exportDict: [String: Any] = [
+            "exportDate": iso8601Formatter.string(from: Date()),
+            "accounts": data.accounts.map { accountToDict($0) },
+            "transactions": data.transactions.map { transactionToDict($0) },
+            "budgets": data.budgets.map { budgetToDict($0) },
+            "goals": data.goals.map { goalToDict($0) },
+        ]
+
+        guard JSONSerialization.isValidJSONObject(exportDict) else {
+            throw ExportError.encodingFailed
+        }
+
+        return try JSONSerialization.data(
+            withJSONObject: exportDict,
+            options: [.prettyPrinted, .sortedKeys]
+        )
+    }
+
+    private func accountToDict(_ account: AccountItem) -> [String: Any] {
+        [
+            "id": account.id,
+            "name": account.name,
+            "balance": Double(account.balanceMinorUnits) / 100.0,
+            "currency": account.currencyCode,
+            "type": account.type.rawValue,
+            "archived": account.isArchived,
+        ]
+    }
+
+    private func transactionToDict(_ transaction: TransactionItem) -> [String: Any] {
+        [
+            "id": transaction.id,
+            "date": iso8601Formatter.string(from: transaction.date),
+            "payee": transaction.payee,
+            "amount": Double(transaction.amountMinorUnits) / 100.0,
+            "currency": transaction.currencyCode,
+            "category": transaction.category,
+            "type": transaction.type.rawValue,
+            "status": transaction.status.rawValue,
+            "account": transaction.accountName,
+        ]
+    }
+
+    private func budgetToDict(_ budget: BudgetItem) -> [String: Any] {
+        [
+            "id": budget.id,
+            "name": budget.name,
+            "category": budget.categoryName,
+            "spent": Double(budget.spentMinorUnits) / 100.0,
+            "limit": Double(budget.limitMinorUnits) / 100.0,
+            "currency": budget.currencyCode,
+            "period": budget.period,
+        ]
+    }
+
+    private func goalToDict(_ goal: GoalItem) -> [String: Any] {
+        var dict: [String: Any] = [
+            "id": goal.id,
+            "name": goal.name,
+            "current": Double(goal.currentMinorUnits) / 100.0,
+            "target": Double(goal.targetMinorUnits) / 100.0,
+            "currency": goal.currencyCode,
+            "status": goal.status.rawValue,
+        ]
+        if let targetDate = goal.targetDate {
+            dict["targetDate"] = iso8601Formatter.string(from: targetDate)
+        }
+        return dict
+    }
+
+    // MARK: - Formatting Helpers
+
+    /// Converts a minor-unit integer (cents) to a decimal string in major
+    /// units (dollars). For example, `12450` becomes `"124.50"`.
+    private func formatAmount(_ minorUnits: Int64) -> String {
+        let major = Double(minorUnits) / 100.0
+        return String(format: "%.2f", major)
+    }
+}

--- a/apps/ios/Finance/ViewModels/SettingsViewModel.swift
+++ b/apps/ios/Finance/ViewModels/SettingsViewModel.swift
@@ -27,6 +27,17 @@ final class SettingsViewModel {
     var showingDeleteConfirmation = false
     var biometricError: BiometricError?
     var showingBiometricError = false
+    var exportFormat: DataExportService.ExportFormat = .csv
+    var exportFileURL: URL?
+    var showExportSheet = false
+    var exportError: String?
+    var showingExportError = false
+
+    private let accountRepository: AccountRepository
+    private let transactionRepository: TransactionRepository
+    private let budgetRepository: BudgetRepository
+    private let goalRepository: GoalRepository
+    private let exportService = DataExportService()
 
     private static let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
@@ -38,6 +49,18 @@ final class SettingsViewModel {
         ("CAD", "Canadian Dollar"), ("JPY", "Japanese Yen"),
         ("AUD", "Australian Dollar"), ("CHF", "Swiss Franc"),
     ]
+
+    init(
+        accountRepository: AccountRepository = MockAccountRepository(),
+        transactionRepository: TransactionRepository = MockTransactionRepository(),
+        budgetRepository: BudgetRepository = MockBudgetRepository(),
+        goalRepository: GoalRepository = MockGoalRepository()
+    ) {
+        self.accountRepository = accountRepository
+        self.transactionRepository = transactionRepository
+        self.budgetRepository = budgetRepository
+        self.goalRepository = goalRepository
+    }
 
     func loadSettings() async {
         biometricEnabled = UserDefaults.standard.bool(
@@ -112,10 +135,50 @@ final class SettingsViewModel {
         }
     }
 
+    /// Exports all user financial data in the selected format.
+    ///
+    /// Fetches current data from all repositories, passes it to the
+    /// `DataExportService`, and presents the resulting file via the
+    /// share sheet. Only metadata (format, filename) is logged —
+    /// actual financial values are never written to the log.
     func exportData() async {
         isExporting = true
         defer { isExporting = false }
-        // TODO: Implement data export via KMP shared logic
-        try? await Task.sleep(for: .seconds(1))
+
+        Self.logger.info(
+            "Starting data export as \(self.exportFormat.rawValue, privacy: .public)"
+        )
+
+        do {
+            async let accounts = accountRepository.getAccounts()
+            async let transactions = transactionRepository.getTransactions()
+            async let budgets = budgetRepository.getBudgets()
+            async let goals = goalRepository.getGoals()
+
+            let exportData = DataExportService.ExportData(
+                accounts: try await accounts,
+                transactions: try await transactions,
+                budgets: try await budgets,
+                goals: try await goals
+            )
+
+            let fileURL = try await exportService.export(
+                data: exportData,
+                format: exportFormat
+            )
+
+            exportFileURL = fileURL
+            showExportSheet = true
+
+            Self.logger.info(
+                "Export complete: \(fileURL.lastPathComponent, privacy: .public)"
+            )
+        } catch {
+            Self.logger.error(
+                "Export failed: \(error.localizedDescription, privacy: .public)"
+            )
+            exportError = error.localizedDescription
+            showingExportError = true
+        }
     }
 }

--- a/apps/ios/Finance/ViewModels/TransactionCreateViewModel.swift
+++ b/apps/ios/Finance/ViewModels/TransactionCreateViewModel.swift
@@ -107,7 +107,8 @@ final class TransactionCreateViewModel {
             currencyCode: currencyCode,
             date: date,
             type: transactionType,
-            status: .pending
+            status: .pending,
+            note: note.isEmpty ? nil : note
         )
 
         do {

--- a/apps/ios/Finance/ViewModels/TransactionEditViewModel.swift
+++ b/apps/ios/Finance/ViewModels/TransactionEditViewModel.swift
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// TransactionEditViewModel.swift
+// Finance
+//
+// ViewModel for editing an existing transaction using the same
+// multi-step wizard flow as transaction creation.
+
+import Observation
+import os
+import SwiftUI
+
+@Observable
+@MainActor
+final class TransactionEditViewModel {
+    private let logger = Logger(subsystem: "com.finance.app", category: "TransactionEditViewModel")
+    private let repository: TransactionRepository
+    private let accountRepository: AccountRepository
+    let originalTransaction: TransactionItem
+
+    // MARK: - Step Tracking
+
+    /// Wizard steps shared with the creation flow.
+    enum Step: Int, CaseIterable {
+        case type = 0, details = 1, review = 2
+
+        var title: String {
+            switch self {
+            case .type: String(localized: "Type")
+            case .details: String(localized: "Details")
+            case .review: String(localized: "Review")
+            }
+        }
+    }
+
+    var currentStep: Step = .type
+
+    // MARK: - Form Fields (pre-populated from original)
+
+    var transactionType: TransactionTypeUI
+    var amountText: String
+    var payee: String
+    var selectedAccountId: String?
+    var selectedCategoryId: String?
+    var date: Date
+    var note: String
+    var currencyCode: String
+
+    // MARK: - State
+
+    var isSaving = false
+    var showingValidationError = false
+    var validationMessage = ""
+    var accounts: [PickerOption] = []
+
+    var categories: [PickerOption] = [
+        PickerOption(id: "c1", name: "Groceries", icon: "cart"),
+        PickerOption(id: "c2", name: "Dining Out", icon: "fork.knife"),
+        PickerOption(id: "c3", name: "Transport", icon: "car"),
+        PickerOption(id: "c4", name: "Entertainment", icon: "film"),
+        PickerOption(id: "c5", name: "Shopping", icon: "bag"),
+        PickerOption(id: "c6", name: "Income", icon: "dollarsign.circle"),
+    ]
+
+    // MARK: - Change Tracking
+
+    /// Stores the resolved account ID from the original transaction after
+    /// `loadData()` maps the account name to an ID.
+    private var originalAccountId: String?
+
+    /// Stores the resolved category ID from the original transaction after
+    /// `loadData()` maps the category name to an ID.
+    private var originalCategoryId: String?
+
+    /// Whether the user has modified any field relative to the original transaction.
+    var hasChanges: Bool {
+        transactionType != originalTransaction.type
+            || amountText != Self.formattedAmount(from: originalTransaction.amountMinorUnits)
+            || payee != originalTransaction.payee
+            || selectedAccountId != originalAccountId
+            || selectedCategoryId != originalCategoryId
+            || !Calendar.current.isDate(date, inSameDayAs: originalTransaction.date)
+            || note != (originalTransaction.note ?? "")
+    }
+
+    // MARK: - Computed
+
+    var canAdvance: Bool {
+        switch currentStep {
+        case .type: true
+        case .details: !amountText.isEmpty && selectedAccountId != nil && !payee.isEmpty
+        case .review: true
+        }
+    }
+
+    var amountMinorUnits: Int64 { Int64((Double(amountText) ?? 0) * 100) }
+
+    // MARK: - Init
+
+    init(
+        transaction: TransactionItem,
+        repository: TransactionRepository,
+        accountRepository: AccountRepository
+    ) {
+        self.originalTransaction = transaction
+        self.repository = repository
+        self.accountRepository = accountRepository
+
+        self.transactionType = transaction.type
+        self.amountText = Self.formattedAmount(from: transaction.amountMinorUnits)
+        self.payee = transaction.payee
+        self.date = transaction.date
+        self.note = transaction.note ?? ""
+        self.currencyCode = transaction.currencyCode
+    }
+
+    // MARK: - Data Loading
+
+    /// Loads accounts for the picker and resolves the original transaction's
+    /// account and category to their respective IDs.
+    func loadData() async {
+        do {
+            let accountItems = try await accountRepository.getAccounts()
+            accounts = accountItems.map { PickerOption(id: $0.id, name: $0.name, icon: $0.icon) }
+        } catch {
+            logger.error("Failed to load accounts: \(error.localizedDescription, privacy: .public)")
+            accounts = []
+        }
+
+        // Resolve account ID from the original transaction's account name
+        selectedAccountId = accounts.first { $0.name == originalTransaction.accountName }?.id
+        originalAccountId = selectedAccountId
+
+        // Resolve category ID from the original transaction's category name
+        selectedCategoryId = categories.first { $0.name == originalTransaction.category }?.id
+        originalCategoryId = selectedCategoryId
+    }
+
+    // MARK: - Navigation
+
+    func advance() {
+        guard let next = Step(rawValue: currentStep.rawValue + 1) else { return }
+        currentStep = next
+    }
+
+    func goBack() {
+        guard let prev = Step(rawValue: currentStep.rawValue - 1) else { return }
+        currentStep = prev
+    }
+
+    // MARK: - Save
+
+    func save() async -> Bool {
+        guard validate() else { return false }
+        isSaving = true
+        defer { isSaving = false }
+
+        let categoryName = categories.first { $0.id == selectedCategoryId }?.name ?? ""
+        let accountName = accounts.first { $0.id == selectedAccountId }?.name ?? ""
+
+        let updated = TransactionItem(
+            id: originalTransaction.id,
+            payee: payee,
+            category: categoryName,
+            accountName: accountName,
+            amountMinorUnits: transactionType == .income ? amountMinorUnits : -amountMinorUnits,
+            currencyCode: currencyCode,
+            date: date,
+            type: transactionType,
+            status: originalTransaction.status,
+            note: note.isEmpty ? nil : note
+        )
+
+        do {
+            try await repository.updateTransaction(updated)
+            logger.info("Transaction \(self.originalTransaction.id, privacy: .private) updated successfully")
+            return true
+        } catch {
+            logger.error("Failed to update transaction: \(error.localizedDescription, privacy: .public)")
+            validationMessage = error.localizedDescription
+            showingValidationError = true
+            return false
+        }
+    }
+
+    // MARK: - Validation
+
+    private func validate() -> Bool {
+        if amountText.isEmpty || (Double(amountText) ?? 0) <= 0 {
+            validationMessage = String(localized: "Please enter a valid amount.")
+            showingValidationError = true
+            return false
+        }
+        if payee.isEmpty {
+            validationMessage = String(localized: "Please enter a payee.")
+            showingValidationError = true
+            return false
+        }
+        if selectedAccountId == nil {
+            validationMessage = String(localized: "Please select an account.")
+            showingValidationError = true
+            return false
+        }
+        return true
+    }
+
+    // MARK: - Helpers
+
+    /// Formats minor-unit amounts (e.g. `8540` → `"85.40"`) for the text field.
+    static func formattedAmount(from minorUnits: Int64) -> String {
+        String(format: "%.2f", Double(abs(minorUnits)) / 100.0)
+    }
+}

--- a/apps/ios/Tests/DataExportServiceTests.swift
+++ b/apps/ios/Tests/DataExportServiceTests.swift
@@ -1,0 +1,558 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// DataExportServiceTests.swift
+// FinanceTests
+//
+// Tests for DataExportService — CSV generation, JSON generation,
+// empty data handling, special character escaping, and amount formatting.
+
+import XCTest
+@testable import FinanceApp
+
+final class DataExportServiceTests: XCTestCase {
+
+    private var service: DataExportService!
+
+    override func setUp() {
+        super.setUp()
+        service = DataExportService()
+    }
+
+    override func tearDown() {
+        service = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    /// Creates standard export data from SampleData for reuse across tests.
+    private func makeSampleExportData() -> DataExportService.ExportData {
+        DataExportService.ExportData(
+            accounts: SampleData.allAccounts,
+            transactions: SampleData.allTransactions,
+            budgets: SampleData.allBudgets,
+            goals: SampleData.allGoals
+        )
+    }
+
+    /// Creates empty export data for edge-case testing.
+    private func makeEmptyExportData() -> DataExportService.ExportData {
+        DataExportService.ExportData(
+            accounts: [],
+            transactions: [],
+            budgets: [],
+            goals: []
+        )
+    }
+
+    // MARK: - CSV Generation Tests
+
+    func testCSVExportCreatesFile() async throws {
+        let data = makeSampleExportData()
+        let url = try await service.export(data: data, format: .csv)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path),
+                      "CSV export file should exist on disk")
+        XCTAssertTrue(url.lastPathComponent.hasSuffix(".csv"),
+                      "File should have .csv extension")
+
+        // Clean up
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    func testCSVExportContainsAccountHeaders() async throws {
+        let data = makeSampleExportData()
+        let url = try await service.export(data: data, format: .csv)
+        let content = try String(contentsOf: url, encoding: .utf8)
+
+        XCTAssertTrue(content.contains("# Accounts"),
+                      "CSV should contain Accounts section header")
+        XCTAssertTrue(content.contains("Name,Type,Balance,Currency,Archived"),
+                      "CSV should contain account column headers")
+
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    func testCSVExportContainsTransactionHeaders() async throws {
+        let data = makeSampleExportData()
+        let url = try await service.export(data: data, format: .csv)
+        let content = try String(contentsOf: url, encoding: .utf8)
+
+        XCTAssertTrue(content.contains("# Transactions"),
+                      "CSV should contain Transactions section header")
+        XCTAssertTrue(content.contains("Date,Payee,Amount,Currency,Category,Type,Status,Account"),
+                      "CSV should contain transaction column headers")
+
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    func testCSVExportContainsBudgetHeaders() async throws {
+        let data = makeSampleExportData()
+        let url = try await service.export(data: data, format: .csv)
+        let content = try String(contentsOf: url, encoding: .utf8)
+
+        XCTAssertTrue(content.contains("# Budgets"),
+                      "CSV should contain Budgets section header")
+        XCTAssertTrue(content.contains("Name,Category,Spent,Limit,Currency,Period"),
+                      "CSV should contain budget column headers")
+
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    func testCSVExportContainsGoalHeaders() async throws {
+        let data = makeSampleExportData()
+        let url = try await service.export(data: data, format: .csv)
+        let content = try String(contentsOf: url, encoding: .utf8)
+
+        XCTAssertTrue(content.contains("# Goals"),
+                      "CSV should contain Goals section header")
+        XCTAssertTrue(content.contains("Name,Current,Target,Currency,Status,Target Date"),
+                      "CSV should contain goal column headers")
+
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    func testCSVExportContainsAccountData() async throws {
+        let data = makeSampleExportData()
+        let url = try await service.export(data: data, format: .csv)
+        let content = try String(contentsOf: url, encoding: .utf8)
+
+        // Main Checking: 12450.00 cents = 124.50 dollars? No.
+        // balanceMinorUnits: 12_450_00 = 1245000 cents → 12450.00 dollars
+        XCTAssertTrue(content.contains("Main Checking"),
+                      "CSV should contain account name")
+        XCTAssertTrue(content.contains("12450.00"),
+                      "CSV should contain account balance in major units")
+        XCTAssertTrue(content.contains("checking"),
+                      "CSV should contain account type")
+
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    func testCSVExportContainsTransactionData() async throws {
+        let data = makeSampleExportData()
+        let url = try await service.export(data: data, format: .csv)
+        let content = try String(contentsOf: url, encoding: .utf8)
+
+        XCTAssertTrue(content.contains("Whole Foods"),
+                      "CSV should contain transaction payee")
+        // -85_40 = -8540 minor units → -85.40
+        XCTAssertTrue(content.contains("-85.40"),
+                      "CSV should contain transaction amount in major units")
+        XCTAssertTrue(content.contains("Groceries"),
+                      "CSV should contain transaction category")
+
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    func testCSVExportContainsBudgetData() async throws {
+        let data = makeSampleExportData()
+        let url = try await service.export(data: data, format: .csv)
+        let content = try String(contentsOf: url, encoding: .utf8)
+
+        XCTAssertTrue(content.contains("Groceries"),
+                      "CSV should contain budget name")
+        // 320_00 = 32000 minor units → 320.00
+        XCTAssertTrue(content.contains("320.00"),
+                      "CSV should contain budget spent amount in major units")
+        // 500_00 = 50000 minor units → 500.00
+        XCTAssertTrue(content.contains("500.00"),
+                      "CSV should contain budget limit amount in major units")
+
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    func testCSVExportContainsGoalData() async throws {
+        let data = makeSampleExportData()
+        let url = try await service.export(data: data, format: .csv)
+        let content = try String(contentsOf: url, encoding: .utf8)
+
+        XCTAssertTrue(content.contains("Emergency Fund"),
+                      "CSV should contain goal name")
+        // 7_500_00 = 750000 minor units → 7500.00
+        XCTAssertTrue(content.contains("7500.00"),
+                      "CSV should contain goal current amount in major units")
+        // 10_000_00 = 1000000 minor units → 10000.00
+        XCTAssertTrue(content.contains("10000.00"),
+                      "CSV should contain goal target amount in major units")
+        XCTAssertTrue(content.contains("active"),
+                      "CSV should contain goal status")
+
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    func testCSVAmountConversionFromMinorToMajorUnits() async throws {
+        let account = AccountItem(
+            id: "test", name: "Test",
+            balanceMinorUnits: 1_234_56, currencyCode: "USD",
+            type: .checking, icon: "building.columns", isArchived: false
+        )
+        let data = DataExportService.ExportData(
+            accounts: [account],
+            transactions: [],
+            budgets: [],
+            goals: []
+        )
+        let url = try await service.export(data: data, format: .csv)
+        let content = try String(contentsOf: url, encoding: .utf8)
+
+        // 1_234_56 = 123456 minor units → 1234.56
+        XCTAssertTrue(content.contains("1234.56"),
+                      "Amount should be converted from minor units (cents) to major units (dollars)")
+
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    func testCSVNegativeAmountFormatting() async throws {
+        let account = AccountItem(
+            id: "test", name: "Credit Card",
+            balanceMinorUnits: -1_200_00, currencyCode: "USD",
+            type: .creditCard, icon: "creditcard", isArchived: false
+        )
+        let data = DataExportService.ExportData(
+            accounts: [account],
+            transactions: [],
+            budgets: [],
+            goals: []
+        )
+        let url = try await service.export(data: data, format: .csv)
+        let content = try String(contentsOf: url, encoding: .utf8)
+
+        // -1_200_00 = -120000 minor units → -1200.00
+        XCTAssertTrue(content.contains("-1200.00"),
+                      "Negative amounts should be formatted correctly")
+
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    // MARK: - CSV Special Characters Tests
+
+    func testCSVEscapesCommasInFields() async throws {
+        let account = AccountItem(
+            id: "test", name: "Checking, Primary",
+            balanceMinorUnits: 100_00, currencyCode: "USD",
+            type: .checking, icon: "building.columns", isArchived: false
+        )
+        let data = DataExportService.ExportData(
+            accounts: [account],
+            transactions: [],
+            budgets: [],
+            goals: []
+        )
+        let url = try await service.export(data: data, format: .csv)
+        let content = try String(contentsOf: url, encoding: .utf8)
+
+        XCTAssertTrue(content.contains("\"Checking, Primary\""),
+                      "Fields containing commas should be wrapped in double quotes")
+
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    func testCSVEscapesQuotesInFields() async throws {
+        let account = AccountItem(
+            id: "test", name: "My \"Special\" Account",
+            balanceMinorUnits: 100_00, currencyCode: "USD",
+            type: .checking, icon: "building.columns", isArchived: false
+        )
+        let data = DataExportService.ExportData(
+            accounts: [account],
+            transactions: [],
+            budgets: [],
+            goals: []
+        )
+        let url = try await service.export(data: data, format: .csv)
+        let content = try String(contentsOf: url, encoding: .utf8)
+
+        XCTAssertTrue(content.contains("\"My \"\"Special\"\" Account\""),
+                      "Fields containing quotes should have quotes doubled and be wrapped in double quotes")
+
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    func testCSVEscapesNewlinesInFields() async throws {
+        let transaction = TransactionItem(
+            id: "test", payee: "Store\nName",
+            category: "Shopping", accountName: "Main",
+            amountMinorUnits: -50_00, currencyCode: "USD",
+            date: Date(timeIntervalSince1970: 1_700_000_000),
+            type: .expense, status: .cleared
+        )
+        let data = DataExportService.ExportData(
+            accounts: [],
+            transactions: [transaction],
+            budgets: [],
+            goals: []
+        )
+        let url = try await service.export(data: data, format: .csv)
+        let content = try String(contentsOf: url, encoding: .utf8)
+
+        XCTAssertTrue(content.contains("\"Store\nName\""),
+                      "Fields containing newlines should be wrapped in double quotes")
+
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    // MARK: - JSON Generation Tests
+
+    func testJSONExportCreatesFile() async throws {
+        let data = makeSampleExportData()
+        let url = try await service.export(data: data, format: .json)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path),
+                      "JSON export file should exist on disk")
+        XCTAssertTrue(url.lastPathComponent.hasSuffix(".json"),
+                      "File should have .json extension")
+
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    func testJSONExportProducesValidJSON() async throws {
+        let data = makeSampleExportData()
+        let url = try await service.export(data: data, format: .json)
+        let jsonData = try Data(contentsOf: url)
+
+        let json = try JSONSerialization.jsonObject(with: jsonData) as? [String: Any]
+        XCTAssertNotNil(json, "Export should produce valid JSON")
+
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    func testJSONExportContainsExportDate() async throws {
+        let data = makeSampleExportData()
+        let url = try await service.export(data: data, format: .json)
+        let jsonData = try Data(contentsOf: url)
+        let json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: jsonData) as? [String: Any]
+        )
+
+        let exportDate = json["exportDate"] as? String
+        XCTAssertNotNil(exportDate, "JSON should contain exportDate")
+        XCTAssertFalse(exportDate?.isEmpty ?? true,
+                       "exportDate should not be empty")
+
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    func testJSONExportContainsAllSections() async throws {
+        let data = makeSampleExportData()
+        let url = try await service.export(data: data, format: .json)
+        let jsonData = try Data(contentsOf: url)
+        let json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: jsonData) as? [String: Any]
+        )
+
+        XCTAssertNotNil(json["accounts"] as? [[String: Any]],
+                        "JSON should contain accounts array")
+        XCTAssertNotNil(json["transactions"] as? [[String: Any]],
+                        "JSON should contain transactions array")
+        XCTAssertNotNil(json["budgets"] as? [[String: Any]],
+                        "JSON should contain budgets array")
+        XCTAssertNotNil(json["goals"] as? [[String: Any]],
+                        "JSON should contain goals array")
+
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    func testJSONExportAccountData() async throws {
+        let data = makeSampleExportData()
+        let url = try await service.export(data: data, format: .json)
+        let jsonData = try Data(contentsOf: url)
+        let json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: jsonData) as? [String: Any]
+        )
+        let accounts = try XCTUnwrap(json["accounts"] as? [[String: Any]])
+
+        XCTAssertEqual(accounts.count, SampleData.allAccounts.count,
+                       "JSON should contain all accounts")
+
+        let firstAccount = try XCTUnwrap(accounts.first { ($0["name"] as? String) == "Main Checking" })
+        XCTAssertEqual(firstAccount["name"] as? String, "Main Checking")
+        XCTAssertEqual(firstAccount["type"] as? String, "checking")
+        XCTAssertEqual(firstAccount["currency"] as? String, "USD")
+        XCTAssertEqual(firstAccount["archived"] as? Bool, false)
+        // 12_450_00 = 1245000 minor units → 12450.0
+        XCTAssertEqual(firstAccount["balance"] as? Double, 12450.0, accuracy: 0.01,
+                       "Balance should be in major units")
+
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    func testJSONExportTransactionData() async throws {
+        let data = makeSampleExportData()
+        let url = try await service.export(data: data, format: .json)
+        let jsonData = try Data(contentsOf: url)
+        let json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: jsonData) as? [String: Any]
+        )
+        let transactions = try XCTUnwrap(json["transactions"] as? [[String: Any]])
+
+        XCTAssertEqual(transactions.count, SampleData.allTransactions.count,
+                       "JSON should contain all transactions")
+
+        let expense = try XCTUnwrap(transactions.first { ($0["payee"] as? String) == "Whole Foods" })
+        XCTAssertEqual(expense["category"] as? String, "Groceries")
+        XCTAssertEqual(expense["type"] as? String, "expense")
+        XCTAssertEqual(expense["status"] as? String, "cleared")
+        // -85_40 = -8540 minor units → -85.40
+        XCTAssertEqual(expense["amount"] as? Double, -85.40, accuracy: 0.01,
+                       "Amount should be in major units")
+
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    func testJSONExportBudgetData() async throws {
+        let data = makeSampleExportData()
+        let url = try await service.export(data: data, format: .json)
+        let jsonData = try Data(contentsOf: url)
+        let json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: jsonData) as? [String: Any]
+        )
+        let budgets = try XCTUnwrap(json["budgets"] as? [[String: Any]])
+
+        XCTAssertEqual(budgets.count, SampleData.allBudgets.count,
+                       "JSON should contain all budgets")
+
+        let groceries = try XCTUnwrap(budgets.first { ($0["name"] as? String) == "Groceries" })
+        XCTAssertEqual(groceries["category"] as? String, "Groceries")
+        // 320_00 = 32000 minor units → 320.00
+        XCTAssertEqual(groceries["spent"] as? Double, 320.0, accuracy: 0.01)
+        // 500_00 = 50000 minor units → 500.00
+        XCTAssertEqual(groceries["limit"] as? Double, 500.0, accuracy: 0.01)
+        XCTAssertEqual(groceries["period"] as? String, "Monthly")
+
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    func testJSONExportGoalData() async throws {
+        let data = makeSampleExportData()
+        let url = try await service.export(data: data, format: .json)
+        let jsonData = try Data(contentsOf: url)
+        let json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: jsonData) as? [String: Any]
+        )
+        let goals = try XCTUnwrap(json["goals"] as? [[String: Any]])
+
+        XCTAssertEqual(goals.count, SampleData.allGoals.count,
+                       "JSON should contain all goals")
+
+        let emergencyFund = try XCTUnwrap(goals.first { ($0["name"] as? String) == "Emergency Fund" })
+        XCTAssertEqual(emergencyFund["status"] as? String, "active")
+        // 7_500_00 = 750000 minor units → 7500.0
+        XCTAssertEqual(emergencyFund["current"] as? Double, 7500.0, accuracy: 0.01)
+        // 10_000_00 = 1000000 minor units → 10000.0
+        XCTAssertEqual(emergencyFund["target"] as? Double, 10000.0, accuracy: 0.01)
+        XCTAssertNotNil(emergencyFund["targetDate"] as? String,
+                        "Active goal should have a target date")
+    }
+
+    func testJSONExportGoalWithoutTargetDate() async throws {
+        let data = makeSampleExportData()
+        let url = try await service.export(data: data, format: .json)
+        let jsonData = try Data(contentsOf: url)
+        let json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: jsonData) as? [String: Any]
+        )
+        let goals = try XCTUnwrap(json["goals"] as? [[String: Any]])
+
+        let completedGoal = try XCTUnwrap(goals.first { ($0["name"] as? String) == "New Laptop" })
+        XCTAssertNil(completedGoal["targetDate"],
+                     "Goal without target date should not have targetDate key")
+
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    // MARK: - Empty Data Tests
+
+    func testCSVExportWithEmptyData() async throws {
+        let data = makeEmptyExportData()
+        let url = try await service.export(data: data, format: .csv)
+        let content = try String(contentsOf: url, encoding: .utf8)
+
+        // Should still contain section headers even with no data rows
+        XCTAssertTrue(content.contains("# Accounts"),
+                      "Empty CSV should still have Accounts header")
+        XCTAssertTrue(content.contains("# Transactions"),
+                      "Empty CSV should still have Transactions header")
+        XCTAssertTrue(content.contains("# Budgets"),
+                      "Empty CSV should still have Budgets header")
+        XCTAssertTrue(content.contains("# Goals"),
+                      "Empty CSV should still have Goals header")
+
+        // Column headers should be present
+        XCTAssertTrue(content.contains("Name,Type,Balance,Currency,Archived"),
+                      "Empty CSV should still have account column headers")
+
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    func testJSONExportWithEmptyData() async throws {
+        let data = makeEmptyExportData()
+        let url = try await service.export(data: data, format: .json)
+        let jsonData = try Data(contentsOf: url)
+        let json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: jsonData) as? [String: Any]
+        )
+
+        let accounts = try XCTUnwrap(json["accounts"] as? [[String: Any]])
+        let transactions = try XCTUnwrap(json["transactions"] as? [[String: Any]])
+        let budgets = try XCTUnwrap(json["budgets"] as? [[String: Any]])
+        let goals = try XCTUnwrap(json["goals"] as? [[String: Any]])
+
+        XCTAssertTrue(accounts.isEmpty, "Accounts array should be empty")
+        XCTAssertTrue(transactions.isEmpty, "Transactions array should be empty")
+        XCTAssertTrue(budgets.isEmpty, "Budgets array should be empty")
+        XCTAssertTrue(goals.isEmpty, "Goals array should be empty")
+        XCTAssertNotNil(json["exportDate"],
+                        "Empty export should still have exportDate")
+
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    // MARK: - File Naming Tests
+
+    func testCSVFileHasCorrectExtension() async throws {
+        let data = makeEmptyExportData()
+        let url = try await service.export(data: data, format: .csv)
+
+        XCTAssertEqual(url.pathExtension, "csv",
+                       "CSV export should have .csv extension")
+
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    func testJSONFileHasCorrectExtension() async throws {
+        let data = makeEmptyExportData()
+        let url = try await service.export(data: data, format: .json)
+
+        XCTAssertEqual(url.pathExtension, "json",
+                       "JSON export should have .json extension")
+
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    func testExportFilenameContainsPrefix() async throws {
+        let data = makeEmptyExportData()
+        let url = try await service.export(data: data, format: .csv)
+
+        XCTAssertTrue(url.lastPathComponent.hasPrefix("finance-export-"),
+                      "Export filename should start with 'finance-export-'")
+
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    // MARK: - ExportFormat Tests
+
+    func testExportFormatProperties() {
+        XCTAssertEqual(DataExportService.ExportFormat.csv.fileExtension, "csv")
+        XCTAssertEqual(DataExportService.ExportFormat.json.fileExtension, "json")
+        XCTAssertEqual(DataExportService.ExportFormat.csv.mimeType, "text/csv")
+        XCTAssertEqual(DataExportService.ExportFormat.json.mimeType, "application/json")
+        XCTAssertEqual(DataExportService.ExportFormat.csv.displayName, "CSV")
+        XCTAssertEqual(DataExportService.ExportFormat.json.displayName, "JSON")
+    }
+
+    func testExportFormatAllCases() {
+        XCTAssertEqual(DataExportService.ExportFormat.allCases.count, 2,
+                       "ExportFormat should have exactly 2 cases")
+    }
+}

--- a/apps/ios/Tests/TestHelpers.swift
+++ b/apps/ios/Tests/TestHelpers.swift
@@ -52,6 +52,7 @@ final class StubTransactionRepository: TransactionRepository, @unchecked Sendabl
     var errorToThrow: Error?
     private(set) var deletedTransactionIds: [String] = []
     private(set) var createdTransactions: [TransactionItem] = []
+    private(set) var updatedTransactions: [TransactionItem] = []
 
     func getTransactions() async throws -> [TransactionItem] {
         if let error = errorToThrow { throw error }
@@ -76,6 +77,11 @@ final class StubTransactionRepository: TransactionRepository, @unchecked Sendabl
     func deleteTransaction(id: String) async throws {
         if let error = errorToThrow { throw error }
         deletedTransactionIds.append(id)
+    }
+
+    func updateTransaction(_ transaction: TransactionItem) async throws {
+        if let error = errorToThrow { throw error }
+        updatedTransactions.append(transaction)
     }
 }
 

--- a/apps/ios/Tests/TransactionEditViewModelTests.swift
+++ b/apps/ios/Tests/TransactionEditViewModelTests.swift
@@ -1,0 +1,450 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// TransactionEditViewModelTests.swift
+// FinanceTests
+//
+// Tests for TransactionEditViewModel — pre-population, change detection,
+// validation, save flow, and cancel behaviour.
+
+import XCTest
+@testable import FinanceApp
+
+final class TransactionEditViewModelTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    @MainActor
+    private func makeViewModel(
+        transaction: TransactionItem = SampleData.expenseTransaction
+    ) -> (
+        vm: TransactionEditViewModel,
+        transactionRepo: StubTransactionRepository,
+        accountRepo: StubAccountRepository
+    ) {
+        let transactionRepo = StubTransactionRepository()
+        let accountRepo = StubAccountRepository()
+        accountRepo.accountsToReturn = SampleData.allAccounts
+        let vm = TransactionEditViewModel(
+            transaction: transaction,
+            repository: transactionRepo,
+            accountRepository: accountRepo
+        )
+        return (vm, transactionRepo, accountRepo)
+    }
+
+    // MARK: - Test: Pre-population from existing transaction
+
+    @MainActor
+    func testInitPrePopulatesFieldsFromTransaction() async {
+        let transaction = TransactionItem(
+            id: "t-edit-1", payee: "Trader Joe's",
+            category: "Groceries", accountName: "Main Checking",
+            amountMinorUnits: -42_50, currencyCode: "USD",
+            date: Date(timeIntervalSince1970: 1_700_000_000),
+            type: .expense, status: .cleared, note: "Weekly groceries"
+        )
+        let (vm, _, _) = makeViewModel(transaction: transaction)
+
+        XCTAssertEqual(vm.transactionType, .expense,
+                       "Transaction type should be pre-populated from original")
+        XCTAssertEqual(vm.amountText, "42.50",
+                       "Amount text should format absolute minor units to decimal string")
+        XCTAssertEqual(vm.payee, "Trader Joe's",
+                       "Payee should be pre-populated from original")
+        XCTAssertEqual(vm.note, "Weekly groceries",
+                       "Note should be pre-populated from original")
+        XCTAssertEqual(vm.currencyCode, "USD",
+                       "Currency code should be pre-populated from original")
+        XCTAssertTrue(Calendar.current.isDate(vm.date, equalTo: transaction.date, toGranularity: .second),
+                      "Date should be pre-populated from original")
+    }
+
+    @MainActor
+    func testInitPrePopulatesNilNoteAsEmptyString() async {
+        let transaction = TransactionItem(
+            id: "t-edit-2", payee: "Netflix",
+            category: "Entertainment", accountName: "Travel Card",
+            amountMinorUnits: -15_99, currencyCode: "USD",
+            date: .now, type: .expense, status: .cleared
+        )
+        let (vm, _, _) = makeViewModel(transaction: transaction)
+
+        XCTAssertEqual(vm.note, "",
+                       "Nil note on transaction should be pre-populated as empty string")
+    }
+
+    @MainActor
+    func testLoadDataResolvesAccountAndCategoryIds() async {
+        let (vm, _, _) = makeViewModel(transaction: SampleData.expenseTransaction)
+
+        await vm.loadData()
+
+        XCTAssertEqual(vm.accounts.count, SampleData.allAccounts.count,
+                       "Should load all accounts for the picker")
+        XCTAssertNotNil(vm.selectedAccountId,
+                        "Should resolve account ID from transaction's account name")
+        XCTAssertEqual(vm.selectedAccountId, "a1",
+                       "Main Checking should resolve to account ID a1")
+    }
+
+    // MARK: - Test: hasChanges detection
+
+    @MainActor
+    func testHasChangesReturnsFalseWhenUnmodified() async {
+        let (vm, _, _) = makeViewModel()
+
+        await vm.loadData()
+
+        XCTAssertFalse(vm.hasChanges,
+                       "hasChanges should be false when no fields have been modified")
+    }
+
+    @MainActor
+    func testHasChangesDetectsPayeeChange() async {
+        let (vm, _, _) = makeViewModel()
+
+        await vm.loadData()
+        vm.payee = "New Payee Name"
+
+        XCTAssertTrue(vm.hasChanges,
+                      "hasChanges should be true after modifying the payee")
+    }
+
+    @MainActor
+    func testHasChangesDetectsAmountChange() async {
+        let (vm, _, _) = makeViewModel()
+
+        await vm.loadData()
+        vm.amountText = "999.99"
+
+        XCTAssertTrue(vm.hasChanges,
+                      "hasChanges should be true after modifying the amount")
+    }
+
+    @MainActor
+    func testHasChangesDetectsTypeChange() async {
+        let (vm, _, _) = makeViewModel()
+
+        await vm.loadData()
+        vm.transactionType = .income
+
+        XCTAssertTrue(vm.hasChanges,
+                      "hasChanges should be true after modifying the transaction type")
+    }
+
+    @MainActor
+    func testHasChangesDetectsNoteChange() async {
+        let (vm, _, _) = makeViewModel()
+
+        await vm.loadData()
+        vm.note = "A new note"
+
+        XCTAssertTrue(vm.hasChanges,
+                      "hasChanges should be true after adding a note")
+    }
+
+    @MainActor
+    func testHasChangesDetectsDateChange() async {
+        let (vm, _, _) = makeViewModel()
+
+        await vm.loadData()
+        vm.date = Calendar.current.date(byAdding: .day, value: -7, to: vm.date)!
+
+        XCTAssertTrue(vm.hasChanges,
+                      "hasChanges should be true after modifying the date")
+    }
+
+    @MainActor
+    func testHasChangesDetectsAccountChange() async {
+        let (vm, _, _) = makeViewModel()
+
+        await vm.loadData()
+        vm.selectedAccountId = "a2"
+
+        XCTAssertTrue(vm.hasChanges,
+                      "hasChanges should be true after selecting a different account")
+    }
+
+    // MARK: - Test: Save calls updateTransaction on repository
+
+    @MainActor
+    func testSaveCallsUpdateTransactionOnRepository() async {
+        let (vm, transactionRepo, _) = makeViewModel()
+
+        await vm.loadData()
+        vm.payee = "Updated Payee"
+
+        let result = await vm.save()
+
+        XCTAssertTrue(result, "Save should succeed with valid pre-populated data")
+        XCTAssertEqual(transactionRepo.updatedTransactions.count, 1,
+                       "Repository should have one updated transaction")
+        XCTAssertEqual(transactionRepo.updatedTransactions.first?.payee, "Updated Payee",
+                       "Updated transaction should reflect the new payee")
+        XCTAssertEqual(transactionRepo.updatedTransactions.first?.id, SampleData.expenseTransaction.id,
+                       "Updated transaction should preserve the original ID")
+    }
+
+    @MainActor
+    func testSavePreservesOriginalIdAndStatus() async {
+        let transaction = TransactionItem(
+            id: "original-id-123", payee: "Test Payee",
+            category: "Groceries", accountName: "Main Checking",
+            amountMinorUnits: -50_00, currencyCode: "USD",
+            date: .now, type: .expense, status: .pending
+        )
+        let (vm, transactionRepo, _) = makeViewModel(transaction: transaction)
+
+        await vm.loadData()
+
+        let result = await vm.save()
+
+        XCTAssertTrue(result, "Save should succeed")
+        let updated = transactionRepo.updatedTransactions.first
+        XCTAssertEqual(updated?.id, "original-id-123",
+                       "Updated transaction must preserve the original ID")
+        XCTAssertEqual(updated?.status, .pending,
+                       "Updated transaction must preserve the original status")
+    }
+
+    @MainActor
+    func testSaveDoesNotCreateNewTransaction() async {
+        let (vm, transactionRepo, _) = makeViewModel()
+
+        await vm.loadData()
+
+        _ = await vm.save()
+
+        XCTAssertTrue(transactionRepo.createdTransactions.isEmpty,
+                      "Edit save should call updateTransaction, not createTransaction")
+    }
+
+    @MainActor
+    func testSaveIncludesNoteWhenProvided() async {
+        let (vm, transactionRepo, _) = makeViewModel()
+
+        await vm.loadData()
+        vm.note = "Updated note text"
+
+        _ = await vm.save()
+
+        XCTAssertEqual(transactionRepo.updatedTransactions.first?.note, "Updated note text",
+                       "Updated transaction should include the note")
+    }
+
+    @MainActor
+    func testSaveOmitsNoteWhenEmpty() async {
+        let (vm, transactionRepo, _) = makeViewModel()
+
+        await vm.loadData()
+        vm.note = ""
+
+        _ = await vm.save()
+
+        XCTAssertNil(transactionRepo.updatedTransactions.first?.note,
+                     "Updated transaction should have nil note when note is empty")
+    }
+
+    @MainActor
+    func testSaveHandlesRepositoryError() async {
+        let (vm, transactionRepo, _) = makeViewModel()
+
+        await vm.loadData()
+        transactionRepo.errorToThrow = TestError.simulated
+
+        let result = await vm.save()
+
+        XCTAssertFalse(result, "Save should return false when repository throws")
+        XCTAssertTrue(vm.showingValidationError, "Should show error to user")
+        XCTAssertFalse(vm.validationMessage.isEmpty, "Error message should be populated")
+    }
+
+    // MARK: - Test: Validation (same rules as create)
+
+    @MainActor
+    func testSaveFailsWithEmptyAmount() async {
+        let (vm, transactionRepo, _) = makeViewModel()
+
+        await vm.loadData()
+        vm.amountText = ""
+
+        let result = await vm.save()
+
+        XCTAssertFalse(result, "Save should fail with empty amount")
+        XCTAssertTrue(vm.showingValidationError, "Should show validation error")
+        XCTAssertTrue(transactionRepo.updatedTransactions.isEmpty,
+                      "Repository should not be called when validation fails")
+    }
+
+    @MainActor
+    func testSaveFailsWithZeroAmount() async {
+        let (vm, transactionRepo, _) = makeViewModel()
+
+        await vm.loadData()
+        vm.amountText = "0.00"
+
+        let result = await vm.save()
+
+        XCTAssertFalse(result, "Save should fail with zero amount")
+        XCTAssertTrue(vm.showingValidationError, "Should show validation error")
+        XCTAssertTrue(transactionRepo.updatedTransactions.isEmpty,
+                      "Repository should not be called when validation fails")
+    }
+
+    @MainActor
+    func testSaveFailsWithEmptyPayee() async {
+        let (vm, transactionRepo, _) = makeViewModel()
+
+        await vm.loadData()
+        vm.payee = ""
+
+        let result = await vm.save()
+
+        XCTAssertFalse(result, "Save should fail with empty payee")
+        XCTAssertTrue(vm.showingValidationError, "Should show validation error")
+        XCTAssertTrue(transactionRepo.updatedTransactions.isEmpty,
+                      "Repository should not be called when validation fails")
+    }
+
+    @MainActor
+    func testSaveFailsWithNoAccount() async {
+        let (vm, transactionRepo, _) = makeViewModel()
+
+        await vm.loadData()
+        vm.selectedAccountId = nil
+
+        let result = await vm.save()
+
+        XCTAssertFalse(result, "Save should fail without a selected account")
+        XCTAssertTrue(vm.showingValidationError, "Should show validation error")
+        XCTAssertTrue(transactionRepo.updatedTransactions.isEmpty,
+                      "Repository should not be called when validation fails")
+    }
+
+    // MARK: - Test: Cancel doesn't modify original
+
+    @MainActor
+    func testCancelDoesNotModifyOriginalTransaction() async {
+        let original = SampleData.expenseTransaction
+        let (vm, transactionRepo, _) = makeViewModel(transaction: original)
+
+        await vm.loadData()
+
+        // Modify every field
+        vm.transactionType = .income
+        vm.amountText = "9999.99"
+        vm.payee = "Completely Different Payee"
+        vm.selectedAccountId = "a2"
+        vm.selectedCategoryId = "c4"
+        vm.date = Date.distantPast
+        vm.note = "Modified note"
+
+        // Simulate cancel — don't call save
+
+        XCTAssertEqual(vm.originalTransaction.id, original.id,
+                       "Original transaction ID should be unchanged")
+        XCTAssertEqual(vm.originalTransaction.payee, original.payee,
+                       "Original transaction payee should be unchanged")
+        XCTAssertEqual(vm.originalTransaction.amountMinorUnits, original.amountMinorUnits,
+                       "Original transaction amount should be unchanged")
+        XCTAssertEqual(vm.originalTransaction.type, original.type,
+                       "Original transaction type should be unchanged")
+        XCTAssertTrue(transactionRepo.updatedTransactions.isEmpty,
+                      "No repository calls should be made on cancel")
+    }
+
+    // MARK: - Test: Step navigation
+
+    @MainActor
+    func testStepNavigation() async {
+        let (vm, _, _) = makeViewModel()
+
+        XCTAssertEqual(vm.currentStep, .type, "Initial step should be .type")
+
+        vm.advance()
+        XCTAssertEqual(vm.currentStep, .details, "Should advance to .details")
+
+        vm.advance()
+        XCTAssertEqual(vm.currentStep, .review, "Should advance to .review")
+
+        vm.advance()
+        XCTAssertEqual(vm.currentStep, .review, "Should stay at .review when at last step")
+
+        vm.goBack()
+        XCTAssertEqual(vm.currentStep, .details, "Should go back to .details")
+
+        vm.goBack()
+        XCTAssertEqual(vm.currentStep, .type, "Should go back to .type")
+
+        vm.goBack()
+        XCTAssertEqual(vm.currentStep, .type, "Should stay at .type when at first step")
+    }
+
+    // MARK: - Test: canAdvance
+
+    @MainActor
+    func testCanAdvanceOnTypeStepAlwaysTrue() async {
+        let (vm, _, _) = makeViewModel()
+
+        XCTAssertTrue(vm.canAdvance,
+                      "Should always be able to advance from the type step")
+    }
+
+    @MainActor
+    func testCanAdvanceRequiresDetailsFields() async {
+        let (vm, _, _) = makeViewModel()
+
+        vm.currentStep = .details
+        vm.amountText = ""
+        vm.payee = ""
+        vm.selectedAccountId = nil
+
+        XCTAssertFalse(vm.canAdvance,
+                       "Should not advance on details step without amount, payee, and account")
+
+        vm.amountText = "50.00"
+        vm.payee = "Test Payee"
+        vm.selectedAccountId = "a1"
+
+        XCTAssertTrue(vm.canAdvance,
+                      "Should advance when all details fields are populated")
+    }
+
+    // MARK: - Test: Income amount sign
+
+    @MainActor
+    func testSaveAppliesPositiveAmountForIncome() async {
+        let transaction = TransactionItem(
+            id: "t-income", payee: "Payroll",
+            category: "Income", accountName: "Main Checking",
+            amountMinorUnits: 4_250_00, currencyCode: "USD",
+            date: .now, type: .income, status: .cleared
+        )
+        let (vm, transactionRepo, _) = makeViewModel(transaction: transaction)
+
+        await vm.loadData()
+
+        let result = await vm.save()
+
+        XCTAssertTrue(result, "Save should succeed")
+        let updated = transactionRepo.updatedTransactions.first
+        XCTAssertNotNil(updated)
+        XCTAssertGreaterThan(updated?.amountMinorUnits ?? 0, 0,
+                             "Income transaction should have positive amount")
+    }
+
+    @MainActor
+    func testSaveAppliesNegativeAmountForExpense() async {
+        let (vm, transactionRepo, _) = makeViewModel()
+
+        await vm.loadData()
+
+        let result = await vm.save()
+
+        XCTAssertTrue(result, "Save should succeed")
+        let updated = transactionRepo.updatedTransactions.first
+        XCTAssertNotNil(updated)
+        XCTAssertLessThan(updated?.amountMinorUnits ?? 0, 0,
+                          "Expense transaction should have negative amount")
+    }
+}


### PR DESCRIPTION
New feature screens and services:

**Data Export (#472):** DataExportService actor with CSV/JSON generation, RFC 4180 escaping, share sheet. 28 tests.

**Transaction Edit (#473):** TransactionEditView 3-step wizard with change detection and discard confirmation. 20 tests.

**Privacy & About (#474):** PrivacyPolicyView (9 sections), AboutView, LicensesView (8 libraries). 80 localized strings.

> **Stacked PR** — merge #491 first

Closes #472
Closes #473
Closes #474