### PR TITLE
style: fix Prettier formatting across repository (#591)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+# Auto-detect text files and ensure LF line endings everywhere.
+# This prevents `core.autocrlf` from converting LF → CRLF on Windows,
+# keeping Prettier (`endOfLine: "lf"`) and EditorConfig (`end_of_line = lf`)
+# happy on all platforms.
+
+* text=auto eol=lf
+
+# Windows batch files must keep CRLF
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Binary files — do not touch
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.webp binary
+*.jar binary
+*.apk binary
+*.aab binary
+*.keystore binary


### PR DESCRIPTION
## Summary
Fix Prettier formatting warnings on 20 files caused by CRLF line endings on Windows.

## Root Cause
The repo has `endOfLine: "lf"` in `.prettierrc.json` and `end_of_line = lf` in `.editorconfig`, but Windows `core.autocrlf=true` converts LF to CRLF on checkout, causing `npm run format:check` to fail.

## Changes
- Add `.gitattributes` with `* text=auto eol=lf` to enforce LF line endings
- CRLF exception for `.bat` and `.cmd` files
- Binary file markers for images, JARs, APKs, keystores

## Files Affected
- 13 `.github/agents/*.agent.md` files
- 2 workflow YAML files
- 5 docs/config files

Formatting-only — no functional code changes.

## Issues
Closes #591

## Testing
- [x] `npm run format:check` passes cleanly
- [x] No functional code changes