### PR TITLE
feat(api): add webhook and event infrastructure (#683)

### DIFF
--- a/services/api/supabase/functions/_shared/env.ts
+++ b/services/api/supabase/functions/_shared/env.ts
@@ -22,6 +22,7 @@ const FUNCTION_ENV_VARS: Record<string, readonly string[]> = {
   'account-deletion': [],
   'sync-health-report': ['ALLOWED_ORIGINS'],
   'process-recurring': ['CRON_SECRET'],
+  'manage-webhooks': ['ALLOWED_ORIGINS'],
 };
 
 /**

--- a/services/api/supabase/functions/_shared/rate-limit.ts
+++ b/services/api/supabase/functions/_shared/rate-limit.ts
@@ -77,6 +77,7 @@ export const RATE_LIMITS: Record<string, RateLimitConfig> = {
   'account-deletion': { maxRequests: 3, windowSeconds: 3600, keyPrefix: 'account-deletion' },
   'sync-health-report': { maxRequests: 60, windowSeconds: 3600, keyPrefix: 'sync-health-report' },
   'process-recurring': { maxRequests: 10, windowSeconds: 60, keyPrefix: 'process-recurring' },
+  'manage-webhooks': { maxRequests: 30, windowSeconds: 60, keyPrefix: 'manage-webhooks' },
 };
 
 // ---------------------------------------------------------------------------

--- a/services/api/supabase/functions/_shared/webhook.test.ts
+++ b/services/api/supabase/functions/_shared/webhook.test.ts
@@ -35,10 +35,7 @@ import {
   createWebhookEvent,
   VALID_EVENT_TYPES,
 } from '../_shared/webhook.ts';
-import type {
-  WebhookEndpoint,
-  WebhookDeliveryResult,
-} from '../_shared/webhook.ts';
+import type { WebhookEndpoint, WebhookDeliveryResult } from '../_shared/webhook.ts';
 
 // ===========================================================================
 // Inline handler logic for isolated testing (same pattern as household-invite)
@@ -256,8 +253,13 @@ async function handleManageWebhooks(
 
       case 'PUT': {
         const body = await req.json();
-        const { id: endpointId, url: newUrl, events: newEvents, description: newDesc, is_active } =
-          body;
+        const {
+          id: endpointId,
+          url: newUrl,
+          events: newEvents,
+          description: newDesc,
+          is_active,
+        } = body;
 
         if (!endpointId) {
           return errRes('id is required');
@@ -366,15 +368,18 @@ const TEST_ENDPOINT = {
 // HMAC Signing Tests (4 tests)
 // ===========================================================================
 
-Deno.test('webhook: signWebhookPayload produces consistent signatures for same payload+secret', async () => {
-  const payload = '{"type":"transaction.created","entity_id":"abc"}';
-  const secret = 'test-secret-key-1234567890';
+Deno.test(
+  'webhook: signWebhookPayload produces consistent signatures for same payload+secret',
+  async () => {
+    const payload = '{"type":"transaction.created","entity_id":"abc"}';
+    const secret = 'test-secret-key-1234567890';
 
-  const sig1 = await signWebhookPayload(payload, secret);
-  const sig2 = await signWebhookPayload(payload, secret);
+    const sig1 = await signWebhookPayload(payload, secret);
+    const sig2 = await signWebhookPayload(payload, secret);
 
-  assertEquals(sig1, sig2, 'Same payload+secret should produce identical signatures');
-});
+    assertEquals(sig1, sig2, 'Same payload+secret should produce identical signatures');
+  },
+);
 
 Deno.test('webhook: different secrets produce different signatures', async () => {
   const payload = '{"type":"transaction.created","entity_id":"abc"}';
@@ -420,30 +425,36 @@ Deno.test('webhook: empty payload is handled correctly', async () => {
 // Note: Actual HTTP fetch tests would require network access. These tests
 // validate the module's interface and structure using the mock handler.
 
-Deno.test('webhook: deliverWebhook interface — successful delivery returns success: true', async () => {
-  const result: WebhookDeliveryResult = {
-    success: true,
-    status_code: 200,
-    duration_ms: 120,
-  };
+Deno.test(
+  'webhook: deliverWebhook interface — successful delivery returns success: true',
+  async () => {
+    const result: WebhookDeliveryResult = {
+      success: true,
+      status_code: 200,
+      duration_ms: 120,
+    };
 
-  assertEquals(result.success, true);
-  assertEquals(result.status_code, 200);
-  assertExists(result.duration_ms);
-});
+    assertEquals(result.success, true);
+    assertEquals(result.status_code, 200);
+    assertExists(result.duration_ms);
+  },
+);
 
-Deno.test('webhook: deliverWebhook interface — failed delivery (non-2xx) returns success: false', () => {
-  const result: WebhookDeliveryResult = {
-    success: false,
-    status_code: 500,
-    error: 'HTTP 500',
-    duration_ms: 200,
-  };
+Deno.test(
+  'webhook: deliverWebhook interface — failed delivery (non-2xx) returns success: false',
+  () => {
+    const result: WebhookDeliveryResult = {
+      success: false,
+      status_code: 500,
+      error: 'HTTP 500',
+      duration_ms: 200,
+    };
 
-  assertEquals(result.success, false);
-  assertEquals(result.status_code, 500);
-  assertExists(result.error);
-});
+    assertEquals(result.success, false);
+    assertEquals(result.status_code, 500);
+    assertExists(result.error);
+  },
+);
 
 Deno.test('webhook: deliverWebhook interface — timeout returns error with duration', () => {
   const result: WebhookDeliveryResult = {
@@ -460,12 +471,9 @@ Deno.test('webhook: deliverWebhook interface — timeout returns error with dura
 
 Deno.test('webhook: delivery headers structure is correct', async () => {
   // Verify the expected headers structure
-  const event = createWebhookEvent(
-    'transaction.created',
-    TEST_HOUSEHOLD.id,
-    'entity-123',
-    { amount_changed: true },
-  );
+  const event = createWebhookEvent('transaction.created', TEST_HOUSEHOLD.id, 'entity-123', {
+    amount_changed: true,
+  });
 
   const endpoint: WebhookEndpoint = {
     id: TEST_ENDPOINT.id,
@@ -552,12 +560,9 @@ Deno.test('webhook: shouldRetry returns false when at or beyond max attempts', (
 // ===========================================================================
 
 Deno.test('webhook: createWebhookEvent includes all required fields', () => {
-  const event = createWebhookEvent(
-    'transaction.created',
-    TEST_HOUSEHOLD.id,
-    'entity-uuid-123',
-    { account_id: 'acc-123' },
-  );
+  const event = createWebhookEvent('transaction.created', TEST_HOUSEHOLD.id, 'entity-uuid-123', {
+    account_id: 'acc-123',
+  });
 
   assertEquals(event.type, 'transaction.created');
   assertEquals(event.household_id, TEST_HOUSEHOLD.id);

--- a/services/api/supabase/functions/_shared/webhook.test.ts
+++ b/services/api/supabase/functions/_shared/webhook.test.ts
@@ -36,7 +36,6 @@ import {
   VALID_EVENT_TYPES,
 } from '../_shared/webhook.ts';
 import type {
-  WebhookEvent,
   WebhookEndpoint,
   WebhookDeliveryResult,
 } from '../_shared/webhook.ts';

--- a/services/api/supabase/functions/_shared/webhook.test.ts
+++ b/services/api/supabase/functions/_shared/webhook.test.ts
@@ -1,0 +1,973 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the webhook shared module and manage-webhooks Edge Function (#683).
+ *
+ * Validates HMAC signing, delivery logic, retry calculation, event creation,
+ * and the full Edge Function CRUD lifecycle with authorization checks.
+ */
+
+import {
+  assertEquals,
+  assertExists,
+  assertMatch,
+  assertNotEquals,
+  assertStringIncludes,
+} from 'https://deno.land/std@0.208.0/testing/asserts.ts';
+import {
+  assertStatus,
+  assertJsonBody,
+  assertErrorResponse,
+  assertNoContent,
+} from '../_test_helpers/assertions.ts';
+import { createMockRequest } from '../_test_helpers/mock-request.ts';
+import {
+  TEST_USER,
+  TEST_USER_2,
+  TEST_HOUSEHOLD,
+  TEST_MEMBERSHIP,
+  TEST_MEMBERSHIP_SHARED,
+} from '../_test_helpers/test-fixtures.ts';
+import {
+  signWebhookPayload,
+  calculateRetryDelay,
+  shouldRetry,
+  createWebhookEvent,
+  VALID_EVENT_TYPES,
+} from '../_shared/webhook.ts';
+import type {
+  WebhookEvent,
+  WebhookEndpoint,
+  WebhookDeliveryResult,
+} from '../_shared/webhook.ts';
+
+// ===========================================================================
+// Inline handler logic for isolated testing (same pattern as household-invite)
+// ===========================================================================
+
+interface MockManageWebhooksDeps {
+  authenticatedUser?: { id: string; email: string } | null;
+  membership?: { id: string; role: string } | null;
+  endpoint?: {
+    id: string;
+    household_id: string;
+    url: string;
+    secret: string;
+    events: string[];
+    is_active: boolean;
+    description?: string | null;
+    failure_count?: number;
+    last_success_at?: string | null;
+    last_failure_at?: string | null;
+    created_at?: string;
+    updated_at?: string;
+  } | null;
+  endpoints?: Array<{
+    id: string;
+    url: string;
+    description?: string | null;
+    events: string[];
+    is_active: boolean;
+    failure_count?: number;
+    last_success_at?: string | null;
+    last_failure_at?: string | null;
+    created_at?: string;
+    updated_at?: string;
+  }>;
+  insertResult?: {
+    id: string;
+    url: string;
+    events: string[];
+    secret: string;
+    description?: string | null;
+    is_active: boolean;
+    created_at: string;
+  } | null;
+  insertError?: { message: string } | null;
+  updateResult?: Record<string, unknown> | null;
+  updateError?: { message: string } | null;
+  deleteError?: { message: string } | null;
+  rateLimited?: boolean;
+  deliveryResult?: WebhookDeliveryResult | null;
+}
+
+const testCorsHeaders: Record<string, string> = {
+  'Access-Control-Allow-Origin': 'https://app.finance.example.com',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, accept',
+  'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+  'Access-Control-Max-Age': '86400',
+};
+
+function jsonRes(data: Record<string, unknown>, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { ...testCorsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+
+function errRes(message: string, status = 400): Response {
+  return jsonRes({ error: message }, status);
+}
+
+async function handleManageWebhooks(
+  req: Request,
+  deps: MockManageWebhooksDeps = {},
+): Promise<Response> {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: testCorsHeaders });
+  }
+
+  try {
+    const user = deps.authenticatedUser ?? null;
+    if (!user) {
+      return errRes('Authentication required', 401);
+    }
+
+    if (deps.rateLimited) {
+      return new Response(JSON.stringify({ error: 'Too many requests' }), {
+        status: 429,
+        headers: { ...testCorsHeaders, 'Content-Type': 'application/json', 'Retry-After': '60' },
+      });
+    }
+
+    const url = new URL(req.url);
+    const action = url.searchParams.get('action');
+
+    // POST ?action=test — Test Webhook Delivery
+    if (req.method === 'POST' && action === 'test') {
+      const body = await req.json();
+      const { endpoint_id } = body;
+
+      if (!endpoint_id) {
+        return errRes('endpoint_id is required');
+      }
+
+      const endpoint = deps.endpoint ?? null;
+      if (!endpoint) {
+        return errRes('Webhook endpoint not found', 404);
+      }
+
+      const membership = deps.membership ?? null;
+      if (!membership || !['owner', 'admin'].includes(membership.role)) {
+        return errRes('Only household owners and admins can test webhooks', 403);
+      }
+
+      if (!endpoint.is_active) {
+        return errRes('Cannot test a disabled webhook endpoint');
+      }
+
+      const result = deps.deliveryResult ?? {
+        success: true,
+        status_code: 200,
+        duration_ms: 150,
+      };
+
+      return jsonRes({
+        success: result.success,
+        status_code: result.status_code,
+        duration_ms: result.duration_ms,
+        ...(result.error ? { error: result.error } : {}),
+      });
+    }
+
+    switch (req.method) {
+      case 'POST': {
+        const body = await req.json();
+        const { household_id, url: endpointUrl, description, events } = body;
+
+        if (!household_id) {
+          return errRes('household_id is required');
+        }
+
+        if (!endpointUrl) {
+          return errRes('url is required');
+        }
+
+        if (typeof endpointUrl !== 'string' || !endpointUrl.startsWith('https://')) {
+          return errRes('Webhook URL must start with https://');
+        }
+
+        if (endpointUrl.length > 2048) {
+          return errRes('Webhook URL must not exceed 2048 characters');
+        }
+
+        if (!Array.isArray(events) || events.length === 0) {
+          return errRes('events must be a non-empty array');
+        }
+
+        const invalidEvents = events.filter(
+          (e: unknown) => typeof e !== 'string' || !VALID_EVENT_TYPES.has(e as string),
+        );
+        if (invalidEvents.length > 0) {
+          return errRes(`Invalid event types: ${invalidEvents.join(', ')}`);
+        }
+
+        const membership = deps.membership ?? null;
+        if (!membership || !['owner', 'admin'].includes(membership.role)) {
+          return errRes('Only household owners and admins can manage webhooks', 403);
+        }
+
+        if (deps.insertError) {
+          return errRes('Internal server error', 500);
+        }
+
+        const result = deps.insertResult ?? {
+          id: crypto.randomUUID(),
+          url: endpointUrl,
+          events,
+          secret: 'generated-secret-hex-string-64-chars-long-for-testing-purposes!',
+          description: description ?? null,
+          is_active: true,
+          created_at: new Date().toISOString(),
+        };
+
+        return new Response(
+          JSON.stringify({
+            id: result.id,
+            url: result.url,
+            events: result.events,
+            secret: result.secret,
+            description: result.description,
+            is_active: result.is_active,
+            created_at: result.created_at,
+          }),
+          {
+            status: 201,
+            headers: { ...testCorsHeaders, 'Content-Type': 'application/json' },
+          },
+        );
+      }
+
+      case 'GET': {
+        const household_id = url.searchParams.get('household_id');
+
+        if (!household_id) {
+          return errRes('household_id query parameter is required');
+        }
+
+        const membership = deps.membership ?? null;
+        if (!membership || !['owner', 'admin'].includes(membership.role)) {
+          return errRes('Only household owners and admins can view webhooks', 403);
+        }
+
+        const endpoints = deps.endpoints ?? [];
+
+        return jsonRes({ endpoints });
+      }
+
+      case 'PUT': {
+        const body = await req.json();
+        const { id: endpointId, url: newUrl, events: newEvents, description: newDesc, is_active } =
+          body;
+
+        if (!endpointId) {
+          return errRes('id is required');
+        }
+
+        const existing = deps.endpoint ?? null;
+        if (!existing) {
+          return errRes('Webhook endpoint not found', 404);
+        }
+
+        const membership = deps.membership ?? null;
+        if (!membership || !['owner', 'admin'].includes(membership.role)) {
+          return errRes('Only household owners and admins can manage webhooks', 403);
+        }
+
+        if (newUrl !== undefined) {
+          if (typeof newUrl !== 'string' || !newUrl.startsWith('https://')) {
+            return errRes('Webhook URL must start with https://');
+          }
+        }
+
+        if (newEvents !== undefined) {
+          if (!Array.isArray(newEvents) || newEvents.length === 0) {
+            return errRes('events must be a non-empty array');
+          }
+          const invalidEvents = newEvents.filter(
+            (e: unknown) => typeof e !== 'string' || !VALID_EVENT_TYPES.has(e as string),
+          );
+          if (invalidEvents.length > 0) {
+            return errRes(`Invalid event types: ${invalidEvents.join(', ')}`);
+          }
+        }
+
+        if (deps.updateError) {
+          return errRes('Internal server error', 500);
+        }
+
+        const updated = deps.updateResult ?? {
+          id: endpointId,
+          url: newUrl ?? existing.url,
+          description: newDesc !== undefined ? newDesc : existing.description,
+          events: newEvents ?? existing.events,
+          is_active: is_active !== undefined ? is_active : existing.is_active,
+          failure_count: existing.failure_count ?? 0,
+          last_success_at: existing.last_success_at ?? null,
+          last_failure_at: existing.last_failure_at ?? null,
+          created_at: existing.created_at,
+          updated_at: new Date().toISOString(),
+        };
+
+        // NEVER include secret in update response
+        return jsonRes(updated as Record<string, unknown>);
+      }
+
+      case 'DELETE': {
+        const endpointId = url.searchParams.get('id');
+        if (!endpointId) {
+          return errRes('id is required');
+        }
+
+        const existing = deps.endpoint ?? null;
+        if (!existing) {
+          return errRes('Webhook endpoint not found', 404);
+        }
+
+        const membership = deps.membership ?? null;
+        if (!membership || !['owner', 'admin'].includes(membership.role)) {
+          return errRes('Only household owners and admins can manage webhooks', 403);
+        }
+
+        if (deps.deleteError) {
+          return errRes('Internal server error', 500);
+        }
+
+        return new Response(null, { status: 204, headers: testCorsHeaders });
+      }
+
+      default:
+        return errRes('Method not allowed', 405);
+    }
+  } catch {
+    return errRes('Internal server error', 500);
+  }
+}
+
+// ===========================================================================
+// Test data
+// ===========================================================================
+
+const TEST_ENDPOINT = {
+  id: 'aaaa1111-bbbb-4ccc-dddd-eeee2222ffff',
+  household_id: TEST_HOUSEHOLD.id,
+  url: 'https://hooks.example.com/finance',
+  secret: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6',
+  events: ['transaction.created', 'account.updated'] as string[],
+  is_active: true,
+  description: 'Production webhook',
+  failure_count: 0,
+  last_success_at: null,
+  last_failure_at: null,
+  created_at: '2026-03-24T10:00:00.000Z',
+  updated_at: '2026-03-24T10:00:00.000Z',
+};
+
+// ===========================================================================
+// HMAC Signing Tests (4 tests)
+// ===========================================================================
+
+Deno.test('webhook: signWebhookPayload produces consistent signatures for same payload+secret', async () => {
+  const payload = '{"type":"transaction.created","entity_id":"abc"}';
+  const secret = 'test-secret-key-1234567890';
+
+  const sig1 = await signWebhookPayload(payload, secret);
+  const sig2 = await signWebhookPayload(payload, secret);
+
+  assertEquals(sig1, sig2, 'Same payload+secret should produce identical signatures');
+});
+
+Deno.test('webhook: different secrets produce different signatures', async () => {
+  const payload = '{"type":"transaction.created","entity_id":"abc"}';
+  const secret1 = 'secret-key-alpha';
+  const secret2 = 'secret-key-bravo';
+
+  const sig1 = await signWebhookPayload(payload, secret1);
+  const sig2 = await signWebhookPayload(payload, secret2);
+
+  assertNotEquals(sig1, sig2, 'Different secrets should produce different signatures');
+});
+
+Deno.test('webhook: signature format is hex string prefixed with sha256=', async () => {
+  const payload = '{"test":"data"}';
+  const secret = 'my-signing-secret';
+
+  const signature = await signWebhookPayload(payload, secret);
+
+  assertMatch(
+    signature,
+    /^sha256=[0-9a-f]{64}$/,
+    'Signature should be sha256= followed by 64 hex chars (SHA-256 = 32 bytes)',
+  );
+});
+
+Deno.test('webhook: empty payload is handled correctly', async () => {
+  const payload = '';
+  const secret = 'test-secret';
+
+  const signature = await signWebhookPayload(payload, secret);
+
+  assertMatch(
+    signature,
+    /^sha256=[0-9a-f]{64}$/,
+    'Empty payload should still produce a valid HMAC signature',
+  );
+});
+
+// ===========================================================================
+// Delivery Tests (5 tests)
+// ===========================================================================
+
+// Note: Actual HTTP fetch tests would require network access. These tests
+// validate the module's interface and structure using the mock handler.
+
+Deno.test('webhook: deliverWebhook interface — successful delivery returns success: true', async () => {
+  const result: WebhookDeliveryResult = {
+    success: true,
+    status_code: 200,
+    duration_ms: 120,
+  };
+
+  assertEquals(result.success, true);
+  assertEquals(result.status_code, 200);
+  assertExists(result.duration_ms);
+});
+
+Deno.test('webhook: deliverWebhook interface — failed delivery (non-2xx) returns success: false', () => {
+  const result: WebhookDeliveryResult = {
+    success: false,
+    status_code: 500,
+    error: 'HTTP 500',
+    duration_ms: 200,
+  };
+
+  assertEquals(result.success, false);
+  assertEquals(result.status_code, 500);
+  assertExists(result.error);
+});
+
+Deno.test('webhook: deliverWebhook interface — timeout returns error with duration', () => {
+  const result: WebhookDeliveryResult = {
+    success: false,
+    error: 'Timeout after 10000ms',
+    duration_ms: 10000,
+  };
+
+  assertEquals(result.success, false);
+  assertStringIncludes(result.error!, 'Timeout');
+  assertEquals(result.duration_ms, 10000);
+  assertEquals(result.status_code, undefined);
+});
+
+Deno.test('webhook: delivery headers structure is correct', async () => {
+  // Verify the expected headers structure
+  const event = createWebhookEvent(
+    'transaction.created',
+    TEST_HOUSEHOLD.id,
+    'entity-123',
+    { amount_changed: true },
+  );
+
+  const endpoint: WebhookEndpoint = {
+    id: TEST_ENDPOINT.id,
+    url: TEST_ENDPOINT.url,
+    secret: TEST_ENDPOINT.secret,
+    events: TEST_ENDPOINT.events,
+    is_active: true,
+  };
+
+  const body = JSON.stringify(event);
+  const signature = await signWebhookPayload(body, endpoint.secret);
+
+  // Verify the signature would be included in X-Webhook-Signature
+  assertMatch(signature, /^sha256=[0-9a-f]{64}$/);
+  assertEquals(event.type, 'transaction.created');
+  assertExists(endpoint.id); // Would be used as delivery UUID base
+});
+
+Deno.test('webhook: deliverWebhook interface — network error is handled gracefully', () => {
+  const result: WebhookDeliveryResult = {
+    success: false,
+    error: 'Network error: Connection refused',
+    duration_ms: 50,
+  };
+
+  assertEquals(result.success, false);
+  assertStringIncludes(result.error!, 'Network error');
+  assertEquals(result.status_code, undefined);
+});
+
+// ===========================================================================
+// Retry Logic Tests (4 tests)
+// ===========================================================================
+
+Deno.test('webhook: calculateRetryDelay returns exponential values', () => {
+  // Base delays (before jitter): 1s, 2s, 4s, 8s, 16s
+  const delay0 = calculateRetryDelay(0);
+  const delay1 = calculateRetryDelay(1);
+  const delay2 = calculateRetryDelay(2);
+  const delay3 = calculateRetryDelay(3);
+
+  // With ±10% jitter, delay0 should be roughly 1000ms (900-1100)
+  assertEquals(delay0 >= 900, true, `delay0=${delay0} should be >= 900`);
+  assertEquals(delay0 <= 1100, true, `delay0=${delay0} should be <= 1100`);
+
+  // delay1 should be roughly 2000ms (1800-2200)
+  assertEquals(delay1 >= 1800, true, `delay1=${delay1} should be >= 1800`);
+  assertEquals(delay1 <= 2200, true, `delay1=${delay1} should be <= 2200`);
+
+  // delay2 should be roughly 4000ms (3600-4400)
+  assertEquals(delay2 >= 3600, true, `delay2=${delay2} should be >= 3600`);
+  assertEquals(delay2 <= 4400, true, `delay2=${delay2} should be <= 4400`);
+
+  // delay3 should be roughly 8000ms (7200-8800)
+  assertEquals(delay3 >= 7200, true, `delay3=${delay3} should be >= 7200`);
+  assertEquals(delay3 <= 8800, true, `delay3=${delay3} should be <= 8800`);
+});
+
+Deno.test('webhook: calculateRetryDelay caps at 1 hour (3600000ms)', () => {
+  // 2^22 * 1000 = 4,194,304,000 which exceeds 3,600,000
+  const delay = calculateRetryDelay(22);
+
+  // With ±10% jitter on 3600000: 3240000 to 3960000
+  assertEquals(delay >= 3_240_000, true, `delay=${delay} should be >= 3240000`);
+  assertEquals(delay <= 3_960_000, true, `delay=${delay} should be <= 3960000`);
+});
+
+Deno.test('webhook: shouldRetry returns true when under max attempts', () => {
+  assertEquals(shouldRetry(0, 5), true, 'Attempt 0 of 5 should retry');
+  assertEquals(shouldRetry(1, 5), true, 'Attempt 1 of 5 should retry');
+  assertEquals(shouldRetry(4, 5), true, 'Attempt 4 of 5 should retry');
+  assertEquals(shouldRetry(2, 3), true, 'Attempt 2 of 3 should retry');
+});
+
+Deno.test('webhook: shouldRetry returns false when at or beyond max attempts', () => {
+  assertEquals(shouldRetry(5, 5), false, 'Attempt 5 of 5 should NOT retry');
+  assertEquals(shouldRetry(6, 5), false, 'Attempt 6 of 5 should NOT retry');
+  assertEquals(shouldRetry(10, 5), false, 'Attempt 10 of 5 should NOT retry');
+  assertEquals(shouldRetry(3, 3), false, 'Attempt 3 of 3 should NOT retry');
+});
+
+// ===========================================================================
+// Event Creation Tests (2 tests)
+// ===========================================================================
+
+Deno.test('webhook: createWebhookEvent includes all required fields', () => {
+  const event = createWebhookEvent(
+    'transaction.created',
+    TEST_HOUSEHOLD.id,
+    'entity-uuid-123',
+    { account_id: 'acc-123' },
+  );
+
+  assertEquals(event.type, 'transaction.created');
+  assertEquals(event.household_id, TEST_HOUSEHOLD.id);
+  assertEquals(event.entity_id, 'entity-uuid-123');
+  assertEquals(event.data.account_id, 'acc-123');
+  assertExists(event.timestamp, 'Event should have a timestamp');
+});
+
+Deno.test('webhook: createWebhookEvent timestamp is valid ISO 8601', () => {
+  const event = createWebhookEvent('account.created', 'hh-123', 'ent-456', {});
+
+  assertMatch(
+    event.timestamp,
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+    'Timestamp should be ISO 8601 format',
+  );
+
+  // Verify it parses as a valid date
+  const parsed = new Date(event.timestamp);
+  assertEquals(isNaN(parsed.getTime()), false, 'Timestamp should parse as a valid Date');
+});
+
+// ===========================================================================
+// Edge Function Tests: POST — Create Webhook Endpoint (3 tests)
+// ===========================================================================
+
+Deno.test('manage-webhooks: POST creates endpoint and returns secret', async () => {
+  const req = createMockRequest({
+    method: 'POST',
+    body: {
+      household_id: TEST_HOUSEHOLD.id,
+      url: 'https://hooks.example.com/events',
+      events: ['transaction.created'],
+      description: 'My webhook',
+    },
+  });
+
+  const res = await handleManageWebhooks(req, {
+    authenticatedUser: { id: TEST_USER.id, email: TEST_USER.email },
+    membership: { id: TEST_MEMBERSHIP.id, role: 'owner' },
+  });
+
+  assertStatus(res, 201);
+  const body = await assertJsonBody(res);
+  assertExists(body.id, 'Response should include endpoint id');
+  assertEquals(body.url, 'https://hooks.example.com/events');
+  assertExists(body.secret, 'POST response MUST include the secret');
+  assertEquals(body.is_active, true);
+  assertEquals((body.events as string[]).length, 1);
+});
+
+Deno.test('manage-webhooks: POST validates URL starts with https://', async () => {
+  const req = createMockRequest({
+    method: 'POST',
+    body: {
+      household_id: TEST_HOUSEHOLD.id,
+      url: 'http://insecure.example.com/hook',
+      events: ['transaction.created'],
+    },
+  });
+
+  const res = await handleManageWebhooks(req, {
+    authenticatedUser: { id: TEST_USER.id, email: TEST_USER.email },
+    membership: { id: TEST_MEMBERSHIP.id, role: 'owner' },
+  });
+
+  await assertErrorResponse(res, 400, 'https://');
+});
+
+Deno.test('manage-webhooks: POST validates events array is non-empty', async () => {
+  const req = createMockRequest({
+    method: 'POST',
+    body: {
+      household_id: TEST_HOUSEHOLD.id,
+      url: 'https://hooks.example.com/events',
+      events: [],
+    },
+  });
+
+  const res = await handleManageWebhooks(req, {
+    authenticatedUser: { id: TEST_USER.id, email: TEST_USER.email },
+    membership: { id: TEST_MEMBERSHIP.id, role: 'owner' },
+  });
+
+  await assertErrorResponse(res, 400, 'non-empty');
+});
+
+Deno.test('manage-webhooks: POST returns 403 for non-admin household members', async () => {
+  const req = createMockRequest({
+    method: 'POST',
+    body: {
+      household_id: TEST_HOUSEHOLD.id,
+      url: 'https://hooks.example.com/events',
+      events: ['transaction.created'],
+    },
+  });
+
+  const res = await handleManageWebhooks(req, {
+    authenticatedUser: { id: TEST_USER_2.id, email: TEST_USER_2.email },
+    membership: { id: TEST_MEMBERSHIP_SHARED.id, role: 'member' },
+  });
+
+  await assertErrorResponse(res, 403, 'owners and admins');
+});
+
+Deno.test('manage-webhooks: POST rejects invalid event types', async () => {
+  const req = createMockRequest({
+    method: 'POST',
+    body: {
+      household_id: TEST_HOUSEHOLD.id,
+      url: 'https://hooks.example.com/events',
+      events: ['transaction.created', 'invalid.event'],
+    },
+  });
+
+  const res = await handleManageWebhooks(req, {
+    authenticatedUser: { id: TEST_USER.id, email: TEST_USER.email },
+    membership: { id: TEST_MEMBERSHIP.id, role: 'owner' },
+  });
+
+  await assertErrorResponse(res, 400, 'Invalid event types');
+});
+
+// ===========================================================================
+// Edge Function Tests: GET — List Webhook Endpoints (3 tests)
+// ===========================================================================
+
+Deno.test('manage-webhooks: GET lists endpoints without secrets', async () => {
+  const req = createMockRequest({
+    method: 'GET',
+    url: `https://test.supabase.co/functions/v1/manage-webhooks?household_id=${TEST_HOUSEHOLD.id}`,
+  });
+
+  const endpointWithoutSecret = {
+    id: TEST_ENDPOINT.id,
+    url: TEST_ENDPOINT.url,
+    description: TEST_ENDPOINT.description,
+    events: TEST_ENDPOINT.events,
+    is_active: TEST_ENDPOINT.is_active,
+    failure_count: 0,
+    last_success_at: null,
+    last_failure_at: null,
+    created_at: TEST_ENDPOINT.created_at,
+    updated_at: TEST_ENDPOINT.updated_at,
+  };
+
+  const res = await handleManageWebhooks(req, {
+    authenticatedUser: { id: TEST_USER.id, email: TEST_USER.email },
+    membership: { id: TEST_MEMBERSHIP.id, role: 'owner' },
+    endpoints: [endpointWithoutSecret],
+  });
+
+  assertStatus(res, 200);
+  const body = await assertJsonBody(res);
+  const endpoints = body.endpoints as Array<Record<string, unknown>>;
+  assertEquals(endpoints.length, 1);
+  assertEquals(endpoints[0].url, TEST_ENDPOINT.url);
+  assertEquals(endpoints[0].secret, undefined, 'GET response must NEVER include secret');
+});
+
+Deno.test('manage-webhooks: GET returns 400 without household_id', async () => {
+  const req = createMockRequest({
+    method: 'GET',
+    url: 'https://test.supabase.co/functions/v1/manage-webhooks',
+  });
+
+  const res = await handleManageWebhooks(req, {
+    authenticatedUser: { id: TEST_USER.id, email: TEST_USER.email },
+    membership: { id: TEST_MEMBERSHIP.id, role: 'owner' },
+  });
+
+  await assertErrorResponse(res, 400, 'household_id');
+});
+
+Deno.test('manage-webhooks: GET returns 403 for non-admin members', async () => {
+  const req = createMockRequest({
+    method: 'GET',
+    url: `https://test.supabase.co/functions/v1/manage-webhooks?household_id=${TEST_HOUSEHOLD.id}`,
+  });
+
+  const res = await handleManageWebhooks(req, {
+    authenticatedUser: { id: TEST_USER_2.id, email: TEST_USER_2.email },
+    membership: { id: TEST_MEMBERSHIP_SHARED.id, role: 'member' },
+  });
+
+  await assertErrorResponse(res, 403, 'owners and admins');
+});
+
+// ===========================================================================
+// Edge Function Tests: PUT — Update Webhook Endpoint (2 tests)
+// ===========================================================================
+
+Deno.test('manage-webhooks: PUT updates endpoint fields', async () => {
+  const req = createMockRequest({
+    method: 'PUT',
+    body: {
+      id: TEST_ENDPOINT.id,
+      url: 'https://new-hooks.example.com/v2',
+      events: ['account.created', 'account.updated'],
+      description: 'Updated webhook',
+    },
+  });
+
+  const res = await handleManageWebhooks(req, {
+    authenticatedUser: { id: TEST_USER.id, email: TEST_USER.email },
+    membership: { id: TEST_MEMBERSHIP.id, role: 'owner' },
+    endpoint: TEST_ENDPOINT,
+  });
+
+  assertStatus(res, 200);
+  const body = await assertJsonBody(res);
+  assertEquals(body.url, 'https://new-hooks.example.com/v2');
+  assertEquals(body.description, 'Updated webhook');
+  assertEquals(body.secret, undefined, 'PUT response must NEVER include secret');
+});
+
+Deno.test('manage-webhooks: PUT rejects http:// URL', async () => {
+  const req = createMockRequest({
+    method: 'PUT',
+    body: {
+      id: TEST_ENDPOINT.id,
+      url: 'http://insecure.example.com/hook',
+    },
+  });
+
+  const res = await handleManageWebhooks(req, {
+    authenticatedUser: { id: TEST_USER.id, email: TEST_USER.email },
+    membership: { id: TEST_MEMBERSHIP.id, role: 'owner' },
+    endpoint: TEST_ENDPOINT,
+  });
+
+  await assertErrorResponse(res, 400, 'https://');
+});
+
+// ===========================================================================
+// Edge Function Tests: DELETE — Soft-delete Webhook Endpoint (1 test)
+// ===========================================================================
+
+Deno.test('manage-webhooks: DELETE soft-deletes endpoint', async () => {
+  const req = createMockRequest({
+    method: 'DELETE',
+    url: `https://test.supabase.co/functions/v1/manage-webhooks?id=${TEST_ENDPOINT.id}`,
+  });
+
+  const res = await handleManageWebhooks(req, {
+    authenticatedUser: { id: TEST_USER.id, email: TEST_USER.email },
+    membership: { id: TEST_MEMBERSHIP.id, role: 'owner' },
+    endpoint: TEST_ENDPOINT,
+  });
+
+  await assertNoContent(res);
+});
+
+// ===========================================================================
+// Edge Function Tests: POST ?action=test — Test Delivery (2 tests)
+// ===========================================================================
+
+Deno.test('manage-webhooks: POST ?action=test sends test delivery', async () => {
+  const req = createMockRequest({
+    method: 'POST',
+    url: 'https://test.supabase.co/functions/v1/manage-webhooks?action=test',
+    body: { endpoint_id: TEST_ENDPOINT.id },
+  });
+
+  const res = await handleManageWebhooks(req, {
+    authenticatedUser: { id: TEST_USER.id, email: TEST_USER.email },
+    membership: { id: TEST_MEMBERSHIP.id, role: 'owner' },
+    endpoint: TEST_ENDPOINT,
+    deliveryResult: { success: true, status_code: 200, duration_ms: 150 },
+  });
+
+  assertStatus(res, 200);
+  const body = await assertJsonBody(res);
+  assertEquals(body.success, true);
+  assertEquals(body.status_code, 200);
+  assertExists(body.duration_ms);
+});
+
+Deno.test('manage-webhooks: POST ?action=test returns failure for disabled endpoint', async () => {
+  const req = createMockRequest({
+    method: 'POST',
+    url: 'https://test.supabase.co/functions/v1/manage-webhooks?action=test',
+    body: { endpoint_id: TEST_ENDPOINT.id },
+  });
+
+  const res = await handleManageWebhooks(req, {
+    authenticatedUser: { id: TEST_USER.id, email: TEST_USER.email },
+    membership: { id: TEST_MEMBERSHIP.id, role: 'owner' },
+    endpoint: { ...TEST_ENDPOINT, is_active: false },
+  });
+
+  await assertErrorResponse(res, 400, 'disabled');
+});
+
+// ===========================================================================
+// Edge Function Tests: Authentication & Rate Limiting (3 tests)
+// ===========================================================================
+
+Deno.test('manage-webhooks: returns 401 for unauthenticated requests', async () => {
+  const req = createMockRequest({
+    method: 'GET',
+    url: `https://test.supabase.co/functions/v1/manage-webhooks?household_id=${TEST_HOUSEHOLD.id}`,
+  });
+
+  const res = await handleManageWebhooks(req, {
+    authenticatedUser: null,
+  });
+
+  await assertErrorResponse(res, 401, 'Authentication required');
+});
+
+Deno.test('manage-webhooks: returns 429 when rate limited', async () => {
+  const req = createMockRequest({
+    method: 'GET',
+    url: `https://test.supabase.co/functions/v1/manage-webhooks?household_id=${TEST_HOUSEHOLD.id}`,
+  });
+
+  const res = await handleManageWebhooks(req, {
+    authenticatedUser: { id: TEST_USER.id, email: TEST_USER.email },
+    rateLimited: true,
+  });
+
+  assertStatus(res, 429);
+  const body = await assertJsonBody(res);
+  assertEquals(body.error, 'Too many requests');
+});
+
+Deno.test('manage-webhooks: OPTIONS returns 204', async () => {
+  const req = createMockRequest({ method: 'OPTIONS' });
+  const res = await handleManageWebhooks(req);
+  assertStatus(res, 204);
+});
+
+// ===========================================================================
+// Edge Function Tests: Method restrictions (1 test)
+// ===========================================================================
+
+Deno.test('manage-webhooks: returns 405 for PATCH method', async () => {
+  const req = createMockRequest({ method: 'PATCH', body: {} });
+  const res = await handleManageWebhooks(req, {
+    authenticatedUser: { id: TEST_USER.id, email: TEST_USER.email },
+  });
+  await assertErrorResponse(res, 405, 'Method not allowed');
+});
+
+// ===========================================================================
+// Validation edge cases (2 tests)
+// ===========================================================================
+
+Deno.test('manage-webhooks: POST requires household_id', async () => {
+  const req = createMockRequest({
+    method: 'POST',
+    body: {
+      url: 'https://hooks.example.com/events',
+      events: ['transaction.created'],
+    },
+  });
+
+  const res = await handleManageWebhooks(req, {
+    authenticatedUser: { id: TEST_USER.id, email: TEST_USER.email },
+    membership: { id: TEST_MEMBERSHIP.id, role: 'owner' },
+  });
+
+  await assertErrorResponse(res, 400, 'household_id is required');
+});
+
+Deno.test('manage-webhooks: POST requires url', async () => {
+  const req = createMockRequest({
+    method: 'POST',
+    body: {
+      household_id: TEST_HOUSEHOLD.id,
+      events: ['transaction.created'],
+    },
+  });
+
+  const res = await handleManageWebhooks(req, {
+    authenticatedUser: { id: TEST_USER.id, email: TEST_USER.email },
+    membership: { id: TEST_MEMBERSHIP.id, role: 'owner' },
+  });
+
+  await assertErrorResponse(res, 400, 'url is required');
+});
+
+// ===========================================================================
+// VALID_EVENT_TYPES constant tests (1 test)
+// ===========================================================================
+
+Deno.test('webhook: VALID_EVENT_TYPES contains all expected event types', () => {
+  const expected = [
+    'transaction.created',
+    'transaction.updated',
+    'transaction.deleted',
+    'account.created',
+    'account.updated',
+    'account.deleted',
+    'budget.created',
+    'budget.updated',
+    'budget.threshold_reached',
+    'goal.created',
+    'goal.updated',
+    'goal.completed',
+    'household.member_joined',
+    'household.member_left',
+    'invitation.created',
+    'invitation.accepted',
+  ];
+
+  assertEquals(VALID_EVENT_TYPES.size, expected.length, 'Should have all event types');
+  for (const eventType of expected) {
+    assertEquals(VALID_EVENT_TYPES.has(eventType), true, `Should contain ${eventType}`);
+  }
+});

--- a/services/api/supabase/functions/_shared/webhook.ts
+++ b/services/api/supabase/functions/_shared/webhook.ts
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Webhook dispatch module for external integrations (#683).
+ *
+ * Provides HMAC-SHA256 payload signing, HTTP delivery with timeout,
+ * and exponential-backoff retry logic for webhook event delivery.
+ *
+ * Security:
+ *   - Uses Web Crypto API (crypto.subtle) for HMAC — NOT Node.js crypto.
+ *   - NEVER log webhook secrets or raw payload contents.
+ *   - Delivery timeout is 10 seconds to prevent Edge Function timeout.
+ *   - All endpoints must use HTTPS — HTTP is rejected at the DB level.
+ */
+
+import type { Logger } from './logger.ts';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A webhook event to be delivered to subscribed endpoints. */
+export interface WebhookEvent {
+  /** Event type (e.g. 'transaction.created'). */
+  type: string;
+  /** The household that owns the entity. */
+  household_id: string;
+  /** The UUID of the affected entity. */
+  entity_id: string;
+  /** Event-specific data. NEVER include raw financial amounts. */
+  data: Record<string, unknown>;
+  /** ISO 8601 timestamp of when the event occurred. */
+  timestamp: string;
+}
+
+/** Result of a single webhook delivery attempt. */
+export interface WebhookDeliveryResult {
+  /** Whether the endpoint returned a 2xx status. */
+  success: boolean;
+  /** HTTP status code returned by the endpoint (if any). */
+  status_code?: number;
+  /** Error description (if delivery failed). */
+  error?: string;
+  /** Time taken for the delivery attempt in milliseconds. */
+  duration_ms: number;
+}
+
+/** A registered webhook endpoint (subset used for delivery). */
+export interface WebhookEndpoint {
+  /** Endpoint UUID. */
+  id: string;
+  /** The HTTPS URL to POST events to. */
+  url: string;
+  /** HMAC-SHA256 signing secret. */
+  secret: string;
+  /** Event types this endpoint subscribes to. */
+  events: string[];
+  /** Whether this endpoint is currently active. */
+  is_active: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Valid event types
+// ---------------------------------------------------------------------------
+
+/** The complete set of valid webhook event types. */
+export const VALID_EVENT_TYPES: ReadonlySet<string> = new Set([
+  'transaction.created',
+  'transaction.updated',
+  'transaction.deleted',
+  'account.created',
+  'account.updated',
+  'account.deleted',
+  'budget.created',
+  'budget.updated',
+  'budget.threshold_reached',
+  'goal.created',
+  'goal.updated',
+  'goal.completed',
+  'household.member_joined',
+  'household.member_left',
+  'invitation.created',
+  'invitation.accepted',
+]);
+
+// ---------------------------------------------------------------------------
+// HMAC signing (Web Crypto API)
+// ---------------------------------------------------------------------------
+
+/**
+ * Sign a webhook payload with HMAC-SHA256 using the Web Crypto API.
+ *
+ * @param payload The JSON string payload to sign.
+ * @param secret The hex-encoded HMAC secret.
+ * @returns A hex-encoded signature prefixed with "sha256=".
+ */
+export async function signWebhookPayload(payload: string, secret: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const keyData = encoder.encode(secret);
+  const payloadData = encoder.encode(payload);
+
+  const cryptoKey = await crypto.subtle.importKey(
+    'raw',
+    keyData,
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+
+  const signature = await crypto.subtle.sign('HMAC', cryptoKey, payloadData);
+
+  // Convert ArrayBuffer to hex string
+  const hex = Array.from(new Uint8Array(signature))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+
+  return `sha256=${hex}`;
+}
+
+// ---------------------------------------------------------------------------
+// Delivery
+// ---------------------------------------------------------------------------
+
+/** Delivery timeout in milliseconds (10 seconds). */
+const DELIVERY_TIMEOUT_MS = 10_000;
+
+/**
+ * Deliver a webhook event to an endpoint via HTTP POST.
+ *
+ * Sends the event as a JSON body with HMAC signature and metadata
+ * headers. Enforces a 10-second timeout to prevent Edge Function
+ * timeout cascade.
+ *
+ * @param endpoint The webhook endpoint to deliver to.
+ * @param event The webhook event to send.
+ * @param logger Logger instance (NEVER logs secrets or payload contents).
+ * @returns The delivery result with success/failure status and timing.
+ */
+export async function deliverWebhook(
+  endpoint: WebhookEndpoint,
+  event: WebhookEvent,
+  logger: Logger,
+): Promise<WebhookDeliveryResult> {
+  const startTime = performance.now();
+  const deliveryId = crypto.randomUUID();
+  const timestamp = new Date().toISOString();
+  const body = JSON.stringify(event);
+
+  try {
+    const signature = await signWebhookPayload(body, endpoint.secret);
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), DELIVERY_TIMEOUT_MS);
+
+    try {
+      const response = await fetch(endpoint.url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Webhook-Signature': signature,
+          'X-Webhook-Event': event.type,
+          'X-Webhook-Delivery': deliveryId,
+          'X-Webhook-Timestamp': timestamp,
+        },
+        body,
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      const durationMs = Math.round(performance.now() - startTime);
+      const success = response.status >= 200 && response.status < 300;
+
+      logger.info('Webhook delivery completed', {
+        endpointId: endpoint.id,
+        deliveryId,
+        eventType: event.type,
+        statusCode: response.status,
+        success,
+        duration_ms: durationMs,
+      });
+
+      return {
+        success,
+        status_code: response.status,
+        duration_ms: durationMs,
+        ...(success ? {} : { error: `HTTP ${response.status}` }),
+      };
+    } catch (fetchError) {
+      clearTimeout(timeoutId);
+
+      const durationMs = Math.round(performance.now() - startTime);
+
+      // Distinguish timeout from network error
+      const isTimeout =
+        fetchError instanceof DOMException && fetchError.name === 'AbortError';
+      const errorMessage = isTimeout
+        ? `Timeout after ${DELIVERY_TIMEOUT_MS}ms`
+        : `Network error: ${(fetchError as Error).message}`;
+
+      logger.warn('Webhook delivery failed', {
+        endpointId: endpoint.id,
+        deliveryId,
+        eventType: event.type,
+        error: errorMessage,
+        duration_ms: durationMs,
+      });
+
+      return {
+        success: false,
+        error: errorMessage,
+        duration_ms: durationMs,
+      };
+    }
+  } catch (signingError) {
+    const durationMs = Math.round(performance.now() - startTime);
+
+    logger.error('Webhook signing failed', {
+      endpointId: endpoint.id,
+      error: (signingError as Error).message,
+      duration_ms: durationMs,
+    });
+
+    return {
+      success: false,
+      error: `Signing error: ${(signingError as Error).message}`,
+      duration_ms: durationMs,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Retry logic
+// ---------------------------------------------------------------------------
+
+/**
+ * Calculate the retry delay for a given attempt using exponential backoff.
+ *
+ * Formula: min(2^attemptCount * 1000, 3600000) with ±10% jitter.
+ *
+ * @param attemptCount The current attempt number (0-based).
+ * @returns Delay in milliseconds before the next retry.
+ */
+export function calculateRetryDelay(attemptCount: number): number {
+  const baseDelay = Math.min(Math.pow(2, attemptCount) * 1000, 3_600_000);
+  // Add ±10% jitter to avoid thundering herd
+  const jitter = baseDelay * 0.1 * (2 * Math.random() - 1);
+  return Math.round(baseDelay + jitter);
+}
+
+/**
+ * Determine whether a delivery should be retried.
+ *
+ * @param attemptCount The number of attempts already made.
+ * @param maxAttempts The maximum number of attempts allowed.
+ * @returns True if another retry should be attempted.
+ */
+export function shouldRetry(attemptCount: number, maxAttempts: number): boolean {
+  return attemptCount < maxAttempts;
+}
+
+// ---------------------------------------------------------------------------
+// Event factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a new webhook event with the current timestamp.
+ *
+ * @param type The event type (e.g. 'transaction.created').
+ * @param householdId The household UUID that owns the entity.
+ * @param entityId The UUID of the affected entity.
+ * @param data Event-specific data. NEVER include raw financial amounts.
+ * @returns A fully-formed WebhookEvent.
+ */
+export function createWebhookEvent(
+  type: string,
+  householdId: string,
+  entityId: string,
+  data: Record<string, unknown>,
+): WebhookEvent {
+  return {
+    type,
+    household_id: householdId,
+    entity_id: entityId,
+    data,
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/services/api/supabase/functions/_shared/webhook.ts
+++ b/services/api/supabase/functions/_shared/webhook.ts
@@ -192,8 +192,7 @@ export async function deliverWebhook(
       const durationMs = Math.round(performance.now() - startTime);
 
       // Distinguish timeout from network error
-      const isTimeout =
-        fetchError instanceof DOMException && fetchError.name === 'AbortError';
+      const isTimeout = fetchError instanceof DOMException && fetchError.name === 'AbortError';
       const errorMessage = isTimeout
         ? `Timeout after ${DELIVERY_TIMEOUT_MS}ms`
         : `Network error: ${(fetchError as Error).message}`;

--- a/services/api/supabase/functions/manage-webhooks/index.ts
+++ b/services/api/supabase/functions/manage-webhooks/index.ts
@@ -37,11 +37,7 @@ import {
   methodNotAllowedResponse,
   noContentResponse,
 } from '../_shared/response.ts';
-import {
-  createWebhookEvent,
-  deliverWebhook,
-  VALID_EVENT_TYPES,
-} from '../_shared/webhook.ts';
+import { createWebhookEvent, deliverWebhook, VALID_EVENT_TYPES } from '../_shared/webhook.ts';
 import type { WebhookEndpoint } from '../_shared/webhook.ts';
 
 serve(async (req: Request): Promise<Response> => {
@@ -79,11 +75,7 @@ serve(async (req: Request): Promise<Response> => {
     // -----------------------------------------------------------------------
     // Rate limiting (user-based, 30 req/min)
     // -----------------------------------------------------------------------
-    const rateLimitResult = await checkRateLimit(
-      supabase,
-      user.id,
-      RATE_LIMITS['manage-webhooks'],
-    );
+    const rateLimitResult = await checkRateLimit(supabase, user.id, RATE_LIMITS['manage-webhooks']);
     if (!rateLimitResult.allowed) {
       logger.warn('Rate limit exceeded', { httpStatus: 429 });
       return rateLimitResponse(req, rateLimitResult, RATE_LIMITS['manage-webhooks']);
@@ -137,12 +129,9 @@ serve(async (req: Request): Promise<Response> => {
       }
 
       // Send a test event
-      const testEvent = createWebhookEvent(
-        'test',
-        endpoint.household_id,
-        endpoint.id,
-        { message: 'Webhook test delivery' },
-      );
+      const testEvent = createWebhookEvent('test', endpoint.household_id, endpoint.id, {
+        message: 'Webhook test delivery',
+      });
 
       const deliveryEndpoint: WebhookEndpoint = {
         id: endpoint.id,
@@ -205,10 +194,7 @@ serve(async (req: Request): Promise<Response> => {
           (e: unknown) => typeof e !== 'string' || !VALID_EVENT_TYPES.has(e),
         );
         if (invalidEvents.length > 0) {
-          return errorResponse(
-            req,
-            `Invalid event types: ${invalidEvents.join(', ')}`,
-          );
+          return errorResponse(req, `Invalid event types: ${invalidEvents.join(', ')}`);
         }
 
         // Verify user is owner/admin of the household
@@ -313,7 +299,13 @@ serve(async (req: Request): Promise<Response> => {
         // UPDATE WEBHOOK ENDPOINT
         // ===================================================================
         const body = await req.json();
-        const { id: endpointId, url: newUrl, events: newEvents, description: newDesc, is_active } = body;
+        const {
+          id: endpointId,
+          url: newUrl,
+          events: newEvents,
+          description: newDesc,
+          is_active,
+        } = body;
 
         if (!endpointId) {
           return errorResponse(req, 'id is required');
@@ -366,10 +358,7 @@ serve(async (req: Request): Promise<Response> => {
             (e: unknown) => typeof e !== 'string' || !VALID_EVENT_TYPES.has(e),
           );
           if (invalidEvents.length > 0) {
-            return errorResponse(
-              req,
-              `Invalid event types: ${invalidEvents.join(', ')}`,
-            );
+            return errorResponse(req, `Invalid event types: ${invalidEvents.join(', ')}`);
           }
           updates.events = newEvents;
         }

--- a/services/api/supabase/functions/manage-webhooks/index.ts
+++ b/services/api/supabase/functions/manage-webhooks/index.ts
@@ -1,0 +1,497 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Manage Webhooks Edge Function (#683)
+ *
+ * Full CRUD for webhook endpoints plus test delivery:
+ *   POST               — Create a new webhook endpoint (returns secret ONCE)
+ *   GET                — List webhook endpoints for a household (no secrets)
+ *   PUT                — Update an existing webhook endpoint
+ *   DELETE             — Soft-delete a webhook endpoint
+ *   POST ?action=test  — Send a test event to verify endpoint connectivity
+ *
+ * Security:
+ *   - All operations require authentication (Bearer JWT).
+ *   - Only household owners and admins can manage webhooks.
+ *   - Webhook secrets are NEVER returned in GET/list/update responses.
+ *   - NEVER log webhook secrets or payload contents.
+ *   - All webhook URLs must use HTTPS.
+ *
+ * Environment Variables:
+ *   SUPABASE_URL              — Project URL
+ *   SUPABASE_SERVICE_ROLE_KEY — Service role key
+ *   ALLOWED_ORIGINS           — Comma-separated allowed CORS origins
+ */
+
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts';
+import { createAdminClient, requireAuth } from '../_shared/auth.ts';
+import { handleCorsPreflightRequest } from '../_shared/cors.ts';
+import { validateEnv } from '../_shared/env.ts';
+import { createLogger } from '../_shared/logger.ts';
+import { checkRateLimit, rateLimitResponse, RATE_LIMITS } from '../_shared/rate-limit.ts';
+import {
+  createdResponse,
+  errorResponse,
+  internalErrorResponse,
+  jsonResponse,
+  methodNotAllowedResponse,
+  noContentResponse,
+} from '../_shared/response.ts';
+import {
+  createWebhookEvent,
+  deliverWebhook,
+  VALID_EVENT_TYPES,
+} from '../_shared/webhook.ts';
+import type { WebhookEndpoint } from '../_shared/webhook.ts';
+
+serve(async (req: Request): Promise<Response> => {
+  // -------------------------------------------------------------------------
+  // CORS preflight
+  // -------------------------------------------------------------------------
+  if (req.method === 'OPTIONS') {
+    return handleCorsPreflightRequest(req);
+  }
+
+  const logger = createLogger('manage-webhooks');
+  logger.info('Request received', { method: req.method });
+
+  // -------------------------------------------------------------------------
+  // Environment validation
+  // -------------------------------------------------------------------------
+  const envError = validateEnv('manage-webhooks', req);
+  if (envError) return envError;
+
+  try {
+    // -----------------------------------------------------------------------
+    // Authentication
+    // -----------------------------------------------------------------------
+    let user;
+    try {
+      user = await requireAuth(req);
+    } catch (response) {
+      return response as Response;
+    }
+
+    logger.setUserId(user.id);
+
+    const supabase = createAdminClient();
+
+    // -----------------------------------------------------------------------
+    // Rate limiting (user-based, 30 req/min)
+    // -----------------------------------------------------------------------
+    const rateLimitResult = await checkRateLimit(
+      supabase,
+      user.id,
+      RATE_LIMITS['manage-webhooks'],
+    );
+    if (!rateLimitResult.allowed) {
+      logger.warn('Rate limit exceeded', { httpStatus: 429 });
+      return rateLimitResponse(req, rateLimitResult, RATE_LIMITS['manage-webhooks']);
+    }
+
+    // -----------------------------------------------------------------------
+    // Check for ?action=test on POST
+    // -----------------------------------------------------------------------
+    const url = new URL(req.url);
+    const action = url.searchParams.get('action');
+
+    if (req.method === 'POST' && action === 'test') {
+      // =====================================================================
+      // TEST WEBHOOK DELIVERY
+      // =====================================================================
+      const body = await req.json();
+      const { endpoint_id } = body;
+
+      if (!endpoint_id) {
+        return errorResponse(req, 'endpoint_id is required');
+      }
+
+      // Fetch the endpoint (with secret for signing)
+      const { data: endpoint, error: epError } = await supabase
+        .from('webhook_endpoints')
+        .select('id, household_id, url, secret, events, is_active')
+        .eq('id', endpoint_id)
+        .is('deleted_at', null)
+        .single();
+
+      if (epError || !endpoint) {
+        return errorResponse(req, 'Webhook endpoint not found', 404);
+      }
+
+      // Verify user is owner/admin of the endpoint's household
+      const { data: membership, error: memError } = await supabase
+        .from('household_members')
+        .select('id, role')
+        .eq('household_id', endpoint.household_id)
+        .eq('user_id', user.id)
+        .is('deleted_at', null)
+        .in('role', ['owner', 'admin'])
+        .single();
+
+      if (memError || !membership) {
+        return errorResponse(req, 'Only household owners and admins can test webhooks', 403);
+      }
+
+      if (!endpoint.is_active) {
+        return errorResponse(req, 'Cannot test a disabled webhook endpoint');
+      }
+
+      // Send a test event
+      const testEvent = createWebhookEvent(
+        'test',
+        endpoint.household_id,
+        endpoint.id,
+        { message: 'Webhook test delivery' },
+      );
+
+      const deliveryEndpoint: WebhookEndpoint = {
+        id: endpoint.id,
+        url: endpoint.url,
+        secret: endpoint.secret,
+        events: endpoint.events,
+        is_active: endpoint.is_active,
+      };
+
+      const result = await deliverWebhook(deliveryEndpoint, testEvent, logger);
+
+      logger.info('Test webhook delivery completed', {
+        endpointId: endpoint.id,
+        success: result.success,
+        httpStatus: 200,
+      });
+
+      return jsonResponse(req, {
+        success: result.success,
+        status_code: result.status_code,
+        duration_ms: result.duration_ms,
+        ...(result.error ? { error: result.error } : {}),
+      });
+    }
+
+    // -----------------------------------------------------------------------
+    // Method routing
+    // -----------------------------------------------------------------------
+    switch (req.method) {
+      case 'POST': {
+        // ===================================================================
+        // CREATE WEBHOOK ENDPOINT
+        // ===================================================================
+        const body = await req.json();
+        const { household_id, url: endpointUrl, description, events } = body;
+
+        if (!household_id) {
+          return errorResponse(req, 'household_id is required');
+        }
+
+        if (!endpointUrl) {
+          return errorResponse(req, 'url is required');
+        }
+
+        // Validate HTTPS-only
+        if (typeof endpointUrl !== 'string' || !endpointUrl.startsWith('https://')) {
+          return errorResponse(req, 'Webhook URL must start with https://');
+        }
+
+        if (endpointUrl.length > 2048) {
+          return errorResponse(req, 'Webhook URL must not exceed 2048 characters');
+        }
+
+        // Validate events array
+        if (!Array.isArray(events) || events.length === 0) {
+          return errorResponse(req, 'events must be a non-empty array');
+        }
+
+        const invalidEvents = events.filter(
+          (e: unknown) => typeof e !== 'string' || !VALID_EVENT_TYPES.has(e),
+        );
+        if (invalidEvents.length > 0) {
+          return errorResponse(
+            req,
+            `Invalid event types: ${invalidEvents.join(', ')}`,
+          );
+        }
+
+        // Verify user is owner/admin of the household
+        const { data: membership, error: memError } = await supabase
+          .from('household_members')
+          .select('id, role')
+          .eq('household_id', household_id)
+          .eq('user_id', user.id)
+          .is('deleted_at', null)
+          .in('role', ['owner', 'admin'])
+          .single();
+
+        if (memError || !membership) {
+          return errorResponse(req, 'Only household owners and admins can manage webhooks', 403);
+        }
+
+        // Insert endpoint (secret is generated by DB default)
+        const { data: endpoint, error: insertError } = await supabase
+          .from('webhook_endpoints')
+          .insert({
+            household_id,
+            url: endpointUrl,
+            description: description ?? null,
+            events,
+            created_by: user.id,
+          })
+          .select('id, url, events, secret, description, is_active, created_at')
+          .single();
+
+        if (insertError) {
+          logger.error('Failed to create webhook endpoint', {
+            errorMessage: insertError.message,
+          });
+          return internalErrorResponse(req);
+        }
+
+        logger.info('Webhook endpoint created', { httpStatus: 201, endpointId: endpoint.id });
+
+        // Return secret ONLY on creation
+        return createdResponse(req, {
+          id: endpoint.id,
+          url: endpoint.url,
+          events: endpoint.events,
+          secret: endpoint.secret,
+          description: endpoint.description,
+          is_active: endpoint.is_active,
+          created_at: endpoint.created_at,
+        });
+      }
+
+      case 'GET': {
+        // ===================================================================
+        // LIST WEBHOOK ENDPOINTS
+        // ===================================================================
+        const household_id = url.searchParams.get('household_id');
+
+        if (!household_id) {
+          return errorResponse(req, 'household_id query parameter is required');
+        }
+
+        // Verify user belongs to household as owner/admin
+        const { data: membership, error: memError } = await supabase
+          .from('household_members')
+          .select('id, role')
+          .eq('household_id', household_id)
+          .eq('user_id', user.id)
+          .is('deleted_at', null)
+          .in('role', ['owner', 'admin'])
+          .single();
+
+        if (memError || !membership) {
+          return errorResponse(req, 'Only household owners and admins can view webhooks', 403);
+        }
+
+        const { data: endpoints, error: listError } = await supabase
+          .from('webhook_endpoints')
+          .select(
+            'id, url, description, events, is_active, failure_count, last_success_at, last_failure_at, created_at, updated_at',
+          )
+          .eq('household_id', household_id)
+          .is('deleted_at', null)
+          .order('created_at', { ascending: false });
+
+        if (listError) {
+          logger.error('Failed to list webhook endpoints', {
+            errorMessage: listError.message,
+          });
+          return internalErrorResponse(req);
+        }
+
+        logger.info('Webhook endpoints listed', {
+          httpStatus: 200,
+          count: endpoints?.length ?? 0,
+        });
+
+        // NEVER include secret in list response
+        return jsonResponse(req, { endpoints: endpoints ?? [] });
+      }
+
+      case 'PUT': {
+        // ===================================================================
+        // UPDATE WEBHOOK ENDPOINT
+        // ===================================================================
+        const body = await req.json();
+        const { id: endpointId, url: newUrl, events: newEvents, description: newDesc, is_active } = body;
+
+        if (!endpointId) {
+          return errorResponse(req, 'id is required');
+        }
+
+        // Fetch the endpoint to verify ownership
+        const { data: existing, error: fetchError } = await supabase
+          .from('webhook_endpoints')
+          .select('id, household_id')
+          .eq('id', endpointId)
+          .is('deleted_at', null)
+          .single();
+
+        if (fetchError || !existing) {
+          return errorResponse(req, 'Webhook endpoint not found', 404);
+        }
+
+        // Verify user is owner/admin
+        const { data: membership, error: memError } = await supabase
+          .from('household_members')
+          .select('id, role')
+          .eq('household_id', existing.household_id)
+          .eq('user_id', user.id)
+          .is('deleted_at', null)
+          .in('role', ['owner', 'admin'])
+          .single();
+
+        if (memError || !membership) {
+          return errorResponse(req, 'Only household owners and admins can manage webhooks', 403);
+        }
+
+        // Build update payload
+        const updates: Record<string, unknown> = {};
+
+        if (newUrl !== undefined) {
+          if (typeof newUrl !== 'string' || !newUrl.startsWith('https://')) {
+            return errorResponse(req, 'Webhook URL must start with https://');
+          }
+          if (newUrl.length > 2048) {
+            return errorResponse(req, 'Webhook URL must not exceed 2048 characters');
+          }
+          updates.url = newUrl;
+        }
+
+        if (newEvents !== undefined) {
+          if (!Array.isArray(newEvents) || newEvents.length === 0) {
+            return errorResponse(req, 'events must be a non-empty array');
+          }
+          const invalidEvents = newEvents.filter(
+            (e: unknown) => typeof e !== 'string' || !VALID_EVENT_TYPES.has(e),
+          );
+          if (invalidEvents.length > 0) {
+            return errorResponse(
+              req,
+              `Invalid event types: ${invalidEvents.join(', ')}`,
+            );
+          }
+          updates.events = newEvents;
+        }
+
+        if (newDesc !== undefined) {
+          updates.description = newDesc;
+        }
+
+        if (is_active !== undefined) {
+          if (typeof is_active !== 'boolean') {
+            return errorResponse(req, 'is_active must be a boolean');
+          }
+          updates.is_active = is_active;
+        }
+
+        if (Object.keys(updates).length === 0) {
+          return errorResponse(req, 'No fields to update');
+        }
+
+        const { data: updated, error: updateError } = await supabase
+          .from('webhook_endpoints')
+          .update(updates)
+          .eq('id', endpointId)
+          .select(
+            'id, url, description, events, is_active, failure_count, last_success_at, last_failure_at, created_at, updated_at',
+          )
+          .single();
+
+        if (updateError) {
+          logger.error('Failed to update webhook endpoint', {
+            errorMessage: updateError.message,
+          });
+          return internalErrorResponse(req);
+        }
+
+        logger.info('Webhook endpoint updated', { httpStatus: 200, endpointId });
+
+        // NEVER include secret in update response
+        return jsonResponse(req, updated);
+      }
+
+      case 'DELETE': {
+        // ===================================================================
+        // SOFT-DELETE WEBHOOK ENDPOINT
+        // ===================================================================
+        const endpointId = url.searchParams.get('id');
+
+        if (!endpointId) {
+          // Try reading from body as fallback
+          try {
+            const body = await req.json();
+            if (!body.id) {
+              return errorResponse(req, 'id is required');
+            }
+            return await handleDelete(supabase, req, user, body.id, logger);
+          } catch {
+            return errorResponse(req, 'id is required');
+          }
+        }
+
+        return await handleDelete(supabase, req, user, endpointId, logger);
+      }
+
+      default:
+        return methodNotAllowedResponse(req);
+    }
+  } catch (err) {
+    logger.error('manage-webhooks error', { errorMessage: (err as Error).message });
+    return internalErrorResponse(req);
+  }
+});
+
+/**
+ * Handle soft-deletion of a webhook endpoint.
+ * Extracted to avoid duplicating the ownership verification logic.
+ */
+async function handleDelete(
+  supabase: ReturnType<typeof createAdminClient>,
+  req: Request,
+  user: { id: string; email: string },
+  endpointId: string,
+  logger: ReturnType<typeof createLogger>,
+): Promise<Response> {
+  // Fetch the endpoint to verify ownership
+  const { data: existing, error: fetchError } = await supabase
+    .from('webhook_endpoints')
+    .select('id, household_id')
+    .eq('id', endpointId)
+    .is('deleted_at', null)
+    .single();
+
+  if (fetchError || !existing) {
+    return errorResponse(req, 'Webhook endpoint not found', 404);
+  }
+
+  // Verify user is owner/admin
+  const { data: membership, error: memError } = await supabase
+    .from('household_members')
+    .select('id, role')
+    .eq('household_id', existing.household_id)
+    .eq('user_id', user.id)
+    .is('deleted_at', null)
+    .in('role', ['owner', 'admin'])
+    .single();
+
+  if (memError || !membership) {
+    return errorResponse(req, 'Only household owners and admins can manage webhooks', 403);
+  }
+
+  const { error: deleteError } = await supabase
+    .from('webhook_endpoints')
+    .update({ deleted_at: new Date().toISOString() })
+    .eq('id', endpointId);
+
+  if (deleteError) {
+    logger.error('Failed to soft-delete webhook endpoint', {
+      errorMessage: deleteError.message,
+    });
+    return internalErrorResponse(req);
+  }
+
+  logger.info('Webhook endpoint soft-deleted', { httpStatus: 204, endpointId });
+
+  return noContentResponse(req);
+}

--- a/services/api/supabase/migrations/20260324000004_webhook_infrastructure.sql
+++ b/services/api/supabase/migrations/20260324000004_webhook_infrastructure.sql
@@ -1,0 +1,364 @@
+-- SPDX-License-Identifier: BUSL-1.1
+
+-- Migration: 20260324000004_webhook_infrastructure
+-- Description: Webhook system for external integrations with event delivery,
+--              retry logic, and HMAC signature verification.
+-- Issues: #683
+--
+-- Webhook Lifecycle:
+--   1. Household owner/admin registers an endpoint (URL + event subscriptions).
+--   2. A server-side HMAC signing secret is generated and returned ONCE.
+--   3. When a subscribed event fires, a delivery record is created.
+--   4. The Edge Function POSTs the event payload to the endpoint URL with
+--      an HMAC-SHA256 signature header (X-Webhook-Signature).
+--   5. On success (2xx): failure_count resets, last_success_at updates.
+--   6. On failure (non-2xx / timeout): failure_count increments, delivery
+--      is scheduled for retry with exponential backoff (2^attempt seconds,
+--      capped at 1 hour, ±10% jitter).
+--   7. After max_attempts (default 5) the delivery is marked 'failed'.
+--   8. After 10 consecutive failures the endpoint is auto-disabled.
+--
+-- Retry Strategy:
+--   attempt 1: ~2s,  attempt 2: ~4s,  attempt 3: ~8s,
+--   attempt 4: ~16s, attempt 5: ~32s  (all ±10% jitter)
+--   Capped at 3600s (1 hour) for any attempt beyond ~12.
+
+-- =============================================================================
+-- Valid event types (reference list)
+-- =============================================================================
+-- transaction.created, transaction.updated, transaction.deleted,
+-- account.created, account.updated, account.deleted,
+-- budget.created, budget.updated, budget.threshold_reached,
+-- goal.created, goal.updated, goal.completed,
+-- household.member_joined, household.member_left,
+-- invitation.created, invitation.accepted
+
+-- =============================================================================
+-- Helper: generate_webhook_secret()
+-- =============================================================================
+-- Returns a cryptographically random 32-byte hex string suitable for
+-- HMAC-SHA256 signing. Uses gen_random_bytes() from pgcrypto.
+
+CREATE OR REPLACE FUNCTION public.generate_webhook_secret()
+RETURNS TEXT AS $$
+BEGIN
+    RETURN encode(gen_random_bytes(32), 'hex');
+END;
+$$ LANGUAGE plpgsql VOLATILE SECURITY DEFINER;
+
+COMMENT ON FUNCTION public.generate_webhook_secret() IS
+    'Generate a random 32-byte hex string for HMAC webhook signing.';
+
+-- =============================================================================
+-- webhook_endpoints
+-- =============================================================================
+-- Registered webhook endpoints that receive event notifications.
+-- Each endpoint belongs to a household and is managed by owners/admins.
+
+CREATE TABLE webhook_endpoints (
+    id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    household_id    UUID        NOT NULL REFERENCES households(id),
+    url             TEXT        NOT NULL
+                    CONSTRAINT  webhook_endpoints_url_max_length
+                        CHECK (char_length(url) <= 2048)
+                    CONSTRAINT  webhook_endpoints_url_https
+                        CHECK (url LIKE 'https://%'),
+    secret          TEXT        NOT NULL DEFAULT public.generate_webhook_secret(),
+    description     TEXT,
+    events          TEXT[]      NOT NULL
+                    CONSTRAINT  webhook_endpoints_events_nonempty
+                        CHECK (array_length(events, 1) >= 1),
+    is_active       BOOLEAN     NOT NULL DEFAULT true,
+    failure_count   INTEGER     NOT NULL DEFAULT 0,
+    last_success_at TIMESTAMPTZ,
+    last_failure_at TIMESTAMPTZ,
+    created_by      UUID        NOT NULL REFERENCES auth.users(id),
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    deleted_at      TIMESTAMPTZ
+);
+
+-- Validate that all event types in the array are from the allowed set
+CREATE OR REPLACE FUNCTION public.validate_webhook_events(events TEXT[])
+RETURNS BOOLEAN AS $$
+DECLARE
+    valid_events TEXT[] := ARRAY[
+        'transaction.created', 'transaction.updated', 'transaction.deleted',
+        'account.created', 'account.updated', 'account.deleted',
+        'budget.created', 'budget.updated', 'budget.threshold_reached',
+        'goal.created', 'goal.updated', 'goal.completed',
+        'household.member_joined', 'household.member_left',
+        'invitation.created', 'invitation.accepted'
+    ];
+    event TEXT;
+BEGIN
+    FOREACH event IN ARRAY events LOOP
+        IF NOT (event = ANY(valid_events)) THEN
+            RETURN false;
+        END IF;
+    END LOOP;
+    RETURN true;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+ALTER TABLE webhook_endpoints
+    ADD CONSTRAINT webhook_endpoints_events_valid
+    CHECK (public.validate_webhook_events(events));
+
+COMMENT ON TABLE webhook_endpoints IS
+    'Registered webhook endpoints for external integrations. '
+    'Each endpoint subscribes to specific event types and receives '
+    'HMAC-signed POST payloads when those events occur.';
+
+COMMENT ON COLUMN webhook_endpoints.secret IS
+    'HMAC-SHA256 signing secret. Generated server-side, returned ONLY on creation. '
+    'NEVER include in list/get responses.';
+
+COMMENT ON COLUMN webhook_endpoints.events IS
+    'Array of event types this endpoint subscribes to.';
+
+COMMENT ON COLUMN webhook_endpoints.failure_count IS
+    'Consecutive delivery failures. Resets to 0 on success. '
+    'Endpoint is auto-disabled when this exceeds the threshold (default 10).';
+
+-- =============================================================================
+-- webhook_deliveries
+-- =============================================================================
+-- Individual delivery attempts for webhook events. Tracks status, retries,
+-- and response metadata for debugging and monitoring.
+
+CREATE TABLE webhook_deliveries (
+    id                  UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    webhook_endpoint_id UUID        NOT NULL REFERENCES webhook_endpoints(id) ON DELETE CASCADE,
+    event_type          TEXT        NOT NULL,
+    payload             JSONB       NOT NULL,
+    status              TEXT        NOT NULL DEFAULT 'pending'
+                        CONSTRAINT  webhook_deliveries_status_valid
+                            CHECK (status IN ('pending', 'delivered', 'failed', 'retrying')),
+    attempt_count       INTEGER     NOT NULL DEFAULT 0,
+    max_attempts        INTEGER     NOT NULL DEFAULT 5,
+    next_retry_at       TIMESTAMPTZ,
+    response_status     INTEGER,
+    response_body       TEXT
+                        CONSTRAINT  webhook_deliveries_response_body_max
+                            CHECK (response_body IS NULL OR char_length(response_body) <= 1000),
+    error_message       TEXT,
+    delivered_at        TIMESTAMPTZ,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE webhook_deliveries IS
+    'Individual webhook delivery attempts with retry tracking. '
+    'Deliveries use exponential backoff (2^attempt seconds, capped at 1 hour). '
+    'After max_attempts (default 5) the delivery is marked as failed.';
+
+COMMENT ON COLUMN webhook_deliveries.response_body IS
+    'First 1000 characters of the response body, for debugging failed deliveries.';
+
+COMMENT ON COLUMN webhook_deliveries.next_retry_at IS
+    'When the next retry attempt should be made. NULL for delivered or terminal failures.';
+
+-- =============================================================================
+-- Indexes
+-- =============================================================================
+
+-- Active endpoints for a household (soft-delete filtered)
+CREATE INDEX idx_webhook_endpoints_household
+    ON webhook_endpoints (household_id)
+    WHERE deleted_at IS NULL;
+
+-- Delivery history for an endpoint (most recent first)
+CREATE INDEX idx_webhook_deliveries_endpoint
+    ON webhook_deliveries (webhook_endpoint_id, created_at DESC);
+
+-- Pending/retrying deliveries for the retry processor
+CREATE INDEX idx_webhook_deliveries_pending
+    ON webhook_deliveries (status, next_retry_at)
+    WHERE status IN ('pending', 'retrying');
+
+-- Delivered items for cleanup/archival
+CREATE INDEX idx_webhook_deliveries_cleanup
+    ON webhook_deliveries (created_at)
+    WHERE status = 'delivered';
+
+-- =============================================================================
+-- RLS — Enable on both tables
+-- =============================================================================
+
+ALTER TABLE webhook_endpoints  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE webhook_deliveries ENABLE ROW LEVEL SECURITY;
+
+-- ---------------------------------------------------------------------------
+-- webhook_endpoints: Only household owners/admins can manage endpoints
+-- ---------------------------------------------------------------------------
+
+CREATE POLICY webhook_endpoints_select ON webhook_endpoints
+    FOR SELECT
+    USING (
+        household_id IN (
+            SELECT household_id FROM household_members
+            WHERE user_id = auth.uid()
+              AND deleted_at IS NULL
+              AND role IN ('owner', 'admin')
+        )
+    );
+
+CREATE POLICY webhook_endpoints_insert ON webhook_endpoints
+    FOR INSERT
+    WITH CHECK (
+        household_id IN (
+            SELECT household_id FROM household_members
+            WHERE user_id = auth.uid()
+              AND deleted_at IS NULL
+              AND role IN ('owner', 'admin')
+        )
+    );
+
+CREATE POLICY webhook_endpoints_update ON webhook_endpoints
+    FOR UPDATE
+    USING (
+        household_id IN (
+            SELECT household_id FROM household_members
+            WHERE user_id = auth.uid()
+              AND deleted_at IS NULL
+              AND role IN ('owner', 'admin')
+        )
+    )
+    WITH CHECK (
+        household_id IN (
+            SELECT household_id FROM household_members
+            WHERE user_id = auth.uid()
+              AND deleted_at IS NULL
+              AND role IN ('owner', 'admin')
+        )
+    );
+
+CREATE POLICY webhook_endpoints_delete ON webhook_endpoints
+    FOR DELETE
+    USING (
+        household_id IN (
+            SELECT household_id FROM household_members
+            WHERE user_id = auth.uid()
+              AND deleted_at IS NULL
+              AND role IN ('owner', 'admin')
+        )
+    );
+
+-- ---------------------------------------------------------------------------
+-- webhook_deliveries: Users can view deliveries for their household's endpoints
+-- ---------------------------------------------------------------------------
+
+CREATE POLICY webhook_deliveries_select ON webhook_deliveries
+    FOR SELECT
+    USING (
+        webhook_endpoint_id IN (
+            SELECT we.id FROM webhook_endpoints we
+            INNER JOIN household_members hm
+                ON hm.household_id = we.household_id
+            WHERE hm.user_id = auth.uid()
+              AND hm.deleted_at IS NULL
+              AND hm.role IN ('owner', 'admin')
+              AND we.deleted_at IS NULL
+        )
+    );
+
+-- Deliveries are created by the system (service role), not end users.
+-- No INSERT/UPDATE/DELETE policies for webhook_deliveries — only service role writes.
+
+-- =============================================================================
+-- Triggers
+-- =============================================================================
+
+-- Reuse existing updated_at trigger function from initial schema
+CREATE TRIGGER trg_webhook_endpoints_updated_at
+    BEFORE UPDATE ON webhook_endpoints
+    FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+-- ---------------------------------------------------------------------------
+-- After failed delivery: increment failure_count, update last_failure_at
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.webhook_delivery_failure_handler()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.status = 'failed' OR NEW.status = 'retrying' THEN
+        UPDATE webhook_endpoints
+        SET failure_count = failure_count + 1,
+            last_failure_at = now()
+        WHERE id = NEW.webhook_endpoint_id;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE TRIGGER trg_webhook_delivery_failure
+    AFTER INSERT OR UPDATE ON webhook_deliveries
+    FOR EACH ROW
+    WHEN (NEW.status IN ('failed', 'retrying'))
+    EXECUTE FUNCTION public.webhook_delivery_failure_handler();
+
+-- ---------------------------------------------------------------------------
+-- After successful delivery: reset failure_count, update last_success_at
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.webhook_delivery_success_handler()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.status = 'delivered' THEN
+        UPDATE webhook_endpoints
+        SET failure_count = 0,
+            last_success_at = now()
+        WHERE id = NEW.webhook_endpoint_id;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE TRIGGER trg_webhook_delivery_success
+    AFTER INSERT OR UPDATE ON webhook_deliveries
+    FOR EACH ROW
+    WHEN (NEW.status = 'delivered')
+    EXECUTE FUNCTION public.webhook_delivery_success_handler();
+
+-- =============================================================================
+-- Auto-disable failing endpoints
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.disable_failing_webhook(
+    p_endpoint_id UUID,
+    p_max_failures INTEGER DEFAULT 10
+)
+RETURNS VOID AS $$
+BEGIN
+    UPDATE webhook_endpoints
+    SET is_active = false
+    WHERE id = p_endpoint_id
+      AND failure_count >= p_max_failures
+      AND is_active = true
+      AND deleted_at IS NULL;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+COMMENT ON FUNCTION public.disable_failing_webhook(UUID, INTEGER) IS
+    'Disable a webhook endpoint when its failure_count exceeds the threshold. '
+    'Called after delivery failures to auto-disable consistently failing endpoints.';
+
+-- ---------------------------------------------------------------------------
+-- Trigger to auto-disable after failure count update
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.webhook_auto_disable_handler()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.failure_count >= 10 AND NEW.is_active = true THEN
+        NEW.is_active := false;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_webhook_auto_disable
+    BEFORE UPDATE ON webhook_endpoints
+    FOR EACH ROW
+    WHEN (NEW.failure_count >= 10 AND NEW.is_active = true)
+    EXECUTE FUNCTION public.webhook_auto_disable_handler();


### PR DESCRIPTION
Closes #683

## Summary

Complete webhook system for external integrations with HMAC-signed event delivery, retry logic, and automatic failure handling.

### New Tables
- **webhook_endpoints** — HTTPS-only endpoints with HMAC secrets, event subscriptions, failure tracking
- **webhook_deliveries** — Delivery attempts with status, response tracking, retry scheduling

### Edge Function: manage-webhooks
| Method | Description |
|--------|-------------|
| POST | Create webhook endpoint (returns secret only on creation) |
| GET | List endpoints for household (secrets never exposed) |
| PUT | Update endpoint URL, events, or active status |
| DELETE | Soft-delete endpoint |
| POST ?action=test | Send test delivery to verify connectivity |

### Shared Module: _shared/webhook.ts
- HMAC-SHA256 signing via Web Crypto API
- HTTP delivery with 10s timeout
- Exponential backoff retry (caps at 1 hour)
- ±10% jitter on retry delays

### Security
- RLS: only household owners/admins can manage webhooks
- HTTPS-only URL validation (no HTTP)
- Secrets never returned after creation
- Auto-disable after 10 consecutive failures
- Rate limited: 30 req/min per user

### Tests
- 35 Deno tests: signing (4), delivery (5), retry (4), event creation (2), CRUD (10+), auth (3+)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>