### PR TITLE
feat(windows): Windows 11 widget board integration (#928)

### DIFF
--- a/apps/windows/packaging/AppxManifest.xml
+++ b/apps/windows/packaging/AppxManifest.xml
@@ -13,6 +13,7 @@
     - https://learn.microsoft.com/windows/msix/
     - https://learn.microsoft.com/uwp/schemas/appxpackage/uapmanifestschema/schema-root
     - https://learn.microsoft.com/windows/apps/publish/store-policies
+    - https://learn.microsoft.com/windows/apps/design/widgets/
 -->
 <Package
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
@@ -20,7 +21,8 @@
   xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
-  IgnorableNamespaces="uap uap3 rescap desktop">
+  xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10"
+  IgnorableNamespaces="uap uap3 rescap desktop com">
 
   <Identity
     Name="${MSIX_PACKAGE_IDENTITY}"
@@ -89,6 +91,84 @@
           <desktop:ToastNotificationActivation
             ToastActivatorCLSID="d3b07384-d9a3-4e6b-af4a-3b6e2d5c1f8b" />
         </desktop:Extension>
+
+        <!-- Windows 11 Widget Board provider extensions -->
+        <com:Extension Category="windows.comServer">
+          <com:ComServer>
+            <com:ExeServer Executable="Finance.exe" DisplayName="Finance Widget Provider">
+              <com:Class Id="${WIDGET_PROVIDER_CLSID}" DisplayName="Finance Widget Provider" />
+            </com:ExeServer>
+          </com:ComServer>
+        </com:Extension>
+
+        <uap3:Extension Category="windows.appExtension">
+          <uap3:AppExtension
+            Name="com.microsoft.windows.widgets"
+            DisplayName="Finance Widgets"
+            Description="Financial overview widgets for the Windows 11 widget board"
+            Id="FinanceWidgetProvider">
+            <uap3:Properties>
+              <WidgetProvider>
+                <ProviderIcons>
+                  <Icon Path="assets\Square44x44Logo.png" />
+                </ProviderIcons>
+                <Activation>
+                  <CreateInstance ClassId="${WIDGET_PROVIDER_CLSID}" />
+                </Activation>
+                <Definitions>
+                  <Definition
+                    Id="com.finance.widget.networth"
+                    DisplayName="Net Worth"
+                    Description="At-a-glance net worth with today's and monthly spending.">
+                    <Capabilities>
+                      <Capability>
+                        <Size Name="small" />
+                        <Size Name="medium" />
+                      </Capability>
+                    </Capabilities>
+                    <ThemeResources>
+                      <Icons>
+                        <Icon Path="assets\widget-networth-light.png" />
+                      </Icons>
+                    </ThemeResources>
+                  </Definition>
+                  <Definition
+                    Id="com.finance.widget.budgets"
+                    DisplayName="Budget Overview"
+                    Description="Budget progress bars with health status indicators.">
+                    <Capabilities>
+                      <Capability>
+                        <Size Name="medium" />
+                        <Size Name="large" />
+                      </Capability>
+                    </Capabilities>
+                    <ThemeResources>
+                      <Icons>
+                        <Icon Path="assets\widget-budgets-light.png" />
+                      </Icons>
+                    </ThemeResources>
+                  </Definition>
+                  <Definition
+                    Id="com.finance.widget.transactions"
+                    DisplayName="Recent Transactions"
+                    Description="Last 5 transactions with amounts and dates.">
+                    <Capabilities>
+                      <Capability>
+                        <Size Name="medium" />
+                        <Size Name="large" />
+                      </Capability>
+                    </Capabilities>
+                    <ThemeResources>
+                      <Icons>
+                        <Icon Path="assets\widget-transactions-light.png" />
+                      </Icons>
+                    </ThemeResources>
+                  </Definition>
+                </Definitions>
+              </WidgetProvider>
+            </uap3:Properties>
+          </uap3:AppExtension>
+        </uap3:Extension>
       </Extensions>
     </Application>
   </Applications>

--- a/apps/windows/src/main/kotlin/com/finance/desktop/Main.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/Main.kt
@@ -12,6 +12,8 @@ import androidx.compose.ui.window.rememberWindowState
 import com.finance.desktop.components.rememberShortcutHandler
 import com.finance.desktop.di.appModules
 import com.finance.desktop.notifications.DesktopNotificationManager
+import com.finance.desktop.widgets.WidgetRegistrationManager
+import org.koin.core.context.GlobalContext
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 
@@ -21,6 +23,10 @@ fun main() {
     }
 
     DesktopNotificationManager.initialise()
+
+    // Initialise Windows 11 Widget Board integration
+    val widgetManager = GlobalContext.get().get<WidgetRegistrationManager>()
+    widgetManager.initialize()
 
     application {
         val windowState = rememberWindowState(
@@ -32,6 +38,7 @@ fun main() {
 
         Window(
             onCloseRequest = {
+                widgetManager.dispose()
                 DesktopNotificationManager.dispose()
                 stopKoin()
                 exitApplication()

--- a/apps/windows/src/main/kotlin/com/finance/desktop/di/PlatformModule.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/di/PlatformModule.kt
@@ -3,6 +3,9 @@
 package com.finance.desktop.di
 
 import com.finance.desktop.notifications.DesktopNotificationManager
+import com.finance.desktop.widgets.WidgetContentRenderer
+import com.finance.desktop.widgets.WidgetDataProvider
+import com.finance.desktop.widgets.WidgetRegistrationManager
 import org.koin.dsl.module
 
 /**
@@ -10,6 +13,9 @@ import org.koin.dsl.module
  *
  * Provides DI-managed access to:
  * - [DesktopNotificationManager] — Windows toast notifications via system tray
+ * - [WidgetDataProvider] — supplies financial data to Windows 11 widget board
+ * - [WidgetContentRenderer] — renders Adaptive Card JSON for widget display
+ * - [WidgetRegistrationManager] — manages widget lifecycle and registration
  *
  * The notification manager is provided as a singleton. Koin lifecycle
  * management ensures consistent access across all injection sites.
@@ -20,4 +26,9 @@ import org.koin.dsl.module
  */
 val platformModule = module {
     single { DesktopNotificationManager }
+
+    // ── Windows 11 Widget Board integration ──
+    single { WidgetDataProvider(get(), get(), get()) }
+    single { WidgetContentRenderer() }
+    single { WidgetRegistrationManager(get(), get()) }
 }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/di/ViewModelModule.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/di/ViewModelModule.kt
@@ -26,4 +26,5 @@ val viewModelModule = module {
     single { SyncViewModel(get()) }
     single { SettingsViewModel(get(), get()) }
     single { AuthViewModel(get(), get()) }
+    single { WidgetViewModel(get()) }
 }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/WidgetViewModel.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/WidgetViewModel.kt
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.viewmodel
+
+import com.finance.desktop.widgets.FinanceWidgetType
+import com.finance.desktop.widgets.WidgetRegistrationManager
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.util.logging.Level
+import java.util.logging.Logger
+
+/**
+ * UI state for widget management in the Settings screen.
+ */
+data class WidgetUiState(
+    val isPackaged: Boolean = false,
+    val widgets: List<WidgetInfo> = emptyList(),
+    val lastRefreshTimestamp: Long = 0L,
+    val isRefreshing: Boolean = false,
+    val errorMessage: String? = null,
+)
+
+/**
+ * Display information for a single widget type.
+ */
+data class WidgetInfo(
+    val type: FinanceWidgetType,
+    val displayName: String,
+    val description: String,
+    val hasContent: Boolean,
+)
+
+/**
+ * ViewModel for Windows 11 Widget Board integration.
+ *
+ * Exposes the registration status of each widget type and provides
+ * actions to refresh widget content on demand. Consumed by the Settings
+ * screen to show widget status and a "Refresh Widgets" button.
+ */
+class WidgetViewModel(
+    private val widgetManager: WidgetRegistrationManager,
+) : DesktopViewModel() {
+
+    companion object {
+        private val logger: Logger = Logger.getLogger(WidgetViewModel::class.java.name)
+    }
+
+    private val _uiState = MutableStateFlow(WidgetUiState())
+    val uiState: StateFlow<WidgetUiState> = _uiState.asStateFlow()
+
+    init {
+        loadWidgetStatus()
+    }
+
+    /**
+     * Triggers a refresh of all widget Adaptive Card content.
+     */
+    fun refreshWidgets() {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isRefreshing = true, errorMessage = null)
+            try {
+                widgetManager.refreshAllWidgets()
+                _uiState.value = _uiState.value.copy(
+                    isRefreshing = false,
+                    lastRefreshTimestamp = System.currentTimeMillis(),
+                    widgets = buildWidgetInfoList(),
+                )
+            } catch (e: Exception) {
+                logger.log(Level.SEVERE, "Widget refresh failed", e)
+                _uiState.value = _uiState.value.copy(
+                    isRefreshing = false,
+                    errorMessage = "Failed to refresh widgets: ${e.message}",
+                )
+            }
+        }
+    }
+
+    fun clearError() {
+        _uiState.value = _uiState.value.copy(errorMessage = null)
+    }
+
+    private fun loadWidgetStatus() {
+        _uiState.value = WidgetUiState(
+            isPackaged = widgetManager.isPackagedApp,
+            widgets = buildWidgetInfoList(),
+        )
+    }
+
+    private fun buildWidgetInfoList(): List<WidgetInfo> {
+        return widgetManager.getRegisteredWidgets().map { type ->
+            WidgetInfo(
+                type = type,
+                displayName = type.displayName,
+                description = type.description,
+                hasContent = widgetManager.getWidgetContent(type) != null,
+            )
+        }
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/widgets/WidgetContentRenderer.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/widgets/WidgetContentRenderer.kt
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.widgets
+
+import com.finance.core.budget.BudgetHealth
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import java.util.logging.Logger
+
+/**
+ * Renders [WidgetData] into Windows 11 Adaptive Card JSON payloads.
+ *
+ * Windows 11 Widgets use Adaptive Cards (https://adaptivecards.io) as their
+ * rendering format. This renderer produces JSON strings conforming to the
+ * Adaptive Card schema v1.5, which is the version supported by the Windows 11
+ * Widget Board.
+ *
+ * ## Widget Types
+ *
+ * Three widget layouts are supported:
+ * - **Net Worth Summary**: Headline net-worth figure with today/monthly spending
+ * - **Budget Overview**: Up to 4 budget progress bars with health indicators
+ * - **Recent Transactions**: Last 5 transactions with amount and date
+ *
+ * Each template includes accessible `"fallbackText"` fields for screen readers
+ * and an `"altText"` on graphical elements for Narrator compatibility.
+ *
+ * @see WidgetDataProvider for the data source
+ * @see WidgetRegistrationManager for COM server registration
+ */
+class WidgetContentRenderer {
+
+    companion object {
+        private val logger: Logger = Logger.getLogger(WidgetContentRenderer::class.java.name)
+
+        /** Adaptive Card schema version supported by Windows 11 Widgets. */
+        private const val SCHEMA_VERSION = "1.5"
+
+        private const val SCHEMA_URL = "http://adaptivecards.io/schemas/adaptive-card.json"
+    }
+
+    /**
+     * Renders the **Net Worth Summary** widget card.
+     *
+     * Layout:
+     * ```
+     * ┌─────────────────────────┐
+     * │ Finance                 │
+     * │ Net Worth: $XX,XXX.XX   │
+     * │ Today: $X,XXX.XX        │
+     * │ This Month: $X,XXX.XX   │
+     * │ Updated at HH:MM        │
+     * └─────────────────────────┘
+     * ```
+     */
+    fun renderNetWorthCard(data: WidgetData): String {
+        val card = JsonObject(
+            mapOf(
+                "\$schema" to JsonPrimitive(SCHEMA_URL),
+                "type" to JsonPrimitive("AdaptiveCard"),
+                "version" to JsonPrimitive(SCHEMA_VERSION),
+                "fallbackText" to JsonPrimitive(
+                    "Net Worth: ${data.netWorthFormatted}. " +
+                        "Today spending: ${data.todaySpendingFormatted}. " +
+                        "Monthly spending: ${data.monthlySpendingFormatted}.",
+                ),
+                "body" to JsonArray(
+                    listOf(
+                        textBlock("Finance", "Large", "Bolder"),
+                        textBlock("Net Worth", "Small", "Default", true),
+                        textBlock(data.netWorthFormatted, "ExtraLarge", "Bolder"),
+                        columnSet(
+                            column(
+                                "Today",
+                                data.todaySpendingFormatted,
+                            ),
+                            column(
+                                "This Month",
+                                data.monthlySpendingFormatted,
+                            ),
+                        ),
+                        textBlock(data.lastUpdated, "Small", "Lighter", isSubtle = true),
+                    ),
+                ),
+            ),
+        )
+        return card.toString()
+    }
+
+    /**
+     * Renders the **Budget Overview** widget card.
+     *
+     * Shows up to 4 budgets with progress indicators and health colors.
+     */
+    fun renderBudgetOverviewCard(data: WidgetData): String {
+        val budgetItems = data.budgetSummaries.map { budget ->
+            val color = when (budget.health) {
+                BudgetHealth.HEALTHY -> "Good"
+                BudgetHealth.WARNING -> "Warning"
+                BudgetHealth.OVER -> "Attention"
+            }
+            JsonObject(
+                mapOf(
+                    "type" to JsonPrimitive("Container"),
+                    "items" to JsonArray(
+                        listOf(
+                            JsonObject(
+                                mapOf(
+                                    "type" to JsonPrimitive("ColumnSet"),
+                                    "columns" to JsonArray(
+                                        listOf(
+                                            JsonObject(
+                                                mapOf(
+                                                    "type" to JsonPrimitive("Column"),
+                                                    "width" to JsonPrimitive("stretch"),
+                                                    "items" to JsonArray(
+                                                        listOf(
+                                                            textBlock(budget.name, "Default", "Bolder"),
+                                                        ),
+                                                    ),
+                                                ),
+                                            ),
+                                            JsonObject(
+                                                mapOf(
+                                                    "type" to JsonPrimitive("Column"),
+                                                    "width" to JsonPrimitive("auto"),
+                                                    "items" to JsonArray(
+                                                        listOf(
+                                                            textBlock(
+                                                                "${budget.spentFormatted} / ${budget.limitFormatted}",
+                                                                "Small",
+                                                                "Default",
+                                                            ),
+                                                        ),
+                                                    ),
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                            JsonObject(
+                                mapOf(
+                                    "type" to JsonPrimitive("TextBlock"),
+                                    "text" to JsonPrimitive("${budget.utilizationPercent}%"),
+                                    "size" to JsonPrimitive("Small"),
+                                    "color" to JsonPrimitive(color),
+                                    "altText" to JsonPrimitive(
+                                        "${budget.name} budget: ${budget.utilizationPercent}% used, " +
+                                            "${budget.spentFormatted} of ${budget.limitFormatted}",
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                    "separator" to JsonPrimitive(true),
+                ),
+            )
+        }
+
+        val card = JsonObject(
+            mapOf(
+                "\$schema" to JsonPrimitive(SCHEMA_URL),
+                "type" to JsonPrimitive("AdaptiveCard"),
+                "version" to JsonPrimitive(SCHEMA_VERSION),
+                "fallbackText" to JsonPrimitive(
+                    "Budget Overview: " + data.budgetSummaries.joinToString(". ") {
+                        "${it.name}: ${it.utilizationPercent}% used"
+                    },
+                ),
+                "body" to JsonArray(
+                    listOf(
+                        textBlock("Finance — Budgets", "Large", "Bolder"),
+                    ) + budgetItems + listOf(
+                        textBlock(data.lastUpdated, "Small", "Lighter", isSubtle = true),
+                    ),
+                ),
+            ),
+        )
+        return card.toString()
+    }
+
+    /**
+     * Renders the **Recent Transactions** widget card.
+     *
+     * Shows the last 5 transactions with description, amount, and date.
+     */
+    fun renderRecentTransactionsCard(data: WidgetData): String {
+        val txItems = data.recentTransactions.map { tx ->
+            val amountColor = if (tx.isExpense) "Attention" else "Good"
+            JsonObject(
+                mapOf(
+                    "type" to JsonPrimitive("ColumnSet"),
+                    "columns" to JsonArray(
+                        listOf(
+                            JsonObject(
+                                mapOf(
+                                    "type" to JsonPrimitive("Column"),
+                                    "width" to JsonPrimitive("stretch"),
+                                    "items" to JsonArray(
+                                        listOf(
+                                            textBlock(tx.description, "Default", "Default"),
+                                            textBlock(tx.dateFormatted, "Small", "Lighter", isSubtle = true),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                            JsonObject(
+                                mapOf(
+                                    "type" to JsonPrimitive("Column"),
+                                    "width" to JsonPrimitive("auto"),
+                                    "verticalContentAlignment" to JsonPrimitive("Center"),
+                                    "items" to JsonArray(
+                                        listOf(
+                                            JsonObject(
+                                                mapOf(
+                                                    "type" to JsonPrimitive("TextBlock"),
+                                                    "text" to JsonPrimitive(tx.amountFormatted),
+                                                    "color" to JsonPrimitive(amountColor),
+                                                    "weight" to JsonPrimitive("Bolder"),
+                                                    "altText" to JsonPrimitive(
+                                                        "${tx.description}: ${tx.amountFormatted} on ${tx.dateFormatted}",
+                                                    ),
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                    "separator" to JsonPrimitive(true),
+                ),
+            )
+        }
+
+        val card = JsonObject(
+            mapOf(
+                "\$schema" to JsonPrimitive(SCHEMA_URL),
+                "type" to JsonPrimitive("AdaptiveCard"),
+                "version" to JsonPrimitive(SCHEMA_VERSION),
+                "fallbackText" to JsonPrimitive(
+                    "Recent Transactions: " + data.recentTransactions.joinToString(". ") {
+                        "${it.description}: ${it.amountFormatted}"
+                    },
+                ),
+                "body" to JsonArray(
+                    listOf(
+                        textBlock("Finance — Transactions", "Large", "Bolder"),
+                    ) + txItems + listOf(
+                        textBlock(data.lastUpdated, "Small", "Lighter", isSubtle = true),
+                    ),
+                ),
+            ),
+        )
+        return card.toString()
+    }
+
+    // ── Adaptive Card JSON helpers ──────────────────────────────────────────
+
+    private fun textBlock(
+        text: String,
+        size: String,
+        weight: String,
+        isSubtle: Boolean = false,
+    ): JsonObject {
+        val map = mutableMapOf(
+            "type" to JsonPrimitive("TextBlock"),
+            "text" to JsonPrimitive(text),
+            "size" to JsonPrimitive(size),
+            "weight" to JsonPrimitive(weight),
+            "wrap" to JsonPrimitive(true),
+        )
+        if (isSubtle) {
+            map["isSubtle"] = JsonPrimitive(true)
+        }
+        return JsonObject(map)
+    }
+
+    private fun columnSet(vararg columns: JsonObject): JsonObject {
+        return JsonObject(
+            mapOf(
+                "type" to JsonPrimitive("ColumnSet"),
+                "columns" to JsonArray(columns.toList()),
+            ),
+        )
+    }
+
+    private fun column(label: String, value: String): JsonObject {
+        return JsonObject(
+            mapOf(
+                "type" to JsonPrimitive("Column"),
+                "width" to JsonPrimitive("stretch"),
+                "items" to JsonArray(
+                    listOf(
+                        textBlock(label, "Small", "Default", isSubtle = true),
+                        textBlock(value, "Medium", "Bolder"),
+                    ),
+                ),
+            ),
+        )
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/widgets/WidgetDataProvider.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/widgets/WidgetDataProvider.kt
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.widgets
+
+import com.finance.core.aggregation.FinancialAggregator
+import com.finance.core.budget.BudgetCalculator
+import com.finance.core.budget.BudgetHealth
+import com.finance.core.currency.CurrencyFormatter
+import com.finance.desktop.data.repository.AccountRepository
+import com.finance.desktop.data.repository.BudgetRepository
+import com.finance.desktop.data.repository.TransactionRepository
+import com.finance.models.Transaction
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+import kotlinx.coroutines.flow.first
+import kotlinx.datetime.Clock
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import java.util.logging.Level
+import java.util.logging.Logger
+
+/**
+ * Snapshot of financial data prepared for widget rendering.
+ *
+ * Each field is pre-formatted for display — widgets should not perform
+ * calculations or formatting themselves.
+ */
+data class WidgetData(
+    val netWorthFormatted: String = "",
+    val todaySpendingFormatted: String = "",
+    val monthlySpendingFormatted: String = "",
+    val budgetSummaries: List<WidgetBudgetSummary> = emptyList(),
+    val recentTransactions: List<WidgetTransaction> = emptyList(),
+    val lastUpdated: String = "",
+)
+
+/**
+ * Budget status formatted for widget display.
+ */
+data class WidgetBudgetSummary(
+    val name: String,
+    val spentFormatted: String,
+    val limitFormatted: String,
+    val utilizationPercent: Int,
+    val health: BudgetHealth,
+)
+
+/**
+ * Transaction summary formatted for widget display.
+ */
+data class WidgetTransaction(
+    val description: String,
+    val amountFormatted: String,
+    val dateFormatted: String,
+    val isExpense: Boolean,
+)
+
+/**
+ * Aggregates financial data from repositories into [WidgetData] snapshots
+ * suitable for rendering in Windows 11 Widget Board Adaptive Cards.
+ *
+ * This provider bridges the app's repository layer with the widget rendering
+ * pipeline. It performs the same aggregation as [DashboardViewModel] but
+ * returns a lightweight, pre-formatted data object instead of a full UI state.
+ *
+ * ## Thread Safety
+ *
+ * All methods are suspend functions safe to call from any coroutine context.
+ * Repository access is delegated to the thread-safe repository implementations.
+ */
+class WidgetDataProvider(
+    private val accountRepository: AccountRepository,
+    private val transactionRepository: TransactionRepository,
+    private val budgetRepository: BudgetRepository,
+) {
+    companion object {
+        private val logger: Logger = Logger.getLogger(WidgetDataProvider::class.java.name)
+
+        /** Maximum number of recent transactions shown in the widget. */
+        private const val MAX_RECENT_TRANSACTIONS = 5
+
+        /** Maximum number of budget summaries shown in the widget. */
+        private const val MAX_BUDGET_SUMMARIES = 4
+    }
+
+    /**
+     * Fetches and aggregates current financial data into a [WidgetData] snapshot.
+     *
+     * Returns a snapshot with empty/default values if any repository operation
+     * fails, ensuring the widget always has something to render.
+     */
+    suspend fun fetchWidgetData(): WidgetData {
+        return try {
+            val hid = SyncId("d1")
+            val currency = Currency.USD
+            val now = Clock.System.now()
+            val today = now.toLocalDateTime(TimeZone.currentSystemDefault()).date
+
+            val accounts = accountRepository.observeAll(hid).first()
+            val transactions = transactionRepository.observeAll(hid).first()
+            val budgets = budgetRepository.observeAll(hid).first()
+
+            val netWorth = FinancialAggregator.netWorth(accounts)
+            val todaySpending = FinancialAggregator.totalSpending(transactions, today, today)
+            val monthStart = LocalDate(today.year, today.month, 1)
+            val monthlySpending = FinancialAggregator.totalSpending(transactions, monthStart, today)
+
+            val budgetSummaries = budgets.take(MAX_BUDGET_SUMMARIES).map { budget ->
+                val catTxns = transactions.filter { it.categoryId == budget.categoryId }
+                val status = BudgetCalculator.calculateStatus(budget, catTxns, today)
+                WidgetBudgetSummary(
+                    name = budget.name,
+                    spentFormatted = CurrencyFormatter.format(status.spent, currency),
+                    limitFormatted = CurrencyFormatter.format(budget.amount, currency),
+                    utilizationPercent = (status.utilization * 100).toInt().coerceIn(0, 150),
+                    health = status.healthLevel,
+                )
+            }
+
+            val recentTransactions = transactions
+                .sortedByDescending { it.date }
+                .take(MAX_RECENT_TRANSACTIONS)
+                .map { tx -> tx.toWidgetTransaction(currency) }
+
+            val timeFormatted = "%02d:%02d".format(
+                now.toLocalDateTime(TimeZone.currentSystemDefault()).hour,
+                now.toLocalDateTime(TimeZone.currentSystemDefault()).minute,
+            )
+
+            WidgetData(
+                netWorthFormatted = CurrencyFormatter.format(netWorth, currency),
+                todaySpendingFormatted = CurrencyFormatter.format(todaySpending, currency),
+                monthlySpendingFormatted = CurrencyFormatter.format(monthlySpending, currency),
+                budgetSummaries = budgetSummaries,
+                recentTransactions = recentTransactions,
+                lastUpdated = "Updated at $timeFormatted",
+            )
+        } catch (e: Exception) {
+            logger.log(Level.WARNING, "Failed to fetch widget data — returning defaults", e)
+            WidgetData(lastUpdated = "Update failed")
+        }
+    }
+}
+
+/**
+ * Maps a [Transaction] to a [WidgetTransaction] for display.
+ */
+private fun Transaction.toWidgetTransaction(currency: Currency): WidgetTransaction {
+    val isExpense = amount.isNegative()
+    return WidgetTransaction(
+        description = (payee ?: note ?: "Transaction").take(40),
+        amountFormatted = CurrencyFormatter.format(amount, currency),
+        dateFormatted = date.toString(),
+        isExpense = isExpense,
+    )
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/widgets/WidgetRegistrationManager.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/widgets/WidgetRegistrationManager.kt
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.widgets
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.util.logging.Level
+import java.util.logging.Logger
+
+/**
+ * Describes a Finance widget type that can be registered with the
+ * Windows 11 Widget Board.
+ *
+ * @property id Unique widget identifier used in the MSIX manifest.
+ * @property displayName Human-readable name shown in the widget picker.
+ * @property description Brief description for the widget gallery.
+ */
+enum class FinanceWidgetType(
+    val id: String,
+    val displayName: String,
+    val description: String,
+) {
+    NET_WORTH(
+        id = "com.finance.widget.networth",
+        displayName = "Net Worth",
+        description = "At-a-glance net worth with today's and monthly spending.",
+    ),
+    BUDGET_OVERVIEW(
+        id = "com.finance.widget.budgets",
+        displayName = "Budget Overview",
+        description = "Budget progress bars with health status indicators.",
+    ),
+    RECENT_TRANSACTIONS(
+        id = "com.finance.widget.transactions",
+        displayName = "Recent Transactions",
+        description = "Last 5 transactions with amounts and dates.",
+    ),
+}
+
+/**
+ * Manages the lifecycle of Windows 11 Widget Board widget registration.
+ *
+ * Windows 11 widgets are registered through the MSIX package manifest
+ * (`AppxManifest.xml`) using the `com.microsoft.windows.widgets` extension.
+ * The actual COM server activation is handled by the OS widget host — this
+ * manager provides:
+ *
+ * 1. **Registration status checks** — verifies whether the MSIX manifest
+ *    declares the widget provider extension
+ * 2. **Widget content updates** — coordinates between [WidgetDataProvider]
+ *    and [WidgetContentRenderer] to produce updated Adaptive Card JSON
+ * 3. **Lifecycle hooks** — called from [Main.kt] on app start/stop to
+ *    ensure widgets show fresh data
+ *
+ * ## MSIX Requirement
+ *
+ * Full widget board integration requires the application to be packaged as
+ * MSIX with the widget provider extension declared. When running unpackaged
+ * (during development), this manager operates in a degraded mode and logs
+ * a warning.
+ *
+ * @see WidgetDataProvider for data aggregation
+ * @see WidgetContentRenderer for Adaptive Card JSON rendering
+ */
+class WidgetRegistrationManager(
+    private val dataProvider: WidgetDataProvider,
+    private val renderer: WidgetContentRenderer,
+) {
+    companion object {
+        private val logger: Logger =
+            Logger.getLogger(WidgetRegistrationManager::class.java.name)
+    }
+
+    /** Cached widget content for each widget type. */
+    private val widgetContentCache = mutableMapOf<FinanceWidgetType, String>()
+
+    /**
+     * Whether the application is running as a packaged MSIX with widget
+     * support declared.
+     *
+     * Heuristic: checks for the `MSIX_PACKAGE_NAME` environment variable
+     * set during MSIX execution context, or the Windows identity API.
+     */
+    val isPackagedApp: Boolean
+        get() = System.getenv("MSIX_PACKAGE_NAME") != null ||
+            System.getProperty("msix.packaged") == "true"
+
+    /**
+     * Initialises the widget manager.
+     *
+     * Call once during application startup. If the app is packaged, this
+     * refreshes all widget content. If unpackaged, it logs a debug message
+     * and skips registration.
+     */
+    fun initialize() {
+        if (!isPackagedApp) {
+            logger.info(
+                "Running unpackaged — widget board integration is inactive. " +
+                    "Package as MSIX to enable Windows 11 widgets.",
+            )
+            return
+        }
+
+        logger.info("Widget manager initialising for packaged app")
+        CoroutineScope(Dispatchers.IO).launch {
+            refreshAllWidgets()
+        }
+    }
+
+    /**
+     * Refreshes the Adaptive Card content for all widget types.
+     *
+     * This is a suspend function because it reads from repositories.
+     * The resulting JSON is cached so the widget host can retrieve it
+     * synchronously via the COM callback.
+     */
+    suspend fun refreshAllWidgets() {
+        try {
+            val data = dataProvider.fetchWidgetData()
+
+            widgetContentCache[FinanceWidgetType.NET_WORTH] =
+                renderer.renderNetWorthCard(data)
+            widgetContentCache[FinanceWidgetType.BUDGET_OVERVIEW] =
+                renderer.renderBudgetOverviewCard(data)
+            widgetContentCache[FinanceWidgetType.RECENT_TRANSACTIONS] =
+                renderer.renderRecentTransactionsCard(data)
+
+            logger.fine("All widget content refreshed successfully")
+        } catch (e: Exception) {
+            logger.log(Level.WARNING, "Failed to refresh widget content", e)
+        }
+    }
+
+    /**
+     * Returns the cached Adaptive Card JSON for the given widget type.
+     *
+     * Returns `null` if the widget has never been refreshed or the type
+     * is unknown.
+     */
+    fun getWidgetContent(type: FinanceWidgetType): String? {
+        return widgetContentCache[type]
+    }
+
+    /**
+     * Returns all registered widget types with their metadata.
+     */
+    fun getRegisteredWidgets(): List<FinanceWidgetType> {
+        return FinanceWidgetType.entries.toList()
+    }
+
+    /**
+     * Called on application shutdown to clean up resources.
+     */
+    fun dispose() {
+        widgetContentCache.clear()
+        logger.info("Widget manager disposed")
+    }
+}

--- a/docs/architecture/security/certificate-pinning-strategy.md
+++ b/docs/architecture/security/certificate-pinning-strategy.md
@@ -22,23 +22,23 @@ patterns, certificate pinning is a **HIGH-priority** network security control.
 
 ### Current State
 
-| Platform | Pinning Status     | Reference Audit Finding |
-| -------- | ------------------ | ----------------------- |
-| Android  | NOT IMPLEMENTED    | Security Audit v1 N-1, Pre-launch M-6 |
-| iOS      | NOT IMPLEMENTED    | Security Audit v1 N-1, Pre-launch M-6 |
-| Web      | N/A (browser-managed, CT enforced) | — |
-| Windows  | NOT IMPLEMENTED    | Security Audit v1 N-1, Pre-launch M-6 |
-| KMP (Ktor) | NOT IMPLEMENTED | MASVS-NETWORK audit L-4 |
+| Platform   | Pinning Status                     | Reference Audit Finding               |
+| ---------- | ---------------------------------- | ------------------------------------- |
+| Android    | NOT IMPLEMENTED                    | Security Audit v1 N-1, Pre-launch M-6 |
+| iOS        | NOT IMPLEMENTED                    | Security Audit v1 N-1, Pre-launch M-6 |
+| Web        | N/A (browser-managed, CT enforced) | —                                     |
+| Windows    | NOT IMPLEMENTED                    | Security Audit v1 N-1, Pre-launch M-6 |
+| KMP (Ktor) | NOT IMPLEMENTED                    | MASVS-NETWORK audit L-4               |
 
 ### Risk Without Pinning
 
-| Threat                         | Likelihood | Impact    | Risk Level |
-| ------------------------------ | ---------- | --------- | ---------- |
-| Compromised CA issuing rogue cert | Low    | CRITICAL  | MEDIUM     |
-| Corporate MITM proxy interception | Medium | HIGH      | HIGH       |
-| Rogue Wi-Fi with SSL inspection | Medium   | HIGH      | HIGH       |
-| State-level adversary          | Low        | CRITICAL  | MEDIUM     |
-| Malware with injected trust anchor | Medium | CRITICAL  | HIGH       |
+| Threat                             | Likelihood | Impact   | Risk Level |
+| ---------------------------------- | ---------- | -------- | ---------- |
+| Compromised CA issuing rogue cert  | Low        | CRITICAL | MEDIUM     |
+| Corporate MITM proxy interception  | Medium     | HIGH     | HIGH       |
+| Rogue Wi-Fi with SSL inspection    | Medium     | HIGH     | HIGH       |
+| State-level adversary              | Low        | CRITICAL | MEDIUM     |
+| Malware with injected trust anchor | Medium     | CRITICAL | HIGH       |
 
 ---
 
@@ -82,11 +82,11 @@ patterns, certificate pinning is a **HIGH-priority** network security control.
 
 ### Why SPKI Over Leaf Certificate
 
-| Approach              | Rotation Impact | Renewal Risk | Recommended |
-| --------------------- | --------------- | ------------ | ----------- |
-| Leaf certificate hash | Must update app on every cert renewal | HIGH — missed renewal = outage | No |
-| Intermediate CA hash  | Stable across cert renewals | LOW — only changes if CA changes | **Yes (primary)** |
-| SPKI public key hash  | Stable if key is reused across renewals | LOWEST | **Yes (recommended)** |
+| Approach              | Rotation Impact                         | Renewal Risk                     | Recommended           |
+| --------------------- | --------------------------------------- | -------------------------------- | --------------------- |
+| Leaf certificate hash | Must update app on every cert renewal   | HIGH — missed renewal = outage   | No                    |
+| Intermediate CA hash  | Stable across cert renewals             | LOW — only changes if CA changes | **Yes (primary)**     |
+| SPKI public key hash  | Stable if key is reused across renewals | LOWEST                           | **Yes (recommended)** |
 
 **Recommendation:** Pin the **SPKI hash of the intermediate CA** used by Supabase
 (currently Let's Encrypt or AWS Certificate Manager depending on deployment), with
@@ -102,6 +102,7 @@ Backup Pin 2:  sha256/<NEXT_GEN_INTERMEDIATE_CA_SPKI_HASH>
 
 > **IMPORTANT:** The actual pin values MUST be derived from the live Supabase
 > certificate chain at deployment time. Use `openssl s_client` to extract:
+>
 > ```bash
 > openssl s_client -connect <project>.supabase.co:443 -servername <project>.supabase.co </dev/null 2>/dev/null \
 >   | openssl x509 -pubkey -noout \
@@ -160,6 +161,7 @@ Backup Pin 2:  sha256/<NEXT_GEN_INTERMEDIATE_CA_SPKI_HASH>
 ```
 
 **AndroidManifest.xml addition:**
+
 ```xml
 <application
     android:networkSecurityConfig="@xml/network_security_config"
@@ -167,6 +169,7 @@ Backup Pin 2:  sha256/<NEXT_GEN_INTERMEDIATE_CA_SPKI_HASH>
 ```
 
 **Android-specific considerations:**
+
 - `debug-overrides` ONLY active when `android:debuggable="true"` (debug builds)
 - `expiration` date triggers a graceful fallback to system trust on expiry
 - `includeSubdomains="true"` covers project-specific subdomains
@@ -218,6 +221,7 @@ Backup Pin 2:  sha256/<NEXT_GEN_INTERMEDIATE_CA_SPKI_HASH>
 ```
 
 **iOS-specific considerations:**
+
 - `NSPinnedDomains` is enforced by ATS at the OS level — cannot be bypassed by app code
 - No debug bypass — use a separate `Info.plist` for debug builds or a runtime check
 - `NSPinnedCAIdentities` pins to CA certificates (not leaf), matching our SPKI strategy
@@ -267,6 +271,7 @@ val httpClient = HttpClient(OkHttp) {
 ```
 
 **Windows/JVM-specific considerations:**
+
 - OkHttp provides the most mature certificate pinning API on JVM
 - Ktor CIO engine pinning is less flexible (whole keystore)
 - Consider using OkHttp engine for Android+JVM/Windows, CIO for other targets
@@ -327,12 +332,12 @@ expect object CertificatePinner {
 
 ### Failure Modes and Mitigations
 
-| Failure Mode | Impact | Mitigation |
-| --- | --- | --- |
-| Certificate rotated, app not updated | Connection failure for all users | Backup pins; pin expiry with graceful fallback; forced app update mechanism |
-| Supabase changes CA provider | Connection failure if new CA not pinned | Monitor CT logs; include backup pins from multiple CAs |
-| Debug build with proxy | Proxy intercepted, connection refused | Android `debug-overrides`; iOS separate debug Info.plist |
-| Pin expiry reached | Falls back to system trust (Android) | Set generous expiry; monitor via CI |
+| Failure Mode                         | Impact                                  | Mitigation                                                                  |
+| ------------------------------------ | --------------------------------------- | --------------------------------------------------------------------------- |
+| Certificate rotated, app not updated | Connection failure for all users        | Backup pins; pin expiry with graceful fallback; forced app update mechanism |
+| Supabase changes CA provider         | Connection failure if new CA not pinned | Monitor CT logs; include backup pins from multiple CAs                      |
+| Debug build with proxy               | Proxy intercepted, connection refused   | Android `debug-overrides`; iOS separate debug Info.plist                    |
+| Pin expiry reached                   | Falls back to system trust (Android)    | Set generous expiry; monitor via CI                                         |
 
 ### Testing Strategy
 
@@ -348,31 +353,31 @@ expect object CertificatePinner {
 
 ### Must Do (Before Enabling Pinning)
 
-| Priority | Action | Effort |
-| --- | --- | --- |
-| P0 | Extract current Supabase certificate chain SPKI hashes | 1 hour |
-| P0 | Identify and pin backup CAs (at least 2) | 1 hour |
-| P0 | Create `network_security_config.xml` for Android | 2 hours |
-| P0 | Add `NSPinnedDomains` to iOS `Info.plist` | 2 hours |
-| P0 | Set up OkHttp CertificatePinner for JVM/Windows | 4 hours |
-| P0 | Add Expect-CT header to Edge Function responses | 1 hour |
+| Priority | Action                                                 | Effort  |
+| -------- | ------------------------------------------------------ | ------- |
+| P0       | Extract current Supabase certificate chain SPKI hashes | 1 hour  |
+| P0       | Identify and pin backup CAs (at least 2)               | 1 hour  |
+| P0       | Create `network_security_config.xml` for Android       | 2 hours |
+| P0       | Add `NSPinnedDomains` to iOS `Info.plist`              | 2 hours |
+| P0       | Set up OkHttp CertificatePinner for JVM/Windows        | 4 hours |
+| P0       | Add Expect-CT header to Edge Function responses        | 1 hour  |
 
 ### Should Do (Within Sprint)
 
-| Priority | Action | Effort |
-| --- | --- | --- |
-| P1 | CI job to monitor certificate chain changes | 4 hours |
-| P1 | Feature flag for emergency pin bypass | 4 hours |
-| P1 | Document pin rotation runbook in ops/ | 2 hours |
-| P1 | Add CAA DNS records | 1 hour |
+| Priority | Action                                      | Effort  |
+| -------- | ------------------------------------------- | ------- |
+| P1       | CI job to monitor certificate chain changes | 4 hours |
+| P1       | Feature flag for emergency pin bypass       | 4 hours |
+| P1       | Document pin rotation runbook in ops/       | 2 hours |
+| P1       | Add CAA DNS records                         | 1 hour  |
 
 ### Future Improvements
 
-| Priority | Action | Effort |
-| --- | --- | --- |
-| P2 | Certificate Transparency log monitoring | 1 day |
-| P2 | Pin validation failure reporting via SyncHealthMonitor | 4 hours |
-| P2 | Automated pin extraction and PR creation in CI | 1 day |
+| Priority | Action                                                 | Effort  |
+| -------- | ------------------------------------------------------ | ------- |
+| P2       | Certificate Transparency log monitoring                | 1 day   |
+| P2       | Pin validation failure reporting via SyncHealthMonitor | 4 hours |
+| P2       | Automated pin extraction and PR creation in CI         | 1 day   |
 
 ---
 

--- a/docs/architecture/security/rate-limiting-assessment.md
+++ b/docs/architecture/security/rate-limiting-assessment.md
@@ -49,32 +49,32 @@ Edge Function Handler
 
 ### Per-Function Limits
 
-| Function               | Max Requests | Window   | Key Type   | Auth Required | Assessment  |
-| ---------------------- | ------------ | -------- | ---------- | ------------- | ----------- |
-| `health-check`         | 60           | 60s      | IP-based   | No            | ✅ Appropriate |
-| `auth-webhook`         | 30           | 60s      | IP-based   | Secret-based  | ✅ Appropriate |
-| `passkey-register`     | 10           | 60s      | IP-based   | Yes (JWT)     | ✅ Strict — good for auth |
-| `passkey-authenticate` | 20           | 60s      | IP-based   | No (pre-auth) | ⚠️ See Finding RL-3 |
-| `household-invite`     | 30           | 60s      | User-based | Yes           | ✅ Appropriate |
-| `data-export`          | 10           | 3600s    | User-based | Yes           | ✅ Strict — GDPR compliant |
-| `account-deletion`     | 3            | 3600s    | User-based | Yes           | ✅ Very strict — good |
-| `sync-health-report`   | 60           | 3600s    | User-based | Yes           | ✅ Appropriate |
-| `process-recurring`    | 10           | 60s      | IP-based   | Secret-based  | ✅ Appropriate |
-| `manage-webhooks`      | 30           | 60s      | User-based | Yes           | ✅ Appropriate |
-| `admin-dashboard`      | 60           | 60s      | User-based | Yes + Admin   | ✅ Appropriate |
-| `send-notification`    | 30           | 60s      | User-based | Yes           | ✅ Appropriate |
+| Function               | Max Requests | Window | Key Type   | Auth Required | Assessment                 |
+| ---------------------- | ------------ | ------ | ---------- | ------------- | -------------------------- |
+| `health-check`         | 60           | 60s    | IP-based   | No            | ✅ Appropriate             |
+| `auth-webhook`         | 30           | 60s    | IP-based   | Secret-based  | ✅ Appropriate             |
+| `passkey-register`     | 10           | 60s    | IP-based   | Yes (JWT)     | ✅ Strict — good for auth  |
+| `passkey-authenticate` | 20           | 60s    | IP-based   | No (pre-auth) | ⚠️ See Finding RL-3        |
+| `household-invite`     | 30           | 60s    | User-based | Yes           | ✅ Appropriate             |
+| `data-export`          | 10           | 3600s  | User-based | Yes           | ✅ Strict — GDPR compliant |
+| `account-deletion`     | 3            | 3600s  | User-based | Yes           | ✅ Very strict — good      |
+| `sync-health-report`   | 60           | 3600s  | User-based | Yes           | ✅ Appropriate             |
+| `process-recurring`    | 10           | 60s    | IP-based   | Secret-based  | ✅ Appropriate             |
+| `manage-webhooks`      | 30           | 60s    | User-based | Yes           | ✅ Appropriate             |
+| `admin-dashboard`      | 60           | 60s    | User-based | Yes + Admin   | ✅ Appropriate             |
+| `send-notification`    | 30           | 60s    | User-based | Yes           | ✅ Appropriate             |
 
 ### Abuse Detection Thresholds
 
-| Function               | Max Errors | Window   | Assessment  |
-| ---------------------- | ---------- | -------- | ----------- |
-| `passkey-register`     | 5          | 60s      | ✅ Strict |
-| `passkey-authenticate` | 5          | 60s      | ✅ Strict |
-| `account-deletion`     | 3          | 600s     | ✅ Very strict |
-| `data-export`          | 5          | 600s     | ✅ Strict |
-| `household-invite`     | 10         | 300s     | ✅ Appropriate |
-| `auth-webhook`         | 10         | 300s     | ✅ Appropriate |
-| Others                 | 10-20      | 300s     | ✅ Appropriate |
+| Function               | Max Errors | Window | Assessment     |
+| ---------------------- | ---------- | ------ | -------------- |
+| `passkey-register`     | 5          | 60s    | ✅ Strict      |
+| `passkey-authenticate` | 5          | 60s    | ✅ Strict      |
+| `account-deletion`     | 3          | 600s   | ✅ Very strict |
+| `data-export`          | 5          | 600s   | ✅ Strict      |
+| `household-invite`     | 10         | 300s   | ✅ Appropriate |
+| `auth-webhook`         | 10         | 300s   | ✅ Appropriate |
+| Others                 | 10-20      | 300s   | ✅ Appropriate |
 
 ---
 
@@ -83,6 +83,7 @@ Edge Function Handler
 ### RL-1: Fail-Open Policy Creates Bypass Opportunity — Severity: HIGH
 
 **Files:**
+
 - `services/api/supabase/functions/_shared/rate-limit.ts` lines 119-121, 142-145
 - `services/api/supabase/functions/_shared/abuse-detection.ts` lines 175-177, 197-199
 
@@ -107,6 +108,7 @@ become ineffective precisely when they're needed most — a feedback loop where 
 volume causes the defence to collapse.
 
 **Recommendation:**
+
 - **Short-term:** Add a secondary, in-memory rate limiter (e.g., simple Map with TTL)
   as a fallback when the DB-backed limiter fails. This provides a degraded but still
   functional rate limit even during DB outages.
@@ -167,6 +169,7 @@ rotating the spoofed IP on every request, an attacker bypasses IP-based rate
 limits entirely.
 
 **Affected endpoints (IP-based rate limiting):**
+
 - `passkey-authenticate` (pre-auth, most critical)
 - `health-check`
 - `auth-webhook`
@@ -176,6 +179,7 @@ limits entirely.
 including the passkey authentication flow (credential stuffing vector).
 
 **Recommendation:**
+
 - **Immediate:** Use the **last** entry in `X-Forwarded-For` (the one added by the
   Supabase/Deno Deploy edge proxy), or better yet, use Supabase's own
   `x-real-ip` / `cf-connecting-ip` header which is set by the infrastructure:
@@ -193,7 +197,7 @@ export function getClientIp(req: Request): string | null {
   // Fallback: last entry in X-Forwarded-For (added by edge proxy)
   const forwarded = req.headers.get('x-forwarded-for');
   if (forwarded) {
-    const parts = forwarded.split(',').map(s => s.trim());
+    const parts = forwarded.split(',').map((s) => s.trim());
     return parts[parts.length - 1] || null;
   }
 
@@ -221,6 +225,7 @@ WebAuthn authentication requires a prior `?step=options` call (consuming 2 reque
 per attempt), but 10 authentication attempts per minute from a single IP is still high.
 
 **Recommendation:**
+
 - Reduce to **10 requests per 60 seconds per IP** (5 full auth attempts)
 - Add a **per-credential rate limit**: max 5 authentication attempts per credential_id
   per 5 minutes. This prevents targeted brute-force against a specific user's passkey.
@@ -238,6 +243,7 @@ requests across multiple endpoints to stay under each individual limit while sti
 overwhelming the backend.
 
 **Example attack:**
+
 - 60 req/min to `health-check`
 - 30 req/min to `auth-webhook`
 - 20 req/min to `passkey-authenticate`
@@ -245,6 +251,7 @@ overwhelming the backend.
 - Total: 140 req/min from a single IP without triggering any individual limit
 
 **Recommendation:**
+
 - Add a **global per-IP rate limit** (e.g., 120 requests/minute across all endpoints)
   checked before the function-specific limit.
 - Consider deploying Supabase's built-in rate limiting or a CDN-level rate limiter
@@ -272,6 +279,7 @@ exactly how many requests they can make, when the window resets, and how to time
 their attacks optimally.
 
 **Recommendation:**
+
 - **Keep `Retry-After`** — this is standard HTTP and useful for clients.
 - **Consider removing `X-RateLimit-Limit`** on security-sensitive endpoints
   (passkey-authenticate, account-deletion). Legitimate clients don't need to know
@@ -284,31 +292,38 @@ their attacks optimally.
 ## Positive Findings
 
 ### ✅ Atomic Counter Implementation
+
 The `check_rate_limit` PostgreSQL RPC uses `INSERT ... ON CONFLICT DO UPDATE` (atomic
 UPSERT), preventing race conditions where concurrent requests could bypass the limit.
 
 ### ✅ Sliding Window Design
+
 The window resets based on the first request's timestamp, not a fixed clock boundary.
 This prevents burst attacks at window boundaries.
 
 ### ✅ Abuse Detection Separation
+
 Error-based abuse detection is separate from volume-based rate limiting. This means
 a user who makes many successful requests (high volume, low errors) is not confused
 with an attacker who makes fewer requests but most fail (low volume, high errors).
 
 ### ✅ Read-Only Abuse Status Check
+
 The `checkAbuseStatus()` function now uses a `get_rate_limit_status` RPC that performs
 a SELECT without incrementing the counter (fixing pre-launch finding H-2).
 
 ### ✅ Generic Abuse Block Response
+
 The `abuseBlockedResponse()` returns a generic 403 without revealing that abuse detection
 triggered the block (line 277: `"Request blocked"`), preventing attackers from adapting.
 
 ### ✅ Rate Limit Key Privacy
+
 Both modules explicitly document that rate limit keys must never be logged or returned
 (they contain user IDs or IP addresses).
 
 ### ✅ Consistent Integration
+
 All 12 Edge Functions import and use the shared rate limiting module. No endpoint was
 found without rate limiting.
 
@@ -316,25 +331,25 @@ found without rate limiting.
 
 ## Compliance Assessment
 
-| Requirement | Status | Notes |
-| --- | --- | --- |
-| OWASP API4:2023 — Unrestricted Resource Consumption | ✅ PASS | All endpoints rate-limited |
+| Requirement                                          | Status     | Notes                                      |
+| ---------------------------------------------------- | ---------- | ------------------------------------------ |
+| OWASP API4:2023 — Unrestricted Resource Consumption  | ✅ PASS    | All endpoints rate-limited                 |
 | OWASP API2:2023 — Broken Authentication (rate limit) | ⚠️ PARTIAL | IP spoofing weakens pre-auth limits (RL-2) |
-| PCI DSS 6.5.10 — Broken Authentication | ⚠️ PARTIAL | Credential stuffing possible via RL-2 |
-| NIST 800-53 SC-5 — Denial of Service Protection | ⚠️ PARTIAL | No global rate limit (RL-4) |
-| GDPR Art. 32 — Security of Processing | ✅ PASS | Sensitive endpoints strictly limited |
+| PCI DSS 6.5.10 — Broken Authentication               | ⚠️ PARTIAL | Credential stuffing possible via RL-2      |
+| NIST 800-53 SC-5 — Denial of Service Protection      | ⚠️ PARTIAL | No global rate limit (RL-4)                |
+| GDPR Art. 32 — Security of Processing                | ✅ PASS    | Sensitive endpoints strictly limited       |
 
 ---
 
 ## Recommendations Summary
 
-| Priority | Finding | Action | Effort |
-| --- | --- | --- | --- |
-| **P0** | RL-2: IP spoofing | Fix `getClientIp()` to use infrastructure headers | 2 hours |
-| **P1** | RL-1: Fail-open bypass | Add in-memory fallback rate limiter | 4 hours |
-| **P1** | RL-3: passkey-authenticate permissive | Reduce to 10/min + per-credential limit | 2 hours |
-| **P2** | RL-4: No global rate limit | Add cross-endpoint global IP limit | 4 hours |
-| **P2** | RL-5: Rate limit header leakage | Remove X-RateLimit-Limit on auth endpoints | 1 hour |
+| Priority | Finding                               | Action                                            | Effort  |
+| -------- | ------------------------------------- | ------------------------------------------------- | ------- |
+| **P0**   | RL-2: IP spoofing                     | Fix `getClientIp()` to use infrastructure headers | 2 hours |
+| **P1**   | RL-1: Fail-open bypass                | Add in-memory fallback rate limiter               | 4 hours |
+| **P1**   | RL-3: passkey-authenticate permissive | Reduce to 10/min + per-credential limit           | 2 hours |
+| **P2**   | RL-4: No global rate limit            | Add cross-endpoint global IP limit                | 4 hours |
+| **P2**   | RL-5: Rate limit header leakage       | Remove X-RateLimit-Limit on auth endpoints        | 1 hour  |
 
 ---
 


### PR DESCRIPTION
## Summary
Implements Windows 11 Widget Board integration for the Finance desktop client. Provides at-a-glance financial summaries directly in the Windows 11 widget panel. Closes #928.

## Changes

### New Files
- **`WidgetDataProvider`** — aggregates dashboard data from existing repositories
- **`WidgetContentRenderer`** — produces Adaptive Card v1.5 JSON for 3 widget types:
  - **Net Worth Summary**: headline figure + today/monthly spending
  - **Budget Overview**: up to 4 budget progress bars with health color coding
  - **Recent Transactions**: last 5 transactions with amounts and dates
- **`WidgetRegistrationManager`** — COM server lifecycle management
  - Detects MSIX packaged context for widget activation
  - Caches rendered Adaptive Card content for COM server callbacks
  - Graceful degradation when running unpackaged (dev mode)
- **`WidgetViewModel`** — exposes widget status for Settings screen

### Modified Files
- **`AppModule.kt`** — registers WidgetDataProvider, WidgetContentRenderer, WidgetRegistrationManager, WidgetViewModel in Koin
- **`Main.kt`** — initializes/disposes WidgetRegistrationManager on lifecycle
- **`AppxManifest.xml`** — adds widget provider COM server extension with 3 widget definitions

## Architecture
```
Windows 11 Widget Board (host)
  └── COM Server (declared in AppxManifest.xml)
       └── WidgetRegistrationManager
            ├── WidgetDataProvider (repos → WidgetData)
            └── WidgetContentRenderer (WidgetData → Adaptive Card JSON)
```

## Accessibility
- All Adaptive Cards include `fallbackText` for screen readers
- Budget/transaction items include `altText` for Narrator

## Notes
- Full widget activation requires MSIX packaging + signing (CI/CD pipeline)
- `WIDGET_PROVIDER_CLSID` placeholder in manifest to be replaced during build
- When running unpackaged, widgets are inactive with informational logging