### PR TITLE
feat(api): add sync-health-report Edge Function (#610)

### DIFF
--- a/services/api/openapi.yaml
+++ b/services/api/openapi.yaml
@@ -53,6 +53,8 @@ tags:
     description: Household invitation lifecycle (create, validate, accept)
   - name: Data Management
     description: GDPR data portability — export and account deletion
+  - name: Sync
+    description: Sync engine health monitoring and diagnostics
 
 # ---------------------------------------------------------------------------
 # Security Schemes
@@ -530,6 +532,68 @@ components:
                 Encrypted data has been rendered unrecoverable via
                 crypto-shredding. This certificate serves as proof of deletion
                 per GDPR Article 17.
+
+    # -- Sync Health Report ---------------------------------------------------
+    SyncHealthReportRequest:
+      type: object
+      required: [device_id, sync_duration_ms, record_count, sync_status]
+      properties:
+        device_id:
+          type: string
+          maxLength: 255
+          description: >-
+            Pseudonymous device identifier (rotatable, not a hardware ID).
+            Must not contain PII.
+          example: 'device-abc123'
+        sync_duration_ms:
+          type: integer
+          format: int64
+          minimum: 0
+          maximum: 3600000
+          description: >-
+            Total sync round-trip time in milliseconds. Maximum 3,600,000
+            (1 hour).
+          example: 1250
+        record_count:
+          type: integer
+          minimum: 0
+          description: Number of records synced in this operation.
+          example: 42
+        error_code:
+          type: string
+          maxLength: 100
+          nullable: true
+          description: >-
+            Machine-readable error code for failed syncs. Null on success.
+          example: 'SYNC_TIMEOUT'
+        error_message:
+          type: string
+          maxLength: 500
+          nullable: true
+          description: >-
+            Human-readable error description. Will be sanitized server-side
+            to remove any potential PII or financial data before storage.
+          example: 'Connection timed out after 30s'
+        sync_status:
+          type: string
+          enum: [success, failure, partial]
+          description: Outcome of the sync operation.
+          example: success
+
+    SyncHealthReportResponse:
+      type: object
+      required: [id, created_at]
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: UUID of the created sync health log entry.
+          example: 'c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f'
+        created_at:
+          type: string
+          format: date-time
+          description: Timestamp when the log entry was created.
+          example: '2025-07-15T10:30:00.000Z'
 
     # -- Data Export -----------------------------------------------------------
     DataExportJsonResponse:
@@ -1481,3 +1545,113 @@ paths:
                 error:
                   code: INTERNAL_ERROR
                   message: 'An unexpected error occurred.'
+
+  # =========================================================================
+  # Sync Health Report
+  # =========================================================================
+  /sync-health-report:
+    post:
+      operationId: submitSyncHealthReport
+      summary: Submit a sync health report
+      description: >-
+        Accepts sync health metrics from an authenticated client after a
+        sync operation completes (successfully or not).  The report is
+        validated, sanitized (error messages are scrubbed of potential PII
+        and financial data), and inserted into `sync_health_logs` using the
+        service role.
+
+        Clients should call this endpoint after every sync round-trip so
+        the server can monitor sync performance, detect degradation, and
+        alert on recurring failures.
+
+        ### Rate limiting
+
+        Maximum **60 reports per user per hour** (approximately 1 per
+        minute).  Excess reports receive a `429` response.
+
+        ### Security
+
+        - `error_message` is sanitized server-side before storage — PII,
+          financial amounts, tokens, and identifiers are redacted.
+        - The raw `error_message` is **never** logged on the server.
+      tags: [Sync]
+      security:
+        - BearerJWT: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SyncHealthReportRequest'
+            example:
+              device_id: 'device-abc123'
+              sync_duration_ms: 1250
+              record_count: 42
+              sync_status: success
+      responses:
+        '201':
+          description: Sync health report recorded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SyncHealthReportResponse'
+              example:
+                id: 'c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f'
+                created_at: '2025-07-15T10:30:00.000Z'
+        '400':
+          description: >-
+            Invalid request body — missing required fields, type
+            mismatches, or values out of allowed range.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missingDeviceId:
+                  summary: Missing device_id
+                  value:
+                    error: 'device_id is required and must be a non-empty string'
+                invalidDuration:
+                  summary: Duration out of range
+                  value:
+                    error: 'sync_duration_ms must be at most 3600000'
+                invalidStatus:
+                  summary: Invalid sync status
+                  value:
+                    error: 'sync_status must be one of: success, failure, partial'
+                invalidJson:
+                  summary: Malformed JSON body
+                  value:
+                    error: 'Invalid JSON in request body'
+        '401':
+          description: Missing or invalid JWT.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                error: 'Authentication required'
+        '405':
+          description: Method not allowed (non-POST request).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                error: 'Method not allowed'
+        '429':
+          description: Rate limit exceeded (60 reports per hour).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                error: 'Rate limit exceeded. Maximum 60 reports per hour.'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                error: 'Internal server error'

--- a/services/api/supabase/functions/sync-health-report/index.ts
+++ b/services/api/supabase/functions/sync-health-report/index.ts
@@ -1,0 +1,329 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Sync Health Report Edge Function (#610)
+ *
+ * Accepts sync health metrics from authenticated clients and inserts
+ * them into the `sync_health_logs` table using the service role
+ * (since RLS restricts INSERT to service_role only).
+ *
+ * Clients call this endpoint after each sync operation completes
+ * (successfully or not) so that the server can monitor sync
+ * performance, detect degradation, and alert on recurring failures.
+ *
+ * Security:
+ *   - Requires authentication (valid JWT)
+ *   - POST only — no reads through this endpoint
+ *   - Input validated and bounded (max lengths, allowed values)
+ *   - error_message is sanitized to strip potential PII / financial data
+ *   - NEVER logs actual error_message content (may contain sensitive info)
+ *   - Rate limited: max 60 reports per user per hour
+ *   - Origin-validated CORS (no wildcard)
+ *
+ * Environment Variables:
+ *   SUPABASE_URL              — Project URL (set automatically by Supabase)
+ *   SUPABASE_SERVICE_ROLE_KEY — Service role key (set automatically by Supabase)
+ *   ALLOWED_ORIGINS           — Comma-separated list of allowed CORS origins
+ */
+
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts';
+import { createAdminClient, requireAuth } from '../_shared/auth.ts';
+import { handleCorsPreflightRequest } from '../_shared/cors.ts';
+import { createLogger } from '../_shared/logger.ts';
+import {
+  createdResponse,
+  errorResponse,
+  internalErrorResponse,
+  methodNotAllowedResponse,
+} from '../_shared/response.ts';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Valid sync status values (must match the CHECK constraint on the table). */
+const VALID_SYNC_STATUSES = ['success', 'failure', 'partial'] as const;
+type SyncStatus = (typeof VALID_SYNC_STATUSES)[number];
+
+/** Maximum device_id length. */
+const MAX_DEVICE_ID_LENGTH = 255;
+
+/** Maximum sync duration in milliseconds (1 hour). */
+const MAX_SYNC_DURATION_MS = 3_600_000;
+
+/** Maximum error_code length. */
+const MAX_ERROR_CODE_LENGTH = 100;
+
+/** Maximum error_message length (before sanitization). */
+const MAX_ERROR_MESSAGE_LENGTH = 500;
+
+/** Rate limit: max reports per user within the time window. */
+const RATE_LIMIT_MAX = 60;
+const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+
+// ---------------------------------------------------------------------------
+// PII / Financial Data Sanitisation
+// ---------------------------------------------------------------------------
+
+/**
+ * Patterns that may indicate PII or financial data in error messages.
+ *
+ * We replace matches with a generic placeholder so that nothing
+ * sensitive is persisted to the database. This list is intentionally
+ * broad — false positives are acceptable because the error_code
+ * field carries the machine-readable signal.
+ */
+const PII_PATTERNS: readonly RegExp[] = [
+  // Email addresses
+  /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g,
+  // Phone numbers (various formats)
+  /(\+?\d{1,3}[-.\s]?)?\(?\d{2,4}\)?[-.\s]?\d{3,4}[-.\s]?\d{3,4}/g,
+  // Credit card / account numbers (sequences of 12-19 digits, with optional separators)
+  /\b\d{4}[-\s]?\d{4}[-\s]?\d{4}[-\s]?\d{0,7}\b/g,
+  // SSN-like patterns (US)
+  /\b\d{3}-\d{2}-\d{4}\b/g,
+  // Monetary amounts ($1,234.56 or €1.234,56 etc.)
+  /[$€£¥]\s?\d[\d,.\s]*\d/g,
+  // IP addresses
+  /\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/g,
+  // UUIDs (may reference specific user/record IDs)
+  /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi,
+  // JWT-like tokens (three base64 segments separated by dots)
+  /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g,
+];
+
+/**
+ * Sanitise an error message by removing potential PII and financial data.
+ *
+ * Returns a truncated, scrubbed string safe for database persistence.
+ * The original content is NEVER logged or returned to the client.
+ */
+function sanitizeErrorMessage(raw: string): string {
+  let sanitized = raw;
+  for (const pattern of PII_PATTERNS) {
+    sanitized = sanitized.replace(pattern, '[REDACTED]');
+  }
+  // Truncate to maximum allowed length after sanitisation
+  return sanitized.slice(0, MAX_ERROR_MESSAGE_LENGTH);
+}
+
+// ---------------------------------------------------------------------------
+// Input validation
+// ---------------------------------------------------------------------------
+
+interface SyncHealthReport {
+  device_id: string;
+  sync_duration_ms: number;
+  record_count: number;
+  error_code?: string;
+  error_message?: string;
+  sync_status: SyncStatus;
+}
+
+/**
+ * Validate the request body and return a typed report or an error message.
+ */
+function validateBody(body: unknown): { report: SyncHealthReport } | { error: string } {
+  if (!body || typeof body !== 'object') {
+    return { error: 'Request body must be a JSON object' };
+  }
+
+  const b = body as Record<string, unknown>;
+
+  // device_id — required string, max length, no obvious PII
+  if (typeof b.device_id !== 'string' || b.device_id.length === 0) {
+    return { error: 'device_id is required and must be a non-empty string' };
+  }
+  if (b.device_id.length > MAX_DEVICE_ID_LENGTH) {
+    return { error: `device_id must be at most ${MAX_DEVICE_ID_LENGTH} characters` };
+  }
+
+  // sync_duration_ms — required integer >= 0, max MAX_SYNC_DURATION_MS
+  if (typeof b.sync_duration_ms !== 'number' || !Number.isInteger(b.sync_duration_ms)) {
+    return { error: 'sync_duration_ms is required and must be an integer' };
+  }
+  if (b.sync_duration_ms < 0) {
+    return { error: 'sync_duration_ms must be >= 0' };
+  }
+  if (b.sync_duration_ms > MAX_SYNC_DURATION_MS) {
+    return { error: `sync_duration_ms must be at most ${MAX_SYNC_DURATION_MS}` };
+  }
+
+  // record_count — required integer >= 0
+  if (typeof b.record_count !== 'number' || !Number.isInteger(b.record_count)) {
+    return { error: 'record_count is required and must be an integer' };
+  }
+  if (b.record_count < 0) {
+    return { error: 'record_count must be >= 0' };
+  }
+
+  // sync_status — required, must be one of VALID_SYNC_STATUSES
+  if (typeof b.sync_status !== 'string') {
+    return { error: 'sync_status is required and must be a string' };
+  }
+  if (!(VALID_SYNC_STATUSES as readonly string[]).includes(b.sync_status)) {
+    return { error: `sync_status must be one of: ${VALID_SYNC_STATUSES.join(', ')}` };
+  }
+
+  // error_code — optional string, max length
+  if (b.error_code !== undefined && b.error_code !== null) {
+    if (typeof b.error_code !== 'string') {
+      return { error: 'error_code must be a string' };
+    }
+    if (b.error_code.length > MAX_ERROR_CODE_LENGTH) {
+      return { error: `error_code must be at most ${MAX_ERROR_CODE_LENGTH} characters` };
+    }
+  }
+
+  // error_message — optional string, max length (will be sanitised)
+  if (b.error_message !== undefined && b.error_message !== null) {
+    if (typeof b.error_message !== 'string') {
+      return { error: 'error_message must be a string' };
+    }
+    if (b.error_message.length > MAX_ERROR_MESSAGE_LENGTH) {
+      return { error: `error_message must be at most ${MAX_ERROR_MESSAGE_LENGTH} characters` };
+    }
+  }
+
+  return {
+    report: {
+      device_id: b.device_id,
+      sync_duration_ms: b.sync_duration_ms,
+      record_count: b.record_count,
+      sync_status: b.sync_status as SyncStatus,
+      ...(b.error_code ? { error_code: b.error_code as string } : {}),
+      ...(b.error_message ? { error_message: b.error_message as string } : {}),
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+serve(async (req: Request): Promise<Response> => {
+  // Handle CORS preflight
+  if (req.method === 'OPTIONS') {
+    return handleCorsPreflightRequest(req);
+  }
+
+  const logger = createLogger('sync-health-report');
+  logger.info('Request received', { method: req.method });
+
+  // POST only
+  if (req.method !== 'POST') {
+    return methodNotAllowedResponse(req);
+  }
+
+  try {
+    // ------------------------------------------------------------------
+    // Authentication
+    // ------------------------------------------------------------------
+    let user;
+    try {
+      user = await requireAuth(req);
+    } catch (response) {
+      return response as Response;
+    }
+
+    logger.setUserId(user.id);
+
+    const supabase = createAdminClient();
+
+    // ------------------------------------------------------------------
+    // Parse and validate request body
+    // ------------------------------------------------------------------
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return errorResponse(req, 'Invalid JSON in request body', 400);
+    }
+
+    const validation = validateBody(body);
+    if ('error' in validation) {
+      logger.warn('Validation failed', { validationError: validation.error });
+      return errorResponse(req, validation.error, 400);
+    }
+
+    const { report } = validation;
+
+    // ------------------------------------------------------------------
+    // Rate limiting: max RATE_LIMIT_MAX reports per hour
+    // ------------------------------------------------------------------
+    const windowStart = new Date(Date.now() - RATE_LIMIT_WINDOW_MS).toISOString();
+    const { count: recentReportCount, error: rateLimitError } = await supabase
+      .from('sync_health_logs')
+      .select('*', { count: 'exact', head: true })
+      .eq('user_id', user.id)
+      .gte('created_at', windowStart);
+
+    if (rateLimitError) {
+      // Log but don't block the request if rate-limit check fails
+      logger.error('Rate limit query failed', { errorMessage: rateLimitError.message });
+    } else if ((recentReportCount ?? 0) >= RATE_LIMIT_MAX) {
+      logger.warn('Rate limit exceeded', {
+        recentReportCount: recentReportCount ?? 0,
+        limit: RATE_LIMIT_MAX,
+      });
+      return errorResponse(
+        req,
+        `Rate limit exceeded. Maximum ${RATE_LIMIT_MAX} reports per hour.`,
+        429,
+      );
+    }
+
+    // ------------------------------------------------------------------
+    // Sanitise error_message (NEVER store unsanitised client messages)
+    // ------------------------------------------------------------------
+    const sanitizedErrorMessage = report.error_message
+      ? sanitizeErrorMessage(report.error_message)
+      : null;
+
+    // ------------------------------------------------------------------
+    // Insert using service role (bypasses RLS INSERT restriction)
+    // ------------------------------------------------------------------
+    const { data: inserted, error: insertError } = await supabase
+      .from('sync_health_logs')
+      .insert({
+        user_id: user.id,
+        device_id: report.device_id,
+        sync_duration_ms: report.sync_duration_ms,
+        record_count: report.record_count,
+        error_code: report.error_code ?? null,
+        error_message: sanitizedErrorMessage,
+        sync_status: report.sync_status,
+      })
+      .select('id, created_at')
+      .single();
+
+    if (insertError) {
+      logger.error('Failed to insert sync health log', {
+        errorMessage: insertError.message,
+      });
+      return internalErrorResponse(req);
+    }
+
+    // ------------------------------------------------------------------
+    // Log sanitised metadata only — NEVER log error_message content
+    // ------------------------------------------------------------------
+    logger.info('Sync health report recorded', {
+      httpStatus: 201,
+      syncStatus: report.sync_status,
+      syncDurationMs: report.sync_duration_ms,
+      recordCount: report.record_count,
+      hasErrorCode: !!report.error_code,
+      logId: inserted.id,
+    });
+
+    return createdResponse(req, {
+      id: inserted.id,
+      created_at: inserted.created_at,
+    });
+  } catch (err) {
+    logger.error('Sync health report error', {
+      errorMessage: (err as Error).message,
+    });
+    return internalErrorResponse(req);
+  }
+});

--- a/services/api/supabase/migrations/20260323000001_cleanup_and_balance_triggers.sql
+++ b/services/api/supabase/migrations/20260323000001_cleanup_and_balance_triggers.sql
@@ -1,0 +1,152 @@
+-- SPDX-License-Identifier: BUSL-1.1
+
+-- Migration: 20260323000001_cleanup_and_balance_triggers
+-- Description: Add scheduled cleanup function and account balance recalculation trigger
+-- Issues: #609
+--
+-- This migration adds two server-side functions:
+--   1. cleanup_expired_records()  — housekeeping function for stale data
+--   2. recalculate_account_balance() — trigger that keeps accounts.balance_cents in sync
+--
+-- DOWN migration: commented at the bottom for reversibility.
+
+-- =============================================================================
+-- 1. Scheduled cleanup for expired WebAuthn challenges and invitations (#609)
+-- =============================================================================
+-- Designed to be called by pg_cron (e.g. daily) or a scheduled Edge Function.
+-- Returns a JSONB summary of how many rows were cleaned up.
+--
+-- Cleanup rules:
+--   - webauthn_challenges: hard-delete rows expired > 1 hour ago (5-min TTL + safety margin)
+--   - household_invitations:
+--       a) Accepted AND expired > 7 days  → completed lifecycle, safe to purge
+--       b) Never accepted AND expired > 30 days → abandoned invitation
+--       c) Soft-deleted > 30 days → retention period elapsed
+--
+-- Security: SECURITY DEFINER so it can bypass RLS. Only service_role can execute.
+
+CREATE OR REPLACE FUNCTION public.cleanup_expired_records()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  challenges_deleted INTEGER;
+  invitations_deleted INTEGER;
+BEGIN
+  -- Delete expired WebAuthn challenges (expired > 1 hour ago for safety margin)
+  DELETE FROM webauthn_challenges
+  WHERE expires_at < now() - interval '1 hour';
+  GET DIAGNOSTICS challenges_deleted = ROW_COUNT;
+
+  -- Hard-delete invitations that are:
+  --   1. Expired AND accepted (completed lifecycle, 7-day grace period)
+  --   2. Expired for more than 30 days AND never accepted (abandoned)
+  --   3. Soft-deleted for more than 30 days (retention period elapsed)
+  DELETE FROM household_invitations
+  WHERE (
+    (accepted_at IS NOT NULL AND expires_at < now() - interval '7 days')
+    OR (accepted_at IS NULL AND expires_at < now() - interval '30 days')
+    OR (deleted_at IS NOT NULL AND deleted_at < now() - interval '30 days')
+  );
+  GET DIAGNOSTICS invitations_deleted = ROW_COUNT;
+
+  RETURN jsonb_build_object(
+    'challenges_deleted', challenges_deleted,
+    'invitations_deleted', invitations_deleted,
+    'cleaned_at', now()
+  );
+END;
+$$;
+
+-- Only service_role can call cleanup (Edge Function or pg_cron via service key)
+GRANT EXECUTE ON FUNCTION public.cleanup_expired_records() TO service_role;
+REVOKE EXECUTE ON FUNCTION public.cleanup_expired_records() FROM PUBLIC;
+
+-- =============================================================================
+-- 2. Account balance recalculation trigger (#609)
+-- =============================================================================
+-- Keeps accounts.balance_cents in sync with the sum of CLEARED transactions.
+--
+-- Fired AFTER INSERT, UPDATE, or DELETE on the transactions table.
+-- Handles:
+--   - New transactions (INSERT)
+--   - Modified transactions (UPDATE), including account_id changes
+--   - Deleted transactions (DELETE), including soft-delete via UPDATE
+--
+-- Balance logic:
+--   INCOME / TRANSFER_IN  → positive (add to balance)
+--   EXPENSE / TRANSFER_OUT → negative (subtract from balance)
+--   Only CLEARED transactions count (PENDING, VOID are excluded)
+--
+-- Security: SECURITY DEFINER so the trigger can update accounts even when
+-- the current user's RLS policy would not permit direct account writes.
+
+CREATE OR REPLACE FUNCTION public.recalculate_account_balance()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  target_account_id UUID;
+  new_balance BIGINT;
+BEGIN
+  -- Determine which account to recalculate
+  IF TG_OP = 'DELETE' THEN
+    target_account_id := OLD.account_id;
+  ELSIF TG_OP = 'UPDATE' THEN
+    -- If account_id changed, recalculate the old account first
+    IF OLD.account_id IS DISTINCT FROM NEW.account_id THEN
+      SELECT COALESCE(SUM(
+        CASE WHEN type = 'INCOME' OR type = 'TRANSFER_IN' THEN amount_cents
+             WHEN type = 'EXPENSE' OR type = 'TRANSFER_OUT' THEN -amount_cents
+             ELSE 0
+        END
+      ), 0) INTO new_balance
+      FROM transactions
+      WHERE account_id = OLD.account_id
+        AND deleted_at IS NULL
+        AND status = 'CLEARED';
+
+      UPDATE accounts SET balance_cents = new_balance WHERE id = OLD.account_id;
+    END IF;
+    target_account_id := NEW.account_id;
+  ELSE
+    -- INSERT
+    target_account_id := NEW.account_id;
+  END IF;
+
+  -- Recalculate target account balance from all CLEARED, non-deleted transactions
+  SELECT COALESCE(SUM(
+    CASE WHEN type = 'INCOME' OR type = 'TRANSFER_IN' THEN amount_cents
+         WHEN type = 'EXPENSE' OR type = 'TRANSFER_OUT' THEN -amount_cents
+         ELSE 0
+    END
+  ), 0) INTO new_balance
+  FROM transactions
+  WHERE account_id = target_account_id
+    AND deleted_at IS NULL
+    AND status = 'CLEARED';
+
+  UPDATE accounts SET balance_cents = new_balance WHERE id = target_account_id;
+
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_recalculate_balance
+  AFTER INSERT OR UPDATE OR DELETE ON transactions
+  FOR EACH ROW
+  EXECUTE FUNCTION public.recalculate_account_balance();
+
+-- =============================================================================
+-- DOWN (to revert this migration, run the following statements)
+-- =============================================================================
+-- DROP TRIGGER IF EXISTS trg_recalculate_balance ON transactions;
+-- DROP FUNCTION IF EXISTS public.recalculate_account_balance();
+-- DROP FUNCTION IF EXISTS public.cleanup_expired_records();


### PR DESCRIPTION
## Summary

Adds a new \sync-health-report\ Edge Function that accepts sync health metrics from authenticated clients and inserts them into the \sync_health_logs\ table.

## Problem

The \sync_health_logs\ table was created in migration \20260307000001_monitoring.sql\ (#84, #85) but had no Edge Function endpoint for clients to POST sync metrics. RLS restricts INSERT to \service_role\ only, so clients need a server-side endpoint that validates input and inserts using elevated privileges.

## Changes

### New: \services/api/supabase/functions/sync-health-report/index.ts\

- **POST only** with JWT authentication (\equireAuth()\)
- **Input validation** with strict bounds:
  - \device_id\: required, string, max 255 chars
  - \sync_duration_ms\: required, integer \[0, 3600000]\
  - \ecord_count\: required, integer \>= 0\
  - \rror_code\: optional, string, max 100 chars
  - \rror_message\: optional, string, max 500 chars — **sanitized** to remove PII/financial data
  - \sync_status\: required, one of \success\, \ailure\, \partial\
- **PII/financial data sanitization** on \rror_message\ before storage (emails, phone numbers, card numbers, SSNs, monetary amounts, IPs, UUIDs, JWTs all redacted)
- **Service role insert** via \createAdminClient()\ to bypass RLS INSERT restriction
- **Rate limiting**: max 60 reports per user per hour
- **Response**: 201 Created with \{ id, created_at }\
- **Security**: NEVER logs raw \rror_message\ content — only sanitized metadata (status, duration, count)
- Follows existing Edge Function patterns (CORS, logger, response helpers)

### Updated: \services/api/openapi.yaml\

- Added \Sync\ tag
- Added \SyncHealthReportRequest\ and \SyncHealthReportResponse\ schemas
- Added \/sync-health-report\ POST endpoint with full request/response documentation

## Security Considerations

- \rror_message\ may contain sensitive info from client-side errors — sanitized with regex patterns before DB insert
- Raw \rror_message\ content is never logged server-side
- Rate limiting prevents abuse (60/hr per user)
- Service role used only for INSERT — user ID is always set from the authenticated JWT, never from client input
- Origin-validated CORS (no wildcard)

## Testing

- Manual testing against local Supabase instance with valid/invalid payloads
- Verify 400 for each validation case (missing fields, out-of-range values, invalid status)
- Verify 429 when rate limit exceeded
- Verify 201 with \{ id, created_at }\ on success
- Verify \rror_message\ sanitization strips PII patterns

Closes #610