### PR TITLE
feat(android): add create screens for accounts, budgets, and goals (#630)

### DIFF
--- a/apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt
@@ -17,9 +17,12 @@ import com.finance.android.ui.screens.BiometricAvailabilityChecker
 import com.finance.android.ui.screens.DefaultBiometricAvailabilityChecker
 import com.finance.android.ui.screens.SettingsViewModel
 import com.finance.android.ui.theme.ThemePreferenceManager
+import com.finance.android.ui.viewmodel.AccountCreateViewModel
 import com.finance.android.ui.viewmodel.AccountsViewModel
+import com.finance.android.ui.viewmodel.BudgetCreateViewModel
 import com.finance.android.ui.viewmodel.BudgetsViewModel
 import com.finance.android.ui.viewmodel.DashboardViewModel
+import com.finance.android.ui.viewmodel.GoalCreateViewModel
 import com.finance.android.ui.viewmodel.TransactionCreateViewModel
 import com.finance.android.ui.viewmodel.GoalsViewModel
 import com.finance.android.ui.viewmodel.TransactionsViewModel
@@ -84,9 +87,12 @@ val appModule = module {
 
     viewModelOf(::DashboardViewModel)
     viewModelOf(::AccountsViewModel)
+    viewModelOf(::AccountCreateViewModel)
     viewModelOf(::BudgetsViewModel)
+    viewModelOf(::BudgetCreateViewModel)
     viewModelOf(::TransactionsViewModel)
     viewModelOf(::TransactionCreateViewModel)
     viewModelOf(::GoalsViewModel)
+    viewModelOf(::GoalCreateViewModel)
     viewModelOf(::SettingsViewModel)
 }

--- a/apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceNavHost.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceNavHost.kt
@@ -25,9 +25,12 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import androidx.navigation.navDeepLink
+import com.finance.android.ui.screens.AccountCreateScreen
 import com.finance.android.ui.screens.AccountsScreen
+import com.finance.android.ui.screens.BudgetCreateScreen
 import com.finance.android.ui.screens.BudgetsScreen
 import com.finance.android.ui.screens.DashboardScreen
+import com.finance.android.ui.screens.GoalCreateScreen
 import com.finance.android.ui.screens.GoalsScreen
 import com.finance.android.ui.screens.SettingsScreen
 import com.finance.android.ui.screens.TransactionCreateScreen
@@ -58,6 +61,15 @@ sealed class Route(val route: String) {
             if (accountId != null) "transactions/create?accountId=$accountId"
             else "transactions/create"
     }
+
+    /** Account creation screen. */
+    data object AccountCreate : Route("account/create")
+
+    /** Budget creation screen. */
+    data object BudgetCreate : Route("budget/create")
+
+    /** Goal creation screen. */
+    data object GoalCreate : Route("goal/create")
 
     /**
      * OAuth callback deep link destination.
@@ -129,6 +141,11 @@ fun FinanceNavHost(
                 onAccountClick = { id ->
                     navController.navigate(Route.AccountDetail.createRoute(id))
                 },
+                onAddAccount = {
+                    navController.navigate(Route.AccountCreate.route) {
+                        launchSingleTop = true
+                    }
+                },
             )
         }
 
@@ -139,8 +156,9 @@ fun FinanceNavHost(
         composable(Route.Budgets.route) {
             BudgetsScreen(
                 onCreateBudget = {
-                    Timber.d("FAB: Create new budget tapped")
-                    // TODO: navigate to BudgetCreate screen once route is defined
+                    navController.navigate(Route.BudgetCreate.route) {
+                        launchSingleTop = true
+                    }
                 },
             )
         }
@@ -148,8 +166,9 @@ fun FinanceNavHost(
         composable(Route.Goals.route) {
             GoalsScreen(
                 onCreateGoal = {
-                    Timber.d("FAB: Create new goal tapped")
-                    // TODO: navigate to GoalCreate screen once route is defined
+                    navController.navigate(Route.GoalCreate.route) {
+                        launchSingleTop = true
+                    }
                 },
             )
         }
@@ -188,6 +207,27 @@ fun FinanceNavHost(
             ),
         ) {
             TransactionCreateScreen(
+                onSaved = { navController.popBackStack() },
+                onBack = { navController.popBackStack() },
+            )
+        }
+
+        composable(Route.AccountCreate.route) {
+            AccountCreateScreen(
+                onSaved = { navController.popBackStack() },
+                onBack = { navController.popBackStack() },
+            )
+        }
+
+        composable(Route.BudgetCreate.route) {
+            BudgetCreateScreen(
+                onSaved = { navController.popBackStack() },
+                onBack = { navController.popBackStack() },
+            )
+        }
+
+        composable(Route.GoalCreate.route) {
+            GoalCreateScreen(
                 onSaved = { navController.popBackStack() },
                 onBack = { navController.popBackStack() },
             )

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/AccountCreateScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/AccountCreateScreen.kt
@@ -1,0 +1,471 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.AttachMoney
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.finance.android.ui.theme.FinanceTheme
+import com.finance.android.ui.viewmodel.AccountCreateUiState
+import com.finance.android.ui.viewmodel.AccountCreateViewModel
+import com.finance.models.AccountType
+import org.koin.compose.viewmodel.koinViewModel
+
+/**
+ * Account creation screen — single-page form for adding a new account.
+ *
+ * Fields: name, type, currency, initial balance, optional note.
+ * Uses Material 3 components with full TalkBack accessibility.
+ * Navigates back on successful save via [onSaved].
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AccountCreateScreen(
+    onSaved: () -> Unit = {},
+    onBack: () -> Unit = {},
+    viewModel: AccountCreateViewModel = koinViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    if (state.isSaved) { onSaved(); return }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = "New Account",
+                        modifier = Modifier.semantics {
+                            contentDescription = "New Account screen"
+                        },
+                    )
+                },
+                navigationIcon = {
+                    IconButton(
+                        onClick = onBack,
+                        modifier = Modifier.semantics {
+                            contentDescription = "Navigate back"
+                        },
+                    ) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        AccountCreateForm(
+            state = state,
+            supportedCurrencies = viewModel.supportedCurrencies,
+            onNameChange = viewModel::updateName,
+            onTypeChange = viewModel::updateAccountType,
+            onCurrencyChange = viewModel::updateCurrency,
+            onBalanceChange = viewModel::updateInitialBalance,
+            onNoteChange = viewModel::updateNote,
+            onSave = viewModel::save,
+            modifier = Modifier.padding(innerPadding),
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AccountCreateForm(
+    state: AccountCreateUiState,
+    supportedCurrencies: List<String>,
+    onNameChange: (String) -> Unit,
+    onTypeChange: (AccountType) -> Unit,
+    onCurrencyChange: (String) -> Unit,
+    onBalanceChange: (String) -> Unit,
+    onNoteChange: (String) -> Unit,
+    onSave: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        // ── Error messages ──────────────────────────────────────────
+        if (state.errors.isNotEmpty()) {
+            item(key = "errors") {
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .semantics {
+                            contentDescription = "Errors: ${state.errors.joinToString(", ")}"
+                        },
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.errorContainer,
+                    ),
+                ) {
+                    Column(Modifier.padding(12.dp)) {
+                        state.errors.forEach { error ->
+                            Text(
+                                text = "• $error",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onErrorContainer,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        // ── Account name ────────────────────────────────────────────
+        item(key = "name") {
+            Text(
+                text = "Account Name",
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier.semantics { heading() },
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = state.name,
+                onValueChange = onNameChange,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics { contentDescription = "Account name input" },
+                label = { Text("Name") },
+                placeholder = { Text("e.g. Main Checking") },
+                singleLine = true,
+                isError = state.errors.any { it.contains("name", ignoreCase = true) },
+            )
+        }
+
+        // ── Account type ────────────────────────────────────────────
+        item(key = "type") {
+            Text(
+                text = "Account Type",
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier.semantics { heading() },
+            )
+            Spacer(Modifier.height(8.dp))
+            AccountTypeDropdown(
+                selectedType = state.accountType,
+                onTypeSelected = onTypeChange,
+            )
+        }
+
+        // ── Currency ────────────────────────────────────────────────
+        item(key = "currency") {
+            Text(
+                text = "Currency",
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier.semantics { heading() },
+            )
+            Spacer(Modifier.height(8.dp))
+            CurrencyDropdown(
+                selectedCurrency = state.currency,
+                currencies = supportedCurrencies,
+                onCurrencySelected = onCurrencyChange,
+            )
+        }
+
+        // ── Initial balance ─────────────────────────────────────────
+        item(key = "balance") {
+            Text(
+                text = "Initial Balance",
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier.semantics { heading() },
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = state.initialBalance,
+                onValueChange = onBalanceChange,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics { contentDescription = "Initial balance in dollars" },
+                label = { Text("Balance") },
+                placeholder = { Text("0.00") },
+                leadingIcon = { Icon(Icons.Filled.AttachMoney, contentDescription = null) },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                singleLine = true,
+            )
+        }
+
+        // ── Note (optional) ─────────────────────────────────────────
+        item(key = "note") {
+            Text(
+                text = "Note (optional)",
+                style = MaterialTheme.typography.labelLarge,
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = state.note,
+                onValueChange = onNoteChange,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics { contentDescription = "Optional note" },
+                label = { Text("Note") },
+                placeholder = { Text("Add a note...") },
+                maxLines = 3,
+            )
+        }
+
+        // ── Save button ─────────────────────────────────────────────
+        item(key = "save") {
+            Spacer(Modifier.height(8.dp))
+            Button(
+                onClick = onSave,
+                enabled = !state.isSaving,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics {
+                        contentDescription =
+                            if (state.isSaving) "Saving account" else "Save account"
+                    },
+            ) {
+                if (state.isSaving) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(18.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text("Saving...")
+                } else {
+                    Icon(Icons.Filled.Check, contentDescription = null, Modifier.size(18.dp))
+                    Spacer(Modifier.width(8.dp))
+                    Text("Save Account")
+                }
+            }
+        }
+
+        // ── Bottom spacer for FAB clearance ─────────────────────────
+        item(key = "spacer") { Spacer(Modifier.height(32.dp)) }
+    }
+}
+
+/**
+ * Dropdown selector for [AccountType] values.
+ *
+ * Displays each type as a human-readable name (e.g. "Credit Card").
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AccountTypeDropdown(
+    selectedType: AccountType,
+    onTypeSelected: (AccountType) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val displayName = accountTypeDisplayName(selectedType)
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        modifier = modifier,
+    ) {
+        OutlinedTextField(
+            value = displayName,
+            onValueChange = {},
+            readOnly = true,
+            modifier = Modifier
+                .fillMaxWidth()
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                .semantics { contentDescription = "Account type: $displayName" },
+            label = { Text("Type") },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            AccountType.entries.forEach { type ->
+                val name = accountTypeDisplayName(type)
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = name,
+                            modifier = Modifier.semantics {
+                                contentDescription = "Account type: $name"
+                            },
+                        )
+                    },
+                    onClick = {
+                        onTypeSelected(type)
+                        expanded = false
+                    },
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Dropdown selector for currency codes.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CurrencyDropdown(
+    selectedCurrency: String,
+    currencies: List<String>,
+    onCurrencySelected: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        modifier = modifier,
+    ) {
+        OutlinedTextField(
+            value = selectedCurrency,
+            onValueChange = {},
+            readOnly = true,
+            modifier = Modifier
+                .fillMaxWidth()
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                .semantics { contentDescription = "Currency: $selectedCurrency" },
+            label = { Text("Currency") },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            currencies.forEach { currency ->
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = currency,
+                            modifier = Modifier.semantics {
+                                contentDescription = "Currency: $currency"
+                            },
+                        )
+                    },
+                    onClick = {
+                        onCurrencySelected(currency)
+                        expanded = false
+                    },
+                )
+            }
+        }
+    }
+}
+
+/** Maps [AccountType] enum values to user-friendly display names. */
+private fun accountTypeDisplayName(type: AccountType): String = when (type) {
+    AccountType.CHECKING -> "Checking"
+    AccountType.SAVINGS -> "Savings"
+    AccountType.CREDIT_CARD -> "Credit Card"
+    AccountType.CASH -> "Cash"
+    AccountType.INVESTMENT -> "Investment"
+    AccountType.LOAN -> "Loan"
+    AccountType.OTHER -> "Other"
+}
+
+// ── Previews ────────────────────────────────────────────────────────
+
+@Preview(showBackground = true, showSystemUi = true, name = "Account Create - Light")
+@Preview(
+    showBackground = true,
+    showSystemUi = true,
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+    name = "Account Create - Dark",
+)
+@Composable
+private fun AccountCreateFormPreview() {
+    FinanceTheme(dynamicColor = false) {
+        AccountCreateForm(
+            state = AccountCreateUiState(
+                name = "Main Checking",
+                accountType = AccountType.CHECKING,
+                currency = "USD",
+                initialBalance = "1500.00",
+            ),
+            supportedCurrencies = listOf("USD", "EUR", "GBP", "JPY", "CAD"),
+            onNameChange = {},
+            onTypeChange = {},
+            onCurrencyChange = {},
+            onBalanceChange = {},
+            onNoteChange = {},
+            onSave = {},
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Account Create - Errors")
+@Composable
+private fun AccountCreateErrorsPreview() {
+    FinanceTheme(dynamicColor = false) {
+        AccountCreateForm(
+            state = AccountCreateUiState(
+                errors = listOf("Account name is required"),
+            ),
+            supportedCurrencies = listOf("USD", "EUR", "GBP", "JPY", "CAD"),
+            onNameChange = {},
+            onTypeChange = {},
+            onCurrencyChange = {},
+            onBalanceChange = {},
+            onNoteChange = {},
+            onSave = {},
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Account Create - Saving")
+@Composable
+private fun AccountCreateSavingPreview() {
+    FinanceTheme(dynamicColor = false) {
+        AccountCreateForm(
+            state = AccountCreateUiState(
+                name = "Savings Account",
+                accountType = AccountType.SAVINGS,
+                currency = "USD",
+                initialBalance = "5000.00",
+                isSaving = true,
+            ),
+            supportedCurrencies = listOf("USD", "EUR", "GBP", "JPY", "CAD"),
+            onNameChange = {},
+            onTypeChange = {},
+            onCurrencyChange = {},
+            onBalanceChange = {},
+            onNoteChange = {},
+            onSave = {},
+        )
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/BudgetCreateScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/BudgetCreateScreen.kt
@@ -1,0 +1,411 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.AttachMoney
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.finance.android.ui.theme.FinanceTheme
+import com.finance.android.ui.viewmodel.BudgetCreateUiState
+import com.finance.android.ui.viewmodel.BudgetCreateViewModel
+import com.finance.models.BudgetPeriod
+import com.finance.models.Category
+import com.finance.models.types.SyncId
+import kotlinx.datetime.Clock
+import org.koin.compose.viewmodel.koinViewModel
+
+/**
+ * Budget creation screen — single-page form for adding a new budget.
+ *
+ * Fields: category selector, budgeted amount, period.
+ * Uses Material 3 components with full TalkBack accessibility.
+ * Navigates back on successful save via [onSaved].
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BudgetCreateScreen(
+    onSaved: () -> Unit = {},
+    onBack: () -> Unit = {},
+    viewModel: BudgetCreateViewModel = koinViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    if (state.isSaved) { onSaved(); return }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = "New Budget",
+                        modifier = Modifier.semantics {
+                            contentDescription = "New Budget screen"
+                        },
+                    )
+                },
+                navigationIcon = {
+                    IconButton(
+                        onClick = onBack,
+                        modifier = Modifier.semantics {
+                            contentDescription = "Navigate back"
+                        },
+                    ) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        BudgetCreateForm(
+            state = state,
+            onCategorySelect = viewModel::selectCategory,
+            onAmountChange = viewModel::updateAmount,
+            onPeriodChange = viewModel::updatePeriod,
+            onSave = viewModel::save,
+            modifier = Modifier.padding(innerPadding),
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+private fun BudgetCreateForm(
+    state: BudgetCreateUiState,
+    onCategorySelect: (SyncId) -> Unit,
+    onAmountChange: (String) -> Unit,
+    onPeriodChange: (BudgetPeriod) -> Unit,
+    onSave: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        // ── Error messages ──────────────────────────────────────────
+        if (state.errors.isNotEmpty()) {
+            item(key = "errors") {
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .semantics {
+                            contentDescription = "Errors: ${state.errors.joinToString(", ")}"
+                        },
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.errorContainer,
+                    ),
+                ) {
+                    Column(Modifier.padding(12.dp)) {
+                        state.errors.forEach { error ->
+                            Text(
+                                text = "• $error",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onErrorContainer,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        // ── Category selector ───────────────────────────────────────
+        item(key = "category") {
+            Text(
+                text = "Category",
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier.semantics {
+                    heading()
+                    contentDescription = "Select a category"
+                },
+            )
+            Spacer(Modifier.height(8.dp))
+            if (state.categories.isEmpty()) {
+                Text(
+                    text = "No categories available",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.semantics {
+                        contentDescription = "No categories available"
+                    },
+                )
+            } else {
+                FlowRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    state.categories.forEach { cat ->
+                        val selected = cat.id == state.selectedCategory?.id
+                        FilterChip(
+                            selected = selected,
+                            onClick = { onCategorySelect(cat.id) },
+                            label = {
+                                Text(
+                                    text = cat.name,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            },
+                            modifier = Modifier.semantics {
+                                contentDescription = if (selected) {
+                                    "Category: ${cat.name}, selected"
+                                } else {
+                                    "Category: ${cat.name}"
+                                }
+                            },
+                        )
+                    }
+                }
+            }
+        }
+
+        // ── Budgeted amount ─────────────────────────────────────────
+        item(key = "amount") {
+            Text(
+                text = "Budgeted Amount",
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier.semantics { heading() },
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = state.amount,
+                onValueChange = onAmountChange,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics { contentDescription = "Budgeted amount in dollars" },
+                label = { Text("Amount") },
+                placeholder = { Text("0.00") },
+                leadingIcon = { Icon(Icons.Filled.AttachMoney, contentDescription = null) },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                singleLine = true,
+                isError = state.errors.any { it.contains("amount", ignoreCase = true) },
+            )
+        }
+
+        // ── Period selector ─────────────────────────────────────────
+        item(key = "period") {
+            Text(
+                text = "Period",
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier.semantics { heading() },
+            )
+            Spacer(Modifier.height(8.dp))
+            BudgetPeriodDropdown(
+                selectedPeriod = state.period,
+                onPeriodSelected = onPeriodChange,
+            )
+        }
+
+        // ── Save button ─────────────────────────────────────────────
+        item(key = "save") {
+            Spacer(Modifier.height(8.dp))
+            Button(
+                onClick = onSave,
+                enabled = !state.isSaving,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics {
+                        contentDescription =
+                            if (state.isSaving) "Saving budget" else "Save budget"
+                    },
+            ) {
+                if (state.isSaving) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(18.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text("Saving...")
+                } else {
+                    Icon(Icons.Filled.Check, contentDescription = null, Modifier.size(18.dp))
+                    Spacer(Modifier.width(8.dp))
+                    Text("Save Budget")
+                }
+            }
+        }
+
+        // ── Bottom spacer ───────────────────────────────────────────
+        item(key = "spacer") { Spacer(Modifier.height(32.dp)) }
+    }
+}
+
+/**
+ * Dropdown selector for [BudgetPeriod] values.
+ *
+ * Displays each period as a human-readable name (e.g. "Monthly").
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun BudgetPeriodDropdown(
+    selectedPeriod: BudgetPeriod,
+    onPeriodSelected: (BudgetPeriod) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val displayName = budgetPeriodDisplayName(selectedPeriod)
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        modifier = modifier,
+    ) {
+        OutlinedTextField(
+            value = displayName,
+            onValueChange = {},
+            readOnly = true,
+            modifier = Modifier
+                .fillMaxWidth()
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                .semantics { contentDescription = "Period: $displayName" },
+            label = { Text("Period") },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            BudgetPeriod.entries.forEach { period ->
+                val name = budgetPeriodDisplayName(period)
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = name,
+                            modifier = Modifier.semantics {
+                                contentDescription = "Period: $name"
+                            },
+                        )
+                    },
+                    onClick = {
+                        onPeriodSelected(period)
+                        expanded = false
+                    },
+                )
+            }
+        }
+    }
+}
+
+/** Maps [BudgetPeriod] enum values to user-friendly display names. */
+private fun budgetPeriodDisplayName(period: BudgetPeriod): String = when (period) {
+    BudgetPeriod.WEEKLY -> "Weekly"
+    BudgetPeriod.BIWEEKLY -> "Biweekly"
+    BudgetPeriod.MONTHLY -> "Monthly"
+    BudgetPeriod.QUARTERLY -> "Quarterly"
+    BudgetPeriod.YEARLY -> "Yearly"
+}
+
+// ── Previews ────────────────────────────────────────────────────────
+
+@Preview(showBackground = true, showSystemUi = true, name = "Budget Create - Light")
+@Preview(
+    showBackground = true,
+    showSystemUi = true,
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+    name = "Budget Create - Dark",
+)
+@Composable
+private fun BudgetCreateFormPreview() {
+    val now = Clock.System.now()
+    FinanceTheme(dynamicColor = false) {
+        BudgetCreateForm(
+            state = BudgetCreateUiState(
+                categories = listOf(
+                    Category(SyncId("cat-1"), SyncId("h-1"), "Groceries", createdAt = now, updatedAt = now),
+                    Category(SyncId("cat-2"), SyncId("h-1"), "Dining Out", createdAt = now, updatedAt = now),
+                    Category(SyncId("cat-3"), SyncId("h-1"), "Transportation", createdAt = now, updatedAt = now),
+                    Category(SyncId("cat-4"), SyncId("h-1"), "Entertainment", createdAt = now, updatedAt = now),
+                ),
+                selectedCategory = Category(SyncId("cat-1"), SyncId("h-1"), "Groceries", createdAt = now, updatedAt = now),
+                amount = "600.00",
+                period = BudgetPeriod.MONTHLY,
+            ),
+            onCategorySelect = {},
+            onAmountChange = {},
+            onPeriodChange = {},
+            onSave = {},
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Budget Create - Errors")
+@Composable
+private fun BudgetCreateErrorsPreview() {
+    FinanceTheme(dynamicColor = false) {
+        BudgetCreateForm(
+            state = BudgetCreateUiState(
+                errors = listOf("Please select a category", "Budgeted amount must be greater than zero"),
+            ),
+            onCategorySelect = {},
+            onAmountChange = {},
+            onPeriodChange = {},
+            onSave = {},
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Budget Create - Saving")
+@Composable
+private fun BudgetCreateSavingPreview() {
+    val now = Clock.System.now()
+    FinanceTheme(dynamicColor = false) {
+        BudgetCreateForm(
+            state = BudgetCreateUiState(
+                selectedCategory = Category(SyncId("cat-1"), SyncId("h-1"), "Groceries", createdAt = now, updatedAt = now),
+                amount = "300.00",
+                period = BudgetPeriod.WEEKLY,
+                isSaving = true,
+            ),
+            onCategorySelect = {},
+            onAmountChange = {},
+            onPeriodChange = {},
+            onSave = {},
+        )
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/GoalCreateScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/GoalCreateScreen.kt
@@ -1,0 +1,557 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.AttachMoney
+import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.finance.android.ui.theme.FinanceTheme
+import com.finance.android.ui.viewmodel.GoalCreateUiState
+import com.finance.android.ui.viewmodel.GoalCreateViewModel
+import com.finance.models.Account
+import com.finance.models.AccountType
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.toLocalDateTime
+import org.koin.compose.viewmodel.koinViewModel
+
+/**
+ * Goal creation screen — single-page form for adding a new savings goal.
+ *
+ * Fields: name, target amount, target date, linked account, optional note.
+ * Uses Material 3 components with full TalkBack accessibility.
+ * Navigates back on successful save via [onSaved].
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun GoalCreateScreen(
+    onSaved: () -> Unit = {},
+    onBack: () -> Unit = {},
+    viewModel: GoalCreateViewModel = koinViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    if (state.isSaved) { onSaved(); return }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = "New Goal",
+                        modifier = Modifier.semantics {
+                            contentDescription = "New Goal screen"
+                        },
+                    )
+                },
+                navigationIcon = {
+                    IconButton(
+                        onClick = onBack,
+                        modifier = Modifier.semantics {
+                            contentDescription = "Navigate back"
+                        },
+                    ) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        GoalCreateForm(
+            state = state,
+            onNameChange = viewModel::updateName,
+            onTargetAmountChange = viewModel::updateTargetAmount,
+            onTargetDateChange = viewModel::updateTargetDate,
+            onAccountSelect = viewModel::selectAccount,
+            onNoteChange = viewModel::updateNote,
+            onSave = viewModel::save,
+            modifier = Modifier.padding(innerPadding),
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun GoalCreateForm(
+    state: GoalCreateUiState,
+    onNameChange: (String) -> Unit,
+    onTargetAmountChange: (String) -> Unit,
+    onTargetDateChange: (LocalDate) -> Unit,
+    onAccountSelect: (SyncId?) -> Unit,
+    onNoteChange: (String) -> Unit,
+    onSave: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var showDatePicker by remember { mutableStateOf(false) }
+
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        // ── Error messages ──────────────────────────────────────────
+        if (state.errors.isNotEmpty()) {
+            item(key = "errors") {
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .semantics {
+                            contentDescription = "Errors: ${state.errors.joinToString(", ")}"
+                        },
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.errorContainer,
+                    ),
+                ) {
+                    Column(Modifier.padding(12.dp)) {
+                        state.errors.forEach { error ->
+                            Text(
+                                text = "• $error",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onErrorContainer,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        // ── Goal name ───────────────────────────────────────────────
+        item(key = "name") {
+            Text(
+                text = "Goal Name",
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier.semantics { heading() },
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = state.name,
+                onValueChange = onNameChange,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics { contentDescription = "Goal name input" },
+                label = { Text("Name") },
+                placeholder = { Text("e.g. Emergency Fund") },
+                singleLine = true,
+                isError = state.errors.any { it.contains("name", ignoreCase = true) },
+            )
+        }
+
+        // ── Target amount ───────────────────────────────────────────
+        item(key = "amount") {
+            Text(
+                text = "Target Amount",
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier.semantics { heading() },
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = state.targetAmount,
+                onValueChange = onTargetAmountChange,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics { contentDescription = "Target amount in dollars" },
+                label = { Text("Amount") },
+                placeholder = { Text("0.00") },
+                leadingIcon = { Icon(Icons.Filled.AttachMoney, contentDescription = null) },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                singleLine = true,
+                isError = state.errors.any { it.contains("amount", ignoreCase = true) },
+            )
+        }
+
+        // ── Target date ─────────────────────────────────────────────
+        item(key = "date") {
+            Text(
+                text = "Target Date",
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier.semantics { heading() },
+            )
+            Spacer(Modifier.height(8.dp))
+            val dateDisplay = state.targetDate?.let { formatDateDisplay(it) } ?: ""
+            OutlinedTextField(
+                value = dateDisplay,
+                onValueChange = {},
+                readOnly = true,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics {
+                        contentDescription = if (dateDisplay.isNotEmpty()) {
+                            "Target date: $dateDisplay"
+                        } else {
+                            "Target date: not selected, tap to choose"
+                        }
+                    },
+                label = { Text("Date") },
+                placeholder = { Text("Select a date") },
+                leadingIcon = { Icon(Icons.Filled.CalendarMonth, contentDescription = null) },
+                trailingIcon = {
+                    IconButton(
+                        onClick = { showDatePicker = true },
+                        modifier = Modifier.semantics {
+                            contentDescription = "Open date picker"
+                        },
+                    ) {
+                        Icon(Icons.Filled.CalendarMonth, contentDescription = null)
+                    }
+                },
+                isError = state.errors.any { it.contains("date", ignoreCase = true) },
+            )
+        }
+
+        // ── Linked account (optional) ───────────────────────────────
+        item(key = "account") {
+            Text(
+                text = "Linked Account (optional)",
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier.semantics { heading() },
+            )
+            Spacer(Modifier.height(8.dp))
+            AccountSelectorDropdown(
+                accounts = state.accounts,
+                selectedAccount = state.selectedAccount,
+                onAccountSelected = onAccountSelect,
+            )
+        }
+
+        // ── Note (optional) ─────────────────────────────────────────
+        item(key = "note") {
+            Text(
+                text = "Note (optional)",
+                style = MaterialTheme.typography.labelLarge,
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = state.note,
+                onValueChange = onNoteChange,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics { contentDescription = "Optional note" },
+                label = { Text("Note") },
+                placeholder = { Text("Add a note...") },
+                maxLines = 3,
+            )
+        }
+
+        // ── Save button ─────────────────────────────────────────────
+        item(key = "save") {
+            Spacer(Modifier.height(8.dp))
+            Button(
+                onClick = onSave,
+                enabled = !state.isSaving,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics {
+                        contentDescription =
+                            if (state.isSaving) "Saving goal" else "Save goal"
+                    },
+            ) {
+                if (state.isSaving) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(18.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text("Saving...")
+                } else {
+                    Icon(Icons.Filled.Check, contentDescription = null, Modifier.size(18.dp))
+                    Spacer(Modifier.width(8.dp))
+                    Text("Save Goal")
+                }
+            }
+        }
+
+        // ── Bottom spacer ───────────────────────────────────────────
+        item(key = "spacer") { Spacer(Modifier.height(32.dp)) }
+    }
+
+    // ── Date picker dialog ──────────────────────────────────────────
+    if (showDatePicker) {
+        GoalDatePickerDialog(
+            initialDate = state.targetDate,
+            onDateSelected = { date ->
+                onTargetDateChange(date)
+                showDatePicker = false
+            },
+            onDismiss = { showDatePicker = false },
+        )
+    }
+}
+
+/**
+ * Material 3 [DatePickerDialog] for selecting a future target date.
+ *
+ * Only dates after today are selectable.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun GoalDatePickerDialog(
+    initialDate: LocalDate?,
+    onDateSelected: (LocalDate) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val initialMillis = initialDate?.atStartOfDayIn(TimeZone.UTC)?.toEpochMilliseconds()
+    val datePickerState = rememberDatePickerState(initialSelectedDateMillis = initialMillis)
+
+    DatePickerDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    datePickerState.selectedDateMillis?.let { millis ->
+                        val instant = Instant.fromEpochMilliseconds(millis)
+                        val date = instant.toLocalDateTime(TimeZone.UTC).date
+                        onDateSelected(date)
+                    }
+                },
+                modifier = Modifier.semantics {
+                    contentDescription = "Confirm selected date"
+                },
+            ) {
+                Text("OK")
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismiss,
+                modifier = Modifier.semantics {
+                    contentDescription = "Cancel date selection"
+                },
+            ) {
+                Text("Cancel")
+            }
+        },
+    ) {
+        DatePicker(
+            state = datePickerState,
+            modifier = Modifier.semantics {
+                contentDescription = "Select a target date for your goal"
+            },
+        )
+    }
+}
+
+/**
+ * Dropdown selector for linking an optional account to the goal.
+ *
+ * Includes a "None" option to clear the selection.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AccountSelectorDropdown(
+    accounts: List<Account>,
+    selectedAccount: Account?,
+    onAccountSelected: (SyncId?) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val displayName = selectedAccount?.name ?: "None"
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        modifier = modifier,
+    ) {
+        OutlinedTextField(
+            value = displayName,
+            onValueChange = {},
+            readOnly = true,
+            modifier = Modifier
+                .fillMaxWidth()
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                .semantics { contentDescription = "Linked account: $displayName" },
+            label = { Text("Account") },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            // "None" option to clear selection
+            DropdownMenuItem(
+                text = {
+                    Text(
+                        text = "None",
+                        modifier = Modifier.semantics {
+                            contentDescription = "No linked account"
+                        },
+                    )
+                },
+                onClick = {
+                    onAccountSelected(null)
+                    expanded = false
+                },
+            )
+            accounts.forEach { account ->
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = account.name,
+                            modifier = Modifier.semantics {
+                                contentDescription = "Account: ${account.name}"
+                            },
+                        )
+                    },
+                    onClick = {
+                        onAccountSelected(account.id)
+                        expanded = false
+                    },
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Formats a [LocalDate] as "MMM dd, yyyy" (e.g. "Jun 15, 2025").
+ * Consistent with the format used in [GoalsViewModel].
+ */
+private fun formatDateDisplay(date: LocalDate): String {
+    val month = date.month.name
+        .lowercase()
+        .replaceFirstChar { it.uppercase() }
+        .take(3)
+    return "$month ${date.dayOfMonth}, ${date.year}"
+}
+
+// ── Previews ────────────────────────────────────────────────────────
+
+@Preview(showBackground = true, showSystemUi = true, name = "Goal Create - Light")
+@Preview(
+    showBackground = true,
+    showSystemUi = true,
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+    name = "Goal Create - Dark",
+)
+@Composable
+private fun GoalCreateFormPreview() {
+    val now = Clock.System.now()
+    FinanceTheme(dynamicColor = false) {
+        GoalCreateForm(
+            state = GoalCreateUiState(
+                name = "Emergency Fund",
+                targetAmount = "10000.00",
+                targetDate = LocalDate(2025, 12, 31),
+                accounts = listOf(
+                    Account(
+                        SyncId("acc-1"), SyncId("h-1"), "Main Checking",
+                        AccountType.CHECKING, Currency.USD, Cents(52473L),
+                        createdAt = now, updatedAt = now,
+                    ),
+                    Account(
+                        SyncId("acc-2"), SyncId("h-1"), "Savings",
+                        AccountType.SAVINGS, Currency.USD, Cents(1867000L),
+                        createdAt = now, updatedAt = now,
+                    ),
+                ),
+                selectedAccount = Account(
+                    SyncId("acc-2"), SyncId("h-1"), "Savings",
+                    AccountType.SAVINGS, Currency.USD, Cents(1867000L),
+                    createdAt = now, updatedAt = now,
+                ),
+            ),
+            onNameChange = {},
+            onTargetAmountChange = {},
+            onTargetDateChange = {},
+            onAccountSelect = {},
+            onNoteChange = {},
+            onSave = {},
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Goal Create - Errors")
+@Composable
+private fun GoalCreateErrorsPreview() {
+    FinanceTheme(dynamicColor = false) {
+        GoalCreateForm(
+            state = GoalCreateUiState(
+                errors = listOf(
+                    "Goal name is required",
+                    "Target amount must be greater than zero",
+                    "Target date is required",
+                ),
+            ),
+            onNameChange = {},
+            onTargetAmountChange = {},
+            onTargetDateChange = {},
+            onAccountSelect = {},
+            onNoteChange = {},
+            onSave = {},
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Goal Create - Saving")
+@Composable
+private fun GoalCreateSavingPreview() {
+    FinanceTheme(dynamicColor = false) {
+        GoalCreateForm(
+            state = GoalCreateUiState(
+                name = "Vacation Fund",
+                targetAmount = "5000.00",
+                targetDate = LocalDate(2025, 8, 15),
+                isSaving = true,
+            ),
+            onNameChange = {},
+            onTargetAmountChange = {},
+            onTargetDateChange = {},
+            onAccountSelect = {},
+            onNoteChange = {},
+            onSave = {},
+        )
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/AccountCreateViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/AccountCreateViewModel.kt
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.finance.android.data.repository.AccountRepository
+import com.finance.models.Account
+import com.finance.models.AccountType
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import timber.log.Timber
+import java.util.UUID
+
+// TODO(#434): Replace with authenticated user's household ID
+private val PLACEHOLDER_HOUSEHOLD_ID = SyncId("household-1")
+
+/**
+ * UI state for the Account creation form.
+ *
+ * @property name User-entered account name.
+ * @property accountType Selected account type (defaults to CHECKING).
+ * @property currency ISO 4217 currency code (defaults to "USD").
+ * @property initialBalance Text representation of the starting balance.
+ * @property note Optional user note (max 500 chars).
+ * @property errors Validation error messages to display.
+ * @property isSaving True while the save operation is in progress.
+ * @property isSaved True after a successful save — triggers navigation back.
+ * @property isEditing Reserved for future edit-mode reuse.
+ */
+data class AccountCreateUiState(
+    val name: String = "",
+    val accountType: AccountType = AccountType.CHECKING,
+    val currency: String = "USD",
+    val initialBalance: String = "",
+    val note: String = "",
+    val errors: List<String> = emptyList(),
+    val isSaving: Boolean = false,
+    val isSaved: Boolean = false,
+    val isEditing: Boolean = false,
+)
+
+/**
+ * ViewModel for the Account creation screen.
+ *
+ * Manages form state, validation, and persistence of new [Account] entities
+ * via [AccountRepository]. Follows the same reactive [StateFlow] pattern
+ * used throughout the Finance app.
+ *
+ * @param accountRepository Repository used to persist the new account.
+ */
+class AccountCreateViewModel(
+    private val accountRepository: AccountRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(AccountCreateUiState())
+    val uiState: StateFlow<AccountCreateUiState> = _uiState.asStateFlow()
+
+    /** Supported currency codes for the currency dropdown. */
+    val supportedCurrencies: List<String> = listOf("USD", "EUR", "GBP", "JPY", "CAD")
+
+    // ── Field updaters ──────────────────────────────────────────────
+
+    /** Updates the account name, clearing previous errors. */
+    fun updateName(name: String) {
+        _uiState.update { it.copy(name = name.take(100), errors = emptyList()) }
+    }
+
+    /** Updates the selected account type, clearing previous errors. */
+    fun updateAccountType(type: AccountType) {
+        _uiState.update { it.copy(accountType = type, errors = emptyList()) }
+    }
+
+    /** Updates the selected currency code, clearing previous errors. */
+    fun updateCurrency(currency: String) {
+        _uiState.update { it.copy(currency = currency, errors = emptyList()) }
+    }
+
+    /** Updates the initial balance text, filtering to valid decimal input. */
+    fun updateInitialBalance(text: String) {
+        val cleaned = text.filter { it.isDigit() || it == '.' }
+        val parts = cleaned.split(".")
+        val limited = if (parts.size > 1) "${parts[0]}.${parts[1].take(2)}" else cleaned
+        _uiState.update { it.copy(initialBalance = limited, errors = emptyList()) }
+    }
+
+    /** Updates the optional note field, clearing previous errors. */
+    fun updateNote(note: String) {
+        _uiState.update { it.copy(note = note.take(500), errors = emptyList()) }
+    }
+
+    // ── Validation ──────────────────────────────────────────────────
+
+    private fun validate(state: AccountCreateUiState): List<String> = buildList {
+        if (state.name.isBlank()) add("Account name is required")
+        if (state.name.length > 100) add("Account name is too long (max 100 characters)")
+    }
+
+    // ── Save ────────────────────────────────────────────────────────
+
+    /**
+     * Validates and persists the new account.
+     *
+     * On success, sets [AccountCreateUiState.isSaved] to `true` so the
+     * composable layer can navigate back.
+     */
+    fun save() {
+        val errors = validate(_uiState.value)
+        if (errors.isNotEmpty()) {
+            _uiState.update { it.copy(errors = errors) }
+            return
+        }
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSaving = true, errors = emptyList()) }
+            try {
+                val s = _uiState.value
+                val now = Clock.System.now()
+                val balanceCents = Cents.fromDollars(s.initialBalance.toDoubleOrNull() ?: 0.0)
+
+                val account = Account(
+                    id = SyncId(UUID.randomUUID().toString()),
+                    householdId = PLACEHOLDER_HOUSEHOLD_ID,
+                    name = s.name.trim(),
+                    type = s.accountType,
+                    currency = Currency(s.currency),
+                    currentBalance = balanceCents,
+                    createdAt = now,
+                    updatedAt = now,
+                )
+
+                accountRepository.insert(account)
+                Timber.d("Account created: id=%s, type=%s", account.id.value, account.type)
+                _uiState.update { it.copy(isSaving = false, isSaved = true) }
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to create account")
+                _uiState.update {
+                    it.copy(
+                        isSaving = false,
+                        errors = listOf(e.message ?: "Failed to create account"),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/BudgetCreateViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/BudgetCreateViewModel.kt
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.finance.android.data.repository.BudgetRepository
+import com.finance.android.data.repository.CategoryRepository
+import com.finance.models.Budget
+import com.finance.models.BudgetPeriod
+import com.finance.models.Category
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import timber.log.Timber
+import java.util.UUID
+
+// TODO(#434): Replace with authenticated user's household ID
+private val PLACEHOLDER_HOUSEHOLD_ID = SyncId("household-1")
+
+/**
+ * UI state for the Budget creation form.
+ *
+ * @property selectedCategory Currently selected category, or null if none chosen.
+ * @property categories Available categories loaded from [CategoryRepository].
+ * @property amount Text representation of the budgeted amount.
+ * @property period Selected budget recurrence period (defaults to MONTHLY).
+ * @property errors Validation error messages to display.
+ * @property isSaving True while the save operation is in progress.
+ * @property isSaved True after a successful save — triggers navigation back.
+ */
+data class BudgetCreateUiState(
+    val selectedCategory: Category? = null,
+    val categories: List<Category> = emptyList(),
+    val amount: String = "",
+    val period: BudgetPeriod = BudgetPeriod.MONTHLY,
+    val errors: List<String> = emptyList(),
+    val isSaving: Boolean = false,
+    val isSaved: Boolean = false,
+)
+
+/**
+ * ViewModel for the Budget creation screen.
+ *
+ * Loads available categories on initialization and manages form state,
+ * validation, and persistence of new [Budget] entities via [BudgetRepository].
+ *
+ * @param budgetRepository Repository used to persist the new budget.
+ * @param categoryRepository Repository used to load available categories.
+ */
+class BudgetCreateViewModel(
+    private val budgetRepository: BudgetRepository,
+    private val categoryRepository: CategoryRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(BudgetCreateUiState())
+    val uiState: StateFlow<BudgetCreateUiState> = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            val categories = categoryRepository.observeAll(PLACEHOLDER_HOUSEHOLD_ID).first()
+            _uiState.update { it.copy(categories = categories) }
+        }
+    }
+
+    // ── Field updaters ──────────────────────────────────────────────
+
+    /** Selects a category by its [SyncId], clearing previous errors. */
+    fun selectCategory(id: SyncId) {
+        val cat = _uiState.value.categories.find { it.id == id }
+        _uiState.update { it.copy(selectedCategory = cat, errors = emptyList()) }
+    }
+
+    /** Updates the budgeted amount text, filtering to valid decimal input. */
+    fun updateAmount(text: String) {
+        val cleaned = text.filter { it.isDigit() || it == '.' }
+        val parts = cleaned.split(".")
+        val limited = if (parts.size > 1) "${parts[0]}.${parts[1].take(2)}" else cleaned
+        _uiState.update { it.copy(amount = limited, errors = emptyList()) }
+    }
+
+    /** Updates the selected budget period, clearing previous errors. */
+    fun updatePeriod(period: BudgetPeriod) {
+        _uiState.update { it.copy(period = period, errors = emptyList()) }
+    }
+
+    // ── Validation ──────────────────────────────────────────────────
+
+    private fun validate(state: BudgetCreateUiState): List<String> = buildList {
+        if (state.selectedCategory == null) add("Please select a category")
+        val amountValue = state.amount.toDoubleOrNull() ?: 0.0
+        if (amountValue <= 0.0) add("Budgeted amount must be greater than zero")
+    }
+
+    // ── Save ────────────────────────────────────────────────────────
+
+    /**
+     * Validates and persists the new budget.
+     *
+     * On success, sets [BudgetCreateUiState.isSaved] to `true` so the
+     * composable layer can navigate back.
+     */
+    fun save() {
+        val errors = validate(_uiState.value)
+        if (errors.isNotEmpty()) {
+            _uiState.update { it.copy(errors = errors) }
+            return
+        }
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSaving = true, errors = emptyList()) }
+            try {
+                val s = _uiState.value
+                val now = Clock.System.now()
+                val today = now.toLocalDateTime(TimeZone.currentSystemDefault()).date
+                val amountCents = Cents.fromDollars(s.amount.toDoubleOrNull() ?: 0.0)
+
+                val budget = Budget(
+                    id = SyncId(UUID.randomUUID().toString()),
+                    householdId = PLACEHOLDER_HOUSEHOLD_ID,
+                    categoryId = s.selectedCategory!!.id,
+                    name = s.selectedCategory.name,
+                    amount = amountCents,
+                    currency = Currency.USD,
+                    period = s.period,
+                    startDate = today,
+                    createdAt = now,
+                    updatedAt = now,
+                )
+
+                budgetRepository.insert(budget)
+                Timber.d("Budget created: id=%s, period=%s", budget.id.value, budget.period)
+                _uiState.update { it.copy(isSaving = false, isSaved = true) }
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to create budget")
+                _uiState.update {
+                    it.copy(
+                        isSaving = false,
+                        errors = listOf(e.message ?: "Failed to create budget"),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/GoalCreateViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/GoalCreateViewModel.kt
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.finance.android.data.repository.AccountRepository
+import com.finance.android.data.repository.GoalRepository
+import com.finance.models.Account
+import com.finance.models.Goal
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import timber.log.Timber
+import java.util.UUID
+
+// TODO(#434): Replace with authenticated user's household ID
+private val PLACEHOLDER_HOUSEHOLD_ID = SyncId("household-1")
+
+/**
+ * UI state for the Goal creation form.
+ *
+ * @property name User-entered goal name.
+ * @property targetAmount Text representation of the target savings amount.
+ * @property targetDate Selected target date, or null if not yet chosen.
+ * @property selectedAccount Optionally linked account for this goal.
+ * @property accounts Available accounts loaded from [AccountRepository].
+ * @property note Optional user note (max 500 chars).
+ * @property errors Validation error messages to display.
+ * @property isSaving True while the save operation is in progress.
+ * @property isSaved True after a successful save — triggers navigation back.
+ */
+data class GoalCreateUiState(
+    val name: String = "",
+    val targetAmount: String = "",
+    val targetDate: LocalDate? = null,
+    val selectedAccount: Account? = null,
+    val accounts: List<Account> = emptyList(),
+    val note: String = "",
+    val errors: List<String> = emptyList(),
+    val isSaving: Boolean = false,
+    val isSaved: Boolean = false,
+)
+
+/**
+ * ViewModel for the Goal creation screen.
+ *
+ * Loads available accounts on initialization and manages form state,
+ * validation, and persistence of new [Goal] entities via [GoalRepository].
+ *
+ * @param goalRepository Repository used to persist the new goal.
+ * @param accountRepository Repository used to load accounts for the optional link.
+ */
+class GoalCreateViewModel(
+    private val goalRepository: GoalRepository,
+    private val accountRepository: AccountRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(GoalCreateUiState())
+    val uiState: StateFlow<GoalCreateUiState> = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            val accounts = accountRepository.observeAll(PLACEHOLDER_HOUSEHOLD_ID).first()
+            _uiState.update { it.copy(accounts = accounts) }
+        }
+    }
+
+    // ── Field updaters ──────────────────────────────────────────────
+
+    /** Updates the goal name, clamped to 100 characters, clearing previous errors. */
+    fun updateName(name: String) {
+        _uiState.update { it.copy(name = name.take(100), errors = emptyList()) }
+    }
+
+    /** Updates the target amount text, filtering to valid decimal input. */
+    fun updateTargetAmount(text: String) {
+        val cleaned = text.filter { it.isDigit() || it == '.' }
+        val parts = cleaned.split(".")
+        val limited = if (parts.size > 1) "${parts[0]}.${parts[1].take(2)}" else cleaned
+        _uiState.update { it.copy(targetAmount = limited, errors = emptyList()) }
+    }
+
+    /** Updates the target date, clearing previous errors. */
+    fun updateTargetDate(date: LocalDate) {
+        _uiState.update { it.copy(targetDate = date, errors = emptyList()) }
+    }
+
+    /** Selects a linked account by its [SyncId], or deselects if null. */
+    fun selectAccount(id: SyncId?) {
+        val account = if (id != null) _uiState.value.accounts.find { it.id == id } else null
+        _uiState.update { it.copy(selectedAccount = account, errors = emptyList()) }
+    }
+
+    /** Updates the optional note field, clamped to 500 characters. */
+    fun updateNote(note: String) {
+        _uiState.update { it.copy(note = note.take(500), errors = emptyList()) }
+    }
+
+    // ── Validation ──────────────────────────────────────────────────
+
+    private fun validate(state: GoalCreateUiState): List<String> = buildList {
+        if (state.name.isBlank()) add("Goal name is required")
+        if (state.name.length > 100) add("Goal name is too long (max 100 characters)")
+        val amountValue = state.targetAmount.toDoubleOrNull() ?: 0.0
+        if (amountValue <= 0.0) add("Target amount must be greater than zero")
+        if (state.targetDate == null) add("Target date is required")
+        else {
+            val today = Clock.System.now()
+                .toLocalDateTime(TimeZone.currentSystemDefault()).date
+            if (state.targetDate <= today) add("Target date must be in the future")
+        }
+    }
+
+    // ── Save ────────────────────────────────────────────────────────
+
+    /**
+     * Validates and persists the new goal.
+     *
+     * On success, sets [GoalCreateUiState.isSaved] to `true` so the
+     * composable layer can navigate back.
+     */
+    fun save() {
+        val errors = validate(_uiState.value)
+        if (errors.isNotEmpty()) {
+            _uiState.update { it.copy(errors = errors) }
+            return
+        }
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSaving = true, errors = emptyList()) }
+            try {
+                val s = _uiState.value
+                val now = Clock.System.now()
+                val targetCents = Cents.fromDollars(s.targetAmount.toDoubleOrNull() ?: 0.0)
+
+                val goal = Goal(
+                    id = SyncId(UUID.randomUUID().toString()),
+                    householdId = PLACEHOLDER_HOUSEHOLD_ID,
+                    name = s.name.trim(),
+                    targetAmount = targetCents,
+                    currentAmount = Cents.ZERO,
+                    currency = Currency.USD,
+                    targetDate = s.targetDate,
+                    accountId = s.selectedAccount?.id,
+                    createdAt = now,
+                    updatedAt = now,
+                )
+
+                goalRepository.insert(goal)
+                Timber.d("Goal created: id=%s", goal.id.value)
+                _uiState.update { it.copy(isSaving = false, isSaved = true) }
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to create goal")
+                _uiState.update {
+                    it.copy(
+                        isSaving = false,
+                        errors = listOf(e.message ?: "Failed to create goal"),
+                    )
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add full create flows for accounts, budgets, and goals — closing the biggest feature parity gap with Web/iOS.

## New Screens (1,970 lines across 8 files)

### AccountCreateScreen
- Form: name, type dropdown (7 AccountTypes), currency selector, initial balance, optional note
- Validation: name required (≤100 chars)
- Saves via AccountRepository with Cents conversion

### BudgetCreateScreen  
- Category chip selector (FlowRow of FilterChips from CategoryRepository)
- Amount input with decimal keyboard
- Period dropdown (Weekly/Biweekly/Monthly/Quarterly/Yearly)
- Validation: category required, amount > 0

### GoalCreateScreen
- Name, target amount, Material 3 DatePicker for target date
- Optional account linking (dropdown from AccountRepository)
- Optional note
- Validation: name required, amount > 0, date must be in future

## Navigation
- Added Route.AccountCreate, Route.BudgetCreate, Route.GoalCreate
- Wired FAB on Accounts, Budgets, Goals list screens
- 3 new ViewModels registered in Koin

## Quality
- ✅ Build successful (compileDebugKotlin)
- ✅ 112 unit tests pass
- Full TalkBack accessibility on all forms
- Follows existing TransactionCreateScreen patterns

Closes #630