### PR TITLE
feat(sync): complete PowerSync sync-rules.yaml for all entity types (#534)

### DIFF
--- a/services/api/powersync/sync-rules.yaml
+++ b/services/api/powersync/sync-rules.yaml
@@ -82,6 +82,16 @@ bucket_definitions:
         FROM goals
         WHERE household_id = bucket.household_id AND deleted_at IS NULL
 
+      # Household members - all members of each household the user belongs to.
+      # Enables the client to display co-member names, roles, and household
+      # member lists. (The user_profile bucket syncs only the user's OWN
+      # membership records; this syncs ALL members for the household.)
+      - >
+        SELECT id, household_id, user_id, role, joined_at,
+               created_at, updated_at, deleted_at
+        FROM household_members
+        WHERE household_id = bucket.household_id AND deleted_at IS NULL
+
       # Household invitations — lets members see pending/accepted invites
       - >
         SELECT id, household_id, invited_by, invite_code, invited_email,


### PR DESCRIPTION
## Summary

Add the missing `household_members` sync rule to the `by_household` bucket in PowerSync sync-rules.yaml.

### Problem

`household_members` was only synced in the `user_profile` bucket (scoped to the authenticated user's own membership records). This meant clients could see *which* households they belonged to, but could **not** see the other members of those households — blocking household member lists, co-member name display, and role visibility.

### Solution

Add a `household_members` data query to the `by_household` bucket, scoped by `household_id = bucket.household_id` and filtered with `deleted_at IS NULL`. This mirrors the existing RLS policy (`household_id = ANY(auth.household_ids())`) and is consistent with how all other household-scoped entities are synced.

### Sync coverage (all 11 entity types)

| Bucket | Tables |
|---|---|
| `by_household` | households, accounts, transactions, categories, budgets, goals, **household_members** (new), household_invitations, recurring_transaction_templates |
| `user_profile` | users, household_members (own records), passkey_credentials |

### Server-only tables (correctly excluded)

- `audit_log` — immutable financial audit trail
- `data_export_audit_log` — GDPR/CCPA compliance log
- `webauthn_challenges` — temporary auth ceremony data
- `sync_health_logs` — server monitoring telemetry
- `rate_limits` — rate limiting infrastructure

### Security

- Household isolation enforced via `bucket.household_id` scoping
- Soft-delete filtering via `deleted_at IS NULL`
- Column allowlisting (no `sync_version`, `is_synced`, or `public_key`)

Closes #534