### PR TITLE
feat(core): analytics event tracking and KPI instrumentation (#764)

### DIFF
--- a/packages/core/src/commonMain/kotlin/com/finance/core/analytics/AnalyticsEvent.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/analytics/AnalyticsEvent.kt
@@ -1,0 +1,370 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.analytics
+
+import kotlinx.datetime.Instant
+
+/**
+ * Sealed hierarchy of analytics events for v1.0 KPI instrumentation.
+ *
+ * Every event carries a [timestamp] and a [properties] map for structured
+ * context. Properties must **never** contain PII, financial amounts, account
+ * numbers, or any data that could identify a user. The property map is
+ * deliberately `Map<String, String>` — analytics backends expect string
+ * key-value pairs and this prevents accidentally attaching complex objects.
+ *
+ * Events are consumed by [AnalyticsTracker] implementations, which handle
+ * consent gating and transport. Platform apps provide concrete trackers
+ * backed by Firebase Analytics, Amplitude, PostHog, or similar services.
+ *
+ * ## Event naming convention
+ * Each event has a [name] property that follows the `snake_case` convention
+ * expected by most analytics backends (e.g., `"transaction_created"`,
+ * `"budget_exceeded"`).
+ *
+ * ## Adding new events
+ * 1. Add a new `data class` subclass to this sealed hierarchy.
+ * 2. Override [name] with a unique `snake_case` identifier.
+ * 3. Populate [properties] with anonymous metadata only.
+ * 4. Add the event to the corresponding test in `AnalyticsEventTest.kt`.
+ *
+ * @see AnalyticsTracker for the tracking interface
+ */
+sealed class AnalyticsEvent {
+    /** Event name identifier sent to the analytics backend. */
+    abstract val name: String
+
+    /** When the event occurred. */
+    abstract val timestamp: Instant
+
+    /** Anonymous key-value properties attached to the event. */
+    abstract val properties: Map<String, String>
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Session & Navigation
+    // ═══════════════════════════════════════════════════════════════════
+
+    /**
+     * User opened the app or returned from background.
+     *
+     * @property platform The client platform (e.g., "ios", "android", "web", "windows").
+     * @property appVersion Semantic version string of the running app.
+     */
+    data class AppOpened(
+        override val timestamp: Instant,
+        val platform: String,
+        val appVersion: String,
+    ) : AnalyticsEvent() {
+        override val name: String = "app_opened"
+        override val properties: Map<String, String> = mapOf(
+            "platform" to platform,
+            "app_version" to appVersion,
+        )
+    }
+
+    /**
+     * User navigated to a screen.
+     *
+     * @property screenName Identifier for the screen (e.g., "dashboard", "budget_list").
+     */
+    data class ScreenViewed(
+        override val timestamp: Instant,
+        val screenName: String,
+    ) : AnalyticsEvent() {
+        override val name: String = "screen_viewed"
+        override val properties: Map<String, String> = mapOf(
+            "screen_name" to screenName,
+        )
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Transaction Events
+    // ═══════════════════════════════════════════════════════════════════
+
+    /**
+     * A new transaction was created.
+     *
+     * Properties include the transaction type (expense/income/transfer) and
+     * whether it was categorised. **Never** include the amount or payee.
+     */
+    data class TransactionCreated(
+        override val timestamp: Instant,
+        val transactionType: String,
+        val hasCategoryAssigned: Boolean,
+        val hasNotes: Boolean,
+        val hasTags: Boolean,
+    ) : AnalyticsEvent() {
+        override val name: String = "transaction_created"
+        override val properties: Map<String, String> = mapOf(
+            "transaction_type" to transactionType,
+            "has_category" to hasCategoryAssigned.toString(),
+            "has_notes" to hasNotes.toString(),
+            "has_tags" to hasTags.toString(),
+        )
+    }
+
+    /**
+     * A transaction was edited (amount, category, date, etc. changed).
+     */
+    data class TransactionUpdated(
+        override val timestamp: Instant,
+        val transactionType: String,
+        val fieldsChanged: Int,
+    ) : AnalyticsEvent() {
+        override val name: String = "transaction_updated"
+        override val properties: Map<String, String> = mapOf(
+            "transaction_type" to transactionType,
+            "fields_changed" to fieldsChanged.toString(),
+        )
+    }
+
+    /**
+     * A transaction was soft-deleted.
+     */
+    data class TransactionDeleted(
+        override val timestamp: Instant,
+        val transactionType: String,
+    ) : AnalyticsEvent() {
+        override val name: String = "transaction_deleted"
+        override val properties: Map<String, String> = mapOf(
+            "transaction_type" to transactionType,
+        )
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Budget Events
+    // ═══════════════════════════════════════════════════════════════════
+
+    /**
+     * A new budget was created.
+     *
+     * @property period Budget period type (e.g., "MONTHLY", "WEEKLY").
+     * @property isRollover Whether the budget carries unused amounts forward.
+     */
+    data class BudgetCreated(
+        override val timestamp: Instant,
+        val period: String,
+        val isRollover: Boolean,
+    ) : AnalyticsEvent() {
+        override val name: String = "budget_created"
+        override val properties: Map<String, String> = mapOf(
+            "period" to period,
+            "is_rollover" to isRollover.toString(),
+        )
+    }
+
+    /**
+     * Budget spending has exceeded the budgeted amount.
+     *
+     * @property utilizationPercent How far over budget (e.g., 115 = 15% over).
+     */
+    data class BudgetExceeded(
+        override val timestamp: Instant,
+        val utilizationPercent: Int,
+    ) : AnalyticsEvent() {
+        override val name: String = "budget_exceeded"
+        override val properties: Map<String, String> = mapOf(
+            "utilization_percent" to utilizationPercent.toString(),
+        )
+    }
+
+    /**
+     * Budget spending has reached a warning threshold (e.g., 80%, 90%).
+     *
+     * @property thresholdPercent The threshold that was crossed.
+     */
+    data class BudgetThresholdReached(
+        override val timestamp: Instant,
+        val thresholdPercent: Int,
+    ) : AnalyticsEvent() {
+        override val name: String = "budget_threshold_reached"
+        override val properties: Map<String, String> = mapOf(
+            "threshold_percent" to thresholdPercent.toString(),
+        )
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Goal Events
+    // ═══════════════════════════════════════════════════════════════════
+
+    /**
+     * A new savings goal was created.
+     *
+     * @property hasTargetDate Whether the goal has a deadline.
+     * @property hasLinkedAccount Whether the goal is linked to a savings account.
+     */
+    data class GoalCreated(
+        override val timestamp: Instant,
+        val hasTargetDate: Boolean,
+        val hasLinkedAccount: Boolean,
+    ) : AnalyticsEvent() {
+        override val name: String = "goal_created"
+        override val properties: Map<String, String> = mapOf(
+            "has_target_date" to hasTargetDate.toString(),
+            "has_linked_account" to hasLinkedAccount.toString(),
+        )
+    }
+
+    /**
+     * A savings goal was completed (current amount ≥ target amount).
+     */
+    data class GoalCompleted(
+        override val timestamp: Instant,
+        val daysToComplete: Int?,
+    ) : AnalyticsEvent() {
+        override val name: String = "goal_completed"
+        override val properties: Map<String, String> = buildMap {
+            daysToComplete?.let { put("days_to_complete", it.toString()) }
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Sync Events
+    // ═══════════════════════════════════════════════════════════════════
+
+    /**
+     * A sync operation completed (success or failure).
+     *
+     * @property durationMs How long the sync took.
+     * @property recordCount Number of records synced.
+     * @property success Whether the sync succeeded.
+     * @property syncType The type of sync ("full", "delta", "push").
+     */
+    data class SyncCompleted(
+        override val timestamp: Instant,
+        val durationMs: Long,
+        val recordCount: Int,
+        val success: Boolean,
+        val syncType: String,
+    ) : AnalyticsEvent() {
+        override val name: String = "sync_completed"
+        override val properties: Map<String, String> = mapOf(
+            "duration_ms" to durationMs.toString(),
+            "record_count" to recordCount.toString(),
+            "success" to success.toString(),
+            "sync_type" to syncType,
+        )
+    }
+
+    /**
+     * A sync conflict was detected and resolved.
+     *
+     * @property resolutionStrategy How the conflict was resolved.
+     * @property entityType The entity type involved ("transaction", "budget", etc.).
+     */
+    data class SyncConflictResolved(
+        override val timestamp: Instant,
+        val resolutionStrategy: String,
+        val entityType: String,
+    ) : AnalyticsEvent() {
+        override val name: String = "sync_conflict_resolved"
+        override val properties: Map<String, String> = mapOf(
+            "resolution_strategy" to resolutionStrategy,
+            "entity_type" to entityType,
+        )
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Data Export / Import Events
+    // ═══════════════════════════════════════════════════════════════════
+
+    /**
+     * User exported financial data.
+     *
+     * @property format Export format ("json", "csv").
+     * @property recordCount Total records exported.
+     */
+    data class DataExported(
+        override val timestamp: Instant,
+        val format: String,
+        val recordCount: Int,
+    ) : AnalyticsEvent() {
+        override val name: String = "data_exported"
+        override val properties: Map<String, String> = mapOf(
+            "format" to format,
+            "record_count" to recordCount.toString(),
+        )
+    }
+
+    /**
+     * User imported financial data.
+     *
+     * @property format Import format ("csv", "ofx", etc.).
+     * @property recordCount Total records imported.
+     * @property success Whether the import completed without errors.
+     */
+    data class DataImported(
+        override val timestamp: Instant,
+        val format: String,
+        val recordCount: Int,
+        val success: Boolean,
+    ) : AnalyticsEvent() {
+        override val name: String = "data_imported"
+        override val properties: Map<String, String> = mapOf(
+            "format" to format,
+            "record_count" to recordCount.toString(),
+            "success" to success.toString(),
+        )
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Account Events
+    // ═══════════════════════════════════════════════════════════════════
+
+    /**
+     * A new account was created.
+     *
+     * @property accountType The type of account (e.g., "CHECKING", "SAVINGS").
+     * @property currencyCode ISO 4217 currency code.
+     */
+    data class AccountCreated(
+        override val timestamp: Instant,
+        val accountType: String,
+        val currencyCode: String,
+    ) : AnalyticsEvent() {
+        override val name: String = "account_created"
+        override val properties: Map<String, String> = mapOf(
+            "account_type" to accountType,
+            "currency_code" to currencyCode,
+        )
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Feature Adoption Events
+    // ═══════════════════════════════════════════════════════════════════
+
+    /**
+     * User engaged with a specific feature for the first time.
+     *
+     * Used to track v1.0 feature adoption rates.
+     *
+     * @property featureKey Unique key identifying the feature.
+     */
+    data class FeatureAdopted(
+        override val timestamp: Instant,
+        val featureKey: String,
+    ) : AnalyticsEvent() {
+        override val name: String = "feature_adopted"
+        override val properties: Map<String, String> = mapOf(
+            "feature_key" to featureKey,
+        )
+    }
+
+    /**
+     * User encountered an error in the application.
+     *
+     * @property errorCode Machine-readable error code.
+     * @property screen Screen where the error occurred.
+     */
+    data class ErrorOccurred(
+        override val timestamp: Instant,
+        val errorCode: String,
+        val screen: String,
+    ) : AnalyticsEvent() {
+        override val name: String = "error_occurred"
+        override val properties: Map<String, String> = mapOf(
+            "error_code" to errorCode,
+            "screen" to screen,
+        )
+    }
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/analytics/AnalyticsTracker.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/analytics/AnalyticsTracker.kt
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.analytics
+
+/**
+ * Platform-agnostic interface for tracking analytics events.
+ *
+ * Implementations must:
+ * - Gate all tracking behind user consent ([isEnabled]).
+ * - Never transmit PII, financial amounts, or account identifiers.
+ * - Buffer events locally when offline and flush when connectivity resumes.
+ *
+ * Each platform app provides a concrete implementation backed by its
+ * analytics SDK (e.g., Firebase Analytics on Android/iOS, PostHog on Web).
+ *
+ * Usage:
+ * ```
+ * tracker.track(AnalyticsEvent.TransactionCreated(
+ *     timestamp = Clock.System.now(),
+ *     transactionType = "EXPENSE",
+ *     hasCategoryAssigned = true,
+ *     hasNotes = false,
+ *     hasTags = false,
+ * ))
+ * ```
+ *
+ * @see AnalyticsEvent for the event hierarchy
+ * @see NoOpAnalyticsTracker for the disabled/no-consent stub
+ * @see BufferedAnalyticsTracker for the shared buffered implementation
+ */
+interface AnalyticsTracker {
+
+    /**
+     * Track an analytics event.
+     *
+     * If [isEnabled] returns false, this call must be a silent no-op.
+     * Implementations may buffer events and batch-send them.
+     *
+     * @param event The analytics event to track.
+     */
+    fun track(event: AnalyticsEvent)
+
+    /**
+     * Set a user property that persists across events.
+     *
+     * User properties provide segmentation dimensions (e.g., "plan_type",
+     * "account_count_bucket"). Values must be anonymous — no PII.
+     *
+     * If [isEnabled] returns false, this call must be a silent no-op.
+     *
+     * @param key Property key (snake_case, no PII).
+     * @param value Property value (anonymous string).
+     */
+    fun setUserProperty(key: String, value: String)
+
+    /**
+     * Associate a pseudonymous user ID with subsequent events.
+     *
+     * The ID must be a non-reversible hash or random UUID that cannot
+     * be linked back to the user's real identity.
+     *
+     * @param userId Pseudonymous user identifier, or null to clear.
+     */
+    fun setUserId(userId: String?)
+
+    /**
+     * Whether analytics tracking is currently enabled and consented.
+     *
+     * When false, [track], [setUserProperty], and [setUserId] must be no-ops.
+     */
+    fun isEnabled(): Boolean
+
+    /**
+     * Flush any buffered events immediately.
+     *
+     * Called before app backgrounding or sign-out to avoid data loss.
+     * No-op if the implementation does not buffer.
+     */
+    fun flush()
+}
+
+/**
+ * No-op [AnalyticsTracker] used when analytics is disabled or
+ * user consent has not been granted.
+ */
+object NoOpAnalyticsTracker : AnalyticsTracker {
+    override fun track(event: AnalyticsEvent) = Unit
+    override fun setUserProperty(key: String, value: String) = Unit
+    override fun setUserId(userId: String?) = Unit
+    override fun isEnabled(): Boolean = false
+    override fun flush() = Unit
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/analytics/BufferedAnalyticsTracker.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/analytics/BufferedAnalyticsTracker.kt
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.analytics
+
+/**
+ * An [AnalyticsTracker] that buffers events in memory and delegates
+ * flushing to a platform-specific [AnalyticsTransport].
+ *
+ * This class implements consent gating, buffering, and batch flushing
+ * in commonMain so platform implementations only need to provide a
+ * lightweight [AnalyticsTransport] adapter.
+ *
+ * Events are buffered up to [maxBufferSize]. When the buffer is full,
+ * the oldest events are dropped (FIFO eviction) and the overflow is
+ * counted in [droppedEventCount] for monitoring.
+ *
+ * Thread-safety: this class is **not** thread-safe. Confine usage to
+ * a single coroutine dispatcher or synchronise externally.
+ *
+ * @param consentProvider Returns true when the user has opted in to analytics.
+ * @param transport Platform-specific transport for sending events.
+ * @param maxBufferSize Maximum number of events to buffer before eviction.
+ */
+class BufferedAnalyticsTracker(
+    private val consentProvider: () -> Boolean,
+    private val transport: AnalyticsTransport,
+    private val maxBufferSize: Int = DEFAULT_BUFFER_SIZE,
+) : AnalyticsTracker {
+
+    private val buffer = mutableListOf<AnalyticsEvent>()
+    private val userProperties = mutableMapOf<String, String>()
+    private var userId: String? = null
+
+    /** Number of events dropped due to buffer overflow since creation. */
+    var droppedEventCount: Long = 0L
+        private set
+
+    /** Number of events currently in the buffer. */
+    val bufferedEventCount: Int get() = buffer.size
+
+    override fun track(event: AnalyticsEvent) {
+        if (!consentProvider()) return
+
+        if (buffer.size >= maxBufferSize) {
+            buffer.removeAt(0)
+            droppedEventCount++
+        }
+        buffer.add(event)
+
+        if (buffer.size >= FLUSH_THRESHOLD) {
+            flush()
+        }
+    }
+
+    override fun setUserProperty(key: String, value: String) {
+        if (!consentProvider()) return
+        userProperties[key] = value
+        transport.setUserProperty(key, value)
+    }
+
+    override fun setUserId(userId: String?) {
+        if (!consentProvider() && userId != null) return
+        this.userId = userId
+        transport.setUserId(userId)
+    }
+
+    override fun isEnabled(): Boolean = consentProvider()
+
+    override fun flush() {
+        if (buffer.isEmpty()) return
+        if (!consentProvider()) {
+            buffer.clear()
+            return
+        }
+
+        val batch = buffer.toList()
+        buffer.clear()
+        transport.sendEvents(batch)
+    }
+
+    companion object {
+        /** Default maximum buffer size. */
+        const val DEFAULT_BUFFER_SIZE = 500
+
+        /** Auto-flush when buffer reaches this percentage of max. */
+        private const val FLUSH_THRESHOLD = 50
+    }
+}
+
+/**
+ * Platform-specific transport adapter for sending analytics events
+ * to the analytics backend.
+ *
+ * Platform apps implement this interface to bridge to their chosen
+ * analytics SDK (Firebase, Amplitude, PostHog, etc.).
+ *
+ * Implementations should:
+ * - Handle network failures gracefully (events can be lost if send fails).
+ * - Not block the calling thread — schedule transmission asynchronously.
+ * - Never log or persist PII.
+ */
+interface AnalyticsTransport {
+
+    /**
+     * Send a batch of analytics events to the backend.
+     *
+     * @param events The events to send. May be empty.
+     */
+    fun sendEvents(events: List<AnalyticsEvent>)
+
+    /**
+     * Set a persistent user property on the analytics backend.
+     */
+    fun setUserProperty(key: String, value: String)
+
+    /**
+     * Set the pseudonymous user ID on the analytics backend.
+     */
+    fun setUserId(userId: String?)
+}
+
+/**
+ * No-op [AnalyticsTransport] for testing and disabled environments.
+ */
+object NoOpAnalyticsTransport : AnalyticsTransport {
+    override fun sendEvents(events: List<AnalyticsEvent>) = Unit
+    override fun setUserProperty(key: String, value: String) = Unit
+    override fun setUserId(userId: String?) = Unit
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/analytics/KpiMetrics.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/analytics/KpiMetrics.kt
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.analytics
+
+/**
+ * v1.0 Key Performance Indicator (KPI) definitions.
+ *
+ * These constants define the feature keys and property names used
+ * throughout the analytics instrumentation. Centralising them prevents
+ * typos and makes it easy to search for all usage sites.
+ *
+ * ## KPI Categories
+ *
+ * | Category        | Metric                            | Event                          |
+ * |-----------------|-----------------------------------|--------------------------------|
+ * | Engagement      | DAU / MAU                         | `app_opened`                   |
+ * | Feature Adopt.  | % users creating budgets          | `budget_created`               |
+ * | Feature Adopt.  | % users setting goals             | `goal_created`                 |
+ * | Feature Adopt.  | % users using transfers           | `transaction_created` (TRANSFER) |
+ * | Data Health     | Sync success rate                 | `sync_completed`               |
+ * | Data Health     | Average sync latency              | `sync_completed`               |
+ * | Retention       | Feature first-use                 | `feature_adopted`              |
+ * | Errors          | Client error rate                 | `error_occurred`               |
+ */
+object KpiMetrics {
+
+    // ── Feature keys for FeatureAdopted events ────────────────────────
+
+    /** First transaction created by the user. */
+    const val FEATURE_FIRST_TRANSACTION = "first_transaction"
+
+    /** First budget created by the user. */
+    const val FEATURE_FIRST_BUDGET = "first_budget"
+
+    /** First savings goal created by the user. */
+    const val FEATURE_FIRST_GOAL = "first_goal"
+
+    /** First data export performed by the user. */
+    const val FEATURE_FIRST_EXPORT = "first_export"
+
+    /** First data import performed by the user. */
+    const val FEATURE_FIRST_IMPORT = "first_import"
+
+    /** First recurring transaction rule set up by the user. */
+    const val FEATURE_FIRST_RECURRING = "first_recurring"
+
+    /** First account transfer created by the user. */
+    const val FEATURE_FIRST_TRANSFER = "first_transfer"
+
+    // ── User property keys ────────────────────────────────────────────
+
+    /** Number of active accounts (bucketed: "0", "1-3", "4-10", "11+"). */
+    const val PROP_ACCOUNT_COUNT_BUCKET = "account_count_bucket"
+
+    /** Number of active budgets (bucketed: "0", "1-3", "4-10", "11+"). */
+    const val PROP_BUDGET_COUNT_BUCKET = "budget_count_bucket"
+
+    /** Primary currency code (e.g., "USD", "EUR"). */
+    const val PROP_PRIMARY_CURRENCY = "primary_currency"
+
+    /** Client platform (e.g., "ios", "android", "web", "windows"). */
+    const val PROP_PLATFORM = "platform"
+
+    /** App version (e.g., "1.0.0"). */
+    const val PROP_APP_VERSION = "app_version"
+
+    // ── Screen names ──────────────────────────────────────────────────
+
+    const val SCREEN_DASHBOARD = "dashboard"
+    const val SCREEN_TRANSACTIONS = "transactions"
+    const val SCREEN_BUDGETS = "budgets"
+    const val SCREEN_GOALS = "goals"
+    const val SCREEN_ACCOUNTS = "accounts"
+    const val SCREEN_SETTINGS = "settings"
+    const val SCREEN_EXPORT = "export"
+    const val SCREEN_IMPORT = "import"
+    const val SCREEN_REPORTS = "reports"
+
+    // ── Bucket helpers ────────────────────────────────────────────────
+
+    /**
+     * Converts a count to a bucketed string for user properties.
+     *
+     * Buckets: "0", "1-3", "4-10", "11+"
+     */
+    fun countToBucket(count: Int): String = when {
+        count <= 0 -> "0"
+        count <= 3 -> "1-3"
+        count <= 10 -> "4-10"
+        else -> "11+"
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/analytics/AnalyticsEventTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/analytics/AnalyticsEventTest.kt
@@ -1,0 +1,343 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.analytics
+
+import kotlinx.datetime.Instant
+import kotlin.test.*
+
+/**
+ * Tests for [AnalyticsEvent] sealed hierarchy — verifies event names,
+ * property construction, and that no PII leaks into properties.
+ */
+class AnalyticsEventTest {
+
+    private val fixedInstant = Instant.parse("2024-06-15T12:00:00Z")
+
+    // ── AppOpened ────────────────────────────────────────────────────
+
+    @Test
+    fun appOpenedEventName() {
+        val event = AnalyticsEvent.AppOpened(
+            timestamp = fixedInstant,
+            platform = "android",
+            appVersion = "1.0.0",
+        )
+        assertEquals("app_opened", event.name)
+    }
+
+    @Test
+    fun appOpenedProperties() {
+        val event = AnalyticsEvent.AppOpened(
+            timestamp = fixedInstant,
+            platform = "ios",
+            appVersion = "2.1.0",
+        )
+        assertEquals("ios", event.properties["platform"])
+        assertEquals("2.1.0", event.properties["app_version"])
+        assertEquals(2, event.properties.size)
+    }
+
+    // ── ScreenViewed ─────────────────────────────────────────────────
+
+    @Test
+    fun screenViewedEventName() {
+        val event = AnalyticsEvent.ScreenViewed(
+            timestamp = fixedInstant,
+            screenName = "dashboard",
+        )
+        assertEquals("screen_viewed", event.name)
+        assertEquals("dashboard", event.properties["screen_name"])
+    }
+
+    // ── TransactionCreated ───────────────────────────────────────────
+
+    @Test
+    fun transactionCreatedProperties() {
+        val event = AnalyticsEvent.TransactionCreated(
+            timestamp = fixedInstant,
+            transactionType = "EXPENSE",
+            hasCategoryAssigned = true,
+            hasNotes = false,
+            hasTags = true,
+        )
+        assertEquals("transaction_created", event.name)
+        assertEquals("EXPENSE", event.properties["transaction_type"])
+        assertEquals("true", event.properties["has_category"])
+        assertEquals("false", event.properties["has_notes"])
+        assertEquals("true", event.properties["has_tags"])
+        assertEquals(4, event.properties.size)
+    }
+
+    @Test
+    fun transactionCreatedTimestamp() {
+        val event = AnalyticsEvent.TransactionCreated(
+            timestamp = fixedInstant,
+            transactionType = "INCOME",
+            hasCategoryAssigned = false,
+            hasNotes = false,
+            hasTags = false,
+        )
+        assertEquals(fixedInstant, event.timestamp)
+    }
+
+    // ── TransactionUpdated ───────────────────────────────────────────
+
+    @Test
+    fun transactionUpdatedEventName() {
+        val event = AnalyticsEvent.TransactionUpdated(
+            timestamp = fixedInstant,
+            transactionType = "TRANSFER",
+            fieldsChanged = 3,
+        )
+        assertEquals("transaction_updated", event.name)
+        assertEquals("3", event.properties["fields_changed"])
+    }
+
+    // ── TransactionDeleted ───────────────────────────────────────────
+
+    @Test
+    fun transactionDeletedEventName() {
+        val event = AnalyticsEvent.TransactionDeleted(
+            timestamp = fixedInstant,
+            transactionType = "EXPENSE",
+        )
+        assertEquals("transaction_deleted", event.name)
+        assertEquals("EXPENSE", event.properties["transaction_type"])
+    }
+
+    // ── BudgetCreated ────────────────────────────────────────────────
+
+    @Test
+    fun budgetCreatedProperties() {
+        val event = AnalyticsEvent.BudgetCreated(
+            timestamp = fixedInstant,
+            period = "MONTHLY",
+            isRollover = true,
+        )
+        assertEquals("budget_created", event.name)
+        assertEquals("MONTHLY", event.properties["period"])
+        assertEquals("true", event.properties["is_rollover"])
+    }
+
+    // ── BudgetExceeded ───────────────────────────────────────────────
+
+    @Test
+    fun budgetExceededProperties() {
+        val event = AnalyticsEvent.BudgetExceeded(
+            timestamp = fixedInstant,
+            utilizationPercent = 115,
+        )
+        assertEquals("budget_exceeded", event.name)
+        assertEquals("115", event.properties["utilization_percent"])
+    }
+
+    // ── BudgetThresholdReached ───────────────────────────────────────
+
+    @Test
+    fun budgetThresholdReachedProperties() {
+        val event = AnalyticsEvent.BudgetThresholdReached(
+            timestamp = fixedInstant,
+            thresholdPercent = 80,
+        )
+        assertEquals("budget_threshold_reached", event.name)
+        assertEquals("80", event.properties["threshold_percent"])
+    }
+
+    // ── GoalCreated ──────────────────────────────────────────────────
+
+    @Test
+    fun goalCreatedProperties() {
+        val event = AnalyticsEvent.GoalCreated(
+            timestamp = fixedInstant,
+            hasTargetDate = true,
+            hasLinkedAccount = false,
+        )
+        assertEquals("goal_created", event.name)
+        assertEquals("true", event.properties["has_target_date"])
+        assertEquals("false", event.properties["has_linked_account"])
+    }
+
+    // ── GoalCompleted ────────────────────────────────────────────────
+
+    @Test
+    fun goalCompletedWithDays() {
+        val event = AnalyticsEvent.GoalCompleted(
+            timestamp = fixedInstant,
+            daysToComplete = 90,
+        )
+        assertEquals("goal_completed", event.name)
+        assertEquals("90", event.properties["days_to_complete"])
+    }
+
+    @Test
+    fun goalCompletedWithoutDays() {
+        val event = AnalyticsEvent.GoalCompleted(
+            timestamp = fixedInstant,
+            daysToComplete = null,
+        )
+        assertEquals("goal_completed", event.name)
+        assertFalse(event.properties.containsKey("days_to_complete"))
+        assertTrue(event.properties.isEmpty())
+    }
+
+    // ── SyncCompleted ────────────────────────────────────────────────
+
+    @Test
+    fun syncCompletedProperties() {
+        val event = AnalyticsEvent.SyncCompleted(
+            timestamp = fixedInstant,
+            durationMs = 1500,
+            recordCount = 42,
+            success = true,
+            syncType = "delta",
+        )
+        assertEquals("sync_completed", event.name)
+        assertEquals("1500", event.properties["duration_ms"])
+        assertEquals("42", event.properties["record_count"])
+        assertEquals("true", event.properties["success"])
+        assertEquals("delta", event.properties["sync_type"])
+    }
+
+    // ── SyncConflictResolved ─────────────────────────────────────────
+
+    @Test
+    fun syncConflictResolvedProperties() {
+        val event = AnalyticsEvent.SyncConflictResolved(
+            timestamp = fixedInstant,
+            resolutionStrategy = "server_wins",
+            entityType = "transaction",
+        )
+        assertEquals("sync_conflict_resolved", event.name)
+        assertEquals("server_wins", event.properties["resolution_strategy"])
+        assertEquals("transaction", event.properties["entity_type"])
+    }
+
+    // ── DataExported ─────────────────────────────────────────────────
+
+    @Test
+    fun dataExportedProperties() {
+        val event = AnalyticsEvent.DataExported(
+            timestamp = fixedInstant,
+            format = "json",
+            recordCount = 150,
+        )
+        assertEquals("data_exported", event.name)
+        assertEquals("json", event.properties["format"])
+        assertEquals("150", event.properties["record_count"])
+    }
+
+    // ── DataImported ─────────────────────────────────────────────────
+
+    @Test
+    fun dataImportedProperties() {
+        val event = AnalyticsEvent.DataImported(
+            timestamp = fixedInstant,
+            format = "csv",
+            recordCount = 200,
+            success = false,
+        )
+        assertEquals("data_imported", event.name)
+        assertEquals("csv", event.properties["format"])
+        assertEquals("200", event.properties["record_count"])
+        assertEquals("false", event.properties["success"])
+    }
+
+    // ── AccountCreated ───────────────────────────────────────────────
+
+    @Test
+    fun accountCreatedProperties() {
+        val event = AnalyticsEvent.AccountCreated(
+            timestamp = fixedInstant,
+            accountType = "CHECKING",
+            currencyCode = "USD",
+        )
+        assertEquals("account_created", event.name)
+        assertEquals("CHECKING", event.properties["account_type"])
+        assertEquals("USD", event.properties["currency_code"])
+    }
+
+    // ── FeatureAdopted ───────────────────────────────────────────────
+
+    @Test
+    fun featureAdoptedProperties() {
+        val event = AnalyticsEvent.FeatureAdopted(
+            timestamp = fixedInstant,
+            featureKey = KpiMetrics.FEATURE_FIRST_BUDGET,
+        )
+        assertEquals("feature_adopted", event.name)
+        assertEquals("first_budget", event.properties["feature_key"])
+    }
+
+    // ── ErrorOccurred ────────────────────────────────────────────────
+
+    @Test
+    fun errorOccurredProperties() {
+        val event = AnalyticsEvent.ErrorOccurred(
+            timestamp = fixedInstant,
+            errorCode = "SYNC_TIMEOUT",
+            screen = "dashboard",
+        )
+        assertEquals("error_occurred", event.name)
+        assertEquals("SYNC_TIMEOUT", event.properties["error_code"])
+        assertEquals("dashboard", event.properties["screen"])
+    }
+
+    // ── All events have unique names ─────────────────────────────────
+
+    @Test
+    fun allEventNamesAreUnique() {
+        val events = listOf(
+            AnalyticsEvent.AppOpened(fixedInstant, "test", "1.0"),
+            AnalyticsEvent.ScreenViewed(fixedInstant, "test"),
+            AnalyticsEvent.TransactionCreated(fixedInstant, "E", true, false, false),
+            AnalyticsEvent.TransactionUpdated(fixedInstant, "E", 1),
+            AnalyticsEvent.TransactionDeleted(fixedInstant, "E"),
+            AnalyticsEvent.BudgetCreated(fixedInstant, "M", false),
+            AnalyticsEvent.BudgetExceeded(fixedInstant, 100),
+            AnalyticsEvent.BudgetThresholdReached(fixedInstant, 80),
+            AnalyticsEvent.GoalCreated(fixedInstant, false, false),
+            AnalyticsEvent.GoalCompleted(fixedInstant, null),
+            AnalyticsEvent.SyncCompleted(fixedInstant, 0, 0, true, "full"),
+            AnalyticsEvent.SyncConflictResolved(fixedInstant, "s", "t"),
+            AnalyticsEvent.DataExported(fixedInstant, "json", 0),
+            AnalyticsEvent.DataImported(fixedInstant, "csv", 0, true),
+            AnalyticsEvent.AccountCreated(fixedInstant, "C", "USD"),
+            AnalyticsEvent.FeatureAdopted(fixedInstant, "f"),
+            AnalyticsEvent.ErrorOccurred(fixedInstant, "E", "s"),
+        )
+        val names = events.map { it.name }
+        assertEquals(names.size, names.toSet().size, "Duplicate event names found: ${names.groupBy { it }.filter { it.value.size > 1 }.keys}")
+    }
+
+    // ── Event names are snake_case ───────────────────────────────────
+
+    @Test
+    fun allEventNamesAreSnakeCase() {
+        val events = listOf(
+            AnalyticsEvent.AppOpened(fixedInstant, "test", "1.0"),
+            AnalyticsEvent.ScreenViewed(fixedInstant, "test"),
+            AnalyticsEvent.TransactionCreated(fixedInstant, "E", true, false, false),
+            AnalyticsEvent.TransactionUpdated(fixedInstant, "E", 1),
+            AnalyticsEvent.TransactionDeleted(fixedInstant, "E"),
+            AnalyticsEvent.BudgetCreated(fixedInstant, "M", false),
+            AnalyticsEvent.BudgetExceeded(fixedInstant, 100),
+            AnalyticsEvent.BudgetThresholdReached(fixedInstant, 80),
+            AnalyticsEvent.GoalCreated(fixedInstant, false, false),
+            AnalyticsEvent.GoalCompleted(fixedInstant, null),
+            AnalyticsEvent.SyncCompleted(fixedInstant, 0, 0, true, "full"),
+            AnalyticsEvent.SyncConflictResolved(fixedInstant, "s", "t"),
+            AnalyticsEvent.DataExported(fixedInstant, "json", 0),
+            AnalyticsEvent.DataImported(fixedInstant, "csv", 0, true),
+            AnalyticsEvent.AccountCreated(fixedInstant, "C", "USD"),
+            AnalyticsEvent.FeatureAdopted(fixedInstant, "f"),
+            AnalyticsEvent.ErrorOccurred(fixedInstant, "E", "s"),
+        )
+        val snakeCaseRegex = Regex("^[a-z][a-z0-9_]*$")
+        for (event in events) {
+            assertTrue(
+                snakeCaseRegex.matches(event.name),
+                "Event name '${event.name}' is not valid snake_case",
+            )
+        }
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/analytics/BufferedAnalyticsTrackerTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/analytics/BufferedAnalyticsTrackerTest.kt
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.analytics
+
+import kotlinx.datetime.Instant
+import kotlin.test.*
+
+/**
+ * Tests for [BufferedAnalyticsTracker] — consent gating, buffering,
+ * auto-flush, overflow eviction, and transport delegation.
+ */
+class BufferedAnalyticsTrackerTest {
+
+    private val fixedInstant = Instant.parse("2024-06-15T12:00:00Z")
+
+    /** Captures events sent through the transport. */
+    private class RecordingTransport : AnalyticsTransport {
+        val sentBatches = mutableListOf<List<AnalyticsEvent>>()
+        val userProperties = mutableMapOf<String, String>()
+        var lastUserId: String? = null
+
+        override fun sendEvents(events: List<AnalyticsEvent>) {
+            sentBatches.add(events.toList())
+        }
+
+        override fun setUserProperty(key: String, value: String) {
+            userProperties[key] = value
+        }
+
+        override fun setUserId(userId: String?) {
+            this.lastUserId = userId
+        }
+
+        val totalEventsSent: Int get() = sentBatches.sumOf { it.size }
+    }
+
+    private fun sampleEvent(name: String = "test"): AnalyticsEvent =
+        AnalyticsEvent.ScreenViewed(fixedInstant, name)
+
+    // ── Consent gating ───────────────────────────────────────────────
+
+    @Test
+    fun trackIsNoOpWhenConsentDenied() {
+        val transport = RecordingTransport()
+        val tracker = BufferedAnalyticsTracker(
+            consentProvider = { false },
+            transport = transport,
+        )
+
+        tracker.track(sampleEvent())
+        assertEquals(0, tracker.bufferedEventCount)
+        assertEquals(0, transport.totalEventsSent)
+    }
+
+    @Test
+    fun setUserPropertyIsNoOpWhenConsentDenied() {
+        val transport = RecordingTransport()
+        val tracker = BufferedAnalyticsTracker(
+            consentProvider = { false },
+            transport = transport,
+        )
+
+        tracker.setUserProperty("key", "value")
+        assertTrue(transport.userProperties.isEmpty())
+    }
+
+    @Test
+    fun setUserIdIsNoOpWhenConsentDeniedAndNonNull() {
+        val transport = RecordingTransport()
+        val tracker = BufferedAnalyticsTracker(
+            consentProvider = { false },
+            transport = transport,
+        )
+
+        tracker.setUserId("user-123")
+        assertNull(transport.lastUserId)
+    }
+
+    @Test
+    fun setUserIdAllowsNullEvenWithoutConsent() {
+        val transport = RecordingTransport()
+        // Start with consent to set a user ID
+        var consent = true
+        val tracker = BufferedAnalyticsTracker(
+            consentProvider = { consent },
+            transport = transport,
+        )
+
+        tracker.setUserId("user-123")
+        assertEquals("user-123", transport.lastUserId)
+
+        // Revoke consent, but clearing (null) should still work
+        consent = false
+        tracker.setUserId(null)
+        assertNull(transport.lastUserId)
+    }
+
+    @Test
+    fun isEnabledReflectsConsentProvider() {
+        var consent = false
+        val tracker = BufferedAnalyticsTracker(
+            consentProvider = { consent },
+            transport = RecordingTransport(),
+        )
+
+        assertFalse(tracker.isEnabled())
+        consent = true
+        assertTrue(tracker.isEnabled())
+    }
+
+    // ── Buffering ────────────────────────────────────────────────────
+
+    @Test
+    fun eventsBufferedUntilFlush() {
+        val transport = RecordingTransport()
+        val tracker = BufferedAnalyticsTracker(
+            consentProvider = { true },
+            transport = transport,
+            maxBufferSize = 100,
+        )
+
+        // Track fewer than FLUSH_THRESHOLD events
+        repeat(10) { tracker.track(sampleEvent("screen-$it")) }
+
+        assertEquals(10, tracker.bufferedEventCount)
+        assertEquals(0, transport.totalEventsSent, "Should not auto-flush below threshold")
+    }
+
+    @Test
+    fun flushSendsAllBufferedEvents() {
+        val transport = RecordingTransport()
+        val tracker = BufferedAnalyticsTracker(
+            consentProvider = { true },
+            transport = transport,
+            maxBufferSize = 100,
+        )
+
+        repeat(10) { tracker.track(sampleEvent("screen-$it")) }
+        tracker.flush()
+
+        assertEquals(0, tracker.bufferedEventCount)
+        assertEquals(10, transport.totalEventsSent)
+    }
+
+    @Test
+    fun flushIsNoOpWhenBufferEmpty() {
+        val transport = RecordingTransport()
+        val tracker = BufferedAnalyticsTracker(
+            consentProvider = { true },
+            transport = transport,
+        )
+
+        tracker.flush()
+        assertTrue(transport.sentBatches.isEmpty())
+    }
+
+    @Test
+    fun flushClearsBufferWhenConsentRevoked() {
+        val transport = RecordingTransport()
+        var consent = true
+        val tracker = BufferedAnalyticsTracker(
+            consentProvider = { consent },
+            transport = transport,
+            maxBufferSize = 100,
+        )
+
+        repeat(10) { tracker.track(sampleEvent()) }
+        assertEquals(10, tracker.bufferedEventCount)
+
+        consent = false
+        tracker.flush()
+
+        assertEquals(0, tracker.bufferedEventCount)
+        assertEquals(0, transport.totalEventsSent, "Events should be discarded, not sent")
+    }
+
+    // ── Overflow eviction ────────────────────────────────────────────
+
+    @Test
+    fun bufferOverflowEvictsOldestEvent() {
+        val transport = RecordingTransport()
+        val tracker = BufferedAnalyticsTracker(
+            consentProvider = { true },
+            transport = transport,
+            maxBufferSize = 5,
+        )
+
+        // Track 5 events (fills buffer) — note: small buffer means auto-flush triggers
+        // We need maxBufferSize > FLUSH_THRESHOLD for this test
+        // Actually FLUSH_THRESHOLD is 50, so with maxBufferSize=5, auto-flush won't trigger
+        // because 5 < 50. But eviction happens at 5.
+        repeat(5) { tracker.track(sampleEvent("screen-$it")) }
+        assertEquals(5, tracker.bufferedEventCount)
+        assertEquals(0L, tracker.droppedEventCount)
+
+        // 6th event should evict the oldest
+        tracker.track(sampleEvent("screen-5"))
+        assertEquals(5, tracker.bufferedEventCount)
+        assertEquals(1L, tracker.droppedEventCount)
+    }
+
+    // ── Transport delegation ─────────────────────────────────────────
+
+    @Test
+    fun setUserPropertyDelegatesToTransport() {
+        val transport = RecordingTransport()
+        val tracker = BufferedAnalyticsTracker(
+            consentProvider = { true },
+            transport = transport,
+        )
+
+        tracker.setUserProperty("plan_type", "premium")
+        assertEquals("premium", transport.userProperties["plan_type"])
+    }
+
+    @Test
+    fun setUserIdDelegatesToTransport() {
+        val transport = RecordingTransport()
+        val tracker = BufferedAnalyticsTracker(
+            consentProvider = { true },
+            transport = transport,
+        )
+
+        tracker.setUserId("pseudo-abc")
+        assertEquals("pseudo-abc", transport.lastUserId)
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/analytics/KpiMetricsTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/analytics/KpiMetricsTest.kt
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.analytics
+
+import kotlin.test.*
+
+/**
+ * Tests for [KpiMetrics] constants and helper functions.
+ */
+class KpiMetricsTest {
+
+    // ── countToBucket ────────────────────────────────────────────────
+
+    @Test
+    fun zeroCountBucketsToZero() {
+        assertEquals("0", KpiMetrics.countToBucket(0))
+    }
+
+    @Test
+    fun negativeCountBucketsToZero() {
+        assertEquals("0", KpiMetrics.countToBucket(-5))
+    }
+
+    @Test
+    fun oneCountBucketsToOneToThree() {
+        assertEquals("1-3", KpiMetrics.countToBucket(1))
+    }
+
+    @Test
+    fun threeCountBucketsToOneToThree() {
+        assertEquals("1-3", KpiMetrics.countToBucket(3))
+    }
+
+    @Test
+    fun fourCountBucketsToFourToTen() {
+        assertEquals("4-10", KpiMetrics.countToBucket(4))
+    }
+
+    @Test
+    fun tenCountBucketsToFourToTen() {
+        assertEquals("4-10", KpiMetrics.countToBucket(10))
+    }
+
+    @Test
+    fun elevenCountBucketsToElevenPlus() {
+        assertEquals("11+", KpiMetrics.countToBucket(11))
+    }
+
+    @Test
+    fun largeCountBucketsToElevenPlus() {
+        assertEquals("11+", KpiMetrics.countToBucket(999))
+    }
+
+    // ── Constants are non-blank ──────────────────────────────────────
+
+    @Test
+    fun featureKeysAreNonBlank() {
+        val keys = listOf(
+            KpiMetrics.FEATURE_FIRST_TRANSACTION,
+            KpiMetrics.FEATURE_FIRST_BUDGET,
+            KpiMetrics.FEATURE_FIRST_GOAL,
+            KpiMetrics.FEATURE_FIRST_EXPORT,
+            KpiMetrics.FEATURE_FIRST_IMPORT,
+            KpiMetrics.FEATURE_FIRST_RECURRING,
+            KpiMetrics.FEATURE_FIRST_TRANSFER,
+        )
+        for (key in keys) {
+            assertTrue(key.isNotBlank(), "Feature key should not be blank")
+        }
+    }
+
+    @Test
+    fun screenNamesAreNonBlank() {
+        val screens = listOf(
+            KpiMetrics.SCREEN_DASHBOARD,
+            KpiMetrics.SCREEN_TRANSACTIONS,
+            KpiMetrics.SCREEN_BUDGETS,
+            KpiMetrics.SCREEN_GOALS,
+            KpiMetrics.SCREEN_ACCOUNTS,
+            KpiMetrics.SCREEN_SETTINGS,
+            KpiMetrics.SCREEN_EXPORT,
+            KpiMetrics.SCREEN_IMPORT,
+            KpiMetrics.SCREEN_REPORTS,
+        )
+        for (screen in screens) {
+            assertTrue(screen.isNotBlank(), "Screen name should not be blank")
+        }
+    }
+
+    @Test
+    fun userPropertyKeysAreNonBlank() {
+        val props = listOf(
+            KpiMetrics.PROP_ACCOUNT_COUNT_BUCKET,
+            KpiMetrics.PROP_BUDGET_COUNT_BUCKET,
+            KpiMetrics.PROP_PRIMARY_CURRENCY,
+            KpiMetrics.PROP_PLATFORM,
+            KpiMetrics.PROP_APP_VERSION,
+        )
+        for (prop in props) {
+            assertTrue(prop.isNotBlank(), "Property key should not be blank")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements the analytics instrumentation layer in \packages/core/\ for v1.0 KPI tracking (closes #764).

### Changes

**New files in \packages/core/src/commonMain/kotlin/com/finance/core/analytics/\:**

| File | Description |
|------|-------------|
| \AnalyticsEvent.kt\ | Sealed hierarchy of 17 event types: session, transaction, budget, goal, sync, export/import, account, feature adoption, error |
| \AnalyticsTracker.kt\ | Platform-agnostic tracking interface with consent gating + \NoOpAnalyticsTracker\ stub |
| \BufferedAnalyticsTracker.kt\ | Shared buffered implementation with FIFO eviction, auto-flush, and \AnalyticsTransport\ delegation |
| \KpiMetrics.kt\ | Centralized constants for feature keys, user property names, screen names, and \countToBucket()\ helper |

**Tests in \packages/core/src/commonTest/\:**
- \AnalyticsEventTest.kt\ — event names, properties, uniqueness, snake_case validation
- \BufferedAnalyticsTrackerTest.kt\ — consent gating, buffering, flush, overflow, transport delegation
- \KpiMetricsTest.kt\ — bucket helper, constant validation

### Design Decisions
- All events carry \Map<String, String>\ properties — no PII, no financial amounts
- \BufferedAnalyticsTracker\ handles consent + buffering in commonMain; platforms only implement \AnalyticsTransport\
- FIFO eviction at buffer capacity with \droppedEventCount\ for monitoring
- Event names follow \snake_case\ convention for analytics backend compatibility

### Platform integration (follow-up)
- iOS: implement \AnalyticsTransport\ backed by Firebase Analytics
- Android: implement \AnalyticsTransport\ backed by Firebase Analytics
- Web: implement \AnalyticsTransport\ backed by PostHog
- Windows: implement \AnalyticsTransport\ backed by Application Insights

Closes #764