### PR TITLE
feat(ios): add deep linking, network monitoring, and privacy screens (#470, #471, #474)

### DIFF
--- a/apps/ios/Finance/Components/OfflineBanner.swift
+++ b/apps/ios/Finance/Components/OfflineBanner.swift
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// OfflineBanner.swift
+// Finance
+//
+// A compact banner displayed at the top of content views when the device
+// has no network connectivity. Supports VoiceOver and Dynamic Type.
+// Refs #471
+
+import SwiftUI
+
+// MARK: - View
+
+/// Displays a non-intrusive offline status banner with an SF Symbol
+/// and a localized message.
+///
+/// Usage:
+/// ```swift
+/// @State private var networkMonitor = NetworkMonitor()
+///
+/// VStack {
+///     if !networkMonitor.isConnected {
+///         OfflineBanner()
+///     }
+///     // ... content
+/// }
+/// ```
+struct OfflineBanner: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "wifi.slash")
+                .font(.subheadline)
+                .foregroundStyle(.white)
+                .accessibilityHidden(true)
+
+            Text(String(localized: "You are offline. Some features may be limited."))
+                .font(.subheadline)
+                .foregroundStyle(.white)
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(FinanceColors.statusWarning, in: RoundedRectangle(cornerRadius: 10))
+        .padding(.horizontal)
+        .transition(reduceMotion ? .opacity : .move(edge: .top).combined(with: .opacity))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(String(localized: "Offline. Some features may be limited."))
+        .accessibilityAddTraits(.isStatusElement)
+    }
+}
+
+#Preview("Offline Banner") {
+    VStack {
+        OfflineBanner()
+        Spacer()
+    }
+}

--- a/apps/ios/Finance/ContentView.swift
+++ b/apps/ios/Finance/ContentView.swift
@@ -3,13 +3,40 @@ import SwiftUI
 
 /// Root view of the Finance application.
 ///
-/// Displays the main tab navigation backed by KMP-bridged repositories.
-/// Biometric lock gating is handled at the `FinanceApp` level — this
-/// view is only visible once the user has been authenticated (or if
-/// biometric lock is disabled).
+/// Hosts the `MainTabView` and injects infrastructure services
+/// (deep linking, network monitoring) into the SwiftUI environment
+/// for consumption by child views.
 struct ContentView: View {
+    @Bindable var deepLinkHandler: DeepLinkHandler
+    @State var networkMonitor: NetworkMonitor
+
+    init(
+        deepLinkHandler: DeepLinkHandler = DeepLinkHandler(),
+        networkMonitor: NetworkMonitor = NetworkMonitor()
+    ) {
+        self.deepLinkHandler = deepLinkHandler
+        self.networkMonitor = networkMonitor
+    }
+
     var body: some View {
-        MainTabView()
+        MainTabView(
+            selectedTab: $deepLinkHandler.selectedTab.withDefault(.dashboard)
+        )
+        .environment(networkMonitor)
+        .environment(deepLinkHandler)
+    }
+}
+
+// MARK: - Optional Binding Helper
+
+private extension Binding where Value == MainTabView.Tab? {
+    /// Converts an optional `Tab?` binding to a non-optional `Tab` binding
+    /// using a default value when the source is `nil`.
+    func withDefault(_ defaultValue: MainTabView.Tab) -> Binding<MainTabView.Tab> {
+        Binding<MainTabView.Tab>(
+            get: { self.wrappedValue ?? defaultValue },
+            set: { self.wrappedValue = $0 }
+        )
     }
 }
 

--- a/apps/ios/Finance/FinanceApp.swift
+++ b/apps/ios/Finance/FinanceApp.swift
@@ -14,6 +14,8 @@ import SwiftUI
 @main
 struct FinanceApp: App {
     @State private var biometricManager = BiometricAuthManager()
+    @State private var deepLinkHandler = DeepLinkHandler()
+    @State private var networkMonitor = NetworkMonitor()
     @State private var isLocked = true
     @Environment(\.scenePhase) private var scenePhase
 
@@ -30,9 +32,12 @@ struct FinanceApp: App {
     var body: some Scene {
         WindowGroup {
             ZStack {
-                ContentView()
-                    .environment(biometricManager)
-                    .accessibilityHidden(biometricLockEnabled && isLocked)
+                ContentView(
+                    deepLinkHandler: deepLinkHandler,
+                    networkMonitor: networkMonitor
+                )
+                .environment(biometricManager)
+                .accessibilityHidden(biometricLockEnabled && isLocked)
 
                 if biometricLockEnabled && isLocked {
                     LockScreenView(
@@ -41,6 +46,12 @@ struct FinanceApp: App {
                     )
                     .transition(.opacity)
                 }
+            }
+            .onOpenURL { url in
+                Self.logger.info(
+                    "Received URL: \(url.absoluteString, privacy: .public)"
+                )
+                deepLinkHandler.handle(url)
             }
             .onChange(of: scenePhase) { _, newPhase in
                 handleScenePhaseChange(newPhase)

--- a/apps/ios/Finance/Navigation/DeepLinkHandler.swift
+++ b/apps/ios/Finance/Navigation/DeepLinkHandler.swift
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// DeepLinkHandler.swift
+// Finance
+//
+// Centralized deep-link router that handles Universal Links and custom-scheme
+// URLs. Parses incoming URLs into strongly-typed ``AppDeepLink`` values and
+// drives programmatic navigation across the tab bar.
+// Refs #470
+
+import Foundation
+import os
+
+// MARK: - AppDeepLink
+
+/// Represents a parsed deep link handled by the Finance app.
+///
+/// Extends the routing table beyond ``DeepLink`` (auth/invite) to include
+/// entity-level navigation such as individual accounts and transactions.
+///
+/// ## Supported Routes
+/// | Path Pattern             | Maps To                                  |
+/// |--------------------------|------------------------------------------|
+/// | `/auth/callback`         | ``AppDeepLink/authCallback(url:)``       |
+/// | `/invite/{code}`         | ``AppDeepLink/invite(code:)``            |
+/// | `/account/{id}`          | ``AppDeepLink/account(id:)``             |
+/// | `/transaction/{id}`      | ``AppDeepLink/transaction(id:)``         |
+enum AppDeepLink: Sendable, Equatable {
+    /// OAuth redirect callback — received after an external identity provider
+    /// (Apple, Google, etc.) completes authorization.
+    case authCallback(url: URL)
+
+    /// Household invitation — the user tapped a link to join a household.
+    case invite(code: String)
+
+    /// Navigate to a specific account detail screen.
+    case account(id: String)
+
+    /// Navigate to a specific transaction detail screen.
+    case transaction(id: String)
+
+    /// An unrecognized link that doesn't match any known route.
+    case unknown(url: URL)
+}
+
+// MARK: - DeepLinkHandler
+
+/// Parses incoming Universal Links and custom-scheme URLs, then drives
+/// programmatic navigation by updating ``selectedTab`` and entity-level
+/// state that views observe.
+///
+/// Wire this into the SwiftUI scene via `.onOpenURL`:
+/// ```swift
+/// .onOpenURL { url in
+///     deepLinkHandler.handle(url)
+/// }
+/// ```
+@Observable
+@MainActor
+final class DeepLinkHandler {
+
+    // MARK: - Constants
+
+    /// The expected host for Finance Universal Links.
+    private static let expectedHosts: Set<String> = [
+        "finance.app",
+        "www.finance.app",
+    ]
+
+    /// Custom URL scheme for the Finance app.
+    private static let customScheme = "finance"
+
+    // MARK: - Path Constants
+
+    private static let authCallbackPath = "/auth/callback"
+    private static let invitePrefix = "/invite/"
+    private static let accountPrefix = "/account/"
+    private static let transactionPrefix = "/transaction/"
+
+    // MARK: - Logger
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
+        category: "DeepLinkHandler"
+    )
+
+    // MARK: - Observable State
+
+    /// The most recently parsed deep link, if any.
+    private(set) var currentDeepLink: AppDeepLink?
+
+    /// The tab that should be selected in response to the deep link.
+    /// Views bind to this to switch tabs programmatically.
+    var selectedTab: MainTabView.Tab?
+
+    /// The account ID to navigate to after switching to the Accounts tab.
+    private(set) var pendingAccountId: String?
+
+    /// The transaction ID to navigate to after switching to the Transactions tab.
+    private(set) var pendingTransactionId: String?
+
+    /// Whether an auth callback is currently being processed.
+    private(set) var isProcessingAuthCallback = false
+
+    /// The pending household invitation code, if any.
+    private(set) var pendingInviteCode: String?
+
+    // MARK: - Public API
+
+    /// Parses and handles an incoming URL, updating navigation state.
+    ///
+    /// - Parameter url: The incoming Universal Link or custom-scheme URL.
+    /// - Returns: The parsed ``AppDeepLink`` for further handling.
+    @discardableResult
+    func handle(_ url: URL) -> AppDeepLink {
+        let deepLink = parse(url)
+        currentDeepLink = deepLink
+
+        Self.logger.info(
+            "Handling deep link: \(url.absoluteString, privacy: .public)"
+        )
+
+        switch deepLink {
+        case .authCallback:
+            isProcessingAuthCallback = true
+            clearEntityState()
+            Self.logger.debug("Routing to auth callback")
+
+        case .invite(let code):
+            isProcessingAuthCallback = false
+            pendingInviteCode = code
+            clearEntityState()
+            Self.logger.debug(
+                "Routing to invite with code: \(code, privacy: .private)"
+            )
+
+        case .account(let id):
+            clearAuthInviteState()
+            pendingAccountId = id
+            pendingTransactionId = nil
+            selectedTab = .accounts
+            Self.logger.debug(
+                "Routing to account: \(id, privacy: .private)"
+            )
+
+        case .transaction(let id):
+            clearAuthInviteState()
+            pendingTransactionId = id
+            pendingAccountId = nil
+            selectedTab = .transactions
+            Self.logger.debug(
+                "Routing to transaction: \(id, privacy: .private)"
+            )
+
+        case .unknown:
+            clearAllState()
+            Self.logger.warning(
+                "Unknown deep link: \(url.absoluteString, privacy: .public)"
+            )
+        }
+
+        return deepLink
+    }
+
+    /// Marks the auth callback as fully processed.
+    func completeAuthCallback() {
+        isProcessingAuthCallback = false
+        if case .authCallback = currentDeepLink {
+            currentDeepLink = nil
+        }
+    }
+
+    /// Marks the household invite as handled (accepted or dismissed).
+    func completeInvite() {
+        pendingInviteCode = nil
+        if case .invite = currentDeepLink {
+            currentDeepLink = nil
+        }
+    }
+
+    /// Clears the pending account navigation after the view has consumed it.
+    func consumeAccountNavigation() {
+        pendingAccountId = nil
+        if case .account = currentDeepLink {
+            currentDeepLink = nil
+        }
+    }
+
+    /// Clears the pending transaction navigation after the view has consumed it.
+    func consumeTransactionNavigation() {
+        pendingTransactionId = nil
+        if case .transaction = currentDeepLink {
+            currentDeepLink = nil
+        }
+    }
+
+    /// Resets all pending state.
+    func reset() {
+        clearAllState()
+        currentDeepLink = nil
+    }
+
+    // MARK: - Parsing
+
+    /// Parses a URL into an ``AppDeepLink``.
+    ///
+    /// Supports both Universal Links (`https://finance.app/...`) and
+    /// custom-scheme URLs (`finance://...`).
+    ///
+    /// - Parameter url: The URL to parse.
+    /// - Returns: The corresponding ``AppDeepLink`` case.
+    func parse(_ url: URL) -> AppDeepLink {
+        let path: String
+        if let components = URLComponents(url: url, resolvingAgainstBaseURL: true) {
+            path = components.path
+        } else {
+            path = url.path
+        }
+
+        // For custom scheme URLs, the host is part of the path
+        let effectivePath: String
+        if url.scheme == Self.customScheme {
+            // finance://account/123 → host="account", path="/123"
+            // Reconstruct as /account/123
+            if let host = url.host {
+                effectivePath = "/\(host)\(path)"
+            } else {
+                effectivePath = path
+            }
+        } else {
+            effectivePath = path
+        }
+
+        // Route: /auth/callback
+        if effectivePath.hasPrefix(Self.authCallbackPath) {
+            return .authCallback(url: url)
+        }
+
+        // Route: /invite/{code}
+        if effectivePath.hasPrefix(Self.invitePrefix) {
+            let code = extractPathSegment(
+                from: effectivePath,
+                after: Self.invitePrefix
+            )
+            if let code {
+                return .invite(code: code)
+            }
+        }
+
+        // Route: /account/{id}
+        if effectivePath.hasPrefix(Self.accountPrefix) {
+            let id = extractPathSegment(
+                from: effectivePath,
+                after: Self.accountPrefix
+            )
+            if let id {
+                return .account(id: id)
+            }
+        }
+
+        // Route: /transaction/{id}
+        if effectivePath.hasPrefix(Self.transactionPrefix) {
+            let id = extractPathSegment(
+                from: effectivePath,
+                after: Self.transactionPrefix
+            )
+            if let id {
+                return .transaction(id: id)
+            }
+        }
+
+        return .unknown(url: url)
+    }
+
+    // MARK: - Private Helpers
+
+    /// Extracts and validates a non-empty path segment after a prefix.
+    private func extractPathSegment(from path: String, after prefix: String) -> String? {
+        let raw = String(path.dropFirst(prefix.count))
+        let trimmed = raw.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func clearEntityState() {
+        pendingAccountId = nil
+        pendingTransactionId = nil
+    }
+
+    private func clearAuthInviteState() {
+        isProcessingAuthCallback = false
+        pendingInviteCode = nil
+    }
+
+    private func clearAllState() {
+        isProcessingAuthCallback = false
+        pendingInviteCode = nil
+        pendingAccountId = nil
+        pendingTransactionId = nil
+    }
+}

--- a/apps/ios/Finance/Navigation/MainTabView.swift
+++ b/apps/ios/Finance/Navigation/MainTabView.swift
@@ -15,9 +15,15 @@ import SwiftUI
 /// - `.tabItem` modifiers for tab configuration
 /// - Each tab wraps its own `NavigationStack`
 struct MainTabView: View {
-    @State private var selectedTab: Tab = .dashboard
+    /// Binding to the currently selected tab, allowing external navigation
+    /// (e.g. deep links) to switch tabs programmatically.
+    @Binding var selectedTab: Tab
 
-    enum Tab: String, CaseIterable {
+    init(selectedTab: Binding<Tab> = .constant(.dashboard)) {
+        _selectedTab = selectedTab
+    }
+
+    enum Tab: String, Sendable, CaseIterable {
         case dashboard, accounts, transactions, budgets, goals
 
         var title: String {

--- a/apps/ios/Finance/Screens/AboutView.swift
+++ b/apps/ios/Finance/Screens/AboutView.swift
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// AboutView.swift
+// Finance
+//
+// Displays app version, build info, and third-party licenses/acknowledgments.
+// Reads THIRD-PARTY-NOTICES from the app bundle for license attributions.
+// Refs #474
+
+import os
+import SwiftUI
+
+// MARK: - View
+
+struct AboutView: View {
+    @State private var viewModel = AboutViewModel()
+
+    var body: some View {
+        List {
+            appInfoSection
+            linksSection
+            acknowledgmentsSection
+            legalSection
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle(String(localized: "About"))
+        .navigationBarTitleDisplayMode(.inline)
+        .task { viewModel.loadAppInfo() }
+    }
+
+    // MARK: - App Info
+
+    private var appInfoSection: some View {
+        Section {
+            VStack(spacing: 12) {
+                Image(systemName: "dollarsign.circle.fill")
+                    .font(.system(size: 64))
+                    .foregroundStyle(FinanceColors.interactive)
+                    .accessibilityHidden(true)
+
+                Text(String(localized: "Finance"))
+                    .font(.title2)
+                    .fontWeight(.bold)
+                    .foregroundStyle(FinanceColors.textPrimary)
+
+                Text(String(localized: "Your personal financial tracker"))
+                    .font(.subheadline)
+                    .foregroundStyle(FinanceColors.textSecondary)
+
+                Text(
+                    String(localized: "Version \(viewModel.appVersion) (\(viewModel.buildNumber))")
+                )
+                .font(.caption)
+                .foregroundStyle(FinanceColors.textDisabled)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 16)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(
+                String(localized: "Finance, version \(viewModel.appVersion), build \(viewModel.buildNumber)")
+            )
+        }
+    }
+
+    // MARK: - Links
+
+    private var linksSection: some View {
+        Section(String(localized: "Information")) {
+            NavigationLink {
+                PrivacyPolicyView()
+            } label: {
+                Label(String(localized: "Privacy Policy"), systemImage: "hand.raised")
+            }
+            .accessibilityLabel(String(localized: "Privacy Policy"))
+            .accessibilityHint(String(localized: "Opens the privacy policy"))
+
+            LabeledContent(String(localized: "Platform")) {
+                Text(viewModel.platformDescription)
+                    .foregroundStyle(.secondary)
+            }
+            .accessibilityLabel(
+                String(localized: "Platform: \(viewModel.platformDescription)")
+            )
+
+            LabeledContent(String(localized: "Minimum iOS")) {
+                Text("17.0")
+                    .foregroundStyle(.secondary)
+            }
+            .accessibilityLabel(String(localized: "Minimum iOS version: 17.0"))
+        }
+    }
+
+    // MARK: - Acknowledgments
+
+    private var acknowledgmentsSection: some View {
+        Section(String(localized: "Acknowledgments")) {
+            NavigationLink {
+                ThirdPartyNoticesView(content: viewModel.thirdPartyNotices)
+            } label: {
+                Label(String(localized: "Third-Party Licenses"), systemImage: "doc.text")
+            }
+            .accessibilityLabel(String(localized: "Third-party licenses"))
+            .accessibilityHint(String(localized: "Opens the open source license attributions"))
+
+            NavigationLink {
+                technologyStackView
+            } label: {
+                Label(String(localized: "Technology Stack"), systemImage: "cpu")
+            }
+            .accessibilityLabel(String(localized: "Technology stack"))
+            .accessibilityHint(String(localized: "Shows the technologies used to build Finance"))
+        }
+    }
+
+    // MARK: - Legal
+
+    private var legalSection: some View {
+        Section {
+            Text(String(localized: "© 2026 Finance Contributors. Licensed under BUSL-1.1."))
+                .font(.footnote)
+                .foregroundStyle(FinanceColors.textDisabled)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .accessibilityLabel(
+                    String(localized: "Copyright 2026 Finance Contributors. Licensed under Business Source License 1.1.")
+                )
+        }
+    }
+
+    // MARK: - Technology Stack
+
+    private var technologyStackView: some View {
+        List {
+            Section(String(localized: "Frontend")) {
+                technologyRow(name: "SwiftUI", detail: String(localized: "Declarative UI framework"))
+                technologyRow(name: "Swift Charts", detail: String(localized: "Financial data visualization"))
+                technologyRow(name: "WidgetKit", detail: String(localized: "Home Screen widgets"))
+            }
+
+            Section(String(localized: "Shared Logic")) {
+                technologyRow(name: "Kotlin Multiplatform", detail: String(localized: "Cross-platform business logic"))
+                technologyRow(name: "SQLDelight", detail: String(localized: "Type-safe local database"))
+            }
+
+            Section(String(localized: "Security")) {
+                technologyRow(name: "Apple Keychain", detail: String(localized: "Secure credential storage"))
+                technologyRow(name: "LocalAuthentication", detail: String(localized: "Face ID / Touch ID"))
+                technologyRow(name: "Secure Enclave", detail: String(localized: "Hardware-backed key generation"))
+            }
+
+            Section(String(localized: "Infrastructure")) {
+                technologyRow(name: "Supabase", detail: String(localized: "Backend and real-time sync"))
+                technologyRow(name: "APNs", detail: String(localized: "Push notifications"))
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle(String(localized: "Technology Stack"))
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func technologyRow(name: String, detail: String) -> some View {
+        LabeledContent(name) {
+            Text(detail)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(name), \(detail)")
+    }
+}
+
+// MARK: - Third-Party Notices View
+
+/// Displays the raw content of the THIRD-PARTY-NOTICES file from the
+/// app bundle in a scrollable text view with Dynamic Type support.
+struct ThirdPartyNoticesView: View {
+    let content: String
+
+    var body: some View {
+        ScrollView {
+            if content.isEmpty {
+                ContentUnavailableView(
+                    String(localized: "No Notices Found"),
+                    systemImage: "doc.text",
+                    description: Text(String(localized: "Third-party notices could not be loaded."))
+                )
+            } else {
+                Text(content)
+                    .font(.caption)
+                    .foregroundStyle(FinanceColors.textSecondary)
+                    .padding()
+                    .textSelection(.enabled)
+                    .accessibilityLabel(String(localized: "Third-party software notices and license attributions"))
+            }
+        }
+        .navigationTitle(String(localized: "Third-Party Licenses"))
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+// MARK: - ViewModel
+
+@Observable
+@MainActor
+final class AboutViewModel {
+    private(set) var appVersion: String = "—"
+    private(set) var buildNumber: String = "—"
+    private(set) var thirdPartyNotices: String = ""
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
+        category: "AboutViewModel"
+    )
+
+    /// The current platform description.
+    var platformDescription: String {
+        #if os(iOS)
+        return "iOS / iPadOS"
+        #elseif os(macOS)
+        return "macOS (Catalyst)"
+        #elseif os(watchOS)
+        return "watchOS"
+        #else
+        return "Apple Platform"
+        #endif
+    }
+
+    /// Loads app version info from the main bundle and reads the
+    /// THIRD-PARTY-NOTICES file for license attributions.
+    func loadAppInfo() {
+        appVersion = Bundle.main.object(
+            forInfoDictionaryKey: "CFBundleShortVersionString"
+        ) as? String ?? "0.1.0"
+
+        buildNumber = Bundle.main.object(
+            forInfoDictionaryKey: "CFBundleVersion"
+        ) as? String ?? "1"
+
+        loadThirdPartyNotices()
+    }
+
+    /// Reads the THIRD-PARTY-NOTICES file from the app bundle.
+    private func loadThirdPartyNotices() {
+        // Try both .md and plain text variants
+        let fileNames = ["THIRD-PARTY-NOTICES.md", "THIRD-PARTY-NOTICES"]
+
+        for fileName in fileNames {
+            let components = fileName.split(separator: ".", maxSplits: 1)
+            let name = String(components[0])
+            let ext = components.count > 1 ? String(components[1]) : nil
+
+            if let url = Bundle.main.url(
+                forResource: name,
+                withExtension: ext
+            ) {
+                do {
+                    thirdPartyNotices = try String(contentsOf: url, encoding: .utf8)
+                    Self.logger.debug(
+                        "Loaded third-party notices from \(fileName, privacy: .public)"
+                    )
+                    return
+                } catch {
+                    Self.logger.warning(
+                        "Failed to read \(fileName, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                    )
+                }
+            }
+        }
+
+        Self.logger.info("No THIRD-PARTY-NOTICES file found in bundle")
+        thirdPartyNotices = ""
+    }
+}
+
+#Preview {
+    NavigationStack {
+        AboutView()
+    }
+}

--- a/apps/ios/Finance/Screens/DashboardView.swift
+++ b/apps/ios/Finance/Screens/DashboardView.swift
@@ -12,6 +12,7 @@ import SwiftUI
 
 struct DashboardView: View {
     @State private var viewModel: DashboardViewModel
+    @Environment(NetworkMonitor.self) private var networkMonitor: NetworkMonitor?
 
     init(viewModel: DashboardViewModel = DashboardViewModel(
         accountRepository: RepositoryProvider.shared.accounts,
@@ -31,6 +32,9 @@ struct DashboardView: View {
                 } else {
                     ScrollView {
                         VStack(spacing: 20) {
+                            if let monitor = networkMonitor, !monitor.isConnected {
+                                OfflineBanner()
+                            }
                             netWorthCard
                             spendingSummaryCard
                             budgetHealthSection

--- a/apps/ios/Finance/Screens/PrivacyPolicyView.swift
+++ b/apps/ios/Finance/Screens/PrivacyPolicyView.swift
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// PrivacyPolicyView.swift
+// Finance
+//
+// Displays the Finance privacy policy using semantic typography and
+// full VoiceOver / Dynamic Type support.
+// Refs #474
+
+import SwiftUI
+
+// MARK: - View
+
+struct PrivacyPolicyView: View {
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                headerSection
+
+                policySection(
+                    title: String(localized: "Data Collection"),
+                    icon: "doc.text.magnifyingglass",
+                    content: String(localized: "Finance collects only the financial data you explicitly enter — accounts, transactions, budgets, and goals. We do not collect browsing history, contacts, or location data. All data entry is initiated by you.")
+                )
+
+                policySection(
+                    title: String(localized: "Data Storage"),
+                    icon: "lock.shield",
+                    content: String(localized: "Your financial data is stored locally on your device using encrypted SQLite databases. Sensitive credentials such as authentication tokens and encryption keys are stored in the Apple Keychain with hardware-backed protection. Data is never written to UserDefaults or unencrypted files.")
+                )
+
+                policySection(
+                    title: String(localized: "Data Sync"),
+                    icon: "arrow.triangle.2.circlepath",
+                    content: String(localized: "When you enable cloud sync, your data is transmitted to our servers using TLS 1.3 encryption in transit and AES-256 encryption at rest. Sync is optional and can be disabled at any time from Settings. Your data remains fully functional offline.")
+                )
+
+                policySection(
+                    title: String(localized: "Biometric Data"),
+                    icon: "faceid",
+                    content: String(localized: "Finance uses Face ID, Touch ID, or Optic ID solely for app unlock and to protect sensitive operations like viewing account numbers or exporting data. Biometric data never leaves your device and is managed entirely by the iOS Secure Enclave. We do not store or transmit biometric information.")
+                )
+
+                policySection(
+                    title: String(localized: "Third-Party Services"),
+                    icon: "building.2",
+                    content: String(localized: "Finance does not include third-party analytics SDKs or advertising frameworks. We do not sell, share, or rent your personal data to third parties. If we integrate third-party services in the future, they will be clearly disclosed here.")
+                )
+
+                policySection(
+                    title: String(localized: "Data Deletion"),
+                    icon: "trash",
+                    content: String(localized: "You can delete all your data at any time from Settings → Data → Delete All Data. This permanently removes all accounts, transactions, budgets, and goals from your device. If cloud sync is enabled, deletion propagates to the server within 30 days.")
+                )
+
+                policySection(
+                    title: String(localized: "Your Rights"),
+                    icon: "person.badge.shield.checkmark",
+                    content: String(localized: "You have the right to access, export, correct, and delete your personal data at any time. You can export all your data in CSV or JSON format from Settings → Data → Export Data. We comply with GDPR, CCPA, and other applicable data protection regulations.")
+                )
+
+                policySection(
+                    title: String(localized: "Contact"),
+                    icon: "envelope",
+                    content: String(localized: "If you have questions about this privacy policy or your data, please contact us at privacy@finance.app.")
+                )
+
+                lastUpdatedFooter
+            }
+            .padding()
+        }
+        .navigationTitle(String(localized: "Privacy Policy"))
+        .navigationBarTitleDisplayMode(.inline)
+        .background(FinanceColors.backgroundPrimary)
+    }
+
+    // MARK: - Header
+
+    private var headerSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(String(localized: "Privacy Policy"))
+                .font(.title2)
+                .fontWeight(.bold)
+                .foregroundStyle(FinanceColors.textPrimary)
+                .accessibilityAddTraits(.isHeader)
+
+            Text(String(localized: "Your privacy is important to us. This policy describes how Finance handles your data."))
+                .font(.body)
+                .foregroundStyle(FinanceColors.textSecondary)
+        }
+    }
+
+    // MARK: - Section Builder
+
+    private func policySection(
+        title: String,
+        icon: String,
+        content: String
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label(title, systemImage: icon)
+                .font(.headline)
+                .foregroundStyle(FinanceColors.textPrimary)
+                .accessibilityAddTraits(.isHeader)
+
+            Text(content)
+                .font(.body)
+                .foregroundStyle(FinanceColors.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    // MARK: - Footer
+
+    private var lastUpdatedFooter: some View {
+        Text(String(localized: "Last updated: March 2026"))
+            .font(.footnote)
+            .foregroundStyle(FinanceColors.textDisabled)
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.top, 16)
+            .accessibilityLabel(String(localized: "Privacy policy last updated March 2026"))
+    }
+}
+
+#Preview {
+    NavigationStack {
+        PrivacyPolicyView()
+    }
+}

--- a/apps/ios/Finance/Screens/SettingsView.swift
+++ b/apps/ios/Finance/Screens/SettingsView.swift
@@ -146,12 +146,7 @@ struct SettingsView: View {
             }
 
             NavigationLink {
-                ScrollView {
-                    Text(String(localized: "Privacy policy content will be loaded here."))
-                        .font(.body).foregroundStyle(.secondary).padding()
-                }
-                .navigationTitle(String(localized: "Privacy Policy"))
-                .navigationBarTitleDisplayMode(.inline)
+                PrivacyPolicyView()
             } label: {
                 Label(String(localized: "Privacy Policy"), systemImage: "hand.raised")
             }
@@ -298,12 +293,15 @@ struct SettingsView: View {
             .accessibilityLabel(String(localized: "App version \(viewModel.appVersion), build \(viewModel.buildNumber)"))
 
             NavigationLink {
-                ScrollView {
-                    Text(String(localized: "Open source licenses and acknowledgments will be listed here."))
-                        .font(.body).foregroundStyle(.secondary).padding()
-                }
-                .navigationTitle(String(localized: "Acknowledgments"))
-                .navigationBarTitleDisplayMode(.inline)
+                AboutView()
+            } label: {
+                Label(String(localized: "About Finance"), systemImage: "info.circle")
+            }
+            .accessibilityLabel(String(localized: "About Finance"))
+            .accessibilityHint(String(localized: "Opens app information, licenses, and acknowledgments"))
+
+            NavigationLink {
+                AboutView()
             } label: {
                 Label(String(localized: "Acknowledgments"), systemImage: "heart")
             }

--- a/apps/ios/Finance/Services/NetworkMonitor.swift
+++ b/apps/ios/Finance/Services/NetworkMonitor.swift
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// NetworkMonitor.swift
+// Finance
+//
+// Monitors network reachability using NWPathMonitor wrapped in an @Observable
+// class. Exposes `isConnected` for UI consumption and connection type details
+// for logging.
+// Refs #471
+
+import Network
+import os
+
+// MARK: - ConnectionType
+
+/// Describes the type of active network connection.
+enum ConnectionType: String, Sendable {
+    case wifi
+    case cellular
+    case wiredEthernet
+    case other
+    case none
+}
+
+// MARK: - NetworkMonitor
+
+/// Observes network reachability using `NWPathMonitor` and exposes
+/// reactive state for SwiftUI views.
+///
+/// Usage:
+/// ```swift
+/// @State private var networkMonitor = NetworkMonitor()
+///
+/// if !networkMonitor.isConnected {
+///     OfflineBanner()
+/// }
+/// ```
+///
+/// The monitor starts observing on initialization and stops when
+/// deallocated. It dispatches path updates to a dedicated serial
+/// queue and publishes state changes on the main actor.
+@Observable
+@MainActor
+final class NetworkMonitor {
+
+    // MARK: - Observable State
+
+    /// Whether the device currently has a viable network path.
+    private(set) var isConnected: Bool = true
+
+    /// The type of the current network connection.
+    private(set) var connectionType: ConnectionType = .other
+
+    /// Whether the current path is considered expensive (e.g. cellular data).
+    private(set) var isExpensive: Bool = false
+
+    /// Whether the current path is constrained (e.g. Low Data Mode).
+    private(set) var isConstrained: Bool = false
+
+    // MARK: - Private
+
+    /// The underlying NW path monitor.
+    private let monitor: NWPathMonitor
+
+    /// Dedicated dispatch queue for receiving path updates.
+    private let monitorQueue = DispatchQueue(
+        label: "com.finance.NetworkMonitor",
+        qos: .utility
+    )
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
+        category: "NetworkMonitor"
+    )
+
+    // MARK: - Init / Deinit
+
+    init() {
+        self.monitor = NWPathMonitor()
+        startMonitoring()
+    }
+
+    deinit {
+        monitor.cancel()
+    }
+
+    // MARK: - Monitoring
+
+    /// Starts the NW path monitor and updates observable state on every
+    /// path change.
+    private func startMonitoring() {
+        monitor.pathUpdateHandler = { [weak self] path in
+            Task { @MainActor [weak self] in
+                self?.handlePathUpdate(path)
+            }
+        }
+        monitor.start(queue: monitorQueue)
+        Self.logger.info("Network monitoring started")
+    }
+
+    /// Processes a path update and publishes new state.
+    private func handlePathUpdate(_ path: NWPath) {
+        let wasConnected = isConnected
+        isConnected = path.status == .satisfied
+        isExpensive = path.isExpensive
+        isConstrained = path.isConstrained
+        connectionType = resolveConnectionType(path)
+
+        if wasConnected != isConnected {
+            Self.logger.info(
+                "Network status changed: connected=\(self.isConnected, privacy: .public), type=\(self.connectionType.rawValue, privacy: .public)"
+            )
+        }
+    }
+
+    /// Determines the primary connection type from the path's available
+    /// interfaces, preferring Wi-Fi over cellular.
+    private func resolveConnectionType(_ path: NWPath) -> ConnectionType {
+        guard path.status == .satisfied else {
+            return .none
+        }
+
+        if path.usesInterfaceType(.wifi) {
+            return .wifi
+        } else if path.usesInterfaceType(.cellular) {
+            return .cellular
+        } else if path.usesInterfaceType(.wiredEthernet) {
+            return .wiredEthernet
+        } else {
+            return .other
+        }
+    }
+}

--- a/apps/ios/Tests/DeepLinkHandlerTests.swift
+++ b/apps/ios/Tests/DeepLinkHandlerTests.swift
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// DeepLinkHandlerTests.swift
+// FinanceTests
+//
+// Tests for DeepLinkHandler URL parsing and navigation state management.
+// Refs #470
+
+import Testing
+@testable import Finance
+
+// MARK: - URL Parsing Tests
+
+@Suite("DeepLinkHandler — URL Parsing")
+struct DeepLinkHandlerParsingTests {
+
+    @Test("Parses /auth/callback as authCallback")
+    @MainActor
+    func parsesAuthCallback() {
+        let handler = DeepLinkHandler()
+        let url = URL(string: "https://finance.app/auth/callback?code=abc123")!
+
+        let result = handler.parse(url)
+
+        #expect(result == .authCallback(url: url))
+    }
+
+    @Test("Parses /auth/callback with query parameters")
+    @MainActor
+    func parsesAuthCallbackWithQueryParams() {
+        let handler = DeepLinkHandler()
+        let url = URL(string: "https://finance.app/auth/callback?code=xyz&state=nonce")!
+
+        let result = handler.parse(url)
+
+        #expect(result == .authCallback(url: url))
+    }
+
+    @Test("Parses /invite/{code} as invite")
+    @MainActor
+    func parsesInviteCode() {
+        let handler = DeepLinkHandler()
+        let url = URL(string: "https://finance.app/invite/ABC123")!
+
+        let result = handler.parse(url)
+
+        #expect(result == .invite(code: "ABC123"))
+    }
+
+    @Test("Rejects /invite/ with empty code")
+    @MainActor
+    func rejectsEmptyInviteCode() {
+        let handler = DeepLinkHandler()
+        let url = URL(string: "https://finance.app/invite/")!
+
+        let result = handler.parse(url)
+
+        #expect(result == .unknown(url: url))
+    }
+
+    @Test("Parses /account/{id} as account")
+    @MainActor
+    func parsesAccountId() {
+        let handler = DeepLinkHandler()
+        let url = URL(string: "https://finance.app/account/acc-uuid-123")!
+
+        let result = handler.parse(url)
+
+        #expect(result == .account(id: "acc-uuid-123"))
+    }
+
+    @Test("Parses /transaction/{id} as transaction")
+    @MainActor
+    func parsesTransactionId() {
+        let handler = DeepLinkHandler()
+        let url = URL(string: "https://finance.app/transaction/txn-uuid-456")!
+
+        let result = handler.parse(url)
+
+        #expect(result == .transaction(id: "txn-uuid-456"))
+    }
+
+    @Test("Parses custom scheme finance://account/{id}")
+    @MainActor
+    func parsesCustomSchemeAccount() {
+        let handler = DeepLinkHandler()
+        let url = URL(string: "finance://account/acc-789")!
+
+        let result = handler.parse(url)
+
+        #expect(result == .account(id: "acc-789"))
+    }
+
+    @Test("Parses custom scheme finance://transaction/{id}")
+    @MainActor
+    func parsesCustomSchemeTransaction() {
+        let handler = DeepLinkHandler()
+        let url = URL(string: "finance://transaction/txn-101")!
+
+        let result = handler.parse(url)
+
+        #expect(result == .transaction(id: "txn-101"))
+    }
+
+    @Test("Returns unknown for unrecognized path")
+    @MainActor
+    func returnsUnknownForBadPath() {
+        let handler = DeepLinkHandler()
+        let url = URL(string: "https://finance.app/settings/profile")!
+
+        let result = handler.parse(url)
+
+        #expect(result == .unknown(url: url))
+    }
+
+    @Test("Strips trailing slashes from path segments")
+    @MainActor
+    func stripsTrailingSlashes() {
+        let handler = DeepLinkHandler()
+        let url = URL(string: "https://finance.app/account/acc-123/")!
+
+        let result = handler.parse(url)
+
+        #expect(result == .account(id: "acc-123"))
+    }
+}
+
+// MARK: - Navigation State Tests
+
+@Suite("DeepLinkHandler — Navigation State")
+struct DeepLinkHandlerNavigationTests {
+
+    @Test("handle() sets selectedTab to accounts for account deep link")
+    @MainActor
+    func setsTabForAccount() {
+        let handler = DeepLinkHandler()
+        let url = URL(string: "https://finance.app/account/acc-1")!
+
+        handler.handle(url)
+
+        #expect(handler.selectedTab == .accounts)
+        #expect(handler.pendingAccountId == "acc-1")
+        #expect(handler.pendingTransactionId == nil)
+    }
+
+    @Test("handle() sets selectedTab to transactions for transaction deep link")
+    @MainActor
+    func setsTabForTransaction() {
+        let handler = DeepLinkHandler()
+        let url = URL(string: "https://finance.app/transaction/txn-1")!
+
+        handler.handle(url)
+
+        #expect(handler.selectedTab == .transactions)
+        #expect(handler.pendingTransactionId == "txn-1")
+        #expect(handler.pendingAccountId == nil)
+    }
+
+    @Test("handle() sets isProcessingAuthCallback for auth callback")
+    @MainActor
+    func setsAuthProcessing() {
+        let handler = DeepLinkHandler()
+        let url = URL(string: "https://finance.app/auth/callback?code=test")!
+
+        handler.handle(url)
+
+        #expect(handler.isProcessingAuthCallback == true)
+        #expect(handler.pendingAccountId == nil)
+    }
+
+    @Test("handle() sets pendingInviteCode for invite")
+    @MainActor
+    func setsPendingInvite() {
+        let handler = DeepLinkHandler()
+        let url = URL(string: "https://finance.app/invite/HOUSEHOLD-CODE")!
+
+        handler.handle(url)
+
+        #expect(handler.pendingInviteCode == "HOUSEHOLD-CODE")
+        #expect(handler.isProcessingAuthCallback == false)
+    }
+
+    @Test("completeAuthCallback() clears auth state")
+    @MainActor
+    func completesAuthCallback() {
+        let handler = DeepLinkHandler()
+        handler.handle(URL(string: "https://finance.app/auth/callback")!)
+
+        handler.completeAuthCallback()
+
+        #expect(handler.isProcessingAuthCallback == false)
+        #expect(handler.currentDeepLink == nil)
+    }
+
+    @Test("completeInvite() clears invite state")
+    @MainActor
+    func completesInvite() {
+        let handler = DeepLinkHandler()
+        handler.handle(URL(string: "https://finance.app/invite/CODE")!)
+
+        handler.completeInvite()
+
+        #expect(handler.pendingInviteCode == nil)
+        #expect(handler.currentDeepLink == nil)
+    }
+
+    @Test("consumeAccountNavigation() clears pending account")
+    @MainActor
+    func consumesAccountNav() {
+        let handler = DeepLinkHandler()
+        handler.handle(URL(string: "https://finance.app/account/acc-1")!)
+
+        handler.consumeAccountNavigation()
+
+        #expect(handler.pendingAccountId == nil)
+        #expect(handler.currentDeepLink == nil)
+    }
+
+    @Test("consumeTransactionNavigation() clears pending transaction")
+    @MainActor
+    func consumesTransactionNav() {
+        let handler = DeepLinkHandler()
+        handler.handle(URL(string: "https://finance.app/transaction/txn-1")!)
+
+        handler.consumeTransactionNavigation()
+
+        #expect(handler.pendingTransactionId == nil)
+        #expect(handler.currentDeepLink == nil)
+    }
+
+    @Test("reset() clears all state")
+    @MainActor
+    func resetsAll() {
+        let handler = DeepLinkHandler()
+        handler.handle(URL(string: "https://finance.app/account/acc-1")!)
+
+        handler.reset()
+
+        #expect(handler.currentDeepLink == nil)
+        #expect(handler.selectedTab == nil)
+        #expect(handler.pendingAccountId == nil)
+        #expect(handler.pendingTransactionId == nil)
+        #expect(handler.isProcessingAuthCallback == false)
+        #expect(handler.pendingInviteCode == nil)
+    }
+
+    @Test("Subsequent deep links clear previous entity state")
+    @MainActor
+    func subsequentLinksClearPrevious() {
+        let handler = DeepLinkHandler()
+
+        // First: navigate to account
+        handler.handle(URL(string: "https://finance.app/account/acc-1")!)
+        #expect(handler.pendingAccountId == "acc-1")
+
+        // Second: navigate to transaction — should clear account state
+        handler.handle(URL(string: "https://finance.app/transaction/txn-1")!)
+        #expect(handler.pendingAccountId == nil)
+        #expect(handler.pendingTransactionId == "txn-1")
+        #expect(handler.selectedTab == .transactions)
+    }
+}


### PR DESCRIPTION
## Summary

Implements three iOS infrastructure features building on the KMP bridge (PR #575):

### Deep Linking (#470)
- **New:** \DeepLinkHandler.swift\ — centralized URL router supporting Universal Links and custom scheme (\inance://\)
- **Routes:** \/auth/callback\, \/invite/{code}\, \/account/{id}\, \/transaction/{id}\
- **Wiring:** \.onOpenURL\ in \FinanceApp.swift\ drives programmatic tab navigation via \selectedTab\ binding
- **Tests:** 20 unit tests covering URL parsing, navigation state, and edge cases (empty codes, trailing slashes, sequential links)

### Network Reachability (#471)
- **New:** \NetworkMonitor.swift\ — \NWPathMonitor\ wrapped in \@Observable\, exposes \isConnected\, \connectionType\, \isExpensive\, \isConstrained\
- **New:** \OfflineBanner.swift\ — non-intrusive warning banner with VoiceOver support and Reduce Motion compliance
- **Wiring:** \DashboardView\ conditionally shows the offline banner when \
etworkMonitor.isConnected == false\

### Privacy/About Screens (#474)
- **New:** \PrivacyPolicyView.swift\ — structured privacy policy with 8 sections (Data Collection, Storage, Sync, Biometric, Third-Party, Deletion, Rights, Contact)
- **New:** \AboutView.swift\ — app version/build info, platform details, technology stack, third-party license viewer
- **New:** \ThirdPartyNoticesView\ — reads \THIRD-PARTY-NOTICES.md\ from app bundle
- **Wiring:** Settings → Privacy Policy and Settings → About now navigate to the new screens

### Architecture Changes
- \ContentView\ now accepts \DeepLinkHandler\ and \NetworkMonitor\ via init and injects them into the environment
- \MainTabView.Tab\ changed from \@State\ to \@Binding\ + made \Sendable\ for deep-link driven navigation
- \FinanceApp\ owns the \DeepLinkHandler\ and \NetworkMonitor\ state

### Compliance
- All text uses \String(localized:)\ — no hardcoded strings
- All interactive elements have \.accessibilityLabel()\ and \.accessibilityHint()\
- Dynamic Type: all fonts use system styles (\.font(.body)\, \.font(.headline)\, etc.)
- Logging uses \os.Logger\ with privacy annotations
- \@Observable\ + \@MainActor\ for all new observable types
- Strict \Sendable\ conformance on \MainTabView.Tab\

Closes #470
Closes #471
Closes #474