### PR TITLE
docs(agents): refresh agent reference files (#541)

### DIFF
--- a/.github/agents/accessibility-reviewer.agent.md
+++ b/.github/agents/accessibility-reviewer.agent.md
@@ -66,11 +66,12 @@ You are the accessibility reviewer for Finance. Inspired by Tiimo's disability-i
 - Use SwiftUI accessibility modifiers (.accessibilityLabel, .accessibilityHint, etc.)
 - Support Dynamic Type for all text
 - Test with VoiceOver and Voice Control
+- App targets: FinanceApp (iOS 17+), FinanceWatch (watchOS 10+), FinanceClip (App Clip), FinanceWidget (Home/Lock Screen)
 
 ### Android
 
 - Use Jetpack Compose semantics (contentDescription, Role, etc.)
-- Support system font scaling
+- Support system font scaling (minSdk 28, API 9.0+)
 - Test with TalkBack and Switch Access
 
 ### Web

--- a/.github/agents/android-engineer.agent.md
+++ b/.github/agents/android-engineer.agent.md
@@ -25,7 +25,7 @@ You are the Android platform engineer for Finance, a multi-platform financial tr
 - Wear OS companion (Tiles, Complications, DataLayer API)
 - Gradle KMP Android configuration (AGP, version catalogs)
 - Kotlin coroutines and Flow integration with Compose
-- Room KMP or SQLDelight Android driver
+- SQLDelight Android driver with SQLCipher 4.6.1 encryption
 - WorkManager for background sync
 - Firebase Cloud Messaging or Supabase push for notifications
 - Google Play submission (app signing, release tracks, privacy declarations)
@@ -63,7 +63,7 @@ You are the Android platform engineer for Finance, a multi-platform financial tr
 - Material 3 with dynamic color support
 - Use BiometricPrompt with Android Keystore for auth
 - All Composables must have contentDescription for TalkBack
-- Minimum SDK: API 26 (Android 8.0) for broad coverage with modern APIs
+- Minimum SDK: API 28 (Android 9.0), compileSdk/targetSdk: 35
 - Use WorkManager (not AlarmManager) for all background work
 
 # Key Responsibilities
@@ -103,7 +103,7 @@ You are the Android platform engineer for Finance, a multi-platform financial tr
 - Do NOT use AlarmManager, JobScheduler, or other legacy scheduling APIs
 - Do NOT store secrets or credentials in SharedPreferences or plain files
 - Do NOT skip contentDescription on interactive or informational Composables
-- Do NOT target below API 26 without explicit architectural approval
+- Do NOT target below API 28 without explicit architectural approval
 - NEVER execute shell commands that modify remote state, publish packages, or access resources outside the project directory
 
 ## Human-Gated Operations (applies to ALL agents)

--- a/.github/agents/architect.agent.md
+++ b/.github/agents/architect.agent.md
@@ -44,6 +44,13 @@ When making architectural decisions:
 - Review cross-cutting changes that affect multiple apps or packages
 - Ensure the backend remains a thin sync layer, not a business logic server
 
+## Reference Files
+
+- `docs/architecture/` — Architecture Decision Records (ADRs 0001–0009) covering cross-platform strategy, sync architecture, local storage, auth/security, design system, CI/CD, hosting, and legal/monetization.
+- `packages/core/src/commonMain/kotlin/com/finance/core/` — Shared business logic modules (aggregation, analytics, budget, categorization, currency, events, export, household, money, monitoring, recurring, validation).
+- `packages/sync/src/commonMain/kotlin/com/finance/sync/` — Sync engine with delta sync, queue processing, and conflict resolution.
+- `services/api/powersync/sync-rules.yaml` — PowerSync sync rules (two buckets: by_household, user_profile).
+
 # Commands
 
 - Review architecture: examine the current structure and identify issues

--- a/.github/agents/backend-engineer.agent.md
+++ b/.github/agents/backend-engineer.agent.md
@@ -27,7 +27,7 @@ You are the backend engineer for Finance, responsible for the sync layer that co
 - Database migrations (versioned, reversible, zero-downtime)
 - PostgreSQL indexes, materialized views for financial reporting
 - Encryption at rest (PostgreSQL TDE, application-level encryption)
-- CRDT-based conflict resolution for shared household data
+- PowerSync last-write-wins (LWW) sync with custom merge logic for complex data
 - API rate limiting and abuse prevention
 - GDPR/CCPA data export and deletion implementation
 - Database backup and point-in-time recovery
@@ -47,6 +47,13 @@ You are the backend engineer for Finance, responsible for the sync layer that co
 - Configure PowerSync sync rules
 - Implement Edge Functions for server-side operations
 - Manage database migrations
+
+## Reference Files
+
+- `services/api/supabase/migrations/` — 10 versioned migration files defining the complete schema (users, households, accounts, transactions, categories, budgets, goals, recurring templates, invitations, audit/monitoring tables).
+- `services/api/supabase/functions/` — 12 Edge Functions (Deno/TypeScript): account-deletion, auth-webhook, data-export, health-check, household-invite, passkey-authenticate, passkey-register, process-recurring, sync-health-report, plus `_shared/` utilities (auth, cors, logger, rate-limit, response).
+- `services/api/powersync/sync-rules.yaml` — PowerSync sync rules defining two buckets: `by_household` (tenant-isolated data) and `user_profile` (per-user data).
+- `services/api/openapi.yaml` — API specification.
 
 # Boundaries
 

--- a/.github/agents/design-engineer.agent.md
+++ b/.github/agents/design-engineer.agent.md
@@ -39,6 +39,15 @@ You are the design systems engineer for Finance, a multi-platform financial trac
 - Maintain iconography alignment across SF Symbols, Material Icons, and Fluent Icons
 - Support Figma-to-code handoff workflows
 
+## Reference Files
+
+- `packages/design-tokens/` — DTCG-compliant design token package built with Style Dictionary 5.3.3.
+- `packages/design-tokens/tokens/primitive/` — Base values (colors, dimensions).
+- `packages/design-tokens/tokens/semantic/` — Theme-aware tokens (light/dark colors, typography, elevation).
+- `packages/design-tokens/tokens/component/` — Component-level tokens.
+- `packages/design-tokens/build/` — Generated platform outputs: CSS (`tokens.css`, `tokens-dark.css`), Swift (`FinanceTokens.swift`, `FinanceTokensDark.swift`), Android XML (`colors.xml`, `dimens.xml`, `colors-night.xml`).
+- `config/style-dictionary.config.mjs` — Style Dictionary build configuration (ESM, DTCG-compliant).
+
 # Key Rules
 
 - All colors must meet WCAG AA contrast (4.5:1 text, 3:1 UI)

--- a/.github/agents/devops-engineer.agent.md
+++ b/.github/agents/devops-engineer.agent.md
@@ -32,8 +32,20 @@ You are the DevOps and CI/CD engineer for Finance, a multi-platform financial tr
 
 ## Active CI Workflows
 
-- **`lint-format.yml`** — Runs ESLint and Prettier checks on all pull requests. Ensures consistent code style and catches lint errors before merge.
-- **`release.yml`** — Release automation triggered by tag pushes. Creates a GitHub Release with auto-generated release notes when a version tag (e.g., `v1.0.0`) is pushed.
+- **`ci.yml`** — Main integration tests on push/PR.
+- **`android-ci.yml`** — Android app build and test.
+- **`ios-ci.yml`** — iOS app build and test.
+- **`web-ci.yml`** — Web app build and test.
+- **`windows-ci.yml`** — Windows app build and test.
+- **`lint-format.yml`** — ESLint and Prettier checks on all pull requests.
+- **`security.yml`** — SAST and dependency scanning (periodic/PR).
+- **`changesets.yml`** — Changelog and version management on PRs.
+- **`release.yml`** — Release automation triggered by tag pushes.
+- **`pr-title.yml`** — Conventional commit title validation on PRs.
+- **`pen-test.yml`** — Penetration testing workflow.
+- **`auto-add-to-project.yml`** — GitHub project board integration.
+- **`stale-detection.yml`** — Scheduled stale issue/PR cleanup.
+- **`copilot-setup-steps.yml`** — AI-assisted setup documentation.
 - When adding or modifying workflows, ensure consistency with these existing pipelines (pinned action versions, secret handling, caching strategies).
 
 # Key Responsibilities

--- a/.github/agents/docs-writer.agent.md
+++ b/.github/agents/docs-writer.agent.md
@@ -56,6 +56,18 @@ You are the documentation writer for Finance. Your role is to create, maintain, 
 - Document API endpoints and data models
 - Create onboarding guides for new contributors
 
+## Reference Files
+
+- `docs/ai/` — AI system prompts and guidelines (agents.md, ai-code-policy.md, instructions.md, mcp.md, responsible-ai.md, restrictions.md, skills.md, workflow.md).
+- `docs/architecture/` — ADRs (0001–0009), security/privacy audits, monitoring guide, android-architecture.md.
+- `docs/audits/` — MASVS mobile security audits, dependency audit.
+- `docs/compliance/` — GDPR, data privacy, incident response runbook.
+- `docs/guides/` — Branch protection, labels, workflow cheatsheet, monitoring.
+- `docs/testing/` — Alerting rules, monitoring configuration.
+- `.github/agents/` — 13 AI agent definition files.
+- `.github/skills/` — Reusable AI agent skill files.
+- `.github/instructions/` — Path-specific Copilot instruction files.
+
 ## Current Documentation State
 
 - **README.md** (root) includes a **Project Status** section showing all 8 roadmap phases complete (marked with ✅). Keep this section updated as new phases are added.

--- a/.github/agents/finance-domain.agent.md
+++ b/.github/agents/finance-domain.agent.md
@@ -54,6 +54,17 @@ You are the financial domain expert for the Finance application. Your role is to
 - **Split** — How a transaction or budget is divided between household members
 - **Permission** — What each household member can see and do
 
+## Reference Files
+
+- `packages/core/src/commonMain/kotlin/com/finance/core/budget/BudgetCalculator.kt` — Budget calculations and tracking.
+- `packages/core/src/commonMain/kotlin/com/finance/core/categorization/CategorizationEngine.kt` — Auto-categorization of transactions.
+- `packages/core/src/commonMain/kotlin/com/finance/core/analytics/` — Report generation, spending insights, net worth snapshots, monthly comparisons.
+- `packages/core/src/commonMain/kotlin/com/finance/core/currency/` — Multi-currency conversion, formatting, exchange rates.
+- `packages/core/src/commonMain/kotlin/com/finance/core/recurring/` — Recurring transaction engine, recurrence rules, reminders.
+- `packages/core/src/commonMain/kotlin/com/finance/core/household/` — Household management and RBAC permissions.
+- `packages/core/src/commonMain/kotlin/com/finance/core/export/` — GDPR Article 20 data export (JSON/CSV, SHA-256 checksums, user ID anonymization).
+- `packages/models/src/commonMain/sqldelight/com/finance/db/` — SQLDelight `.sq` schema files for all entities.
+
 # Key Responsibilities
 
 - Review and validate all financial calculation logic

--- a/.github/agents/ios-engineer.agent.md
+++ b/.github/agents/ios-engineer.agent.md
@@ -27,10 +27,11 @@ You are the iOS platform engineer for Finance, a multi-platform financial tracki
 - Support multi-window (`WindowGroup`, `DocumentGroup`) and multi-scene on iPadOS/macOS.
 - Implement responsive layouts with `ViewThatFits`, `AnyLayout`, adaptive grids, and `horizontalSizeClass` / `verticalSizeClass`.
 
-## KMP Integration via Swift Export
+## KMP Integration via XCFramework
 
-- Consume Kotlin Multiplatform shared logic (`packages/core`, `packages/models`, `packages/sync`) via Swift Export or KMP-NativeCoroutines.
-- Understand the KMP → iOS bridge: Kotlin compiles to an Apple framework (`.xcframework`) that Swift imports directly.
+- Consume Kotlin Multiplatform shared logic (`packages/core`, `packages/models`, `packages/sync`) via the FinanceSync XCFramework built from `packages/sync/` (which re-exports core and models).
+- The KMP → iOS bridge: Kotlin compiles to an Apple framework (`.xcframework`) that Swift imports directly. Build command: `./gradlew :packages:sync:assembleFinanceSyncXCFramework`.
+- XCFramework output path: `packages/sync/build/XCFrameworks/release/FinanceSync.xcframework`.
 - Map Kotlin types to Swift equivalents — `kotlin.Int` → `Swift.Int32`, `kotlin.String` → `Swift.String`, `kotlin.collections.List` → `Swift.Array`, sealed classes → Swift enums with associated values.
 - Use `SKIE` or `KMP-NativeCoroutines` to expose Kotlin coroutine `Flow` as Swift `AsyncSequence` / `AsyncStream`.
 - Configure the Xcode project to consume the KMP framework — embed in `Frameworks, Libraries, and Embedded Content`, set `FRAMEWORK_SEARCH_PATHS`, link `packages/core` output.
@@ -79,7 +80,7 @@ You are the iOS platform engineer for Finance, a multi-platform financial tracki
 
 ## watchOS Companion App
 
-- Implement a watchOS companion app in `apps/ios/WatchApp/` using SwiftUI and WatchKit.
+- Implement a watchOS companion app in `apps/ios/FinanceWatch/` using SwiftUI and WatchKit.
 - Core screens: account balance at-a-glance, recent transactions (last 5), budget status summary.
 - Use `WatchConnectivity` (`WCSession`) for transferring lightweight data from the iPhone app.
 - Implement WidgetKit complications — show current balance or budget remaining on the watch face.
@@ -89,8 +90,8 @@ You are the iOS platform engineer for Finance, a multi-platform financial tracki
 
 ## Xcode Project Configuration for KMP Frameworks
 
-- Configure the Xcode project to embed the KMP-generated `.xcframework` — set `FRAMEWORK_SEARCH_PATHS` to the Gradle build output directory.
-- Use a Run Script Build Phase to invoke `./gradlew :packages:core:assembleFATFramework` (or equivalent) before compilation.
+- Configure the Xcode project to embed the KMP-generated `.xcframework` — set `FRAMEWORK_SEARCH_PATHS` to the Gradle build output directory (`packages/sync/build/XCFrameworks/release/`).
+- Use a Run Script Build Phase to invoke `./gradlew :packages:sync:assembleFinanceSyncXCFramework` before compilation.
 - Set `ENABLE_USER_SCRIPT_SANDBOXING = NO` for the KMP build phase (Gradle needs file system access).
 - Configure `OTHER_LINKER_FLAGS = -lsqlite3` if SQLDelight links against system SQLite.
 - Manage scheme configurations: Debug (local KMP build), Release (pre-built framework from CI artifacts).
@@ -178,7 +179,7 @@ You are the iOS platform engineer for Finance, a multi-platform financial tracki
 
 - Build iOS app: `cd apps/ios && xcodebuild -scheme Finance -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16' build`
 - Run tests: `cd apps/ios && xcodebuild -scheme Finance -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16' test`
-- Build KMP framework: `./gradlew :packages:core:linkReleaseFrameworkIosArm64`
+- Build KMP framework: `./gradlew :packages:sync:assembleFinanceSyncXCFramework`
 - Lint Swift: `swiftlint lint --config apps/ios/.swiftlint.yml`
 - Accessibility audit: Run Accessibility Inspector via Xcode → Open Developer Tool → Accessibility Inspector
 

--- a/.github/agents/kmp-engineer.agent.md
+++ b/.github/agents/kmp-engineer.agent.md
@@ -27,8 +27,8 @@ You are the KMP engineer for Finance, a multi-platform financial tracking applic
 - kotlinx-coroutines (Flow, StateFlow, structured concurrency, dispatcher management)
 - Gradle Kotlin DSL for KMP (version catalogs, composite builds, target configuration)
 - KMP testing (kotlin.test, turbine for Flow testing, MockK)
-- Swift Export and Objective-C interop patterns (planned — iOS is currently pure SwiftUI, KMP bridge not yet wired)
-- Kotlin/JS target for web (IR compiler, npm interop — web app currently uses TypeScript + React with planned KMP integration)
+- Swift Export and Objective-C interop patterns — iOS app consumes the FinanceSync XCFramework built from `packages/sync/` (which re-exports core and models)
+- Kotlin/JS target for web (IR compiler, npm interop — web app uses TypeScript + React with a `src/kmp/` bridge directory for KMP integration)
 - PowerSync Kotlin SDK integration for offline-first sync
 - Shared data export services and serializers in `packages/core/export`
 - Multiplatform Settings / MMKV for key-value storage
@@ -50,13 +50,13 @@ These are non-negotiable rules for all shared KMP code:
 
 # Key Responsibilities
 
-- Define and maintain KMP module structure in `packages/` (core, models, sync, networking)
+- Define and maintain KMP module structure in `packages/` (core, models, sync)
 - Write SQLDelight schemas (`.sq` files) and versioned migrations for all financial entities
 - Implement core business logic in commonMain (budget engine, transaction categorization, aggregations)
 - Configure Gradle for all KMP targets (iOS via framework export, Android, JVM for desktop, JS/Wasm for web)
 - Implement Ktor client networking layer with proper auth, retry, and content negotiation
 - Write platform-specific actual implementations for crypto, secure storage, and biometrics
-- Review all shared code for platform compatibility across all six source sets
+- Review all shared code for platform compatibility across all target source sets (commonMain, iosMain, androidMain, jvmMain, jsMain — varies by package)
 - Maintain version catalog (`libs.versions.toml`) for all KMP dependencies
 - Write comprehensive tests using kotlin.test and turbine for Flow-based APIs
 

--- a/.github/agents/security-reviewer.agent.md
+++ b/.github/agents/security-reviewer.agent.md
@@ -70,11 +70,20 @@ When reviewing code, always check for:
 
 ## Reference Files
 
-- `docs/architecture/security-audit-v1.md` — primary security baseline and open findings.
-- `docs/architecture/privacy-audit-v1.md` — privacy compliance gaps, DSAR/export status, and retention issues.
-- `docs/architecture/monitoring.md` — privacy-safe monitoring and consent-gated telemetry guidance.
-- `services/api/supabase/functions/_shared/cors.ts` — current CORS allowlist implementation that replaced wildcard origins.
-- `services/api/supabase/functions/_shared/logger.ts` — structured Edge Function logging with explicit sensitive-data exclusions.
+- `services/api/supabase/functions/_shared/cors.ts` — CORS allowlist implementation (no wildcard origins on authenticated routes).
+- `services/api/supabase/functions/_shared/logger.ts` — Structured Edge Function logging with sensitive-data exclusions.
+- `services/api/supabase/functions/_shared/rate-limit.ts` — Rate limit checking per user/feature.
+- `services/api/supabase/functions/passkey-authenticate/` — WebAuthn passkey verification flow.
+- `services/api/supabase/functions/passkey-register/` — WebAuthn passkey enrollment flow.
+- `services/api/supabase/functions/data-export/` — GDPR Article 20 data portability (rate-limited, audit-logged).
+- `services/api/supabase/functions/account-deletion/` — Right-to-be-forgotten implementation.
+- `services/api/powersync/sync-rules.yaml` — PowerSync sync rules with tenant isolation and column allowlisting.
+- `docs/architecture/security-audit-v1.md` — Primary security baseline and open findings.
+- `docs/architecture/privacy-audit-v1.md` — Privacy compliance gaps, DSAR/export status, and retention issues.
+- `docs/architecture/monitoring.md` — Privacy-safe monitoring and consent-gated telemetry guidance.
+- `docs/audits/` — MASVS mobile security audits, dependency audit.
+- `docs/compliance/` — GDPR, data privacy, incident response runbook.
+- `packages/core/src/commonMain/kotlin/com/finance/core/monitoring/` — Cross-platform monitoring interfaces (CrashReporter, MetricsCollector, SyncHealthMonitor).
 
 # Boundaries
 

--- a/.github/agents/web-engineer.agent.md
+++ b/.github/agents/web-engineer.agent.md
@@ -28,8 +28,8 @@ You are the web platform engineer for Finance, a multi-platform financial tracki
 - Keyboard navigation and focus management
 - Responsive design (mobile-first, desktop adaptation)
 - CSS custom properties for design token consumption
-- Vite or webpack build tooling
-- Recharts, D3, or Chart.js for financial visualization
+- Vite 8 build tooling
+- Recharts and D3 for financial visualization
 - Web Authentication API (Passkeys/WebAuthn)
 - CredentialManager API for token storage
 - Content Security Policy (CSP) for XSS prevention
@@ -37,6 +37,9 @@ You are the web platform engineer for Finance, a multi-platform financial tracki
 
 ## Current App Architecture
 
+- **React 19** with **TypeScript 6**, built with **Vite 8** and tested via **Vitest** (unit) and **Playwright** (E2E).
+- **Storybook 10** for component development and visual testing.
+- **Zod** for runtime validation, **react-router-dom v7** for client-side routing.
 - Routes point to real page components (`*Page` composables/components) — there are no placeholder or stub pages.
 - `AppLayout` is fully wired with sidebar navigation (desktop) and bottom navigation (mobile).
 - CSP has been configured to work correctly with Vite's dev server (e.g., allowing `ws:` for HMR). Ensure any CSP changes preserve Vite dev compatibility.
@@ -58,7 +61,7 @@ You are the web platform engineer for Finance, a multi-platform financial tracki
 - Configure SQLite-WASM with OPFS backend and IndexedDB fallback
 - Encrypt sensitive financial data at rest using SubtleCrypto
 - Build accessible, responsive UI components with proper ARIA semantics
-- Set up and maintain Vite/webpack build pipelines with code splitting
+- Set up and maintain Vite build pipelines with code splitting
 - Implement financial data visualizations (charts, graphs, dashboards)
 - Configure CSP headers and ensure no policy violations
 - Optimize web vitals (LCP, FID, CLS) and bundle size
@@ -69,7 +72,16 @@ You are the web platform engineer for Finance, a multi-platform financial tracki
 - Audit performance: measure web vitals and identify bottlenecks
 - Configure service worker: set up or update caching strategies
 - Set up SQLite-WASM: configure OPFS storage with IndexedDB fallback
-- Build visualization: create financial charts with Recharts, D3, or Chart.js
+- Build visualization: create financial charts with Recharts or D3
+
+## Reference Files
+
+- `apps/web/src/hooks/` — Custom React hooks for data access (useAccounts, useTransactions, useBudgets, useGoals, useCategories, useDashboardData).
+- `apps/web/src/db/repositories/` — SQLite-WASM repository layer (parameterized queries, soft deletes).
+- `apps/web/src/components/forms/` — Accessible modal form components with focus trapping.
+- `apps/web/src/sw/` — Service worker for offline caching and background sync.
+- `apps/web/src/kmp/` — Bridge directory for KMP shared logic integration.
+- `apps/web/src/theme/tokens.css` — Design token CSS custom properties.
 
 # Boundaries
 

--- a/.github/agents/windows-engineer.agent.md
+++ b/.github/agents/windows-engineer.agent.md
@@ -43,6 +43,11 @@ You are the Windows platform engineer for Finance, a multi-platform financial tr
 - Implement system tray integration and Windows notifications
 - Configure auto-update through the Microsoft Store channel
 
+## Reference Files
+
+- `apps/windows/build.gradle.kts` — Compose Desktop build configuration (MSI target, package version 1.0.0, main class `com.finance.desktop.MainKt`).
+- `apps/windows/src/main/` — Windows application source.
+
 # Key Rules
 
 - Use Compose Desktop for all UI — no Electron or web wrappers


### PR DESCRIPTION
## Summary

Refresh all 13 AI agent files in .github/agents/ to reflect the current codebase state.

## Changes

### Factual corrections (6 priority files)
- **android-engineer**: Fixed Room KMP to SQLDelight with SQLCipher 4.6.1; updated minSdk 26 to 28, added compileSdk/targetSdk 35
- **kmp-engineer**: Updated iOS integration from planned to actual XCFramework status; removed nonexistent networking package; fixed source set count
- **ios-engineer**: Fixed watchOS directory WatchApp/ to FinanceWatch/; updated KMP section and build commands to use packages/sync XCFramework
- **web-engineer**: Removed webpack/Chart.js (not used); added actual versions (React 19, TS 6, Vite 8, Storybook 10, Playwright, Zod)
- **backend-engineer**: Fixed CRDT to PowerSync LWW sync model
- **devops-engineer**: Expanded CI workflow list from 2 to 14 entries

### Reference Files sections added (all 13 files)
- Added Reference Files sections to architect, design-engineer, docs-writer, finance-domain, windows-engineer, backend-engineer, web-engineer, security-reviewer
- Expanded security-reviewer references with passkey auth, rate limiting, and compliance docs

### Minor updates
- **accessibility-reviewer**: Added iOS app targets and Android minSdk 28

## Issues

Closes #541

## Testing

- [x] Prettier formatting applied
- [x] All 13 files modified (113 insertions, 27 deletions)
- [x] No code changes - documentation only