### PR TITLE
test(web): set up Playwright E2E framework (#559)

### DIFF
--- a/apps/web/e2e/auth.spec.ts
+++ b/apps/web/e2e/auth.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '@playwright/test';
+
+test('login page renders', async ({ page }) => {
+  await page.goto('/login');
+  await expect(page.getByRole('heading', { name: /sign in/i })).toBeVisible();
+  await expect(page.getByLabel(/email/i)).toBeVisible();
+  await expect(page.getByLabel(/password/i)).toBeVisible();
+});
+
+test('signup page renders', async ({ page }) => {
+  await page.goto('/signup');
+  await expect(page.getByRole('heading', { name: /create.*account/i })).toBeVisible();
+});
+
+test('unauthenticated redirect to login', async ({ page }) => {
+  await page.goto('/dashboard');
+  await expect(page).toHaveURL(/login/);
+});
+
+test('login page links to signup', async ({ page }) => {
+  await page.goto('/login');
+  const signupLink = page.getByRole('link', { name: /sign up/i });
+  await expect(signupLink).toBeVisible();
+});

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -1,0 +1,6 @@
+import { expect, test } from '@playwright/test';
+
+test('404 page for invalid routes', async ({ page }) => {
+  await page.goto('/invalid-route');
+  await expect(page.getByText(/not found|404/i)).toBeVisible();
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,8 @@
     "lint": "eslint src/ --ext .ts,.tsx",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
     "clean": "rimraf dist",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
@@ -25,6 +27,7 @@
     "wa-sqlite": "^1.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@storybook/addon-a11y": "^10.2.19",
     "@storybook/react": "^10.2.19",
     "@storybook/react-vite": "^10.2.19",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  use: {
+    baseURL: 'http://localhost:5173',
+    headless: true,
+  },
+  webServer: {
+    command: 'npm run dev',
+    port: 5173,
+    reuseExistingServer: true,
+  },
+});

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -12,11 +12,12 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "types": ["node"],
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]
     }
   },
-  "include": ["src"],
+  "include": ["src", "e2e", "playwright.config.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import { defineConfig } from 'vitest/config';
+import { configDefaults, defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import { resolve } from 'node:path';
 
@@ -15,5 +15,6 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['src/test-setup.ts'],
+    exclude: [...configDefaults.exclude, 'e2e/**'],
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "wa-sqlite": "^1.0.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "@storybook/addon-a11y": "^10.2.19",
         "@storybook/react": "^10.2.19",
         "@storybook/react-vite": "^10.2.19",
@@ -3547,6 +3548,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -10956,6 +10973,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pluralize": {


### PR DESCRIPTION
## Summary
Sets up Playwright E2E testing infrastructure with initial auth and navigation tests.

## Changes
- Playwright config with webServer integration
- Auth E2E tests (login render, signup render, auth redirect)
- Navigation E2E tests (404 handling)
- Vitest exclusion for e2e/, tsconfig inclusion

## Validation
- TSC: zero errors | Unit tests: all passing
- E2E tests ready to run with \
pm run test:e2e\

Closes #559
