### PR TITLE
fix(api): use getCorsHeaders(req) instead of removed corsHeaders export (#599)

### DIFF
--- a/services/api/supabase/functions/health-check/index.ts
+++ b/services/api/supabase/functions/health-check/index.ts
@@ -18,7 +18,7 @@
 
 import { serve } from 'https://deno.land/std@0.208.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.0';
-import { corsHeaders, handleCorsPreflightRequest } from '../_shared/cors.ts';
+import { getCorsHeaders, handleCorsPreflightRequest } from '../_shared/cors.ts';
 import { createLogger } from '../_shared/logger.ts';
 
 /** Individual service status. */
@@ -114,7 +114,7 @@ async function checkAuth(supabaseUrl: string, serviceRoleKey: string): Promise<S
 serve(async (req: Request): Promise<Response> => {
   // Handle CORS preflight
   if (req.method === 'OPTIONS') {
-    return handleCorsPreflightRequest();
+    return handleCorsPreflightRequest(req);
   }
 
   const logger = createLogger('health-check');
@@ -126,7 +126,7 @@ serve(async (req: Request): Promise<Response> => {
     return new Response(JSON.stringify({ error: 'Method not allowed' }), {
       status: 405,
       headers: {
-        ...corsHeaders,
+        ...getCorsHeaders(req),
         'Content-Type': 'application/json',
       },
     });
@@ -150,7 +150,7 @@ serve(async (req: Request): Promise<Response> => {
     return new Response(JSON.stringify(errorResponse), {
       status: 503,
       headers: {
-        ...corsHeaders,
+        ...getCorsHeaders(req),
         'Content-Type': 'application/json',
         'Cache-Control': 'no-cache, no-store, must-revalidate',
       },
@@ -186,7 +186,7 @@ serve(async (req: Request): Promise<Response> => {
   return new Response(JSON.stringify(response), {
     status: httpStatus,
     headers: {
-      ...corsHeaders,
+      ...getCorsHeaders(req),
       'Content-Type': 'application/json',
       // Prevent caching of health status — always fresh
       'Cache-Control': 'no-cache, no-store, must-revalidate',


### PR DESCRIPTION
## Summary

Fixes a runtime error in the health-check Edge Function caused by importing a non-existent \corsHeaders\ constant from the shared CORS module.

## Changes

- Replace \import { corsHeaders }\ with \import { getCorsHeaders }\`n- Replace all \...corsHeaders\ spreads with \...getCorsHeaders(req)\ to pass the request for origin validation
- Fix \handleCorsPreflightRequest()\ call to pass the \eq\ parameter

## Root Cause

The shared \_shared/cors.ts\ module was refactored (P-1 security fix) to validate origins against an allowlist. The old \corsHeaders\ constant was replaced with \getCorsHeaders(request)\ function, but the health-check function was not updated.

## Issues

Closes #599

## Testing

- [x] Import matches actual exports from \_shared/cors.ts\`n- [x] All CORS header usages pass the request object for origin validation
- [x] No other Edge Functions use the old \corsHeaders\ import