### PR TITLE
feat(windows): restructure Koin DI into modular architecture with security services

### DIFF
--- a/apps/windows/src/main/kotlin/com/finance/desktop/Main.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/Main.kt
@@ -10,14 +10,14 @@ import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
 import com.finance.desktop.components.rememberShortcutHandler
-import com.finance.desktop.di.appModule
+import com.finance.desktop.di.appModules
 import com.finance.desktop.notifications.DesktopNotificationManager
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 
 fun main() {
     startKoin {
-        modules(appModule)
+        modules(appModules)
     }
 
     DesktopNotificationManager.initialise()

--- a/apps/windows/src/main/kotlin/com/finance/desktop/di/AppModule.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/di/AppModule.kt
@@ -2,61 +2,35 @@
 
 package com.finance.desktop.di
 
-import com.finance.desktop.data.repository.*
-import com.finance.desktop.data.repository.impl.*
-import com.finance.desktop.sync.DesktopSyncProvider
-import com.finance.desktop.viewmodel.*
-import com.finance.sync.DefaultSyncEngine
-import com.finance.sync.SyncConfig
-import com.finance.sync.SyncProvider
-import com.finance.sync.delta.DeltaSyncManager
-import com.finance.sync.delta.InMemorySequenceTracker
-import com.finance.sync.delta.SequenceTracker
-import com.finance.sync.queue.InMemoryMutationQueue
-import com.finance.sync.queue.MutationQueue
-import org.koin.core.module.dsl.singleOf
-import org.koin.dsl.bind
-import org.koin.dsl.module
+import org.koin.core.module.Module
 
-val appModule = module {
-    // ── Repositories (in-memory, to be replaced by SQLDelight-backed impls) ──
-    singleOf(::InMemoryAccountRepository) bind AccountRepository::class
-    singleOf(::InMemoryTransactionRepository) bind TransactionRepository::class
-    singleOf(::InMemoryBudgetRepository) bind BudgetRepository::class
-    singleOf(::InMemoryCategoryRepository) bind CategoryRepository::class
-    singleOf(::InMemoryGoalRepository) bind GoalRepository::class
-
-    // ── Sync infrastructure (KMP shared packages) ──
-    single<SyncConfig> {
-        SyncConfig(
-            endpoint = "https://sync.finance.app",
-            databaseName = "finance-desktop.db",
-        )
-    }
-    singleOf(::DesktopSyncProvider) bind SyncProvider::class
-    singleOf(::InMemoryMutationQueue) bind MutationQueue::class
-    singleOf(::InMemorySequenceTracker) bind SequenceTracker::class
-    single {
-        DeltaSyncManager(
-            provider = get(),
-            sequenceTracker = get(),
-            config = get(),
-        )
-    }
-    single {
-        DefaultSyncEngine(
-            config = get(),
-            provider = get(),
-            mutationQueue = get(),
-            deltaSyncManager = get(),
-        )
-    }
-
-    // ── ViewModels ──
-    single { DashboardViewModel(get(), get(), get()) }
-    single { AccountsViewModel(get(), get()) }
-    single { TransactionsViewModel(get()) }
-    single { BudgetsViewModel(get(), get()) }
-    single { GoalsViewModel(get()) }
-    single { SyncViewModel(get()) }
-}
+/**
+ * Aggregated Koin module list for the Finance Windows desktop application.
+ *
+ * Composes all feature-specific modules into a single list suitable for
+ * `startKoin { modules(appModules) }`. Module ordering does not matter —
+ * Koin resolves dependencies lazily at injection time.
+ *
+ * ## Module Breakdown
+ *
+ * | Module             | Contents                                         |
+ * |--------------------|--------------------------------------------------|
+ * | [repositoryModule] | In-memory repository bindings (→ SQLDelight)     |
+ * | [syncModule]       | KMP sync engine, provider, mutation queue         |
+ * | [securityModule]   | WindowsHelloManager, DpapiManager, TokenStorage  |
+ * | [platformModule]   | DesktopNotificationManager                       |
+ * | [viewModelModule]  | All ViewModels (Dashboard, Accounts, Auth, etc.) |
+ *
+ * @see repositoryModule
+ * @see syncModule
+ * @see securityModule
+ * @see platformModule
+ * @see viewModelModule
+ */
+val appModules: List<Module> = listOf(
+    repositoryModule,
+    syncModule,
+    securityModule,
+    platformModule,
+    viewModelModule,
+)

--- a/apps/windows/src/main/kotlin/com/finance/desktop/di/PlatformModule.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/di/PlatformModule.kt
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.di
+
+import com.finance.desktop.notifications.DesktopNotificationManager
+import org.koin.dsl.module
+
+/**
+ * Koin module for Windows platform services.
+ *
+ * Provides DI-managed access to:
+ * - [DesktopNotificationManager] — Windows toast notifications via system tray
+ *
+ * The notification manager is provided as a singleton. Koin lifecycle
+ * management ensures consistent access across all injection sites.
+ *
+ * Note: [DesktopNotificationManager.initialise] must still be called
+ * during application startup (from Main.kt) before notifications can
+ * be displayed. Koin provides the instance; the caller handles lifecycle.
+ */
+val platformModule = module {
+    single { DesktopNotificationManager }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/di/RepositoryModule.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/di/RepositoryModule.kt
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.di
+
+import com.finance.desktop.data.repository.*
+import com.finance.desktop.data.repository.impl.*
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+/**
+ * Koin module for repository bindings.
+ *
+ * Binds in-memory repository implementations to their interfaces.
+ * When SQLDelight-backed implementations are ready, swap them here
+ * without touching any ViewModel or screen code.
+ */
+val repositoryModule = module {
+    singleOf(::InMemoryAccountRepository) bind AccountRepository::class
+    singleOf(::InMemoryTransactionRepository) bind TransactionRepository::class
+    singleOf(::InMemoryBudgetRepository) bind BudgetRepository::class
+    singleOf(::InMemoryCategoryRepository) bind CategoryRepository::class
+    singleOf(::InMemoryGoalRepository) bind GoalRepository::class
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/di/SecurityModule.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/di/SecurityModule.kt
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.di
+
+import com.finance.desktop.security.DpapiManager
+import com.finance.desktop.security.SecureTokenStorage
+import com.finance.desktop.security.WindowsHelloManager
+import org.koin.dsl.module
+
+/**
+ * Koin module for Windows security services.
+ *
+ * Provides DI-managed instances of:
+ * - [WindowsHelloManager] — biometric/PIN authentication via Windows Hello
+ * - [DpapiManager] — DPAPI encryption for credential storage
+ * - [SecureTokenStorage] — encrypted token persistence using DPAPI
+ *
+ * All security services are singletons to ensure consistent state across
+ * the application lifecycle. The [SecureTokenStorage] depends on
+ * [DpapiManager], which Koin resolves automatically.
+ *
+ * ## Testing
+ *
+ * For unit tests, provide alternative implementations via
+ * `WindowsHelloManager.create(testProvider)` and
+ * `DpapiManager.create(testProvider)` — then override this module
+ * in the test Koin configuration.
+ */
+val securityModule = module {
+    single { WindowsHelloManager.create() }
+    single { DpapiManager.create() }
+    single { SecureTokenStorage.create(get(), SecureTokenStorage.defaultStorageDir()) }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/di/SyncModule.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/di/SyncModule.kt
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.di
+
+import com.finance.desktop.sync.DesktopSyncProvider
+import com.finance.sync.DefaultSyncEngine
+import com.finance.sync.SyncConfig
+import com.finance.sync.SyncProvider
+import com.finance.sync.delta.DeltaSyncManager
+import com.finance.sync.delta.InMemorySequenceTracker
+import com.finance.sync.delta.SequenceTracker
+import com.finance.sync.queue.InMemoryMutationQueue
+import com.finance.sync.queue.MutationQueue
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+/**
+ * Koin module for sync infrastructure from KMP shared packages.
+ *
+ * Wires the desktop sync provider, mutation queue, sequence tracker,
+ * delta sync manager, and the top-level sync engine. The [SyncConfig]
+ * specifies the remote endpoint and local database name.
+ *
+ * When moving to a production backend (PowerSync), update [SyncConfig]
+ * and swap [DesktopSyncProvider] for a Ktor-backed implementation.
+ */
+val syncModule = module {
+    single<SyncConfig> {
+        SyncConfig(
+            endpoint = "https://sync.finance.app",
+            databaseName = "finance-desktop.db",
+        )
+    }
+    singleOf(::DesktopSyncProvider) bind SyncProvider::class
+    singleOf(::InMemoryMutationQueue) bind MutationQueue::class
+    singleOf(::InMemorySequenceTracker) bind SequenceTracker::class
+    single {
+        DeltaSyncManager(
+            provider = get(),
+            sequenceTracker = get(),
+            config = get(),
+        )
+    }
+    single {
+        DefaultSyncEngine(
+            config = get(),
+            provider = get(),
+            mutationQueue = get(),
+            deltaSyncManager = get(),
+        )
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/di/ViewModelModule.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/di/ViewModelModule.kt
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.di
+
+import com.finance.desktop.viewmodel.*
+import org.koin.dsl.module
+
+/**
+ * Koin module for all ViewModel instances.
+ *
+ * ViewModels are registered as singletons since Compose Desktop does not
+ * have Android-style lifecycle scoping. Each ViewModel's [DesktopViewModel.onCleared]
+ * can be called manually if needed during navigation transitions.
+ *
+ * The ViewModel dependency graph mirrors the Android app:
+ * - Each ViewModel receives repositories and services via constructor injection
+ * - No ViewModel depends on another ViewModel directly
+ * - UI state is exposed as [StateFlow] and collected in composables via [koinGet]
+ */
+val viewModelModule = module {
+    single { DashboardViewModel(get(), get(), get()) }
+    single { AccountsViewModel(get(), get()) }
+    single { TransactionsViewModel(get()) }
+    single { BudgetsViewModel(get(), get()) }
+    single { GoalsViewModel(get()) }
+    single { SyncViewModel(get()) }
+    single { SettingsViewModel(get(), get()) }
+    single { AuthViewModel(get(), get()) }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/SettingsScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/SettingsScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -47,7 +48,9 @@ import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
+import com.finance.desktop.di.koinGet
 import com.finance.desktop.theme.FinanceDesktopTheme
+import com.finance.desktop.viewmodel.SettingsViewModel
 
 // =============================================================================
 // Settings Screen — Form-style layout
@@ -68,15 +71,8 @@ import com.finance.desktop.theme.FinanceDesktopTheme
  */
 @Composable
 fun SettingsScreen(modifier: Modifier = Modifier) {
-    // Local state for toggles/dropdowns (UI-layer placeholders)
-    var darkMode by remember { mutableStateOf(false) }
-    var windowsHello by remember { mutableStateOf(true) }
-    var autoLock by remember { mutableStateOf(true) }
-    var budgetNotifications by remember { mutableStateOf(true) }
-    var goalNotifications by remember { mutableStateOf(true) }
-    var syncEnabled by remember { mutableStateOf(true) }
-    var selectedCurrency by remember { mutableStateOf("USD") }
-    var selectedLanguage by remember { mutableStateOf("English") }
+    val viewModel = koinGet<SettingsViewModel>()
+    val state by viewModel.uiState.collectAsState()
 
     Column(
         modifier = modifier
@@ -103,15 +99,15 @@ fun SettingsScreen(modifier: Modifier = Modifier) {
                 icon = Icons.Filled.DarkMode,
                 label = "Dark Mode",
                 description = "Use dark color scheme",
-                checked = darkMode,
-                onCheckedChange = { darkMode = it },
+                checked = state.darkMode,
+                onCheckedChange = { viewModel.setDarkMode(it) },
             )
             DropdownSetting(
                 icon = Icons.Filled.Language,
                 label = "Language",
-                currentValue = selectedLanguage,
+                currentValue = state.selectedLanguage,
                 options = listOf("English", "Spanish", "French", "German", "Japanese"),
-                onValueChange = { selectedLanguage = it },
+                onValueChange = { viewModel.setLanguage(it) },
             )
             DropdownSetting(
                 icon = Icons.Filled.ColorLens,
@@ -129,16 +125,19 @@ fun SettingsScreen(modifier: Modifier = Modifier) {
             ToggleSetting(
                 icon = Icons.Filled.Fingerprint,
                 label = "Windows Hello",
-                description = "Use biometric or PIN authentication",
-                checked = windowsHello,
-                onCheckedChange = { windowsHello = it },
+                description = if (state.windowsHelloAvailable)
+                    "Use biometric or PIN authentication"
+                else
+                    "Windows Hello is not configured on this device",
+                checked = state.windowsHelloEnabled,
+                onCheckedChange = { viewModel.setWindowsHelloEnabled(it) },
             )
             ToggleSetting(
                 icon = Icons.Filled.Lock,
                 label = "Auto-Lock",
-                description = "Lock app after 5 minutes of inactivity",
-                checked = autoLock,
-                onCheckedChange = { autoLock = it },
+                description = "Lock app after ${state.autoLockMinutes} minutes of inactivity",
+                checked = state.autoLockEnabled,
+                onCheckedChange = { viewModel.setAutoLockEnabled(it) },
             )
         }
 
@@ -150,15 +149,15 @@ fun SettingsScreen(modifier: Modifier = Modifier) {
                 icon = Icons.Filled.Notifications,
                 label = "Budget Alerts",
                 description = "Notify when approaching budget limits",
-                checked = budgetNotifications,
-                onCheckedChange = { budgetNotifications = it },
+                checked = state.budgetNotifications,
+                onCheckedChange = { viewModel.setBudgetNotifications(it) },
             )
             ToggleSetting(
                 icon = Icons.Filled.Notifications,
                 label = "Goal Milestones",
                 description = "Notify when reaching savings milestones",
-                checked = goalNotifications,
-                onCheckedChange = { goalNotifications = it },
+                checked = state.goalNotifications,
+                onCheckedChange = { viewModel.setGoalNotifications(it) },
             )
         }
 
@@ -169,16 +168,16 @@ fun SettingsScreen(modifier: Modifier = Modifier) {
             DropdownSetting(
                 icon = Icons.Filled.CurrencyExchange,
                 label = "Default Currency",
-                currentValue = selectedCurrency,
+                currentValue = state.selectedCurrency,
                 options = listOf("USD", "EUR", "GBP", "JPY", "CAD", "AUD"),
-                onValueChange = { selectedCurrency = it },
+                onValueChange = { viewModel.setCurrency(it) },
             )
             ToggleSetting(
                 icon = Icons.Filled.Sync,
                 label = "Cloud Sync",
                 description = "Sync data across devices",
-                checked = syncEnabled,
-                onCheckedChange = { syncEnabled = it },
+                checked = state.syncEnabled,
+                onCheckedChange = { viewModel.setSyncEnabled(it) },
             )
         }
 
@@ -189,12 +188,12 @@ fun SettingsScreen(modifier: Modifier = Modifier) {
             InfoSetting(
                 icon = Icons.Filled.Info,
                 label = "Version",
-                value = "1.0.0",
+                value = state.appVersion,
             )
             InfoSetting(
                 icon = Icons.Filled.Info,
                 label = "Build",
-                value = "2025.03.06",
+                value = state.buildDate,
             )
         }
 

--- a/apps/windows/src/main/kotlin/com/finance/desktop/security/SecureTokenStorage.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/security/SecureTokenStorage.kt
@@ -43,19 +43,29 @@ class SecureTokenStorage private constructor(
         private const val TOKEN_FILE_EXTENSION = ".enc"
 
         /**
+         * Returns the default storage directory for encrypted token files.
+         *
+         * Resolves to `%LOCALAPPDATA%\Finance\security\` on Windows, falling
+         * back to `~\AppData\Local\Finance\security\` if the environment
+         * variable is not set.
+         */
+        fun defaultStorageDir(): Path {
+            val localAppData = System.getenv("LOCALAPPDATA")
+                ?: System.getProperty("user.home") + "\\AppData\\Local"
+            return Path.of(localAppData, "Finance", "security")
+        }
+
+        /**
          * Creates a [SecureTokenStorage] using the default storage directory
          * (`%LOCALAPPDATA%\Finance\security\`) and a default [DpapiManager].
          */
         fun create(): SecureTokenStorage {
-            val localAppData = System.getenv("LOCALAPPDATA")
-                ?: System.getProperty("user.home") + "\\AppData\\Local"
-            val storageDir = Path.of(localAppData, "Finance", "security")
-            return create(DpapiManager.create(), storageDir)
+            return create(DpapiManager.create(), defaultStorageDir())
         }
 
         /**
          * Creates a [SecureTokenStorage] with explicit dependencies.
-         * Useful for testing or custom storage locations.
+         * Useful for testing, custom storage locations, or DI injection.
          */
         fun create(dpapiManager: DpapiManager, storageDir: Path): SecureTokenStorage {
             return SecureTokenStorage(dpapiManager, storageDir)

--- a/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/AuthViewModel.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/AuthViewModel.kt
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.viewmodel
+
+import com.finance.desktop.security.SecureTokenStorage
+import com.finance.desktop.security.WindowsHelloManager
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Authentication state for the Windows desktop application.
+ *
+ * @property isAuthenticated Whether the user has passed authentication.
+ * @property isWindowsHelloAvailable Whether Windows Hello is configured on this device.
+ * @property isAuthenticating Whether an authentication attempt is in progress.
+ * @property authError Human-readable error message from the last failed attempt, if any.
+ * @property requiresAuth Whether the app requires authentication before use.
+ */
+data class AuthUiState(
+    val isAuthenticated: Boolean = false,
+    val isWindowsHelloAvailable: Boolean = false,
+    val isAuthenticating: Boolean = false,
+    val authError: String? = null,
+    val requiresAuth: Boolean = true,
+)
+
+/**
+ * ViewModel managing authentication state for the Finance Windows app.
+ *
+ * Coordinates Windows Hello biometric/PIN authentication with DPAPI-backed
+ * secure token storage. The authentication flow:
+ *
+ * 1. On startup, checks if Windows Hello is available via [WindowsHelloManager]
+ * 2. If available and auth is required, presents the lock screen
+ * 3. User authenticates via Windows Hello (biometric → PIN fallback)
+ * 4. On success, loads tokens from [SecureTokenStorage] for API access
+ * 5. On failure, shows error and allows retry
+ *
+ * The ViewModel also manages auto-lock state — when the app is inactive
+ * for a configured period, [lockApp] is called to require re-authentication.
+ *
+ * ## Thread Safety
+ *
+ * All state mutations happen on the [viewModelScope] dispatcher. The
+ * [WindowsHelloManager] calls are blocking (PowerShell subprocess) and
+ * are dispatched to [Dispatchers.IO] via the coroutine scope.
+ */
+class AuthViewModel(
+    private val windowsHelloManager: WindowsHelloManager,
+    private val secureTokenStorage: SecureTokenStorage,
+) : DesktopViewModel() {
+
+    private val _uiState = MutableStateFlow(AuthUiState())
+    val uiState: StateFlow<AuthUiState> = _uiState.asStateFlow()
+
+    init {
+        checkWindowsHelloAvailability()
+    }
+
+    /**
+     * Checks whether Windows Hello is configured on this device and
+     * whether stored credentials exist (indicating auth should be required).
+     */
+    private fun checkWindowsHelloAvailability() {
+        viewModelScope.launch {
+            val available = windowsHelloManager.canAuthenticate()
+            val hasTokens = secureTokenStorage.hasToken(SecureTokenStorage.KEY_ACCESS_TOKEN)
+            _uiState.value = _uiState.value.copy(
+                isWindowsHelloAvailable = available,
+                requiresAuth = available && hasTokens,
+                // If no Windows Hello or no stored tokens, skip auth
+                isAuthenticated = !available || !hasTokens,
+            )
+        }
+    }
+
+    /**
+     * Initiates a Windows Hello authentication prompt.
+     *
+     * Displays the system Windows Hello dialog (fingerprint, face, or PIN).
+     * On success, sets [AuthUiState.isAuthenticated] to true. On failure
+     * or cancellation, sets an error message.
+     *
+     * @param reason Human-readable reason shown in the Windows Hello dialog.
+     */
+    fun authenticate(reason: String = "Finance needs to verify your identity") {
+        if (_uiState.value.isAuthenticating) return
+
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(
+                isAuthenticating = true,
+                authError = null,
+            )
+
+            val success = windowsHelloManager.authenticate(reason)
+
+            _uiState.value = _uiState.value.copy(
+                isAuthenticated = success,
+                isAuthenticating = false,
+                authError = if (success) null else "Authentication failed. Please try again.",
+            )
+        }
+    }
+
+    /**
+     * Locks the application, requiring re-authentication.
+     *
+     * Called by the auto-lock timer or manually from the Settings screen.
+     */
+    fun lockApp() {
+        _uiState.value = _uiState.value.copy(
+            isAuthenticated = false,
+            authError = null,
+        )
+    }
+
+    /**
+     * Bypasses authentication (for development or when Windows Hello is unavailable).
+     *
+     * In production builds, this should only be called when Windows Hello
+     * is not available on the device.
+     */
+    fun skipAuth() {
+        _uiState.value = _uiState.value.copy(
+            isAuthenticated = true,
+            authError = null,
+        )
+    }
+
+    /**
+     * Clears all stored credentials and resets authentication state.
+     *
+     * Used during sign-out to ensure no sensitive data remains on disk.
+     */
+    fun signOut() {
+        viewModelScope.launch {
+            secureTokenStorage.clearAllTokens()
+            _uiState.value = AuthUiState(
+                isWindowsHelloAvailable = _uiState.value.isWindowsHelloAvailable,
+                requiresAuth = false,
+                isAuthenticated = false,
+            )
+        }
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/SettingsViewModel.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/SettingsViewModel.kt
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.viewmodel
+
+import com.finance.desktop.security.SecureTokenStorage
+import com.finance.desktop.security.WindowsHelloManager
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * UI state for the Settings screen.
+ *
+ * All preference values are stored as simple types. Preferences that
+ * affect security (Windows Hello, auto-lock) are backed by [SecureTokenStorage]
+ * via DPAPI encryption. Display preferences are stored locally.
+ *
+ * @property darkMode Whether the dark color scheme is active.
+ * @property windowsHelloEnabled Whether Windows Hello authentication is enabled.
+ * @property windowsHelloAvailable Whether the device supports Windows Hello.
+ * @property autoLockEnabled Whether the app auto-locks after inactivity.
+ * @property autoLockMinutes Minutes of inactivity before auto-lock triggers.
+ * @property budgetNotifications Whether budget alert notifications are enabled.
+ * @property goalNotifications Whether goal milestone notifications are enabled.
+ * @property syncEnabled Whether cloud sync is active.
+ * @property selectedCurrency ISO 4217 currency code for display.
+ * @property selectedLanguage Display language name.
+ * @property appVersion Application version string.
+ */
+data class SettingsUiState(
+    val darkMode: Boolean = false,
+    val windowsHelloEnabled: Boolean = true,
+    val windowsHelloAvailable: Boolean = false,
+    val autoLockEnabled: Boolean = true,
+    val autoLockMinutes: Int = 5,
+    val budgetNotifications: Boolean = true,
+    val goalNotifications: Boolean = true,
+    val syncEnabled: Boolean = true,
+    val selectedCurrency: String = "USD",
+    val selectedLanguage: String = "English",
+    val appVersion: String = "1.0.0",
+    val buildDate: String = "2025.06.01",
+)
+
+/**
+ * ViewModel for the Settings screen.
+ *
+ * Manages user preferences with persistence for security-related settings
+ * via [SecureTokenStorage] and [WindowsHelloManager]. Display preferences
+ * are held in memory (to be backed by SharedPreferences/DataStore in a
+ * future iteration).
+ *
+ * Each setter method updates the UI state immediately and persists the
+ * value asynchronously. This ensures a responsive UI while maintaining
+ * data consistency.
+ */
+class SettingsViewModel(
+    private val windowsHelloManager: WindowsHelloManager,
+    private val secureTokenStorage: SecureTokenStorage,
+) : DesktopViewModel() {
+
+    private val _uiState = MutableStateFlow(SettingsUiState())
+    val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
+
+    companion object {
+        private const val PREF_WINDOWS_HELLO = "pref_windows_hello"
+        private const val PREF_AUTO_LOCK = "pref_auto_lock"
+        private const val PREF_DARK_MODE = "pref_dark_mode"
+    }
+
+    init {
+        loadPreferences()
+    }
+
+    private fun loadPreferences() {
+        viewModelScope.launch {
+            val windowsHelloAvailable = windowsHelloManager.canAuthenticate()
+
+            // Load persisted security preferences from DPAPI-encrypted storage
+            val windowsHelloEnabled = loadBooleanPref(PREF_WINDOWS_HELLO, true)
+            val autoLockEnabled = loadBooleanPref(PREF_AUTO_LOCK, true)
+            val darkMode = loadBooleanPref(PREF_DARK_MODE, false)
+
+            _uiState.value = _uiState.value.copy(
+                windowsHelloAvailable = windowsHelloAvailable,
+                windowsHelloEnabled = windowsHelloEnabled && windowsHelloAvailable,
+                autoLockEnabled = autoLockEnabled,
+                darkMode = darkMode,
+            )
+        }
+    }
+
+    fun setDarkMode(enabled: Boolean) {
+        _uiState.value = _uiState.value.copy(darkMode = enabled)
+        persistBooleanPref(PREF_DARK_MODE, enabled)
+    }
+
+    fun setWindowsHelloEnabled(enabled: Boolean) {
+        _uiState.value = _uiState.value.copy(windowsHelloEnabled = enabled)
+        persistBooleanPref(PREF_WINDOWS_HELLO, enabled)
+    }
+
+    fun setAutoLockEnabled(enabled: Boolean) {
+        _uiState.value = _uiState.value.copy(autoLockEnabled = enabled)
+        persistBooleanPref(PREF_AUTO_LOCK, enabled)
+    }
+
+    fun setBudgetNotifications(enabled: Boolean) {
+        _uiState.value = _uiState.value.copy(budgetNotifications = enabled)
+    }
+
+    fun setGoalNotifications(enabled: Boolean) {
+        _uiState.value = _uiState.value.copy(goalNotifications = enabled)
+    }
+
+    fun setSyncEnabled(enabled: Boolean) {
+        _uiState.value = _uiState.value.copy(syncEnabled = enabled)
+    }
+
+    fun setCurrency(currency: String) {
+        _uiState.value = _uiState.value.copy(selectedCurrency = currency)
+    }
+
+    fun setLanguage(language: String) {
+        _uiState.value = _uiState.value.copy(selectedLanguage = language)
+    }
+
+    /**
+     * Loads a boolean preference from DPAPI-encrypted storage.
+     * Returns [default] if the preference is not found or cannot be read.
+     */
+    private fun loadBooleanPref(key: String, default: Boolean): Boolean {
+        return try {
+            secureTokenStorage.loadToken(key)?.toBooleanStrictOrNull() ?: default
+        } catch (_: Exception) {
+            default
+        }
+    }
+
+    /**
+     * Persists a boolean preference to DPAPI-encrypted storage.
+     */
+    private fun persistBooleanPref(key: String, value: Boolean) {
+        viewModelScope.launch {
+            try {
+                secureTokenStorage.saveToken(key, value.toString())
+            } catch (e: Exception) {
+                // Log but don't crash — preferences are not critical
+                java.util.logging.Logger.getLogger("SettingsViewModel")
+                    .warning("Failed to persist preference $key: ${e.message}")
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #854 - Split monolithic appModule into repositoryModule, syncModule, securityModule, platformModule, viewModelModule. Added AuthViewModel and SettingsViewModel. Wired SettingsScreen to ViewModel.