### PR TITLE
ci(web): remove continue-on-error from unit and E2E tests (#718)

### DIFF
--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -40,14 +40,12 @@ jobs:
       - run: npm run build -w apps/web
 
       - run: npm test -w apps/web
-        continue-on-error: true
 
       - name: Install Playwright browsers
         run: npx -w apps/web playwright install --with-deps chromium
 
       - name: Run E2E tests
         run: npm run test:e2e -w apps/web
-        continue-on-error: true
 
       - name: Lighthouse Audit
         id: lighthouse-audit


### PR DESCRIPTION
## Summary

Removes \continue-on-error: true\ from unit test and E2E test steps in the Web CI workflow so that test failures now properly fail the CI check, enforcing CI gating.

## Changes

- **Unit tests** (\
pm test -w apps/web\): removed \continue-on-error: true\
- **E2E tests** (\
pm run test:e2e -w apps/web\): removed \continue-on-error: true\
- **Lighthouse Audit**: \continue-on-error: true\ **kept** (truly optional — audit tooling may be flaky)
- **Lighthouse Budget Check**: \continue-on-error: false\ **kept** (already strict)

## Acceptance Criteria

- [x] Unit test failures fail the CI check
- [x] E2E test failures fail the CI check
- [x] Existing tests all pass before removing the flag

Closes #718