### PR TITLE
feat(web): add login/signup pages, route protection, and real data export (#507, #508)

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,11 @@
+# Finance Web App - Environment Variables
+# Copy this file to .env.local and fill in real values
+
+# Supabase Configuration
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your-supabase-anon-key
+
+# Auth Endpoints
+VITE_LOGIN_ENDPOINT=/api/auth/login
+VITE_REFRESH_ENDPOINT=/api/auth/refresh
+VITE_LOGOUT_ENDPOINT=/api/auth/logout

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -16,17 +16,28 @@ const PAGE_TITLES: Record<string, string> = {
   '/settings': 'Settings',
 };
 
+/** Routes that should render WITHOUT AppLayout (pre-auth pages). */
+const STANDALONE_ROUTES = ['/login', '/signup'];
+
 /**
  * Root application component.
  *
- * Wraps routes in the AppLayout shell which provides sidebar
+ * Wraps authenticated routes in the AppLayout shell which provides sidebar
  * navigation on desktop and bottom navigation on mobile.
+ *
+ * Pre-authentication routes (login, signup) render standalone without layout.
  */
 export const App: FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const activePath = location.pathname === '/' ? '/' : location.pathname;
   const pageTitle = PAGE_TITLES[activePath] ?? 'Finance';
+  const isStandalonePage = STANDALONE_ROUTES.includes(activePath);
+
+  if (isStandalonePage) {
+    // Render pre-auth pages without AppLayout
+    return <AppRoutes />;
+  }
 
   return (
     <AppLayout activePath={activePath} onNavigate={(path) => navigate(path)} pageTitle={pageTitle}>

--- a/apps/web/src/components/DataExport.test.tsx
+++ b/apps/web/src/components/DataExport.test.tsx
@@ -1,13 +1,104 @@
 // SPDX-License-Identifier: BUSL-1.1
 
+import React from 'react';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { DataExport } from './DataExport';
+import type { SqliteDb } from '../db/sqlite-wasm';
+import { DatabaseContext } from '../db/DatabaseProvider';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/** Create a minimal mock database for testing. */
+function createMockDb(): SqliteDb {
+  return {
+    exec: vi.fn(),
+    close: vi.fn(),
+  } as unknown as SqliteDb;
+}
+
+/** Mock the database repositories. */
+vi.mock('../db/repositories/accounts', () => ({
+  getAllAccounts: vi.fn(() => [
+    {
+      id: 'acc-1',
+      householdId: 'hh-1',
+      name: 'Checking',
+      type: 'CHECKING',
+      currency: { code: 'USD', symbol: '$', name: 'US Dollar' },
+      currentBalance: { amount: 100000 },
+      isArchived: false,
+      sortOrder: 0,
+      icon: null,
+      color: null,
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+      deletedAt: null,
+      syncVersion: 1,
+      isSynced: false,
+    },
+  ]),
+}));
+
+vi.mock('../db/repositories/transactions', () => ({
+  getAllTransactions: vi.fn(() => [
+    {
+      id: 'txn-1',
+      householdId: 'hh-1',
+      accountId: 'acc-1',
+      categoryId: 'cat-1',
+      type: 'EXPENSE',
+      status: 'CLEARED',
+      amount: { amount: -6742 },
+      currency: { code: 'USD', symbol: '$', name: 'US Dollar' },
+      payee: 'Grocery Store',
+      note: null,
+      date: '2024-03-06',
+      transferAccountId: null,
+      transferTransactionId: null,
+      isRecurring: false,
+      recurringRuleId: null,
+      tags: [],
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+      deletedAt: null,
+      syncVersion: 1,
+      isSynced: false,
+    },
+  ]),
+}));
+
+vi.mock('../db/repositories/budgets', () => ({
+  getAllBudgets: vi.fn(() => []),
+}));
+
+vi.mock('../db/repositories/goals', () => ({
+  getAllGoals: vi.fn(() => []),
+}));
+
+vi.mock('../db/repositories/categories', () => ({
+  getAllCategories: vi.fn(() => [
+    {
+      id: 'cat-1',
+      householdId: 'hh-1',
+      name: 'Food',
+      icon: null,
+      color: null,
+      parentId: null,
+      isIncome: false,
+      isSystem: false,
+      sortOrder: 0,
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+      deletedAt: null,
+      syncVersion: 1,
+      isSynced: false,
+    },
+  ]),
+}));
 
 /** Stub URL.createObjectURL / revokeObjectURL since jsdom doesn't provide them. */
 beforeEach(() => {
@@ -27,23 +118,46 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe('DataExport', () => {
+  // Helper to create test wrapper with database context
+  const createTestWrapper = (db: SqliteDb | null) => {
+    const TestWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+      <DatabaseContext.Provider value={db}>{children}</DatabaseContext.Provider>
+    );
+    return TestWrapper;
+  };
+
   // -- Render ---------------------------------------------------------------
 
   it('renders both export format buttons', () => {
-    render(<DataExport />);
+    const mockDb = createMockDb();
+    const TestWrapper = createTestWrapper(mockDb);
+    render(<DataExport />, { wrapper: TestWrapper });
     expect(screen.getByRole('button', { name: /export as json/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /export as csv/i })).toBeInTheDocument();
   });
 
   it('renders description text', () => {
-    render(<DataExport />);
+    const mockDb = createMockDb();
+    const TestWrapper = createTestWrapper(mockDb);
+    render(<DataExport />, { wrapper: TestWrapper });
     expect(screen.getByText(/download your financial data/i)).toBeInTheDocument();
+  });
+
+  it('shows database unavailable message when db is null', () => {
+    const TestWrapper = createTestWrapper(null);
+    render(<DataExport />, { wrapper: TestWrapper });
+    expect(screen.getByText(/database is not available/i)).toBeInTheDocument();
+    // Buttons should be disabled when database is not available
+    expect(screen.getByRole('button', { name: /export as json/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /export as csv/i })).toBeDisabled();
   });
 
   // -- Accessibility --------------------------------------------------------
 
   it('export buttons are keyboard focusable', () => {
-    render(<DataExport />);
+    const mockDb = createMockDb();
+    const TestWrapper = createTestWrapper(mockDb);
+    render(<DataExport />, { wrapper: TestWrapper });
     const jsonBtn = screen.getByRole('button', { name: /export as json/i });
     const csvBtn = screen.getByRole('button', { name: /export as csv/i });
 
@@ -53,7 +167,9 @@ describe('DataExport', () => {
   });
 
   it('buttons have type="button" (not submit)', () => {
-    render(<DataExport />);
+    const mockDb = createMockDb();
+    const TestWrapper = createTestWrapper(mockDb);
+    render(<DataExport />, { wrapper: TestWrapper });
     const jsonBtn = screen.getByRole('button', { name: /export as json/i });
     const csvBtn = screen.getByRole('button', { name: /export as csv/i });
 
@@ -62,7 +178,9 @@ describe('DataExport', () => {
   });
 
   it('buttons are grouped with role="group"', () => {
-    render(<DataExport />);
+    const mockDb = createMockDb();
+    const TestWrapper = createTestWrapper(mockDb);
+    render(<DataExport />, { wrapper: TestWrapper });
     const group = screen.getByRole('group');
     expect(group).toBeInTheDocument();
 
@@ -75,7 +193,9 @@ describe('DataExport', () => {
 
   it('shows progress state when exporting', async () => {
     const user = userEvent.setup();
-    render(<DataExport />);
+    const mockDb = createMockDb();
+    const TestWrapper = createTestWrapper(mockDb);
+    render(<DataExport />, { wrapper: TestWrapper });
 
     const jsonBtn = screen.getByRole('button', { name: /export as json/i });
     await user.click(jsonBtn);
@@ -86,7 +206,9 @@ describe('DataExport', () => {
 
   it('disables buttons during export', async () => {
     const user = userEvent.setup();
-    render(<DataExport />);
+    const mockDb = createMockDb();
+    const TestWrapper = createTestWrapper(mockDb);
+    render(<DataExport />, { wrapper: TestWrapper });
 
     await user.click(screen.getByRole('button', { name: /export as json/i }));
 
@@ -106,7 +228,9 @@ describe('DataExport', () => {
   it('shows success message after export completes', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
-    render(<DataExport />);
+    const mockDb = createMockDb();
+    const TestWrapper = createTestWrapper(mockDb);
+    render(<DataExport />, { wrapper: TestWrapper });
 
     await user.click(screen.getByRole('button', { name: /export as json/i }));
 
@@ -121,7 +245,9 @@ describe('DataExport', () => {
   // -- Custom class ---------------------------------------------------------
 
   it('applies custom className', () => {
-    const { container } = render(<DataExport className="my-custom" />);
+    const mockDb = createMockDb();
+    const TestWrapper = createTestWrapper(mockDb);
+    const { container } = render(<DataExport className="my-custom" />, { wrapper: TestWrapper });
     const wrapper = container.firstElementChild;
     expect(wrapper?.className).toContain('my-custom');
     expect(wrapper?.className).toContain('data-export');

--- a/apps/web/src/components/DataExport.tsx
+++ b/apps/web/src/components/DataExport.tsx
@@ -1,6 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { useCallback, useRef, useState } from 'react';
+import { useDatabase } from '../db/DatabaseProvider';
+import type { SqliteDb } from '../db/sqlite-wasm';
+import { getAllAccounts } from '../db/repositories/accounts';
+import { getAllTransactions } from '../db/repositories/transactions';
+import { getAllBudgets } from '../db/repositories/budgets';
+import { getAllGoals } from '../db/repositories/goals';
+import { getAllCategories } from '../db/repositories/categories';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -12,6 +19,16 @@ export type ExportFormat = 'json' | 'csv';
 /** Current state of the export operation. */
 type ExportStatus = 'idle' | 'exporting' | 'success' | 'error';
 
+type ExportRecord = Record<string, unknown>;
+
+interface ExportData {
+  accounts: ReturnType<typeof getAllAccounts>;
+  transactions: ReturnType<typeof getAllTransactions>;
+  budgets: ReturnType<typeof getAllBudgets>;
+  goals: ReturnType<typeof getAllGoals>;
+  categories: ReturnType<typeof getAllCategories>;
+}
+
 export interface DataExportProps {
   className?: string;
 }
@@ -20,49 +37,75 @@ export interface DataExportProps {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/**
- * Generate mock financial data for export.
- *
- * TODO: Replace with real data from SQLite-WASM / KMP shared logic once the
- * DataExportService (packages/core/export) is integrated on the JS target.
- */
-function gatherExportData(): Record<string, unknown>[] {
-  return [
-    { id: 'txn-1', date: '2024-03-06', payee: 'Grocery Store', category: 'Food', amount: -67.42 },
-    { id: 'txn-2', date: '2024-03-06', payee: 'Monthly Salary', category: 'Income', amount: 4500 },
-    {
-      id: 'txn-3',
-      date: '2024-03-05',
-      payee: 'Electric Bill',
-      category: 'Utilities',
-      amount: -124,
-    },
-    { id: 'txn-4', date: '2024-03-05', payee: 'Coffee Shop', category: 'Dining', amount: -5.75 },
-    { id: 'txn-5', date: '2024-03-04', payee: 'Gas Station', category: 'Transport', amount: -48.3 },
-  ];
+/** Gather all exportable financial data from the local SQLite-WASM database. */
+function gatherExportData(db: SqliteDb): ExportData {
+  return {
+    accounts: getAllAccounts(db),
+    transactions: getAllTransactions(db),
+    budgets: getAllBudgets(db),
+    goals: getAllGoals(db),
+    categories: getAllCategories(db),
+  };
+}
+
+/** Safely read the shared database instance when the provider may be unavailable. */
+function useExportDatabase(): SqliteDb | null {
+  try {
+    return useDatabase();
+  } catch {
+    return null;
+  }
+}
+
+/** Return `true` when at least one exported collection contains records. */
+function hasExportData(data: ExportData): boolean {
+  return Object.values(data).some((records) => records.length > 0);
 }
 
 /** Serialize records to JSON string. */
-function serializeJson(data: Record<string, unknown>[]): string {
-  return JSON.stringify({ exportedAt: new Date().toISOString(), transactions: data }, null, 2);
+function serializeJson(data: ExportData): string {
+  return JSON.stringify({ exportedAt: new Date().toISOString(), data }, null, 2);
 }
 
-/** Serialize records to CSV string with header row. */
-function serializeCsv(data: Record<string, unknown>[]): string {
-  if (data.length === 0) return '';
-  const headers = Object.keys(data[0]);
-  const rows = data.map((row) =>
-    headers
-      .map((h) => {
-        const val = String(row[h] ?? '');
-        // Escape values containing commas, quotes, or newlines
-        return val.includes(',') || val.includes('"') || val.includes('\n')
-          ? `"${val.replace(/"/g, '""')}"`
-          : val;
-      })
-      .join(','),
+/** Serialize a single value for safe CSV output. */
+function serializeCsvValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  const serializedValue = typeof value === 'object' ? JSON.stringify(value) : String(value);
+  return serializedValue.includes(',') ||
+    serializedValue.includes('"') ||
+    serializedValue.includes('\n')
+    ? `"${serializedValue.replace(/"/g, '""')}"`
+    : serializedValue;
+}
+
+/** Serialize a homogeneous record collection to CSV with a header row. */
+function serializeRecordCollection(records: ExportRecord[]): string {
+  if (records.length === 0) {
+    return '';
+  }
+
+  const headers = Object.keys(records[0]);
+  const rows = records.map((record) =>
+    headers.map((header) => serializeCsvValue(record[header])).join(','),
   );
   return [headers.join(','), ...rows].join('\n');
+}
+
+/** Serialize exported data collections to a multi-section CSV string. */
+function serializeCsv(data: ExportData): string {
+  return (Object.entries(data) as [keyof ExportData, ExportData[keyof ExportData]][])
+    .map(([tableName, records]) => {
+      const lines = [`# Table: ${String(tableName)}`, `# Records: ${records.length}`];
+      const section = serializeRecordCollection(records as unknown as ExportRecord[]);
+      if (section) {
+        lines.push(section);
+      }
+      return lines.join('\n');
+    })
+    .join('\n\n');
 }
 
 /** Trigger a browser file download from a Blob. */
@@ -97,6 +140,7 @@ function downloadBlob(content: string, filename: string, mimeType: string): void
  * - Full keyboard navigation
  */
 export const DataExport: React.FC<DataExportProps> = ({ className = '' }) => {
+  const db = useExportDatabase();
   const [status, setStatus] = useState<ExportStatus>('idle');
   const [errorMessage, setErrorMessage] = useState('');
   const [lastFormat, setLastFormat] = useState<ExportFormat | null>(null);
@@ -105,43 +149,49 @@ export const DataExport: React.FC<DataExportProps> = ({ className = '' }) => {
   const jsonBtnRef = useRef<HTMLButtonElement>(null);
   const csvBtnRef = useRef<HTMLButtonElement>(null);
 
-  const handleExport = useCallback(async (format: ExportFormat) => {
-    setStatus('exporting');
-    setErrorMessage('');
-    setLastFormat(format);
+  const handleExport = useCallback(
+    async (format: ExportFormat) => {
+      setStatus('exporting');
+      setErrorMessage('');
+      setLastFormat(format);
 
-    try {
-      // Simulate a brief processing delay for UX feedback (real export may
-      // involve reading from SQLite-WASM which is async).
-      await new Promise((resolve) => setTimeout(resolve, 400));
+      try {
+        // Simulate a brief processing delay for UX feedback while queries run.
+        await new Promise((resolve) => setTimeout(resolve, 400));
 
-      const data = gatherExportData();
+        if (!db) {
+          setStatus('error');
+          setErrorMessage('Database is still initializing. Please wait a moment and try again.');
+          return;
+        }
 
-      if (data.length === 0) {
+        const data = gatherExportData(db);
+        if (!hasExportData(data)) {
+          setStatus('error');
+          setErrorMessage('No data available to export.');
+          return;
+        }
+
+        const timestamp = new Date().toISOString().slice(0, 10);
+        if (format === 'json') {
+          const content = serializeJson(data);
+          downloadBlob(content, `finance-export-${timestamp}.json`, 'application/json');
+        } else {
+          const content = serializeCsv(data);
+          downloadBlob(content, `finance-export-${timestamp}.csv`, 'text/csv');
+        }
+
+        setStatus('success');
+
+        // Auto-clear success after a few seconds
+        setTimeout(() => setStatus('idle'), 4000);
+      } catch {
         setStatus('error');
-        setErrorMessage('No data available to export.');
-        return;
+        setErrorMessage('Export failed. Please try again.');
       }
-
-      const timestamp = new Date().toISOString().slice(0, 10);
-
-      if (format === 'json') {
-        const content = serializeJson(data);
-        downloadBlob(content, `finance-export-${timestamp}.json`, 'application/json');
-      } else {
-        const content = serializeCsv(data);
-        downloadBlob(content, `finance-export-${timestamp}.csv`, 'text/csv');
-      }
-
-      setStatus('success');
-
-      // Auto-clear success after a few seconds
-      setTimeout(() => setStatus('idle'), 4000);
-    } catch {
-      setStatus('error');
-      setErrorMessage('Export failed. Please try again.');
-    }
-  }, []);
+    },
+    [db],
+  );
 
   const handleDismissError = useCallback(() => {
     setStatus('idle');
@@ -155,6 +205,7 @@ export const DataExport: React.FC<DataExportProps> = ({ className = '' }) => {
   }, [lastFormat]);
 
   const isExporting = status === 'exporting';
+  const isDatabaseUnavailable = db === null;
 
   return (
     <div className={`data-export ${className}`.trim()}>
@@ -166,7 +217,9 @@ export const DataExport: React.FC<DataExportProps> = ({ className = '' }) => {
           marginBottom: 'var(--spacing-4)',
         }}
       >
-        Download your financial data for backup or use in other applications.
+        {isDatabaseUnavailable
+          ? 'Database is not available. Please wait for it to initialize.'
+          : 'Download your financial data for backup or use in other applications.'}
       </p>
 
       {/* Export buttons */}
@@ -182,7 +235,7 @@ export const DataExport: React.FC<DataExportProps> = ({ className = '' }) => {
         <button
           ref={jsonBtnRef}
           type="button"
-          disabled={isExporting}
+          disabled={isExporting || isDatabaseUnavailable}
           onClick={() => handleExport('json')}
           aria-describedby="data-export-description"
           style={{
@@ -194,8 +247,8 @@ export const DataExport: React.FC<DataExportProps> = ({ className = '' }) => {
             borderRadius: 'var(--border-radius-md)',
             background: 'none',
             color: 'var(--semantic-interactive-default)',
-            cursor: isExporting ? 'not-allowed' : 'pointer',
-            opacity: isExporting ? 0.6 : 1,
+            cursor: isExporting || isDatabaseUnavailable ? 'not-allowed' : 'pointer',
+            opacity: isExporting || isDatabaseUnavailable ? 0.6 : 1,
             fontSize: 'var(--type-scale-body-font-size)',
             fontWeight: 'var(--font-weight-medium)',
           }}
@@ -216,7 +269,7 @@ export const DataExport: React.FC<DataExportProps> = ({ className = '' }) => {
         <button
           ref={csvBtnRef}
           type="button"
-          disabled={isExporting}
+          disabled={isExporting || isDatabaseUnavailable}
           onClick={() => handleExport('csv')}
           aria-describedby="data-export-description"
           style={{
@@ -228,8 +281,8 @@ export const DataExport: React.FC<DataExportProps> = ({ className = '' }) => {
             borderRadius: 'var(--border-radius-md)',
             background: 'none',
             color: 'var(--semantic-interactive-default)',
-            cursor: isExporting ? 'not-allowed' : 'pointer',
-            opacity: isExporting ? 0.6 : 1,
+            cursor: isExporting || isDatabaseUnavailable ? 'not-allowed' : 'pointer',
+            opacity: isExporting || isDatabaseUnavailable ? 0.6 : 1,
             fontSize: 'var(--type-scale-body-font-size)',
             fontWeight: 'var(--font-weight-medium)',
           }}

--- a/apps/web/src/db/DatabaseProvider.tsx
+++ b/apps/web/src/db/DatabaseProvider.tsx
@@ -5,7 +5,8 @@ import { ErrorBanner, LoadingSpinner } from '../components/common';
 import { seedDatabase } from './seed';
 import { initDatabase, type SqliteDb } from './sqlite-wasm';
 
-const DatabaseContext = createContext<SqliteDb | null>(null);
+/** React context that stores the shared SQLite-WASM database instance. */
+export const DatabaseContext = createContext<SqliteDb | null>(null);
 DatabaseContext.displayName = 'DatabaseContext';
 
 interface DatabaseProviderProps {

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -4,6 +4,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { App } from './App';
+import { AuthProvider } from './auth/auth-context';
 import { DatabaseProvider } from './db/DatabaseProvider';
 import './theme/tokens.css';
 import './styles/responsive.css';
@@ -14,12 +15,29 @@ if (!rootElement) {
   throw new Error('Root element not found. Ensure <div id="root"></div> exists in index.html.');
 }
 
+// Auth configuration - in production these would come from environment variables
+const authConfig = {
+  supabaseUrl: import.meta.env.VITE_SUPABASE_URL ?? 'https://placeholder.supabase.co',
+  supabaseAnonKey: import.meta.env.VITE_SUPABASE_ANON_KEY ?? 'placeholder-anon-key',
+  loginEndpoint: import.meta.env.VITE_LOGIN_ENDPOINT ?? '/api/auth/login',
+  refreshEndpoint: import.meta.env.VITE_REFRESH_ENDPOINT ?? '/api/auth/refresh',
+  logoutEndpoint: import.meta.env.VITE_LOGOUT_ENDPOINT ?? '/api/auth/logout',
+  onUnauthenticated: () => {
+    // Redirect to login when session expires or user is not authenticated
+    if (window.location.pathname !== '/login' && window.location.pathname !== '/signup') {
+      window.location.href = '/login';
+    }
+  },
+};
+
 createRoot(rootElement).render(
   <StrictMode>
-    <DatabaseProvider>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
-    </DatabaseProvider>
+    <AuthProvider config={authConfig}>
+      <DatabaseProvider>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </DatabaseProvider>
+    </AuthProvider>
   </StrictMode>,
 );

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import React, { useEffect, useId, useRef, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '../auth/auth-context';
+import { LoadingSpinner } from '../components/common/LoadingSpinner';
+import '../components/forms/forms.css';
+import '../styles/auth.css';
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+interface LoginFieldErrors {
+  email?: string;
+  password?: string;
+}
+
+/**
+ * Standalone login page for pre-authentication web access.
+ */
+export const LoginPage: React.FC = () => {
+  const navigate = useNavigate();
+  const { loginWithEmail, loginWithPasskey, isAuthenticated, isLoading, error, webAuthnSupported } =
+    useAuth();
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [fieldErrors, setFieldErrors] = useState<LoginFieldErrors>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const uid = useId();
+  const emailId = `${uid}-email`;
+  const passwordId = `${uid}-password`;
+  const emailErrorId = `${uid}-email-error`;
+  const passwordErrorId = `${uid}-password-error`;
+  const authErrorId = `${uid}-auth-error`;
+
+  const emailInputRef = useRef<HTMLInputElement>(null);
+  const passwordInputRef = useRef<HTMLInputElement>(null);
+  const errorRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      navigate('/dashboard', { replace: true });
+    }
+  }, [isAuthenticated, navigate]);
+
+  useEffect(() => {
+    if (error) {
+      errorRef.current?.focus();
+    }
+  }, [error]);
+
+  const handleEmailLogin = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const nextFieldErrors: LoginFieldErrors = {};
+    const normalizedEmail = email.trim();
+
+    if (!normalizedEmail) {
+      nextFieldErrors.email = 'Email is required.';
+    } else if (!EMAIL_PATTERN.test(normalizedEmail)) {
+      nextFieldErrors.email = 'Enter a valid email address.';
+    }
+
+    if (!password) {
+      nextFieldErrors.password = 'Password is required.';
+    }
+
+    setFieldErrors(nextFieldErrors);
+
+    if (nextFieldErrors.email) {
+      emailInputRef.current?.focus();
+      return;
+    }
+
+    if (nextFieldErrors.password) {
+      passwordInputRef.current?.focus();
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      await loginWithEmail(normalizedEmail, password);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handlePasskeyLogin = async () => {
+    setFieldErrors({});
+    setIsSubmitting(true);
+
+    try {
+      await loginWithPasskey();
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const isBusy = isSubmitting || isLoading;
+
+  return (
+    <main className="auth-page">
+      <section className="auth-card auth-card--login" aria-labelledby={`${uid}-title`}>
+        <header className="auth-brand">
+          <h1 id={`${uid}-title`} className="auth-brand__name">
+            Finance
+          </h1>
+          <p className="auth-brand__tagline">
+            Secure financial tracking for you and your household
+          </p>
+        </header>
+
+        {error && (
+          <div
+            ref={errorRef}
+            id={authErrorId}
+            className="auth-error"
+            aria-live="polite"
+            tabIndex={-1}
+          >
+            {error}
+          </div>
+        )}
+
+        <form className="auth-form" onSubmit={handleEmailLogin} aria-label="Sign in" noValidate>
+          <div className="form-fields">
+            <div className="form-group">
+              <label htmlFor={emailId} className="form-group__label form-group__label--required">
+                Email
+              </label>
+              <input
+                ref={emailInputRef}
+                id={emailId}
+                name="email"
+                type="email"
+                required
+                autoComplete="email"
+                className={`form-input${fieldErrors.email ? ' form-input--error' : ''}`}
+                value={email}
+                onChange={(event) => {
+                  setEmail(event.target.value);
+                  setFieldErrors((current) => ({ ...current, email: undefined }));
+                }}
+                disabled={isBusy}
+                aria-label="Email address"
+                aria-invalid={fieldErrors.email ? 'true' : undefined}
+                aria-describedby={[
+                  fieldErrors.email ? emailErrorId : null,
+                  error ? authErrorId : null,
+                ]
+                  .filter(Boolean)
+                  .join(' ')}
+              />
+              <p id={emailErrorId} className="form-error">
+                {fieldErrors.email ?? ' '}
+              </p>
+            </div>
+
+            <div className="form-group">
+              <label htmlFor={passwordId} className="form-group__label form-group__label--required">
+                Password
+              </label>
+              <input
+                ref={passwordInputRef}
+                id={passwordId}
+                name="password"
+                type="password"
+                required
+                autoComplete="current-password"
+                className={`form-input${fieldErrors.password ? ' form-input--error' : ''}`}
+                value={password}
+                onChange={(event) => {
+                  setPassword(event.target.value);
+                  setFieldErrors((current) => ({ ...current, password: undefined }));
+                }}
+                disabled={isBusy}
+                aria-label="Password"
+                aria-invalid={fieldErrors.password ? 'true' : undefined}
+                aria-describedby={[
+                  fieldErrors.password ? passwordErrorId : null,
+                  error ? authErrorId : null,
+                ]
+                  .filter(Boolean)
+                  .join(' ')}
+              />
+              <p id={passwordErrorId} className="form-error">
+                {fieldErrors.password ?? ' '}
+              </p>
+            </div>
+          </div>
+
+          <div className="auth-actions">
+            <button type="submit" className="auth-submit" disabled={isBusy} aria-busy={isBusy}>
+              {isBusy ? (
+                <>
+                  <LoadingSpinner size={20} label="Signing in" />
+                  <span>Signing in...</span>
+                </>
+              ) : (
+                'Sign in'
+              )}
+            </button>
+
+            {webAuthnSupported ? (
+              <>
+                <div className="auth-divider" aria-hidden="true">
+                  <span className="auth-divider__text">or</span>
+                </div>
+                <button
+                  type="button"
+                  className="form-button form-button--secondary auth-passkey-button"
+                  onClick={handlePasskeyLogin}
+                  disabled={isBusy}
+                  aria-busy={isBusy}
+                >
+                  Sign in with passkey
+                </button>
+              </>
+            ) : null}
+          </div>
+        </form>
+
+        <p className="auth-footer">
+          Don&apos;t have an account?{' '}
+          <Link to="/signup" className="auth-footer__link">
+            Sign up
+          </Link>
+        </p>
+      </section>
+    </main>
+  );
+};
+
+export default LoginPage;

--- a/apps/web/src/pages/SignupPage.tsx
+++ b/apps/web/src/pages/SignupPage.tsx
@@ -1,0 +1,291 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * SignupPage — standalone account-creation page for the Finance PWA.
+ *
+ * This page is rendered outside of `AppLayout` and reuses the shared
+ * auth-card layout from `auth.css`.
+ */
+
+import React, { useCallback, useId, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth, type AuthContextValue } from '../auth/auth-context';
+import { LoadingSpinner } from '../components/common/LoadingSpinner';
+import '../styles/auth.css';
+
+/** Minimum password length enforced by client-side validation. */
+const MIN_PASSWORD_LENGTH = 8;
+
+/** Lightweight email format check for custom validation feedback. */
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+interface SignupFieldErrors {
+  email?: string;
+  password?: string;
+  confirmPassword?: string;
+}
+
+interface SubmitMessage {
+  type: 'error' | 'info';
+  text: string;
+}
+
+type SignupCapableAuth = AuthContextValue & {
+  signup?: (email: string, password: string) => Promise<void>;
+  register?: (email: string, password: string) => Promise<void>;
+};
+
+/**
+ * Standalone signup page for the web app.
+ *
+ * The current auth context does not expose a registration action, so the page
+ * validates the form and shows a friendly "coming soon" message until signup
+ * support is wired into the backend and auth context.
+ */
+export const SignupPage: React.FC = () => {
+  const auth = useAuth() as SignupCapableAuth;
+  const { error: authError, isLoading } = auth;
+  const signupAction = auth.signup ?? auth.register;
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [fieldErrors, setFieldErrors] = useState<SignupFieldErrors>({});
+  const [submitMessage, setSubmitMessage] = useState<SubmitMessage | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const uid = useId();
+  const emailId = `${uid}-email`;
+  const passwordId = `${uid}-password`;
+  const confirmPasswordId = `${uid}-confirm-password`;
+  const emailErrorId = `${uid}-email-error`;
+  const passwordHintId = `${uid}-password-hint`;
+  const passwordErrorId = `${uid}-password-error`;
+  const confirmPasswordErrorId = `${uid}-confirm-password-error`;
+
+  const confirmPasswordError = useMemo(() => {
+    if (fieldErrors.confirmPassword) {
+      return fieldErrors.confirmPassword;
+    }
+
+    if (confirmPassword.length > 0 && password !== confirmPassword) {
+      return 'Passwords do not match.';
+    }
+
+    return undefined;
+  }, [confirmPassword, fieldErrors.confirmPassword, password]);
+
+  const displayMessage = useMemo<SubmitMessage | null>(() => {
+    if (submitMessage) {
+      return submitMessage;
+    }
+
+    return authError ? { type: 'error', text: authError } : null;
+  }, [authError, submitMessage]);
+
+  const validate = useCallback((): boolean => {
+    const errors: SignupFieldErrors = {};
+    const normalizedEmail = email.trim();
+
+    if (!normalizedEmail) {
+      errors.email = 'Email is required.';
+    } else if (!EMAIL_PATTERN.test(normalizedEmail)) {
+      errors.email = 'Enter a valid email address.';
+    }
+
+    if (!password) {
+      errors.password = 'Password is required.';
+    } else if (password.length < MIN_PASSWORD_LENGTH) {
+      errors.password = `Password must be at least ${MIN_PASSWORD_LENGTH} characters.`;
+    }
+
+    if (!confirmPassword) {
+      errors.confirmPassword = 'Please confirm your password.';
+    } else if (password !== confirmPassword) {
+      errors.confirmPassword = 'Passwords do not match.';
+    }
+
+    setFieldErrors(errors);
+    return Object.keys(errors).length === 0;
+  }, [confirmPassword, email, password]);
+
+  const handleSubmit = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      setSubmitMessage(null);
+
+      if (!validate()) {
+        return;
+      }
+
+      setIsSubmitting(true);
+
+      try {
+        if (signupAction) {
+          await signupAction(email.trim(), password);
+          setSubmitMessage({
+            type: 'info',
+            text: 'Account created. You can now sign in.',
+          });
+          return;
+        }
+
+        await new Promise((resolve) => window.setTimeout(resolve, 600));
+        setSubmitMessage({
+          type: 'info',
+          text: 'Registration coming soon. Please check back later.',
+        });
+      } catch (error) {
+        setSubmitMessage({
+          type: 'error',
+          text: error instanceof Error ? error.message : 'Registration failed.',
+        });
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [email, password, signupAction, validate],
+  );
+
+  const isBusy = isSubmitting || isLoading;
+
+  return (
+    <main className="auth-page">
+      <div className="auth-card">
+        <header className="auth-brand">
+          <h1 className="auth-brand__name">Finance</h1>
+          <p className="auth-brand__tagline">Create your account</p>
+        </header>
+
+        {displayMessage && (
+          <div
+            className={displayMessage.type === 'error' ? 'auth-error' : 'auth-info'}
+            role="status"
+            aria-live="polite"
+          >
+            {displayMessage.text}
+          </div>
+        )}
+
+        <form className="auth-form" onSubmit={handleSubmit} noValidate>
+          <div className="auth-field">
+            <label className="auth-field__label" htmlFor={emailId}>
+              Email
+            </label>
+            <input
+              id={emailId}
+              className="auth-field__input"
+              type="email"
+              autoComplete="email"
+              required
+              value={email}
+              onChange={(event) => {
+                const nextEmail = event.target.value;
+                setEmail(nextEmail);
+                setFieldErrors((current) => ({ ...current, email: undefined }));
+              }}
+              aria-invalid={fieldErrors.email ? 'true' : undefined}
+              aria-describedby={fieldErrors.email ? emailErrorId : undefined}
+            />
+            {fieldErrors.email && (
+              <p id={emailErrorId} className="auth-field__error" role="alert">
+                {fieldErrors.email}
+              </p>
+            )}
+          </div>
+
+          <div className="auth-field">
+            <label className="auth-field__label" htmlFor={passwordId}>
+              Password
+            </label>
+            <input
+              id={passwordId}
+              className="auth-field__input"
+              type="password"
+              autoComplete="new-password"
+              required
+              minLength={MIN_PASSWORD_LENGTH}
+              value={password}
+              onChange={(event) => {
+                const nextPassword = event.target.value;
+                setPassword(nextPassword);
+                setFieldErrors((current) => ({
+                  ...current,
+                  password: undefined,
+                  confirmPassword:
+                    confirmPassword.length > 0 && nextPassword !== confirmPassword
+                      ? 'Passwords do not match.'
+                      : undefined,
+                }));
+              }}
+              aria-invalid={fieldErrors.password ? 'true' : undefined}
+              aria-describedby={[passwordHintId, fieldErrors.password ? passwordErrorId : null]
+                .filter(Boolean)
+                .join(' ')}
+            />
+            <p id={passwordHintId} className="auth-field__hint">
+              Must be at least {MIN_PASSWORD_LENGTH} characters
+            </p>
+            {fieldErrors.password && (
+              <p id={passwordErrorId} className="auth-field__error" role="alert">
+                {fieldErrors.password}
+              </p>
+            )}
+          </div>
+
+          <div className="auth-field">
+            <label className="auth-field__label" htmlFor={confirmPasswordId}>
+              Confirm password
+            </label>
+            <input
+              id={confirmPasswordId}
+              className="auth-field__input"
+              type="password"
+              autoComplete="new-password"
+              required
+              value={confirmPassword}
+              onChange={(event) => {
+                const nextConfirmPassword = event.target.value;
+                setConfirmPassword(nextConfirmPassword);
+                setFieldErrors((current) => ({
+                  ...current,
+                  confirmPassword:
+                    nextConfirmPassword.length > 0 && password !== nextConfirmPassword
+                      ? 'Passwords do not match.'
+                      : undefined,
+                }));
+              }}
+              aria-invalid={confirmPasswordError ? 'true' : undefined}
+              aria-describedby={confirmPasswordError ? confirmPasswordErrorId : undefined}
+            />
+            {confirmPasswordError && (
+              <p id={confirmPasswordErrorId} className="auth-field__error" role="alert">
+                {confirmPasswordError}
+              </p>
+            )}
+          </div>
+
+          <button type="submit" className="auth-submit" disabled={isBusy} aria-busy={isBusy}>
+            {isBusy ? (
+              <>
+                <LoadingSpinner size={20} label="Creating account" />
+                <span>Creating account...</span>
+              </>
+            ) : (
+              'Sign up'
+            )}
+          </button>
+        </form>
+
+        <p className="auth-footer">
+          Already have an account?{' '}
+          <Link to="/login" className="auth-footer__link">
+            Sign in
+          </Link>
+        </p>
+      </div>
+    </main>
+  );
+};
+
+export default SignupPage;

--- a/apps/web/src/pages/index.ts
+++ b/apps/web/src/pages/index.ts
@@ -6,3 +6,5 @@ export { TransactionsPage } from './TransactionsPage';
 export { BudgetsPage } from './BudgetsPage';
 export { GoalsPage } from './GoalsPage';
 export { SettingsPage } from './SettingsPage';
+export { LoginPage } from './LoginPage';
+export { SignupPage } from './SignupPage';

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import { lazy, Suspense } from 'react';
-import type { FC } from 'react';
-import { Routes, Route, Navigate } from 'react-router-dom';
+import { lazy, Suspense, useCallback } from 'react';
+import type { FC, ReactNode } from 'react';
+import { Routes, Route, Navigate, useNavigate } from 'react-router-dom';
+
+import { ProtectedRoute, useAuth } from './auth/auth-context';
 
 /*
  * Lazy-loaded route pages - each is code-split into its own chunk.
@@ -14,6 +16,8 @@ const Transactions = lazy(() => import('./pages/TransactionsPage'));
 const Budgets = lazy(() => import('./pages/BudgetsPage'));
 const Goals = lazy(() => import('./pages/GoalsPage'));
 const Settings = lazy(() => import('./pages/SettingsPage'));
+const Login = lazy(() => import('./pages/LoginPage'));
+const Signup = lazy(() => import('./pages/SignupPage'));
 
 /**
  * Loading fallback shown while a lazy route chunk is being fetched.
@@ -26,22 +30,119 @@ const PageLoader: FC = () => (
   </div>
 );
 
+interface AuthenticatedRouteProps {
+  children: ReactNode;
+}
+
+const AuthenticatedRoute: FC<AuthenticatedRouteProps> = ({ children }) => {
+  const navigate = useNavigate();
+  const handleUnauthenticated = useCallback(() => {
+    navigate('/login', { replace: true });
+  }, [navigate]);
+
+  return (
+    <ProtectedRoute fallback={<PageLoader />} onUnauthenticated={handleUnauthenticated}>
+      {children}
+    </ProtectedRoute>
+  );
+};
+
+const RootRedirect: FC = () => {
+  const { isAuthenticated, isLoading } = useAuth();
+
+  if (isLoading) {
+    return <PageLoader />;
+  }
+
+  return <Navigate to={isAuthenticated ? '/dashboard' : '/login'} replace />;
+};
+
 /**
  * Application route definitions.
  *
  * Route structure mirrors the mobile app tabs:
  *   /dashboard, /accounts, /transactions, /budgets, /goals, /settings
+ *
+ * Pre-auth routes (login, signup) are rendered WITHOUT AppLayout.
  */
 export const AppRoutes: FC = () => (
-  <Suspense fallback={<PageLoader />}>
-    <Routes>
-      <Route path="/" element={<Navigate to="/dashboard" replace />} />
-      <Route path="/dashboard" element={<Dashboard />} />
-      <Route path="/accounts" element={<Accounts />} />
-      <Route path="/transactions" element={<Transactions />} />
-      <Route path="/budgets" element={<Budgets />} />
-      <Route path="/goals" element={<Goals />} />
-      <Route path="/settings" element={<Settings />} />
-    </Routes>
-  </Suspense>
+  <Routes>
+    <Route path="/" element={<RootRedirect />} />
+    <Route
+      path="/login"
+      element={
+        <Suspense fallback={<PageLoader />}>
+          <Login />
+        </Suspense>
+      }
+    />
+    <Route
+      path="/signup"
+      element={
+        <Suspense fallback={<PageLoader />}>
+          <Signup />
+        </Suspense>
+      }
+    />
+    <Route
+      path="/dashboard"
+      element={
+        <AuthenticatedRoute>
+          <Suspense fallback={<PageLoader />}>
+            <Dashboard />
+          </Suspense>
+        </AuthenticatedRoute>
+      }
+    />
+    <Route
+      path="/accounts"
+      element={
+        <AuthenticatedRoute>
+          <Suspense fallback={<PageLoader />}>
+            <Accounts />
+          </Suspense>
+        </AuthenticatedRoute>
+      }
+    />
+    <Route
+      path="/transactions"
+      element={
+        <AuthenticatedRoute>
+          <Suspense fallback={<PageLoader />}>
+            <Transactions />
+          </Suspense>
+        </AuthenticatedRoute>
+      }
+    />
+    <Route
+      path="/budgets"
+      element={
+        <AuthenticatedRoute>
+          <Suspense fallback={<PageLoader />}>
+            <Budgets />
+          </Suspense>
+        </AuthenticatedRoute>
+      }
+    />
+    <Route
+      path="/goals"
+      element={
+        <AuthenticatedRoute>
+          <Suspense fallback={<PageLoader />}>
+            <Goals />
+          </Suspense>
+        </AuthenticatedRoute>
+      }
+    />
+    <Route
+      path="/settings"
+      element={
+        <AuthenticatedRoute>
+          <Suspense fallback={<PageLoader />}>
+            <Settings />
+          </Suspense>
+        </AuthenticatedRoute>
+      }
+    />
+  </Routes>
 );

--- a/apps/web/src/styles/auth.css
+++ b/apps/web/src/styles/auth.css
@@ -1,0 +1,258 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/**
+ * Shared auth page styles (Login, Signup, etc.)
+ *
+ * Provides a vertically-and-horizontally centred card layout that sits
+ * outside of the main AppLayout shell.  Re-uses design-token custom
+ * properties for colour, spacing, typography and border-radius so that
+ * light / dark themes and high-contrast mode work automatically.
+ */
+
+/* ─── Full-viewport wrapper ──────────────────────────────────────────────── */
+
+.auth-page {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100dvh;
+  padding: var(--spacing-4);
+  background: var(--semantic-background-primary);
+}
+
+/* ─── Centred card ───────────────────────────────────────────────────────── */
+
+.auth-card {
+  width: 100%;
+  max-width: 420px;
+  padding: var(--spacing-6);
+  background: var(--card-background);
+  border: 1px solid var(--card-border);
+  border-radius: var(--card-border-radius);
+  box-shadow: var(--card-shadow);
+}
+
+/* ─── Branding ───────────────────────────────────────────────────────────── */
+
+.auth-brand {
+  text-align: center;
+  margin-bottom: var(--spacing-6);
+}
+
+.auth-brand__name {
+  font-size: var(--type-scale-headline-font-size);
+  font-weight: var(--type-scale-headline-font-weight);
+  color: var(--semantic-interactive-default);
+  margin-bottom: var(--spacing-2);
+}
+
+.auth-brand__tagline {
+  font-size: var(--type-scale-body-font-size, 1rem);
+  color: var(--semantic-text-secondary);
+}
+
+/* ─── Form elements ──────────────────────────────────────────────────────── */
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
+.auth-actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
+.auth-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.auth-field__label {
+  font-size: var(--type-scale-label-font-size);
+  font-weight: var(--type-scale-label-font-weight);
+  color: var(--semantic-text-primary);
+}
+
+.auth-field__input {
+  padding: var(--input-padding-y, 0.5rem) var(--input-padding-x, 0.75rem);
+  border: 1px solid var(--input-border);
+  border-radius: var(--input-border-radius);
+  background: var(--input-background);
+  color: var(--input-text);
+  font: inherit;
+}
+
+.auth-field__input:focus {
+  outline: none;
+  border-color: var(--input-border-focus);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+}
+
+.auth-field__input[aria-invalid='true'] {
+  border-color: var(--semantic-border-error);
+}
+
+.auth-field__hint {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+.auth-field__error {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-status-negative);
+}
+
+/* ─── Primary submit button ──────────────────────────────────────────────── */
+
+.auth-submit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  gap: var(--spacing-2);
+  min-height: 44px;
+  padding: var(--spacing-2) var(--spacing-4);
+  border: 1px solid var(--semantic-interactive-default);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-interactive-default);
+  color: var(--semantic-text-inverse);
+  font: inherit;
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  transition:
+    background-color var(--duration-fast, 100ms) ease,
+    border-color var(--duration-fast, 100ms) ease;
+}
+
+.auth-passkey-button {
+  width: 100%;
+}
+
+.auth-submit:hover:not(:disabled) {
+  background: var(--semantic-interactive-hover);
+  border-color: var(--semantic-interactive-hover);
+}
+
+.auth-submit:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+}
+
+.auth-submit:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+/* ─── Error / status banners ─────────────────────────────────────────────── */
+
+.auth-error {
+  padding: var(--spacing-3);
+  border-radius: var(--border-radius-md);
+  background: var(--color-red-50, #fef2f2);
+  color: var(--semantic-status-negative);
+  font-size: var(--type-scale-body-font-size, 1rem);
+  text-align: center;
+}
+
+.auth-info {
+  padding: var(--spacing-3);
+  border-radius: var(--border-radius-md);
+  background: var(--color-blue-50, #eff6ff);
+  color: var(--semantic-status-info, var(--semantic-interactive-default));
+  font-size: var(--type-scale-body-font-size, 1rem);
+  text-align: center;
+}
+
+/* ─── Divider (separator between auth methods) ──────────────────────────── */
+
+.auth-divider {
+  display: flex;
+  align-items: center;
+  text-align: center;
+  margin: var(--spacing-4) 0;
+}
+
+.auth-divider::before,
+.auth-divider::after {
+  content: '';
+  flex: 1;
+  border-bottom: 1px solid var(--semantic-border-default, #e5e7eb);
+}
+
+.auth-divider__text {
+  padding: 0 var(--spacing-3);
+  font-size: var(--type-scale-caption-font-size, 0.875rem);
+  color: var(--semantic-text-secondary);
+}
+
+/* ─── Footer link ────────────────────────────────────────────────────────── */
+
+.auth-footer {
+  text-align: center;
+  margin-top: var(--spacing-4);
+  font-size: var(--type-scale-body-font-size, 1rem);
+  color: var(--semantic-text-secondary);
+}
+
+.auth-footer__link {
+  color: var(--semantic-interactive-default);
+  text-decoration: none;
+  font-weight: var(--font-weight-medium);
+}
+
+.auth-footer__link:hover {
+  text-decoration: underline;
+  color: var(--semantic-interactive-hover);
+}
+
+.auth-footer__link:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+  border-radius: var(--border-radius-sm, 2px);
+}
+
+/* ─── Reduced-motion ─────────────────────────────────────────────────────── */
+
+@media (max-width: 480px) {
+  .auth-page {
+    padding: var(--spacing-3);
+  }
+
+  .auth-card {
+    padding: var(--spacing-5);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .auth-submit {
+    transition: none;
+  }
+}
+
+/* ─── High-contrast ──────────────────────────────────────────────────────── */
+
+@media (prefers-contrast: more) {
+  .auth-card {
+    border-width: 2px;
+  }
+
+  .auth-field__input {
+    border-width: 2px;
+  }
+}
+
+/* ─── Dark-mode error/info box overrides ─────────────────────────────────── */
+
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme='light']) .auth-error {
+    background: rgba(239, 68, 68, 0.12);
+  }
+
+  html:not([data-theme='light']) .auth-info {
+    background: rgba(59, 130, 246, 0.12);
+  }
+}


### PR DESCRIPTION
## Summary
Adds authentication UI, route protection, and wires DataExport to real database data.

## Changes

### Auth Pages
- **LoginPage** — Email/password form + passkey button, error display, centered auth card layout
- **SignupPage** — Email/password with confirmation, password strength hint, registration stub

### Route Protection
- ProtectedRoute wraps all app routes (dashboard, accounts, transactions, budgets, goals, settings)
- /login and /signup are public routes
- Auth-aware root redirect: authenticated → /dashboard, unauthenticated → /login
- Standalone layout for auth pages (no navigation shell)

### DataExport Integration
- Replaced mock data with real SQLite-WASM repository queries
- Exports accounts, transactions, budgets, goals, categories
- Handles empty database gracefully
- Disabled state when database unavailable

### Infrastructure
- AuthProvider configured in main.tsx with Supabase endpoints
- .env.example with placeholder API URLs
- Auth CSS with dark mode support and responsive layout

## Validation
- TSC: zero errors
- ESLint: zero warnings
- Prettier: clean
- 35/35 tests passing

Closes #507
Closes #508
