### PR TITLE
feat(backend): schema alignment migrations and sync rule updates (#866)

### DIFF
--- a/services/api/powersync/sync-rules.yaml
+++ b/services/api/powersync/sync-rules.yaml
@@ -44,7 +44,7 @@ bucket_definitions:
       # Financial accounts (checking, savings, credit cards, etc.)
       - >
         SELECT id, household_id, name, type, currency_code, balance_cents,
-               is_active, icon, color, sort_order,
+               is_active, icon, color, sort_order, owner_id,
                created_at, updated_at, deleted_at
         FROM accounts
         WHERE household_id = bucket.household_id AND deleted_at IS NULL
@@ -54,6 +54,7 @@ bucket_definitions:
         SELECT id, household_id, account_id, category_id, amount_cents,
                currency_code, type, payee, note, date, is_recurring,
                recurring_rule, transfer_account_id, status,
+               transfer_transaction_id, recurring_rule_id, owner_id,
                created_at, updated_at, deleted_at
         FROM transactions
         WHERE household_id = bucket.household_id AND deleted_at IS NULL
@@ -61,7 +62,7 @@ bucket_definitions:
       # Spending / income categories
       - >
         SELECT id, household_id, name, icon, color, parent_id, is_income,
-               sort_order,
+               sort_order, owner_id,
                created_at, updated_at, deleted_at
         FROM categories
         WHERE household_id = bucket.household_id AND deleted_at IS NULL
@@ -69,7 +70,7 @@ bucket_definitions:
       # Budget allocations per category/period
       - >
         SELECT id, household_id, category_id, amount_cents, currency_code,
-               period, start_date, end_date,
+               period, start_date, end_date, is_rollover, owner_id,
                created_at, updated_at, deleted_at
         FROM budgets
         WHERE household_id = bucket.household_id AND deleted_at IS NULL
@@ -78,6 +79,7 @@ bucket_definitions:
       - >
         SELECT id, household_id, name, target_cents, current_cents,
                currency_code, target_date, icon, color,
+               account_id, status, owner_id,
                created_at, updated_at, deleted_at
         FROM goals
         WHERE household_id = bucket.household_id AND deleted_at IS NULL
@@ -108,7 +110,7 @@ bucket_definitions:
         SELECT id, household_id, account_id, category_id, amount_cents,
                currency_code, type, payee, note, frequency, day_of_month,
                day_of_week, start_date, end_date, last_generated_date,
-               next_due_date, is_active,
+               next_due_date, is_active, owner_id,
                created_at, updated_at, deleted_at
         FROM recurring_transaction_templates
         WHERE household_id = bucket.household_id AND deleted_at IS NULL

--- a/services/api/supabase/migrations/20260326000002_add_transfer_recurring_to_transactions.sql
+++ b/services/api/supabase/migrations/20260326000002_add_transfer_recurring_to_transactions.sql
@@ -1,0 +1,55 @@
+-- SPDX-License-Identifier: BUSL-1.1
+
+-- Migration: 20260326000002_add_transfer_recurring_to_transactions
+-- Description: Add transfer_transaction_id and recurring_rule_id to transactions
+-- Issues: #866
+--
+-- Changes:
+--   1. Add transfer_transaction_id UUID — nullable self-FK linking transfer pairs
+--   2. Add recurring_rule_id UUID — nullable FK to recurring_transaction_templates
+--   3. Add indexes for efficient lookups
+--
+-- These columns enable:
+--   - Linking the two sides of a transfer (debit + credit) via transfer_transaction_id
+--   - Tracking which recurring template generated a transaction via recurring_rule_id
+--
+-- Security: No RLS changes needed — existing household-scoped policies cover
+-- all SELECT/INSERT/UPDATE/DELETE operations on transactions. The new columns
+-- are nullable FKs that don't change the row's household_id.
+--
+-- DOWN migration: at the bottom.
+
+-- =============================================================================
+-- UP
+-- =============================================================================
+
+-- 1. Self-referencing FK for transfer pairs
+ALTER TABLE transactions
+    ADD COLUMN transfer_transaction_id UUID REFERENCES transactions(id);
+
+COMMENT ON COLUMN transactions.transfer_transaction_id IS
+    'Self-FK linking the two sides of a transfer. The debit transaction points to the credit, and vice versa.';
+
+-- 2. FK to recurring template that generated this transaction
+ALTER TABLE transactions
+    ADD COLUMN recurring_rule_id UUID REFERENCES recurring_transaction_templates(id);
+
+COMMENT ON COLUMN transactions.recurring_rule_id IS
+    'FK to the recurring_transaction_templates row that generated this transaction (NULL for manual transactions).';
+
+-- 3. Indexes for efficient lookups
+CREATE INDEX idx_transactions_transfer_pair
+    ON transactions (transfer_transaction_id)
+    WHERE transfer_transaction_id IS NOT NULL AND deleted_at IS NULL;
+
+CREATE INDEX idx_transactions_recurring_rule
+    ON transactions (recurring_rule_id)
+    WHERE recurring_rule_id IS NOT NULL AND deleted_at IS NULL;
+
+-- =============================================================================
+-- DOWN (to revert, run these statements)
+-- =============================================================================
+-- DROP INDEX IF EXISTS idx_transactions_recurring_rule;
+-- DROP INDEX IF EXISTS idx_transactions_transfer_pair;
+-- ALTER TABLE transactions DROP COLUMN IF EXISTS recurring_rule_id;
+-- ALTER TABLE transactions DROP COLUMN IF EXISTS transfer_transaction_id;

--- a/services/api/supabase/migrations/20260326000003_add_rollover_to_budgets.sql
+++ b/services/api/supabase/migrations/20260326000003_add_rollover_to_budgets.sql
@@ -1,0 +1,33 @@
+-- SPDX-License-Identifier: BUSL-1.1
+
+-- Migration: 20260326000003_add_rollover_to_budgets
+-- Description: Add is_rollover column to budgets table
+-- Issues: #866
+--
+-- Changes:
+--   1. Add is_rollover BOOLEAN NOT NULL DEFAULT false
+--
+-- This enables carry-forward of unused budget amounts into the next period.
+-- When is_rollover = true, unspent budget from the current period rolls into
+-- the next period's allocation. The client-side logic computes the effective
+-- budget as: current_period_amount + rollover_from_previous_period.
+--
+-- Security: No RLS changes needed — existing household-scoped policies cover
+-- all operations on budgets. The new column doesn't change access patterns.
+--
+-- DOWN migration: at the bottom.
+
+-- =============================================================================
+-- UP
+-- =============================================================================
+
+ALTER TABLE budgets
+    ADD COLUMN is_rollover BOOLEAN NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN budgets.is_rollover IS
+    'When true, unused budget from the current period carries forward into the next period.';
+
+-- =============================================================================
+-- DOWN (to revert, run this statement)
+-- =============================================================================
+-- ALTER TABLE budgets DROP COLUMN IF EXISTS is_rollover;

--- a/services/api/supabase/migrations/20260326000004_add_account_status_to_goals.sql
+++ b/services/api/supabase/migrations/20260326000004_add_account_status_to_goals.sql
@@ -1,0 +1,63 @@
+-- SPDX-License-Identifier: BUSL-1.1
+
+-- Migration: 20260326000004_add_account_status_to_goals
+-- Description: Add account_id and status columns to goals table
+-- Issues: #866
+--
+-- Changes:
+--   1. Add account_id UUID — nullable FK to accounts, links a goal to a specific savings account
+--   2. Add status TEXT — tracks goal lifecycle: 'active', 'completed', 'archived'
+--   3. Add CHECK constraint on status
+--   4. Add index on account_id for efficient joins
+--   5. Add index on status for filtering
+--
+-- This enables:
+--   - Linking goals to specific savings accounts for automatic progress tracking
+--   - Tracking goal lifecycle (active → completed/archived)
+--   - Querying goals by status (e.g. show only active goals)
+--
+-- Security: No RLS changes needed — existing household-scoped policies cover
+-- all operations on goals. The account_id FK is within the same household
+-- (enforced by the application layer + the fact that accounts are household-scoped).
+--
+-- DOWN migration: at the bottom.
+
+-- =============================================================================
+-- UP
+-- =============================================================================
+
+-- 1. Link goal to a specific account (nullable — not all goals are account-linked)
+ALTER TABLE goals
+    ADD COLUMN account_id UUID REFERENCES accounts(id);
+
+COMMENT ON COLUMN goals.account_id IS
+    'Optional FK to the savings account funding this goal. NULL for goals not tied to a specific account.';
+
+-- 2. Goal lifecycle status
+ALTER TABLE goals
+    ADD COLUMN status TEXT NOT NULL DEFAULT 'active';
+
+ALTER TABLE goals
+    ADD CONSTRAINT chk_goals_status
+    CHECK (status IN ('active', 'completed', 'archived'));
+
+COMMENT ON COLUMN goals.status IS
+    'Goal lifecycle: active (in progress), completed (target reached), archived (abandoned/paused).';
+
+-- 3. Indexes
+CREATE INDEX idx_goals_account
+    ON goals (account_id)
+    WHERE account_id IS NOT NULL AND deleted_at IS NULL;
+
+CREATE INDEX idx_goals_status
+    ON goals (status)
+    WHERE deleted_at IS NULL;
+
+-- =============================================================================
+-- DOWN (to revert, run these statements)
+-- =============================================================================
+-- DROP INDEX IF EXISTS idx_goals_status;
+-- DROP INDEX IF EXISTS idx_goals_account;
+-- ALTER TABLE goals DROP CONSTRAINT IF EXISTS chk_goals_status;
+-- ALTER TABLE goals DROP COLUMN IF EXISTS status;
+-- ALTER TABLE goals DROP COLUMN IF EXISTS account_id;

--- a/services/api/supabase/migrations/20260326000005_standardize_owner_id.sql
+++ b/services/api/supabase/migrations/20260326000005_standardize_owner_id.sql
@@ -1,0 +1,158 @@
+-- SPDX-License-Identifier: BUSL-1.1
+
+-- Migration: 20260326000005_standardize_owner_id
+-- Description: Add owner_id to all sync-enabled tables
+-- Issues: #866
+--
+-- Schema Design Rule: "All sync-enabled tables carry owner_id UUID REFERENCES
+-- auth.users(id) for direct per-user queries in addition to household-level RLS."
+--
+-- Changes:
+--   1. Add owner_id UUID column to: accounts, categories, transactions,
+--      budgets, goals, recurring_transaction_templates
+--   2. Add indexes on owner_id for each table
+--   3. Add RLS policies that allow owner-based SELECT as an alternative path
+--
+-- owner_id represents the user who CREATED the record. It is used for:
+--   - Direct per-user queries (e.g. "show me all transactions I created")
+--   - PowerSync user-scoped filtering optimization
+--   - Audit trail attribution
+--
+-- Note: owner_id is nullable initially to support backfilling existing data.
+-- A future migration should set NOT NULL after backfill is complete.
+--
+-- Security: RLS policies are ADDITIVE. The new owner-based SELECT policies
+-- provide an additional access path but do NOT weaken household isolation.
+-- INSERT/UPDATE/DELETE still require household membership.
+--
+-- DOWN migration: at the bottom.
+
+-- =============================================================================
+-- UP
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Add owner_id columns
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE accounts
+    ADD COLUMN owner_id UUID REFERENCES auth.users(id);
+
+ALTER TABLE categories
+    ADD COLUMN owner_id UUID REFERENCES auth.users(id);
+
+ALTER TABLE transactions
+    ADD COLUMN owner_id UUID REFERENCES auth.users(id);
+
+ALTER TABLE budgets
+    ADD COLUMN owner_id UUID REFERENCES auth.users(id);
+
+ALTER TABLE goals
+    ADD COLUMN owner_id UUID REFERENCES auth.users(id);
+
+ALTER TABLE recurring_transaction_templates
+    ADD COLUMN owner_id UUID REFERENCES auth.users(id);
+
+-- ---------------------------------------------------------------------------
+-- 2. Add indexes for owner-based lookups
+-- ---------------------------------------------------------------------------
+
+CREATE INDEX idx_accounts_owner
+    ON accounts (owner_id)
+    WHERE owner_id IS NOT NULL AND deleted_at IS NULL;
+
+CREATE INDEX idx_categories_owner
+    ON categories (owner_id)
+    WHERE owner_id IS NOT NULL AND deleted_at IS NULL;
+
+CREATE INDEX idx_transactions_owner
+    ON transactions (owner_id)
+    WHERE owner_id IS NOT NULL AND deleted_at IS NULL;
+
+CREATE INDEX idx_budgets_owner
+    ON budgets (owner_id)
+    WHERE owner_id IS NOT NULL AND deleted_at IS NULL;
+
+CREATE INDEX idx_goals_owner
+    ON goals (owner_id)
+    WHERE owner_id IS NOT NULL AND deleted_at IS NULL;
+
+CREATE INDEX idx_recurring_templates_owner
+    ON recurring_transaction_templates (owner_id)
+    WHERE owner_id IS NOT NULL AND deleted_at IS NULL;
+
+-- ---------------------------------------------------------------------------
+-- 3. Owner-based SELECT policies (additive — does not replace household policies)
+-- ---------------------------------------------------------------------------
+-- These allow a user to SELECT rows they own, even if the household_ids()
+-- lookup hasn't been evaluated yet (e.g. during PowerSync initial sync).
+-- They do NOT grant INSERT/UPDATE/DELETE — those still require household membership.
+
+CREATE POLICY accounts_select_owner ON accounts
+    FOR SELECT
+    USING (owner_id = auth.uid());
+
+CREATE POLICY categories_select_owner ON categories
+    FOR SELECT
+    USING (owner_id = auth.uid());
+
+CREATE POLICY transactions_select_owner ON transactions
+    FOR SELECT
+    USING (owner_id = auth.uid());
+
+CREATE POLICY budgets_select_owner ON budgets
+    FOR SELECT
+    USING (owner_id = auth.uid());
+
+CREATE POLICY goals_select_owner ON goals
+    FOR SELECT
+    USING (owner_id = auth.uid());
+
+CREATE POLICY recurring_templates_select_owner ON recurring_transaction_templates
+    FOR SELECT
+    USING (owner_id = auth.uid());
+
+-- ---------------------------------------------------------------------------
+-- Comments
+-- ---------------------------------------------------------------------------
+
+COMMENT ON COLUMN accounts.owner_id IS
+    'UUID of the user who created this account. Used for per-user queries and audit attribution.';
+COMMENT ON COLUMN categories.owner_id IS
+    'UUID of the user who created this category. Used for per-user queries and audit attribution.';
+COMMENT ON COLUMN transactions.owner_id IS
+    'UUID of the user who created this transaction. Used for per-user queries and audit attribution.';
+COMMENT ON COLUMN budgets.owner_id IS
+    'UUID of the user who created this budget. Used for per-user queries and audit attribution.';
+COMMENT ON COLUMN goals.owner_id IS
+    'UUID of the user who created this goal. Used for per-user queries and audit attribution.';
+COMMENT ON COLUMN recurring_transaction_templates.owner_id IS
+    'UUID of the user who created this template. Used for per-user queries and audit attribution.';
+
+
+-- =============================================================================
+-- DOWN (to revert, run these statements IN ORDER)
+-- =============================================================================
+-- -- 3. Drop owner-based SELECT policies
+-- DROP POLICY IF EXISTS recurring_templates_select_owner ON recurring_transaction_templates;
+-- DROP POLICY IF EXISTS goals_select_owner ON goals;
+-- DROP POLICY IF EXISTS budgets_select_owner ON budgets;
+-- DROP POLICY IF EXISTS transactions_select_owner ON transactions;
+-- DROP POLICY IF EXISTS categories_select_owner ON categories;
+-- DROP POLICY IF EXISTS accounts_select_owner ON accounts;
+--
+-- -- 2. Drop indexes
+-- DROP INDEX IF EXISTS idx_recurring_templates_owner;
+-- DROP INDEX IF EXISTS idx_goals_owner;
+-- DROP INDEX IF EXISTS idx_budgets_owner;
+-- DROP INDEX IF EXISTS idx_transactions_owner;
+-- DROP INDEX IF EXISTS idx_categories_owner;
+-- DROP INDEX IF EXISTS idx_accounts_owner;
+--
+-- -- 1. Drop columns
+-- ALTER TABLE recurring_transaction_templates DROP COLUMN IF EXISTS owner_id;
+-- ALTER TABLE goals DROP COLUMN IF EXISTS owner_id;
+-- ALTER TABLE budgets DROP COLUMN IF EXISTS owner_id;
+-- ALTER TABLE transactions DROP COLUMN IF EXISTS owner_id;
+-- ALTER TABLE categories DROP COLUMN IF EXISTS owner_id;
+-- ALTER TABLE accounts DROP COLUMN IF EXISTS owner_id;


### PR DESCRIPTION
## Summary

Resolves #866 — Schema alignment with approved design specifications.

### Migrations

| Migration | Description | Tables |
|-----------|-------------|--------|
| \20260326000002\ | Add \	ransfer_transaction_id\ (self-FK) and \ecurring_rule_id\ (FK to templates) | \	ransactions\ |
| \20260326000003\ | Add \is_rollover\ boolean for budget carry-forward | \udgets\ |
| \20260326000004\ | Add \ccount_id\ (FK to accounts) and \status\ (active/completed/archived) | \goals\ |
| \20260326000005\ | Standardize \owner_id UUID REFERENCES auth.users(id)\ | 6 tables |

### New Columns

#### transactions
- \	ransfer_transaction_id UUID\ — Self-FK linking transfer debit ↔ credit pairs
- \ecurring_rule_id UUID\ — FK to \ecurring_transaction_templates\ that generated the transaction

#### budgets
- \is_rollover BOOLEAN NOT NULL DEFAULT false\ — Enables carry-forward of unused amounts

#### goals
- \ccount_id UUID\ — Links goal to a specific savings account
- \status TEXT NOT NULL DEFAULT 'active'\ — CHECK IN ('active','completed','archived')

#### accounts, categories, transactions, budgets, goals, recurring_transaction_templates
- \owner_id UUID\ — References \uth.users(id)\ for per-user queries alongside household RLS

### PowerSync Sync Rules

Updated \sync-rules.yaml\ to include all new columns in the appropriate bucket queries:
- \y_household\ bucket: accounts, transactions, categories, budgets, goals, recurring_transaction_templates
- Maintains explicit column allowlisting (no \SELECT *\)

### Security

- **RLS**: 6 new additive SELECT policies for \owner_id\-based access (does not weaken household isolation)
- **CHECK constraints**: \goals.status\ restricted to approved values
- **Indexes**: Partial indexes on all new nullable columns (\WHERE ... IS NOT NULL AND deleted_at IS NULL\)
- **Reversibility**: All 4 migrations include complete DOWN statements

### Migration Order

The migrations are numbered sequentially and can be applied with \supabase db push\:
1. \