### PR TITLE
ci(ios): add Swift Package Manager build caching (#719)

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -30,6 +30,17 @@ jobs:
         with:
           xcode-version: latest-stable
 
+      - name: Cache SPM dependencies
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: |
+            apps/ios/.build
+            ~/Library/Developer/Xcode/DerivedData
+            ~/.swiftpm
+          key: ${{ runner.os }}-spm-${{ hashFiles('apps/ios/Package.resolved', 'apps/ios/Package.swift') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
       - name: Build
         run: |
           cd apps/ios


### PR DESCRIPTION
## Summary

Add ctions/cache step for Swift Package Manager dependencies to the iOS CI workflow, reducing build times on expensive macOS runners.

## Changes

- Added **Cache SPM dependencies** step using ctions/cache@v4.2.4 (pinned SHA 