### PR TITLE
ci: fix auto-add-to-project workflow (#721)

### DIFF
--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -8,11 +8,6 @@ on:
 
 jobs:
   add-to-project:
-    # Projects V2 requires a PAT with `project` scope — GITHUB_TOKEN is insufficient.
-    # This job is skipped when the ADD_TO_PROJECT_PAT secret is not configured.
-    # Setup: create a PAT (classic) with `project` scope, add it as a repository
-    # secret named ADD_TO_PROJECT_PAT.
-    if: ${{ secrets.ADD_TO_PROJECT_PAT != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -20,7 +15,14 @@ jobs:
       pull-requests: write
     steps:
       - name: Add to project
+        # Projects V2 requires a PAT with `project` scope — GITHUB_TOKEN is insufficient.
+        # This step is skipped when the ADD_TO_PROJECT_PAT secret is not configured.
+        # Setup: create a PAT (classic) with `project` scope, add it as a repository
+        # secret named ADD_TO_PROJECT_PAT.
+        if: ${{ env.ADD_TO_PROJECT_PAT != '' }}
         uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
+        env:
+          ADD_TO_PROJECT_PAT: ${{ secrets.ADD_TO_PROJECT_PAT }}
         with:
           project-url: https://github.com/users/jrmoulckers/projects/2
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
## Summary

Fixes auto-add-to-project workflow.

## Root Cause

Job-level if referencing secrets context caused workflow file validation failure.

## Changes

- Moved secret check from job-level if to step-level if using env context
- Added env block to map secret to environment variable

Closes #721
