### PR TITLE
feat(web): implement service worker offline mutation queue (#416)

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -226,6 +226,50 @@ empty. Runs inside a single transaction for atomicity.
 - 3 monthly budgets (Food, Transport, Entertainment)
 - 2 savings goals (Emergency Fund, Vacation)
 
+### Offline Mutation Queue (`db/sync/`)
+
+The sync layer provides a durable offline mutation queue backed by IndexedDB.
+When the user performs write operations (create, update, delete) while offline,
+mutations are enqueued for later replay when connectivity is restored.
+
+**Architecture:**
+
+```
+Repository write (SQLite) ──→ enqueueMutation() ──→ IndexedDB queue
+                                      │
+                                      ├── Service Worker (Background Sync API)
+                                      │         │
+                                      │         └── replayMutations() ──→ POST /api/sync/push
+                                      │
+                                      └── Main-thread fallback (online event / periodic timer)
+                                                │
+                                                └── replayMutations() ──→ POST /api/sync/push
+```
+
+**Key components:**
+
+| Module               | Purpose                                                    |
+| -------------------- | ---------------------------------------------------------- |
+| `types.ts`           | Shared types: `QueuedMutation`, `SyncStatus`, SW messages  |
+| `idb.ts`             | IndexedDB CRUD helpers for the mutation object store       |
+| `MutationQueue.ts`   | `WebMutationQueue` class: enqueue, dequeue, acknowledge    |
+| `enqueueMutation.ts` | Main-thread entry point + Background Sync registration     |
+| `replayMutations.ts` | Replay orchestrator: push to server, ack/retry/dead-letter |
+
+**Replay lifecycle:**
+
+1. `enqueueMutation()` writes the mutation to IndexedDB and requests a Background Sync.
+2. When connectivity is restored, the service worker's `sync` event fires.
+3. `replayMutations()` dequeues a batch (up to 50), POSTs them to the server.
+4. Successfully acknowledged mutations are removed from the queue.
+5. Failed mutations have their retry counter incremented (max 5 attempts).
+6. Mutations exceeding max retries are dead-lettered (removed).
+
+**Fallback for browsers without Background Sync:**
+
+- The `useSyncStatus` hook listens for the `online` event and replays directly.
+- A periodic timer (30s) flushes the queue while the device is online.
+
 ## Hooks
 
 All entity hooks follow a consistent pattern: they call `useDatabase()` to
@@ -243,6 +287,7 @@ loading/error/empty states gracefully.
 | `useCategories()`           | `UseCategoriesResult`    | All non-deleted categories (root and child). Includes CRUD mutations.                                                                                                                                                    |
 | `useDashboardData()`        | `UseDashboardDataResult` | Aggregated read-only snapshot: net worth, monthly income/spending, budget progress, recent transactions, and account totals by type.                                                                                     |
 | `useOfflineStatus()`        | `OfflineStatus`          | Network connectivity via `navigator.onLine` + `online`/`offline` events. Triggers Background Sync on reconnect.                                                                                                          |
+| `useSyncStatus()`           | `UseSyncStatusResult`    | Sync engine status: `isOnline`, `pendingMutations`, `lastSyncTime`, `isSyncing`, and `syncNow()` for manual replay.                                                                                                      |
 
 **Common return shape** (entity hooks):
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -36,6 +36,7 @@
     "@types/react-dom": "^19.1.5",
     "@types/sql.js": "^1.4.9",
     "@vitejs/plugin-react": "^4.5.2",
+    "fake-indexeddb": "^6.2.5",
     "jsdom": "^28.1.0",
     "nanoid": "^5.1.6",
     "source-map-js": "^1.2.1",

--- a/apps/web/src/db/sync/MutationQueue.ts
+++ b/apps/web/src/db/sync/MutationQueue.ts
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Offline mutation queue backed by IndexedDB.
+ *
+ * Provides a durable, ordered queue of local write operations that have not
+ * yet been pushed to the server.  Mutations survive page reloads, service
+ * worker restarts, and browser crashes because they are persisted in
+ * IndexedDB rather than in-memory state.
+ *
+ * This class is safe to use from both the main thread and the service worker
+ * context -- it has no dependencies on React or the DOM beyond `indexedDB`
+ * and `crypto.randomUUID()`.
+ *
+ * Usage:
+ * ```ts
+ * const queue = new WebMutationQueue();
+ * await queue.enqueue({
+ *   tableName: 'transaction',
+ *   recordId: 'abc-123',
+ *   operation: 'INSERT',
+ *   data: { amount: 1500, payee: 'Grocery Store' },
+ *   householdId: 'hh-1',
+ * });
+ * const pending = await queue.dequeue(50);
+ * // ... push to server ...
+ * await queue.acknowledge(pending.map(m => m.id));
+ * ```
+ *
+ * References: issue #416
+ */
+
+import {
+  clearMutations,
+  countMutations,
+  deleteMutations,
+  getMutationBatch,
+  putMutation,
+} from './idb';
+import { MAX_RETRY_COUNT, type MutationOperation, type QueuedMutation } from './types';
+
+// ---------------------------------------------------------------------------
+// Enqueue input (subset -- id / timestamp / retryCount are generated)
+// ---------------------------------------------------------------------------
+
+/** Input for enqueuing a new mutation (without auto-generated fields). */
+export interface EnqueueInput {
+  /** Database table the mutation targets. */
+  readonly tableName: string;
+  /** Primary key of the affected row. */
+  readonly recordId: string;
+  /** The write operation performed locally. */
+  readonly operation: MutationOperation;
+  /** Row data snapshot for INSERT/UPDATE; `null` for DELETE. */
+  readonly data: Record<string, unknown> | null;
+  /** Household scope for server-side routing. */
+  readonly householdId: string;
+}
+
+// ---------------------------------------------------------------------------
+// WebMutationQueue
+// ---------------------------------------------------------------------------
+
+/**
+ * Durable offline mutation queue.
+ *
+ * All methods are async because they interact with IndexedDB.  The class
+ * is stateless -- every call opens (and closes) its own IndexedDB
+ * connection so there is no risk of holding a stale handle.
+ */
+export class WebMutationQueue {
+  // -------------------------------------------------------------------------
+  // Enqueue
+  // -------------------------------------------------------------------------
+
+  /**
+   * Append a mutation to the end of the queue.
+   *
+   * The mutation is assigned a unique ID and the current timestamp.  The
+   * retry count starts at zero.
+   */
+  async enqueue(input: EnqueueInput): Promise<QueuedMutation> {
+    const mutation: QueuedMutation = {
+      id: crypto.randomUUID(),
+      tableName: input.tableName,
+      recordId: input.recordId,
+      operation: input.operation,
+      data: input.data,
+      timestamp: Date.now(),
+      retryCount: 0,
+      householdId: input.householdId,
+    };
+
+    await putMutation(mutation);
+    return mutation;
+  }
+
+  // -------------------------------------------------------------------------
+  // Dequeue (peek -- does NOT remove)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Retrieve up to `count` of the oldest pending mutations.
+   *
+   * The mutations are **not** removed from the queue -- call
+   * {@link acknowledge} after they have been successfully pushed to the
+   * server.
+   *
+   * @param count  Maximum number of mutations to return. Defaults to 50.
+   */
+  async dequeue(count = 50): Promise<QueuedMutation[]> {
+    return getMutationBatch(count);
+  }
+
+  // -------------------------------------------------------------------------
+  // Acknowledge (remove successfully synced mutations)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Remove mutations from the queue after they have been successfully
+   * pushed to the server.
+   */
+  async acknowledge(ids: readonly string[]): Promise<void> {
+    await deleteMutations(ids);
+  }
+
+  // -------------------------------------------------------------------------
+  // Retry bookkeeping
+  // -------------------------------------------------------------------------
+
+  /**
+   * Increment the retry counter for a failed mutation and re-persist it.
+   *
+   * If the mutation has exceeded {@link MAX_RETRY_COUNT}, it is removed
+   * from the queue (dead-lettered) and `false` is returned.
+   *
+   * @returns `true` if the mutation was re-queued, `false` if dead-lettered.
+   */
+  async retry(mutation: QueuedMutation): Promise<boolean> {
+    const nextRetry = mutation.retryCount + 1;
+
+    if (nextRetry > MAX_RETRY_COUNT) {
+      // Dead-letter: remove from queue.
+      await deleteMutations([mutation.id]);
+      return false;
+    }
+
+    const updated: QueuedMutation = { ...mutation, retryCount: nextRetry };
+    await putMutation(updated);
+    return true;
+  }
+
+  // -------------------------------------------------------------------------
+  // Inspection helpers
+  // -------------------------------------------------------------------------
+
+  /** Return the number of mutations currently in the queue. */
+  async getPendingCount(): Promise<number> {
+    return countMutations();
+  }
+
+  /** Remove all mutations from the queue. */
+  async clear(): Promise<void> {
+    await clearMutations();
+  }
+}

--- a/apps/web/src/db/sync/__tests__/MutationQueue.test.ts
+++ b/apps/web/src/db/sync/__tests__/MutationQueue.test.ts
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the WebMutationQueue and its IndexedDB persistence layer.
+ *
+ * Uses `fake-indexeddb` to provide an IndexedDB implementation in the
+ * jsdom/Node test environment.
+ *
+ * References: issue #416
+ */
+
+import 'fake-indexeddb/auto';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { WebMutationQueue, type EnqueueInput } from '../MutationQueue';
+import { MUTATION_QUEUE_DB_NAME } from '../types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeInput(overrides: Partial<EnqueueInput> = {}): EnqueueInput {
+  return {
+    tableName: 'transaction',
+    recordId: crypto.randomUUID(),
+    operation: 'INSERT',
+    data: { amount: 1500, payee: 'Test Store' },
+    householdId: 'hh-1',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('WebMutationQueue', () => {
+  let queue: WebMutationQueue;
+
+  beforeEach(() => {
+    queue = new WebMutationQueue();
+  });
+
+  afterEach(async () => {
+    await queue.clear();
+
+    // Delete the database to avoid state leakage.
+    await new Promise<void>((resolve) => {
+      const req = indexedDB.deleteDatabase(MUTATION_QUEUE_DB_NAME);
+      req.onsuccess = () => resolve();
+      req.onerror = () => resolve();
+      req.onblocked = () => resolve();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // enqueue
+  // -----------------------------------------------------------------------
+
+  it('should enqueue a mutation and assign an id and timestamp', async () => {
+    const input = makeInput();
+    const mutation = await queue.enqueue(input);
+
+    expect(mutation.id).toBeDefined();
+    expect(typeof mutation.id).toBe('string');
+    expect(mutation.id.length).toBeGreaterThan(0);
+    expect(mutation.tableName).toBe('transaction');
+    expect(mutation.recordId).toBe(input.recordId);
+    expect(mutation.operation).toBe('INSERT');
+    expect(mutation.data).toEqual({ amount: 1500, payee: 'Test Store' });
+    expect(mutation.timestamp).toBeGreaterThan(0);
+    expect(mutation.retryCount).toBe(0);
+    expect(mutation.householdId).toBe('hh-1');
+  });
+
+  it('should assign unique IDs to each enqueued mutation', async () => {
+    const m1 = await queue.enqueue(makeInput());
+    const m2 = await queue.enqueue(makeInput());
+
+    expect(m1.id).not.toBe(m2.id);
+  });
+
+  // -----------------------------------------------------------------------
+  // dequeue
+  // -----------------------------------------------------------------------
+
+  it('should return an empty array when the queue is empty', async () => {
+    const result = await queue.dequeue();
+    expect(result).toEqual([]);
+  });
+
+  it('should return all enqueued mutations in order', async () => {
+    const m1 = await queue.enqueue(makeInput({ recordId: 'r1' }));
+    const m2 = await queue.enqueue(makeInput({ recordId: 'r2' }));
+    const m3 = await queue.enqueue(makeInput({ recordId: 'r3' }));
+
+    const result = await queue.dequeue();
+    expect(result).toHaveLength(3);
+
+    // All three mutations must be present (order may vary when timestamps
+    // are identical because Date.now() resolution is limited).
+    const ids = new Set(result.map((m) => m.id));
+    expect(ids.has(m1.id)).toBe(true);
+    expect(ids.has(m2.id)).toBe(true);
+    expect(ids.has(m3.id)).toBe(true);
+  });
+
+  it('should respect the count parameter', async () => {
+    await queue.enqueue(makeInput({ recordId: 'r1' }));
+    await queue.enqueue(makeInput({ recordId: 'r2' }));
+    await queue.enqueue(makeInput({ recordId: 'r3' }));
+
+    const result = await queue.dequeue(2);
+    expect(result).toHaveLength(2);
+  });
+
+  it('should not remove mutations on dequeue (peek semantics)', async () => {
+    await queue.enqueue(makeInput());
+
+    const first = await queue.dequeue();
+    expect(first).toHaveLength(1);
+
+    const second = await queue.dequeue();
+    expect(second).toHaveLength(1);
+    expect(second[0].id).toBe(first[0].id);
+  });
+
+  // -----------------------------------------------------------------------
+  // acknowledge
+  // -----------------------------------------------------------------------
+
+  it('should remove acknowledged mutations', async () => {
+    const m1 = await queue.enqueue(makeInput({ recordId: 'r1' }));
+    const m2 = await queue.enqueue(makeInput({ recordId: 'r2' }));
+
+    await queue.acknowledge([m1.id]);
+
+    const remaining = await queue.dequeue();
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].id).toBe(m2.id);
+  });
+
+  it('should handle acknowledging an empty array gracefully', async () => {
+    await queue.enqueue(makeInput());
+    await queue.acknowledge([]);
+
+    const count = await queue.getPendingCount();
+    expect(count).toBe(1);
+  });
+
+  it('should handle acknowledging non-existent IDs gracefully', async () => {
+    await queue.enqueue(makeInput());
+    await queue.acknowledge(['non-existent-id']);
+
+    const count = await queue.getPendingCount();
+    expect(count).toBe(1);
+  });
+
+  // -----------------------------------------------------------------------
+  // retry
+  // -----------------------------------------------------------------------
+
+  it('should increment retry count and re-persist', async () => {
+    const mutation = await queue.enqueue(makeInput());
+
+    const result = await queue.retry(mutation);
+    expect(result).toBe(true);
+
+    const pending = await queue.dequeue();
+    expect(pending).toHaveLength(1);
+    expect(pending[0].retryCount).toBe(1);
+  });
+
+  it('should dead-letter mutations that exceed max retries', async () => {
+    const mutation = await queue.enqueue(makeInput());
+
+    // Simulate reaching max retries (MAX_RETRY_COUNT = 5).
+    mutation.retryCount = 5;
+    const result = await queue.retry(mutation);
+
+    expect(result).toBe(false);
+
+    const count = await queue.getPendingCount();
+    expect(count).toBe(0);
+  });
+
+  // -----------------------------------------------------------------------
+  // getPendingCount
+  // -----------------------------------------------------------------------
+
+  it('should return the correct count', async () => {
+    expect(await queue.getPendingCount()).toBe(0);
+
+    await queue.enqueue(makeInput());
+    expect(await queue.getPendingCount()).toBe(1);
+
+    await queue.enqueue(makeInput());
+    expect(await queue.getPendingCount()).toBe(2);
+  });
+
+  // -----------------------------------------------------------------------
+  // clear
+  // -----------------------------------------------------------------------
+
+  it('should remove all mutations', async () => {
+    await queue.enqueue(makeInput());
+    await queue.enqueue(makeInput());
+    await queue.enqueue(makeInput());
+
+    await queue.clear();
+
+    expect(await queue.getPendingCount()).toBe(0);
+    expect(await queue.dequeue()).toEqual([]);
+  });
+
+  // -----------------------------------------------------------------------
+  // Various operations
+  // -----------------------------------------------------------------------
+
+  it('should support DELETE operations with null data', async () => {
+    const mutation = await queue.enqueue(
+      makeInput({
+        operation: 'DELETE',
+        data: null,
+      }),
+    );
+
+    expect(mutation.operation).toBe('DELETE');
+    expect(mutation.data).toBeNull();
+
+    const pending = await queue.dequeue();
+    expect(pending[0].data).toBeNull();
+  });
+
+  it('should support UPDATE operations', async () => {
+    const mutation = await queue.enqueue(
+      makeInput({
+        operation: 'UPDATE',
+        data: { amount: 2000, payee: 'Updated Store' },
+      }),
+    );
+
+    expect(mutation.operation).toBe('UPDATE');
+
+    const pending = await queue.dequeue();
+    expect(pending[0].data).toEqual({ amount: 2000, payee: 'Updated Store' });
+  });
+
+  it('should support different table names', async () => {
+    await queue.enqueue(makeInput({ tableName: 'account' }));
+    await queue.enqueue(makeInput({ tableName: 'transaction' }));
+    await queue.enqueue(makeInput({ tableName: 'budget' }));
+
+    const pending = await queue.dequeue();
+    const tableNames = pending.map((m) => m.tableName).sort();
+    expect(tableNames).toEqual(['account', 'budget', 'transaction']);
+  });
+
+  it('should survive a full enqueue-dequeue-acknowledge cycle', async () => {
+    // Simulate the complete offline -> online flow.
+    const m1 = await queue.enqueue(makeInput({ recordId: 'r1' }));
+    const m2 = await queue.enqueue(makeInput({ recordId: 'r2' }));
+    const m3 = await queue.enqueue(makeInput({ recordId: 'r3' }));
+
+    // Verify all three are present.
+    expect(await queue.getPendingCount()).toBe(3);
+
+    // Acknowledge m1 (succeeded on server).
+    await queue.acknowledge([m1.id]);
+    expect(await queue.getPendingCount()).toBe(2);
+
+    // Retry m2 (failed on server).
+    await queue.retry(m2);
+
+    // Check state -- m2 (retried) + m3 should remain.
+    const remaining = await queue.dequeue();
+    expect(remaining).toHaveLength(2);
+
+    const remainingIds = new Set(remaining.map((m) => m.id));
+    expect(remainingIds.has(m2.id)).toBe(true);
+    expect(remainingIds.has(m3.id)).toBe(true);
+
+    // m2 should have its retry count incremented.
+    const retriedM2 = remaining.find((m) => m.id === m2.id);
+    expect(retriedM2?.retryCount).toBe(1);
+
+    // m3 should be untouched.
+    const untouchedM3 = remaining.find((m) => m.id === m3.id);
+    expect(untouchedM3?.retryCount).toBe(0);
+  });
+});

--- a/apps/web/src/db/sync/__tests__/replayMutations.test.ts
+++ b/apps/web/src/db/sync/__tests__/replayMutations.test.ts
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the replayMutations orchestrator.
+ *
+ * These tests mock `fetch()` to simulate server responses and verify
+ * that mutations are acknowledged, retried, or dead-lettered correctly.
+ *
+ * References: issue #416
+ */
+
+import 'fake-indexeddb/auto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { WebMutationQueue, type EnqueueInput } from '../MutationQueue';
+import { replayMutations } from '../replayMutations';
+import { MUTATION_QUEUE_DB_NAME, type SwToClientMessage } from '../types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeInput(overrides: Partial<EnqueueInput> = {}): EnqueueInput {
+  return {
+    tableName: 'transaction',
+    recordId: crypto.randomUUID(),
+    operation: 'INSERT',
+    data: { amount: 1500 },
+    householdId: 'hh-1',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('replayMutations', () => {
+  let queue: WebMutationQueue;
+
+  beforeEach(() => {
+    queue = new WebMutationQueue();
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(async () => {
+    await queue.clear();
+    vi.restoreAllMocks();
+
+    await new Promise<void>((resolve) => {
+      const req = indexedDB.deleteDatabase(MUTATION_QUEUE_DB_NAME);
+      req.onsuccess = () => resolve();
+      req.onerror = () => resolve();
+      req.onblocked = () => resolve();
+    });
+  });
+
+  it('should return zero counts when the queue is empty', async () => {
+    const result = await replayMutations();
+
+    expect(result.syncedCount).toBe(0);
+    expect(result.failedCount).toBe(0);
+  });
+
+  it('should acknowledge all mutations on a successful server response', async () => {
+    const m1 = await queue.enqueue(makeInput({ recordId: 'r1' }));
+    const m2 = await queue.enqueue(makeInput({ recordId: 'r2' }));
+
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ acknowledged: [m1.id, m2.id] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await replayMutations();
+
+    expect(result.syncedCount).toBe(2);
+    expect(result.failedCount).toBe(0);
+    expect(await queue.getPendingCount()).toBe(0);
+  });
+
+  it('should retry mutations that the server did not acknowledge', async () => {
+    const m1 = await queue.enqueue(makeInput({ recordId: 'r1' }));
+    await queue.enqueue(makeInput({ recordId: 'r2' }));
+
+    // Server only acknowledges m1.
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ acknowledged: [m1.id] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await replayMutations();
+
+    expect(result.syncedCount).toBe(1);
+    expect(result.failedCount).toBe(1);
+
+    // m2 should still be in the queue with incremented retry count.
+    const remaining = await queue.dequeue();
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].retryCount).toBe(1);
+  });
+
+  it('should treat a network error as all mutations failed', async () => {
+    await queue.enqueue(makeInput({ recordId: 'r1' }));
+    await queue.enqueue(makeInput({ recordId: 'r2' }));
+
+    vi.mocked(fetch).mockRejectedValueOnce(new TypeError('Failed to fetch'));
+
+    const result = await replayMutations();
+
+    expect(result.syncedCount).toBe(0);
+    expect(result.failedCount).toBe(2);
+
+    // Both should still be in the queue.
+    expect(await queue.getPendingCount()).toBe(2);
+  });
+
+  it('should treat a non-OK response as all mutations failed', async () => {
+    await queue.enqueue(makeInput());
+
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response('Internal Server Error', { status: 500 }),
+    );
+
+    const result = await replayMutations();
+
+    expect(result.syncedCount).toBe(0);
+    expect(result.failedCount).toBe(1);
+  });
+
+  it('should broadcast lifecycle messages when a callback is provided', async () => {
+    await queue.enqueue(makeInput());
+
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const messages: SwToClientMessage[] = [];
+    await replayMutations((msg) => messages.push(msg));
+
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toEqual({ type: 'SYNC_STARTED' });
+    expect(messages[1]).toMatchObject({ type: 'SYNC_COMPLETED' });
+  });
+
+  it('should broadcast SYNC_COMPLETED with failures on network error', async () => {
+    await queue.enqueue(makeInput());
+
+    vi.mocked(fetch).mockRejectedValueOnce(new Error('Network down'));
+
+    const messages: SwToClientMessage[] = [];
+    await replayMutations((msg) => messages.push(msg));
+
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toEqual({ type: 'SYNC_STARTED' });
+    // pushToServer catches the error internally and returns [] (no
+    // acknowledged IDs), so replayMutations treats all as failed.
+    expect(messages[1]).toMatchObject({
+      type: 'SYNC_COMPLETED',
+      syncedCount: 0,
+      failedCount: 1,
+    });
+  });
+});

--- a/apps/web/src/db/sync/__tests__/replayMutations.test.ts
+++ b/apps/web/src/db/sync/__tests__/replayMutations.test.ts
@@ -120,9 +120,7 @@ describe('replayMutations', () => {
   it('should treat a non-OK response as all mutations failed', async () => {
     await queue.enqueue(makeInput());
 
-    vi.mocked(fetch).mockResolvedValueOnce(
-      new Response('Internal Server Error', { status: 500 }),
-    );
+    vi.mocked(fetch).mockResolvedValueOnce(new Response('Internal Server Error', { status: 500 }));
 
     const result = await replayMutations();
 

--- a/apps/web/src/db/sync/enqueueMutation.ts
+++ b/apps/web/src/db/sync/enqueueMutation.ts
@@ -96,8 +96,11 @@ function requestBackgroundSync(): void {
   void navigator.serviceWorker.ready
     .then((registration) => {
       if ('sync' in registration) {
-        return (registration as ServiceWorkerRegistration & { sync: { register(tag: string): Promise<void> } })
-          .sync.register(SYNC_TAG);
+        return (
+          registration as ServiceWorkerRegistration & {
+            sync: { register(tag: string): Promise<void> };
+          }
+        ).sync.register(SYNC_TAG);
       }
       // Fallback: ask the SW via postMessage.
       navigator.serviceWorker.controller?.postMessage({ type: 'REGISTER_SYNC' });

--- a/apps/web/src/db/sync/enqueueMutation.ts
+++ b/apps/web/src/db/sync/enqueueMutation.ts
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Main-thread helper for enqueuing offline mutations.
+ *
+ * After writing to the local SQLite database, call {@link enqueueMutation}
+ * to persist the mutation in the IndexedDB queue and signal the service
+ * worker to register a Background Sync so the mutation is replayed when
+ * the device regains connectivity.
+ *
+ * This module is designed to be imported by repository-layer code and React
+ * hooks -- it must NOT import any React APIs so it can also be used from
+ * plain utility functions.
+ *
+ * References: issue #416
+ */
+
+import { WebMutationQueue, type EnqueueInput } from './MutationQueue';
+import { SYNC_TAG } from './types';
+
+// ---------------------------------------------------------------------------
+// Singleton queue instance
+// ---------------------------------------------------------------------------
+
+let _queue: WebMutationQueue | null = null;
+
+/** Lazily initialised singleton to avoid creating the queue at import time. */
+function getQueue(): WebMutationQueue {
+  if (_queue === null) {
+    _queue = new WebMutationQueue();
+  }
+  return _queue;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Enqueue a mutation for eventual sync and request a Background Sync.
+ *
+ * This is the primary entry point for the repository / hook layer.  It:
+ * 1. Writes the mutation to the IndexedDB queue.
+ * 2. Asks the service worker to register a Background Sync so that the
+ *    mutation is replayed when connectivity is restored.
+ *
+ * If Background Sync is not available (e.g. Firefox), the main thread
+ * fallback in {@link useSyncStatus} will replay mutations via the
+ * `online` event.
+ */
+export async function enqueueMutation(input: EnqueueInput): Promise<void> {
+  const queue = getQueue();
+  await queue.enqueue(input);
+  requestBackgroundSync();
+}
+
+/**
+ * Return the number of mutations currently pending in the queue.
+ *
+ * Useful for badge counts and status indicators.
+ */
+export async function getPendingMutationCount(): Promise<number> {
+  const queue = getQueue();
+  return queue.getPendingCount();
+}
+
+/**
+ * Get direct access to the singleton queue instance.
+ *
+ * Prefer {@link enqueueMutation} for most use cases.  This is exposed for
+ * advanced consumers like the sync-status hook that need to dequeue and
+ * acknowledge mutations.
+ */
+export function getMutationQueue(): WebMutationQueue {
+  return getQueue();
+}
+
+// ---------------------------------------------------------------------------
+// Service-worker messaging
+// ---------------------------------------------------------------------------
+
+/**
+ * Ask the service worker to register a Background Sync so that pending
+ * mutations are replayed when the device regains connectivity.
+ *
+ * Fails silently when:
+ * - No service worker is registered / controlling the page.
+ * - Background Sync API is not supported.
+ */
+function requestBackgroundSync(): void {
+  if (!('serviceWorker' in navigator) || !navigator.serviceWorker.controller) {
+    return;
+  }
+
+  // Prefer direct registration if the SW registration is available.
+  void navigator.serviceWorker.ready
+    .then((registration) => {
+      if ('sync' in registration) {
+        return (registration as ServiceWorkerRegistration & { sync: { register(tag: string): Promise<void> } })
+          .sync.register(SYNC_TAG);
+      }
+      // Fallback: ask the SW via postMessage.
+      navigator.serviceWorker.controller?.postMessage({ type: 'REGISTER_SYNC' });
+    })
+    .catch(() => {
+      // Background Sync not supported -- main-thread fallback will handle it.
+    });
+}

--- a/apps/web/src/db/sync/idb.ts
+++ b/apps/web/src/db/sync/idb.ts
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Low-level IndexedDB helpers for the mutation queue.
+ *
+ * Provides typed `open`, `getAll`, `put`, `delete`, and `clear` wrappers
+ * around the raw IndexedDB API.  All operations return Promises so they
+ * integrate cleanly with both the main thread and service worker contexts.
+ *
+ * References: issue #416
+ */
+
+import {
+  MUTATION_QUEUE_DB_NAME,
+  MUTATION_QUEUE_DB_VERSION,
+  MUTATION_QUEUE_STORE_NAME,
+  type QueuedMutation,
+} from './types';
+
+// ---------------------------------------------------------------------------
+// Database lifecycle
+// ---------------------------------------------------------------------------
+
+/**
+ * Open (or create) the IndexedDB database for the mutation queue.
+ *
+ * The database has a single object store keyed on the mutation `id` with an
+ * index on `timestamp` for ordered retrieval.
+ */
+export function openMutationDb(): Promise<IDBDatabase> {
+  return new Promise<IDBDatabase>((resolve, reject) => {
+    const request = indexedDB.open(MUTATION_QUEUE_DB_NAME, MUTATION_QUEUE_DB_VERSION);
+
+    request.onupgradeneeded = () => {
+      const db = request.result;
+
+      if (!db.objectStoreNames.contains(MUTATION_QUEUE_STORE_NAME)) {
+        const store = db.createObjectStore(MUTATION_QUEUE_STORE_NAME, { keyPath: 'id' });
+        store.createIndex('by_timestamp', 'timestamp', { unique: false });
+        store.createIndex('by_table', 'tableName', { unique: false });
+        store.createIndex('by_household', 'householdId', { unique: false });
+      }
+    };
+
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// CRUD helpers
+// ---------------------------------------------------------------------------
+
+/** Insert or update a mutation in the queue. */
+export async function putMutation(mutation: QueuedMutation): Promise<void> {
+  const db = await openMutationDb();
+  try {
+    await idbPut(db, mutation);
+  } finally {
+    db.close();
+  }
+}
+
+/** Retrieve all queued mutations ordered by timestamp (oldest first). */
+export async function getAllMutations(): Promise<QueuedMutation[]> {
+  const db = await openMutationDb();
+  try {
+    return await idbGetAllByIndex(db);
+  } finally {
+    db.close();
+  }
+}
+
+/** Retrieve a batch of the oldest queued mutations. */
+export async function getMutationBatch(count: number): Promise<QueuedMutation[]> {
+  const db = await openMutationDb();
+  try {
+    return await idbGetBatchByIndex(db, count);
+  } finally {
+    db.close();
+  }
+}
+
+/** Delete specific mutations by their IDs. */
+export async function deleteMutations(ids: readonly string[]): Promise<void> {
+  if (ids.length === 0) return;
+
+  const db = await openMutationDb();
+  try {
+    await idbDeleteMany(db, ids);
+  } finally {
+    db.close();
+  }
+}
+
+/** Return the total number of queued mutations. */
+export async function countMutations(): Promise<number> {
+  const db = await openMutationDb();
+  try {
+    return await idbCount(db);
+  } finally {
+    db.close();
+  }
+}
+
+/** Remove all mutations from the queue. */
+export async function clearMutations(): Promise<void> {
+  const db = await openMutationDb();
+  try {
+    await idbClear(db);
+  } finally {
+    db.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal IndexedDB transaction wrappers
+// ---------------------------------------------------------------------------
+
+function idbPut(db: IDBDatabase, mutation: QueuedMutation): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(MUTATION_QUEUE_STORE_NAME, 'readwrite');
+    const store = tx.objectStore(MUTATION_QUEUE_STORE_NAME);
+    store.put(mutation);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error ?? new Error('Transaction aborted'));
+  });
+}
+
+function idbGetAllByIndex(db: IDBDatabase): Promise<QueuedMutation[]> {
+  return new Promise<QueuedMutation[]>((resolve, reject) => {
+    const tx = db.transaction(MUTATION_QUEUE_STORE_NAME, 'readonly');
+    const store = tx.objectStore(MUTATION_QUEUE_STORE_NAME);
+    const index = store.index('by_timestamp');
+    const request = index.getAll();
+    request.onsuccess = () => resolve(request.result as QueuedMutation[]);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function idbGetBatchByIndex(db: IDBDatabase, count: number): Promise<QueuedMutation[]> {
+  return new Promise<QueuedMutation[]>((resolve, reject) => {
+    const results: QueuedMutation[] = [];
+    const tx = db.transaction(MUTATION_QUEUE_STORE_NAME, 'readonly');
+    const store = tx.objectStore(MUTATION_QUEUE_STORE_NAME);
+    const index = store.index('by_timestamp');
+    const request = index.openCursor();
+
+    request.onsuccess = () => {
+      const cursor = request.result;
+      if (cursor && results.length < count) {
+        results.push(cursor.value as QueuedMutation);
+        cursor.continue();
+      } else {
+        resolve(results);
+      }
+    };
+
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function idbDeleteMany(db: IDBDatabase, ids: readonly string[]): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(MUTATION_QUEUE_STORE_NAME, 'readwrite');
+    const store = tx.objectStore(MUTATION_QUEUE_STORE_NAME);
+
+    for (const id of ids) {
+      store.delete(id);
+    }
+
+    // Resolve when the full transaction is committed -- not on individual
+    // request success -- so that subsequent reads see the deletions.
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error ?? new Error('Transaction aborted'));
+  });
+}
+
+function idbCount(db: IDBDatabase): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const tx = db.transaction(MUTATION_QUEUE_STORE_NAME, 'readonly');
+    const store = tx.objectStore(MUTATION_QUEUE_STORE_NAME);
+    const request = store.count();
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function idbClear(db: IDBDatabase): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(MUTATION_QUEUE_STORE_NAME, 'readwrite');
+    const store = tx.objectStore(MUTATION_QUEUE_STORE_NAME);
+    store.clear();
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error ?? new Error('Transaction aborted'));
+  });
+}

--- a/apps/web/src/db/sync/index.ts
+++ b/apps/web/src/db/sync/index.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+export { WebMutationQueue, type EnqueueInput } from './MutationQueue';
+export { enqueueMutation, getMutationQueue, getPendingMutationCount } from './enqueueMutation';
+export { replayMutations, type ReplayResult } from './replayMutations';
+export type {
+  ClientToSwMessage,
+  MutationOperation,
+  QueuedMutation,
+  SwToClientMessage,
+  SyncStatus,
+} from './types';
+export {
+  LAST_SYNC_TIME_KEY,
+  MAX_RETRY_COUNT,
+  MUTATION_QUEUE_DB_NAME,
+  MUTATION_QUEUE_STORE_NAME,
+  PERIODIC_SYNC_INTERVAL_MS,
+  REPLAY_BATCH_SIZE,
+  SYNC_TAG,
+} from './types';

--- a/apps/web/src/db/sync/replayMutations.ts
+++ b/apps/web/src/db/sync/replayMutations.ts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Mutation replay logic -- shared between the service worker and the
+ * main-thread fallback.
+ *
+ * This module opens its own IndexedDB connection, reads a batch of pending
+ * mutations, pushes them to the server, and acknowledges the successful
+ * ones.  Failed mutations have their retry counter incremented; mutations
+ * that exceed {@link MAX_RETRY_COUNT} are dead-lettered (removed).
+ *
+ * The module is intentionally free of DOM, React, and service-worker-specific
+ * APIs so it can be imported from either context.
+ *
+ * References: issue #416
+ */
+
+import { WebMutationQueue } from './MutationQueue';
+import {
+  LAST_SYNC_TIME_KEY,
+  REPLAY_BATCH_SIZE,
+  type QueuedMutation,
+  type SwToClientMessage,
+} from './types';
+
+// ---------------------------------------------------------------------------
+// Server push (stub -- to be wired to real API)
+// ---------------------------------------------------------------------------
+
+/**
+ * Push a batch of mutations to the server.
+ *
+ * Returns the IDs of mutations that were successfully accepted.  Mutations
+ * whose IDs are NOT in the returned array are considered failed and will
+ * be retried.
+ *
+ * **TODO:** Replace this stub with a real `fetch()` call to the sync
+ * endpoint once the server API is available.
+ */
+async function pushToServer(mutations: QueuedMutation[]): Promise<string[]> {
+  // The API base URL would come from env / config.  For now we attempt
+  // a real POST and handle failures gracefully.
+  const apiBase = self.location?.origin ?? '';
+  const url = `${apiBase}/api/sync/push`;
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mutations }),
+    });
+
+    if (!response.ok) {
+      // Server rejected the batch -- treat all as failed.
+      return [];
+    }
+
+    const body = (await response.json()) as { acknowledged?: string[] };
+    return body.acknowledged ?? mutations.map((m) => m.id);
+  } catch {
+    // Network error -- nothing was synced.
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Replay orchestrator
+// ---------------------------------------------------------------------------
+
+export interface ReplayResult {
+  /** Number of mutations successfully pushed. */
+  syncedCount: number;
+  /** Number of mutations that failed (and were retried or dead-lettered). */
+  failedCount: number;
+}
+
+/**
+ * Replay pending offline mutations.
+ *
+ * 1. Dequeue up to {@link REPLAY_BATCH_SIZE} oldest mutations.
+ * 2. Push them to the server.
+ * 3. Acknowledge (remove) successfully synced mutations.
+ * 4. Increment retry counters on failures; dead-letter if exhausted.
+ * 5. Persist the last-sync timestamp.
+ *
+ * @param broadcastResult  Optional callback to broadcast the result to
+ *   main-thread clients (used by the service worker).
+ */
+export async function replayMutations(
+  broadcastResult?: (message: SwToClientMessage) => void,
+): Promise<ReplayResult> {
+  const queue = new WebMutationQueue();
+
+  const pending = await queue.dequeue(REPLAY_BATCH_SIZE);
+
+  if (pending.length === 0) {
+    return { syncedCount: 0, failedCount: 0 };
+  }
+
+  broadcastResult?.({ type: 'SYNC_STARTED' });
+
+  let syncedIds: string[];
+  try {
+    syncedIds = await pushToServer(pending);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown sync error';
+    broadcastResult?.({ type: 'SYNC_FAILED', error: message });
+    return { syncedCount: 0, failedCount: pending.length };
+  }
+
+  // Acknowledge successful mutations.
+  const syncedSet = new Set(syncedIds);
+  if (syncedSet.size > 0) {
+    await queue.acknowledge([...syncedSet]);
+  }
+
+  // Retry or dead-letter failed mutations.
+  const failed = pending.filter((m) => !syncedSet.has(m.id));
+  for (const mutation of failed) {
+    await queue.retry(mutation);
+  }
+
+  // Persist last-sync timestamp (best-effort -- storage may not exist
+  // in the service worker context).
+  try {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(LAST_SYNC_TIME_KEY, new Date().toISOString());
+    }
+  } catch {
+    // Ignore -- service workers don't have localStorage.
+  }
+
+  const result: ReplayResult = {
+    syncedCount: syncedSet.size,
+    failedCount: failed.length,
+  };
+
+  broadcastResult?.({
+    type: 'SYNC_COMPLETED',
+    syncedCount: result.syncedCount,
+    failedCount: result.failedCount,
+  });
+
+  return result;
+}

--- a/apps/web/src/db/sync/types.ts
+++ b/apps/web/src/db/sync/types.ts
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Shared types for the offline mutation queue and sync system.
+ *
+ * These types are used by both the main thread (React hooks, repositories)
+ * and the service worker context.  They must remain free of DOM/React
+ * dependencies so the service worker can import them.
+ *
+ * References: issue #416
+ */
+
+// ---------------------------------------------------------------------------
+// Mutation operations
+// ---------------------------------------------------------------------------
+
+/** The type of write operation that was performed locally. */
+export type MutationOperation = 'INSERT' | 'UPDATE' | 'DELETE';
+
+// ---------------------------------------------------------------------------
+// Queued mutation
+// ---------------------------------------------------------------------------
+
+/**
+ * A single mutation recorded while the device is offline (or batched for
+ * eventual sync).
+ *
+ * Stored in IndexedDB so that mutations survive page reloads and service
+ * worker restarts.
+ */
+export interface QueuedMutation {
+  /** Unique identifier for this queue entry (UUID). */
+  readonly id: string;
+  /** Database table the mutation targets (e.g. "transaction", "account"). */
+  readonly tableName: string;
+  /** Primary key of the affected row. */
+  readonly recordId: string;
+  /** The write operation that was performed locally. */
+  readonly operation: MutationOperation;
+  /**
+   * Snapshot of the row data for INSERT/UPDATE operations.
+   * `null` for DELETE operations.
+   */
+  readonly data: Record<string, unknown> | null;
+  /** Unix epoch milliseconds when the mutation was enqueued. */
+  readonly timestamp: number;
+  /** Number of times replay has been attempted (starts at 0). */
+  retryCount: number;
+  /** Household scope for server-side routing. */
+  readonly householdId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Sync status
+// ---------------------------------------------------------------------------
+
+/** Snapshot of the current sync state, consumed by the UI. */
+export interface SyncStatus {
+  /** Whether the browser reports network connectivity. */
+  readonly isOnline: boolean;
+  /** Number of mutations waiting to be pushed to the server. */
+  readonly pendingMutations: number;
+  /** ISO-8601 timestamp of the last successful sync, or `null` if never. */
+  readonly lastSyncTime: string | null;
+  /** Whether a sync operation is currently in progress. */
+  readonly isSyncing: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Service-worker <-> main-thread messages
+// ---------------------------------------------------------------------------
+
+/** Messages sent FROM the main thread TO the service worker. */
+export type ClientToSwMessage =
+  | { readonly type: 'REGISTER_SYNC' }
+  | { readonly type: 'SKIP_WAITING' }
+  | { readonly type: 'SYNC_NOW' }
+  | { readonly type: 'GET_PENDING_COUNT' };
+
+/** Messages sent FROM the service worker TO the main thread. */
+export type SwToClientMessage =
+  | { readonly type: 'SYNC_STARTED' }
+  | { readonly type: 'SYNC_COMPLETED'; readonly syncedCount: number; readonly failedCount: number }
+  | { readonly type: 'SYNC_FAILED'; readonly error: string }
+  | { readonly type: 'PENDING_COUNT'; readonly count: number };
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** IndexedDB database name for the mutation queue. */
+export const MUTATION_QUEUE_DB_NAME = 'finance-mutation-queue';
+
+/** IndexedDB object store name. */
+export const MUTATION_QUEUE_STORE_NAME = 'mutations';
+
+/** IndexedDB database version. */
+export const MUTATION_QUEUE_DB_VERSION = 1;
+
+/** Maximum number of retry attempts before a mutation is dead-lettered. */
+export const MAX_RETRY_COUNT = 5;
+
+/** Background Sync tag registered with the service worker. */
+export const SYNC_TAG = 'finance-offline-mutations';
+
+/** localStorage key for persisting the last successful sync timestamp. */
+export const LAST_SYNC_TIME_KEY = 'finance-last-sync-time';
+
+/** Interval (ms) for the periodic sync fallback when Background Sync is unavailable. */
+export const PERIODIC_SYNC_INTERVAL_MS = 30_000;
+
+/** Maximum number of mutations to replay in a single batch. */
+export const REPLAY_BATCH_SIZE = 50;

--- a/apps/web/src/hooks/index.ts
+++ b/apps/web/src/hooks/index.ts
@@ -9,3 +9,5 @@ export { useCategories } from './useCategories';
 export { useDashboardData } from './useDashboardData';
 export { useOfflineStatus } from './useOfflineStatus';
 export { useMutationQueue } from './useMutationQueue';
+export { useSyncStatus } from './useSyncStatus';
+export type { UseSyncStatusResult } from './useSyncStatus';

--- a/apps/web/src/hooks/useSyncStatus.ts
+++ b/apps/web/src/hooks/useSyncStatus.ts
@@ -78,7 +78,11 @@ export interface UseSyncStatusResult {
 // ---------------------------------------------------------------------------
 
 export function useSyncStatus(): UseSyncStatusResult {
-  const isOnline = useSyncExternalStore(subscribeOnline, getOnlineSnapshot, getServerOnlineSnapshot);
+  const isOnline = useSyncExternalStore(
+    subscribeOnline,
+    getOnlineSnapshot,
+    getServerOnlineSnapshot,
+  );
 
   const [pendingMutations, setPendingMutations] = useState(0);
   const [lastSyncTime, setLastSyncTime] = useState<string | null>(() => {
@@ -170,7 +174,6 @@ export function useSyncStatus(): UseSyncStatusResult {
 
     window.addEventListener('online', handleOnline);
     return () => window.removeEventListener('online', handleOnline);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // -------------------------------------------------------------------------
@@ -179,9 +182,7 @@ export function useSyncStatus(): UseSyncStatusResult {
 
   useEffect(() => {
     // Check whether Background Sync is supported.
-    const hasBackgroundSync =
-      'serviceWorker' in navigator &&
-      'SyncManager' in self;
+    const hasBackgroundSync = 'serviceWorker' in navigator && 'SyncManager' in self;
 
     if (!hasBackgroundSync && isOnline) {
       // Poll periodically to flush queued mutations.
@@ -196,7 +197,6 @@ export function useSyncStatus(): UseSyncStatusResult {
         periodicTimerRef.current = null;
       }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOnline]);
 
   // -------------------------------------------------------------------------

--- a/apps/web/src/hooks/useSyncStatus.ts
+++ b/apps/web/src/hooks/useSyncStatus.ts
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * React hook for monitoring sync status and triggering manual sync.
+ *
+ * Exposes:
+ * - `isOnline` / `isOffline` -- current network state.
+ * - `pendingMutations` -- number of mutations waiting to be pushed.
+ * - `lastSyncTime` -- ISO-8601 timestamp of the last successful sync.
+ * - `isSyncing` -- whether a sync operation is currently in progress.
+ * - `syncNow` -- manually trigger an immediate sync replay.
+ *
+ * The hook listens for messages from the service worker to keep
+ * `pendingMutations`, `lastSyncTime`, and `isSyncing` up to date.
+ *
+ * When Background Sync is not available (e.g. Firefox), the hook
+ * automatically replays mutations when the `online` event fires.
+ *
+ * Usage:
+ * ```tsx
+ * const { isOnline, pendingMutations, lastSyncTime, isSyncing, syncNow } = useSyncStatus();
+ * ```
+ *
+ * References: issue #416
+ */
+
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react';
+import { replayMutations } from '../db/sync/replayMutations';
+import {
+  LAST_SYNC_TIME_KEY,
+  PERIODIC_SYNC_INTERVAL_MS,
+  type SwToClientMessage,
+} from '../db/sync/types';
+import { getPendingMutationCount } from '../db/sync/enqueueMutation';
+
+// ---------------------------------------------------------------------------
+// navigator.onLine external store (same pattern as useOfflineStatus)
+// ---------------------------------------------------------------------------
+
+function subscribeOnline(callback: () => void): () => void {
+  window.addEventListener('online', callback);
+  window.addEventListener('offline', callback);
+  return () => {
+    window.removeEventListener('online', callback);
+    window.removeEventListener('offline', callback);
+  };
+}
+
+function getOnlineSnapshot(): boolean {
+  return navigator.onLine;
+}
+
+function getServerOnlineSnapshot(): boolean {
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Public interface
+// ---------------------------------------------------------------------------
+
+export interface UseSyncStatusResult {
+  /** `true` when the browser reports network connectivity. */
+  isOnline: boolean;
+  /** `true` when the browser reports no network connectivity. */
+  isOffline: boolean;
+  /** Number of mutations waiting to be pushed to the server. */
+  pendingMutations: number;
+  /** ISO-8601 timestamp of the last successful sync, or `null`. */
+  lastSyncTime: string | null;
+  /** Whether a sync operation is currently in progress. */
+  isSyncing: boolean;
+  /** Manually trigger an immediate sync replay. */
+  syncNow: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useSyncStatus(): UseSyncStatusResult {
+  const isOnline = useSyncExternalStore(subscribeOnline, getOnlineSnapshot, getServerOnlineSnapshot);
+
+  const [pendingMutations, setPendingMutations] = useState(0);
+  const [lastSyncTime, setLastSyncTime] = useState<string | null>(() => {
+    try {
+      return localStorage.getItem(LAST_SYNC_TIME_KEY);
+    } catch {
+      return null;
+    }
+  });
+  const [isSyncing, setIsSyncing] = useState(false);
+
+  // Track whether a periodic fallback timer is needed.
+  const periodicTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // -------------------------------------------------------------------------
+  // Refresh pending count from IndexedDB
+  // -------------------------------------------------------------------------
+
+  const refreshPendingCount = useCallback(async () => {
+    try {
+      const count = await getPendingMutationCount();
+      setPendingMutations(count);
+    } catch {
+      // IndexedDB may be unavailable (e.g. private browsing in some browsers).
+    }
+  }, []);
+
+  // -------------------------------------------------------------------------
+  // Listen for messages from the service worker
+  // -------------------------------------------------------------------------
+
+  useEffect(() => {
+    if (!('serviceWorker' in navigator)) return;
+
+    const handleMessage = (event: MessageEvent) => {
+      const data = event.data as SwToClientMessage | undefined;
+      if (!data?.type) return;
+
+      switch (data.type) {
+        case 'SYNC_STARTED':
+          setIsSyncing(true);
+          break;
+
+        case 'SYNC_COMPLETED':
+          setIsSyncing(false);
+          setLastSyncTime(new Date().toISOString());
+          void refreshPendingCount();
+          break;
+
+        case 'SYNC_FAILED':
+          setIsSyncing(false);
+          void refreshPendingCount();
+          break;
+
+        case 'PENDING_COUNT':
+          setPendingMutations(data.count);
+          break;
+      }
+    };
+
+    navigator.serviceWorker.addEventListener('message', handleMessage);
+    return () => navigator.serviceWorker.removeEventListener('message', handleMessage);
+  }, [refreshPendingCount]);
+
+  // -------------------------------------------------------------------------
+  // Poll the pending count on mount and whenever online status changes
+  // -------------------------------------------------------------------------
+
+  useEffect(() => {
+    void refreshPendingCount();
+  }, [isOnline, refreshPendingCount]);
+
+  // -------------------------------------------------------------------------
+  // Main-thread fallback: replay when coming back online
+  // -------------------------------------------------------------------------
+
+  useEffect(() => {
+    const handleOnline = () => {
+      // First, try to let the service worker handle it via Background Sync.
+      if ('serviceWorker' in navigator && navigator.serviceWorker.controller) {
+        navigator.serviceWorker.controller.postMessage({ type: 'REGISTER_SYNC' });
+      }
+
+      // Also replay from the main thread as a fallback -- the queue is
+      // idempotent so double-processing is safe (the server should
+      // de-duplicate by mutation ID).
+      void performMainThreadSync();
+    };
+
+    window.addEventListener('online', handleOnline);
+    return () => window.removeEventListener('online', handleOnline);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // -------------------------------------------------------------------------
+  // Periodic fallback when Background Sync is unavailable
+  // -------------------------------------------------------------------------
+
+  useEffect(() => {
+    // Check whether Background Sync is supported.
+    const hasBackgroundSync =
+      'serviceWorker' in navigator &&
+      'SyncManager' in self;
+
+    if (!hasBackgroundSync && isOnline) {
+      // Poll periodically to flush queued mutations.
+      periodicTimerRef.current = setInterval(() => {
+        void performMainThreadSync();
+      }, PERIODIC_SYNC_INTERVAL_MS);
+    }
+
+    return () => {
+      if (periodicTimerRef.current !== null) {
+        clearInterval(periodicTimerRef.current);
+        periodicTimerRef.current = null;
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOnline]);
+
+  // -------------------------------------------------------------------------
+  // Main-thread sync (fallback)
+  // -------------------------------------------------------------------------
+
+  const performMainThreadSync = useCallback(async () => {
+    setIsSyncing(true);
+    try {
+      await replayMutations();
+      try {
+        const now = new Date().toISOString();
+        localStorage.setItem(LAST_SYNC_TIME_KEY, now);
+        setLastSyncTime(now);
+      } catch {
+        // localStorage may be unavailable.
+      }
+    } catch {
+      // Sync failed -- will retry later.
+    } finally {
+      setIsSyncing(false);
+      await refreshPendingCount();
+    }
+  }, [refreshPendingCount]);
+
+  // -------------------------------------------------------------------------
+  // Manual sync trigger
+  // -------------------------------------------------------------------------
+
+  const syncNow = useCallback(() => {
+    if (isSyncing) return;
+
+    // Prefer the service-worker path.
+    if ('serviceWorker' in navigator && navigator.serviceWorker.controller) {
+      navigator.serviceWorker.controller.postMessage({ type: 'SYNC_NOW' });
+      setIsSyncing(true);
+      return;
+    }
+
+    // Fallback to main-thread replay.
+    void performMainThreadSync();
+  }, [isSyncing, performMainThreadSync]);
+
+  return {
+    isOnline,
+    isOffline: !isOnline,
+    pendingMutations,
+    lastSyncTime,
+    isSyncing,
+    syncNow,
+  };
+}

--- a/apps/web/src/sw/service-worker.ts
+++ b/apps/web/src/sw/service-worker.ts
@@ -4,28 +4,26 @@
  * Service Worker for the Finance PWA.
  *
  * Caching strategies:
- *   ΓÇó Cache-first ΓÇö static assets (JS, CSS, images, fonts, WASM)
- *   ΓÇó Network-first ΓÇö API calls (`/api/`)
+ *   - Cache-first -- static assets (JS, CSS, images, fonts, WASM)
+ *   - Network-first -- API calls (`/api/`)
  *
- * Background sync is registered for offline mutations so that queued
- * writes are replayed once the device regains connectivity.
+ * Offline mutation replay:
+ *   Listens for the Background Sync API `sync` event and replays queued
+ *   mutations from the IndexedDB-backed {@link WebMutationQueue}.  When
+ *   Background Sync is not available the main thread falls back to the
+ *   `online` event (see {@link useSyncStatus}).
  *
  * Cache versioning is enforced: when CACHE_VERSION changes, old caches
  * are automatically purged during activation.
  *
- * References: issue #58
+ * References: issues #58, #416
  */
 
 /// <reference lib="webworker" />
-
 declare const self: ServiceWorkerGlobalScope;
 
-import {
-  dequeueMutations,
-  getQueueSize,
-  removeMutation,
-  updateMutationRetryCount,
-} from '../db/mutation-queue';
+import { replayMutations } from '../db/sync/replayMutations';
+import { SYNC_TAG, type ClientToSwMessage, type SwToClientMessage } from '../db/sync/types';
 
 // ---------------------------------------------------------------------------
 // Cache configuration
@@ -37,13 +35,6 @@ const CACHE_VERSION = 'v1';
 /** Cache bucket names. */
 const STATIC_CACHE = `finance-static-${CACHE_VERSION}`;
 const API_CACHE = `finance-api-${CACHE_VERSION}`;
-
-/** Sync tag used for Background Sync registration. */
-const SYNC_TAG = 'finance-offline-mutations';
-const MAX_MUTATION_RETRIES = 3;
-const MUTATION_SYNC_ENDPOINT = '/api/sync/mutations';
-
-let isReplayingMutations = false;
 
 /**
  * App-shell resources to pre-cache during installation.
@@ -60,7 +51,7 @@ const APP_SHELL: string[] = ['/', '/index.html', '/manifest.json'];
 const STATIC_EXTENSIONS = /\.(js|css|woff2?|ttf|otf|eot|png|jpe?g|gif|svg|ico|webp|avif|wasm)$/i;
 
 // ---------------------------------------------------------------------------
-// Install ΓÇö pre-cache app shell
+// Install -- pre-cache app shell
 // ---------------------------------------------------------------------------
 
 self.addEventListener('install', (event: ExtendableEvent) => {
@@ -70,7 +61,7 @@ self.addEventListener('install', (event: ExtendableEvent) => {
 });
 
 // ---------------------------------------------------------------------------
-// Activate ΓÇö purge stale caches
+// Activate -- purge stale caches
 // ---------------------------------------------------------------------------
 
 self.addEventListener('activate', (event: ExtendableEvent) => {
@@ -90,7 +81,7 @@ self.addEventListener('activate', (event: ExtendableEvent) => {
 });
 
 // ---------------------------------------------------------------------------
-// Fetch ΓÇö strategy router
+// Fetch -- strategy router
 // ---------------------------------------------------------------------------
 
 self.addEventListener('fetch', (event: FetchEvent) => {
@@ -102,60 +93,84 @@ self.addEventListener('fetch', (event: FetchEvent) => {
     return;
   }
 
-  // API requests ΓåÆ network-first
+  // API requests -> network-first
   if (url.pathname.startsWith('/api/')) {
     event.respondWith(networkFirst(request));
     return;
   }
 
-  // Static assets & app shell ΓåÆ cache-first
+  // Static assets & app shell -> cache-first
   if (isStaticAsset(url.pathname)) {
     event.respondWith(cacheFirst(request));
     return;
   }
 
-  // Navigation requests (HTML) ΓåÆ cache-first (SPA)
+  // Navigation requests (HTML) -> cache-first (SPA)
   if (request.mode === 'navigate') {
     event.respondWith(cacheFirst(request, '/index.html'));
     return;
   }
 
-  // Everything else ΓÇö try cache, fall back to network
+  // Everything else -- try cache, fall back to network
   event.respondWith(cacheFirst(request));
 });
 
 // ---------------------------------------------------------------------------
-// Background Sync
+// Background Sync -- replay offline mutations
 // ---------------------------------------------------------------------------
 
 self.addEventListener('sync', (event: SyncEvent) => {
   if (event.tag === SYNC_TAG) {
-    event.waitUntil(replayOfflineMutations());
+    event.waitUntil(replayMutations((message) => broadcastToClients(message)));
   }
 });
 
+// ---------------------------------------------------------------------------
+// Message handler -- main-thread <-> service-worker communication
+// ---------------------------------------------------------------------------
+
 /**
- * Register a background-sync so that pending mutations are retried
- * when the browser regains connectivity.
+ * Handle messages from the main thread.
  *
- * Called from the main thread via `postMessage`.
+ * Supported message types:
+ *   - `REGISTER_SYNC` -- register a Background Sync for mutation replay.
+ *   - `SKIP_WAITING` -- activate a waiting service worker immediately.
+ *   - `SYNC_NOW` -- immediately replay pending mutations (manual trigger).
+ *   - `GET_PENDING_COUNT` -- reply with the current pending mutation count.
  */
 self.addEventListener('message', (event: ExtendableMessageEvent) => {
-  if (event.data?.type === 'REGISTER_SYNC') {
-    event.waitUntil(
-      self.registration.sync.register(SYNC_TAG).catch(() => {
-        // Background Sync not supported — replay immediately instead.
-        return replayOfflineMutations();
-      }),
-    );
-  }
+  const data = event.data as ClientToSwMessage | undefined;
+  if (!data?.type) return;
 
-  if (event.data?.type === 'REPLAY_MUTATIONS') {
-    event.waitUntil(replayOfflineMutations());
-  }
+  switch (data.type) {
+    case 'REGISTER_SYNC':
+      event.waitUntil(
+        self.registration.sync.register(SYNC_TAG).catch(() => {
+          // Background Sync not supported -- the main thread will
+          // retry via online/offline listeners instead.
+        }),
+      );
+      break;
 
-  if (event.data?.type === 'SKIP_WAITING') {
-    void self.skipWaiting();
+    case 'SKIP_WAITING':
+      void self.skipWaiting();
+      break;
+
+    case 'SYNC_NOW':
+      event.waitUntil(replayMutations((message) => broadcastToClients(message)));
+      break;
+
+    case 'GET_PENDING_COUNT': {
+      event.waitUntil(
+        (async () => {
+          const { WebMutationQueue } = await import('../db/sync/MutationQueue');
+          const queue = new WebMutationQueue();
+          const count = await queue.getPendingCount();
+          broadcastToClients({ type: 'PENDING_COUNT', count });
+        })(),
+      );
+      break;
+    }
   }
 });
 
@@ -189,7 +204,7 @@ async function cacheFirst(request: Request, fallbackUrl?: string): Promise<Respo
     }
     return response;
   } catch {
-    return new Response('Offline ΓÇö resource not cached', {
+    return new Response('Offline -- resource not cached', {
       status: 503,
       statusText: 'Service Unavailable',
       headers: { 'Content-Type': 'text/plain' },
@@ -231,99 +246,20 @@ function isStaticAsset(pathname: string): boolean {
   return STATIC_EXTENSIONS.test(pathname);
 }
 
-/* eslint-disable no-console -- replay attempts must be logged for offline diagnostics. */
-type MutationReplayMessage =
-  | { type: 'MUTATION_REPLAY_STARTED' }
-  | {
-      type: 'MUTATION_REPLAY_FINISHED';
-      queueSize: number;
-      succeeded: number;
-      failed: number;
-    };
+// ---------------------------------------------------------------------------
+// Client broadcast helper
+// ---------------------------------------------------------------------------
 
-async function broadcastMutationReplayMessage(message: MutationReplayMessage): Promise<void> {
-  const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+/**
+ * Send a message to all controlled browser tabs so the UI can react to
+ * sync lifecycle events (started, completed, failed, pending count).
+ */
+async function broadcastToClients(message: SwToClientMessage): Promise<void> {
+  const clients = await self.clients.matchAll({ type: 'window' });
   for (const client of clients) {
     client.postMessage(message);
   }
 }
-
-/** Replay queued offline mutations against the placeholder sync API. */
-async function replayOfflineMutations(): Promise<void> {
-  if (isReplayingMutations) {
-    console.info('[finance-sw] Offline mutation replay already in progress.');
-    return;
-  }
-
-  isReplayingMutations = true;
-  let succeeded = 0;
-  let failed = 0;
-
-  await broadcastMutationReplayMessage({ type: 'MUTATION_REPLAY_STARTED' });
-
-  try {
-    const queuedMutations = await dequeueMutations();
-
-    if (queuedMutations.length === 0) {
-      console.info('[finance-sw] No queued offline mutations to replay.');
-      return;
-    }
-
-    for (const mutation of queuedMutations) {
-      try {
-        const response = await fetch(MUTATION_SYNC_ENDPOINT, {
-          method: 'POST',
-          credentials: 'include',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify(mutation),
-        });
-
-        if (!response.ok) {
-          throw new Error(`Mutation replay failed with status ${response.status}.`);
-        }
-
-        await removeMutation(mutation.id);
-        succeeded += 1;
-      } catch (error) {
-        const nextRetryCount = mutation.retryCount + 1;
-        failed += 1;
-
-        if (nextRetryCount >= MAX_MUTATION_RETRIES) {
-          await removeMutation(mutation.id);
-          console.error(
-            `[finance-sw] Giving up on queued ${mutation.entity} ${mutation.type} mutation ${mutation.id} after ${nextRetryCount} attempts.`,
-            error,
-          );
-          continue;
-        }
-
-        await updateMutationRetryCount(mutation.id, nextRetryCount);
-        console.warn(
-          `[finance-sw] Failed to replay queued ${mutation.entity} ${mutation.type} mutation ${mutation.id}; retry ${nextRetryCount}/${MAX_MUTATION_RETRIES}.`,
-          error,
-        );
-      }
-    }
-
-    console.info(
-      `[finance-sw] Offline mutation replay finished. Succeeded: ${succeeded}, failed: ${failed}, remaining: ${await getQueueSize()}.`,
-    );
-  } catch (error) {
-    console.error('[finance-sw] Unexpected error while replaying offline mutations.', error);
-  } finally {
-    const queueSize = await getQueueSize().catch(() => 0);
-    isReplayingMutations = false;
-    await broadcastMutationReplayMessage({
-      type: 'MUTATION_REPLAY_FINISHED',
-      queueSize,
-      succeeded,
-      failed,
-    });
-  }
-}
-/* eslint-enable no-console */
 
 // ---------------------------------------------------------------------------
 // TypeScript SyncEvent augmentation (not yet in lib.webworker.d.ts)

--- a/apps/web/src/test-setup.ts
+++ b/apps/web/src/test-setup.ts
@@ -1,3 +1,4 @@
 // SPDX-License-Identifier: BUSL-1.1
 
+import 'fake-indexeddb/auto';
 import '@testing-library/jest-dom/vitest';

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "@types/react-dom": "^19.1.5",
         "@types/sql.js": "^1.4.9",
         "@vitejs/plugin-react": "^4.5.2",
+        "fake-indexeddb": "^6.2.5",
         "jsdom": "^28.1.0",
         "nanoid": "^5.1.6",
         "source-map-js": "^1.2.1",
@@ -6973,6 +6974,16 @@
       "integrity": "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",


### PR DESCRIPTION
Implements offline-first mutation queue with IndexedDB persistence, Background Sync replay, retry with dead-lettering, and useSyncStatus React hook. 24 tests covering queue CRUD, replay, and error handling. Closes #416