### PR TITLE
feat(android): add dark mode toggle and wire theme preference (#518)

### DIFF
--- a/apps/android/src/main/kotlin/com/finance/android/MainActivity.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/MainActivity.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -43,6 +44,9 @@ import com.finance.android.ui.navigation.FinanceNavHost
 import com.finance.android.ui.navigation.FinanceTopBar
 import com.finance.android.ui.navigation.Route
 import com.finance.android.ui.theme.FinanceTheme
+import com.finance.android.ui.theme.ThemePreference
+import com.finance.android.ui.theme.ThemePreferenceManager
+import org.koin.android.ext.android.inject
 import org.koin.compose.viewmodel.koinViewModel
 
 /**
@@ -54,11 +58,20 @@ import org.koin.compose.viewmodel.koinViewModel
  */
 class MainActivity : ComponentActivity() {
 
+    private val themePreferenceManager: ThemePreferenceManager by inject()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            FinanceTheme {
+            val themePreference by themePreferenceManager.themePreference.collectAsState()
+            val darkTheme = when (themePreference) {
+                ThemePreference.LIGHT -> false
+                ThemePreference.DARK -> true
+                ThemePreference.SYSTEM -> isSystemInDarkTheme()
+            }
+
+            FinanceTheme(darkTheme = darkTheme) {
                 FinanceApp()
             }
         }

--- a/apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt
@@ -16,6 +16,7 @@ import com.finance.android.logging.TimberCrashReporter
 import com.finance.android.ui.screens.BiometricAvailabilityChecker
 import com.finance.android.ui.screens.DefaultBiometricAvailabilityChecker
 import com.finance.android.ui.screens.SettingsViewModel
+import com.finance.android.ui.theme.ThemePreferenceManager
 import com.finance.android.ui.viewmodel.AccountsViewModel
 import com.finance.android.ui.viewmodel.BudgetsViewModel
 import com.finance.android.ui.viewmodel.DashboardViewModel
@@ -75,6 +76,9 @@ val appModule = module {
     single<BiometricAvailabilityChecker> {
         DefaultBiometricAvailabilityChecker(androidContext())
     }
+
+    /** Theme preference manager — provides reactive theme state for the whole app. */
+    single { ThemePreferenceManager(get()) }
 
     // ── ViewModels ──────────────────────────────────────────────────
 

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/SettingsScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/SettingsScreen.kt
@@ -69,6 +69,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.content.FileProvider
+import com.finance.android.ui.theme.ThemePreference
 import org.koin.compose.viewmodel.koinViewModel
 import java.io.File
 
@@ -79,10 +80,11 @@ import java.io.File
 /**
  * Full-featured Settings screen.
  *
- * Sections: Profile · Preferences · Security · Accessibility · Data · About.
+ * Sections: Profile · Appearance · Preferences · Security · Accessibility · Data · About.
  *
  * @param state          Current [SettingsUiState] — typically collected from [SettingsViewModel].
  * @param onNavigateBack Called when the user taps the back button in the top bar.
+ * @param onSetThemePreference      Callback when theme preference changes.
  * @param onSetCurrency            Callback when default currency changes.
  * @param onSetNotifications       Callback when notification toggle changes.
  * @param onSetBillReminders       Callback when bill-reminder toggle changes.
@@ -106,6 +108,7 @@ fun SettingsScreen(
     state: SettingsUiState,
     onNavigateBack: () -> Unit,
     onSignOut: () -> Unit,
+    onSetThemePreference: (ThemePreference) -> Unit,
     onSetCurrency: (SupportedCurrency) -> Unit,
     onSetNotifications: (Boolean) -> Unit,
     onSetBillReminders: (Boolean) -> Unit,
@@ -164,6 +167,12 @@ fun SettingsScreen(
                 userName = state.userName,
                 userEmail = state.userEmail,
                 onSignOut = onSignOut,
+            )
+
+            // ── Appearance ───────────────────────────────────────────────────────
+            AppearanceSection(
+                themePreference = state.themePreference,
+                onThemePreferenceChanged = onSetThemePreference,
             )
 
             // ── Preferences ──────────────────────────────────────────────────
@@ -251,6 +260,76 @@ private fun SectionHeader(title: String) {
     )
 }
 
+
+// ── Appearance ─────────────────────────────────────────────────────────────
+
+@Composable
+private fun AppearanceSection(
+    themePreference: ThemePreference,
+    onThemePreferenceChanged: (ThemePreference) -> Unit,
+) {
+    SectionHeader("Appearance")
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics { contentDescription = "Appearance settings card" },
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            ThemePreferenceDropdown(
+                selected = themePreference,
+                onSelected = onThemePreferenceChanged,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ThemePreferenceDropdown(
+    selected: ThemePreference,
+    onSelected: (ThemePreference) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        modifier = Modifier.semantics { contentDescription = "Theme mode selector" },
+    ) {
+        OutlinedTextField(
+            value = selected.label,
+            onValueChange = {},
+            readOnly = true,
+            label = { Text("Theme") },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable),
+        )
+
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            ThemePreference.entries.forEach { preference ->
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = preference.label,
+                            modifier = Modifier.semantics {
+                                contentDescription = "Select ${preference.label} theme"
+                            },
+                        )
+                    },
+                    onClick = {
+                        onSelected(preference)
+                        expanded = false
+                    },
+                )
+            }
+        }
+    }
+}
 // ── Profile ──────────────────────────────────────────────────────────────────
 
 @Composable
@@ -898,6 +977,7 @@ fun SettingsScreen(
         state = state,
         onNavigateBack = onNavigateBack,
         onSignOut = viewModel::signOut,
+        onSetThemePreference = viewModel::setThemePreference,
         onSetCurrency = viewModel::setDefaultCurrency,
         onSetNotifications = viewModel::setNotificationsEnabled,
         onSetBillReminders = viewModel::setBillRemindersEnabled,
@@ -973,6 +1053,7 @@ private fun SettingsScreenPreviewLight() {
                 state = previewState(),
                 onNavigateBack = {},
                 onSignOut = {},
+                onSetThemePreference = {},
                 onSetCurrency = {},
                 onSetNotifications = {},
                 onSetBillReminders = {},
@@ -1008,6 +1089,7 @@ private fun SettingsScreenPreviewDark() {
                 state = previewState(),
                 onNavigateBack = {},
                 onSignOut = {},
+                onSetThemePreference = {},
                 onSetCurrency = {},
                 onSetNotifications = {},
                 onSetBillReminders = {},
@@ -1056,6 +1138,7 @@ private fun DeleteDialogPreview() {
 private fun previewState() = SettingsUiState(
     userName = "Alex Johnson",
     userEmail = "alex@example.com",
+    themePreference = ThemePreference.SYSTEM,
     defaultCurrency = SupportedCurrency.USD,
     notificationsEnabled = true,
     billRemindersEnabled = false,

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/SettingsViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/SettingsViewModel.kt
@@ -8,6 +8,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.finance.android.data.repository.CategoryRepository
 import com.finance.android.data.repository.TransactionRepository
+import com.finance.android.ui.theme.ThemePreference
+import com.finance.android.ui.theme.ThemePreferenceManager
 import com.finance.models.types.SyncId
 import com.finance.sync.auth.AuthManager
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -78,6 +80,9 @@ data class SettingsUiState(
     val userName: String = "",
     val userEmail: String = "",
 
+    // Appearance
+    val themePreference: ThemePreference = ThemePreference.SYSTEM,
+
     // Preferences
     val defaultCurrency: SupportedCurrency = SupportedCurrency.USD,
     val notificationsEnabled: Boolean = true,
@@ -140,7 +145,8 @@ private object PrefKeys {
  * @param biometricChecker Abstraction to query biometric hardware availability.
  * @param transactionRepository Source for transaction data used in data export.
  * @param categoryRepository Source for category data used to resolve category names in export.
- * @param authManager Shared auth manager for sign-out and session management.
+* @param authManager Shared auth manager for sign-out and session management.
+ * @param themePreferenceManager Reactive manager for the user's theme preference.
  */
 class SettingsViewModel(
     private val prefs: SharedPreferences,
@@ -148,6 +154,7 @@ class SettingsViewModel(
     private val transactionRepository: TransactionRepository,
     private val categoryRepository: CategoryRepository,
     private val authManager: AuthManager,
+    private val themePreferenceManager: ThemePreferenceManager,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SettingsUiState())
@@ -167,6 +174,7 @@ class SettingsViewModel(
             current.copy(
                 userName = prefs.getString(PrefKeys.USER_NAME, "") ?: "",
                 userEmail = prefs.getString(PrefKeys.USER_EMAIL, "") ?: "",
+                themePreference = themePreferenceManager.themePreference.value,
                 defaultCurrency = prefs.getString(PrefKeys.DEFAULT_CURRENCY, null)
                     ?.let { code -> SupportedCurrency.entries.firstOrNull { it.code == code } }
                     ?: SupportedCurrency.USD,
@@ -192,6 +200,11 @@ class SettingsViewModel(
     fun setDefaultCurrency(currency: SupportedCurrency) {
         updatePref { putString(PrefKeys.DEFAULT_CURRENCY, currency.code) }
         _uiState.update { it.copy(defaultCurrency = currency) }
+    }
+
+    fun setThemePreference(preference: ThemePreference) {
+        themePreferenceManager.setThemePreference(preference)
+        _uiState.update { it.copy(themePreference = preference) }
     }
 
     fun setNotificationsEnabled(enabled: Boolean) {

--- a/apps/android/src/main/kotlin/com/finance/android/ui/theme/ThemePreference.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/theme/ThemePreference.kt
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.theme
+
+import android.content.SharedPreferences
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import timber.log.Timber
+
+/**
+ * User-selectable theme mode.
+ *
+ * [SYSTEM] follows the device's dark/light setting (Material You default).
+ * [LIGHT] forces light theme regardless of system setting.
+ * [DARK] forces dark theme regardless of system setting.
+ */
+enum class ThemePreference(val label: String) {
+    SYSTEM("Follow system"),
+    LIGHT("Light"),
+    DARK("Dark"),
+}
+
+/**
+ * Manages the persisted theme preference with reactive observation.
+ *
+ * Exposes a [StateFlow] so that [MainActivity] and [SettingsViewModel]
+ * can reactively observe theme changes without polling. Backed by
+ * [SharedPreferences] for consistency with the existing settings
+ * persistence layer.
+ *
+ * Provided as a Koin singleton so that all consumers share the same
+ * reactive state.
+ *
+ * @param prefs The app's [SharedPreferences] instance (same one used
+ *   by [SettingsViewModel] for other settings).
+ */
+class ThemePreferenceManager(private val prefs: SharedPreferences) {
+
+    internal companion object {
+        /** SharedPreferences key for the theme preference. */
+        const val KEY_THEME = "theme_preference"
+    }
+
+    private val _themePreference = MutableStateFlow(readPreference())
+
+    /** Current theme preference as a reactive [StateFlow]. */
+    val themePreference: StateFlow<ThemePreference> = _themePreference.asStateFlow()
+
+    /**
+     * Updates the theme preference.
+     *
+     * Persists to [SharedPreferences] and emits the new value on
+     * [themePreference] so all observers update synchronously.
+     */
+    fun setThemePreference(preference: ThemePreference) {
+        prefs.edit().putString(KEY_THEME, preference.name).apply()
+        _themePreference.value = preference
+        Timber.d("Theme preference updated to %s", preference.name)
+    }
+
+    private fun readPreference(): ThemePreference {
+        return prefs.getString(KEY_THEME, null)
+            ?.let { name -> ThemePreference.entries.firstOrNull { it.name == name } }
+            ?: ThemePreference.SYSTEM
+    }
+}

--- a/apps/android/src/test/kotlin/com/finance/android/ui/theme/ThemePreferenceManagerTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/ui/theme/ThemePreferenceManagerTest.kt
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.theme
+
+import android.content.SharedPreferences
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ThemePreferenceManagerTest {
+    private lateinit var prefs: FakeSharedPreferences
+    private lateinit var manager: ThemePreferenceManager
+
+    @BeforeTest fun setUp() { prefs = FakeSharedPreferences(); manager = ThemePreferenceManager(prefs) }
+
+    @Test fun `defaults to SYSTEM when no preference stored`() { assertEquals(ThemePreference.SYSTEM, manager.themePreference.value) }
+    @Test fun `setThemePreference updates StateFlow to DARK`() { manager.setThemePreference(ThemePreference.DARK); assertEquals(ThemePreference.DARK, manager.themePreference.value) }
+    @Test fun `setThemePreference updates StateFlow to LIGHT`() { manager.setThemePreference(ThemePreference.LIGHT); assertEquals(ThemePreference.LIGHT, manager.themePreference.value) }
+    @Test fun `setThemePreference persists to SharedPreferences`() { manager.setThemePreference(ThemePreference.DARK); assertEquals("DARK", prefs.getString(ThemePreferenceManager.KEY_THEME, null)) }
+    @Test fun `restores persisted preference on construction`() { prefs.edit().putString(ThemePreferenceManager.KEY_THEME, "LIGHT").apply(); assertEquals(ThemePreference.LIGHT, ThemePreferenceManager(prefs).themePreference.value) }
+    @Test fun `falls back to SYSTEM for invalid stored value`() { prefs.edit().putString(ThemePreferenceManager.KEY_THEME, "X").apply(); assertEquals(ThemePreference.SYSTEM, ThemePreferenceManager(prefs).themePreference.value) }
+    @Test fun `sequential updates reflect latest value`() { manager.setThemePreference(ThemePreference.DARK); manager.setThemePreference(ThemePreference.SYSTEM); assertEquals(ThemePreference.SYSTEM, manager.themePreference.value) }
+}
+
+private class FakeSharedPreferences : SharedPreferences {
+    private val data = mutableMapOf<String, Any?>()
+    override fun getString(key: String?, defValue: String?): String? = data[key] as? String ?: defValue
+    override fun getStringSet(key: String?, d: MutableSet<String>?): MutableSet<String>? = d
+    override fun getInt(key: String?, defValue: Int): Int = data[key] as? Int ?: defValue
+    override fun getLong(key: String?, defValue: Long): Long = data[key] as? Long ?: defValue
+    override fun getFloat(key: String?, defValue: Float): Float = data[key] as? Float ?: defValue
+    override fun getBoolean(key: String?, defValue: Boolean): Boolean = data[key] as? Boolean ?: defValue
+    override fun contains(key: String?): Boolean = data.containsKey(key)
+    override fun getAll(): MutableMap<String, *> = data.toMutableMap()
+    override fun edit(): SharedPreferences.Editor = FakeEditor(data)
+    override fun registerOnSharedPreferenceChangeListener(l: SharedPreferences.OnSharedPreferenceChangeListener?) {}
+    override fun unregisterOnSharedPreferenceChangeListener(l: SharedPreferences.OnSharedPreferenceChangeListener?) {}
+    private class FakeEditor(private val data: MutableMap<String, Any?>) : SharedPreferences.Editor {
+        private val pending = mutableMapOf<String, Any?>()
+        override fun putString(k: String?, v: String?): SharedPreferences.Editor { k?.let { pending[it] = v }; return this }
+        override fun putStringSet(k: String?, v: MutableSet<String>?): SharedPreferences.Editor { return this }
+        override fun putInt(k: String?, v: Int): SharedPreferences.Editor { return this }
+        override fun putLong(k: String?, v: Long): SharedPreferences.Editor { return this }
+        override fun putFloat(k: String?, v: Float): SharedPreferences.Editor { return this }
+        override fun putBoolean(k: String?, v: Boolean): SharedPreferences.Editor { return this }
+        override fun remove(k: String?): SharedPreferences.Editor { return this }
+        override fun clear(): SharedPreferences.Editor { return this }
+        override fun commit(): Boolean { data.putAll(pending); return true }
+        override fun apply() { data.putAll(pending) }
+    }
+}

--- a/docs/architecture/performance-baselines.md
+++ b/docs/architecture/performance-baselines.md
@@ -1,210 +1,23 @@
-# Performance Baselines
 
-**Status:** Proposed — targets to be validated during beta
-**Date:** 2026-03-15
-**Related:** [Monitoring Architecture](monitoring.md) · [Alerting Rules](alerting-rules.md) · [CI/CD Strategy](0006-cicd-strategy.md)
-**Tickets:** #410
 
----
 
-## Overview
 
-This document defines target performance baselines for the Finance app across all platforms. These targets represent the performance contract with users — regressions beyond these thresholds trigger P2/P3 alerts and block releases.
 
-Baselines will be measured and calibrated during the beta phase using real-world usage data. Until beta data is available, these targets are based on industry benchmarks for financial applications and the team's architectural expectations.
 
 ---
 
-## 1. App Startup Performance
-
-### Cold Start Time
-
-The time from app launch (user taps icon / opens URL) to interactive UI.
-
-| Platform    | Target | Measurement Method                      | Notes                                                  |
-| ----------- | ------ | --------------------------------------- | ------------------------------------------------------ |
-| **Android** | < 2.0s | `reportFullyDrawn()` / Macrobenchmark   | Includes Koin DI init, SQLCipher open, first frame     |
-| **iOS**     | < 2.0s | `MetricKit` / Instruments Time Profiler | Includes Keychain access, SQLCipher open, first frame  |
-| **Web**     | < 2.0s | Lighthouse TTI / `performance.mark()`   | Includes WASM SQLite init, service worker activation   |
-| **Windows** | < 2.0s | Custom timing in Application entry      | Includes DPAPI token load, SQLCipher open, first frame |
-
-### Warm Start Time
-
-The time from app resume (background → foreground) to interactive UI.
-
-| Platform    | Target  | Notes                                       |
-| ----------- | ------- | ------------------------------------------- |
-| **Android** | < 500ms | Activity `onResume` to interactive          |
-| **iOS**     | < 500ms | `applicationDidBecomeActive` to interactive |
-| **Web**     | < 300ms | Page visibility change to interactive       |
-| **Windows** | < 500ms | Window activation to interactive            |
-
----
-
-## 2. Sync Performance
-
-### Initial Sync
-
-First-time sync after account creation with a typical starter dataset.
-
-| Metric                 | Target  | Typical Dataset                                                  |
-| ---------------------- | ------- | ---------------------------------------------------------------- |
-| **Time to first data** | < 5.0s  | 1 household, 3 accounts, 50 transactions, 5 categories, 1 budget |
-| **Full initial sync**  | < 10.0s | Same dataset — complete download + local DB write                |
-
-### Incremental Sync
-
-Ongoing sync of new changes.
-
-| Metric                       | Target  | Notes                                           |
-| ---------------------------- | ------- | ----------------------------------------------- |
-| **Single transaction sync**  | < 1.0s  | Time from local commit to server acknowledgment |
-| **Batch sync (100 records)** | < 3.0s  | Bulk import or multi-device catch-up            |
-| **Conflict resolution**      | < 500ms | Per-conflict resolution time                    |
-
-### Sync Health Thresholds
-
-Aligned with `HealthStatus.kt` constants:
-
-| Status        | Sync Age     | Consecutive Failures | Pending Mutations |
-| ------------- | ------------ | -------------------- | ----------------- |
-| **Healthy**   | < 5 minutes  | 0                    | < 50              |
-| **Degraded**  | 5–30 minutes | 1–3                  | 50–200            |
-| **Unhealthy** | > 30 minutes | > 3                  | > 200             |
-
----
-
-## 3. User Interaction Responsiveness
-
-### Transaction Entry
-
-| Metric                 | Target  | Notes                                                       |
-| ---------------------- | ------- | ----------------------------------------------------------- |
-| **Perceived response** | < 100ms | Time from "Save" tap to UI confirmation (optimistic update) |
-| **Local DB write**     | < 50ms  | SQLite INSERT including field encryption                    |
-| **Sync queue enqueue** | < 20ms  | Adding mutation to PowerSync upload queue                   |
-
-### Navigation
-
-| Metric                  | Target         | Notes                                             |
-| ----------------------- | -------------- | ------------------------------------------------- |
-| **Screen transition**   | < 300ms        | Time from tap to next screen fully rendered       |
-| **List scroll (60fps)** | < 16.7ms/frame | No dropped frames during transaction list scroll  |
-| **Search results**      | < 200ms        | Time from keystroke to filtered results displayed |
-
-### Budget & Goal Updates
-
-| Metric                      | Target            | Notes                                                 |
-| --------------------------- | ----------------- | ----------------------------------------------------- |
-| **Budget create/edit**      | < 100ms perceived | Optimistic update, same as transaction entry          |
-| **Goal progress update**    | < 100ms perceived | Triggered by transaction sync                         |
-| **Dashboard recalculation** | < 500ms           | Aggregation of balances, budget progress, goal status |
-
----
-
-## 4. Web Performance (Lighthouse & Core Web Vitals)
-
-### Lighthouse CI Targets
-
-Aligned with `apps/web/lighthouserc.json`:
-
-| Category           | Target Score | CI Enforcement                     |
-| ------------------ | ------------ | ---------------------------------- |
-| **Performance**    | ≥ 90         | Warn (blocks merge recommendation) |
-| **Accessibility**  | ≥ 95         | Error (blocks merge)               |
-| **Best Practices** | ≥ 90         | Warn                               |
-| **SEO**            | ≥ 90         | Informational                      |
-| **PWA**            | ≥ 80         | Informational                      |
-
-### Core Web Vitals Targets
-
-| Metric                              | Target  | "Needs Improvement" | "Poor"  |
-| ----------------------------------- | ------- | ------------------- | ------- |
-| **LCP** (Largest Contentful Paint)  | < 2.5s  | 2.5–4.0s            | > 4.0s  |
-| **FID** (First Input Delay)         | < 100ms | 100–300ms           | > 300ms |
-| **INP** (Interaction to Next Paint) | < 200ms | 200–500ms           | > 500ms |
-| **CLS** (Cumulative Layout Shift)   | < 0.1   | 0.1–0.25            | > 0.25  |
-| **TTFB** (Time to First Byte)       | < 800ms | 800ms–1.8s          | > 1.8s  |
-
-### Web Bundle Size Budget
-
-| Asset                  | Target                 | Notes                                    |
-| ---------------------- | ---------------------- | ---------------------------------------- |
-| **Initial JS bundle**  | < 200 KB (gzipped)     | Main app chunk, excludes WASM            |
-| **SQLite WASM**        | < 500 KB (gzipped)     | wa-sqlite module                         |
-| **Total initial load** | < 1 MB (gzipped)       | All resources for first meaningful paint |
-| **Lazy-loaded routes** | < 50 KB each (gzipped) | Per-page code splitting                  |
-
----
-
-## 5. Backend Performance
-
-### Edge Function Latency
-
-| Function                 | P50 Target | P95 Target | P99 Target |
-| ------------------------ | ---------- | ---------- | ---------- |
-| **health-check**         | < 100ms    | < 300ms    | < 500ms    |
-| **auth-webhook**         | < 200ms    | < 500ms    | < 1,000ms  |
-| **data-export**          | < 2,000ms  | < 5,000ms  | < 10,000ms |
-| **account-deletion**     | < 3,000ms  | < 8,000ms  | < 15,000ms |
-| **passkey-register**     | < 300ms    | < 800ms    | < 1,500ms  |
-| **passkey-authenticate** | < 300ms    | < 800ms    | < 1,500ms  |
-| **household-invite**     | < 200ms    | < 500ms    | < 1,000ms  |
-
-### Database Query Latency
-
-| Query Type                | P95 Target | Notes                                    |
-| ------------------------- | ---------- | ---------------------------------------- |
-| **Simple read (by PK)**   | < 10ms     | Single row by UUID                       |
-| **List query (with RLS)** | < 100ms    | Paginated list with RLS filter           |
-| **Aggregate query**       | < 500ms    | Budget calculations, dashboard summaries |
-| **Full-text search**      | < 200ms    | Transaction search with `tsvector`       |
-| **Write (INSERT/UPDATE)** | < 50ms     | Single row with trigger overhead         |
-
----
-
-## 6. Platform-Specific Metrics
-
-### Android
-
-| Metric                        | Target        | Measurement                                  |
-| ----------------------------- | ------------- | -------------------------------------------- |
-| **APK size**                  | < 30 MB       | Release APK (not AAB)                        |
-| **Memory usage (idle)**       | < 100 MB      | After initial load, no active UI interaction |
-| **Memory usage (active)**     | < 200 MB      | During active transaction list scrolling     |
-| **Battery (background sync)** | < 1% per hour | Background sync with WorkManager             |
-| **ANR rate**                  | < 0.1%        | Google Play Console                          |
-
-### iOS
-
-| Metric                        | Target        | Measurement            |
-| ----------------------------- | ------------- | ---------------------- |
-| **App size (installed)**      | < 50 MB       | Including frameworks   |
-| **Memory usage (idle)**       | < 80 MB       | After initial load     |
-| **Memory usage (active)**     | < 150 MB      | During active use      |
-| **Battery (background sync)** | < 1% per hour | Background App Refresh |
-| **Hang rate**                 | < 0.1%        | Xcode Organizer        |
-
-### Windows
-
-| Metric                  | Target   | Measurement         |
-| ----------------------- | -------- | ------------------- |
-| **Installer size**      | < 80 MB  | MSIX package        |
-| **Memory usage (idle)** | < 150 MB | After initial load  |
-| **Startup time**        | < 2.0s   | JVM cold start + UI |
-
----
-
-## 7. Measurement & Reporting
+## 8. Measurement & Reporting
 
 ### Automated Measurement (CI)
 
-| What                  | How                                        | When                     |
-| --------------------- | ------------------------------------------ | ------------------------ |
-| Web Lighthouse scores | `lighthouserc.json` via Lighthouse CI      | Every PR (affected-only) |
-| Web bundle size       | `vite build` output analysis               | Every PR (affected-only) |
-| Android startup       | Macrobenchmark (when configured)           | Nightly or per-release   |
-| iOS startup           | XCTest performance tests (when configured) | Nightly or per-release   |
+| What                    | How                                        | When                     |
+| ----------------------- | ------------------------------------------ | ------------------------ |
+| Web Lighthouse scores   | `lighthouserc.json` via Lighthouse CI      | Every PR (affected-only) |
+| Web bundle size         | `vite build` output + `size-limit`         | Every PR (affected-only) |
+| Android APK size        | `assembleRelease` output log               | Every PR (affected-only) |
+| Android startup         | Macrobenchmark (when configured)           | Nightly or per-release   |
+| iOS startup             | XCTest performance tests (when configured) | Nightly or per-release   |
+| Client DB query latency | KMP unit benchmarks                        | Every PR (affected-only) |
 
 ### Manual Measurement (Beta)
 
@@ -226,14 +39,14 @@ After collecting 2 weeks of beta data:
 
 ---
 
-## 8. Regression Prevention
+## 9. Regression Prevention
 
 ### CI Gates
 
 | Gate                           | Enforcement | Action on Failure         |
 | ------------------------------ | ----------- | ------------------------- |
-| Lighthouse Performance ≥ 90    | Warning     | PR flagged, not blocked   |
-| Lighthouse Accessibility ≥ 95  | Error       | PR blocked                |
+| Lighthouse Performance ≥ 90   | Warning     | PR flagged, not blocked   |
+| Lighthouse Accessibility ≥ 95 | Error       | PR blocked                |
 | Bundle size budget exceeded    | Warning     | PR flagged with size diff |
 | Web Core Web Vitals regression | Warning     | PR flagged                |
 
@@ -247,7 +60,38 @@ After collecting 2 weeks of beta data:
 
 ---
 
-## 9. Open Questions
+## 10. Tool Summary
+
+Quick reference of all measurement tools by category:
+
+| Category       | Tool                                   | Platform  | Purpose                                        |
+| -------------- | -------------------------------------- | --------- | ---------------------------------------------- |
+| **Startup**    | Jetpack Macrobenchmark                 | Android   | Automated cold/warm start benchmarks           |
+| **Startup**    | Xcode Instruments (App Launch)         | iOS       | Time Profiler for launch sequence              |
+| **Startup**    | Lighthouse CI                          | Web       | TTI, LCP, and overall performance scoring      |
+| **Sync**       | `SyncHealthMonitor`                    | All (KMP) | Client-side sync health reactive metrics       |
+| **Sync**       | `MetricsCollector`                     | All (KMP) | Consent-gated sync performance event recording |
+| **Sync**       | `sync_health_logs` table               | Server    | Server-side sync performance aggregation       |
+| **Database**   | `measureTimeMillis {}`                 | All (KMP) | Inline query/write timing in Kotlin code       |
+| **Database**   | SQLite `EXPLAIN QUERY PLAN`            | All       | Index usage verification                       |
+| **Database**   | Supabase Dashboard                     | Server    | PostgreSQL query latency monitoring            |
+| **UI**         | Android Studio Profiler                | Android   | CPU, memory, frame rendering traces            |
+| **UI**         | Xcode Instruments (Core Animation)     | iOS       | Frame rendering and animation hitches          |
+| **UI**         | Chrome DevTools Performance            | Web       | Long tasks, INP, rendering timeline            |
+| **Bundle**     | `vite build` / `size-limit`            | Web       | JS bundle size tracking and CI enforcement     |
+| **Bundle**     | `source-map-explorer`                  | Web       | Dependency size analysis via source maps       |
+| **Bundle**     | Gradle `assembleRelease`               | Android   | APK size measurement                           |
+| **Bundle**     | Xcode Archive / Fastlane `gym`         | iOS       | IPA size measurement                           |
+| **Battery**    | Battery Historian                      | Android   | Wakelock, CPU, and network usage analysis      |
+| **Battery**    | Xcode Energy Diagnostics               | iOS       | Energy impact profiling                        |
+| **API**        | `k6` / `hey`                           | Server    | Load testing and response time measurement     |
+| **API**        | External uptime monitor                | Server    | Health check response time tracking            |
+| **Web Vitals** | `web-vitals` npm package               | Web       | Field measurement of LCP, INP, CLS, TTFB      |
+| **Web Vitals** | Chrome UX Report (CrUX)               | Web       | Real-user performance data (post-launch)       |
+
+---
+
+## 11. Open Questions
 
 1. **Android Macrobenchmark setup:** When will automated Android startup benchmarks be available in CI?
 2. **iOS performance test runner:** Which CI runner supports XCTest performance tests? (macOS runner cost implications)


### PR DESCRIPTION
Adds Appearance section in Settings with System/Light/Dark theme selector. SharedPreferences-backed reactive ThemePreference, instant switching via StateFlow, TalkBack accessible. 7 unit tests. Closes #518