### PR TITLE
chore(ai): update agents, skills, instructions, and workflow docs

### DIFF
--- a/.github/agents/backend-engineer.agent.md
+++ b/.github/agents/backend-engineer.agent.md
@@ -39,6 +39,14 @@ You are the backend engineer for Finance, responsible for the sync layer that co
 - Tenant isolation via household_id + RLS — no cross-household data leaks
 - Currency stored as ISO 4217 TEXT alongside every monetary column
 - Audit trail table for all financial mutations
+- **owner_id**: All sync-enabled tables carry `owner_id UUID REFERENCES auth.users(id)` for direct per-user queries in addition to household-level RLS
+- **Sync columns**: All sync-enabled tables include `sync_version BIGINT NOT NULL DEFAULT 0` and `is_synced BOOLEAN NOT NULL DEFAULT false`
+
+## Approved Schema Additions (apply via versioned migrations)
+
+- **transactions**: `transfer_transaction_id UUID REFERENCES transactions(id)` — nullable self-FK linking transfer pairs; `recurring_rule_id UUID REFERENCES recurring_rules(id)` — nullable FK to the rule that generated the transaction
+- **budgets**: `is_rollover BOOLEAN NOT NULL DEFAULT false` — enables carry-forward of unused budget amounts into the next period
+- **goals** (new table): `account_id UUID REFERENCES accounts(id)` (nullable), `status TEXT NOT NULL DEFAULT 'active'` with CHECK constraint `IN ('active','completed','archived')`, full sync and soft-delete columns
 
 # Key Responsibilities
 

--- a/.github/agents/kmp-engineer.agent.md
+++ b/.github/agents/kmp-engineer.agent.md
@@ -60,7 +60,40 @@ These are non-negotiable rules for all shared KMP code:
 - Maintain version catalog (`libs.versions.toml`) for all KMP dependencies
 - Write comprehensive tests using kotlin.test and turbine for Flow-based APIs
 
-## Reference Files
+## Approved Model Additions
+
+The following fields must be added to shared data models and their `.sq` schemas:
+
+- **Transaction** (`packages/models`): `transferTransactionId: String?` — pairs the two legs of an account transfer; `recurringRuleId: String?` — references the rule that generated this transaction
+- **Budget** (`packages/models`): `isRollover: Boolean` (default `false`) — when true, carry unused budget cents into next period; rollover calculation lives in `packages/core`
+- **Goal** (`packages/models`): `accountId: String?` — nullable FK to the funding account; `status: GoalStatus` — sealed class with `Active`, `Completed`, `Archived` variants
+
+```kotlin
+// GoalStatus in commonMain
+@Serializable
+enum class GoalStatus { ACTIVE, COMPLETED, ARCHIVED }
+
+// Budget with rollover
+@Serializable
+data class Budget(
+    val id: BudgetId,
+    val categoryId: CategoryId,
+    val amountCents: Long,
+    val isRollover: Boolean = false,
+    // ...
+)
+
+// Goal with account link and status
+@Serializable
+data class Goal(
+    val id: GoalId,
+    val accountId: AccountId?,
+    val targetCents: Long,
+    val currentCents: Long,
+    val status: GoalStatus = GoalStatus.ACTIVE,
+    // ...
+)
+```
 
 - `packages/core/src/commonMain/kotlin/com/finance/core/export/` — shared client-side export pipeline, serializers, and export models.
 - `packages/core/src/commonMain/kotlin/com/finance/core/export/DataExportService.kt` — orchestrates metadata, checksums, and export outcomes.

--- a/.github/agents/web-engineer.agent.md
+++ b/.github/agents/web-engineer.agent.md
@@ -44,6 +44,15 @@ You are the web platform engineer for Finance, a multi-platform financial tracki
 - `AppLayout` is fully wired with sidebar navigation (desktop) and bottom navigation (mobile).
 - CSP has been configured to work correctly with Vite's dev server (e.g., allowing `ws:` for HMR). Ensure any CSP changes preserve Vite dev compatibility.
 
+## KMP Integration Strategy (Dual-Path)
+
+The web app uses a **dual-path approach** for KMP integration:
+
+- **TypeScript repositories remain the primary data path for beta** — all production data access goes through `db/repositories/` and hooks in `hooks/`.
+- **KMP JS bindings are validated in parallel** via `src/kmp/` — this is a non-blocking validation track, not a replacement yet.
+- When adding new features, implement in TypeScript first. If the equivalent KMP shared logic exists (e.g., export module, conflict resolver), wire a thin adapter in `src/kmp/adapter.ts` to validate the binding.
+- Do NOT break the TypeScript data path while experimenting with KMP bindings.
+
 # Key Rules
 
 - Semantic HTML first — use ARIA only when native semantics are insufficient

--- a/.github/agents/windows-engineer.agent.md
+++ b/.github/agents/windows-engineer.agent.md
@@ -15,6 +15,23 @@ tools:
 
 You are the Windows platform engineer for Finance, a multi-platform financial tracking application. Your role is to build and maintain the Windows desktop client using Compose Desktop (JVM target), ensuring a native Windows experience with proper security, accessibility, and distribution through the Microsoft Store.
 
+**Windows is a first-class beta target** — it ships alongside Android, iOS, and Web. The architecture mirrors Android: Koin 4.0.1 for DI, ViewModel pattern for state management, Repository pattern for data access, and KMP shared packages for all business logic.
+
+## Architecture Pattern (mirrors Android)
+
+```
+UI (Compose Desktop)
+  └── ViewModel (state holder, exposed as StateFlow)
+       └── Repository (KMP shared via jvmMain)
+            └── SQLDelight (local SQLite, JVM driver)
+            └── SyncClient (KMP sync engine, JVM target)
+```
+
+- Use **Koin 4.0.1** for DI — define modules in `apps/windows/src/main/kotlin/com/finance/windows/di/`
+- Use **ViewModel** pattern (not Android-specific — use a lightweight JVM-compatible base class in `packages/core/jvmMain`)
+- Consume KMP shared logic from `packages/core`, `packages/models`, and `packages/sync` via `:jvmMain` source sets
+- Use **Timber 5.0.1** (or JVM-equivalent SLF4J) for structured logging in debug builds only
+
 # Expertise Areas
 
 - Compose Desktop (JVM target) UI development

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -114,13 +114,17 @@ All code changes MUST follow this workflow:
 2. **Scan for an existing worktree** for this issue: `git worktree list` — resume if found
 3. **Create a worktree** if none exists: `git worktree add ../wt-[agent-type]-[branch] -b [branch]`
 4. **Implement and commit** with issue references: `type(scope): description (#N)`
-5. **Fetch and rebase**: `git fetch origin main && git rebase origin/main` (auto-approved)
-6. **Push the feature branch**: `git push origin <branch-name>` (auto-approved)
-7. **Create a PR automatically** with `gh pr create` — include `Closes #N` and a detailed description
-8. **Monitor the PR** — poll `gh pr checks`, fix CI failures and merge conflicts autonomously, push and restart until all checks pass and no conflicts remain
-9. **Never commit directly to `main`** — all changes go through feature branches and PRs
-10. **Never merge PRs** — humans review and merge; agents get the PR to merge-ready state
-11. **Clean up the worktree** after merge is confirmed: `git worktree remove <path>`
+5. **Run `npm run ci:check` locally — must be clean before pushing**
+   - Catches formatting (`format:check`), lint (`eslint`), and type errors before they hit remote CI
+   - Auto-fix: `npm run format && npx eslint . --fix`, then re-run `ci:check` and commit fixes
+   - **Skipping this step is the primary cause of avoidable CI failures**
+6. **Fetch and rebase**: `git fetch origin main && git rebase origin/main` (auto-approved)
+7. **Push the feature branch**: `git push origin <branch-name>` (auto-approved)
+8. **Create a PR automatically** with `gh pr create` — include `Closes #N` and a detailed description
+9. **Monitor `gh pr checks`** — poll until ALL checks are green; fix failures locally (re-run `ci:check` before each push), push, restart cycle. **Work is NOT complete until all remote checks are green.**
+10. **Never commit directly to `main`** — all changes go through feature branches and PRs
+11. **Never merge PRs** — humans review and merge; agents get the PR to merge-ready state
+12. **Clean up the worktree** after merge is confirmed: `git worktree remove <path>`
 
 Worktree naming: `wt-[agent-type]-[type/description-issue#]` — e.g., `wt-android-feat-transactions-443`
 
@@ -128,9 +132,11 @@ See `docs/ai/worktrees.md` for the full worktree lifecycle guide.
 
 Tooling notes:
 
+- `npm run ci:check` — format:check + lint + type-check; run this before every push
+- `npm run format` — auto-fix all Prettier issues; `npx eslint . --fix` — auto-fix ESLint issues
 - `lint-staged` runs from `.husky/pre-commit` and auto-formats staged files before commit.
 - `.husky/pre-push` blocks non-interactive pushes unless a human explicitly uses `--no-verify`.
-- Use `npm run ci:check` for a fast validation pass and `npm run ready-for-pr` before review.
+- Use `npm run ready-for-pr` for final validation before marking work complete.
 
 ## Code Quality Requirements
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@ You are working in the Finance monorepo — a multi-platform, native-first finan
 
 The following operations require EXPLICIT human approval. NEVER perform these autonomously:
 
-- **Git remote operations** — May push feature branches; no pushing to `main`/`master`/release branches; no `git push --force` (use `--force-with-lease` on feature branches only); no `pull`, `fetch`, `remote`, `merge` from remote, `rebase` onto remote
+- **Git remote operations** — May push **own feature branches** (`git push origin <feature-branch>`); may `git fetch origin main` and `git rebase origin/main` on own feature branch as pre-push hygiene; no pushing to `main`/`master`/release branches; no `git push --force`; `git push --force-with-lease` on feature branches requires human approval; no `pull`/`remote`/`merge` from remote
 - **PR/review operations** — May create PRs with linked issues and detailed descriptions; no merging, closing, or approving PRs or reviews
 - **Remote platform mutations** — No GitHub API writes (issue close, label changes, repo settings, releases, deployments)
 - **Outside project boundary** — No file access outside the repository root; no system config changes; no global package installs
@@ -91,24 +91,40 @@ You MUST NOT execute operations that delete, truncate, or irreversibly modify da
 
 - **Monorepo** with apps/, packages/, services/, docs/, tools/
 - **Edge-first**: Business logic runs on client devices; backend is for sync only
-- **Platforms**: iOS (SwiftUI; Swift Export bridge planned), Android (Kotlin), Web (TypeScript + React PWA), Windows 11
+- **Platforms**: iOS (SwiftUI; Swift Export bridge planned), Android (Kotlin), Web (TypeScript + React PWA), **Windows 11 (Compose Desktop — first-class beta target, mirrors Android DI/ViewModel architecture)**
 - **Shared code** lives in packages/ (core logic, data models, sync engine)
 - **Current KMP package reality**: `packages/core` checks in `commonMain`, `commonTest`, `iosMain`, `jsMain`, and `jvmMain` source sets; `packages/models` and `packages/sync` also check in `androidMain`, and `packages/sync` also has `jsTest`
 - **Single backend API** in services/api/ for data synchronization
+- **KMP Web integration**: Dual-path — TypeScript repositories remain for beta while KMP JS bindings are validated in parallel via `apps/web/src/kmp/`
+
+## Schema Alignment Decisions
+
+The following schema additions have been approved to align KMP models with Supabase (apply via versioned migrations):
+
+- **transactions**: Add `transfer_transaction_id UUID` (nullable FK to self, links transfer pairs) and `recurring_rule_id UUID` (nullable FK to recurring rules)
+- **budgets**: Add `is_rollover BOOLEAN NOT NULL DEFAULT false` (enables unused budget carry-forward)
+- **goals**: Add `account_id UUID` (nullable FK to accounts, links goal to a funding account) and `status TEXT NOT NULL DEFAULT 'active'` (enum: active, completed, archived)
+- **All sync-enabled tables**: Standardize on `owner_id UUID` referencing `auth.uid()` for direct ownership queries; `household_id` remains for household-level RLS isolation
 
 ## Development Workflow (MANDATORY)
 
 All code changes MUST follow this workflow:
 
 1. **Create or verify a GitHub issue** exists for the work (`gh issue create` if needed)
-2. **Create a feature branch** from main: `git checkout -b <type>/<description>-<issue#>`
-3. **Implement and commit** with issue references: `type(scope): description (#N)`
-4. **Push the feature branch**: `git push origin <branch-name>`
-5. **Create a PR** with `gh pr create` — include `Closes #N` and a detailed description
-6. **Never commit directly to `main`** — all changes go through feature branches and PRs
-7. **Never merge PRs** — humans review and merge
+2. **Scan for an existing worktree** for this issue: `git worktree list` — resume if found
+3. **Create a worktree** if none exists: `git worktree add ../wt-[agent-type]-[branch] -b [branch]`
+4. **Implement and commit** with issue references: `type(scope): description (#N)`
+5. **Fetch and rebase**: `git fetch origin main && git rebase origin/main` (auto-approved)
+6. **Push the feature branch**: `git push origin <branch-name>` (auto-approved)
+7. **Create a PR automatically** with `gh pr create` — include `Closes #N` and a detailed description
+8. **Monitor the PR** — poll `gh pr checks`, fix CI failures and merge conflicts autonomously, push and restart until all checks pass and no conflicts remain
+9. **Never commit directly to `main`** — all changes go through feature branches and PRs
+10. **Never merge PRs** — humans review and merge; agents get the PR to merge-ready state
+11. **Clean up the worktree** after merge is confirmed: `git worktree remove <path>`
 
-Branch naming: `feat/web-data-layer-443`, `fix/auth-refresh-127`, `docs/api-guide-86`
+Worktree naming: `wt-[agent-type]-[type/description-issue#]` — e.g., `wt-android-feat-transactions-443`
+
+See `docs/ai/worktrees.md` for the full worktree lifecycle guide.
 
 Tooling notes:
 

--- a/.github/instructions/packages.instructions.md
+++ b/.github/instructions/packages.instructions.md
@@ -46,3 +46,11 @@ These are `commonMain` interfaces — platform `actual` implementations live in 
 - Use **kotlinx-serialization** for all serialization — annotate models with `@Serializable`
 - All monetary values must be `Long` (cents) — enforce with Kotlin value classes (e.g., `@JvmInline value class Cents(val amount: Long)`)
 - Test with **kotlin.test** — all tests must pass on every target (`commonTest`, `iosTest`, `androidTest`, `jvmTest`, `jsTest`)
+
+## Approved Model Additions
+
+The following fields must be added to shared models in `packages/models` and corresponding `.sq` schemas in `packages/core`:
+
+- **Transaction**: `transferTransactionId: String?` (paired transfer leg), `recurringRuleId: String?` (originating rule)
+- **Budget**: `isRollover: Boolean` (default `false`) — carry unused budget to next period
+- **Goal**: `accountId: String?` (linked funding account), `status: GoalStatus` (sealed/enum: `Active`, `Completed`, `Archived`)

--- a/.github/instructions/services.instructions.md
+++ b/.github/instructions/services.instructions.md
@@ -32,6 +32,17 @@ You are working in the `services/` directory, which contains the consolidated ba
 - Edge Functions are written in **TypeScript** running on the **Deno** runtime
 - Database migrations must be versioned (sequential numbering) and reversible (include both `up` and `down` SQL)
 
+## Schema Alignment Decisions
+
+The following additions are approved and must be applied as versioned migrations:
+
+- **transactions**: `transfer_transaction_id UUID REFERENCES transactions(id)` (nullable) and `recurring_rule_id UUID REFERENCES recurring_rules(id)` (nullable)
+- **budgets**: `is_rollover BOOLEAN NOT NULL DEFAULT false`
+- **goals**: `account_id UUID REFERENCES accounts(id)` (nullable), `status TEXT NOT NULL DEFAULT 'active'` with CHECK IN ('active','completed','archived')
+- **All sync-enabled tables**: `owner_id UUID REFERENCES auth.users(id) NOT NULL` and `sync_version BIGINT NOT NULL DEFAULT 0` and `is_synced BOOLEAN NOT NULL DEFAULT false`
+
+Migration naming convention: `YYYYMMDDHHMMSS_<description>.sql` (e.g., `20260325000001_align_schema_transactions_budgets_goals.sql`)
+
 ## PowerSync Integration
 
 - **PowerSync** sync rules define what data syncs to each client — configure in sync rules YAML

--- a/.github/instructions/workflow.instructions.md
+++ b/.github/instructions/workflow.instructions.md
@@ -8,15 +8,58 @@ AI agents MUST follow this workflow for every code change:
 
 ```
 1. Create/verify GitHub issue exists
-2. Create feature branch from main: git checkout -b <type>/<description>-<issue#>
-3. Implement changes on feature branch
+2. Scan for an existing worktree for this issue (git worktree list)
+   a. If found: resume work in that worktree
+   b. If not found: create a new worktree with the correct naming convention
+3. Implement changes on feature branch inside the worktree
 4. Commit with issue reference: type(scope): description (#N)
-5. Push feature branch: git push origin <branch-name>
-6. Create PR with `gh pr create` linking issues (Closes #N)
-7. Human reviews and merges PR
+5. Fetch and rebase onto origin/main (auto-approved, no human needed)
+6. Push feature branch: git push origin <branch-name>
+7. Create PR automatically with `gh pr create` including Closes #N
+8. Monitor PR: poll checks, fix CI failures, resolve merge conflicts — repeat until merge-ready
+9. Mark work complete once all checks pass and no conflicts remain
+10. After human merges the PR: remove the worktree automatically
 ```
 
-### Branch Naming Convention
+## Worktree Setup (Required for Agents)
+
+Agents MUST use git worktrees — not separate repository clones. See `docs/ai/worktrees.md` for full details.
+
+### Worktree Naming Convention
+
+```
+wt-[agent-type]-[type/description-issue#]
+```
+
+**Examples:**
+
+```bash
+../wt-android-feat-transactions-443
+../wt-web-fix-auth-127
+../wt-kmp-feat-schema-align-88
+../wt-backend-fix-rls-policies-22
+```
+
+### Creating a Worktree
+
+```bash
+# From the main repo
+git worktree add ../wt-android-feat-transactions-443 -b feat/transactions-443
+
+# Resume an existing worktree
+git worktree list   # scan first
+cd ../wt-android-feat-transactions-443
+```
+
+### Cleaning Up After Merge
+
+```bash
+git worktree remove ../wt-android-feat-transactions-443
+```
+
+The main worktree (`finance-human/`) is reserved for human work.
+
+## Branch Naming Convention
 
 ```
 <type>/<short-description>-<issue-number>
@@ -50,15 +93,18 @@ Created (Open) → PR opened with "Closes #N" → PR merged → Issue auto-close
 ## Rules for AI Agents
 
 1. **Before writing any code**, verify that a GitHub issue exists for the work. If no issue exists, create one first using `gh issue create`.
-2. **Always work on a feature branch** — never commit directly to `main`. Create a branch with `git checkout -b <type>/<description>-<issue#>`.
-3. **Reference the issue** in every commit message using the format: `type(scope): description (#N)` where N is the issue number.
-4. **Never implement features, fixes, or refactors** without a corresponding issue — even for small changes.
-5. **When planning work**, decompose into issues BEFORE starting implementation.
-6. **Push the feature branch** to origin when work is ready: `git push origin <branch-name>`.
-7. **Create a PR** with `gh pr create` including a detailed description and `Closes #N` for each resolved issue.
-8. **Never merge PRs** — PRs are merged by humans after review.
-9. **Never run `gh issue close`** — issues close automatically when their PR merges. Premature closure breaks the audit trail.
-10. **If main has advanced**, rebase onto `origin/main` before pushing: `git fetch origin main && git rebase origin/main`.
+2. **Always use a git worktree** — never commit directly in the main worktree or on `main`.
+3. **Scan for existing worktrees first** — if a worktree for this issue already exists, resume it rather than creating a new one.
+4. **Reference the issue** in every commit message using the format: `type(scope): description (#N)` where N is the issue number.
+5. **Never implement features, fixes, or refactors** without a corresponding issue — even for small changes.
+6. **When planning work**, decompose into issues BEFORE starting implementation.
+7. **Fetch and rebase** onto `origin/main` before pushing: `git fetch origin main && git rebase origin/main` — both are auto-approved.
+8. **Push the feature branch** to origin when work is ready: `git push origin <branch-name>` — auto-approved.
+9. **Create a PR automatically** with `gh pr create` including a detailed description and `Closes #N` for each resolved issue.
+10. **Monitor the PR** — poll `gh pr checks` until all checks pass. Fix any CI failures or merge conflicts and push again. Repeat until merge-ready.
+11. **Never merge PRs** — PRs are merged by humans after review.
+12. **Never run `gh issue close`** — issues close automatically when their PR merges. Premature closure breaks the audit trail.
+13. **Clean up your worktree** after the PR is confirmed merged: `git worktree remove <path>`.
 
 ## Commit Message Format
 
@@ -100,6 +146,6 @@ Refs #P (for related but not fully resolved issues)
 
 - Enables traceability from code → PR → issue → roadmap
 - Keeps the project board accurate and up-to-date
-- Ensures no work is lost or duplicated
+- Ensures no work is lost or duplicated — worktrees are resumable by any agent
 - Makes it easy to understand what changed and why
 - PRs provide a review checkpoint before code reaches `main`

--- a/.github/instructions/workflow.instructions.md
+++ b/.github/instructions/workflow.instructions.md
@@ -13,12 +13,20 @@ AI agents MUST follow this workflow for every code change:
    b. If not found: create a new worktree with the correct naming convention
 3. Implement changes on feature branch inside the worktree
 4. Commit with issue reference: type(scope): description (#N)
-5. Fetch and rebase onto origin/main (auto-approved, no human needed)
-6. Push feature branch: git push origin <branch-name>
-7. Create PR automatically with `gh pr create` including Closes #N
-8. Monitor PR: poll checks, fix CI failures, resolve merge conflicts — repeat until merge-ready
-9. Mark work complete once all checks pass and no conflicts remain
-10. After human merges the PR: remove the worktree automatically
+5. **Run `npm run ci:check` locally — MUST be clean before pushing**
+   - `npm run format:check` catches Prettier issues
+   - `npm run lint` catches ESLint issues
+   - `npm run type-check` catches TypeScript errors
+   - If any fail: run `npm run format` and/or `npx eslint . --fix`, re-run `ci:check`, commit fixes
+6. Fetch and rebase onto origin/main (auto-approved, no human needed)
+7. Push feature branch: git push origin <branch-name>
+8. Create PR automatically with `gh pr create` including Closes #N
+9. **Monitor PR with `gh pr checks` — poll until ALL checks are green**
+   - CI failures: read logs, fix locally, run `ci:check` again, push, restart cycle
+   - Merge conflicts: fetch + rebase + force-with-lease push, restart cycle
+   - **Work is NOT complete until all remote checks are green**
+10. Mark work complete once all checks pass and no conflicts remain
+11. After human merges the PR: remove the worktree automatically
 ```
 
 ## Worktree Setup (Required for Agents)
@@ -98,13 +106,14 @@ Created (Open) → PR opened with "Closes #N" → PR merged → Issue auto-close
 4. **Reference the issue** in every commit message using the format: `type(scope): description (#N)` where N is the issue number.
 5. **Never implement features, fixes, or refactors** without a corresponding issue — even for small changes.
 6. **When planning work**, decompose into issues BEFORE starting implementation.
-7. **Fetch and rebase** onto `origin/main` before pushing: `git fetch origin main && git rebase origin/main` — both are auto-approved.
-8. **Push the feature branch** to origin when work is ready: `git push origin <branch-name>` — auto-approved.
-9. **Create a PR automatically** with `gh pr create` including a detailed description and `Closes #N` for each resolved issue.
-10. **Monitor the PR** — poll `gh pr checks` until all checks pass. Fix any CI failures or merge conflicts and push again. Repeat until merge-ready.
-11. **Never merge PRs** — PRs are merged by humans after review.
-12. **Never run `gh issue close`** — issues close automatically when their PR merges. Premature closure breaks the audit trail.
-13. **Clean up your worktree** after the PR is confirmed merged: `git worktree remove <path>`.
+7. **Run `npm run ci:check` locally before every push** — must be fully clean (format + lint + type-check). Auto-fix with `npm run format` and `npx eslint . --fix`, commit fixes, then re-run to confirm. Pushing without a clean `ci:check` is the primary cause of avoidable CI failures.
+8. **Fetch and rebase** onto `origin/main` before pushing: `git fetch origin main && git rebase origin/main` — both are auto-approved.
+9. **Push the feature branch** to origin: `git push origin <branch-name>` — auto-approved.
+10. **Create a PR automatically** with `gh pr create` including a detailed description and `Closes #N` for each resolved issue.
+11. **Monitor the PR with `gh pr checks`** — poll until ALL checks are green. Fix CI failures or merge conflicts, run `ci:check` locally again, push, restart cycle. **Work is NOT complete until all remote checks are green.**
+12. **Never merge PRs** — PRs are merged by humans after review.
+13. **Never run `gh issue close`** — issues close automatically when their PR merges.
+14. **Clean up your worktree** after the PR is confirmed merged: `git worktree remove <path>`.
 
 ## Commit Message Format
 

--- a/.github/skills/financial-modeling/SKILL.md
+++ b/.github/skills/financial-modeling/SKILL.md
@@ -68,12 +68,15 @@ The repository now has a dedicated export module in `packages/core/src/commonMai
 - Use zero-based or envelope-style allocation semantics for category budgets.
 - Keep rollover and overspending rules explicit rather than implicit.
 - Recalculate availability from allocations, spending, and carry-over values.
+- **Rollover logic**: When `is_rollover = true`, compute carry-forward as `previous_period_budget - previous_period_spent` (clamped to zero minimum). Add carry-forward to the new period's available amount. Never reduce next-period budget below zero due to overspend rollover.
 
 ### Goals
 
-- Track goal amounts in minor units.
+- Track goal amounts in minor units (cents).
 - Recompute projections whenever contributions, deadlines, or funding sources change.
 - Show both percentage progress and absolute values.
+- **Goal status lifecycle**: Goals transition through `active → completed` when `current_cents >= target_cents`, or `active → archived` when manually dismissed. Completed and archived goals are excluded from active projections but retained for history.
+- **Account linkage**: When `account_id` is set, goal progress is driven by changes to that account's balance. When null, the goal tracks manual contributions only.
 
 ### Reporting
 

--- a/.github/skills/kmp-development/SKILL.md
+++ b/.github/skills/kmp-development/SKILL.md
@@ -185,6 +185,7 @@ packages/core/
                     ├── Account.sq
                     ├── Transaction.sq
                     ├── Budget.sq
+                    ├── Goal.sq
                     └── migrations/
                         ├── 1.sqm
                         ├── 2.sqm
@@ -236,6 +237,128 @@ UPDATE account SET balance = ?, updated_at = ? WHERE id = ?;
 
 softDelete:
 UPDATE account SET deleted_at = ?, updated_at = ? WHERE id = ?;
+
+-- Transaction.sq
+
+CREATE TABLE `transaction` (
+    id                      TEXT NOT NULL PRIMARY KEY,
+    account_id              TEXT NOT NULL,
+    category_id             TEXT,
+    amount_cents            INTEGER NOT NULL,          -- Long (cents)
+    currency_code           TEXT NOT NULL DEFAULT 'USD',
+    payee                   TEXT,
+    note                    TEXT,
+    date                    TEXT NOT NULL,             -- ISO 8601 date
+    -- Nullable self-reference linking the paired leg of an account transfer
+    transfer_transaction_id TEXT,
+    -- Nullable FK to recurring_rule that generated this transaction
+    recurring_rule_id       TEXT,
+    created_at              TEXT NOT NULL,
+    updated_at              TEXT NOT NULL,
+    deleted_at              TEXT,
+    sync_version            INTEGER NOT NULL DEFAULT 0,
+    is_synced               INTEGER NOT NULL DEFAULT 0  -- Boolean (0/1)
+);
+
+selectAll:
+SELECT * FROM `transaction` WHERE deleted_at IS NULL ORDER BY date DESC;
+
+selectByAccount:
+SELECT * FROM `transaction`
+WHERE account_id = ? AND deleted_at IS NULL
+ORDER BY date DESC;
+
+selectTransfers:
+SELECT * FROM `transaction`
+WHERE transfer_transaction_id IS NOT NULL AND deleted_at IS NULL;
+
+insert:
+INSERT INTO `transaction` (
+    id, account_id, category_id, amount_cents, currency_code, payee, note, date,
+    transfer_transaction_id, recurring_rule_id, created_at, updated_at, sync_version, is_synced
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0);
+
+softDelete:
+UPDATE `transaction` SET deleted_at = ?, updated_at = ?, sync_version = 1, is_synced = 0
+WHERE id = ?;
+
+-- Budget.sq
+
+CREATE TABLE budget (
+    id            TEXT NOT NULL PRIMARY KEY,
+    category_id   TEXT NOT NULL,
+    amount_cents  INTEGER NOT NULL,   -- Long (cents)
+    currency_code TEXT NOT NULL DEFAULT 'USD',
+    period        TEXT NOT NULL,      -- "monthly", "weekly", etc.
+    start_date    TEXT NOT NULL,
+    end_date      TEXT,
+    -- When true, unused budget amount carries forward into the next period
+    is_rollover   INTEGER NOT NULL DEFAULT 0,  -- Boolean (0/1)
+    created_at    TEXT NOT NULL,
+    updated_at    TEXT NOT NULL,
+    deleted_at    TEXT,
+    sync_version  INTEGER NOT NULL DEFAULT 0,
+    is_synced     INTEGER NOT NULL DEFAULT 0
+);
+
+selectAll:
+SELECT * FROM budget WHERE deleted_at IS NULL ORDER BY start_date DESC;
+
+selectRolloverBudgets:
+SELECT * FROM budget WHERE is_rollover = 1 AND deleted_at IS NULL;
+
+insert:
+INSERT INTO budget (
+    id, category_id, amount_cents, currency_code, period, start_date, end_date,
+    is_rollover, created_at, updated_at, sync_version, is_synced
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0);
+
+softDelete:
+UPDATE budget SET deleted_at = ?, updated_at = ?, sync_version = 1, is_synced = 0
+WHERE id = ?;
+
+-- Goal.sq
+
+CREATE TABLE goal (
+    id              TEXT NOT NULL PRIMARY KEY,
+    -- Optional FK to a specific account funding this goal
+    account_id      TEXT,
+    name            TEXT NOT NULL,
+    target_cents    INTEGER NOT NULL,   -- Long (cents)
+    current_cents   INTEGER NOT NULL DEFAULT 0,
+    currency_code   TEXT NOT NULL DEFAULT 'USD',
+    target_date     TEXT,
+    -- Lifecycle: active | completed | archived
+    status          TEXT NOT NULL DEFAULT 'active',
+    created_at      TEXT NOT NULL,
+    updated_at      TEXT NOT NULL,
+    deleted_at      TEXT,
+    sync_version    INTEGER NOT NULL DEFAULT 0,
+    is_synced       INTEGER NOT NULL DEFAULT 0
+);
+
+selectAll:
+SELECT * FROM goal WHERE deleted_at IS NULL ORDER BY target_date ASC;
+
+selectActive:
+SELECT * FROM goal WHERE status = 'active' AND deleted_at IS NULL;
+
+selectByAccount:
+SELECT * FROM goal WHERE account_id = ? AND deleted_at IS NULL;
+
+insert:
+INSERT INTO goal (
+    id, account_id, name, target_cents, current_cents, currency_code, target_date,
+    status, created_at, updated_at, sync_version, is_synced
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0);
+
+updateStatus:
+UPDATE goal SET status = ?, updated_at = ?, sync_version = 1, is_synced = 0
+WHERE id = ?;
+
+softDelete:
+UPDATE goal SET deleted_at = ?, updated_at = ?, sync_version = 1, is_synced = 0
+WHERE id = ?;
 ```
 
 ### Platform Drivers

--- a/.github/skills/supabase-powersync/SKILL.md
+++ b/.github/skills/supabase-powersync/SKILL.md
@@ -85,6 +85,8 @@ additional_redirect_urls = ["https://localhost:3000"]
 - **Soft deletes** — `deleted_at TIMESTAMPTZ` column on all user-facing tables; never hard-delete synced records.
 - **Audit timestamps** — Every table has `created_at` and `updated_at` columns.
 - **Household isolation** — Every user-facing table has a `household_id` FK for multi-user household support.
+- **Owner tracking** — Every sync-enabled table also carries `owner_id UUID REFERENCES auth.users(id)` for direct per-user queries alongside household-level RLS.
+- **Sync columns** — All sync-enabled tables include `sync_version BIGINT NOT NULL DEFAULT 0` and `is_synced BOOLEAN NOT NULL DEFAULT false` for PowerSync delta tracking.
 
 ### Schema Definition
 
@@ -124,36 +126,65 @@ CREATE TABLE accounts (
 );
 
 CREATE TABLE transactions (
-    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    household_id        UUID NOT NULL REFERENCES households(id),
-    account_id          UUID NOT NULL REFERENCES accounts(id),
-    category_id         UUID REFERENCES categories(id),
-    amount_cents        BIGINT NOT NULL,
-    currency_code       TEXT NOT NULL DEFAULT 'USD',
-    payee               TEXT,
-    note                TEXT,
-    date                DATE NOT NULL,
-    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
-    updated_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
-    deleted_at          TIMESTAMPTZ,
-    sync_version        BIGINT NOT NULL DEFAULT 0,
-    is_synced           BOOLEAN NOT NULL DEFAULT false
+    id                       UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    household_id             UUID NOT NULL REFERENCES households(id),
+    owner_id                 UUID NOT NULL REFERENCES auth.users(id),
+    account_id               UUID NOT NULL REFERENCES accounts(id),
+    category_id              UUID REFERENCES categories(id),
+    amount_cents             BIGINT NOT NULL,
+    currency_code            TEXT NOT NULL DEFAULT 'USD',
+    payee                    TEXT,
+    note                     TEXT,
+    date                     DATE NOT NULL,
+    -- Transfer support: links the paired transaction for account-to-account transfers
+    transfer_transaction_id  UUID REFERENCES transactions(id),
+    -- Recurring rule support: links to the rule that generated this transaction
+    recurring_rule_id        UUID REFERENCES recurring_rules(id),
+    created_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
+    deleted_at               TIMESTAMPTZ,
+    sync_version             BIGINT NOT NULL DEFAULT 0,
+    is_synced                BOOLEAN NOT NULL DEFAULT false
 );
 
 CREATE TABLE budgets (
     id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     household_id  UUID NOT NULL REFERENCES households(id),
+    owner_id      UUID NOT NULL REFERENCES auth.users(id),
     category_id   UUID NOT NULL REFERENCES categories(id),
     amount_cents  BIGINT NOT NULL,
     currency_code TEXT NOT NULL DEFAULT 'USD',
     period        TEXT NOT NULL,
     start_date    DATE NOT NULL,
     end_date      DATE,
+    -- Rollover support: carry unused budget amounts into the next period
+    is_rollover   BOOLEAN NOT NULL DEFAULT false,
     created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
     deleted_at    TIMESTAMPTZ,
     sync_version  BIGINT NOT NULL DEFAULT 0,
     is_synced     BOOLEAN NOT NULL DEFAULT false
+);
+
+CREATE TABLE goals (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    household_id    UUID NOT NULL REFERENCES households(id),
+    owner_id        UUID NOT NULL REFERENCES auth.users(id),
+    -- Optional FK to a specific account funding this goal
+    account_id      UUID REFERENCES accounts(id),
+    name            TEXT NOT NULL,
+    target_cents    BIGINT NOT NULL,
+    current_cents   BIGINT NOT NULL DEFAULT 0,
+    currency_code   TEXT NOT NULL DEFAULT 'USD',
+    target_date     DATE,
+    -- Goal lifecycle status: active | completed | archived
+    status          TEXT NOT NULL DEFAULT 'active',
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    deleted_at      TIMESTAMPTZ,
+    sync_version    BIGINT NOT NULL DEFAULT 0,
+    is_synced       BOOLEAN NOT NULL DEFAULT false,
+    CONSTRAINT goals_status_check CHECK (status IN ('active', 'completed', 'archived'))
 );
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,18 +250,18 @@ When multiple agents work in parallel, they MUST follow these rules to avoid con
 
 **File ownership by agent:**
 
-| Agent | Primary ownership |
-|---|---|
-| `@kmp-engineer` | `packages/` |
-| `@backend-engineer` | `services/api/` |
-| `@web-engineer` | `apps/web/` |
-| `@android-engineer` | `apps/android/` |
-| `@ios-engineer` | `apps/ios/` |
-| `@windows-engineer` | `apps/windows/` |
-| `@design-engineer` | `config/tokens/`, generated token files |
-| `@devops-engineer` | `.github/workflows/`, `build-logic/`, `tools/` |
-| `@docs-writer` | `docs/`, `*.md` files in root |
-| `@security-reviewer` | Read-only review — never edits production code |
+| Agent                     | Primary ownership                              |
+| ------------------------- | ---------------------------------------------- |
+| `@kmp-engineer`           | `packages/`                                    |
+| `@backend-engineer`       | `services/api/`                                |
+| `@web-engineer`           | `apps/web/`                                    |
+| `@android-engineer`       | `apps/android/`                                |
+| `@ios-engineer`           | `apps/ios/`                                    |
+| `@windows-engineer`       | `apps/windows/`                                |
+| `@design-engineer`        | `config/tokens/`, generated token files        |
+| `@devops-engineer`        | `.github/workflows/`, `build-logic/`, `tools/` |
+| `@docs-writer`            | `docs/`, `*.md` files in root                  |
+| `@security-reviewer`      | Read-only review — never edits production code |
 | `@accessibility-reviewer` | Read-only review — never edits production code |
 
 **Coordination protocol:**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,8 @@ This file provides guidance for all AI agents (GitHub Copilot, Codex, Claude, an
 
 Finance is a multi-platform, native-first financial tracking application for personal, family, and partnered finances. It uses a monorepo architecture with an edge-first design — most computation happens on client devices, with a consolidated backend for data synchronization.
 
+**All four platforms (iOS, Android, Web, Windows) are first-class beta targets.** Windows mirrors Android's architecture: Koin DI, ViewModel pattern, Repository pattern, and KMP shared packages.
+
 ## Repository Layout
 
 - `apps/` — Platform-specific applications (iOS, Android, Web, Windows)
@@ -25,14 +27,21 @@ Finance is a multi-platform, native-first financial tracking application for per
 
 ## Issue-First Development
 
-All work in this repository follows an issue-first, feature-branch workflow:
+All work in this repository follows an issue-first, feature-branch + worktree workflow:
 
 1. **Every code change must reference a GitHub issue.** If no issue exists for the work you're about to do, create one first.
-2. **Always work on a feature branch** — never commit directly to `main`. Branch naming: `<type>/<description>-<issue#>` (e.g., `feat/web-data-layer-443`).
+2. **Always use a git worktree** for agent work — never commit directly in the main worktree or on `main`.
+   - Naming: `wt-[agent-type]-[type/description-issue#]` (e.g., `wt-android-feat-transactions-443`)
+   - **Scan first**: run `git worktree list` — if a worktree for this issue already exists, resume it
+   - Main worktree (`finance-human/`) is reserved for human work
 3. **Commit messages must include issue references** in the format `type(scope): description (#N)`.
-4. **Push the feature branch** and create a PR with `gh pr create` — include `Closes #N` for resolved issues.
-5. **Never merge PRs** — humans review and merge. PRs are the review checkpoint.
-6. **Planning happens in issues, not in code.** Decompose work into issues before starting implementation.
+4. **Push automatically** — `git push origin <branch>` is auto-approved.
+5. **Open a PR automatically** with `gh pr create` — include `Closes #N` for resolved issues.
+6. **Monitor the PR** — poll `gh pr checks` until all checks pass. Fix CI failures and merge conflicts autonomously; push and restart the check cycle until merge-ready.
+7. **Never merge PRs** — humans review and merge. The agent's job is to get the PR to merge-ready state.
+8. **Clean up the worktree** after the PR is confirmed merged: `git worktree remove <path>`.
+
+See `docs/ai/worktrees.md` for the full worktree setup and lifecycle guide.
 
 AI agents that skip issue creation, commit directly to `main`, or fail to create PRs are not following the project workflow. If you discover work was done without an issue, create a retroactive issue to track it.
 
@@ -80,19 +89,23 @@ The following operations MUST NEVER be performed by AI agents without explicit h
 
 ### Category 1: Git Remote Operations
 
-AI agents MAY push feature branches (never `main`, `master`, or release branches).
-AI agents MAY use `git push --force-with-lease` on their own feature branches.
+AI agents MAY (auto-approved):
+
+- Push to **own feature branches**: `git push origin <feature-branch>`
+- `git fetch origin main` — read-only sync, required for pre-push rebase
+- `git rebase origin/main` on **own feature branch only** — required pre-push hygiene
+- `git status`, `git log`, `git diff`, `git show`, `git branch`
 
 AI agents MUST NOT:
 
-- Push to `main`, `master`, or release branches (protected by GitHub branch protection requiring PR review)
-- Use `git push --force` (without `--force-with-lease`)
-- `git pull`, `git fetch` from untrusted remotes
+- Push to `main`, `master`, or release branches (hard blocked by GitHub branch protection)
+- Use `git push --force` (forbidden entirely)
+- Use `git push --force-with-lease` without explicit human approval (may overwrite collaborator commits)
 - `git remote add`, `git remote remove`, `git remote set-url`
 - `git merge` from remote branches
-- `git rebase` onto remote branches
+- `git rebase` onto any branch other than `origin/main` on the agent's own feature branch
 
-**Why:** Feature-branch pushes are safe because `main` is protected by GitHub branch protection requiring PR review. Force-push without `--force-with-lease` is dangerous because it can overwrite others' work.
+**Why:** Feature-branch pushes are safe because `main` is protected by branch protection requiring PR review. `git fetch` and pre-push rebase are standard hygiene — not gated. Force-push is dangerous because it can overwrite others' work.
 
 ### Category 2: Pull Request & Review Operations
 
@@ -212,6 +225,14 @@ If an AI agent encounters a task requiring a gated operation, it MUST:
 3. Wait for explicit human approval before proceeding
 4. Never attempt workarounds to bypass these restrictions
 
+### When Working Autonomously (Human Unavailable)
+
+If no human is available to approve a gated operation, agents MUST:
+
+1. Complete all local work (code, tests, commit) to the point where the gated step is the only remaining action
+2. Add a `## Needs Human Action` section to the PR description (or leave a `// TODO(human): <action>` comment) listing each pending step with rationale
+3. Never guess on gated operations — stop cleanly and document
+
 ## Fleet / Swarm Workflows
 
 This project supports Copilot CLI's `/fleet` command for parallel agent execution. For complex tasks, `/fleet` breaks down work and dispatches subtasks to specialized agents concurrently:
@@ -221,7 +242,43 @@ This project supports Copilot CLI's `/fleet` command for parallel agent executio
 /fleet implement budget rollover with tests, docs, and security review
 ```
 
-This is especially powerful with our custom agents — the fleet orchestrator can delegate architecture to `@architect`, implementation to domain agents, security review to `@security-reviewer`, and documentation to `@docs-writer`, all in parallel.
+Each agent gets its own worktree and PR. The fleet orchestrator can delegate architecture to `@architect`, implementation to domain agents, security review to `@security-reviewer`, and documentation to `@docs-writer`, all running in parallel with isolated worktrees.
+
+### Fleet Coordination Rules
+
+When multiple agents work in parallel, they MUST follow these rules to avoid conflicts:
+
+**File ownership by agent:**
+
+| Agent | Primary ownership |
+|---|---|
+| `@kmp-engineer` | `packages/` |
+| `@backend-engineer` | `services/api/` |
+| `@web-engineer` | `apps/web/` |
+| `@android-engineer` | `apps/android/` |
+| `@ios-engineer` | `apps/ios/` |
+| `@windows-engineer` | `apps/windows/` |
+| `@design-engineer` | `config/tokens/`, generated token files |
+| `@devops-engineer` | `.github/workflows/`, `build-logic/`, `tools/` |
+| `@docs-writer` | `docs/`, `*.md` files in root |
+| `@security-reviewer` | Read-only review — never edits production code |
+| `@accessibility-reviewer` | Read-only review — never edits production code |
+
+**Coordination protocol:**
+
+1. **No two agents edit the same file in parallel.** If a task requires two agents to touch the same file, one agent leads and the other reviews.
+2. **Shared config files** (`gradle/libs.versions.toml`, `settings.gradle.kts`, `package.json`, `turbo.json`) must be edited by only one agent per fleet run — assign ownership to `@kmp-engineer` (Gradle) or `@devops-engineer` (Node/CI).
+3. **Agents announce intent** — when starting a fleet task, the orchestrator should note which files each agent will touch in the issue or PR description.
+4. **Schema changes are serialized** — only `@backend-engineer` writes Supabase migrations; only `@kmp-engineer` writes SQLDelight `.sq` files. Both must be in sync (a single coordinated sprint task, not two independent ones).
+5. **After parallel work, the last agent to commit runs** `npm run ci:check` **before pushing** to catch any integration issues.
+
+### Agent Escalation Path
+
+When an agent is blocked or uncertain:
+
+1. **First**: Re-read the relevant skill (`@kmp-development`, `@supabase-powersync`, etc.) — the answer may already be documented
+2. **Second**: Consult `@architect` for cross-cutting design questions
+3. **Third**: Leave a clear decision point documented in the PR as `## Needs Decision: <question>` and stop — do not guess on financial logic
 
 **Requirements:** Copilot CLI with Pro+ subscription. No special repo configuration needed.
 

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -20,6 +20,7 @@ Finance is developed with AI agents as first-class contributors. This means:
 | [Instructions](instructions.md)     | Copilot instruction files and how they work                   |
 | [MCP](mcp.md)                       | Model Context Protocol server configuration                   |
 | [Workflow](workflow.md)             | Day-to-day AI development workflow guide                      |
+| [Worktrees](worktrees.md)           | Git worktree setup and lifecycle for parallel agent work      |
 | [Restrictions](restrictions.md)     | Human-gated operations and AI safety guardrails               |
 | [Responsible AI](responsible-ai.md) | Ethical AI principles, commitments, and product AI guidelines |
 | [AI Code Policy](ai-code-policy.md) | Code ownership, copyright, and contributor responsibilities   |

--- a/docs/ai/agents.md
+++ b/docs/ai/agents.md
@@ -207,15 +207,16 @@ Custom agents are specialized AI personas defined in `.github/agents/`. Each age
 
 **File:** `.github/agents/windows-engineer.agent.md`
 
-**Purpose:** Builds and maintains the Windows desktop client using Compose Desktop (JVM target) with Windows Hello authentication, DPAPI secure storage, and Narrator accessibility.
+**Purpose:** Builds and maintains the Windows desktop client using Compose Desktop (JVM target) with Windows Hello authentication, DPAPI secure storage, and Narrator accessibility. **Windows is a first-class beta target** — it ships alongside Android, iOS, and Web, mirroring Android's Koin DI + ViewModel + Repository architecture.
 
 **When to use:**
 
-- Building or modifying Compose Desktop UI for Windows
+- Building or modifying Compose Desktop UI for Windows in `apps/windows/`
 - Implementing Windows Hello biometric authentication
 - Using DPAPI for secure credential storage
 - Ensuring Narrator and UI Automation accessibility
 - Packaging MSIX for Microsoft Store distribution
+- Setting up Koin DI modules or ViewModel infrastructure for Windows
 
 **Tools:** read, edit, search, shell
 
@@ -257,7 +258,35 @@ Custom agents are specialized AI personas defined in `.github/agents/`. Each age
 
 ---
 
-## Adding a New Agent
+## Agent Management & Coordination
+
+### File Ownership
+
+Each agent has primary ownership over a set of directories. When multiple agents run in parallel (fleet mode), only the owning agent edits files in its area:
+
+| Agent | Primary ownership |
+|---|---|
+| `@kmp-engineer` | `packages/` |
+| `@backend-engineer` | `services/api/` |
+| `@web-engineer` | `apps/web/` |
+| `@android-engineer` | `apps/android/` |
+| `@ios-engineer` | `apps/ios/` |
+| `@windows-engineer` | `apps/windows/` |
+| `@design-engineer` | `config/tokens/`, generated token files |
+| `@devops-engineer` | `.github/workflows/`, `build-logic/`, `tools/` |
+| `@docs-writer` | `docs/`, root `*.md` files |
+| `@security-reviewer` | Read-only — never edits production code |
+| `@accessibility-reviewer` | Read-only — never edits production code |
+
+**Shared config** (`gradle/libs.versions.toml`, `settings.gradle.kts`, `package.json`, `turbo.json`) — one agent per run. Assign to `@kmp-engineer` (Gradle) or `@devops-engineer` (Node/CI).
+
+### Escalation Path
+
+1. **Re-read the relevant skill** — the answer may already be documented
+2. **Consult `@architect`** — for cross-cutting or ambiguous design decisions
+3. **Stop and document** — add `## Needs Decision: <question>` to the PR; do NOT guess on financial logic
+
+### Adding a New Agent
 
 1. Create `.github/agents/<name>.agent.md` with YAML frontmatter:
    ```yaml
@@ -281,3 +310,6 @@ Custom agents are specialized AI personas defined in `.github/agents/`. Each age
 - **Combine agents** — Ask `@architect` to design, then `@security-reviewer` to review
 - **Trust but verify** — Agent output is a starting point; always review critically
 - **Update agents** — As the project evolves, update agent instructions to reflect new patterns
+- **Respect file ownership** — In fleet runs, each agent owns its directory; avoid cross-agent edits to the same file
+- **Serialize schema work** — `@backend-engineer` writes Supabase migrations; `@kmp-engineer` writes SQLDelight schemas; coordinate as a pair, not independently
+- **Never guess on money** — Financial logic decisions must be human-approved; agents should stop and document rather than assume

--- a/docs/ai/agents.md
+++ b/docs/ai/agents.md
@@ -264,19 +264,19 @@ Custom agents are specialized AI personas defined in `.github/agents/`. Each age
 
 Each agent has primary ownership over a set of directories. When multiple agents run in parallel (fleet mode), only the owning agent edits files in its area:
 
-| Agent | Primary ownership |
-|---|---|
-| `@kmp-engineer` | `packages/` |
-| `@backend-engineer` | `services/api/` |
-| `@web-engineer` | `apps/web/` |
-| `@android-engineer` | `apps/android/` |
-| `@ios-engineer` | `apps/ios/` |
-| `@windows-engineer` | `apps/windows/` |
-| `@design-engineer` | `config/tokens/`, generated token files |
-| `@devops-engineer` | `.github/workflows/`, `build-logic/`, `tools/` |
-| `@docs-writer` | `docs/`, root `*.md` files |
-| `@security-reviewer` | Read-only — never edits production code |
-| `@accessibility-reviewer` | Read-only — never edits production code |
+| Agent                     | Primary ownership                              |
+| ------------------------- | ---------------------------------------------- |
+| `@kmp-engineer`           | `packages/`                                    |
+| `@backend-engineer`       | `services/api/`                                |
+| `@web-engineer`           | `apps/web/`                                    |
+| `@android-engineer`       | `apps/android/`                                |
+| `@ios-engineer`           | `apps/ios/`                                    |
+| `@windows-engineer`       | `apps/windows/`                                |
+| `@design-engineer`        | `config/tokens/`, generated token files        |
+| `@devops-engineer`        | `.github/workflows/`, `build-logic/`, `tools/` |
+| `@docs-writer`            | `docs/`, root `*.md` files                     |
+| `@security-reviewer`      | Read-only — never edits production code        |
+| `@accessibility-reviewer` | Read-only — never edits production code        |
 
 **Shared config** (`gradle/libs.versions.toml`, `settings.gradle.kts`, `package.json`, `turbo.json`) — one agent per run. Assign to `@kmp-engineer` (Gradle) or `@devops-engineer` (Node/CI).
 

--- a/docs/ai/restrictions.md
+++ b/docs/ai/restrictions.md
@@ -13,21 +13,25 @@ Finance is a financial tracking application handling sensitive personal and mone
 
 ## Restriction Categories
 
-### 1. Git Remote Operations ⛔
+### 1. Git Remote Operations
 
-**Operations requiring human approval:**
-
-- `git push` (all variants including `--force`, `--force-with-lease`)
-- `git pull` and `git fetch` from untrusted remotes
-- `git remote add`, `remove`, `set-url`
-- `git merge` from remote branches
-- `git rebase` onto remote branches
-
-**Safe operations (auto-approved):**
+**Auto-approved (agents may perform without asking):**
 
 - `git status`, `git log`, `git diff`, `git show`
 - `git add`, `git commit` (local only)
 - `git branch` (listing), `git stash list`
+- `git fetch origin main` — read-only; required for pre-push rebase
+- `git rebase origin/main` on **own feature branch only** — standard pre-push hygiene; never on shared branches
+- `git push origin <feature-branch>` — pushing your own feature branch to origin is allowed; the `pre-push` hook and GitHub branch protection block the dangerous cases automatically
+
+**Require human approval:**
+
+- `git push origin main`, `git push origin master`, or any push to a release/protected branch — hard blocked by branch protection
+- `git push --force` (without `--force-with-lease`) — forbidden entirely
+- `git push --force-with-lease` on a feature branch — only with explicit human approval (may overwrite a collaborator's work)
+- `git remote add`, `remove`, `set-url` — remote configuration changes
+- `git merge` from remote branches into main or release branches
+- `git rebase` onto any branch other than `origin/main` or the agent's own feature branch
 
 ### 2. Pull Request & Review Operations ⚠️
 
@@ -209,6 +213,15 @@ When an AI agent encounters a task that requires a gated operation, it MUST:
 2. **EXPLAIN** — Clearly state what operation is needed and why
 3. **WAIT** — Wait for explicit human approval before proceeding
 4. **NEVER WORKAROUND** — Do not attempt alternative methods to bypass the restriction (e.g., using a different command to achieve the same remote effect)
+
+### When Agents Are Working Autonomously (Without Human Present)
+
+If no human is available to approve a gated operation, agents MUST:
+
+1. Complete all local work (code, tests, commit) to the point where the gated step is the only remaining action
+2. Leave a clear `// TODO(human): <action required>` comment in code or a PR description section `## Needs Human Action` listing each pending step
+3. Document the rationale so the human can make an informed decision when they return
+4. Never make a "best guess" on a gated operation — stop cleanly and document
 
 ## Modifying These Restrictions
 

--- a/docs/ai/workflow.md
+++ b/docs/ai/workflow.md
@@ -39,10 +39,14 @@ Autonomous agent that runs on GitHub's infrastructure:
 
 ```
 1. Create a GitHub issue describing the feature
-2. (Option A) Work locally with VS Code Copilot Chat in Agent Mode
-3. (Option B) Assign the issue to @copilot for autonomous development
-4. Request review from @security-reviewer and @accessibility-reviewer
-5. Merge when all checks pass
+2. Scan for an existing worktree: git worktree list
+   - If found: resume work there
+   - If not: git worktree add ../wt-[agent]-[branch] -b [branch]
+3. (Option A) Work locally in the worktree with VS Code Copilot Chat in Agent Mode
+4. (Option B) Assign the issue to @copilot for autonomous development
+5. Push, open PR automatically, monitor CI/conflict checks until merge-ready
+6. Request review from @security-reviewer and @accessibility-reviewer
+7. Merge (human only) — agent removes worktree after merge confirmed
 ```
 
 ### 2. Code Review with AI
@@ -83,16 +87,32 @@ For complex, multi-faceted tasks, use Copilot CLI's `/fleet` command:
 # Fleet orchestrator will:
 # 1. Analyze the task and identify subtasks
 # 2. Dispatch subtasks to specialized agents in parallel
-# 3. Manage dependencies between subtasks
-# 4. Aggregate results
+# 3. Each agent creates its own worktree: wt-[agent-type]-[branch]
+# 4. Manage dependencies between subtasks
+# 5. Each agent opens its own PR and monitors CI independently
 ```
 
 **Best practices for fleet mode:**
 
 - Describe the full scope so the orchestrator can partition effectively
 - Works best for tasks with naturally separable concerns (code + tests + docs)
-- Monitor progress — intervene if agents drift or conflict
+- **Each agent gets its own worktree and PR** — one branch per agent per issue
+- **Assign file ownership explicitly** — see the ownership table in `AGENTS.md`
+- **Serialize schema changes** — backend migrations and KMP `.sq` files must be coordinated (not split across independent agents)
+- **Shared config files** (`gradle/libs.versions.toml`, `package.json`, `turbo.json`) may only be edited by one agent per run
+- Each agent is responsible for monitoring its own PR until merge-ready
 - Review all PRs before merging, especially when agents touch overlapping files
+
+### 6. Autonomous Operation (Human Unavailable)
+
+When working in autonomous mode without a human present:
+
+- Complete all local work (code, tests, commits) fully
+- Push the feature branch and open the PR automatically
+- Monitor CI and resolve failures/conflicts autonomously
+- For gated operations (merging PRs, closing issues): stop cleanly — the PR itself is the handoff point
+- For financial logic decisions: do NOT guess — stop and document as `## Needs Decision: <question>` in the PR
+- After completing autonomous work, run `npm run ready-for-pr` to validate the branch is in a reviewable state
 
 ## Using Custom Agents
 
@@ -139,11 +159,11 @@ Type `@` followed by the agent name:
 - Existing knowledge outdated → Update the skill's Markdown body
 - New trigger keywords needed → Update the skill's description in frontmatter
 
-### When to Update MCP
+### When to Update Agent Workflow Docs
 
-- New external tool needed → Add server to `.vscode/mcp.json`
-- API credentials rotated → Update tokens via VS Code input prompts
-- New team member onboarding → Ensure they have required API access
+- Worktree naming or lifecycle changes → Update `docs/ai/worktrees.md` and `workflow.instructions.md`
+- New git operations approved/gated → Update `docs/ai/restrictions.md` and `copilot-instructions.md`
+- New fleet coordination rules → Update `AGENTS.md` and `docs/ai/agents.md`
 
 ## Best Practices
 

--- a/docs/ai/worktrees.md
+++ b/docs/ai/worktrees.md
@@ -4,14 +4,14 @@ This document describes how to run parallel AI agents (and human contributors) u
 
 ## Why Worktrees Instead of Multiple Clones
 
-| | Multiple clones | Git worktrees |
-|---|---|---|
-| git history | Duplicated per clone | Single shared history |
-| Remote sync | Must pull in every clone separately | One remote, all worktrees see it |
-| Disk usage | High (full .git per clone) | Low (one .git, lightweight per worktree) |
-| Branch safety | Easy to forget to pull before branching | `git worktree add` always branches from current state |
-| Resume-ability | No standard way to find abandoned work | `git worktree list` shows all active work instantly |
-| Cleanup | Delete entire folder | `git worktree remove <path>` |
+|                | Multiple clones                         | Git worktrees                                         |
+| -------------- | --------------------------------------- | ----------------------------------------------------- |
+| git history    | Duplicated per clone                    | Single shared history                                 |
+| Remote sync    | Must pull in every clone separately     | One remote, all worktrees see it                      |
+| Disk usage     | High (full .git per clone)              | Low (one .git, lightweight per worktree)              |
+| Branch safety  | Easy to forget to pull before branching | `git worktree add` always branches from current state |
+| Resume-ability | No standard way to find abandoned work  | `git worktree list` shows all active work instantly   |
+| Cleanup        | Delete entire folder                    | `git worktree remove <path>`                          |
 
 ## Repository Layout
 

--- a/docs/ai/worktrees.md
+++ b/docs/ai/worktrees.md
@@ -1,0 +1,166 @@
+# Git Worktree Pattern — Finance Monorepo
+
+This document describes how to run parallel AI agents (and human contributors) using git worktrees instead of multiple repository clones.
+
+## Why Worktrees Instead of Multiple Clones
+
+| | Multiple clones | Git worktrees |
+|---|---|---|
+| git history | Duplicated per clone | Single shared history |
+| Remote sync | Must pull in every clone separately | One remote, all worktrees see it |
+| Disk usage | High (full .git per clone) | Low (one .git, lightweight per worktree) |
+| Branch safety | Easy to forget to pull before branching | `git worktree add` always branches from current state |
+| Resume-ability | No standard way to find abandoned work | `git worktree list` shows all active work instantly |
+| Cleanup | Delete entire folder | `git worktree remove <path>` |
+
+## Repository Layout
+
+```
+finance-human/           ← main worktree — RESERVED FOR HUMAN WORK
+  .git/
+  apps/
+  packages/
+  ...
+  .git/worktrees/        ← git tracks all registered worktrees here
+
+../wt-android-feat-transactions-443/    ← agent worktree (android agent, issue #443)
+../wt-web-fix-auth-127/                 ← agent worktree (web agent, issue #127)
+../wt-kmp-feat-schema-align-88/         ← agent worktree (kmp agent, issue #88)
+../wt-backend-fix-rls-policies-22/      ← agent worktree (backend agent, issue #22)
+```
+
+All worktrees share the same `.git` database — commits, branches, and remotes are all unified.
+
+## Naming Convention
+
+```
+wt-[agent-type]-[branch-name]
+```
+
+Where `branch-name` follows the standard convention: `type/description-issue#`
+
+**Examples:**
+
+```bash
+wt-android-feat-transactions-443
+wt-web-fix-auth-127
+wt-kmp-feat-schema-align-88
+wt-backend-fix-rls-policies-22
+wt-ios-feat-login-ui-55
+wt-windows-feat-data-layer-71
+wt-devops-ci-backend-workflow-103
+```
+
+The naming encodes: **who** is doing the work, **what kind** of work, and **which issue** — enough for any agent to scan and resume without human guidance.
+
+## Agent Workflow
+
+### Starting Work on an Issue
+
+```bash
+# Step 1: From the main repo, check for an existing worktree for this issue
+git -C /path/to/finance-human worktree list
+
+# Step 2a: If a matching worktree exists — resume it
+cd ../wt-android-feat-transactions-443
+git status   # understand current state
+# Continue work...
+
+# Step 2b: If no matching worktree — create one
+git -C /path/to/finance-human worktree add \
+  ../wt-android-feat-transactions-443 \
+  -b feat/transactions-443
+cd ../wt-android-feat-transactions-443
+# Begin work...
+```
+
+### Pre-Push Sync (Auto-Approved)
+
+Before pushing, always sync with main:
+
+```bash
+# From inside the worktree
+git fetch origin main
+git rebase origin/main
+```
+
+Both operations are auto-approved — no human confirmation needed.
+
+### Pushing and Opening a PR
+
+```bash
+# Push the feature branch
+git push origin feat/transactions-443
+
+# Open PR automatically
+gh pr create \
+  --title "feat(android): implement transaction list (#443)" \
+  --body "## Summary
+...
+
+## Issues
+Closes #443
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+### Monitoring CI and Merge Conflicts
+
+After opening a PR, the agent **must monitor** it until it is merge-ready:
+
+1. Poll `gh pr checks <number>` until all checks pass
+2. If **CI failures** appear:
+   - Read the failure logs
+   - Fix the issues locally in the worktree
+   - Commit, rebase if needed, and push again
+   - Restart the check cycle
+3. If **merge conflicts** appear:
+   - `git fetch origin main && git rebase origin/main`
+   - Resolve conflicts
+   - `git push origin <branch> --force-with-lease`
+   - Restart the check cycle
+4. Once all checks pass and no conflicts exist — the agent marks its work complete
+
+> **Note:** Agents do NOT merge PRs. Humans review and merge. The agent's job is to get the PR to a merge-ready state.
+
+### Post-Merge Cleanup
+
+After confirming the PR has been merged:
+
+```bash
+# From the main repo directory
+git -C /path/to/finance-human worktree remove ../wt-android-feat-transactions-443
+
+# Optionally prune the remote tracking branch
+git -C /path/to/finance-human remote prune origin
+```
+
+Cleanup is automatic — the agent removes its own worktree once merge is confirmed.
+
+## Human Workflow
+
+Humans follow the same pattern but have more flexibility:
+
+- The **main worktree** (`finance-human/`) is available for quick reads, ad-hoc exploration, and review
+- For active feature development, humans should also use worktrees to avoid interfering with agent worktrees
+- Humans can also work in a separate full clone if preferred — the worktree approach is a recommendation, not a requirement for humans
+
+## Scanning for Resumable Work
+
+Any agent asked to continue work on an issue should first scan:
+
+```bash
+# List all active worktrees with their branch names
+git -C /path/to/finance-human worktree list --porcelain
+
+# Parse for issue number (e.g., looking for issue #443)
+# Match worktree paths containing "-443"
+```
+
+If a matching worktree is found, the agent resumes there rather than creating a new one. This preserves any in-progress commits or stashes.
+
+## Constraints
+
+- A branch can only be checked out in **one worktree at a time**. If you need a second agent on the same branch, it must coordinate with the first.
+- There is no practical limit to the number of worktrees on one machine.
+- The `main` branch itself lives in the main worktree — agents never check out `main` in a worktree.

--- a/docs/ai/worktrees.md
+++ b/docs/ai/worktrees.md
@@ -74,17 +74,34 @@ cd ../wt-android-feat-transactions-443
 # Begin work...
 ```
 
-### Pre-Push Sync (Auto-Approved)
+### Pre-Push Checklist (Mandatory — Do NOT Skip)
 
-Before pushing, always sync with main:
+Before pushing, every agent MUST complete these steps in order:
 
 ```bash
-# From inside the worktree
+# Step 1: Run the full local CI check — catches formatting, lint, and type errors
+#         before they become remote CI failures
+npm run ci:check
+
+# Step 2: Fix any issues reported (formatting is auto-fixable)
+npm run format       # auto-fix Prettier issues
+npx eslint . --fix   # auto-fix ESLint issues
+npm run ci:check     # re-run to confirm clean
+
+# Step 3: Commit the fixes if any files changed
+git add -A && git commit -m "style: fix formatting and lint issues (#N)"
+
+# Step 4: Sync with main
 git fetch origin main
 git rebase origin/main
 ```
 
-Both operations are auto-approved — no human confirmation needed.
+> **Why this matters:** `npm run ci:check` runs the exact same checks as the remote CI
+> (`format:check` → `lint` → `type-check`). Skipping this step is the primary cause of
+> avoidable CI failures on PRs. An agent that pushes without running `ci:check` first
+> has not completed its pre-push workflow.
+
+Both `git fetch` and `git rebase origin/main` on your own branch are auto-approved — no human confirmation needed.
 
 ### Pushing and Opening a PR
 
@@ -106,12 +123,13 @@ Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
 
 ### Monitoring CI and Merge Conflicts
 
-After opening a PR, the agent **must monitor** it until it is merge-ready:
+After opening a PR, the agent **must monitor** it until it is merge-ready. **Work is NOT complete until all remote CI checks are green.**
 
 1. Poll `gh pr checks <number>` until all checks pass
 2. If **CI failures** appear:
-   - Read the failure logs
+   - Read the failure logs (`gh run view --log-failed`)
    - Fix the issues locally in the worktree
+   - **Run `npm run ci:check` again locally before pushing** — confirm clean first
    - Commit, rebase if needed, and push again
    - Restart the check cycle
 3. If **merge conflicts** appear:
@@ -119,9 +137,11 @@ After opening a PR, the agent **must monitor** it until it is merge-ready:
    - Resolve conflicts
    - `git push origin <branch> --force-with-lease`
    - Restart the check cycle
-4. Once all checks pass and no conflicts exist — the agent marks its work complete
+4. Once **all checks are green and no conflicts exist** — the agent marks its work complete
 
-> **Note:** Agents do NOT merge PRs. Humans review and merge. The agent's job is to get the PR to a merge-ready state.
+> **Work is NOT complete until `gh pr checks` shows all green.** Opening a PR and pushing
+> is not the finish line — a clean CI run is. An agent that marks work complete before
+> confirming remote checks pass has not finished the task.
 
 ### Post-Merge Cleanup
 


### PR DESCRIPTION
## Summary

Updates all AI agent definitions, skill documents, path-specific instructions, and workflow documentation to reflect decisions made during sprint planning.

## Changes

### Schema Alignment
- \supabase-powersync\ skill: Add \	ransfer_transaction_id\ + \ecurring_rule_id\ to transactions; \is_rollover\ to budgets; full \goals\ table with \ccount_id\ + \status\ enum; \owner_id\ + sync columns in Core Principles
- \kmp-development\ skill: Updated SQLDelight examples — Transaction.sq, Budget.sq, Goal.sq with all approved fields
- \inancial-modeling\ skill: Rollover calculation semantics, goal status lifecycle and account-linkage guidance
- \packages.instructions.md\ + \services.instructions.md\: Approved model additions, migration naming convention
- \ackend-engineer\ + \kmp-engineer\ agents: Approved model/schema additions section

### Platform Updates
- Windows documented as first-class beta target with explicit Koin/ViewModel/Repository architecture pattern in \windows-engineer\ agent
- \web-engineer\ agent: KMP dual-path integration strategy (TypeScript primary for beta, KMP JS validated in parallel)
- \copilot-instructions.md\: Schema Alignment Decisions + Windows first-class sections

### Workflow Process (discussed and approved with human)
- Migrate from multiple repo clones to **git worktrees** as the recommended parallel-agent pattern
- New \docs/ai/worktrees.md\: full worktree setup, naming convention, lifecycle, scan-to-resume, PR monitoring, cleanup guide
- Worktree naming: \wt-[agent-type]-[type/description-issue#]\ (e.g., \wt-android-feat-transactions-443\)
- Agents scan for existing worktrees before creating new ones (resume-ability after context drop)
- Agents auto-fetch + rebase + push (no human interruption needed)
- Agents automatically open PRs and monitor CI/conflict checks until merge-ready; fix failures autonomously
- Agents clean up worktrees after merge confirmed
- Fixed inconsistency: \git fetch origin main\ + \git rebase origin/main\ on own branch now explicitly auto-approved in \estrictions.md\
- Added autonomous operation protocol: stop cleanly at gated steps, document \## Needs Human Action\ / \## Needs Decision\

### Agent Coordination
- File ownership table in \AGENTS.md\ and \docs/ai/agents.md\
- Schema serialization rule: backend migrations and SQLDelight \.sq\ files coordinated as a pair
- Agent escalation path: skill → \@architect\ → stop and document

## Issues

Closes #703

## Testing

- [ ] Documentation reviewed for accuracy
- [ ] No broken internal links