### PR TITLE
fix(android): resolve duplicate TopAppBar and navigation routing (#516, #517)

### DIFF
--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/SettingsScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/SettingsScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.AlertDialog
@@ -39,18 +38,14 @@ import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -127,98 +122,69 @@ fun SettingsScreen(
     onTermsClick: () -> Unit = {},
     onLicensesClick: () -> Unit = {},
 ) {
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = {
-                    Text(
-                        text = "Settings",
-                        modifier = Modifier.semantics { contentDescription = "Settings screen title" },
-                    )
-                },
-                navigationIcon = {
-                    IconButton(
-                        onClick = onNavigateBack,
-                        modifier = Modifier.semantics { contentDescription = "Navigate back" },
-                    ) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Back",
-                        )
-                    }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.surface,
-                    titleContentColor = MaterialTheme.colorScheme.onSurface,
-                ),
-            )
-        },
-    ) { innerPadding ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(innerPadding)
-                .verticalScroll(rememberScrollState())
-                .padding(horizontal = 16.dp, vertical = 8.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-        ) {
-            // ── Profile ──────────────────────────────────────────────────────
-            ProfileSection(
-                userName = state.userName,
-                userEmail = state.userEmail,
-                onSignOut = onSignOut,
-            )
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        // ── Profile ──────────────────────────────────────────────────────
+        ProfileSection(
+            userName = state.userName,
+            userEmail = state.userEmail,
+            onSignOut = onSignOut,
+        )
 
-            // ── Appearance ───────────────────────────────────────────────────────
-            AppearanceSection(
-                themePreference = state.themePreference,
-                onThemePreferenceChanged = onSetThemePreference,
-            )
+        // ── Appearance ───────────────────────────────────────────────────
+        AppearanceSection(
+            themePreference = state.themePreference,
+            onThemePreferenceChanged = onSetThemePreference,
+        )
 
-            // ── Preferences ──────────────────────────────────────────────────
-            PreferencesSection(
-                currency = state.defaultCurrency,
-                notificationsEnabled = state.notificationsEnabled,
-                billRemindersEnabled = state.billRemindersEnabled,
-                onCurrencyChanged = onSetCurrency,
-                onNotificationsChanged = onSetNotifications,
-                onBillRemindersChanged = onSetBillReminders,
-            )
+        // ── Preferences ──────────────────────────────────────────────────
+        PreferencesSection(
+            currency = state.defaultCurrency,
+            notificationsEnabled = state.notificationsEnabled,
+            billRemindersEnabled = state.billRemindersEnabled,
+            onCurrencyChanged = onSetCurrency,
+            onNotificationsChanged = onSetNotifications,
+            onBillRemindersChanged = onSetBillReminders,
+        )
 
-            // ── Security ─────────────────────────────────────────────────────
-            SecuritySection(
-                biometricEnabled = state.biometricEnabled,
-                biometricAvailable = state.biometricAvailable,
-                appLockTimeout = state.appLockTimeout,
-                onBiometricChanged = onSetBiometric,
-                onAppLockTimeoutChanged = onSetAppLockTimeout,
-            )
+        // ── Security ─────────────────────────────────────────────────────
+        SecuritySection(
+            biometricEnabled = state.biometricEnabled,
+            biometricAvailable = state.biometricAvailable,
+            appLockTimeout = state.appLockTimeout,
+            onBiometricChanged = onSetBiometric,
+            onAppLockTimeoutChanged = onSetAppLockTimeout,
+        )
 
-            // ── Accessibility ────────────────────────────────────────────────
-            AccessibilitySection(
-                simplifiedViewEnabled = state.simplifiedViewEnabled,
-                highContrastEnabled = state.highContrastEnabled,
-                onSimplifiedViewChanged = onSetSimplifiedView,
-                onHighContrastChanged = onSetHighContrast,
-            )
+        // ── Accessibility ────────────────────────────────────────────────
+        AccessibilitySection(
+            simplifiedViewEnabled = state.simplifiedViewEnabled,
+            highContrastEnabled = state.highContrastEnabled,
+            onSimplifiedViewChanged = onSetSimplifiedView,
+            onHighContrastChanged = onSetHighContrast,
+        )
 
-            // ── Data ─────────────────────────────────────────────────────────
-            DataSection(
-                onExportClick = onExportClick,
-                onDeleteClick = onDeleteClick,
-                isExporting = state.isExporting,
-            )
+        // ── Data ─────────────────────────────────────────────────────────
+        DataSection(
+            onExportClick = onExportClick,
+            onDeleteClick = onDeleteClick,
+            isExporting = state.isExporting,
+        )
 
-            // ── About ────────────────────────────────────────────────────────
-            AboutSection(
-                appVersion = state.appVersion,
-                onPrivacyPolicyClick = onPrivacyPolicyClick,
-                onTermsClick = onTermsClick,
-                onLicensesClick = onLicensesClick,
-            )
+        // ── About ────────────────────────────────────────────────────────
+        AboutSection(
+            appVersion = state.appVersion,
+            onPrivacyPolicyClick = onPrivacyPolicyClick,
+            onTermsClick = onTermsClick,
+            onLicensesClick = onLicensesClick,
+        )
 
-            Spacer(modifier = Modifier.height(24.dp))
-        }
+        Spacer(modifier = Modifier.height(24.dp))
     }
 
     // ── Dialogs ──────────────────────────────────────────────────────────────

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/TransactionCreateScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/TransactionCreateScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.AttachMoney
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.Category
@@ -54,17 +53,14 @@ import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -108,32 +104,21 @@ fun TransactionCreateScreen(
     val state by viewModel.uiState.collectAsState()
     if (state.isSaved) { onSaved(); return }
 
-    Scaffold(topBar = {
-        TopAppBar(title = { Text("New Transaction", modifier = Modifier.semantics {
-            contentDescription = "New Transaction, ${state.currentStep.label}" }) },
-            navigationIcon = {
-                IconButton(onClick = { if (state.currentStep == CreateStep.AMOUNT) onBack() else viewModel.previousStep() },
-                    modifier = Modifier.semantics { contentDescription = if (state.currentStep == CreateStep.AMOUNT) "Cancel" else "Previous step" }) {
-                    Icon(Icons.AutoMirrored.Filled.ArrowBack, null)
-                }
-            })
-    }) { innerPadding ->
-        Column(Modifier.fillMaxSize().padding(innerPadding)) {
-            StepIndicator(state.currentStep, Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
-            if (state.errors.isNotEmpty()) ErrorMessages(state.errors, Modifier.padding(horizontal = 16.dp))
-            AnimatedContent(state.currentStep, transitionSpec = {
-                slideInHorizontally { it } togetherWith slideOutHorizontally { -it }
-            }, label = "step", modifier = Modifier.weight(1f).fillMaxWidth()) { step ->
-                when (step) {
-                    CreateStep.AMOUNT -> AmountStep(state, viewModel::updateAmount, viewModel::updatePayee,
-                        viewModel::selectPayeeSuggestion, viewModel::updateTransactionType)
-                    CreateStep.CATEGORY -> CategoryStep(state, viewModel::selectCategory, viewModel::selectAccount,
-                        viewModel::selectTransferAccount, viewModel::updateNote)
-                    CreateStep.CONFIRM -> ConfirmStep(state)
-                }
+    Column(Modifier.fillMaxSize()) {
+        StepIndicator(state.currentStep, Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
+        if (state.errors.isNotEmpty()) ErrorMessages(state.errors, Modifier.padding(horizontal = 16.dp))
+        AnimatedContent(state.currentStep, transitionSpec = {
+            slideInHorizontally { it } togetherWith slideOutHorizontally { -it }
+        }, label = "step", modifier = Modifier.weight(1f).fillMaxWidth()) { step ->
+            when (step) {
+                CreateStep.AMOUNT -> AmountStep(state, viewModel::updateAmount, viewModel::updatePayee,
+                    viewModel::selectPayeeSuggestion, viewModel::updateTransactionType)
+                CreateStep.CATEGORY -> CategoryStep(state, viewModel::selectCategory, viewModel::selectAccount,
+                    viewModel::selectTransferAccount, viewModel::updateNote)
+                CreateStep.CONFIRM -> ConfirmStep(state)
             }
-            ActionBar(state.currentStep, state.isSaving, viewModel::nextStep, viewModel::save, Modifier.padding(16.dp))
         }
+        ActionBar(state.currentStep, state.isSaving, viewModel::nextStep, viewModel::save, Modifier.padding(16.dp))
     }
 }
 


### PR DESCRIPTION
Removes duplicate Scaffold+TopAppBar from SettingsScreen and TransactionCreateScreen. Closes #516 Closes #517