### PR TITLE
docs(security): RASP strategy and device attestation specification (#330, #331)

### DIFF
--- a/docs/architecture/security/device-attestation-strategy.md
+++ b/docs/architecture/security/device-attestation-strategy.md
@@ -1,0 +1,451 @@
+<!-- SPDX-License-Identifier: BUSL-1.1 -->
+
+# Device Attestation and Integrity Verification — Finance App
+
+**Issue:** #331
+**Date:** 2025-07-27
+**Author:** Security & Privacy Reviewer
+**Status:** Assessment Complete — Implementation Specification
+**MASVS Control:** MASVS-RESILIENCE-4
+
+---
+
+## Executive Summary
+
+Device attestation provides **server-verifiable proof** that the Finance app is running
+on a genuine, uncompromised device. Unlike client-side RASP (which can be hooked/bypassed),
+device attestation is validated server-side using cryptographic proofs from the device
+manufacturer (Google, Apple, Microsoft).
+
+This document specifies the attestation strategy for each platform, the server-side
+verification architecture, and the integration with the existing auth and sync flows.
+
+### Platform Attestation APIs
+
+| Platform | API                             | Verification                 | Key Features                                           |
+| -------- | ------------------------------- | ---------------------------- | ------------------------------------------------------ |
+| Android  | Play Integrity API              | Server-side (Google servers) | Device integrity verdict, app licensing, app integrity |
+| iOS      | App Attest (DCAppAttestService) | Server-side (Apple servers)  | App identity, device identity, assertion counter       |
+| Windows  | TPM 2.0 Attestation             | Server-side (custom)         | Hardware-backed key, platform state                    |
+| Web      | N/A                             | N/A                          | No device attestation available                        |
+
+---
+
+## Threat Model for Device Attestation
+
+### What Attestation Proves
+
+| Property         | Meaning                                     | Threat Mitigated                |
+| ---------------- | ------------------------------------------- | ------------------------------- |
+| Device integrity | Device is not rooted/jailbroken             | Keystore/Keychain bypass        |
+| App integrity    | App has not been tampered with              | Repackaged APK, modified binary |
+| App licensing    | App was installed from official store       | Sideloaded malicious builds     |
+| App identity     | App is signed with the expected certificate | Impersonation attacks           |
+
+### What Attestation Does NOT Prove
+
+- User identity (that's what auth is for)
+- Network integrity (that's what cert pinning is for)
+- Data confidentiality (that's what encryption is for)
+- Runtime integrity between attestation checks (that's what RASP is for)
+
+### Combined Defence: Attestation + RASP
+
+```
+                     ┌─────────────────────────┐
+                     │   Server-Side Policy     │
+                     │                          │
+                     │  Attestation Valid?       │
+                     │  ├── Yes → Normal access  │
+                     │  └── No  → Degraded mode  │
+                     └──────────┬──────────────┘
+                                │
+          ┌─────────────────────┼─────────────────────┐
+          │                     │                     │
+    ┌─────▼─────┐         ┌────▼────┐          ┌─────▼─────┐
+    │  Android   │         │  iOS    │          │  Windows  │
+    │            │         │         │          │           │
+    │ Play       │         │ App     │          │ TPM 2.0   │
+    │ Integrity  │         │ Attest  │          │ Attest    │
+    │ API        │         │         │          │           │
+    │            │         │         │          │           │
+    │ + RASP     │         │ + RASP  │          │ + RASP    │
+    │ (local)    │         │ (local) │          │ (local)   │
+    └────────────┘         └─────────┘          └───────────┘
+```
+
+---
+
+## Platform Implementation Specifications
+
+### 1. Android — Play Integrity API
+
+#### Overview
+
+The Play Integrity API (successor to SafetyNet) provides three integrity verdicts:
+
+- **Device integrity:** `MEETS_DEVICE_INTEGRITY` (genuine, non-rooted)
+- **App integrity:** `MEETS_BASIC_INTEGRITY` + `MEETS_STRONG_INTEGRITY`
+- **Account licensing:** `LICENSED` (installed from Play Store)
+
+#### Client-Side Integration
+
+```kotlin
+/**
+ * Android device attestation via Play Integrity API.
+ *
+ * Called during:
+ *   1. Initial authentication (after successful passkey/OAuth)
+ *   2. Periodic re-attestation (configurable interval, default 24h)
+ *   3. Before high-value operations (account deletion, data export)
+ *
+ * The integrity token is sent to the backend for server-side verification.
+ * The client NEVER evaluates the token directly.
+ */
+class PlayIntegrityAttestor(
+    private val context: Context,
+    private val cloudProjectNumber: Long,
+) {
+    private val integrityManager = IntegrityManagerFactory.create(context)
+
+    /**
+     * Request an integrity token with a server-generated nonce.
+     *
+     * @param nonce Server-generated, single-use nonce (base64url, min 16 bytes)
+     * @return The integrity token string to send to the backend
+     */
+    suspend fun requestIntegrityToken(nonce: String): Result<String> {
+        return try {
+            val request = IntegrityTokenRequest.builder()
+                .setNonce(nonce)
+                .setCloudProjectNumber(cloudProjectNumber)
+                .build()
+
+            val response = integrityManager
+                .requestIntegrityToken(request)
+                .await()
+
+            Result.success(response.token())
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+}
+```
+
+#### Server-Side Verification (Edge Function)
+
+```typescript
+/**
+ * Verify a Play Integrity token server-side.
+ *
+ * Uses Google's Play Integrity API to decrypt and validate the token.
+ * NEVER trust the client to evaluate integrity verdicts.
+ */
+async function verifyPlayIntegrityToken(
+  token: string,
+  expectedNonce: string,
+): Promise<IntegrityVerdict> {
+  const response = await fetch(
+    'https://playintegrity.googleapis.com/v1/' + `${PACKAGE_NAME}:decryptToken`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${await getGoogleAccessToken()}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ integrity_token: token }),
+    },
+  );
+
+  const result = await response.json();
+
+  // Verify nonce matches
+  if (result.tokenPayloadExternal?.requestDetails?.nonce !== expectedNonce) {
+    return { valid: false, reason: 'nonce_mismatch' };
+  }
+
+  // Check device integrity
+  const deviceIntegrity = result.tokenPayloadExternal?.deviceIntegrity?.deviceRecognitionVerdict;
+  const appIntegrity = result.tokenPayloadExternal?.appIntegrity?.appRecognitionVerdict;
+
+  return {
+    valid: true,
+    deviceIntegrity: deviceIntegrity?.includes('MEETS_DEVICE_INTEGRITY') ?? false,
+    appIntegrity: appIntegrity === 'PLAY_RECOGNIZED',
+    verdicts: deviceIntegrity ?? [],
+  };
+}
+```
+
+#### Play Integrity Specific Considerations
+
+- **Rate limits:** Google limits Play Integrity API to 10,000 requests/day (standard tier)
+- **Nonce generation:** Server MUST generate nonces; client MUST NOT generate its own
+- **Token caching:** Tokens are single-use; do NOT cache or replay
+- **Grace period:** Allow 1-2 failed attestations before restricting (network issues)
+- **Emulator handling:** Emulators fail attestation — provide dev mode bypass (debug builds only)
+
+### 2. iOS — App Attest (DCAppAttestService)
+
+#### Overview
+
+App Attest provides two capabilities:
+
+1. **Key attestation:** Proves a key was generated in the Secure Enclave of a genuine Apple device
+2. **Assertion:** Proves a specific request came from the attested app instance
+
+#### Client-Side Integration
+
+```swift
+/// iOS device attestation via App Attest.
+///
+/// Flow:
+///   1. Generate a key pair in the Secure Enclave (one-time)
+///   2. Attest the key (proves device + app identity to Apple)
+///   3. For each protected request, generate an assertion (proves request authenticity)
+actor AppAttestManager {
+
+    private let service = DCAppAttestService.shared
+    private var keyId: String?
+
+    /// Check if App Attest is available on this device.
+    var isSupported: Bool {
+        service.isSupported
+    }
+
+    /// Generate and attest a new key pair.
+    /// Call once during initial app setup (after first authentication).
+    func attestKey(serverChallenge: Data) async throws -> Data {
+        // Generate key in Secure Enclave
+        let keyId = try await service.generateKey()
+        self.keyId = keyId
+
+        // Attest the key with a server-provided challenge
+        let attestation = try await service.attestKey(keyId, clientDataHash: serverChallenge)
+
+        return attestation // Send to server for verification
+    }
+
+    /// Generate an assertion for a protected request.
+    /// Call before data-export, account-deletion, or other high-value operations.
+    func generateAssertion(for requestHash: Data) async throws -> Data {
+        guard let keyId else {
+            throw AppAttestError.keyNotGenerated
+        }
+
+        return try await service.generateAssertion(keyId, clientDataHash: requestHash)
+    }
+}
+```
+
+#### Server-Side Verification
+
+```typescript
+/**
+ * Verify an App Attest attestation object.
+ *
+ * Validates:
+ *   1. The attestation is signed by Apple's App Attest CA
+ *   2. The nonce matches the server-generated challenge
+ *   3. The app ID matches the expected bundle identifier
+ *   4. The counter is as expected (prevents replay)
+ *
+ * Uses Apple's attestation verification format (CBOR + X.509).
+ */
+async function verifyAppAttestation(
+  attestation: Uint8Array,
+  challenge: Uint8Array,
+  expectedAppId: string,
+): Promise<AttestationResult> {
+  // 1. Decode CBOR attestation object
+  // 2. Verify X.509 certificate chain to Apple App Attest CA
+  // 3. Verify nonce = SHA256(challenge || clientDataHash)
+  // 4. Extract and store the public key + counter for future assertions
+  // Implementation uses @simplewebauthn/server or custom CBOR/X.509 parsing
+}
+```
+
+#### App Attest Specific Considerations
+
+- **Availability:** Requires iOS 14+, A12+ chip (already met: deployment target iOS 17)
+- **One key per device:** The key is tied to the Secure Enclave; lost if device is wiped
+- **Counter tracking:** Server must track the assertion counter per device to prevent replay
+- **Simulator handling:** App Attest is not available in simulator — use feature flag
+- **Key migration:** No key migration between devices; new attestation required on new device
+
+### 3. Windows — TPM 2.0 Attestation
+
+#### Overview
+
+Windows devices with TPM 2.0 can generate hardware-backed attestation statements.
+The Finance app on Windows (JVM/Kotlin) can use the TPM to prove device integrity.
+
+#### Implementation Approach
+
+```kotlin
+/**
+ * Windows device attestation via TPM 2.0.
+ *
+ * Uses the Windows CNG (Cryptography Next Generation) API to generate
+ * a TPM-backed key and attestation statement.
+ *
+ * Note: This requires JNI or a native helper (e.g., PowerShell script
+ * via ProcessBuilder) since Java has no direct TPM API.
+ */
+class WindowsTpmAttestor {
+    /**
+     * Check if TPM 2.0 is available.
+     */
+    fun isTpmAvailable(): Boolean {
+        // Check via WMI or registry:
+        // HKLM\SYSTEM\CurrentControlSet\Services\TPM\WMI\SpecVersion
+        return checkTpmRegistry()
+    }
+
+    /**
+     * Generate a TPM-backed attestation statement.
+     *
+     * Uses Windows Hello or the Platform Crypto Provider to create
+     * a key pair in the TPM and generate an attestation blob.
+     */
+    suspend fun attest(nonce: ByteArray): Result<AttestationBlob> {
+        // Implementation via JNI to Windows CNG API
+        // or via PowerShell: Get-TpmEndorsementKeyInfo
+    }
+}
+```
+
+**Windows-specific considerations:**
+
+- TPM 2.0 is required for Windows 11 but optional on Windows 10
+- Fallback: DPAPI-protected attestation for non-TPM devices (lower assurance)
+- Enterprise environments may restrict TPM access — handle gracefully
+
+---
+
+## Server-Side Attestation Policy
+
+### Architecture
+
+```
+New Edge Function: verify-device-attestation
+    │
+    ├─► Receive attestation token + platform identifier
+    ├─► Route to platform-specific verification
+    │   ├─► Android: Google Play Integrity API
+    │   ├─► iOS: Apple App Attest verification
+    │   └─► Windows: TPM attestation validation
+    ├─► Store attestation result in device_attestations table
+    ├─► Return attestation status + any policy adjustments
+    └─► Other Edge Functions check attestation status
+```
+
+### Database Schema
+
+```sql
+CREATE TABLE device_attestations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id),
+    platform TEXT NOT NULL CHECK (platform IN ('android', 'ios', 'windows')),
+    attestation_id TEXT NOT NULL, -- Platform-specific device/key ID
+    device_integrity BOOLEAN NOT NULL DEFAULT false,
+    app_integrity BOOLEAN NOT NULL DEFAULT false,
+    last_attested_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    attestation_counter INTEGER DEFAULT 0,
+    -- Privacy: NO device identifiers, IMEI, serial numbers, etc.
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- RLS: Users can only see their own attestations
+ALTER TABLE device_attestations ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "users_own_attestations" ON device_attestations
+    FOR ALL USING (auth.uid() = user_id);
+```
+
+### Policy Enforcement
+
+| Attestation Result            | Session Lifetime  | Allowed Operations            | Additional Checks                             |
+| ----------------------------- | ----------------- | ----------------------------- | --------------------------------------------- |
+| Device + App integrity PASS   | Standard (1 hour) | All                           | None                                          |
+| Device integrity FAIL         | Reduced (15 min)  | Read-only, no export/deletion | Require re-auth for writes                    |
+| App integrity FAIL            | Reduced (15 min)  | Read-only                     | Show warning, log alert                       |
+| Attestation unavailable (Web) | Standard          | All                           | Rely on other controls (CSP, CORS)            |
+| Attestation failed (error)    | Standard          | All                           | Log, don't block (fail-open for availability) |
+
+---
+
+## Integration Points
+
+### 1. Authentication Flow
+
+```
+User authenticates (passkey/OAuth)
+    │
+    ├─► Client requests device attestation (platform-specific)
+    │
+    ├─► Client sends attestation token to verify-device-attestation
+    │
+    ├─► Server validates attestation
+    │   ├─► PASS: Set session.device_integrity = true
+    │   └─► FAIL: Set session.device_integrity = false, reduce session lifetime
+    │
+    └─► Session includes device integrity flag for downstream policy
+```
+
+### 2. High-Value Operations
+
+Before `account-deletion` or `data-export`:
+
+```typescript
+// In the Edge Function handler, after requireAuth():
+const attestation = await getLatestAttestation(supabase, user.id);
+if (!attestation?.device_integrity) {
+  // Require re-attestation for high-value operations
+  return errorResponse(req, 'Device attestation required', 403);
+}
+```
+
+### 3. Sync Health Integration
+
+Device attestation status is included in sync health reports (generic flag only,
+no attestation details) to enable server-side monitoring of fleet integrity.
+
+---
+
+## Privacy Safeguards
+
+Device attestation MUST comply with privacy requirements:
+
+1. **No device identifiers stored** — only a platform-generated attestation ID
+2. **No hardware identifiers** (IMEI, serial, MAC) ever collected
+3. **Attestation results are per-user** — protected by RLS
+4. **No cross-device tracking** — attestation IDs are opaque and non-correlatable
+5. **Attestation failure does not reveal reason** to client — generic error only
+6. **Data retention:** Attestation records deleted with account (GDPR Art. 17)
+7. **DSAR export:** Attestation records included in data export (GDPR Art. 20)
+
+---
+
+## Implementation Roadmap
+
+| Phase   | Priority | Control                                   | Effort   | Target               |
+| ------- | -------- | ----------------------------------------- | -------- | -------------------- |
+| Phase 1 | P1       | Play Integrity API (Android)              | 3-4 days | Post-launch sprint 1 |
+| Phase 1 | P1       | Server-side verification Edge Function    | 2-3 days | Post-launch sprint 1 |
+| Phase 1 | P1       | device_attestations table + RLS           | 1 day    | Post-launch sprint 1 |
+| Phase 2 | P2       | App Attest (iOS)                          | 3-4 days | Post-launch sprint 2 |
+| Phase 2 | P2       | Assertion verification for high-value ops | 2 days   | Post-launch sprint 2 |
+| Phase 3 | P3       | TPM attestation (Windows)                 | 5-7 days | Post-launch sprint 3 |
+| Phase 3 | P3       | Policy engine integration                 | 3-5 days | Post-launch sprint 3 |
+
+---
+
+## References
+
+- Google Play Integrity API: https://developer.android.com/google/play/integrity
+- Apple App Attest: https://developer.apple.com/documentation/devicecheck/dcappattestservice
+- OWASP MASVS v2: MASVS-RESILIENCE-4 (Integrity Verification)
+- FIDO Alliance: Device attestation standards
+- TPM 2.0 Specification: https://trustedcomputinggroup.org/resource/tpm-library-specification/

--- a/docs/architecture/security/rasp-strategy.md
+++ b/docs/architecture/security/rasp-strategy.md
@@ -1,0 +1,524 @@
+<!-- SPDX-License-Identifier: BUSL-1.1 -->
+
+# Runtime Application Self-Protection (RASP) Strategy — Finance App
+
+**Issue:** #330
+**Date:** 2025-07-27
+**Author:** Security & Privacy Reviewer
+**Status:** Assessment Complete — Implementation Specification
+**MASVS Control:** MASVS-RESILIENCE-1 through MASVS-RESILIENCE-5
+
+---
+
+## Executive Summary
+
+Runtime Application Self-Protection (RASP) provides defence against attacks that occur
+at runtime on the user's device — including jailbreak/root exploitation, debugger
+attachment, code injection (Frida, Substrate), and binary tampering. For a financial
+application handling transaction data and cryptographic keys, RASP controls are
+**essential** to protect the client-side security boundary.
+
+### Current State (from MASVS-RESILIENCE Audit)
+
+| Control                | Android     | iOS              | Web            | Windows        |
+| ---------------------- | ----------- | ---------------- | -------------- | -------------- |
+| Root/Jailbreak detect  | ❌ Not impl | ❌ Not impl      | N/A            | N/A            |
+| Debugger detection     | ⚠️ Partial  | ❌ Not impl      | ⚠️ Partial     | ❌ Not impl    |
+| Code obfuscation       | ⚠️ Partial  | ✅ Bitcode/strip | ⚠️ Source maps | ✅ MSIX signed |
+| Integrity verification | ❌ Not impl | ❌ Not impl      | ✅ SRI/hashes  | ✅ MSIX signed |
+| Anti-instrumentation   | ❌ Not impl | ❌ Not impl      | N/A            | N/A            |
+
+**Risk Assessment:** On rooted/jailbroken devices, an attacker can:
+
+- Extract OAuth tokens from secure storage (bypass Keychain/Keystore protections)
+- Intercept HTTPS traffic via custom CA injection
+- Hook biometric authentication to bypass identity verification
+- Read the SQLCipher database key from memory
+- Modify transaction data before it's synced to the server
+
+**Critical Backstop:** Server-side RLS policies remain the ultimate security boundary.
+Even with full client compromise, an attacker can only access the compromised user's
+household data. RASP reduces the attack surface but does not replace server-side security.
+
+---
+
+## Threat Model
+
+### Threat Actors
+
+| Actor                                     | Motivation                            | Capability  | Risk   |
+| ----------------------------------------- | ------------------------------------- | ----------- | ------ |
+| Opportunistic attacker with rooted device | Access own financial data outside app | Low-Medium  | MEDIUM |
+| Sophisticated attacker with Frida         | Extract tokens, modify transactions   | High        | HIGH   |
+| Malware on compromised device             | Steal credentials, financial data     | Medium-High | HIGH   |
+| Corporate espionage / insider threat      | Access financial data of target       | High        | HIGH   |
+| Automated attack tool (MagiskHide)        | Bypass root detection at scale        | Medium      | MEDIUM |
+
+### Attack Tree
+
+```
+Goal: Extract financial data from client device
+├── 1. Root/Jailbreak device
+│   ├── 1a. Extract tokens from Keystore/Keychain
+│   ├── 1b. Read SQLCipher DB key from memory
+│   ├── 1c. Install custom CA for MITM
+│   └── 1d. Hook biometric auth to bypass
+├── 2. Attach debugger
+│   ├── 2a. Set breakpoints in crypto functions
+│   ├── 2b. Dump decrypted data from memory
+│   └── 2c. Modify transaction amounts in-flight
+├── 3. Inject code (Frida/Substrate)
+│   ├── 3a. Hook TokenManager.getAccessToken()
+│   ├── 3b. Hook EncryptionService.decrypt()
+│   ├── 3c. Hook BiometricAuthManager.authenticate()
+│   └── 3d. Bypass certificate pinning hooks
+└── 4. Tamper with binary
+    ├── 4a. Repackage APK with modifications
+    ├── 4b. Patch binary to disable security checks
+    └── 4c. Replace libraries with instrumented versions
+```
+
+---
+
+## RASP Implementation Strategy
+
+### Design Principles
+
+1. **Defence in Depth:** Multiple overlapping detection mechanisms — no single check
+   to bypass.
+2. **Graceful Degradation:** Detection triggers a security response proportional to
+   the threat — not an immediate crash (which reveals detection to attacker).
+3. **Server-Side Validation:** Client-side detections inform server-side policy
+   (e.g., reduced session lifetime, additional verification required).
+4. **Privacy Preservation:** RASP telemetry must NOT include device identifiers,
+   user PII, or financial data. Only detection flags and anonymized metrics.
+5. **No False Positives in Production:** Custom ROMs, accessibility services, and
+   developer devices must not be falsely flagged.
+
+### Response Hierarchy
+
+| Detection Level        | Response                 | Example                                                         |
+| ---------------------- | ------------------------ | --------------------------------------------------------------- |
+| Level 0: Clean         | Normal operation         | —                                                               |
+| Level 1: Suspicious    | Log + monitor            | Emulator detected, debug build sideloaded                       |
+| Level 2: Compromised   | Degrade security posture | Root detected → disable biometric auth, require re-auth         |
+| Level 3: Active Attack | Restrict functionality   | Frida detected → clear tokens, lock app, require server re-auth |
+| Level 4: Tampered      | Refuse to operate        | APK signature mismatch → show error, refuse to start            |
+
+---
+
+## Platform-Specific Implementation
+
+### 1. Android RASP
+
+#### 1.1 Root Detection
+
+**Multi-vector approach** (no single check is sufficient):
+
+```kotlin
+/**
+ * Detect whether the device is rooted using multiple heuristics.
+ *
+ * Each check returns a risk signal. The combined result determines
+ * the security response level.
+ */
+object RootDetector {
+
+    data class RootCheckResult(
+        val isRooted: Boolean,
+        val signals: List<String>, // Generic signal names, no device-specific data
+        val confidence: Float,     // 0.0-1.0
+    )
+
+    fun check(context: Context): RootCheckResult {
+        val signals = mutableListOf<String>()
+
+        // Check 1: su binary presence
+        if (checkSuBinary()) signals.add("su_binary")
+
+        // Check 2: Root management apps (Magisk, SuperSU, etc.)
+        if (checkRootManagementApps(context)) signals.add("root_app")
+
+        // Check 3: Dangerous system properties
+        if (checkDangerousProps()) signals.add("dangerous_props")
+
+        // Check 4: Read/write access to system partition
+        if (checkRWSystem()) signals.add("rw_system")
+
+        // Check 5: SELinux status
+        if (checkSELinuxPermissive()) signals.add("selinux_permissive")
+
+        // Check 6: Test key signing
+        if (checkTestKeys()) signals.add("test_keys")
+
+        // Check 7: Magisk-specific artifacts
+        if (checkMagiskArtifacts()) signals.add("magisk")
+
+        // Check 8: Native check via JNI (harder to hook)
+        if (nativeRootCheck()) signals.add("native_check")
+
+        val confidence = signals.size.toFloat() / 8f
+        return RootCheckResult(
+            isRooted = signals.isNotEmpty(),
+            signals = signals,
+            confidence = confidence,
+        )
+    }
+
+    private external fun nativeRootCheck(): Boolean
+}
+```
+
+**Recommended library:** Consider `rootbeer` (open source) for baseline checks,
+supplemented with custom native checks that are harder to hook.
+
+#### 1.2 Debugger Detection
+
+```kotlin
+object DebugDetector {
+    fun isDebuggerAttached(): Boolean {
+        // Check 1: Android Debug.isDebuggerConnected()
+        if (android.os.Debug.isDebuggerConnected()) return true
+
+        // Check 2: TracerPid in /proc/self/status
+        if (checkTracerPid()) return true
+
+        // Check 3: Debug.waitingForDebugger()
+        if (android.os.Debug.waitingForDebugger()) return true
+
+        return false
+    }
+
+    private fun checkTracerPid(): Boolean {
+        return try {
+            val status = File("/proc/self/status").readText()
+            val tracerPid = status.lineSequence()
+                .find { it.startsWith("TracerPid:") }
+                ?.substringAfter("TracerPid:")?.trim()?.toIntOrNull()
+            tracerPid != null && tracerPid != 0
+        } catch (_: Exception) {
+            false
+        }
+    }
+}
+```
+
+#### 1.3 Frida Detection
+
+```kotlin
+object FridaDetector {
+    fun isFridaPresent(): Boolean {
+        // Check 1: Frida default port (27042)
+        if (checkFridaPort()) return true
+
+        // Check 2: Frida libraries in /proc/self/maps
+        if (checkFridaLibraries()) return true
+
+        // Check 3: Frida named pipes
+        if (checkFridaNamedPipes()) return true
+
+        // Check 4: Frida-specific strings in memory (native)
+        if (nativeFridaCheck()) return true
+
+        return false
+    }
+
+    private fun checkFridaPort(): Boolean {
+        return try {
+            java.net.Socket("127.0.0.1", 27042).close()
+            true // Port is open — Frida server likely running
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    private fun checkFridaLibraries(): Boolean {
+        return try {
+            File("/proc/self/maps").readText().let { maps ->
+                maps.contains("frida") || maps.contains("gadget")
+            }
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    private external fun nativeFridaCheck(): Boolean
+}
+```
+
+#### 1.4 APK Integrity Verification
+
+```kotlin
+object IntegrityVerifier {
+    /** Expected signing certificate SHA-256 fingerprint. */
+    private const val EXPECTED_SIGNING_CERT_HASH = "PLACEHOLDER_RELEASE_CERT_HASH"
+
+    fun verifyApkSignature(context: Context): Boolean {
+        val packageInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            context.packageManager.getPackageInfo(
+                context.packageName,
+                PackageManager.GET_SIGNING_CERTIFICATES
+            )
+        } else {
+            @Suppress("DEPRECATION")
+            context.packageManager.getPackageInfo(
+                context.packageName,
+                PackageManager.GET_SIGNATURES
+            )
+        }
+
+        val signatures = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            packageInfo.signingInfo?.apkContentsSigners
+        } else {
+            @Suppress("DEPRECATION")
+            packageInfo.signatures
+        }
+
+        return signatures?.any { sig ->
+            val hash = MessageDigest.getInstance("SHA-256")
+                .digest(sig.toByteArray())
+            Base64.encodeToString(hash, Base64.NO_WRAP) == EXPECTED_SIGNING_CERT_HASH
+        } ?: false
+    }
+}
+```
+
+### 2. iOS RASP
+
+#### 2.1 Jailbreak Detection
+
+```swift
+/// Multi-vector jailbreak detection for iOS.
+///
+/// Uses file system checks, URL scheme checks, sandbox integrity,
+/// and dynamic library inspection. No single check is authoritative.
+enum JailbreakDetector {
+
+    struct JailbreakResult: Sendable {
+        let isJailbroken: Bool
+        let signals: [String]
+        let confidence: Double
+    }
+
+    static func check() -> JailbreakResult {
+        var signals: [String] = []
+
+        // Check 1: Cydia/Sileo URL schemes
+        if canOpenJailbreakApps() { signals.append("jailbreak_app") }
+
+        // Check 2: Suspicious file paths
+        if checkSuspiciousPaths() { signals.append("suspicious_paths") }
+
+        // Check 3: Writable system directories
+        if checkWritableSystemPaths() { signals.append("writable_system") }
+
+        // Check 4: Symbolic link manipulation
+        if checkSymlinks() { signals.append("symlinks") }
+
+        // Check 5: Fork ability (sandbox escape)
+        if checkForkability() { signals.append("fork_available") }
+
+        // Check 6: dylib injection
+        if checkDyldInjection() { signals.append("dyld_injection") }
+
+        let confidence = Double(signals.count) / 6.0
+        return JailbreakResult(
+            isJailbroken: !signals.isEmpty,
+            signals: signals,
+            confidence: confidence
+        )
+    }
+
+    private static func canOpenJailbreakApps() -> Bool {
+        let schemes = ["cydia://", "sileo://", "zbra://", "filza://"]
+        return schemes.contains { scheme in
+            UIApplication.shared.canOpenURL(URL(string: scheme)!)
+        }
+    }
+
+    private static func checkSuspiciousPaths() -> Bool {
+        let paths = [
+            "/Applications/Cydia.app",
+            "/Library/MobileSubstrate/MobileSubstrate.dylib",
+            "/bin/bash", "/usr/sbin/sshd", "/etc/apt",
+            "/private/var/lib/apt/", "/usr/bin/ssh",
+        ]
+        return paths.contains { FileManager.default.fileExists(atPath: $0) }
+    }
+
+    private static func checkWritableSystemPaths() -> Bool {
+        let testPath = "/private/jailbreak_test_\(UUID().uuidString)"
+        do {
+            try "test".write(toFile: testPath, atomically: true, encoding: .utf8)
+            try FileManager.default.removeItem(atPath: testPath)
+            return true // Should NOT be writable on non-jailbroken device
+        } catch {
+            return false
+        }
+    }
+
+    private static func checkForkability() -> Bool {
+        let pid = fork()
+        if pid >= 0 {
+            // Fork succeeded — sandbox is broken
+            if pid > 0 { kill(pid, SIGTERM) } // Kill child
+            return true
+        }
+        return false
+    }
+
+    private static func checkDyldInjection() -> Bool {
+        let env = ProcessInfo.processInfo.environment
+        return env["DYLD_INSERT_LIBRARIES"] != nil
+    }
+
+    private static func checkSymlinks() -> Bool {
+        let paths = ["/Applications", "/Library/Ringtones", "/Library/Wallpaper"]
+        return paths.contains { path in
+            var isSymlink: ObjCBool = false
+            let attrs = try? FileManager.default.attributesOfItem(atPath: path)
+            return attrs?[.type] as? FileAttributeType == .typeSymbolicLink
+        }
+    }
+}
+```
+
+#### 2.2 iOS Debugger Detection
+
+```swift
+enum DebugDetector {
+    static func isDebuggerAttached() -> Bool {
+        // Check 1: sysctl P_TRACED flag
+        var info = kinfo_proc()
+        var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid()]
+        var size = MemoryLayout<kinfo_proc>.stride
+        let result = sysctl(&mib, UInt32(mib.count), &info, &size, nil, 0)
+        if result == 0 {
+            return (info.kp_proc.p_flag & P_TRACED) != 0
+        }
+        return false
+    }
+}
+```
+
+### 3. Web RASP
+
+Web RASP capabilities are inherently limited but should include:
+
+```typescript
+// Extension/tampering detection heuristics
+function checkWebIntegrity(): { suspicious: boolean; signals: string[] } {
+  const signals: string[] = [];
+
+  // Check 1: DevTools open detection (debugger timing)
+  const start = performance.now();
+  debugger; // This statement pauses execution when DevTools is open
+  if (performance.now() - start > 100) signals.push('devtools_open');
+
+  // Check 2: Console override detection
+  if (console.log.toString().length !== /* expected native length */) {
+    signals.push('console_override');
+  }
+
+  // Check 3: Verify CSP is active
+  if (!document.querySelector('meta[http-equiv="Content-Security-Policy"]')) {
+    signals.push('csp_missing');
+  }
+
+  return { suspicious: signals.length > 0, signals };
+}
+```
+
+> **Note:** Web RASP is inherently weak. The primary web security boundary
+> should be the CSP, SRI, and server-side controls. Client-side web checks
+> are informational only.
+
+### 4. KMP Shared Interface
+
+```kotlin
+/**
+ * Cross-platform runtime integrity checking interface.
+ *
+ * Each platform implements detection appropriate to its capabilities.
+ * Results are reported to the server via the existing SyncHealthMonitor
+ * for security posture tracking.
+ *
+ * PRIVACY: Detection results MUST only contain generic signal names
+ * (e.g., "root_detected"), never device identifiers, user PII, or
+ * financial data.
+ */
+interface RuntimeIntegrityChecker {
+    /** Check device integrity and return the result. */
+    suspend fun checkIntegrity(): IntegrityResult
+
+    /** The current integrity level based on the last check. */
+    val currentLevel: IntegrityLevel
+}
+
+enum class IntegrityLevel {
+    CLEAN,        // No threats detected
+    SUSPICIOUS,   // Minor signals (emulator, debug build)
+    COMPROMISED,  // Root/jailbreak or debugger detected
+    ACTIVE_ATTACK, // Frida/instrumentation detected
+    TAMPERED,     // Binary integrity violated
+}
+
+data class IntegrityResult(
+    val level: IntegrityLevel,
+    val signals: List<String>, // Generic signal names only
+    val timestamp: Long,
+)
+```
+
+---
+
+## Security Response Matrix
+
+| Detection                        | Level             | Client Response                                      | Server Notification          |
+| -------------------------------- | ----------------- | ---------------------------------------------------- | ---------------------------- |
+| Emulator detected                | 1 - Suspicious    | Log warning                                          | Sync health report flag      |
+| Root/jailbreak (low confidence)  | 2 - Compromised   | Show warning dialog                                  | Integrity flag on next sync  |
+| Root/jailbreak (high confidence) | 2 - Compromised   | Disable biometric auth, require PIN + server re-auth | Integrity alert              |
+| Debugger attached                | 3 - Active Attack | Clear in-memory tokens, require re-auth              | Session invalidation request |
+| Frida detected                   | 3 - Active Attack | Clear all tokens, lock app                           | Force session revocation     |
+| APK signature mismatch           | 4 - Tampered      | Refuse to start, show error                          | N/A (cannot connect)         |
+
+---
+
+## Privacy Safeguards
+
+RASP telemetry MUST comply with the existing monitoring privacy policy:
+
+1. **No device identifiers** in integrity reports (no IMEI, serial, MAC)
+2. **No user PII** in detection signals
+3. **Generic signal names only** — never raw file paths or process names
+4. **Consent-gated** — integrity reporting uses the same consent provider
+   as CrashReporter and MetricsCollector
+5. **No financial data** ever included in integrity reports
+
+---
+
+## Implementation Roadmap
+
+| Phase   | Priority | Controls                                 | Effort   | Target           |
+| ------- | -------- | ---------------------------------------- | -------- | ---------------- |
+| Phase 1 | P0       | Root/jailbreak detection (Android + iOS) | 3-4 days | Pre-launch       |
+| Phase 1 | P0       | APK signature verification (Android)     | 1 day    | Pre-launch       |
+| Phase 1 | P0       | Enable R8 minification (Android)         | 1 hour   | Pre-launch       |
+| Phase 1 | P0       | Disable web source maps (production)     | 1 hour   | Pre-launch       |
+| Phase 2 | P1       | Debugger detection (Android + iOS)       | 2-3 days | Launch +1 sprint |
+| Phase 2 | P1       | KMP RuntimeIntegrityChecker interface    | 2 days   | Launch +1 sprint |
+| Phase 2 | P1       | Security response matrix integration     | 2 days   | Launch +1 sprint |
+| Phase 3 | P2       | Frida detection (Android + iOS)          | 3-4 days | Post-launch      |
+| Phase 3 | P2       | Emulator detection (Android)             | 1 day    | Post-launch      |
+| Phase 3 | P2       | Server-side integrity policy engine      | 3-5 days | Post-launch      |
+
+---
+
+## References
+
+- OWASP MASVS v2: MASVS-RESILIENCE (all controls)
+- OWASP Mobile Testing Guide: Testing Resilience Against Reverse Engineering
+- MASVS-RESILIENCE Audit (docs/architecture/masvs-resilience-audit.md)
+- Android SafetyNet/Play Integrity API documentation
+- Apple DeviceCheck / App Attest documentation


### PR DESCRIPTION
## Security Sprint 2: Runtime Protection + Device Attestation

### RASP Strategy (#330)
- Multi-vector root/jailbreak detection for Android (8 checks) and iOS (6 checks)
- Debugger detection: \Debug.isDebuggerConnected()\, TracerPid, \sysctl P_TRACED\
- Frida detection: port scanning, /proc/self/maps, named pipes, native checks
- APK integrity verification via PackageManager signing certificate
- Web RASP heuristics (DevTools detection, console override, CSP verification)
- KMP \RuntimeIntegrityChecker\ interface with \IntegrityLevel\ enum
- 5-level security response hierarchy with proportional responses
- Privacy-preserving telemetry (generic signal names only)

### Device Attestation Strategy (#331)
- **Android:** Play Integrity API with server-side Google verification
- **iOS:** App Attest (DCAppAttestService) with assertion counter tracking
- **Windows:** TPM 2.0 attestation via CNG/JNI
- Server-side verification Edge Function architecture
- \device_attestations\ table schema with RLS
- Policy enforcement matrix linking attestation to session parameters
- Integration with auth flow and high-value operations

### Key Design Decisions
- Defence in depth: RASP (client-side) + Attestation (server-verified)
- Graceful degradation over hard blocks (fail-open for availability)
- Server-side RLS remains the ultimate security boundary
- All telemetry consent-gated and PII-free

### References
- OWASP MASVS v2: MASVS-RESILIENCE-1 through MASVS-RESILIENCE-5
- Existing MASVS-RESILIENCE audit findings