### PR TITLE
ci: harden CI pipelines — activate iOS, enable Playwright E2E, remove Windows gating (#605)

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -19,27 +19,15 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Check if iOS project exists
-        id: check
-        run: |
-          if [ -d "apps/ios/Finance" ]; then
-            echo "exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "exists=false" >> $GITHUB_OUTPUT
-            echo "iOS project not yet set up — skipping build"
-          fi
       - name: Select Xcode
-        if: steps.check.outputs.exists == 'true'
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: latest-stable
       - name: Build
-        if: steps.check.outputs.exists == 'true'
         run: |
           cd apps/ios
           swift build 2>&1 || echo "Swift build completed (SPM)"
       - name: Test
-        if: steps.check.outputs.exists == 'true'
         run: |
           cd apps/ios
           swift test 2>&1 || echo "Swift test completed (SPM)"

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -38,6 +38,13 @@ jobs:
       - run: npm test -w apps/web
         continue-on-error: true
 
+      - name: Install Playwright browsers
+        run: npx -w apps/web playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: npm run test:e2e -w apps/web
+        continue-on-error: true
+
       - name: Lighthouse Audit
         uses: treosh/lighthouse-ci-action@3e7e23fb74242897f95c0ba9cabad3d0227b9b18 # v12.6.2
         continue-on-error: true

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -21,19 +21,8 @@ jobs:
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with: { distribution: temurin, java-version: '21' }
       - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
-      - name: Check if Windows app exists
-        id: check
-        shell: bash
-        run: |
-          if [ -f "apps/windows/build.gradle.kts" ]; then
-            echo "exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "exists=false" >> $GITHUB_OUTPUT
-          fi
       - name: Build
-        if: steps.check.outputs.exists == 'true'
         run: ./gradlew :apps:windows:build
       - name: Package MSIX
-        if: steps.check.outputs.exists == 'true'
         run: ./gradlew :apps:windows:packageMsi
         continue-on-error: true


### PR DESCRIPTION
## Summary

Removes unnecessary project-existence gating from CI pipelines and enables Playwright E2E tests in the web pipeline.

## Changes

- **iOS CI**: Remove \pps/ios/Finance\ directory check — project exists and should always build
- **Web CI**: Add Playwright browser install + E2E test step (chromium only, continue-on-error)
- **Windows CI**: Remove \uild.gradle.kts\ existence check — file exists and should always build

## Issues

Closes #605
Refs #591

## Testing

- [x] Workflow YAML is valid
- [x] All gated projects confirmed to exist in repo
- [x] E2E tests exist in \pps/web/e2e/\ (auth.spec.ts, navigation.spec.ts)