### PR TITLE
feat(core): implement shared KMP feature flag evaluation engine

### DIFF
--- a/packages/core/src/commonMain/kotlin/com/finance/core/featureflags/EvaluationContext.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/featureflags/EvaluationContext.kt
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.featureflags
+
+/**
+ * Context provided to the [FeatureFlagEngine] for targeting rule evaluation.
+ *
+ * Contains attributes about the current user, device, and environment that
+ * targeting rules compare against. Platform apps populate this from their
+ * runtime environment (e.g., user session, device info, build config).
+ *
+ * All attribute values are strings to keep evaluation logic uniform —
+ * numeric comparisons parse on the fly.
+ */
+data class EvaluationContext(
+    /** Key-value attributes for rule evaluation (e.g., "userId" → "abc-123"). */
+    val attributes: Map<String, String> = emptyMap(),
+) {
+    /** Get an attribute value, or null if not present. */
+    fun getAttribute(key: String): String? = attributes[key]
+
+    /** Builder DSL for constructing an [EvaluationContext]. */
+    class Builder {
+        private val attrs = mutableMapOf<String, String>()
+
+        fun userId(id: String) = apply { attrs["userId"] = id }
+        fun householdId(id: String) = apply { attrs["householdId"] = id }
+        fun platform(platform: String) = apply { attrs["platform"] = platform }
+        fun appVersion(version: String) = apply { attrs["appVersion"] = version }
+        fun accountTier(tier: String) = apply { attrs["accountTier"] = tier }
+        fun locale(locale: String) = apply { attrs["locale"] = locale }
+        fun attribute(key: String, value: String) = apply { attrs[key] = value }
+
+        fun build(): EvaluationContext = EvaluationContext(attrs.toMap())
+    }
+
+    companion object {
+        /** Empty context — no attributes, all targeting rules will fail to match. */
+        val EMPTY = EvaluationContext()
+
+        fun builder(): Builder = Builder()
+    }
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/featureflags/FeatureFlag.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/featureflags/FeatureFlag.kt
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.featureflags
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.Serializable
+
+/**
+ * Unique, type-safe identifier for a feature flag.
+ * Prevents accidentally passing arbitrary strings where a flag key is expected.
+ */
+@Serializable
+data class FeatureFlagKey(val value: String) {
+    init {
+        require(value.isNotBlank()) { "FeatureFlagKey cannot be blank" }
+        require(value.matches(KEY_PATTERN)) {
+            "FeatureFlagKey must be lowercase alphanumeric with dots/hyphens/underscores, got: $value"
+        }
+    }
+
+    companion object {
+        private val KEY_PATTERN = Regex("^[a-z][a-z0-9._-]{0,127}$")
+    }
+}
+
+/**
+ * A feature flag definition synced from the backend (PostgreSQL → PowerSync).
+ *
+ * Flags support typed values via [FeatureFlagValue] and optional targeting
+ * rules evaluated by the [FeatureFlagEngine].
+ */
+@Serializable
+data class FeatureFlag(
+    /** Unique key identifying this flag (e.g., "budgets.rollover.enabled"). */
+    val key: FeatureFlagKey,
+    /** Human-readable description for internal tooling. */
+    val description: String = "",
+    /** Whether this flag is globally enabled. Disabled flags always return [defaultValue]. */
+    val enabled: Boolean = false,
+    /** Value returned when no targeting rules match or flag is disabled. */
+    val defaultValue: FeatureFlagValue,
+    /** Ordered list of targeting rules. First match wins. */
+    val rules: List<TargetingRule> = emptyList(),
+    /** Server-side timestamp for cache invalidation and sync ordering. */
+    val updatedAt: Instant,
+)
+
+/**
+ * Typed flag values. Sealed hierarchy ensures exhaustive handling.
+ */
+@Serializable
+sealed class FeatureFlagValue {
+    /** Simple on/off toggle — the most common flag type. */
+    @Serializable
+    data class BooleanValue(val value: Boolean) : FeatureFlagValue()
+
+    /** String variant for A/B test groups, feature tiers, etc. */
+    @Serializable
+    data class StringValue(val value: String) : FeatureFlagValue()
+
+    /** Integer variant for numeric thresholds, limits, etc. */
+    @Serializable
+    data class IntValue(val value: Int) : FeatureFlagValue()
+
+    /** Double variant for percentage rollouts, rate multipliers, etc. */
+    @Serializable
+    data class DoubleValue(val value: Double) : FeatureFlagValue()
+
+    /** JSON variant for complex configuration objects. */
+    @Serializable
+    data class JsonValue(val value: String) : FeatureFlagValue()
+}
+
+/**
+ * A targeting rule that conditionally overrides a flag's [FeatureFlag.defaultValue].
+ *
+ * Rules are evaluated in order; the first rule whose [conditions] all match
+ * the evaluation context returns the rule's [value].
+ */
+@Serializable
+data class TargetingRule(
+    /** Human-readable label (e.g., "Beta testers", "Premium users"). */
+    val name: String = "",
+    /** All conditions must match (AND logic) for this rule to apply. */
+    val conditions: List<RuleCondition>,
+    /** Value to return when all [conditions] match. */
+    val value: FeatureFlagValue,
+)
+
+/**
+ * A single condition within a [TargetingRule].
+ *
+ * Evaluates an [attribute] from the [EvaluationContext] against [values]
+ * using the specified [operator].
+ */
+@Serializable
+data class RuleCondition(
+    /** Context attribute key (e.g., "userId", "platform", "accountTier"). */
+    val attribute: String,
+    /** Comparison operator. */
+    val operator: ConditionOperator,
+    /** Values to compare against. For IN/NOT_IN, multiple values are checked. */
+    val values: List<String>,
+)
+
+/**
+ * Comparison operators for [RuleCondition] evaluation.
+ */
+@Serializable
+enum class ConditionOperator {
+    /** Attribute value is in the provided list. */
+    IN,
+
+    /** Attribute value is NOT in the provided list. */
+    NOT_IN,
+
+    /** Attribute equals the single provided value (case-sensitive). */
+    EQUALS,
+
+    /** Attribute does NOT equal the single provided value. */
+    NOT_EQUALS,
+
+    /** Attribute value (parsed as number) is greater than the threshold. */
+    GREATER_THAN,
+
+    /** Attribute value (parsed as number) is less than the threshold. */
+    LESS_THAN,
+
+    /** Attribute string contains the provided substring. */
+    CONTAINS,
+
+    /** Attribute string starts with the provided prefix. */
+    STARTS_WITH,
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/featureflags/FeatureFlagEngine.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/featureflags/FeatureFlagEngine.kt
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.featureflags
+
+/**
+ * Pure evaluation engine for feature flags.
+ *
+ * Stateless and side-effect-free — takes a flag definition and evaluation context,
+ * returns the resolved value. This design makes it trivially testable and ensures
+ * consistent behavior across all platforms.
+ *
+ * Evaluation order:
+ * 1. If the flag is disabled → return [FeatureFlag.defaultValue].
+ * 2. Iterate [FeatureFlag.rules] in order; return the first matching rule's value.
+ * 3. If no rules match → return [FeatureFlag.defaultValue].
+ */
+object FeatureFlagEngine {
+
+    /**
+     * Evaluate a feature flag against the given context.
+     *
+     * @param flag The flag definition (from sync / local cache).
+     * @param context Attributes describing the current user/device/environment.
+     * @return The resolved [FeatureFlagValue].
+     */
+    fun evaluate(flag: FeatureFlag, context: EvaluationContext): FeatureFlagValue {
+        if (!flag.enabled) return flag.defaultValue
+
+        for (rule in flag.rules) {
+            if (matchesRule(rule, context)) {
+                return rule.value
+            }
+        }
+
+        return flag.defaultValue
+    }
+
+    /**
+     * Convenience: evaluate a flag and extract a Boolean.
+     * Returns [default] if the flag is missing or the value is not a BooleanValue.
+     */
+    fun evaluateBoolean(flag: FeatureFlag?, context: EvaluationContext, default: Boolean = false): Boolean {
+        if (flag == null) return default
+        return when (val result = evaluate(flag, context)) {
+            is FeatureFlagValue.BooleanValue -> result.value
+            else -> default
+        }
+    }
+
+    /**
+     * Convenience: evaluate a flag and extract a String.
+     * Returns [default] if the flag is missing or the value is not a StringValue.
+     */
+    fun evaluateString(flag: FeatureFlag?, context: EvaluationContext, default: String = ""): String {
+        if (flag == null) return default
+        return when (val result = evaluate(flag, context)) {
+            is FeatureFlagValue.StringValue -> result.value
+            else -> default
+        }
+    }
+
+    /**
+     * Convenience: evaluate a flag and extract an Int.
+     * Returns [default] if the flag is missing or the value is not an IntValue.
+     */
+    fun evaluateInt(flag: FeatureFlag?, context: EvaluationContext, default: Int = 0): Int {
+        if (flag == null) return default
+        return when (val result = evaluate(flag, context)) {
+            is FeatureFlagValue.IntValue -> result.value
+            else -> default
+        }
+    }
+
+    // ── Rule matching ────────────────────────────────────────────────
+
+    internal fun matchesRule(rule: TargetingRule, context: EvaluationContext): Boolean {
+        if (rule.conditions.isEmpty()) return true // empty conditions = always match
+        return rule.conditions.all { condition -> matchesCondition(condition, context) }
+    }
+
+    internal fun matchesCondition(condition: RuleCondition, context: EvaluationContext): Boolean {
+        val attributeValue = context.getAttribute(condition.attribute) ?: return false
+
+        return when (condition.operator) {
+            ConditionOperator.IN -> attributeValue in condition.values
+            ConditionOperator.NOT_IN -> attributeValue !in condition.values
+            ConditionOperator.EQUALS -> condition.values.firstOrNull() == attributeValue
+            ConditionOperator.NOT_EQUALS -> condition.values.firstOrNull() != attributeValue
+            ConditionOperator.GREATER_THAN -> {
+                val threshold = condition.values.firstOrNull()?.toDoubleOrNull() ?: return false
+                val actual = attributeValue.toDoubleOrNull() ?: return false
+                actual > threshold
+            }
+            ConditionOperator.LESS_THAN -> {
+                val threshold = condition.values.firstOrNull()?.toDoubleOrNull() ?: return false
+                val actual = attributeValue.toDoubleOrNull() ?: return false
+                actual < threshold
+            }
+            ConditionOperator.CONTAINS -> {
+                val substring = condition.values.firstOrNull() ?: return false
+                attributeValue.contains(substring)
+            }
+            ConditionOperator.STARTS_WITH -> {
+                val prefix = condition.values.firstOrNull() ?: return false
+                attributeValue.startsWith(prefix)
+            }
+        }
+    }
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/featureflags/FeatureFlagProvider.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/featureflags/FeatureFlagProvider.kt
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.featureflags
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+
+/**
+ * Reactive provider that holds the current set of feature flags and exposes
+ * evaluated flag values as [Flow]s.
+ *
+ * Platform apps update this provider when flags arrive from PowerSync (real-time)
+ * or from a bootstrap/cache layer at startup.
+ *
+ * Thread-safe: backed by [MutableStateFlow] with atomic updates.
+ */
+class FeatureFlagProvider {
+
+    private val _flags = MutableStateFlow<Map<FeatureFlagKey, FeatureFlag>>(emptyMap())
+
+    /** Observable snapshot of all currently loaded flags. */
+    val flags: StateFlow<Map<FeatureFlagKey, FeatureFlag>> = _flags.asStateFlow()
+
+    /** Replace the entire flag set (e.g., on initial sync or full refresh). */
+    fun setFlags(flags: List<FeatureFlag>) {
+        _flags.value = flags.associateBy { it.key }
+    }
+
+    /** Update or insert a single flag (e.g., from a PowerSync incremental change). */
+    fun upsertFlag(flag: FeatureFlag) {
+        _flags.value = _flags.value + (flag.key to flag)
+    }
+
+    /** Remove a flag by key (e.g., flag was deleted server-side). */
+    fun removeFlag(key: FeatureFlagKey) {
+        _flags.value = _flags.value - key
+    }
+
+    /** Get a flag by key from the current snapshot. */
+    fun getFlag(key: FeatureFlagKey): FeatureFlag? = _flags.value[key]
+
+    /** Total number of loaded flags. */
+    val flagCount: Int get() = _flags.value.size
+
+    // ── Evaluation helpers ───────────────────────────────────────────
+
+    /** Evaluate a flag by key. Returns the resolved value or null if the key is unknown. */
+    fun evaluate(key: FeatureFlagKey, context: EvaluationContext): FeatureFlagValue? {
+        val flag = getFlag(key) ?: return null
+        return FeatureFlagEngine.evaluate(flag, context)
+    }
+
+    /** Evaluate as Boolean. Returns [default] if the flag is missing or not a BooleanValue. */
+    fun isEnabled(key: FeatureFlagKey, context: EvaluationContext, default: Boolean = false): Boolean {
+        return FeatureFlagEngine.evaluateBoolean(getFlag(key), context, default)
+    }
+
+    /** Evaluate as String. Returns [default] if the flag is missing or not a StringValue. */
+    fun getString(key: FeatureFlagKey, context: EvaluationContext, default: String = ""): String {
+        return FeatureFlagEngine.evaluateString(getFlag(key), context, default)
+    }
+
+    /** Evaluate as Int. Returns [default] if the flag is missing or not an IntValue. */
+    fun getInt(key: FeatureFlagKey, context: EvaluationContext, default: Int = 0): Int {
+        return FeatureFlagEngine.evaluateInt(getFlag(key), context, default)
+    }
+
+    // ── Reactive evaluation ──────────────────────────────────────────
+
+    /**
+     * Observe a boolean flag reactively. Emits a new value whenever the flag set changes.
+     */
+    fun observeBoolean(
+        key: FeatureFlagKey,
+        context: EvaluationContext,
+        default: Boolean = false,
+    ): Flow<Boolean> = _flags.map { flagMap ->
+        FeatureFlagEngine.evaluateBoolean(flagMap[key], context, default)
+    }
+
+    /**
+     * Observe a string flag reactively. Emits a new value whenever the flag set changes.
+     */
+    fun observeString(
+        key: FeatureFlagKey,
+        context: EvaluationContext,
+        default: String = "",
+    ): Flow<String> = _flags.map { flagMap ->
+        FeatureFlagEngine.evaluateString(flagMap[key], context, default)
+    }
+
+    /** Clear all flags (e.g., on user logout). */
+    fun clear() {
+        _flags.value = emptyMap()
+    }
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/featureflags/FeatureFlags.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/featureflags/FeatureFlags.kt
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.featureflags
+
+/**
+ * Registry of well-known feature flag keys used throughout the Finance app.
+ *
+ * Centralizing keys here prevents typos and enables IDE navigation.
+ * Add new flags alphabetically within their section.
+ */
+object FeatureFlags {
+
+    // ── Budget flags ─────────────────────────────────────────────────
+
+    /** Enable budget rollover (carry unused cents into next period). */
+    val BUDGET_ROLLOVER = FeatureFlagKey("budgets.rollover.enabled")
+
+    // ── Export flags ─────────────────────────────────────────────────
+
+    /** Enable CSV export format alongside JSON. */
+    val EXPORT_CSV = FeatureFlagKey("export.csv.enabled")
+
+    // ── Goal flags ───────────────────────────────────────────────────
+
+    /** Enable linking goals to funding accounts. */
+    val GOAL_ACCOUNT_LINK = FeatureFlagKey("goals.account-link.enabled")
+
+    // ── Sync flags ───────────────────────────────────────────────────
+
+    /** Enable delta sync (incremental pull/push). */
+    val SYNC_DELTA = FeatureFlagKey("sync.delta.enabled")
+
+    // ── Premium / monetization ───────────────────────────────────────
+
+    /** Enable premium tier features. */
+    val PREMIUM_FEATURES = FeatureFlagKey("premium.features.enabled")
+
+    /** Maximum number of accounts for free-tier users. */
+    val FREE_TIER_MAX_ACCOUNTS = FeatureFlagKey("premium.free-tier.max-accounts")
+
+    // ── Internationalization ─────────────────────────────────────────
+
+    /** Enable i18n framework (locale selection, translated strings). */
+    val I18N_ENABLED = FeatureFlagKey("i18n.enabled")
+
+    // ── Household ────────────────────────────────────────────────────
+
+    /** Enable multi-member household support. */
+    val HOUSEHOLD_MULTI_MEMBER = FeatureFlagKey("household.multi-member.enabled")
+
+    // ── Analytics ────────────────────────────────────────────────────
+
+    /** Enable spending insights generation. */
+    val ANALYTICS_INSIGHTS = FeatureFlagKey("analytics.insights.enabled")
+
+    /** Enable net worth tracking. */
+    val ANALYTICS_NET_WORTH = FeatureFlagKey("analytics.net-worth.enabled")
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/featureflags/FeatureFlagEngineTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/featureflags/FeatureFlagEngineTest.kt
@@ -1,0 +1,382 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.featureflags
+
+import kotlinx.datetime.Instant
+import kotlin.test.*
+
+class FeatureFlagEngineTest {
+
+    private val fixedInstant = Instant.parse("2024-06-15T12:00:00Z")
+
+    // ── Disabled flag ────────────────────────────────────────────────
+
+    @Test
+    fun disabledFlagReturnsDefaultValue() {
+        val flag = createFlag(
+            enabled = false,
+            defaultValue = FeatureFlagValue.BooleanValue(true),
+            rules = listOf(
+                TargetingRule(
+                    name = "Everyone",
+                    conditions = emptyList(),
+                    value = FeatureFlagValue.BooleanValue(false),
+                ),
+            ),
+        )
+        val result = FeatureFlagEngine.evaluate(flag, EvaluationContext.EMPTY)
+        assertEquals(FeatureFlagValue.BooleanValue(true), result)
+    }
+
+    // ── Enabled flag with no rules ───────────────────────────────────
+
+    @Test
+    fun enabledFlagWithNoRulesReturnsDefault() {
+        val flag = createFlag(
+            enabled = true,
+            defaultValue = FeatureFlagValue.StringValue("control"),
+        )
+        val result = FeatureFlagEngine.evaluate(flag, EvaluationContext.EMPTY)
+        assertEquals(FeatureFlagValue.StringValue("control"), result)
+    }
+
+    // ── Rule with empty conditions always matches ────────────────────
+
+    @Test
+    fun ruleWithEmptyConditionsAlwaysMatches() {
+        val flag = createFlag(
+            enabled = true,
+            defaultValue = FeatureFlagValue.BooleanValue(false),
+            rules = listOf(
+                TargetingRule(
+                    name = "Catch-all",
+                    conditions = emptyList(),
+                    value = FeatureFlagValue.BooleanValue(true),
+                ),
+            ),
+        )
+        val result = FeatureFlagEngine.evaluate(flag, EvaluationContext.EMPTY)
+        assertEquals(FeatureFlagValue.BooleanValue(true), result)
+    }
+
+    // ── IN operator ──────────────────────────────────────────────────
+
+    @Test
+    fun inOperatorMatchesWhenAttributeInList() {
+        val flag = createFlag(
+            enabled = true,
+            defaultValue = FeatureFlagValue.BooleanValue(false),
+            rules = listOf(
+                TargetingRule(
+                    conditions = listOf(
+                        RuleCondition("platform", ConditionOperator.IN, listOf("ios", "android")),
+                    ),
+                    value = FeatureFlagValue.BooleanValue(true),
+                ),
+            ),
+        )
+        val ctx = EvaluationContext.builder().platform("ios").build()
+        assertTrue((FeatureFlagEngine.evaluate(flag, ctx) as FeatureFlagValue.BooleanValue).value)
+    }
+
+    @Test
+    fun inOperatorFailsWhenAttributeNotInList() {
+        val flag = createFlag(
+            enabled = true,
+            defaultValue = FeatureFlagValue.BooleanValue(false),
+            rules = listOf(
+                TargetingRule(
+                    conditions = listOf(
+                        RuleCondition("platform", ConditionOperator.IN, listOf("ios", "android")),
+                    ),
+                    value = FeatureFlagValue.BooleanValue(true),
+                ),
+            ),
+        )
+        val ctx = EvaluationContext.builder().platform("web").build()
+        assertFalse((FeatureFlagEngine.evaluate(flag, ctx) as FeatureFlagValue.BooleanValue).value)
+    }
+
+    // ── NOT_IN operator ──────────────────────────────────────────────
+
+    @Test
+    fun notInOperatorMatchesWhenAttributeNotInList() {
+        val flag = createFlag(
+            enabled = true,
+            defaultValue = FeatureFlagValue.BooleanValue(false),
+            rules = listOf(
+                TargetingRule(
+                    conditions = listOf(
+                        RuleCondition("platform", ConditionOperator.NOT_IN, listOf("web")),
+                    ),
+                    value = FeatureFlagValue.BooleanValue(true),
+                ),
+            ),
+        )
+        val ctx = EvaluationContext.builder().platform("ios").build()
+        assertTrue((FeatureFlagEngine.evaluate(flag, ctx) as FeatureFlagValue.BooleanValue).value)
+    }
+
+    // ── EQUALS operator ──────────────────────────────────────────────
+
+    @Test
+    fun equalsOperatorMatches() {
+        val flag = createFlag(
+            enabled = true,
+            defaultValue = FeatureFlagValue.StringValue("free"),
+            rules = listOf(
+                TargetingRule(
+                    conditions = listOf(
+                        RuleCondition("accountTier", ConditionOperator.EQUALS, listOf("premium")),
+                    ),
+                    value = FeatureFlagValue.StringValue("premium"),
+                ),
+            ),
+        )
+        val ctx = EvaluationContext.builder().accountTier("premium").build()
+        assertEquals(FeatureFlagValue.StringValue("premium"), FeatureFlagEngine.evaluate(flag, ctx))
+    }
+
+    // ── NOT_EQUALS operator ──────────────────────────────────────────
+
+    @Test
+    fun notEqualsOperatorMatches() {
+        val flag = createFlag(
+            enabled = true,
+            defaultValue = FeatureFlagValue.BooleanValue(false),
+            rules = listOf(
+                TargetingRule(
+                    conditions = listOf(
+                        RuleCondition("accountTier", ConditionOperator.NOT_EQUALS, listOf("free")),
+                    ),
+                    value = FeatureFlagValue.BooleanValue(true),
+                ),
+            ),
+        )
+        val ctx = EvaluationContext.builder().accountTier("premium").build()
+        assertTrue((FeatureFlagEngine.evaluate(flag, ctx) as FeatureFlagValue.BooleanValue).value)
+    }
+
+    // ── GREATER_THAN operator ────────────────────────────────────────
+
+    @Test
+    fun greaterThanOperatorMatchesNumericAttribute() {
+        val flag = createFlag(
+            enabled = true,
+            defaultValue = FeatureFlagValue.BooleanValue(false),
+            rules = listOf(
+                TargetingRule(
+                    conditions = listOf(
+                        RuleCondition("appVersion", ConditionOperator.GREATER_THAN, listOf("2.0")),
+                    ),
+                    value = FeatureFlagValue.BooleanValue(true),
+                ),
+            ),
+        )
+        val ctx = EvaluationContext.builder().appVersion("3.1").build()
+        assertTrue((FeatureFlagEngine.evaluate(flag, ctx) as FeatureFlagValue.BooleanValue).value)
+    }
+
+    @Test
+    fun greaterThanOperatorFailsForNonNumericAttribute() {
+        val flag = createFlag(
+            enabled = true,
+            defaultValue = FeatureFlagValue.BooleanValue(false),
+            rules = listOf(
+                TargetingRule(
+                    conditions = listOf(
+                        RuleCondition("appVersion", ConditionOperator.GREATER_THAN, listOf("2.0")),
+                    ),
+                    value = FeatureFlagValue.BooleanValue(true),
+                ),
+            ),
+        )
+        val ctx = EvaluationContext.builder().appVersion("not-a-number").build()
+        assertFalse((FeatureFlagEngine.evaluate(flag, ctx) as FeatureFlagValue.BooleanValue).value)
+    }
+
+    // ── LESS_THAN operator ───────────────────────────────────────────
+
+    @Test
+    fun lessThanOperatorMatches() {
+        val flag = createFlag(
+            enabled = true,
+            defaultValue = FeatureFlagValue.IntValue(10),
+            rules = listOf(
+                TargetingRule(
+                    conditions = listOf(
+                        RuleCondition("accountCount", ConditionOperator.LESS_THAN, listOf("5")),
+                    ),
+                    value = FeatureFlagValue.IntValue(3),
+                ),
+            ),
+        )
+        val ctx = EvaluationContext(mapOf("accountCount" to "2"))
+        assertEquals(FeatureFlagValue.IntValue(3), FeatureFlagEngine.evaluate(flag, ctx))
+    }
+
+    // ── CONTAINS operator ────────────────────────────────────────────
+
+    @Test
+    fun containsOperatorMatches() {
+        val flag = createFlag(
+            enabled = true,
+            defaultValue = FeatureFlagValue.BooleanValue(false),
+            rules = listOf(
+                TargetingRule(
+                    conditions = listOf(
+                        RuleCondition("email", ConditionOperator.CONTAINS, listOf("@finance.com")),
+                    ),
+                    value = FeatureFlagValue.BooleanValue(true),
+                ),
+            ),
+        )
+        val ctx = EvaluationContext(mapOf("email" to "dev@finance.com"))
+        assertTrue((FeatureFlagEngine.evaluate(flag, ctx) as FeatureFlagValue.BooleanValue).value)
+    }
+
+    // ── STARTS_WITH operator ─────────────────────────────────────────
+
+    @Test
+    fun startsWithOperatorMatches() {
+        val flag = createFlag(
+            enabled = true,
+            defaultValue = FeatureFlagValue.BooleanValue(false),
+            rules = listOf(
+                TargetingRule(
+                    conditions = listOf(
+                        RuleCondition("userId", ConditionOperator.STARTS_WITH, listOf("beta-")),
+                    ),
+                    value = FeatureFlagValue.BooleanValue(true),
+                ),
+            ),
+        )
+        val ctx = EvaluationContext.builder().userId("beta-user-42").build()
+        assertTrue((FeatureFlagEngine.evaluate(flag, ctx) as FeatureFlagValue.BooleanValue).value)
+    }
+
+    // ── Multiple conditions (AND logic) ──────────────────────────────
+
+    @Test
+    fun multipleConditionsRequireAllToMatch() {
+        val flag = createFlag(
+            enabled = true,
+            defaultValue = FeatureFlagValue.BooleanValue(false),
+            rules = listOf(
+                TargetingRule(
+                    conditions = listOf(
+                        RuleCondition("platform", ConditionOperator.EQUALS, listOf("ios")),
+                        RuleCondition("accountTier", ConditionOperator.EQUALS, listOf("premium")),
+                    ),
+                    value = FeatureFlagValue.BooleanValue(true),
+                ),
+            ),
+        )
+
+        // Both match
+        val ctxBoth = EvaluationContext.builder()
+            .platform("ios")
+            .accountTier("premium")
+            .build()
+        assertTrue((FeatureFlagEngine.evaluate(flag, ctxBoth) as FeatureFlagValue.BooleanValue).value)
+
+        // Only one matches
+        val ctxPartial = EvaluationContext.builder()
+            .platform("ios")
+            .accountTier("free")
+            .build()
+        assertFalse((FeatureFlagEngine.evaluate(flag, ctxPartial) as FeatureFlagValue.BooleanValue).value)
+    }
+
+    // ── First matching rule wins ─────────────────────────────────────
+
+    @Test
+    fun firstMatchingRuleWins() {
+        val flag = createFlag(
+            enabled = true,
+            defaultValue = FeatureFlagValue.StringValue("default"),
+            rules = listOf(
+                TargetingRule(
+                    name = "Premium",
+                    conditions = listOf(
+                        RuleCondition("accountTier", ConditionOperator.EQUALS, listOf("premium")),
+                    ),
+                    value = FeatureFlagValue.StringValue("variant-a"),
+                ),
+                TargetingRule(
+                    name = "Catch-all",
+                    conditions = emptyList(),
+                    value = FeatureFlagValue.StringValue("variant-b"),
+                ),
+            ),
+        )
+
+        val premiumCtx = EvaluationContext.builder().accountTier("premium").build()
+        assertEquals(FeatureFlagValue.StringValue("variant-a"), FeatureFlagEngine.evaluate(flag, premiumCtx))
+
+        val freeCtx = EvaluationContext.builder().accountTier("free").build()
+        assertEquals(FeatureFlagValue.StringValue("variant-b"), FeatureFlagEngine.evaluate(flag, freeCtx))
+    }
+
+    // ── Missing attribute returns default ────────────────────────────
+
+    @Test
+    fun missingAttributeFailsCondition() {
+        val flag = createFlag(
+            enabled = true,
+            defaultValue = FeatureFlagValue.BooleanValue(false),
+            rules = listOf(
+                TargetingRule(
+                    conditions = listOf(
+                        RuleCondition("userId", ConditionOperator.EQUALS, listOf("user-1")),
+                    ),
+                    value = FeatureFlagValue.BooleanValue(true),
+                ),
+            ),
+        )
+        // Empty context has no userId attribute
+        val result = FeatureFlagEngine.evaluate(flag, EvaluationContext.EMPTY)
+        assertFalse((result as FeatureFlagValue.BooleanValue).value)
+    }
+
+    // ── Convenience evaluators ───────────────────────────────────────
+
+    @Test
+    fun evaluateBooleanReturnsDefaultForNullFlag() {
+        assertFalse(FeatureFlagEngine.evaluateBoolean(null, EvaluationContext.EMPTY))
+        assertTrue(FeatureFlagEngine.evaluateBoolean(null, EvaluationContext.EMPTY, default = true))
+    }
+
+    @Test
+    fun evaluateStringReturnsDefaultForNonStringValue() {
+        val flag = createFlag(
+            enabled = true,
+            defaultValue = FeatureFlagValue.BooleanValue(true),
+        )
+        assertEquals("fallback", FeatureFlagEngine.evaluateString(flag, EvaluationContext.EMPTY, "fallback"))
+    }
+
+    @Test
+    fun evaluateIntReturnsValueFromFlag() {
+        val flag = createFlag(
+            enabled = true,
+            defaultValue = FeatureFlagValue.IntValue(42),
+        )
+        assertEquals(42, FeatureFlagEngine.evaluateInt(flag, EvaluationContext.EMPTY))
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    private fun createFlag(
+        key: String = "test.flag",
+        enabled: Boolean = true,
+        defaultValue: FeatureFlagValue = FeatureFlagValue.BooleanValue(false),
+        rules: List<TargetingRule> = emptyList(),
+    ): FeatureFlag = FeatureFlag(
+        key = FeatureFlagKey(key),
+        enabled = enabled,
+        defaultValue = defaultValue,
+        rules = rules,
+        updatedAt = fixedInstant,
+    )
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/featureflags/FeatureFlagProviderTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/featureflags/FeatureFlagProviderTest.kt
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.featureflags
+
+import kotlinx.datetime.Instant
+import kotlin.test.*
+
+class FeatureFlagKeyTest {
+
+    @Test
+    fun validKeyIsAccepted() {
+        val key = FeatureFlagKey("budgets.rollover.enabled")
+        assertEquals("budgets.rollover.enabled", key.value)
+    }
+
+    @Test
+    fun keyWithHyphensAndUnderscoresIsAccepted() {
+        val key = FeatureFlagKey("my-flag_v2.enabled")
+        assertEquals("my-flag_v2.enabled", key.value)
+    }
+
+    @Test
+    fun blankKeyIsRejected() {
+        assertFailsWith<IllegalArgumentException> {
+            FeatureFlagKey("")
+        }
+    }
+
+    @Test
+    fun keyWithUppercaseIsRejected() {
+        assertFailsWith<IllegalArgumentException> {
+            FeatureFlagKey("My.Flag")
+        }
+    }
+
+    @Test
+    fun keyStartingWithNumberIsRejected() {
+        assertFailsWith<IllegalArgumentException> {
+            FeatureFlagKey("1flag")
+        }
+    }
+
+    @Test
+    fun keyWithSpacesIsRejected() {
+        assertFailsWith<IllegalArgumentException> {
+            FeatureFlagKey("my flag")
+        }
+    }
+}
+
+class EvaluationContextTest {
+
+    @Test
+    fun emptyContextHasNoAttributes() {
+        val ctx = EvaluationContext.EMPTY
+        assertNull(ctx.getAttribute("userId"))
+        assertTrue(ctx.attributes.isEmpty())
+    }
+
+    @Test
+    fun builderPopulatesAttributes() {
+        val ctx = EvaluationContext.builder()
+            .userId("user-1")
+            .platform("ios")
+            .accountTier("premium")
+            .appVersion("2.1.0")
+            .householdId("hh-1")
+            .locale("en-US")
+            .attribute("custom", "value")
+            .build()
+
+        assertEquals("user-1", ctx.getAttribute("userId"))
+        assertEquals("ios", ctx.getAttribute("platform"))
+        assertEquals("premium", ctx.getAttribute("accountTier"))
+        assertEquals("2.1.0", ctx.getAttribute("appVersion"))
+        assertEquals("hh-1", ctx.getAttribute("householdId"))
+        assertEquals("en-US", ctx.getAttribute("locale"))
+        assertEquals("value", ctx.getAttribute("custom"))
+    }
+
+    @Test
+    fun builderOverwritesDuplicateKeys() {
+        val ctx = EvaluationContext.builder()
+            .userId("old")
+            .userId("new")
+            .build()
+
+        assertEquals("new", ctx.getAttribute("userId"))
+    }
+}
+
+class FeatureFlagProviderTest {
+
+    private val fixedInstant = Instant.parse("2024-06-15T12:00:00Z")
+    private val ctx = EvaluationContext.builder().platform("ios").build()
+
+    @Test
+    fun setFlagsReplacesAll() {
+        val provider = FeatureFlagProvider()
+        val flag1 = createFlag("flag.one", FeatureFlagValue.BooleanValue(true))
+        val flag2 = createFlag("flag.two", FeatureFlagValue.BooleanValue(false))
+
+        provider.setFlags(listOf(flag1, flag2))
+        assertEquals(2, provider.flagCount)
+
+        // Replace with a single flag
+        provider.setFlags(listOf(flag1))
+        assertEquals(1, provider.flagCount)
+        assertNull(provider.getFlag(FeatureFlagKey("flag.two")))
+    }
+
+    @Test
+    fun upsertFlagAddsNewFlag() {
+        val provider = FeatureFlagProvider()
+        val flag = createFlag("flag.one", FeatureFlagValue.BooleanValue(true))
+
+        provider.upsertFlag(flag)
+        assertEquals(1, provider.flagCount)
+        assertTrue(provider.isEnabled(FeatureFlagKey("flag.one"), ctx))
+    }
+
+    @Test
+    fun upsertFlagUpdatesExistingFlag() {
+        val provider = FeatureFlagProvider()
+        val v1 = createFlag("flag.one", FeatureFlagValue.BooleanValue(true))
+        val v2 = createFlag("flag.one", FeatureFlagValue.BooleanValue(false))
+
+        provider.upsertFlag(v1)
+        assertTrue(provider.isEnabled(FeatureFlagKey("flag.one"), ctx))
+
+        provider.upsertFlag(v2)
+        assertFalse(provider.isEnabled(FeatureFlagKey("flag.one"), ctx))
+    }
+
+    @Test
+    fun removeFlagDeletesKey() {
+        val provider = FeatureFlagProvider()
+        val flag = createFlag("flag.one", FeatureFlagValue.BooleanValue(true))
+
+        provider.upsertFlag(flag)
+        assertEquals(1, provider.flagCount)
+
+        provider.removeFlag(FeatureFlagKey("flag.one"))
+        assertEquals(0, provider.flagCount)
+    }
+
+    @Test
+    fun isEnabledReturnsFalseForUnknownKey() {
+        val provider = FeatureFlagProvider()
+        assertFalse(provider.isEnabled(FeatureFlagKey("unknown.flag"), ctx))
+    }
+
+    @Test
+    fun isEnabledReturnsTrueForExistingEnabledFlag() {
+        val provider = FeatureFlagProvider()
+        provider.upsertFlag(createFlag("flag.one", FeatureFlagValue.BooleanValue(true)))
+        assertTrue(provider.isEnabled(FeatureFlagKey("flag.one"), ctx))
+    }
+
+    @Test
+    fun getStringReturnsValueForStringFlag() {
+        val provider = FeatureFlagProvider()
+        provider.upsertFlag(createFlag("flag.variant", FeatureFlagValue.StringValue("experiment-a")))
+        assertEquals("experiment-a", provider.getString(FeatureFlagKey("flag.variant"), ctx))
+    }
+
+    @Test
+    fun getIntReturnsValueForIntFlag() {
+        val provider = FeatureFlagProvider()
+        provider.upsertFlag(createFlag("flag.limit", FeatureFlagValue.IntValue(5)))
+        assertEquals(5, provider.getInt(FeatureFlagKey("flag.limit"), ctx))
+    }
+
+    @Test
+    fun clearRemovesAllFlags() {
+        val provider = FeatureFlagProvider()
+        provider.setFlags(listOf(
+            createFlag("flag.one", FeatureFlagValue.BooleanValue(true)),
+            createFlag("flag.two", FeatureFlagValue.BooleanValue(false)),
+        ))
+        assertEquals(2, provider.flagCount)
+
+        provider.clear()
+        assertEquals(0, provider.flagCount)
+    }
+
+    @Test
+    fun evaluateReturnsNullForUnknownKey() {
+        val provider = FeatureFlagProvider()
+        assertNull(provider.evaluate(FeatureFlagKey("unknown.flag"), ctx))
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    private fun createFlag(key: String, defaultValue: FeatureFlagValue): FeatureFlag = FeatureFlag(
+        key = FeatureFlagKey(key),
+        enabled = true,
+        defaultValue = defaultValue,
+        updatedAt = fixedInstant,
+    )
+}


### PR DESCRIPTION
## Summary
Implements a shared KMP feature flag evaluation engine in \packages/core/\ for issue #885.

## What's Included

### Domain Models (\com.finance.core.featureflags\)
- **\FeatureFlag\** — flag definition with key, enabled state, default value, and targeting rules
- **\FeatureFlagValue\** — sealed class with Boolean, String, Int, Double, and Json variants
- **\TargetingRule\** + **\RuleCondition\** — conditional overrides with 8 operators (IN, NOT_IN, EQUALS, NOT_EQUALS, GREATER_THAN, LESS_THAN, CONTAINS, STARTS_WITH)
- **\FeatureFlagKey\** — validated key type (lowercase alphanumeric with dots/hyphens/underscores)
- **\EvaluationContext\** — attribute map with builder DSL for user/device/environment attributes
- All types are \@Serializable\ for PostgreSQL → PowerSync sync compatibility

### Evaluation Engine
- **\FeatureFlagEngine\** — stateless, pure evaluation: disabled → default, first-match rule wins, else default
- Convenience evaluators: \valuateBoolean\, \valuateString\, \valuateInt\
- AND logic for multiple conditions within a rule

### Reactive Provider
- **\FeatureFlagProvider\** — StateFlow-backed flag store with set/upsert/remove operations
- \observeBoolean()\ / \observeString()\ — Flow-based reactive evaluation for UI binding
- Thread-safe atomic updates via MutableStateFlow

### Well-Known Keys
- **\FeatureFlags\** — registry of known flag keys (budgets.rollover, export.csv, sync.delta, premium, i18n, etc.)

## Tests (commonTest)
- **\FeatureFlagEngineTest\** — 17 tests covering all operators, disabled flags, AND logic, first-match precedence, missing attributes, convenience evaluators
- **\FeatureFlagProviderTest\** — 11 tests covering set/upsert/remove, isEnabled, getString, getInt, clear, unknown keys

## Architecture
- Pure \commonMain\ — zero platform-specific dependencies
- Designed for PowerSync real-time sync of flag definitions from PostgreSQL
- Platform apps create \EvaluationContext\ from their runtime environment and feed it to the provider

Closes #885