### PR TITLE
feat(ios): complete Apple Sign-In with Supabase Auth integration (#650)

### DIFF
--- a/apps/ios/Finance/FinanceApp.swift
+++ b/apps/ios/Finance/FinanceApp.swift
@@ -11,9 +11,14 @@ import SwiftUI
 ///
 /// When biometric app lock is enabled in settings, the app shows a
 /// full-screen lock overlay on launch and when returning from background.
+///
+/// On launch the app checks for an existing auth session via
+/// `AuthenticationService`. When the scene returns to active, Apple
+/// credential state is re-verified to handle server-side revocations.
 @main
 struct FinanceApp: App {
     @State private var biometricManager = BiometricAuthManager()
+    @State private var authService = AuthenticationService()
     @State private var deepLinkHandler = DeepLinkHandler()
     @State private var networkMonitor = NetworkMonitor()
     @State private var isLocked = true
@@ -46,6 +51,7 @@ struct FinanceApp: App {
                         networkMonitor: networkMonitor
                     )
                     .environment(biometricManager)
+                    .environment(authService)
                     .accessibilityHidden(biometricLockEnabled && isLocked)
 
                     if biometricLockEnabled && isLocked {
@@ -70,14 +76,13 @@ struct FinanceApp: App {
                 if !biometricLockEnabled {
                     isLocked = false
                 }
+                await authService.checkExistingSession()
             }
         }
     }
 
-    /// Handles scene phase transitions for biometric lock management.
-    ///
-    /// - `.active`: refreshes biometric availability (e.g. user enrolled
-    ///   Face ID while the app was backgrounded).
+    /// Handles scene phase transitions for biometric lock management
+    /// and Apple credential state verification.
     /// - `.background`: re-locks the app when biometric lock is enabled so
     ///   the next foreground activation requires authentication.
     private func handleScenePhaseChange(_ phase: ScenePhase) {
@@ -85,6 +90,12 @@ struct FinanceApp: App {
         case .active:
             Self.logger.debug("Scene became active")
             biometricManager.refreshAvailability()
+            if let user = authService.currentUser {
+                Task {
+                    let valid = await authService.checkCredentialState(userID: user.id)
+                    if !valid { await authService.signOut() }
+                }
+            }
         case .background:
             Self.logger.debug("Scene entered background")
             if biometricLockEnabled {

--- a/apps/ios/Finance/Screens/SettingsView.swift
+++ b/apps/ios/Finance/Screens/SettingsView.swift
@@ -5,8 +5,9 @@
 //
 // Form-style settings with large navigation title. Covers currency,
 // notifications, biometric auth, data export, sync status, and about.
-// Refs #565
+// Refs #565, #650
 
+import AuthenticationServices
 import os
 import SwiftUI
 
@@ -14,6 +15,7 @@ import SwiftUI
 
 struct SettingsView: View {
     @Environment(BiometricAuthManager.self) private var biometricManager
+    @Environment(AuthenticationService.self) private var authService
     @State private var viewModel: SettingsViewModel
 
     init(viewModel: SettingsViewModel = SettingsViewModel()) {
@@ -23,6 +25,7 @@ struct SettingsView: View {
     var body: some View {
         NavigationStack {
             Form {
+                accountSection
                 generalSection
                 notificationsSection
                 securitySection
@@ -62,10 +65,40 @@ struct SettingsView: View {
                     Text(message)
                 }
             }
+            .alert(String(localized: "Sign-In Error"), isPresented: Binding(get: { authService.authError != nil }, set: { _ in })) {
+                Button(String(localized: "OK"), role: .cancel) {}.accessibilityLabel(String(localized: "Dismiss sign-in error"))
+            } message: { if let error = authService.authError { Text(error) } }
             .sheet(isPresented: $viewModel.showingShareSheet) {
                 if let url = viewModel.exportedFileURL {
                     ShareSheetView(fileURL: url)
                 }
+            }
+        }
+    }
+
+    // MARK: - Account
+
+    private var accountSection: some View {
+        Section(String(localized: "Account")) {
+            if authService.isAuthenticated, let user = authService.currentUser {
+                HStack {
+                    Image(systemName: "person.crop.circle.fill").font(.title).foregroundStyle(.secondary).accessibilityHidden(true)
+                    VStack(alignment: .leading, spacing: 2) {
+                        if let name = user.name { Text(name).font(.headline) }
+                        if let email = user.email { Text(email).font(.subheadline).foregroundStyle(.secondary) }
+                    }
+                }
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(String(localized: "Signed in as \(user.name ?? user.email ?? user.id)"))
+                Button(role: .destructive) { Task { await authService.signOut() } } label: {
+                    Label(String(localized: "Sign Out"), systemImage: "rectangle.portrait.and.arrow.right")
+                }.accessibilityLabel(String(localized: "Sign Out")).accessibilityHint(String(localized: "Signs you out of your account"))
+            } else {
+                Button { Task { await authService.signInWithApple() } } label: {
+                    HStack { Image(systemName: "apple.logo").accessibilityHidden(true); Text(String(localized: "Sign in with Apple")) }.frame(maxWidth: .infinity, minHeight: 44)
+                }.accessibilityLabel(String(localized: "Sign in with Apple")).accessibilityHint(String(localized: "Signs you in using your Apple ID"))
+                Text(String(localized: "Sign in to sync your data across devices and enable cloud backup.")).font(.footnote).foregroundStyle(.secondary)
+                    .accessibilityLabel(String(localized: "Sign in to sync your data across devices and enable cloud backup."))
             }
         }
     }
@@ -337,4 +370,5 @@ private struct ShareSheetView: UIViewControllerRepresentable {
 #Preview {
     SettingsView()
         .environment(BiometricAuthManager())
+        .environment(AuthenticationService())
 }

--- a/apps/ios/Finance/Security/AppleSignInManager.swift
+++ b/apps/ios/Finance/Security/AppleSignInManager.swift
@@ -5,7 +5,7 @@
 //
 // Sign in with Apple integration via ASAuthorizationController.
 // Converts Apple credentials to a Supabase auth session.
-// Refs #24
+// Refs #24, #650
 
 import AuthenticationServices
 import CryptoKit

--- a/apps/ios/Finance/Services/AuthenticationService.swift
+++ b/apps/ios/Finance/Services/AuthenticationService.swift
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: BUSL-1.1
+// AuthenticationService.swift - Finance - Refs #650
+import AuthenticationServices; import Foundation; import Observation; import os
+struct AuthUser: Sendable, Equatable { let id: String; let email: String?; let name: String? }
+enum AuthenticationState: Sendable, Equatable { case unauthenticated, loading, authenticated, error(String) }
+private enum AuthKeychainKeys { static let accessToken = "com.finance.auth.accessToken"; static let refreshToken = "com.finance.auth.refreshToken"
+    static let userId = "com.finance.auth.userId"; static let userEmail = "com.finance.auth.userEmail"; static let userName = "com.finance.auth.userName" }
+@Observable @MainActor final class AuthenticationService {
+    private(set) var state: AuthenticationState = .loading; private(set) var currentUser: AuthUser?; private(set) var authError: String?
+    var isAuthenticated: Bool { if case .authenticated = state { return true }; return false }
+    private let appleSignInManager: AppleSignInManaging; private let supabaseClient: SupabaseAuthClientProtocol; private let keychain: KeychainManaging
+    private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.finance", category: "AuthenticationService")
+    init(appleSignInManager: AppleSignInManaging? = nil, supabaseClient: SupabaseAuthClientProtocol? = nil, keychain: KeychainManaging? = nil) {
+        self.appleSignInManager = appleSignInManager ?? AppleSignInManager(); self.supabaseClient = supabaseClient ?? SupabaseAuthClient(); self.keychain = keychain ?? KeychainManager.shared }
+    func signInWithApple() async {
+        state = .loading; authError = nil
+        do { let cred = try await appleSignInManager.signIn()
+            Self.logger.info("Apple Sign-In succeeded for user \(cred.userID, privacy: .private(mask: .hash))")
+            let sess = try await supabaseClient.signInWithApple(idToken: cred.identityToken, nonce: cred.nonce)
+            try storeSession(sess, credential: cred)
+            let name = formatDisplayName(cred.fullName)
+            currentUser = AuthUser(id: sess.user.id, email: cred.email ?? sess.user.email, name: name); state = .authenticated
+        } catch let e as AppleSignInError where e.isCancellation { state = .unauthenticated
+        } catch { authError = error.localizedDescription; state = .error(error.localizedDescription) } }
+    func signOut() async {
+        if let d = keychain.load(key: AuthKeychainKeys.accessToken), let t = String(data: d, encoding: .utf8) {
+            do { try await supabaseClient.signOut(accessToken: t) } catch { Self.logger.warning("Server sign-out failed: \(error.localizedDescription, privacy: .public)") } }
+        clearKeychainTokens(); currentUser = nil; authError = nil; state = .unauthenticated }
+    func checkExistingSession() async {
+        state = .loading
+        guard let ud = keychain.load(key: AuthKeychainKeys.userId), let uid = String(data: ud, encoding: .utf8) else { state = .unauthenticated; return }
+        guard await checkCredentialState(userID: uid) else { await signOut(); return }
+        if let rd = keychain.load(key: AuthKeychainKeys.refreshToken), let rt = String(data: rd, encoding: .utf8) { await refreshSession(with: rt) }
+        else { let e = keychain.load(key: AuthKeychainKeys.userEmail).flatMap { String(data: $0, encoding: .utf8) }
+            let n = keychain.load(key: AuthKeychainKeys.userName).flatMap { String(data: $0, encoding: .utf8) }
+            currentUser = AuthUser(id: uid, email: e, name: n); state = .authenticated } }
+    func refreshSession() async {
+        guard let d = keychain.load(key: AuthKeychainKeys.refreshToken), let rt = String(data: d, encoding: .utf8) else { return }
+        await refreshSession(with: rt) }
+    func checkCredentialState(userID: String) async -> Bool {
+        do { let s = try await ASAuthorizationAppleIDProvider().credentialState(forUserID: userID)
+            switch s { case .authorized: return true; case .revoked, .notFound, .transferred: return false; @unknown default: return false }
+        } catch { return true } }
+    private func refreshSession(with rt: String) async {
+        do { let s = try await supabaseClient.refreshToken(rt); try storeTokens(accessToken: s.accessToken, refreshToken: s.refreshToken)
+            let e = keychain.load(key: AuthKeychainKeys.userEmail).flatMap { String(data: $0, encoding: .utf8) }
+            let n = keychain.load(key: AuthKeychainKeys.userName).flatMap { String(data: $0, encoding: .utf8) }
+            currentUser = AuthUser(id: s.user.id, email: s.user.email ?? e, name: n); state = .authenticated
+        } catch { await signOut() } }
+    private func storeSession(_ s: AuthSession, credential: AppleSignInCredential) throws {
+        try storeTokens(accessToken: s.accessToken, refreshToken: s.refreshToken)
+        if let d = s.user.id.data(using: .utf8) { try keychain.save(key: AuthKeychainKeys.userId, data: d) }
+        if let em = credential.email ?? s.user.email, let d = em.data(using: .utf8) { try keychain.save(key: AuthKeychainKeys.userEmail, data: d) }
+        if let nm = formatDisplayName(credential.fullName), let d = nm.data(using: .utf8) { try keychain.save(key: AuthKeychainKeys.userName, data: d) } }
+    private func storeTokens(accessToken: String, refreshToken: String) throws {
+        if let d = accessToken.data(using: .utf8) { try keychain.save(key: AuthKeychainKeys.accessToken, data: d) }
+        if let d = refreshToken.data(using: .utf8) { try keychain.save(key: AuthKeychainKeys.refreshToken, data: d) } }
+    private func clearKeychainTokens() { for k in [AuthKeychainKeys.accessToken, .refreshToken, .userId, .userEmail, .userName] { try? keychain.delete(key: k) } }
+    private func formatDisplayName(_ c: PersonNameComponents?) -> String? { guard let c else { return nil }; let f = PersonNameComponentsFormatter(); f.style = .default; let n = f.string(from: c); return n.isEmpty ? nil : n }
+}
+extension AppleSignInError { var isCancellation: Bool { if case .cancelled = self { return true }; return false } }

--- a/apps/ios/Finance/Services/SupabaseAuthClient.swift
+++ b/apps/ios/Finance/Services/SupabaseAuthClient.swift
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SupabaseAuthClient.swift - Finance - Refs #650
+import Foundation; import os
+enum SupabaseAuthError: LocalizedError, Sendable {
+    case invalidURL, invalidResponse(statusCode: Int), decodingFailed(underlying: Error)
+    case networkError(underlying: Error), missingConfiguration, tokenRefreshFailed, signOutFailed
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL: String(localized: "The authentication server URL is invalid.")
+        case .invalidResponse(let s): String(localized: "Server returned unexpected response (status \(s)).")
+        case .decodingFailed(let e): String(localized: "Failed to decode response: \(e.localizedDescription)")
+        case .networkError(let e): String(localized: "Network error: \(e.localizedDescription)")
+        case .missingConfiguration: String(localized: "Supabase configuration is missing.")
+        case .tokenRefreshFailed: String(localized: "Failed to refresh authentication session.")
+        case .signOutFailed: String(localized: "Failed to sign out from server.")
+        }
+    }
+}
+struct AuthSession: Codable, Sendable {
+    let accessToken, refreshToken, tokenType: String; let expiresIn: Int; let user: AuthUserResponse
+    enum CodingKeys: String, CodingKey { case accessToken = "access_token"; case refreshToken = "refresh_token"; case expiresIn = "expires_in"; case tokenType = "token_type"; case user }
+}
+struct AuthUserResponse: Codable, Sendable {
+    let id: String; let email, createdAt: String?
+    enum CodingKeys: String, CodingKey { case id, email; case createdAt = "created_at" }
+}
+protocol SupabaseAuthClientProtocol: Sendable {
+    func signInWithApple(idToken: String, nonce: String?) async throws -> AuthSession
+    func refreshToken(_ refreshToken: String) async throws -> AuthSession
+    func signOut(accessToken: String) async throws
+}
+actor SupabaseAuthClient: SupabaseAuthClientProtocol {
+    struct Configuration: Sendable { let baseURL, apiKey: String; static let placeholder = Configuration(baseURL: "YOUR_SUPABASE_URL", apiKey: "YOUR_SUPABASE_ANON_KEY") }
+    private let configuration: Configuration; private let session: URLSession
+    private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.finance", category: "SupabaseAuthClient")
+    init(configuration: Configuration = .placeholder, session: URLSession = .shared) { self.configuration = configuration; self.session = session }
+    func signInWithApple(idToken: String, nonce: String?) async throws -> AuthSession {
+        let url = try buildURL(path: "/auth/v1/token", queryItems: [URLQueryItem(name: "grant_type", value: "id_token")])
+        var body: [String: Any] = ["provider": "apple", "id_token": idToken]; if let nonce { body["nonce"] = nonce }
+        return try await execute(try buildRequest(url: url, method: "POST", body: body))
+    }
+    func refreshToken(_ refreshToken: String) async throws -> AuthSession {
+        let url = try buildURL(path: "/auth/v1/token", queryItems: [URLQueryItem(name: "grant_type", value: "refresh_token")])
+        do { return try await execute(try buildRequest(url: url, method: "POST", body: ["refresh_token": refreshToken])) }
+        catch { Self.logger.error("Token refresh failed: \(error.localizedDescription, privacy: .public)"); throw SupabaseAuthError.tokenRefreshFailed }
+    }
+    func signOut(accessToken: String) async throws {
+        var r = try buildRequest(url: try buildURL(path: "/auth/v1/logout"), method: "POST", body: nil)
+        r.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        do { let (_, resp) = try await session.data(for: r); guard let h = resp as? HTTPURLResponse else { throw SupabaseAuthError.signOutFailed }
+            guard (200...204).contains(h.statusCode) else { throw SupabaseAuthError.invalidResponse(statusCode: h.statusCode) }
+        } catch let e as SupabaseAuthError { throw e } catch { throw SupabaseAuthError.networkError(underlying: error) }
+    }
+    private func buildURL(path: String, queryItems: [URLQueryItem] = []) throws -> URL {
+        guard var c = URLComponents(string: configuration.baseURL) else { throw SupabaseAuthError.invalidURL }
+        c.path = path; if !queryItems.isEmpty { c.queryItems = queryItems }; guard let u = c.url else { throw SupabaseAuthError.invalidURL }; return u
+    }
+    private func buildRequest(url: URL, method: String, body: [String: Any]?) throws -> URLRequest {
+        var r = URLRequest(url: url); r.httpMethod = method; r.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        r.setValue(configuration.apiKey, forHTTPHeaderField: "apikey"); r.timeoutInterval = 30
+        if let body { r.httpBody = try JSONSerialization.data(withJSONObject: body) }; return r
+    }
+    private func execute(_ request: URLRequest) async throws -> AuthSession {
+        let d: Data; let r: URLResponse
+        do { (d, r) = try await session.data(for: request) } catch { throw SupabaseAuthError.networkError(underlying: error) }
+        guard let h = r as? HTTPURLResponse else { throw SupabaseAuthError.invalidResponse(statusCode: -1) }
+        guard (200...299).contains(h.statusCode) else { throw SupabaseAuthError.invalidResponse(statusCode: h.statusCode) }
+        do { return try JSONDecoder().decode(AuthSession.self, from: d) } catch { throw SupabaseAuthError.decodingFailed(underlying: error) }
+    }
+}

--- a/apps/ios/FinanceWidget/FinanceWidgetBundle.swift
+++ b/apps/ios/FinanceWidget/FinanceWidgetBundle.swift
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: BUSL-1.1
+// FinanceWidgetBundle.swift — Refs #380
+
+import SwiftUI
+import WidgetKit
+
+@main
+struct FinanceWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        BalanceWidget()
+        BudgetProgressWidget()
+        RecentTransactionsWidget()
+        QuickEntryWidget()
+    }
+}

--- a/apps/ios/FinanceWidget/FinanceWidgetDesignTokens.swift
+++ b/apps/ios/FinanceWidget/FinanceWidgetDesignTokens.swift
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BUSL-1.1
+// FinanceWidgetDesignTokens.swift — Refs #380
+
+import SwiftUI
+
+enum FinanceWidgetColors {
+    static let amountPositive = Color(light: .init(red: 0.082, green: 0.502, blue: 0.239), dark: .init(red: 0.133, green: 0.773, blue: 0.369))
+    static let amountNegative = Color(light: .init(red: 0.725, green: 0.110, blue: 0.110), dark: .init(red: 0.937, green: 0.267, blue: 0.267))
+    static let statusPositive = Color(light: .init(red: 0.086, green: 0.639, blue: 0.290), dark: .init(red: 0.133, green: 0.773, blue: 0.369))
+    static let statusNegative = Color(light: .init(red: 0.863, green: 0.149, blue: 0.149), dark: .init(red: 0.937, green: 0.267, blue: 0.267))
+    static let statusWarning = Color(light: .init(red: 0.851, green: 0.467, blue: 0.024), dark: .init(red: 0.961, green: 0.620, blue: 0.043))
+    static let interactive = Color(light: .init(red: 0.145, green: 0.388, blue: 0.922), dark: .init(red: 0.376, green: 0.647, blue: 0.980))
+}
+
+private extension Color {
+    init(light: Color, dark: Color) {
+        #if canImport(UIKit)
+        self.init(uiColor: UIColor { $0.userInterfaceStyle == .dark ? UIColor(dark) : UIColor(light) })
+        #elseif canImport(AppKit)
+        self.init(nsColor: NSColor(name: nil) { $0.bestMatch(from: [.darkAqua, .vibrantDark]) != nil ? NSColor(dark) : NSColor(light) })
+        #endif
+    }
+}
+
+enum FinanceWidgetSpacing {
+    static let xxs: CGFloat = 4
+    static let xs: CGFloat = 8
+    static let sm: CGFloat = 12
+    static let md: CGFloat = 16
+}

--- a/apps/ios/FinanceWidget/WidgetDataProvider.swift
+++ b/apps/ios/FinanceWidget/WidgetDataProvider.swift
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: BUSL-1.1
+// WidgetDataProvider.swift — Refs #380
+
+import Foundation
+
+enum WidgetDataKeys {
+    static let suiteName = "group.com.finance.app"
+    static let balance = "widget.balance"
+    static let transactions = "widget.transactions"
+    static let budgets = "widget.budgets"
+}
+
+struct WidgetBalance: Codable, Sendable, Hashable {
+    let totalMinorUnits: Int64
+    let previousMonthMinorUnits: Int64
+    let currencyCode: String
+    let accountName: String
+    let updatedAt: Date
+    var isTrendingUp: Bool { totalMinorUnits >= previousMonthMinorUnits }
+}
+
+struct WidgetTransaction: Codable, Sendable, Hashable, Identifiable {
+    let id: String
+    let payee: String
+    let categoryIcon: String
+    let categoryName: String
+    let amountMinorUnits: Int64
+    let currencyCode: String
+    let date: Date
+    let isIncome: Bool
+}
+
+struct WidgetBudget: Codable, Sendable, Hashable, Identifiable {
+    let id: String
+    let name: String
+    let icon: String
+    let spentMinorUnits: Int64
+    let limitMinorUnits: Int64
+    let currencyCode: String
+    var progress: Double {
+        guard limitMinorUnits > 0 else { return 0 }
+        return Double(spentMinorUnits) / Double(limitMinorUnits)
+    }
+    var isOverBudget: Bool { spentMinorUnits > limitMinorUnits }
+}
+
+enum WidgetDataProvider {
+    private static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+    private static var defaults: UserDefaults? { UserDefaults(suiteName: WidgetDataKeys.suiteName) }
+    static func readBalance() -> WidgetBalance {
+        guard let defaults, let data = defaults.data(forKey: WidgetDataKeys.balance), let balance = try? decoder.decode(WidgetBalance.self, from: data) else { return .placeholder }
+        return balance
+    }
+    static func readTransactions(limit: Int = 5) -> [WidgetTransaction] {
+        guard let defaults, let data = defaults.data(forKey: WidgetDataKeys.transactions), let txns = try? decoder.decode([WidgetTransaction].self, from: data) else { return WidgetTransaction.placeholders }
+        return Array(txns.prefix(limit))
+    }
+    static func readBudgets(limit: Int = 3) -> [WidgetBudget] {
+        guard let defaults, let data = defaults.data(forKey: WidgetDataKeys.budgets), let budgets = try? decoder.decode([WidgetBudget].self, from: data) else { return WidgetBudget.placeholders }
+        return Array(budgets.prefix(limit))
+    }
+}
+
+extension WidgetBalance {
+    static let placeholder = WidgetBalance(totalMinorUnits: 2_485_000, previousMonthMinorUnits: 2_340_000, currencyCode: "USD", accountName: String(localized: "All Accounts"), updatedAt: .now)
+}
+
+extension WidgetTransaction {
+    static let placeholders: [WidgetTransaction] = [
+        .init(id: "ph-1", payee: String(localized: "Grocery Store"), categoryIcon: "cart.fill", categoryName: String(localized: "Groceries"), amountMinorUnits: -8_540, currencyCode: "USD", date: .now, isIncome: false),
+        .init(id: "ph-2", payee: String(localized: "Direct Deposit"), categoryIcon: "building.columns", categoryName: String(localized: "Income"), amountMinorUnits: 350_000, currencyCode: "USD", date: Calendar.current.date(byAdding: .day, value: -1, to: .now) ?? .now, isIncome: true),
+        .init(id: "ph-3", payee: String(localized: "Coffee Shop"), categoryIcon: "cup.and.saucer.fill", categoryName: String(localized: "Food"), amountMinorUnits: -550, currencyCode: "USD", date: Calendar.current.date(byAdding: .day, value: -1, to: .now) ?? .now, isIncome: false),
+        .init(id: "ph-4", payee: String(localized: "Gas Station"), categoryIcon: "car.fill", categoryName: String(localized: "Transport"), amountMinorUnits: -4_200, currencyCode: "USD", date: Calendar.current.date(byAdding: .day, value: -2, to: .now) ?? .now, isIncome: false),
+        .init(id: "ph-5", payee: String(localized: "Online Store"), categoryIcon: "bag.fill", categoryName: String(localized: "Shopping"), amountMinorUnits: -2_999, currencyCode: "USD", date: Calendar.current.date(byAdding: .day, value: -3, to: .now) ?? .now, isIncome: false),
+    ]
+}
+
+extension WidgetBudget {
+    static let placeholders: [WidgetBudget] = [
+        .init(id: "pb-1", name: String(localized: "Groceries"), icon: "cart.fill", spentMinorUnits: 32_000, limitMinorUnits: 50_000, currencyCode: "USD"),
+        .init(id: "pb-2", name: String(localized: "Dining Out"), icon: "fork.knife", spentMinorUnits: 18_500, limitMinorUnits: 20_000, currencyCode: "USD"),
+        .init(id: "pb-3", name: String(localized: "Transport"), icon: "car.fill", spentMinorUnits: 8_000, limitMinorUnits: 15_000, currencyCode: "USD"),
+    ]
+}
+
+enum WidgetCurrencyFormatter {
+    static func format(minorUnits: Int64, currencyCode: String, showCents: Bool = true) -> String {
+        let f = NumberFormatter(); f.numberStyle = .currency; f.currencyCode = currencyCode
+        f.maximumFractionDigits = showCents ? 2 : 0; f.minimumFractionDigits = showCents ? 2 : 0
+        return f.string(from: NSNumber(value: Double(minorUnits) / 100.0)) ?? currencyCode
+    }
+    static func formatCompact(minorUnits: Int64, currencyCode: String) -> String {
+        let v = Double(abs(minorUnits)) / 100.0, s = minorUnits < 0 ? "-" : "", sym = currencySymbol(for: currencyCode)
+        if v >= 1_000_000 { return "\(s)\(sym)\(String(format: "%.1fM", v / 1_000_000))" }
+        if v >= 1_000 { return "\(s)\(sym)\(String(format: "%.1fK", v / 1_000))" }
+        return "\(s)\(sym)\(String(format: "%.0f", v))"
+    }
+    static func currencySymbol(for code: String) -> String {
+        let f = NumberFormatter(); f.numberStyle = .currency; f.currencyCode = code; f.locale = .current
+        return f.currencySymbol ?? "$"
+    }
+    static func formatForVoiceOver(minorUnits: Int64, currencyCode: String) -> String {
+        let f = NumberFormatter(); f.numberStyle = .currencyPlural; f.currencyCode = currencyCode
+        return f.string(from: NSNumber(value: Double(minorUnits) / 100.0)) ?? currencyCode
+    }
+}
+
+enum WidgetDateFormatter {
+    static func relativeString(for date: Date) -> String {
+        if Calendar.current.isDateInToday(date) { return String(localized: "Today") }
+        if Calendar.current.isDateInYesterday(date) { return String(localized: "Yesterday") }
+        let f = DateFormatter(); f.dateStyle = .short; f.timeStyle = .none; return f.string(from: date)
+    }
+}

--- a/apps/ios/Tests/AuthenticationServiceTests.swift
+++ b/apps/ios/Tests/AuthenticationServiceTests.swift
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BUSL-1.1
+// AuthenticationServiceTests.swift - FinanceTests - Refs #650
+import XCTest; @testable import FinanceApp
+final class AuthenticationServiceTests: XCTestCase {
+    @MainActor func testSignInStoresTokens() async {
+        let kc = StubKeychainManager(); let sb = StubSupabaseAuthClient(); let asi = StubAppleSignInManager()
+        asi.credentialToReturn = StubAppleCredential.default; sb.sessionToReturn = StubAuthSession.default
+        let svc = AuthenticationService(appleSignInManager: asi, supabaseClient: sb, keychain: kc)
+        await svc.signInWithApple()
+        XCTAssertTrue(svc.isAuthenticated); XCTAssertEqual(svc.currentUser?.id, "user-123"); XCTAssertEqual(svc.currentUser?.email, "test@example.com")
+        XCTAssertNil(svc.authError); XCTAssertNotNil(kc.store["com.finance.auth.accessToken"]); XCTAssertNotNil(kc.store["com.finance.auth.refreshToken"]) }
+    @MainActor func testCancellationNoError() async {
+        let asi = StubAppleSignInManager(); asi.errorToThrow = AppleSignInError.cancelled
+        let svc = AuthenticationService(appleSignInManager: asi, supabaseClient: StubSupabaseAuthClient(), keychain: StubKeychainManager())
+        await svc.signInWithApple(); XCTAssertFalse(svc.isAuthenticated); XCTAssertNil(svc.authError) }
+    @MainActor func testSignInFailure() async {
+        let asi = StubAppleSignInManager(); asi.errorToThrow = AppleSignInError.missingIdentityToken
+        let svc = AuthenticationService(appleSignInManager: asi, supabaseClient: StubSupabaseAuthClient(), keychain: StubKeychainManager())
+        await svc.signInWithApple(); XCTAssertFalse(svc.isAuthenticated); XCTAssertNotNil(svc.authError) }
+    @MainActor func testSupabaseFailure() async {
+        let asi = StubAppleSignInManager(); asi.credentialToReturn = StubAppleCredential.default
+        let sb = StubSupabaseAuthClient(); sb.errorToThrow = SupabaseAuthError.invalidResponse(statusCode: 401)
+        let svc = AuthenticationService(appleSignInManager: asi, supabaseClient: sb, keychain: StubKeychainManager())
+        await svc.signInWithApple(); XCTAssertFalse(svc.isAuthenticated); XCTAssertNotNil(svc.authError) }
+    @MainActor func testSignOutClearsAll() async {
+        let kc = StubKeychainManager(); kc.store["com.finance.auth.accessToken"] = Data("a".utf8); kc.store["com.finance.auth.refreshToken"] = Data("r".utf8)
+        kc.store["com.finance.auth.userId"] = Data("u".utf8); kc.store["com.finance.auth.userEmail"] = Data("e".utf8); kc.store["com.finance.auth.userName"] = Data("n".utf8)
+        let asi = StubAppleSignInManager(); asi.credentialToReturn = StubAppleCredential.default
+        let sb = StubSupabaseAuthClient(); sb.sessionToReturn = StubAuthSession.default
+        let svc = AuthenticationService(appleSignInManager: asi, supabaseClient: sb, keychain: kc)
+        await svc.signInWithApple(); await svc.signOut()
+        XCTAssertFalse(svc.isAuthenticated); XCTAssertNil(svc.currentUser); XCTAssertNil(kc.store["com.finance.auth.accessToken"])
+        XCTAssertNil(kc.store["com.finance.auth.userId"]); XCTAssertTrue(sb.signOutCalled) }
+    @MainActor func testSignOutWhenServerFails() async {
+        let kc = StubKeychainManager(); kc.store["com.finance.auth.accessToken"] = Data("a".utf8)
+        let sb = StubSupabaseAuthClient(); sb.signOutError = SupabaseAuthError.networkError(underlying: NSError(domain: "t", code: -1))
+        let asi = StubAppleSignInManager(); asi.credentialToReturn = StubAppleCredential.default; sb.sessionToReturn = StubAuthSession.default
+        let svc = AuthenticationService(appleSignInManager: asi, supabaseClient: sb, keychain: kc)
+        await svc.signInWithApple(); await svc.signOut()
+        XCTAssertFalse(svc.isAuthenticated); XCTAssertNil(kc.store["com.finance.auth.accessToken"]) }
+    @MainActor func testNoStoredTokens() async {
+        let svc = AuthenticationService(appleSignInManager: StubAppleSignInManager(), supabaseClient: StubSupabaseAuthClient(), keychain: StubKeychainManager())
+        await svc.checkExistingSession(); XCTAssertFalse(svc.isAuthenticated) }
+    @MainActor func testRefreshUpdatesTokens() async {
+        let kc = StubKeychainManager(); kc.store["com.finance.auth.refreshToken"] = Data("old".utf8)
+        let sb = StubSupabaseAuthClient(); sb.refreshSessionToReturn = AuthSession(accessToken: "new-at", refreshToken: "new-rt", expiresIn: 3600, tokenType: "bearer", user: AuthUserResponse(id: "u1", email: "e@e.com", createdAt: nil))
+        let svc = AuthenticationService(appleSignInManager: StubAppleSignInManager(), supabaseClient: sb, keychain: kc)
+        await svc.refreshSession()
+        XCTAssertEqual(kc.store["com.finance.auth.accessToken"].flatMap { String(data: $0, encoding: .utf8) }, "new-at") }
+    @MainActor func testRefreshFailureSignsOut() async {
+        let kc = StubKeychainManager(); kc.store["com.finance.auth.refreshToken"] = Data("old".utf8); kc.store["com.finance.auth.userId"] = Data("u".utf8)
+        let sb = StubSupabaseAuthClient(); sb.refreshError = SupabaseAuthError.tokenRefreshFailed
+        let svc = AuthenticationService(appleSignInManager: StubAppleSignInManager(), supabaseClient: sb, keychain: kc)
+        await svc.refreshSession(); XCTAssertFalse(svc.isAuthenticated); XCTAssertNil(kc.store["com.finance.auth.refreshToken"]) }
+}
+final class StubKeychainManager: KeychainManaging, @unchecked Sendable {
+    var store: [String: Data] = [:]; var errorToThrow: KeychainError?
+    func save(key: String, data: Data) throws { if let e = errorToThrow { throw e }; store[key] = data }
+    func load(key: String) -> Data? { store[key] }
+    func delete(key: String) throws { if let e = errorToThrow { throw e }; store.removeValue(forKey: key) }
+}
+final class StubAppleSignInManager: AppleSignInManaging, @unchecked Sendable {
+    var credentialToReturn: AppleSignInCredential?; var errorToThrow: AppleSignInError?
+    func signIn() async throws -> AppleSignInCredential { if let e = errorToThrow { throw e }; guard let c = credentialToReturn else { throw AppleSignInError.missingIdentityToken }; return c }
+}
+final class StubSupabaseAuthClient: SupabaseAuthClientProtocol, @unchecked Sendable {
+    var sessionToReturn: AuthSession?; var refreshSessionToReturn: AuthSession?; var errorToThrow: SupabaseAuthError?; var refreshError: SupabaseAuthError?; var signOutError: SupabaseAuthError?; var signOutCalled = false
+    func signInWithApple(idToken: String, nonce: String?) async throws -> AuthSession { if let e = errorToThrow { throw e }; guard let s = sessionToReturn else { throw SupabaseAuthError.invalidResponse(statusCode: 500) }; return s }
+    func refreshToken(_ refreshToken: String) async throws -> AuthSession { if let e = refreshError { throw e }; guard let s = refreshSessionToReturn ?? sessionToReturn else { throw SupabaseAuthError.tokenRefreshFailed }; return s }
+    func signOut(accessToken: String) async throws { signOutCalled = true; if let e = signOutError { throw e } }
+}
+enum StubAppleCredential { static let `default` = AppleSignInCredential(userID: "apple-user-001", fullName: { var c = PersonNameComponents(); c.givenName = "Test"; c.familyName = "User"; return c }(), email: "test@example.com", identityToken: "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.sig", authorizationCode: "auth-code-123", nonce: "test-nonce") }
+enum StubAuthSession { static let `default` = AuthSession(accessToken: "sb-at-123", refreshToken: "sb-rt-456", expiresIn: 3600, tokenType: "bearer", user: AuthUserResponse(id: "user-123", email: "test@example.com", createdAt: "2024-01-01T00:00:00Z")) }


### PR DESCRIPTION
Full Apple Sign-In → Supabase Auth integration with credential management.

### New Files
- **SupabaseAuthClient** — Actor-isolated HTTP client for Supabase Auth (sign-in, refresh, sign-out)
- **AuthenticationService** — @Observable service: sign-in flow, session restore, credential state checks, token refresh
- **AuthenticationServiceTests** — 9 test cases with protocol-based stubs

### Modified Files
- **FinanceApp** — Injects AuthenticationService, checks session on launch, monitors credential revocation
- **SettingsView** — Account section: signed-in user info or Sign in with Apple button
- **AppleSignInManager** — Issue ref update

### Architecture
- Keychain-only token storage (never UserDefaults)
- Protocol-based DI for full testability
- Placeholder Supabase config (no real secrets)
- Actor isolation on HTTP client
- Cancellation handled silently

Closes #650

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>