### PR TITLE
fix(ios): add missing Package.swift targets and deterministic SPM CI caching (#712, #719)

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -23,24 +23,43 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 30
 
+    env:
+      SPM_CACHE_DIR: apps/ios/.spm-packages
+      DERIVED_DATA_DIR: apps/ios/.derivedData
+
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Select Xcode
+        id: xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: latest-stable
 
-      - name: Cache SPM dependencies
+      - name: Cache SPM packages
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
-          path: |
-            apps/ios/.build
-            ~/Library/Developer/Xcode/DerivedData
-            ~/.swiftpm
-          key: ${{ runner.os }}-spm-${{ hashFiles('apps/ios/Package.resolved', 'apps/ios/Package.swift') }}
+          path: ${{ env.SPM_CACHE_DIR }}
+          key: ${{ runner.os }}-spm-pkgs-${{ hashFiles('apps/ios/Package.resolved', 'apps/ios/Package.swift') }}
           restore-keys: |
-            ${{ runner.os }}-spm-
+            ${{ runner.os }}-spm-pkgs-
+
+      - name: Cache DerivedData
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: ${{ env.DERIVED_DATA_DIR }}
+          key: ${{ runner.os }}-dd-${{ hashFiles('apps/ios/Package.resolved', 'apps/ios/Package.swift', 'apps/ios/**/*.swift') }}
+          restore-keys: |
+            ${{ runner.os }}-dd-${{ hashFiles('apps/ios/Package.resolved', 'apps/ios/Package.swift') }}
+            ${{ runner.os }}-dd-
+
+      - name: Resolve SPM dependencies
+        run: |
+          cd apps/ios
+          xcodebuild -resolvePackageDependencies \
+            -scheme FinanceApp \
+            -clonedSourcePackagesDirPath "${{ github.workspace }}/${{ env.SPM_CACHE_DIR }}" \
+            2>&1 | tail -10
 
       - name: Build
         run: |
@@ -48,6 +67,8 @@ jobs:
           xcodebuild build \
             -scheme FinanceApp \
             -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+            -clonedSourcePackagesDirPath "${{ github.workspace }}/${{ env.SPM_CACHE_DIR }}" \
+            -derivedDataPath "${{ github.workspace }}/${{ env.DERIVED_DATA_DIR }}" \
             CODE_SIGNING_ALLOWED=NO \
             2>&1 | tail -20
 
@@ -57,6 +78,8 @@ jobs:
           xcodebuild test \
             -scheme FinanceApp \
             -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+            -clonedSourcePackagesDirPath "${{ github.workspace }}/${{ env.SPM_CACHE_DIR }}" \
+            -derivedDataPath "${{ github.workspace }}/${{ env.DERIVED_DATA_DIR }}" \
             -enableCodeCoverage YES \
             CODE_SIGNING_ALLOWED=NO \
             -resultBundlePath .build/TestResults.xcresult \

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ venv/
 
 # === Swift / Xcode ===
 DerivedData/
+.derivedData/
+.spm-packages/
 *.pbxuser
 *.mode1v3
 *.mode2v3

--- a/apps/ios/Package.swift
+++ b/apps/ios/Package.swift
@@ -18,13 +18,24 @@ let package = Package(
     ],
     products: [
         .library(name: "FinanceApp", targets: ["FinanceApp"]),
+        .library(name: "FinanceShared", targets: ["FinanceShared"]),
+        .library(name: "FinanceClip", targets: ["FinanceClip"]),
         .library(name: "FinanceWatch", targets: ["FinanceWatch"]),
         .library(name: "FinanceWidget", targets: ["FinanceWidget"]),
     ],
     targets: [
+        // MARK: - Shared module
+        // Shared types consumed by the main app, App Clip, and widgets.
+        .target(
+            name: "FinanceShared",
+            dependencies: [],
+            path: "Shared"
+        ),
+
+        // MARK: - Main app
         .target(
             name: "FinanceApp",
-            dependencies: [],
+            dependencies: ["FinanceShared"],
             path: "Finance",
             exclude: [
                 "Info.plist",
@@ -33,11 +44,27 @@ let package = Package(
                 "Data",
             ]
         ),
+
+        // MARK: - App Clip (#648)
+        // Quick transaction entry via Universal Links and NFC App Clip codes.
+        .target(
+            name: "FinanceClip",
+            dependencies: ["FinanceShared"],
+            path: "FinanceClip",
+            exclude: [
+                "Info.plist",
+                "FinanceClipApp.swift",
+            ]
+        ),
+
+        // MARK: - Widget extension
         .target(
             name: "FinanceWidget",
-            dependencies: [],
+            dependencies: ["FinanceShared"],
             path: "FinanceWidget"
         ),
+
+        // MARK: - watchOS companion
         .target(
             name: "FinanceWatch",
             dependencies: [],
@@ -50,6 +77,8 @@ let package = Package(
                 "ComplicationProvider.swift",
             ]
         ),
+
+        // MARK: - Tests
         .testTarget(
             name: "FinanceTests",
             dependencies: ["FinanceApp"],


### PR DESCRIPTION
## Summary

This PR fixes two Sprint 1 iOS issues:

### #712 (P1 Bug) — Missing Package.swift targets for FinanceShared and FinanceClip

The \Package.swift\ declared products for \FinanceApp\, \FinanceWatch\, and \FinanceWidget\ but omitted \FinanceShared\ (\Shared/\) and \FinanceClip\ (\FinanceClip/\), causing SPM resolution failures when building.

**Changes:**
- Add \FinanceShared\ library product and target pointing to \Shared/\
- Add \FinanceClip\ library product and target pointing to \FinanceClip/\, excluding \Info.plist\ and \FinanceClipApp.swift\ (\@main\ entry point)
- Wire dependency graph: \FinanceClip\ → \FinanceShared\, \FinanceApp\ → \FinanceShared\, \FinanceWidget\ → \FinanceShared\
- Add MARK section comments for readability

### #719 (P2) — Deterministic SPM build caching in iOS CI

The previous cache step cached \~/Library/Developer/Xcode/DerivedData\ (non-deterministic, huge) and \~/.swiftpm\ (global, wrong scope), making cache hits unreliable and bloating storage.

**Changes:**
- Use \-clonedSourcePackagesDirPath\ for deterministic SPM package location (\.spm-packages/\)
- Use \-derivedDataPath\ for deterministic build artifact caching (\.derivedData/\)
- Split into two cache layers: SPM packages (keyed on \Package.swift\ + \Package.resolved\) and DerivedData (keyed on packages + Swift sources) with cascading \estore-keys\
- Add explicit \xcodebuild -resolvePackageDependencies\ step before build
- Add \.derivedData/\ and \.spm-packages/\ to \.gitignore\

## Testing
- Verified Package.swift YAML and structure are valid
- Prettier formatting passes for CI workflow YAML
- Cache key hashing validated against file patterns

Closes #712
Closes #719