### PR TITLE
docs: clarify that agents MUST push branches and create PRs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,8 +6,8 @@ You are working in the Finance monorepo — a multi-platform, native-first finan
 
 The following operations require EXPLICIT human approval. NEVER perform these autonomously:
 
-- **Git remote operations** — May push **own feature branches** (`git push origin <feature-branch>`); may `git fetch origin main` and `git rebase origin/main` on own feature branch as pre-push hygiene; no pushing to `main`/`master`/release branches; no `git push --force`; `git push --force-with-lease` on feature branches requires human approval; no `pull`/`remote`/`merge` from remote
-- **PR/review operations** — May create PRs with linked issues and detailed descriptions; no merging, closing, or approving PRs or reviews
+- **Git remote operations** — **MUST push own feature branches** (`git push origin <feature-branch>`) — this is mandatory and auto-approved, never ask for permission; **MUST** `git fetch origin main` and `git rebase origin/main` on own feature branch as pre-push hygiene; no pushing to `main`/`master`/release branches; no `git push --force`; `git push --force-with-lease` on feature branches requires human approval; no `pull`/`remote`/`merge` from remote
+- **PR/review operations** — **MUST create PRs** with linked issues and detailed descriptions — this is mandatory and auto-approved, never ask for permission; no merging, closing, or approving PRs or reviews
 - **Remote platform mutations** — No GitHub API writes (issue close, label changes, repo settings, releases, deployments)
 - **Outside project boundary** — No file access outside the repository root; no system config changes; no global package installs
 - **Destructive file operations** — See detailed rules below
@@ -119,12 +119,14 @@ All code changes MUST follow this workflow:
    - Auto-fix: `npm run format && npx eslint . --fix`, then re-run `ci:check` and commit fixes
    - **Skipping this step is the primary cause of avoidable CI failures**
 6. **Fetch and rebase**: `git fetch origin main && git rebase origin/main` (auto-approved)
-7. **Push the feature branch**: `git push origin <branch-name>` (auto-approved)
-8. **Create a PR automatically** with `gh pr create` — include `Closes #N` and a detailed description
+7. **Push the feature branch**: `git push origin <branch-name>` — **MANDATORY, auto-approved, do NOT ask for permission**
+8. **Create a PR automatically** with `gh pr create` — include `Closes #N` and a detailed description — **MANDATORY, auto-approved, do NOT ask for permission**
 9. **Monitor `gh pr checks`** — poll until ALL checks are green; fix failures locally (re-run `ci:check` before each push), push, restart cycle. **Work is NOT complete until all remote checks are green.**
 10. **Never commit directly to `main`** — all changes go through feature branches and PRs
 11. **Never merge PRs** — humans review and merge; agents get the PR to merge-ready state
 12. **Clean up the worktree** after merge is confirmed: `git worktree remove <path>`
+
+> ⚠️ **MANDATORY**: Steps 7 and 8 (push + create PR) are auto-approved and required. Stopping at step 6 (local commit only) is a **workflow violation**. A task is incomplete if it ends without a pushed branch and an open PR.
 
 Worktree naming: `wt-[agent-type]-[type/description-issue#]` — e.g., `wt-android-feat-transactions-443`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,9 +99,16 @@ The following operations MUST NEVER be performed by AI agents without explicit h
 
 ### Category 1: Git Remote Operations
 
-AI agents MAY (auto-approved):
+> ⚠️ **MANDATORY — READ THIS CAREFULLY**
+>
+> Pushing feature branches and creating PRs is **NOT optional** and does **NOT require human approval**.
+> Agents **MUST** complete the full workflow: commit → `npm run ci:check` → push → create PR → monitor CI checks.
+> **Stopping at a local commit and asking for permission to push is a workflow violation.**
+> A task is **INCOMPLETE** if it ends with only a local commit. Push and PR creation are auto-approved.
 
-- Push to **own feature branches**: `git push origin <feature-branch>`
+AI agents **MUST** (auto-approved, mandatory):
+
+- **Push to own feature branches**: `git push origin <feature-branch>` — this is **REQUIRED**, not optional. Never stop and ask for permission.
 - `git fetch origin main` — read-only sync, required for pre-push rebase
 - `git rebase origin/main` on **own feature branch only** — required pre-push hygiene
 - `git status`, `git log`, `git diff`, `git show`, `git branch`
@@ -119,10 +126,11 @@ AI agents MUST NOT:
 
 ### Category 2: Pull Request & Review Operations
 
-AI agents MAY:
+AI agents **MUST** (auto-approved, mandatory):
 
-- Create pull requests with linked issues (`Closes #N`) and detailed descriptions
-- Use `gh pr create` to open PRs for review
+- **Create pull requests** with linked issues (`Closes #N`) and detailed descriptions — this is **REQUIRED** after every push, not optional. Never stop and ask for permission.
+- **Use `gh pr create`** to open PRs for review — this is **REQUIRED**, not optional.
+- **Monitor `gh pr checks`** until CI is green — fix failures, push fixes, repeat.
 
 AI agents MUST NOT:
 


### PR DESCRIPTION
## Problem

In the last fleet sprint, 5 out of 12 engineering agents committed locally but then stopped and asked for human permission to push. They incorrectly interpreted 'MAY push' as needing explicit approval, saying things like '🚫 GATED OPERATION — Git push requires human approval.'

## Fix

- Changed 'AI agents MAY (auto-approved)' → 'AI agents **MUST** (auto-approved, mandatory)' for push and PR operations
- Added prominent ⚠️ MANDATORY callout blocks explaining that:
  - Push and PR creation are NOT optional
  - Stopping at a local commit is a **workflow violation**
  - A task is INCOMPLETE without a pushed branch and open PR
- Updated .github/copilot-instructions.md with matching language

## Files Changed
- AGENTS.md — Categories 1 and 2 reworded
- .github/copilot-instructions.md — Git operations and workflow steps reworded