### PR TITLE
feat(core): monitoring interfaces — facade, timer, platform logger (#910)

### DIFF
--- a/packages/core/src/androidMain/kotlin/com/finance/core/monitoring/PlatformLogger.kt
+++ b/packages/core/src/androidMain/kotlin/com/finance/core/monitoring/PlatformLogger.kt
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.monitoring
+
+import android.util.Log
+
+/**
+ * Android [PlatformLogger] implementation backed by [android.util.Log].
+ *
+ * Maps log levels to Android's Logcat:
+ * - debug → Log.d
+ * - info  → Log.i
+ * - warn  → Log.w
+ * - error → Log.e
+ */
+actual object PlatformLogger {
+    actual fun debug(tag: String, message: String) {
+        Log.d(tag, message)
+    }
+
+    actual fun info(tag: String, message: String) {
+        Log.i(tag, message)
+    }
+
+    actual fun warn(tag: String, message: String) {
+        Log.w(tag, message)
+    }
+
+    actual fun error(tag: String, message: String, throwable: Throwable?) {
+        if (throwable != null) {
+            Log.e(tag, message, throwable)
+        } else {
+            Log.e(tag, message)
+        }
+    }
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/monitoring/MonitoringFacade.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/monitoring/MonitoringFacade.kt
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.monitoring
+
+import kotlinx.datetime.Clock
+
+/**
+ * Composes all monitoring subsystems into a single facade.
+ *
+ * Platform app entry points create a [MonitoringFacade] at startup and inject
+ * it into business logic layers. This avoids scattering individual monitoring
+ * dependencies across the codebase.
+ *
+ * All operations are consent-gated: if the user has not opted in to analytics
+ * and crash reporting, the facade's components silently discard data.
+ *
+ * Usage:
+ * ```
+ * val monitoring = MonitoringFacade(
+ *     crashReporter = platformCrashReporter,
+ *     metricsCollector = MetricsCollector(consentProvider = { userConsent }),
+ *     syncHealthMonitor = SyncHealthMonitor(),
+ * )
+ *
+ * // Track a sync operation
+ * val timer = monitoring.startTimer()
+ * try {
+ *     performSync()
+ *     monitoring.recordSyncSuccess(timer.stop())
+ * } catch (e: Exception) {
+ *     monitoring.recordSyncFailure(e)
+ * }
+ * ```
+ *
+ * @param crashReporter Platform crash reporter (or [NoOpCrashReporter]).
+ * @param metricsCollector Consent-gated metrics collector.
+ * @param syncHealthMonitor Sync health tracker.
+ * @param clock Clock source for timestamps (injectable for testing).
+ */
+class MonitoringFacade(
+    val crashReporter: CrashReporter = NoOpCrashReporter,
+    val metricsCollector: MetricsCollector = MetricsCollector(consentProvider = { false }),
+    val syncHealthMonitor: SyncHealthMonitor = SyncHealthMonitor(),
+    private val clock: Clock = Clock.System,
+) {
+
+    /**
+     * Start a [PerformanceTimer] for measuring operation duration.
+     *
+     * @param operationName Optional name for the operation being timed.
+     * @return A started [PerformanceTimer].
+     */
+    fun startTimer(operationName: String = ""): PerformanceTimer {
+        return PerformanceTimer.start(clock, operationName)
+    }
+
+    /**
+     * Record a successful sync operation.
+     *
+     * Updates both the sync health monitor and metrics collector.
+     *
+     * @param durationMs Duration of the sync in milliseconds.
+     * @param recordCount Number of records synced.
+     */
+    fun recordSyncSuccess(durationMs: Long, recordCount: Int = 0) {
+        syncHealthMonitor.recordSyncSuccess(durationMs)
+        metricsCollector.recordSyncPerformance(
+            durationMs = durationMs,
+            recordCount = recordCount,
+            success = true,
+        )
+    }
+
+    /**
+     * Record a failed sync operation.
+     *
+     * Updates the sync health monitor, metrics collector, and crash reporter.
+     *
+     * @param exception The exception that caused the failure, or null.
+     * @param durationMs Duration of the sync attempt in milliseconds.
+     */
+    fun recordSyncFailure(exception: Throwable? = null, durationMs: Long = 0) {
+        syncHealthMonitor.recordSyncFailure()
+        metricsCollector.recordSyncPerformance(
+            durationMs = durationMs,
+            recordCount = 0,
+            success = false,
+        )
+        if (exception != null) {
+            crashReporter.reportError(
+                exception = exception,
+                context = mapOf("component" to "sync_engine"),
+            )
+        }
+    }
+
+    /**
+     * Record a screen view in the metrics collector.
+     *
+     * @param screenName Screen identifier (e.g., "dashboard", "budget_list").
+     */
+    fun recordScreenView(screenName: String) {
+        metricsCollector.recordScreenView(screenName)
+    }
+
+    /**
+     * Record a feature usage event in the metrics collector.
+     *
+     * @param featureName Feature identifier (e.g., "create_budget").
+     * @param properties Optional anonymous metadata.
+     */
+    fun recordFeatureUsage(featureName: String, properties: Map<String, String> = emptyMap()) {
+        metricsCollector.recordFeatureUsage(featureName, properties)
+    }
+
+    /**
+     * Report a non-fatal error through the crash reporter.
+     *
+     * @param exception The exception to report.
+     * @param context Optional diagnostic context (no PII or financial data).
+     */
+    fun reportError(exception: Throwable, context: Map<String, String> = emptyMap()) {
+        crashReporter.reportError(exception, context)
+    }
+
+    /**
+     * Log a diagnostic breadcrumb.
+     *
+     * @param message Descriptive message (no PII or financial data).
+     */
+    fun logBreadcrumb(message: String) {
+        crashReporter.log(message)
+    }
+
+    /**
+     * Reset all monitoring state.
+     *
+     * Call on user sign-out or account switch.
+     */
+    fun reset() {
+        syncHealthMonitor.reset()
+        metricsCollector.clearEvents()
+        crashReporter.setUserId(null)
+    }
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/monitoring/PerformanceTimer.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/monitoring/PerformanceTimer.kt
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.monitoring
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+
+/**
+ * Measures wall-clock duration of an operation in milliseconds.
+ *
+ * Create instances via [start] and call [stop] to get the elapsed time.
+ * The timer uses [kotlinx.datetime.Clock] for multiplatform compatibility
+ * (no `java.lang.System.nanoTime()`).
+ *
+ * Timers are single-use: calling [stop] multiple times returns the same
+ * duration (captured on the first [stop] call).
+ *
+ * Usage:
+ * ```
+ * val timer = PerformanceTimer.start()
+ * // ... perform operation ...
+ * val durationMs = timer.stop()
+ * ```
+ *
+ * @param clock Clock source for timestamps.
+ * @param operationName Optional name for diagnostic logging.
+ * @param startTime The instant when the timer was started.
+ */
+class PerformanceTimer private constructor(
+    private val clock: Clock,
+    val operationName: String,
+    private val startTime: Instant,
+) {
+    private var endTime: Instant? = null
+
+    /**
+     * Stop the timer and return elapsed milliseconds.
+     *
+     * Subsequent calls return the same value (first-stop semantics).
+     *
+     * @return Elapsed time in milliseconds (always ≥ 0).
+     */
+    fun stop(): Long {
+        if (endTime == null) {
+            endTime = clock.now()
+        }
+        return elapsedMs
+    }
+
+    /**
+     * Elapsed time in milliseconds since the timer was started.
+     *
+     * If [stop] has been called, returns the frozen duration.
+     * If [stop] has not been called, returns the live elapsed time.
+     */
+    val elapsedMs: Long
+        get() {
+            val end = endTime ?: clock.now()
+            return (end - startTime).inWholeMilliseconds.coerceAtLeast(0)
+        }
+
+    /** Whether [stop] has been called. */
+    val isStopped: Boolean get() = endTime != null
+
+    /** The instant when the timer was started. */
+    val startedAt: Instant get() = startTime
+
+    companion object {
+        /**
+         * Create and start a new [PerformanceTimer].
+         *
+         * @param clock Clock source. Defaults to [Clock.System].
+         * @param operationName Optional name for the timed operation.
+         * @return A running [PerformanceTimer].
+         */
+        fun start(
+            clock: Clock = Clock.System,
+            operationName: String = "",
+        ): PerformanceTimer {
+            return PerformanceTimer(
+                clock = clock,
+                operationName = operationName,
+                startTime = clock.now(),
+            )
+        }
+    }
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/monitoring/PlatformLogger.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/monitoring/PlatformLogger.kt
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.monitoring
+
+/**
+ * Platform-agnostic logging sink for diagnostic output.
+ *
+ * Each platform provides an `actual` implementation backed by its native
+ * logging facility (Android Logcat, iOS os_log, console.log for JS/Web,
+ * java.util.logging for JVM/Windows).
+ *
+ * Log levels follow the standard severity hierarchy:
+ * DEBUG < INFO < WARN < ERROR
+ *
+ * Implementations must:
+ * - Never log PII, financial amounts, or account identifiers.
+ * - Be safe to call from any thread/dispatcher.
+ * - Be lightweight (no I/O blocking on the calling thread).
+ */
+expect object PlatformLogger {
+    /** Log a debug-level message. */
+    fun debug(tag: String, message: String)
+
+    /** Log an info-level message. */
+    fun info(tag: String, message: String)
+
+    /** Log a warning-level message. */
+    fun warn(tag: String, message: String)
+
+    /** Log an error-level message with optional throwable. */
+    fun error(tag: String, message: String, throwable: Throwable? = null)
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/monitoring/HealthStatusTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/monitoring/HealthStatusTest.kt
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.monitoring
+
+import kotlinx.datetime.Instant
+import kotlin.test.*
+import kotlin.time.Duration.Companion.minutes
+
+/**
+ * Tests for [HealthStatus.evaluate] — verifies all threshold boundaries
+ * and priority ordering.
+ */
+class HealthStatusTest {
+
+    private val baseTime = Instant.parse("2024-06-15T12:00:00Z")
+
+    // ── Healthy ──────────────────────────────────────────────────────
+
+    @Test
+    fun healthyWhenAllGood() {
+        val status = HealthStatus.evaluate(
+            lastSyncTime = baseTime,
+            currentTime = baseTime + 1.minutes,
+            failureCount = 0,
+            pendingMutations = 0,
+        )
+        assertEquals(HealthStatus.Healthy, status)
+    }
+
+    @Test
+    fun healthyWithLowPendingMutations() {
+        val status = HealthStatus.evaluate(
+            lastSyncTime = baseTime,
+            currentTime = baseTime + 1.minutes,
+            failureCount = 0,
+            pendingMutations = 49, // just below degraded threshold
+        )
+        assertEquals(HealthStatus.Healthy, status)
+    }
+
+    // ── Unhealthy — no sync history ──────────────────────────────────
+
+    @Test
+    fun unhealthyWhenNeverSynced() {
+        val status = HealthStatus.evaluate(
+            lastSyncTime = null,
+            currentTime = baseTime,
+            failureCount = 0,
+            pendingMutations = 0,
+        )
+        assertTrue(status is HealthStatus.Unhealthy)
+        assertTrue(status.reason.contains("No successful sync"))
+    }
+
+    // ── Degraded — sync age ──────────────────────────────────────────
+
+    @Test
+    fun degradedWhenSyncAge5MinPlus() {
+        val status = HealthStatus.evaluate(
+            lastSyncTime = baseTime,
+            currentTime = baseTime + 6.minutes,
+            failureCount = 0,
+            pendingMutations = 0,
+        )
+        assertTrue(status is HealthStatus.Degraded)
+        assertTrue(status.reason.contains("5 minutes"))
+    }
+
+    @Test
+    fun notDegradedWhenSyncAgeExactly5Min() {
+        val status = HealthStatus.evaluate(
+            lastSyncTime = baseTime,
+            currentTime = baseTime + 5.minutes,
+            failureCount = 0,
+            pendingMutations = 0,
+        )
+        assertEquals(HealthStatus.Healthy, status)
+    }
+
+    // ── Unhealthy — sync age ─────────────────────────────────────────
+
+    @Test
+    fun unhealthyWhenSyncAge30MinPlus() {
+        val status = HealthStatus.evaluate(
+            lastSyncTime = baseTime,
+            currentTime = baseTime + 31.minutes,
+            failureCount = 0,
+            pendingMutations = 0,
+        )
+        assertTrue(status is HealthStatus.Unhealthy)
+        assertTrue(status.reason.contains("30 minutes"))
+    }
+
+    // ── Degraded — failure count ─────────────────────────────────────
+
+    @Test
+    fun degradedWithOneFailure() {
+        val status = HealthStatus.evaluate(
+            lastSyncTime = baseTime,
+            currentTime = baseTime + 1.minutes,
+            failureCount = 1,
+            pendingMutations = 0,
+        )
+        assertTrue(status is HealthStatus.Degraded)
+    }
+
+    // ── Unhealthy — failure count ────────────────────────────────────
+
+    @Test
+    fun unhealthyWithManyFailures() {
+        val status = HealthStatus.evaluate(
+            lastSyncTime = baseTime,
+            currentTime = baseTime + 1.minutes,
+            failureCount = 4,
+            pendingMutations = 0,
+        )
+        assertTrue(status is HealthStatus.Unhealthy)
+    }
+
+    @Test
+    fun degradedWithThreeFailures() {
+        // exactly at threshold (>= 1, not > 3)
+        val status = HealthStatus.evaluate(
+            lastSyncTime = baseTime,
+            currentTime = baseTime + 1.minutes,
+            failureCount = 3,
+            pendingMutations = 0,
+        )
+        assertTrue(status is HealthStatus.Degraded)
+    }
+
+    // ── Degraded — pending mutations ─────────────────────────────────
+
+    @Test
+    fun degradedWithHighPendingMutations() {
+        val status = HealthStatus.evaluate(
+            lastSyncTime = baseTime,
+            currentTime = baseTime + 1.minutes,
+            failureCount = 0,
+            pendingMutations = 50,
+        )
+        assertTrue(status is HealthStatus.Degraded)
+    }
+
+    // ── Unhealthy — pending mutations ────────────────────────────────
+
+    @Test
+    fun unhealthyWithVeryHighPendingMutations() {
+        val status = HealthStatus.evaluate(
+            lastSyncTime = baseTime,
+            currentTime = baseTime + 1.minutes,
+            failureCount = 0,
+            pendingMutations = 201,
+        )
+        assertTrue(status is HealthStatus.Unhealthy)
+    }
+
+    // ── Priority: unhealthy takes precedence ─────────────────────────
+
+    @Test
+    fun unhealthyTakesPrecedenceOverDegraded() {
+        val status = HealthStatus.evaluate(
+            lastSyncTime = baseTime,
+            currentTime = baseTime + 31.minutes, // unhealthy by age
+            failureCount = 1, // degraded by failure
+            pendingMutations = 50, // degraded by pending
+        )
+        assertTrue(status is HealthStatus.Unhealthy)
+    }
+
+    // ── Sealed class ─────────────────────────────────────────────────
+
+    @Test
+    fun healthyIsDataObject() {
+        assertSame(HealthStatus.Healthy, HealthStatus.Healthy)
+    }
+
+    @Test
+    fun degradedHasReason() {
+        val status = HealthStatus.Degraded("test reason")
+        assertEquals("test reason", status.reason)
+    }
+
+    @Test
+    fun unhealthyHasReason() {
+        val status = HealthStatus.Unhealthy("test reason")
+        assertEquals("test reason", status.reason)
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/monitoring/MetricsCollectorTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/monitoring/MetricsCollectorTest.kt
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.monitoring
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlin.test.*
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+
+/**
+ * Tests for [MetricsCollector] — consent gating, event recording,
+ * buffering, and flushing.
+ */
+class MetricsCollectorTest {
+
+    private var currentTime = Instant.parse("2024-06-15T12:00:00Z")
+
+    private val testClock = object : Clock {
+        override fun now(): Instant = currentTime
+    }
+
+    // ── Consent gating ───────────────────────────────────────────────
+
+    @Test
+    fun recordScreenViewIsNoOpWithoutConsent() {
+        val collector = MetricsCollector(consentProvider = { false }, clock = testClock)
+        collector.recordScreenView("dashboard")
+        assertEquals(0, collector.bufferedEventCount)
+    }
+
+    @Test
+    fun recordFeatureUsageIsNoOpWithoutConsent() {
+        val collector = MetricsCollector(consentProvider = { false }, clock = testClock)
+        collector.recordFeatureUsage("create_budget")
+        assertEquals(0, collector.bufferedEventCount)
+    }
+
+    @Test
+    fun recordSyncPerformanceIsNoOpWithoutConsent() {
+        val collector = MetricsCollector(consentProvider = { false }, clock = testClock)
+        collector.recordSyncPerformance(100L, 10, true)
+        assertEquals(0, collector.bufferedEventCount)
+    }
+
+    @Test
+    fun flushReturnsEmptyWithoutConsent() {
+        val collector = MetricsCollector(consentProvider = { false }, clock = testClock)
+        val events = collector.flushEvents()
+        assertTrue(events.isEmpty())
+    }
+
+    // ── Event recording ──────────────────────────────────────────────
+
+    @Test
+    fun recordScreenViewAddsEvent() {
+        val collector = MetricsCollector(consentProvider = { true }, clock = testClock)
+        collector.recordScreenView("dashboard")
+        assertEquals(1, collector.bufferedEventCount)
+    }
+
+    @Test
+    fun recordScreenViewEventProperties() {
+        val collector = MetricsCollector(consentProvider = { true }, clock = testClock)
+        collector.recordScreenView("budget_list")
+        val events = collector.flushEvents()
+        assertEquals(1, events.size)
+        val event = events[0]
+        assertEquals("screen_view", event.name)
+        assertEquals("budget_list", event.properties["screen"])
+        assertEquals(currentTime, event.timestamp)
+    }
+
+    @Test
+    fun recordFeatureUsageAddsEvent() {
+        val collector = MetricsCollector(consentProvider = { true }, clock = testClock)
+        collector.recordFeatureUsage("create_budget", mapOf("period" to "MONTHLY"))
+        val events = collector.flushEvents()
+        assertEquals(1, events.size)
+        val event = events[0]
+        assertEquals("feature_usage", event.name)
+        assertEquals("create_budget", event.properties["feature"])
+        assertEquals("MONTHLY", event.properties["period"])
+    }
+
+    @Test
+    fun recordSyncPerformanceAddsEvent() {
+        val collector = MetricsCollector(consentProvider = { true }, clock = testClock)
+        collector.recordSyncPerformance(1500L, 42, true)
+        val events = collector.flushEvents()
+        assertEquals(1, events.size)
+        val event = events[0]
+        assertEquals("sync_performance", event.name)
+        assertEquals("1500", event.properties["duration_ms"])
+        assertEquals("42", event.properties["record_count"])
+        assertEquals("true", event.properties["success"])
+    }
+
+    // ── Flushing ─────────────────────────────────────────────────────
+
+    @Test
+    fun flushReturnsCopiedEvents() {
+        val collector = MetricsCollector(consentProvider = { true }, clock = testClock)
+        collector.recordScreenView("a")
+        collector.recordScreenView("b")
+        val flushed = collector.flushEvents()
+        assertEquals(2, flushed.size)
+        assertEquals(0, collector.bufferedEventCount, "Buffer should be empty after flush")
+    }
+
+    @Test
+    fun flushDoesNotReturnEventsAfterConsentRevoked() {
+        var consent = true
+        val collector = MetricsCollector(consentProvider = { consent }, clock = testClock)
+        collector.recordScreenView("a")
+        consent = false
+        val flushed = collector.flushEvents()
+        assertTrue(flushed.isEmpty())
+    }
+
+    // ── Clear ────────────────────────────────────────────────────────
+
+    @Test
+    fun clearEventsEmptiesBuffer() {
+        val collector = MetricsCollector(consentProvider = { true }, clock = testClock)
+        collector.recordScreenView("a")
+        collector.recordScreenView("b")
+        assertEquals(2, collector.bufferedEventCount)
+        collector.clearEvents()
+        assertEquals(0, collector.bufferedEventCount)
+    }
+
+    // ── Multiple events ──────────────────────────────────────────────
+
+    @Test
+    fun multipleEventsAreBuffered() {
+        val collector = MetricsCollector(consentProvider = { true }, clock = testClock)
+        collector.recordScreenView("a")
+        collector.recordFeatureUsage("b")
+        collector.recordSyncPerformance(100, 5, false)
+        assertEquals(3, collector.bufferedEventCount)
+    }
+
+    // ── Timestamp progression ────────────────────────────────────────
+
+    @Test
+    fun eventsRecordTimestampsFromClock() {
+        val collector = MetricsCollector(consentProvider = { true }, clock = testClock)
+        val t1 = currentTime
+        collector.recordScreenView("first")
+        currentTime = currentTime + 5.minutes
+        val t2 = currentTime
+        collector.recordScreenView("second")
+
+        val events = collector.flushEvents()
+        assertEquals(t1, events[0].timestamp)
+        assertEquals(t2, events[1].timestamp)
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/monitoring/MonitoringFacadeTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/monitoring/MonitoringFacadeTest.kt
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.monitoring
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlin.test.*
+
+/**
+ * Tests for [MonitoringFacade] — composition, delegation, and reset.
+ */
+class MonitoringFacadeTest {
+
+    private var currentTime = Instant.parse("2024-06-15T12:00:00Z")
+
+    private val testClock = object : Clock {
+        override fun now(): Instant = currentTime
+    }
+
+    /** Recording crash reporter for assertions. */
+    private class RecordingCrashReporter : CrashReporter {
+        val errors = mutableListOf<Pair<Throwable, Map<String, String>>>()
+        val breadcrumbs = mutableListOf<String>()
+        var capturedUserId: String? = null
+        var enabled = true
+
+        override fun reportError(exception: Throwable, context: Map<String, String>) {
+            errors.add(exception to context)
+        }
+
+        override fun setUserId(id: String?) { capturedUserId = id }
+        override fun log(message: String) { breadcrumbs.add(message) }
+        override fun isEnabled(): Boolean = enabled
+    }
+
+    private fun createFacade(
+        crashReporter: CrashReporter = NoOpCrashReporter,
+        consent: Boolean = true,
+    ): MonitoringFacade {
+        return MonitoringFacade(
+            crashReporter = crashReporter,
+            metricsCollector = MetricsCollector(consentProvider = { consent }, clock = testClock),
+            syncHealthMonitor = SyncHealthMonitor(clock = testClock),
+            clock = testClock,
+        )
+    }
+
+    // ── recordSyncSuccess ────────────────────────────────────────────
+
+    @Test
+    fun recordSyncSuccessUpdatesBothMonitorAndMetrics() {
+        val facade = createFacade()
+        facade.recordSyncSuccess(durationMs = 100, recordCount = 10)
+
+        assertEquals(HealthStatus.Healthy, facade.syncHealthMonitor.healthStatus.value)
+        assertEquals(1, facade.metricsCollector.bufferedEventCount)
+    }
+
+    // ── recordSyncFailure ────────────────────────────────────────────
+
+    @Test
+    fun recordSyncFailureUpdatesBothMonitorAndMetrics() {
+        val recorder = RecordingCrashReporter()
+        val facade = createFacade(crashReporter = recorder)
+        facade.recordSyncSuccess(50) // establish baseline
+
+        val error = RuntimeException("sync timeout")
+        facade.recordSyncFailure(exception = error, durationMs = 200)
+
+        assertEquals(1, facade.syncHealthMonitor.failureCount.value)
+        assertEquals(1, recorder.errors.size)
+        assertEquals("sync_engine", recorder.errors[0].second["component"])
+    }
+
+    @Test
+    fun recordSyncFailureWithoutExceptionDoesNotReportCrash() {
+        val recorder = RecordingCrashReporter()
+        val facade = createFacade(crashReporter = recorder)
+        facade.recordSyncSuccess(50)
+
+        facade.recordSyncFailure(exception = null)
+        assertTrue(recorder.errors.isEmpty())
+    }
+
+    // ── recordScreenView ─────────────────────────────────────────────
+
+    @Test
+    fun recordScreenViewDelegatesToMetrics() {
+        val facade = createFacade()
+        facade.recordScreenView("dashboard")
+        assertEquals(1, facade.metricsCollector.bufferedEventCount)
+    }
+
+    // ── recordFeatureUsage ───────────────────────────────────────────
+
+    @Test
+    fun recordFeatureUsageDelegatesToMetrics() {
+        val facade = createFacade()
+        facade.recordFeatureUsage("create_budget", mapOf("period" to "MONTHLY"))
+        assertEquals(1, facade.metricsCollector.bufferedEventCount)
+    }
+
+    // ── reportError ──────────────────────────────────────────────────
+
+    @Test
+    fun reportErrorDelegatesToCrashReporter() {
+        val recorder = RecordingCrashReporter()
+        val facade = createFacade(crashReporter = recorder)
+        val error = IllegalStateException("test error")
+        facade.reportError(error, mapOf("screen" to "budget_list"))
+
+        assertEquals(1, recorder.errors.size)
+        assertEquals("budget_list", recorder.errors[0].second["screen"])
+    }
+
+    // ── logBreadcrumb ────────────────────────────────────────────────
+
+    @Test
+    fun logBreadcrumbDelegatesToCrashReporter() {
+        val recorder = RecordingCrashReporter()
+        val facade = createFacade(crashReporter = recorder)
+        facade.logBreadcrumb("Sync started")
+
+        assertEquals(1, recorder.breadcrumbs.size)
+        assertEquals("Sync started", recorder.breadcrumbs[0])
+    }
+
+    // ── startTimer ───────────────────────────────────────────────────
+
+    @Test
+    fun startTimerCreatesRunningTimer() {
+        val facade = createFacade()
+        val timer = facade.startTimer("test_op")
+        assertFalse(timer.isStopped)
+        assertEquals("test_op", timer.operationName)
+    }
+
+    // ── reset ────────────────────────────────────────────────────────
+
+    @Test
+    fun resetClearsAllState() {
+        val recorder = RecordingCrashReporter()
+        val facade = createFacade(crashReporter = recorder)
+
+        facade.recordSyncSuccess(50, 10)
+        facade.recordScreenView("dashboard")
+        recorder.capturedUserId = "user-123"
+
+        facade.reset()
+
+        assertNull(facade.syncHealthMonitor.lastSyncTime.value)
+        assertEquals(0, facade.metricsCollector.bufferedEventCount)
+        assertNull(recorder.capturedUserId)
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/monitoring/PerformanceTimerTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/monitoring/PerformanceTimerTest.kt
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.monitoring
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlin.test.*
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Tests for [PerformanceTimer] — start/stop, elapsed measurement,
+ * single-stop semantics, and operation naming.
+ */
+class PerformanceTimerTest {
+
+    private var currentTime = Instant.parse("2024-06-15T12:00:00Z")
+
+    private val testClock = object : Clock {
+        override fun now(): Instant = currentTime
+    }
+
+    // ── Basic measurement ────────────────────────────────────────────
+
+    @Test
+    fun timerMeasuresElapsedTime() {
+        val timer = PerformanceTimer.start(clock = testClock, operationName = "test")
+        currentTime = currentTime + 500.milliseconds
+        val elapsed = timer.stop()
+        assertEquals(500L, elapsed)
+    }
+
+    @Test
+    fun timerMeasuresZeroDuration() {
+        val timer = PerformanceTimer.start(clock = testClock)
+        val elapsed = timer.stop()
+        assertEquals(0L, elapsed)
+    }
+
+    // ── Single-stop semantics ────────────────────────────────────────
+
+    @Test
+    fun stopReturnsConsistentValue() {
+        val timer = PerformanceTimer.start(clock = testClock)
+        currentTime = currentTime + 100.milliseconds
+        val first = timer.stop()
+        currentTime = currentTime + 500.milliseconds // time advances but timer is stopped
+        val second = timer.stop()
+        assertEquals(first, second, "Multiple stop() calls should return the same value")
+    }
+
+    @Test
+    fun isStoppedIsFalseBeforeStop() {
+        val timer = PerformanceTimer.start(clock = testClock)
+        assertFalse(timer.isStopped)
+    }
+
+    @Test
+    fun isStoppedIsTrueAfterStop() {
+        val timer = PerformanceTimer.start(clock = testClock)
+        timer.stop()
+        assertTrue(timer.isStopped)
+    }
+
+    // ── Live elapsed (before stop) ───────────────────────────────────
+
+    @Test
+    fun elapsedMsReturnsLiveValueBeforeStop() {
+        val timer = PerformanceTimer.start(clock = testClock)
+        currentTime = currentTime + 200.milliseconds
+        assertEquals(200L, timer.elapsedMs)
+        currentTime = currentTime + 300.milliseconds
+        assertEquals(500L, timer.elapsedMs)
+    }
+
+    @Test
+    fun elapsedMsFrozenAfterStop() {
+        val timer = PerformanceTimer.start(clock = testClock)
+        currentTime = currentTime + 200.milliseconds
+        timer.stop()
+        currentTime = currentTime + 1000.milliseconds
+        assertEquals(200L, timer.elapsedMs)
+    }
+
+    // ── Operation name ───────────────────────────────────────────────
+
+    @Test
+    fun operationNameIsRecorded() {
+        val timer = PerformanceTimer.start(clock = testClock, operationName = "sync_delta")
+        assertEquals("sync_delta", timer.operationName)
+    }
+
+    @Test
+    fun defaultOperationNameIsEmpty() {
+        val timer = PerformanceTimer.start(clock = testClock)
+        assertEquals("", timer.operationName)
+    }
+
+    // ── Start time ───────────────────────────────────────────────────
+
+    @Test
+    fun startedAtCapturesStartInstant() {
+        val startInstant = currentTime
+        val timer = PerformanceTimer.start(clock = testClock)
+        assertEquals(startInstant, timer.startedAt)
+    }
+
+    // ── Coerce non-negative ──────────────────────────────────────────
+
+    @Test
+    fun elapsedMsNeverNegative() {
+        // If clock goes backward (e.g., NTP adjustment), elapsed should be 0
+        val timer = PerformanceTimer.start(clock = testClock)
+        currentTime = currentTime - 100.milliseconds // time goes backward
+        assertEquals(0L, timer.elapsedMs)
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/monitoring/SyncHealthMonitorTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/monitoring/SyncHealthMonitorTest.kt
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.monitoring
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlin.test.*
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Tests for [SyncHealthMonitor] — state transitions, threshold evaluation,
+ * rolling averages, and reset.
+ */
+class SyncHealthMonitorTest {
+
+    private var currentTime = Instant.parse("2024-06-15T12:00:00Z")
+
+    private val testClock = object : Clock {
+        override fun now(): Instant = currentTime
+    }
+
+    private fun createMonitor(maxSamples: Int = 100) =
+        SyncHealthMonitor(clock = testClock, maxDurationSamples = maxSamples)
+
+    // ── Initial state ────────────────────────────────────────────────
+
+    @Test
+    fun initialLastSyncTimeIsNull() {
+        val monitor = createMonitor()
+        assertNull(monitor.lastSyncTime.value)
+    }
+
+    @Test
+    fun initialPendingMutationsIsZero() {
+        val monitor = createMonitor()
+        assertEquals(0, monitor.pendingMutations.value)
+    }
+
+    @Test
+    fun initialFailureCountIsZero() {
+        val monitor = createMonitor()
+        assertEquals(0, monitor.failureCount.value)
+    }
+
+    @Test
+    fun initialHealthStatusIsHealthyBeforeRefresh() {
+        // Before any refreshHealthStatus call, the default is Healthy
+        val monitor = createMonitor()
+        assertEquals(HealthStatus.Healthy, monitor.healthStatus.value)
+    }
+
+    @Test
+    fun initialHealthAfterRefreshIsUnhealthy() {
+        // After refreshing with no sync history, should be Unhealthy
+        val monitor = createMonitor()
+        monitor.refreshHealthStatus()
+        assertTrue(monitor.healthStatus.value is HealthStatus.Unhealthy)
+    }
+
+    // ── recordSyncSuccess ────────────────────────────────────────────
+
+    @Test
+    fun recordSyncSuccessUpdatesLastSyncTime() {
+        val monitor = createMonitor()
+        monitor.recordSyncSuccess(100L)
+        assertEquals(currentTime, monitor.lastSyncTime.value)
+    }
+
+    @Test
+    fun recordSyncSuccessResetsFailureCount() {
+        val monitor = createMonitor()
+        monitor.recordSyncFailure()
+        monitor.recordSyncFailure()
+        assertEquals(2, monitor.failureCount.value)
+        monitor.recordSyncSuccess(50L)
+        assertEquals(0, monitor.failureCount.value)
+    }
+
+    @Test
+    fun recordSyncSuccessSetsHealthToHealthy() {
+        val monitor = createMonitor()
+        monitor.recordSyncSuccess(50L)
+        assertEquals(HealthStatus.Healthy, monitor.healthStatus.value)
+    }
+
+    @Test
+    fun recordSyncSuccessRejectNegativeDuration() {
+        val monitor = createMonitor()
+        assertFailsWith<IllegalArgumentException> {
+            monitor.recordSyncSuccess(-1L)
+        }
+    }
+
+    // ── recordSyncFailure ────────────────────────────────────────────
+
+    @Test
+    fun recordSyncFailureIncrementsCount() {
+        val monitor = createMonitor()
+        monitor.recordSyncFailure()
+        assertEquals(1, monitor.failureCount.value)
+        monitor.recordSyncFailure()
+        assertEquals(2, monitor.failureCount.value)
+    }
+
+    @Test
+    fun singleFailureDegrades() {
+        val monitor = createMonitor()
+        monitor.recordSyncSuccess(50L) // establish healthy baseline
+        monitor.recordSyncFailure()
+        val status = monitor.healthStatus.value
+        assertTrue(status is HealthStatus.Degraded, "Expected Degraded, got $status")
+    }
+
+    @Test
+    fun multipleFailuresBecomeUnhealthy() {
+        val monitor = createMonitor()
+        monitor.recordSyncSuccess(50L)
+        repeat(4) { monitor.recordSyncFailure() }
+        val status = monitor.healthStatus.value
+        assertTrue(status is HealthStatus.Unhealthy, "Expected Unhealthy, got $status")
+    }
+
+    // ── updatePendingMutations ───────────────────────────────────────
+
+    @Test
+    fun updatePendingMutationsSetsValue() {
+        val monitor = createMonitor()
+        monitor.updatePendingMutations(25)
+        assertEquals(25, monitor.pendingMutations.value)
+    }
+
+    @Test
+    fun highPendingMutationsDegrades() {
+        val monitor = createMonitor()
+        monitor.recordSyncSuccess(50L)
+        monitor.updatePendingMutations(50)
+        val status = monitor.healthStatus.value
+        assertTrue(status is HealthStatus.Degraded, "Expected Degraded, got $status")
+    }
+
+    @Test
+    fun veryHighPendingMutationsIsUnhealthy() {
+        val monitor = createMonitor()
+        monitor.recordSyncSuccess(50L)
+        monitor.updatePendingMutations(201)
+        val status = monitor.healthStatus.value
+        assertTrue(status is HealthStatus.Unhealthy, "Expected Unhealthy, got $status")
+    }
+
+    @Test
+    fun rejectNegativePendingMutations() {
+        val monitor = createMonitor()
+        assertFailsWith<IllegalArgumentException> {
+            monitor.updatePendingMutations(-1)
+        }
+    }
+
+    // ── Sync age thresholds ──────────────────────────────────────────
+
+    @Test
+    fun healthDegradesByAge() {
+        val monitor = createMonitor()
+        monitor.recordSyncSuccess(50L)
+        currentTime = currentTime + 6.minutes // > 5 min threshold
+        monitor.refreshHealthStatus()
+        val status = monitor.healthStatus.value
+        assertTrue(status is HealthStatus.Degraded, "Expected Degraded after 6 min, got $status")
+    }
+
+    @Test
+    fun healthIsUnhealthyByAge() {
+        val monitor = createMonitor()
+        monitor.recordSyncSuccess(50L)
+        currentTime = currentTime + 31.minutes // > 30 min threshold
+        monitor.refreshHealthStatus()
+        val status = monitor.healthStatus.value
+        assertTrue(status is HealthStatus.Unhealthy, "Expected Unhealthy after 31 min, got $status")
+    }
+
+    // ── Rolling average ──────────────────────────────────────────────
+
+    @Test
+    fun averageSyncDurationMs() {
+        val monitor = createMonitor()
+        monitor.recordSyncSuccess(100L)
+        monitor.recordSyncSuccess(200L)
+        monitor.recordSyncSuccess(300L)
+        assertEquals(200L, monitor.averageSyncDurationMs.value)
+    }
+
+    @Test
+    fun averageRollsOverMaxSamples() {
+        val monitor = createMonitor(maxSamples = 3)
+        monitor.recordSyncSuccess(100L) // [100]
+        monitor.recordSyncSuccess(200L) // [100, 200]
+        monitor.recordSyncSuccess(300L) // [100, 200, 300]
+        monitor.recordSyncSuccess(400L) // [200, 300, 400] — dropped 100
+        assertEquals(300L, monitor.averageSyncDurationMs.value)
+    }
+
+    // ── Reset ────────────────────────────────────────────────────────
+
+    @Test
+    fun resetClearsAllState() {
+        val monitor = createMonitor()
+        monitor.recordSyncSuccess(50L)
+        monitor.recordSyncFailure()
+        monitor.updatePendingMutations(10)
+
+        monitor.reset()
+
+        assertNull(monitor.lastSyncTime.value)
+        assertEquals(0, monitor.failureCount.value)
+        assertEquals(0, monitor.pendingMutations.value)
+        assertEquals(0L, monitor.averageSyncDurationMs.value)
+        assertEquals(HealthStatus.Healthy, monitor.healthStatus.value)
+    }
+}

--- a/packages/core/src/iosMain/kotlin/com/finance/core/monitoring/PlatformLogger.kt
+++ b/packages/core/src/iosMain/kotlin/com/finance/core/monitoring/PlatformLogger.kt
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.monitoring
+
+import platform.Foundation.NSLog
+
+/**
+ * iOS [PlatformLogger] implementation backed by [NSLog].
+ *
+ * NSLog writes to the unified logging system (Console.app / Xcode console).
+ * For production apps, consider migrating to os_log for better filtering.
+ */
+actual object PlatformLogger {
+    actual fun debug(tag: String, message: String) {
+        NSLog("D/[$tag] %@", message)
+    }
+
+    actual fun info(tag: String, message: String) {
+        NSLog("I/[$tag] %@", message)
+    }
+
+    actual fun warn(tag: String, message: String) {
+        NSLog("W/[$tag] %@", message)
+    }
+
+    actual fun error(tag: String, message: String, throwable: Throwable?) {
+        if (throwable != null) {
+            NSLog("E/[$tag] %@ — %@", message, throwable.message ?: "unknown")
+        } else {
+            NSLog("E/[$tag] %@", message)
+        }
+    }
+}

--- a/packages/core/src/jsMain/kotlin/com/finance/core/monitoring/PlatformLogger.kt
+++ b/packages/core/src/jsMain/kotlin/com/finance/core/monitoring/PlatformLogger.kt
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.monitoring
+
+/**
+ * JS [PlatformLogger] implementation backed by `console.*`.
+ *
+ * Used in the Web app (TypeScript + React). Browser dev-tools
+ * display these at the appropriate log level.
+ */
+actual object PlatformLogger {
+    actual fun debug(tag: String, message: String) {
+        console.log("[$tag] $message")
+    }
+
+    actual fun info(tag: String, message: String) {
+        console.info("[$tag] $message")
+    }
+
+    actual fun warn(tag: String, message: String) {
+        console.warn("[$tag] $message")
+    }
+
+    actual fun error(tag: String, message: String, throwable: Throwable?) {
+        if (throwable != null) {
+            console.error("[$tag] $message", throwable)
+        } else {
+            console.error("[$tag] $message")
+        }
+    }
+}

--- a/packages/core/src/jvmMain/kotlin/com/finance/core/monitoring/PlatformLogger.kt
+++ b/packages/core/src/jvmMain/kotlin/com/finance/core/monitoring/PlatformLogger.kt
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.monitoring
+
+import java.util.logging.Level
+import java.util.logging.Logger
+
+/**
+ * JVM [PlatformLogger] implementation backed by [java.util.logging.Logger].
+ *
+ * Used on Android (via JVM target) and Windows (JVM desktop).
+ * Android apps may redirect JUL to Logcat via a logging bridge.
+ */
+actual object PlatformLogger {
+    private fun logger(tag: String): Logger = Logger.getLogger(tag)
+
+    actual fun debug(tag: String, message: String) {
+        logger(tag).log(Level.FINE, message)
+    }
+
+    actual fun info(tag: String, message: String) {
+        logger(tag).log(Level.INFO, message)
+    }
+
+    actual fun warn(tag: String, message: String) {
+        logger(tag).log(Level.WARNING, message)
+    }
+
+    actual fun error(tag: String, message: String, throwable: Throwable?) {
+        if (throwable != null) {
+            logger(tag).log(Level.SEVERE, message, throwable)
+        } else {
+            logger(tag).log(Level.SEVERE, message)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Completes the monitoring interface layer in \packages/core/\ with a facade, performance timer, and platform-specific logging. Closes #910.

### New Components

| File | Source Set | Description |
|------|-----------|-------------|
| \MonitoringFacade.kt\ | commonMain | Composes CrashReporter + MetricsCollector + SyncHealthMonitor |
| \PerformanceTimer.kt\ | commonMain | Duration measurement with kotlinx.datetime Clock |
| \PlatformLogger.kt\ | commonMain (expect) | Platform-agnostic log interface |
| \PlatformLogger.kt\ | jvmMain (actual) | java.util.logging (Android/Windows) |
| \PlatformLogger.kt\ | jsMain (actual) | console.log/info/warn/error (Web) |
| \PlatformLogger.kt\ | iosMain (actual) | NSLog (iOS) |

### MonitoringFacade API
- \ecordSyncSuccess(durationMs, recordCount)\ — updates health + metrics
- \ecordSyncFailure(exception?, durationMs)\ — updates health + metrics + crash reporter
- \ecordScreenView(screenName)\ / \ecordFeatureUsage(featureName)\
- \eportError(exception, context)\ / \logBreadcrumb(message)\
- \startTimer(operationName)\ — creates a \PerformanceTimer\
- \eset()\ — clears all state on sign-out

### Tests (5 test files, 65+ test cases)
- \MetricsCollectorTest\ — consent gating, event recording, flush, clear
- \SyncHealthMonitorTest\ — state transitions, thresholds, rolling averages, reset
- \HealthStatusTest\ — all boundary conditions, priority ordering
- \PerformanceTimerTest\ — measurement, single-stop semantics, live elapsed
- \MonitoringFacadeTest\ — composition, delegation, reset

Closes #910