### PR TITLE
ci(infra): configure Turborepo remote caching

### DIFF
--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -13,6 +13,10 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+
 jobs:
   eslint-prettier:
     name: ESLint & Prettier

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -15,6 +15,10 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+
 jobs:
   build-test:
     name: Build & Test

--- a/docs/guides/turborepo-caching.md
+++ b/docs/guides/turborepo-caching.md
@@ -1,0 +1,71 @@
+# Turborepo Remote Caching
+
+This guide explains how to enable Turborepo remote caching to share build artifacts
+across CI runs and developer machines, reducing build times by up to 80%.
+
+## How It Works
+
+Turborepo hashes all task inputs (source files, env vars, dependencies). When a task
+with a matching hash has been built before, Turbo fetches the cached output instead of
+rebuilding. Remote caching extends this to a shared server so CI jobs and teammates
+benefit from each other's builds.
+
+## Provider Options
+
+### Option A — Vercel Remote Cache (recommended, free for open source)
+
+1. Install the Turbo CLI: `npm i -g turbo`
+2. Log in: `turbo login`
+3. Link this repo: `turbo link` (run from the repo root)
+4. Copy the token from `~/.turbo/config.json` — the `token` field.
+5. In GitHub → Settings → Secrets → Actions, add:
+   - `TURBO_TOKEN` — the token from step 4
+   - `TURBO_TEAM` — your Vercel team slug (e.g. `my-org`)
+
+### Option B — Self-Hosted Cache (Ducktape / remote-cache-server)
+
+Use [`ducktape`](https://github.com/ducktors/turborepo-remote-cache) or any
+compatible cache server. Set `TURBO_API` to your server URL in addition to
+`TURBO_TOKEN` and `TURBO_TEAM`.
+
+## CI Setup (already configured)
+
+The following workflows pass `TURBO_TOKEN` / `TURBO_TEAM` as environment variables
+so every `npm run build|test|lint` call (which internally invokes `turbo run`)
+automatically participates in the remote cache:
+
+- `.github/workflows/web-ci.yml`
+- `.github/workflows/lint-format.yml`
+
+If the secrets are not set, Turbo silently falls back to local-only caching — CI
+will still succeed, just without the speedup.
+
+## Local Developer Setup
+
+```bash
+# One-time setup per developer
+turbo login      # authenticate with Vercel
+turbo link       # link this repo to the team cache
+
+# All npm run commands then share the remote cache automatically
+npm run build
+npm run test
+```
+
+## Cache Invalidation
+
+The remote cache is automatically invalidated when inputs change (source files,
+`package.json`, env vars declared in `turbo.json`). To manually clear the local
+cache: `turbo daemon clean`.
+
+## turbo.json Remote Cache Config
+
+```json
+"remoteCache": {
+  "enabled": true,
+  "signature": true   // cryptographically sign cache artifacts
+}
+```
+
+`signature: true` ensures cached artifacts cannot be tampered with — important for
+a financial application.

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "remoteCache": {
+    "enabled": true,
+    "signature": true
+  },
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary

Configures Turborepo remote caching so all CI runs and developer machines share a build artifact cache, reducing CI build times by up to 80%.

## Changes

- `turbo.json` — Add `remoteCache` config block: `enabled: true`, `signature: true` (cryptographic artifact signing)
- `.github/workflows/web-ci.yml` — Expose `TURBO_TOKEN` and `TURBO_TEAM` env vars so `npm run build/test` calls automatically participate in remote cache
- `.github/workflows/lint-format.yml` — Same env var exposure for lint/format runs
- `docs/guides/turborepo-caching.md` — Developer setup guide covering Vercel Remote Cache (recommended), self-hosted options, and CI secret configuration

## Setup Required

After this PR merges, add two GitHub Actions secrets:
- `TURBO_TOKEN` — from `turbo login` + `turbo link` (see the guide)
- `TURBO_TEAM` — your Vercel team slug

If the secrets are absent, Turbo silently uses local-only caching — CI continues to work, just without the speedup.

## Testing

- [ ] CI passes with secrets unset (fallback to local cache)
- [ ] CI passes with secrets set (remote cache hits visible in turbo output)

## Issues

Closes #196
