### PR TITLE
feat(ios): configure KMP XCFramework generation for iOS (#563)

### DIFF
--- a/apps/ios/Package.swift
+++ b/apps/ios/Package.swift
@@ -6,6 +6,20 @@
 // Swift Package Manager manifest for the Finance iOS & watchOS targets.
 // The iOS app uses Swift Charts for financial data visualisation (#28).
 // The watchOS companion app displays balance, transactions, and budgets (#30).
+//
+// KMP Integration (Issue #563)
+// ----------------------------
+// The FinanceSync XCFramework bundles all shared Kotlin Multiplatform code
+// (models, core business logic, and sync engine) into a single static framework.
+//
+// Build the XCFramework on macOS:
+//   ./gradlew :packages:sync:assembleFinanceSyncXCFramework
+//
+// The framework is generated at:
+//   packages/sync/build/XCFrameworks/release/FinanceSync.xcframework
+//
+// After building, the binaryTarget below resolves automatically via the
+// relative path. No manual copying is required.
 
 import PackageDescription
 
@@ -21,9 +35,15 @@ let package = Package(
         .library(name: "FinanceWatch", targets: ["FinanceWatch"]),
     ],
     targets: [
+        // KMP shared framework — contains models, core, and sync modules.
+        // Built via: ./gradlew :packages:sync:assembleFinanceSyncXCFramework
+        .binaryTarget(
+            name: "FinanceSync",
+            path: "../../packages/sync/build/XCFrameworks/release/FinanceSync.xcframework"
+        ),
         .target(
             name: "FinanceApp",
-            dependencies: [],
+            dependencies: ["FinanceSync"],
             path: "Finance",
             exclude: [
                 "Info.plist",

--- a/build-logic/src/main/kotlin/finance.kmp.library.gradle.kts
+++ b/build-logic/src/main/kotlin/finance.kmp.library.gradle.kts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import com.android.build.gradle.LibraryExtension
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
 
 plugins {
     id("org.jetbrains.kotlin.multiplatform")
@@ -32,10 +33,25 @@ kotlin {
         androidTarget()
     }
 
-    // iOS targets
-    iosArm64()
-    iosSimulatorArm64()
-    iosX64()
+    // iOS targets — configured with framework binaries and XCFramework generation.
+    // Each module produces a "Finance<ModuleName>" static framework.
+    // Modules that re-export dependencies (e.g. sync exporting core + models)
+    // should add `export(project(...))` in their own build.gradle.kts via
+    // targets.withType<KotlinNativeTarget> { binaries.withType<Framework> { ... } }
+    val frameworkBaseName = "Finance${project.name.replaceFirstChar { it.uppercase() }}"
+    val xcf = XCFramework(frameworkBaseName)
+
+    listOf(
+        iosArm64(),
+        iosSimulatorArm64(),
+        iosX64(),
+    ).forEach { iosTarget ->
+        iosTarget.binaries.framework {
+            baseName = frameworkBaseName
+            isStatic = true
+            xcf.add(this)
+        }
+    }
 
     // JS target (browser)
     js(IR) {

--- a/packages/core/build.gradle.kts
+++ b/packages/core/build.gradle.kts
@@ -1,14 +1,26 @@
 // SPDX-License-Identifier: BUSL-1.1
 
+import org.jetbrains.kotlin.gradle.plugin.mpp.Framework
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+
 plugins {
     id("finance.kmp.library")
     alias(libs.plugins.kotlin.serialization)
 }
 
 kotlin {
+    // Export models through the FinanceCore iOS framework so model types
+    // are visible to Swift consumers without a separate import.
+    targets.withType<KotlinNativeTarget> {
+        binaries.withType<Framework> {
+            export(project(":packages:models"))
+        }
+    }
+
     sourceSets {
         commonMain.dependencies {
-            implementation(project(":packages:models"))
+            // api — re-exported to iOS framework consumers via export() above
+            api(project(":packages:models"))
             implementation(libs.kotlinx.serialization.json)
             implementation(libs.kotlinx.datetime)
             implementation(libs.kotlinx.coroutines.core)

--- a/packages/sync/build.gradle.kts
+++ b/packages/sync/build.gradle.kts
@@ -1,14 +1,28 @@
 // SPDX-License-Identifier: BUSL-1.1
 
+import org.jetbrains.kotlin.gradle.plugin.mpp.Framework
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+
 plugins {
     id("finance.kmp.library")
     alias(libs.plugins.kotlin.serialization)
 }
 
 kotlin {
+    // Export models and core through the FinanceSync iOS framework so the iOS app
+    // only needs a single import to access all shared KMP types.
+    targets.withType<KotlinNativeTarget> {
+        binaries.withType<Framework> {
+            export(project(":packages:models"))
+            export(project(":packages:core"))
+        }
+    }
+
     sourceSets {
         commonMain.dependencies {
-            implementation(project(":packages:models"))
+            // api — re-exported to iOS framework consumers via export() above
+            api(project(":packages:models"))
+            api(project(":packages:core"))
             implementation(libs.kotlinx.serialization.json)
             implementation(libs.kotlinx.datetime)
             implementation(libs.kotlinx.coroutines.core)


### PR DESCRIPTION
Configures KMP to produce an XCFramework that the iOS app consumes via SPM.

### Changes

**Convention plugin** (\inance.kmp.library.gradle.kts\):
- Registers XCFramework for all KMP packages (static frameworks)
- Each iOS target produces \Finance<Module>\ framework

**FinanceSync as umbrella** (\packages/sync/build.gradle.kts\):
- \pi()\ + \xport()\ both \:packages:models\ and \:packages:core\
- Single \import FinanceSync\ in Swift gives access to all shared types

**Package.swift**:
- Added \.binaryTarget\ for FinanceSync XCFramework
- Wired as dependency of FinanceApp target

### Build command (macOS)
\\\ash
./gradlew :packages:sync:assembleFinanceSyncReleaseXCFramework
\\\

Closes #563

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>