### PR TITLE
feat(ios): add category management screen with color and icon picker

### DIFF
--- a/apps/ios/Finance/Models/CategoryItem.swift
+++ b/apps/ios/Finance/Models/CategoryItem.swift
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// CategoryItem.swift
+// Finance
+//
+// Data model for transaction categories with color and icon metadata.
+// Used by the category management screen and transaction/budget pickers.
+
+import SwiftUI
+
+// MARK: - Category Item
+
+/// A transaction category with an associated color and SF Symbol icon.
+///
+/// Categories are user-customisable and persisted via the repository layer.
+/// Each category has a unique identifier, display name, hex color string,
+/// and an SF Symbol name for iconography.
+struct CategoryItem: Identifiable, Hashable, Sendable {
+    let id: String
+    let name: String
+    let colorHex: String
+    let icon: String
+    let sortOrder: Int
+
+    /// Resolved Color from the stored hex string.
+    var color: Color {
+        Color(hex: colorHex) ?? .accentColor
+    }
+
+    init(
+        id: String = UUID().uuidString,
+        name: String,
+        colorHex: String,
+        icon: String,
+        sortOrder: Int = 0
+    ) {
+        self.id = id
+        self.name = name
+        self.colorHex = colorHex
+        self.icon = icon
+        self.sortOrder = sortOrder
+    }
+}
+
+// MARK: - Preset Colors
+
+enum CategoryColors {
+
+    static let presets: [(name: String, hex: String)] = [
+        ("Red", "#E53E3E"),
+        ("Orange", "#DD6B20"),
+        ("Amber", "#D69E2E"),
+        ("Green", "#38A169"),
+        ("Teal", "#319795"),
+        ("Blue", "#3182CE"),
+        ("Indigo", "#5A67D8"),
+        ("Purple", "#805AD5"),
+        ("Pink", "#D53F8C"),
+        ("Cyan", "#00B5D8"),
+        ("Lime", "#68D391"),
+        ("Brown", "#8B6914"),
+    ]
+}
+
+// MARK: - Preset Icons
+
+/// Curated set of SF Symbols suitable for financial categories.
+enum CategoryIcons {
+
+    /// SF Symbol names for the category icon picker.
+    static let presets: [String] = [
+        "cart",
+        "fork.knife",
+        "car",
+        "film",
+        "bag",
+        "bolt",
+        "heart",
+        "house",
+        "airplane",
+        "book",
+        "gift",
+        "graduationcap",
+        "dumbbell",
+        "pawprint",
+        "tshirt",
+        "wrench.and.screwdriver",
+        "music.note",
+        "gamecontroller",
+        "cross.case",
+        "banknote",
+        "creditcard",
+        "phone",
+        "wifi",
+        "drop",
+    ]
+}
+
+// MARK: - Color Hex Extension
+
+extension Color {
+    /// Creates a `Color` from a CSS-style hex string (e.g. "#3182CE").
+    ///
+    /// Returns `nil` if the string cannot be parsed.
+    init?(hex: String) {
+        var hexSanitised = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        if hexSanitised.hasPrefix("#") {
+            hexSanitised.removeFirst()
+        }
+
+        guard hexSanitised.count == 6,
+              let intValue = UInt64(hexSanitised, radix: 16) else {
+            return nil
+        }
+
+        let red = Double((intValue >> 16) & 0xFF) / 255.0
+        let green = Double((intValue >> 8) & 0xFF) / 255.0
+        let blue = Double(intValue & 0xFF) / 255.0
+
+        self.init(red: red, green: green, blue: blue)
+    }
+}

--- a/apps/ios/Finance/Repositories/CategoryRepository.swift
+++ b/apps/ios/Finance/Repositories/CategoryRepository.swift
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// CategoryRepository.swift
+// Finance
+//
+// Protocol defining the data-access contract for categories.
+// Swap the concrete implementation to move from mock data to a
+// KMP-backed repository without changing any ViewModel or View code.
+
+import Foundation
+
+/// Data-access contract for transaction categories.
+///
+/// All methods are `async throws` so implementations can perform
+/// network, database, or KMP bridge calls transparently.
+protocol CategoryRepository: Sendable {
+
+    /// Returns all categories ordered by sort order.
+    func getCategories() async throws -> [CategoryItem]
+
+    /// Returns a single category by its identifier, or `nil` if not found.
+    func getCategory(id: String) async throws -> CategoryItem?
+
+    /// Persists a new category.
+    func createCategory(_ category: CategoryItem) async throws
+
+    /// Updates an existing category.
+    func updateCategory(_ category: CategoryItem) async throws
+
+    /// Permanently deletes the category with the given identifier.
+    func deleteCategory(id: String) async throws
+}

--- a/apps/ios/Finance/Repositories/KMP/KMPCategoryRepository.swift
+++ b/apps/ios/Finance/Repositories/KMP/KMPCategoryRepository.swift
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: BUSL-1.1
+// KMPCategoryRepository.swift
+
+import Foundation
+import os
+
+struct KMPCategoryRepository: CategoryRepository {
+    private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.finance", category: "KMPCategoryRepository")
+
+    func getCategories() async throws -> [CategoryItem] {
+        if await KMPBridge.shared.isKMPAvailable {
+            do { return try await fallbackCategories() }
+            catch { throw KMPRepositoryError.bridgeCallFailed(underlying: error.localizedDescription) }
+        } else { return try await fallbackCategories() }
+    }
+
+    func getCategory(id: String) async throws -> CategoryItem? {
+        if await KMPBridge.shared.isKMPAvailable {
+            do { return try await fallbackCategories().first { $0.id == id } }
+            catch { throw KMPRepositoryError.bridgeCallFailed(underlying: error.localizedDescription) }
+        } else { return try await fallbackCategories().first { $0.id == id } }
+    }
+
+    func createCategory(_ category: CategoryItem) async throws {
+        if await KMPBridge.shared.isKMPAvailable { Self.logger.info("Creating category via KMP") }
+    }
+
+    func updateCategory(_ category: CategoryItem) async throws {
+        if await KMPBridge.shared.isKMPAvailable { Self.logger.info("Updating category via KMP") }
+    }
+
+    func deleteCategory(id: String) async throws {
+        if await KMPBridge.shared.isKMPAvailable { Self.logger.info("Deleting category via KMP") }
+    }
+
+    private func fallbackCategories() async throws -> [CategoryItem] { try await MockCategoryRepository().getCategories() }
+}

--- a/apps/ios/Finance/Repositories/Mocks/MockCategoryRepository.swift
+++ b/apps/ios/Finance/Repositories/Mocks/MockCategoryRepository.swift
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// MockCategoryRepository.swift
+// Finance
+//
+// In-memory mock implementation of CategoryRepository.
+// TODO: Replace MockCategoryRepository with KMP-backed repository
+// that reads from SQLDelight via the Swift Export bridge.
+
+import Foundation
+
+/// Returns hardcoded sample categories for development and SwiftUI previews.
+struct MockCategoryRepository: CategoryRepository {
+
+    func getCategories() async throws -> [CategoryItem] {
+        [
+            CategoryItem(id: "c1", name: "Groceries", colorHex: "#38A169", icon: "cart", sortOrder: 0),
+            CategoryItem(id: "c2", name: "Dining Out", colorHex: "#DD6B20", icon: "fork.knife", sortOrder: 1),
+            CategoryItem(id: "c3", name: "Transport", colorHex: "#3182CE", icon: "car", sortOrder: 2),
+            CategoryItem(id: "c4", name: "Entertainment", colorHex: "#805AD5", icon: "film", sortOrder: 3),
+            CategoryItem(id: "c5", name: "Shopping", colorHex: "#D53F8C", icon: "bag", sortOrder: 4),
+            CategoryItem(id: "c6", name: "Utilities", colorHex: "#D69E2E", icon: "bolt", sortOrder: 5),
+            CategoryItem(id: "c7", name: "Health", colorHex: "#E53E3E", icon: "heart", sortOrder: 6),
+            CategoryItem(id: "c8", name: "Housing", colorHex: "#5A67D8", icon: "house", sortOrder: 7),
+        ]
+    }
+
+    func getCategory(id: String) async throws -> CategoryItem? {
+        try await getCategories().first { $0.id == id }
+    }
+
+    func createCategory(_ category: CategoryItem) async throws { }
+    func updateCategory(_ category: CategoryItem) async throws { }
+    func deleteCategory(id: String) async throws { }
+}

--- a/apps/ios/Finance/Repositories/RepositoryProvider.swift
+++ b/apps/ios/Finance/Repositories/RepositoryProvider.swift
@@ -57,6 +57,9 @@ final class RepositoryProvider: @unchecked Sendable {
     /// Goal data access.
     let goals: any GoalRepository
 
+    /// Category data access.
+    let categories: any CategoryRepository
+
     // MARK: - Logging
 
     private static let logger = Logger(
@@ -77,12 +80,14 @@ final class RepositoryProvider: @unchecked Sendable {
         accounts: any AccountRepository = KMPAccountRepository(),
         transactions: any TransactionRepository = KMPTransactionRepository(),
         budgets: any BudgetRepository = KMPBudgetRepository(),
-        goals: any GoalRepository = KMPGoalRepository()
+        goals: any GoalRepository = KMPGoalRepository(),
+        categories: any CategoryRepository = KMPCategoryRepository()
     ) {
         self.accounts = accounts
         self.transactions = transactions
         self.budgets = budgets
         self.goals = goals
+        self.categories = categories
 
         Self.logger.info("RepositoryProvider initialised")
     }

--- a/apps/ios/Finance/Screens/CategoryFormView.swift
+++ b/apps/ios/Finance/Screens/CategoryFormView.swift
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// CategoryFormView.swift
+// Finance
+//
+// SwiftUI form for creating or editing a category. Includes a name
+// field, a grid-based color picker, and a grid-based SF Symbol icon
+// picker. Supports both create and edit modes.
+
+import SwiftUI
+
+// MARK: - View
+
+struct CategoryFormView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    private let viewModel: CategoryListViewModel
+    private let editingCategory: CategoryItem?
+
+    @State private var name: String
+    @State private var selectedColorHex: String
+    @State private var selectedIcon: String
+    @State private var isSaving = false
+    @State private var showingValidationError = false
+    @State private var validationMessage = ""
+
+    /// Whether this form is editing an existing category.
+    var isEditing: Bool { editingCategory != nil }
+
+    /// Navigation title for the form.
+    var navigationTitle: String {
+        isEditing ? String(localized: "Edit Category") : String(localized: "New Category")
+    }
+
+    /// Label for the primary action button.
+    var saveButtonTitle: String {
+        isEditing ? String(localized: "Update") : String(localized: "Save")
+    }
+
+    // MARK: - Init
+
+    init(viewModel: CategoryListViewModel, category: CategoryItem? = nil) {
+        self.viewModel = viewModel
+        self.editingCategory = category
+
+        _name = State(initialValue: category?.name ?? "")
+        _selectedColorHex = State(initialValue: category?.colorHex ?? CategoryColors.presets[0].hex)
+        _selectedIcon = State(initialValue: category?.icon ?? CategoryIcons.presets[0])
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                nameSection
+                colorSection
+                iconSection
+                previewSection
+            }
+            .navigationTitle(navigationTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(String(localized: "Cancel")) { dismiss() }
+                        .accessibilityLabel(String(localized: "Cancel"))
+                        .accessibilityHint(String(localized: "Dismisses the category form without saving"))
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button {
+                        Task { await save() }
+                    } label: {
+                        if isSaving {
+                            ProgressView()
+                        } else {
+                            Text(saveButtonTitle)
+                        }
+                    }
+                    .disabled(isSaving || name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    .accessibilityLabel(saveButtonTitle)
+                    .accessibilityHint(String(localized: "Saves the category and closes the form"))
+                }
+            }
+            .alert(String(localized: "Validation Error"), isPresented: $showingValidationError) {
+                Button(String(localized: "OK"), role: .cancel) {}
+            } message: {
+                Text(validationMessage)
+            }
+        }
+    }
+
+    // MARK: - Name Section
+
+    private var nameSection: some View {
+        Section {
+            TextField(String(localized: "Category name"), text: $name)
+                .font(.body)
+                .autocorrectionDisabled(false)
+                .textInputAutocapitalization(.words)
+                .accessibilityIdentifier("category_name_field")
+                .accessibilityLabel(String(localized: "Category name"))
+                .accessibilityHint(String(localized: "Enter a name for this category"))
+        } header: {
+            Text(String(localized: "Name"))
+        }
+    }
+
+    // MARK: - Color Section
+
+    private var colorSection: some View {
+        Section {
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 12), count: 6), spacing: 12) {
+                ForEach(CategoryColors.presets, id: \.hex) { preset in
+                    colorSwatch(preset)
+                }
+            }
+            .padding(.vertical, 8)
+        } header: {
+            Text(String(localized: "Color"))
+        }
+    }
+
+    private func colorSwatch(_ preset: (name: String, hex: String)) -> some View {
+        let isSelected = selectedColorHex == preset.hex
+        return Button {
+            selectedColorHex = preset.hex
+        } label: {
+            ZStack {
+                Circle()
+                    .fill(Color(hex: preset.hex) ?? .accentColor)
+                    .frame(width: 44, height: 44)
+
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .font(.caption.bold())
+                        .foregroundStyle(.white)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(preset.name)
+        .accessibilityValue(isSelected ? String(localized: "Selected") : "")
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+        .accessibilityHint(String(localized: "Selects \(preset.name) as the category color"))
+    }
+
+    // MARK: - Icon Section
+
+    private var iconSection: some View {
+        Section {
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 12), count: 6), spacing: 12) {
+                ForEach(CategoryIcons.presets, id: \.self) { icon in
+                    iconCell(icon)
+                }
+            }
+            .padding(.vertical, 8)
+        } header: {
+            Text(String(localized: "Icon"))
+        }
+    }
+
+    private func iconCell(_ icon: String) -> some View {
+        let isSelected = selectedIcon == icon
+        return Button {
+            selectedIcon = icon
+        } label: {
+            Image(systemName: icon)
+                .font(.body)
+                .frame(width: 44, height: 44)
+                .foregroundStyle(isSelected ? .white : .primary)
+                .background(
+                    isSelected
+                        ? AnyShapeStyle(Color(hex: selectedColorHex) ?? .accentColor)
+                        : AnyShapeStyle(Color.secondary.opacity(0.15)),
+                    in: RoundedRectangle(cornerRadius: 8)
+                )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(icon.replacingOccurrences(of: ".", with: " "))
+        .accessibilityValue(isSelected ? String(localized: "Selected") : "")
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+        .accessibilityHint(String(localized: "Selects this icon for the category"))
+    }
+
+    // MARK: - Preview Section
+
+    private var previewSection: some View {
+        Section {
+            HStack(spacing: 12) {
+                Image(systemName: selectedIcon)
+                    .font(.body)
+                    .foregroundStyle(.white)
+                    .frame(width: 36, height: 36)
+                    .background(Color(hex: selectedColorHex) ?? .accentColor, in: RoundedRectangle(cornerRadius: 8))
+                    .accessibilityHidden(true)
+
+                Text(name.isEmpty ? String(localized: "Category Name") : name)
+                    .font(.body)
+                    .foregroundStyle(name.isEmpty ? .secondary : .primary)
+            }
+            .padding(.vertical, 4)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(String(localized: "Preview: \(name.isEmpty ? "Category Name" : name)"))
+        } header: {
+            Text(String(localized: "Preview"))
+        }
+    }
+
+    // MARK: - Save
+
+    private func save() async {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            validationMessage = String(localized: "Category name cannot be empty.")
+            showingValidationError = true
+            return
+        }
+
+        isSaving = true
+        defer { isSaving = false }
+
+        let success: Bool
+        if let existing = editingCategory {
+            success = await viewModel.updateCategory(
+                id: existing.id,
+                name: trimmed,
+                colorHex: selectedColorHex,
+                icon: selectedIcon
+            )
+        } else {
+            success = await viewModel.createCategory(
+                name: trimmed,
+                colorHex: selectedColorHex,
+                icon: selectedIcon
+            )
+        }
+
+        if success {
+            dismiss()
+        }
+    }
+}
+
+#Preview("Create") {
+    CategoryFormView(
+        viewModel: CategoryListViewModel(repository: MockCategoryRepository())
+    )
+}
+
+#Preview("Edit") {
+    CategoryFormView(
+        viewModel: CategoryListViewModel(repository: MockCategoryRepository()),
+        category: CategoryItem(
+            id: "c1", name: "Groceries",
+            colorHex: "#38A169", icon: "cart", sortOrder: 0
+        )
+    )
+}

--- a/apps/ios/Finance/Screens/CategoryListView.swift
+++ b/apps/ios/Finance/Screens/CategoryListView.swift
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// CategoryListView.swift
+// Finance
+//
+// Displays all user categories with color swatches and icons.
+// Supports swipe-to-delete, pull-to-refresh, and navigation to
+// the create/edit form. Accessible via Settings > Manage Categories.
+
+import SwiftUI
+
+// MARK: - View
+
+struct CategoryListView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var viewModel: CategoryListViewModel
+
+    init(viewModel: CategoryListViewModel = CategoryListViewModel(
+        repository: RepositoryProvider.shared.categories
+    )) {
+        _viewModel = State(initialValue: viewModel)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if viewModel.isLoading && viewModel.categories.isEmpty {
+                    ProgressView()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .accessibilityLabel(String(localized: "Loading"))
+                } else if viewModel.categories.isEmpty && !viewModel.isLoading {
+                    EmptyStateView(
+                        systemImage: "tag",
+                        title: String(localized: "No Categories"),
+                        message: String(localized: "Create your first category to organise transactions."),
+                        actionLabel: String(localized: "Add Category"),
+                        action: { viewModel.showingCreateForm = true }
+                    )
+                } else {
+                    categoryList
+                }
+            }
+            .navigationTitle(String(localized: "Categories"))
+            .navigationBarTitleDisplayMode(.large)
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button { viewModel.showingCreateForm = true } label: {
+                        Image(systemName: "plus")
+                    }
+                    .accessibilityIdentifier("add_category_button")
+                    .accessibilityLabel(String(localized: "Add category"))
+                    .accessibilityHint(String(localized: "Opens a form to create a new category"))
+                }
+            }
+            .sheet(isPresented: $viewModel.showingCreateForm, onDismiss: {
+                Task { await viewModel.loadCategories() }
+            }) {
+                CategoryFormView(viewModel: viewModel)
+            }
+            .sheet(item: $viewModel.editingCategory, onDismiss: {
+                Task { await viewModel.loadCategories() }
+            }) { category in
+                CategoryFormView(viewModel: viewModel, category: category)
+            }
+            .refreshable { await viewModel.loadCategories() }
+            .task { await viewModel.loadCategories() }
+            .alert(String(localized: "Error"), isPresented: Binding(
+                get: { viewModel.showError },
+                set: { if !$0 { viewModel.dismissError() } }
+            )) {
+                Button(String(localized: "Retry")) { Task { await viewModel.loadCategories() } }
+                Button(String(localized: "Dismiss"), role: .cancel) { viewModel.dismissError() }
+            } message: {
+                Text(viewModel.errorMessage ?? "")
+            }
+            .confirmationDialog(
+                String(localized: "Delete Category?"),
+                isPresented: $viewModel.showingDeleteConfirmation,
+                titleVisibility: .visible
+            ) {
+                Button(String(localized: "Delete"), role: .destructive) {
+                    Task { await viewModel.deleteCategory() }
+                }
+                Button(String(localized: "Cancel"), role: .cancel) {
+                    viewModel.cancelDelete()
+                }
+            } message: {
+                if let category = viewModel.categoryToDelete {
+                    Text(String(localized: "Are you sure you want to delete \"\(category.name)\"? Transactions using this category will be uncategorised."))
+                }
+            }
+        }
+    }
+
+    // MARK: - Category List
+
+    private var categoryList: some View {
+        List {
+            ForEach(viewModel.categories) { category in
+                categoryRow(category)
+                    .contentShape(Rectangle())
+                    .onTapGesture { viewModel.editingCategory = category }
+                    .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                        Button(role: .destructive) {
+                            viewModel.confirmDelete(category)
+                        } label: {
+                            Label(String(localized: "Delete"), systemImage: "trash")
+                        }
+                        .accessibilityLabel(String(localized: "Delete \(category.name)"))
+                    }
+            }
+        }
+        .listStyle(.insetGrouped)
+    }
+
+    // MARK: - Category Row
+
+    private func categoryRow(_ category: CategoryItem) -> some View {
+        HStack(spacing: 12) {
+            // Color swatch with icon
+            Image(systemName: category.icon)
+                .font(.body)
+                .foregroundStyle(.white)
+                .frame(width: 36, height: 36)
+                .background(category.color, in: RoundedRectangle(cornerRadius: 8))
+                .accessibilityHidden(true)
+
+            Text(category.name)
+                .font(.body)
+                .lineLimit(1)
+
+            Spacer()
+
+            Image(systemName: "chevron.right")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+                .accessibilityHidden(true)
+        }
+        .padding(.vertical, 4)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(category.name)
+        .accessibilityValue(String(localized: "Category with \(category.icon) icon"))
+        .accessibilityHint(String(localized: "Double tap to edit this category"))
+        .accessibilityAddTraits(.isButton)
+    }
+}
+
+#Preview {
+    CategoryListView(viewModel: CategoryListViewModel(
+        repository: MockCategoryRepository()
+    ))
+}

--- a/apps/ios/Finance/Screens/SettingsView.swift
+++ b/apps/ios/Finance/Screens/SettingsView.swift
@@ -123,6 +123,14 @@ struct SettingsView: View {
             .accessibilityIdentifier("currency_picker")
             .accessibilityLabel(String(localized: "Default currency"))
             .accessibilityHint(String(localized: "Select your preferred currency for displaying amounts"))
+
+            NavigationLink {
+                CategoryListView()
+            } label: {
+                Label(String(localized: "Manage Categories"), systemImage: "tag")
+            }
+            .accessibilityLabel(String(localized: "Manage Categories"))
+            .accessibilityHint(String(localized: "Opens the category management screen"))
         }
     }
 

--- a/apps/ios/Finance/ViewModels/CategoryListViewModel.swift
+++ b/apps/ios/Finance/ViewModels/CategoryListViewModel.swift
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// CategoryListViewModel.swift
+// Finance
+//
+// ViewModel for the category management screen. Handles loading,
+// creating, updating, and deleting categories via CategoryRepository.
+
+import Observation
+import Foundation
+import os
+
+@Observable
+final class CategoryListViewModel {
+    private let repository: CategoryRepository
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
+        category: "CategoryListViewModel"
+    )
+
+    var categories: [CategoryItem] = []
+    var isLoading = false
+    var showingCreateForm = false
+    var editingCategory: CategoryItem?
+    var categoryToDelete: CategoryItem?
+    var showingDeleteConfirmation = false
+    var errorMessage: String?
+
+    /// Whether an error alert should be presented.
+    var showError: Bool { errorMessage != nil }
+
+    /// Clears the current error message, dismissing the alert.
+    func dismissError() { errorMessage = nil }
+
+    init(repository: CategoryRepository) {
+        self.repository = repository
+    }
+
+    // MARK: - Load
+
+    func loadCategories() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            categories = try await repository.getCategories()
+            Self.logger.info("Loaded \(self.categories.count, privacy: .public) categories")
+        } catch {
+            errorMessage = String(localized: "Failed to load categories. Please try again.")
+            Self.logger.error("Categories load failed: \(error.localizedDescription, privacy: .public)")
+            categories = []
+        }
+    }
+
+    // MARK: - Create
+
+    func createCategory(name: String, colorHex: String, icon: String) async -> Bool {
+        guard validateName(name) else { return false }
+
+        let category = CategoryItem(
+            name: name,
+            colorHex: colorHex,
+            icon: icon,
+            sortOrder: categories.count
+        )
+
+        do {
+            try await repository.createCategory(category)
+            categories.append(category)
+            Self.logger.info("Category created: \(category.id, privacy: .private)")
+            return true
+        } catch {
+            errorMessage = String(localized: "Failed to create category. Please try again.")
+            Self.logger.error("Category creation failed: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+    }
+
+    // MARK: - Update
+
+    func updateCategory(id: String, name: String, colorHex: String, icon: String) async -> Bool {
+        guard validateName(name) else { return false }
+
+        guard let existing = categories.first(where: { $0.id == id }) else {
+            errorMessage = String(localized: "Category not found.")
+            return false
+        }
+
+        let updated = CategoryItem(
+            id: existing.id,
+            name: name,
+            colorHex: colorHex,
+            icon: icon,
+            sortOrder: existing.sortOrder
+        )
+
+        do {
+            try await repository.updateCategory(updated)
+            if let index = categories.firstIndex(where: { $0.id == id }) {
+                categories[index] = updated
+            }
+            Self.logger.info("Category updated: \(updated.id, privacy: .private)")
+            return true
+        } catch {
+            errorMessage = String(localized: "Failed to update category. Please try again.")
+            Self.logger.error("Category update failed: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+    }
+
+    // MARK: - Delete
+
+    func confirmDelete(_ category: CategoryItem) {
+        categoryToDelete = category
+        showingDeleteConfirmation = true
+    }
+
+    func deleteCategory() async {
+        guard let category = categoryToDelete else { return }
+
+        do {
+            try await repository.deleteCategory(id: category.id)
+            categories.removeAll { $0.id == category.id }
+            Self.logger.info("Category deleted: \(category.id, privacy: .private)")
+        } catch {
+            errorMessage = String(localized: "Failed to delete category. Please try again.")
+            Self.logger.error("Category deletion failed: \(error.localizedDescription, privacy: .public)")
+        }
+
+        categoryToDelete = nil
+        showingDeleteConfirmation = false
+    }
+
+    func cancelDelete() {
+        categoryToDelete = nil
+        showingDeleteConfirmation = false
+    }
+
+    // MARK: - Validation
+
+    private func validateName(_ name: String) -> Bool {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            errorMessage = String(localized: "Category name cannot be empty.")
+            return false
+        }
+        return true
+    }
+}

--- a/apps/ios/Tests/CategoryListViewModelTests.swift
+++ b/apps/ios/Tests/CategoryListViewModelTests.swift
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// CategoryListViewModelTests.swift
+// FinanceTests
+//
+// Tests for CategoryListViewModel — loading, create, update, delete,
+// and error handling.
+
+import XCTest
+@testable import FinanceApp
+
+final class CategoryListViewModelTests: XCTestCase {
+
+    // MARK: - Test: loadCategories populates list
+
+    @MainActor
+    func testLoadCategoriesPopulatesList() async {
+        let repo = StubCategoryRepository()
+        repo.categoriesToReturn = SampleData.allCategories
+        let vm = CategoryListViewModel(repository: repo)
+
+        await vm.loadCategories()
+
+        XCTAssertEqual(vm.categories.count, SampleData.allCategories.count,
+                       "Should load all categories from the repository")
+        XCTAssertFalse(vm.isLoading, "isLoading should be false after loading")
+    }
+
+    // MARK: - Test: error clears categories
+
+    @MainActor
+    func testErrorHandlingClearsCategories() async {
+        let repo = StubCategoryRepository()
+        repo.errorToThrow = TestError.simulated
+        let vm = CategoryListViewModel(repository: repo)
+
+        await vm.loadCategories()
+
+        XCTAssertTrue(vm.categories.isEmpty,
+                      "Categories should be empty when repository throws")
+        XCTAssertFalse(vm.isLoading, "isLoading should be false after error")
+        XCTAssertNotNil(vm.errorMessage, "Error message should be set")
+    }
+
+    // MARK: - Test: create category succeeds
+
+    @MainActor
+    func testCreateCategorySucceeds() async {
+        let repo = StubCategoryRepository()
+        let vm = CategoryListViewModel(repository: repo)
+
+        let result = await vm.createCategory(
+            name: "Travel",
+            colorHex: "#3182CE",
+            icon: "airplane"
+        )
+
+        XCTAssertTrue(result, "Create should succeed with valid data")
+        XCTAssertEqual(repo.createdCategories.count, 1,
+                       "Repository should have one created category")
+        XCTAssertEqual(repo.createdCategories.first?.name, "Travel",
+                       "Created category name should match")
+        XCTAssertEqual(vm.categories.count, 1,
+                       "ViewModel should have one category after creation")
+    }
+
+    // MARK: - Test: create fails with empty name
+
+    @MainActor
+    func testCreateCategoryFailsWithEmptyName() async {
+        let repo = StubCategoryRepository()
+        let vm = CategoryListViewModel(repository: repo)
+
+        let result = await vm.createCategory(
+            name: "   ",
+            colorHex: "#3182CE",
+            icon: "airplane"
+        )
+
+        XCTAssertFalse(result, "Create should fail with empty name")
+        XCTAssertNotNil(vm.errorMessage, "Error message should be set")
+        XCTAssertTrue(repo.createdCategories.isEmpty,
+                      "Repository should not be called when validation fails")
+    }
+
+    // MARK: - Test: update category succeeds
+
+    @MainActor
+    func testUpdateCategorySucceeds() async {
+        let repo = StubCategoryRepository()
+        let existing = SampleData.groceriesCategory
+        let vm = CategoryListViewModel(repository: repo)
+        vm.categories = [existing]
+
+        let result = await vm.updateCategory(
+            id: existing.id,
+            name: "Food & Groceries",
+            colorHex: "#38A169",
+            icon: "cart"
+        )
+
+        XCTAssertTrue(result, "Update should succeed with valid data")
+        XCTAssertEqual(repo.updatedCategories.count, 1,
+                       "Repository should have one updated category")
+        XCTAssertEqual(vm.categories.first?.name, "Food & Groceries",
+                       "Category name should be updated in local state")
+    }
+
+    // MARK: - Test: update fails for unknown category
+
+    @MainActor
+    func testUpdateCategoryFailsForUnknownId() async {
+        let repo = StubCategoryRepository()
+        let vm = CategoryListViewModel(repository: repo)
+
+        let result = await vm.updateCategory(
+            id: "unknown-id",
+            name: "Test",
+            colorHex: "#3182CE",
+            icon: "cart"
+        )
+
+        XCTAssertFalse(result, "Update should fail for unknown category ID")
+        XCTAssertNotNil(vm.errorMessage, "Error message should be set")
+    }
+
+    // MARK: - Test: delete category
+
+    @MainActor
+    func testDeleteCategoryRemovesFromList() async {
+        let repo = StubCategoryRepository()
+        let existing = SampleData.groceriesCategory
+        let vm = CategoryListViewModel(repository: repo)
+        vm.categories = [existing]
+        vm.categoryToDelete = existing
+
+        await vm.deleteCategory()
+
+        XCTAssertTrue(vm.categories.isEmpty,
+                      "Category should be removed from local state")
+        XCTAssertEqual(repo.deletedCategoryIds.count, 1,
+                       "Repository should have one deleted category")
+        XCTAssertEqual(repo.deletedCategoryIds.first, existing.id,
+                       "Deleted ID should match")
+        XCTAssertFalse(vm.showingDeleteConfirmation,
+                       "Delete confirmation should be dismissed")
+    }
+
+    // MARK: - Test: delete handles repository error
+
+    @MainActor
+    func testDeleteCategoryHandlesError() async {
+        let repo = StubCategoryRepository()
+        repo.errorToThrow = TestError.simulated
+        let existing = SampleData.groceriesCategory
+        let vm = CategoryListViewModel(repository: repo)
+        vm.categories = [existing]
+        vm.categoryToDelete = existing
+
+        await vm.deleteCategory()
+
+        XCTAssertNotNil(vm.errorMessage, "Error message should be set on failure")
+    }
+
+    // MARK: - Test: confirmDelete sets state
+
+    @MainActor
+    func testConfirmDeleteSetsState() {
+        let repo = StubCategoryRepository()
+        let vm = CategoryListViewModel(repository: repo)
+        let category = SampleData.groceriesCategory
+
+        vm.confirmDelete(category)
+
+        XCTAssertEqual(vm.categoryToDelete?.id, category.id,
+                       "categoryToDelete should be set")
+        XCTAssertTrue(vm.showingDeleteConfirmation,
+                      "showingDeleteConfirmation should be true")
+    }
+
+    // MARK: - Test: cancelDelete resets state
+
+    @MainActor
+    func testCancelDeleteResetsState() {
+        let repo = StubCategoryRepository()
+        let vm = CategoryListViewModel(repository: repo)
+
+        vm.categoryToDelete = SampleData.groceriesCategory
+        vm.showingDeleteConfirmation = true
+
+        vm.cancelDelete()
+
+        XCTAssertNil(vm.categoryToDelete, "categoryToDelete should be nil")
+        XCTAssertFalse(vm.showingDeleteConfirmation,
+                       "showingDeleteConfirmation should be false")
+    }
+
+    // MARK: - Test: dismissError clears message
+
+    @MainActor
+    func testDismissErrorClearsMessage() {
+        let repo = StubCategoryRepository()
+        let vm = CategoryListViewModel(repository: repo)
+
+        vm.errorMessage = "Test error"
+        XCTAssertTrue(vm.showError)
+
+        vm.dismissError()
+
+        XCTAssertNil(vm.errorMessage)
+        XCTAssertFalse(vm.showError)
+    }
+}

--- a/apps/ios/Tests/TestHelpers.swift
+++ b/apps/ios/Tests/TestHelpers.swift
@@ -157,6 +157,43 @@ final class StubGoalRepository: GoalRepository, @unchecked Sendable {
     }
 }
 
+
+// MARK: - Stub Category Repository
+
+/// Configurable stub that returns pre-set categories or throws on demand.
+final class StubCategoryRepository: CategoryRepository, @unchecked Sendable {
+    var categoriesToReturn: [CategoryItem] = []
+    var errorToThrow: Error?
+    private(set) var createdCategories: [CategoryItem] = []
+    private(set) var updatedCategories: [CategoryItem] = []
+    private(set) var deletedCategoryIds: [String] = []
+
+    func getCategories() async throws -> [CategoryItem] {
+        if let error = errorToThrow { throw error }
+        return categoriesToReturn
+    }
+
+    func getCategory(id: String) async throws -> CategoryItem? {
+        if let error = errorToThrow { throw error }
+        return categoriesToReturn.first { $0.id == id }
+    }
+
+    func createCategory(_ category: CategoryItem) async throws {
+        if let error = errorToThrow { throw error }
+        createdCategories.append(category)
+    }
+
+    func updateCategory(_ category: CategoryItem) async throws {
+        if let error = errorToThrow { throw error }
+        updatedCategories.append(category)
+    }
+
+    func deleteCategory(id: String) async throws {
+        if let error = errorToThrow { throw error }
+        deletedCategoryIds.append(id)
+    }
+}
+
 // MARK: - Stub Biometric Auth Manager
 
 /// Configurable stub for biometric authentication in tests.
@@ -316,4 +353,25 @@ enum SampleData {
     )
 
     static let allGoals: [GoalItem] = [activeGoal, completedGoal]
+
+    // MARK: Categories
+
+    static let groceriesCategory = CategoryItem(
+        id: "cat1", name: "Groceries",
+        colorHex: "#38A169", icon: "cart", sortOrder: 0
+    )
+
+    static let diningCategory = CategoryItem(
+        id: "cat2", name: "Dining Out",
+        colorHex: "#DD6B20", icon: "fork.knife", sortOrder: 1
+    )
+
+    static let transportCategory = CategoryItem(
+        id: "cat3", name: "Transport",
+        colorHex: "#3182CE", icon: "car", sortOrder: 2
+    )
+
+    static let allCategories: [CategoryItem] = [
+        groceriesCategory, diningCategory, transportCategory,
+    ]
 }


### PR DESCRIPTION
Implements a complete category management screen for the iOS app with full CRUD operations, color picker, and icon picker.

Closes #681