### PR TITLE
fix(android): fix bottom navigation routing and wire theme propagation (#601)

### DIFF
--- a/apps/android/src/main/kotlin/com/finance/android/MainActivity.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/MainActivity.kt
@@ -71,7 +71,9 @@ class MainActivity : ComponentActivity() {
                 ThemePreference.SYSTEM -> isSystemInDarkTheme()
             }
 
-            FinanceTheme(darkTheme = darkTheme) {
+            val highContrast by themePreferenceManager.highContrastEnabled.collectAsState()
+
+            FinanceTheme(darkTheme = darkTheme, highContrast = highContrast) {
                 FinanceApp()
             }
         }

--- a/apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceBottomBar.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceBottomBar.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -47,8 +46,8 @@ enum class TopLevelDestination(
     Transactions(
         route = Route.Transactions.route,
         icon = Icons.Filled.SwapHoriz,
-        label = "Transactions",
-        a11yDescription = "Navigate to Transactions",
+        label = "Activity",
+        a11yDescription = "View transaction activity",
     ),
     Budgets(
         route = Route.Budgets.route,
@@ -83,9 +82,7 @@ fun FinanceBottomBar(
 
     NavigationBar(modifier = modifier) {
         TopLevelDestination.entries.forEach { destination ->
-            val selected = currentDestination?.hierarchy?.any {
-                it.route == destination.route
-            } == true
+            val selected = currentDestination?.route == destination.route
 
             NavigationBarItem(
                 selected = selected,

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/SettingsScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/SettingsScreen.kt
@@ -66,6 +66,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.core.content.FileProvider
 import com.finance.core.export.ExportFormat
 import com.finance.android.ui.theme.ThemePreference
+import com.finance.android.ui.theme.ThemePreferenceManager
+import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import java.io.File
 
@@ -166,8 +168,10 @@ fun SettingsScreen(
         AccessibilitySection(
             simplifiedViewEnabled = state.simplifiedViewEnabled,
             highContrastEnabled = state.highContrastEnabled,
+            themePreference = state.themePreference,
             onSimplifiedViewChanged = onSetSimplifiedView,
             onHighContrastChanged = onSetHighContrast,
+            onThemePreferenceChanged = onSetThemePreference,
         )
 
         // ── Data ─────────────────────────────────────────────────────────
@@ -555,8 +559,10 @@ private fun AppLockTimeoutSelector(
 private fun AccessibilitySection(
     simplifiedViewEnabled: Boolean,
     highContrastEnabled: Boolean,
+    themePreference: ThemePreference,
     onSimplifiedViewChanged: (Boolean) -> Unit,
     onHighContrastChanged: (Boolean) -> Unit,
+    onThemePreferenceChanged: (ThemePreference) -> Unit,
 ) {
     SectionHeader("Accessibility")
     Card(
@@ -564,6 +570,56 @@ private fun AccessibilitySection(
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
+            // ── Dark mode selector ───────────────────────────────────────
+            Text(
+                text = "Dark mode",
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text = "Choose light, dark, or follow system setting",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics { contentDescription = "Dark mode preference selector" },
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                ThemePreference.entries.forEach { preference ->
+                    val isSelected = preference == themePreference
+                    if (isSelected) {
+                        Button(
+                            onClick = { /* already selected */ },
+                            modifier = Modifier
+                                .weight(1f)
+                                .semantics {
+                                    contentDescription =
+                                        "${preference.label} theme, selected"
+                                },
+                        ) {
+                            Text(text = preference.label)
+                        }
+                    } else {
+                        OutlinedButton(
+                            onClick = { onThemePreferenceChanged(preference) },
+                            modifier = Modifier
+                                .weight(1f)
+                                .semantics {
+                                    contentDescription =
+                                        "Select ${preference.label} theme"
+                                },
+                        ) {
+                            Text(text = preference.label)
+                        }
+                    }
+                }
+            }
+
+            HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
+
             SettingsToggleRow(
                 label = "Simplified view",
                 description = "Reduce visual complexity for easier reading",
@@ -916,6 +972,8 @@ fun SettingsScreen(
     val context = LocalContext.current
     val viewModel: SettingsViewModel = koinViewModel()
     val state by viewModel.uiState.collectAsState()
+    val themePreferenceManager: ThemePreferenceManager = koinInject()
+    val themePreference by themePreferenceManager.themePreference.collectAsState()
 
     // Collect one-shot events
     LaunchedEffect(Unit) {
@@ -944,14 +1002,14 @@ fun SettingsScreen(
         state = state,
         onNavigateBack = onNavigateBack,
         onSignOut = viewModel::signOut,
-        onSetThemePreference = viewModel::setThemePreference,
+        onSetThemePreference = themePreferenceManager::setThemePreference,
         onSetCurrency = viewModel::setDefaultCurrency,
         onSetNotifications = viewModel::setNotificationsEnabled,
         onSetBillReminders = viewModel::setBillRemindersEnabled,
         onSetBiometric = viewModel::setBiometricEnabled,
         onSetAppLockTimeout = viewModel::setAppLockTimeout,
         onSetSimplifiedView = viewModel::setSimplifiedViewEnabled,
-        onSetHighContrast = viewModel::setHighContrastEnabled,
+        onSetHighContrast = themePreferenceManager::setHighContrastEnabled,
         onExportClick = viewModel::showExportDialog,
         onDeleteClick = viewModel::showDeleteDialog,
         onExportFormat = viewModel::exportData,

--- a/apps/android/src/main/kotlin/com/finance/android/ui/theme/FinanceTheme.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/theme/FinanceTheme.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
+import com.finance.android.ui.accessibility.highContrastColorScheme
 
 /**
  * Finance Material 3 color schemes.
@@ -147,16 +148,19 @@ val FinanceTypography = Typography(
  * composition local accessible via [FinanceTheme.spacing].
  *
  * @param darkTheme Whether to use the dark color scheme.
+ * @param highContrast Whether to use WCAG AAA high-contrast color schemes.
  * @param dynamicColor Whether to use Android 12+ dynamic colors (Material You).
  * @param content The composable content to theme.
  */
 @Composable
 fun FinanceTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
+    highContrast: Boolean = false,
     dynamicColor: Boolean = true,
     content: @Composable () -> Unit,
 ) {
     val colorScheme = when {
+        highContrast -> highContrastColorScheme(darkTheme)
         dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
             val context = LocalContext.current
             if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)

--- a/apps/android/src/main/kotlin/com/finance/android/ui/theme/ThemePreference.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/theme/ThemePreference.kt
@@ -40,12 +40,22 @@ class ThemePreferenceManager(private val prefs: SharedPreferences) {
     internal companion object {
         /** SharedPreferences key for the theme preference. */
         const val KEY_THEME = "theme_preference"
+
+        /** SharedPreferences key for the high-contrast toggle. */
+        const val KEY_HIGH_CONTRAST = "high_contrast_enabled"
     }
 
     private val _themePreference = MutableStateFlow(readPreference())
 
     /** Current theme preference as a reactive [StateFlow]. */
     val themePreference: StateFlow<ThemePreference> = _themePreference.asStateFlow()
+
+    private val _highContrastEnabled = MutableStateFlow(
+        prefs.getBoolean(KEY_HIGH_CONTRAST, false),
+    )
+
+    /** Whether high-contrast mode is active, as a reactive [StateFlow]. */
+    val highContrastEnabled: StateFlow<Boolean> = _highContrastEnabled.asStateFlow()
 
     /**
      * Updates the theme preference.
@@ -57,6 +67,19 @@ class ThemePreferenceManager(private val prefs: SharedPreferences) {
         prefs.edit().putString(KEY_THEME, preference.name).apply()
         _themePreference.value = preference
         Timber.d("Theme preference updated to %s", preference.name)
+    }
+
+    /**
+     * Updates the high-contrast mode setting.
+     *
+     * Persists to [SharedPreferences] and emits the new value on
+     * [highContrastEnabled] so all observers (including [FinanceTheme])
+     * update synchronously.
+     */
+    fun setHighContrastEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_HIGH_CONTRAST, enabled).apply()
+        _highContrastEnabled.value = enabled
+        Timber.d("High contrast mode updated to %s", enabled)
     }
 
     private fun readPreference(): ThemePreference {


### PR DESCRIPTION
## Summary

Fixes bottom navigation routing ambiguity and wires theme propagation so high contrast and dark mode settings take immediate effect.

## Changes

### Bottom Navigation (Closes #516, #517)
- **FinanceBottomBar.kt** — Replace hierarchy-based selection with direct route comparison, fixing Dashboard unreachable from other tabs
- Rename \Transactions\ → \Activity\ (prevents 12-char label truncation in 5-item bar)
- Update a11y description to \View transaction activity\

### Theme Propagation (Closes #518, #519)
- **ThemePreference.kt** — Add \highContrastEnabled\ reactive StateFlow + \setHighContrastEnabled()\ to ThemePreferenceManager
- **FinanceTheme.kt** — Add \highContrast: Boolean\ parameter; use WCAG AAA color schemes when enabled
- **MainActivity.kt** — Observe \highContrastEnabled\ and pass to FinanceTheme
- **SettingsScreen.kt** — Add dark mode selector (System/Light/Dark buttons) to Accessibility section; route high contrast + theme toggles through ThemePreferenceManager for immediate reactivity

## Testing
- [ ] Bottom nav: Dashboard → Activity → Dashboard works both ways
- [ ] All 5 tabs highlight correctly when selected
- [ ] \Activity\ label fits without truncation
- [ ] High contrast: toggle ON → colors change immediately
- [ ] Dark mode: select Light/Dark/System → theme updates instantly
- [ ] Persistence: kill app, relaunch → settings retained
- [ ] TalkBack: reads updated labels and selector state

Closes #601, Closes #516, Closes #517, Closes #518, Closes #519