### PR TITLE
feat(models): align KMP schema with Supabase additions — ownerId standardization (#861)

### DIFF
--- a/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/SqlDelightAccountRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/SqlDelightAccountRepository.kt
@@ -60,6 +60,7 @@ class SqlDelightAccountRepository(
             queries.insert(
                 id = entity.id.value,
                 household_id = entity.householdId.value,
+                owner_id = entity.ownerId.value,
                 name = entity.name,
                 type = entity.type.name,
                 currency = entity.currency.code,
@@ -161,6 +162,7 @@ class SqlDelightAccountRepository(
     private fun AccountRow.toDomain(): Account = Account(
         id = SyncId(id),
         householdId = SyncId(household_id),
+        ownerId = SyncId(owner_id),
         name = name,
         type = AccountType.valueOf(type),
         currency = Currency(currency),

--- a/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/SqlDelightBudgetRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/SqlDelightBudgetRepository.kt
@@ -62,6 +62,7 @@ class SqlDelightBudgetRepository(
             queries.insert(
                 id = entity.id.value,
                 household_id = entity.householdId.value,
+                owner_id = entity.ownerId.value,
                 category_id = entity.categoryId.value,
                 name = entity.name,
                 amount = entity.amount.amount,
@@ -153,6 +154,7 @@ class SqlDelightBudgetRepository(
     private fun BudgetRow.toDomain(): Budget = Budget(
         id = SyncId(id),
         householdId = SyncId(household_id),
+        ownerId = SyncId(owner_id),
         categoryId = SyncId(category_id),
         name = name,
         amount = Cents(amount),

--- a/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/SqlDelightCategoryRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/SqlDelightCategoryRepository.kt
@@ -56,6 +56,7 @@ class SqlDelightCategoryRepository(
             queries.insert(
                 id = entity.id.value,
                 household_id = entity.householdId.value,
+                owner_id = entity.ownerId.value,
                 name = entity.name,
                 icon = entity.icon,
                 color = entity.color,
@@ -159,6 +160,7 @@ class SqlDelightCategoryRepository(
     private fun CategoryRow.toDomain(): Category = Category(
         id = SyncId(id),
         householdId = SyncId(household_id),
+        ownerId = SyncId(owner_id),
         name = name,
         icon = icon,
         color = color,

--- a/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/SqlDelightGoalRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/SqlDelightGoalRepository.kt
@@ -60,6 +60,7 @@ class SqlDelightGoalRepository(
             queries.insert(
                 id = entity.id.value,
                 household_id = entity.householdId.value,
+                owner_id = entity.ownerId.value,
                 name = entity.name,
                 target_amount = entity.targetAmount.amount,
                 current_amount = entity.currentAmount.amount,
@@ -155,6 +156,7 @@ class SqlDelightGoalRepository(
     private fun GoalRow.toDomain(): Goal = Goal(
         id = SyncId(id),
         householdId = SyncId(household_id),
+        ownerId = SyncId(owner_id),
         name = name,
         targetAmount = Cents(target_amount),
         currentAmount = Cents(current_amount),

--- a/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/SqlDelightTransactionRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/SqlDelightTransactionRepository.kt
@@ -67,6 +67,7 @@ class SqlDelightTransactionRepository(
             queries.insert(
                 id = entity.id.value,
                 household_id = entity.householdId.value,
+                owner_id = entity.ownerId.value,
                 account_id = entity.accountId.value,
                 category_id = entity.categoryId?.value,
                 type = entity.type.name,
@@ -197,6 +198,7 @@ class SqlDelightTransactionRepository(
     private fun TransactionRow.toDomain(): Transaction = Transaction(
         id = SyncId(id),
         householdId = SyncId(household_id),
+        ownerId = SyncId(owner_id),
         accountId = SyncId(account_id),
         categoryId = category_id?.let { SyncId(it) },
         type = TransactionType.valueOf(type),

--- a/apps/android/src/main/kotlin/com/finance/android/ui/data/SampleData.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/data/SampleData.kt
@@ -158,17 +158,17 @@ object SampleData {
     // -- Factory helpers ------------------------------------------------------
 
     private fun category(id: String, name: String, icon: String, isIncome: Boolean = false) =
-        Category(id = SyncId(id), householdId = SyncId("household-1"), name = name, icon = icon,
+        Category(id = SyncId(id), householdId = SyncId("household-1"), ownerId = SyncId("owner-1"), name = name, icon = icon,
             color = null, parentId = null, isIncome = isIncome, isSystem = false, sortOrder = 0,
             createdAt = now, updatedAt = now)
 
     private fun account(id: String, name: String, type: AccountType, balanceCents: Long) =
-        Account(id = SyncId(id), householdId = SyncId("household-1"), name = name, type = type,
+        Account(id = SyncId(id), householdId = SyncId("household-1"), ownerId = SyncId("owner-1"), name = name, type = type,
             currency = Currency.USD, currentBalance = Cents(balanceCents), isArchived = false,
             sortOrder = 0, icon = null, color = null, createdAt = now, updatedAt = now)
 
     private fun budget(id: String, categoryId: String, name: String, amountCents: Long, period: BudgetPeriod) =
-        Budget(id = SyncId(id), householdId = SyncId("household-1"), categoryId = SyncId(categoryId),
+        Budget(id = SyncId(id), householdId = SyncId("household-1"), ownerId = SyncId("owner-1"), categoryId = SyncId(categoryId),
             name = name, amount = Cents(amountCents), currency = Currency.USD, period = period,
             startDate = LocalDate(today.year, today.month, 1), isRollover = false,
             createdAt = now, updatedAt = now)
@@ -178,7 +178,7 @@ object SampleData {
         targetDate: LocalDate?, status: GoalStatus = GoalStatus.ACTIVE,
         icon: String? = null, accountId: String? = null,
     ) = Goal(
-        id = SyncId(id), householdId = SyncId("household-1"), name = name,
+        id = SyncId(id), householdId = SyncId("household-1"), ownerId = SyncId("owner-1"), name = name,
         targetAmount = Cents(targetCents), currentAmount = Cents(currentCents),
         currency = Currency.USD, targetDate = targetDate, status = status,
         icon = icon, color = null, accountId = accountId?.let { SyncId(it) },
@@ -187,7 +187,7 @@ object SampleData {
 
     private fun expense(id: String, payee: String, amountCents: Long, categoryId: String,
         accountId: String, date: LocalDate, note: String? = null) =
-        Transaction(id = SyncId(id), householdId = SyncId("household-1"),
+        Transaction(id = SyncId(id), householdId = SyncId("household-1"), ownerId = SyncId("owner-1"),
             accountId = SyncId(accountId), categoryId = SyncId(categoryId),
             type = TransactionType.EXPENSE, status = TransactionStatus.CLEARED,
             amount = Cents(-amountCents), currency = Currency.USD, payee = payee,
@@ -195,7 +195,7 @@ object SampleData {
 
     private fun income(id: String, payee: String, amountCents: Long, categoryId: String,
         accountId: String, date: LocalDate) =
-        Transaction(id = SyncId(id), householdId = SyncId("household-1"),
+        Transaction(id = SyncId(id), householdId = SyncId("household-1"), ownerId = SyncId("owner-1"),
             accountId = SyncId(accountId), categoryId = SyncId(categoryId),
             type = TransactionType.INCOME, status = TransactionStatus.CLEARED,
             amount = Cents(amountCents), currency = Currency.USD, payee = payee,

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/BudgetCreateScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/BudgetCreateScreen.kt
@@ -357,12 +357,12 @@ private fun BudgetCreateFormPreview() {
         BudgetCreateForm(
             state = BudgetCreateUiState(
                 categories = listOf(
-                    Category(SyncId("cat-1"), SyncId("h-1"), "Groceries", createdAt = now, updatedAt = now),
-                    Category(SyncId("cat-2"), SyncId("h-1"), "Dining Out", createdAt = now, updatedAt = now),
-                    Category(SyncId("cat-3"), SyncId("h-1"), "Transportation", createdAt = now, updatedAt = now),
-                    Category(SyncId("cat-4"), SyncId("h-1"), "Entertainment", createdAt = now, updatedAt = now),
+                    Category(SyncId("cat-1"), SyncId("h-1"), SyncId("owner-1"), "Groceries", createdAt = now, updatedAt = now),
+                    Category(SyncId("cat-2"), SyncId("h-1"), SyncId("owner-1"), "Dining Out", createdAt = now, updatedAt = now),
+                    Category(SyncId("cat-3"), SyncId("h-1"), SyncId("owner-1"), "Transportation", createdAt = now, updatedAt = now),
+                    Category(SyncId("cat-4"), SyncId("h-1"), SyncId("owner-1"), "Entertainment", createdAt = now, updatedAt = now),
                 ),
-                selectedCategory = Category(SyncId("cat-1"), SyncId("h-1"), "Groceries", createdAt = now, updatedAt = now),
+                selectedCategory = Category(SyncId("cat-1"), SyncId("h-1"), SyncId("owner-1"), "Groceries", createdAt = now, updatedAt = now),
                 amount = "600.00",
                 period = BudgetPeriod.MONTHLY,
             ),
@@ -397,7 +397,7 @@ private fun BudgetCreateSavingPreview() {
     FinanceTheme(dynamicColor = false) {
         BudgetCreateForm(
             state = BudgetCreateUiState(
-                selectedCategory = Category(SyncId("cat-1"), SyncId("h-1"), "Groceries", createdAt = now, updatedAt = now),
+                selectedCategory = Category(SyncId("cat-1"), SyncId("h-1"), SyncId("owner-1"), "Groceries", createdAt = now, updatedAt = now),
                 amount = "300.00",
                 period = BudgetPeriod.WEEKLY,
                 isSaving = true,

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/GoalCreateScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/GoalCreateScreen.kt
@@ -487,18 +487,18 @@ private fun GoalCreateFormPreview() {
                 targetDate = LocalDate(2025, 12, 31),
                 accounts = listOf(
                     Account(
-                        SyncId("acc-1"), SyncId("h-1"), "Main Checking",
+                        SyncId("acc-1"), SyncId("h-1"), SyncId("owner-1"), "Main Checking",
                         AccountType.CHECKING, Currency.USD, Cents(52473L),
                         createdAt = now, updatedAt = now,
                     ),
                     Account(
-                        SyncId("acc-2"), SyncId("h-1"), "Savings",
+                        SyncId("acc-2"), SyncId("h-1"), SyncId("owner-1"), "Savings",
                         AccountType.SAVINGS, Currency.USD, Cents(1867000L),
                         createdAt = now, updatedAt = now,
                     ),
                 ),
                 selectedAccount = Account(
-                    SyncId("acc-2"), SyncId("h-1"), "Savings",
+                    SyncId("acc-2"), SyncId("h-1"), SyncId("owner-1"), "Savings",
                     AccountType.SAVINGS, Currency.USD, Cents(1867000L),
                     createdAt = now, updatedAt = now,
                 ),

--- a/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/AccountCreateViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/AccountCreateViewModel.kt
@@ -133,6 +133,7 @@ class AccountCreateViewModel(
                 val account = Account(
                     id = SyncId(UUID.randomUUID().toString()),
                     householdId = householdId,
+                    ownerId = householdId,
                     name = s.name.trim(),
                     type = s.accountType,
                     currency = Currency(s.currency),

--- a/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/BudgetCreateViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/BudgetCreateViewModel.kt
@@ -136,6 +136,7 @@ class BudgetCreateViewModel(
                 val budget = Budget(
                     id = SyncId(UUID.randomUUID().toString()),
                     householdId = householdId,
+                    ownerId = householdId,
                     categoryId = s.selectedCategory!!.id,
                     name = s.selectedCategory.name,
                     amount = amountCents,

--- a/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/GoalCreateViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/GoalCreateViewModel.kt
@@ -156,6 +156,7 @@ class GoalCreateViewModel(
                 val goal = Goal(
                     id = SyncId(UUID.randomUUID().toString()),
                     householdId = householdId,
+                    ownerId = householdId,
                     name = s.name.trim(),
                     targetAmount = targetCents,
                     currentAmount = Cents.ZERO,

--- a/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/TransactionCreateViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/TransactionCreateViewModel.kt
@@ -259,6 +259,7 @@ class TransactionCreateViewModel(
             ) ?: Transaction(
                 id = SyncId("txn-${now.toEpochMilliseconds()}"),
                 householdId = householdId,
+                ownerId = householdId,
                 accountId = s.selectedAccountId!!,
                 categoryId = s.selectedCategoryId,
                 type = s.transactionType,

--- a/apps/android/src/test/kotlin/com/finance/android/data/repository/mock/MockAccountRepositoryTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/data/repository/mock/MockAccountRepositoryTest.kt
@@ -39,6 +39,7 @@ class MockAccountRepositoryTest {
     ) = Account(
         id = SyncId(id),
         householdId = SyncId("household-1"),
+        ownerId = SyncId("owner-1"),
         name = name,
         type = type,
         currency = Currency.USD,

--- a/apps/android/src/test/kotlin/com/finance/android/data/repository/mock/MockBudgetRepositoryTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/data/repository/mock/MockBudgetRepositoryTest.kt
@@ -46,6 +46,7 @@ class MockBudgetRepositoryTest {
     ) = Budget(
         id = SyncId(id),
         householdId = SyncId("household-1"),
+        ownerId = SyncId("owner-1"),
         categoryId = SyncId(categoryId),
         name = name,
         amount = Cents(amountCents),

--- a/apps/android/src/test/kotlin/com/finance/android/data/repository/mock/MockCategoryRepositoryTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/data/repository/mock/MockCategoryRepositoryTest.kt
@@ -35,6 +35,7 @@ class MockCategoryRepositoryTest {
     ) = Category(
         id = SyncId(id),
         householdId = SyncId("household-1"),
+        ownerId = SyncId("owner-1"),
         name = name,
         icon = "label",
         color = null,

--- a/apps/android/src/test/kotlin/com/finance/android/data/repository/mock/MockGoalRepositoryTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/data/repository/mock/MockGoalRepositoryTest.kt
@@ -41,6 +41,7 @@ class MockGoalRepositoryTest {
     ) = Goal(
         id = SyncId(id),
         householdId = SyncId("household-1"),
+        ownerId = SyncId("owner-1"),
         name = name,
         targetAmount = Cents(targetCents),
         currentAmount = Cents(currentCents),

--- a/apps/android/src/test/kotlin/com/finance/android/data/repository/mock/MockTransactionRepositoryTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/data/repository/mock/MockTransactionRepositoryTest.kt
@@ -50,6 +50,7 @@ class MockTransactionRepositoryTest {
     ) = Transaction(
         id = SyncId(id),
         householdId = SyncId("household-1"),
+        ownerId = SyncId("owner-1"),
         accountId = SyncId(accountId),
         categoryId = SyncId(categoryId),
         type = type,

--- a/apps/android/src/test/kotlin/com/finance/android/ui/viewmodel/AccountsViewModelTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/ui/viewmodel/AccountsViewModelTest.kt
@@ -80,6 +80,7 @@ class AccountsViewModelTest {
     ) = Account(
         id = SyncId(id),
         householdId = householdId,
+        ownerId = householdId,
         name = name,
         type = type,
         currency = Currency.USD,
@@ -101,6 +102,7 @@ class AccountsViewModelTest {
         return Transaction(
             id = SyncId(id),
             householdId = householdId,
+            ownerId = householdId,
             accountId = SyncId(accountId),
             type = type,
             status = TransactionStatus.CLEARED,

--- a/apps/android/src/test/kotlin/com/finance/android/ui/viewmodel/BudgetsViewModelTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/ui/viewmodel/BudgetsViewModelTest.kt
@@ -79,6 +79,7 @@ class BudgetsViewModelTest {
     ) = Category(
         id = SyncId(id),
         householdId = householdId,
+        ownerId = householdId,
         name = name,
         icon = icon,
         createdAt = now,
@@ -94,6 +95,7 @@ class BudgetsViewModelTest {
     ) = Budget(
         id = SyncId(id),
         householdId = householdId,
+        ownerId = householdId,
         categoryId = SyncId(categoryId),
         name = name,
         amount = Cents(amountCents),
@@ -112,6 +114,7 @@ class BudgetsViewModelTest {
     ) = Transaction(
         id = SyncId(id),
         householdId = householdId,
+        ownerId = householdId,
         accountId = SyncId("acc-test"),
         categoryId = SyncId(categoryId),
         type = TransactionType.EXPENSE,

--- a/apps/android/src/test/kotlin/com/finance/android/ui/viewmodel/DashboardViewModelTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/ui/viewmodel/DashboardViewModelTest.kt
@@ -86,6 +86,7 @@ class DashboardViewModelTest {
     ) = Account(
         id = SyncId(id),
         householdId = householdId,
+        ownerId = householdId,
         name = name,
         type = type,
         currency = Currency.USD,
@@ -108,6 +109,7 @@ class DashboardViewModelTest {
         return Transaction(
             id = SyncId(id),
             householdId = householdId,
+            ownerId = householdId,
             accountId = SyncId(accountId),
             categoryId = categoryId?.let { SyncId(it) },
             type = type,
@@ -129,6 +131,7 @@ class DashboardViewModelTest {
     ) = Category(
         id = SyncId(id),
         householdId = householdId,
+        ownerId = householdId,
         name = name,
         icon = icon,
         createdAt = now,
@@ -144,6 +147,7 @@ class DashboardViewModelTest {
     ) = Budget(
         id = SyncId(id),
         householdId = householdId,
+        ownerId = householdId,
         categoryId = SyncId(categoryId),
         name = name,
         amount = Cents(amountCents),

--- a/apps/android/src/test/kotlin/com/finance/android/ui/viewmodel/GoalsViewModelTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/ui/viewmodel/GoalsViewModelTest.kt
@@ -73,6 +73,7 @@ class GoalsViewModelTest {
     ) = Goal(
         id = SyncId(id),
         householdId = householdId,
+        ownerId = householdId,
         name = name,
         targetAmount = Cents(targetCents),
         currentAmount = Cents(currentCents),

--- a/apps/android/src/test/kotlin/com/finance/android/ui/viewmodel/TransactionCreateViewModelTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/ui/viewmodel/TransactionCreateViewModelTest.kt
@@ -80,6 +80,7 @@ class TransactionCreateViewModelTest {
     ) = Account(
         id = SyncId(id),
         householdId = householdId,
+        ownerId = householdId,
         name = name,
         type = type,
         currency = Currency.USD,
@@ -95,6 +96,7 @@ class TransactionCreateViewModelTest {
     ) = Category(
         id = SyncId(id),
         householdId = householdId,
+        ownerId = householdId,
         name = name,
         icon = icon,
         createdAt = now,
@@ -785,6 +787,7 @@ class TransactionCreateViewModelTest {
         val existingTxn = Transaction(
             id = SyncId("txn-existing"),
             householdId = householdId,
+            ownerId = householdId,
             accountId = SyncId("acc-1"),
             type = TransactionType.EXPENSE,
             status = TransactionStatus.CLEARED,
@@ -813,6 +816,7 @@ class TransactionCreateViewModelTest {
         val existingTxn = Transaction(
             id = SyncId("txn-existing"),
             householdId = householdId,
+            ownerId = householdId,
             accountId = SyncId("acc-1"),
             type = TransactionType.EXPENSE,
             status = TransactionStatus.CLEARED,

--- a/apps/android/src/test/kotlin/com/finance/android/ui/viewmodel/TransactionsViewModelTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/ui/viewmodel/TransactionsViewModelTest.kt
@@ -84,6 +84,7 @@ class TransactionsViewModelTest {
         return Transaction(
             id = SyncId(id),
             householdId = householdId,
+            ownerId = householdId,
             accountId = SyncId(accountId),
             categoryId = categoryId?.let { SyncId(it) },
             type = type,
@@ -106,6 +107,7 @@ class TransactionsViewModelTest {
     ) = Category(
         id = SyncId(id),
         householdId = householdId,
+        ownerId = householdId,
         name = name,
         icon = icon,
         createdAt = now,

--- a/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/impl/InMemoryAccountRepository.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/impl/InMemoryAccountRepository.kt
@@ -21,10 +21,10 @@ class InMemoryAccountRepository : AccountRepository {
 }
 
 private fun createSampleAccounts(): List<Account> {
-    val now = Clock.System.now(); val hid = SyncId("d1")
+    val now = Clock.System.now(); val hid = SyncId("d1"); val oid = SyncId("owner-1")
     return listOf(
-        Account(SyncId("a1"), hid, "Checking", AccountType.CHECKING, Currency.USD, Cents(524730), sortOrder = 0, createdAt = now, updatedAt = now),
-        Account(SyncId("a2"), hid, "Savings", AccountType.SAVINGS, Currency.USD, Cents(1867000), sortOrder = 1, createdAt = now, updatedAt = now),
-        Account(SyncId("a3"), hid, "Visa Card", AccountType.CREDIT_CARD, Currency.USD, Cents(128450), sortOrder = 2, createdAt = now, updatedAt = now),
+        Account(SyncId("a1"), hid, oid, "Checking", AccountType.CHECKING, Currency.USD, Cents(524730), sortOrder = 0, createdAt = now, updatedAt = now),
+        Account(SyncId("a2"), hid, oid, "Savings", AccountType.SAVINGS, Currency.USD, Cents(1867000), sortOrder = 1, createdAt = now, updatedAt = now),
+        Account(SyncId("a3"), hid, oid, "Visa Card", AccountType.CREDIT_CARD, Currency.USD, Cents(128450), sortOrder = 2, createdAt = now, updatedAt = now),
     )
 }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/impl/InMemoryBudgetRepository.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/impl/InMemoryBudgetRepository.kt
@@ -17,11 +17,11 @@ class InMemoryBudgetRepository : BudgetRepository {
 }
 
 private fun createSampleBudgets(): List<Budget> {
-    val now = Clock.System.now(); val hid = SyncId("d1")
+    val now = Clock.System.now(); val hid = SyncId("d1"); val oid = SyncId("owner-1")
     val today = now.toLocalDateTime(TimeZone.currentSystemDefault()).date
     val monthStart = LocalDate(today.year, today.month, 1)
     return listOf(
-        Budget(SyncId("b1"), hid, SyncId("c1"), "Groceries", Cents(60000), Currency.USD, BudgetPeriod.MONTHLY, monthStart, createdAt = now, updatedAt = now),
-        Budget(SyncId("b2"), hid, SyncId("c2"), "Dining", Cents(30000), Currency.USD, BudgetPeriod.MONTHLY, monthStart, createdAt = now, updatedAt = now),
+        Budget(SyncId("b1"), hid, oid, SyncId("c1"), "Groceries", Cents(60000), Currency.USD, BudgetPeriod.MONTHLY, monthStart, createdAt = now, updatedAt = now),
+        Budget(SyncId("b2"), hid, oid, SyncId("c2"), "Dining", Cents(30000), Currency.USD, BudgetPeriod.MONTHLY, monthStart, createdAt = now, updatedAt = now),
     )
 }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/impl/InMemoryGoalRepository.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/impl/InMemoryGoalRepository.kt
@@ -18,9 +18,9 @@ class InMemoryGoalRepository : GoalRepository {
 }
 
 private fun createSampleGoals(): List<Goal> {
-    val now = Clock.System.now(); val hid = SyncId("d1")
+    val now = Clock.System.now(); val hid = SyncId("d1"); val oid = SyncId("owner-1")
     return listOf(
-        Goal(SyncId("g1"), hid, "Emergency Fund", Cents(1000000), Cents(850000), Currency.USD, createdAt = now, updatedAt = now),
-        Goal(SyncId("g2"), hid, "Vacation", Cents(300000), Cents(120000), Currency.USD, createdAt = now, updatedAt = now),
+        Goal(SyncId("g1"), hid, oid, "Emergency Fund", Cents(1000000), Cents(850000), Currency.USD, createdAt = now, updatedAt = now),
+        Goal(SyncId("g2"), hid, oid, "Vacation", Cents(300000), Cents(120000), Currency.USD, createdAt = now, updatedAt = now),
     )
 }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/impl/InMemoryTransactionRepository.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/impl/InMemoryTransactionRepository.kt
@@ -19,11 +19,11 @@ class InMemoryTransactionRepository : TransactionRepository {
 }
 
 private fun createSampleTransactions(): List<Transaction> {
-    val now = Clock.System.now(); val hid = SyncId("d1")
+    val now = Clock.System.now(); val hid = SyncId("d1"); val oid = SyncId("owner-1")
     val today = now.toLocalDateTime(TimeZone.currentSystemDefault()).date
     return listOf(
-        Transaction(SyncId("t1"), hid, SyncId("a1"), null, TransactionType.EXPENSE, TransactionStatus.CLEARED, Cents(5230), Currency.USD, payee = "Whole Foods", date = today, createdAt = now, updatedAt = now),
-        Transaction(SyncId("t2"), hid, SyncId("a1"), null, TransactionType.INCOME, TransactionStatus.CLEARED, Cents(420000), Currency.USD, payee = "Salary", date = today, createdAt = now, updatedAt = now),
-        Transaction(SyncId("t3"), hid, SyncId("a3"), null, TransactionType.EXPENSE, TransactionStatus.CLEARED, Cents(1599), Currency.USD, payee = "Netflix", date = today.minus(1, DateTimeUnit.DAY), createdAt = now, updatedAt = now),
+        Transaction(SyncId("t1"), hid, oid, SyncId("a1"), null, TransactionType.EXPENSE, TransactionStatus.CLEARED, Cents(5230), Currency.USD, payee = "Whole Foods", date = today, createdAt = now, updatedAt = now),
+        Transaction(SyncId("t2"), hid, oid, SyncId("a1"), null, TransactionType.INCOME, TransactionStatus.CLEARED, Cents(420000), Currency.USD, payee = "Salary", date = today, createdAt = now, updatedAt = now),
+        Transaction(SyncId("t3"), hid, oid, SyncId("a3"), null, TransactionType.EXPENSE, TransactionStatus.CLEARED, Cents(1599), Currency.USD, payee = "Netflix", date = today.minus(1, DateTimeUnit.DAY), createdAt = now, updatedAt = now),
     )
 }

--- a/packages/core/src/commonMain/kotlin/com/finance/core/dataimport/CsvImportParser.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/dataimport/CsvImportParser.kt
@@ -276,6 +276,7 @@ internal object CsvImportParser {
                 val account = Account(
                     id = SyncId(id),
                     householdId = SyncId(getField(row, columnIndex, "household_id") ?: defaultHouseholdId.value),
+                    ownerId = SyncId(getField(row, columnIndex, "owner_id") ?: defaultHouseholdId.value),
                     name = name,
                     type = parseEnum(getField(row, columnIndex, "type"), AccountType.entries) ?: AccountType.OTHER,
                     currency = parseCurrency(getField(row, columnIndex, "currency")) ?: defaultCurrency,
@@ -336,6 +337,7 @@ internal object CsvImportParser {
                 val transaction = Transaction(
                     id = SyncId(id),
                     householdId = SyncId(getField(row, columnIndex, "household_id") ?: defaultHouseholdId.value),
+                    ownerId = SyncId(getField(row, columnIndex, "owner_id") ?: defaultHouseholdId.value),
                     accountId = SyncId(accountId),
                     categoryId = getField(row, columnIndex, "category_id")?.ifEmpty { null }?.let { SyncId(it) },
                     type = type,
@@ -396,6 +398,7 @@ internal object CsvImportParser {
                 val category = Category(
                     id = SyncId(id),
                     householdId = SyncId(getField(row, columnIndex, "household_id") ?: defaultHouseholdId.value),
+                    ownerId = SyncId(getField(row, columnIndex, "owner_id") ?: defaultHouseholdId.value),
                     name = name,
                     icon = getField(row, columnIndex, "icon")?.ifEmpty { null },
                     color = getField(row, columnIndex, "color")?.ifEmpty { null },
@@ -449,6 +452,7 @@ internal object CsvImportParser {
                 val budget = Budget(
                     id = SyncId(id),
                     householdId = SyncId(getField(row, columnIndex, "household_id") ?: defaultHouseholdId.value),
+                    ownerId = SyncId(getField(row, columnIndex, "owner_id") ?: defaultHouseholdId.value),
                     categoryId = SyncId(categoryId),
                     name = name,
                     amount = parseCentsFromDisplay(amountStr, currency),
@@ -505,6 +509,7 @@ internal object CsvImportParser {
                 val goal = Goal(
                     id = SyncId(id),
                     householdId = SyncId(getField(row, columnIndex, "household_id") ?: defaultHouseholdId.value),
+                    ownerId = SyncId(getField(row, columnIndex, "owner_id") ?: defaultHouseholdId.value),
                     name = name,
                     targetAmount = parseCentsFromDisplay(targetStr, currency),
                     currentAmount = parseCentsFromDisplay(
@@ -604,6 +609,7 @@ internal object CsvImportParser {
             val transaction = Transaction(
                 id = SyncId("import-${rowNum}-${date}"),
                 householdId = defaultHouseholdId,
+                ownerId = defaultHouseholdId,
                 accountId = SyncId(
                     getFieldFlexible(row, columnIndex, listOf("account_id", "account")) ?: "import-default-account"
                 ),

--- a/packages/core/src/commonMain/kotlin/com/finance/core/export/CsvExportSerializer.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/export/CsvExportSerializer.kt
@@ -73,7 +73,7 @@ class CsvExportSerializer : ExportSerializer {
     private fun appendAccountsSection(sb: StringBuilder, accounts: List<Account>) {
         sb.appendLine("# ACCOUNTS")
         val headers = listOf(
-            "id", "household_id", "name", "type", "currency",
+            "id", "household_id", "owner_id", "name", "type", "currency",
             "current_balance", "is_archived", "sort_order",
             "icon", "color", "created_at", "updated_at", "deleted_at",
         )
@@ -82,6 +82,7 @@ class CsvExportSerializer : ExportSerializer {
             sb.appendRow(
                 account.id.value,
                 account.householdId.value,
+                account.ownerId.value,
                 account.name,
                 account.type.name,
                 account.currency.code,
@@ -101,7 +102,7 @@ class CsvExportSerializer : ExportSerializer {
     private fun appendTransactionsSection(sb: StringBuilder, transactions: List<Transaction>) {
         sb.appendLine("# TRANSACTIONS")
         val headers = listOf(
-            "id", "household_id", "account_id", "category_id",
+            "id", "household_id", "owner_id", "account_id", "category_id",
             "type", "status", "amount", "currency",
             "payee", "note", "date",
             "transfer_account_id", "transfer_transaction_id",
@@ -113,6 +114,7 @@ class CsvExportSerializer : ExportSerializer {
             sb.appendRow(
                 txn.id.value,
                 txn.householdId.value,
+                txn.ownerId.value,
                 txn.accountId.value,
                 txn.categoryId?.value ?: "",
                 txn.type.name,
@@ -138,7 +140,7 @@ class CsvExportSerializer : ExportSerializer {
     private fun appendCategoriesSection(sb: StringBuilder, categories: List<Category>) {
         sb.appendLine("# CATEGORIES")
         val headers = listOf(
-            "id", "household_id", "name", "icon", "color",
+            "id", "household_id", "owner_id", "name", "icon", "color",
             "parent_id", "is_income", "is_system", "sort_order",
             "created_at", "updated_at", "deleted_at",
         )
@@ -147,6 +149,7 @@ class CsvExportSerializer : ExportSerializer {
             sb.appendRow(
                 category.id.value,
                 category.householdId.value,
+                category.ownerId.value,
                 category.name,
                 category.icon ?: "",
                 category.color ?: "",
@@ -165,7 +168,7 @@ class CsvExportSerializer : ExportSerializer {
     private fun appendBudgetsSection(sb: StringBuilder, budgets: List<Budget>) {
         sb.appendLine("# BUDGETS")
         val headers = listOf(
-            "id", "household_id", "category_id", "name",
+            "id", "household_id", "owner_id", "category_id", "name",
             "amount", "currency", "period",
             "start_date", "end_date", "is_rollover",
             "created_at", "updated_at", "deleted_at",
@@ -175,6 +178,7 @@ class CsvExportSerializer : ExportSerializer {
             sb.appendRow(
                 budget.id.value,
                 budget.householdId.value,
+                budget.ownerId.value,
                 budget.categoryId.value,
                 budget.name,
                 formatCentsDisplay(budget.amount, budget.currency),
@@ -194,7 +198,7 @@ class CsvExportSerializer : ExportSerializer {
     private fun appendGoalsSection(sb: StringBuilder, goals: List<Goal>) {
         sb.appendLine("# GOALS")
         val headers = listOf(
-            "id", "household_id", "name",
+            "id", "household_id", "owner_id", "name",
             "target_amount", "current_amount", "currency",
             "target_date", "status", "icon", "color", "account_id",
             "created_at", "updated_at", "deleted_at",
@@ -204,6 +208,7 @@ class CsvExportSerializer : ExportSerializer {
             sb.appendRow(
                 goal.id.value,
                 goal.householdId.value,
+                goal.ownerId.value,
                 goal.name,
                 formatCentsDisplay(goal.targetAmount, goal.currency),
                 formatCentsDisplay(goal.currentAmount, goal.currency),

--- a/packages/core/src/commonMain/kotlin/com/finance/core/export/JsonExportSerializer.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/export/JsonExportSerializer.kt
@@ -173,6 +173,7 @@ class JsonExportSerializer : ExportSerializer {
     private data class AccountDto(
         val id: String,
         @SerialName("household_id") val householdId: String,
+        @SerialName("owner_id") val ownerId: String,
         val name: String,
         val type: String,
         val currency: String,
@@ -189,6 +190,7 @@ class JsonExportSerializer : ExportSerializer {
             fun from(account: Account): AccountDto = AccountDto(
                 id = account.id.value,
                 householdId = account.householdId.value,
+                ownerId = account.ownerId.value,
                 name = account.name,
                 type = account.type.name,
                 currency = account.currency.code,
@@ -208,6 +210,7 @@ class JsonExportSerializer : ExportSerializer {
     private data class TransactionDto(
         val id: String,
         @SerialName("household_id") val householdId: String,
+        @SerialName("owner_id") val ownerId: String,
         @SerialName("account_id") val accountId: String,
         @SerialName("category_id") val categoryId: String?,
         val type: String,
@@ -229,6 +232,7 @@ class JsonExportSerializer : ExportSerializer {
             fun from(transaction: Transaction): TransactionDto = TransactionDto(
                 id = transaction.id.value,
                 householdId = transaction.householdId.value,
+                ownerId = transaction.ownerId.value,
                 accountId = transaction.accountId.value,
                 categoryId = transaction.categoryId?.value,
                 type = transaction.type.name,
@@ -253,6 +257,7 @@ class JsonExportSerializer : ExportSerializer {
     private data class CategoryDto(
         val id: String,
         @SerialName("household_id") val householdId: String,
+        @SerialName("owner_id") val ownerId: String,
         val name: String,
         val icon: String?,
         val color: String?,
@@ -268,6 +273,7 @@ class JsonExportSerializer : ExportSerializer {
             fun from(category: Category): CategoryDto = CategoryDto(
                 id = category.id.value,
                 householdId = category.householdId.value,
+                ownerId = category.ownerId.value,
                 name = category.name,
                 icon = category.icon,
                 color = category.color,
@@ -286,6 +292,7 @@ class JsonExportSerializer : ExportSerializer {
     private data class BudgetDto(
         val id: String,
         @SerialName("household_id") val householdId: String,
+        @SerialName("owner_id") val ownerId: String,
         @SerialName("category_id") val categoryId: String,
         val name: String,
         val amount: MoneyDto,
@@ -301,6 +308,7 @@ class JsonExportSerializer : ExportSerializer {
             fun from(budget: Budget): BudgetDto = BudgetDto(
                 id = budget.id.value,
                 householdId = budget.householdId.value,
+                ownerId = budget.ownerId.value,
                 categoryId = budget.categoryId.value,
                 name = budget.name,
                 amount = MoneyDto.from(budget.amount, budget.currency),
@@ -319,6 +327,7 @@ class JsonExportSerializer : ExportSerializer {
     private data class GoalDto(
         val id: String,
         @SerialName("household_id") val householdId: String,
+        @SerialName("owner_id") val ownerId: String,
         val name: String,
         @SerialName("target_amount") val targetAmount: MoneyDto,
         @SerialName("current_amount") val currentAmount: MoneyDto,
@@ -335,6 +344,7 @@ class JsonExportSerializer : ExportSerializer {
             fun from(goal: Goal): GoalDto = GoalDto(
                 id = goal.id.value,
                 householdId = goal.householdId.value,
+                ownerId = goal.ownerId.value,
                 name = goal.name,
                 targetAmount = MoneyDto.from(goal.targetAmount, goal.currency),
                 currentAmount = MoneyDto.from(goal.currentAmount, goal.currency),

--- a/packages/core/src/commonTest/kotlin/com/finance/core/TestFixtures.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/TestFixtures.kt
@@ -31,6 +31,7 @@ object TestFixtures {
     fun createAccount(
         id: SyncId = nextId(),
         householdId: SyncId = SyncId("household-1"),
+        ownerId: SyncId = SyncId("owner-1"),
         name: String = "Test Account",
         type: AccountType = AccountType.CHECKING,
         currency: Currency = Currency.USD,
@@ -42,6 +43,7 @@ object TestFixtures {
     ): Account = Account(
         id = id,
         householdId = householdId,
+        ownerId = ownerId,
         name = name,
         type = type,
         currency = currency,
@@ -57,6 +59,7 @@ object TestFixtures {
     fun createTransaction(
         id: SyncId = nextId(),
         householdId: SyncId = SyncId("household-1"),
+        ownerId: SyncId = SyncId("owner-1"),
         accountId: SyncId = SyncId("account-1"),
         categoryId: SyncId? = SyncId("category-1"),
         type: TransactionType = TransactionType.EXPENSE,
@@ -73,6 +76,7 @@ object TestFixtures {
     ): Transaction = Transaction(
         id = id,
         householdId = householdId,
+        ownerId = ownerId,
         accountId = accountId,
         categoryId = categoryId,
         type = type,
@@ -127,6 +131,7 @@ object TestFixtures {
     fun createBudget(
         id: SyncId = nextId(),
         householdId: SyncId = SyncId("household-1"),
+        ownerId: SyncId = SyncId("owner-1"),
         categoryId: SyncId = SyncId("category-1"),
         name: String = "Test Budget",
         amount: Cents = Cents(50000), // $500.00
@@ -138,6 +143,7 @@ object TestFixtures {
     ): Budget = Budget(
         id = id,
         householdId = householdId,
+        ownerId = ownerId,
         categoryId = categoryId,
         name = name,
         amount = amount,

--- a/packages/core/src/commonTest/kotlin/com/finance/core/dataimport/ExportImportRoundTripTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/dataimport/ExportImportRoundTripTest.kt
@@ -30,6 +30,7 @@ class ExportImportRoundTripTest {
                 Account(
                     id = SyncId("acc-1"),
                     householdId = testHouseholdId,
+                    ownerId = SyncId("owner-1"),
                     name = "Checking",
                     type = AccountType.CHECKING,
                     currency = Currency.USD,
@@ -42,6 +43,7 @@ class ExportImportRoundTripTest {
                 Account(
                     id = SyncId("acc-2"),
                     householdId = testHouseholdId,
+                    ownerId = SyncId("owner-1"),
                     name = "Savings",
                     type = AccountType.SAVINGS,
                     currency = Currency.USD,
@@ -56,6 +58,7 @@ class ExportImportRoundTripTest {
                 Transaction(
                     id = SyncId("txn-1"),
                     householdId = testHouseholdId,
+                    ownerId = SyncId("owner-1"),
                     accountId = SyncId("acc-1"),
                     categoryId = SyncId("cat-1"),
                     type = TransactionType.EXPENSE,
@@ -74,6 +77,7 @@ class ExportImportRoundTripTest {
                 Category(
                     id = SyncId("cat-1"),
                     householdId = testHouseholdId,
+                    ownerId = SyncId("owner-1"),
                     name = "Food",
                     icon = "🍕",
                     isIncome = false,
@@ -87,6 +91,7 @@ class ExportImportRoundTripTest {
                 Budget(
                     id = SyncId("bud-1"),
                     householdId = testHouseholdId,
+                    ownerId = SyncId("owner-1"),
                     categoryId = SyncId("cat-1"),
                     name = "Food Budget",
                     amount = Cents(50000),
@@ -102,6 +107,7 @@ class ExportImportRoundTripTest {
                 Goal(
                     id = SyncId("goal-1"),
                     householdId = testHouseholdId,
+                    ownerId = SyncId("owner-1"),
                     name = "Emergency Fund",
                     targetAmount = Cents(100000),
                     currentAmount = Cents(25000),
@@ -334,6 +340,7 @@ class ExportImportRoundTripTest {
                 Account(
                     id = SyncId("acc-1"),
                     householdId = testHouseholdId,
+                    ownerId = SyncId("owner-1"),
                     name = "Checking",
                     type = AccountType.CHECKING,
                     currency = Currency.USD,

--- a/packages/core/src/commonTest/kotlin/com/finance/core/export/CsvExportSerializerTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/export/CsvExportSerializerTest.kt
@@ -47,6 +47,7 @@ class CsvExportSerializerTest {
                 Category(
                     id = TestFixtures.nextId(),
                     householdId = SyncId("household-1"),
+                    ownerId = SyncId("owner-1"),
                     name = "Groceries",
                     createdAt = fixedInstant,
                     updatedAt = fixedInstant,
@@ -59,6 +60,7 @@ class CsvExportSerializerTest {
                 Goal(
                     id = TestFixtures.nextId(),
                     householdId = SyncId("household-1"),
+                    ownerId = SyncId("owner-1"),
                     name = "Emergency Fund",
                     targetAmount = Cents(100000),
                     currentAmount = Cents(25000),
@@ -263,6 +265,7 @@ class CsvExportSerializerTest {
                 Transaction(
                     id = TestFixtures.nextId(),
                     householdId = SyncId("household-1"),
+                    ownerId = SyncId("owner-1"),
                     accountId = SyncId("account-1"),
                     type = TransactionType.EXPENSE,
                     amount = Cents(500),

--- a/packages/core/src/commonTest/kotlin/com/finance/core/export/DataExportServiceTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/export/DataExportServiceTest.kt
@@ -61,6 +61,7 @@ class DataExportServiceTest {
                 com.finance.models.Category(
                     id = TestFixtures.nextId(),
                     householdId = SyncId("household-1"),
+                    ownerId = SyncId("owner-1"),
                     name = "Food",
                     createdAt = TestFixtures.fixedInstant,
                     updatedAt = TestFixtures.fixedInstant,
@@ -73,6 +74,7 @@ class DataExportServiceTest {
                 com.finance.models.Goal(
                     id = TestFixtures.nextId(),
                     householdId = SyncId("household-1"),
+                    ownerId = SyncId("owner-1"),
                     name = "Emergency Fund",
                     targetAmount = com.finance.models.types.Cents(100000),
                     currency = com.finance.models.types.Currency.USD,

--- a/packages/core/src/commonTest/kotlin/com/finance/core/export/ExportComplianceValidatorTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/export/ExportComplianceValidatorTest.kt
@@ -29,6 +29,7 @@ class ExportComplianceValidatorTest {
                 Category(
                     id = TestFixtures.nextId(),
                     householdId = SyncId("household-1"),
+                    ownerId = SyncId("owner-1"),
                     name = "Food",
                     createdAt = fixedInstant,
                     updatedAt = fixedInstant,

--- a/packages/core/src/commonTest/kotlin/com/finance/core/export/JsonExportSerializerTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/export/JsonExportSerializerTest.kt
@@ -51,6 +51,7 @@ class JsonExportSerializerTest {
                 Category(
                     id = TestFixtures.nextId(),
                     householdId = SyncId("household-1"),
+                    ownerId = SyncId("owner-1"),
                     name = "Groceries",
                     createdAt = fixedInstant,
                     updatedAt = fixedInstant,
@@ -63,6 +64,7 @@ class JsonExportSerializerTest {
                 Goal(
                     id = TestFixtures.nextId(),
                     householdId = SyncId("household-1"),
+                    ownerId = SyncId("owner-1"),
                     name = "Emergency Fund",
                     targetAmount = Cents(100000),
                     currentAmount = Cents(25000),
@@ -460,6 +462,7 @@ class JsonExportSerializerTest {
                 Transaction(
                     id = TestFixtures.nextId(),
                     householdId = SyncId("household-1"),
+                    ownerId = SyncId("owner-1"),
                     accountId = SyncId("account-1"),
                     type = TransactionType.EXPENSE,
                     amount = Cents(500),

--- a/packages/models/src/commonMain/kotlin/com/finance/models/Account.kt
+++ b/packages/models/src/commonMain/kotlin/com/finance/models/Account.kt
@@ -15,6 +15,7 @@ enum class AccountType { CHECKING, SAVINGS, CREDIT_CARD, CASH, INVESTMENT, LOAN,
 data class Account(
     val id: SyncId,
     val householdId: SyncId,
+    val ownerId: SyncId,
     val name: String,
     val type: AccountType,
     val currency: Currency,

--- a/packages/models/src/commonMain/kotlin/com/finance/models/Budget.kt
+++ b/packages/models/src/commonMain/kotlin/com/finance/models/Budget.kt
@@ -16,6 +16,7 @@ enum class BudgetPeriod { WEEKLY, BIWEEKLY, MONTHLY, QUARTERLY, YEARLY }
 data class Budget(
     val id: SyncId,
     val householdId: SyncId,
+    val ownerId: SyncId,
     val categoryId: SyncId,
     val name: String,
     val amount: Cents,

--- a/packages/models/src/commonMain/kotlin/com/finance/models/Category.kt
+++ b/packages/models/src/commonMain/kotlin/com/finance/models/Category.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.Serializable
 data class Category(
     val id: SyncId,
     val householdId: SyncId,
+    val ownerId: SyncId,
     val name: String,
     val icon: String? = null,
     val color: String? = null,

--- a/packages/models/src/commonMain/kotlin/com/finance/models/Goal.kt
+++ b/packages/models/src/commonMain/kotlin/com/finance/models/Goal.kt
@@ -16,6 +16,7 @@ enum class GoalStatus { ACTIVE, PAUSED, COMPLETED, CANCELLED }
 data class Goal(
     val id: SyncId,
     val householdId: SyncId,
+    val ownerId: SyncId,
     val name: String,
     val targetAmount: Cents,
     val currentAmount: Cents = Cents.ZERO,

--- a/packages/models/src/commonMain/kotlin/com/finance/models/Transaction.kt
+++ b/packages/models/src/commonMain/kotlin/com/finance/models/Transaction.kt
@@ -19,6 +19,7 @@ enum class TransactionStatus { PENDING, CLEARED, RECONCILED, VOID }
 data class Transaction(
     val id: SyncId,
     val householdId: SyncId,
+    val ownerId: SyncId,
     val accountId: SyncId,
     val categoryId: SyncId? = null,
     val type: TransactionType,

--- a/packages/models/src/commonMain/sqldelight/com/finance/db/Account.sq
+++ b/packages/models/src/commonMain/sqldelight/com/finance/db/Account.sq
@@ -4,6 +4,7 @@
 CREATE TABLE IF NOT EXISTS account (
     id TEXT NOT NULL PRIMARY KEY,
     household_id TEXT NOT NULL,
+    owner_id TEXT NOT NULL,
     name TEXT NOT NULL,
     type TEXT NOT NULL,
     currency TEXT NOT NULL DEFAULT 'USD',
@@ -17,10 +18,12 @@ CREATE TABLE IF NOT EXISTS account (
     deleted_at TEXT,
     sync_version INTEGER NOT NULL DEFAULT 0,
     is_synced INTEGER NOT NULL DEFAULT 0,
-    FOREIGN KEY (household_id) REFERENCES household(id)
+    FOREIGN KEY (household_id) REFERENCES household(id),
+    FOREIGN KEY (owner_id) REFERENCES user(id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_account_household ON account (household_id);
+CREATE INDEX IF NOT EXISTS idx_account_owner ON account (owner_id);
 CREATE INDEX IF NOT EXISTS idx_account_type ON account (type);
 CREATE INDEX IF NOT EXISTS idx_account_sync ON account (is_synced);
 
@@ -35,6 +38,9 @@ SELECT * FROM account WHERE id = ? AND deleted_at IS NULL;
 selectByHousehold:
 SELECT * FROM account WHERE household_id = ? AND deleted_at IS NULL ORDER BY sort_order ASC;
 
+selectByOwner:
+SELECT * FROM account WHERE owner_id = ? AND deleted_at IS NULL ORDER BY sort_order ASC;
+
 selectByHouseholdAndType:
 SELECT * FROM account WHERE household_id = ? AND type = ? AND deleted_at IS NULL ORDER BY sort_order ASC;
 
@@ -42,8 +48,8 @@ selectActive:
 SELECT * FROM account WHERE household_id = ? AND is_archived = 0 AND deleted_at IS NULL ORDER BY sort_order ASC;
 
 insert:
-INSERT INTO account (id, household_id, name, type, currency, current_balance, is_archived, sort_order, icon, color, created_at, updated_at, sync_version, is_synced)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+INSERT INTO account (id, household_id, owner_id, name, type, currency, current_balance, is_archived, sort_order, icon, color, created_at, updated_at, sync_version, is_synced)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 update:
 UPDATE account SET

--- a/packages/models/src/commonMain/sqldelight/com/finance/db/Budget.sq
+++ b/packages/models/src/commonMain/sqldelight/com/finance/db/Budget.sq
@@ -4,6 +4,7 @@
 CREATE TABLE IF NOT EXISTS budget (
     id TEXT NOT NULL PRIMARY KEY,
     household_id TEXT NOT NULL,
+    owner_id TEXT NOT NULL,
     category_id TEXT NOT NULL,
     name TEXT NOT NULL,
     amount INTEGER NOT NULL,
@@ -18,10 +19,12 @@ CREATE TABLE IF NOT EXISTS budget (
     sync_version INTEGER NOT NULL DEFAULT 0,
     is_synced INTEGER NOT NULL DEFAULT 0,
     FOREIGN KEY (household_id) REFERENCES household(id),
+    FOREIGN KEY (owner_id) REFERENCES user(id),
     FOREIGN KEY (category_id) REFERENCES category(id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_budget_household ON budget (household_id);
+CREATE INDEX IF NOT EXISTS idx_budget_owner ON budget (owner_id);
 CREATE INDEX IF NOT EXISTS idx_budget_category ON budget (category_id);
 CREATE INDEX IF NOT EXISTS idx_budget_period ON budget (period);
 CREATE INDEX IF NOT EXISTS idx_budget_sync ON budget (is_synced);
@@ -37,6 +40,9 @@ SELECT * FROM budget WHERE id = ? AND deleted_at IS NULL;
 selectByHousehold:
 SELECT * FROM budget WHERE household_id = ? AND deleted_at IS NULL ORDER BY name ASC;
 
+selectByOwner:
+SELECT * FROM budget WHERE owner_id = ? AND deleted_at IS NULL ORDER BY name ASC;
+
 selectByCategory:
 SELECT * FROM budget WHERE category_id = ? AND deleted_at IS NULL;
 
@@ -49,8 +55,8 @@ WHERE household_id = ? AND (end_date IS NULL OR end_date >= ?) AND deleted_at IS
 ORDER BY name ASC;
 
 insert:
-INSERT INTO budget (id, household_id, category_id, name, amount, currency, period, start_date, end_date, is_rollover, created_at, updated_at, sync_version, is_synced)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+INSERT INTO budget (id, household_id, owner_id, category_id, name, amount, currency, period, start_date, end_date, is_rollover, created_at, updated_at, sync_version, is_synced)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 update:
 UPDATE budget SET

--- a/packages/models/src/commonMain/sqldelight/com/finance/db/Category.sq
+++ b/packages/models/src/commonMain/sqldelight/com/finance/db/Category.sq
@@ -4,6 +4,7 @@
 CREATE TABLE IF NOT EXISTS category (
     id TEXT NOT NULL PRIMARY KEY,
     household_id TEXT NOT NULL,
+    owner_id TEXT NOT NULL,
     name TEXT NOT NULL,
     icon TEXT,
     color TEXT,
@@ -17,10 +18,12 @@ CREATE TABLE IF NOT EXISTS category (
     sync_version INTEGER NOT NULL DEFAULT 0,
     is_synced INTEGER NOT NULL DEFAULT 0,
     FOREIGN KEY (household_id) REFERENCES household(id),
+    FOREIGN KEY (owner_id) REFERENCES user(id),
     FOREIGN KEY (parent_id) REFERENCES category(id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_category_household ON category (household_id);
+CREATE INDEX IF NOT EXISTS idx_category_owner ON category (owner_id);
 CREATE INDEX IF NOT EXISTS idx_category_parent ON category (parent_id);
 CREATE INDEX IF NOT EXISTS idx_category_sync ON category (is_synced);
 
@@ -35,6 +38,9 @@ SELECT * FROM category WHERE id = ? AND deleted_at IS NULL;
 selectByHousehold:
 SELECT * FROM category WHERE household_id = ? AND deleted_at IS NULL ORDER BY sort_order ASC;
 
+selectByOwner:
+SELECT * FROM category WHERE owner_id = ? AND deleted_at IS NULL ORDER BY sort_order ASC;
+
 selectTopLevel:
 SELECT * FROM category WHERE household_id = ? AND parent_id IS NULL AND deleted_at IS NULL ORDER BY sort_order ASC;
 
@@ -48,8 +54,8 @@ selectExpenseCategories:
 SELECT * FROM category WHERE household_id = ? AND is_income = 0 AND deleted_at IS NULL ORDER BY sort_order ASC;
 
 insert:
-INSERT INTO category (id, household_id, name, icon, color, parent_id, is_income, is_system, sort_order, created_at, updated_at, sync_version, is_synced)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+INSERT INTO category (id, household_id, owner_id, name, icon, color, parent_id, is_income, is_system, sort_order, created_at, updated_at, sync_version, is_synced)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 update:
 UPDATE category SET

--- a/packages/models/src/commonMain/sqldelight/com/finance/db/Goal.sq
+++ b/packages/models/src/commonMain/sqldelight/com/finance/db/Goal.sq
@@ -4,6 +4,7 @@
 CREATE TABLE IF NOT EXISTS goal (
     id TEXT NOT NULL PRIMARY KEY,
     household_id TEXT NOT NULL,
+    owner_id TEXT NOT NULL,
     name TEXT NOT NULL,
     target_amount INTEGER NOT NULL,
     current_amount INTEGER NOT NULL DEFAULT 0,
@@ -19,10 +20,12 @@ CREATE TABLE IF NOT EXISTS goal (
     sync_version INTEGER NOT NULL DEFAULT 0,
     is_synced INTEGER NOT NULL DEFAULT 0,
     FOREIGN KEY (household_id) REFERENCES household(id),
+    FOREIGN KEY (owner_id) REFERENCES user(id),
     FOREIGN KEY (account_id) REFERENCES account(id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_goal_household ON goal (household_id);
+CREATE INDEX IF NOT EXISTS idx_goal_owner ON goal (owner_id);
 CREATE INDEX IF NOT EXISTS idx_goal_status ON goal (status);
 CREATE INDEX IF NOT EXISTS idx_goal_account ON goal (account_id);
 CREATE INDEX IF NOT EXISTS idx_goal_sync ON goal (is_synced);
@@ -38,6 +41,9 @@ SELECT * FROM goal WHERE id = ? AND deleted_at IS NULL;
 selectByHousehold:
 SELECT * FROM goal WHERE household_id = ? AND deleted_at IS NULL ORDER BY name ASC;
 
+selectByOwner:
+SELECT * FROM goal WHERE owner_id = ? AND deleted_at IS NULL ORDER BY name ASC;
+
 selectByStatus:
 SELECT * FROM goal WHERE household_id = ? AND status = ? AND deleted_at IS NULL ORDER BY name ASC;
 
@@ -48,8 +54,8 @@ selectByAccount:
 SELECT * FROM goal WHERE account_id = ? AND deleted_at IS NULL;
 
 insert:
-INSERT INTO goal (id, household_id, name, target_amount, current_amount, currency, target_date, status, icon, color, account_id, created_at, updated_at, sync_version, is_synced)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+INSERT INTO goal (id, household_id, owner_id, name, target_amount, current_amount, currency, target_date, status, icon, color, account_id, created_at, updated_at, sync_version, is_synced)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 update:
 UPDATE goal SET

--- a/packages/models/src/commonMain/sqldelight/com/finance/db/Transaction.sq
+++ b/packages/models/src/commonMain/sqldelight/com/finance/db/Transaction.sq
@@ -4,6 +4,7 @@
 CREATE TABLE IF NOT EXISTS "transaction" (
     id TEXT NOT NULL PRIMARY KEY,
     household_id TEXT NOT NULL,
+    owner_id TEXT NOT NULL,
     account_id TEXT NOT NULL,
     category_id TEXT,
     type TEXT NOT NULL,
@@ -24,12 +25,14 @@ CREATE TABLE IF NOT EXISTS "transaction" (
     sync_version INTEGER NOT NULL DEFAULT 0,
     is_synced INTEGER NOT NULL DEFAULT 0,
     FOREIGN KEY (household_id) REFERENCES household(id),
+    FOREIGN KEY (owner_id) REFERENCES user(id),
     FOREIGN KEY (account_id) REFERENCES account(id),
     FOREIGN KEY (category_id) REFERENCES category(id),
     FOREIGN KEY (transfer_account_id) REFERENCES account(id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_transaction_household ON "transaction" (household_id);
+CREATE INDEX IF NOT EXISTS idx_transaction_owner ON "transaction" (owner_id);
 CREATE INDEX IF NOT EXISTS idx_transaction_account ON "transaction" (account_id);
 CREATE INDEX IF NOT EXISTS idx_transaction_category ON "transaction" (category_id);
 CREATE INDEX IF NOT EXISTS idx_transaction_date ON "transaction" (date);
@@ -47,6 +50,9 @@ SELECT * FROM "transaction" WHERE id = ? AND deleted_at IS NULL;
 
 selectByHousehold:
 SELECT * FROM "transaction" WHERE household_id = ? AND deleted_at IS NULL ORDER BY date DESC;
+
+selectByOwner:
+SELECT * FROM "transaction" WHERE owner_id = ? AND deleted_at IS NULL ORDER BY date DESC;
 
 selectByAccount:
 SELECT * FROM "transaction" WHERE account_id = ? AND deleted_at IS NULL ORDER BY date DESC;
@@ -82,8 +88,8 @@ WHERE household_id = ? AND date >= ? AND date <= ? AND deleted_at IS NULL
 GROUP BY account_id;
 
 insert:
-INSERT INTO "transaction" (id, household_id, account_id, category_id, type, status, amount, currency, payee, note, date, transfer_account_id, transfer_transaction_id, is_recurring, recurring_rule_id, tags, created_at, updated_at, sync_version, is_synced)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+INSERT INTO "transaction" (id, household_id, owner_id, account_id, category_id, type, status, amount, currency, payee, note, date, transfer_account_id, transfer_transaction_id, is_recurring, recurring_rule_id, tags, created_at, updated_at, sync_version, is_synced)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 update:
 UPDATE "transaction" SET

--- a/packages/models/src/commonMain/sqldelight/migrations/1.sqm
+++ b/packages/models/src/commonMain/sqldelight/migrations/1.sqm
@@ -1,0 +1,27 @@
+-- Migration v1 → v2: Add owner_id to financial entity tables
+-- This standardizes ownership tracking across all entities, enabling
+-- per-user RLS policies in Supabase and local data isolation.
+--
+-- The owner_id defaults to '' (empty string) for existing rows.
+-- A post-migration data fix must populate owner_id from the
+-- household's owner_id for all existing records.
+
+-- Account
+ALTER TABLE account ADD COLUMN owner_id TEXT NOT NULL DEFAULT '';
+CREATE INDEX IF NOT EXISTS idx_account_owner ON account (owner_id);
+
+-- Transaction (quoted — reserved keyword)
+ALTER TABLE "transaction" ADD COLUMN owner_id TEXT NOT NULL DEFAULT '';
+CREATE INDEX IF NOT EXISTS idx_transaction_owner ON "transaction" (owner_id);
+
+-- Budget
+ALTER TABLE budget ADD COLUMN owner_id TEXT NOT NULL DEFAULT '';
+CREATE INDEX IF NOT EXISTS idx_budget_owner ON budget (owner_id);
+
+-- Goal
+ALTER TABLE goal ADD COLUMN owner_id TEXT NOT NULL DEFAULT '';
+CREATE INDEX IF NOT EXISTS idx_goal_owner ON goal (owner_id);
+
+-- Category
+ALTER TABLE category ADD COLUMN owner_id TEXT NOT NULL DEFAULT '';
+CREATE INDEX IF NOT EXISTS idx_category_owner ON category (owner_id);

--- a/packages/models/src/commonTest/kotlin/com/finance/models/AccountTest.kt
+++ b/packages/models/src/commonTest/kotlin/com/finance/models/AccountTest.kt
@@ -33,6 +33,7 @@ class AccountTest {
     ) = Account(
         id = SyncId("account-1"),
         householdId = householdId,
+        ownerId = SyncId("owner-1"),
         name = name,
         type = AccountType.CHECKING,
         currency = Currency.USD,
@@ -60,6 +61,7 @@ class AccountTest {
         val account = Account(
             id = SyncId("account-2"),
             householdId = householdId,
+            ownerId = SyncId("owner-1"),
             name = "Emergency Fund",
             type = AccountType.SAVINGS,
             currency = Currency.USD,
@@ -75,6 +77,7 @@ class AccountTest {
         val account = Account(
             id = SyncId("account-3"),
             householdId = householdId,
+            ownerId = SyncId("owner-1"),
             name = "Visa Platinum",
             type = AccountType.CREDIT_CARD,
             currency = Currency.USD,

--- a/packages/models/src/commonTest/kotlin/com/finance/models/BudgetAndGoalTest.kt
+++ b/packages/models/src/commonTest/kotlin/com/finance/models/BudgetAndGoalTest.kt
@@ -34,6 +34,7 @@ class BudgetAndGoalTest {
     ) = Budget(
         id = SyncId("budget-1"),
         householdId = householdId,
+        ownerId = SyncId("owner-1"),
         categoryId = categoryId,
         name = name,
         amount = amount,
@@ -115,6 +116,7 @@ class BudgetAndGoalTest {
     ) = Goal(
         id = SyncId("goal-1"),
         householdId = householdId,
+        ownerId = SyncId("owner-1"),
         name = name,
         targetAmount = targetAmount,
         currentAmount = currentAmount,

--- a/packages/models/src/commonTest/kotlin/com/finance/models/CategoryAndHouseholdTest.kt
+++ b/packages/models/src/commonTest/kotlin/com/finance/models/CategoryAndHouseholdTest.kt
@@ -28,6 +28,7 @@ class CategoryAndHouseholdTest {
     private fun category(name: String = "Groceries") = Category(
         id = SyncId("cat-1"),
         householdId = householdId,
+        ownerId = SyncId("owner-1"),
         name = name,
         createdAt = now,
         updatedAt = now,
@@ -84,6 +85,7 @@ class CategoryAndHouseholdTest {
         val sub = Category(
             id = SyncId("cat-2"),
             householdId = householdId,
+            ownerId = SyncId("owner-1"),
             name = "Produce",
             parentId = SyncId("cat-1"),
             createdAt = now,
@@ -97,6 +99,7 @@ class CategoryAndHouseholdTest {
         val income = Category(
             id = SyncId("cat-3"),
             householdId = householdId,
+            ownerId = SyncId("owner-1"),
             name = "Salary",
             isIncome = true,
             createdAt = now,

--- a/packages/models/src/commonTest/kotlin/com/finance/models/TransactionTest.kt
+++ b/packages/models/src/commonTest/kotlin/com/finance/models/TransactionTest.kt
@@ -40,6 +40,7 @@ class TransactionTest {
     ) = Transaction(
         id = SyncId("txn-1"),
         householdId = householdId,
+        ownerId = SyncId("owner-1"),
         accountId = accountId,
         categoryId = categoryId,
         type = TransactionType.EXPENSE,
@@ -72,6 +73,7 @@ class TransactionTest {
         val txn = Transaction(
             id = SyncId("txn-2"),
             householdId = householdId,
+            ownerId = SyncId("owner-1"),
             accountId = accountId,
             type = TransactionType.INCOME,
             amount = Cents(500000L),
@@ -89,6 +91,7 @@ class TransactionTest {
         val txn = Transaction(
             id = SyncId("txn-3"),
             householdId = householdId,
+            ownerId = SyncId("owner-1"),
             accountId = accountId,
             type = TransactionType.TRANSFER,
             amount = Cents(10000L),
@@ -117,6 +120,7 @@ class TransactionTest {
             Transaction(
                 id = SyncId("txn-4"),
                 householdId = householdId,
+                ownerId = SyncId("owner-1"),
                 accountId = accountId,
                 type = TransactionType.TRANSFER,
                 amount = Cents(1000L),
@@ -160,6 +164,7 @@ class TransactionTest {
         val txn = Transaction(
             id = SyncId("txn-5"),
             householdId = householdId,
+            ownerId = SyncId("owner-1"),
             accountId = accountId,
             type = TransactionType.EXPENSE,
             amount = Cents(100L),


### PR DESCRIPTION
## Summary

Standardizes \owner_id\ across all financial entity tables to enable per-user RLS policies in Supabase and local data isolation. Closes #861.

### Schema Changes

| Table | Change |
|-------|--------|
| account | + \owner_id TEXT NOT NULL\, FK → user(id), index |
| transaction | + \owner_id TEXT NOT NULL\, FK → user(id), index |
| budget | + \owner_id TEXT NOT NULL\, FK → user(id), index |
| goal | + \owner_id TEXT NOT NULL\, FK → user(id), index |
| category | + \owner_id TEXT NOT NULL\, FK → user(id), index |

### Files Changed (22 files)

**SQLDelight schemas** — \Account.sq\, \Transaction.sq\, \Budget.sq\, \Goal.sq\, \Category.sq\
- Added \owner_id\ column, FK constraint, index
- Added \selectByOwner\ queries
- Updated \insert\ queries

**Migration** — \migrations/1.sqm\
- ALTER TABLE ADD COLUMN for all 5 tables
- Creates indexes

**Kotlin models** — \Account.kt\, \Transaction.kt\, \Budget.kt\, \Goal.kt\, \Category.kt\
- Added \ownerId: SyncId\ field

**Export serializers** — \JsonExportSerializer.kt\, \CsvExportSerializer.kt\
- Include \owner_id\ in export output

**Tests** — 8 test files updated
- All model constructors include \ownerId\
- TestFixtures factories updated

### ⚠️ Post-merge action needed
After migration, existing rows will have \owner_id = ''\. A data-fix script must populate \owner_id\ from \household.owner_id\ for all existing records.

Closes #861