### PR TITLE
feat(android): add signup screen, wire auth navigation, harden background sync (#631)

### DIFF
--- a/apps/android/src/main/kotlin/com/finance/android/MainActivity.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/MainActivity.kt
@@ -26,6 +26,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -39,6 +42,8 @@ import androidx.navigation.compose.rememberNavController
 import com.finance.android.auth.AuthState
 import com.finance.android.auth.AuthViewModel
 import com.finance.android.auth.LoginScreen
+import com.finance.android.auth.SignupScreen
+import com.finance.android.auth.SignupViewModel
 import com.finance.android.ui.navigation.FinanceBottomBar
 import com.finance.android.ui.navigation.FinanceNavHost
 import com.finance.android.ui.navigation.FinanceTopBar
@@ -83,10 +88,14 @@ class MainActivity : ComponentActivity() {
  *
  * Observes [AuthViewModel.authState] to gate content:
  * - [AuthState.Loading] → splash / loading indicator
- * - [AuthState.Unauthenticated] or [AuthState.Error] → [LoginScreen]
+ * - [AuthState.Unauthenticated] or [AuthState.Error] → [LoginScreen] or [SignupScreen]
  * - [AuthState.Authenticated] → main [Scaffold] with nav host
  *
- * This ensures the login screen is shown without the app chrome
+ * Auth screens are toggled via a local `showSignup` flag rather than a
+ * full nav graph — the auth surface is small (two screens) and does
+ * not benefit from back-stack management.
+ *
+ * This ensures the login/signup screens are shown without the app chrome
  * (top bar, bottom bar, FAB) while the authenticated experience
  * retains the full navigation shell.
  */
@@ -94,13 +103,26 @@ class MainActivity : ComponentActivity() {
 fun FinanceApp(modifier: Modifier = Modifier) {
     val authViewModel: AuthViewModel = koinViewModel()
     val authState by authViewModel.authState.collectAsState()
+    var showSignup by rememberSaveable { mutableStateOf(false) }
 
     when (authState) {
         is AuthState.Loading -> {
             AuthLoadingScreen(modifier = modifier)
         }
         is AuthState.Unauthenticated, is AuthState.Error -> {
-            LoginScreen(viewModel = authViewModel)
+            if (showSignup) {
+                val signupViewModel: SignupViewModel = koinViewModel()
+                SignupScreen(
+                    viewModel = signupViewModel,
+                    onNavigateToLogin = { showSignup = false },
+                    onSignupSuccess = { showSignup = false },
+                )
+            } else {
+                LoginScreen(
+                    viewModel = authViewModel,
+                    onNavigateToSignup = { showSignup = true },
+                )
+            }
         }
         is AuthState.Authenticated -> {
             AuthenticatedContent(modifier = modifier)

--- a/apps/android/src/main/kotlin/com/finance/android/auth/LoginScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/auth/LoginScreen.kt
@@ -61,11 +61,13 @@ import androidx.core.util.Consumer
  * - Loading and error states use live regions for announcements.
  * - Focus management ensures logical tab/switch-access order.
  *
- * @param viewModel The [AuthViewModel] managing authentication state.
+ * @param viewModel          The [AuthViewModel] managing authentication state.
+ * @param onNavigateToSignup Callback to navigate to the sign-up screen.
  */
 @Composable
 fun LoginScreen(
     viewModel: AuthViewModel,
+    onNavigateToSignup: () -> Unit = {},
 ) {
     val context = LocalContext.current
     val activity = context as ComponentActivity
@@ -121,6 +123,7 @@ fun LoginScreen(
                         isError = authState is AuthState.Error,
                         onSignInWithGoogle = { viewModel.signInWithGoogle(context) },
                         onSignInWithPasskey = { viewModel.signInWithPasskey(activity) },
+                        onNavigateToSignup = onNavigateToSignup,
                     )
                 }
             }
@@ -137,6 +140,7 @@ private fun LoginContent(
     isError: Boolean,
     onSignInWithGoogle: () -> Unit,
     onSignInWithPasskey: () -> Unit,
+    onNavigateToSignup: () -> Unit = {},
 ) {
     Column(
         modifier = Modifier
@@ -237,6 +241,22 @@ private fun LoginContent(
 
         Spacer(modifier = Modifier.height(32.dp))
 
+        // ── Sign-up link ────────────────────────────────────────────────
+        TextButton(
+            onClick = onNavigateToSignup,
+            modifier = Modifier.semantics {
+                contentDescription = "Don't have an account? Sign up"
+            },
+        ) {
+            Text(
+                text = "Don't have an account? Sign up",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
         // ── Terms ───────────────────────────────────────────────────────
         Text(
             text = "By signing in, you agree to our Terms of Service and Privacy Policy.",
@@ -314,6 +334,7 @@ private fun LoginScreenPreviewLight() {
                 isError = false,
                 onSignInWithGoogle = {},
                 onSignInWithPasskey = {},
+                onNavigateToSignup = {},
             )
         }
     }
@@ -333,6 +354,7 @@ private fun LoginScreenPreviewDark() {
                 isError = false,
                 onSignInWithGoogle = {},
                 onSignInWithPasskey = {},
+                onNavigateToSignup = {},
             )
         }
     }
@@ -347,6 +369,7 @@ private fun LoginScreenPreviewError() {
                 isError = true,
                 onSignInWithGoogle = {},
                 onSignInWithPasskey = {},
+                onNavigateToSignup = {},
             )
         }
     }

--- a/apps/android/src/main/kotlin/com/finance/android/auth/SignupScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/auth/SignupScreen.kt
@@ -1,0 +1,512 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.finance.android.auth
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+/**
+ * Sign-up screen for the Finance app.
+ *
+ * Displays email, password, and confirm-password fields with
+ * inline validation, a "Create Account" action, and a link
+ * back to the sign-in screen.
+ *
+ * **Accessibility:**
+ * - All fields have labels and [contentDescription] for TalkBack.
+ * - Validation errors appear in [supportingText] and are announced.
+ * - The API error banner uses [LiveRegionMode.Assertive].
+ * - The loading state has a semantic description for screen readers.
+ * - The password visibility toggle provides context-aware descriptions.
+ *
+ * @param viewModel           The [SignupViewModel] managing sign-up state.
+ * @param onNavigateToLogin   Callback to navigate back to the login screen.
+ * @param onSignupSuccess     Callback invoked when sign-up succeeds.
+ */
+@Composable
+fun SignupScreen(
+    viewModel: SignupViewModel,
+    onNavigateToLogin: () -> Unit,
+    onSignupSuccess: () -> Unit,
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    // Navigate away on successful sign-up.
+    LaunchedEffect(uiState.isSuccess) {
+        if (uiState.isSuccess) {
+            onSignupSuccess()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = "Create Account",
+                        modifier = Modifier.semantics {
+                            heading()
+                            contentDescription = "Create Account"
+                        },
+                    )
+                },
+                navigationIcon = {
+                    IconButton(
+                        onClick = onNavigateToLogin,
+                        modifier = Modifier.semantics {
+                            contentDescription = "Navigate back to sign in"
+                        },
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        SignupContent(
+            uiState = uiState,
+            onEmailChanged = viewModel::onEmailChanged,
+            onPasswordChanged = viewModel::onPasswordChanged,
+            onConfirmPasswordChanged = viewModel::onConfirmPasswordChanged,
+            onTogglePasswordVisibility = viewModel::togglePasswordVisibility,
+            onSubmit = viewModel::onSubmit,
+            onNavigateToLogin = onNavigateToLogin,
+            modifier = Modifier.padding(innerPadding),
+        )
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Content composable
+// ─────────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun SignupContent(
+    uiState: SignupUiState,
+    onEmailChanged: (String) -> Unit,
+    onPasswordChanged: (String) -> Unit,
+    onConfirmPasswordChanged: (String) -> Unit,
+    onTogglePasswordVisibility: () -> Unit,
+    onSubmit: () -> Unit,
+    onNavigateToLogin: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val focusManager = LocalFocusManager.current
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 32.dp, vertical = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Top,
+    ) {
+        // ── API error banner ────────────────────────────────────────────
+        if (uiState.apiError != null) {
+            Text(
+                text = uiState.apiError,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onError,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+                    .semantics {
+                        liveRegion = LiveRegionMode.Assertive
+                        contentDescription = uiState.apiError
+                    }
+                    .then(
+                        Modifier.padding(0.dp), // Surface handles background
+                    ),
+            )
+            // Wrap with error-colored background
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = "Create your Finance account to start tracking your finances securely.",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.semantics {
+                contentDescription =
+                    "Create your Finance account to start tracking your finances securely"
+            },
+        )
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        // ── Email field ─────────────────────────────────────────────────
+        OutlinedTextField(
+            value = uiState.email,
+            onValueChange = onEmailChanged,
+            label = { Text("Email") },
+            placeholder = { Text("you@example.com") },
+            isError = uiState.emailError != null,
+            supportingText = uiState.emailError?.let { error ->
+                {
+                    Text(
+                        text = error,
+                        modifier = Modifier.semantics {
+                            liveRegion = LiveRegionMode.Polite
+                            contentDescription = error
+                        },
+                    )
+                }
+            },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Email,
+                imeAction = ImeAction.Next,
+            ),
+            keyboardActions = KeyboardActions(
+                onNext = { focusManager.moveFocus(FocusDirection.Down) },
+            ),
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics { contentDescription = "Email address" },
+            enabled = !uiState.isLoading,
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // ── Password field ──────────────────────────────────────────────
+        OutlinedTextField(
+            value = uiState.password,
+            onValueChange = onPasswordChanged,
+            label = { Text("Password") },
+            isError = uiState.passwordError != null,
+            supportingText = uiState.passwordError?.let { error ->
+                {
+                    Text(
+                        text = error,
+                        modifier = Modifier.semantics {
+                            liveRegion = LiveRegionMode.Polite
+                            contentDescription = error
+                        },
+                    )
+                }
+            },
+            singleLine = true,
+            visualTransformation = if (uiState.passwordVisible) {
+                VisualTransformation.None
+            } else {
+                PasswordVisualTransformation()
+            },
+            trailingIcon = {
+                IconButton(
+                    onClick = onTogglePasswordVisibility,
+                    modifier = Modifier.semantics {
+                        contentDescription = if (uiState.passwordVisible) {
+                            "Hide password"
+                        } else {
+                            "Show password"
+                        }
+                    },
+                ) {
+                    Icon(
+                        imageVector = if (uiState.passwordVisible) {
+                            Icons.Filled.VisibilityOff
+                        } else {
+                            Icons.Filled.Visibility
+                        },
+                        contentDescription = null, // button semantics covers this
+                    )
+                }
+            },
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Password,
+                imeAction = ImeAction.Next,
+            ),
+            keyboardActions = KeyboardActions(
+                onNext = { focusManager.moveFocus(FocusDirection.Down) },
+            ),
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics { contentDescription = "Password" },
+            enabled = !uiState.isLoading,
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // ── Confirm password field ──────────────────────────────────────
+        OutlinedTextField(
+            value = uiState.confirmPassword,
+            onValueChange = onConfirmPasswordChanged,
+            label = { Text("Confirm Password") },
+            isError = uiState.confirmPasswordError != null,
+            supportingText = uiState.confirmPasswordError?.let { error ->
+                {
+                    Text(
+                        text = error,
+                        modifier = Modifier.semantics {
+                            liveRegion = LiveRegionMode.Polite
+                            contentDescription = error
+                        },
+                    )
+                }
+            },
+            singleLine = true,
+            visualTransformation = if (uiState.passwordVisible) {
+                VisualTransformation.None
+            } else {
+                PasswordVisualTransformation()
+            },
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Password,
+                imeAction = ImeAction.Done,
+            ),
+            keyboardActions = KeyboardActions(
+                onDone = {
+                    focusManager.clearFocus()
+                    onSubmit()
+                },
+            ),
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics { contentDescription = "Confirm password" },
+            enabled = !uiState.isLoading,
+        )
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        // ── Create Account button ───────────────────────────────────────
+        Button(
+            onClick = onSubmit,
+            enabled = !uiState.isLoading,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp)
+                .semantics {
+                    contentDescription = if (uiState.isLoading) {
+                        "Creating account, please wait"
+                    } else {
+                        "Create Account"
+                    }
+                },
+        ) {
+            if (uiState.isLoading) {
+                CircularProgressIndicator(
+                    modifier = Modifier
+                        .size(24.dp)
+                        .semantics {
+                            contentDescription = "Creating account, please wait"
+                        },
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    strokeWidth = 2.dp,
+                )
+            } else {
+                Text(
+                    text = "Create Account",
+                    style = MaterialTheme.typography.labelLarge,
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // ── Navigate to login ───────────────────────────────────────────
+        TextButton(
+            onClick = onNavigateToLogin,
+            modifier = Modifier.semantics {
+                contentDescription = "Already have an account? Sign in"
+            },
+            enabled = !uiState.isLoading,
+        ) {
+            Text(
+                text = "Already have an account? Sign in",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // ── Terms ───────────────────────────────────────────────────────
+        Text(
+            text = "By creating an account, you agree to our Terms of Service and Privacy Policy.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.semantics {
+                contentDescription =
+                    "By creating an account, you agree to our Terms of Service and Privacy Policy"
+            },
+        )
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Previews
+// ─────────────────────────────────────────────────────────────────────────────
+
+@Preview(
+    name = "Signup – Light",
+    showBackground = true,
+    showSystemUi = true,
+    uiMode = Configuration.UI_MODE_NIGHT_NO,
+)
+@Composable
+private fun SignupScreenPreviewLight() {
+    MaterialTheme {
+        Surface {
+            SignupContent(
+                uiState = SignupUiState(),
+                onEmailChanged = {},
+                onPasswordChanged = {},
+                onConfirmPasswordChanged = {},
+                onTogglePasswordVisibility = {},
+                onSubmit = {},
+                onNavigateToLogin = {},
+            )
+        }
+    }
+}
+
+@Preview(
+    name = "Signup – Dark",
+    showBackground = true,
+    showSystemUi = true,
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+private fun SignupScreenPreviewDark() {
+    MaterialTheme(colorScheme = androidx.compose.material3.darkColorScheme()) {
+        Surface {
+            SignupContent(
+                uiState = SignupUiState(),
+                onEmailChanged = {},
+                onPasswordChanged = {},
+                onConfirmPasswordChanged = {},
+                onTogglePasswordVisibility = {},
+                onSubmit = {},
+                onNavigateToLogin = {},
+            )
+        }
+    }
+}
+
+@Preview(name = "Signup – Validation Errors")
+@Composable
+private fun SignupScreenPreviewErrors() {
+    MaterialTheme {
+        Surface {
+            SignupContent(
+                uiState = SignupUiState(
+                    email = "bad-email",
+                    password = "short",
+                    confirmPassword = "nope",
+                    emailError = "Enter a valid email address",
+                    passwordError = "Password must be at least 8 characters",
+                    confirmPasswordError = "Passwords do not match",
+                ),
+                onEmailChanged = {},
+                onPasswordChanged = {},
+                onConfirmPasswordChanged = {},
+                onTogglePasswordVisibility = {},
+                onSubmit = {},
+                onNavigateToLogin = {},
+            )
+        }
+    }
+}
+
+@Preview(name = "Signup – API Error")
+@Composable
+private fun SignupScreenPreviewApiError() {
+    MaterialTheme {
+        Surface {
+            SignupContent(
+                uiState = SignupUiState(
+                    email = "user@example.com",
+                    password = "Password1",
+                    confirmPassword = "Password1",
+                    apiError = "An account with this email already exists",
+                ),
+                onEmailChanged = {},
+                onPasswordChanged = {},
+                onConfirmPasswordChanged = {},
+                onTogglePasswordVisibility = {},
+                onSubmit = {},
+                onNavigateToLogin = {},
+            )
+        }
+    }
+}
+
+@Preview(name = "Signup – Loading")
+@Composable
+private fun SignupScreenPreviewLoading() {
+    MaterialTheme {
+        Surface {
+            SignupContent(
+                uiState = SignupUiState(
+                    email = "user@example.com",
+                    password = "Password1",
+                    confirmPassword = "Password1",
+                    isLoading = true,
+                ),
+                onEmailChanged = {},
+                onPasswordChanged = {},
+                onConfirmPasswordChanged = {},
+                onTogglePasswordVisibility = {},
+                onSubmit = {},
+                onNavigateToLogin = {},
+            )
+        }
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/auth/SignupViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/auth/SignupViewModel.kt
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.auth
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+/**
+ * UI state for the sign-up screen.
+ *
+ * Field-level validation errors are shown inline under each input.
+ * [apiError] holds server-side errors (duplicate email, network
+ * failure, etc.) displayed as a top-level banner.
+ */
+data class SignupUiState(
+    val email: String = "",
+    val password: String = "",
+    val confirmPassword: String = "",
+    val emailError: String? = null,
+    val passwordError: String? = null,
+    val confirmPasswordError: String? = null,
+    val apiError: String? = null,
+    val isLoading: Boolean = false,
+    val isSuccess: Boolean = false,
+    val passwordVisible: Boolean = false,
+)
+
+/**
+ * ViewModel for the sign-up screen.
+ *
+ * Handles local validation, delegates sign-up to [SupabaseAuthManager],
+ * and maps errors to user-facing messages. On success, sets
+ * [SignupUiState.isSuccess] so the composable navigates away.
+ *
+ * **Security:** Passwords and emails are NEVER logged.
+ *
+ * @property authManager The [SupabaseAuthManager] for sign-up API calls.
+ */
+class SignupViewModel(
+    private val authManager: SupabaseAuthManager,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(SignupUiState())
+
+    /** Observable sign-up UI state. */
+    val uiState: StateFlow<SignupUiState> = _uiState.asStateFlow()
+
+    // ── Field updates ───────────────────────────────────────────────────
+
+    /** Update the email field, clearing its validation error. */
+    fun onEmailChanged(email: String) {
+        _uiState.update { it.copy(email = email, emailError = null, apiError = null) }
+    }
+
+    /** Update the password field, clearing its validation error. */
+    fun onPasswordChanged(password: String) {
+        _uiState.update { it.copy(password = password, passwordError = null, apiError = null) }
+    }
+
+    /** Update the confirm-password field, clearing its validation error. */
+    fun onConfirmPasswordChanged(confirmPassword: String) {
+        _uiState.update {
+            it.copy(confirmPassword = confirmPassword, confirmPasswordError = null, apiError = null)
+        }
+    }
+
+    /** Toggle password visibility (show / hide). */
+    fun togglePasswordVisibility() {
+        _uiState.update { it.copy(passwordVisible = !it.passwordVisible) }
+    }
+
+    /** Dismiss the API error banner. */
+    fun clearApiError() {
+        _uiState.update { it.copy(apiError = null) }
+    }
+
+    // ── Submit ───────────────────────────────────────────────────────────
+
+    /**
+     * Validate inputs and submit the sign-up request.
+     *
+     * Runs local validation first; if all checks pass, calls
+     * [SupabaseAuthManager.signUp]. Errors are mapped to
+     * user-friendly messages.
+     */
+    fun onSubmit() {
+        val state = _uiState.value
+        if (state.isLoading) return
+
+        // ── Local validation ────────────────────────────────────────────
+        val emailError = validateEmail(state.email)
+        val passwordError = validatePassword(state.password)
+        val confirmPasswordError = validateConfirmPassword(state.password, state.confirmPassword)
+
+        if (emailError != null || passwordError != null || confirmPasswordError != null) {
+            _uiState.update {
+                it.copy(
+                    emailError = emailError,
+                    passwordError = passwordError,
+                    confirmPasswordError = confirmPasswordError,
+                )
+            }
+            return
+        }
+
+        // ── API call ────────────────────────────────────────────────────
+        Timber.d("Sign-up validation passed — submitting request")
+        _uiState.update { it.copy(isLoading = true, apiError = null) }
+
+        viewModelScope.launch {
+            val result = authManager.signUp(
+                email = state.email.trim(),
+                password = state.password,
+            )
+
+            result.onSuccess {
+                Timber.i("Sign-up completed successfully")
+                _uiState.update { it.copy(isLoading = false, isSuccess = true) }
+            }.onFailure { error ->
+                Timber.e(error, "Sign-up API call failed")
+                val message = when (error) {
+                    is SupabaseAuthManager.EmailAlreadyExistsException ->
+                        "An account with this email already exists"
+                    is java.net.UnknownHostException, is java.net.SocketTimeoutException ->
+                        "Network error. Please check your connection and try again."
+                    else ->
+                        error.message ?: "Sign-up failed. Please try again."
+                }
+                _uiState.update { it.copy(isLoading = false, apiError = message) }
+            }
+        }
+    }
+
+    // ── Validation helpers ──────────────────────────────────────────────
+
+    companion object {
+        /** Minimal email format check: non-blank, contains `@` and `.`. */
+        internal fun validateEmail(email: String): String? {
+            val trimmed = email.trim()
+            return when {
+                trimmed.isBlank() -> "Email is required"
+                !trimmed.contains("@") || !trimmed.contains(".") ->
+                    "Enter a valid email address"
+                else -> null
+            }
+        }
+
+        /** Password must be ≥ 8 chars, have at least 1 uppercase and 1 digit. */
+        internal fun validatePassword(password: String): String? {
+            return when {
+                password.length < 8 ->
+                    "Password must be at least 8 characters"
+                !password.any { it.isUpperCase() } ->
+                    "Password must contain at least one uppercase letter"
+                !password.any { it.isDigit() } ->
+                    "Password must contain at least one digit"
+                else -> null
+            }
+        }
+
+        /** Confirm password must match the original password. */
+        internal fun validateConfirmPassword(password: String, confirmPassword: String): String? {
+            return when {
+                confirmPassword.isBlank() -> "Please confirm your password"
+                confirmPassword != password -> "Passwords do not match"
+                else -> null
+            }
+        }
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/auth/SupabaseAuthManager.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/auth/SupabaseAuthManager.kt
@@ -227,6 +227,56 @@ class SupabaseAuthManager(
         }
     }
 
+    // ── Sign-up (email + password) ──────────────────────────────────────
+
+    /**
+     * Register a new user with email and password via Supabase Auth.
+     *
+     * On success, stores tokens, updates [currentSession], and sets
+     * [isAuthenticated] to `true`. On failure, returns the error —
+     * callers should inspect the message for duplicate-email detection.
+     *
+     * **Security:** credentials are transmitted over TLS; passwords and
+     * tokens are NEVER logged.
+     *
+     * @param email    The new user's email address.
+     * @param password The new user's password.
+     * @return [Result.success] with the new [AuthSession], or
+     *         [Result.failure] with the error.
+     */
+    suspend fun signUp(email: String, password: String): Result<AuthSession> {
+        Timber.d("Sign-up requested for new account")
+        return runCatching {
+            val response = httpClient.post("$supabaseUrl/auth/v1/signup") {
+                contentType(ContentType.Application.Json)
+                setBody("""{"email":"$email","password":"$password"}""")
+            }
+            if (!response.status.isSuccess()) {
+                val body = response.bodyAsText()
+                // Supabase returns 422 for duplicate email registrations.
+                if (response.status.value == 422 || body.contains("already registered", ignoreCase = true)) {
+                    throw EmailAlreadyExistsException()
+                }
+                throw IllegalStateException(
+                    "Sign-up failed with status ${response.status.value}",
+                )
+            }
+            parseAuthResponse(response.bodyAsText())
+        }.onSuccess { session ->
+            tokenManager.storeTokens(session)
+            _currentSession.value = session
+            _isAuthenticated.value = true
+            Timber.i("Sign-up successful — new account created")
+        }.onFailure { error ->
+            Timber.e(error, "Sign-up failed")
+        }
+    }
+
+    /**
+     * Thrown when a sign-up attempt uses an email that is already registered.
+     */
+    class EmailAlreadyExistsException : Exception("An account with this email already exists")
+
     // ── Private sign-in implementations ─────────────────────────────────
 
     private suspend fun signInWithEmail(

--- a/apps/android/src/main/kotlin/com/finance/android/di/AuthModule.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/di/AuthModule.kt
@@ -4,6 +4,7 @@ package com.finance.android.di
 
 import com.finance.android.BuildConfig
 import com.finance.android.auth.AuthViewModel
+import com.finance.android.auth.SignupViewModel
 import com.finance.android.auth.SupabaseAuthManager
 import com.finance.sync.auth.AuthManager
 import com.finance.sync.auth.TokenManager
@@ -65,6 +66,7 @@ val authModule = module {
         )
     } bind AuthManager::class
 
-    // ── ViewModel ───────────────────────────────────────────────────────
+    // ── ViewModels ──────────────────────────────────────────────────────
     viewModelOf(::AuthViewModel)
+    viewModelOf(::SignupViewModel)
 }

--- a/apps/android/src/main/kotlin/com/finance/android/sync/SyncWorker.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/sync/SyncWorker.kt
@@ -22,17 +22,24 @@ import java.util.concurrent.TimeUnit
 /**
  * WorkManager [CoroutineWorker] for background data synchronisation.
  *
- * Runs periodically when the device has network connectivity, respecting
- * Doze mode and battery optimisation constraints. Each execution triggers
- * a one-shot sync via [AndroidSyncManager.syncNow].
+ * Runs periodically when the device has network connectivity and the
+ * battery is not critically low, respecting Doze mode and battery
+ * optimisation constraints. Each execution triggers a one-shot sync
+ * via [AndroidSyncManager.syncNow].
  *
  * ### Scheduling
  * Call [SyncWorker.enqueuePeriodicSync] to register the periodic work request.
  * The request is "keep existing" so re-enqueuing is idempotent.
  *
  * ### Retry strategy
- * On transient failures the worker returns [Result.retry] with exponential
- * back-off (initial 30 s, linear policy).
+ * On transient failures the worker returns [Result.retry] with
+ * **exponential** back-off (initial 30 s). Permanent errors (auth
+ * failures, unrecoverable server errors) return [Result.failure]
+ * immediately.
+ *
+ * ### Constraints
+ * - **Network:** requires [NetworkType.CONNECTED]
+ * - **Battery:** requires battery not critically low
  */
 class SyncWorker(
     context: Context,
@@ -44,8 +51,9 @@ class SyncWorker(
     private val syncConfig: SyncConfig by inject()
 
     override suspend fun doWork(): Result {
-        Timber.i("SyncWorker executing — attempt %d", runAttemptCount)
+        Timber.i("SyncWorker starting — attempt %d of %d", runAttemptCount + 1, MAX_RETRIES)
 
+        // ── Pre-flight: valid session ───────────────────────────────────
         val session = tokenManager.retrieveTokens()
         if (session == null) {
             Timber.w("SyncWorker: no stored session — skipping sync")
@@ -58,18 +66,46 @@ class SyncWorker(
             userId = session.userId,
         )
 
+        // ── Execute sync ────────────────────────────────────────────────
         return try {
             syncManager.syncNow(credentials)
             Timber.i("SyncWorker completed successfully")
             Result.success()
+        } catch (e: java.net.UnknownHostException) {
+            Timber.w(e, "SyncWorker: DNS resolution failed (transient)")
+            retryOrFail()
+        } catch (e: java.net.SocketTimeoutException) {
+            Timber.w(e, "SyncWorker: connection timed out (transient)")
+            retryOrFail()
+        } catch (e: java.io.IOException) {
+            Timber.w(e, "SyncWorker: I/O error (transient)")
+            retryOrFail()
+        } catch (e: IllegalStateException) {
+            // Typically indicates a server-side contract violation or
+            // auth token rejection — retrying is unlikely to help.
+            Timber.e(e, "SyncWorker: permanent error — will not retry")
+            Result.failure()
         } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            Timber.e(e, "SyncWorker failed")
-            if (runAttemptCount < MAX_RETRIES) {
-                Result.retry()
-            } else {
-                Timber.e("SyncWorker exhausted retries — reporting failure")
-                Result.failure()
-            }
+            Timber.e(e, "SyncWorker: unexpected error")
+            retryOrFail()
+        }
+    }
+
+    /**
+     * Return [Result.retry] if within the retry budget, otherwise
+     * [Result.failure]. Logs the decision for diagnostics.
+     */
+    private fun retryOrFail(): Result {
+        return if (runAttemptCount < MAX_RETRIES) {
+            Timber.i(
+                "SyncWorker scheduling retry — attempt %d of %d",
+                runAttemptCount + 1,
+                MAX_RETRIES,
+            )
+            Result.retry()
+        } else {
+            Timber.e("SyncWorker exhausted %d retries — reporting failure", MAX_RETRIES)
+            Result.failure()
         }
     }
 
@@ -89,6 +125,13 @@ class SyncWorker(
         /**
          * Enqueue (or update) the periodic background sync.
          *
+         * Constraints:
+         * - **Network:** [NetworkType.CONNECTED] — sync only when online.
+         * - **Battery:** `requiresBatteryNotLow` — skip sync when the
+         *   device battery is critically low.
+         * - **Back-off:** [BackoffPolicy.EXPONENTIAL] with a 30-second
+         *   initial delay — retries at 30 s, 60 s, 120 s, 240 s, …
+         *
          * Safe to call multiple times — existing work is kept unless
          * the constraints have changed.
          *
@@ -97,6 +140,7 @@ class SyncWorker(
         fun enqueuePeriodicSync(context: Context) {
             val constraints = Constraints.Builder()
                 .setRequiredNetworkType(NetworkType.CONNECTED)
+                .setRequiresBatteryNotLow(true)
                 .build()
 
             val syncRequest = PeriodicWorkRequestBuilder<SyncWorker>(
@@ -104,7 +148,7 @@ class SyncWorker(
             )
                 .setConstraints(constraints)
                 .setBackoffCriteria(
-                    BackoffPolicy.LINEAR,
+                    BackoffPolicy.EXPONENTIAL,
                     BACKOFF_DELAY_SECONDS, TimeUnit.SECONDS,
                 )
                 .build()
@@ -116,7 +160,7 @@ class SyncWorker(
             )
 
             Timber.i(
-                "Periodic sync scheduled — interval=%d min, backoff=%d s",
+                "Periodic sync scheduled — interval=%d min, backoff=%d s (exponential)",
                 SYNC_INTERVAL_MINUTES,
                 BACKOFF_DELAY_SECONDS,
             )


### PR DESCRIPTION
## Summary

Add email registration, fix the login-to-signup navigation gap, and harden the background sync worker.

## Signup Flow (688 new lines)
- **SignupScreen.kt** — Email, password (with visibility toggle), confirm password form. Inline validation errors, API error banner with assertive live region, full TalkBack support
- **SignupViewModel.kt** — Local validation (email format, password strength ≥8 chars + uppercase + digit, confirm match) then Supabase signUp(). Maps EmailAlreadyExistsException to user-friendly message
- **LoginScreen.kt** — Added 'Don't have an account? Sign up' navigation
- **MainActivity.kt** — Toggle login/signup views in unauthenticated state via rememberSaveable
- **SupabaseAuthManager.kt** — Added signUp() with HTTP 422 duplicate email detection
- **AuthModule.kt** — Registered SignupViewModel in Koin

## Sync Hardening
- **SyncWorker.kt** — Exponential backoff (30s→60s→120s…), battery-not-low constraint, error classification (transient → retry, permanent → fail), attempt logging

## Security
- Never logs passwords, emails, or tokens
- Password visibility toggle with proper a11y labeling

Closes #631