### PR TITLE
feat(api): add recurring transaction processing (#612)

### DIFF
--- a/services/api/openapi.yaml
+++ b/services/api/openapi.yaml
@@ -669,6 +669,42 @@ components:
                   Passkey credential metadata.  The `public_key` column
                   is redacted to `[REDACTED]`.
 
+    # -- Process Recurring ----------------------------------------------------
+    ProcessRecurringRequest:
+      type: object
+      properties:
+        as_of_date:
+          type: string
+          format: date
+          description: >-
+            ISO 8601 date (YYYY-MM-DD) to use as the "current date" for
+            determining which templates are due.  Defaults to today if
+            omitted.
+          example: '2026-03-23'
+
+    ProcessRecurringResponse:
+      type: object
+      required: [ok, generated_count, as_of_date, generated_at]
+      properties:
+        ok:
+          type: boolean
+          description: Always `true` on success.
+          example: true
+        generated_count:
+          type: integer
+          description: Number of transactions generated in this run.
+          example: 5
+        as_of_date:
+          type: string
+          format: date
+          description: The effective date used for generation.
+          example: '2026-03-23'
+        generated_at:
+          type: string
+          format: date-time
+          description: Server timestamp when generation completed.
+          example: '2026-03-23T02:00:00.000Z'
+
 # ---------------------------------------------------------------------------
 # Paths
 # ---------------------------------------------------------------------------
@@ -1647,6 +1683,84 @@ paths:
                 $ref: '#/components/schemas/Error'
               example:
                 error: 'Rate limit exceeded. Maximum 60 reports per hour.'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                error: 'Internal server error'
+
+  # =========================================================================
+  # Process Recurring Transactions
+  # =========================================================================
+  /process-recurring:
+    post:
+      operationId: processRecurring
+      summary: Generate transactions from recurring templates
+      description: >-
+        Server-to-server endpoint that generates transaction instances from
+        all active recurring templates whose `next_due_date` is on or before
+        the given `as_of_date` (defaults to today).
+
+
+        Designed to be called by a cron scheduler (pg_cron, external cron,
+        or manual invocation for testing).  Authenticates via `CRON_SECRET`
+        shared secret, **not** user JWT.
+
+
+        The underlying `generate_recurring_transactions` PL/pgSQL function
+        uses `FOR UPDATE SKIP LOCKED` for safe concurrent execution.
+      tags: [Recurring]
+      security:
+        - CronSecret: []
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProcessRecurringRequest'
+            example:
+              as_of_date: '2026-03-23'
+      responses:
+        '200':
+          description: >-
+            Recurring transactions processed successfully.  Returns a
+            summary of how many transactions were generated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProcessRecurringResponse'
+              example:
+                ok: true
+                generated_count: 5
+                as_of_date: '2026-03-23'
+                generated_at: '2026-03-23T02:00:00.000Z'
+        '400':
+          description: Invalid request body or `as_of_date` format.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                error: 'Invalid as_of_date format. Expected ISO 8601 date: YYYY-MM-DD.'
+        '401':
+          description: Missing or invalid `CRON_SECRET` in Authorization header.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                error: 'Unauthorized'
+        '405':
+          description: Method not allowed (non-POST request).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                error: 'Method not allowed'
         '500':
           description: Internal server error.
           content:

--- a/services/api/powersync/sync-rules.yaml
+++ b/services/api/powersync/sync-rules.yaml
@@ -90,6 +90,15 @@ bucket_definitions:
         FROM household_invitations
         WHERE household_id = bucket.household_id AND deleted_at IS NULL
 
+      # Recurring transaction templates
+      - >
+        SELECT id, household_id, account_id, category_id, amount_cents,
+               currency_code, type, payee, note, frequency, day_of_month,
+               day_of_week, start_date, end_date, last_generated_date,
+               next_due_date, is_active,
+               created_at, updated_at, deleted_at
+        FROM recurring_transaction_templates
+        WHERE household_id = bucket.household_id AND deleted_at IS NULL
   # ---------------------------------------------------------------------------
   # user_profile — per-user data that is NOT household-scoped.
   # Contains the user's own profile and their passkey credential metadata

--- a/services/api/supabase/functions/process-recurring/index.ts
+++ b/services/api/supabase/functions/process-recurring/index.ts
@@ -23,7 +23,7 @@
 
 import { serve } from 'https://deno.land/std@0.208.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.0';
-import { getCorsHeaders, handleCorsPreflightRequest } from '../_shared/cors.ts';
+import { handleCorsPreflightRequest } from '../_shared/cors.ts';
 import { createLogger } from '../_shared/logger.ts';
 import {
   errorResponse,

--- a/services/api/supabase/functions/process-recurring/index.ts
+++ b/services/api/supabase/functions/process-recurring/index.ts
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Process Recurring Transactions Edge Function (#612)
+ *
+ * Generates transaction instances from recurring templates that are due.
+ * Designed to be called by a cron scheduler (pg_cron, external cron, or
+ * manual invocation for testing).
+ *
+ * Authentication: CRON_SECRET header (shared secret), NOT user JWT.
+ * This is a server-to-server endpoint — no end-user should call it directly.
+ *
+ * - POST only
+ * - Accepts optional `as_of_date` in body (ISO 8601 date string, defaults to today)
+ * - Calls `generate_recurring_transactions` RPC via service_role client
+ * - Returns a summary: { generated_count, as_of_date, generated_at }
+ *
+ * Environment Variables:
+ *   SUPABASE_URL              — Project URL (set automatically by Supabase)
+ *   SUPABASE_SERVICE_ROLE_KEY — Service role key (set automatically by Supabase)
+ *   CRON_SECRET               — Shared secret for authenticating cron requests
+ */
+
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.0';
+import { getCorsHeaders, handleCorsPreflightRequest } from '../_shared/cors.ts';
+import { createLogger } from '../_shared/logger.ts';
+import {
+  errorResponse,
+  jsonResponse,
+  methodNotAllowedResponse,
+  internalErrorResponse,
+} from '../_shared/response.ts';
+
+/** ISO 8601 date pattern: YYYY-MM-DD */
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+serve(async (req: Request): Promise<Response> => {
+  // Handle CORS preflight
+  if (req.method === 'OPTIONS') {
+    return handleCorsPreflightRequest(req);
+  }
+
+  const logger = createLogger('process-recurring');
+  logger.info('Request received', { method: req.method });
+
+  // Only accept POST
+  if (req.method !== 'POST') {
+    logger.warn('Method not allowed', { method: req.method, httpStatus: 405 });
+    return methodNotAllowedResponse(req);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Authenticate via CRON_SECRET header
+  // ---------------------------------------------------------------------------
+  const cronSecret = Deno.env.get('CRON_SECRET');
+  if (!cronSecret) {
+    logger.error('CRON_SECRET environment variable is not configured');
+    return internalErrorResponse(req);
+  }
+
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader || authHeader !== `Bearer ${cronSecret}`) {
+    logger.warn('Unauthorized request — invalid or missing CRON_SECRET', {
+      httpStatus: 401,
+    });
+    return errorResponse(req, 'Unauthorized', 401);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Parse optional as_of_date from request body
+  // ---------------------------------------------------------------------------
+  let asOfDate: string | undefined;
+
+  try {
+    const contentType = req.headers.get('Content-Type') || '';
+    if (contentType.includes('application/json')) {
+      const body = await req.json();
+      if (body.as_of_date !== undefined) {
+        if (typeof body.as_of_date !== 'string' || !ISO_DATE_PATTERN.test(body.as_of_date)) {
+          logger.warn('Invalid as_of_date format', { httpStatus: 400 });
+          return errorResponse(
+            req,
+            'Invalid as_of_date format. Expected ISO 8601 date: YYYY-MM-DD.',
+            400,
+          );
+        }
+        asOfDate = body.as_of_date;
+      }
+    }
+  } catch {
+    logger.warn('Failed to parse request body', { httpStatus: 400 });
+    return errorResponse(req, 'Invalid JSON in request body.', 400);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Call the database function via service_role client
+  // ---------------------------------------------------------------------------
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    logger.error('Missing required Supabase environment variables');
+    return internalErrorResponse(req);
+  }
+
+  const supabase = createClient(supabaseUrl, serviceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+
+  try {
+    const rpcArgs: Record<string, string> = {};
+    if (asOfDate) {
+      rpcArgs.p_as_of_date = asOfDate;
+    }
+
+    const { data, error } = await supabase.rpc('generate_recurring_transactions', rpcArgs);
+
+    if (error) {
+      logger.error('RPC call failed', {
+        errorCode: error.code,
+        errorMessage: error.message,
+        httpStatus: 500,
+      });
+      return internalErrorResponse(req);
+    }
+
+    // data is the JSONB result from the PL/pgSQL function
+    const result = data as { generated_count: number; as_of_date: string; generated_at: string };
+
+    logger.info('Recurring transactions processed', {
+      generatedCount: result.generated_count,
+      asOfDate: result.as_of_date,
+      httpStatus: 200,
+    });
+
+    return jsonResponse(req, {
+      ok: true,
+      generated_count: result.generated_count,
+      as_of_date: result.as_of_date,
+      generated_at: result.generated_at,
+    });
+  } catch (err) {
+    logger.error('Unexpected error during recurring transaction processing', {
+      errorType: err instanceof Error ? err.constructor.name : 'Unknown',
+      httpStatus: 500,
+    });
+    return internalErrorResponse(req);
+  }
+});

--- a/services/api/supabase/migrations/20260323000002_recurring_transactions.sql
+++ b/services/api/supabase/migrations/20260323000002_recurring_transactions.sql
@@ -1,0 +1,180 @@
+-- SPDX-License-Identifier: BUSL-1.1
+
+-- Migration: 20260323000002_recurring_transactions
+-- Description: Add recurring transaction templates table and generation function
+-- Issues: #612
+--
+-- Creates a dedicated table for recurring transaction configuration and a
+-- PL/pgSQL function that generates transaction instances from due templates.
+--
+-- Security:
+--   - RLS enabled with household-scoped policies using auth.household_ids()
+--   - Generation function is SECURITY DEFINER (bypasses RLS for cross-household batch)
+--   - GRANT EXECUTE only to service_role; REVOKE from PUBLIC
+--   - FOR UPDATE SKIP LOCKED prevents deadlocks during concurrent cron runs
+
+-- =============================================================================
+-- recurring_transaction_templates
+-- =============================================================================
+-- Stores recurrence configuration separately from individual transaction rows.
+-- Each template describes a repeating financial event (rent, salary, subscription)
+-- and tracks the next date a transaction should be generated.
+
+CREATE TABLE recurring_transaction_templates (
+    id                  UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    household_id        UUID        NOT NULL REFERENCES households(id),
+    account_id          UUID        NOT NULL REFERENCES accounts(id),
+    category_id         UUID        REFERENCES categories(id),
+    amount_cents        BIGINT      NOT NULL,
+    currency_code       TEXT        NOT NULL DEFAULT 'USD',
+    type                TEXT        NOT NULL,
+    payee               TEXT,
+    note                TEXT,
+    -- Recurrence configuration
+    frequency           TEXT        NOT NULL CHECK (frequency IN (
+                            'daily', 'weekly', 'biweekly',
+                            'monthly', 'quarterly', 'yearly'
+                        )),
+    day_of_month        INTEGER,                    -- For monthly: 1-31
+    day_of_week         INTEGER,                    -- For weekly: 0=Sun..6=Sat
+    start_date          DATE        NOT NULL,
+    end_date            DATE,                       -- NULL = indefinite
+    last_generated_date DATE,                       -- Last date a transaction was generated
+    next_due_date       DATE        NOT NULL,       -- Next date to generate
+    is_active           BOOLEAN     NOT NULL DEFAULT true,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    deleted_at          TIMESTAMPTZ,
+    sync_version        BIGINT      NOT NULL DEFAULT 0,
+    is_synced           BOOLEAN     NOT NULL DEFAULT false
+);
+
+-- Household lookup for sync and queries
+CREATE INDEX idx_recurring_templates_household
+    ON recurring_transaction_templates (household_id);
+
+-- Efficiently find templates that are due for generation
+CREATE INDEX idx_recurring_templates_next_due
+    ON recurring_transaction_templates (next_due_date)
+    WHERE deleted_at IS NULL AND is_active = true;
+
+-- =============================================================================
+-- RLS — household members only
+-- =============================================================================
+
+ALTER TABLE recurring_transaction_templates ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY recurring_templates_select ON recurring_transaction_templates
+    FOR SELECT
+    USING (household_id = ANY(auth.household_ids()));
+
+CREATE POLICY recurring_templates_insert ON recurring_transaction_templates
+    FOR INSERT
+    WITH CHECK (household_id = ANY(auth.household_ids()));
+
+CREATE POLICY recurring_templates_update ON recurring_transaction_templates
+    FOR UPDATE
+    USING (household_id = ANY(auth.household_ids()))
+    WITH CHECK (household_id = ANY(auth.household_ids()));
+
+CREATE POLICY recurring_templates_delete ON recurring_transaction_templates
+    FOR DELETE
+    USING (household_id = ANY(auth.household_ids()));
+
+-- =============================================================================
+-- updated_at trigger
+-- =============================================================================
+
+CREATE TRIGGER trg_recurring_templates_updated_at
+    BEFORE UPDATE ON recurring_transaction_templates
+    FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+-- =============================================================================
+-- generate_recurring_transactions(p_as_of_date DATE)
+-- =============================================================================
+-- Iterates all active, non-deleted templates whose next_due_date <= p_as_of_date,
+-- inserts a transaction for each, advances next_due_date, and deactivates
+-- templates that have passed their end_date.
+--
+-- Returns a JSONB summary: { generated_count, as_of_date, generated_at }
+--
+-- SECURITY DEFINER: runs as the function owner (superuser/migration role) so it
+-- can read all households in a single batch. The Edge Function calling this
+-- authenticates via CRON_SECRET, not a user JWT.
+--
+-- FOR UPDATE SKIP LOCKED: allows safe concurrent invocation without deadlocks.
+-- If two cron runs overlap, the second skips rows already locked by the first.
+
+CREATE OR REPLACE FUNCTION public.generate_recurring_transactions(
+    p_as_of_date DATE DEFAULT CURRENT_DATE
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    template RECORD;
+    generated_count INTEGER := 0;
+    next_date DATE;
+BEGIN
+    FOR template IN
+        SELECT * FROM recurring_transaction_templates
+        WHERE deleted_at IS NULL
+          AND is_active = true
+          AND next_due_date <= p_as_of_date
+          AND (end_date IS NULL OR next_due_date <= end_date)
+        ORDER BY next_due_date ASC
+        FOR UPDATE SKIP LOCKED
+    LOOP
+        -- Insert the generated transaction instance
+        INSERT INTO transactions (
+            household_id, account_id, category_id,
+            amount_cents, currency_code, type,
+            payee, note, date,
+            is_recurring, status
+        ) VALUES (
+            template.household_id, template.account_id, template.category_id,
+            template.amount_cents, template.currency_code, template.type,
+            template.payee, template.note, template.next_due_date,
+            true, 'CLEARED'
+        );
+
+        -- Calculate the next due date based on the template frequency
+        next_date := CASE template.frequency
+            WHEN 'daily'     THEN template.next_due_date + INTERVAL '1 day'
+            WHEN 'weekly'    THEN template.next_due_date + INTERVAL '1 week'
+            WHEN 'biweekly'  THEN template.next_due_date + INTERVAL '2 weeks'
+            WHEN 'monthly'   THEN template.next_due_date + INTERVAL '1 month'
+            WHEN 'quarterly' THEN template.next_due_date + INTERVAL '3 months'
+            WHEN 'yearly'    THEN template.next_due_date + INTERVAL '1 year'
+        END;
+
+        -- Deactivate template if the next occurrence would be past end_date
+        IF template.end_date IS NOT NULL AND next_date > template.end_date THEN
+            UPDATE recurring_transaction_templates
+            SET is_active = false,
+                last_generated_date = template.next_due_date
+            WHERE id = template.id;
+        ELSE
+            UPDATE recurring_transaction_templates
+            SET last_generated_date = template.next_due_date,
+                next_due_date = next_date
+            WHERE id = template.id;
+        END IF;
+
+        generated_count := generated_count + 1;
+    END LOOP;
+
+    RETURN jsonb_build_object(
+        'generated_count', generated_count,
+        'as_of_date', p_as_of_date,
+        'generated_at', now()
+    );
+END;
+$$;
+
+-- Only the service_role (used by Edge Functions) can execute this function.
+-- End-user JWTs (anon, authenticated) cannot call it directly.
+GRANT EXECUTE ON FUNCTION public.generate_recurring_transactions(DATE) TO service_role;
+REVOKE EXECUTE ON FUNCTION public.generate_recurring_transactions(DATE) FROM PUBLIC;


### PR DESCRIPTION
Closes #612

## Summary

Adds a complete recurring transaction generation system: template table, PL/pgSQL generator function, Edge Function endpoint, sync rules, and OpenAPI docs.

### Changes

| File | Description |
|------|-------------|
| \`migrations/20260323000002_recurring_transactions.sql`\ | New \`recurring_transaction_templates`\ table (RLS) + \`generate_recurring_transactions()`\ function |
| \`functions/process-recurring/index.ts`\ | Edge Function — POST, CRON_SECRET auth, calls DB function |
| \`powersync/sync-rules.yaml`\ | Adds templates to by_household bucket (explicit columns) |
| \`openapi.yaml`\ | Documents endpoint, CronSecret scheme, schemas |

### Security
- RLS with 4 household-scoped policies via \`auth.household_ids()`\
- DB function: SECURITY DEFINER, service_role only
- Edge Function: CRON_SECRET header auth
- FOR UPDATE SKIP LOCKED for safe concurrent execution
- \`amount_cents BIGINT`\ — cents, never float

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>