### PR TITLE
docs: rename finance-human references to finance

### DIFF
--- a/.github/instructions/workflow.instructions.md
+++ b/.github/instructions/workflow.instructions.md
@@ -65,7 +65,7 @@ cd ../wt-android-feat-transactions-443
 git worktree remove ../wt-android-feat-transactions-443
 ```
 
-The main worktree (`finance-human/`) is reserved for human work.
+The main worktree (`finance/`) is reserved for human work.
 
 ## Branch Naming Convention
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ All work in this repository follows an issue-first, feature-branch + worktree wo
 2. **Always use a git worktree** for agent work — never commit directly in the main worktree or on `main`.
    - Naming: `wt-[agent-type]-[type/description-issue#]` (e.g., `wt-android-feat-transactions-443`)
    - **Scan first**: run `git worktree list` — if a worktree for this issue already exists, resume it
-   - Main worktree (`finance-human/`) is reserved for human work
+   - Main worktree (`finance/`) is reserved for human work
 3. **Commit messages must include issue references** in the format `type(scope): description (#N)`.
 4. **Push automatically** — `git push origin <branch>` is auto-approved.
 5. **Open a PR automatically** with `gh pr create` — include `Closes #N` for resolved issues.

--- a/docs/ai/worktrees.md
+++ b/docs/ai/worktrees.md
@@ -16,7 +16,7 @@ This document describes how to run parallel AI agents (and human contributors) u
 ## Repository Layout
 
 ```
-finance-human/           ← main worktree — RESERVED FOR HUMAN WORK
+finance/                 ← main worktree — RESERVED FOR HUMAN WORK
   .git/
   apps/
   packages/
@@ -59,7 +59,7 @@ The naming encodes: **who** is doing the work, **what kind** of work, and **whic
 
 ```bash
 # Step 1: From the main repo, check for an existing worktree for this issue
-git -C /path/to/finance-human worktree list
+git -C /path/to/finance worktree list
 
 # Step 2a: If a matching worktree exists — resume it
 cd ../wt-android-feat-transactions-443
@@ -67,7 +67,7 @@ git status   # understand current state
 # Continue work...
 
 # Step 2b: If no matching worktree — create one
-git -C /path/to/finance-human worktree add \
+git -C /path/to/finance worktree add \
   ../wt-android-feat-transactions-443 \
   -b feat/transactions-443
 cd ../wt-android-feat-transactions-443
@@ -149,10 +149,10 @@ After confirming the PR has been merged:
 
 ```bash
 # From the main repo directory
-git -C /path/to/finance-human worktree remove ../wt-android-feat-transactions-443
+git -C /path/to/finance worktree remove ../wt-android-feat-transactions-443
 
 # Optionally prune the remote tracking branch
-git -C /path/to/finance-human remote prune origin
+git -C /path/to/finance remote prune origin
 ```
 
 Cleanup is automatic — the agent removes its own worktree once merge is confirmed.
@@ -161,7 +161,7 @@ Cleanup is automatic — the agent removes its own worktree once merge is confir
 
 Humans follow the same pattern but have more flexibility:
 
-- The **main worktree** (`finance-human/`) is available for quick reads, ad-hoc exploration, and review
+- The **main worktree** (`finance/`) is available for quick reads, ad-hoc exploration, and review
 - For active feature development, humans should also use worktrees to avoid interfering with agent worktrees
 - Humans can also work in a separate full clone if preferred — the worktree approach is a recommendation, not a requirement for humans
 
@@ -171,7 +171,7 @@ Any agent asked to continue work on an issue should first scan:
 
 ```bash
 # List all active worktrees with their branch names
-git -C /path/to/finance-human worktree list --porcelain
+git -C /path/to/finance worktree list --porcelain
 
 # Parse for issue number (e.g., looking for issue #443)
 # Match worktree paths containing "-443"


### PR DESCRIPTION
## Summary

Updates all documentation references from \inance-human/\ to \inance/\ to reflect the main worktree directory rename.

## Changes

- **AGENTS.md** — Updated main worktree reference in Issue-First Development section
- **.github/instructions/workflow.instructions.md** — Updated main worktree reference
- **docs/ai/worktrees.md** — Updated all 7 path references in code examples and prose

## Context

The main worktree was renamed from \inance-human/\ to \inance/\ as part of a workspace cleanup that removed redundant clones and broken worktree directories. All agent documentation now correctly points to the new directory name.

## Testing

- \
pm run ci:check\ passes (format:check + lint + type-check)
- Grep confirms zero remaining \inance-human\ references in tracked files

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>