### PR TITLE
docs(privacy): GDPR consent management and data minimization audits (#367, #369)

### DIFF
--- a/docs/compliance/README.md
+++ b/docs/compliance/README.md
@@ -1,14 +1,18 @@
 # Compliance Documentation
 
-This directory contains audits, gap analyses, and implementation guides related
-to regulatory compliance — primarily the EU General Data Protection Regulation
-(GDPR) and similar privacy frameworks.
+This directory contains audits, gap analyses, inventories, and implementation
+guides related to regulatory compliance — primarily the EU General Data
+Protection Regulation (GDPR) and similar privacy frameworks.
 
 ## Contents
 
-| Document                                 | Description                                                 |
-| ---------------------------------------- | ----------------------------------------------------------- |
-| [GDPR Data Inventory](data-inventory.md) | Personal data inventory, processing map, and DPIA screening |
+| Document                                                      | Description                                                                     |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| [GDPR Data Inventory](data-inventory.md)                      | Personal data inventory, processing map, and DPIA screening                     |
+| [GDPR Right to Access Audit](gdpr-right-to-access-audit.md)   | Art. 15 right to access audit and implementation status                         |
+| [GDPR Right to Erasure Audit](gdpr-right-to-erasure-audit.md) | Art. 17 right to erasure audit and implementation status                        |
+| [GDPR Consent Management Audit](consent-management-audit.md)  | Current consent posture, Art. 7 gaps, and a recommended consent architecture    |
+| [GDPR Data Minimization Audit](data-minimization-audit.md)    | Field-level schema review, retention guidance, and minimization recommendations |
 
 ## Related Resources
 

--- a/docs/compliance/consent-management-audit.md
+++ b/docs/compliance/consent-management-audit.md
@@ -1,0 +1,142 @@
+# GDPR Consent Management Audit
+
+## Scope and evidence
+
+This audit reviews the current consent posture for optional telemetry and related privacy controls using:
+
+- `packages/core/src/commonMain/kotlin/com/finance/core/monitoring/CrashReporter.kt`
+- `packages/core/src/commonMain/kotlin/com/finance/core/monitoring/MetricsCollector.kt`
+- `apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt`
+- `apps/android/src/main/kotlin/com/finance/android/logging/TimberCrashReporter.kt`
+- `apps/android/src/main/kotlin/com/finance/android/ui/screens/SettingsViewModel.kt`
+- `apps/web/src/lib/monitoring.ts`
+- `apps/web/src/pages/SettingsPage.tsx`
+- `apps/ios/Finance/Screens/SettingsView.swift`
+- `apps/ios/Finance/ViewModels/SettingsViewModel.swift`
+
+## Current consent state
+
+### What already exists in code
+
+1. **Shared monitoring contracts are consent-gated by design.**
+   - `CrashReporter.kt` requires reporting to occur only after explicit consent and ships a `NoOpCrashReporter` that always reports disabled.
+   - `MetricsCollector.kt` checks `consentProvider()` before every event write and returns an empty buffer when consent is not granted.
+2. **Android defaults optional telemetry to off.**
+   - `AppModule.kt` wires both `TimberCrashReporter(consentProvider = { false })` and `MetricsCollector(consentProvider = { false })`, so crash reporting and analytics are effectively disabled by default.
+   - `TimberCrashReporter.kt` also keeps logs on-device only; no third-party crash SDK is active in the current DI path.
+3. **Web monitoring is privacy-aware but not enabled.**
+   - `apps/web/src/lib/monitoring.ts` contains PII and financial-data scrubbing, pseudonymous-user guidance, and an explicit TODO to check user consent before Sentry initialization.
+   - Sentry initialization is commented out, so optional web monitoring is currently disabled rather than silently enabled.
+4. **Existing platform settings storage can host consent state later.**
+   - Android currently persists settings with `SharedPreferences` in `SettingsViewModel.kt`, with a comment noting future migration to DataStore or Multiplatform Settings.
+   - Web already uses `localStorage` in `SettingsPage.tsx` for theme, currency, and notifications.
+   - iOS already uses `UserDefaults` for settings and biometric preferences in `SettingsViewModel.swift`, but no telemetry consent setting exists.
+5. **Backend logging guidance is restrictive.**
+   - `services/api/supabase/functions/_shared/logger.ts` explicitly forbids logging tokens, passwords, emails, account numbers, and financial amounts.
+
+### What does not exist yet
+
+- No consent banner, onboarding step, or settings toggle for analytics or crash reporting on any platform.
+- No backend consent record showing **what** the user agreed to, **when**, **how**, and under **which policy version**.
+- No withdrawal flow that propagates revocation to SDK initialization, event buffers, or backend retention jobs.
+- No cross-device consent sync model for users who use multiple platforms.
+- No iOS or Windows telemetry implementation that consumes the shared consent contract.
+
+## Gap analysis
+
+| Area                     | Current state                                                               | Gap                                                          | GDPR risk                                 |
+| ------------------------ | --------------------------------------------------------------------------- | ------------------------------------------------------------ | ----------------------------------------- |
+| Consent capture          | Shared contracts expect consent, but no UI exists                           | Users cannot actively grant consent                          | Optional processing cannot lawfully start |
+| Granularity              | Telemetry is conceptually split between crash reporting and metrics         | No separate toggles per purpose                              | Consent would not be specific enough      |
+| Demonstrability          | No consent ledger in backend or local audit record                          | Cannot prove Art. 7 consent after the fact                   | High                                      |
+| Withdrawal               | `MetricsCollector.clearEvents()` exists, but no UX or orchestration uses it | Revocation is not as easy as granting                        | High                                      |
+| Platform coverage        | Android and web have hooks/placeholders; iOS and Windows do not             | Inconsistent behavior across devices                         | Medium                                    |
+| SDK gating               | Web Sentry is disabled pending consent; Android Sentry is placeholder-only  | No end-to-end initialization guard for future SDK enablement | Medium                                    |
+| Policy linkage           | Login and settings surfaces only privacy-policy references                  | Consent copy is not purpose-specific or versioned            | Medium                                    |
+| Cross-device consistency | No consent sync schema                                                      | Users may see different telemetry states per device          | Medium                                    |
+
+## Platform-by-platform implementation needs
+
+| Platform | Current evidence                                                                                                              | Recommended storage               | Implementation needs                                                                                                                                                                                                                             |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Android  | `AppModule.kt` hard-codes `false`; `SettingsViewModel.kt` uses `SharedPreferences`                                            | **Jetpack DataStore**             | Add explicit toggles for analytics and crash reporting, migrate preferences from `SharedPreferences`, expose a reactive consent repository to Koin, and gate SDK initialization plus `MetricsCollector` and `CrashReporter` from that repository |
+| iOS      | `SettingsViewModel.swift` uses `UserDefaults` for biometric settings; `SettingsView.swift` exposes only a privacy-policy link | **UserDefaults**                  | Add consent toggles in Settings and onboarding, persist per-purpose consent plus policy version and timestamp, and wire future monitoring initialization to those values                                                                         |
+| Web      | `SettingsPage.tsx` already uses `localStorage`; `monitoring.ts` leaves Sentry disabled pending consent                        | **localStorage**                  | Add consent controls to Settings and onboarding, read consent before `initMonitoring()`, clear pseudonymous user context and queued events on withdrawal, and re-prompt on policy version changes                                                |
+| Windows  | No telemetry implementation or consent storage found in `apps/windows/` review                                                | **ApplicationData.LocalSettings** | Introduce a settings store for telemetry consent, add privacy controls in the desktop settings UI, and ensure any future crash or metrics pipeline stays disabled until opt-in                                                                   |
+
+## GDPR Art. 7 requirements
+
+For optional telemetry, the implementation should satisfy the following Art. 7 duties:
+
+1. **Demonstrable consent** — record the consent decision, policy version, timestamp, platform, and consent text identifier.
+2. **Clear separation** — telemetry consent must be separate from Terms of Service acceptance or account creation.
+3. **Plain language** — explain each purpose in concise, non-bundled language, such as crash diagnostics versus product analytics.
+4. **Freely given and specific** — no forced opt-in for analytics or third-party crash reporting as a condition of core finance features.
+5. **Easy withdrawal** — revocation must be available from the same settings area and take effect immediately.
+6. **No ambiguity** — use unticked toggles or equivalent explicit affirmative action; avoid pre-checked boxes.
+
+## Recommended consent architecture
+
+### 1. Canonical consent model
+
+Create a shared consent model with at least:
+
+- `analytics: granted | denied | unknown`
+- `crashReporting: granted | denied | unknown`
+- `policyVersion: string`
+- `updatedAt: Instant`
+- `source: onboarding | settings | migration`
+
+`unknown` should block all optional processing until the user takes an explicit action.
+
+### 2. Local consent repository per platform
+
+Each platform should provide a small storage-backed repository:
+
+- Android: DataStore-backed repository
+- iOS: UserDefaults-backed repository
+- Web: localStorage-backed repository
+- Windows: ApplicationData-backed repository
+
+That repository should expose reactive reads so SDK and bootstrap code can decide whether optional processing may start.
+
+### 3. Backend consent ledger
+
+Store server-side consent evidence for auditability, for example:
+
+- current snapshot per purpose
+- append-only consent events
+- policy version accepted
+- platform and app version
+- withdrawal timestamp
+
+This is needed to demonstrate consent independently of device-local storage loss.
+
+### 4. Startup and withdrawal flow
+
+1. App starts with optional telemetry disabled.
+2. Consent repository loads stored choice.
+3. Only if the relevant purpose is `granted` should crash and analytics SDKs initialize.
+4. On withdrawal:
+   - stop future event capture
+   - clear buffered analytics events via `MetricsCollector.clearEvents()`
+   - clear crash-reporting user context
+   - persist the new denied state locally and server-side
+
+### 5. Purpose boundaries
+
+Treat the following separately:
+
+- **Essential processing**: authentication, sync, security logging, fraud prevention
+- **Optional crash reporting**: third-party error collection or off-device diagnostics
+- **Optional analytics**: feature usage, screen views, performance analytics used for product improvement
+
+Essential security logging should not be mixed into the optional-consent toggle set, but it must still remain minimized and documented.
+
+## Recommended next steps
+
+1. Add platform privacy controls for analytics and crash reporting before enabling any third-party telemetry.
+2. Introduce a shared consent repository abstraction consumed by `CrashReporter` and `MetricsCollector` providers.
+3. Add a backend consent-evidence schema and API so consent can be demonstrated across devices.
+4. Re-enable web and future Android Sentry initialization only after consent checks run before SDK startup.
+5. Add automated tests covering default-off behavior, opt-in, withdrawal, and policy-version re-consent.

--- a/docs/compliance/data-minimization-audit.md
+++ b/docs/compliance/data-minimization-audit.md
@@ -1,0 +1,222 @@
+# GDPR Data Minimization Audit
+
+## Scope and evidence
+
+This audit reviews data necessity and retention based on:
+
+- `services/api/supabase/migrations/20260306000001_initial_schema.sql`
+- `services/api/supabase/functions/auth-webhook/index.ts`
+- `services/api/supabase/functions/_shared/logger.ts`
+- `packages/core/src/commonMain/kotlin/com/finance/core/monitoring/CrashReporter.kt`
+- `packages/core/src/commonMain/kotlin/com/finance/core/monitoring/MetricsCollector.kt`
+- `apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt`
+- `apps/android/src/main/kotlin/com/finance/android/logging/TimberCrashReporter.kt`
+- `apps/web/src/lib/monitoring.ts`
+
+## Executive summary
+
+The initial schema is relatively lean for a sync-first finance product, but the main minimization pressure points are:
+
+- `users.display_name` is mandatory even though account provisioning can function with only an email and user ID.
+- `users.avatar_url`, `accounts.icon`, `accounts.color`, `categories.icon`, `categories.color`, `goals.icon`, and `goals.color` are optional UX metadata and should stay optional.
+- `transactions.note` is high-risk free text and should be tightly bounded, encrypted at rest, and excluded from logs and telemetry.
+- Optional telemetry is currently default-off in shared/common code and Android DI, and web Sentry is disabled pending consent UI.
+- Backend logging guidance is strong, but `logger.ts` still allows `userId`, and `auth-webhook/index.ts` has one direct `console.log` path that emits `record.id`.
+
+### Decision labels
+
+- **Required** — necessary for core finance, sync, security, or relational integrity
+- **Conditional** — needed only for a specific feature or state
+- **Optional UX** — user-experience enhancement only; keep optional
+- **Review** — reconsider necessity, nullability, retention, or collection timing
+
+## Field-by-field necessity review
+
+### `users`
+
+| Field           | Necessity   | Review                                                                                                          |
+| --------------- | ----------- | --------------------------------------------------------------------------------------------------------------- |
+| `id`            | Required    | Primary key and sync identity                                                                                   |
+| `email`         | Required    | Needed for authentication and account recovery                                                                  |
+| `display_name`  | Review      | Useful for household UX, but should not be mandatory at signup if the product can operate with a fallback label |
+| `avatar_url`    | Optional UX | Not used by `auth-webhook/index.ts` today; only collect and store if avatars are displayed                      |
+| `currency_code` | Required    | Needed for defaults and presentation                                                                            |
+| `created_at`    | Required    | Operational audit and sync metadata                                                                             |
+| `updated_at`    | Required    | Operational audit and sync metadata                                                                             |
+| `deleted_at`    | Required    | Supports soft deletion and downstream erasure workflows                                                         |
+
+### `households`
+
+| Field        | Necessity | Review                                                                                     |
+| ------------ | --------- | ------------------------------------------------------------------------------------------ |
+| `id`         | Required  | Primary key                                                                                |
+| `name`       | Required  | Needed for shared-finance UX, though it should remain user-editable and not over-validated |
+| `created_by` | Required  | Ownership and authorization link                                                           |
+| `created_at` | Required  | Operational audit                                                                          |
+| `updated_at` | Required  | Operational audit                                                                          |
+| `deleted_at` | Required  | Soft delete support                                                                        |
+
+### `household_members`
+
+| Field          | Necessity | Review                                  |
+| -------------- | --------- | --------------------------------------- |
+| `id`           | Required  | Primary key                             |
+| `household_id` | Required  | Relationship integrity                  |
+| `user_id`      | Required  | Relationship integrity                  |
+| `role`         | Required  | Authorization and household governance  |
+| `joined_at`    | Required  | Membership timeline and troubleshooting |
+| `created_at`   | Required  | Operational audit                       |
+| `updated_at`   | Required  | Operational audit                       |
+| `deleted_at`   | Required  | Soft delete support                     |
+
+### `accounts`
+
+| Field           | Necessity   | Review                                                   |
+| --------------- | ----------- | -------------------------------------------------------- |
+| `id`            | Required    | Primary key                                              |
+| `household_id`  | Required    | Household scoping                                        |
+| `name`          | Required    | User-facing identification of the account                |
+| `type`          | Required    | Needed for behavior and reporting                        |
+| `currency_code` | Required    | Multi-currency support                                   |
+| `balance_cents` | Required    | Core financial state                                     |
+| `is_active`     | Required    | Enables archive and deactivate behavior without deletion |
+| `icon`          | Optional UX | Convenience metadata only                                |
+| `color`         | Optional UX | Convenience metadata only                                |
+| `sort_order`    | Optional UX | Presentation-only ordering                               |
+| `created_at`    | Required    | Operational audit                                        |
+| `updated_at`    | Required    | Operational audit                                        |
+| `deleted_at`    | Required    | Soft delete support                                      |
+| `sync_version`  | Required    | Sync conflict and version control                        |
+| `is_synced`     | Required    | Sync state management                                    |
+
+### `categories`
+
+| Field          | Necessity   | Review                                              |
+| -------------- | ----------- | --------------------------------------------------- |
+| `id`           | Required    | Primary key                                         |
+| `household_id` | Required    | Household scoping                                   |
+| `name`         | Required    | User-facing label                                   |
+| `icon`         | Optional UX | Convenience metadata only                           |
+| `color`        | Optional UX | Convenience metadata only                           |
+| `parent_id`    | Conditional | Needed only for nested categories                   |
+| `is_income`    | Required    | Behavioral distinction for reporting and validation |
+| `sort_order`   | Optional UX | Presentation-only ordering                          |
+| `created_at`   | Required    | Operational audit                                   |
+| `updated_at`   | Required    | Operational audit                                   |
+| `deleted_at`   | Required    | Soft delete support                                 |
+| `sync_version` | Required    | Sync conflict and version control                   |
+| `is_synced`    | Required    | Sync state management                               |
+
+### `transactions`
+
+| Field                 | Necessity   | Review                                                                       |
+| --------------------- | ----------- | ---------------------------------------------------------------------------- |
+| `id`                  | Required    | Primary key                                                                  |
+| `household_id`        | Required    | Household scoping                                                            |
+| `account_id`          | Required    | Ledger linkage                                                               |
+| `category_id`         | Conditional | Needed when categorization is used                                           |
+| `amount_cents`        | Required    | Core financial state                                                         |
+| `currency_code`       | Required    | Multi-currency support                                                       |
+| `type`                | Required    | Distinguishes expense, income, transfer, and related flows                   |
+| `payee`               | Conditional | Valuable for reconciliation and search, but should remain optional           |
+| `note`                | Review      | Highest minimization risk; free text can capture sensitive data unexpectedly |
+| `date`                | Required    | Core ledger chronology                                                       |
+| `is_recurring`        | Required    | Needed for recurring-flow behavior                                           |
+| `recurring_rule`      | Conditional | Needed only when `is_recurring = true`                                       |
+| `transfer_account_id` | Conditional | Needed only for transfers                                                    |
+| `status`              | Required    | Reconciliation and workflow state                                            |
+| `created_at`          | Required    | Operational audit                                                            |
+| `updated_at`          | Required    | Operational audit                                                            |
+| `deleted_at`          | Required    | Soft delete support                                                          |
+| `sync_version`        | Required    | Sync conflict and version control                                            |
+| `is_synced`           | Required    | Sync state management                                                        |
+
+### `budgets`
+
+| Field           | Necessity   | Review                            |
+| --------------- | ----------- | --------------------------------- |
+| `id`            | Required    | Primary key                       |
+| `household_id`  | Required    | Household scoping                 |
+| `category_id`   | Required    | Budget target linkage             |
+| `amount_cents`  | Required    | Core budget rule                  |
+| `currency_code` | Required    | Multi-currency support            |
+| `period`        | Required    | Needed to interpret recurrence    |
+| `start_date`    | Required    | Budget period anchor              |
+| `end_date`      | Conditional | Needed only for finite budgets    |
+| `created_at`    | Required    | Operational audit                 |
+| `updated_at`    | Required    | Operational audit                 |
+| `deleted_at`    | Required    | Soft delete support               |
+| `sync_version`  | Required    | Sync conflict and version control |
+| `is_synced`     | Required    | Sync state management             |
+
+### `goals`
+
+| Field           | Necessity   | Review                            |
+| --------------- | ----------- | --------------------------------- |
+| `id`            | Required    | Primary key                       |
+| `household_id`  | Required    | Household scoping                 |
+| `name`          | Required    | User-facing label                 |
+| `target_cents`  | Required    | Core goal rule                    |
+| `current_cents` | Required    | Progress tracking                 |
+| `currency_code` | Required    | Multi-currency support            |
+| `target_date`   | Conditional | Needed only for date-bound goals  |
+| `icon`          | Optional UX | Convenience metadata only         |
+| `color`         | Optional UX | Convenience metadata only         |
+| `created_at`    | Required    | Operational audit                 |
+| `updated_at`    | Required    | Operational audit                 |
+| `deleted_at`    | Required    | Soft delete support               |
+| `sync_version`  | Required    | Sync conflict and version control |
+| `is_synced`     | Required    | Sync state management             |
+
+## Signup data collection review
+
+`services/api/supabase/functions/auth-webhook/index.ts` processes new `auth.users` inserts and reads:
+
+- `record.id`
+- `record.email`
+- optional `record.raw_user_meta_data.full_name`
+- optional `record.raw_user_meta_data.name`
+- optional `record.raw_user_meta_data.avatar_url`
+
+The current implementation is fairly minimized because it only forwards `id`, `email`, and a derived `displayName` to the signup RPC. `avatar_url` is accepted in the webhook payload type but is not persisted in the code path shown. The main remaining minimization question is whether `display_name` must be mandatory at provisioning time.
+
+## Retention and TTL recommendations
+
+The initial schema file does **not** define `audit_log`, `sync_health_logs`, or `invitations` tables. If those operational tables are added in future migrations, adopt retention by default:
+
+| Table              | Recommended TTL | Reason                                                                                                        |
+| ------------------ | --------------- | ------------------------------------------------------------------------------------------------------------- |
+| `audit_log`        | **6 months**    | Long enough for security and compliance investigations without keeping operational event history indefinitely |
+| `sync_health_logs` | **3 months**    | Enough for reliability trend analysis while limiting device and server observability retention                |
+| `invitations`      | **72 hours**    | Invitation links and email-based collaboration artifacts should expire quickly                                |
+
+Implementation note: apply TTL with scheduled purge jobs or partition-based retention so expiry is automatic rather than manual.
+
+## SDK and logging data collection review
+
+| Surface                                | Current state                                                                               | Minimization assessment                                                                                    |
+| -------------------------------------- | ------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `MetricsCollector.kt`                  | Anonymous events only; gated by `consentProvider()` on every call                           | Strong default, assuming event properties stay schema-controlled                                           |
+| `CrashReporter.kt`                     | Requires consent and pseudonymous IDs only                                                  | Strong contract, but platform implementations must preserve it                                             |
+| Android `TimberCrashReporter.kt`       | On-device logging only; disabled by current `consentProvider = { false }` wiring            | Low current exposure; still avoid logging raw context maps that may grow over time                         |
+| Android placeholder Sentry integration | Present in `apps/android/.../SentryConfig.kt` but not active in DI                          | Safe while disabled; review sampling, scrubbing, and user-ID handling before activation                    |
+| Web `monitoring.ts`                    | Sentry disabled pending consent UI; scrubbers remove PII and financial patterns             | Good preconditions; ensure consent is checked before any SDK import or init                                |
+| Backend `logger.ts`                    | Structured logger bans sensitive fields in comments, but schema allows optional `userId`    | Treat `userId` as personal data; hash or omit unless operationally necessary                               |
+| `auth-webhook/index.ts`                | Success path uses structured logger, but idempotent path calls `console.log(... record.id)` | Replace raw `console.log` with structured logger and avoid emitting persistent identifiers when not needed |
+
+## Anonymization and pseudonymization opportunities
+
+1. **Telemetry user identity** — if a user identifier is needed for crash grouping, use a rotatable pseudonymous ID derived from a one-way mapping rather than a stable backend UUID.
+2. **Operational logs** — prefer request IDs, function names, and status codes over user-linked identifiers in `logger.ts` contexts.
+3. **Free-text transaction notes** — consider local-only storage options, stricter length caps, or on-device classification instead of server-side processing.
+4. **Display names** — allow null or empty display names and render a local fallback label until the user voluntarily adds one.
+5. **Deleted records** — where legal and operationally possible, convert soft-deleted rows into tombstones containing only the minimum sync metadata required for replication cleanup.
+
+## Recommendations
+
+1. Make `users.display_name` nullable or defer collection until after account creation.
+2. Keep `avatar_url` optional and do not start persisting it unless a concrete UI need exists.
+3. Add explicit product rules for `transactions.note`: character limit, no secrets guidance, encryption-at-rest confirmation, and exclusion from logs and telemetry.
+4. Treat `userId` in backend logs as personal data and minimize or pseudonymize it.
+5. Add future retention automation for `audit_log`, `sync_health_logs`, and `invitations` at table creation time.
+6. Before enabling Android or web Sentry, document the exact event schema, sampling rates, and scrubbing guarantees in the compliance inventory.


### PR DESCRIPTION
## Summary
- add a GDPR consent management audit covering current consent controls, Art. 7 gaps, and a recommended architecture
- add a GDPR data minimization audit covering field-level schema review, SDK/logging review, TTL guidance, and recommendations
- add a compliance README index for the new audits

Closes #367
Closes #369