### PR TITLE
feat(android): consolidate bottom navigation to 4 tabs (#520)

### DIFF
--- a/apps/android/src/androidTest/kotlin/com/finance/android/e2e/AccountCreationE2ETest.kt
+++ b/apps/android/src/androidTest/kotlin/com/finance/android/e2e/AccountCreationE2ETest.kt
@@ -13,8 +13,8 @@ import com.finance.android.e2e.robot.NavigationRobot
 /**
  * E2E tests for the account creation flow.
  *
- * Exercises the full journey: navigate to Accounts -> tap FAB ->
- * fill form -> save -> verify account appears in the list.
+ * Exercises the full journey: Dashboard net-worth card -> Accounts ->
+ * tap FAB -> fill form -> save -> verify account appears in the list.
  */
 class AccountCreationE2ETest : BaseE2ETest() {
 
@@ -24,12 +24,11 @@ class AccountCreationE2ETest : BaseE2ETest() {
      */
     @Test
     fun tapFab_opensAccountCreationForm() {
-        val nav = NavigationRobot(composeTestRule)
         val dash = DashboardRobot(composeTestRule)
         val acct = AccountRobot(composeTestRule)
 
         dash.waitForDashboardLoaded()
-        nav.navigateToAccounts()
+        dash.tapNetWorthCard()
         acct.tapAddAccountFab()
         acct.assertCreateFormVisible()
     }
@@ -40,12 +39,11 @@ class AccountCreationE2ETest : BaseE2ETest() {
      */
     @Test
     fun createAccount_withValidData_showsInList() {
-        val nav = NavigationRobot(composeTestRule)
         val dash = DashboardRobot(composeTestRule)
         val acct = AccountRobot(composeTestRule)
 
         dash.waitForDashboardLoaded()
-        nav.navigateToAccounts()
+        dash.tapNetWorthCard()
         acct.tapAddAccountFab()
         acct.assertCreateFormVisible()
 
@@ -63,12 +61,11 @@ class AccountCreationE2ETest : BaseE2ETest() {
      */
     @Test
     fun accountCreationForm_showsTypeDropdown() {
-        val nav = NavigationRobot(composeTestRule)
         val dash = DashboardRobot(composeTestRule)
         val acct = AccountRobot(composeTestRule)
 
         dash.waitForDashboardLoaded()
-        nav.navigateToAccounts()
+        dash.tapNetWorthCard()
         acct.tapAddAccountFab()
         acct.assertAccountTypeDropdownVisible()
     }
@@ -78,11 +75,10 @@ class AccountCreationE2ETest : BaseE2ETest() {
      */
     @Test
     fun accountCreationForm_saveButton_hasAccessibilityLabel() {
-        val nav = NavigationRobot(composeTestRule)
         val dash = DashboardRobot(composeTestRule)
 
         dash.waitForDashboardLoaded()
-        nav.navigateToAccounts()
+        dash.tapNetWorthCard()
         AccountRobot(composeTestRule).tapAddAccountFab()
         composeTestRule.onNodeWithContentDescription("Save account")
             .assertIsDisplayed()

--- a/apps/android/src/androidTest/kotlin/com/finance/android/e2e/NavigationE2ETest.kt
+++ b/apps/android/src/androidTest/kotlin/com/finance/android/e2e/NavigationE2ETest.kt
@@ -4,6 +4,7 @@ package com.finance.android.e2e
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
 import org.junit.Test
 import com.finance.android.e2e.robot.DashboardRobot
 import com.finance.android.e2e.robot.NavigationRobot
@@ -18,7 +19,7 @@ import com.finance.android.e2e.robot.NavigationRobot
 class NavigationE2ETest : BaseE2ETest() {
 
     /**
-     * Verify all five bottom-nav items are rendered on launch.
+     * Verify all four bottom-nav items are rendered on launch.
      */
     @Test
     fun bottomNav_allItemsVisible() {
@@ -29,14 +30,14 @@ class NavigationE2ETest : BaseE2ETest() {
     }
 
     /**
-     * Verify navigating to Accounts displays the Accounts screen.
+     * Verify navigating to Accounts via the Net Worth card on Dashboard.
      */
     @Test
-    fun navigateToAccounts_displaysAccountsScreen() {
+    fun tapNetWorthCard_displaysAccountsScreen() {
         val nav = NavigationRobot(composeTestRule)
         val dash = DashboardRobot(composeTestRule)
         dash.waitForDashboardLoaded()
-        nav.navigateToAccounts()
+        dash.tapNetWorthCard()
         composeTestRule.onNodeWithContentDescription("Add new account")
             .assertIsDisplayed()
     }
@@ -54,39 +55,40 @@ class NavigationE2ETest : BaseE2ETest() {
     }
 
     /**
-     * Verify navigating to Budgets tab displays the Budgets screen.
+     * Verify navigating to Planning tab displays the Budgets/Goals tabs.
      */
     @Test
-    fun navigateToBudgets_displaysBudgetsScreen() {
+    fun navigateToPlanning_displaysPlanningScreen() {
         val nav = NavigationRobot(composeTestRule)
         val dash = DashboardRobot(composeTestRule)
         dash.waitForDashboardLoaded()
-        nav.navigateToBudgets()
+        nav.navigateToPlanning()
+        composeTestRule.onNodeWithText("Budgets").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Goals").assertIsDisplayed()
+    }
+
+    /**
+     * Verify navigating to Settings tab displays the Settings screen.
+     */
+    @Test
+    fun navigateToSettings_displaysSettingsScreen() {
+        val nav = NavigationRobot(composeTestRule)
+        val dash = DashboardRobot(composeTestRule)
+        dash.waitForDashboardLoaded()
+        nav.navigateToSettings()
         composeTestRule.waitForIdle()
     }
 
     /**
-     * Verify navigating to Goals tab displays the Goals screen.
-     */
-    @Test
-    fun navigateToGoals_displaysGoalsScreen() {
-        val nav = NavigationRobot(composeTestRule)
-        val dash = DashboardRobot(composeTestRule)
-        dash.waitForDashboardLoaded()
-        nav.navigateToGoals()
-        composeTestRule.waitForIdle()
-    }
-
-    /**
-     * Verify a full round-trip: Dashboard -> Accounts -> Dashboard.
+     * Verify a full round-trip: Dashboard -> Planning -> Dashboard.
      * Ensures back-stack management preserves the Dashboard state.
      */
     @Test
-    fun roundTrip_dashboardToAccountsAndBack() {
+    fun roundTrip_dashboardToPlanningAndBack() {
         val nav = NavigationRobot(composeTestRule)
         val dash = DashboardRobot(composeTestRule)
         dash.waitForDashboardLoaded()
-        nav.navigateToAccounts()
+        nav.navigateToPlanning()
         composeTestRule.waitForIdle()
         nav.navigateToDashboard()
         dash.waitForDashboardLoaded()

--- a/apps/android/src/androidTest/kotlin/com/finance/android/e2e/robot/DashboardRobot.kt
+++ b/apps/android/src/androidTest/kotlin/com/finance/android/e2e/robot/DashboardRobot.kt
@@ -78,4 +78,11 @@ class DashboardRobot(
             .performClick()
         rule.waitForIdle()
     }
+
+    /** Tap the Net Worth card to navigate to Accounts. */
+    fun tapNetWorthCard() {
+        rule.onNode(hasContentDescription("Net worth", substring = true))
+            .performClick()
+        rule.waitForIdle()
+    }
 }

--- a/apps/android/src/androidTest/kotlin/com/finance/android/e2e/robot/NavigationRobot.kt
+++ b/apps/android/src/androidTest/kotlin/com/finance/android/e2e/robot/NavigationRobot.kt
@@ -27,13 +27,6 @@ class NavigationRobot(
         rule.waitForIdle()
     }
 
-    /** Tap the Accounts bottom-nav item. */
-    fun navigateToAccounts() {
-        rule.onNodeWithContentDescription("Navigate to Accounts")
-            .performClick()
-        rule.waitForIdle()
-    }
-
     /** Tap the Activity (Transactions) bottom-nav item. */
     fun navigateToTransactions() {
         rule.onNodeWithContentDescription("View transaction activity")
@@ -41,16 +34,16 @@ class NavigationRobot(
         rule.waitForIdle()
     }
 
-    /** Tap the Budgets bottom-nav item. */
-    fun navigateToBudgets() {
-        rule.onNodeWithContentDescription("Navigate to Budgets")
+    /** Tap the Planning bottom-nav item. */
+    fun navigateToPlanning() {
+        rule.onNodeWithContentDescription("Navigate to Planning")
             .performClick()
         rule.waitForIdle()
     }
 
-    /** Tap the Goals bottom-nav item. */
-    fun navigateToGoals() {
-        rule.onNodeWithContentDescription("Navigate to Goals")
+    /** Tap the Settings bottom-nav item. */
+    fun navigateToSettings() {
+        rule.onNodeWithContentDescription("Navigate to Settings")
             .performClick()
         rule.waitForIdle()
     }
@@ -60,12 +53,11 @@ class NavigationRobot(
         rule.onNodeWithText(label).assertIsDisplayed()
     }
 
-    /** Assert all five bottom-nav items are present. */
+    /** Assert all four bottom-nav items are present. */
     fun assertAllBottomNavItemsVisible() {
         assertBottomNavItemVisible("Dashboard")
-        assertBottomNavItemVisible("Accounts")
         assertBottomNavItemVisible("Activity")
-        assertBottomNavItemVisible("Budgets")
-        assertBottomNavItemVisible("Goals")
+        assertBottomNavItemVisible("Planning")
+        assertBottomNavItemVisible("Settings")
     }
 }

--- a/apps/android/src/main/kotlin/com/finance/android/MainActivity.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/MainActivity.kt
@@ -195,10 +195,9 @@ private fun AuthenticatedContent(modifier: Modifier = Modifier) {
     // Show bottom bar only on top-level destinations
     val showBottomBar = currentRoute in setOf(
         Route.Dashboard.route,
-        Route.Accounts.route,
         Route.Transactions.route,
-        Route.Budgets.route,
-        Route.Goals.route,
+        Route.Planning.route,
+        Route.Settings.route,
     )
 
     Scaffold(

--- a/apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceBottomBar.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceBottomBar.kt
@@ -3,10 +3,9 @@
 package com.finance.android.ui.navigation
 
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.AccountBalance
-import androidx.compose.material.icons.filled.Flag
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.PieChart
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.SwapHoriz
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
@@ -37,34 +36,28 @@ enum class TopLevelDestination(
         label = "Dashboard",
         a11yDescription = "Navigate to Dashboard",
     ),
-    Accounts(
-        route = Route.Accounts.route,
-        icon = Icons.Filled.AccountBalance,
-        label = "Accounts",
-        a11yDescription = "Navigate to Accounts",
-    ),
     Transactions(
         route = Route.Transactions.route,
         icon = Icons.Filled.SwapHoriz,
         label = "Activity",
         a11yDescription = "View transaction activity",
     ),
-    Budgets(
-        route = Route.Budgets.route,
+    Planning(
+        route = Route.Planning.route,
         icon = Icons.Filled.PieChart,
-        label = "Budgets",
-        a11yDescription = "Navigate to Budgets",
+        label = "Planning",
+        a11yDescription = "Navigate to Planning",
     ),
-    Goals(
-        route = Route.Goals.route,
-        icon = Icons.Filled.Flag,
-        label = "Goals",
-        a11yDescription = "Navigate to Goals",
+    Settings(
+        route = Route.Settings.route,
+        icon = Icons.Filled.Settings,
+        label = "Settings",
+        a11yDescription = "Navigate to Settings",
     ),
 }
 
 /**
- * Material 3 [NavigationBar] with the five primary Finance tabs.
+ * Material 3 [NavigationBar] with the four primary Finance tabs.
  *
  * Each item carries a `contentDescription` for TalkBack and uses the
  * Material 3 selected-state indicator.

--- a/apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceNavHost.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceNavHost.kt
@@ -29,10 +29,9 @@ import com.finance.android.ui.screens.AccountCreateScreen
 import com.finance.android.ui.screens.AccountsScreen
 import com.finance.android.ui.screens.AnalyticsScreen
 import com.finance.android.ui.screens.BudgetCreateScreen
-import com.finance.android.ui.screens.BudgetsScreen
 import com.finance.android.ui.screens.DashboardScreen
 import com.finance.android.ui.screens.GoalCreateScreen
-import com.finance.android.ui.screens.GoalsScreen
+import com.finance.android.ui.screens.PlanningScreen
 import com.finance.android.ui.screens.SettingsScreen
 import com.finance.android.ui.screens.TransactionCreateScreen
 import com.finance.android.ui.screens.TransactionsScreen
@@ -53,6 +52,7 @@ sealed class Route(val route: String) {
     data object Transactions : Route("transactions")
     data object Budgets : Route("budgets")
     data object Goals : Route("goals")
+    data object Planning : Route("planning")
     data object Settings : Route("settings")
     data object AccountDetail : Route("accounts/{id}") {
         fun createRoute(id: String): String = "accounts/$id"
@@ -142,9 +142,45 @@ fun FinanceNavHost(
                         launchSingleTop = true
                     }
                 },
+                onViewAccounts = {
+                    navController.navigate(Route.Accounts.route) {
+                        launchSingleTop = true
+                    }
+                },
             )
         }
 
+        composable(Route.Transactions.route) {
+            TransactionsScreen()
+        }
+
+        composable(Route.Planning.route) {
+            PlanningScreen(
+                onCreateBudget = {
+                    navController.navigate(Route.BudgetCreate.route) {
+                        launchSingleTop = true
+                    }
+                },
+                onCreateGoal = {
+                    navController.navigate(Route.GoalCreate.route) {
+                        launchSingleTop = true
+                    }
+                },
+            )
+        }
+
+        composable(Route.Settings.route) {
+            SettingsScreen(
+                onNavigateBack = { navController.popBackStack() },
+                onNavigateToLogin = {
+                    navController.navigate(Route.Dashboard.route) {
+                        popUpTo(0) { inclusive = true }
+                    }
+                },
+            )
+        }
+
+        // ── Secondary screens ───────────────────────────────────────
         composable(Route.Accounts.route) {
             AccountsScreen(
                 onAccountClick = { id ->
@@ -158,44 +194,8 @@ fun FinanceNavHost(
             )
         }
 
-        composable(Route.Transactions.route) {
-            TransactionsScreen()
-        }
-
-        composable(Route.Budgets.route) {
-            BudgetsScreen(
-                onCreateBudget = {
-                    navController.navigate(Route.BudgetCreate.route) {
-                        launchSingleTop = true
-                    }
-                },
-            )
-        }
-
-        composable(Route.Goals.route) {
-            GoalsScreen(
-                onCreateGoal = {
-                    navController.navigate(Route.GoalCreate.route) {
-                        launchSingleTop = true
-                    }
-                },
-            )
-        }
-
         composable(Route.Analytics.route) {
             AnalyticsScreen()
-        }
-
-        // ── Secondary screens ───────────────────────────────────────
-        composable(Route.Settings.route) {
-            SettingsScreen(
-                onNavigateBack = { navController.popBackStack() },
-                onNavigateToLogin = {
-                    navController.navigate(Route.Dashboard.route) {
-                        popUpTo(0) { inclusive = true }
-                    }
-                },
-            )
         }
 
         composable(

--- a/apps/android/src/main/kotlin/com/finance/android/ui/navigation/TopBarConfig.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/navigation/TopBarConfig.kt
@@ -5,7 +5,6 @@ package com.finance.android.ui.navigation
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -26,6 +25,7 @@ private fun titleForRoute(route: String?): String = when (route) {
     Route.Dashboard.route -> "Dashboard"
     Route.Accounts.route -> "Accounts"
     Route.Transactions.route -> "Transactions"
+    Route.Planning.route -> "Planning"
     Route.Budgets.route -> "Budgets"
     Route.Goals.route -> "Goals"
     Route.Analytics.route -> "Analytics"
@@ -43,10 +43,9 @@ private fun titleForRoute(route: String?): String = when (route) {
  */
 private fun isTopLevel(route: String?): Boolean = route in setOf(
     Route.Dashboard.route,
-    Route.Accounts.route,
     Route.Transactions.route,
-    Route.Budgets.route,
-    Route.Goals.route,
+    Route.Planning.route,
+    Route.Settings.route,
 )
 
 /**
@@ -54,8 +53,7 @@ private fun isTopLevel(route: String?): Boolean = route in setOf(
  *
  * - Title changes based on the current navigation destination.
  * - A back arrow is shown for non-top-level screens.
- * - A Settings gear icon is shown on top-level screens.
- * - A Search icon placeholder is available on Dashboard.
+ * - A Search icon is available on Dashboard (navigates to Transactions).
  *
  * @param navController The [NavHostController] for reading current route and navigation.
  * @param modifier Modifier applied to the [TopAppBar].
@@ -110,23 +108,6 @@ fun FinanceTopBar(
                     Icon(
                         imageVector = Icons.Filled.Search,
                         contentDescription = "Search",
-                    )
-                }
-            }
-            if (topLevel) {
-                IconButton(
-                    onClick = {
-                        navController.navigate(Route.Settings.route) {
-                            launchSingleTop = true
-                        }
-                    },
-                    modifier = Modifier.semantics {
-                        contentDescription = "Open settings"
-                    },
-                ) {
-                    Icon(
-                        imageVector = Icons.Filled.Settings,
-                        contentDescription = "Open settings",
                     )
                 }
             }

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/DashboardScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/DashboardScreen.kt
@@ -80,6 +80,7 @@ fun DashboardScreen(
     onAddTransaction: () -> Unit = {},
     onViewAllTransactions: () -> Unit = {},
     onViewInsights: () -> Unit = {},
+    onViewAccounts: () -> Unit = {},
     modifier: Modifier = Modifier,
     viewModel: DashboardViewModel = koinViewModel(),
 ) {
@@ -91,7 +92,7 @@ fun DashboardScreen(
         }
         return
     }
-    DashboardContent(state, viewModel::refresh, onAddTransaction, onViewAllTransactions, onViewInsights, modifier)
+    DashboardContent(state, viewModel::refresh, onAddTransaction, onViewAllTransactions, onViewInsights, onViewAccounts, modifier)
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -99,14 +100,14 @@ fun DashboardScreen(
 private fun DashboardContent(
     state: DashboardUiState, onRefresh: () -> Unit,
     onAddTransaction: () -> Unit, onViewAllTransactions: () -> Unit,
-    onViewInsights: () -> Unit,
+    onViewInsights: () -> Unit, onViewAccounts: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     PullToRefreshBox(isRefreshing = state.isRefreshing, onRefresh = onRefresh,
         modifier = modifier.fillMaxSize()) {
         LazyColumn(modifier = Modifier.fillMaxSize(), contentPadding = PaddingValues(16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)) {
-            item(key = "net-worth") { NetWorthCard(state.netWorthFormatted) }
+            item(key = "net-worth") { NetWorthCard(state.netWorthFormatted, onClick = onViewAccounts) }
             item(key = "spending") { SpendingSummaryRow(state.todaySpendingFormatted, state.monthlySpendingFormatted) }
             item(key = "insights") { InsightsCard(onViewInsights) }
             if (state.budgetStatuses.isNotEmpty()) {
@@ -138,8 +139,10 @@ private fun DashboardContent(
 }
 
 @Composable
-private fun NetWorthCard(formatted: String) {
-    ElevatedCard(modifier = Modifier.fillMaxWidth().semantics { contentDescription = "Net worth: $formatted" },
+private fun NetWorthCard(formatted: String, onClick: () -> Unit = {}) {
+    ElevatedCard(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth().semantics { contentDescription = "Net worth: $formatted. Tap to view accounts." },
         colors = CardDefaults.elevatedCardColors(containerColor = MaterialTheme.colorScheme.primaryContainer)) {
         Column(Modifier.padding(24.dp), horizontalAlignment = Alignment.CenterHorizontally) {
             Text("Net Worth", style = MaterialTheme.typography.labelLarge,
@@ -309,7 +312,7 @@ private fun DashboardScreenPreview() {
                     BudgetStatusUi("Transport", "$89", "$200", "+$111", 0.45f, BudgetHealth.HEALTHY, null),
                 ),
                 recentTransactions = SampleData.transactions.take(5), currency = Currency.USD),
-            onRefresh = {}, onAddTransaction = {}, onViewAllTransactions = {}, onViewInsights = {})
+            onRefresh = {}, onAddTransaction = {}, onViewAllTransactions = {}, onViewInsights = {}, onViewAccounts = {})
     }
 }
 
@@ -323,7 +326,7 @@ private fun DashboardLoadingPreview() {
                 netWorthFormatted = "$0.00", todaySpendingFormatted = "$0.00",
                 monthlySpendingFormatted = "$0.00", budgetStatuses = emptyList(),
                 recentTransactions = emptyList(), currency = Currency.USD),
-            onRefresh = {}, onAddTransaction = {}, onViewAllTransactions = {}, onViewInsights = {})
+            onRefresh = {}, onAddTransaction = {}, onViewAllTransactions = {}, onViewInsights = {}, onViewAccounts = {})
     }
 }
 
@@ -341,6 +344,6 @@ private fun DashboardOverBudgetPreview() {
                     BudgetStatusUi("Groceries", "$580", "$600", "+$20", 0.97f, BudgetHealth.WARNING, null),
                 ),
                 recentTransactions = SampleData.transactions.take(3), currency = Currency.USD),
-            onRefresh = {}, onAddTransaction = {}, onViewAllTransactions = {}, onViewInsights = {})
+            onRefresh = {}, onAddTransaction = {}, onViewAllTransactions = {}, onViewInsights = {}, onViewAccounts = {})
     }
 }

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/PlanningScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/PlanningScreen.kt
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+
+/**
+ * Composite "Planning" screen that hosts Budgets and Goals behind an
+ * internal [TabRow].
+ *
+ * This replaces the former separate bottom-navigation entries for
+ * Budgets and Goals, consolidating them into a single top-level tab.
+ *
+ * The selected tab index is preserved across configuration changes via
+ * [rememberSaveable]. Child screens ([BudgetsScreen], [GoalsScreen])
+ * retain their own ViewModel state scoped to the [NavBackStackEntry].
+ *
+ * @param onCreateBudget Called when the user taps the FAB on the Budgets tab.
+ * @param onCreateGoal   Called when the user taps the FAB on the Goals tab.
+ * @param modifier       Modifier applied to the root layout.
+ */
+@Composable
+fun PlanningScreen(
+    onCreateBudget: () -> Unit = {},
+    onCreateGoal: () -> Unit = {},
+    modifier: Modifier = Modifier,
+) {
+    var selectedTab by rememberSaveable { mutableIntStateOf(0) }
+
+    Column(modifier = modifier.fillMaxSize()) {
+        TabRow(
+            selectedTabIndex = selectedTab,
+            modifier = Modifier.semantics {
+                contentDescription = "Planning section tabs"
+            },
+        ) {
+            Tab(
+                selected = selectedTab == 0,
+                onClick = { selectedTab = 0 },
+                text = { Text("Budgets") },
+                modifier = Modifier.semantics {
+                    contentDescription = "Budgets tab"
+                },
+            )
+            Tab(
+                selected = selectedTab == 1,
+                onClick = { selectedTab = 1 },
+                text = { Text("Goals") },
+                modifier = Modifier.semantics {
+                    contentDescription = "Goals tab"
+                },
+            )
+        }
+
+        when (selectedTab) {
+            0 -> BudgetsScreen(onCreateBudget = onCreateBudget)
+            1 -> GoalsScreen(onCreateGoal = onCreateGoal)
+        }
+    }
+}


### PR DESCRIPTION
Closes #520

## Summary
Reorganizes 5-tab bottom nav into 4 tabs: Dashboard, Transactions, Planning (Budgets+Goals), Settings.

## Changes
- New PlanningScreen with Material 3 TabRow for Budgets/Goals
- Accounts accessible via Dashboard NetWorth card tap
- Settings promoted to bottom nav tab
- E2E tests updated for new navigation structure

## Files Changed: 10 (1 new + 9 modified)