### PR TITLE
feat(ios): enhanced data export with filtering and progress (#680)

### DIFF
--- a/apps/ios/Finance/Screens/DataExportView.swift
+++ b/apps/ios/Finance/Screens/DataExportView.swift
@@ -1,0 +1,353 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// DataExportView.swift
+// Finance
+//
+// Enhanced data export screen with date-range filtering, account
+// multi-select, format selection, and progress reporting. Navigated
+// to from the Settings > Data section after biometric authentication.
+// Refs #680
+
+import SwiftUI
+
+// MARK: - DataExportView
+
+struct DataExportView: View {
+    @State private var viewModel: DataExportViewModel
+
+    init(viewModel: DataExportViewModel = DataExportViewModel()) {
+        _viewModel = State(initialValue: viewModel)
+    }
+
+    var body: some View {
+        Form {
+            formatSection
+            dateRangeSection
+            accountsSection
+            summarySection
+            exportSection
+        }
+        .navigationTitle(String(localized: "Export Data"))
+        .navigationBarTitleDisplayMode(.large)
+        .task { await viewModel.loadAccounts() }
+        .overlay { exportProgressOverlay }
+        .sheet(isPresented: $viewModel.showingShareSheet) {
+            if let url = viewModel.exportedFileURL {
+                ExportShareSheetView(fileURL: url)
+            }
+        }
+        .alert(
+            String(localized: "Export Failed"),
+            isPresented: $viewModel.showingExportError
+        ) {
+            Button(String(localized: "OK"), role: .cancel) {}
+                .accessibilityLabel(String(localized: "Dismiss export error"))
+        } message: {
+            if let message = viewModel.exportErrorMessage {
+                Text(message)
+            }
+        }
+    }
+
+    // MARK: - Format Section
+
+    private var formatSection: some View {
+        Section {
+            Picker(
+                String(localized: "Format"),
+                selection: $viewModel.selectedFormat
+            ) {
+                ForEach(ExportFormat.allCases, id: \.self) { format in
+                    Text(format.displayName).tag(format)
+                }
+            }
+            .pickerStyle(.segmented)
+            .accessibilityLabel(String(localized: "Export format"))
+            .accessibilityHint(
+                String(localized: "Select CSV for transactions only, or JSON for all data")
+            )
+        } header: {
+            Text(String(localized: "Format"))
+        } footer: {
+            Text(
+                viewModel.selectedFormat == .csv
+                    ? String(localized: "CSV exports transactions only. Compatible with spreadsheet apps.")
+                    : String(localized: "JSON exports all data: accounts, transactions, budgets, and goals.")
+            )
+        }
+    }
+
+    // MARK: - Date Range Section
+
+    private var dateRangeSection: some View {
+        Section {
+            Toggle(isOn: $viewModel.dateFilterEnabled) {
+                Label(
+                    String(localized: "Filter by Date"),
+                    systemImage: "calendar"
+                )
+            }
+            .accessibilityLabel(String(localized: "Filter by date range"))
+            .accessibilityHint(
+                String(localized: "When enabled, only transactions within the selected date range are exported")
+            )
+            .accessibilityValue(
+                viewModel.dateFilterEnabled
+                    ? String(localized: "Enabled")
+                    : String(localized: "Disabled")
+            )
+
+            if viewModel.dateFilterEnabled {
+                DatePicker(
+                    String(localized: "Start Date"),
+                    selection: $viewModel.startDate,
+                    in: ...viewModel.endDate,
+                    displayedComponents: .date
+                )
+                .accessibilityLabel(String(localized: "Export start date"))
+                .accessibilityHint(
+                    String(localized: "Transactions before this date are excluded")
+                )
+
+                DatePicker(
+                    String(localized: "End Date"),
+                    selection: $viewModel.endDate,
+                    in: viewModel.startDate...,
+                    displayedComponents: .date
+                )
+                .accessibilityLabel(String(localized: "Export end date"))
+                .accessibilityHint(
+                    String(localized: "Transactions after this date are excluded")
+                )
+
+                if viewModel.startDate > viewModel.endDate {
+                    Label(
+                        String(localized: "Start date must be before end date"),
+                        systemImage: "exclamationmark.triangle"
+                    )
+                    .foregroundStyle(.red)
+                    .font(.footnote)
+                    .accessibilityLabel(
+                        String(localized: "Error: Start date must be before end date")
+                    )
+                }
+            }
+        } header: {
+            Text(String(localized: "Date Range"))
+        } footer: {
+            if !viewModel.dateFilterEnabled {
+                Text(String(localized: "All transactions will be included regardless of date."))
+            }
+        }
+    }
+
+    // MARK: - Accounts Section
+
+    private var accountsSection: some View {
+        Section {
+            Button {
+                viewModel.toggleAllAccounts()
+            } label: {
+                HStack {
+                    Label(
+                        String(localized: "All Accounts"),
+                        systemImage: viewModel.allAccountsSelected
+                            ? "checkmark.circle.fill"
+                            : "circle"
+                    )
+                    Spacer()
+                    if !viewModel.allAccountsSelected {
+                        Text(
+                            String(localized: "\(viewModel.selectedAccountIDs.count) selected")
+                        )
+                        .foregroundStyle(.secondary)
+                        .font(.subheadline)
+                    }
+                }
+            }
+            .accessibilityLabel(String(localized: "All accounts"))
+            .accessibilityHint(
+                String(localized: "Toggles between selecting all accounts and deselecting all")
+            )
+            .accessibilityValue(
+                viewModel.allAccountsSelected
+                    ? String(localized: "All selected")
+                    : String(localized: "\(viewModel.selectedAccountIDs.count) of \(viewModel.availableAccounts.count) selected")
+            )
+
+            if !viewModel.hasLoadedAccounts {
+                HStack {
+                    Spacer()
+                    ProgressView()
+                        .accessibilityLabel(String(localized: "Loading accounts"))
+                    Spacer()
+                }
+            } else {
+                ForEach(viewModel.availableAccounts) { account in
+                    Button {
+                        viewModel.toggleAccount(account)
+                    } label: {
+                        HStack {
+                            Image(
+                                systemName: viewModel.selectedAccountIDs.contains(account.id)
+                                    ? "checkmark.circle.fill"
+                                    : "circle"
+                            )
+                            .foregroundStyle(
+                                viewModel.selectedAccountIDs.contains(account.id)
+                                    ? Color.accentColor
+                                    : .secondary
+                            )
+                            .accessibilityHidden(true)
+
+                            Image(systemName: account.type.systemImage)
+                                .foregroundStyle(.secondary)
+                                .frame(width: 24)
+                                .accessibilityHidden(true)
+
+                            Text(account.name)
+                                .font(.body)
+                        }
+                    }
+                    .accessibilityLabel(account.name)
+                    .accessibilityHint(
+                        String(localized: "Double-tap to toggle selection")
+                    )
+                    .accessibilityValue(
+                        viewModel.selectedAccountIDs.contains(account.id)
+                            ? String(localized: "Selected")
+                            : String(localized: "Not selected")
+                    )
+                    .accessibilityAddTraits(
+                        viewModel.selectedAccountIDs.contains(account.id)
+                            ? .isSelected
+                            : []
+                    )
+                }
+            }
+        } header: {
+            Text(String(localized: "Accounts"))
+        } footer: {
+            Text(
+                String(localized: "Select specific accounts to include, or leave all selected to export everything.")
+            )
+        }
+    }
+
+    // MARK: - Summary Section
+
+    private var summarySection: some View {
+        Section(String(localized: "Summary")) {
+            Text(viewModel.filterSummary)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .accessibilityLabel(viewModel.filterSummary)
+        }
+    }
+
+    // MARK: - Export Section
+
+    private var exportSection: some View {
+        Section {
+            Button {
+                Task { await viewModel.exportData() }
+            } label: {
+                HStack {
+                    Spacer()
+                    Label(
+                        String(localized: "Export"),
+                        systemImage: "square.and.arrow.up"
+                    )
+                    .font(.headline)
+                    Spacer()
+                }
+                .frame(minHeight: 44)
+            }
+            .disabled(!viewModel.canExport || viewModel.isExporting)
+            .accessibilityLabel(String(localized: "Export data"))
+            .accessibilityHint(
+                String(localized: "Exports your financial data with the selected filters and format")
+            )
+        }
+    }
+
+    // MARK: - Progress Overlay
+
+    @ViewBuilder
+    private var exportProgressOverlay: some View {
+        if viewModel.isExporting {
+            ZStack {
+                Color.black.opacity(0.35)
+                    .ignoresSafeArea()
+
+                VStack(spacing: 16) {
+                    ProgressView(
+                        value: viewModel.progressFraction,
+                        total: 1.0
+                    )
+                    .progressViewStyle(.linear)
+                    .tint(.accentColor)
+                    .frame(width: 200)
+                    .accessibilityLabel(
+                        String(localized: "Export progress")
+                    )
+                    .accessibilityValue(
+                        String(localized: "\(Int(viewModel.progressFraction * 100)) percent")
+                    )
+
+                    Text(viewModel.progressDescription)
+                        .foregroundStyle(.white)
+                        .font(.subheadline.weight(.medium))
+                        .accessibilityLabel(viewModel.progressDescription)
+
+                    Text(
+                        String(localized: "\(Int(viewModel.progressFraction * 100))%")
+                    )
+                    .foregroundStyle(.white.opacity(0.7))
+                    .font(.caption)
+                    .monospacedDigit()
+                }
+                .padding(24)
+                .background(
+                    .ultraThinMaterial,
+                    in: RoundedRectangle(cornerRadius: 16)
+                )
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(
+                String(localized: "Exporting data, \(viewModel.progressDescription)")
+            )
+        }
+    }
+}
+
+// MARK: - ExportShareSheetView
+
+/// Wraps `UIActivityViewController` for sharing export files.
+///
+/// UIKit is required here because SwiftUI's `ShareLink` does not support
+/// sharing arbitrary file URLs produced at runtime. This is the only UIKit
+/// usage in the export flow.
+private struct ExportShareSheetView: UIViewControllerRepresentable {
+    let fileURL: URL
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(
+            activityItems: [fileURL],
+            applicationActivities: nil
+        )
+    }
+
+    func updateUIViewController(
+        _ uiViewController: UIActivityViewController,
+        context: Context
+    ) {}
+}
+
+// MARK: - Preview
+
+#Preview {
+    NavigationStack {
+        DataExportView()
+    }
+}

--- a/apps/ios/Finance/Screens/SettingsView.swift
+++ b/apps/ios/Finance/Screens/SettingsView.swift
@@ -31,7 +31,6 @@ struct SettingsView: View {
                 securitySection
                 syncSection
                 dataSection
-                dangerZoneSection
                 aboutSection
             }
             .navigationTitle(String(localized: "Settings"))
@@ -77,25 +76,9 @@ struct SettingsView: View {
             } message: { error in
                 Text(error.localizedDescription)
             }
-            .alert(
-                String(localized: "Export Failed"),
-                isPresented: $viewModel.showingExportError
-            ) {
-                Button(String(localized: "OK"), role: .cancel) {}
-                    .accessibilityLabel(String(localized: "Dismiss error"))
-            } message: {
-                if let message = viewModel.exportErrorMessage {
-                    Text(message)
-                }
-            }
             .alert(String(localized: "Sign-In Error"), isPresented: Binding(get: { authService.authError != nil }, set: { _ in })) {
                 Button(String(localized: "OK"), role: .cancel) {}.accessibilityLabel(String(localized: "Dismiss sign-in error"))
             } message: { if let error = authService.authError { Text(error) } }
-            .sheet(isPresented: $viewModel.showingShareSheet) {
-                if let url = viewModel.exportedFileURL {
-                    ShareSheetView(fileURL: url)
-                }
-            }
             // After deletion, re-launch the app into onboarding by marking
             // the root view's auth state unauthenticated (handled by authService.signOut).
             .onChange(of: viewModel.hasDeletionCompleted) { _, completed in
@@ -288,51 +271,15 @@ struct SettingsView: View {
 
     private var dataSection: some View {
         Section(String(localized: "Data")) {
-            Button {
-                Task {
-                    let authorized = await viewModel.authenticateForExport(
-                        using: biometricManager
-                    )
-                    if authorized {
-                        viewModel.showingExportConfirmation = true
-                    }
-                }
+            NavigationLink {
+                DataExportView()
             } label: {
-                Label {
-                    if viewModel.isExporting {
-                        HStack(spacing: 8) {
-                            Text(String(localized: "Exporting..."))
-                            ProgressView()
-                        }
-                    } else {
-                        Text(String(localized: "Export Data"))
-                    }
-                } icon: {
-                    Image(systemName: "square.and.arrow.up")
-                }
+                Label(String(localized: "Export Data"), systemImage: "square.and.arrow.up")
             }
-            .disabled(viewModel.isExporting)
             .accessibilityLabel(String(localized: "Export data"))
-            .accessibilityHint(String(localized: "Exports all your financial data as a file"))
-            .confirmationDialog(
-                String(localized: "Export Data"),
-                isPresented: $viewModel.showingExportConfirmation,
-                titleVisibility: .visible
-            ) {
-                Button(String(localized: "Export as CSV")) {
-                    Task { await viewModel.exportData(format: .csv) }
-                }
-                .accessibilityLabel(String(localized: "Export as CSV"))
-
-                Button(String(localized: "Export as JSON")) {
-                    Task { await viewModel.exportData(format: .json) }
-                }
-                .accessibilityLabel(String(localized: "Export as JSON"))
-
-                Button(String(localized: "Cancel"), role: .cancel) {}
-            } message: {
-                Text(String(localized: "Choose your preferred export format."))
-            }
+            .accessibilityHint(
+                String(localized: "Opens the export screen with filtering and format options")
+            )
 
             Button(role: .destructive) {
                 viewModel.showingDeleteConfirmation = true
@@ -387,29 +334,6 @@ struct SettingsView: View {
             .accessibilityHint(String(localized: "Opens the open source acknowledgments"))
         }
     }
-}
-
-// MARK: - ShareSheetView
-
-/// Wraps `UIActivityViewController` for presenting share actions.
-///
-/// UIKit is required here because SwiftUI's `ShareLink` does not support
-/// sharing arbitrary file URLs produced at runtime. This is the only UIKit
-/// usage in the settings flow.
-private struct ShareSheetView: UIViewControllerRepresentable {
-    let fileURL: URL
-
-    func makeUIViewController(context: Context) -> UIActivityViewController {
-        UIActivityViewController(
-            activityItems: [fileURL],
-            applicationActivities: nil
-        )
-    }
-
-    func updateUIViewController(
-        _ uiViewController: UIActivityViewController,
-        context: Context
-    ) {}
 }
 
 #Preview {

--- a/apps/ios/Finance/Services/ExportFilter.swift
+++ b/apps/ios/Finance/Services/ExportFilter.swift
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// ExportFilter.swift
+// Finance
+//
+// Pure-function filtering logic for data export. Filters transactions
+// by date range and account selection, and filters accounts by selected
+// IDs. All functions are static and side-effect-free for testability.
+// Refs #680
+
+import Foundation
+
+// MARK: - ExportFilter
+
+/// Pure filtering utilities for scoping data exports by date range
+/// and account selection.
+///
+/// All methods are static and deterministic — they take input data and
+/// filter criteria, and return filtered results with no side effects.
+/// This makes them straightforward to unit test without mocks.
+enum ExportFilter {
+
+    // MARK: - Transaction Filtering
+
+    /// Filters transactions by date range and account selection.
+    ///
+    /// - Parameters:
+    ///   - transactions: The full list of transactions to filter.
+    ///   - accounts: All available accounts, used to resolve selected
+    ///     account IDs to account names for matching.
+    ///   - startDate: If non-nil, excludes transactions before this date.
+    ///     Comparison uses start-of-day for the given date.
+    ///   - endDate: If non-nil, excludes transactions after this date.
+    ///     Comparison uses end-of-day for the given date.
+    ///   - selectedAccountIDs: Account IDs to include. An empty set means
+    ///     "all accounts" (no account filter applied).
+    /// - Returns: Transactions matching all active filter criteria.
+    static func filterTransactions(
+        _ transactions: [TransactionItem],
+        accounts: [AccountItem],
+        startDate: Date?,
+        endDate: Date?,
+        selectedAccountIDs: Set<String>
+    ) -> [TransactionItem] {
+        let selectedNames: Set<String>
+        if selectedAccountIDs.isEmpty {
+            selectedNames = []
+        } else {
+            selectedNames = Set(
+                accounts
+                    .filter { selectedAccountIDs.contains($0.id) }
+                    .map(\.name)
+            )
+        }
+
+        let calendar = Calendar.current
+
+        // Normalise date boundaries to include the full start/end days.
+        let normalisedStart: Date? = startDate.flatMap {
+            calendar.startOfDay(for: $0)
+        }
+
+        let normalisedEnd: Date? = endDate.flatMap { date in
+            guard let nextDay = calendar.date(byAdding: .day, value: 1, to: calendar.startOfDay(for: date)) else {
+                return date
+            }
+            return nextDay
+        }
+
+        return transactions.filter { transaction in
+            // Date range check
+            if let start = normalisedStart, transaction.date < start {
+                return false
+            }
+            if let end = normalisedEnd, transaction.date >= end {
+                return false
+            }
+
+            // Account filter check
+            if !selectedNames.isEmpty, !selectedNames.contains(transaction.accountName) {
+                return false
+            }
+
+            return true
+        }
+    }
+
+    // MARK: - Account Filtering
+
+    /// Filters accounts to only those selected by the user.
+    ///
+    /// - Parameters:
+    ///   - accounts: The full list of accounts.
+    ///   - selectedIDs: Account IDs to include. An empty set means
+    ///     "all accounts" (no filter applied).
+    /// - Returns: Accounts whose IDs are in the selected set, or all
+    ///   accounts if the set is empty.
+    static func filterAccounts(
+        _ accounts: [AccountItem],
+        selectedIDs: Set<String>
+    ) -> [AccountItem] {
+        guard !selectedIDs.isEmpty else { return accounts }
+        return accounts.filter { selectedIDs.contains($0.id) }
+    }
+
+    // MARK: - Summary
+
+    /// Returns a human-readable summary of the active filters for
+    /// accessibility announcements and confirmation display.
+    ///
+    /// - Parameters:
+    ///   - dateFilterEnabled: Whether the date range filter is active.
+    ///   - startDate: The start date if date filtering is enabled.
+    ///   - endDate: The end date if date filtering is enabled.
+    ///   - selectedAccountCount: Number of accounts selected (0 = all).
+    ///   - totalAccountCount: Total number of available accounts.
+    ///   - format: The selected export format.
+    /// - Returns: A localized summary string.
+    static func filterSummary(
+        dateFilterEnabled: Bool,
+        startDate: Date,
+        endDate: Date,
+        selectedAccountCount: Int,
+        totalAccountCount: Int,
+        format: ExportFormat
+    ) -> String {
+        var parts: [String] = []
+
+        parts.append(String(localized: "Format: \(format.displayName)"))
+
+        if dateFilterEnabled {
+            let formatter = DateFormatter()
+            formatter.dateStyle = .medium
+            formatter.timeStyle = .none
+            let start = formatter.string(from: startDate)
+            let end = formatter.string(from: endDate)
+            parts.append(String(localized: "Date range: \(start) to \(end)"))
+        } else {
+            parts.append(String(localized: "Date range: All time"))
+        }
+
+        if selectedAccountCount > 0, selectedAccountCount < totalAccountCount {
+            parts.append(String(localized: "Accounts: \(selectedAccountCount) of \(totalAccountCount) selected"))
+        } else {
+            parts.append(String(localized: "Accounts: All"))
+        }
+
+        return parts.joined(separator: ". ")
+    }
+}

--- a/apps/ios/Finance/ViewModels/DataExportViewModel.swift
+++ b/apps/ios/Finance/ViewModels/DataExportViewModel.swift
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// DataExportViewModel.swift
+// Finance
+//
+// ViewModel for the enhanced data export screen. Manages filter state
+// (date range, account selection, format), drives export progress, and
+// produces a shareable file URL on completion. Uses @Observable (iOS 17+).
+// Refs #680
+
+import Foundation
+import Observation
+import os
+
+// MARK: - Export Progress Step
+
+/// Discrete steps reported during an export operation, used to drive
+/// both the progress bar and VoiceOver announcements.
+enum ExportProgressStep: String, Sendable {
+    case idle
+    case fetchingAccounts
+    case fetchingTransactions
+    case fetchingBudgets
+    case fetchingGoals
+    case filtering
+    case encoding
+    case writingFile
+    case complete
+
+    var displayName: String {
+        switch self {
+        case .idle: String(localized: "Ready")
+        case .fetchingAccounts: String(localized: "Fetching accounts…")
+        case .fetchingTransactions: String(localized: "Fetching transactions…")
+        case .fetchingBudgets: String(localized: "Fetching budgets…")
+        case .fetchingGoals: String(localized: "Fetching goals…")
+        case .filtering: String(localized: "Filtering data…")
+        case .encoding: String(localized: "Encoding export…")
+        case .writingFile: String(localized: "Writing file…")
+        case .complete: String(localized: "Export complete")
+        }
+    }
+
+    /// Approximate progress fraction (0.0–1.0) for the progress bar.
+    var progressFraction: Double {
+        switch self {
+        case .idle: 0
+        case .fetchingAccounts: 0.1
+        case .fetchingTransactions: 0.25
+        case .fetchingBudgets: 0.35
+        case .fetchingGoals: 0.45
+        case .filtering: 0.6
+        case .encoding: 0.75
+        case .writingFile: 0.9
+        case .complete: 1.0
+        }
+    }
+}
+
+// MARK: - DataExportViewModel
+
+@Observable
+@MainActor
+final class DataExportViewModel {
+
+    // MARK: - Filter State
+
+    /// The selected export format (CSV or JSON).
+    var selectedFormat: ExportFormat = .csv
+
+    /// Whether date-range filtering is enabled.
+    var dateFilterEnabled: Bool = false
+
+    /// Start date for the date-range filter (defaults to 30 days ago).
+    var startDate: Date = Calendar.current.date(
+        byAdding: .month, value: -1, to: .now
+    ) ?? .now
+
+    /// End date for the date-range filter (defaults to today).
+    var endDate: Date = .now
+
+    /// IDs of accounts selected for export. Empty means all accounts.
+    var selectedAccountIDs: Set<String> = []
+
+    // MARK: - Data
+
+    /// All available accounts loaded from the repository.
+    private(set) var availableAccounts: [AccountItem] = []
+
+    /// Whether accounts have been loaded at least once.
+    private(set) var hasLoadedAccounts: Bool = false
+
+    // MARK: - Export Progress
+
+    /// Whether an export is currently in flight.
+    private(set) var isExporting: Bool = false
+
+    /// Current step of the export pipeline.
+    private(set) var progressStep: ExportProgressStep = .idle
+
+    /// Fractional progress (0.0–1.0) for the progress bar.
+    var progressFraction: Double { progressStep.progressFraction }
+
+    /// User-facing description of the current progress step.
+    var progressDescription: String { progressStep.displayName }
+
+    // MARK: - Result State
+
+    /// File URL produced by a successful export, used to drive the share sheet.
+    var exportedFileURL: URL?
+
+    /// Whether the share sheet should be presented.
+    var showingShareSheet: Bool = false
+
+    /// Error message from a failed export.
+    var exportErrorMessage: String?
+
+    /// Whether the export error alert should be shown.
+    var showingExportError: Bool = false
+
+    // MARK: - Computed Helpers
+
+    /// Human-readable summary of the current filter configuration.
+    var filterSummary: String {
+        ExportFilter.filterSummary(
+            dateFilterEnabled: dateFilterEnabled,
+            startDate: startDate,
+            endDate: endDate,
+            selectedAccountCount: selectedAccountIDs.count,
+            totalAccountCount: availableAccounts.count,
+            format: selectedFormat
+        )
+    }
+
+    /// Whether the current filter configuration is valid for export.
+    var canExport: Bool {
+        if dateFilterEnabled && startDate > endDate { return false }
+        return true
+    }
+
+    /// `true` when all accounts are selected (or none explicitly selected).
+    var allAccountsSelected: Bool {
+        selectedAccountIDs.isEmpty
+            || selectedAccountIDs.count == availableAccounts.count
+    }
+
+    // MARK: - Private Dependencies
+
+    private let accountRepository: AccountRepository
+    private let transactionRepository: TransactionRepository
+    private let budgetRepository: BudgetRepository
+    private let goalRepository: GoalRepository
+    private let exportService: DataExportService
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
+        category: "DataExportViewModel"
+    )
+
+    // MARK: - Initialisation
+
+    /// Creates a new export view model.
+    ///
+    /// - Parameters:
+    ///   - accountRepository: Data source for accounts.
+    ///   - transactionRepository: Data source for transactions.
+    ///   - budgetRepository: Data source for budgets.
+    ///   - goalRepository: Data source for goals.
+    ///   - exportService: Service used to serialise data for export.
+    init(
+        accountRepository: AccountRepository = MockAccountRepository(),
+        transactionRepository: TransactionRepository = MockTransactionRepository(),
+        budgetRepository: BudgetRepository = MockBudgetRepository(),
+        goalRepository: GoalRepository = MockGoalRepository(),
+        exportService: DataExportService = DataExportService()
+    ) {
+        self.accountRepository = accountRepository
+        self.transactionRepository = transactionRepository
+        self.budgetRepository = budgetRepository
+        self.goalRepository = goalRepository
+        self.exportService = exportService
+    }
+
+    // MARK: - Data Loading
+
+    /// Fetches accounts from the repository to populate the account picker.
+    func loadAccounts() async {
+        do {
+            availableAccounts = try await accountRepository.getAccounts()
+            hasLoadedAccounts = true
+            Self.logger.info(
+                "Loaded \(self.availableAccounts.count, privacy: .public) accounts for export picker"
+            )
+        } catch {
+            Self.logger.error(
+                "Failed to load accounts: \(error.localizedDescription, privacy: .public)"
+            )
+            availableAccounts = []
+            hasLoadedAccounts = true
+        }
+    }
+
+    // MARK: - Account Selection
+
+    /// Toggles selection of a single account.
+    func toggleAccount(_ account: AccountItem) {
+        if selectedAccountIDs.contains(account.id) {
+            selectedAccountIDs.remove(account.id)
+        } else {
+            selectedAccountIDs.insert(account.id)
+        }
+    }
+
+    /// Selects all available accounts.
+    func selectAllAccounts() {
+        selectedAccountIDs = Set(availableAccounts.map(\.id))
+    }
+
+    /// Deselects all accounts (which means "export all" — no filter).
+    func deselectAllAccounts() {
+        selectedAccountIDs = []
+    }
+
+    /// Toggles between "all selected" and "none selected".
+    func toggleAllAccounts() {
+        if allAccountsSelected {
+            deselectAllAccounts()
+        } else {
+            selectAllAccounts()
+        }
+    }
+
+    // MARK: - Export
+
+    /// Runs the full export pipeline: fetch → filter → encode → share.
+    ///
+    /// Progress is reported through ``progressStep`` so the view can
+    /// display an animated progress bar and VoiceOver announcements.
+    func exportData() async {
+        guard canExport else { return }
+        guard !isExporting else { return }
+
+        isExporting = true
+        exportedFileURL = nil
+        exportErrorMessage = nil
+
+        defer {
+            isExporting = false
+        }
+
+        do {
+            // Step 1: Fetch accounts
+            updateProgress(.fetchingAccounts)
+            let accounts = try await accountRepository.getAccounts()
+
+            // Step 2: Fetch transactions
+            updateProgress(.fetchingTransactions)
+            let allTransactions = try await transactionRepository.getTransactions()
+
+            // Step 3: Apply filters
+            updateProgress(.filtering)
+            let filteredTransactions = ExportFilter.filterTransactions(
+                allTransactions,
+                accounts: accounts,
+                startDate: dateFilterEnabled ? startDate : nil,
+                endDate: dateFilterEnabled ? endDate : nil,
+                selectedAccountIDs: selectedAccountIDs
+            )
+
+            let filteredAccounts = ExportFilter.filterAccounts(
+                accounts,
+                selectedIDs: selectedAccountIDs
+            )
+
+            // Step 4: Encode and write
+            let fileURL: URL
+
+            switch selectedFormat {
+            case .csv:
+                updateProgress(.encoding)
+                guard !filteredTransactions.isEmpty else {
+                    throw ExportError.noDataToExport
+                }
+                updateProgress(.writingFile)
+                fileURL = try await exportService.exportCSV(
+                    transactions: filteredTransactions
+                )
+
+            case .json:
+                updateProgress(.fetchingBudgets)
+                let budgets = try await budgetRepository.getBudgets()
+                updateProgress(.fetchingGoals)
+                let goals = try await goalRepository.getGoals()
+                updateProgress(.encoding)
+                updateProgress(.writingFile)
+                fileURL = try await exportService.exportJSON(
+                    accounts: filteredAccounts,
+                    transactions: filteredTransactions,
+                    budgets: budgets,
+                    goals: goals
+                )
+            }
+
+            // Step 5: Complete
+            updateProgress(.complete)
+            exportedFileURL = fileURL
+            showingShareSheet = true
+
+            Self.logger.info(
+                "Export completed: \(self.selectedFormat.rawValue, privacy: .public), "
+                + "\(filteredTransactions.count, privacy: .public) transactions, "
+                + "\(filteredAccounts.count, privacy: .public) accounts"
+            )
+        } catch {
+            Self.logger.error(
+                "Export failed: \(error.localizedDescription, privacy: .public)"
+            )
+            exportErrorMessage = error.localizedDescription
+            showingExportError = true
+            updateProgress(.idle)
+        }
+    }
+
+    // MARK: - Private Helpers
+
+    /// Updates the progress step and logs the transition.
+    private func updateProgress(_ step: ExportProgressStep) {
+        progressStep = step
+    }
+}

--- a/apps/ios/Tests/ExportFilterTests.swift
+++ b/apps/ios/Tests/ExportFilterTests.swift
@@ -1,0 +1,600 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// ExportFilterTests.swift
+// FinanceTests
+//
+// Unit tests for ExportFilter — date range filtering, account selection
+// filtering, combined filters, edge cases, and summary generation.
+// Refs #680
+
+import XCTest
+@testable import FinanceApp
+
+final class ExportFilterTests: XCTestCase {
+
+    // MARK: - Test Data
+
+    /// Fixed reference date: 2024-01-15 12:00:00 UTC
+    private let referenceDate = Date(timeIntervalSince1970: 1_705_315_200)
+
+    private lazy var jan1 = calendar.date(
+        from: DateComponents(year: 2024, month: 1, day: 1)
+    )!
+    private lazy var jan10 = calendar.date(
+        from: DateComponents(year: 2024, month: 1, day: 10)
+    )!
+    private lazy var jan15 = calendar.date(
+        from: DateComponents(year: 2024, month: 1, day: 15)
+    )!
+    private lazy var jan20 = calendar.date(
+        from: DateComponents(year: 2024, month: 1, day: 20)
+    )!
+    private lazy var jan31 = calendar.date(
+        from: DateComponents(year: 2024, month: 1, day: 31)
+    )!
+    private lazy var feb15 = calendar.date(
+        from: DateComponents(year: 2024, month: 2, day: 15)
+    )!
+
+    private let calendar = Calendar.current
+
+    private let checkingAccount = AccountItem(
+        id: "acc-1", name: "Main Checking",
+        balanceMinorUnits: 10_000_00, currencyCode: "USD",
+        type: .checking, icon: "building.columns", isArchived: false
+    )
+
+    private let savingsAccount = AccountItem(
+        id: "acc-2", name: "Savings",
+        balanceMinorUnits: 25_000_00, currencyCode: "USD",
+        type: .savings, icon: "banknote", isArchived: false
+    )
+
+    private let creditAccount = AccountItem(
+        id: "acc-3", name: "Travel Card",
+        balanceMinorUnits: -1_200_00, currencyCode: "USD",
+        type: .creditCard, icon: "creditcard", isArchived: false
+    )
+
+    private var allAccounts: [AccountItem] {
+        [checkingAccount, savingsAccount, creditAccount]
+    }
+
+    private lazy var transactionJan5Checking = TransactionItem(
+        id: "t1", payee: "Grocery Store",
+        category: "Groceries", accountName: "Main Checking",
+        amountMinorUnits: -50_00, currencyCode: "USD",
+        date: calendar.date(
+            from: DateComponents(year: 2024, month: 1, day: 5, hour: 10)
+        )!,
+        type: .expense, status: .cleared
+    )
+
+    private lazy var transactionJan10Savings = TransactionItem(
+        id: "t2", payee: "Interest Payment",
+        category: "Income", accountName: "Savings",
+        amountMinorUnits: 25_00, currencyCode: "USD",
+        date: calendar.date(
+            from: DateComponents(year: 2024, month: 1, day: 10, hour: 9)
+        )!,
+        type: .income, status: .cleared
+    )
+
+    private lazy var transactionJan15Checking = TransactionItem(
+        id: "t3", payee: "Gas Station",
+        category: "Transport", accountName: "Main Checking",
+        amountMinorUnits: -45_00, currencyCode: "USD",
+        date: calendar.date(
+            from: DateComponents(year: 2024, month: 1, day: 15, hour: 14)
+        )!,
+        type: .expense, status: .cleared
+    )
+
+    private lazy var transactionJan20Card = TransactionItem(
+        id: "t4", payee: "Restaurant",
+        category: "Dining", accountName: "Travel Card",
+        amountMinorUnits: -85_00, currencyCode: "USD",
+        date: calendar.date(
+            from: DateComponents(year: 2024, month: 1, day: 20, hour: 19)
+        )!,
+        type: .expense, status: .pending
+    )
+
+    private lazy var transactionFeb1Checking = TransactionItem(
+        id: "t5", payee: "Payroll",
+        category: "Income", accountName: "Main Checking",
+        amountMinorUnits: 3_000_00, currencyCode: "USD",
+        date: calendar.date(
+            from: DateComponents(year: 2024, month: 2, day: 1, hour: 8)
+        )!,
+        type: .income, status: .cleared
+    )
+
+    private var allTransactions: [TransactionItem] {
+        [
+            transactionJan5Checking,
+            transactionJan10Savings,
+            transactionJan15Checking,
+            transactionJan20Card,
+            transactionFeb1Checking,
+        ]
+    }
+
+    // MARK: - No Filters (Pass-Through)
+
+    func testNoFiltersReturnsAllTransactions() {
+        let result = ExportFilter.filterTransactions(
+            allTransactions,
+            accounts: allAccounts,
+            startDate: nil,
+            endDate: nil,
+            selectedAccountIDs: []
+        )
+
+        XCTAssertEqual(
+            result.count, allTransactions.count,
+            "With no filters, all transactions should be returned"
+        )
+    }
+
+    func testEmptyAccountSelectionReturnsAll() {
+        let result = ExportFilter.filterAccounts(
+            allAccounts,
+            selectedIDs: []
+        )
+
+        XCTAssertEqual(
+            result.count, allAccounts.count,
+            "Empty selection set should return all accounts"
+        )
+    }
+
+    // MARK: - Date Range Filtering
+
+    func testStartDateFilterExcludesEarlierTransactions() {
+        let result = ExportFilter.filterTransactions(
+            allTransactions,
+            accounts: allAccounts,
+            startDate: jan10,
+            endDate: nil,
+            selectedAccountIDs: []
+        )
+
+        // Jan 5 should be excluded; Jan 10, 15, 20, Feb 1 remain
+        XCTAssertEqual(result.count, 4, "Should exclude transactions before start date")
+        XCTAssertFalse(
+            result.contains { $0.id == "t1" },
+            "Transaction on Jan 5 should be excluded"
+        )
+    }
+
+    func testEndDateFilterExcludesLaterTransactions() {
+        let result = ExportFilter.filterTransactions(
+            allTransactions,
+            accounts: allAccounts,
+            startDate: nil,
+            endDate: jan20,
+            selectedAccountIDs: []
+        )
+
+        // Jan 5, 10, 15, 20 included; Feb 1 excluded
+        XCTAssertEqual(result.count, 4, "Should exclude transactions after end date")
+        XCTAssertFalse(
+            result.contains { $0.id == "t5" },
+            "Transaction on Feb 1 should be excluded"
+        )
+    }
+
+    func testDateRangeFilterIncludesBoundaryDates() {
+        let result = ExportFilter.filterTransactions(
+            allTransactions,
+            accounts: allAccounts,
+            startDate: jan10,
+            endDate: jan20,
+            selectedAccountIDs: []
+        )
+
+        // Jan 10, 15, 20 should be included (inclusive boundaries)
+        XCTAssertEqual(
+            result.count, 3,
+            "Boundary dates should be inclusive"
+        )
+        XCTAssertTrue(
+            result.contains { $0.id == "t2" },
+            "Transaction exactly on start date should be included"
+        )
+        XCTAssertTrue(
+            result.contains { $0.id == "t4" },
+            "Transaction exactly on end date should be included"
+        )
+    }
+
+    func testDateRangeFilterSingleDay() {
+        let result = ExportFilter.filterTransactions(
+            allTransactions,
+            accounts: allAccounts,
+            startDate: jan15,
+            endDate: jan15,
+            selectedAccountIDs: []
+        )
+
+        XCTAssertEqual(
+            result.count, 1,
+            "Single-day range should include only that day's transactions"
+        )
+        XCTAssertEqual(
+            result.first?.id, "t3",
+            "Should include the Jan 15 transaction"
+        )
+    }
+
+    func testDateRangeFilterExcludesAll() {
+        let narrowStart = calendar.date(
+            from: DateComponents(year: 2023, month: 6, day: 1)
+        )!
+        let narrowEnd = calendar.date(
+            from: DateComponents(year: 2023, month: 6, day: 30)
+        )!
+
+        let result = ExportFilter.filterTransactions(
+            allTransactions,
+            accounts: allAccounts,
+            startDate: narrowStart,
+            endDate: narrowEnd,
+            selectedAccountIDs: []
+        )
+
+        XCTAssertTrue(
+            result.isEmpty,
+            "Date range with no matching transactions should return empty"
+        )
+    }
+
+    // MARK: - Account Filtering
+
+    func testSingleAccountSelection() {
+        let result = ExportFilter.filterTransactions(
+            allTransactions,
+            accounts: allAccounts,
+            startDate: nil,
+            endDate: nil,
+            selectedAccountIDs: ["acc-1"]
+        )
+
+        // t1 (Jan 5 Checking), t3 (Jan 15 Checking), t5 (Feb 1 Checking)
+        XCTAssertEqual(
+            result.count, 3,
+            "Should only include transactions from Main Checking"
+        )
+        XCTAssertTrue(
+            result.allSatisfy { $0.accountName == "Main Checking" },
+            "All results should belong to Main Checking"
+        )
+    }
+
+    func testMultipleAccountSelection() {
+        let result = ExportFilter.filterTransactions(
+            allTransactions,
+            accounts: allAccounts,
+            startDate: nil,
+            endDate: nil,
+            selectedAccountIDs: ["acc-1", "acc-3"]
+        )
+
+        // Checking: t1, t3, t5; Travel Card: t4 — total 4
+        XCTAssertEqual(result.count, 4, "Should include transactions from both selected accounts")
+        XCTAssertFalse(
+            result.contains { $0.accountName == "Savings" },
+            "Savings transactions should be excluded"
+        )
+    }
+
+    func testAllAccountsSelectedEquivalentToNoFilter() {
+        let allIDs: Set<String> = ["acc-1", "acc-2", "acc-3"]
+
+        let result = ExportFilter.filterTransactions(
+            allTransactions,
+            accounts: allAccounts,
+            startDate: nil,
+            endDate: nil,
+            selectedAccountIDs: allIDs
+        )
+
+        XCTAssertEqual(
+            result.count, allTransactions.count,
+            "Selecting all accounts should return all transactions"
+        )
+    }
+
+    func testAccountFilterWithNonexistentID() {
+        let result = ExportFilter.filterTransactions(
+            allTransactions,
+            accounts: allAccounts,
+            startDate: nil,
+            endDate: nil,
+            selectedAccountIDs: ["nonexistent-id"]
+        )
+
+        XCTAssertTrue(
+            result.isEmpty,
+            "Non-existent account ID should match no transactions"
+        )
+    }
+
+    func testFilterAccountsBySelectedIDs() {
+        let result = ExportFilter.filterAccounts(
+            allAccounts,
+            selectedIDs: ["acc-1", "acc-3"]
+        )
+
+        XCTAssertEqual(result.count, 2)
+        XCTAssertTrue(result.contains { $0.id == "acc-1" })
+        XCTAssertTrue(result.contains { $0.id == "acc-3" })
+        XCTAssertFalse(result.contains { $0.id == "acc-2" })
+    }
+
+    // MARK: - Combined Filters
+
+    func testDateRangeAndAccountFilter() {
+        let result = ExportFilter.filterTransactions(
+            allTransactions,
+            accounts: allAccounts,
+            startDate: jan10,
+            endDate: jan31,
+            selectedAccountIDs: ["acc-1"]
+        )
+
+        // Date range Jan 10–31 from Checking: t3 (Jan 15)
+        XCTAssertEqual(
+            result.count, 1,
+            "Should apply both date and account filters"
+        )
+        XCTAssertEqual(result.first?.id, "t3")
+    }
+
+    func testDateRangeAndMultipleAccountFilter() {
+        let result = ExportFilter.filterTransactions(
+            allTransactions,
+            accounts: allAccounts,
+            startDate: jan1,
+            endDate: jan15,
+            selectedAccountIDs: ["acc-1", "acc-2"]
+        )
+
+        // Date Jan 1-15 from Checking+Savings: t1 (Jan 5 Checking),
+        // t2 (Jan 10 Savings), t3 (Jan 15 Checking)
+        XCTAssertEqual(result.count, 3)
+    }
+
+    func testCombinedFiltersResultingInEmpty() {
+        let result = ExportFilter.filterTransactions(
+            allTransactions,
+            accounts: allAccounts,
+            startDate: jan20,
+            endDate: jan31,
+            selectedAccountIDs: ["acc-2"]
+        )
+
+        // No Savings transactions between Jan 20-31
+        XCTAssertTrue(
+            result.isEmpty,
+            "Combined filters with no matching data should return empty"
+        )
+    }
+
+    // MARK: - Edge Cases
+
+    func testEmptyTransactionList() {
+        let result = ExportFilter.filterTransactions(
+            [],
+            accounts: allAccounts,
+            startDate: jan1,
+            endDate: jan31,
+            selectedAccountIDs: ["acc-1"]
+        )
+
+        XCTAssertTrue(result.isEmpty, "Empty input should produce empty output")
+    }
+
+    func testEmptyAccountList() {
+        let result = ExportFilter.filterTransactions(
+            allTransactions,
+            accounts: [],
+            startDate: nil,
+            endDate: nil,
+            selectedAccountIDs: ["acc-1"]
+        )
+
+        // No accounts to resolve IDs → no names match → all filtered out
+        XCTAssertTrue(
+            result.isEmpty,
+            "Non-empty account selection with empty account list should filter all"
+        )
+    }
+
+    func testEmptyAccountListWithNoSelection() {
+        let result = ExportFilter.filterTransactions(
+            allTransactions,
+            accounts: [],
+            startDate: nil,
+            endDate: nil,
+            selectedAccountIDs: []
+        )
+
+        XCTAssertEqual(
+            result.count, allTransactions.count,
+            "Empty account selection with empty account list should pass all through"
+        )
+    }
+
+    func testFilterAccountsWithEmptyList() {
+        let result = ExportFilter.filterAccounts([], selectedIDs: ["acc-1"])
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // MARK: - Date Boundary Precision
+
+    func testTransactionAtMidnightStartOfDay() {
+        let midnightTransaction = TransactionItem(
+            id: "t-midnight", payee: "Midnight Purchase",
+            category: "Shopping", accountName: "Main Checking",
+            amountMinorUnits: -10_00, currencyCode: "USD",
+            date: calendar.date(
+                from: DateComponents(year: 2024, month: 1, day: 15, hour: 0, minute: 0, second: 0)
+            )!,
+            type: .expense, status: .cleared
+        )
+
+        let result = ExportFilter.filterTransactions(
+            [midnightTransaction],
+            accounts: allAccounts,
+            startDate: jan15,
+            endDate: jan15,
+            selectedAccountIDs: []
+        )
+
+        XCTAssertEqual(
+            result.count, 1,
+            "Transaction at midnight of the start date should be included"
+        )
+    }
+
+    func testTransactionAtEndOfDay() {
+        let lateTransaction = TransactionItem(
+            id: "t-late", payee: "Late Night Purchase",
+            category: "Shopping", accountName: "Main Checking",
+            amountMinorUnits: -10_00, currencyCode: "USD",
+            date: calendar.date(
+                from: DateComponents(year: 2024, month: 1, day: 15, hour: 23, minute: 59, second: 59)
+            )!,
+            type: .expense, status: .cleared
+        )
+
+        let result = ExportFilter.filterTransactions(
+            [lateTransaction],
+            accounts: allAccounts,
+            startDate: jan15,
+            endDate: jan15,
+            selectedAccountIDs: []
+        )
+
+        XCTAssertEqual(
+            result.count, 1,
+            "Transaction at 23:59:59 of the end date should be included"
+        )
+    }
+
+    // MARK: - Filter Summary
+
+    func testFilterSummaryAllDefaults() {
+        let summary = ExportFilter.filterSummary(
+            dateFilterEnabled: false,
+            startDate: jan1,
+            endDate: jan31,
+            selectedAccountCount: 0,
+            totalAccountCount: 3,
+            format: .csv
+        )
+
+        XCTAssertTrue(
+            summary.contains("CSV"),
+            "Summary should mention the format"
+        )
+        XCTAssertTrue(
+            summary.contains("All time"),
+            "Summary should indicate no date filter"
+        )
+        XCTAssertTrue(
+            summary.contains("All"),
+            "Summary should indicate all accounts"
+        )
+    }
+
+    func testFilterSummaryWithDateRange() {
+        let summary = ExportFilter.filterSummary(
+            dateFilterEnabled: true,
+            startDate: jan1,
+            endDate: jan31,
+            selectedAccountCount: 0,
+            totalAccountCount: 3,
+            format: .json
+        )
+
+        XCTAssertTrue(
+            summary.contains("JSON"),
+            "Summary should mention JSON format"
+        )
+        XCTAssertTrue(
+            summary.contains("Date range"),
+            "Summary should mention date range when enabled"
+        )
+    }
+
+    func testFilterSummaryWithPartialAccountSelection() {
+        let summary = ExportFilter.filterSummary(
+            dateFilterEnabled: false,
+            startDate: jan1,
+            endDate: jan31,
+            selectedAccountCount: 2,
+            totalAccountCount: 5,
+            format: .csv
+        )
+
+        XCTAssertTrue(
+            summary.contains("2"),
+            "Summary should include selected count"
+        )
+        XCTAssertTrue(
+            summary.contains("5"),
+            "Summary should include total count"
+        )
+    }
+
+    func testFilterSummaryWithAllAccountsSelected() {
+        let summary = ExportFilter.filterSummary(
+            dateFilterEnabled: false,
+            startDate: jan1,
+            endDate: jan31,
+            selectedAccountCount: 3,
+            totalAccountCount: 3,
+            format: .csv
+        )
+
+        // When all are selected, it should show "All" rather than "3 of 3"
+        XCTAssertTrue(
+            summary.contains("All"),
+            "When all accounts are selected, summary should show 'All'"
+        )
+    }
+
+    // MARK: - Order Preservation
+
+    func testFilterPreservesTransactionOrder() {
+        let result = ExportFilter.filterTransactions(
+            allTransactions,
+            accounts: allAccounts,
+            startDate: jan1,
+            endDate: feb15,
+            selectedAccountIDs: []
+        )
+
+        // Verify the original order is preserved
+        let resultIDs = result.map(\.id)
+        let inputIDs = allTransactions.map(\.id)
+        XCTAssertEqual(
+            resultIDs, inputIDs,
+            "Filter should preserve the original transaction order"
+        )
+    }
+
+    func testFilterAccountsPreservesOrder() {
+        let result = ExportFilter.filterAccounts(
+            allAccounts,
+            selectedIDs: ["acc-3", "acc-1"]
+        )
+
+        // Should match original order: acc-1 before acc-3
+        XCTAssertEqual(result[0].id, "acc-1")
+        XCTAssertEqual(result[1].id, "acc-3")
+    }
+}


### PR DESCRIPTION
Closes #680

## Summary

Enhances the iOS data export flow with date-range filtering, account multi-select, format selection, progress reporting, and share sheet — replacing the previous inline confirmation dialog in Settings.

## Changes

### New Files
- **\ExportFilter.swift\** — Pure static filtering logic (date range + account scoping) with full-day boundary normalisation. Uses \num\ namespace with no stored state for testability.
- **\DataExportViewModel.swift\** — \@Observable\ \@MainActor\ view model managing filter state, export pipeline, and step-by-step progress (\ExportProgressStep\ enum).
- **\DataExportView.swift\** — SwiftUI Form with:
  - Segmented format picker (CSV/JSON) with contextual footer text
  - Date range toggle with start/end \DatePicker\s (constrained to valid ranges)
  - Account multi-select list with Select All toggle and per-row checkmarks
  - Summary section showing active filter configuration
  - Export button with progress overlay (linear \ProgressView\ + step description)
  - Share sheet (\UIActivityViewController\ wrapper) on completion
- **\ExportFilterTests.swift\** — 24 unit tests covering all filtering logic

### Modified Files
- **\SettingsView.swift\** — Data section now uses \NavigationLink\ to \DataExportView\ instead of inline export confirmation dialog. Removed undefined \dangerZoneSection\ reference. Moved \ShareSheetView\ into \DataExportView\.

## Accessibility
- All form controls have \.accessibilityLabel()\, \.accessibilityHint()\, and \.accessibilityValue()\
- Account rows use \.accessibilityAddTraits(.isSelected)\ for selected state
- Progress overlay uses \.accessibilityElement(children: .combine)\ with live step description
- All text uses Dynamic Type system font styles
- Minimum 44pt tap targets on export button

## Test Coverage
- Date range: boundary inclusion, single-day, out-of-range, start/end of day precision
- Account selection: single, multiple, all, nonexistent ID, empty lists
- Combined filters: date + account intersection, empty result sets
- Filter summary: all defaults, date range enabled, partial/full account selection
- Order preservation: filtered results maintain original input order