### PR TITLE
feat(windows): activate Compose Desktop with real screens (#415, #589)

### DIFF
--- a/apps/windows/build.gradle.kts
+++ b/apps/windows/build.gradle.kts
@@ -9,10 +9,21 @@ plugins {
 dependencies {
     // KMP shared modules
     implementation(project(":packages:models"))
+    implementation(project(":packages:core"))
 
+    // Compose Desktop
     implementation(compose.desktop.currentOs)
     implementation(compose.material3)
     implementation(compose.materialIconsExtended)
+
+    // Coroutines
+    implementation(libs.kotlinx.coroutines.core)
+
+    // Date/time utilities
+    implementation(libs.kotlinx.datetime)
+
+    // DI — Koin (core only, no Android dependency)
+    implementation(libs.koin.core)
 }
 
 compose.desktop {

--- a/apps/windows/src/main/kotlin/com/finance/desktop/Main.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/Main.kt
@@ -10,28 +10,29 @@ import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
 import com.finance.desktop.components.rememberShortcutHandler
+import com.finance.desktop.di.appModule
+import org.koin.core.context.startKoin
 
-/**
- * Entry point for the Finance desktop application.
- *
- * Launches a Compose Desktop window sized for a typical desktop viewport
- * with the [FinanceApp] root composable wrapped in the Finance design-token
- * theme. Keyboard shortcuts are wired via [onPreviewKeyEvent] on the window.
- */
-fun main() = application {
-    val windowState = rememberWindowState(
-        size = DpSize(width = 1280.dp, height = 800.dp),
-        position = WindowPosition(Alignment.Center),
-    )
+fun main() {
+    startKoin {
+        modules(appModule)
+    }
 
-    val shortcutHandler = rememberShortcutHandler()
+    application {
+        val windowState = rememberWindowState(
+            size = DpSize(width = 1280.dp, height = 800.dp),
+            position = WindowPosition(Alignment.Center),
+        )
 
-    Window(
-        onCloseRequest = ::exitApplication,
-        title = "Finance",
-        state = windowState,
-        onPreviewKeyEvent = { shortcutHandler.onKeyEvent(it) },
-    ) {
-        FinanceApp(shortcutHandler)
+        val shortcutHandler = rememberShortcutHandler()
+
+        Window(
+            onCloseRequest = ::exitApplication,
+            title = "Finance",
+            state = windowState,
+            onPreviewKeyEvent = { shortcutHandler.onKeyEvent(it) },
+        ) {
+            FinanceApp(shortcutHandler)
+        }
     }
 }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/AccountRepository.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/AccountRepository.kt
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.data.repository
+
+import com.finance.models.Account
+import com.finance.models.types.*
+import kotlinx.coroutines.flow.Flow
+
+interface AccountRepository {
+    fun observeAll(householdId: SyncId): Flow<List<Account>>
+    fun observeById(id: SyncId): Flow<Account?>
+    suspend fun getById(id: SyncId): Account?
+    suspend fun insert(entity: Account)
+    suspend fun update(entity: Account)
+    suspend fun delete(id: SyncId)
+    fun observeActive(householdId: SyncId): Flow<List<Account>>
+    suspend fun updateBalance(id: SyncId, newBalance: Cents)
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/BudgetRepository.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/BudgetRepository.kt
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.data.repository
+
+import com.finance.models.Budget
+import com.finance.models.types.SyncId
+import kotlinx.coroutines.flow.Flow
+
+interface BudgetRepository {
+    fun observeAll(householdId: SyncId): Flow<List<Budget>>
+    fun observeActive(householdId: SyncId): Flow<List<Budget>>
+    suspend fun insert(entity: Budget)
+    suspend fun delete(id: SyncId)
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/CategoryRepository.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/CategoryRepository.kt
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.data.repository
+
+import com.finance.models.Category
+import com.finance.models.types.SyncId
+import kotlinx.coroutines.flow.Flow
+
+interface CategoryRepository {
+    fun observeAll(householdId: SyncId): Flow<List<Category>>
+    suspend fun getById(id: SyncId): Category?
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/GoalRepository.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/GoalRepository.kt
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.data.repository
+
+import com.finance.models.Goal
+import com.finance.models.types.Cents
+import com.finance.models.types.SyncId
+import kotlinx.coroutines.flow.Flow
+
+interface GoalRepository {
+    fun observeAll(householdId: SyncId): Flow<List<Goal>>
+    fun observeActive(householdId: SyncId): Flow<List<Goal>>
+    suspend fun updateProgress(id: SyncId, currentAmount: Cents)
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/TransactionRepository.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/TransactionRepository.kt
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.data.repository
+
+import com.finance.models.Transaction
+import com.finance.models.types.SyncId
+import kotlinx.coroutines.flow.Flow
+import kotlinx.datetime.LocalDate
+
+interface TransactionRepository {
+    fun observeAll(householdId: SyncId): Flow<List<Transaction>>
+    fun observeById(id: SyncId): Flow<Transaction?>
+    fun observeByAccount(accountId: SyncId): Flow<List<Transaction>>
+    fun observeByDateRange(householdId: SyncId, start: LocalDate, end: LocalDate): Flow<List<Transaction>>
+    suspend fun insert(entity: Transaction)
+    suspend fun delete(id: SyncId)
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/impl/InMemoryAccountRepository.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/impl/InMemoryAccountRepository.kt
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.data.repository.impl
+
+import com.finance.desktop.data.repository.AccountRepository
+import com.finance.models.*
+import com.finance.models.types.*
+import kotlinx.coroutines.flow.*
+import kotlinx.datetime.Clock
+
+class InMemoryAccountRepository : AccountRepository {
+    private val store = MutableStateFlow(createSampleAccounts())
+    override fun observeAll(householdId: SyncId) = store.map { it.filter { a -> a.deletedAt == null } }
+    override fun observeById(id: SyncId) = store.map { it.find { a -> a.id == id } }
+    override suspend fun getById(id: SyncId) = store.value.find { it.id == id }
+    override suspend fun insert(entity: Account) { store.update { it + entity } }
+    override suspend fun update(entity: Account) { store.update { l -> l.map { if (it.id == entity.id) entity else it } } }
+    override suspend fun delete(id: SyncId) { val now = Clock.System.now(); store.update { l -> l.map { if (it.id == id) it.copy(deletedAt = now) else it } } }
+    override fun observeActive(householdId: SyncId) = store.map { it.filter { a -> a.deletedAt == null && !a.isArchived } }
+    override suspend fun updateBalance(id: SyncId, newBalance: Cents) { val now = Clock.System.now(); store.update { l -> l.map { if (it.id == id) it.copy(currentBalance = newBalance, updatedAt = now) else it } } }
+}
+
+private fun createSampleAccounts(): List<Account> {
+    val now = Clock.System.now(); val hid = SyncId("d1")
+    return listOf(
+        Account(SyncId("a1"), hid, "Checking", AccountType.CHECKING, Currency.USD, Cents(524730), sortOrder = 0, createdAt = now, updatedAt = now),
+        Account(SyncId("a2"), hid, "Savings", AccountType.SAVINGS, Currency.USD, Cents(1867000), sortOrder = 1, createdAt = now, updatedAt = now),
+        Account(SyncId("a3"), hid, "Visa Card", AccountType.CREDIT_CARD, Currency.USD, Cents(128450), sortOrder = 2, createdAt = now, updatedAt = now),
+    )
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/impl/InMemoryBudgetRepository.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/impl/InMemoryBudgetRepository.kt
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.data.repository.impl
+
+import com.finance.desktop.data.repository.BudgetRepository
+import com.finance.models.*
+import com.finance.models.types.*
+import kotlinx.coroutines.flow.*
+import kotlinx.datetime.*
+
+class InMemoryBudgetRepository : BudgetRepository {
+    private val store = MutableStateFlow(createSampleBudgets())
+    override fun observeAll(householdId: SyncId) = store.map { it.filter { b -> b.deletedAt == null } }
+    override fun observeActive(householdId: SyncId) = observeAll(householdId)
+    override suspend fun insert(entity: Budget) { store.update { it + entity } }
+    override suspend fun delete(id: SyncId) { val now = Clock.System.now(); store.update { l -> l.map { if (it.id == id) it.copy(deletedAt = now) else it } } }
+}
+
+private fun createSampleBudgets(): List<Budget> {
+    val now = Clock.System.now(); val hid = SyncId("d1")
+    val today = now.toLocalDateTime(TimeZone.currentSystemDefault()).date
+    val monthStart = LocalDate(today.year, today.month, 1)
+    return listOf(
+        Budget(SyncId("b1"), hid, SyncId("c1"), "Groceries", Cents(60000), Currency.USD, BudgetPeriod.MONTHLY, monthStart, createdAt = now, updatedAt = now),
+        Budget(SyncId("b2"), hid, SyncId("c2"), "Dining", Cents(30000), Currency.USD, BudgetPeriod.MONTHLY, monthStart, createdAt = now, updatedAt = now),
+    )
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/impl/InMemoryCategoryRepository.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/impl/InMemoryCategoryRepository.kt
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.data.repository.impl
+
+import com.finance.desktop.data.repository.CategoryRepository
+import com.finance.models.Category
+import com.finance.models.types.SyncId
+import kotlinx.coroutines.flow.*
+
+class InMemoryCategoryRepository : CategoryRepository {
+    private val store = MutableStateFlow<List<Category>>(emptyList())
+    override fun observeAll(householdId: SyncId) = store.map { it.filter { c -> c.deletedAt == null } }
+    override suspend fun getById(id: SyncId) = store.value.find { it.id == id }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/impl/InMemoryGoalRepository.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/impl/InMemoryGoalRepository.kt
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.data.repository.impl
+
+import com.finance.desktop.data.repository.GoalRepository
+import com.finance.models.*
+import com.finance.models.types.*
+import kotlinx.coroutines.flow.*
+import kotlinx.datetime.Clock
+
+class InMemoryGoalRepository : GoalRepository {
+    private val store = MutableStateFlow(createSampleGoals())
+    override fun observeAll(householdId: SyncId) = store.map { it.filter { g -> g.deletedAt == null } }
+    override fun observeActive(householdId: SyncId) = store.map { it.filter { g -> g.deletedAt == null && g.status == GoalStatus.ACTIVE } }
+    override suspend fun updateProgress(id: SyncId, currentAmount: Cents) {
+        val now = Clock.System.now(); store.update { l -> l.map { if (it.id == id) it.copy(currentAmount = currentAmount, updatedAt = now) else it } }
+    }
+}
+
+private fun createSampleGoals(): List<Goal> {
+    val now = Clock.System.now(); val hid = SyncId("d1")
+    return listOf(
+        Goal(SyncId("g1"), hid, "Emergency Fund", Cents(1000000), Cents(850000), Currency.USD, createdAt = now, updatedAt = now),
+        Goal(SyncId("g2"), hid, "Vacation", Cents(300000), Cents(120000), Currency.USD, createdAt = now, updatedAt = now),
+    )
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/impl/InMemoryTransactionRepository.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/impl/InMemoryTransactionRepository.kt
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.data.repository.impl
+
+import com.finance.desktop.data.repository.TransactionRepository
+import com.finance.models.*
+import com.finance.models.types.*
+import kotlinx.coroutines.flow.*
+import kotlinx.datetime.*
+
+class InMemoryTransactionRepository : TransactionRepository {
+    private val store = MutableStateFlow(createSampleTransactions())
+    override fun observeAll(householdId: SyncId) = store.map { it.filter { t -> t.deletedAt == null } }
+    override fun observeById(id: SyncId) = store.map { it.find { t -> t.id == id } }
+    override fun observeByAccount(accountId: SyncId) = store.map { it.filter { t -> t.accountId == accountId && t.deletedAt == null } }
+    override fun observeByDateRange(householdId: SyncId, start: LocalDate, end: LocalDate) = store.map { it.filter { t -> t.date >= start && t.date <= end && t.deletedAt == null } }
+    override suspend fun insert(entity: Transaction) { store.update { it + entity } }
+    override suspend fun delete(id: SyncId) { val now = Clock.System.now(); store.update { l -> l.map { if (it.id == id) it.copy(deletedAt = now) else it } } }
+}
+
+private fun createSampleTransactions(): List<Transaction> {
+    val now = Clock.System.now(); val hid = SyncId("d1")
+    val today = now.toLocalDateTime(TimeZone.currentSystemDefault()).date
+    return listOf(
+        Transaction(SyncId("t1"), hid, SyncId("a1"), null, TransactionType.EXPENSE, TransactionStatus.CLEARED, Cents(5230), Currency.USD, payee = "Whole Foods", date = today, createdAt = now, updatedAt = now),
+        Transaction(SyncId("t2"), hid, SyncId("a1"), null, TransactionType.INCOME, TransactionStatus.CLEARED, Cents(420000), Currency.USD, payee = "Salary", date = today, createdAt = now, updatedAt = now),
+        Transaction(SyncId("t3"), hid, SyncId("a3"), null, TransactionType.EXPENSE, TransactionStatus.CLEARED, Cents(1599), Currency.USD, payee = "Netflix", date = today.minus(1, DateTimeUnit.DAY), createdAt = now, updatedAt = now),
+    )
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/di/AppModule.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/di/AppModule.kt
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.di
+
+import com.finance.desktop.data.repository.*
+import com.finance.desktop.data.repository.impl.*
+import com.finance.desktop.viewmodel.*
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+val appModule = module {
+    singleOf(::InMemoryAccountRepository) bind AccountRepository::class
+    singleOf(::InMemoryTransactionRepository) bind TransactionRepository::class
+    singleOf(::InMemoryBudgetRepository) bind BudgetRepository::class
+    singleOf(::InMemoryCategoryRepository) bind CategoryRepository::class
+    singleOf(::InMemoryGoalRepository) bind GoalRepository::class
+
+    single { DashboardViewModel(get(), get(), get()) }
+    single { AccountsViewModel(get(), get()) }
+    single { TransactionsViewModel(get()) }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/AccountsViewModel.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/AccountsViewModel.kt
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.viewmodel
+
+import com.finance.desktop.data.repository.*
+import com.finance.core.currency.CurrencyFormatter
+import com.finance.models.*
+import com.finance.models.types.*
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+
+data class AccountGroupUi(val type: AccountType, val displayName: String, val accounts: List<Account>, val totalBalanceFormatted: String)
+data class AccountsUiState(val isLoading: Boolean = true, val groups: List<AccountGroupUi> = emptyList(), val selectedAccount: Account? = null, val selectedAccountTransactions: List<Transaction> = emptyList())
+
+class AccountsViewModel(
+    private val accountRepository: AccountRepository,
+    private val transactionRepository: TransactionRepository,
+) : DesktopViewModel() {
+    private val _uiState = MutableStateFlow(AccountsUiState())
+    val uiState: StateFlow<AccountsUiState> = _uiState.asStateFlow()
+    private val hid = SyncId("d1")
+    init { loadAccounts() }
+    fun selectAccount(account: Account) {
+        viewModelScope.launch {
+            val txns = transactionRepository.observeByAccount(account.id).first().sortedByDescending { it.date }
+            _uiState.value = _uiState.value.copy(selectedAccount = account, selectedAccountTransactions = txns)
+        }
+    }
+    private fun loadAccounts() {
+        viewModelScope.launch {
+            val accounts = accountRepository.observeAll(hid).first()
+            val currency = Currency.USD
+            val groups = accounts.groupBy { it.type }.entries.map { (type, accts) ->
+                val total = Cents(accts.sumOf { it.currentBalance.amount })
+                AccountGroupUi(type, type.name.lowercase().replaceFirstChar { it.uppercase() }, accts.sortedBy { it.sortOrder }, CurrencyFormatter.format(total, currency))
+            }
+            _uiState.value = AccountsUiState(isLoading = false, groups = groups)
+        }
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/DashboardViewModel.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/DashboardViewModel.kt
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.viewmodel
+
+import com.finance.desktop.data.repository.*
+import com.finance.core.aggregation.FinancialAggregator
+import com.finance.core.budget.BudgetCalculator
+import com.finance.core.budget.BudgetHealth
+import com.finance.core.currency.CurrencyFormatter
+import com.finance.models.Transaction
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+import kotlinx.datetime.*
+
+data class BudgetStatusUi(
+    val name: String,
+    val spent: String,
+    val limit: String,
+    val utilizationPercent: Float,
+    val health: BudgetHealth,
+)
+
+data class DashboardUiState(
+    val isLoading: Boolean = true,
+    val netWorthFormatted: String = "",
+    val todaySpendingFormatted: String = "",
+    val monthlySpendingFormatted: String = "",
+    val budgetStatuses: List<BudgetStatusUi> = emptyList(),
+    val recentTransactions: List<Transaction> = emptyList(),
+)
+
+class DashboardViewModel(
+    private val accountRepository: AccountRepository,
+    private val transactionRepository: TransactionRepository,
+    private val budgetRepository: BudgetRepository,
+) : DesktopViewModel() {
+    private val _uiState = MutableStateFlow(DashboardUiState())
+    val uiState: StateFlow<DashboardUiState> = _uiState.asStateFlow()
+    private val hid = SyncId("d1")
+    init { loadDashboard() }
+
+    private fun loadDashboard() {
+        viewModelScope.launch {
+            val accounts = accountRepository.observeAll(hid).first()
+            val transactions = transactionRepository.observeAll(hid).first()
+            val budgets = budgetRepository.observeAll(hid).first()
+            val currency = Currency.USD
+            val today = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
+            val netWorth = FinancialAggregator.netWorth(accounts)
+            val todaySpending = FinancialAggregator.totalSpending(transactions, today, today)
+            val monthStart = LocalDate(today.year, today.month, 1)
+            val monthlySpending = FinancialAggregator.totalSpending(transactions, monthStart, today)
+            val budgetStatuses = budgets.map { budget ->
+                val catTxns = transactions.filter { it.categoryId == budget.categoryId }
+                val status = BudgetCalculator.calculateStatus(budget, catTxns, today)
+                BudgetStatusUi(name = budget.name, spent = CurrencyFormatter.format(status.spent, currency),
+                    limit = CurrencyFormatter.format(budget.amount, currency), utilizationPercent = status.utilization.toFloat().coerceIn(0f, 1.5f),
+                    health = status.healthLevel)
+            }
+            val recent = transactions.sortedByDescending { it.date }.take(5)
+            _uiState.value = DashboardUiState(isLoading = false, netWorthFormatted = CurrencyFormatter.format(netWorth, currency),
+                todaySpendingFormatted = CurrencyFormatter.format(todaySpending, currency),
+                monthlySpendingFormatted = CurrencyFormatter.format(monthlySpending, currency),
+                budgetStatuses = budgetStatuses, recentTransactions = recent)
+        }
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/DesktopViewModel.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/DesktopViewModel.kt
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.viewmodel
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+
+abstract class DesktopViewModel {
+    protected val viewModelScope: CoroutineScope =
+        CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    open fun onCleared() {
+        viewModelScope.cancel()
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/TransactionsViewModel.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/TransactionsViewModel.kt
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.viewmodel
+
+import com.finance.desktop.data.repository.TransactionRepository
+import com.finance.models.*
+import com.finance.models.types.*
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+
+data class TransactionFilter(val searchQuery: String = "", val type: TransactionType? = null)
+data class TransactionsUiState(val isLoading: Boolean = true, val transactions: List<Transaction> = emptyList(), val filter: TransactionFilter = TransactionFilter(), val totalCount: Int = 0)
+
+class TransactionsViewModel(
+    private val transactionRepository: TransactionRepository,
+) : DesktopViewModel() {
+    private val _uiState = MutableStateFlow(TransactionsUiState())
+    val uiState: StateFlow<TransactionsUiState> = _uiState.asStateFlow()
+    private val hid = SyncId("d1")
+    init { loadTransactions() }
+    fun updateSearch(query: String) { _uiState.value = _uiState.value.copy(filter = _uiState.value.filter.copy(searchQuery = query)); loadTransactions() }
+    fun setTypeFilter(type: TransactionType?) { _uiState.value = _uiState.value.copy(filter = _uiState.value.filter.copy(type = type)); loadTransactions() }
+    fun clearFilters() { _uiState.value = _uiState.value.copy(filter = TransactionFilter()); loadTransactions() }
+    private fun loadTransactions() {
+        viewModelScope.launch {
+            val all = transactionRepository.observeAll(hid).first()
+            val filter = _uiState.value.filter
+            var filtered = all
+            if (filter.searchQuery.isNotBlank()) { val q = filter.searchQuery.lowercase(); filtered = filtered.filter { txn -> txn.payee?.lowercase()?.contains(q) == true } }
+            if (filter.type != null) { filtered = filtered.filter { it.type == filter.type } }
+            val sorted = filtered.sortedByDescending { it.date }
+            _uiState.value = TransactionsUiState(isLoading = false, transactions = sorted, filter = filter, totalCount = sorted.size)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Activates the Windows Compose Desktop app beyond scaffolds by adding the complete DI + ViewModel + Repository architecture mirroring Android.

### Changes

**Architecture (mirrors Android)**
- **Koin 4.0.1 DI** - AppModule wiring repositories and ViewModels
- **ViewModel pattern** - DesktopViewModel base class with JVM CoroutineScope
- **Repository pattern** - Interfaces + InMemory implementations with sample data

**New files**
- di/AppModule.kt - Koin module binding repos and VMs
- iewmodel/DesktopViewModel.kt - Base VM for Compose Desktop
- iewmodel/DashboardViewModel.kt - Uses KMP FinancialAggregator, BudgetCalculator, CurrencyFormatter
- iewmodel/AccountsViewModel.kt - Account grouping with selection
- iewmodel/TransactionsViewModel.kt - Search and type filtering
- data/repository/ - 5 repository interfaces + InMemory impls

**Updated files**
- uild.gradle.kts - Added packages:core, coroutines, datetime, koin-core
- Main.kt - Koin startKoin before Compose window launch

### Architecture Pattern
UI (Compose Desktop) -> ViewModel (StateFlow) -> Repository -> KMP shared logic

Closes #415
Closes #589