### PR TITLE
feat(android): CRUD screens for accounts, budgets, goals, and transaction edit/delete

### DIFF
--- a/apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt
@@ -18,12 +18,15 @@ import com.finance.android.ui.screens.DefaultBiometricAvailabilityChecker
 import com.finance.android.ui.screens.SettingsViewModel
 import com.finance.android.ui.theme.ThemePreferenceManager
 import com.finance.android.ui.viewmodel.AccountCreateViewModel
+import com.finance.android.ui.viewmodel.AccountEditViewModel
 import com.finance.android.ui.viewmodel.AnalyticsViewModel
 import com.finance.android.ui.viewmodel.AccountsViewModel
 import com.finance.android.ui.viewmodel.BudgetCreateViewModel
+import com.finance.android.ui.viewmodel.BudgetEditViewModel
 import com.finance.android.ui.viewmodel.BudgetsViewModel
 import com.finance.android.ui.viewmodel.DashboardViewModel
 import com.finance.android.ui.viewmodel.GoalCreateViewModel
+import com.finance.android.ui.viewmodel.GoalEditViewModel
 import com.finance.android.ui.viewmodel.TransactionCreateViewModel
 import com.finance.android.ui.viewmodel.TransactionDetailViewModel
 import com.finance.android.ui.viewmodel.GoalsViewModel
@@ -91,12 +94,15 @@ val appModule = module {
     viewModelOf(::AnalyticsViewModel)
     viewModelOf(::AccountsViewModel)
     viewModelOf(::AccountCreateViewModel)
+    viewModelOf(::AccountEditViewModel)
     viewModelOf(::BudgetsViewModel)
     viewModelOf(::BudgetCreateViewModel)
+    viewModelOf(::BudgetEditViewModel)
     viewModelOf(::TransactionsViewModel)
     viewModelOf(::TransactionCreateViewModel)
     viewModelOf(::TransactionDetailViewModel)
     viewModelOf(::GoalsViewModel)
     viewModelOf(::GoalCreateViewModel)
+    viewModelOf(::GoalEditViewModel)
     viewModelOf(::SettingsViewModel)
 }

--- a/apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceNavHost.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceNavHost.kt
@@ -26,14 +26,18 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import androidx.navigation.navDeepLink
 import com.finance.android.ui.screens.AccountCreateScreen
+import com.finance.android.ui.screens.AccountEditScreen
 import com.finance.android.ui.screens.AccountsScreen
 import com.finance.android.ui.screens.AnalyticsScreen
 import com.finance.android.ui.screens.BudgetCreateScreen
+import com.finance.android.ui.screens.BudgetEditScreen
 import com.finance.android.ui.screens.DashboardScreen
 import com.finance.android.ui.screens.GoalCreateScreen
+import com.finance.android.ui.screens.GoalEditScreen
 import com.finance.android.ui.screens.PlanningScreen
 import com.finance.android.ui.screens.SettingsScreen
 import com.finance.android.ui.screens.TransactionCreateScreen
+import com.finance.android.ui.screens.TransactionDetailScreen
 import com.finance.android.ui.screens.TransactionsScreen
 import timber.log.Timber
 
@@ -90,6 +94,26 @@ sealed class Route(val route: String) {
      */
     data object Invite : Route("invite/{code}") {
         fun createRoute(code: String): String = "invite/$code"
+    }
+
+    /** Account edit screen. */
+    data object AccountEdit : Route("account/edit/{id}") {
+        fun createRoute(id: String): String = "account/edit/$id"
+    }
+
+    /** Budget edit screen. */
+    data object BudgetEdit : Route("budget/edit/{id}") {
+        fun createRoute(id: String): String = "budget/edit/$id"
+    }
+
+    /** Goal edit screen. */
+    data object GoalEdit : Route("goal/edit/{id}") {
+        fun createRoute(id: String): String = "goal/edit/$id"
+    }
+
+    /** Transaction edit screen (reuses create wizard with pre-populated data). */
+    data object TransactionEdit : Route("transaction/edit/{id}") {
+        fun createRoute(id: String): String = "transaction/edit/$id"
     }
 
     /** Analytics / Spending Trends screen. */
@@ -151,7 +175,18 @@ fun FinanceNavHost(
         }
 
         composable(Route.Transactions.route) {
-            TransactionsScreen()
+            TransactionsScreen(
+                onTransactionClick = { id ->
+                    navController.navigate(Route.TransactionDetail.createRoute(id.value)) {
+                        launchSingleTop = true
+                    }
+                },
+                onEditTransaction = { id ->
+                    navController.navigate(Route.TransactionEdit.createRoute(id.value)) {
+                        launchSingleTop = true
+                    }
+                },
+            )
         }
 
         composable(Route.Planning.route) {
@@ -163,6 +198,16 @@ fun FinanceNavHost(
                 },
                 onCreateGoal = {
                     navController.navigate(Route.GoalCreate.route) {
+                        launchSingleTop = true
+                    }
+                },
+                onEditBudget = { id ->
+                    navController.navigate(Route.BudgetEdit.createRoute(id)) {
+                        launchSingleTop = true
+                    }
+                },
+                onEditGoal = { id ->
+                    navController.navigate(Route.GoalEdit.createRoute(id)) {
                         launchSingleTop = true
                     }
                 },
@@ -188,6 +233,11 @@ fun FinanceNavHost(
                 },
                 onAddAccount = {
                     navController.navigate(Route.AccountCreate.route) {
+                        launchSingleTop = true
+                    }
+                },
+                onEditAccount = { id ->
+                    navController.navigate(Route.AccountEdit.createRoute(id)) {
                         launchSingleTop = true
                     }
                 },
@@ -241,6 +291,51 @@ fun FinanceNavHost(
 
         composable(Route.GoalCreate.route) {
             GoalCreateScreen(
+                onSaved = { navController.popBackStack() },
+                onBack = { navController.popBackStack() },
+            )
+        }
+
+        // ── Edit screens ────────────────────────────────────────────
+
+        composable(
+            route = Route.AccountEdit.route,
+            arguments = listOf(navArgument("id") { type = NavType.StringType }),
+        ) {
+            AccountEditScreen(
+                onSaved = { navController.popBackStack() },
+                onDeleted = { navController.popBackStack() },
+                onBack = { navController.popBackStack() },
+            )
+        }
+
+        composable(
+            route = Route.BudgetEdit.route,
+            arguments = listOf(navArgument("id") { type = NavType.StringType }),
+        ) {
+            BudgetEditScreen(
+                onSaved = { navController.popBackStack() },
+                onDeleted = { navController.popBackStack() },
+                onBack = { navController.popBackStack() },
+            )
+        }
+
+        composable(
+            route = Route.GoalEdit.route,
+            arguments = listOf(navArgument("id") { type = NavType.StringType }),
+        ) {
+            GoalEditScreen(
+                onSaved = { navController.popBackStack() },
+                onDeleted = { navController.popBackStack() },
+                onBack = { navController.popBackStack() },
+            )
+        }
+
+        composable(
+            route = Route.TransactionEdit.route,
+            arguments = listOf(navArgument("id") { type = NavType.StringType }),
+        ) {
+            TransactionCreateScreen(
                 onSaved = { navController.popBackStack() },
                 onBack = { navController.popBackStack() },
             )
@@ -347,36 +442,14 @@ fun FinanceNavHost(
             val transactionId = backStackEntry.arguments?.getString("id").orEmpty()
             Timber.d("Deep link: transaction detail for id=%s", transactionId)
 
-            // TODO: Build full TransactionDetailScreen with transaction data loading
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .semantics { contentDescription = "Transaction details" },
-                contentAlignment = Alignment.Center,
-            ) {
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.Center,
-                    modifier = Modifier.padding(24.dp),
-                ) {
-                    Text(
-                        text = "Transaction Details",
-                        style = MaterialTheme.typography.headlineSmall,
-                        modifier = Modifier.semantics {
-                            contentDescription = "Transaction Details heading"
-                        },
-                    )
-                    Spacer(Modifier.height(16.dp))
-                    Text(
-                        text = "Transaction detail view coming soon.",
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.semantics {
-                            contentDescription = "Transaction detail view coming soon"
-                        },
-                    )
-                }
-            }
+            TransactionDetailScreen(
+                onBack = { navController.popBackStack() },
+                onEdit = { txnId ->
+                    navController.navigate(Route.TransactionEdit.createRoute(txnId.value)) {
+                        launchSingleTop = true
+                    }
+                },
+            )
         }
     }
 }

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/AccountEditScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/AccountEditScreen.kt
@@ -1,0 +1,460 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.AttachMoney
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.finance.android.ui.viewmodel.AccountEditUiState
+import com.finance.android.ui.viewmodel.AccountEditViewModel
+import com.finance.models.AccountType
+import org.koin.compose.viewmodel.koinViewModel
+
+/**
+ * Account edit screen — single-page form for editing an existing account.
+ *
+ * Mirrors [AccountCreateScreen] layout but pre-populates fields from the
+ * existing account and provides update/delete actions.
+ * Full TalkBack accessibility with contentDescription on all elements.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AccountEditScreen(
+    onSaved: () -> Unit = {},
+    onDeleted: () -> Unit = {},
+    onBack: () -> Unit = {},
+    viewModel: AccountEditViewModel = koinViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    var showDeleteDialog by remember { mutableStateOf(false) }
+
+    LaunchedEffect(state.isSaved) { if (state.isSaved) onSaved() }
+    LaunchedEffect(state.isDeleted) { if (state.isDeleted) onDeleted() }
+
+    if (state.isLoading) {
+        Box(
+            Modifier
+                .fillMaxSize()
+                .semantics { contentDescription = "Loading account" },
+            contentAlignment = Alignment.Center,
+        ) {
+            CircularProgressIndicator(
+                Modifier.semantics { contentDescription = "Loading indicator" },
+            )
+        }
+        return
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = "Edit Account",
+                        modifier = Modifier.semantics {
+                            contentDescription = "Edit Account screen"
+                        },
+                    )
+                },
+                navigationIcon = {
+                    IconButton(
+                        onClick = onBack,
+                        modifier = Modifier.semantics {
+                            contentDescription = "Navigate back"
+                        },
+                    ) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                },
+                actions = {
+                    IconButton(
+                        onClick = { showDeleteDialog = true },
+                        modifier = Modifier.semantics {
+                            contentDescription = "Delete account"
+                        },
+                    ) {
+                        Icon(
+                            Icons.Filled.Delete,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        AccountEditForm(
+            state = state,
+            supportedCurrencies = viewModel.supportedCurrencies,
+            onNameChange = viewModel::updateName,
+            onTypeChange = viewModel::updateAccountType,
+            onCurrencyChange = viewModel::updateCurrency,
+            onBalanceChange = viewModel::updateInitialBalance,
+            onNoteChange = viewModel::updateNote,
+            onSave = viewModel::save,
+            modifier = Modifier.padding(innerPadding),
+        )
+    }
+
+    if (showDeleteDialog) {
+        AlertDialog(
+            onDismissRequest = { showDeleteDialog = false },
+            title = {
+                Text(
+                    text = "Delete Account?",
+                    modifier = Modifier.semantics {
+                        contentDescription = "Delete Account confirmation"
+                    },
+                )
+            },
+            text = {
+                Text(
+                    text = "This will permanently remove this account and cannot be undone.",
+                    modifier = Modifier.semantics {
+                        contentDescription =
+                            "This will permanently remove this account and cannot be undone"
+                    },
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showDeleteDialog = false
+                        viewModel.delete()
+                    },
+                    modifier = Modifier.semantics {
+                        contentDescription = "Confirm delete"
+                    },
+                ) {
+                    Text("Delete", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = { showDeleteDialog = false },
+                    modifier = Modifier.semantics {
+                        contentDescription = "Cancel delete"
+                    },
+                ) {
+                    Text("Cancel")
+                }
+            },
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AccountEditForm(
+    state: AccountEditUiState,
+    supportedCurrencies: List<String>,
+    onNameChange: (String) -> Unit,
+    onTypeChange: (AccountType) -> Unit,
+    onCurrencyChange: (String) -> Unit,
+    onBalanceChange: (String) -> Unit,
+    onNoteChange: (String) -> Unit,
+    onSave: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        // ── Error messages ──────────────────────────────────────────
+        if (state.errors.isNotEmpty()) {
+            item(key = "errors") {
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .semantics {
+                            contentDescription = "Errors: ${state.errors.joinToString(", ")}"
+                        },
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.errorContainer,
+                    ),
+                ) {
+                    Column(Modifier.padding(12.dp)) {
+                        state.errors.forEach { error ->
+                            Text(
+                                text = "• $error",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onErrorContainer,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        // ── Account name ────────────────────────────────────────────
+        item(key = "name") {
+            Text(
+                text = "Account Name",
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier.semantics { heading() },
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = state.name,
+                onValueChange = onNameChange,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics { contentDescription = "Account name input" },
+                label = { Text("Name") },
+                placeholder = { Text("e.g. Main Checking") },
+                singleLine = true,
+                isError = state.errors.any { it.contains("name", ignoreCase = true) },
+            )
+        }
+
+        // ── Account type ────────────────────────────────────────────
+        item(key = "type") {
+            Text(
+                text = "Account Type",
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier.semantics { heading() },
+            )
+            Spacer(Modifier.height(8.dp))
+            AccountEditTypeDropdown(
+                selectedType = state.accountType,
+                onTypeSelected = onTypeChange,
+            )
+        }
+
+        // ── Currency ────────────────────────────────────────────────
+        item(key = "currency") {
+            Text(
+                text = "Currency",
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier.semantics { heading() },
+            )
+            Spacer(Modifier.height(8.dp))
+            AccountEditCurrencyDropdown(
+                selectedCurrency = state.currency,
+                currencies = supportedCurrencies,
+                onCurrencySelected = onCurrencyChange,
+            )
+        }
+
+        // ── Balance ─────────────────────────────────────────────────
+        item(key = "balance") {
+            Text(
+                text = "Current Balance",
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier.semantics { heading() },
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = state.initialBalance,
+                onValueChange = onBalanceChange,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics { contentDescription = "Current balance in dollars" },
+                label = { Text("Balance") },
+                placeholder = { Text("0.00") },
+                leadingIcon = { Icon(Icons.Filled.AttachMoney, contentDescription = null) },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                singleLine = true,
+            )
+        }
+
+        // ── Note (optional) ─────────────────────────────────────────
+        item(key = "note") {
+            Text(
+                text = "Note (optional)",
+                style = MaterialTheme.typography.labelLarge,
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = state.note,
+                onValueChange = onNoteChange,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics { contentDescription = "Optional note" },
+                label = { Text("Note") },
+                placeholder = { Text("Add a note...") },
+                maxLines = 3,
+            )
+        }
+
+        // ── Save button ─────────────────────────────────────────────
+        item(key = "save") {
+            Spacer(Modifier.height(8.dp))
+            Button(
+                onClick = onSave,
+                enabled = !state.isSaving,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics {
+                        contentDescription =
+                            if (state.isSaving) "Saving changes" else "Save changes"
+                    },
+            ) {
+                if (state.isSaving) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(18.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text("Saving...")
+                } else {
+                    Icon(Icons.Filled.Check, contentDescription = null, Modifier.size(18.dp))
+                    Spacer(Modifier.width(8.dp))
+                    Text("Save Changes")
+                }
+            }
+        }
+
+        item(key = "spacer") { Spacer(Modifier.height(32.dp)) }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AccountEditTypeDropdown(
+    selectedType: AccountType,
+    onTypeSelected: (AccountType) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val displayName = accountEditTypeDisplayName(selectedType)
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        modifier = modifier,
+    ) {
+        OutlinedTextField(
+            value = displayName,
+            onValueChange = {},
+            readOnly = true,
+            modifier = Modifier
+                .fillMaxWidth()
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                .semantics { contentDescription = "Account type: $displayName" },
+            label = { Text("Type") },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
+        )
+        ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            AccountType.entries.forEach { type ->
+                val name = accountEditTypeDisplayName(type)
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = name,
+                            modifier = Modifier.semantics {
+                                contentDescription = "Account type: $name"
+                            },
+                        )
+                    },
+                    onClick = { onTypeSelected(type); expanded = false },
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AccountEditCurrencyDropdown(
+    selectedCurrency: String,
+    currencies: List<String>,
+    onCurrencySelected: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        modifier = modifier,
+    ) {
+        OutlinedTextField(
+            value = selectedCurrency,
+            onValueChange = {},
+            readOnly = true,
+            modifier = Modifier
+                .fillMaxWidth()
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                .semantics { contentDescription = "Currency: $selectedCurrency" },
+            label = { Text("Currency") },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
+        )
+        ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            currencies.forEach { currency ->
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = currency,
+                            modifier = Modifier.semantics {
+                                contentDescription = "Currency: $currency"
+                            },
+                        )
+                    },
+                    onClick = { onCurrencySelected(currency); expanded = false },
+                )
+            }
+        }
+    }
+}
+
+private fun accountEditTypeDisplayName(type: AccountType): String = when (type) {
+    AccountType.CHECKING -> "Checking"
+    AccountType.SAVINGS -> "Savings"
+    AccountType.CREDIT_CARD -> "Credit Card"
+    AccountType.CASH -> "Cash"
+    AccountType.INVESTMENT -> "Investment"
+    AccountType.LOAN -> "Loan"
+    AccountType.OTHER -> "Other"
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/AccountEditScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/AccountEditScreen.kt
@@ -139,7 +139,6 @@ fun AccountEditScreen(
             onTypeChange = viewModel::updateAccountType,
             onCurrencyChange = viewModel::updateCurrency,
             onBalanceChange = viewModel::updateInitialBalance,
-            onNoteChange = viewModel::updateNote,
             onSave = viewModel::save,
             modifier = Modifier.padding(innerPadding),
         )
@@ -201,7 +200,6 @@ private fun AccountEditForm(
     onTypeChange: (AccountType) -> Unit,
     onCurrencyChange: (String) -> Unit,
     onBalanceChange: (String) -> Unit,
-    onNoteChange: (String) -> Unit,
     onSave: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -305,25 +303,6 @@ private fun AccountEditForm(
                 leadingIcon = { Icon(Icons.Filled.AttachMoney, contentDescription = null) },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
                 singleLine = true,
-            )
-        }
-
-        // ── Note (optional) ─────────────────────────────────────────
-        item(key = "note") {
-            Text(
-                text = "Note (optional)",
-                style = MaterialTheme.typography.labelLarge,
-            )
-            Spacer(Modifier.height(8.dp))
-            OutlinedTextField(
-                value = state.note,
-                onValueChange = onNoteChange,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .semantics { contentDescription = "Optional note" },
-                label = { Text("Note") },
-                placeholder = { Text("Add a note...") },
-                maxLines = 3,
             )
         }
 

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/AccountsScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/AccountsScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.filled.AccountBalance
 import androidx.compose.material.icons.filled.AccountBalanceWallet
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.CreditCard
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Savings
 import androidx.compose.material.icons.filled.ShowChart
 import androidx.compose.material.icons.filled.TrendingDown
@@ -79,13 +80,19 @@ import com.finance.models.types.Currency
 fun AccountsScreen(
     onAccountClick: (String) -> Unit = {},
     onAddAccount: () -> Unit = {},
+    onEditAccount: (String) -> Unit = {},
     modifier: Modifier = Modifier,
     viewModel: AccountsViewModel = koinViewModel(),
 ) {
     val state by viewModel.uiState.collectAsState()
     val sel = state.selectedAccount
     if (sel != null) {
-        AccountDetailScreen(sel, state.selectedAccountTransactions, viewModel::clearSelection)
+        AccountDetailScreen(
+            sel,
+            state.selectedAccountTransactions,
+            viewModel::clearSelection,
+            onEdit = { onEditAccount(sel.id.value) },
+        )
         return
     }
     if (state.isLoading) {
@@ -164,7 +171,12 @@ private fun AccountCard(account: Account, onClick: () -> Unit) {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-internal fun AccountDetailScreen(account: Account, transactions: List<Transaction>, onBack: () -> Unit) {
+internal fun AccountDetailScreen(
+    account: Account,
+    transactions: List<Transaction>,
+    onBack: () -> Unit,
+    onEdit: () -> Unit = {},
+) {
     val bal = CurrencyFormatter.format(account.currentBalance, account.currency)
     val typeName = account.type.name.lowercase().replace('_', ' ').replaceFirstChar { it.uppercase() }
     Scaffold(topBar = {
@@ -172,6 +184,14 @@ internal fun AccountDetailScreen(account: Account, transactions: List<Transactio
             navigationIcon = {
                 IconButton(onClick = onBack, modifier = Modifier.semantics { contentDescription = "Navigate back" }) {
                     Icon(Icons.AutoMirrored.Filled.ArrowBack, null)
+                }
+            },
+            actions = {
+                IconButton(
+                    onClick = onEdit,
+                    modifier = Modifier.semantics { contentDescription = "Edit account" },
+                ) {
+                    Icon(Icons.Filled.Edit, contentDescription = null)
                 }
             })
     }) { innerPadding ->

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/BudgetEditScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/BudgetEditScreen.kt
@@ -1,0 +1,407 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.AttachMoney
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.finance.android.ui.viewmodel.BudgetEditUiState
+import com.finance.android.ui.viewmodel.BudgetEditViewModel
+import com.finance.models.BudgetPeriod
+import com.finance.models.types.SyncId
+import org.koin.compose.viewmodel.koinViewModel
+
+/**
+ * Budget edit screen — single-page form for editing an existing budget.
+ *
+ * Mirrors [BudgetCreateScreen] layout but pre-populates fields and
+ * provides update/delete actions. Full TalkBack accessibility.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BudgetEditScreen(
+    onSaved: () -> Unit = {},
+    onDeleted: () -> Unit = {},
+    onBack: () -> Unit = {},
+    viewModel: BudgetEditViewModel = koinViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    var showDeleteDialog by remember { mutableStateOf(false) }
+
+    LaunchedEffect(state.isSaved) { if (state.isSaved) onSaved() }
+    LaunchedEffect(state.isDeleted) { if (state.isDeleted) onDeleted() }
+
+    if (state.isLoading) {
+        Box(
+            Modifier
+                .fillMaxSize()
+                .semantics { contentDescription = "Loading budget" },
+            contentAlignment = Alignment.Center,
+        ) {
+            CircularProgressIndicator(
+                Modifier.semantics { contentDescription = "Loading indicator" },
+            )
+        }
+        return
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = "Edit Budget",
+                        modifier = Modifier.semantics {
+                            contentDescription = "Edit Budget screen"
+                        },
+                    )
+                },
+                navigationIcon = {
+                    IconButton(
+                        onClick = onBack,
+                        modifier = Modifier.semantics {
+                            contentDescription = "Navigate back"
+                        },
+                    ) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                },
+                actions = {
+                    IconButton(
+                        onClick = { showDeleteDialog = true },
+                        modifier = Modifier.semantics {
+                            contentDescription = "Delete budget"
+                        },
+                    ) {
+                        Icon(
+                            Icons.Filled.Delete,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        BudgetEditForm(
+            state = state,
+            onCategorySelect = viewModel::selectCategory,
+            onAmountChange = viewModel::updateAmount,
+            onPeriodChange = viewModel::updatePeriod,
+            onSave = viewModel::save,
+            modifier = Modifier.padding(innerPadding),
+        )
+    }
+
+    if (showDeleteDialog) {
+        AlertDialog(
+            onDismissRequest = { showDeleteDialog = false },
+            title = {
+                Text(
+                    text = "Delete Budget?",
+                    modifier = Modifier.semantics {
+                        contentDescription = "Delete Budget confirmation"
+                    },
+                )
+            },
+            text = {
+                Text(
+                    text = "This will permanently remove this budget and cannot be undone.",
+                    modifier = Modifier.semantics {
+                        contentDescription =
+                            "This will permanently remove this budget and cannot be undone"
+                    },
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showDeleteDialog = false
+                        viewModel.delete()
+                    },
+                    modifier = Modifier.semantics {
+                        contentDescription = "Confirm delete"
+                    },
+                ) {
+                    Text("Delete", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = { showDeleteDialog = false },
+                    modifier = Modifier.semantics {
+                        contentDescription = "Cancel delete"
+                    },
+                ) {
+                    Text("Cancel")
+                }
+            },
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+private fun BudgetEditForm(
+    state: BudgetEditUiState,
+    onCategorySelect: (SyncId) -> Unit,
+    onAmountChange: (String) -> Unit,
+    onPeriodChange: (BudgetPeriod) -> Unit,
+    onSave: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        // ── Error messages ──────────────────────────────────────────
+        if (state.errors.isNotEmpty()) {
+            item(key = "errors") {
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .semantics {
+                            contentDescription = "Errors: ${state.errors.joinToString(", ")}"
+                        },
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.errorContainer,
+                    ),
+                ) {
+                    Column(Modifier.padding(12.dp)) {
+                        state.errors.forEach { error ->
+                            Text(
+                                text = "• $error",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onErrorContainer,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        // ── Category selector ───────────────────────────────────────
+        item(key = "category") {
+            Text(
+                text = "Category",
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier.semantics {
+                    heading()
+                    contentDescription = "Select a category"
+                },
+            )
+            Spacer(Modifier.height(8.dp))
+            if (state.categories.isEmpty()) {
+                Text(
+                    text = "No categories available",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.semantics {
+                        contentDescription = "No categories available"
+                    },
+                )
+            } else {
+                FlowRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    state.categories.forEach { cat ->
+                        val selected = cat.id == state.selectedCategory?.id
+                        FilterChip(
+                            selected = selected,
+                            onClick = { onCategorySelect(cat.id) },
+                            label = {
+                                Text(
+                                    text = cat.name,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            },
+                            modifier = Modifier.semantics {
+                                contentDescription = if (selected) {
+                                    "Category: ${cat.name}, selected"
+                                } else {
+                                    "Category: ${cat.name}"
+                                }
+                            },
+                        )
+                    }
+                }
+            }
+        }
+
+        // ── Budgeted amount ─────────────────────────────────────────
+        item(key = "amount") {
+            Text(
+                text = "Budgeted Amount",
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier.semantics { heading() },
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = state.amount,
+                onValueChange = onAmountChange,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics { contentDescription = "Budgeted amount in dollars" },
+                label = { Text("Amount") },
+                placeholder = { Text("0.00") },
+                leadingIcon = { Icon(Icons.Filled.AttachMoney, contentDescription = null) },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                singleLine = true,
+                isError = state.errors.any { it.contains("amount", ignoreCase = true) },
+            )
+        }
+
+        // ── Period selector ─────────────────────────────────────────
+        item(key = "period") {
+            Text(
+                text = "Period",
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier.semantics { heading() },
+            )
+            Spacer(Modifier.height(8.dp))
+            BudgetEditPeriodDropdown(
+                selectedPeriod = state.period,
+                onPeriodSelected = onPeriodChange,
+            )
+        }
+
+        // ── Save button ─────────────────────────────────────────────
+        item(key = "save") {
+            Spacer(Modifier.height(8.dp))
+            Button(
+                onClick = onSave,
+                enabled = !state.isSaving,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics {
+                        contentDescription =
+                            if (state.isSaving) "Saving changes" else "Save changes"
+                    },
+            ) {
+                if (state.isSaving) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(18.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text("Saving...")
+                } else {
+                    Icon(Icons.Filled.Check, contentDescription = null, Modifier.size(18.dp))
+                    Spacer(Modifier.width(8.dp))
+                    Text("Save Changes")
+                }
+            }
+        }
+
+        item(key = "spacer") { Spacer(Modifier.height(32.dp)) }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun BudgetEditPeriodDropdown(
+    selectedPeriod: BudgetPeriod,
+    onPeriodSelected: (BudgetPeriod) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val displayName = budgetEditPeriodDisplayName(selectedPeriod)
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        modifier = modifier,
+    ) {
+        OutlinedTextField(
+            value = displayName,
+            onValueChange = {},
+            readOnly = true,
+            modifier = Modifier
+                .fillMaxWidth()
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                .semantics { contentDescription = "Period: $displayName" },
+            label = { Text("Period") },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
+        )
+        ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            BudgetPeriod.entries.forEach { period ->
+                val name = budgetEditPeriodDisplayName(period)
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = name,
+                            modifier = Modifier.semantics {
+                                contentDescription = "Period: $name"
+                            },
+                        )
+                    },
+                    onClick = { onPeriodSelected(period); expanded = false },
+                )
+            }
+        }
+    }
+}
+
+private fun budgetEditPeriodDisplayName(period: BudgetPeriod): String = when (period) {
+    BudgetPeriod.WEEKLY -> "Weekly"
+    BudgetPeriod.BIWEEKLY -> "Biweekly"
+    BudgetPeriod.MONTHLY -> "Monthly"
+    BudgetPeriod.QUARTERLY -> "Quarterly"
+    BudgetPeriod.YEARLY -> "Yearly"
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/BudgetsScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/BudgetsScreen.kt
@@ -4,6 +4,7 @@ package com.finance.android.ui.screens
 
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -68,6 +69,7 @@ import org.koin.compose.viewmodel.koinViewModel
 @Composable
 fun BudgetsScreen(
     onCreateBudget: () -> Unit = {},
+    onBudgetClick: (String) -> Unit = {},
     modifier: Modifier = Modifier,
     viewModel: BudgetsViewModel = koinViewModel(),
 ) {
@@ -102,6 +104,7 @@ fun BudgetsScreen(
                 state = state,
                 onRefresh = viewModel::refresh,
                 onCreateBudget = onCreateBudget,
+                onBudgetClick = onBudgetClick,
                 modifier = modifier,
             )
         }
@@ -114,6 +117,7 @@ internal fun BudgetsContent(
     state: BudgetsUiState,
     onRefresh: () -> Unit,
     onCreateBudget: () -> Unit,
+    onBudgetClick: (String) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     Box(modifier = modifier.fillMaxSize()) {
@@ -148,7 +152,7 @@ internal fun BudgetsContent(
                         )
                     }
                     items(state.budgets, key = { it.id.value }) { budget ->
-                        BudgetItemCard(budget)
+                        BudgetItemCard(budget, onClick = { onBudgetClick(budget.id.value) })
                     }
                     item(key = "spacer") { Spacer(Modifier.height(80.dp)) }
                 }
@@ -259,7 +263,7 @@ private fun BudgetSummaryCard(
 }
 
 @Composable
-private fun BudgetItemCard(budget: BudgetItemUi) {
+private fun BudgetItemCard(budget: BudgetItemUi, onClick: () -> Unit = {}) {
     val healthColor = when (budget.health) {
         BudgetHealth.HEALTHY -> MaterialTheme.colorScheme.primary
         BudgetHealth.WARNING -> Color(0xFFFF9800)
@@ -287,6 +291,7 @@ private fun BudgetItemCard(budget: BudgetItemUi) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
+            .clickable(onClick = onClick)
             .semantics {
                 contentDescription =
                     "${budget.name}: ${budget.spent} of ${budget.limit}, " +

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/GoalEditScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/GoalEditScreen.kt
@@ -1,0 +1,520 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.AttachMoney
+import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.finance.android.ui.viewmodel.GoalEditUiState
+import com.finance.android.ui.viewmodel.GoalEditViewModel
+import com.finance.models.types.SyncId
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.toLocalDateTime
+import org.koin.compose.viewmodel.koinViewModel
+
+/**
+ * Goal edit screen — single-page form for editing an existing goal.
+ *
+ * Mirrors [GoalCreateScreen] layout but pre-populates fields and
+ * provides update/delete actions. Full TalkBack accessibility.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun GoalEditScreen(
+    onSaved: () -> Unit = {},
+    onDeleted: () -> Unit = {},
+    onBack: () -> Unit = {},
+    viewModel: GoalEditViewModel = koinViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    var showDeleteDialog by remember { mutableStateOf(false) }
+
+    LaunchedEffect(state.isSaved) { if (state.isSaved) onSaved() }
+    LaunchedEffect(state.isDeleted) { if (state.isDeleted) onDeleted() }
+
+    if (state.isLoading) {
+        Box(
+            Modifier
+                .fillMaxSize()
+                .semantics { contentDescription = "Loading goal" },
+            contentAlignment = Alignment.Center,
+        ) {
+            CircularProgressIndicator(
+                Modifier.semantics { contentDescription = "Loading indicator" },
+            )
+        }
+        return
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = "Edit Goal",
+                        modifier = Modifier.semantics {
+                            contentDescription = "Edit Goal screen"
+                        },
+                    )
+                },
+                navigationIcon = {
+                    IconButton(
+                        onClick = onBack,
+                        modifier = Modifier.semantics {
+                            contentDescription = "Navigate back"
+                        },
+                    ) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                },
+                actions = {
+                    IconButton(
+                        onClick = { showDeleteDialog = true },
+                        modifier = Modifier.semantics {
+                            contentDescription = "Delete goal"
+                        },
+                    ) {
+                        Icon(
+                            Icons.Filled.Delete,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        GoalEditForm(
+            state = state,
+            onNameChange = viewModel::updateName,
+            onTargetAmountChange = viewModel::updateTargetAmount,
+            onCurrentAmountChange = viewModel::updateCurrentAmount,
+            onTargetDateChange = viewModel::updateTargetDate,
+            onAccountSelect = viewModel::selectAccount,
+            onNoteChange = viewModel::updateNote,
+            onSave = viewModel::save,
+            modifier = Modifier.padding(innerPadding),
+        )
+    }
+
+    if (showDeleteDialog) {
+        AlertDialog(
+            onDismissRequest = { showDeleteDialog = false },
+            title = {
+                Text(
+                    text = "Delete Goal?",
+                    modifier = Modifier.semantics {
+                        contentDescription = "Delete Goal confirmation"
+                    },
+                )
+            },
+            text = {
+                Text(
+                    text = "This will permanently remove this goal and cannot be undone.",
+                    modifier = Modifier.semantics {
+                        contentDescription =
+                            "This will permanently remove this goal and cannot be undone"
+                    },
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showDeleteDialog = false
+                        viewModel.delete()
+                    },
+                    modifier = Modifier.semantics {
+                        contentDescription = "Confirm delete"
+                    },
+                ) {
+                    Text("Delete", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = { showDeleteDialog = false },
+                    modifier = Modifier.semantics {
+                        contentDescription = "Cancel delete"
+                    },
+                ) {
+                    Text("Cancel")
+                }
+            },
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun GoalEditForm(
+    state: GoalEditUiState,
+    onNameChange: (String) -> Unit,
+    onTargetAmountChange: (String) -> Unit,
+    onCurrentAmountChange: (String) -> Unit,
+    onTargetDateChange: (LocalDate) -> Unit,
+    onAccountSelect: (SyncId?) -> Unit,
+    onNoteChange: (String) -> Unit,
+    onSave: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var showDatePicker by remember { mutableStateOf(false) }
+
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        // ── Error messages ──────────────────────────────────────────
+        if (state.errors.isNotEmpty()) {
+            item(key = "errors") {
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .semantics {
+                            contentDescription = "Errors: ${state.errors.joinToString(", ")}"
+                        },
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.errorContainer,
+                    ),
+                ) {
+                    Column(Modifier.padding(12.dp)) {
+                        state.errors.forEach { error ->
+                            Text(
+                                text = "• $error",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onErrorContainer,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        // ── Goal name ───────────────────────────────────────────────
+        item(key = "name") {
+            Text(
+                text = "Goal Name",
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier.semantics { heading() },
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = state.name,
+                onValueChange = onNameChange,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics { contentDescription = "Goal name input" },
+                label = { Text("Name") },
+                placeholder = { Text("e.g. Emergency Fund") },
+                singleLine = true,
+                isError = state.errors.any { it.contains("name", ignoreCase = true) },
+            )
+        }
+
+        // ── Target amount ───────────────────────────────────────────
+        item(key = "targetAmount") {
+            Text(
+                text = "Target Amount",
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier.semantics { heading() },
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = state.targetAmount,
+                onValueChange = onTargetAmountChange,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics { contentDescription = "Target amount in dollars" },
+                label = { Text("Target") },
+                placeholder = { Text("0.00") },
+                leadingIcon = { Icon(Icons.Filled.AttachMoney, contentDescription = null) },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                singleLine = true,
+                isError = state.errors.any { it.contains("target", ignoreCase = true) },
+            )
+        }
+
+        // ── Current amount ──────────────────────────────────────────
+        item(key = "currentAmount") {
+            Text(
+                text = "Current Amount",
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier.semantics { heading() },
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = state.currentAmount,
+                onValueChange = onCurrentAmountChange,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics { contentDescription = "Current saved amount in dollars" },
+                label = { Text("Current") },
+                placeholder = { Text("0.00") },
+                leadingIcon = { Icon(Icons.Filled.AttachMoney, contentDescription = null) },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                singleLine = true,
+            )
+        }
+
+        // ── Target date ─────────────────────────────────────────────
+        item(key = "targetDate") {
+            Text(
+                text = "Target Date",
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier.semantics { heading() },
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = state.targetDate?.let { goalEditFormatDate(it) } ?: "",
+                onValueChange = {},
+                readOnly = true,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics {
+                        contentDescription = "Target date: ${
+                            state.targetDate?.let { goalEditFormatDate(it) } ?: "not set"
+                        }"
+                    },
+                label = { Text("Date") },
+                placeholder = { Text("Select a target date") },
+                trailingIcon = {
+                    IconButton(
+                        onClick = { showDatePicker = true },
+                        modifier = Modifier.semantics {
+                            contentDescription = "Open date picker"
+                        },
+                    ) {
+                        Icon(Icons.Filled.CalendarMonth, contentDescription = null)
+                    }
+                },
+            )
+        }
+
+        // ── Linked account ──────────────────────────────────────────
+        if (state.accounts.isNotEmpty()) {
+            item(key = "account") {
+                Text(
+                    text = "Linked Account (optional)",
+                    style = MaterialTheme.typography.labelLarge,
+                    modifier = Modifier.semantics { heading() },
+                )
+                Spacer(Modifier.height(8.dp))
+                GoalEditAccountDropdown(
+                    selectedAccount = state.selectedAccount,
+                    accounts = state.accounts,
+                    onAccountSelected = onAccountSelect,
+                )
+            }
+        }
+
+        // ── Note (optional) ─────────────────────────────────────────
+        item(key = "note") {
+            Text(
+                text = "Note (optional)",
+                style = MaterialTheme.typography.labelLarge,
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = state.note,
+                onValueChange = onNoteChange,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics { contentDescription = "Optional note" },
+                label = { Text("Note") },
+                placeholder = { Text("Add a note...") },
+                maxLines = 3,
+            )
+        }
+
+        // ── Save button ─────────────────────────────────────────────
+        item(key = "save") {
+            Spacer(Modifier.height(8.dp))
+            Button(
+                onClick = onSave,
+                enabled = !state.isSaving,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics {
+                        contentDescription =
+                            if (state.isSaving) "Saving changes" else "Save changes"
+                    },
+            ) {
+                if (state.isSaving) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(18.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text("Saving...")
+                } else {
+                    Icon(Icons.Filled.Check, contentDescription = null, Modifier.size(18.dp))
+                    Spacer(Modifier.width(8.dp))
+                    Text("Save Changes")
+                }
+            }
+        }
+
+        item(key = "spacer") { Spacer(Modifier.height(32.dp)) }
+    }
+
+    if (showDatePicker) {
+        val datePickerState = rememberDatePickerState(
+            initialSelectedDateMillis = state.targetDate?.atStartOfDayIn(TimeZone.UTC)
+                ?.toEpochMilliseconds(),
+        )
+        DatePickerDialog(
+            onDismissRequest = { showDatePicker = false },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        datePickerState.selectedDateMillis?.let { millis ->
+                            val date = Instant.fromEpochMilliseconds(millis)
+                                .toLocalDateTime(TimeZone.UTC).date
+                            onTargetDateChange(date)
+                        }
+                        showDatePicker = false
+                    },
+                    modifier = Modifier.semantics {
+                        contentDescription = "Confirm date selection"
+                    },
+                ) {
+                    Text("OK")
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = { showDatePicker = false },
+                    modifier = Modifier.semantics {
+                        contentDescription = "Cancel date selection"
+                    },
+                ) {
+                    Text("Cancel")
+                }
+            },
+        ) {
+            DatePicker(
+                state = datePickerState,
+                modifier = Modifier.semantics {
+                    contentDescription = "Date picker for target date"
+                },
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun GoalEditAccountDropdown(
+    selectedAccount: com.finance.models.Account?,
+    accounts: List<com.finance.models.Account>,
+    onAccountSelected: (SyncId?) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val displayName = selectedAccount?.name ?: "None"
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        modifier = modifier,
+    ) {
+        OutlinedTextField(
+            value = displayName,
+            onValueChange = {},
+            readOnly = true,
+            modifier = Modifier
+                .fillMaxWidth()
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                .semantics { contentDescription = "Linked account: $displayName" },
+            label = { Text("Account") },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
+        )
+        ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            DropdownMenuItem(
+                text = {
+                    Text(
+                        text = "None",
+                        modifier = Modifier.semantics {
+                            contentDescription = "No linked account"
+                        },
+                    )
+                },
+                onClick = { onAccountSelected(null); expanded = false },
+            )
+            accounts.forEach { account ->
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = account.name,
+                            modifier = Modifier.semantics {
+                                contentDescription = "Account: ${account.name}"
+                            },
+                        )
+                    },
+                    onClick = { onAccountSelected(account.id); expanded = false },
+                )
+            }
+        }
+    }
+}
+
+private fun goalEditFormatDate(date: LocalDate): String {
+    val month = date.month.name.lowercase().replaceFirstChar { it.uppercase() }.take(3)
+    return "$month ${date.dayOfMonth}, ${date.year}"
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/GoalEditScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/GoalEditScreen.kt
@@ -146,7 +146,6 @@ fun GoalEditScreen(
             onCurrentAmountChange = viewModel::updateCurrentAmount,
             onTargetDateChange = viewModel::updateTargetDate,
             onAccountSelect = viewModel::selectAccount,
-            onNoteChange = viewModel::updateNote,
             onSave = viewModel::save,
             modifier = Modifier.padding(innerPadding),
         )
@@ -208,7 +207,6 @@ private fun GoalEditForm(
     onCurrentAmountChange: (String) -> Unit,
     onTargetDateChange: (LocalDate) -> Unit,
     onAccountSelect: (SyncId?) -> Unit,
-    onNoteChange: (String) -> Unit,
     onSave: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -360,25 +358,6 @@ private fun GoalEditForm(
                     onAccountSelected = onAccountSelect,
                 )
             }
-        }
-
-        // ── Note (optional) ─────────────────────────────────────────
-        item(key = "note") {
-            Text(
-                text = "Note (optional)",
-                style = MaterialTheme.typography.labelLarge,
-            )
-            Spacer(Modifier.height(8.dp))
-            OutlinedTextField(
-                value = state.note,
-                onValueChange = onNoteChange,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .semantics { contentDescription = "Optional note" },
-                label = { Text("Note") },
-                placeholder = { Text("Add a note...") },
-                maxLines = 3,
-            )
         }
 
         // ── Save button ─────────────────────────────────────────────

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/GoalsScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/GoalsScreen.kt
@@ -4,6 +4,7 @@ package com.finance.android.ui.screens
 
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -66,6 +67,7 @@ import org.koin.compose.viewmodel.koinViewModel
 @Composable
 fun GoalsScreen(
     onCreateGoal: () -> Unit = {},
+    onGoalClick: (String) -> Unit = {},
     modifier: Modifier = Modifier,
     viewModel: GoalsViewModel = koinViewModel(),
 ) {
@@ -89,6 +91,7 @@ fun GoalsScreen(
         state = state,
         onRefresh = viewModel::refresh,
         onCreateGoal = onCreateGoal,
+        onGoalClick = onGoalClick,
         modifier = modifier,
     )
 }
@@ -99,6 +102,7 @@ internal fun GoalsContent(
     state: GoalsUiState,
     onRefresh: () -> Unit,
     onCreateGoal: () -> Unit,
+    onGoalClick: (String) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     Box(modifier = modifier.fillMaxSize()) {
@@ -140,7 +144,7 @@ internal fun GoalsContent(
                 // ── Goal cards ──────────────────────────────────────────
                 if (state.goals.isNotEmpty()) {
                     items(state.goals, key = { it.id.value }) { goal ->
-                        GoalCard(goal = goal)
+                        GoalCard(goal = goal, onClick = { onGoalClick(goal.id.value) })
                     }
                 }
 
@@ -270,6 +274,7 @@ private fun GoalsErrorBanner(
 @Composable
 private fun GoalCard(
     goal: GoalItemUi,
+    onClick: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val animatedProgress by animateFloatAsState(
@@ -287,6 +292,7 @@ private fun GoalCard(
     ElevatedCard(
         modifier = modifier
             .fillMaxWidth()
+            .clickable(onClick = onClick)
             .semantics {
                 contentDescription = "${goal.name}: ${goal.currentFormatted} of ${goal.targetFormatted}, " +
                     "$progressPercent percent" +

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/PlanningScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/PlanningScreen.kt
@@ -29,12 +29,16 @@ import androidx.compose.ui.semantics.semantics
  *
  * @param onCreateBudget Called when the user taps the FAB on the Budgets tab.
  * @param onCreateGoal   Called when the user taps the FAB on the Goals tab.
+ * @param onEditBudget   Called with the budget ID when the user taps a budget to edit.
+ * @param onEditGoal     Called with the goal ID when the user taps a goal to edit.
  * @param modifier       Modifier applied to the root layout.
  */
 @Composable
 fun PlanningScreen(
     onCreateBudget: () -> Unit = {},
     onCreateGoal: () -> Unit = {},
+    onEditBudget: (String) -> Unit = {},
+    onEditGoal: (String) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     var selectedTab by rememberSaveable { mutableIntStateOf(0) }
@@ -65,8 +69,14 @@ fun PlanningScreen(
         }
 
         when (selectedTab) {
-            0 -> BudgetsScreen(onCreateBudget = onCreateBudget)
-            1 -> GoalsScreen(onCreateGoal = onCreateGoal)
+            0 -> BudgetsScreen(
+                onCreateBudget = onCreateBudget,
+                onBudgetClick = { id -> onEditBudget(id) },
+            )
+            1 -> GoalsScreen(
+                onCreateGoal = onCreateGoal,
+                onGoalClick = { id -> onEditGoal(id) },
+            )
         }
     }
 }

--- a/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/AccountEditViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/AccountEditViewModel.kt
@@ -31,7 +31,6 @@ data class AccountEditUiState(
     val accountType: AccountType = AccountType.CHECKING,
     val currency: String = "USD",
     val initialBalance: String = "",
-    val note: String = "",
     val errors: List<String> = emptyList(),
     val isSaving: Boolean = false,
     val isSaved: Boolean = false,
@@ -118,10 +117,6 @@ class AccountEditViewModel(
         val parts = cleaned.split(".")
         val limited = if (parts.size > 1) "${parts[0]}.${parts[1].take(2)}" else cleaned
         _uiState.update { it.copy(initialBalance = limited, errors = emptyList()) }
-    }
-
-    fun updateNote(note: String) {
-        _uiState.update { it.copy(note = note.take(500), errors = emptyList()) }
     }
 
     // ── Validation ──────────────────────────────────────────────────

--- a/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/AccountEditViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/AccountEditViewModel.kt
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.finance.android.data.repository.AccountRepository
+import com.finance.models.Account
+import com.finance.models.AccountType
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import timber.log.Timber
+
+/**
+ * UI state for the Account edit form.
+ *
+ * Reuses the same field set as [AccountCreateUiState] but adds
+ * [isLoaded] to distinguish "loading from repository" from
+ * "ready to edit" and [isDeleted] for post-deletion navigation.
+ */
+data class AccountEditUiState(
+    val name: String = "",
+    val accountType: AccountType = AccountType.CHECKING,
+    val currency: String = "USD",
+    val initialBalance: String = "",
+    val note: String = "",
+    val errors: List<String> = emptyList(),
+    val isSaving: Boolean = false,
+    val isSaved: Boolean = false,
+    val isLoading: Boolean = true,
+    val isDeleted: Boolean = false,
+)
+
+/**
+ * ViewModel for the Account edit screen.
+ *
+ * Loads the existing [Account] from [AccountRepository] via the
+ * navigation argument `id`, populates the form, and persists
+ * updates via [AccountRepository.update].
+ *
+ * @param savedStateHandle Navigation argument handle — must contain key `"id"`.
+ * @param accountRepository Repository used to load and update the account.
+ */
+class AccountEditViewModel(
+    savedStateHandle: SavedStateHandle,
+    private val accountRepository: AccountRepository,
+) : ViewModel() {
+
+    private val accountId: SyncId = SyncId(
+        checkNotNull(savedStateHandle["id"]) {
+            "AccountEditViewModel requires navigation argument 'id'"
+        },
+    )
+
+    private val _uiState = MutableStateFlow(AccountEditUiState())
+    val uiState: StateFlow<AccountEditUiState> = _uiState.asStateFlow()
+
+    /** Supported currency codes for the currency dropdown. */
+    val supportedCurrencies: List<String> = listOf("USD", "EUR", "GBP", "JPY", "CAD")
+
+    private var originalAccount: Account? = null
+
+    init {
+        viewModelScope.launch {
+            val account = accountRepository.getById(accountId)
+            if (account == null) {
+                Timber.w("Account not found for editing: id=%s", accountId.value)
+                _uiState.update {
+                    it.copy(isLoading = false, errors = listOf("Account not found"))
+                }
+                return@launch
+            }
+            originalAccount = account
+            val balanceStr = if (account.currentBalance.amount == 0L) "" else {
+                val dollars = account.currentBalance.amount / 100.0
+                if (dollars == dollars.toLong().toDouble()) {
+                    dollars.toLong().toString()
+                } else {
+                    "%.2f".format(dollars)
+                }
+            }
+            _uiState.update {
+                it.copy(
+                    name = account.name,
+                    accountType = account.type,
+                    currency = account.currency.code,
+                    initialBalance = balanceStr,
+                    isLoading = false,
+                )
+            }
+        }
+    }
+
+    // ── Field updaters ──────────────────────────────────────────────
+
+    fun updateName(name: String) {
+        _uiState.update { it.copy(name = name.take(100), errors = emptyList()) }
+    }
+
+    fun updateAccountType(type: AccountType) {
+        _uiState.update { it.copy(accountType = type, errors = emptyList()) }
+    }
+
+    fun updateCurrency(currency: String) {
+        _uiState.update { it.copy(currency = currency, errors = emptyList()) }
+    }
+
+    fun updateInitialBalance(text: String) {
+        val cleaned = text.filter { it.isDigit() || it == '.' }
+        val parts = cleaned.split(".")
+        val limited = if (parts.size > 1) "${parts[0]}.${parts[1].take(2)}" else cleaned
+        _uiState.update { it.copy(initialBalance = limited, errors = emptyList()) }
+    }
+
+    fun updateNote(note: String) {
+        _uiState.update { it.copy(note = note.take(500), errors = emptyList()) }
+    }
+
+    // ── Validation ──────────────────────────────────────────────────
+
+    private fun validate(state: AccountEditUiState): List<String> = buildList {
+        if (state.name.isBlank()) add("Account name is required")
+        if (state.name.length > 100) add("Account name is too long (max 100 characters)")
+    }
+
+    // ── Save ────────────────────────────────────────────────────────
+
+    fun save() {
+        val errors = validate(_uiState.value)
+        if (errors.isNotEmpty()) {
+            _uiState.update { it.copy(errors = errors) }
+            return
+        }
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSaving = true, errors = emptyList()) }
+            try {
+                val original = originalAccount ?: run {
+                    _uiState.update {
+                        it.copy(isSaving = false, errors = listOf("Account not found"))
+                    }
+                    return@launch
+                }
+                val s = _uiState.value
+                val balanceCents = Cents.fromDollars(s.initialBalance.toDoubleOrNull() ?: 0.0)
+                val updated = original.copy(
+                    name = s.name.trim(),
+                    type = s.accountType,
+                    currency = Currency(s.currency),
+                    currentBalance = balanceCents,
+                    updatedAt = Clock.System.now(),
+                )
+                accountRepository.update(updated)
+                Timber.d("Account updated: id=%s", accountId.value)
+                _uiState.update { it.copy(isSaving = false, isSaved = true) }
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to update account")
+                _uiState.update {
+                    it.copy(
+                        isSaving = false,
+                        errors = listOf(e.message ?: "Failed to update account"),
+                    )
+                }
+            }
+        }
+    }
+
+    // ── Delete ───────────────────────────────────────────────────────
+
+    fun delete() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSaving = true) }
+            try {
+                accountRepository.delete(accountId)
+                Timber.d("Account deleted: id=%s", accountId.value)
+                _uiState.update { it.copy(isSaving = false, isDeleted = true) }
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to delete account")
+                _uiState.update {
+                    it.copy(
+                        isSaving = false,
+                        errors = listOf(e.message ?: "Failed to delete account"),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/BudgetEditViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/BudgetEditViewModel.kt
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.finance.android.auth.HouseholdIdProvider
+import com.finance.android.data.repository.BudgetRepository
+import com.finance.android.data.repository.CategoryRepository
+import com.finance.models.Budget
+import com.finance.models.BudgetPeriod
+import com.finance.models.Category
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import timber.log.Timber
+
+/**
+ * UI state for the Budget edit form.
+ */
+data class BudgetEditUiState(
+    val selectedCategory: Category? = null,
+    val categories: List<Category> = emptyList(),
+    val amount: String = "",
+    val period: BudgetPeriod = BudgetPeriod.MONTHLY,
+    val errors: List<String> = emptyList(),
+    val isSaving: Boolean = false,
+    val isSaved: Boolean = false,
+    val isLoading: Boolean = true,
+    val isDeleted: Boolean = false,
+)
+
+/**
+ * ViewModel for the Budget edit screen.
+ *
+ * Loads the existing [Budget] from [BudgetRepository] via navigation
+ * argument `id`, populates the form, and persists updates.
+ *
+ * @param savedStateHandle Navigation argument handle — must contain key `"id"`.
+ * @param householdIdProvider Provides the authenticated user's household ID.
+ * @param budgetRepository Repository used to load and update the budget.
+ * @param categoryRepository Repository used to load available categories.
+ */
+class BudgetEditViewModel(
+    savedStateHandle: SavedStateHandle,
+    private val householdIdProvider: HouseholdIdProvider,
+    private val budgetRepository: BudgetRepository,
+    private val categoryRepository: CategoryRepository,
+) : ViewModel() {
+
+    private val budgetId: SyncId = SyncId(
+        checkNotNull(savedStateHandle["id"]) {
+            "BudgetEditViewModel requires navigation argument 'id'"
+        },
+    )
+
+    private val _uiState = MutableStateFlow(BudgetEditUiState())
+    val uiState: StateFlow<BudgetEditUiState> = _uiState.asStateFlow()
+
+    private var originalBudget: Budget? = null
+
+    init {
+        viewModelScope.launch {
+            val householdId = householdIdProvider.householdId.value
+            val categories = if (householdId != null) {
+                categoryRepository.observeAll(householdId).first()
+            } else {
+                emptyList()
+            }
+
+            val budget = budgetRepository.getById(budgetId)
+            if (budget == null) {
+                Timber.w("Budget not found for editing: id=%s", budgetId.value)
+                _uiState.update {
+                    it.copy(isLoading = false, errors = listOf("Budget not found"))
+                }
+                return@launch
+            }
+
+            originalBudget = budget
+            val selectedCat = categories.find { it.id == budget.categoryId }
+            val amountStr = if (budget.amount.amount == 0L) "" else {
+                val dollars = budget.amount.amount / 100.0
+                if (dollars == dollars.toLong().toDouble()) {
+                    dollars.toLong().toString()
+                } else {
+                    "%.2f".format(dollars)
+                }
+            }
+
+            _uiState.update {
+                it.copy(
+                    categories = categories,
+                    selectedCategory = selectedCat,
+                    amount = amountStr,
+                    period = budget.period,
+                    isLoading = false,
+                )
+            }
+        }
+    }
+
+    // ── Field updaters ──────────────────────────────────────────────
+
+    fun selectCategory(id: SyncId) {
+        val cat = _uiState.value.categories.find { it.id == id }
+        _uiState.update { it.copy(selectedCategory = cat, errors = emptyList()) }
+    }
+
+    fun updateAmount(text: String) {
+        val cleaned = text.filter { it.isDigit() || it == '.' }
+        val parts = cleaned.split(".")
+        val limited = if (parts.size > 1) "${parts[0]}.${parts[1].take(2)}" else cleaned
+        _uiState.update { it.copy(amount = limited, errors = emptyList()) }
+    }
+
+    fun updatePeriod(period: BudgetPeriod) {
+        _uiState.update { it.copy(period = period, errors = emptyList()) }
+    }
+
+    // ── Validation ──────────────────────────────────────────────────
+
+    private fun validate(state: BudgetEditUiState): List<String> = buildList {
+        if (state.selectedCategory == null) add("Please select a category")
+        val amountValue = state.amount.toDoubleOrNull() ?: 0.0
+        if (amountValue <= 0.0) add("Budgeted amount must be greater than zero")
+    }
+
+    // ── Save ────────────────────────────────────────────────────────
+
+    fun save() {
+        val errors = validate(_uiState.value)
+        if (errors.isNotEmpty()) {
+            _uiState.update { it.copy(errors = errors) }
+            return
+        }
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSaving = true, errors = emptyList()) }
+            try {
+                val original = originalBudget ?: run {
+                    _uiState.update {
+                        it.copy(isSaving = false, errors = listOf("Budget not found"))
+                    }
+                    return@launch
+                }
+                val s = _uiState.value
+                val amountCents = Cents.fromDollars(s.amount.toDoubleOrNull() ?: 0.0)
+                val updated = original.copy(
+                    categoryId = s.selectedCategory!!.id,
+                    name = s.selectedCategory.name,
+                    amount = amountCents,
+                    period = s.period,
+                    updatedAt = Clock.System.now(),
+                )
+                budgetRepository.update(updated)
+                Timber.d("Budget updated: id=%s", budgetId.value)
+                _uiState.update { it.copy(isSaving = false, isSaved = true) }
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to update budget")
+                _uiState.update {
+                    it.copy(
+                        isSaving = false,
+                        errors = listOf(e.message ?: "Failed to update budget"),
+                    )
+                }
+            }
+        }
+    }
+
+    // ── Delete ───────────────────────────────────────────────────────
+
+    fun delete() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSaving = true) }
+            try {
+                budgetRepository.delete(budgetId)
+                Timber.d("Budget deleted: id=%s", budgetId.value)
+                _uiState.update { it.copy(isSaving = false, isDeleted = true) }
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to delete budget")
+                _uiState.update {
+                    it.copy(
+                        isSaving = false,
+                        errors = listOf(e.message ?: "Failed to delete budget"),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/GoalEditViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/GoalEditViewModel.kt
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.finance.android.auth.HouseholdIdProvider
+import com.finance.android.data.repository.AccountRepository
+import com.finance.android.data.repository.GoalRepository
+import com.finance.models.Account
+import com.finance.models.Goal
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import kotlinx.datetime.LocalDate
+import timber.log.Timber
+
+/**
+ * UI state for the Goal edit form.
+ */
+data class GoalEditUiState(
+    val name: String = "",
+    val targetAmount: String = "",
+    val currentAmount: String = "",
+    val targetDate: LocalDate? = null,
+    val selectedAccount: Account? = null,
+    val accounts: List<Account> = emptyList(),
+    val note: String = "",
+    val errors: List<String> = emptyList(),
+    val isSaving: Boolean = false,
+    val isSaved: Boolean = false,
+    val isLoading: Boolean = true,
+    val isDeleted: Boolean = false,
+)
+
+/**
+ * ViewModel for the Goal edit screen.
+ *
+ * Loads the existing [Goal] from [GoalRepository] via navigation
+ * argument `id`, populates the form, and persists updates.
+ *
+ * @param savedStateHandle Navigation argument handle — must contain key `"id"`.
+ * @param householdIdProvider Provides the authenticated user's household ID.
+ * @param goalRepository Repository used to load and update the goal.
+ * @param accountRepository Repository used to load accounts for the optional link.
+ */
+class GoalEditViewModel(
+    savedStateHandle: SavedStateHandle,
+    private val householdIdProvider: HouseholdIdProvider,
+    private val goalRepository: GoalRepository,
+    private val accountRepository: AccountRepository,
+) : ViewModel() {
+
+    private val goalId: SyncId = SyncId(
+        checkNotNull(savedStateHandle["id"]) {
+            "GoalEditViewModel requires navigation argument 'id'"
+        },
+    )
+
+    private val _uiState = MutableStateFlow(GoalEditUiState())
+    val uiState: StateFlow<GoalEditUiState> = _uiState.asStateFlow()
+
+    private var originalGoal: Goal? = null
+
+    init {
+        viewModelScope.launch {
+            val householdId = householdIdProvider.householdId.value
+            val accounts = if (householdId != null) {
+                accountRepository.observeAll(householdId).first()
+            } else {
+                emptyList()
+            }
+
+            val goal = goalRepository.getById(goalId)
+            if (goal == null) {
+                Timber.w("Goal not found for editing: id=%s", goalId.value)
+                _uiState.update {
+                    it.copy(isLoading = false, errors = listOf("Goal not found"))
+                }
+                return@launch
+            }
+
+            originalGoal = goal
+            val targetStr = formatCents(goal.targetAmount)
+            val currentStr = formatCents(goal.currentAmount)
+            val linkedAccount = goal.accountId?.let { aid -> accounts.find { it.id == aid } }
+
+            _uiState.update {
+                it.copy(
+                    name = goal.name,
+                    targetAmount = targetStr,
+                    currentAmount = currentStr,
+                    targetDate = goal.targetDate,
+                    selectedAccount = linkedAccount,
+                    accounts = accounts,
+                    note = goal.note ?: "",
+                    isLoading = false,
+                )
+            }
+        }
+    }
+
+    private fun formatCents(cents: Cents): String {
+        if (cents.amount == 0L) return ""
+        val dollars = cents.amount / 100.0
+        return if (dollars == dollars.toLong().toDouble()) {
+            dollars.toLong().toString()
+        } else {
+            "%.2f".format(dollars)
+        }
+    }
+
+    // ── Field updaters ──────────────────────────────────────────────
+
+    fun updateName(name: String) {
+        _uiState.update { it.copy(name = name.take(100), errors = emptyList()) }
+    }
+
+    fun updateTargetAmount(text: String) {
+        val cleaned = text.filter { it.isDigit() || it == '.' }
+        val parts = cleaned.split(".")
+        val limited = if (parts.size > 1) "${parts[0]}.${parts[1].take(2)}" else cleaned
+        _uiState.update { it.copy(targetAmount = limited, errors = emptyList()) }
+    }
+
+    fun updateCurrentAmount(text: String) {
+        val cleaned = text.filter { it.isDigit() || it == '.' }
+        val parts = cleaned.split(".")
+        val limited = if (parts.size > 1) "${parts[0]}.${parts[1].take(2)}" else cleaned
+        _uiState.update { it.copy(currentAmount = limited, errors = emptyList()) }
+    }
+
+    fun updateTargetDate(date: LocalDate) {
+        _uiState.update { it.copy(targetDate = date, errors = emptyList()) }
+    }
+
+    fun selectAccount(id: SyncId?) {
+        val account = if (id != null) _uiState.value.accounts.find { it.id == id } else null
+        _uiState.update { it.copy(selectedAccount = account, errors = emptyList()) }
+    }
+
+    fun updateNote(note: String) {
+        _uiState.update { it.copy(note = note.take(500), errors = emptyList()) }
+    }
+
+    // ── Validation ──────────────────────────────────────────────────
+
+    private fun validate(state: GoalEditUiState): List<String> = buildList {
+        if (state.name.isBlank()) add("Goal name is required")
+        if (state.name.length > 100) add("Goal name is too long (max 100 characters)")
+        val amountValue = state.targetAmount.toDoubleOrNull() ?: 0.0
+        if (amountValue <= 0.0) add("Target amount must be greater than zero")
+    }
+
+    // ── Save ────────────────────────────────────────────────────────
+
+    fun save() {
+        val errors = validate(_uiState.value)
+        if (errors.isNotEmpty()) {
+            _uiState.update { it.copy(errors = errors) }
+            return
+        }
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSaving = true, errors = emptyList()) }
+            try {
+                val original = originalGoal ?: run {
+                    _uiState.update {
+                        it.copy(isSaving = false, errors = listOf("Goal not found"))
+                    }
+                    return@launch
+                }
+                val s = _uiState.value
+                val targetCents = Cents.fromDollars(s.targetAmount.toDoubleOrNull() ?: 0.0)
+                val currentCents = Cents.fromDollars(s.currentAmount.toDoubleOrNull() ?: 0.0)
+                val updated = original.copy(
+                    name = s.name.trim(),
+                    targetAmount = targetCents,
+                    currentAmount = currentCents,
+                    targetDate = s.targetDate,
+                    accountId = s.selectedAccount?.id,
+                    updatedAt = Clock.System.now(),
+                )
+                goalRepository.update(updated)
+                Timber.d("Goal updated: id=%s", goalId.value)
+                _uiState.update { it.copy(isSaving = false, isSaved = true) }
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to update goal")
+                _uiState.update {
+                    it.copy(
+                        isSaving = false,
+                        errors = listOf(e.message ?: "Failed to update goal"),
+                    )
+                }
+            }
+        }
+    }
+
+    // ── Delete ───────────────────────────────────────────────────────
+
+    fun delete() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSaving = true) }
+            try {
+                goalRepository.delete(goalId)
+                Timber.d("Goal deleted: id=%s", goalId.value)
+                _uiState.update { it.copy(isSaving = false, isDeleted = true) }
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to delete goal")
+                _uiState.update {
+                    it.copy(
+                        isSaving = false,
+                        errors = listOf(e.message ?: "Failed to delete goal"),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/GoalEditViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/GoalEditViewModel.kt
@@ -33,7 +33,6 @@ data class GoalEditUiState(
     val targetDate: LocalDate? = null,
     val selectedAccount: Account? = null,
     val accounts: List<Account> = emptyList(),
-    val note: String = "",
     val errors: List<String> = emptyList(),
     val isSaving: Boolean = false,
     val isSaved: Boolean = false,
@@ -101,7 +100,6 @@ class GoalEditViewModel(
                     targetDate = goal.targetDate,
                     selectedAccount = linkedAccount,
                     accounts = accounts,
-                    note = goal.note ?: "",
                     isLoading = false,
                 )
             }
@@ -145,10 +143,6 @@ class GoalEditViewModel(
     fun selectAccount(id: SyncId?) {
         val account = if (id != null) _uiState.value.accounts.find { it.id == id } else null
         _uiState.update { it.copy(selectedAccount = account, errors = emptyList()) }
-    }
-
-    fun updateNote(note: String) {
-        _uiState.update { it.copy(note = note.take(500), errors = emptyList()) }
     }
 
     // ── Validation ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Implements full CRUD (Create/Read/Update/Delete) functionality for all entity types in the Android app, completing the Sprint 2 Android work.

### Changes

#### New Edit ViewModels (#630)
- **AccountEditViewModel** — Loads existing account via \SavedStateHandle\, supports update and delete
- **BudgetEditViewModel** — Loads existing budget with categories, supports update and delete  
- **GoalEditViewModel** — Loads existing goal with linked accounts, supports update and delete

#### New Edit Screens (#630)
- **AccountEditScreen** — Material 3 form with pre-populated fields, delete confirmation dialog
- **BudgetEditScreen** — Category chips, amount, period selector with edit/delete support
- **GoalEditScreen** — Name, target/current amounts, date picker, account link with edit/delete

#### Navigation Wiring (#630)
- Added \AccountEdit\, \BudgetEdit\, \GoalEdit\, \TransactionEdit\ routes
- Wired \TransactionDetailScreen\ to deep link route (replacing placeholder)
- Wired \TransactionsScreen\ click → detail and swipe-edit → edit screen
- Added edit button to \AccountDetailScreen\ top bar
- Made \BudgetItemCard\ and \GoalCard\ clickable for edit navigation
- Added edit callbacks to \PlanningScreen\ → budget/goal edit routes
- Transaction edit reuses \TransactionCreateScreen\ wizard in edit mode via \SavedStateHandle\

#### Koin Registration
- Registered \AccountEditViewModel\, \BudgetEditViewModel\, \GoalEditViewModel\ in \AppModule.kt\

#### Signup Screen (#631)
- Already fully implemented: \SignupScreen.kt\, \SignupViewModel.kt\, and wired in \FinanceApp()\
- Email/password/confirm-password with inline validation
- Supabase Auth integration via \SupabaseAuthManager.signUp()\
- Full TalkBack accessibility with live regions for error announcements

### Design Patterns
- All screens use Jetpack Compose with Material 3
- Full TalkBack accessibility (\contentDescription\ on all interactive/informational elements)
- Delete operations use \AlertDialog\ confirmation before proceeding
- Edit ViewModels follow the same \StateFlow\ reactive pattern as create ViewModels
- Timber structured logging (no sensitive data logged)

### Testing
- Existing unit tests remain passing
- New ViewModels follow the testable pattern (constructor injection, \StateFlow\)

Closes #630
Closes #631