### PR TITLE
perf(api): add performance indexes and automated maintenance (#686)

### DIFF
--- a/services/api/supabase/migrations/20260324000002_performance_indexes.sql
+++ b/services/api/supabase/migrations/20260324000002_performance_indexes.sql
@@ -1,0 +1,396 @@
+-- SPDX-License-Identifier: BUSL-1.1
+
+-- Migration: 20260324000002_performance_indexes
+-- Description: Composite and partial indexes for high-frequency query patterns
+-- Issues: #686
+--
+-- This migration replaces broad single-column indexes from the initial schema
+-- with targeted composite indexes using partial filters (WHERE deleted_at IS NULL)
+-- to match the soft-delete query pattern used throughout the application.
+--
+-- Key optimizations:
+--   - Composite indexes align with actual WHERE + ORDER BY query patterns
+--   - Partial indexes exclude soft-deleted rows, reducing index size by ~10-30%
+--   - DESC ordering on date columns matches typical "most recent first" queries
+--   - Sync-engine indexes use double partial filters for minimal footprint
+--
+-- IMPORTANT: Do NOT use CREATE INDEX CONCURRENTLY inside a transaction block.
+-- All CREATE INDEX statements use IF NOT EXISTS for idempotency.
+-- All DROP INDEX statements use IF EXISTS for safe re-runs.
+--
+-- Total indexes added: 22 (replacing 23 superseded single-column indexes)
+
+-- =============================================================================
+-- Phase 1: Drop superseded single-column indexes
+-- =============================================================================
+-- These indexes are replaced by more specific composite/partial indexes below.
+-- Removing them reduces write overhead (fewer indexes to maintain on INSERT/UPDATE)
+-- and reclaims disk space without losing query performance.
+--
+-- Indexes NOT dropped (still independently valuable):
+--   idx_users_email (UNIQUE), idx_users_active,
+--   idx_households_created_by, idx_households_active,
+--   idx_household_members_unique (UNIQUE constraint),
+--   idx_household_members_active (different columns from replacement),
+--   idx_transactions_status (low-cardinality standalone filter),
+--   idx_audit_log_household (household-scoped audit queries),
+--   idx_audit_log_created_at (time-range-only queries),
+--   idx_sync_health_logs_status_created (status aggregate queries),
+--   All auth-related indexes (passkey_credentials, webauthn_challenges, invitations)
+
+-- Transactions: single-column indexes superseded by composite date-sorted indexes
+DROP INDEX IF EXISTS idx_transactions_household;   -- → idx_transactions_household_date
+DROP INDEX IF EXISTS idx_transactions_account;     -- → idx_transactions_account_date
+DROP INDEX IF EXISTS idx_transactions_date;        -- → covered by all composite date indexes
+DROP INDEX IF EXISTS idx_transactions_type;        -- → idx_transactions_type_date
+DROP INDEX IF EXISTS idx_transactions_category;    -- → recreated with partial filter
+DROP INDEX IF EXISTS idx_transactions_active;      -- → idx_transactions_household_date
+
+-- Accounts: replaced by filtered composite indexes
+DROP INDEX IF EXISTS idx_accounts_household;       -- → recreated with partial filter
+DROP INDEX IF EXISTS idx_accounts_type;            -- → recreated as (household_id, type)
+DROP INDEX IF EXISTS idx_accounts_active;          -- → superseded by new idx_accounts_household
+
+-- Budgets: single-column replaced by composite
+DROP INDEX IF EXISTS idx_budgets_household;        -- → idx_budgets_household_period
+DROP INDEX IF EXISTS idx_budgets_category;         -- → recreated with partial filter
+DROP INDEX IF EXISTS idx_budgets_period;           -- → idx_budgets_household_period
+DROP INDEX IF EXISTS idx_budgets_active;           -- → idx_budgets_household_period
+
+-- Goals: single-column replaced by composite with target_date
+DROP INDEX IF EXISTS idx_goals_household;          -- → recreated with target_date
+DROP INDEX IF EXISTS idx_goals_active;             -- → superseded by new idx_goals_household
+
+-- Categories: single-column replaced by composite with parent_id
+DROP INDEX IF EXISTS idx_categories_household;     -- → recreated with parent_id
+DROP INDEX IF EXISTS idx_categories_parent;        -- → covered by new composite (parent_id is 2nd col)
+DROP INDEX IF EXISTS idx_categories_active;        -- → superseded by new idx_categories_household
+
+-- Household members: single-column replaced by filtered composites
+DROP INDEX IF EXISTS idx_household_members_household;  -- → recreated with role
+DROP INDEX IF EXISTS idx_household_members_user;       -- → recreated with partial filter
+
+-- Audit log: single-column replaced by time-sorted composites
+DROP INDEX IF EXISTS idx_audit_log_user;           -- → idx_audit_log_user_time
+DROP INDEX IF EXISTS idx_audit_log_table;          -- → idx_audit_log_entity
+
+-- Sync health logs: replaced with consistent naming
+DROP INDEX IF EXISTS idx_sync_health_logs_user_created;  -- → idx_sync_health_user_time
+
+-- Rate limits: replaced with cleanup-oriented index
+DROP INDEX IF EXISTS idx_rate_limits_window;       -- → idx_rate_limits_window_start
+
+-- Recurring templates: upgraded with better column composition
+DROP INDEX IF EXISTS idx_recurring_templates_household;  -- → recreated with partial filter
+DROP INDEX IF EXISTS idx_recurring_templates_next_due;   -- → recreated with is_active column
+
+
+-- =============================================================================
+-- Phase 2: Transaction indexes (highest priority — most queried table)
+-- =============================================================================
+
+-- Account transaction listings:
+--   SELECT * FROM transactions
+--   WHERE account_id = $1 AND deleted_at IS NULL
+--   ORDER BY date DESC
+-- Powers the primary transaction list for a single account.
+-- Estimated improvement: seq scan → index scan; eliminates sort step on date.
+CREATE INDEX IF NOT EXISTS idx_transactions_account_date
+    ON transactions (account_id, date DESC)
+    WHERE deleted_at IS NULL;
+
+-- Household transaction listings:
+--   SELECT * FROM transactions
+--   WHERE household_id = $1 AND deleted_at IS NULL
+--   ORDER BY date DESC
+-- Used by the dashboard and cross-account transaction views.
+-- Estimated improvement: eliminates sort step for household-wide date-ordered queries.
+CREATE INDEX IF NOT EXISTS idx_transactions_household_date
+    ON transactions (household_id, date DESC)
+    WHERE deleted_at IS NULL;
+
+-- Category spending reports:
+--   SELECT SUM(amount_cents) FROM transactions
+--   WHERE category_id = $1 AND deleted_at IS NULL
+-- Used for budget-vs-actual calculations and category breakdowns.
+-- Estimated improvement: narrows scan to single category; skips soft-deleted rows.
+CREATE INDEX IF NOT EXISTS idx_transactions_category
+    ON transactions (category_id)
+    WHERE deleted_at IS NULL;
+
+-- Income vs expense filtering:
+--   SELECT * FROM transactions
+--   WHERE household_id = $1 AND type = $2 AND deleted_at IS NULL
+--   ORDER BY date DESC
+-- Powers the income/expense toggle filter in transaction views.
+-- Estimated improvement: three-column composite avoids scanning irrelevant types.
+CREATE INDEX IF NOT EXISTS idx_transactions_type_date
+    ON transactions (household_id, type, date DESC)
+    WHERE deleted_at IS NULL;
+
+-- PowerSync sync engine — find unsynced records:
+--   SELECT * FROM transactions
+--   WHERE is_synced = false AND deleted_at IS NULL
+-- Extremely selective (typically <1% of rows), so the partial index stays tiny.
+-- Estimated improvement: sub-millisecond lookups for the sync polling query.
+CREATE INDEX IF NOT EXISTS idx_transactions_sync
+    ON transactions (is_synced)
+    WHERE is_synced = false AND deleted_at IS NULL;
+
+-- Recurring transaction queries:
+--   SELECT * FROM transactions
+--   WHERE is_recurring = true AND deleted_at IS NULL
+-- Used for recurring transaction management views.
+-- Estimated improvement: skips non-recurring transactions (typically >90% of rows).
+CREATE INDEX IF NOT EXISTS idx_transactions_recurring
+    ON transactions (is_recurring)
+    WHERE is_recurring = true AND deleted_at IS NULL;
+
+
+-- =============================================================================
+-- Phase 3: Account indexes
+-- =============================================================================
+
+-- Household account listings:
+--   SELECT * FROM accounts
+--   WHERE household_id = $1 AND deleted_at IS NULL
+-- Primary query for the accounts dashboard screen.
+-- Estimated improvement: partial filter excludes deleted accounts from index.
+CREATE INDEX IF NOT EXISTS idx_accounts_household
+    ON accounts (household_id)
+    WHERE deleted_at IS NULL;
+
+-- Accounts by type:
+--   SELECT * FROM accounts
+--   WHERE household_id = $1 AND type = $2 AND deleted_at IS NULL
+-- Used for type-grouped account views (checking, savings, credit, etc.).
+-- Estimated improvement: composite avoids scanning all household accounts.
+CREATE INDEX IF NOT EXISTS idx_accounts_type
+    ON accounts (household_id, type)
+    WHERE deleted_at IS NULL;
+
+-- Sync engine — find unsynced account records:
+--   SELECT * FROM accounts WHERE is_synced = false AND deleted_at IS NULL
+-- Estimated improvement: sub-millisecond sync polling for account changes.
+CREATE INDEX IF NOT EXISTS idx_accounts_sync
+    ON accounts (is_synced)
+    WHERE is_synced = false AND deleted_at IS NULL;
+
+
+-- =============================================================================
+-- Phase 4: Budget indexes
+-- =============================================================================
+
+-- Budget listings:
+--   SELECT * FROM budgets
+--   WHERE household_id = $1 AND period = $2 AND deleted_at IS NULL
+--   ORDER BY start_date DESC
+-- Primary query for the budget management screen.
+-- Estimated improvement: three-column composite eliminates scan + sort.
+CREATE INDEX IF NOT EXISTS idx_budgets_household_period
+    ON budgets (household_id, period, start_date DESC)
+    WHERE deleted_at IS NULL;
+
+-- Category budget lookups:
+--   SELECT * FROM budgets
+--   WHERE category_id = $1 AND deleted_at IS NULL
+-- Used when viewing a category's associated budget.
+-- Estimated improvement: direct lookup by category; skips deleted budgets.
+CREATE INDEX IF NOT EXISTS idx_budgets_category
+    ON budgets (category_id)
+    WHERE deleted_at IS NULL;
+
+
+-- =============================================================================
+-- Phase 5: Goal indexes
+-- =============================================================================
+
+-- Goal tracking:
+--   SELECT * FROM goals
+--   WHERE household_id = $1 AND deleted_at IS NULL
+--   ORDER BY target_date
+-- Used by the goals dashboard with deadline sorting.
+-- Estimated improvement: combined filter + sort avoids a separate sort step.
+CREATE INDEX IF NOT EXISTS idx_goals_household
+    ON goals (household_id, target_date)
+    WHERE deleted_at IS NULL;
+
+
+-- =============================================================================
+-- Phase 6: Category indexes
+-- =============================================================================
+
+-- Category tree:
+--   SELECT * FROM categories
+--   WHERE household_id = $1 AND deleted_at IS NULL
+--   ORDER BY parent_id, sort_order
+-- Used for building the category hierarchy (top-level + children).
+-- Estimated improvement: enables efficient tree traversal with parent_id grouping.
+CREATE INDEX IF NOT EXISTS idx_categories_household
+    ON categories (household_id, parent_id)
+    WHERE deleted_at IS NULL;
+
+
+-- =============================================================================
+-- Phase 7: Household member indexes
+-- =============================================================================
+
+-- User's households lookup:
+--   SELECT household_id FROM household_members
+--   WHERE user_id = $1 AND deleted_at IS NULL
+-- Called by auth.household_ids() and every RLS policy check.
+-- CRITICAL for RLS performance — invoked on every authenticated query.
+-- Estimated improvement: sub-millisecond lookup for the most frequent RLS check.
+CREATE INDEX IF NOT EXISTS idx_household_members_user
+    ON household_members (user_id)
+    WHERE deleted_at IS NULL;
+
+-- Household member listings:
+--   SELECT * FROM household_members
+--   WHERE household_id = $1 AND deleted_at IS NULL
+--   ORDER BY role
+-- Used for household settings / member management screens.
+-- Estimated improvement: composite with role enables grouped member listings.
+CREATE INDEX IF NOT EXISTS idx_household_members_household
+    ON household_members (household_id, role)
+    WHERE deleted_at IS NULL;
+
+
+-- =============================================================================
+-- Phase 8: Audit log indexes
+-- =============================================================================
+-- Note: audit_log schema uses (table_name, record_id) columns.
+-- Index names follow the task convention; column names match the actual schema.
+
+-- User audit history:
+--   SELECT * FROM audit_log
+--   WHERE user_id = $1
+--   ORDER BY created_at DESC
+-- Used for user activity feeds and compliance reporting.
+-- Estimated improvement: composite eliminates the sort step on created_at.
+CREATE INDEX IF NOT EXISTS idx_audit_log_user_time
+    ON audit_log (user_id, created_at DESC);
+
+-- Entity audit trail:
+--   SELECT * FROM audit_log
+--   WHERE table_name = $1 AND record_id = $2
+--   ORDER BY created_at DESC
+-- Used for viewing the complete change history of a specific record.
+-- Estimated improvement: three-column composite replaces old two-column + sort.
+CREATE INDEX IF NOT EXISTS idx_audit_log_entity
+    ON audit_log (table_name, record_id, created_at DESC);
+
+-- Action type filtering:
+--   SELECT * FROM audit_log
+--   WHERE action = $1
+--   ORDER BY created_at DESC
+-- Used for filtering audit events by action type (e.g., 'DELETE', 'UPDATE').
+-- Estimated improvement: enables efficient action-based audit queries.
+CREATE INDEX IF NOT EXISTS idx_audit_log_action_time
+    ON audit_log (action, created_at DESC);
+
+
+-- =============================================================================
+-- Phase 9: Rate limits cleanup index
+-- =============================================================================
+-- The rate_limits table uses window_start to track the current window.
+-- Window expiry is computed as: window_start + configured interval.
+-- This index supports the cleanup_expired_rate_limits() function:
+--   DELETE FROM rate_limits WHERE window_start < NOW() - interval '...'
+
+CREATE INDEX IF NOT EXISTS idx_rate_limits_window_start
+    ON rate_limits (window_start);
+
+
+-- =============================================================================
+-- Phase 10: Sync health logs indexes
+-- =============================================================================
+
+-- Per-user sync history:
+--   SELECT * FROM sync_health_logs
+--   WHERE user_id = $1
+--   ORDER BY created_at DESC
+-- Used by the sync health dashboard and per-user diagnostics.
+CREATE INDEX IF NOT EXISTS idx_sync_health_user_time
+    ON sync_health_logs (user_id, created_at DESC);
+
+
+-- =============================================================================
+-- Phase 11: Recurring template indexes
+-- =============================================================================
+
+-- Due transaction processing:
+--   SELECT * FROM recurring_transaction_templates
+--   WHERE next_due_date <= $1 AND is_active = true AND deleted_at IS NULL
+-- Used by generate_recurring_transactions() cron job.
+-- The is_active column in the index enables index-only visibility checks.
+-- Estimated improvement: sub-millisecond lookup for the cron-driven generation job.
+CREATE INDEX IF NOT EXISTS idx_recurring_templates_next_due
+    ON recurring_transaction_templates (next_due_date, is_active)
+    WHERE deleted_at IS NULL AND is_active = true;
+
+-- Household template listings:
+--   SELECT * FROM recurring_transaction_templates
+--   WHERE household_id = $1 AND deleted_at IS NULL
+-- Used for viewing/managing recurring transactions for a household.
+CREATE INDEX IF NOT EXISTS idx_recurring_templates_household
+    ON recurring_transaction_templates (household_id)
+    WHERE deleted_at IS NULL;
+
+
+-- =============================================================================
+-- Down migration (to revert this migration)
+-- =============================================================================
+-- Run the following statements to restore the original index configuration:
+--
+-- -- Drop new composite/partial indexes
+-- DROP INDEX IF EXISTS idx_transactions_account_date;
+-- DROP INDEX IF EXISTS idx_transactions_household_date;
+-- DROP INDEX IF EXISTS idx_transactions_category;
+-- DROP INDEX IF EXISTS idx_transactions_type_date;
+-- DROP INDEX IF EXISTS idx_transactions_sync;
+-- DROP INDEX IF EXISTS idx_transactions_recurring;
+-- DROP INDEX IF EXISTS idx_accounts_household;
+-- DROP INDEX IF EXISTS idx_accounts_type;
+-- DROP INDEX IF EXISTS idx_accounts_sync;
+-- DROP INDEX IF EXISTS idx_budgets_household_period;
+-- DROP INDEX IF EXISTS idx_budgets_category;
+-- DROP INDEX IF EXISTS idx_goals_household;
+-- DROP INDEX IF EXISTS idx_categories_household;
+-- DROP INDEX IF EXISTS idx_household_members_user;
+-- DROP INDEX IF EXISTS idx_household_members_household;
+-- DROP INDEX IF EXISTS idx_audit_log_user_time;
+-- DROP INDEX IF EXISTS idx_audit_log_entity;
+-- DROP INDEX IF EXISTS idx_audit_log_action_time;
+-- DROP INDEX IF EXISTS idx_rate_limits_window_start;
+-- DROP INDEX IF EXISTS idx_sync_health_user_time;
+-- DROP INDEX IF EXISTS idx_recurring_templates_next_due;
+-- DROP INDEX IF EXISTS idx_recurring_templates_household;
+--
+-- -- Restore original single-column indexes from 20260306000001_initial_schema
+-- CREATE INDEX idx_transactions_household ON transactions (household_id);
+-- CREATE INDEX idx_transactions_account ON transactions (account_id);
+-- CREATE INDEX idx_transactions_category ON transactions (category_id);
+-- CREATE INDEX idx_transactions_date ON transactions (date);
+-- CREATE INDEX idx_transactions_type ON transactions (type);
+-- CREATE INDEX idx_transactions_active ON transactions (household_id, date) WHERE deleted_at IS NULL;
+-- CREATE INDEX idx_accounts_household ON accounts (household_id);
+-- CREATE INDEX idx_accounts_type ON accounts (type);
+-- CREATE INDEX idx_accounts_active ON accounts (household_id) WHERE deleted_at IS NULL;
+-- CREATE INDEX idx_budgets_household ON budgets (household_id);
+-- CREATE INDEX idx_budgets_category ON budgets (category_id);
+-- CREATE INDEX idx_budgets_period ON budgets (period);
+-- CREATE INDEX idx_budgets_active ON budgets (household_id) WHERE deleted_at IS NULL;
+-- CREATE INDEX idx_goals_household ON goals (household_id);
+-- CREATE INDEX idx_goals_active ON goals (household_id) WHERE deleted_at IS NULL;
+-- CREATE INDEX idx_categories_household ON categories (household_id);
+-- CREATE INDEX idx_categories_parent ON categories (parent_id);
+-- CREATE INDEX idx_categories_active ON categories (household_id) WHERE deleted_at IS NULL;
+-- CREATE INDEX idx_household_members_household ON household_members (household_id);
+-- CREATE INDEX idx_household_members_user ON household_members (user_id);
+-- CREATE INDEX idx_audit_log_user ON audit_log (user_id);
+-- CREATE INDEX idx_audit_log_table ON audit_log (table_name, record_id);
+-- CREATE INDEX idx_sync_health_logs_user_created ON sync_health_logs (user_id, created_at DESC);
+-- CREATE INDEX idx_rate_limits_window ON rate_limits (window_start);
+-- CREATE INDEX idx_recurring_templates_household ON recurring_transaction_templates (household_id);
+-- CREATE INDEX idx_recurring_templates_next_due ON recurring_transaction_templates (next_due_date) WHERE deleted_at IS NULL AND is_active = true;

--- a/services/api/supabase/migrations/20260324000003_automated_maintenance.sql
+++ b/services/api/supabase/migrations/20260324000003_automated_maintenance.sql
@@ -1,0 +1,363 @@
+-- SPDX-License-Identifier: BUSL-1.1
+
+-- Migration: 20260324000003_automated_maintenance
+-- Description: Automated database maintenance functions and pg_cron scheduling
+-- Issues: #686
+--
+-- Creates fine-grained maintenance functions for each cleanup concern and an
+-- orchestrator function that calls them all. Complements the existing
+-- cleanup_expired_records() from 20260323000001 with:
+--   - Individual functions for granular scheduling and monitoring
+--   - Configurable retention periods via function parameters
+--   - ANALYZE scheduling for query planner accuracy
+--   - pg_cron integration (guarded — only activates if pg_cron is installed)
+--
+-- Security:
+--   - All functions are SECURITY DEFINER to bypass RLS for maintenance
+--   - EXECUTE granted only to service_role; revoked from PUBLIC and anon
+--   - Functions use SET search_path = public to prevent search_path injection
+--
+-- Note: cleanup_expired_rate_limits replaces the version from 20260323000003
+-- with an hours-based interface (was seconds-based). The signature (INTEGER)
+-- is identical, so CREATE OR REPLACE succeeds.
+
+-- =============================================================================
+-- 1. cleanup_expired_rate_limits(retention_hours INTEGER DEFAULT 2)
+-- =============================================================================
+-- Removes rate limit counter rows whose window has expired beyond the
+-- retention period. The rate_limits table uses window_start; expiry is
+-- computed as window_start + configured interval. After the window passes
+-- plus the retention buffer, the row is stale and safe to delete.
+--
+-- Default retention: 2 hours (well beyond the longest window of 1 hour
+-- used by data-export / account-deletion / sync-health-report).
+--
+-- Replaces: cleanup_expired_rate_limits(p_retention_seconds) from migration
+-- 20260323000003_rate_limits.sql — same signature (INTEGER), new semantics.
+
+CREATE OR REPLACE FUNCTION public.cleanup_expired_rate_limits(
+    retention_hours INTEGER DEFAULT 2
+)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_deleted INTEGER;
+BEGIN
+    DELETE FROM rate_limits
+    WHERE window_start < NOW() - (retention_hours || ' hours')::INTERVAL;
+
+    GET DIAGNOSTICS v_deleted = ROW_COUNT;
+    RETURN v_deleted;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.cleanup_expired_rate_limits(INTEGER) TO service_role;
+REVOKE EXECUTE ON FUNCTION public.cleanup_expired_rate_limits(INTEGER) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.cleanup_expired_rate_limits(INTEGER) FROM anon;
+
+
+-- =============================================================================
+-- 2. cleanup_expired_webauthn_challenges(retention_hours INTEGER DEFAULT 1)
+-- =============================================================================
+-- Hard-deletes WebAuthn challenge rows that expired beyond the retention
+-- period. Challenges have a 5-minute TTL; the 1-hour default retention
+-- provides a generous safety margin for in-flight authentication ceremonies.
+--
+-- Complements: cleanup_expired_records() which also cleans challenges,
+-- but this function provides independent scheduling and monitoring.
+
+CREATE OR REPLACE FUNCTION public.cleanup_expired_webauthn_challenges(
+    retention_hours INTEGER DEFAULT 1
+)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_deleted INTEGER;
+BEGIN
+    DELETE FROM webauthn_challenges
+    WHERE expires_at < NOW() - (retention_hours || ' hours')::INTERVAL;
+
+    GET DIAGNOSTICS v_deleted = ROW_COUNT;
+    RETURN v_deleted;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.cleanup_expired_webauthn_challenges(INTEGER) TO service_role;
+REVOKE EXECUTE ON FUNCTION public.cleanup_expired_webauthn_challenges(INTEGER) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.cleanup_expired_webauthn_challenges(INTEGER) FROM anon;
+
+
+-- =============================================================================
+-- 3. cleanup_old_sync_health_logs(retention_days INTEGER DEFAULT 30)
+-- =============================================================================
+-- Hard-deletes sync health log entries older than the retention period.
+-- These logs are append-only diagnostics; 30 days is sufficient for
+-- trend analysis and debugging. Keeps the table size manageable.
+--
+-- At typical write rates (~100 syncs/user/day, 1000 users), this removes
+-- ~3M rows per run, reclaiming significant disk space.
+
+CREATE OR REPLACE FUNCTION public.cleanup_old_sync_health_logs(
+    retention_days INTEGER DEFAULT 30
+)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_deleted INTEGER;
+BEGIN
+    DELETE FROM sync_health_logs
+    WHERE created_at < NOW() - (retention_days || ' days')::INTERVAL;
+
+    GET DIAGNOSTICS v_deleted = ROW_COUNT;
+    RETURN v_deleted;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.cleanup_old_sync_health_logs(INTEGER) TO service_role;
+REVOKE EXECUTE ON FUNCTION public.cleanup_old_sync_health_logs(INTEGER) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.cleanup_old_sync_health_logs(INTEGER) FROM anon;
+
+
+-- =============================================================================
+-- 4. cleanup_expired_invitations()
+-- =============================================================================
+-- Soft-deletes household invitations that have expired without being accepted.
+-- Unlike cleanup_expired_records() which hard-deletes old invitations, this
+-- function marks freshly expired ones as deleted so they stop appearing in
+-- household invitation lists while preserving them for audit purposes.
+--
+-- Only targets invitations that are:
+--   - Past their expires_at timestamp
+--   - Never accepted (accepted_at IS NULL)
+--   - Not already soft-deleted (deleted_at IS NULL)
+
+CREATE OR REPLACE FUNCTION public.cleanup_expired_invitations()
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_updated INTEGER;
+BEGIN
+    UPDATE household_invitations
+    SET deleted_at = NOW()
+    WHERE expires_at < NOW()
+      AND accepted_at IS NULL
+      AND deleted_at IS NULL;
+
+    GET DIAGNOSTICS v_updated = ROW_COUNT;
+    RETURN v_updated;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.cleanup_expired_invitations() TO service_role;
+REVOKE EXECUTE ON FUNCTION public.cleanup_expired_invitations() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.cleanup_expired_invitations() FROM anon;
+
+
+-- =============================================================================
+-- 5. vacuum_analyze_tables()
+-- =============================================================================
+-- Runs ANALYZE on the most frequently updated tables to keep the query
+-- planner's statistics accurate. This does NOT run VACUUM — that is handled
+-- by PostgreSQL's autovacuum or can be scheduled separately via pg_cron.
+--
+-- ANALYZE is lightweight and non-blocking. It samples table data to update
+-- the pg_statistic catalog, improving query plan accuracy for:
+--   - Index selection (which index to use)
+--   - Join ordering (which table to scan first)
+--   - Row count estimates (affects nested loop vs hash join choice)
+--
+-- Tables analyzed (ordered by update frequency):
+--   1. transactions  — highest write volume
+--   2. accounts      — balance recalculated on every transaction
+--   3. budgets       — updated during budget tracking
+--   4. goals         — updated on savings progress
+--   5. sync_health_logs — append-only but high volume
+--   6. rate_limits   — high-frequency UPSERT from Edge Functions
+
+CREATE OR REPLACE FUNCTION public.vacuum_analyze_tables()
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_tables TEXT[] := ARRAY[
+        'transactions',
+        'accounts',
+        'budgets',
+        'goals',
+        'sync_health_logs',
+        'rate_limits'
+    ];
+    v_table TEXT;
+    v_summary TEXT := '';
+BEGIN
+    FOREACH v_table IN ARRAY v_tables
+    LOOP
+        EXECUTE format('ANALYZE %I', v_table);
+        v_summary := v_summary || 'ANALYZE ' || v_table || ' OK; ';
+    END LOOP;
+
+    RETURN v_summary;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.vacuum_analyze_tables() TO service_role;
+REVOKE EXECUTE ON FUNCTION public.vacuum_analyze_tables() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.vacuum_analyze_tables() FROM anon;
+
+
+-- =============================================================================
+-- 6. run_all_maintenance()
+-- =============================================================================
+-- Orchestrator function that calls all cleanup functions and ANALYZE.
+-- Returns a JSONB summary with counts from each cleanup, the ANALYZE result,
+-- and a timestamp. Designed to be called by pg_cron daily or via an Edge
+-- Function for on-demand maintenance.
+--
+-- Example return value:
+--   {
+--     "rate_limits_deleted": 42,
+--     "webauthn_challenges_deleted": 7,
+--     "sync_health_logs_deleted": 150000,
+--     "invitations_expired": 3,
+--     "analyze_result": "ANALYZE transactions OK; ANALYZE accounts OK; ...",
+--     "completed_at": "2026-03-24T03:00:01.234Z"
+--   }
+
+CREATE OR REPLACE FUNCTION public.run_all_maintenance()
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_rate_limits    INTEGER;
+    v_webauthn       INTEGER;
+    v_sync_logs      INTEGER;
+    v_invitations    INTEGER;
+    v_analyze_result TEXT;
+BEGIN
+    -- Run each cleanup with default retention periods
+    v_rate_limits    := cleanup_expired_rate_limits();
+    v_webauthn       := cleanup_expired_webauthn_challenges();
+    v_sync_logs      := cleanup_old_sync_health_logs();
+    v_invitations    := cleanup_expired_invitations();
+
+    -- Update planner statistics
+    v_analyze_result := vacuum_analyze_tables();
+
+    RETURN jsonb_build_object(
+        'rate_limits_deleted',          v_rate_limits,
+        'webauthn_challenges_deleted',  v_webauthn,
+        'sync_health_logs_deleted',     v_sync_logs,
+        'invitations_expired',          v_invitations,
+        'analyze_result',               v_analyze_result,
+        'completed_at',                 NOW()
+    );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.run_all_maintenance() TO service_role;
+REVOKE EXECUTE ON FUNCTION public.run_all_maintenance() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.run_all_maintenance() FROM anon;
+
+
+-- =============================================================================
+-- 7. pg_cron scheduling (conditional — only if pg_cron extension is installed)
+-- =============================================================================
+-- Supabase Pro plans include pg_cron; free-tier and local dev do not.
+-- The DO block checks for the extension before scheduling to avoid errors.
+--
+-- Schedule:
+--   - Every hour: cleanup rate limits and webauthn challenges (lightweight)
+--   - Daily at 3 AM UTC: full maintenance run (cleanup + ANALYZE)
+--
+-- To verify scheduled jobs after migration:
+--   SELECT * FROM cron.job ORDER BY jobid;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+        -- Hourly: clean up expired rate limit windows (fast, <10ms typical)
+        PERFORM cron.schedule(
+            'cleanup-rate-limits',
+            '0 * * * *',
+            $$SELECT public.cleanup_expired_rate_limits()$$
+        );
+
+        -- Hourly: clean up expired WebAuthn challenges (fast, <10ms typical)
+        PERFORM cron.schedule(
+            'cleanup-webauthn',
+            '0 * * * *',
+            $$SELECT public.cleanup_expired_webauthn_challenges()$$
+        );
+
+        -- Daily at 3 AM UTC: full maintenance (cleanup all + ANALYZE)
+        PERFORM cron.schedule(
+            'daily-maintenance',
+            '0 3 * * *',
+            $$SELECT public.run_all_maintenance()$$
+        );
+
+        RAISE NOTICE 'pg_cron jobs scheduled: cleanup-rate-limits, cleanup-webauthn, daily-maintenance';
+    ELSE
+        RAISE NOTICE 'pg_cron not available — skipping cron schedule. Use Edge Functions or external scheduler.';
+    END IF;
+END $$;
+
+
+-- =============================================================================
+-- Down migration (to revert this migration)
+-- =============================================================================
+--
+-- -- Remove pg_cron jobs (if pg_cron is installed)
+-- DO $$
+-- BEGIN
+--     IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+--         PERFORM cron.unschedule('cleanup-rate-limits');
+--         PERFORM cron.unschedule('cleanup-webauthn');
+--         PERFORM cron.unschedule('daily-maintenance');
+--     END IF;
+-- END $$;
+--
+-- -- Drop new maintenance functions
+-- DROP FUNCTION IF EXISTS public.run_all_maintenance();
+-- DROP FUNCTION IF EXISTS public.vacuum_analyze_tables();
+-- DROP FUNCTION IF EXISTS public.cleanup_expired_invitations();
+-- DROP FUNCTION IF EXISTS public.cleanup_old_sync_health_logs(INTEGER);
+-- DROP FUNCTION IF EXISTS public.cleanup_expired_webauthn_challenges(INTEGER);
+--
+-- -- Restore original cleanup_expired_rate_limits with seconds-based interface
+-- CREATE OR REPLACE FUNCTION public.cleanup_expired_rate_limits(
+--     p_retention_seconds INTEGER DEFAULT 7200
+-- )
+-- RETURNS INTEGER
+-- LANGUAGE plpgsql
+-- SECURITY DEFINER
+-- SET search_path = public
+-- AS $$
+-- DECLARE
+--     v_deleted INTEGER;
+-- BEGIN
+--     DELETE FROM rate_limits
+--     WHERE window_start < now() - make_interval(secs => p_retention_seconds);
+--     GET DIAGNOSTICS v_deleted = ROW_COUNT;
+--     RETURN v_deleted;
+-- END;
+-- $$;
+-- GRANT EXECUTE ON FUNCTION public.cleanup_expired_rate_limits(INTEGER) TO service_role;
+-- REVOKE EXECUTE ON FUNCTION public.cleanup_expired_rate_limits(INTEGER) FROM PUBLIC;
+-- REVOKE EXECUTE ON FUNCTION public.cleanup_expired_rate_limits(INTEGER) FROM anon;

--- a/services/api/supabase/tests/db-optimization.test.sql
+++ b/services/api/supabase/tests/db-optimization.test.sql
@@ -1,0 +1,532 @@
+-- SPDX-License-Identifier: BUSL-1.1
+
+-- =============================================================================
+-- Database Performance Optimization Tests
+-- =============================================================================
+-- Validates that performance indexes and automated maintenance functions from
+-- migrations 20260324000002 and 20260324000003 are correctly installed.
+--
+-- Prerequisites:
+--   - Local Supabase running: supabase start
+--   - Migrations applied:     supabase db reset  (or supabase migration up)
+--
+-- Usage:
+--   psql postgresql://postgres:postgres@localhost:54322/postgres \
+--        -f supabase/tests/db-optimization.test.sql
+--
+-- Exit codes:
+--   0 = all tests passed
+--   3 = one or more tests failed (via \set ON_ERROR_STOP)
+--
+-- Issues: #686
+-- =============================================================================
+
+\set ON_ERROR_STOP on
+\set QUIET on
+\pset tuples_only on
+\pset format unaligned
+
+-- Use a transaction so all test state is rolled back automatically.
+BEGIN;
+
+-- Display a banner
+DO $$ BEGIN RAISE NOTICE ''; END $$;
+DO $$ BEGIN RAISE NOTICE '=== Database Performance Optimization Tests ==='; END $$;
+DO $$ BEGIN RAISE NOTICE ''; END $$;
+
+-- =============================================================================
+-- Test 1: Transaction indexes exist
+-- =============================================================================
+-- The transactions table is the highest-volume table. These composite/partial
+-- indexes optimize the most common query patterns: account listings, household
+-- views, category reports, type filtering, sync polling, and recurring queries.
+
+DO $$
+DECLARE
+    missing TEXT[];
+    required_indexes TEXT[] := ARRAY[
+        'idx_transactions_account_date',
+        'idx_transactions_household_date',
+        'idx_transactions_category',
+        'idx_transactions_type_date',
+        'idx_transactions_sync',
+        'idx_transactions_recurring'
+    ];
+    idx TEXT;
+BEGIN
+    missing := '{}';
+
+    FOREACH idx IN ARRAY required_indexes
+    LOOP
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_indexes
+            WHERE schemaname = 'public'
+              AND indexname = idx
+        ) THEN
+            missing := array_append(missing, idx);
+        END IF;
+    END LOOP;
+
+    IF array_length(missing, 1) > 0 THEN
+        RAISE EXCEPTION 'FAIL Test 1: Missing transaction indexes: %', missing;
+    END IF;
+
+    RAISE NOTICE 'PASS Test 1: All transaction indexes exist (6/6)';
+END $$;
+
+-- =============================================================================
+-- Test 2: Account indexes exist
+-- =============================================================================
+-- Account indexes support household listings, type filtering, and sync polling.
+
+DO $$
+DECLARE
+    missing TEXT[];
+    required_indexes TEXT[] := ARRAY[
+        'idx_accounts_household',
+        'idx_accounts_type',
+        'idx_accounts_sync'
+    ];
+    idx TEXT;
+BEGIN
+    missing := '{}';
+
+    FOREACH idx IN ARRAY required_indexes
+    LOOP
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_indexes
+            WHERE schemaname = 'public'
+              AND indexname = idx
+        ) THEN
+            missing := array_append(missing, idx);
+        END IF;
+    END LOOP;
+
+    IF array_length(missing, 1) > 0 THEN
+        RAISE EXCEPTION 'FAIL Test 2: Missing account indexes: %', missing;
+    END IF;
+
+    RAISE NOTICE 'PASS Test 2: All account indexes exist (3/3)';
+END $$;
+
+-- =============================================================================
+-- Test 3: Budget and goal indexes exist
+-- =============================================================================
+-- Budget indexes support period-based listings and category lookups.
+-- Goal indexes support household goal tracking with deadline sorting.
+
+DO $$
+DECLARE
+    missing TEXT[];
+    required_indexes TEXT[] := ARRAY[
+        'idx_budgets_household_period',
+        'idx_budgets_category',
+        'idx_goals_household'
+    ];
+    idx TEXT;
+BEGIN
+    missing := '{}';
+
+    FOREACH idx IN ARRAY required_indexes
+    LOOP
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_indexes
+            WHERE schemaname = 'public'
+              AND indexname = idx
+        ) THEN
+            missing := array_append(missing, idx);
+        END IF;
+    END LOOP;
+
+    IF array_length(missing, 1) > 0 THEN
+        RAISE EXCEPTION 'FAIL Test 3: Missing budget/goal indexes: %', missing;
+    END IF;
+
+    RAISE NOTICE 'PASS Test 3: All budget and goal indexes exist (3/3)';
+END $$;
+
+-- =============================================================================
+-- Test 4: Category and household member indexes exist
+-- =============================================================================
+-- Category indexes support the parent/child tree structure.
+-- Household member indexes are critical for RLS performance (auth.household_ids).
+
+DO $$
+DECLARE
+    missing TEXT[];
+    required_indexes TEXT[] := ARRAY[
+        'idx_categories_household',
+        'idx_household_members_user',
+        'idx_household_members_household'
+    ];
+    idx TEXT;
+BEGIN
+    missing := '{}';
+
+    FOREACH idx IN ARRAY required_indexes
+    LOOP
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_indexes
+            WHERE schemaname = 'public'
+              AND indexname = idx
+        ) THEN
+            missing := array_append(missing, idx);
+        END IF;
+    END LOOP;
+
+    IF array_length(missing, 1) > 0 THEN
+        RAISE EXCEPTION 'FAIL Test 4: Missing category/member indexes: %', missing;
+    END IF;
+
+    RAISE NOTICE 'PASS Test 4: All category and household member indexes exist (3/3)';
+END $$;
+
+-- =============================================================================
+-- Test 5: Audit log indexes exist
+-- =============================================================================
+-- Audit log indexes support user history, entity trail, and action filtering.
+
+DO $$
+DECLARE
+    missing TEXT[];
+    required_indexes TEXT[] := ARRAY[
+        'idx_audit_log_user_time',
+        'idx_audit_log_entity',
+        'idx_audit_log_action_time'
+    ];
+    idx TEXT;
+BEGIN
+    missing := '{}';
+
+    FOREACH idx IN ARRAY required_indexes
+    LOOP
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_indexes
+            WHERE schemaname = 'public'
+              AND indexname = idx
+        ) THEN
+            missing := array_append(missing, idx);
+        END IF;
+    END LOOP;
+
+    IF array_length(missing, 1) > 0 THEN
+        RAISE EXCEPTION 'FAIL Test 5: Missing audit log indexes: %', missing;
+    END IF;
+
+    RAISE NOTICE 'PASS Test 5: All audit log indexes exist (3/3)';
+END $$;
+
+-- =============================================================================
+-- Test 6: Rate limit and sync health indexes exist
+-- =============================================================================
+-- Rate limit index supports periodic cleanup of expired windows.
+-- Sync health index supports per-user sync history queries.
+
+DO $$
+DECLARE
+    missing TEXT[];
+    required_indexes TEXT[] := ARRAY[
+        'idx_rate_limits_window_start',
+        'idx_sync_health_user_time'
+    ];
+    idx TEXT;
+BEGIN
+    missing := '{}';
+
+    FOREACH idx IN ARRAY required_indexes
+    LOOP
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_indexes
+            WHERE schemaname = 'public'
+              AND indexname = idx
+        ) THEN
+            missing := array_append(missing, idx);
+        END IF;
+    END LOOP;
+
+    IF array_length(missing, 1) > 0 THEN
+        RAISE EXCEPTION 'FAIL Test 6: Missing rate limit/sync health indexes: %', missing;
+    END IF;
+
+    RAISE NOTICE 'PASS Test 6: Rate limit and sync health indexes exist (2/2)';
+END $$;
+
+-- =============================================================================
+-- Test 7: Recurring template indexes exist
+-- =============================================================================
+-- These indexes support the cron-driven transaction generation and household
+-- template management views.
+
+DO $$
+DECLARE
+    missing TEXT[];
+    required_indexes TEXT[] := ARRAY[
+        'idx_recurring_templates_next_due',
+        'idx_recurring_templates_household'
+    ];
+    idx TEXT;
+BEGIN
+    missing := '{}';
+
+    FOREACH idx IN ARRAY required_indexes
+    LOOP
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_indexes
+            WHERE schemaname = 'public'
+              AND indexname = idx
+        ) THEN
+            missing := array_append(missing, idx);
+        END IF;
+    END LOOP;
+
+    IF array_length(missing, 1) > 0 THEN
+        RAISE EXCEPTION 'FAIL Test 7: Missing recurring template indexes: %', missing;
+    END IF;
+
+    RAISE NOTICE 'PASS Test 7: All recurring template indexes exist (2/2)';
+END $$;
+
+-- =============================================================================
+-- Test 8: cleanup_expired_rate_limits function exists and returns INTEGER
+-- =============================================================================
+-- Validates the function signature and SECURITY DEFINER attribute.
+
+DO $$
+DECLARE
+    fn_exists BOOLEAN;
+    is_definer BOOLEAN;
+    return_type TEXT;
+BEGIN
+    SELECT EXISTS (
+        SELECT 1 FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = 'public'
+          AND p.proname = 'cleanup_expired_rate_limits'
+    ) INTO fn_exists;
+
+    IF NOT fn_exists THEN
+        RAISE EXCEPTION 'FAIL Test 8: cleanup_expired_rate_limits() does not exist';
+    END IF;
+
+    SELECT p.prosecdef, pg_get_function_result(p.oid)
+    INTO is_definer, return_type
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'cleanup_expired_rate_limits';
+
+    IF NOT is_definer THEN
+        RAISE EXCEPTION 'FAIL Test 8: cleanup_expired_rate_limits is not SECURITY DEFINER';
+    END IF;
+
+    IF return_type != 'integer' THEN
+        RAISE EXCEPTION 'FAIL Test 8: cleanup_expired_rate_limits returns % (expected integer)', return_type;
+    END IF;
+
+    RAISE NOTICE 'PASS Test 8: cleanup_expired_rate_limits exists (SECURITY DEFINER, returns INTEGER)';
+END $$;
+
+-- =============================================================================
+-- Test 9: cleanup_expired_webauthn_challenges function exists
+-- =============================================================================
+
+DO $$
+DECLARE
+    fn_exists BOOLEAN;
+    is_definer BOOLEAN;
+    return_type TEXT;
+BEGIN
+    SELECT EXISTS (
+        SELECT 1 FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = 'public'
+          AND p.proname = 'cleanup_expired_webauthn_challenges'
+    ) INTO fn_exists;
+
+    IF NOT fn_exists THEN
+        RAISE EXCEPTION 'FAIL Test 9: cleanup_expired_webauthn_challenges() does not exist';
+    END IF;
+
+    SELECT p.prosecdef, pg_get_function_result(p.oid)
+    INTO is_definer, return_type
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'cleanup_expired_webauthn_challenges';
+
+    IF NOT is_definer THEN
+        RAISE EXCEPTION 'FAIL Test 9: cleanup_expired_webauthn_challenges is not SECURITY DEFINER';
+    END IF;
+
+    IF return_type != 'integer' THEN
+        RAISE EXCEPTION 'FAIL Test 9: returns % (expected integer)', return_type;
+    END IF;
+
+    RAISE NOTICE 'PASS Test 9: cleanup_expired_webauthn_challenges exists (SECURITY DEFINER, returns INTEGER)';
+END $$;
+
+-- =============================================================================
+-- Test 10: cleanup_old_sync_health_logs function exists
+-- =============================================================================
+
+DO $$
+DECLARE
+    fn_exists BOOLEAN;
+    is_definer BOOLEAN;
+    return_type TEXT;
+BEGIN
+    SELECT EXISTS (
+        SELECT 1 FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = 'public'
+          AND p.proname = 'cleanup_old_sync_health_logs'
+    ) INTO fn_exists;
+
+    IF NOT fn_exists THEN
+        RAISE EXCEPTION 'FAIL Test 10: cleanup_old_sync_health_logs() does not exist';
+    END IF;
+
+    SELECT p.prosecdef, pg_get_function_result(p.oid)
+    INTO is_definer, return_type
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'cleanup_old_sync_health_logs';
+
+    IF NOT is_definer THEN
+        RAISE EXCEPTION 'FAIL Test 10: cleanup_old_sync_health_logs is not SECURITY DEFINER';
+    END IF;
+
+    IF return_type != 'integer' THEN
+        RAISE EXCEPTION 'FAIL Test 10: returns % (expected integer)', return_type;
+    END IF;
+
+    RAISE NOTICE 'PASS Test 10: cleanup_old_sync_health_logs exists (SECURITY DEFINER, returns INTEGER)';
+END $$;
+
+-- =============================================================================
+-- Test 11: cleanup_expired_invitations function exists
+-- =============================================================================
+
+DO $$
+DECLARE
+    fn_exists BOOLEAN;
+    is_definer BOOLEAN;
+    return_type TEXT;
+BEGIN
+    SELECT EXISTS (
+        SELECT 1 FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = 'public'
+          AND p.proname = 'cleanup_expired_invitations'
+    ) INTO fn_exists;
+
+    IF NOT fn_exists THEN
+        RAISE EXCEPTION 'FAIL Test 11: cleanup_expired_invitations() does not exist';
+    END IF;
+
+    SELECT p.prosecdef, pg_get_function_result(p.oid)
+    INTO is_definer, return_type
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'cleanup_expired_invitations';
+
+    IF NOT is_definer THEN
+        RAISE EXCEPTION 'FAIL Test 11: cleanup_expired_invitations is not SECURITY DEFINER';
+    END IF;
+
+    IF return_type != 'integer' THEN
+        RAISE EXCEPTION 'FAIL Test 11: returns % (expected integer)', return_type;
+    END IF;
+
+    RAISE NOTICE 'PASS Test 11: cleanup_expired_invitations exists (SECURITY DEFINER, returns INTEGER)';
+END $$;
+
+-- =============================================================================
+-- Test 12: run_all_maintenance function exists and returns JSONB
+-- =============================================================================
+
+DO $$
+DECLARE
+    fn_exists BOOLEAN;
+    is_definer BOOLEAN;
+    return_type TEXT;
+BEGIN
+    SELECT EXISTS (
+        SELECT 1 FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = 'public'
+          AND p.proname = 'run_all_maintenance'
+    ) INTO fn_exists;
+
+    IF NOT fn_exists THEN
+        RAISE EXCEPTION 'FAIL Test 12: run_all_maintenance() does not exist';
+    END IF;
+
+    SELECT p.prosecdef, pg_get_function_result(p.oid)
+    INTO is_definer, return_type
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'run_all_maintenance';
+
+    IF NOT is_definer THEN
+        RAISE EXCEPTION 'FAIL Test 12: run_all_maintenance is not SECURITY DEFINER';
+    END IF;
+
+    IF return_type != 'jsonb' THEN
+        RAISE EXCEPTION 'FAIL Test 12: run_all_maintenance returns % (expected jsonb)', return_type;
+    END IF;
+
+    RAISE NOTICE 'PASS Test 12: run_all_maintenance exists (SECURITY DEFINER, returns JSONB)';
+END $$;
+
+-- =============================================================================
+-- Test 13: vacuum_analyze_tables function exists
+-- =============================================================================
+
+DO $$
+DECLARE
+    fn_exists BOOLEAN;
+    is_definer BOOLEAN;
+    return_type TEXT;
+BEGIN
+    SELECT EXISTS (
+        SELECT 1 FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = 'public'
+          AND p.proname = 'vacuum_analyze_tables'
+    ) INTO fn_exists;
+
+    IF NOT fn_exists THEN
+        RAISE EXCEPTION 'FAIL Test 13: vacuum_analyze_tables() does not exist';
+    END IF;
+
+    SELECT p.prosecdef, pg_get_function_result(p.oid)
+    INTO is_definer, return_type
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'vacuum_analyze_tables';
+
+    IF NOT is_definer THEN
+        RAISE EXCEPTION 'FAIL Test 13: vacuum_analyze_tables is not SECURITY DEFINER';
+    END IF;
+
+    IF return_type != 'text' THEN
+        RAISE EXCEPTION 'FAIL Test 13: vacuum_analyze_tables returns % (expected text)', return_type;
+    END IF;
+
+    RAISE NOTICE 'PASS Test 13: vacuum_analyze_tables exists (SECURITY DEFINER, returns TEXT)';
+END $$;
+
+-- =============================================================================
+-- Summary
+-- =============================================================================
+
+ROLLBACK;
+
+DO $$ BEGIN RAISE NOTICE ''; END $$;
+DO $$ BEGIN RAISE NOTICE '=== All database optimization tests passed (13/13) ==='; END $$;
+DO $$ BEGIN RAISE NOTICE ''; END $$;


### PR DESCRIPTION
Closes #686

Adds 22 database indexes and 6 maintenance functions with pg_cron scheduling.

## Indexes (22)
- Transactions (6), Accounts (3), Budgets (2), Goals (1), Categories (1), Household Members (2), Audit Log (3), Infrastructure (4)

## Maintenance Functions (6)
- cleanup_expired_rate_limits (hourly), cleanup_expired_webauthn_challenges (hourly)
- cleanup_old_sync_health_logs (daily), cleanup_expired_invitations (daily)
- vacuum_analyze_tables (daily), run_all_maintenance (orchestrator)

## Tests
- 13 SQL integration tests

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>