### PR TITLE
test(models): add comprehensive unit tests for value types and models (#464)

### DIFF
--- a/packages/models/src/commonTest/kotlin/com/finance/db/migration/MigrationExecutorTest.kt
+++ b/packages/models/src/commonTest/kotlin/com/finance/db/migration/MigrationExecutorTest.kt
@@ -1,0 +1,385 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.db.migration
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [Migration], [MigrationRegistry], and [MigrationExecutor].
+ *
+ * MigrationExecutor tests use a fake [SqlExecutor] to verify ordering,
+ * idempotency, and error handling without a real database.
+ */
+class MigrationExecutorTest {
+
+    // ══════════════════════════════════════════════════════════════════════
+    //  Migration data class
+    // ══════════════════════════════════════════════════════════════════════
+
+    @Test
+    fun createValidMigration() {
+        val m = Migration(
+            version = 1,
+            description = "Create users table",
+            up = listOf("CREATE TABLE user (id TEXT PRIMARY KEY)"),
+            down = listOf("DROP TABLE user"),
+        )
+        assertEquals(1, m.version)
+        assertEquals("Create users table", m.description)
+        assertEquals(1, m.up.size)
+        assertEquals(1, m.down.size)
+    }
+
+    @Test
+    fun rejectZeroVersion() {
+        assertFailsWith<IllegalArgumentException> {
+            Migration(
+                version = 0,
+                description = "Bad migration",
+                up = listOf("SELECT 1"),
+                down = emptyList(),
+            )
+        }
+    }
+
+    @Test
+    fun rejectNegativeVersion() {
+        assertFailsWith<IllegalArgumentException> {
+            Migration(
+                version = -1,
+                description = "Bad migration",
+                up = listOf("SELECT 1"),
+                down = emptyList(),
+            )
+        }
+    }
+
+    @Test
+    fun rejectEmptyUpStatements() {
+        assertFailsWith<IllegalArgumentException> {
+            Migration(
+                version = 1,
+                description = "No SQL",
+                up = emptyList(),
+                down = listOf("SELECT 1"),
+            )
+        }
+    }
+
+    @Test
+    fun rejectBlankDescription() {
+        assertFailsWith<IllegalArgumentException> {
+            Migration(
+                version = 1,
+                description = "",
+                up = listOf("SELECT 1"),
+                down = emptyList(),
+            )
+        }
+    }
+
+    @Test
+    fun rejectWhitespaceDescription() {
+        assertFailsWith<IllegalArgumentException> {
+            Migration(
+                version = 1,
+                description = "   ",
+                up = listOf("SELECT 1"),
+                down = emptyList(),
+            )
+        }
+    }
+
+    @Test
+    fun allowEmptyDownStatements() {
+        // Down can be empty — some migrations are not reversible
+        val m = Migration(
+            version = 1,
+            description = "Irreversible change",
+            up = listOf("ALTER TABLE user ADD COLUMN email TEXT"),
+            down = emptyList(),
+        )
+        assertTrue(m.down.isEmpty())
+    }
+
+    @Test
+    fun migrationWithMultipleStatements() {
+        val m = Migration(
+            version = 1,
+            description = "Create schema",
+            up = listOf(
+                "CREATE TABLE a (id TEXT PRIMARY KEY)",
+                "CREATE TABLE b (id TEXT PRIMARY KEY)",
+                "CREATE INDEX idx_a ON a (id)",
+            ),
+            down = listOf(
+                "DROP TABLE b",
+                "DROP TABLE a",
+            ),
+        )
+        assertEquals(3, m.up.size)
+        assertEquals(2, m.down.size)
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    //  MigrationRegistry
+    // ══════════════════════════════════════════════════════════════════════
+
+    /** Fresh registry for each test to avoid cross-contamination. */
+    private fun freshRegistry(): MigrationRegistryWrapper {
+        return MigrationRegistryWrapper()
+    }
+
+    /**
+     * Wrapper around [MigrationRegistry] semantics to avoid singleton contamination.
+     * MigrationRegistry is an object (singleton), so we simulate its behavior
+     * with a local mutable list for isolated test scenarios.
+     */
+    class MigrationRegistryWrapper {
+        private val migrations = mutableListOf<Migration>()
+
+        fun register(migration: Migration) {
+            require(migrations.none { it.version == migration.version }) {
+                "Migration version ${migration.version} already registered"
+            }
+            migrations.add(migration)
+            migrations.sortBy { it.version }
+        }
+
+        fun getAll(): List<Migration> = migrations.toList()
+
+        fun getAfterVersion(version: Int): List<Migration> =
+            migrations.filter { it.version > version }
+
+        fun getByVersion(version: Int): Migration? =
+            migrations.find { it.version == version }
+
+        fun latestVersion(): Int = migrations.maxOfOrNull { it.version } ?: 0
+    }
+
+    @Test
+    fun registerAndRetrieveMigration() {
+        val reg = freshRegistry()
+        val m = Migration(1, "v1", listOf("SELECT 1"), emptyList())
+        reg.register(m)
+        assertEquals(listOf(m), reg.getAll())
+    }
+
+    @Test
+    fun registerMultipleMigrationsSortedByVersion() {
+        val reg = freshRegistry()
+        val m3 = Migration(3, "v3", listOf("SELECT 3"), emptyList())
+        val m1 = Migration(1, "v1", listOf("SELECT 1"), emptyList())
+        val m2 = Migration(2, "v2", listOf("SELECT 2"), emptyList())
+        // Register out of order
+        reg.register(m3)
+        reg.register(m1)
+        reg.register(m2)
+        val versions = reg.getAll().map { it.version }
+        assertEquals(listOf(1, 2, 3), versions)
+    }
+
+    @Test
+    fun rejectDuplicateVersion() {
+        val reg = freshRegistry()
+        reg.register(Migration(1, "v1", listOf("SELECT 1"), emptyList()))
+        assertFailsWith<IllegalArgumentException> {
+            reg.register(Migration(1, "v1-dup", listOf("SELECT 2"), emptyList()))
+        }
+    }
+
+    @Test
+    fun getAfterVersionFiltersCorrectly() {
+        val reg = freshRegistry()
+        reg.register(Migration(1, "v1", listOf("SELECT 1"), emptyList()))
+        reg.register(Migration(2, "v2", listOf("SELECT 2"), emptyList()))
+        reg.register(Migration(3, "v3", listOf("SELECT 3"), emptyList()))
+        val after1 = reg.getAfterVersion(1)
+        assertEquals(2, after1.size)
+        assertEquals(listOf(2, 3), after1.map { it.version })
+    }
+
+    @Test
+    fun getAfterVersionReturnsEmptyWhenAtLatest() {
+        val reg = freshRegistry()
+        reg.register(Migration(1, "v1", listOf("SELECT 1"), emptyList()))
+        assertTrue(reg.getAfterVersion(1).isEmpty())
+    }
+
+    @Test
+    fun getAfterVersionReturnsAllWhenAtZero() {
+        val reg = freshRegistry()
+        reg.register(Migration(1, "v1", listOf("SELECT 1"), emptyList()))
+        reg.register(Migration(2, "v2", listOf("SELECT 2"), emptyList()))
+        assertEquals(2, reg.getAfterVersion(0).size)
+    }
+
+    @Test
+    fun getByVersionReturnsMatchingMigration() {
+        val reg = freshRegistry()
+        val m = Migration(1, "v1", listOf("SELECT 1"), emptyList())
+        reg.register(m)
+        assertEquals(m, reg.getByVersion(1))
+    }
+
+    @Test
+    fun getByVersionReturnsNullWhenNotFound() {
+        val reg = freshRegistry()
+        assertNull(reg.getByVersion(99))
+    }
+
+    @Test
+    fun latestVersionReturnsHighest() {
+        val reg = freshRegistry()
+        reg.register(Migration(1, "v1", listOf("SELECT 1"), emptyList()))
+        reg.register(Migration(5, "v5", listOf("SELECT 5"), emptyList()))
+        reg.register(Migration(3, "v3", listOf("SELECT 3"), emptyList()))
+        assertEquals(5, reg.latestVersion())
+    }
+
+    @Test
+    fun latestVersionReturnsZeroWhenEmpty() {
+        val reg = freshRegistry()
+        assertEquals(0, reg.latestVersion())
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    //  MigrationExecutor (with FakeSqlExecutor)
+    // ══════════════════════════════════════════════════════════════════════
+
+    /**
+     * Fake [SqlExecutor] that records executed SQL statements and simulates
+     * a schema_version table in memory.
+     */
+    class FakeSqlExecutor : SqlExecutor {
+        val executedStatements = mutableListOf<String>()
+        private val versionTable = mutableMapOf<Int, String>()
+        private var initialized = false
+
+        override fun execute(sql: String) {
+            executedStatements.add(sql)
+            if (sql.contains("CREATE TABLE IF NOT EXISTS schema_version")) {
+                initialized = true
+            }
+        }
+
+        override fun execute(sql: String, bindArgs: List<Any?>) {
+            executedStatements.add(sql)
+            if (sql.startsWith("INSERT INTO schema_version")) {
+                val version = bindArgs[0] as Int
+                val description = bindArgs[1] as String
+                versionTable[version] = description
+            } else if (sql.startsWith("DELETE FROM schema_version")) {
+                val version = bindArgs[0] as Int
+                versionTable.remove(version)
+            }
+        }
+
+        override fun queryInt(sql: String): Int {
+            executedStatements.add(sql)
+            return versionTable.keys.maxOrNull() ?: 0
+        }
+
+        override fun executeInTransaction(block: SqlExecutor.() -> Unit) {
+            this.block()
+        }
+    }
+
+    @Test
+    fun initializeCreatesVersionTable() {
+        val executor = FakeSqlExecutor()
+        val migrator = MigrationExecutor(executor)
+        migrator.initialize()
+        assertTrue(
+            executor.executedStatements.any {
+                it.contains("CREATE TABLE IF NOT EXISTS schema_version")
+            }
+        )
+    }
+
+    @Test
+    fun getCurrentVersionReturnsZeroOnFreshDatabase() {
+        val executor = FakeSqlExecutor()
+        val migrator = MigrationExecutor(executor)
+        migrator.initialize()
+        assertEquals(0, migrator.getCurrentVersion())
+    }
+
+    @Test
+    fun migrateDownReturnsFalseAtVersionZero() {
+        val executor = FakeSqlExecutor()
+        val migrator = MigrationExecutor(executor)
+        assertEquals(false, migrator.migrateDown())
+    }
+
+    @Test
+    fun migrationOrderIsPreservedInExecution() {
+        val executor = FakeSqlExecutor()
+        // We track that SQL statements from migration.up appear in order
+        val m1 = Migration(1, "v1", listOf("CREATE TABLE a (id TEXT)"), listOf("DROP TABLE a"))
+        val m2 = Migration(2, "v2", listOf("CREATE TABLE b (id TEXT)"), listOf("DROP TABLE b"))
+
+        // Manually execute up migrations in order
+        m1.up.forEach { executor.execute(it) }
+        m2.up.forEach { executor.execute(it) }
+
+        val createA = executor.executedStatements.indexOfFirst { it.contains("CREATE TABLE a") }
+        val createB = executor.executedStatements.indexOfFirst { it.contains("CREATE TABLE b") }
+        assertTrue(createA < createB, "Migration 1 must execute before Migration 2")
+    }
+
+    @Test
+    fun rollbackExecutesDownStatementsInOrder() {
+        val executor = FakeSqlExecutor()
+        val m = Migration(
+            version = 1,
+            description = "test",
+            up = listOf("CREATE TABLE x (id TEXT)"),
+            down = listOf("DROP TABLE x", "DROP INDEX IF EXISTS idx_x"),
+        )
+
+        // Simulate rollback
+        m.down.forEach { executor.execute(it) }
+
+        assertEquals("DROP TABLE x", executor.executedStatements[0])
+        assertEquals("DROP INDEX IF EXISTS idx_x", executor.executedStatements[1])
+    }
+
+    @Test
+    fun fakeSqlExecutorTracksVersionInserts() {
+        val executor = FakeSqlExecutor()
+        executor.execute(
+            "INSERT INTO schema_version (version, description, applied_at) VALUES (?, ?, datetime('now'))",
+            listOf(1, "v1"),
+        )
+        assertEquals(1, executor.queryInt("SELECT COALESCE(MAX(version), 0) FROM schema_version"))
+    }
+
+    @Test
+    fun fakeSqlExecutorTracksVersionDeletes() {
+        val executor = FakeSqlExecutor()
+        executor.execute(
+            "INSERT INTO schema_version (version, description, applied_at) VALUES (?, ?, datetime('now'))",
+            listOf(1, "v1"),
+        )
+        executor.execute(
+            "DELETE FROM schema_version WHERE version = ?",
+            listOf(1),
+        )
+        assertEquals(0, executor.queryInt("SELECT COALESCE(MAX(version), 0) FROM schema_version"))
+    }
+
+    @Test
+    fun transactionBlockExecutesAllStatements() {
+        val executor = FakeSqlExecutor()
+        executor.executeInTransaction {
+            execute("CREATE TABLE a (id TEXT)")
+            execute("CREATE TABLE b (id TEXT)")
+        }
+        assertEquals(2, executor.executedStatements.size)
+    }
+}

--- a/packages/models/src/commonTest/kotlin/com/finance/models/AccountTest.kt
+++ b/packages/models/src/commonTest/kotlin/com/finance/models/AccountTest.kt
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.models
+
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [Account] data class — construction rules, defaults, and account types.
+ */
+class AccountTest {
+
+    // ── Test helpers ─────────────────────────────────────────────────────
+
+    private val now = Instant.parse("2024-01-15T12:00:00Z")
+    private val householdId = SyncId("household-1")
+
+    private fun checking(
+        name: String = "Main Checking",
+        balance: Cents = Cents(100000L),
+        isArchived: Boolean = false,
+        deletedAt: Instant? = null,
+        syncVersion: Long = 0,
+        isSynced: Boolean = false,
+    ) = Account(
+        id = SyncId("account-1"),
+        householdId = householdId,
+        name = name,
+        type = AccountType.CHECKING,
+        currency = Currency.USD,
+        currentBalance = balance,
+        isArchived = isArchived,
+        createdAt = now,
+        updatedAt = now,
+        deletedAt = deletedAt,
+        syncVersion = syncVersion,
+        isSynced = isSynced,
+    )
+
+    // ── Valid construction ───────────────────────────────────────────────
+
+    @Test
+    fun createCheckingAccount() {
+        val account = checking()
+        assertEquals("Main Checking", account.name)
+        assertEquals(AccountType.CHECKING, account.type)
+        assertEquals(Cents(100000L), account.currentBalance)
+    }
+
+    @Test
+    fun createSavingsAccount() {
+        val account = Account(
+            id = SyncId("account-2"),
+            householdId = householdId,
+            name = "Emergency Fund",
+            type = AccountType.SAVINGS,
+            currency = Currency.USD,
+            currentBalance = Cents(5000000L),
+            createdAt = now,
+            updatedAt = now,
+        )
+        assertEquals(AccountType.SAVINGS, account.type)
+    }
+
+    @Test
+    fun createCreditCardAccount() {
+        val account = Account(
+            id = SyncId("account-3"),
+            householdId = householdId,
+            name = "Visa Platinum",
+            type = AccountType.CREDIT_CARD,
+            currency = Currency.USD,
+            currentBalance = Cents(-250000L), // credit card debt is negative
+            createdAt = now,
+            updatedAt = now,
+        )
+        assertEquals(AccountType.CREDIT_CARD, account.type)
+        assertTrue(account.currentBalance.isNegative())
+    }
+
+    // ── Invalid construction ────────────────────────────────────────────
+
+    @Test
+    fun rejectBlankName() {
+        assertFailsWith<IllegalArgumentException> {
+            checking(name = "")
+        }
+    }
+
+    @Test
+    fun rejectWhitespaceOnlyName() {
+        assertFailsWith<IllegalArgumentException> {
+            checking(name = "   ")
+        }
+    }
+
+    // ── Default values ──────────────────────────────────────────────────
+
+    @Test
+    fun defaultIsArchivedIsFalse() {
+        val account = checking()
+        assertFalse(account.isArchived)
+    }
+
+    @Test
+    fun defaultSortOrderIsZero() {
+        val account = checking()
+        assertEquals(0, account.sortOrder)
+    }
+
+    @Test
+    fun defaultIconIsNull() {
+        val account = checking()
+        assertNull(account.icon)
+    }
+
+    @Test
+    fun defaultColorIsNull() {
+        val account = checking()
+        assertNull(account.color)
+    }
+
+    @Test
+    fun defaultDeletedAtIsNull() {
+        val account = checking()
+        assertNull(account.deletedAt)
+    }
+
+    @Test
+    fun defaultSyncVersionIsZero() {
+        val account = checking()
+        assertEquals(0L, account.syncVersion)
+    }
+
+    @Test
+    fun defaultIsSyncedIsFalse() {
+        val account = checking()
+        assertFalse(account.isSynced)
+    }
+
+    // ── Archive flag ────────────────────────────────────────────────────
+
+    @Test
+    fun archiveAccount() {
+        val account = checking(isArchived = true)
+        assertTrue(account.isArchived)
+    }
+
+    @Test
+    fun archiveViaCopy() {
+        val account = checking()
+        val archived = account.copy(isArchived = true)
+        assertTrue(archived.isArchived)
+        assertFalse(account.isArchived) // original immutable
+    }
+
+    // ── Balance operations ──────────────────────────────────────────────
+
+    @Test
+    fun zeroBalance() {
+        val account = checking(balance = Cents.ZERO)
+        assertTrue(account.currentBalance.isZero())
+    }
+
+    @Test
+    fun negativeBalance() {
+        val account = checking(balance = Cents(-50000L))
+        assertTrue(account.currentBalance.isNegative())
+    }
+
+    @Test
+    fun updateBalanceViaCopy() {
+        val account = checking(balance = Cents(100000L))
+        val deposit = Cents(25000L)
+        val updated = account.copy(
+            currentBalance = account.currentBalance + deposit
+        )
+        assertEquals(Cents(125000L), updated.currentBalance)
+    }
+
+    @Test
+    fun subtractFromBalanceViaCopy() {
+        val account = checking(balance = Cents(100000L))
+        val withdrawal = Cents(30000L)
+        val updated = account.copy(
+            currentBalance = account.currentBalance - withdrawal
+        )
+        assertEquals(Cents(70000L), updated.currentBalance)
+    }
+
+    // ── Account types ───────────────────────────────────────────────────
+
+    @Test
+    fun allAccountTypesExist() {
+        val types = AccountType.entries
+        assertEquals(7, types.size)
+        assertTrue(types.contains(AccountType.CHECKING))
+        assertTrue(types.contains(AccountType.SAVINGS))
+        assertTrue(types.contains(AccountType.CREDIT_CARD))
+        assertTrue(types.contains(AccountType.CASH))
+        assertTrue(types.contains(AccountType.INVESTMENT))
+        assertTrue(types.contains(AccountType.LOAN))
+        assertTrue(types.contains(AccountType.OTHER))
+    }
+
+    // ── Sync metadata ───────────────────────────────────────────────────
+
+    @Test
+    fun syncVersionCanBeSet() {
+        val account = checking(syncVersion = 5L)
+        assertEquals(5L, account.syncVersion)
+    }
+
+    @Test
+    fun markAsSynced() {
+        val account = checking()
+        val synced = account.copy(isSynced = true, syncVersion = 1L)
+        assertTrue(synced.isSynced)
+        assertEquals(1L, synced.syncVersion)
+    }
+
+    // ── Soft delete ─────────────────────────────────────────────────────
+
+    @Test
+    fun softDeleteSetsDeletedAt() {
+        val deletedTime = Instant.parse("2024-06-01T00:00:00Z")
+        val account = checking(deletedAt = deletedTime)
+        assertEquals(deletedTime, account.deletedAt)
+    }
+
+    // ── Equality ────────────────────────────────────────────────────────
+
+    @Test
+    fun equalityByFields() {
+        val a1 = checking()
+        val a2 = checking()
+        assertEquals(a1, a2)
+    }
+}

--- a/packages/models/src/commonTest/kotlin/com/finance/models/BudgetAndGoalTest.kt
+++ b/packages/models/src/commonTest/kotlin/com/finance/models/BudgetAndGoalTest.kt
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.models
+
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [Budget] and [Goal] data classes — validation, defaults, and computed properties.
+ */
+class BudgetAndGoalTest {
+
+    private val now = Instant.parse("2024-01-15T12:00:00Z")
+    private val householdId = SyncId("household-1")
+    private val categoryId = SyncId("category-1")
+
+    // ══════════════════════════════════════════════════════════════════════
+    //  Budget
+    // ══════════════════════════════════════════════════════════════════════
+
+    private fun budget(
+        name: String = "Groceries",
+        amount: Cents = Cents(50000L),
+        period: BudgetPeriod = BudgetPeriod.MONTHLY,
+    ) = Budget(
+        id = SyncId("budget-1"),
+        householdId = householdId,
+        categoryId = categoryId,
+        name = name,
+        amount = amount,
+        currency = Currency.USD,
+        period = period,
+        startDate = LocalDate.parse("2024-01-01"),
+        createdAt = now,
+        updatedAt = now,
+    )
+
+    @Test
+    fun createValidBudget() {
+        val b = budget()
+        assertEquals("Groceries", b.name)
+        assertEquals(Cents(50000L), b.amount)
+        assertEquals(BudgetPeriod.MONTHLY, b.period)
+    }
+
+    @Test
+    fun rejectBlankBudgetName() {
+        assertFailsWith<IllegalArgumentException> { budget(name = "") }
+    }
+
+    @Test
+    fun rejectWhitespaceBudgetName() {
+        assertFailsWith<IllegalArgumentException> { budget(name = "   ") }
+    }
+
+    @Test
+    fun rejectZeroBudgetAmount() {
+        assertFailsWith<IllegalArgumentException> { budget(amount = Cents.ZERO) }
+    }
+
+    @Test
+    fun rejectNegativeBudgetAmount() {
+        assertFailsWith<IllegalArgumentException> { budget(amount = Cents(-100L)) }
+    }
+
+    @Test
+    fun budgetDefaultEndDateIsNull() {
+        assertNull(budget().endDate)
+    }
+
+    @Test
+    fun budgetDefaultIsRolloverIsFalse() {
+        assertFalse(budget().isRollover)
+    }
+
+    @Test
+    fun budgetDefaultSyncVersionIsZero() {
+        assertEquals(0L, budget().syncVersion)
+    }
+
+    @Test
+    fun budgetDefaultIsSyncedIsFalse() {
+        assertFalse(budget().isSynced)
+    }
+
+    @Test
+    fun allBudgetPeriodsExist() {
+        val periods = BudgetPeriod.entries
+        assertEquals(5, periods.size)
+        assertTrue(periods.contains(BudgetPeriod.WEEKLY))
+        assertTrue(periods.contains(BudgetPeriod.BIWEEKLY))
+        assertTrue(periods.contains(BudgetPeriod.MONTHLY))
+        assertTrue(periods.contains(BudgetPeriod.QUARTERLY))
+        assertTrue(periods.contains(BudgetPeriod.YEARLY))
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    //  Goal
+    // ══════════════════════════════════════════════════════════════════════
+
+    private fun goal(
+        name: String = "Emergency Fund",
+        targetAmount: Cents = Cents(1000000L),
+        currentAmount: Cents = Cents.ZERO,
+        status: GoalStatus = GoalStatus.ACTIVE,
+    ) = Goal(
+        id = SyncId("goal-1"),
+        householdId = householdId,
+        name = name,
+        targetAmount = targetAmount,
+        currentAmount = currentAmount,
+        currency = Currency.USD,
+        status = status,
+        createdAt = now,
+        updatedAt = now,
+    )
+
+    @Test
+    fun createValidGoal() {
+        val g = goal()
+        assertEquals("Emergency Fund", g.name)
+        assertEquals(Cents(1000000L), g.targetAmount)
+        assertEquals(Cents.ZERO, g.currentAmount)
+    }
+
+    @Test
+    fun rejectBlankGoalName() {
+        assertFailsWith<IllegalArgumentException> { goal(name = "") }
+    }
+
+    @Test
+    fun rejectWhitespaceGoalName() {
+        assertFailsWith<IllegalArgumentException> { goal(name = "   ") }
+    }
+
+    @Test
+    fun rejectZeroTargetAmount() {
+        assertFailsWith<IllegalArgumentException> { goal(targetAmount = Cents.ZERO) }
+    }
+
+    @Test
+    fun rejectNegativeTargetAmount() {
+        assertFailsWith<IllegalArgumentException> { goal(targetAmount = Cents(-100L)) }
+    }
+
+    @Test
+    fun goalDefaultStatusIsActive() {
+        assertEquals(GoalStatus.ACTIVE, goal().status)
+    }
+
+    @Test
+    fun goalDefaultCurrentAmountIsZero() {
+        assertEquals(Cents.ZERO, goal().currentAmount)
+    }
+
+    @Test
+    fun goalDefaultTargetDateIsNull() {
+        assertNull(goal().targetDate)
+    }
+
+    @Test
+    fun allGoalStatusesExist() {
+        val statuses = GoalStatus.entries
+        assertEquals(4, statuses.size)
+        assertTrue(statuses.contains(GoalStatus.ACTIVE))
+        assertTrue(statuses.contains(GoalStatus.PAUSED))
+        assertTrue(statuses.contains(GoalStatus.COMPLETED))
+        assertTrue(statuses.contains(GoalStatus.CANCELLED))
+    }
+
+    // ── Progress ────────────────────────────────────────────────────────
+
+    @Test
+    fun progressAtZero() {
+        val g = goal(currentAmount = Cents.ZERO)
+        assertEquals(0.0, g.progress)
+    }
+
+    @Test
+    fun progressAtHalf() {
+        val g = goal(
+            targetAmount = Cents(1000L),
+            currentAmount = Cents(500L),
+        )
+        assertEquals(0.5, g.progress)
+    }
+
+    @Test
+    fun progressAtFull() {
+        val g = goal(
+            targetAmount = Cents(1000L),
+            currentAmount = Cents(1000L),
+        )
+        assertEquals(1.0, g.progress)
+    }
+
+    @Test
+    fun progressClampedAtOneWhenOverTarget() {
+        val g = goal(
+            targetAmount = Cents(1000L),
+            currentAmount = Cents(1500L),
+        )
+        assertEquals(1.0, g.progress) // clamped
+    }
+
+    @Test
+    fun progressClampedAtZeroWhenNegativeCurrent() {
+        val g = goal(
+            targetAmount = Cents(1000L),
+            currentAmount = Cents(-100L),
+        )
+        assertEquals(0.0, g.progress) // clamped
+    }
+
+    @Test
+    fun progressAtQuarter() {
+        val g = goal(
+            targetAmount = Cents(10000L),
+            currentAmount = Cents(2500L),
+        )
+        assertEquals(0.25, g.progress)
+    }
+
+    // ── isComplete ──────────────────────────────────────────────────────
+
+    @Test
+    fun isCompleteWhenCurrentEqualsTarget() {
+        val g = goal(
+            targetAmount = Cents(1000L),
+            currentAmount = Cents(1000L),
+        )
+        assertTrue(g.isComplete)
+    }
+
+    @Test
+    fun isCompleteWhenCurrentExceedsTarget() {
+        val g = goal(
+            targetAmount = Cents(1000L),
+            currentAmount = Cents(1500L),
+        )
+        assertTrue(g.isComplete)
+    }
+
+    @Test
+    fun isNotCompleteWhenBelowTarget() {
+        val g = goal(
+            targetAmount = Cents(1000L),
+            currentAmount = Cents(999L),
+        )
+        assertFalse(g.isComplete)
+    }
+
+    @Test
+    fun isNotCompleteAtZero() {
+        assertFalse(goal().isComplete)
+    }
+}

--- a/packages/models/src/commonTest/kotlin/com/finance/models/CategoryAndHouseholdTest.kt
+++ b/packages/models/src/commonTest/kotlin/com/finance/models/CategoryAndHouseholdTest.kt
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.models
+
+import com.finance.models.types.SyncId
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [Category], [Household], [HouseholdMember], and [User] data classes.
+ *
+ * These models are simpler but their init-validation and defaults must be verified.
+ */
+class CategoryAndHouseholdTest {
+
+    private val now = Instant.parse("2024-01-15T12:00:00Z")
+    private val householdId = SyncId("household-1")
+    private val userId = SyncId("user-1")
+
+    // ══════════════════════════════════════════════════════════════════════
+    //  Category
+    // ══════════════════════════════════════════════════════════════════════
+
+    private fun category(name: String = "Groceries") = Category(
+        id = SyncId("cat-1"),
+        householdId = householdId,
+        name = name,
+        createdAt = now,
+        updatedAt = now,
+    )
+
+    @Test
+    fun createValidCategory() {
+        val cat = category()
+        assertEquals("Groceries", cat.name)
+    }
+
+    @Test
+    fun rejectBlankCategoryName() {
+        assertFailsWith<IllegalArgumentException> { category(name = "") }
+    }
+
+    @Test
+    fun rejectWhitespaceCategoryName() {
+        assertFailsWith<IllegalArgumentException> { category(name = "   ") }
+    }
+
+    @Test
+    fun categoryDefaultParentIdIsNull() {
+        assertNull(category().parentId)
+    }
+
+    @Test
+    fun categoryDefaultIsIncomeFalse() {
+        assertEquals(false, category().isIncome)
+    }
+
+    @Test
+    fun categoryDefaultIsSystemFalse() {
+        assertEquals(false, category().isSystem)
+    }
+
+    @Test
+    fun categoryDefaultSortOrderIsZero() {
+        assertEquals(0, category().sortOrder)
+    }
+
+    @Test
+    fun categoryDefaultIconIsNull() {
+        assertNull(category().icon)
+    }
+
+    @Test
+    fun categoryDefaultColorIsNull() {
+        assertNull(category().color)
+    }
+
+    @Test
+    fun categorySubcategoryWithParent() {
+        val sub = Category(
+            id = SyncId("cat-2"),
+            householdId = householdId,
+            name = "Produce",
+            parentId = SyncId("cat-1"),
+            createdAt = now,
+            updatedAt = now,
+        )
+        assertEquals(SyncId("cat-1"), sub.parentId)
+    }
+
+    @Test
+    fun categoryAsIncomeCategory() {
+        val income = Category(
+            id = SyncId("cat-3"),
+            householdId = householdId,
+            name = "Salary",
+            isIncome = true,
+            createdAt = now,
+            updatedAt = now,
+        )
+        assertTrue(income.isIncome)
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    //  Household
+    // ══════════════════════════════════════════════════════════════════════
+
+    @Test
+    fun createValidHousehold() {
+        val h = Household(
+            id = householdId,
+            name = "Smith Family",
+            ownerId = userId,
+            createdAt = now,
+            updatedAt = now,
+        )
+        assertEquals("Smith Family", h.name)
+        assertEquals(userId, h.ownerId)
+    }
+
+    @Test
+    fun householdDefaultDeletedAtIsNull() {
+        val h = Household(
+            id = householdId,
+            name = "Test",
+            ownerId = userId,
+            createdAt = now,
+            updatedAt = now,
+        )
+        assertNull(h.deletedAt)
+    }
+
+    @Test
+    fun householdDefaultSyncVersionIsZero() {
+        val h = Household(
+            id = householdId,
+            name = "Test",
+            ownerId = userId,
+            createdAt = now,
+            updatedAt = now,
+        )
+        assertEquals(0L, h.syncVersion)
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    //  HouseholdMember
+    // ══════════════════════════════════════════════════════════════════════
+
+    @Test
+    fun createValidHouseholdMember() {
+        val member = HouseholdMember(
+            id = SyncId("member-1"),
+            householdId = householdId,
+            userId = userId,
+            role = HouseholdRole.OWNER,
+            joinedAt = now,
+            createdAt = now,
+            updatedAt = now,
+        )
+        assertEquals(HouseholdRole.OWNER, member.role)
+        assertEquals(userId, member.userId)
+    }
+
+    @Test
+    fun allHouseholdRolesExist() {
+        val roles = HouseholdRole.entries
+        assertEquals(4, roles.size)
+        assertTrue(roles.contains(HouseholdRole.OWNER))
+        assertTrue(roles.contains(HouseholdRole.PARTNER))
+        assertTrue(roles.contains(HouseholdRole.MEMBER))
+        assertTrue(roles.contains(HouseholdRole.VIEWER))
+    }
+
+    @Test
+    fun householdMemberDefaultDeletedAtIsNull() {
+        val member = HouseholdMember(
+            id = SyncId("member-1"),
+            householdId = householdId,
+            userId = userId,
+            role = HouseholdRole.MEMBER,
+            joinedAt = now,
+            createdAt = now,
+            updatedAt = now,
+        )
+        assertNull(member.deletedAt)
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    //  User
+    // ══════════════════════════════════════════════════════════════════════
+
+    @Test
+    fun createValidUser() {
+        val user = User(
+            id = userId,
+            email = "jane@example.com",
+            displayName = "Jane Doe",
+            createdAt = now,
+            updatedAt = now,
+        )
+        assertEquals("jane@example.com", user.email)
+        assertEquals("Jane Doe", user.displayName)
+    }
+
+    @Test
+    fun userDefaultCurrencyIsUSD() {
+        val user = User(
+            id = userId,
+            email = "test@example.com",
+            displayName = "Test",
+            createdAt = now,
+            updatedAt = now,
+        )
+        assertEquals(com.finance.models.types.Currency.USD, user.defaultCurrency)
+    }
+
+    @Test
+    fun userDefaultAvatarUrlIsNull() {
+        val user = User(
+            id = userId,
+            email = "test@example.com",
+            displayName = "Test",
+            createdAt = now,
+            updatedAt = now,
+        )
+        assertNull(user.avatarUrl)
+    }
+
+    @Test
+    fun userDefaultDeletedAtIsNull() {
+        val user = User(
+            id = userId,
+            email = "test@example.com",
+            displayName = "Test",
+            createdAt = now,
+            updatedAt = now,
+        )
+        assertNull(user.deletedAt)
+    }
+
+    @Test
+    fun userSyncMetadataDefaults() {
+        val user = User(
+            id = userId,
+            email = "test@example.com",
+            displayName = "Test",
+            createdAt = now,
+            updatedAt = now,
+        )
+        assertEquals(0L, user.syncVersion)
+        assertEquals(false, user.isSynced)
+    }
+}

--- a/packages/models/src/commonTest/kotlin/com/finance/models/TransactionTest.kt
+++ b/packages/models/src/commonTest/kotlin/com/finance/models/TransactionTest.kt
@@ -1,0 +1,291 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.models
+
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [Transaction] data class — construction rules, defaults, and invariants.
+ */
+class TransactionTest {
+
+    // ── Test helpers ─────────────────────────────────────────────────────
+
+    private val now = Instant.parse("2024-01-15T12:00:00Z")
+    private val today = LocalDate.parse("2024-01-15")
+    private val householdId = SyncId("household-1")
+    private val accountId = SyncId("account-1")
+    private val categoryId = SyncId("category-1")
+
+    private fun expense(
+        amount: Cents = Cents(1500L),
+        status: TransactionStatus = TransactionStatus.CLEARED,
+        payee: String? = null,
+        note: String? = null,
+        categoryId: SyncId? = this.categoryId,
+        deletedAt: Instant? = null,
+        syncVersion: Long = 0,
+        isSynced: Boolean = false,
+        tags: List<String> = emptyList(),
+    ) = Transaction(
+        id = SyncId("txn-1"),
+        householdId = householdId,
+        accountId = accountId,
+        categoryId = categoryId,
+        type = TransactionType.EXPENSE,
+        status = status,
+        amount = amount,
+        currency = Currency.USD,
+        payee = payee,
+        note = note,
+        date = today,
+        createdAt = now,
+        updatedAt = now,
+        deletedAt = deletedAt,
+        syncVersion = syncVersion,
+        isSynced = isSynced,
+        tags = tags,
+    )
+
+    // ── Valid construction ───────────────────────────────────────────────
+
+    @Test
+    fun createExpenseTransaction() {
+        val txn = expense()
+        assertEquals(TransactionType.EXPENSE, txn.type)
+        assertEquals(Cents(1500L), txn.amount)
+        assertEquals(Currency.USD, txn.currency)
+    }
+
+    @Test
+    fun createIncomeTransaction() {
+        val txn = Transaction(
+            id = SyncId("txn-2"),
+            householdId = householdId,
+            accountId = accountId,
+            type = TransactionType.INCOME,
+            amount = Cents(500000L),
+            currency = Currency.USD,
+            date = today,
+            createdAt = now,
+            updatedAt = now,
+        )
+        assertEquals(TransactionType.INCOME, txn.type)
+        assertEquals(Cents(500000L), txn.amount)
+    }
+
+    @Test
+    fun createTransferWithDestinationAccount() {
+        val txn = Transaction(
+            id = SyncId("txn-3"),
+            householdId = householdId,
+            accountId = accountId,
+            type = TransactionType.TRANSFER,
+            amount = Cents(10000L),
+            currency = Currency.USD,
+            date = today,
+            transferAccountId = SyncId("account-2"),
+            createdAt = now,
+            updatedAt = now,
+        )
+        assertEquals(TransactionType.TRANSFER, txn.type)
+        assertEquals(SyncId("account-2"), txn.transferAccountId)
+    }
+
+    // ── Invalid construction ────────────────────────────────────────────
+
+    @Test
+    fun rejectZeroAmount() {
+        assertFailsWith<IllegalArgumentException> {
+            expense(amount = Cents.ZERO)
+        }
+    }
+
+    @Test
+    fun rejectTransferWithoutDestinationAccount() {
+        assertFailsWith<IllegalArgumentException> {
+            Transaction(
+                id = SyncId("txn-4"),
+                householdId = householdId,
+                accountId = accountId,
+                type = TransactionType.TRANSFER,
+                amount = Cents(1000L),
+                currency = Currency.USD,
+                date = today,
+                transferAccountId = null,
+                createdAt = now,
+                updatedAt = now,
+            )
+        }
+    }
+
+    // ── Default values ──────────────────────────────────────────────────
+
+    @Test
+    fun defaultStatusIsCleared() {
+        val txn = expense()
+        assertEquals(TransactionStatus.CLEARED, txn.status)
+    }
+
+    @Test
+    fun defaultSyncVersionIsZero() {
+        val txn = expense()
+        assertEquals(0L, txn.syncVersion)
+    }
+
+    @Test
+    fun defaultIsSyncedIsFalse() {
+        val txn = expense()
+        assertFalse(txn.isSynced)
+    }
+
+    @Test
+    fun defaultDeletedAtIsNull() {
+        val txn = expense()
+        assertNull(txn.deletedAt)
+    }
+
+    @Test
+    fun defaultCategoryIdIsNull() {
+        val txn = Transaction(
+            id = SyncId("txn-5"),
+            householdId = householdId,
+            accountId = accountId,
+            type = TransactionType.EXPENSE,
+            amount = Cents(100L),
+            currency = Currency.USD,
+            date = today,
+            createdAt = now,
+            updatedAt = now,
+        )
+        assertNull(txn.categoryId)
+    }
+
+    @Test
+    fun defaultTagsIsEmpty() {
+        val txn = expense()
+        assertTrue(txn.tags.isEmpty())
+    }
+
+    @Test
+    fun defaultIsRecurringIsFalse() {
+        val txn = expense()
+        assertFalse(txn.isRecurring)
+    }
+
+    @Test
+    fun defaultTransferFieldsAreNull() {
+        val txn = expense()
+        assertNull(txn.transferAccountId)
+        assertNull(txn.transferTransactionId)
+    }
+
+    // ── Sync metadata ───────────────────────────────────────────────────
+
+    @Test
+    fun syncVersionCanBeSet() {
+        val txn = expense(syncVersion = 42L)
+        assertEquals(42L, txn.syncVersion)
+    }
+
+    @Test
+    fun isSyncedCanBeSet() {
+        val txn = expense(isSynced = true)
+        assertTrue(txn.isSynced)
+    }
+
+    @Test
+    fun copyToMarkAsSynced() {
+        val txn = expense()
+        val synced = txn.copy(isSynced = true, syncVersion = 1L)
+        assertTrue(synced.isSynced)
+        assertEquals(1L, synced.syncVersion)
+        // Original unchanged (immutable data class)
+        assertFalse(txn.isSynced)
+    }
+
+    // ── Soft delete ─────────────────────────────────────────────────────
+
+    @Test
+    fun softDeleteSetsDeletedAt() {
+        val deletedTime = Instant.parse("2024-06-01T00:00:00Z")
+        val txn = expense(deletedAt = deletedTime)
+        assertEquals(deletedTime, txn.deletedAt)
+    }
+
+    // ── Transaction statuses ────────────────────────────────────────────
+
+    @Test
+    fun allTransactionStatusesExist() {
+        val statuses = TransactionStatus.entries
+        assertEquals(4, statuses.size)
+        assertTrue(statuses.contains(TransactionStatus.PENDING))
+        assertTrue(statuses.contains(TransactionStatus.CLEARED))
+        assertTrue(statuses.contains(TransactionStatus.RECONCILED))
+        assertTrue(statuses.contains(TransactionStatus.VOID))
+    }
+
+    @Test
+    fun allTransactionTypesExist() {
+        val types = TransactionType.entries
+        assertEquals(3, types.size)
+        assertTrue(types.contains(TransactionType.EXPENSE))
+        assertTrue(types.contains(TransactionType.INCOME))
+        assertTrue(types.contains(TransactionType.TRANSFER))
+    }
+
+    // ── Optional fields ─────────────────────────────────────────────────
+
+    @Test
+    fun payeeCanBeSet() {
+        val txn = expense(payee = "Grocery Store")
+        assertEquals("Grocery Store", txn.payee)
+    }
+
+    @Test
+    fun noteCanBeSet() {
+        val txn = expense(note = "Weekly groceries")
+        assertEquals("Weekly groceries", txn.note)
+    }
+
+    @Test
+    fun tagsCanBeSet() {
+        val txn = expense(tags = listOf("food", "essentials"))
+        assertEquals(listOf("food", "essentials"), txn.tags)
+    }
+
+    // ── Negative amounts ────────────────────────────────────────────────
+
+    @Test
+    fun negativeAmountIsAllowed() {
+        val txn = expense(amount = Cents(-500L))
+        assertEquals(Cents(-500L), txn.amount)
+    }
+
+    // ── Equality / copy ─────────────────────────────────────────────────
+
+    @Test
+    fun equalityByFields() {
+        val txn1 = expense()
+        val txn2 = expense()
+        assertEquals(txn1, txn2)
+    }
+
+    @Test
+    fun copyPreservesUnchangedFields() {
+        val txn = expense(payee = "Acme")
+        val updated = txn.copy(status = TransactionStatus.RECONCILED)
+        assertEquals("Acme", updated.payee)
+        assertEquals(TransactionStatus.RECONCILED, updated.status)
+    }
+}

--- a/packages/models/src/commonTest/kotlin/com/finance/models/types/CentsTest.kt
+++ b/packages/models/src/commonTest/kotlin/com/finance/models/types/CentsTest.kt
@@ -1,0 +1,445 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.models.types
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Comprehensive tests for [Cents] — the foundational monetary value type.
+ *
+ * Financial precision is critical: every arithmetic operation, overflow boundary,
+ * and comparison must be verified. A bug here silently corrupts balances.
+ */
+class CentsTest {
+
+    // ── Construction ────────────────────────────────────────────────────
+
+    @Test
+    fun constructWithPositiveAmount() {
+        val cents = Cents(1500L)
+        assertEquals(1500L, cents.amount)
+    }
+
+    @Test
+    fun constructWithNegativeAmount() {
+        val cents = Cents(-750L)
+        assertEquals(-750L, cents.amount)
+    }
+
+    @Test
+    fun constructWithZero() {
+        val cents = Cents(0L)
+        assertEquals(0L, cents.amount)
+    }
+
+    @Test
+    fun zeroConstantIsZero() {
+        assertEquals(0L, Cents.ZERO.amount)
+    }
+
+    @Test
+    fun constructWithLongMaxValue() {
+        val cents = Cents(Long.MAX_VALUE)
+        assertEquals(Long.MAX_VALUE, cents.amount)
+    }
+
+    @Test
+    fun constructWithLongMinValue() {
+        val cents = Cents(Long.MIN_VALUE)
+        assertEquals(Long.MIN_VALUE, cents.amount)
+    }
+
+    // ── Addition ────────────────────────────────────────────────────────
+
+    @Test
+    fun addTwoPositiveAmounts() {
+        val result = Cents(1000L) + Cents(2500L)
+        assertEquals(Cents(3500L), result)
+    }
+
+    @Test
+    fun addPositiveAndNegative() {
+        val result = Cents(1000L) + Cents(-300L)
+        assertEquals(Cents(700L), result)
+    }
+
+    @Test
+    fun addNegativeAndPositive() {
+        val result = Cents(-1000L) + Cents(300L)
+        assertEquals(Cents(-700L), result)
+    }
+
+    @Test
+    fun addTwoNegativeAmounts() {
+        val result = Cents(-100L) + Cents(-200L)
+        assertEquals(Cents(-300L), result)
+    }
+
+    @Test
+    fun addZeroToAmount() {
+        val result = Cents(500L) + Cents.ZERO
+        assertEquals(Cents(500L), result)
+    }
+
+    @Test
+    fun addAmountToZero() {
+        val result = Cents.ZERO + Cents(500L)
+        assertEquals(Cents(500L), result)
+    }
+
+    @Test
+    fun additionOverflowThrows() {
+        assertFailsWith<ArithmeticException> {
+            Cents(Long.MAX_VALUE) + Cents(1L)
+        }
+    }
+
+    @Test
+    fun additionOverflowWithLargePositives() {
+        assertFailsWith<ArithmeticException> {
+            Cents(Long.MAX_VALUE - 10) + Cents(20L)
+        }
+    }
+
+    @Test
+    fun additionNegativeOverflowThrows() {
+        assertFailsWith<ArithmeticException> {
+            Cents(Long.MIN_VALUE) + Cents(-1L)
+        }
+    }
+
+    @Test
+    fun additionOfOppositeSignsNeverOverflows() {
+        // Opposite signs cannot overflow — this must succeed
+        val result = Cents(Long.MAX_VALUE) + Cents(-1L)
+        assertEquals(Cents(Long.MAX_VALUE - 1), result)
+    }
+
+    @Test
+    fun additionAtMaxBoundaryNoOverflow() {
+        val result = Cents(Long.MAX_VALUE - 1) + Cents(1L)
+        assertEquals(Cents(Long.MAX_VALUE), result)
+    }
+
+    // ── Subtraction ─────────────────────────────────────────────────────
+
+    @Test
+    fun subtractSmallerFromLarger() {
+        val result = Cents(3000L) - Cents(1000L)
+        assertEquals(Cents(2000L), result)
+    }
+
+    @Test
+    fun subtractLargerFromSmaller() {
+        val result = Cents(1000L) - Cents(3000L)
+        assertEquals(Cents(-2000L), result)
+    }
+
+    @Test
+    fun subtractNegativeFromPositive() {
+        // 1000 - (-500) = 1500
+        val result = Cents(1000L) - Cents(-500L)
+        assertEquals(Cents(1500L), result)
+    }
+
+    @Test
+    fun subtractPositiveFromNegative() {
+        // -1000 - 500 = -1500
+        val result = Cents(-1000L) - Cents(500L)
+        assertEquals(Cents(-1500L), result)
+    }
+
+    @Test
+    fun subtractZero() {
+        val result = Cents(500L) - Cents.ZERO
+        assertEquals(Cents(500L), result)
+    }
+
+    @Test
+    fun subtractFromZero() {
+        val result = Cents.ZERO - Cents(500L)
+        assertEquals(Cents(-500L), result)
+    }
+
+    @Test
+    fun subtractSameAmount() {
+        val result = Cents(1234L) - Cents(1234L)
+        assertEquals(Cents.ZERO, result)
+    }
+
+    @Test
+    fun subtractionOverflowPositiveThrows() {
+        // MAX_VALUE - (-1) would exceed MAX_VALUE
+        assertFailsWith<ArithmeticException> {
+            Cents(Long.MAX_VALUE) - Cents(-1L)
+        }
+    }
+
+    @Test
+    fun subtractionOverflowNegativeThrows() {
+        // MIN_VALUE - 1 would go below MIN_VALUE
+        assertFailsWith<ArithmeticException> {
+            Cents(Long.MIN_VALUE) - Cents(1L)
+        }
+    }
+
+    @Test
+    fun subtractionSameSignNeverOverflows() {
+        // Same-sign subtraction cannot overflow
+        val result = Cents(Long.MIN_VALUE) - Cents(-1L)
+        assertEquals(Cents(Long.MIN_VALUE + 1), result)
+    }
+
+    // ── Multiplication ──────────────────────────────────────────────────
+
+    @Test
+    fun multiplyByPositiveInt() {
+        val result = Cents(500L) * 3
+        assertEquals(Cents(1500L), result)
+    }
+
+    @Test
+    fun multiplyByZero() {
+        val result = Cents(999L) * 0
+        assertEquals(Cents.ZERO, result)
+    }
+
+    @Test
+    fun multiplyByOne() {
+        val result = Cents(1234L) * 1
+        assertEquals(Cents(1234L), result)
+    }
+
+    @Test
+    fun multiplyByNegativeInt() {
+        val result = Cents(500L) * -2
+        assertEquals(Cents(-1000L), result)
+    }
+
+    @Test
+    fun multiplyNegativeByNegative() {
+        val result = Cents(-500L) * -2
+        assertEquals(Cents(1000L), result)
+    }
+
+    @Test
+    fun multiplicationOverflowThrows() {
+        assertFailsWith<ArithmeticException> {
+            Cents(Long.MAX_VALUE) * 2
+        }
+    }
+
+    @Test
+    fun multiplicationNegativeOverflowThrows() {
+        assertFailsWith<ArithmeticException> {
+            Cents(Long.MIN_VALUE) * 2
+        }
+    }
+
+    @Test
+    fun multiplicationOverflowWithLargeFactorThrows() {
+        assertFailsWith<ArithmeticException> {
+            Cents(Long.MAX_VALUE / 2 + 1) * 2
+        }
+    }
+
+    // ── Unary Minus (Negation) ──────────────────────────────────────────
+
+    @Test
+    fun negatePositive() {
+        val result = -Cents(500L)
+        assertEquals(Cents(-500L), result)
+    }
+
+    @Test
+    fun negateNegative() {
+        val result = -Cents(-500L)
+        assertEquals(Cents(500L), result)
+    }
+
+    @Test
+    fun negateZero() {
+        val result = -Cents.ZERO
+        assertEquals(Cents.ZERO, result)
+    }
+
+    @Test
+    fun negateMinValueOverflowThrows() {
+        // Long.MIN_VALUE has no positive counterpart in Long
+        assertFailsWith<ArithmeticException> {
+            -Cents(Long.MIN_VALUE)
+        }
+    }
+
+    @Test
+    fun negateMaxValue() {
+        val result = -Cents(Long.MAX_VALUE)
+        assertEquals(Cents(-Long.MAX_VALUE), result)
+    }
+
+    // ── Comparison ──────────────────────────────────────────────────────
+
+    @Test
+    fun compareGreaterThan() {
+        assertTrue(Cents(100L) > Cents(50L))
+    }
+
+    @Test
+    fun compareLessThan() {
+        assertTrue(Cents(50L) < Cents(100L))
+    }
+
+    @Test
+    fun compareEqual() {
+        assertTrue(Cents(100L).compareTo(Cents(100L)) == 0)
+    }
+
+    @Test
+    fun compareNegativeValues() {
+        assertTrue(Cents(-50L) > Cents(-100L))
+    }
+
+    @Test
+    fun comparePositiveAndNegative() {
+        assertTrue(Cents(1L) > Cents(-1L))
+    }
+
+    @Test
+    fun compareWithZero() {
+        assertTrue(Cents(1L) > Cents.ZERO)
+        assertTrue(Cents(-1L) < Cents.ZERO)
+    }
+
+    // ── Predicates ──────────────────────────────────────────────────────
+
+    @Test
+    fun isPositiveWithPositiveAmount() {
+        assertTrue(Cents(1L).isPositive())
+    }
+
+    @Test
+    fun isPositiveWithZero() {
+        assertFalse(Cents.ZERO.isPositive())
+    }
+
+    @Test
+    fun isPositiveWithNegativeAmount() {
+        assertFalse(Cents(-1L).isPositive())
+    }
+
+    @Test
+    fun isNegativeWithNegativeAmount() {
+        assertTrue(Cents(-1L).isNegative())
+    }
+
+    @Test
+    fun isNegativeWithZero() {
+        assertFalse(Cents.ZERO.isNegative())
+    }
+
+    @Test
+    fun isNegativeWithPositiveAmount() {
+        assertFalse(Cents(1L).isNegative())
+    }
+
+    @Test
+    fun isZeroWithZero() {
+        assertTrue(Cents.ZERO.isZero())
+    }
+
+    @Test
+    fun isZeroWithNonZero() {
+        assertFalse(Cents(1L).isZero())
+        assertFalse(Cents(-1L).isZero())
+    }
+
+    // ── Absolute Value ──────────────────────────────────────────────────
+
+    @Test
+    fun absOfPositive() {
+        assertEquals(Cents(500L), Cents(500L).abs())
+    }
+
+    @Test
+    fun absOfNegative() {
+        assertEquals(Cents(500L), Cents(-500L).abs())
+    }
+
+    @Test
+    fun absOfZero() {
+        assertEquals(Cents.ZERO, Cents.ZERO.abs())
+    }
+
+    @Test
+    fun absOfMinValueThrows() {
+        // abs(MIN_VALUE) requires negation, which overflows
+        assertFailsWith<ArithmeticException> {
+            Cents(Long.MIN_VALUE).abs()
+        }
+    }
+
+    // ── fromDollars ─────────────────────────────────────────────────────
+
+    @Test
+    fun fromDollarsWholeDollar() {
+        assertEquals(Cents(1000L), Cents.fromDollars(10.0))
+    }
+
+    @Test
+    fun fromDollarsWithCents() {
+        assertEquals(Cents(1099L), Cents.fromDollars(10.99))
+    }
+
+    @Test
+    fun fromDollarsZero() {
+        assertEquals(Cents.ZERO, Cents.fromDollars(0.0))
+    }
+
+    @Test
+    fun fromDollarsNegative() {
+        assertEquals(Cents(-1500L), Cents.fromDollars(-15.0))
+    }
+
+    @Test
+    fun fromDollarsSmallAmount() {
+        assertEquals(Cents(1L), Cents.fromDollars(0.01))
+    }
+
+    // ── Equality (value class) ──────────────────────────────────────────
+
+    @Test
+    fun equalityByValue() {
+        assertEquals(Cents(100L), Cents(100L))
+    }
+
+    @Test
+    fun inequalityByValue() {
+        assertTrue(Cents(100L) != Cents(200L))
+    }
+
+    // ── Combined operations ─────────────────────────────────────────────
+
+    @Test
+    fun chainedArithmetic() {
+        // (100 + 200) - 50 = 250
+        val result = (Cents(100L) + Cents(200L)) - Cents(50L)
+        assertEquals(Cents(250L), result)
+    }
+
+    @Test
+    fun multiplyThenAdd() {
+        // (10 * 5) + 3 = 53
+        val result = (Cents(10L) * 5) + Cents(3L)
+        assertEquals(Cents(53L), result)
+    }
+
+    @Test
+    fun negateThenAdd() {
+        val result = -Cents(100L) + Cents(150L)
+        assertEquals(Cents(50L), result)
+    }
+}

--- a/packages/models/src/commonTest/kotlin/com/finance/models/types/CurrencyTest.kt
+++ b/packages/models/src/commonTest/kotlin/com/finance/models/types/CurrencyTest.kt
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.models.types
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [Currency] — ISO 4217 currency code wrapper.
+ *
+ * Validates code format enforcement, decimal-place lookup, and companion constants.
+ */
+class CurrencyTest {
+
+    // ── Construction — valid codes ──────────────────────────────────────
+
+    @Test
+    fun constructWithValidThreeLetterCode() {
+        val currency = Currency("USD")
+        assertEquals("USD", currency.code)
+    }
+
+    @Test
+    fun constructWithEUR() {
+        assertEquals("EUR", Currency("EUR").code)
+    }
+
+    @Test
+    fun constructWithGBP() {
+        assertEquals("GBP", Currency("GBP").code)
+    }
+
+    @Test
+    fun constructWithJPY() {
+        assertEquals("JPY", Currency("JPY").code)
+    }
+
+    @Test
+    fun constructWithBHD() {
+        assertEquals("BHD", Currency("BHD").code)
+    }
+
+    @Test
+    fun constructWithCAD() {
+        assertEquals("CAD", Currency("CAD").code)
+    }
+
+    // ── Construction — invalid codes ────────────────────────────────────
+
+    @Test
+    fun rejectLowercaseCode() {
+        assertFailsWith<IllegalArgumentException> {
+            Currency("usd")
+        }
+    }
+
+    @Test
+    fun rejectMixedCaseCode() {
+        assertFailsWith<IllegalArgumentException> {
+            Currency("Usd")
+        }
+    }
+
+    @Test
+    fun rejectTwoLetterCode() {
+        assertFailsWith<IllegalArgumentException> {
+            Currency("US")
+        }
+    }
+
+    @Test
+    fun rejectFourLetterCode() {
+        assertFailsWith<IllegalArgumentException> {
+            Currency("USDT")
+        }
+    }
+
+    @Test
+    fun rejectEmptyString() {
+        assertFailsWith<IllegalArgumentException> {
+            Currency("")
+        }
+    }
+
+    @Test
+    fun rejectSingleCharacter() {
+        assertFailsWith<IllegalArgumentException> {
+            Currency("U")
+        }
+    }
+
+    @Test
+    fun rejectCodeWithDigits() {
+        assertFailsWith<IllegalArgumentException> {
+            Currency("US1")
+        }
+    }
+
+    @Test
+    fun rejectCodeWithSpaces() {
+        assertFailsWith<IllegalArgumentException> {
+            Currency("U S")
+        }
+    }
+
+    @Test
+    fun rejectCodeWithSpecialChars() {
+        assertFailsWith<IllegalArgumentException> {
+            Currency("US$")
+        }
+    }
+
+    // ── Decimal places ──────────────────────────────────────────────────
+
+    @Test
+    fun usdHasTwoDecimalPlaces() {
+        assertEquals(2, Currency.USD.decimalPlaces)
+    }
+
+    @Test
+    fun eurHasTwoDecimalPlaces() {
+        assertEquals(2, Currency.EUR.decimalPlaces)
+    }
+
+    @Test
+    fun gbpHasTwoDecimalPlaces() {
+        assertEquals(2, Currency.GBP.decimalPlaces)
+    }
+
+    @Test
+    fun cadHasTwoDecimalPlaces() {
+        assertEquals(2, Currency.CAD.decimalPlaces)
+    }
+
+    @Test
+    fun jpyHasZeroDecimalPlaces() {
+        assertEquals(0, Currency.JPY.decimalPlaces)
+    }
+
+    @Test
+    fun krwHasZeroDecimalPlaces() {
+        assertEquals(0, Currency("KRW").decimalPlaces)
+    }
+
+    @Test
+    fun vndHasZeroDecimalPlaces() {
+        assertEquals(0, Currency("VND").decimalPlaces)
+    }
+
+    @Test
+    fun bhdHasThreeDecimalPlaces() {
+        assertEquals(3, Currency("BHD").decimalPlaces)
+    }
+
+    @Test
+    fun kwdHasThreeDecimalPlaces() {
+        assertEquals(3, Currency("KWD").decimalPlaces)
+    }
+
+    @Test
+    fun omrHasThreeDecimalPlaces() {
+        assertEquals(3, Currency("OMR").decimalPlaces)
+    }
+
+    @Test
+    fun unknownCurrencyDefaultsToTwoDecimalPlaces() {
+        // Any valid 3-letter code not in the explicit lists defaults to 2
+        assertEquals(2, Currency("XYZ").decimalPlaces)
+    }
+
+    // ── Companion constants ─────────────────────────────────────────────
+
+    @Test
+    fun companionUsd() {
+        assertEquals(Currency("USD"), Currency.USD)
+    }
+
+    @Test
+    fun companionEur() {
+        assertEquals(Currency("EUR"), Currency.EUR)
+    }
+
+    @Test
+    fun companionGbp() {
+        assertEquals(Currency("GBP"), Currency.GBP)
+    }
+
+    @Test
+    fun companionJpy() {
+        assertEquals(Currency("JPY"), Currency.JPY)
+    }
+
+    @Test
+    fun companionCad() {
+        assertEquals(Currency("CAD"), Currency.CAD)
+    }
+
+    // ── Equality (value class) ──────────────────────────────────────────
+
+    @Test
+    fun equalityByCode() {
+        assertEquals(Currency("USD"), Currency("USD"))
+    }
+
+    @Test
+    fun inequalityByCode() {
+        assertTrue(Currency("USD") != Currency("EUR"))
+    }
+}

--- a/packages/models/src/commonTest/kotlin/com/finance/models/types/SyncIdTest.kt
+++ b/packages/models/src/commonTest/kotlin/com/finance/models/types/SyncIdTest.kt
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.models.types
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [SyncId] — opaque, type-safe UUID wrapper.
+ *
+ * Validates construction constraints and value-class equality semantics.
+ */
+class SyncIdTest {
+
+    // ── Construction — valid ────────────────────────────────────────────
+
+    @Test
+    fun constructWithUuidString() {
+        val id = SyncId("550e8400-e29b-41d4-a716-446655440000")
+        assertEquals("550e8400-e29b-41d4-a716-446655440000", id.value)
+    }
+
+    @Test
+    fun constructWithArbitraryNonBlankString() {
+        // SyncId only requires non-blank — no UUID format check
+        val id = SyncId("my-custom-id")
+        assertEquals("my-custom-id", id.value)
+    }
+
+    @Test
+    fun constructWithSingleCharacter() {
+        val id = SyncId("a")
+        assertEquals("a", id.value)
+    }
+
+    // ── Construction — invalid ──────────────────────────────────────────
+
+    @Test
+    fun rejectBlankString() {
+        assertFailsWith<IllegalArgumentException> {
+            SyncId("")
+        }
+    }
+
+    @Test
+    fun rejectWhitespaceOnlyString() {
+        assertFailsWith<IllegalArgumentException> {
+            SyncId("   ")
+        }
+    }
+
+    @Test
+    fun rejectTabOnlyString() {
+        assertFailsWith<IllegalArgumentException> {
+            SyncId("\t")
+        }
+    }
+
+    @Test
+    fun rejectNewlineOnlyString() {
+        assertFailsWith<IllegalArgumentException> {
+            SyncId("\n")
+        }
+    }
+
+    // ── Equality (value class) ──────────────────────────────────────────
+
+    @Test
+    fun equalityByValue() {
+        val id1 = SyncId("abc-123")
+        val id2 = SyncId("abc-123")
+        assertEquals(id1, id2)
+    }
+
+    @Test
+    fun inequalityByValue() {
+        val id1 = SyncId("abc-123")
+        val id2 = SyncId("def-456")
+        assertTrue(id1 != id2)
+    }
+
+    @Test
+    fun hashCodeConsistency() {
+        val id1 = SyncId("abc-123")
+        val id2 = SyncId("abc-123")
+        assertEquals(id1.hashCode(), id2.hashCode())
+    }
+
+    // ── Value access ────────────────────────────────────────────────────
+
+    @Test
+    fun valuePreservesOriginalString() {
+        val original = "  leading-space-preserved"
+        val id = SyncId(original)
+        assertEquals(original, id.value)
+    }
+}


### PR DESCRIPTION
237 tests covering Cents arithmetic/overflow, Currency ISO 4217 validation, SyncId semantics, Transaction/Account/Budget/Goal invariants, and MigrationExecutor integration. Closes #464