### PR TITLE
chore(infra): add Dockerfile and mobile version sync script (#623, #624)

### DIFF
--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -1,0 +1,28 @@
+# Dockerfile for Finance API — Supabase Edge Functions runtime (#624)
+#
+# Builds a container image that runs the Edge Functions locally or in CI.
+#
+# Usage:
+#   docker build -t finance-api .
+#   docker run -p 9000:9000 \
+#     -e SUPABASE_URL=http://host.docker.internal:54321 \
+#     -e SUPABASE_SERVICE_ROLE_KEY=your-key \
+#     -e ALLOWED_ORIGINS=http://localhost:3000 \
+#     finance-api
+
+FROM denoland/deno:2.3.1
+
+WORKDIR /app
+
+# Copy function source files
+COPY supabase/functions/ /app/functions/
+
+# Expose the Edge Functions port
+EXPOSE 9000
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD deno eval "const r = await fetch('http://localhost:9000/health-check'); if (!r.ok) Deno.exit(1);" || exit 1
+
+# Run the edge runtime
+CMD ["run", "--allow-net", "--allow-env", "--allow-read", "/app/functions/main/index.ts"]

--- a/tools/sync-mobile-versions.js
+++ b/tools/sync-mobile-versions.js
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+
+// tools/sync-mobile-versions.js
+//
+// Synchronizes mobile app version numbers with the monorepo version.
+// Reads the root package.json version and updates:
+//   - apps/android/build.gradle.kts (versionName + versionCode)
+//   - apps/ios/Finance/Info.plist (CFBundleShortVersionString + CFBundleVersion)
+//
+// Usage:
+//   node tools/sync-mobile-versions.js          # Dry run (prints changes)
+//   node tools/sync-mobile-versions.js --apply  # Apply changes
+//
+// Run after `npx changeset version` to keep mobile versions in sync.
+
+import { readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+const ROOT = join(import.meta.dirname, '..');
+const DRY_RUN = !process.argv.includes('--apply');
+
+/** Parse semver string into components. */
+function parseSemver(version) {
+  const [major, minor, patch] = version.replace(/^v/, '').split('.').map(Number);
+  return { major, minor, patch };
+}
+
+/** Compute Android versionCode: MAJOR*10000 + MINOR*100 + PATCH */
+function toVersionCode({ major, minor, patch }) {
+  return major * 10000 + minor * 100 + patch;
+}
+
+/** Read root package.json version. */
+function getRootVersion() {
+  const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8'));
+  return pkg.version;
+}
+
+/**
+ * Safely read a file, returning null if it doesn't exist.
+ * Avoids TOCTOU race between existsSync() and readFileSync().
+ */
+function safeReadFile(filePath) {
+  try {
+    return readFileSync(filePath, 'utf8');
+  } catch (err) {
+    if (err.code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
+/** Update Android build.gradle.kts versionName and versionCode. */
+function updateAndroid(version) {
+  const gradlePath = join(ROOT, 'apps', 'android', 'build.gradle.kts');
+  const content = safeReadFile(gradlePath);
+  if (content === null) {
+    console.log('  ⚠️  Android build.gradle.kts not found — skipping');
+    return false;
+  }
+
+  const { major, minor, patch } = parseSemver(version);
+  const versionCode = toVersionCode({ major, minor, patch });
+
+  const nameRegex = /versionName\s*=\s*"[^"]+"/;
+  const codeRegex = /versionCode\s*=\s*\d+/;
+
+  if (!nameRegex.test(content) || !codeRegex.test(content)) {
+    console.log('  ⚠️  Could not find versionName/versionCode in build.gradle.kts');
+    return false;
+  }
+
+  const updated = content
+    .replace(nameRegex, `versionName = "${version}"`)
+    .replace(codeRegex, `versionCode = ${versionCode}`);
+
+  if (updated === content) {
+    console.log(`  ✅ Android already at ${version} (code ${versionCode})`);
+    return false;
+  }
+
+  console.log(`  📱 Android: ${version} (versionCode ${versionCode})`);
+  if (!DRY_RUN) writeFileSync(gradlePath, updated);
+  return true;
+}
+
+/** Update iOS Info.plist version strings. */
+function updateIOS(version) {
+  const plistPath = join(ROOT, 'apps', 'ios', 'Finance', 'Info.plist');
+  const content = safeReadFile(plistPath);
+  if (content === null) {
+    console.log('  ⚠️  iOS Info.plist not found — skipping');
+    return false;
+  }
+
+  const shortVersionRegex = /(<key>CFBundleShortVersionString<\/key>\s*<string>)[^<]+(<\/string>)/;
+  const bundleVersionRegex = /(<key>CFBundleVersion<\/key>\s*<string>)[^<]+(<\/string>)/;
+
+  let updated = content;
+  if (shortVersionRegex.test(content)) {
+    updated = updated.replace(shortVersionRegex, `$1${version}$2`);
+  }
+  if (bundleVersionRegex.test(content)) {
+    const { major, minor, patch } = parseSemver(version);
+    const buildNumber = toVersionCode({ major, minor, patch });
+    updated = updated.replace(bundleVersionRegex, `$1${buildNumber}$2`);
+  }
+
+  if (updated === content) {
+    console.log(`  ✅ iOS already at ${version}`);
+    return false;
+  }
+
+  console.log(`  🍎 iOS: ${version}`);
+  if (!DRY_RUN) writeFileSync(plistPath, updated);
+  return true;
+}
+
+// Main
+const version = getRootVersion();
+console.log(`\n📦 Root version: ${version}`);
+console.log(DRY_RUN ? '🔍 Dry run (use --apply to write changes)\n' : '✏️  Applying changes\n');
+
+const androidChanged = updateAndroid(version);
+const iosChanged = updateIOS(version);
+
+if (!androidChanged && !iosChanged) {
+  console.log('\n✅ All mobile versions are in sync.');
+} else if (DRY_RUN) {
+  console.log('\n💡 Run with --apply to write these changes.');
+}


### PR DESCRIPTION
## Summary

Adds a Dockerfile for containerized Edge Functions deployment and a mobile version sync script.

## Changes

### Dockerfile (#624)
- Deno-based container image for Edge Functions runtime
- Health check configured against /health-check endpoint
- Suitable for CI integration testing and self-hosted deployment

### Mobile version sync (#623)
- tools/sync-mobile-versions.js reads root package.json version
- Updates Android versionCode/versionName in build.gradle.kts
- Updates iOS CFBundleShortVersionString/CFBundleVersion in Info.plist
- Supports dry-run mode (default) and --apply flag

Note: Rate limiting (#272) was already merged via PR #643, so that work is removed from this PR.

## Issues

Closes #623
Closes #624

## Testing

- [x] Dockerfile uses official Deno image
- [x] sync-mobile-versions.js handles missing files gracefully
- [x] No merge conflicts with main
