### PR TITLE
chore: fix AI instruction inaccuracies and broken doc links

### DIFF
--- a/.github/agents/kmp-engineer.agent.md
+++ b/.github/agents/kmp-engineer.agent.md
@@ -16,7 +16,7 @@ You are the KMP engineer for Finance, a multi-platform financial tracking applic
 
 # Expertise Areas
 
-- Kotlin Multiplatform project configuration (commonMain, iosMain, androidMain, jvmMain, jsMain, wasmJsMain)
+- Kotlin Multiplatform project configuration (commonMain, iosMain, androidMain, jvmMain, jsMain)
 - expect/actual declarations and platform-specific implementations
 - SQLDelight (`.sq` files, type-safe queries, migrations, multi-platform drivers)
 - SQLCipher integration for encrypted SQLite on all platforms
@@ -26,8 +26,8 @@ You are the KMP engineer for Finance, a multi-platform financial tracking applic
 - kotlinx-coroutines (Flow, StateFlow, structured concurrency, dispatcher management)
 - Gradle Kotlin DSL for KMP (version catalogs, composite builds, target configuration)
 - KMP testing (kotlin.test, turbine for Flow testing, MockK)
-- Swift Export and Objective-C interop patterns (nullability annotations, generics mapping)
-- Kotlin/JS and Kotlin/Wasm targets for web (IR compiler, npm interop, WASM memory model)
+- Swift Export and Objective-C interop patterns (planned — iOS is currently pure SwiftUI, KMP bridge not yet wired)
+- Kotlin/JS target for web (IR compiler, npm interop — web app currently uses TypeScript + React with planned KMP integration)
 - PowerSync Kotlin SDK integration for offline-first sync
 - Multiplatform Settings / MMKV for key-value storage
 - Value classes, inline classes, and type-safe domain primitives

--- a/.github/instructions/apps.instructions.md
+++ b/.github/instructions/apps.instructions.md
@@ -8,9 +8,9 @@ You are working in the `apps/` directory, which contains platform-specific appli
 
 ## Platform Subdirectories
 
-- `apps/ios/` — iOS, iPadOS, macOS, watchOS — **SwiftUI**, KMP via Swift Export, Apple Keychain for secure storage, VoiceOver accessibility
+- `apps/ios/` — iOS, iPadOS, macOS, watchOS — **SwiftUI**, KMP integration planned via Swift Export (currently pure Swift), Apple Keychain for secure storage, VoiceOver accessibility
 - `apps/android/` — Android phones, tablets, Wear OS — **Jetpack Compose**, KMP direct dependency, Material 3 design system, TalkBack accessibility
-- `apps/web/` — Progressive Web App — **Kotlin/JS or TypeScript + React**, SQLite-WASM for local storage, ARIA attributes for accessibility, PWA with service worker
+- `apps/web/` — Progressive Web App — **TypeScript + React** (Kotlin/JS integration planned via `src/kmp/`), SQLite via wa-sqlite for local storage, ARIA attributes for accessibility, PWA with service worker
 - `apps/windows/` — Windows 11 native app — **Compose Desktop (JVM)**, Windows Hello for biometric auth, Narrator accessibility
 
 ## Guidelines

--- a/.github/instructions/packages.instructions.md
+++ b/.github/instructions/packages.instructions.md
@@ -36,7 +36,10 @@ These are `commonMain` interfaces — platform `actual` implementations live in 
 
 ## KMP (Kotlin Multiplatform) Requirements
 
-- Code must compile for **all** KMP targets: `commonMain`, `iosMain`, `androidMain`, `jvmMain`, `jsMain`
+- Code must compile for applicable KMP targets per package:
+  - **packages/core** (business logic): `commonMain`, `iosMain`, `jvmMain`, `jsMain`
+  - **packages/models** (data models): `commonMain`, `iosMain`, `androidMain`, `jvmMain`, `jsMain`
+  - **packages/sync** (sync engine): `commonMain`, `iosMain`, `androidMain`, `jvmMain`, `jsMain`
 - Use `expect`/`actual` declarations for platform-specific APIs — keep `expect` in `commonMain`, `actual` in each target source set
 - Use **SQLDelight** for all database access — define schemas and queries in `.sq` files, never write raw SQL strings in Kotlin
 - Use **kotlinx-datetime** for all date/time operations — no `java.time` or platform date APIs in shared code

--- a/docs/architecture/roadmap.md
+++ b/docs/architecture/roadmap.md
@@ -569,12 +569,12 @@ All technology decisions from Phase 0 have been confirmed and documented as ADRs
 
 ### Research Documents
 
-- [Cross-Platform Framework Research](../../.github/research/cross-platform.md) — KMP, React Native, Flutter, .NET MAUI evaluation
-- [Backend & Sync Architecture Research](../../.github/research/backend-sync.md) — Supabase, Firebase, PowerSync, ElectricSQL, Custom, PocketBase
-- [Local Database & Storage Research](../../.github/research/local-storage.md) — SQLite, Realm, WatermelonDB, MMKV, IndexedDB, Drift
-- [Authentication & Security Research](../../.github/research/auth-security.md) — OAuth 2.0/PKCE, Passkeys, biometrics, encryption, RBAC, compliance
-- [Design System & UI Architecture Research](../../.github/research/design-system.md) — Design tokens, accessibility, financial UI patterns, charting
-- [CI/CD & Release Strategy Research](../../.github/research/cicd.md) — GitHub Actions, Turborepo, Fastlane, testing strategy, cost optimization
+- [ADR-0001: Cross-Platform Framework](./0001-cross-platform-framework.md) — KMP, React Native, Flutter, .NET MAUI evaluation
+- [ADR-0002: Backend & Sync Architecture](./0002-backend-sync-architecture.md) — Supabase, Firebase, PowerSync, ElectricSQL, Custom, PocketBase
+- [ADR-0003: Local Database & Storage](./0003-local-storage-strategy.md) — SQLite, Realm, WatermelonDB, MMKV, IndexedDB, Drift
+- [ADR-0004: Authentication & Security](./0004-auth-security-architecture.md) — OAuth 2.0/PKCE, Passkeys, biometrics, encryption, RBAC, compliance
+- [ADR-0005: Design System & UI Architecture](./0005-design-system-approach.md) — Design tokens, accessibility, financial UI patterns, charting
+- [ADR-0006: CI/CD & Release Strategy](./0006-cicd-strategy.md) — GitHub Actions, Turborepo, Fastlane, testing strategy, cost optimization
 
 ### Project Documents
 

--- a/docs/guides/launch-checklist.md
+++ b/docs/guides/launch-checklist.md
@@ -45,7 +45,7 @@ All security audit items must pass before release. A single FAIL-level item bloc
 
 All accessibility audit items must pass on every platform before release.
 
-- [ ] **Accessibility audit passed** — Complete the [WCAG 2.2 AA Accessibility Checklist](../audits/accessibility-checklist.md) on all four platforms.
+- [ ] **Accessibility audit passed** — Complete WCAG 2.2 AA accessibility audit on all four platforms (see [Accessibility Features Guide](../guides/accessibility.md)).
   - [ ] Screen reader verification: TalkBack (Android), VoiceOver (iOS), NVDA/JAWS (Web), Narrator (Windows)
   - [ ] All interactive elements announced with correct roles and descriptive labels
   - [ ] Financial amounts read correctly by screen readers
@@ -136,7 +136,7 @@ All accessibility audit items must pass on every platform before release.
 
 ## Documentation
 
-- [ ] **User documentation published** — the [User Guide](../user-guide/README.md) is complete, accurate, and accessible from in-app help.
+- [ ] **User documentation published** — the [User Guides](../guides/getting-started.md) are complete, accurate, and accessible from in-app help.
   - [ ] Getting started guide covers account creation, first account, first transaction
   - [ ] All features documented: accounts, transactions, budgeting, goals, reports, data management, settings
   - [ ] FAQ answers common questions: offline support, multi-device, security, sharing
@@ -169,10 +169,10 @@ All accessibility audit items must pass on every platform before release.
 
 ## References
 
-- [User Guide](../user-guide/README.md) — End-user documentation
+- [User Guides](../guides/getting-started.md) — End-user documentation
 - [Release Process](release-process.md) — Release workflows, versioning, hotfix, and rollback
 - [Performance Guide](performance.md) — Performance targets and benchmarking
 - [Security Checklist](../audits/security-checklist.md) — OWASP MASVS L1 audit
-- [Accessibility Checklist](../audits/accessibility-checklist.md) — WCAG 2.2 AA audit
+- [Accessibility Guide](../guides/accessibility.md) — WCAG 2.2 AA features and testing
 - [System Architecture Roadmap](../architecture/roadmap.md) — Phase definitions and technology decisions
 - [CI/CD Strategy (ADR-0006)](../architecture/0006-cicd-strategy.md) — Pipeline architecture

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build:tokens": "npm run build -w packages/design-tokens",
     "test": "npm run test:kmp && turbo run test",
     "test:kmp": "node tools/gradle.js :packages:core:jvmTest",
+    "test:web": "npm run test -w apps/web",
     "lint": "turbo run lint && npx eslint .",
     "lint:fix": "npx eslint . --fix",
     "type-check": "turbo run type-check",


### PR DESCRIPTION
## Summary
Fix inaccurate AI agent instructions and broken documentation links that cause agents to produce wrong output and developers to hit dead-end references.

## AI Instruction Fixes

### kmp-engineer.agent.md
- Remove non-existent `wasmJsMain` target from expertise list
- Clarify Swift Export as planned (iOS is currently pure SwiftUI)
- Clarify Kotlin/JS web target as planned (web uses TypeScript+React)

### apps.instructions.md
- Web: `Kotlin/JS or TypeScript + React` -> `TypeScript + React` (Kotlin/JS planned)
- iOS: Clarify KMP integration is planned, not active

### packages.instructions.md
- Replace blanket "all KMP targets" claim with per-package breakdown
- packages/core has no androidMain; only models and sync do

## Documentation Link Fixes

### roadmap.md
- Replace 6 broken `.github/research/` links with existing ADR documents (0001-0006)

### launch-checklist.md
- Fix 4 broken links: accessibility-checklist.md and user-guide/ don't exist
- Point to actual guides: accessibility.md, getting-started.md

## DX
- Add `test:web` npm script

## Related Issues Created
- #494: Add Android CI workflow
- #495: Consolidate duplicate dependency-review workflows
- #496: Document branch protection configuration
- #497: README project status accuracy review
- #498: Add ready-for-pr validation script

Refs #497
