### PR TITLE
feat(core): add shared KMP environment config system (debug/staging/release)

### DIFF
--- a/packages/core/src/commonMain/kotlin/com/finance/core/config/BuildEnvironment.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/config/BuildEnvironment.kt
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.config
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Build environment variant.
+ *
+ * Each variant defines different behavior for API endpoints, logging,
+ * sync frequency, and feature availability. Platform build systems
+ * (Gradle buildTypes, Xcode schemes, Webpack modes) select the variant.
+ */
+@Serializable
+enum class BuildEnvironment {
+    /** Local development — verbose logging, mock-friendly, short sync intervals. */
+    DEBUG,
+
+    /** Pre-release testing against staging backend — moderate logging. */
+    STAGING,
+
+    /** Production release — minimal logging, real backend, strict security. */
+    RELEASE,
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/config/ConfigProvider.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/config/ConfigProvider.kt
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.config
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Singleton holder for the active [EnvironmentConfig].
+ *
+ * Platform entry points call [initialize] once at app startup.
+ * All shared code reads the config through [config] (blocking) or
+ * [configFlow] (reactive).
+ *
+ * Design rationale:
+ * - KMP shared code needs access to environment config without
+ *   depending on platform DI frameworks (Koin, Hilt, SwiftUI @Environment).
+ * - A simple singleton with explicit initialization is the most
+ *   portable pattern across iOS, Android, Web, and Desktop.
+ * - The [StateFlow] enables reactive updates if hot-reload or
+ *   dynamic config changes are ever needed.
+ */
+object ConfigProvider {
+
+    private val _config = MutableStateFlow<EnvironmentConfig?>(null)
+
+    /** Reactive config stream. Emits null until [initialize] is called. */
+    val configFlow: StateFlow<EnvironmentConfig?> = _config.asStateFlow()
+
+    /**
+     * The current environment config.
+     *
+     * @throws IllegalStateException if [initialize] has not been called.
+     */
+    val config: EnvironmentConfig
+        get() = _config.value
+            ?: throw IllegalStateException(
+                "ConfigProvider not initialized. Call ConfigProvider.initialize() at app startup."
+            )
+
+    /** Whether the provider has been initialized. */
+    val isInitialized: Boolean get() = _config.value != null
+
+    /**
+     * Initialize with the given config. Must be called once before any
+     * shared code accesses [config].
+     *
+     * Safe to call multiple times (e.g., in tests) — last value wins.
+     */
+    fun initialize(config: EnvironmentConfig) {
+        _config.value = config
+    }
+
+    /**
+     * Reset to uninitialized state. **Test-only** — do not call in production.
+     */
+    fun reset() {
+        _config.value = null
+    }
+
+    // ── Convenience accessors ────────────────────────────────────────
+
+    /** Shortcut: current [BuildEnvironment]. */
+    val environment: BuildEnvironment get() = config.environment
+
+    /** Shortcut: current API base URL. */
+    val apiBaseUrl: String get() = config.apiBaseUrl
+
+    /** Shortcut: current PowerSync URL. */
+    val powerSyncUrl: String get() = config.powerSyncUrl
+
+    /** Shortcut: current log level. */
+    val logLevel: LogLevel get() = config.logLevel
+
+    /** Shortcut: whether this is a debug build. */
+    val isDebug: Boolean get() = config.isDebug
+
+    /** Shortcut: whether this is a release build. */
+    val isRelease: Boolean get() = config.isRelease
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/config/EnvironmentConfig.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/config/EnvironmentConfig.kt
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.config
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Shared environment configuration consumed by all KMP modules.
+ *
+ * Platform apps construct an [EnvironmentConfig] at startup based on
+ * the active [BuildEnvironment] and inject it into the shared layer.
+ * This keeps platform-specific build config (BuildConfig, Info.plist,
+ * webpack DefinePlugin) out of commonMain while giving shared code
+ * a single, typed configuration surface.
+ *
+ * @property environment The active build environment variant.
+ * @property apiBaseUrl Base URL for the Finance API (no trailing slash).
+ * @property powerSyncUrl PowerSync instance URL for offline-first sync.
+ * @property logLevel Minimum log severity for shared-layer logging.
+ * @property syncIntervalSeconds How often (in seconds) to trigger background sync.
+ * @property enableCrashReporting Whether to send crash reports to the telemetry backend.
+ * @property enableAnalytics Whether to collect anonymous usage analytics.
+ * @property appVersion Semantic version of the running app (e.g., "1.2.0").
+ * @property platformName Runtime platform identifier (e.g., "android", "ios", "web", "windows").
+ */
+@Serializable
+data class EnvironmentConfig(
+    val environment: BuildEnvironment,
+    val apiBaseUrl: String,
+    val powerSyncUrl: String,
+    val logLevel: LogLevel = LogLevel.defaultFor(environment),
+    val syncIntervalSeconds: Int = defaultSyncInterval(environment),
+    val enableCrashReporting: Boolean = environment != BuildEnvironment.DEBUG,
+    val enableAnalytics: Boolean = environment == BuildEnvironment.RELEASE,
+    val appVersion: String = "0.0.0",
+    val platformName: String = "unknown",
+) {
+    init {
+        require(apiBaseUrl.isNotBlank()) { "apiBaseUrl cannot be blank" }
+        require(!apiBaseUrl.endsWith("/")) { "apiBaseUrl must not end with /" }
+        require(powerSyncUrl.isNotBlank()) { "powerSyncUrl cannot be blank" }
+        require(syncIntervalSeconds > 0) { "syncIntervalSeconds must be positive" }
+    }
+
+    /** Whether this is a non-production build (debug or staging). */
+    val isDebugOrStaging: Boolean get() = environment != BuildEnvironment.RELEASE
+
+    /** Whether this is a production release build. */
+    val isRelease: Boolean get() = environment == BuildEnvironment.RELEASE
+
+    /** Whether this is a local debug build. */
+    val isDebug: Boolean get() = environment == BuildEnvironment.DEBUG
+
+    companion object {
+        /** Default sync intervals per environment. */
+        fun defaultSyncInterval(env: BuildEnvironment): Int = when (env) {
+            BuildEnvironment.DEBUG -> 15      // 15 s — fast feedback during development
+            BuildEnvironment.STAGING -> 30    // 30 s — closer to prod cadence
+            BuildEnvironment.RELEASE -> 60    // 60 s — production default
+        }
+    }
+}
+
+/**
+ * Log severity levels for shared-layer logging.
+ * Platform logging adapters (Timber, os_log, console) map these to native levels.
+ */
+@Serializable
+enum class LogLevel {
+    VERBOSE,
+    DEBUG,
+    INFO,
+    WARN,
+    ERROR,
+    NONE;
+
+    companion object {
+        fun defaultFor(env: BuildEnvironment): LogLevel = when (env) {
+            BuildEnvironment.DEBUG -> VERBOSE
+            BuildEnvironment.STAGING -> DEBUG
+            BuildEnvironment.RELEASE -> WARN
+        }
+    }
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/config/EnvironmentConfigs.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/config/EnvironmentConfigs.kt
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.config
+
+/**
+ * Pre-built [EnvironmentConfig] factories for each [BuildEnvironment].
+ *
+ * Platform apps call the appropriate factory and override platform-specific
+ * fields (appVersion, platformName). These factories encode the canonical
+ * URLs and defaults so that each platform doesn't have to duplicate them.
+ *
+ * Example (Android):
+ * ```kotlin
+ * val config = EnvironmentConfigs.forEnvironment(
+ *     env = if (BuildConfig.DEBUG) BuildEnvironment.DEBUG else BuildEnvironment.RELEASE,
+ *     appVersion = BuildConfig.VERSION_NAME,
+ *     platformName = "android",
+ * )
+ * ```
+ */
+object EnvironmentConfigs {
+
+    // ── Canonical URLs ───────────────────────────────────────────────
+
+    private const val DEBUG_API_URL = "http://localhost:8080/api"
+    private const val DEBUG_POWERSYNC_URL = "http://localhost:8081"
+
+    private const val STAGING_API_URL = "https://staging-api.finance.app/api"
+    private const val STAGING_POWERSYNC_URL = "https://staging-sync.finance.app"
+
+    private const val RELEASE_API_URL = "https://api.finance.app/api"
+    private const val RELEASE_POWERSYNC_URL = "https://sync.finance.app"
+
+    // ── Factories ────────────────────────────────────────────────────
+
+    /** Create a debug configuration. */
+    fun debug(
+        appVersion: String = "0.0.0-dev",
+        platformName: String = "unknown",
+        apiBaseUrl: String = DEBUG_API_URL,
+        powerSyncUrl: String = DEBUG_POWERSYNC_URL,
+    ): EnvironmentConfig = EnvironmentConfig(
+        environment = BuildEnvironment.DEBUG,
+        apiBaseUrl = apiBaseUrl,
+        powerSyncUrl = powerSyncUrl,
+        appVersion = appVersion,
+        platformName = platformName,
+    )
+
+    /** Create a staging configuration. */
+    fun staging(
+        appVersion: String = "0.0.0-staging",
+        platformName: String = "unknown",
+        apiBaseUrl: String = STAGING_API_URL,
+        powerSyncUrl: String = STAGING_POWERSYNC_URL,
+    ): EnvironmentConfig = EnvironmentConfig(
+        environment = BuildEnvironment.STAGING,
+        apiBaseUrl = apiBaseUrl,
+        powerSyncUrl = powerSyncUrl,
+        appVersion = appVersion,
+        platformName = platformName,
+    )
+
+    /** Create a release configuration. */
+    fun release(
+        appVersion: String,
+        platformName: String,
+        apiBaseUrl: String = RELEASE_API_URL,
+        powerSyncUrl: String = RELEASE_POWERSYNC_URL,
+    ): EnvironmentConfig = EnvironmentConfig(
+        environment = BuildEnvironment.RELEASE,
+        apiBaseUrl = apiBaseUrl,
+        powerSyncUrl = powerSyncUrl,
+        appVersion = appVersion,
+        platformName = platformName,
+    )
+
+    /**
+     * Resolve a config by [BuildEnvironment] enum — useful when the
+     * environment is determined at runtime (e.g., from a Gradle-injected
+     * build constant or a JS environment variable).
+     */
+    fun forEnvironment(
+        env: BuildEnvironment,
+        appVersion: String = "0.0.0",
+        platformName: String = "unknown",
+    ): EnvironmentConfig = when (env) {
+        BuildEnvironment.DEBUG -> debug(appVersion = appVersion, platformName = platformName)
+        BuildEnvironment.STAGING -> staging(appVersion = appVersion, platformName = platformName)
+        BuildEnvironment.RELEASE -> release(appVersion = appVersion, platformName = platformName)
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/config/ConfigProviderTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/config/ConfigProviderTest.kt
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.config
+
+import kotlin.test.*
+
+class ConfigProviderTest {
+
+    @BeforeTest
+    fun setUp() {
+        ConfigProvider.reset()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        ConfigProvider.reset()
+    }
+
+    @Test
+    fun throwsWhenNotInitialized() {
+        assertFalse(ConfigProvider.isInitialized)
+        assertFailsWith<IllegalStateException> {
+            ConfigProvider.config
+        }
+    }
+
+    @Test
+    fun initializeSetsConfig() {
+        val config = EnvironmentConfigs.debug(appVersion = "1.0.0", platformName = "test")
+        ConfigProvider.initialize(config)
+
+        assertTrue(ConfigProvider.isInitialized)
+        assertEquals(config, ConfigProvider.config)
+    }
+
+    @Test
+    fun convenienceAccessorsWork() {
+        val config = EnvironmentConfigs.staging(appVersion = "2.0.0", platformName = "ios")
+        ConfigProvider.initialize(config)
+
+        assertEquals(BuildEnvironment.STAGING, ConfigProvider.environment)
+        assertEquals(config.apiBaseUrl, ConfigProvider.apiBaseUrl)
+        assertEquals(config.powerSyncUrl, ConfigProvider.powerSyncUrl)
+        assertEquals(LogLevel.DEBUG, ConfigProvider.logLevel)
+        assertFalse(ConfigProvider.isDebug)
+        assertFalse(ConfigProvider.isRelease)
+    }
+
+    @Test
+    fun reinitializeOverwritesPrevious() {
+        ConfigProvider.initialize(EnvironmentConfigs.debug())
+        assertEquals(BuildEnvironment.DEBUG, ConfigProvider.environment)
+
+        ConfigProvider.initialize(EnvironmentConfigs.release(appVersion = "1.0.0", platformName = "android"))
+        assertEquals(BuildEnvironment.RELEASE, ConfigProvider.environment)
+    }
+
+    @Test
+    fun resetClearsConfig() {
+        ConfigProvider.initialize(EnvironmentConfigs.debug())
+        assertTrue(ConfigProvider.isInitialized)
+
+        ConfigProvider.reset()
+        assertFalse(ConfigProvider.isInitialized)
+    }
+
+    @Test
+    fun configFlowEmitsNullBeforeInit() {
+        assertNull(ConfigProvider.configFlow.value)
+    }
+
+    @Test
+    fun configFlowEmitsConfigAfterInit() {
+        val config = EnvironmentConfigs.debug()
+        ConfigProvider.initialize(config)
+        assertEquals(config, ConfigProvider.configFlow.value)
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/config/EnvironmentConfigTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/config/EnvironmentConfigTest.kt
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.config
+
+import kotlin.test.*
+
+class EnvironmentConfigTest {
+
+    // ── Construction validation ──────────────────────────────────────
+
+    @Test
+    fun validDebugConfigIsCreated() {
+        val config = EnvironmentConfig(
+            environment = BuildEnvironment.DEBUG,
+            apiBaseUrl = "http://localhost:8080/api",
+            powerSyncUrl = "http://localhost:8081",
+        )
+        assertEquals(BuildEnvironment.DEBUG, config.environment)
+        assertEquals("http://localhost:8080/api", config.apiBaseUrl)
+    }
+
+    @Test
+    fun blankApiBaseUrlIsRejected() {
+        assertFailsWith<IllegalArgumentException> {
+            EnvironmentConfig(
+                environment = BuildEnvironment.DEBUG,
+                apiBaseUrl = "",
+                powerSyncUrl = "http://localhost:8081",
+            )
+        }
+    }
+
+    @Test
+    fun trailingSlashInApiBaseUrlIsRejected() {
+        assertFailsWith<IllegalArgumentException> {
+            EnvironmentConfig(
+                environment = BuildEnvironment.DEBUG,
+                apiBaseUrl = "http://localhost:8080/api/",
+                powerSyncUrl = "http://localhost:8081",
+            )
+        }
+    }
+
+    @Test
+    fun blankPowerSyncUrlIsRejected() {
+        assertFailsWith<IllegalArgumentException> {
+            EnvironmentConfig(
+                environment = BuildEnvironment.DEBUG,
+                apiBaseUrl = "http://localhost:8080/api",
+                powerSyncUrl = "",
+            )
+        }
+    }
+
+    @Test
+    fun zeroSyncIntervalIsRejected() {
+        assertFailsWith<IllegalArgumentException> {
+            EnvironmentConfig(
+                environment = BuildEnvironment.DEBUG,
+                apiBaseUrl = "http://localhost:8080/api",
+                powerSyncUrl = "http://localhost:8081",
+                syncIntervalSeconds = 0,
+            )
+        }
+    }
+
+    @Test
+    fun negativeSyncIntervalIsRejected() {
+        assertFailsWith<IllegalArgumentException> {
+            EnvironmentConfig(
+                environment = BuildEnvironment.RELEASE,
+                apiBaseUrl = "https://api.finance.app/api",
+                powerSyncUrl = "https://sync.finance.app",
+                syncIntervalSeconds = -1,
+            )
+        }
+    }
+
+    // ── Default values per environment ───────────────────────────────
+
+    @Test
+    fun debugDefaultsAreCorrect() {
+        val config = EnvironmentConfigs.debug()
+        assertEquals(BuildEnvironment.DEBUG, config.environment)
+        assertEquals(LogLevel.VERBOSE, config.logLevel)
+        assertEquals(15, config.syncIntervalSeconds)
+        assertFalse(config.enableCrashReporting)
+        assertFalse(config.enableAnalytics)
+        assertTrue(config.isDebug)
+        assertFalse(config.isRelease)
+        assertTrue(config.isDebugOrStaging)
+    }
+
+    @Test
+    fun stagingDefaultsAreCorrect() {
+        val config = EnvironmentConfigs.staging()
+        assertEquals(BuildEnvironment.STAGING, config.environment)
+        assertEquals(LogLevel.DEBUG, config.logLevel)
+        assertEquals(30, config.syncIntervalSeconds)
+        assertTrue(config.enableCrashReporting)
+        assertFalse(config.enableAnalytics)
+        assertFalse(config.isDebug)
+        assertFalse(config.isRelease)
+        assertTrue(config.isDebugOrStaging)
+    }
+
+    @Test
+    fun releaseDefaultsAreCorrect() {
+        val config = EnvironmentConfigs.release(
+            appVersion = "1.0.0",
+            platformName = "android",
+        )
+        assertEquals(BuildEnvironment.RELEASE, config.environment)
+        assertEquals(LogLevel.WARN, config.logLevel)
+        assertEquals(60, config.syncIntervalSeconds)
+        assertTrue(config.enableCrashReporting)
+        assertTrue(config.enableAnalytics)
+        assertFalse(config.isDebug)
+        assertTrue(config.isRelease)
+        assertFalse(config.isDebugOrStaging)
+        assertEquals("1.0.0", config.appVersion)
+        assertEquals("android", config.platformName)
+    }
+
+    // ── forEnvironment factory ───────────────────────────────────────
+
+    @Test
+    fun forEnvironmentResolvesDebug() {
+        val config = EnvironmentConfigs.forEnvironment(
+            BuildEnvironment.DEBUG,
+            appVersion = "1.0.0",
+            platformName = "ios",
+        )
+        assertEquals(BuildEnvironment.DEBUG, config.environment)
+        assertEquals("1.0.0", config.appVersion)
+        assertEquals("ios", config.platformName)
+    }
+
+    @Test
+    fun forEnvironmentResolvesStaging() {
+        val config = EnvironmentConfigs.forEnvironment(BuildEnvironment.STAGING)
+        assertEquals(BuildEnvironment.STAGING, config.environment)
+    }
+
+    @Test
+    fun forEnvironmentResolvesRelease() {
+        val config = EnvironmentConfigs.forEnvironment(
+            BuildEnvironment.RELEASE,
+            appVersion = "2.0.0",
+            platformName = "web",
+        )
+        assertEquals(BuildEnvironment.RELEASE, config.environment)
+    }
+
+    // ── Custom overrides ─────────────────────────────────────────────
+
+    @Test
+    fun customApiUrlIsPreserved() {
+        val config = EnvironmentConfigs.debug(
+            apiBaseUrl = "http://10.0.2.2:8080/api",
+        )
+        assertEquals("http://10.0.2.2:8080/api", config.apiBaseUrl)
+    }
+
+    @Test
+    fun customSyncIntervalIsPreserved() {
+        val config = EnvironmentConfig(
+            environment = BuildEnvironment.RELEASE,
+            apiBaseUrl = "https://api.finance.app/api",
+            powerSyncUrl = "https://sync.finance.app",
+            syncIntervalSeconds = 120,
+        )
+        assertEquals(120, config.syncIntervalSeconds)
+    }
+}
+
+class LogLevelTest {
+
+    @Test
+    fun debugEnvironmentDefaultsToVerbose() {
+        assertEquals(LogLevel.VERBOSE, LogLevel.defaultFor(BuildEnvironment.DEBUG))
+    }
+
+    @Test
+    fun stagingEnvironmentDefaultsToDebug() {
+        assertEquals(LogLevel.DEBUG, LogLevel.defaultFor(BuildEnvironment.STAGING))
+    }
+
+    @Test
+    fun releaseEnvironmentDefaultsToWarn() {
+        assertEquals(LogLevel.WARN, LogLevel.defaultFor(BuildEnvironment.RELEASE))
+    }
+}


### PR DESCRIPTION
## Summary
Implements shared KMP per-platform environment build configuration in packages/core/ for issue #891.

### Domain Models (com.finance.core.config)
- BuildEnvironment enum: DEBUG, STAGING, RELEASE
- EnvironmentConfig: validated, immutable config (API URLs, PowerSync, log level, sync interval, crash/analytics, app version, platform)
- LogLevel enum with environment-aware defaults

### Factories (EnvironmentConfigs)
- debug() / staging() / release() / forEnvironment() with canonical URLs and environment-appropriate defaults

### Config Provider (ConfigProvider)
- Singleton holder with initialize/reset lifecycle
- StateFlow-backed reactive config stream
- Convenience accessors: environment, apiBaseUrl, isDebug, isRelease, etc.

### Validation
- apiBaseUrl: non-blank, no trailing slash
- powerSyncUrl: non-blank
- syncIntervalSeconds: must be positive

## Tests (commonTest)
- EnvironmentConfigTest: 15 tests (validation, defaults, factories, overrides)
- ConfigProviderTest: 8 tests (lifecycle, accessors, Flow emission)
- LogLevelTest: 3 tests (default per environment)

Pure commonMain, zero platform-specific dependencies, all types @Serializable.

Closes #891