### PR TITLE
feat(web): add edit/delete to all CRUD pages with ConfirmDialog (#487)

### DIFF
--- a/apps/web/src/components/common/ConfirmDialog.tsx
+++ b/apps/web/src/components/common/ConfirmDialog.tsx
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Reusable confirmation dialog for destructive or high-impact actions.
+ *
+ * Renders a compact, centered alert dialog with accessible labeling,
+ * keyboard support, focus trapping, body scroll locking, and a loading
+ * state for asynchronous confirmation flows.
+ *
+ * References: issue #487
+ */
+import { useCallback, useEffect, useId, useRef, type KeyboardEvent } from 'react';
+
+import { announce, useFocusTrap } from '../../accessibility/aria';
+
+import '../forms/forms.css';
+
+/** Props for {@link ConfirmDialog}. */
+export interface ConfirmDialogProps {
+  /** Whether the dialog is open. */
+  isOpen: boolean;
+  /** Visible dialog title announced by assistive technology. */
+  title: string;
+  /** Descriptive message explaining the action being confirmed. */
+  message: string;
+  /** Label for the confirm action button. Defaults to “Delete”. */
+  confirmLabel?: string;
+  /** Label for the cancel action button. Defaults to “Cancel”. */
+  cancelLabel?: string;
+  /** Visual emphasis for the confirm action. Defaults to `danger`. */
+  variant?: 'danger' | 'warning' | 'info';
+  /** Callback invoked when the user confirms the action. */
+  onConfirm: () => void;
+  /** Callback invoked when the user cancels, presses Escape, or clicks the backdrop. */
+  onCancel: () => void;
+  /** Whether the confirm action is currently in progress. */
+  isLoading?: boolean;
+}
+
+/**
+ * Render an accessible alert dialog that asks the user to confirm an action.
+ */
+export function ConfirmDialog({
+  isOpen,
+  title,
+  message,
+  confirmLabel = 'Delete',
+  cancelLabel = 'Cancel',
+  variant = 'danger',
+  onConfirm,
+  onCancel,
+  isLoading = false,
+}: ConfirmDialogProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const cancelButtonRef = useRef<HTMLButtonElement>(null);
+  const titleId = useId();
+  const messageId = useId();
+
+  useFocusTrap(panelRef, {
+    active: isOpen,
+    restoreFocus: true,
+    initialFocusRef: cancelButtonRef,
+  });
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (isOpen && isLoading) {
+      announce(`${confirmLabel} in progress.`, 'assertive');
+    }
+  }, [confirmLabel, isLoading, isOpen]);
+
+  const handleCancel = useCallback(() => {
+    onCancel();
+  }, [onCancel]);
+
+  const handleConfirm = useCallback(() => {
+    if (isLoading) {
+      return;
+    }
+
+    onConfirm();
+  }, [isLoading, onConfirm]);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        handleCancel();
+      }
+    },
+    [handleCancel],
+  );
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="form-dialog confirm-dialog" role="presentation">
+      <div className="form-dialog__backdrop" aria-hidden="true" onClick={handleCancel} />
+
+      <div
+        ref={panelRef}
+        className="form-dialog__panel confirm-dialog__panel"
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={messageId}
+        onKeyDown={handleKeyDown}
+      >
+        <div className="confirm-dialog__content">
+          <h2 id={titleId} className="form-dialog__title confirm-dialog__title">
+            {title}
+          </h2>
+          <p id={messageId} className="confirm-dialog__message">
+            {message}
+          </p>
+        </div>
+
+        <div className="form-actions confirm-dialog__actions">
+          <button
+            ref={cancelButtonRef}
+            type="button"
+            className="form-button form-button--secondary"
+            onClick={handleCancel}
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            className={`form-button confirm-dialog__confirm confirm-dialog__confirm--${variant}`}
+            onClick={handleConfirm}
+            disabled={isLoading}
+            aria-busy={isLoading}
+          >
+            {isLoading && <span className="confirm-dialog__spinner" aria-hidden="true" />}
+            <span>{isLoading ? `${confirmLabel}…` : confirmLabel}</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ConfirmDialog;

--- a/apps/web/src/components/common/index.ts
+++ b/apps/web/src/components/common/index.ts
@@ -8,3 +8,5 @@ export { LoadingSpinner } from './LoadingSpinner';
 export type { LoadingSpinnerProps } from './LoadingSpinner';
 export { ErrorBanner } from './ErrorBanner';
 export type { ErrorBannerProps } from './ErrorBanner';
+export { ConfirmDialog } from './ConfirmDialog';
+export type { ConfirmDialogProps } from './ConfirmDialog';

--- a/apps/web/src/components/forms/AccountForm.tsx
+++ b/apps/web/src/components/forms/AccountForm.tsx
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /**
- * Accessible account creation form.
+ * Accessible account create/edit form.
  *
- * Renders a modal dialog with fields for creating a new financial account:
+ * Renders a modal dialog with fields for creating or editing a financial account:
  * name (required), type, currency, and initial balance. Validates input
  * client-side with accessible error messages (aria-invalid / aria-describedby).
  *
@@ -31,7 +31,7 @@ import {
 import { useFocusTrap } from '../../accessibility/aria';
 import { useDatabase } from '../../db/DatabaseProvider';
 import type { CreateAccountInput } from '../../db/repositories/accounts';
-import type { AccountType, SyncId } from '../../kmp/bridge';
+import type { Account, AccountType, SyncId } from '../../kmp/bridge';
 import { queryOne, type Row } from '../../db/sqlite-wasm';
 
 import './forms.css';
@@ -73,6 +73,8 @@ export interface AccountFormProps {
   onCancel: () => void;
   /** Whether the form dialog is open. */
   isOpen: boolean;
+  /** Existing account data used to populate the form when editing. */
+  initialData?: Account;
 }
 
 // ---------------------------------------------------------------------------
@@ -121,18 +123,38 @@ function getFirstHouseholdId(db: ReturnType<typeof useDatabase>): SyncId | null 
   return null;
 }
 
+function getInitialFormValues(initialData?: Account) {
+  if (!initialData) {
+    return {
+      name: '',
+      accountType: 'CHECKING' as AccountType,
+      currency: 'USD',
+      balance: '0.00',
+    };
+  }
+
+  return {
+    name: initialData.name,
+    accountType: initialData.type,
+    currency: initialData.currency.code,
+    balance: (
+      initialData.currentBalance.amount / Math.pow(10, initialData.currency.decimalPlaces)
+    ).toFixed(initialData.currency.decimalPlaces),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
 /**
- * Accessible modal form for creating a new financial account.
+ * Accessible modal form for creating or editing a financial account.
  *
  * Provides fields for name, account type, currency, and initial balance.
  * Validates input and surfaces errors with ARIA attributes. Traps focus
  * within the dialog while open.
  */
-export function AccountForm({ onSubmit, onCancel, isOpen }: AccountFormProps) {
+export function AccountForm({ onSubmit, onCancel, isOpen, initialData }: AccountFormProps) {
   // -- refs ----------------------------------------------------------------
   const panelRef = useRef<HTMLDivElement>(null);
   const firstInputRef = useRef<HTMLInputElement>(null);
@@ -166,15 +188,16 @@ export function AccountForm({ onSubmit, onCancel, isOpen }: AccountFormProps) {
   // -- reset on open -------------------------------------------------------
   useEffect(() => {
     if (isOpen) {
-      setName('');
-      setAccountType('CHECKING');
-      setCurrency('USD');
-      setBalance('0.00');
+      const initialValues = getInitialFormValues(initialData);
+      setName(initialValues.name);
+      setAccountType(initialValues.accountType);
+      setCurrency(initialValues.currency);
+      setBalance(initialValues.balance);
       setErrors({});
       setSubmitting(false);
       setSubmitError(null);
     }
-  }, [isOpen]);
+  }, [initialData, isOpen]);
 
   // -- handlers ------------------------------------------------------------
 
@@ -203,17 +226,15 @@ export function AccountForm({ onSubmit, onCancel, isOpen }: AccountFormProps) {
         return;
       }
 
-      // Resolve household ID
-      const householdId = getFirstHouseholdId(db);
+      const householdId = initialData?.householdId ?? getFirstHouseholdId(db);
       if (!householdId) {
         setSubmitError('No household found. Please create a household before adding accounts.');
         return;
       }
 
-      const balanceCents = Math.round(parseFloat(balance || '0') * 100);
-
       const currencyObj = CURRENCY_OPTIONS.find((c) => c.code === currency);
       const decimalPlaces = currency === 'JPY' ? 0 : 2;
+      const balanceCents = Math.round(parseFloat(balance || '0') * Math.pow(10, decimalPlaces));
 
       const input: CreateAccountInput = {
         householdId,
@@ -231,19 +252,25 @@ export function AccountForm({ onSubmit, onCancel, isOpen }: AccountFormProps) {
 
       try {
         await onSubmit(input);
-        // Reset form on success
-        setName('');
-        setAccountType('CHECKING');
-        setCurrency('USD');
-        setBalance('0.00');
+        const initialValues = getInitialFormValues();
+        setName(initialValues.name);
+        setAccountType(initialValues.accountType);
+        setCurrency(initialValues.currency);
+        setBalance(initialValues.balance);
         setErrors({});
       } catch (err) {
-        setSubmitError(err instanceof Error ? err.message : 'Failed to create account.');
+        setSubmitError(
+          err instanceof Error
+            ? err.message
+            : initialData
+              ? 'Failed to update account.'
+              : 'Failed to create account.',
+        );
       } finally {
         setSubmitting(false);
       }
     },
-    [name, balance, accountType, currency, db, onSubmit],
+    [name, balance, accountType, currency, db, initialData, onSubmit],
   );
 
   // -- render --------------------------------------------------------------
@@ -269,7 +296,7 @@ export function AccountForm({ onSubmit, onCancel, isOpen }: AccountFormProps) {
         aria-labelledby="account-form-title"
       >
         <h2 id="account-form-title" className="form-dialog__title">
-          Create Account
+          {initialData ? 'Edit Account' : 'Create Account'}
         </h2>
 
         {/* Form-level error */}
@@ -388,7 +415,13 @@ export function AccountForm({ onSubmit, onCancel, isOpen }: AccountFormProps) {
               disabled={submitting}
               aria-busy={submitting}
             >
-              {submitting ? 'Creating…' : 'Create Account'}
+              {submitting
+                ? initialData
+                  ? 'Updating…'
+                  : 'Creating…'
+                : initialData
+                  ? 'Update Account'
+                  : 'Create Account'}
             </button>
           </div>
         </form>

--- a/apps/web/src/components/forms/BudgetForm.tsx
+++ b/apps/web/src/components/forms/BudgetForm.tsx
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /**
- * Accessible budget creation form.
+ * Accessible budget create/edit form.
  *
- * Renders a modal dialog with fields for creating a new budget:
+ * Renders a modal dialog with fields for creating or editing a budget:
  * category (required select), amount (required, dollars → cents),
  * period (select, default Monthly), and start date (default first of current
  * month).
@@ -19,7 +19,7 @@
  *
  * @module components/forms/BudgetForm
  * @see {@link CreateBudgetInput} from db/repositories/budgets
- * References: issue #461
+ * References: issue #461, #487
  */
 
 import {
@@ -33,7 +33,7 @@ import {
 
 import { useFocusTrap } from '../../accessibility/aria';
 import type { CreateBudgetInput } from '../../db/repositories/budgets';
-import type { BudgetPeriod, Category } from '../../kmp/bridge';
+import type { Budget, BudgetPeriod, Category } from '../../kmp/bridge';
 
 import './forms.css';
 
@@ -67,6 +67,8 @@ export interface BudgetFormProps {
   onSubmit: (data: CreateBudgetInput) => Promise<void>;
   /** Available categories to assign the budget to. */
   categories: Category[];
+  /** Existing budget data used to prefill the form when editing. */
+  initialData?: Budget;
 }
 
 // ---------------------------------------------------------------------------
@@ -79,6 +81,12 @@ function firstOfCurrentMonthISO(): string {
   const year = d.getFullYear();
   const month = String(d.getMonth() + 1).padStart(2, '0');
   return `${year}-${month}-01`;
+}
+
+/** Convert a stored cents amount into a decimal string for the amount input. */
+function formatBudgetAmountForInput(budget: Budget): string {
+  const divisor = Math.pow(10, budget.currency.decimalPlaces);
+  return (budget.amount.amount / divisor).toFixed(budget.currency.decimalPlaces);
 }
 
 // ---------------------------------------------------------------------------
@@ -110,13 +118,19 @@ function validate(categoryId: string, amountStr: string): FormErrors {
 // ---------------------------------------------------------------------------
 
 /**
- * Accessible modal form for creating a new budget.
+ * Accessible modal form for creating or editing a budget.
  *
  * Provides fields for category, amount (dollars, converted to integer cents
  * before submission), period, and start date. Validates input and surfaces
  * errors with ARIA attributes. Traps focus within the dialog while open.
  */
-export function BudgetForm({ isOpen, onCancel, onSubmit, categories }: BudgetFormProps) {
+export function BudgetForm({
+  isOpen,
+  onCancel,
+  onSubmit,
+  categories,
+  initialData,
+}: BudgetFormProps) {
   // -- refs ----------------------------------------------------------------
   const panelRef = useRef<HTMLDivElement>(null);
   const firstInputRef = useRef<HTMLSelectElement>(null);
@@ -129,6 +143,7 @@ export function BudgetForm({ isOpen, onCancel, onSubmit, categories }: BudgetFor
   const [errors, setErrors] = useState<FormErrors>({});
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const isEditMode = initialData !== undefined;
 
   // -- focus trap -----------------------------------------------------------
   useFocusTrap(panelRef, { active: isOpen, restoreFocus: true });
@@ -146,15 +161,15 @@ export function BudgetForm({ isOpen, onCancel, onSubmit, categories }: BudgetFor
   // -- reset on open -------------------------------------------------------
   useEffect(() => {
     if (isOpen) {
-      setCategoryId('');
-      setAmount('');
-      setPeriod('MONTHLY');
-      setStartDate(firstOfCurrentMonthISO());
+      setCategoryId(initialData?.categoryId ?? '');
+      setAmount(initialData ? formatBudgetAmountForInput(initialData) : '');
+      setPeriod(initialData?.period ?? 'MONTHLY');
+      setStartDate(initialData?.startDate ?? firstOfCurrentMonthISO());
       setErrors({});
       setSubmitting(false);
       setSubmitError(null);
     }
-  }, [isOpen]);
+  }, [initialData, isOpen]);
 
   // -- handlers ------------------------------------------------------------
 
@@ -209,19 +224,24 @@ export function BudgetForm({ isOpen, onCancel, onSubmit, categories }: BudgetFor
 
       try {
         await onSubmit(input);
-        // Reset form on success
         setCategoryId('');
         setAmount('');
         setPeriod('MONTHLY');
         setStartDate(firstOfCurrentMonthISO());
         setErrors({});
       } catch (err) {
-        setSubmitError(err instanceof Error ? err.message : 'Failed to create budget.');
+        setSubmitError(
+          err instanceof Error
+            ? err.message
+            : isEditMode
+              ? 'Failed to update budget.'
+              : 'Failed to create budget.',
+        );
       } finally {
         setSubmitting(false);
       }
     },
-    [categoryId, amount, period, startDate, categories, onSubmit],
+    [categoryId, amount, period, startDate, categories, isEditMode, onSubmit],
   );
 
   // -- render --------------------------------------------------------------
@@ -247,7 +267,7 @@ export function BudgetForm({ isOpen, onCancel, onSubmit, categories }: BudgetFor
         aria-labelledby="budget-form-title"
       >
         <h2 id="budget-form-title" className="form-dialog__title">
-          Create Budget
+          {isEditMode ? 'Edit Budget' : 'Create Budget'}
         </h2>
 
         {/* Form-level error */}
@@ -371,7 +391,13 @@ export function BudgetForm({ isOpen, onCancel, onSubmit, categories }: BudgetFor
               disabled={submitting}
               aria-busy={submitting}
             >
-              {submitting ? 'Creating…' : 'Create Budget'}
+              {submitting
+                ? isEditMode
+                  ? 'Updating…'
+                  : 'Creating…'
+                : isEditMode
+                  ? 'Update Budget'
+                  : 'Create Budget'}
             </button>
           </div>
         </form>

--- a/apps/web/src/components/forms/GoalForm.tsx
+++ b/apps/web/src/components/forms/GoalForm.tsx
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /**
- * Accessible goal creation form.
+ * Accessible goal creation and editing form.
  *
- * Renders a modal dialog with fields for creating a new savings goal:
+ * Renders a modal dialog with fields for creating or editing a savings goal:
  * name (required), target amount (required), current amount (defaults to zero),
- * target date (optional, must be in the future), and description (optional).
+ * target date (optional), and description (optional).
  *
  * Validates input client-side with accessible error messages using
  * `aria-invalid` and `aria-describedby`. The household ID is resolved from the
@@ -16,7 +16,7 @@
  *
  * @module components/forms/GoalForm
  * @see {@link CreateGoalInput} from db/repositories/goals
- * References: issue #444
+ * References: issues #444, #487
  */
 
 import {
@@ -32,7 +32,7 @@ import { useFocusTrap } from '../../accessibility/aria';
 import { useDatabase } from '../../db/DatabaseProvider';
 import type { CreateGoalInput } from '../../db/repositories/goals';
 import { queryOne, type Row } from '../../db/sqlite-wasm';
-import type { GoalStatus, SyncId } from '../../kmp/bridge';
+import type { Goal, GoalStatus, SyncId } from '../../kmp/bridge';
 
 import './forms.css';
 
@@ -46,6 +46,8 @@ export interface GoalFormProps {
   onCancel: () => void;
   /** Callback invoked with validated form data when the user submits. */
   onSubmit: (data: CreateGoalInput) => Promise<void>;
+  /** Existing goal data used to prefill the form when editing. */
+  initialData?: Goal;
 }
 
 interface FormErrors {
@@ -74,11 +76,24 @@ function tomorrowISO(): string {
   return `${year}-${month}-${day}`;
 }
 
+/** Format a stored currency amount for a decimal text input. */
+function formatAmountForInput(amountInMinorUnits: number, decimalPlaces = 2): string {
+  const divisor = Math.pow(10, decimalPlaces);
+  return (amountInMinorUnits / divisor).toFixed(decimalPlaces);
+}
+
+/** Return an optional goal description when the runtime object includes one. */
+function getGoalDescription(goal?: Goal): string {
+  const goalWithDescription = goal as (Goal & { description?: string | null }) | undefined;
+  return goalWithDescription?.description ?? '';
+}
+
 function validate(
   name: string,
   targetAmountStr: string,
   currentAmountStr: string,
   targetDate: string,
+  requireFutureTargetDate: boolean,
 ): FormErrors {
   const errors: FormErrors = {};
 
@@ -98,7 +113,7 @@ function validate(
     }
   }
 
-  if (targetDate && targetDate <= todayISO()) {
+  if (requireFutureTargetDate && targetDate && targetDate <= todayISO()) {
     errors.targetDate = 'Target date must be in the future.';
   }
 
@@ -122,15 +137,16 @@ function getFirstHouseholdId(db: ReturnType<typeof useDatabase>): SyncId | null 
 }
 
 /**
- * Accessible modal form for creating a new financial goal.
+ * Accessible modal form for creating or editing a financial goal.
  *
  * Provides fields for name, target amount, current amount, target date, and
  * description. Validates input and surfaces errors with ARIA attributes.
  * Traps focus within the dialog while open.
  */
-export function GoalForm({ isOpen, onCancel, onSubmit }: GoalFormProps) {
+export function GoalForm({ isOpen, onCancel, onSubmit, initialData }: GoalFormProps) {
   const panelRef = useRef<HTMLDivElement>(null);
   const firstInputRef = useRef<HTMLInputElement>(null);
+  const isEditing = initialData !== undefined;
 
   const [name, setName] = useState('');
   const [targetAmount, setTargetAmount] = useState('');
@@ -155,17 +171,25 @@ export function GoalForm({ isOpen, onCancel, onSubmit }: GoalFormProps) {
   }, [isOpen]);
 
   useEffect(() => {
-    if (isOpen) {
-      setName('');
-      setTargetAmount('');
-      setCurrentAmount('0.00');
-      setTargetDate('');
-      setDescription('');
-      setErrors({});
-      setSubmitting(false);
-      setSubmitError(null);
+    if (!isOpen) {
+      return;
     }
-  }, [isOpen]);
+
+    const decimalPlaces = initialData?.currency.decimalPlaces ?? 2;
+
+    setName(initialData?.name ?? '');
+    setTargetAmount(
+      initialData ? formatAmountForInput(initialData.targetAmount.amount, decimalPlaces) : '',
+    );
+    setCurrentAmount(
+      initialData ? formatAmountForInput(initialData.currentAmount.amount, decimalPlaces) : '0.00',
+    );
+    setTargetDate(initialData?.targetDate ?? '');
+    setDescription(getGoalDescription(initialData));
+    setErrors({});
+    setSubmitting(false);
+    setSubmitError(null);
+  }, [initialData, isOpen]);
 
   const handleCancel = useCallback(() => {
     onCancel();
@@ -185,16 +209,16 @@ export function GoalForm({ isOpen, onCancel, onSubmit }: GoalFormProps) {
     async (event: FormEvent) => {
       event.preventDefault();
 
-      const fieldErrors = validate(name, targetAmount, currentAmount, targetDate);
+      const fieldErrors = validate(name, targetAmount, currentAmount, targetDate, !isEditing);
       setErrors(fieldErrors);
 
       if (Object.keys(fieldErrors).length > 0) {
         return;
       }
 
-      const householdId = getFirstHouseholdId(db);
+      const householdId = initialData?.householdId ?? getFirstHouseholdId(db);
       if (!householdId) {
-        setSubmitError('No household found. Please create a household before adding goals.');
+        setSubmitError('No household found. Please create a household before saving goals.');
         return;
       }
 
@@ -204,7 +228,7 @@ export function GoalForm({ isOpen, onCancel, onSubmit }: GoalFormProps) {
         targetAmount: { amount: Math.round(parseFloat(targetAmount) * 100) },
         currentAmount: { amount: Math.round(parseFloat(currentAmount || '0') * 100) },
         targetDate: targetDate || null,
-        status: DEFAULT_GOAL_STATUS,
+        status: initialData?.status ?? DEFAULT_GOAL_STATUS,
       };
 
       setSubmitting(true);
@@ -212,19 +236,20 @@ export function GoalForm({ isOpen, onCancel, onSubmit }: GoalFormProps) {
 
       try {
         await onSubmit(input);
-        setName('');
-        setTargetAmount('');
-        setCurrentAmount('0.00');
-        setTargetDate('');
-        setDescription('');
         setErrors({});
       } catch (err) {
-        setSubmitError(err instanceof Error ? err.message : 'Failed to create goal.');
+        setSubmitError(
+          err instanceof Error
+            ? err.message
+            : isEditing
+              ? 'Failed to update goal.'
+              : 'Failed to create goal.',
+        );
       } finally {
         setSubmitting(false);
       }
     },
-    [name, targetAmount, currentAmount, targetDate, db, onSubmit],
+    [currentAmount, db, initialData, isEditing, name, onSubmit, targetAmount, targetDate],
   );
 
   if (!isOpen) {
@@ -235,7 +260,10 @@ export function GoalForm({ isOpen, onCancel, onSubmit }: GoalFormProps) {
   const hasTargetAmountError = Boolean(errors.targetAmount);
   const hasCurrentAmountError = Boolean(errors.currentAmount);
   const hasTargetDateError = Boolean(errors.targetDate);
-  const minimumTargetDate = tomorrowISO();
+  const minimumTargetDate = isEditing ? undefined : tomorrowISO();
+  const dialogTitle = isEditing ? 'Edit Goal' : 'Create Goal';
+  const submitLabel = isEditing ? 'Update Goal' : 'Create Goal';
+  const submittingLabel = isEditing ? 'Updating…' : 'Creating…';
 
   return (
     <div className="form-dialog" role="presentation" onKeyDown={handleKeyDown}>
@@ -249,7 +277,7 @@ export function GoalForm({ isOpen, onCancel, onSubmit }: GoalFormProps) {
         aria-labelledby="goal-form-title"
       >
         <h2 id="goal-form-title" className="form-dialog__title">
-          Create Goal
+          {dialogTitle}
         </h2>
 
         {submitError && (
@@ -389,7 +417,7 @@ export function GoalForm({ isOpen, onCancel, onSubmit }: GoalFormProps) {
               disabled={submitting}
               aria-busy={submitting}
             >
-              {submitting ? 'Creating…' : 'Create Goal'}
+              {submitting ? submittingLabel : submitLabel}
             </button>
           </div>
         </form>

--- a/apps/web/src/components/forms/TransactionForm.tsx
+++ b/apps/web/src/components/forms/TransactionForm.tsx
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /**
- * Accessible transaction creation form.
+ * Accessible transaction form for creating and editing transactions.
  *
- * Renders a modal dialog with fields for creating a new financial transaction:
+ * Renders a modal dialog with fields for creating or editing a financial transaction:
  * amount (required, > 0), description (required, maps to `payee`), type
  * (radio group, default EXPENSE), category (optional select), account
  * (required select), date (default today), and notes (optional textarea).
@@ -18,7 +18,7 @@
  *
  * @module components/forms/TransactionForm
  * @see {@link CreateTransactionInput} from db/repositories/transactions
- * References: issue #445
+ * References: issues #445, #487
  */
 
 import {
@@ -32,7 +32,7 @@ import {
 
 import { useFocusTrap } from '../../accessibility/aria';
 import type { CreateTransactionInput } from '../../db/repositories/transactions';
-import type { Account, Category, TransactionType } from '../../kmp/bridge';
+import type { Account, Category, Transaction, TransactionType } from '../../kmp/bridge';
 
 import './forms.css';
 
@@ -63,6 +63,8 @@ export interface TransactionFormProps {
   categories: Category[];
   /** Whether the form dialog is open. */
   isOpen: boolean;
+  /** Existing transaction data used to prefill the form in edit mode. */
+  initialData?: Transaction;
 }
 
 // ---------------------------------------------------------------------------
@@ -76,6 +78,14 @@ function todayISO(): string {
   const month = String(d.getMonth() + 1).padStart(2, '0');
   const day = String(d.getDate()).padStart(2, '0');
   return `${year}-${month}-${day}`;
+}
+
+/** Convert a stored transaction amount into a decimal string for the amount input. */
+function formatAmountForInput(transaction: Transaction): string {
+  const divisor = Math.pow(10, transaction.currency.decimalPlaces);
+  return (Math.abs(transaction.amount.amount) / divisor).toFixed(
+    transaction.currency.decimalPlaces,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -112,7 +122,7 @@ function validate(amountStr: string, description: string, accountId: string): Fo
 // ---------------------------------------------------------------------------
 
 /**
- * Accessible modal form for creating a new financial transaction.
+ * Accessible modal form for creating or editing a financial transaction.
  *
  * Provides fields for amount, description, transaction type, category,
  * account, date, and notes. Validates input and surfaces errors with
@@ -124,6 +134,7 @@ export function TransactionForm({
   accounts,
   categories,
   isOpen,
+  initialData,
 }: TransactionFormProps) {
   // -- refs ----------------------------------------------------------------
   const panelRef = useRef<HTMLDivElement>(null);
@@ -154,21 +165,23 @@ export function TransactionForm({
     }
   }, [isOpen]);
 
-  // -- reset on open -------------------------------------------------------
+  // -- initialize on open --------------------------------------------------
   useEffect(() => {
-    if (isOpen) {
-      setAmount('');
-      setDescription('');
-      setTransactionType('EXPENSE');
-      setCategoryId('');
-      setAccountId('');
-      setDate(todayISO());
-      setNotes('');
-      setErrors({});
-      setSubmitting(false);
-      setSubmitError(null);
+    if (!isOpen) {
+      return;
     }
-  }, [isOpen]);
+
+    setAmount(initialData ? formatAmountForInput(initialData) : '');
+    setDescription(initialData?.payee ?? '');
+    setTransactionType(initialData?.type ?? 'EXPENSE');
+    setCategoryId(initialData?.categoryId ?? '');
+    setAccountId(initialData?.accountId ?? '');
+    setDate(initialData?.date ?? todayISO());
+    setNotes(initialData?.note ?? '');
+    setErrors({});
+    setSubmitting(false);
+    setSubmitError(null);
+  }, [initialData, isOpen]);
 
   // -- handlers ------------------------------------------------------------
 
@@ -185,6 +198,14 @@ export function TransactionForm({
     },
     [handleCancel],
   );
+
+  const isEditMode = initialData !== undefined;
+  const dialogTitle = isEditMode ? 'Edit Transaction' : 'New Transaction';
+  const submitButtonLabel = isEditMode ? 'Update Transaction' : 'Add Transaction';
+  const submittingLabel = isEditMode ? 'Updating…' : 'Adding…';
+  const submitFailureMessage = isEditMode
+    ? 'Failed to update transaction.'
+    : 'Failed to add transaction.';
 
   const handleSubmit = useCallback(
     async (e: FormEvent) => {
@@ -233,12 +254,23 @@ export function TransactionForm({
         setNotes('');
         setErrors({});
       } catch (err) {
-        setSubmitError(err instanceof Error ? err.message : 'Failed to create transaction.');
+        setSubmitError(err instanceof Error ? err.message : submitFailureMessage);
       } finally {
         setSubmitting(false);
       }
     },
-    [amount, description, accountId, accounts, transactionType, date, categoryId, notes, onSubmit],
+    [
+      amount,
+      description,
+      accountId,
+      accounts,
+      transactionType,
+      date,
+      categoryId,
+      notes,
+      onSubmit,
+      submitFailureMessage,
+    ],
   );
 
   // -- render --------------------------------------------------------------
@@ -265,7 +297,7 @@ export function TransactionForm({
         aria-labelledby="transaction-form-title"
       >
         <h2 id="transaction-form-title" className="form-dialog__title">
-          Create Transaction
+          {dialogTitle}
         </h2>
 
         {/* Form-level error */}
@@ -446,7 +478,7 @@ export function TransactionForm({
               disabled={submitting}
               aria-busy={submitting}
             >
-              {submitting ? 'Creating…' : 'Create Transaction'}
+              {submitting ? submittingLabel : submitButtonLabel}
             </button>
           </div>
         </form>

--- a/apps/web/src/components/forms/forms.css
+++ b/apps/web/src/components/forms/forms.css
@@ -268,6 +268,80 @@
 }
 
 /* ---------------------------------------------------------------------------
+ * Confirm dialog
+ * ------------------------------------------------------------------------- */
+
+.confirm-dialog__panel {
+  max-width: 420px;
+  padding: var(--spacing-5);
+}
+
+.confirm-dialog__title {
+  margin-bottom: var(--spacing-3);
+}
+
+.confirm-dialog__message {
+  margin: 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-body-font-size);
+  line-height: var(--line-height-relaxed, 1.5);
+}
+
+.confirm-dialog__actions {
+  margin-top: var(--spacing-6);
+  flex-wrap: wrap;
+}
+
+.confirm-dialog__confirm {
+  min-width: 120px;
+  transition:
+    filter var(--duration-fast, 100ms) ease,
+    opacity var(--duration-fast, 100ms) ease;
+}
+
+.confirm-dialog__confirm:hover:not(:disabled),
+.confirm-dialog__confirm:active:not(:disabled) {
+  filter: brightness(0.95);
+}
+
+.confirm-dialog__confirm--danger {
+  background: var(--semantic-status-negative);
+  color: var(--color-neutral-50, #ffffff);
+  border-color: var(--semantic-status-negative);
+}
+
+.confirm-dialog__confirm--warning {
+  background: var(--semantic-status-warning);
+  color: var(--color-neutral-950, #111827);
+  border-color: var(--semantic-status-warning);
+}
+
+.confirm-dialog__confirm--info {
+  background: var(--semantic-status-info);
+  color: var(--color-neutral-950, #111827);
+  border-color: var(--semantic-status-info);
+}
+
+.confirm-dialog__spinner {
+  width: 0.875rem;
+  height: 0.875rem;
+  border: 2px solid rgba(255, 255, 255, 0.35);
+  border-top-color: currentColor;
+  border-radius: 999px;
+  animation: confirm-dialog-spinner-rotate 1s linear infinite;
+}
+
+@keyframes confirm-dialog-spinner-rotate {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* ---------------------------------------------------------------------------
  * Form-level error banner
  * ------------------------------------------------------------------------- */
 
@@ -296,12 +370,28 @@
     padding: var(--spacing-4);
   }
 
+  .confirm-dialog__panel {
+    max-width: min(420px, 100%);
+    max-height: calc(100dvh - var(--spacing-8));
+    border-radius: var(--border-radius-lg, var(--border-radius-md));
+    padding: var(--spacing-5);
+  }
+
   .form-actions {
     flex-direction: column-reverse;
   }
 
+  .confirm-dialog__actions {
+    flex-direction: row;
+  }
+
   .form-button {
     width: 100%;
+  }
+
+  .confirm-dialog__actions .form-button {
+    flex: 1 1 140px;
+    width: auto;
   }
 
   .form-radio-group__options {
@@ -348,10 +438,15 @@
     animation: none;
   }
 
+  .confirm-dialog__spinner {
+    display: none;
+  }
+
   .form-input,
   .form-select,
   .form-textarea,
-  .form-button {
+  .form-button,
+  .confirm-dialog__confirm {
     transition: none;
   }
 }

--- a/apps/web/src/pages/AccountsPage.tsx
+++ b/apps/web/src/pages/AccountsPage.tsx
@@ -1,10 +1,16 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { useMemo, useState } from 'react';
-import { CurrencyDisplay, EmptyState, ErrorBanner, LoadingSpinner } from '../components/common';
+import {
+  ConfirmDialog,
+  CurrencyDisplay,
+  EmptyState,
+  ErrorBanner,
+  LoadingSpinner,
+} from '../components/common';
 import { AccountForm } from '../components/forms';
 import { useAccounts } from '../hooks';
-import type { AccountType } from '../kmp/bridge';
+import type { Account, AccountType } from '../kmp/bridge';
 
 const ACCOUNT_TYPE_LABELS: Record<AccountType, string> = {
   CHECKING: 'Checking',
@@ -29,7 +35,10 @@ const ACCOUNT_TYPE_ORDER: AccountType[] = [
 export const AccountsPage: React.FC = () => {
   const [selectedAccountId, setSelectedAccountId] = useState<string | null>(null);
   const [isFormOpen, setIsFormOpen] = useState(false);
-  const { accounts, loading, error, refresh, createAccount } = useAccounts();
+  const [editingAccount, setEditingAccount] = useState<Account | null>(null);
+  const [deletingAccount, setDeletingAccount] = useState<Account | null>(null);
+  const { accounts, loading, error, refresh, createAccount, updateAccount, deleteAccount } =
+    useAccounts();
 
   const accountGroups = useMemo(
     () =>
@@ -51,6 +60,11 @@ export const AccountsPage: React.FC = () => {
     fontWeight: 'var(--type-scale-headline-font-weight)',
     margin: 0,
   } as const;
+  const handleCloseForm = () => {
+    setIsFormOpen(false);
+    setEditingAccount(null);
+  };
+
   const pageHeader = (
     <div
       style={{
@@ -66,7 +80,10 @@ export const AccountsPage: React.FC = () => {
       <button
         type="button"
         className="add-button"
-        onClick={() => setIsFormOpen(true)}
+        onClick={() => {
+          setEditingAccount(null);
+          setIsFormOpen(true);
+        }}
         aria-label="Add new account"
       >
         + Add Account
@@ -76,14 +93,27 @@ export const AccountsPage: React.FC = () => {
   const accountForm = (
     <AccountForm
       isOpen={isFormOpen}
-      onCancel={() => setIsFormOpen(false)}
+      initialData={editingAccount ?? undefined}
+      onCancel={handleCloseForm}
       onSubmit={async (data) => {
-        const createdAccount = createAccount(data);
-        if (createdAccount === null) {
-          throw new Error('Failed to create account.');
+        if (editingAccount !== null) {
+          const updatedAccount = updateAccount(editingAccount.id, {
+            householdId: editingAccount.householdId,
+            name: data.name,
+            type: data.type,
+            currency: data.currency,
+            currentBalance: data.currentBalance,
+          });
+          if (updatedAccount === null) {
+            throw new Error('Failed to update account.');
+          }
+        } else {
+          const createdAccount = createAccount(data);
+          if (createdAccount === null) {
+            throw new Error('Failed to create account.');
+          }
         }
-        setIsFormOpen(false);
-        refresh();
+        handleCloseForm();
       }}
     />
   );
@@ -151,6 +181,34 @@ export const AccountsPage: React.FC = () => {
           </svg>
         </button>
         <h2>{selectedAccount.name}</h2>
+        <div
+          style={{
+            display: 'flex',
+            gap: 'var(--spacing-3)',
+            flexWrap: 'wrap',
+            marginBottom: 'var(--spacing-4)',
+          }}
+        >
+          <button
+            type="button"
+            className="form-button form-button--secondary"
+            onClick={() => {
+              setEditingAccount(selectedAccount);
+              setIsFormOpen(true);
+            }}
+            aria-label={`Edit ${selectedAccount.name}`}
+          >
+            ✏️ Edit
+          </button>
+          <button
+            type="button"
+            className="form-button confirm-dialog__confirm confirm-dialog__confirm--danger"
+            onClick={() => setDeletingAccount(selectedAccount)}
+            aria-label={`Delete ${selectedAccount.name}`}
+          >
+            🗑️ Delete
+          </button>
+        </div>
         <article className="card" aria-label="Account details">
           <dl style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 'var(--spacing-4)' }}>
             <div>
@@ -169,6 +227,31 @@ export const AccountsPage: React.FC = () => {
             </div>
           </dl>
         </article>
+        {accountForm}
+        <ConfirmDialog
+          isOpen={deletingAccount !== null}
+          title="Delete account"
+          message={
+            deletingAccount !== null
+              ? `Are you sure you want to delete ${deletingAccount.name}?`
+              : ''
+          }
+          confirmLabel="Delete"
+          onCancel={() => setDeletingAccount(null)}
+          onConfirm={() => {
+            if (deletingAccount === null) {
+              return;
+            }
+
+            const deleted = deleteAccount(deletingAccount.id);
+            if (!deleted) {
+              return;
+            }
+
+            setDeletingAccount(null);
+            setSelectedAccountId(null);
+          }}
+        />
       </>
     );
   }
@@ -235,6 +318,30 @@ export const AccountsPage: React.FC = () => {
         );
       })}
       {accountForm}
+      <ConfirmDialog
+        isOpen={deletingAccount !== null}
+        title="Delete account"
+        message={
+          deletingAccount !== null ? `Are you sure you want to delete ${deletingAccount.name}?` : ''
+        }
+        confirmLabel="Delete"
+        onCancel={() => setDeletingAccount(null)}
+        onConfirm={() => {
+          if (deletingAccount === null) {
+            return;
+          }
+
+          const deleted = deleteAccount(deletingAccount.id);
+          if (!deleted) {
+            return;
+          }
+
+          setDeletingAccount(null);
+          if (selectedAccountId === deletingAccount.id) {
+            setSelectedAccountId(null);
+          }
+        }}
+      />
     </>
   );
 };

--- a/apps/web/src/pages/BudgetsPage.tsx
+++ b/apps/web/src/pages/BudgetsPage.tsx
@@ -1,10 +1,17 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { useCallback, useMemo, useState } from 'react';
-import { CurrencyDisplay, EmptyState, ErrorBanner, LoadingSpinner } from '../components/common';
+import {
+  ConfirmDialog,
+  CurrencyDisplay,
+  EmptyState,
+  ErrorBanner,
+  LoadingSpinner,
+} from '../components/common';
 import { BudgetForm } from '../components/forms';
 import type { CreateBudgetInput } from '../db/repositories/budgets';
 import { useBudgets, useCategories } from '../hooks';
+import type { Budget } from '../kmp/bridge';
 
 function getBudgetIcon(iconName: string | null | undefined): string {
   switch (iconName) {
@@ -24,7 +31,8 @@ function getBudgetIcon(iconName: string | null | undefined): string {
 }
 
 export const BudgetsPage: React.FC = () => {
-  const { budgets, loading, error, refresh, createBudget } = useBudgets();
+  const { budgets, loading, error, refresh, createBudget, updateBudget, deleteBudget } =
+    useBudgets();
   const {
     categories,
     loading: categoriesLoading,
@@ -33,6 +41,8 @@ export const BudgetsPage: React.FC = () => {
   } = useCategories();
 
   const [isFormOpen, setIsFormOpen] = useState(false);
+  const [editingBudget, setEditingBudget] = useState<Budget | null>(null);
+  const [deletingBudget, setDeletingBudget] = useState<Budget | null>(null);
 
   const categoriesById = useMemo(
     () => new Map(categories.map((category) => [category.id, category])),
@@ -46,32 +56,66 @@ export const BudgetsPage: React.FC = () => {
     refreshCategories();
   };
 
-  /** Open the Create Budget dialog. */
+  /** Open the budget dialog in create mode. */
   const handleAddBudget = useCallback(() => {
+    setEditingBudget(null);
     setIsFormOpen(true);
   }, []);
 
-  /** Close the Create Budget dialog without saving. */
-  const handleFormCancel = useCallback(() => {
-    setIsFormOpen(false);
+  /** Open the budget dialog in edit mode for the selected budget. */
+  const handleEditBudget = useCallback((budget: Budget) => {
+    setEditingBudget(budget);
+    setIsFormOpen(true);
   }, []);
 
-  /**
-   * Submit a new budget.  `createBudget` from the hook is synchronous and
-   * already triggers an internal refresh on success, so we only need to close
-   * the form here.
-   */
+  /** Open the delete confirmation dialog for the selected budget. */
+  const handleDeleteBudget = useCallback((budget: Budget) => {
+    setDeletingBudget(budget);
+  }, []);
+
+  /** Close the budget form dialog without saving. */
+  const handleFormCancel = useCallback(() => {
+    setIsFormOpen(false);
+    setEditingBudget(null);
+  }, []);
+
+  /** Close the delete confirmation dialog without deleting. */
+  const handleDeleteCancel = useCallback(() => {
+    setDeletingBudget(null);
+  }, []);
+
+  /** Create or update a budget, depending on the active dialog mode. */
   const handleFormSubmit = useCallback(
     async (data: CreateBudgetInput) => {
-      const result = createBudget(data);
-      if (result === null) {
-        throw new Error('Failed to create budget.');
+      if (editingBudget) {
+        const updatedBudget = updateBudget(editingBudget.id, data);
+        if (updatedBudget === null) {
+          throw new Error('Failed to update budget.');
+        }
+      } else {
+        const createdBudget = createBudget(data);
+        if (createdBudget === null) {
+          throw new Error('Failed to create budget.');
+        }
       }
+
       setIsFormOpen(false);
-      refresh();
+      setEditingBudget(null);
     },
-    [createBudget, refresh],
+    [createBudget, editingBudget, updateBudget],
   );
+
+  /** Delete the selected budget after the user confirms the action. */
+  const handleDeleteConfirm = useCallback(() => {
+    if (!deletingBudget) {
+      return;
+    }
+
+    const deleted = deleteBudget(deletingBudget.id);
+    if (deleted) {
+      setDeletingBudget(null);
+    }
+  }, [deleteBudget, deletingBudget]);
 
   const totalBudgeted = budgets.reduce((sum, budget) => sum + budget.amount.amount, 0);
   const totalSpent = budgets.reduce((sum, budget) => sum + budget.spentAmount.amount, 0);
@@ -112,6 +156,19 @@ export const BudgetsPage: React.FC = () => {
         onCancel={handleFormCancel}
         onSubmit={handleFormSubmit}
         categories={categories}
+        initialData={editingBudget ?? undefined}
+      />
+      <ConfirmDialog
+        isOpen={deletingBudget !== null}
+        title="Delete Budget"
+        message={
+          deletingBudget
+            ? `Delete the ${deletingBudget.name} budget? This will remove it from your budgets list.`
+            : ''
+        }
+        confirmLabel="Delete Budget"
+        onConfirm={handleDeleteConfirm}
+        onCancel={handleDeleteCancel}
       />
       {isLoading ? (
         <div style={{ display: 'flex', justifyContent: 'center', padding: 'var(--spacing-8) 0' }}>
@@ -215,26 +272,81 @@ export const BudgetsPage: React.FC = () => {
                       </span>
                     </div>
                     <div style={{ flex: 1 }}>
-                      <p style={{ fontWeight: 'var(--font-weight-semibold)' }}>
-                        <span aria-hidden="true">{getBudgetIcon(category?.icon)}</span>{' '}
-                        {budget.name}
-                      </p>
-                      <p
+                      <div
                         style={{
-                          fontSize: 'var(--type-scale-caption-font-size)',
-                          color: 'var(--semantic-text-secondary)',
+                          display: 'flex',
+                          alignItems: 'flex-start',
+                          justifyContent: 'space-between',
+                          gap: 'var(--spacing-3)',
                         }}
                       >
-                        <CurrencyDisplay
-                          amount={budget.spentAmount.amount}
-                          currency={budget.currency.code}
-                        />{' '}
-                        of{' '}
-                        <CurrencyDisplay
-                          amount={budget.amount.amount}
-                          currency={budget.currency.code}
-                        />
-                      </p>
+                        <div>
+                          <p style={{ fontWeight: 'var(--font-weight-semibold)' }}>
+                            <span aria-hidden="true">{getBudgetIcon(category?.icon)}</span>{' '}
+                            {budget.name}
+                          </p>
+                          <p
+                            style={{
+                              fontSize: 'var(--type-scale-caption-font-size)',
+                              color: 'var(--semantic-text-secondary)',
+                            }}
+                          >
+                            <CurrencyDisplay
+                              amount={budget.spentAmount.amount}
+                              currency={budget.currency.code}
+                            />{' '}
+                            of{' '}
+                            <CurrencyDisplay
+                              amount={budget.amount.amount}
+                              currency={budget.currency.code}
+                            />
+                          </p>
+                        </div>
+                        <div style={{ display: 'flex', gap: 'var(--spacing-2)' }}>
+                          <button
+                            type="button"
+                            onClick={() => handleEditBudget(budget)}
+                            aria-label={`Edit ${budget.name}`}
+                            title="Edit budget"
+                            style={{
+                              display: 'inline-flex',
+                              alignItems: 'center',
+                              justifyContent: 'center',
+                              width: '2.25rem',
+                              height: '2.25rem',
+                              border: '1px solid var(--semantic-border-default)',
+                              borderRadius: 'var(--border-radius-md)',
+                              backgroundColor:
+                                'var(--semantic-surface-primary, var(--card-background))',
+                              color: 'var(--semantic-text-primary)',
+                              cursor: 'pointer',
+                            }}
+                          >
+                            <span aria-hidden="true">✏️</span>
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleDeleteBudget(budget)}
+                            aria-label={`Delete ${budget.name}`}
+                            title="Delete budget"
+                            style={{
+                              display: 'inline-flex',
+                              alignItems: 'center',
+                              justifyContent: 'center',
+                              width: '2.25rem',
+                              height: '2.25rem',
+                              border: '1px solid var(--semantic-border-default)',
+                              borderRadius: 'var(--border-radius-md)',
+                              backgroundColor:
+                                'var(--semantic-surface-primary, var(--card-background))',
+                              color: 'var(--semantic-status-negative)',
+                              cursor: 'pointer',
+                            }}
+                          >
+                            <span aria-hidden="true">🗑️</span>
+                          </button>
+                        </div>
+                      </div>
                       <p
                         style={{
                           fontSize: 'var(--type-scale-caption-font-size)',

--- a/apps/web/src/pages/GoalsPage.tsx
+++ b/apps/web/src/pages/GoalsPage.tsx
@@ -1,10 +1,17 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { useCallback, useState } from 'react';
-import { CurrencyDisplay, EmptyState, ErrorBanner, LoadingSpinner } from '../components/common';
+import {
+  ConfirmDialog,
+  CurrencyDisplay,
+  EmptyState,
+  ErrorBanner,
+  LoadingSpinner,
+} from '../components/common';
 import { GoalForm } from '../components/forms';
 import type { CreateGoalInput } from '../db/repositories/goals';
 import { useGoals } from '../hooks';
+import type { Goal } from '../kmp/bridge';
 
 function getGoalIcon(iconName: string | null | undefined): string {
   switch (iconName) {
@@ -23,30 +30,74 @@ function getGoalIcon(iconName: string | null | undefined): string {
 
 export const GoalsPage: React.FC = () => {
   const [isFormOpen, setIsFormOpen] = useState(false);
-  const { goals, loading, error, refresh, createGoal } = useGoals();
+  const [editingGoal, setEditingGoal] = useState<Goal | null>(null);
+  const [deletingGoal, setDeletingGoal] = useState<Goal | null>(null);
+  const [isDeletingGoal, setIsDeletingGoal] = useState(false);
+  const { goals, loading, error, refresh, createGoal, updateGoal, deleteGoal } = useGoals();
   const totalTarget = goals.reduce((sum, goal) => sum + goal.targetAmount.amount, 0);
   const totalSaved = goals.reduce((sum, goal) => sum + goal.currentAmount.amount, 0);
 
   const handleOpenForm = useCallback(() => {
+    setEditingGoal(null);
+    setIsFormOpen(true);
+  }, []);
+
+  const handleEditGoal = useCallback((goal: Goal) => {
+    setEditingGoal(goal);
     setIsFormOpen(true);
   }, []);
 
   const handleCloseForm = useCallback(() => {
+    setEditingGoal(null);
     setIsFormOpen(false);
+  }, []);
+
+  const handleRequestDelete = useCallback((goal: Goal) => {
+    setDeletingGoal(goal);
+  }, []);
+
+  const handleCancelDelete = useCallback(() => {
+    setDeletingGoal(null);
   }, []);
 
   const handleSubmitGoal = useCallback(
     async (data: CreateGoalInput) => {
-      const createdGoal = createGoal(data);
-      if (createdGoal === null) {
-        throw new Error('Failed to create goal.');
+      if (editingGoal !== null) {
+        const updatedGoal = updateGoal(editingGoal.id, data);
+        if (updatedGoal === null) {
+          throw new Error('Failed to update goal.');
+        }
+      } else {
+        const createdGoal = createGoal(data);
+        if (createdGoal === null) {
+          throw new Error('Failed to create goal.');
+        }
       }
 
+      setEditingGoal(null);
       setIsFormOpen(false);
-      refresh();
     },
-    [createGoal, refresh],
+    [createGoal, editingGoal, updateGoal],
   );
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (deletingGoal === null) {
+      return;
+    }
+
+    setIsDeletingGoal(true);
+
+    try {
+      const deletedGoal = deleteGoal(deletingGoal.id);
+      if (!deletedGoal) {
+        throw new Error('Failed to delete goal.');
+      }
+
+      setDeletingGoal(null);
+    } finally {
+      setIsDeletingGoal(false);
+    }
+  }, [deleteGoal, deletingGoal]);
 
   return (
     <>
@@ -146,25 +197,64 @@ export const GoalsPage: React.FC = () => {
                       style={{
                         display: 'flex',
                         justifyContent: 'space-between',
+                        alignItems: 'flex-start',
+                        gap: 'var(--spacing-3)',
                         marginBottom: 'var(--spacing-3)',
                       }}
                     >
                       <h3 style={{ fontWeight: 'var(--font-weight-semibold)' }}>
                         <span aria-hidden="true">{getGoalIcon(goal.icon)}</span> {goal.name}
                       </h3>
-                      <span
+                      <div
                         style={{
-                          fontSize: 'var(--type-scale-caption-font-size)',
-                          color: 'var(--semantic-text-secondary)',
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 'var(--spacing-2)',
                         }}
                       >
-                        {targetDate !== null
-                          ? targetDate.toLocaleDateString('en-US', {
-                              month: 'short',
-                              year: 'numeric',
-                            })
-                          : 'No target date'}
-                      </span>
+                        <span
+                          style={{
+                            fontSize: 'var(--type-scale-caption-font-size)',
+                            color: 'var(--semantic-text-secondary)',
+                          }}
+                        >
+                          {targetDate !== null
+                            ? targetDate.toLocaleDateString('en-US', {
+                                month: 'short',
+                                year: 'numeric',
+                              })
+                            : 'No target date'}
+                        </span>
+                        <div
+                          style={{ display: 'flex', alignItems: 'center', gap: 'var(--spacing-1)' }}
+                        >
+                          <button
+                            type="button"
+                            className="icon-button"
+                            onClick={() => handleEditGoal(goal)}
+                            aria-label={`Edit ${goal.name}`}
+                          >
+                            <svg viewBox="0 0 24 24" aria-hidden="true">
+                              <path d="M12 20h9" />
+                              <path d="M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19l-4 1 1-4 12.5-12.5z" />
+                            </svg>
+                          </button>
+                          <button
+                            type="button"
+                            className="icon-button"
+                            onClick={() => handleRequestDelete(goal)}
+                            aria-label={`Delete ${goal.name}`}
+                          >
+                            <svg viewBox="0 0 24 24" aria-hidden="true">
+                              <path d="M3 6h18" />
+                              <path d="M8 6V4h8v2" />
+                              <path d="M19 6l-1 14H6L5 6" />
+                              <path d="M10 11v6" />
+                              <path d="M14 11v6" />
+                            </svg>
+                          </button>
+                        </div>
+                      </div>
                     </div>
                     <div
                       style={{
@@ -231,7 +321,25 @@ export const GoalsPage: React.FC = () => {
           </section>
         </>
       )}
-      <GoalForm isOpen={isFormOpen} onCancel={handleCloseForm} onSubmit={handleSubmitGoal} />
+      <GoalForm
+        isOpen={isFormOpen}
+        onCancel={handleCloseForm}
+        onSubmit={handleSubmitGoal}
+        initialData={editingGoal ?? undefined}
+      />
+      <ConfirmDialog
+        isOpen={deletingGoal !== null}
+        title="Delete goal?"
+        message={
+          deletingGoal === null
+            ? ''
+            : `Are you sure you want to delete “${deletingGoal.name}”? This action cannot be undone.`
+        }
+        confirmLabel="Delete Goal"
+        onConfirm={handleConfirmDelete}
+        onCancel={handleCancelDelete}
+        isLoading={isDeletingGoal}
+      />
     </>
   );
 };

--- a/apps/web/src/pages/TransactionsPage.test.tsx
+++ b/apps/web/src/pages/TransactionsPage.test.tsx
@@ -193,4 +193,12 @@ describe('TransactionsPage', () => {
     expect(screen.getByText('Monthly Salary')).toBeInTheDocument();
     expect(screen.getByText('Electric Bill')).toBeInTheDocument();
   });
+
+  it('displays edit and delete actions for each transaction', () => {
+    render(<TransactionsPage />);
+    expect(screen.getByRole('button', { name: 'Edit Grocery Store' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete Grocery Store' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Edit Monthly Salary' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete Electric Bill' })).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/pages/TransactionsPage.tsx
+++ b/apps/web/src/pages/TransactionsPage.tsx
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { useCallback, useMemo, useState } from 'react';
-import { CurrencyDisplay, EmptyState, ErrorBanner, LoadingSpinner } from '../components/common';
+import {
+  ConfirmDialog,
+  CurrencyDisplay,
+  EmptyState,
+  ErrorBanner,
+  LoadingSpinner,
+} from '../components/common';
 import { TransactionForm } from '../components/forms';
 import type { CreateTransactionInput } from '../db/repositories/transactions';
 import { useAccounts } from '../hooks/useAccounts';
@@ -19,10 +25,20 @@ function getTransactionDisplayAmount(transaction: Transaction): number {
   return transaction.amount.amount;
 }
 
+function getTransactionLabel(transaction: Transaction): string {
+  return (
+    transaction.payee?.trim() ||
+    transaction.note?.trim() ||
+    (transaction.type === 'TRANSFER' ? 'Transfer' : 'Transaction')
+  );
+}
+
 export const TransactionsPage: React.FC = () => {
   const [query, setQuery] = useState('');
   const [selectedCategoryId, setSelectedCategoryId] = useState(ALL_CATEGORIES_FILTER);
   const [isFormOpen, setIsFormOpen] = useState(false);
+  const [editingTransaction, setEditingTransaction] = useState<Transaction | null>(null);
+  const [deletingTransaction, setDeletingTransaction] = useState<Transaction | null>(null);
 
   const filters = useMemo(
     () => ({
@@ -38,6 +54,8 @@ export const TransactionsPage: React.FC = () => {
     error,
     refresh: refreshTransactions,
     createTransaction,
+    updateTransaction,
+    deleteTransaction,
   } = useTransactions(filters);
   const {
     categories,
@@ -60,17 +78,46 @@ export const TransactionsPage: React.FC = () => {
     refreshAccounts();
   };
 
+  const handleOpenCreateForm = useCallback(() => {
+    setEditingTransaction(null);
+    setIsFormOpen(true);
+  }, []);
+
+  const handleFormCancel = useCallback(() => {
+    setIsFormOpen(false);
+    setEditingTransaction(null);
+  }, []);
+
   const handleTransactionSubmit = useCallback(
     async (data: CreateTransactionInput): Promise<void> => {
-      const result = createTransaction(data);
-      if (result === null) {
-        throw new Error('Failed to create transaction. Please try again.');
+      if (editingTransaction !== null) {
+        const result = updateTransaction(editingTransaction.id, data);
+        if (result === null) {
+          throw new Error('Failed to update transaction. Please try again.');
+        }
+        setEditingTransaction(null);
+      } else {
+        const result = createTransaction(data);
+        if (result === null) {
+          throw new Error('Failed to create transaction. Please try again.');
+        }
       }
+
       setIsFormOpen(false);
       refreshTransactions();
     },
-    [createTransaction, refreshTransactions],
+    [createTransaction, editingTransaction, refreshTransactions, updateTransaction],
   );
+
+  const handleDeleteConfirm = useCallback(() => {
+    if (deletingTransaction === null) {
+      return;
+    }
+
+    deleteTransaction(deletingTransaction.id);
+    setDeletingTransaction(null);
+    refreshTransactions();
+  }, [deleteTransaction, deletingTransaction, refreshTransactions]);
 
   const categoryFilters = useMemo(
     () => [
@@ -128,7 +175,7 @@ export const TransactionsPage: React.FC = () => {
         <button
           type="button"
           className="add-button"
-          onClick={() => setIsFormOpen(true)}
+          onClick={handleOpenCreateForm}
           aria-label="Add new transaction"
         >
           <span aria-hidden="true">+</span> Add Transaction
@@ -184,31 +231,57 @@ export const TransactionsPage: React.FC = () => {
               <h3 className="list-group__header">{group.label}</h3>
               <div className="card">
                 <ul className="list-group" role="list">
-                  {group.transactions.map((transaction) => (
-                    <li key={transaction.id} className="list-item" role="listitem">
-                      <div className="list-item__content">
-                        <p className="list-item__primary">
-                          {transaction.payee ??
-                            transaction.note ??
-                            (transaction.type === 'TRANSFER' ? 'Transfer' : 'Transaction')}
-                        </p>
-                        <p className="list-item__secondary">
-                          {transaction.categoryId !== null
-                            ? (categoryNames.get(transaction.categoryId) ?? 'Uncategorized')
-                            : 'Uncategorized'}{' '}
-                          &middot; {accountNames.get(transaction.accountId) ?? 'Unknown account'}
-                        </p>
-                      </div>
-                      <div className="list-item__trailing">
-                        <CurrencyDisplay
-                          amount={getTransactionDisplayAmount(transaction)}
-                          currency={transaction.currency.code}
-                          colorize
-                          showSign
-                        />
-                      </div>
-                    </li>
-                  ))}
+                  {group.transactions.map((transaction) => {
+                    const transactionLabel = getTransactionLabel(transaction);
+
+                    return (
+                      <li key={transaction.id} className="list-item" role="listitem">
+                        <div className="list-item__content">
+                          <p className="list-item__primary">{transactionLabel}</p>
+                          <p className="list-item__secondary">
+                            {transaction.categoryId !== null
+                              ? (categoryNames.get(transaction.categoryId) ?? 'Uncategorized')
+                              : 'Uncategorized'}{' '}
+                            &middot; {accountNames.get(transaction.accountId) ?? 'Unknown account'}
+                          </p>
+                        </div>
+                        <div className="list-item__trailing transaction-list-item__trailing">
+                          <div className="transaction-list-item__amount">
+                            <CurrencyDisplay
+                              amount={getTransactionDisplayAmount(transaction)}
+                              currency={transaction.currency.code}
+                              colorize
+                              showSign
+                            />
+                          </div>
+                          <div
+                            className="transaction-item__actions"
+                            aria-label="Transaction actions"
+                          >
+                            <button
+                              type="button"
+                              className="icon-button transaction-item__action"
+                              onClick={() => {
+                                setEditingTransaction(transaction);
+                                setIsFormOpen(true);
+                              }}
+                              aria-label={`Edit ${transactionLabel}`}
+                            >
+                              <span aria-hidden="true">✏️</span>
+                            </button>
+                            <button
+                              type="button"
+                              className="icon-button transaction-item__action transaction-item__action--delete"
+                              onClick={() => setDeletingTransaction(transaction)}
+                              aria-label={`Delete ${transactionLabel}`}
+                            >
+                              <span aria-hidden="true">🗑️</span>
+                            </button>
+                          </div>
+                        </div>
+                      </li>
+                    );
+                  })}
                 </ul>
               </div>
             </section>
@@ -219,8 +292,16 @@ export const TransactionsPage: React.FC = () => {
         isOpen={isFormOpen}
         accounts={accounts}
         categories={categories}
+        initialData={editingTransaction ?? undefined}
         onSubmit={handleTransactionSubmit}
-        onCancel={() => setIsFormOpen(false)}
+        onCancel={handleFormCancel}
+      />
+      <ConfirmDialog
+        isOpen={deletingTransaction !== null}
+        title="Delete Transaction"
+        message={`Are you sure you want to delete "${deletingTransaction ? getTransactionLabel(deletingTransaction) : 'this transaction'}"?`}
+        onConfirm={handleDeleteConfirm}
+        onCancel={() => setDeletingTransaction(null)}
       />
     </>
   );

--- a/apps/web/src/styles/responsive.css
+++ b/apps/web/src/styles/responsive.css
@@ -619,9 +619,48 @@
   gap: var(--spacing-3);
   margin-bottom: var(--spacing-4);
 }
+.transaction-list-item__trailing {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+.transaction-list-item__amount {
+  text-align: right;
+}
+.transaction-item__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  opacity: 0.7;
+  transition: opacity var(--duration-fast, 100ms) ease;
+}
+.list-item:hover .transaction-item__actions,
+.list-item:focus-within .transaction-item__actions {
+  opacity: 1;
+}
+.transaction-item__action {
+  width: 32px;
+  height: 32px;
+  font-size: 1rem;
+  color: var(--semantic-text-secondary);
+  transition:
+    color var(--duration-fast, 100ms) ease,
+    background-color var(--duration-fast, 100ms) ease;
+}
+.transaction-item__action:hover,
+.transaction-item__action:focus-visible {
+  background: var(--semantic-background-secondary);
+  color: var(--semantic-text-primary);
+}
+.transaction-item__action--delete:hover,
+.transaction-item__action--delete:focus-visible {
+  color: var(--semantic-status-negative);
+}
 /* ─── End Transactions page ──────────────────────────────────────────────── */
 @media (prefers-reduced-motion: reduce) {
   .add-button,
+  .transaction-item__actions,
+  .transaction-item__action,
   .progress-bar__fill,
   .progress-ring__fill {
     transition: none;


### PR DESCRIPTION
## Summary
Adds full edit and delete functionality to all 4 CRUD pages.

## Changes
### New: ConfirmDialog component
Reusable alert dialog with danger/warning/info variants, focus trap, Escape-to-close

### Form Edit Mode (all 4 forms)
- TransactionForm, AccountForm, BudgetForm, GoalForm accept optional initialData prop
- Pre-fill fields, dynamic heading/button text for edit vs create

### Page Integration (all 4 pages)
- Edit/delete icon buttons on TransactionsPage, AccountsPage, BudgetsPage, GoalsPage
- ConfirmDialog for delete confirmations
- Wire to updateX/deleteX hook functions with list refresh

## Validation
- TypeScript strict: zero errors
- ESLint: zero warnings
- Prettier: clean
- 35/35 tests passing

Closes #487
