### PR TITLE
test(web): add unit tests for hooks and repository modules (#521)

### DIFF
--- a/apps/web/src/hooks/__tests__/useAccounts.test.ts
+++ b/apps/web/src/hooks/__tests__/useAccounts.test.ts
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Account } from '../../kmp/bridge';
+import { useAccounts } from '../useAccounts';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockDb = {} as ReturnType<typeof import('../../db/DatabaseProvider').useDatabase>;
+
+vi.mock('../../db/DatabaseProvider', () => ({
+  useDatabase: () => mockDb,
+}));
+
+const mockGetAllAccounts = vi.fn<(...args: unknown[]) => Account[]>();
+const mockCreateAccount = vi.fn<(...args: unknown[]) => Account>();
+const mockUpdateAccount = vi.fn<(...args: unknown[]) => Account | null>();
+const mockDeleteAccount = vi.fn<(...args: unknown[]) => boolean>();
+
+vi.mock('../../db/repositories/accounts', () => ({
+  getAllAccounts: (...args: unknown[]) => mockGetAllAccounts(...args),
+  createAccount: (...args: unknown[]) => mockCreateAccount(...args),
+  updateAccount: (...args: unknown[]) => mockUpdateAccount(...args),
+  deleteAccount: (...args: unknown[]) => mockDeleteAccount(...args),
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const syncMetadata = {
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-01T00:00:00Z',
+  deletedAt: null,
+  syncVersion: 1,
+  isSynced: true,
+};
+
+function makeAccount(overrides: Partial<Account> = {}): Account {
+  return {
+    id: 'acct-1',
+    householdId: 'hh-1',
+    name: 'Checking',
+    type: 'CHECKING',
+    currency: { code: 'USD', decimalPlaces: 2 },
+    currentBalance: { amount: 100000 },
+    isArchived: false,
+    sortOrder: 1,
+    icon: 'bank',
+    color: '#2563EB',
+    ...syncMetadata,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useAccounts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAllAccounts.mockReturnValue([]);
+  });
+
+  // -----------------------------------------------------------------------
+  // Loading / success state
+  // -----------------------------------------------------------------------
+
+  it('returns loading false and empty list when no accounts exist', () => {
+    const { result } = renderHook(() => useAccounts());
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.accounts).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('returns accounts from the database', () => {
+    const accounts = [
+      makeAccount(),
+      makeAccount({ id: 'acct-2', name: 'Savings', type: 'SAVINGS' }),
+    ];
+    mockGetAllAccounts.mockReturnValue(accounts);
+
+    const { result } = renderHook(() => useAccounts());
+
+    expect(result.current.accounts).toHaveLength(2);
+    expect(result.current.accounts[0]?.name).toBe('Checking');
+    expect(result.current.accounts[1]?.name).toBe('Savings');
+  });
+
+  // -----------------------------------------------------------------------
+  // Error state
+  // -----------------------------------------------------------------------
+
+  it('captures errors and sets error state', () => {
+    mockGetAllAccounts.mockImplementation(() => {
+      throw new Error('DB read failed');
+    });
+
+    const { result } = renderHook(() => useAccounts());
+
+    expect(result.current.error).toBe('DB read failed');
+    expect(result.current.accounts).toEqual([]);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('sets a generic error message for non-Error throws', () => {
+    mockGetAllAccounts.mockImplementation(() => {
+      throw 42;
+    });
+
+    const { result } = renderHook(() => useAccounts());
+
+    expect(result.current.error).toBe('Failed to load accounts.');
+  });
+
+  // -----------------------------------------------------------------------
+  // CRUD — createAccount
+  // -----------------------------------------------------------------------
+
+  it('creates an account and triggers refresh', () => {
+    mockGetAllAccounts.mockReturnValue([]);
+    const created = makeAccount({ id: 'acct-new', name: 'New Account' });
+    mockCreateAccount.mockReturnValue(created);
+
+    const { result } = renderHook(() => useAccounts());
+
+    let returned: Account | null = null;
+    act(() => {
+      returned = result.current.createAccount({
+        householdId: 'hh-1',
+        name: 'New Account',
+        type: 'CHECKING',
+        currentBalance: { amount: 0 },
+      });
+    });
+
+    expect(returned).toEqual(created);
+    expect(mockCreateAccount).toHaveBeenCalledOnce();
+  });
+
+  it('returns null and sets error when createAccount throws', () => {
+    mockGetAllAccounts.mockReturnValue([]);
+    mockCreateAccount.mockImplementation(() => {
+      throw new Error('Insert failed');
+    });
+
+    const { result } = renderHook(() => useAccounts());
+
+    let returned: Account | null = null;
+    act(() => {
+      returned = result.current.createAccount({
+        householdId: 'hh-1',
+        name: 'New Account',
+        type: 'CHECKING',
+        currentBalance: { amount: 0 },
+      });
+    });
+
+    expect(returned).toBeNull();
+    expect(result.current.error).toBe('Insert failed');
+  });
+
+  // -----------------------------------------------------------------------
+  // CRUD — updateAccount
+  // -----------------------------------------------------------------------
+
+  it('updates an account and triggers refresh', () => {
+    const original = makeAccount();
+    mockGetAllAccounts.mockReturnValue([original]);
+    const updated = makeAccount({ name: 'Updated Checking' });
+    mockUpdateAccount.mockReturnValue(updated);
+
+    const { result } = renderHook(() => useAccounts());
+
+    let returned: Account | null = null;
+    act(() => {
+      returned = result.current.updateAccount('acct-1', { name: 'Updated Checking' });
+    });
+
+    expect(returned).toEqual(updated);
+    expect(mockUpdateAccount).toHaveBeenCalledWith(mockDb, 'acct-1', {
+      name: 'Updated Checking',
+    });
+  });
+
+  it('does not refresh when updateAccount returns null', () => {
+    mockGetAllAccounts.mockReturnValue([]);
+    mockUpdateAccount.mockReturnValue(null);
+
+    const { result } = renderHook(() => useAccounts());
+
+    const callCountAfterMount = mockGetAllAccounts.mock.calls.length;
+
+    act(() => {
+      result.current.updateAccount('nonexistent', { name: 'Nope' });
+    });
+
+    expect(mockGetAllAccounts.mock.calls.length).toBe(callCountAfterMount);
+  });
+
+  it('returns null and sets error when updateAccount throws', () => {
+    mockGetAllAccounts.mockReturnValue([]);
+    mockUpdateAccount.mockImplementation(() => {
+      throw new Error('Update failed');
+    });
+
+    const { result } = renderHook(() => useAccounts());
+
+    let returned: Account | null = null;
+    act(() => {
+      returned = result.current.updateAccount('acct-1', { name: 'Nope' });
+    });
+
+    expect(returned).toBeNull();
+    expect(result.current.error).toBe('Update failed');
+  });
+
+  // -----------------------------------------------------------------------
+  // CRUD — deleteAccount
+  // -----------------------------------------------------------------------
+
+  it('deletes an account and triggers refresh', () => {
+    const acct = makeAccount();
+    mockGetAllAccounts.mockReturnValue([acct]);
+    mockDeleteAccount.mockReturnValue(true);
+
+    const { result } = renderHook(() => useAccounts());
+
+    let deleted = false;
+    act(() => {
+      deleted = result.current.deleteAccount('acct-1');
+    });
+
+    expect(deleted).toBe(true);
+    expect(mockDeleteAccount).toHaveBeenCalledWith(mockDb, 'acct-1');
+  });
+
+  it('returns false when deletion target is not found', () => {
+    mockGetAllAccounts.mockReturnValue([]);
+    mockDeleteAccount.mockReturnValue(false);
+
+    const { result } = renderHook(() => useAccounts());
+
+    let deleted = false;
+    act(() => {
+      deleted = result.current.deleteAccount('nonexistent');
+    });
+
+    expect(deleted).toBe(false);
+  });
+
+  it('returns false and sets error when deleteAccount throws', () => {
+    mockGetAllAccounts.mockReturnValue([]);
+    mockDeleteAccount.mockImplementation(() => {
+      throw new Error('Delete failed');
+    });
+
+    const { result } = renderHook(() => useAccounts());
+
+    let deleted = false;
+    act(() => {
+      deleted = result.current.deleteAccount('acct-1');
+    });
+
+    expect(deleted).toBe(false);
+    expect(result.current.error).toBe('Delete failed');
+  });
+
+  // -----------------------------------------------------------------------
+  // Refresh
+  // -----------------------------------------------------------------------
+
+  it('re-fetches data when refresh is called', () => {
+    mockGetAllAccounts.mockReturnValue([]);
+
+    const { result } = renderHook(() => useAccounts());
+
+    const callCountAfterMount = mockGetAllAccounts.mock.calls.length;
+
+    act(() => {
+      result.current.refresh();
+    });
+
+    expect(mockGetAllAccounts.mock.calls.length).toBeGreaterThan(callCountAfterMount);
+  });
+});

--- a/apps/web/src/hooks/__tests__/useBudgets.test.ts
+++ b/apps/web/src/hooks/__tests__/useBudgets.test.ts
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Budget } from '../../kmp/bridge';
+import type { BudgetWithSpending } from '../../db/repositories/budgets';
+import { useBudgets } from '../useBudgets';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockDb = {} as ReturnType<typeof import('../../db/DatabaseProvider').useDatabase>;
+
+vi.mock('../../db/DatabaseProvider', () => ({
+  useDatabase: () => mockDb,
+}));
+
+const mockGetAllBudgets = vi.fn<(...args: unknown[]) => Budget[]>();
+const mockGetBudgetWithSpending = vi.fn<(...args: unknown[]) => BudgetWithSpending | null>();
+const mockCreateBudget = vi.fn<(...args: unknown[]) => Budget>();
+const mockUpdateBudget = vi.fn<(...args: unknown[]) => Budget | null>();
+const mockDeleteBudget = vi.fn<(...args: unknown[]) => boolean>();
+
+vi.mock('../../db/repositories/budgets', () => ({
+  getAllBudgets: (...args: unknown[]) => mockGetAllBudgets(...args),
+  getBudgetWithSpending: (...args: unknown[]) => mockGetBudgetWithSpending(...args),
+  createBudget: (...args: unknown[]) => mockCreateBudget(...args),
+  updateBudget: (...args: unknown[]) => mockUpdateBudget(...args),
+  deleteBudget: (...args: unknown[]) => mockDeleteBudget(...args),
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const syncMetadata = {
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-01T00:00:00Z',
+  deletedAt: null,
+  syncVersion: 1,
+  isSynced: true,
+};
+
+function makeBudget(overrides: Partial<Budget> = {}): Budget {
+  return {
+    id: 'budget-1',
+    householdId: 'hh-1',
+    categoryId: 'cat-food',
+    name: 'Groceries',
+    amount: { amount: 50000 },
+    currency: { code: 'USD', decimalPlaces: 2 },
+    period: 'MONTHLY',
+    startDate: '2025-03-01',
+    endDate: '2025-03-31',
+    isRollover: false,
+    ...syncMetadata,
+    ...overrides,
+  };
+}
+
+function makeBudgetWithSpending(
+  overrides: Partial<Budget> = {},
+  spent = 20000,
+): BudgetWithSpending {
+  const budget = makeBudget(overrides);
+  return {
+    ...budget,
+    spentAmount: { amount: spent },
+    remainingAmount: { amount: budget.amount.amount - spent },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useBudgets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAllBudgets.mockReturnValue([]);
+    mockGetBudgetWithSpending.mockReturnValue(null);
+  });
+
+  // -----------------------------------------------------------------------
+  // Loading / success state
+  // -----------------------------------------------------------------------
+
+  it('returns loading false and empty list when no budgets exist', () => {
+    const { result } = renderHook(() => useBudgets());
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.budgets).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('returns budgets enriched with spending data', () => {
+    const budget = makeBudget();
+    const enriched = makeBudgetWithSpending({}, 15000);
+    mockGetAllBudgets.mockReturnValue([budget]);
+    mockGetBudgetWithSpending.mockReturnValue(enriched);
+
+    const { result } = renderHook(() => useBudgets());
+
+    expect(result.current.budgets).toHaveLength(1);
+    expect(result.current.budgets[0]?.spentAmount.amount).toBe(15000);
+    expect(result.current.budgets[0]?.remainingAmount.amount).toBe(35000);
+  });
+
+  it('falls back to zero spending when getBudgetWithSpending returns null', () => {
+    const budget = makeBudget({ amount: { amount: 50000 } });
+    mockGetAllBudgets.mockReturnValue([budget]);
+    mockGetBudgetWithSpending.mockReturnValue(null);
+
+    const { result } = renderHook(() => useBudgets());
+
+    expect(result.current.budgets).toHaveLength(1);
+    expect(result.current.budgets[0]?.spentAmount.amount).toBe(0);
+    expect(result.current.budgets[0]?.remainingAmount.amount).toBe(50000);
+  });
+
+  // -----------------------------------------------------------------------
+  // Error state
+  // -----------------------------------------------------------------------
+
+  it('captures errors and sets error state', () => {
+    mockGetAllBudgets.mockImplementation(() => {
+      throw new Error('DB read failed');
+    });
+
+    const { result } = renderHook(() => useBudgets());
+
+    expect(result.current.error).toBe('DB read failed');
+    expect(result.current.budgets).toEqual([]);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('sets a generic error message for non-Error throws', () => {
+    mockGetAllBudgets.mockImplementation(() => {
+      throw null;
+    });
+
+    const { result } = renderHook(() => useBudgets());
+
+    expect(result.current.error).toBe('Failed to load budgets.');
+  });
+
+  // -----------------------------------------------------------------------
+  // CRUD — createBudget
+  // -----------------------------------------------------------------------
+
+  it('creates a budget and triggers refresh', () => {
+    mockGetAllBudgets.mockReturnValue([]);
+    const created = makeBudget({ id: 'budget-new', name: 'Dining Out' });
+    mockCreateBudget.mockReturnValue(created);
+
+    const { result } = renderHook(() => useBudgets());
+
+    let returned: Budget | null = null;
+    act(() => {
+      returned = result.current.createBudget({
+        householdId: 'hh-1',
+        categoryId: 'cat-dining',
+        name: 'Dining Out',
+        amount: { amount: 30000 },
+        period: 'MONTHLY',
+        startDate: '2025-04-01',
+      });
+    });
+
+    expect(returned).toEqual(created);
+    expect(mockCreateBudget).toHaveBeenCalledOnce();
+  });
+
+  it('returns null and sets error when createBudget throws', () => {
+    mockGetAllBudgets.mockReturnValue([]);
+    mockCreateBudget.mockImplementation(() => {
+      throw new Error('Insert failed');
+    });
+
+    const { result } = renderHook(() => useBudgets());
+
+    let returned: Budget | null = null;
+    act(() => {
+      returned = result.current.createBudget({
+        householdId: 'hh-1',
+        categoryId: 'cat-dining',
+        name: 'Dining Out',
+        amount: { amount: 30000 },
+        period: 'MONTHLY',
+        startDate: '2025-04-01',
+      });
+    });
+
+    expect(returned).toBeNull();
+    expect(result.current.error).toBe('Insert failed');
+  });
+
+  // -----------------------------------------------------------------------
+  // CRUD — updateBudget
+  // -----------------------------------------------------------------------
+
+  it('updates a budget and triggers refresh', () => {
+    mockGetAllBudgets.mockReturnValue([]);
+    const updated = makeBudget({ name: 'Updated Budget' });
+    mockUpdateBudget.mockReturnValue(updated);
+
+    const { result } = renderHook(() => useBudgets());
+
+    let returned: Budget | null = null;
+    act(() => {
+      returned = result.current.updateBudget('budget-1', { name: 'Updated Budget' });
+    });
+
+    expect(returned).toEqual(updated);
+    expect(mockUpdateBudget).toHaveBeenCalledWith(mockDb, 'budget-1', {
+      name: 'Updated Budget',
+    });
+  });
+
+  it('does not refresh when updateBudget returns null', () => {
+    mockGetAllBudgets.mockReturnValue([]);
+    mockUpdateBudget.mockReturnValue(null);
+
+    const { result } = renderHook(() => useBudgets());
+
+    const callCountAfterMount = mockGetAllBudgets.mock.calls.length;
+
+    act(() => {
+      result.current.updateBudget('nonexistent', { name: 'Nope' });
+    });
+
+    expect(mockGetAllBudgets.mock.calls.length).toBe(callCountAfterMount);
+  });
+
+  it('returns null and sets error when updateBudget throws', () => {
+    mockGetAllBudgets.mockReturnValue([]);
+    mockUpdateBudget.mockImplementation(() => {
+      throw new Error('Update failed');
+    });
+
+    const { result } = renderHook(() => useBudgets());
+
+    let returned: Budget | null = null;
+    act(() => {
+      returned = result.current.updateBudget('budget-1', { name: 'Nope' });
+    });
+
+    expect(returned).toBeNull();
+    expect(result.current.error).toBe('Update failed');
+  });
+
+  // -----------------------------------------------------------------------
+  // CRUD — deleteBudget
+  // -----------------------------------------------------------------------
+
+  it('deletes a budget and triggers refresh', () => {
+    mockGetAllBudgets.mockReturnValue([makeBudget()]);
+    mockGetBudgetWithSpending.mockReturnValue(makeBudgetWithSpending());
+    mockDeleteBudget.mockReturnValue(true);
+
+    const { result } = renderHook(() => useBudgets());
+
+    let deleted = false;
+    act(() => {
+      deleted = result.current.deleteBudget('budget-1');
+    });
+
+    expect(deleted).toBe(true);
+    expect(mockDeleteBudget).toHaveBeenCalledWith(mockDb, 'budget-1');
+  });
+
+  it('returns false when deletion target is not found', () => {
+    mockGetAllBudgets.mockReturnValue([]);
+    mockDeleteBudget.mockReturnValue(false);
+
+    const { result } = renderHook(() => useBudgets());
+
+    let deleted = false;
+    act(() => {
+      deleted = result.current.deleteBudget('nonexistent');
+    });
+
+    expect(deleted).toBe(false);
+  });
+
+  it('returns false and sets error when deleteBudget throws', () => {
+    mockGetAllBudgets.mockReturnValue([]);
+    mockDeleteBudget.mockImplementation(() => {
+      throw new Error('Delete failed');
+    });
+
+    const { result } = renderHook(() => useBudgets());
+
+    let deleted = false;
+    act(() => {
+      deleted = result.current.deleteBudget('budget-1');
+    });
+
+    expect(deleted).toBe(false);
+    expect(result.current.error).toBe('Delete failed');
+  });
+
+  // -----------------------------------------------------------------------
+  // Refresh
+  // -----------------------------------------------------------------------
+
+  it('re-fetches data when refresh is called', () => {
+    mockGetAllBudgets.mockReturnValue([]);
+
+    const { result } = renderHook(() => useBudgets());
+
+    const callCountAfterMount = mockGetAllBudgets.mock.calls.length;
+
+    act(() => {
+      result.current.refresh();
+    });
+
+    expect(mockGetAllBudgets.mock.calls.length).toBeGreaterThan(callCountAfterMount);
+  });
+});

--- a/apps/web/src/hooks/__tests__/useCategories.test.ts
+++ b/apps/web/src/hooks/__tests__/useCategories.test.ts
@@ -1,0 +1,302 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Category } from '../../kmp/bridge';
+import { useCategories } from '../useCategories';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockDb = {} as ReturnType<typeof import('../../db/DatabaseProvider').useDatabase>;
+
+vi.mock('../../db/DatabaseProvider', () => ({
+  useDatabase: () => mockDb,
+}));
+
+const mockGetAllCategories = vi.fn<(...args: unknown[]) => Category[]>();
+const mockCreateCategory = vi.fn<(...args: unknown[]) => Category>();
+const mockUpdateCategory = vi.fn<(...args: unknown[]) => Category | null>();
+const mockDeleteCategory = vi.fn<(...args: unknown[]) => boolean>();
+
+vi.mock('../../db/repositories/categories', () => ({
+  getAllCategories: (...args: unknown[]) => mockGetAllCategories(...args),
+  createCategory: (...args: unknown[]) => mockCreateCategory(...args),
+  updateCategory: (...args: unknown[]) => mockUpdateCategory(...args),
+  deleteCategory: (...args: unknown[]) => mockDeleteCategory(...args),
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const syncMetadata = {
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-01T00:00:00Z',
+  deletedAt: null,
+  syncVersion: 1,
+  isSynced: true,
+};
+
+function makeCategory(overrides: Partial<Category> = {}): Category {
+  return {
+    id: 'cat-1',
+    householdId: 'hh-1',
+    name: 'Food & Drink',
+    icon: 'utensils',
+    color: '#16A34A',
+    parentId: null,
+    isIncome: false,
+    isSystem: false,
+    sortOrder: 1,
+    ...syncMetadata,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useCategories', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAllCategories.mockReturnValue([]);
+  });
+
+  // -----------------------------------------------------------------------
+  // Loading / success state
+  // -----------------------------------------------------------------------
+
+  it('returns loading false and empty list when no categories exist', () => {
+    const { result } = renderHook(() => useCategories());
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.categories).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('returns categories from the database', () => {
+    const categories = [
+      makeCategory(),
+      makeCategory({ id: 'cat-income', name: 'Salary', isIncome: true }),
+    ];
+    mockGetAllCategories.mockReturnValue(categories);
+
+    const { result } = renderHook(() => useCategories());
+
+    expect(result.current.categories).toHaveLength(2);
+    expect(result.current.categories[0]?.name).toBe('Food & Drink');
+    expect(result.current.categories[1]?.isIncome).toBe(true);
+  });
+
+  it('includes both income and expense categories', () => {
+    const categories = [
+      makeCategory({ id: 'cat-expense', isIncome: false }),
+      makeCategory({ id: 'cat-income', name: 'Salary', isIncome: true }),
+      makeCategory({ id: 'cat-expense-2', name: 'Transport', isIncome: false }),
+    ];
+    mockGetAllCategories.mockReturnValue(categories);
+
+    const { result } = renderHook(() => useCategories());
+
+    const incomeCategories = result.current.categories.filter((c) => c.isIncome);
+    const expenseCategories = result.current.categories.filter((c) => !c.isIncome);
+
+    expect(incomeCategories).toHaveLength(1);
+    expect(expenseCategories).toHaveLength(2);
+  });
+
+  // -----------------------------------------------------------------------
+  // Error state
+  // -----------------------------------------------------------------------
+
+  it('captures errors and sets error state', () => {
+    mockGetAllCategories.mockImplementation(() => {
+      throw new Error('DB read failed');
+    });
+
+    const { result } = renderHook(() => useCategories());
+
+    expect(result.current.error).toBe('DB read failed');
+    expect(result.current.categories).toEqual([]);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('sets a generic error message for non-Error throws', () => {
+    mockGetAllCategories.mockImplementation(() => {
+      throw 'string error';
+    });
+
+    const { result } = renderHook(() => useCategories());
+
+    expect(result.current.error).toBe('Failed to load categories.');
+  });
+
+  // -----------------------------------------------------------------------
+  // CRUD — createCategory
+  // -----------------------------------------------------------------------
+
+  it('creates a category and triggers refresh', () => {
+    mockGetAllCategories.mockReturnValue([]);
+    const created = makeCategory({ id: 'cat-new', name: 'Entertainment' });
+    mockCreateCategory.mockReturnValue(created);
+
+    const { result } = renderHook(() => useCategories());
+
+    let returned: Category | null = null;
+    act(() => {
+      returned = result.current.createCategory({
+        householdId: 'hh-1',
+        name: 'Entertainment',
+      });
+    });
+
+    expect(returned).toEqual(created);
+    expect(mockCreateCategory).toHaveBeenCalledOnce();
+  });
+
+  it('returns null and sets error when createCategory throws', () => {
+    mockGetAllCategories.mockReturnValue([]);
+    mockCreateCategory.mockImplementation(() => {
+      throw new Error('Insert failed');
+    });
+
+    const { result } = renderHook(() => useCategories());
+
+    let returned: Category | null = null;
+    act(() => {
+      returned = result.current.createCategory({
+        householdId: 'hh-1',
+        name: 'Entertainment',
+      });
+    });
+
+    expect(returned).toBeNull();
+    expect(result.current.error).toBe('Insert failed');
+  });
+
+  // -----------------------------------------------------------------------
+  // CRUD — updateCategory
+  // -----------------------------------------------------------------------
+
+  it('updates a category and triggers refresh', () => {
+    mockGetAllCategories.mockReturnValue([makeCategory()]);
+    const updated = makeCategory({ name: 'Groceries' });
+    mockUpdateCategory.mockReturnValue(updated);
+
+    const { result } = renderHook(() => useCategories());
+
+    let returned: Category | null = null;
+    act(() => {
+      returned = result.current.updateCategory('cat-1', { name: 'Groceries' });
+    });
+
+    expect(returned).toEqual(updated);
+    expect(mockUpdateCategory).toHaveBeenCalledWith(mockDb, 'cat-1', {
+      name: 'Groceries',
+    });
+  });
+
+  it('does not refresh when updateCategory returns null', () => {
+    mockGetAllCategories.mockReturnValue([]);
+    mockUpdateCategory.mockReturnValue(null);
+
+    const { result } = renderHook(() => useCategories());
+
+    const callCountAfterMount = mockGetAllCategories.mock.calls.length;
+
+    act(() => {
+      result.current.updateCategory('nonexistent', { name: 'Nope' });
+    });
+
+    expect(mockGetAllCategories.mock.calls.length).toBe(callCountAfterMount);
+  });
+
+  it('returns null and sets error when updateCategory throws', () => {
+    mockGetAllCategories.mockReturnValue([]);
+    mockUpdateCategory.mockImplementation(() => {
+      throw new Error('Update failed');
+    });
+
+    const { result } = renderHook(() => useCategories());
+
+    let returned: Category | null = null;
+    act(() => {
+      returned = result.current.updateCategory('cat-1', { name: 'Nope' });
+    });
+
+    expect(returned).toBeNull();
+    expect(result.current.error).toBe('Update failed');
+  });
+
+  // -----------------------------------------------------------------------
+  // CRUD — deleteCategory
+  // -----------------------------------------------------------------------
+
+  it('deletes a category and triggers refresh', () => {
+    mockGetAllCategories.mockReturnValue([makeCategory()]);
+    mockDeleteCategory.mockReturnValue(true);
+
+    const { result } = renderHook(() => useCategories());
+
+    let deleted = false;
+    act(() => {
+      deleted = result.current.deleteCategory('cat-1');
+    });
+
+    expect(deleted).toBe(true);
+    expect(mockDeleteCategory).toHaveBeenCalledWith(mockDb, 'cat-1');
+  });
+
+  it('returns false when deletion target is not found', () => {
+    mockGetAllCategories.mockReturnValue([]);
+    mockDeleteCategory.mockReturnValue(false);
+
+    const { result } = renderHook(() => useCategories());
+
+    let deleted = false;
+    act(() => {
+      deleted = result.current.deleteCategory('nonexistent');
+    });
+
+    expect(deleted).toBe(false);
+  });
+
+  it('returns false and sets error when deleteCategory throws', () => {
+    mockGetAllCategories.mockReturnValue([]);
+    mockDeleteCategory.mockImplementation(() => {
+      throw new Error('Delete failed');
+    });
+
+    const { result } = renderHook(() => useCategories());
+
+    let deleted = false;
+    act(() => {
+      deleted = result.current.deleteCategory('cat-1');
+    });
+
+    expect(deleted).toBe(false);
+    expect(result.current.error).toBe('Delete failed');
+  });
+
+  // -----------------------------------------------------------------------
+  // Refresh
+  // -----------------------------------------------------------------------
+
+  it('re-fetches data when refresh is called', () => {
+    mockGetAllCategories.mockReturnValue([]);
+
+    const { result } = renderHook(() => useCategories());
+
+    const callCountAfterMount = mockGetAllCategories.mock.calls.length;
+
+    act(() => {
+      result.current.refresh();
+    });
+
+    expect(mockGetAllCategories.mock.calls.length).toBeGreaterThan(callCountAfterMount);
+  });
+});

--- a/apps/web/src/hooks/__tests__/useGoals.test.ts
+++ b/apps/web/src/hooks/__tests__/useGoals.test.ts
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Goal } from '../../kmp/bridge';
+import { useGoals } from '../useGoals';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockDb = {} as ReturnType<typeof import('../../db/DatabaseProvider').useDatabase>;
+
+vi.mock('../../db/DatabaseProvider', () => ({
+  useDatabase: () => mockDb,
+}));
+
+const mockGetAllGoals = vi.fn<(...args: unknown[]) => Goal[]>();
+const mockCreateGoal = vi.fn<(...args: unknown[]) => Goal>();
+const mockUpdateGoal = vi.fn<(...args: unknown[]) => Goal | null>();
+const mockDeleteGoal = vi.fn<(...args: unknown[]) => boolean>();
+
+vi.mock('../../db/repositories/goals', () => ({
+  getAllGoals: (...args: unknown[]) => mockGetAllGoals(...args),
+  createGoal: (...args: unknown[]) => mockCreateGoal(...args),
+  updateGoal: (...args: unknown[]) => mockUpdateGoal(...args),
+  deleteGoal: (...args: unknown[]) => mockDeleteGoal(...args),
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const syncMetadata = {
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-01T00:00:00Z',
+  deletedAt: null,
+  syncVersion: 1,
+  isSynced: true,
+};
+
+function makeGoal(overrides: Partial<Goal> = {}): Goal {
+  return {
+    id: 'goal-1',
+    householdId: 'hh-1',
+    name: 'Emergency Fund',
+    targetAmount: { amount: 1000000 },
+    currentAmount: { amount: 250000 },
+    currency: { code: 'USD', decimalPlaces: 2 },
+    targetDate: '2025-12-31',
+    status: 'ACTIVE',
+    icon: 'piggy-bank',
+    color: '#059669',
+    accountId: 'acct-1',
+    ...syncMetadata,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useGoals', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAllGoals.mockReturnValue([]);
+  });
+
+  // -----------------------------------------------------------------------
+  // Loading / success state
+  // -----------------------------------------------------------------------
+
+  it('returns loading false and empty list when no goals exist', () => {
+    const { result } = renderHook(() => useGoals());
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.goals).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('returns goals from the database', () => {
+    const goals = [makeGoal(), makeGoal({ id: 'goal-2', name: 'Vacation Fund', status: 'ACTIVE' })];
+    mockGetAllGoals.mockReturnValue(goals);
+
+    const { result } = renderHook(() => useGoals());
+
+    expect(result.current.goals).toHaveLength(2);
+    expect(result.current.goals[0]?.name).toBe('Emergency Fund');
+    expect(result.current.goals[1]?.name).toBe('Vacation Fund');
+  });
+
+  // -----------------------------------------------------------------------
+  // Error state
+  // -----------------------------------------------------------------------
+
+  it('captures errors and sets error state', () => {
+    mockGetAllGoals.mockImplementation(() => {
+      throw new Error('DB read failed');
+    });
+
+    const { result } = renderHook(() => useGoals());
+
+    expect(result.current.error).toBe('DB read failed');
+    expect(result.current.goals).toEqual([]);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('sets a generic error message for non-Error throws', () => {
+    mockGetAllGoals.mockImplementation(() => {
+      throw undefined;
+    });
+
+    const { result } = renderHook(() => useGoals());
+
+    expect(result.current.error).toBe('Failed to load goals.');
+  });
+
+  // -----------------------------------------------------------------------
+  // CRUD — createGoal
+  // -----------------------------------------------------------------------
+
+  it('creates a goal and triggers refresh', () => {
+    mockGetAllGoals.mockReturnValue([]);
+    const created = makeGoal({ id: 'goal-new', name: 'New Car' });
+    mockCreateGoal.mockReturnValue(created);
+
+    const { result } = renderHook(() => useGoals());
+
+    let returned: Goal | null = null;
+    act(() => {
+      returned = result.current.createGoal({
+        householdId: 'hh-1',
+        name: 'New Car',
+        targetAmount: { amount: 2500000 },
+      });
+    });
+
+    expect(returned).toEqual(created);
+    expect(mockCreateGoal).toHaveBeenCalledOnce();
+  });
+
+  it('returns null and sets error when createGoal throws', () => {
+    mockGetAllGoals.mockReturnValue([]);
+    mockCreateGoal.mockImplementation(() => {
+      throw new Error('Insert failed');
+    });
+
+    const { result } = renderHook(() => useGoals());
+
+    let returned: Goal | null = null;
+    act(() => {
+      returned = result.current.createGoal({
+        householdId: 'hh-1',
+        name: 'New Car',
+        targetAmount: { amount: 2500000 },
+      });
+    });
+
+    expect(returned).toBeNull();
+    expect(result.current.error).toBe('Insert failed');
+  });
+
+  // -----------------------------------------------------------------------
+  // CRUD — updateGoal (progress updates)
+  // -----------------------------------------------------------------------
+
+  it('updates a goal and triggers refresh', () => {
+    mockGetAllGoals.mockReturnValue([makeGoal()]);
+    const updated = makeGoal({ currentAmount: { amount: 500000 } });
+    mockUpdateGoal.mockReturnValue(updated);
+
+    const { result } = renderHook(() => useGoals());
+
+    let returned: Goal | null = null;
+    act(() => {
+      returned = result.current.updateGoal('goal-1', { currentAmount: { amount: 500000 } });
+    });
+
+    expect(returned).toEqual(updated);
+    expect(mockUpdateGoal).toHaveBeenCalledWith(mockDb, 'goal-1', {
+      currentAmount: { amount: 500000 },
+    });
+  });
+
+  it('does not refresh when updateGoal returns null', () => {
+    mockGetAllGoals.mockReturnValue([]);
+    mockUpdateGoal.mockReturnValue(null);
+
+    const { result } = renderHook(() => useGoals());
+
+    const callCountAfterMount = mockGetAllGoals.mock.calls.length;
+
+    act(() => {
+      result.current.updateGoal('nonexistent', { name: 'Nope' });
+    });
+
+    expect(mockGetAllGoals.mock.calls.length).toBe(callCountAfterMount);
+  });
+
+  it('returns null and sets error when updateGoal throws', () => {
+    mockGetAllGoals.mockReturnValue([]);
+    mockUpdateGoal.mockImplementation(() => {
+      throw new Error('Update failed');
+    });
+
+    const { result } = renderHook(() => useGoals());
+
+    let returned: Goal | null = null;
+    act(() => {
+      returned = result.current.updateGoal('goal-1', { name: 'Nope' });
+    });
+
+    expect(returned).toBeNull();
+    expect(result.current.error).toBe('Update failed');
+  });
+
+  // -----------------------------------------------------------------------
+  // CRUD — deleteGoal
+  // -----------------------------------------------------------------------
+
+  it('deletes a goal and triggers refresh', () => {
+    mockGetAllGoals.mockReturnValue([makeGoal()]);
+    mockDeleteGoal.mockReturnValue(true);
+
+    const { result } = renderHook(() => useGoals());
+
+    let deleted = false;
+    act(() => {
+      deleted = result.current.deleteGoal('goal-1');
+    });
+
+    expect(deleted).toBe(true);
+    expect(mockDeleteGoal).toHaveBeenCalledWith(mockDb, 'goal-1');
+  });
+
+  it('returns false when deletion target is not found', () => {
+    mockGetAllGoals.mockReturnValue([]);
+    mockDeleteGoal.mockReturnValue(false);
+
+    const { result } = renderHook(() => useGoals());
+
+    let deleted = false;
+    act(() => {
+      deleted = result.current.deleteGoal('nonexistent');
+    });
+
+    expect(deleted).toBe(false);
+  });
+
+  it('returns false and sets error when deleteGoal throws', () => {
+    mockGetAllGoals.mockReturnValue([]);
+    mockDeleteGoal.mockImplementation(() => {
+      throw new Error('Delete failed');
+    });
+
+    const { result } = renderHook(() => useGoals());
+
+    let deleted = false;
+    act(() => {
+      deleted = result.current.deleteGoal('goal-1');
+    });
+
+    expect(deleted).toBe(false);
+    expect(result.current.error).toBe('Delete failed');
+  });
+
+  // -----------------------------------------------------------------------
+  // Refresh
+  // -----------------------------------------------------------------------
+
+  it('re-fetches data when refresh is called', () => {
+    mockGetAllGoals.mockReturnValue([]);
+
+    const { result } = renderHook(() => useGoals());
+
+    const callCountAfterMount = mockGetAllGoals.mock.calls.length;
+
+    act(() => {
+      result.current.refresh();
+    });
+
+    expect(mockGetAllGoals.mock.calls.length).toBeGreaterThan(callCountAfterMount);
+  });
+});

--- a/apps/web/src/hooks/__tests__/useSyncStatus.test.ts
+++ b/apps/web/src/hooks/__tests__/useSyncStatus.test.ts
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useSyncStatus } from '../useSyncStatus';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockReplayMutations = vi.fn<() => Promise<void>>();
+const mockGetPendingMutationCount = vi.fn<() => Promise<number>>();
+
+vi.mock('../../db/sync/replayMutations', () => ({
+  replayMutations: () => mockReplayMutations(),
+}));
+
+vi.mock('../../db/sync/enqueueMutation', () => ({
+  getPendingMutationCount: () => mockGetPendingMutationCount(),
+}));
+
+vi.mock('../../db/sync/types', () => ({
+  LAST_SYNC_TIME_KEY: 'finance-last-sync-time',
+  PERIODIC_SYNC_INTERVAL_MS: 30_000,
+}));
+
+// ---------------------------------------------------------------------------
+// Navigator stubs
+// ---------------------------------------------------------------------------
+
+let onlineState: boolean;
+const swEventTarget = new EventTarget();
+
+beforeEach(() => {
+  onlineState = true;
+  vi.clearAllMocks();
+  mockGetPendingMutationCount.mockResolvedValue(0);
+  mockReplayMutations.mockResolvedValue(undefined);
+
+  // Mock navigator.onLine
+  Object.defineProperty(navigator, 'onLine', {
+    get: () => onlineState,
+    configurable: true,
+  });
+
+  // Provide a minimal serviceWorker stub so `'serviceWorker' in navigator`
+  // evaluates to true but no controller is available (main-thread fallback).
+  Object.defineProperty(navigator, 'serviceWorker', {
+    value: {
+      controller: null,
+      addEventListener: (type: string, listener: EventListenerOrEventListenerObject) =>
+        swEventTarget.addEventListener(type, listener),
+      removeEventListener: (type: string, listener: EventListenerOrEventListenerObject) =>
+        swEventTarget.removeEventListener(type, listener),
+    },
+    configurable: true,
+    writable: true,
+  });
+
+  // Clear localStorage
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useSyncStatus', () => {
+  // -----------------------------------------------------------------------
+  // Online / offline state
+  // -----------------------------------------------------------------------
+
+  it('reports isOnline as true when navigator.onLine is true', () => {
+    onlineState = true;
+
+    const { result } = renderHook(() => useSyncStatus());
+
+    expect(result.current.isOnline).toBe(true);
+    expect(result.current.isOffline).toBe(false);
+  });
+
+  it('reports isOffline as true when navigator.onLine is false', () => {
+    onlineState = false;
+
+    const { result } = renderHook(() => useSyncStatus());
+
+    expect(result.current.isOnline).toBe(false);
+    expect(result.current.isOffline).toBe(true);
+  });
+
+  it('updates isOnline when online event fires', async () => {
+    onlineState = false;
+
+    const { result } = renderHook(() => useSyncStatus());
+
+    expect(result.current.isOnline).toBe(false);
+
+    await act(async () => {
+      onlineState = true;
+      window.dispatchEvent(new Event('online'));
+    });
+
+    expect(result.current.isOnline).toBe(true);
+    expect(result.current.isOffline).toBe(false);
+  });
+
+  it('updates isOffline when offline event fires', async () => {
+    onlineState = true;
+
+    const { result } = renderHook(() => useSyncStatus());
+
+    expect(result.current.isOffline).toBe(false);
+
+    await act(async () => {
+      onlineState = false;
+      window.dispatchEvent(new Event('offline'));
+    });
+
+    expect(result.current.isOnline).toBe(false);
+    expect(result.current.isOffline).toBe(true);
+  });
+
+  // -----------------------------------------------------------------------
+  // Pending count
+  // -----------------------------------------------------------------------
+
+  it('initialises pendingMutations to 0', () => {
+    const { result } = renderHook(() => useSyncStatus());
+
+    expect(result.current.pendingMutations).toBe(0);
+  });
+
+  it('calls getPendingMutationCount on mount', async () => {
+    mockGetPendingMutationCount.mockResolvedValue(5);
+
+    await act(async () => {
+      renderHook(() => useSyncStatus());
+    });
+
+    expect(mockGetPendingMutationCount).toHaveBeenCalled();
+  });
+
+  // -----------------------------------------------------------------------
+  // Last sync time
+  // -----------------------------------------------------------------------
+
+  it('reads lastSyncTime from localStorage on mount', () => {
+    const timestamp = '2025-03-06T12:00:00.000Z';
+    localStorage.setItem('finance-last-sync-time', timestamp);
+
+    const { result } = renderHook(() => useSyncStatus());
+
+    expect(result.current.lastSyncTime).toBe(timestamp);
+  });
+
+  it('returns null for lastSyncTime when localStorage is empty', () => {
+    const { result } = renderHook(() => useSyncStatus());
+
+    expect(result.current.lastSyncTime).toBeNull();
+  });
+
+  // -----------------------------------------------------------------------
+  // Syncing state
+  // -----------------------------------------------------------------------
+
+  it('initialises isSyncing to false', () => {
+    const { result } = renderHook(() => useSyncStatus());
+
+    expect(result.current.isSyncing).toBe(false);
+  });
+
+  // -----------------------------------------------------------------------
+  // syncNow — main-thread fallback (no service worker)
+  // -----------------------------------------------------------------------
+
+  it('performs main-thread sync when syncNow is called without service worker', async () => {
+    const { result } = renderHook(() => useSyncStatus());
+
+    await act(async () => {
+      result.current.syncNow();
+      // Allow the async performMainThreadSync to complete
+      await vi.waitFor(() => {
+        expect(mockReplayMutations).toHaveBeenCalled();
+      });
+    });
+  });
+
+  it('does not call syncNow when already syncing', async () => {
+    // Set up a long-running replay to keep isSyncing true
+    let resolveReplay: () => void;
+    const replayPromise = new Promise<void>((resolve) => {
+      resolveReplay = resolve;
+    });
+    mockReplayMutations.mockReturnValue(replayPromise);
+
+    const { result } = renderHook(() => useSyncStatus());
+
+    // Trigger first sync
+    act(() => {
+      result.current.syncNow();
+    });
+
+    // Try to sync again while still syncing
+    act(() => {
+      result.current.syncNow();
+    });
+
+    // Should only have been called once
+    expect(mockReplayMutations).toHaveBeenCalledTimes(1);
+
+    // Clean up
+    await act(async () => {
+      resolveReplay!();
+      await replayPromise;
+    });
+  });
+});

--- a/apps/web/src/hooks/__tests__/useTransactions.test.ts
+++ b/apps/web/src/hooks/__tests__/useTransactions.test.ts
@@ -1,0 +1,451 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Transaction } from '../../kmp/bridge';
+import { useTransactions } from '../useTransactions';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockDb = {} as ReturnType<typeof import('../../db/DatabaseProvider').useDatabase>;
+
+vi.mock('../../db/DatabaseProvider', () => ({
+  useDatabase: () => mockDb,
+}));
+
+const mockGetAllTransactions = vi.fn<(...args: unknown[]) => Transaction[]>();
+const mockGetTransactionsByAccount = vi.fn<(...args: unknown[]) => Transaction[]>();
+const mockGetTransactionsByCategory = vi.fn<(...args: unknown[]) => Transaction[]>();
+const mockGetTransactionsByDateRange = vi.fn<(...args: unknown[]) => Transaction[]>();
+const mockCreateTransaction = vi.fn<(...args: unknown[]) => Transaction>();
+const mockUpdateTransaction = vi.fn<(...args: unknown[]) => Transaction | null>();
+const mockDeleteTransaction = vi.fn<(...args: unknown[]) => boolean>();
+
+vi.mock('../../db/repositories/transactions', () => ({
+  getAllTransactions: (...args: unknown[]) => mockGetAllTransactions(...args),
+  getTransactionsByAccount: (...args: unknown[]) => mockGetTransactionsByAccount(...args),
+  getTransactionsByCategory: (...args: unknown[]) => mockGetTransactionsByCategory(...args),
+  getTransactionsByDateRange: (...args: unknown[]) => mockGetTransactionsByDateRange(...args),
+  createTransaction: (...args: unknown[]) => mockCreateTransaction(...args),
+  updateTransaction: (...args: unknown[]) => mockUpdateTransaction(...args),
+  deleteTransaction: (...args: unknown[]) => mockDeleteTransaction(...args),
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const syncMetadata = {
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-01T00:00:00Z',
+  deletedAt: null,
+  syncVersion: 1,
+  isSynced: true,
+};
+
+function makeTransaction(overrides: Partial<Transaction> = {}): Transaction {
+  return {
+    id: 'txn-1',
+    householdId: 'hh-1',
+    accountId: 'acct-1',
+    categoryId: 'cat-1',
+    type: 'EXPENSE',
+    status: 'CLEARED',
+    amount: { amount: 5000 },
+    currency: { code: 'USD', decimalPlaces: 2 },
+    payee: 'Grocery Store',
+    note: null,
+    date: '2025-03-06',
+    transferAccountId: null,
+    transferTransactionId: null,
+    isRecurring: false,
+    recurringRuleId: null,
+    tags: [],
+    ...syncMetadata,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useTransactions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAllTransactions.mockReturnValue([]);
+    mockGetTransactionsByAccount.mockReturnValue([]);
+    mockGetTransactionsByCategory.mockReturnValue([]);
+    mockGetTransactionsByDateRange.mockReturnValue([]);
+  });
+
+  // -----------------------------------------------------------------------
+  // Loading / success state
+  // -----------------------------------------------------------------------
+
+  it('returns loading false and empty list when no transactions exist', () => {
+    const { result } = renderHook(() => useTransactions());
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.transactions).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('returns transactions from the database', () => {
+    const txns = [makeTransaction(), makeTransaction({ id: 'txn-2', payee: 'Coffee Shop' })];
+    mockGetAllTransactions.mockReturnValue(txns);
+
+    const { result } = renderHook(() => useTransactions());
+
+    expect(result.current.transactions).toHaveLength(2);
+    expect(result.current.transactions[0]?.payee).toBe('Grocery Store');
+    expect(result.current.transactions[1]?.payee).toBe('Coffee Shop');
+    expect(result.current.loading).toBe(false);
+  });
+
+  // -----------------------------------------------------------------------
+  // Error state
+  // -----------------------------------------------------------------------
+
+  it('captures errors and sets error state', () => {
+    mockGetAllTransactions.mockImplementation(() => {
+      throw new Error('DB read failed');
+    });
+
+    const { result } = renderHook(() => useTransactions());
+
+    expect(result.current.error).toBe('DB read failed');
+    expect(result.current.transactions).toEqual([]);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('sets a generic error message for non-Error throws', () => {
+    mockGetAllTransactions.mockImplementation(() => {
+      throw 'unknown failure';
+    });
+
+    const { result } = renderHook(() => useTransactions());
+
+    expect(result.current.error).toBe('Failed to load transactions.');
+  });
+
+  // -----------------------------------------------------------------------
+  // Filtering — accountId primary query
+  // -----------------------------------------------------------------------
+
+  it('uses getTransactionsByAccount when accountId filter is provided', () => {
+    const txn = makeTransaction({ accountId: 'acct-1' });
+    mockGetTransactionsByAccount.mockReturnValue([txn]);
+
+    const { result } = renderHook(() => useTransactions({ accountId: 'acct-1' }));
+
+    expect(mockGetTransactionsByAccount).toHaveBeenCalledWith(mockDb, 'acct-1', expect.any(Object));
+    expect(result.current.transactions).toHaveLength(1);
+  });
+
+  // -----------------------------------------------------------------------
+  // Filtering — categoryId primary query
+  // -----------------------------------------------------------------------
+
+  it('uses getTransactionsByCategory when categoryId filter is provided', () => {
+    const txn = makeTransaction({ categoryId: 'cat-food' });
+    mockGetTransactionsByCategory.mockReturnValue([txn]);
+
+    const { result } = renderHook(() => useTransactions({ categoryId: 'cat-food' }));
+
+    expect(mockGetTransactionsByCategory).toHaveBeenCalledWith(
+      mockDb,
+      'cat-food',
+      expect.any(Object),
+    );
+    expect(result.current.transactions).toHaveLength(1);
+  });
+
+  // -----------------------------------------------------------------------
+  // Filtering — date range
+  // -----------------------------------------------------------------------
+
+  it('uses getTransactionsByDateRange when both dates are provided', () => {
+    const txn = makeTransaction({ date: '2025-03-05' });
+    mockGetTransactionsByDateRange.mockReturnValue([txn]);
+
+    const { result } = renderHook(() =>
+      useTransactions({ startDate: '2025-03-01', endDate: '2025-03-31' }),
+    );
+
+    expect(mockGetTransactionsByDateRange).toHaveBeenCalledWith(
+      mockDb,
+      '2025-03-01',
+      '2025-03-31',
+      expect.any(Object),
+    );
+    expect(result.current.transactions).toHaveLength(1);
+  });
+
+  // -----------------------------------------------------------------------
+  // Filtering — startDate only (post-filter)
+  // -----------------------------------------------------------------------
+
+  it('post-filters by startDate when only startDate is provided', () => {
+    mockGetAllTransactions.mockReturnValue([
+      makeTransaction({ id: 'txn-1', date: '2025-02-28' }),
+      makeTransaction({ id: 'txn-2', date: '2025-03-01' }),
+      makeTransaction({ id: 'txn-3', date: '2025-03-15' }),
+    ]);
+
+    const { result } = renderHook(() => useTransactions({ startDate: '2025-03-01' }));
+
+    expect(result.current.transactions).toHaveLength(2);
+    expect(result.current.transactions.map((t) => t.id)).toEqual(['txn-2', 'txn-3']);
+  });
+
+  // -----------------------------------------------------------------------
+  // Filtering — endDate only (post-filter)
+  // -----------------------------------------------------------------------
+
+  it('post-filters by endDate when only endDate is provided', () => {
+    mockGetAllTransactions.mockReturnValue([
+      makeTransaction({ id: 'txn-1', date: '2025-02-28' }),
+      makeTransaction({ id: 'txn-2', date: '2025-03-01' }),
+      makeTransaction({ id: 'txn-3', date: '2025-03-15' }),
+    ]);
+
+    const { result } = renderHook(() => useTransactions({ endDate: '2025-03-01' }));
+
+    expect(result.current.transactions).toHaveLength(2);
+    expect(result.current.transactions.map((t) => t.id)).toEqual(['txn-1', 'txn-2']);
+  });
+
+  // -----------------------------------------------------------------------
+  // Filtering — accountId + categoryId (local post-filter)
+  // -----------------------------------------------------------------------
+
+  it('post-filters by categoryId when both accountId and categoryId are provided', () => {
+    mockGetTransactionsByAccount.mockReturnValue([
+      makeTransaction({ id: 'txn-1', categoryId: 'cat-food' }),
+      makeTransaction({ id: 'txn-2', categoryId: 'cat-transport' }),
+    ]);
+
+    const { result } = renderHook(() =>
+      useTransactions({ accountId: 'acct-1', categoryId: 'cat-food' }),
+    );
+
+    expect(result.current.transactions).toHaveLength(1);
+    expect(result.current.transactions[0]?.categoryId).toBe('cat-food');
+  });
+
+  // -----------------------------------------------------------------------
+  // Filtering — limit
+  // -----------------------------------------------------------------------
+
+  it('applies limit via local slice when local post-filtering is needed', () => {
+    mockGetTransactionsByAccount.mockReturnValue([
+      makeTransaction({ id: 'txn-1', categoryId: 'cat-food' }),
+      makeTransaction({ id: 'txn-2', categoryId: 'cat-food' }),
+      makeTransaction({ id: 'txn-3', categoryId: 'cat-food' }),
+    ]);
+
+    const { result } = renderHook(() =>
+      useTransactions({ accountId: 'acct-1', categoryId: 'cat-food', limit: 2 }),
+    );
+
+    expect(result.current.transactions).toHaveLength(2);
+  });
+
+  // -----------------------------------------------------------------------
+  // Filtering — searchTerm and type passed to repository
+  // -----------------------------------------------------------------------
+
+  it('passes searchTerm and type filters to the repository', () => {
+    mockGetAllTransactions.mockReturnValue([]);
+
+    renderHook(() => useTransactions({ searchTerm: 'coffee', type: 'EXPENSE' }));
+
+    expect(mockGetAllTransactions).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({ searchTerm: 'coffee', type: 'EXPENSE' }),
+    );
+  });
+
+  // -----------------------------------------------------------------------
+  // CRUD — createTransaction
+  // -----------------------------------------------------------------------
+
+  it('creates a transaction and triggers refresh', () => {
+    mockGetAllTransactions.mockReturnValue([]);
+    const created = makeTransaction({ id: 'txn-new' });
+    mockCreateTransaction.mockReturnValue(created);
+
+    const { result } = renderHook(() => useTransactions());
+
+    let returned: Transaction | null = null;
+    act(() => {
+      returned = result.current.createTransaction({
+        householdId: 'hh-1',
+        accountId: 'acct-1',
+        type: 'EXPENSE',
+        amount: { amount: 5000 },
+        date: '2025-03-06',
+      });
+    });
+
+    expect(returned).toEqual(created);
+    expect(mockCreateTransaction).toHaveBeenCalledOnce();
+  });
+
+  it('returns null and sets error when createTransaction throws', () => {
+    mockGetAllTransactions.mockReturnValue([]);
+    mockCreateTransaction.mockImplementation(() => {
+      throw new Error('Insert failed');
+    });
+
+    const { result } = renderHook(() => useTransactions());
+
+    let returned: Transaction | null = null;
+    act(() => {
+      returned = result.current.createTransaction({
+        householdId: 'hh-1',
+        accountId: 'acct-1',
+        type: 'EXPENSE',
+        amount: { amount: 5000 },
+        date: '2025-03-06',
+      });
+    });
+
+    expect(returned).toBeNull();
+    expect(result.current.error).toBe('Insert failed');
+  });
+
+  // -----------------------------------------------------------------------
+  // CRUD — updateTransaction
+  // -----------------------------------------------------------------------
+
+  it('updates a transaction and triggers refresh', () => {
+    const original = makeTransaction();
+    mockGetAllTransactions.mockReturnValue([original]);
+    const updated = makeTransaction({ payee: 'Updated Store' });
+    mockUpdateTransaction.mockReturnValue(updated);
+
+    const { result } = renderHook(() => useTransactions());
+
+    let returned: Transaction | null = null;
+    act(() => {
+      returned = result.current.updateTransaction('txn-1', { payee: 'Updated Store' });
+    });
+
+    expect(returned).toEqual(updated);
+    expect(mockUpdateTransaction).toHaveBeenCalledWith(mockDb, 'txn-1', {
+      payee: 'Updated Store',
+    });
+  });
+
+  it('does not refresh when updateTransaction returns null (not found)', () => {
+    mockGetAllTransactions.mockReturnValue([]);
+    mockUpdateTransaction.mockReturnValue(null);
+
+    const { result } = renderHook(() => useTransactions());
+
+    const initialCallCount = mockGetAllTransactions.mock.calls.length;
+
+    act(() => {
+      result.current.updateTransaction('nonexistent', { payee: 'Nope' });
+    });
+
+    // getAllTransactions should not have been called again after the update
+    // returned null (no refresh triggered). The only calls are from the
+    // initial mount + re-render, not from a refresh.
+    expect(mockUpdateTransaction).toHaveBeenCalledOnce();
+    // Since update returned null, refresh should NOT have been triggered,
+    // so callCount should stay at initialCallCount (no extra call).
+    expect(mockGetAllTransactions.mock.calls.length).toBe(initialCallCount);
+  });
+
+  it('returns null and sets error when updateTransaction throws', () => {
+    mockGetAllTransactions.mockReturnValue([]);
+    mockUpdateTransaction.mockImplementation(() => {
+      throw new Error('Update failed');
+    });
+
+    const { result } = renderHook(() => useTransactions());
+
+    let returned: Transaction | null = null;
+    act(() => {
+      returned = result.current.updateTransaction('txn-1', { payee: 'Nope' });
+    });
+
+    expect(returned).toBeNull();
+    expect(result.current.error).toBe('Update failed');
+  });
+
+  // -----------------------------------------------------------------------
+  // CRUD — deleteTransaction
+  // -----------------------------------------------------------------------
+
+  it('deletes a transaction and triggers refresh', () => {
+    const txn = makeTransaction();
+    mockGetAllTransactions.mockReturnValue([txn]);
+    mockDeleteTransaction.mockReturnValue(true);
+
+    const { result } = renderHook(() => useTransactions());
+
+    let deleted = false;
+    act(() => {
+      deleted = result.current.deleteTransaction('txn-1');
+    });
+
+    expect(deleted).toBe(true);
+    expect(mockDeleteTransaction).toHaveBeenCalledWith(mockDb, 'txn-1');
+  });
+
+  it('returns false when deletion fails (not found)', () => {
+    mockGetAllTransactions.mockReturnValue([]);
+    mockDeleteTransaction.mockReturnValue(false);
+
+    const { result } = renderHook(() => useTransactions());
+
+    let deleted = false;
+    act(() => {
+      deleted = result.current.deleteTransaction('nonexistent');
+    });
+
+    expect(deleted).toBe(false);
+  });
+
+  it('returns false and sets error when deleteTransaction throws', () => {
+    mockGetAllTransactions.mockReturnValue([]);
+    mockDeleteTransaction.mockImplementation(() => {
+      throw new Error('Delete failed');
+    });
+
+    const { result } = renderHook(() => useTransactions());
+
+    let deleted = false;
+    act(() => {
+      deleted = result.current.deleteTransaction('txn-1');
+    });
+
+    expect(deleted).toBe(false);
+    expect(result.current.error).toBe('Delete failed');
+  });
+
+  // -----------------------------------------------------------------------
+  // Refresh
+  // -----------------------------------------------------------------------
+
+  it('re-fetches data when refresh is called', () => {
+    mockGetAllTransactions.mockReturnValue([]);
+
+    const { result } = renderHook(() => useTransactions());
+
+    const callCountAfterMount = mockGetAllTransactions.mock.calls.length;
+
+    act(() => {
+      result.current.refresh();
+    });
+
+    expect(mockGetAllTransactions.mock.calls.length).toBeGreaterThan(callCountAfterMount);
+  });
+});


### PR DESCRIPTION
166 tests across 8 files covering all React hooks (useTransactions, useAccounts, useBudgets, useGoals, useCategories, useSyncStatus), repository helpers (56 tests), and transaction repository SQL queries. Closes #521