### PR TITLE
test(web): add component and chart tests, clean up coming-soon stubs (#527, #528)

### DIFF
--- a/apps/web/src/components/OfflineBanner.test.tsx
+++ b/apps/web/src/components/OfflineBanner.test.tsx
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const offlineStatusMock = {
+  isOffline: false,
+  isOnline: true,
+};
+
+vi.mock('../hooks/useOfflineStatus', () => ({
+  useOfflineStatus: () => offlineStatusMock,
+}));
+
+import { OfflineBanner } from './OfflineBanner';
+
+describe('OfflineBanner', () => {
+  beforeEach(() => {
+    offlineStatusMock.isOffline = false;
+    offlineStatusMock.isOnline = true;
+  });
+
+  it('shows the banner when offline', () => {
+    offlineStatusMock.isOffline = true;
+    offlineStatusMock.isOnline = false;
+
+    render(<OfflineBanner />);
+
+    expect(screen.getByRole('status')).not.toHaveClass('offline-banner--hidden');
+    expect(
+      screen.getByText('You are offline. Changes will sync when connectivity is restored.'),
+    ).toBeInTheDocument();
+  });
+
+  it('hides the banner when online', () => {
+    render(<OfflineBanner />);
+
+    expect(screen.getByRole('status')).toHaveClass('offline-banner--hidden');
+  });
+
+  it('has a polite live region', () => {
+    render(<OfflineBanner />);
+
+    expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'polite');
+  });
+});

--- a/apps/web/src/components/charts/BudgetDonutChart.test.tsx
+++ b/apps/web/src/components/charts/BudgetDonutChart.test.tsx
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { BudgetDonutChart, type BudgetSlice } from './BudgetDonutChart';
+
+// ---------------------------------------------------------------------------
+// Stubs
+// ---------------------------------------------------------------------------
+
+/** Stub window.matchMedia so prefers-reduced-motion checks don't throw. */
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: query === '(prefers-reduced-motion: reduce)',
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+/** Mock Recharts — canvas/SVG APIs are unavailable in jsdom. */
+vi.mock('recharts', async () => {
+  const R = await import('react');
+  const mock = (name: string) =>
+    function MockComponent(props: Record<string, unknown>) {
+      return R.createElement('div', { 'data-testid': name }, props.children as React.ReactNode);
+    };
+  return {
+    ResponsiveContainer: mock('ResponsiveContainer'),
+    PieChart: mock('PieChart'),
+    Pie: mock('Pie'),
+    Cell: mock('Cell'),
+    Tooltip: mock('Tooltip'),
+    Label: mock('Label'),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const sampleData: BudgetSlice[] = [
+  { name: 'Housing', value: 1200 },
+  { name: 'Groceries', value: 400 },
+  { name: 'Savings', value: 600 },
+];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('BudgetDonutChart', () => {
+  // -- Renders with valid data ------------------------------------------------
+
+  it('renders with budget data and default title', () => {
+    render(<BudgetDonutChart data={sampleData} />);
+    expect(screen.getByText('Budget breakdown')).toBeInTheDocument();
+    expect(screen.getByTestId('ResponsiveContainer')).toBeInTheDocument();
+  });
+
+  it('renders a custom title when provided', () => {
+    render(<BudgetDonutChart data={sampleData} title="Q1 Budget" />);
+    expect(screen.getByText('Q1 Budget')).toBeInTheDocument();
+  });
+
+  // -- Empty state ------------------------------------------------------------
+
+  it('handles empty data', () => {
+    render(<BudgetDonutChart data={[]} />);
+    const container = screen.getByRole('figure');
+    expect(container).toHaveAttribute('aria-label', 'Donut chart with no data.');
+  });
+
+  // -- Accessibility ----------------------------------------------------------
+
+  it('has an accessible container with role="figure"', () => {
+    render(<BudgetDonutChart data={sampleData} />);
+    const container = screen.getByRole('figure');
+    expect(container).toBeInTheDocument();
+    expect(container).toHaveAttribute('aria-roledescription', 'donut chart');
+  });
+
+  it('generates aria-label describing categories and total', () => {
+    render(<BudgetDonutChart data={sampleData} />);
+    const container = screen.getByRole('figure');
+    const label = container.getAttribute('aria-label')!;
+    expect(label).toContain('3 categories');
+    expect(label).toContain('$2,200');
+    expect(label).toContain('Housing');
+    expect(label).toContain('Groceries');
+    expect(label).toContain('Savings');
+  });
+
+  it('includes a sr-only description paragraph', () => {
+    render(<BudgetDonutChart data={sampleData} />);
+    const srOnly = document.querySelector('.sr-only');
+    expect(srOnly).toBeInTheDocument();
+    expect(srOnly!.textContent).toContain('3 categories');
+  });
+});

--- a/apps/web/src/components/charts/CategoryPieChart.test.tsx
+++ b/apps/web/src/components/charts/CategoryPieChart.test.tsx
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { CategoryPieChart, type CategorySlice } from './CategoryPieChart';
+
+// ---------------------------------------------------------------------------
+// Stubs
+// ---------------------------------------------------------------------------
+
+/** Stub window.matchMedia so prefers-reduced-motion checks don't throw. */
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: query === '(prefers-reduced-motion: reduce)',
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+// CategoryPieChart uses D3 (not Recharts) — D3 DOM manipulation works in jsdom
+// so no recharts mock is needed here.
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const sampleData: CategorySlice[] = [
+  { name: 'Food', value: 450 },
+  { name: 'Transport', value: 200 },
+  { name: 'Entertainment', value: 150 },
+];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CategoryPieChart', () => {
+  // -- Renders with valid data ------------------------------------------------
+
+  it('renders with category data and default title', () => {
+    render(<CategoryPieChart data={sampleData} />);
+    expect(screen.getByText('Spending by category')).toBeInTheDocument();
+  });
+
+  it('renders a custom title when provided', () => {
+    render(<CategoryPieChart data={sampleData} title="Q1 Breakdown" />);
+    expect(screen.getByText('Q1 Breakdown')).toBeInTheDocument();
+  });
+
+  it('renders an SVG element with role="img"', () => {
+    const { container } = render(<CategoryPieChart data={sampleData} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('role', 'img');
+  });
+
+  it('creates D3 path elements for each data slice', () => {
+    const { container } = render(<CategoryPieChart data={sampleData} />);
+    const paths = container.querySelectorAll('path[data-chart-point]');
+    expect(paths).toHaveLength(sampleData.length);
+  });
+
+  it('assigns aria-label to each D3-generated slice', () => {
+    const { container } = render(<CategoryPieChart data={sampleData} />);
+    const paths = container.querySelectorAll('path[role="listitem"]');
+    expect(paths).toHaveLength(sampleData.length);
+    expect(paths[0].getAttribute('aria-label')).toContain('Food');
+    expect(paths[1].getAttribute('aria-label')).toContain('Transport');
+    expect(paths[2].getAttribute('aria-label')).toContain('Entertainment');
+  });
+
+  // -- Empty state ------------------------------------------------------------
+
+  it('handles empty data', () => {
+    render(<CategoryPieChart data={[]} />);
+    const container = screen.getByRole('figure');
+    expect(container).toHaveAttribute('aria-label', 'Pie chart with no data.');
+  });
+
+  it('renders no path elements when data is empty', () => {
+    const { container } = render(<CategoryPieChart data={[]} />);
+    const paths = container.querySelectorAll('path[data-chart-point]');
+    expect(paths).toHaveLength(0);
+  });
+
+  // -- Accessibility ----------------------------------------------------------
+
+  it('has an accessible container with role="figure"', () => {
+    render(<CategoryPieChart data={sampleData} />);
+    const container = screen.getByRole('figure');
+    expect(container).toBeInTheDocument();
+    expect(container).toHaveAttribute('aria-roledescription', 'pie chart');
+  });
+
+  it('generates aria-label describing categories and total', () => {
+    render(<CategoryPieChart data={sampleData} />);
+    const container = screen.getByRole('figure');
+    const label = container.getAttribute('aria-label')!;
+    expect(label).toContain('3 categories');
+    expect(label).toContain('$800');
+  });
+
+  it('includes a sr-only description paragraph', () => {
+    render(<CategoryPieChart data={sampleData} />);
+    const srOnly = document.querySelector('.sr-only');
+    expect(srOnly).toBeInTheDocument();
+    expect(srOnly!.textContent).toContain('3 categories');
+  });
+});

--- a/apps/web/src/components/charts/SpendingBarChart.test.tsx
+++ b/apps/web/src/components/charts/SpendingBarChart.test.tsx
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { SpendingBarChart, type SpendingCategory } from './SpendingBarChart';
+
+// ---------------------------------------------------------------------------
+// Stubs
+// ---------------------------------------------------------------------------
+
+/** Stub window.matchMedia so prefers-reduced-motion checks don't throw. */
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: query === '(prefers-reduced-motion: reduce)',
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+/** Mock Recharts — canvas/SVG APIs are unavailable in jsdom. */
+vi.mock('recharts', async () => {
+  const R = await import('react');
+  const mock = (name: string) =>
+    function MockComponent(props: Record<string, unknown>) {
+      return R.createElement('div', { 'data-testid': name }, props.children as React.ReactNode);
+    };
+  return {
+    ResponsiveContainer: mock('ResponsiveContainer'),
+    BarChart: mock('BarChart'),
+    Bar: mock('Bar'),
+    XAxis: mock('XAxis'),
+    YAxis: mock('YAxis'),
+    CartesianGrid: mock('CartesianGrid'),
+    Tooltip: mock('Tooltip'),
+    Cell: mock('Cell'),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const sampleData: SpendingCategory[] = [
+  { name: 'Food', amount: 450 },
+  { name: 'Transport', amount: 200 },
+  { name: 'Entertainment', amount: 150 },
+];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SpendingBarChart', () => {
+  // -- Renders with valid data ------------------------------------------------
+
+  it('renders with category spending data', () => {
+    render(<SpendingBarChart data={sampleData} />);
+    expect(screen.getByText('Spending by category')).toBeInTheDocument();
+    expect(screen.getByTestId('ResponsiveContainer')).toBeInTheDocument();
+  });
+
+  it('renders a custom title when provided', () => {
+    render(<SpendingBarChart data={sampleData} title="March Spending" />);
+    expect(screen.getByText('March Spending')).toBeInTheDocument();
+  });
+
+  // -- Empty state ------------------------------------------------------------
+
+  it('handles empty data', () => {
+    render(<SpendingBarChart data={[]} />);
+    const container = screen.getByRole('figure');
+    expect(container).toHaveAttribute('aria-label', 'Bar chart with no data.');
+  });
+
+  // -- Accessibility ----------------------------------------------------------
+
+  it('has an accessible container with role="figure"', () => {
+    render(<SpendingBarChart data={sampleData} />);
+    const container = screen.getByRole('figure');
+    expect(container).toBeInTheDocument();
+    expect(container).toHaveAttribute('aria-roledescription', 'bar chart');
+  });
+
+  it('generates aria-label describing categories and total', () => {
+    render(<SpendingBarChart data={sampleData} />);
+    const container = screen.getByRole('figure');
+    const label = container.getAttribute('aria-label')!;
+    expect(label).toContain('3 categories');
+    expect(label).toContain('$800');
+    expect(label).toContain('Food');
+    expect(label).toContain('Transport');
+    expect(label).toContain('Entertainment');
+  });
+
+  it('includes a sr-only description paragraph', () => {
+    render(<SpendingBarChart data={sampleData} />);
+    const srOnly = document.querySelector('.sr-only');
+    expect(srOnly).toBeInTheDocument();
+    expect(srOnly!.textContent).toContain('3 categories');
+  });
+});

--- a/apps/web/src/components/charts/TrendLineChart.test.tsx
+++ b/apps/web/src/components/charts/TrendLineChart.test.tsx
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { TrendLineChart, type TrendDataPoint, type TrendSeries } from './TrendLineChart';
+
+// ---------------------------------------------------------------------------
+// Stubs
+// ---------------------------------------------------------------------------
+
+/** Stub window.matchMedia so prefers-reduced-motion checks don't throw. */
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: query === '(prefers-reduced-motion: reduce)',
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+/** Mock Recharts — canvas/SVG APIs are unavailable in jsdom. */
+vi.mock('recharts', async () => {
+  const R = await import('react');
+  const mock = (name: string) =>
+    function MockComponent(props: Record<string, unknown>) {
+      return R.createElement('div', { 'data-testid': name }, props.children as React.ReactNode);
+    };
+  return {
+    ResponsiveContainer: mock('ResponsiveContainer'),
+    LineChart: mock('LineChart'),
+    Line: mock('Line'),
+    XAxis: mock('XAxis'),
+    YAxis: mock('YAxis'),
+    CartesianGrid: mock('CartesianGrid'),
+    Tooltip: mock('Tooltip'),
+    Legend: mock('Legend'),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const sampleData: TrendDataPoint[] = [
+  { label: 'Jan', income: 4000, expenses: 2400 },
+  { label: 'Feb', income: 3000, expenses: 1398 },
+  { label: 'Mar', income: 5000, expenses: 3200 },
+];
+
+const sampleSeries: TrendSeries[] = [
+  { dataKey: 'income', name: 'Income' },
+  { dataKey: 'expenses', name: 'Expenses' },
+];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TrendLineChart', () => {
+  // -- Renders with valid data ------------------------------------------------
+
+  it('renders with valid data and default title', () => {
+    render(<TrendLineChart data={sampleData} series={sampleSeries} />);
+    expect(screen.getByText('Trend over time')).toBeInTheDocument();
+    expect(screen.getByTestId('ResponsiveContainer')).toBeInTheDocument();
+  });
+
+  it('renders a custom title when provided', () => {
+    render(<TrendLineChart data={sampleData} series={sampleSeries} title="Monthly Income" />);
+    expect(screen.getByText('Monthly Income')).toBeInTheDocument();
+  });
+
+  // -- Empty state ------------------------------------------------------------
+
+  it('renders empty state with no data', () => {
+    render(<TrendLineChart data={[]} series={sampleSeries} />);
+    const container = screen.getByRole('figure');
+    expect(container).toHaveAttribute('aria-label', 'Line chart with no data.');
+  });
+
+  // -- Accessibility ----------------------------------------------------------
+
+  it('has an accessible container with role="figure"', () => {
+    render(<TrendLineChart data={sampleData} series={sampleSeries} />);
+    const container = screen.getByRole('figure');
+    expect(container).toBeInTheDocument();
+    expect(container).toHaveAttribute('aria-roledescription', 'line chart');
+  });
+
+  it('generates aria-label describing data points and series ranges', () => {
+    render(<TrendLineChart data={sampleData} series={sampleSeries} />);
+    const container = screen.getByRole('figure');
+    const label = container.getAttribute('aria-label')!;
+    expect(label).toContain('3 data points');
+    expect(label).toContain('2 series');
+    expect(label).toContain('Income');
+    expect(label).toContain('Expenses');
+  });
+
+  it('includes a sr-only description paragraph', () => {
+    render(<TrendLineChart data={sampleData} series={sampleSeries} />);
+    const srOnly = document.querySelector('.sr-only');
+    expect(srOnly).toBeInTheDocument();
+    expect(srOnly!.textContent).toContain('3 data points');
+  });
+});

--- a/apps/web/src/components/charts/chart-palette.test.ts
+++ b/apps/web/src/components/charts/chart-palette.test.ts
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect } from 'vitest';
+import {
+  CHART_COLORS,
+  CHART_COLOR_LABELS,
+  chartColor,
+  patternId,
+  formatChartCurrency,
+  buildChartDescription,
+} from './chart-palette';
+
+// ---------------------------------------------------------------------------
+// CHART_COLORS
+// ---------------------------------------------------------------------------
+
+describe('CHART_COLORS', () => {
+  it('has at least 6 colour entries for category variety', () => {
+    expect(CHART_COLORS.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it('contains valid hex colour strings', () => {
+    for (const color of CHART_COLORS) {
+      expect(color).toMatch(/^#[0-9A-Fa-f]{6}$/);
+    }
+  });
+
+  it('has a matching CHART_COLOR_LABELS array of equal length', () => {
+    expect(CHART_COLOR_LABELS.length).toBe(CHART_COLORS.length);
+  });
+
+  it('contains no duplicate colours', () => {
+    const unique = new Set(CHART_COLORS);
+    expect(unique.size).toBe(CHART_COLORS.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// chartColor
+// ---------------------------------------------------------------------------
+
+describe('chartColor', () => {
+  it('returns the colour at the given index', () => {
+    expect(chartColor(0)).toBe(CHART_COLORS[0]);
+    expect(chartColor(2)).toBe(CHART_COLORS[2]);
+  });
+
+  it('wraps around when index exceeds array length', () => {
+    expect(chartColor(CHART_COLORS.length)).toBe(CHART_COLORS[0]);
+    expect(chartColor(CHART_COLORS.length + 1)).toBe(CHART_COLORS[1]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// patternId
+// ---------------------------------------------------------------------------
+
+describe('patternId', () => {
+  it('returns a prefixed pattern ID string', () => {
+    expect(patternId(0)).toBe('chart-pattern-0');
+    expect(patternId(5)).toBe('chart-pattern-5');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatChartCurrency
+// ---------------------------------------------------------------------------
+
+describe('formatChartCurrency', () => {
+  it('formats USD with no decimal places', () => {
+    expect(formatChartCurrency(1234, 'USD')).toBe('$1,234');
+  });
+
+  it('formats zero correctly', () => {
+    expect(formatChartCurrency(0, 'USD')).toBe('$0');
+  });
+
+  it('formats negative values', () => {
+    const result = formatChartCurrency(-500, 'USD');
+    expect(result).toContain('500');
+  });
+
+  it('defaults to USD when currency is omitted', () => {
+    expect(formatChartCurrency(100)).toBe('$100');
+  });
+
+  it('formats EUR with the euro symbol', () => {
+    const result = formatChartCurrency(1000, 'EUR');
+    expect(result).toContain('€');
+    expect(result).toContain('1,000');
+  });
+
+  it('respects a custom locale', () => {
+    const result = formatChartCurrency(1000, 'EUR', 'de-DE');
+    // German locale uses period or narrow-no-break space as thousands separator
+    expect(result).toContain('€');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildChartDescription
+// ---------------------------------------------------------------------------
+
+describe('buildChartDescription', () => {
+  it('returns no-data description for an empty array', () => {
+    expect(buildChartDescription('Bar chart', [])).toBe('Bar chart with no data.');
+  });
+
+  it('includes chart type, category count, and formatted total', () => {
+    const desc = buildChartDescription('Pie chart', [
+      { label: 'Food', value: 200 },
+      { label: 'Rent', value: 800 },
+    ]);
+    expect(desc).toContain('Pie chart');
+    expect(desc).toContain('2 categories');
+    expect(desc).toContain('$1,000');
+  });
+
+  it('lists each category with its formatted value', () => {
+    const desc = buildChartDescription(
+      'Bar chart',
+      [
+        { label: 'Food', value: 50 },
+        { label: 'Transport', value: 150 },
+      ],
+      'USD',
+    );
+    expect(desc).toContain('Food: $50');
+    expect(desc).toContain('Transport: $150');
+  });
+
+  it('handles a single-item array', () => {
+    const desc = buildChartDescription('Donut chart', [{ label: 'Savings', value: 3000 }]);
+    expect(desc).toContain('1 categories');
+    expect(desc).toContain('$3,000');
+    expect(desc).toContain('Savings: $3,000');
+  });
+});

--- a/apps/web/src/components/common/ConfirmDialog.test.tsx
+++ b/apps/web/src/components/common/ConfirmDialog.test.tsx
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../accessibility/aria', () => ({
+  announce: vi.fn(),
+  useFocusTrap: vi.fn(),
+}));
+
+import { ConfirmDialog, type ConfirmDialogProps } from './ConfirmDialog';
+
+function renderConfirmDialog(overrides: Partial<ConfirmDialogProps> = {}) {
+  const onConfirm = overrides.onConfirm ?? vi.fn();
+  const onCancel = overrides.onCancel ?? vi.fn();
+
+  render(
+    <ConfirmDialog
+      isOpen={true}
+      title="Delete transaction"
+      message="This action cannot be undone."
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+      {...overrides}
+    />,
+  );
+
+  return { onConfirm, onCancel };
+}
+
+describe('ConfirmDialog', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders when open and is hidden when closed', () => {
+    const { rerender } = render(
+      <ConfirmDialog
+        isOpen={true}
+        title="Delete transaction"
+        message="This action cannot be undone."
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+
+    rerender(
+      <ConfirmDialog
+        isOpen={false}
+        title="Delete transaction"
+        message="This action cannot be undone."
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+  });
+
+  it('shows the dialog title and message', () => {
+    renderConfirmDialog();
+
+    expect(screen.getByText('Delete transaction')).toBeInTheDocument();
+    expect(screen.getByText('This action cannot be undone.')).toBeInTheDocument();
+  });
+
+  it('calls onCancel when the cancel button is clicked', () => {
+    const { onCancel } = renderConfirmDialog();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onConfirm when the confirm button is clicked', () => {
+    const { onConfirm } = renderConfirmDialog({ confirmLabel: 'Confirm delete' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm delete' }));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCancel when Escape is pressed', () => {
+    const { onCancel } = renderConfirmDialog();
+
+    fireEvent.keyDown(screen.getByRole('alertdialog'), { key: 'Escape' });
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('has accessible alert dialog labelling', () => {
+    renderConfirmDialog();
+
+    const dialog = screen.getByRole('alertdialog');
+    const titleId = dialog.getAttribute('aria-labelledby');
+    const descriptionId = dialog.getAttribute('aria-describedby');
+
+    expect(titleId).toBeTruthy();
+    expect(descriptionId).toBeTruthy();
+    expect(document.getElementById(titleId ?? '')).toHaveTextContent('Delete transaction');
+    expect(document.getElementById(descriptionId ?? '')).toHaveTextContent(
+      'This action cannot be undone.',
+    );
+  });
+
+  it('disables the confirm button while loading', () => {
+    renderConfirmDialog({ isLoading: true });
+
+    expect(screen.getByRole('button', { name: /delete/i })).toBeDisabled();
+  });
+});

--- a/apps/web/src/components/common/CurrencyDisplay.test.tsx
+++ b/apps/web/src/components/common/CurrencyDisplay.test.tsx
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { CurrencyDisplay } from './CurrencyDisplay';
+
+describe('CurrencyDisplay', () => {
+  it('renders a formatted dollar amount from cents', () => {
+    render(<CurrencyDisplay amount={1234} />);
+
+    expect(screen.getByText('$12.34')).toBeInTheDocument();
+  });
+
+  it('handles a zero amount', () => {
+    render(<CurrencyDisplay amount={0} />);
+
+    expect(screen.getByText('$0.00')).toBeInTheDocument();
+  });
+
+  it('handles a negative amount', () => {
+    render(<CurrencyDisplay amount={-1234} />);
+
+    expect(screen.getByText('-$12.34')).toBeInTheDocument();
+  });
+
+  it('applies colorize classes for positive and negative amounts', () => {
+    const { rerender } = render(<CurrencyDisplay amount={2500} colorize={true} />);
+
+    expect(screen.getByText('$25.00')).toHaveClass('amount--positive');
+
+    rerender(<CurrencyDisplay amount={-2500} colorize={true} />);
+
+    expect(screen.getByText('-$25.00')).toHaveClass('amount--negative');
+  });
+});

--- a/apps/web/src/components/common/EmptyState.test.tsx
+++ b/apps/web/src/components/common/EmptyState.test.tsx
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { EmptyState } from './EmptyState';
+
+describe('EmptyState', () => {
+  it('renders message text', () => {
+    render(<EmptyState title="No transactions yet" description="Add one to get started." />);
+
+    expect(screen.getByText('No transactions yet')).toBeInTheDocument();
+    expect(screen.getByText('Add one to get started.')).toBeInTheDocument();
+  });
+
+  it('renders optional icon and action content', () => {
+    render(
+      <EmptyState
+        title="No accounts"
+        icon={<svg data-testid="empty-state-icon" />}
+        action={<button type="button">Create account</button>}
+      />,
+    );
+
+    expect(screen.getByTestId('empty-state-icon')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Create account' })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/common/ErrorBanner.test.tsx
+++ b/apps/web/src/components/common/ErrorBanner.test.tsx
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ErrorBanner } from './ErrorBanner';
+
+describe('ErrorBanner', () => {
+  it('renders the error message', () => {
+    render(<ErrorBanner message="Something went wrong." />);
+
+    expect(screen.getByText('Something went wrong.')).toBeInTheDocument();
+  });
+
+  it('renders a dismiss button when dismissible', () => {
+    const onDismiss = vi.fn();
+
+    render(<ErrorBanner message="Something went wrong." onDismiss={onDismiss} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss error' }));
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('announces the error via an alert role', () => {
+    render(<ErrorBanner message="Something went wrong." />);
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/common/LoadingSpinner.test.tsx
+++ b/apps/web/src/components/common/LoadingSpinner.test.tsx
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { LoadingSpinner } from './LoadingSpinner';
+
+describe('LoadingSpinner', () => {
+  it('renders with a status role', () => {
+    render(<LoadingSpinner />);
+
+    expect(screen.getByRole('status', { name: 'Loading' })).toBeInTheDocument();
+  });
+
+  it('has a polite live region', () => {
+    render(<LoadingSpinner />);
+
+    expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'polite');
+  });
+});

--- a/apps/web/src/components/common/LoadingSpinner.tsx
+++ b/apps/web/src/components/common/LoadingSpinner.tsx
@@ -15,6 +15,7 @@ export const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({
     className={`loading-spinner ${className}`.trim()}
     role="status"
     aria-label={label}
+    aria-live="polite"
     style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}
   >
     <svg

--- a/apps/web/src/pages/SettingsPage.test.tsx
+++ b/apps/web/src/pages/SettingsPage.test.tsx
@@ -77,7 +77,28 @@ describe('SettingsPage', () => {
 
     expect(screen.getByText('alex@example.com')).toBeInTheDocument();
     expect(screen.getByText('Online — synced')).toBeInTheDocument();
-    expect(screen.getByText('Registered')).toBeInTheDocument();
+  });
+
+  it('renders future features as disabled buttons with accessible labels', () => {
+    render(<SettingsPage />);
+
+    const biometricLockButton = screen.getByRole('button', {
+      name: 'Biometric lock — available in a future update',
+    });
+    const passkeyManagementButton = screen.getByRole('button', {
+      name: 'Passkey management — available in a future update',
+    });
+    const accountDeletionButton = screen.getByRole('button', {
+      name: 'Account deletion — available in a future update',
+    });
+
+    expect(biometricLockButton).toBeDisabled();
+    expect(biometricLockButton).toHaveAttribute('aria-disabled', 'true');
+    expect(passkeyManagementButton).toBeDisabled();
+    expect(passkeyManagementButton).toHaveAttribute('aria-disabled', 'true');
+    expect(accountDeletionButton).toBeDisabled();
+    expect(accountDeletionButton).toHaveAttribute('aria-disabled', 'true');
+    expect(screen.getAllByText('Coming soon')).toHaveLength(3);
   });
 
   it('shows offline sync messaging when the app is offline', () => {

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -100,11 +100,6 @@ export const SettingsPage: React.FC = () => {
       initMonitoring();
     }
   }, []);
-
-  const handleComingSoon = useCallback((message: string) => {
-    window.alert(message);
-  }, []);
-
   const handleSignOut = useCallback(async () => {
     if (!isAuthenticated || isLoading) {
       return;
@@ -235,20 +230,22 @@ export const SettingsPage: React.FC = () => {
           <button
             type="button"
             className="settings-item settings-item--button"
-            onClick={() => handleComingSoon('Biometric lock settings are coming soon.')}
+            disabled
+            aria-disabled="true"
+            aria-label="Biometric lock — available in a future update"
           >
             <span className="settings-item__label">Biometric Lock</span>
-            <span className="settings-item__value">Off</span>
+            <span className="settings-item__value settings-item__value--muted">Coming soon</span>
           </button>
           <button
             type="button"
             className="settings-item settings-item--button"
-            onClick={() => handleComingSoon('Passkey management is coming soon.')}
+            disabled
+            aria-disabled="true"
+            aria-label="Passkey management — available in a future update"
           >
-            <span className="settings-item__label">Passkeys</span>
-            <span className="settings-item__value">
-              {user?.hasPasskey ? 'Registered' : 'Not set up'}
-            </span>
+            <span className="settings-item__label">Passkey Management</span>
+            <span className="settings-item__value settings-item__value--muted">Coming soon</span>
           </button>
           <button
             type="button"
@@ -302,10 +299,12 @@ export const SettingsPage: React.FC = () => {
           <button
             type="button"
             className="settings-item settings-item--button settings-item--destructive"
-            onClick={() => handleComingSoon('Account deletion is coming soon.')}
-            aria-label="Delete all data"
+            disabled
+            aria-disabled="true"
+            aria-label="Account deletion — available in a future update"
           >
-            <span className="settings-item__label">Delete All Data</span>
+            <span className="settings-item__label">Account Deletion</span>
+            <span className="settings-item__value settings-item__value--muted">Coming soon</span>
           </button>
         </div>
       </section>

--- a/apps/web/src/pages/SignupPage.test.tsx
+++ b/apps/web/src/pages/SignupPage.test.tsx
@@ -77,4 +77,20 @@ describe('SignupPage', () => {
 
     expect(screen.getByRole('alert')).toHaveTextContent('Passwords do not match');
   });
+
+  it('shows an availability message after valid submission when signup is unavailable', async () => {
+    renderSignupPage();
+
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'alex@example.com' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password123' } });
+    fireEvent.change(screen.getByLabelText('Confirm Password'), {
+      target: { value: 'password123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Sign up' }));
+
+    expect(
+      await screen.findByText('Account creation is not yet available. Please check back soon.'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sign up' })).toBeEnabled();
+  });
 });

--- a/apps/web/src/pages/SignupPage.tsx
+++ b/apps/web/src/pages/SignupPage.tsx
@@ -41,7 +41,7 @@ type SignupCapableAuth = AuthContextValue & {
  * Standalone signup page for the web app.
  *
  * The current auth context does not expose a registration action, so the page
- * validates the form and shows a friendly "coming soon" message until signup
+ * validates the form and shows a friendly availability message until signup
  * support is wired into the backend and auth context.
  */
 export const SignupPage: React.FC = () => {
@@ -120,22 +120,21 @@ export const SignupPage: React.FC = () => {
         return;
       }
 
+      if (!signupAction) {
+        setSubmitMessage({
+          type: 'info',
+          text: 'Account creation is not yet available. Please check back soon.',
+        });
+        return;
+      }
+
       setIsSubmitting(true);
 
       try {
-        if (signupAction) {
-          await signupAction(email.trim(), password);
-          setSubmitMessage({
-            type: 'info',
-            text: 'Account created. You can now sign in.',
-          });
-          return;
-        }
-
-        await new Promise((resolve) => window.setTimeout(resolve, 600));
+        await signupAction(email.trim(), password);
         setSubmitMessage({
           type: 'info',
-          text: 'Registration coming soon. Please check back later.',
+          text: 'Account created. You can now sign in.',
         });
       } catch (error) {
         setSubmitMessage({

--- a/apps/web/src/styles/responsive.css
+++ b/apps/web/src/styles/responsive.css
@@ -467,6 +467,10 @@
 .settings-item__value {
   color: var(--semantic-text-secondary);
 }
+.settings-item__value--muted {
+  opacity: 0.5;
+  font-style: italic;
+}
 .settings-item__control,
 .settings-item__status {
   display: inline-flex;


### PR DESCRIPTION
## Summary
Adds tests for all remaining untested UI components and replaces coming-soon alert stubs with proper disabled states.

## Changes

### Common Component Tests (6 files)
- ConfirmDialog: open/close, confirm/cancel, Escape key, alertdialog role, loading state
- CurrencyDisplay: cents formatting, zero/negative amounts, colorization
- EmptyState: message rendering
- ErrorBanner: error display, dismiss, aria-live
- LoadingSpinner: status role, aria-live (added)
- OfflineBanner: online/offline states, aria-live

### Chart Tests (5 files)
- TrendLineChart, SpendingBarChart, CategoryPieChart, BudgetDonutChart
- Mocked Recharts, accessible labels, empty data handling
- chart-palette helper tests

### Coming-Soon Cleanup
- SettingsPage: replaced 3 window.alert() stubs with disabled buttons + aria-disabled
- SignupPage: replaced coming-soon alert with inline info message
- Removed handleComingSoon function

## Validation
- TSC: zero errors | ESLint: zero warnings | Prettier: clean
- **26 test files, 161 tests passing**

Closes #527
Closes #528
