### PR TITLE
feat(web): configure Caddy static file serving and CDN cache policies (#897)

### DIFF
--- a/apps/web/src/lib/cdn/cache-policy.test.ts
+++ b/apps/web/src/lib/cdn/cache-policy.test.ts
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  CACHE_CONTROL_HTML,
+  CACHE_CONTROL_IMMUTABLE,
+  CACHE_CONTROL_MANIFEST,
+  CACHE_CONTROL_SERVICE_WORKER,
+  CACHE_CONTROL_STATIC,
+  CACHE_MAX_AGE_IMMUTABLE,
+  CACHE_MAX_AGE_MANIFEST,
+  CACHE_MAX_AGE_NO_CACHE,
+  CACHE_MAX_AGE_STATIC,
+  classifyCachePolicy,
+  getCacheControlHeader,
+  SECURITY_HEADERS,
+} from './cache-policy';
+
+// ---------------------------------------------------------------------------
+// Cache duration constants
+// ---------------------------------------------------------------------------
+
+describe('Cache duration constants', () => {
+  it('defines immutable cache as 1 year (31536000s)', () => {
+    expect(CACHE_MAX_AGE_IMMUTABLE).toBe(31_536_000);
+  });
+
+  it('defines static cache as 1 day (86400s)', () => {
+    expect(CACHE_MAX_AGE_STATIC).toBe(86_400);
+  });
+
+  it('defines manifest cache as 1 hour (3600s)', () => {
+    expect(CACHE_MAX_AGE_MANIFEST).toBe(3_600);
+  });
+
+  it('defines no-cache age as 0', () => {
+    expect(CACHE_MAX_AGE_NO_CACHE).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cache-Control header values
+// ---------------------------------------------------------------------------
+
+describe('Cache-Control header constants', () => {
+  it('immutable assets include "immutable" directive', () => {
+    expect(CACHE_CONTROL_IMMUTABLE).toContain('immutable');
+    expect(CACHE_CONTROL_IMMUTABLE).toContain('public');
+    expect(CACHE_CONTROL_IMMUTABLE).toContain('max-age=31536000');
+  });
+
+  it('static assets require revalidation', () => {
+    expect(CACHE_CONTROL_STATIC).toContain('must-revalidate');
+    expect(CACHE_CONTROL_STATIC).toContain('public');
+  });
+
+  it('manifest has short cache with revalidation', () => {
+    expect(CACHE_CONTROL_MANIFEST).toContain('max-age=3600');
+    expect(CACHE_CONTROL_MANIFEST).toContain('must-revalidate');
+  });
+
+  it('service worker must never be cached', () => {
+    expect(CACHE_CONTROL_SERVICE_WORKER).toContain('no-cache');
+    expect(CACHE_CONTROL_SERVICE_WORKER).toContain('no-store');
+    expect(CACHE_CONTROL_SERVICE_WORKER).toContain('must-revalidate');
+  });
+
+  it('HTML shell must revalidate on every request', () => {
+    expect(CACHE_CONTROL_HTML).toContain('no-cache');
+    expect(CACHE_CONTROL_HTML).toContain('must-revalidate');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyCachePolicy
+// ---------------------------------------------------------------------------
+
+describe('classifyCachePolicy', () => {
+  it('classifies /sw.js as service-worker', () => {
+    expect(classifyCachePolicy('/sw.js')).toBe('service-worker');
+  });
+
+  it('classifies /manifest.json as manifest', () => {
+    expect(classifyCachePolicy('/manifest.json')).toBe('manifest');
+  });
+
+  it('classifies /assets/*.js as immutable', () => {
+    expect(classifyCachePolicy('/assets/main-a1b2c3d4.js')).toBe('immutable');
+  });
+
+  it('classifies /assets/*.css as immutable', () => {
+    expect(classifyCachePolicy('/assets/styles-abc123.css')).toBe('immutable');
+  });
+
+  it('classifies /assets/*.wasm as immutable', () => {
+    expect(classifyCachePolicy('/assets/sqlite-xyz.wasm')).toBe('immutable');
+  });
+
+  it('classifies /assets/image.png as immutable (hashed by Vite)', () => {
+    expect(classifyCachePolicy('/assets/logo-hash123.png')).toBe('immutable');
+  });
+
+  it('classifies root-level .ico as static', () => {
+    expect(classifyCachePolicy('/favicon.ico')).toBe('static');
+  });
+
+  it('classifies root-level .png as static', () => {
+    expect(classifyCachePolicy('/icon-192.png')).toBe('static');
+  });
+
+  it('classifies robots.txt as static', () => {
+    expect(classifyCachePolicy('/robots.txt')).toBe('static');
+  });
+
+  it('classifies .woff2 font files as static', () => {
+    expect(classifyCachePolicy('/fonts/inter.woff2')).toBe('static');
+  });
+
+  it('classifies /rest/* as api', () => {
+    expect(classifyCachePolicy('/rest/accounts')).toBe('api');
+  });
+
+  it('classifies /auth/* as api', () => {
+    expect(classifyCachePolicy('/auth/v1/token')).toBe('api');
+  });
+
+  it('classifies /functions/* as api', () => {
+    expect(classifyCachePolicy('/functions/sync')).toBe('api');
+  });
+
+  it('classifies / as html', () => {
+    expect(classifyCachePolicy('/')).toBe('html');
+  });
+
+  it('classifies /dashboard as html', () => {
+    expect(classifyCachePolicy('/dashboard')).toBe('html');
+  });
+
+  it('classifies /accounts/123 as html (SPA route)', () => {
+    expect(classifyCachePolicy('/accounts/123')).toBe('html');
+  });
+
+  it('strips query strings before classification', () => {
+    expect(classifyCachePolicy('/assets/main-abc.js?v=1')).toBe('immutable');
+  });
+
+  it('strips fragments before classification', () => {
+    expect(classifyCachePolicy('/robots.txt#section')).toBe('static');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getCacheControlHeader
+// ---------------------------------------------------------------------------
+
+describe('getCacheControlHeader', () => {
+  it('returns immutable header for hashed assets', () => {
+    expect(getCacheControlHeader('/assets/chunk-abc123.js')).toBe(CACHE_CONTROL_IMMUTABLE);
+  });
+
+  it('returns static header for favicon', () => {
+    expect(getCacheControlHeader('/favicon.ico')).toBe(CACHE_CONTROL_STATIC);
+  });
+
+  it('returns manifest header for /manifest.json', () => {
+    expect(getCacheControlHeader('/manifest.json')).toBe(CACHE_CONTROL_MANIFEST);
+  });
+
+  it('returns service-worker header for /sw.js', () => {
+    expect(getCacheControlHeader('/sw.js')).toBe(CACHE_CONTROL_SERVICE_WORKER);
+  });
+
+  it('returns HTML header for SPA routes', () => {
+    expect(getCacheControlHeader('/dashboard')).toBe(CACHE_CONTROL_HTML);
+    expect(getCacheControlHeader('/transactions/new')).toBe(CACHE_CONTROL_HTML);
+  });
+
+  it('returns null for API routes (upstream handles caching)', () => {
+    expect(getCacheControlHeader('/rest/accounts')).toBeNull();
+    expect(getCacheControlHeader('/auth/v1/token')).toBeNull();
+    expect(getCacheControlHeader('/functions/sync')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Security headers
+// ---------------------------------------------------------------------------
+
+describe('SECURITY_HEADERS', () => {
+  it('includes HSTS with preload', () => {
+    expect(SECURITY_HEADERS['Strict-Transport-Security']).toContain('preload');
+    expect(SECURITY_HEADERS['Strict-Transport-Security']).toContain('max-age=31536000');
+  });
+
+  it('includes X-Content-Type-Options: nosniff', () => {
+    expect(SECURITY_HEADERS['X-Content-Type-Options']).toBe('nosniff');
+  });
+
+  it('includes X-Frame-Options: DENY', () => {
+    expect(SECURITY_HEADERS['X-Frame-Options']).toBe('DENY');
+  });
+
+  it('includes Referrer-Policy', () => {
+    expect(SECURITY_HEADERS['Referrer-Policy']).toBe('strict-origin-when-cross-origin');
+  });
+});

--- a/apps/web/src/lib/cdn/cache-policy.ts
+++ b/apps/web/src/lib/cdn/cache-policy.ts
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * CDN and static file cache policy definitions for the Finance PWA.
+ *
+ * These policies mirror the Caddy configuration in `deploy/Caddyfile` and are
+ * consumed by:
+ *   - The service worker (`sw/service-worker.ts`) for runtime cache strategy
+ *   - The Vite build for asset output naming conventions
+ *   - Validation tests to ensure Caddy and app-side caching stay in sync
+ *
+ * References: issue #897
+ * @module lib/cdn/cache-policy
+ */
+
+// ---------------------------------------------------------------------------
+// Cache duration constants (in seconds)
+// ---------------------------------------------------------------------------
+
+/** One year in seconds — used for content-hashed immutable assets. */
+export const CACHE_MAX_AGE_IMMUTABLE = 31_536_000;
+
+/** One day in seconds — used for non-hashed static files (icons, fonts). */
+export const CACHE_MAX_AGE_STATIC = 86_400;
+
+/** One hour in seconds — used for the PWA manifest. */
+export const CACHE_MAX_AGE_MANIFEST = 3_600;
+
+/** Zero — service worker and HTML must always revalidate. */
+export const CACHE_MAX_AGE_NO_CACHE = 0;
+
+// ---------------------------------------------------------------------------
+// Cache-Control header values
+// ---------------------------------------------------------------------------
+
+/** Cache-Control for Vite hashed assets under `/assets/*`. */
+export const CACHE_CONTROL_IMMUTABLE = `public, max-age=${CACHE_MAX_AGE_IMMUTABLE}, immutable`;
+
+/** Cache-Control for non-hashed static files (icons, robots.txt, etc.). */
+export const CACHE_CONTROL_STATIC = `public, max-age=${CACHE_MAX_AGE_STATIC}, must-revalidate`;
+
+/** Cache-Control for the PWA manifest.json. */
+export const CACHE_CONTROL_MANIFEST = `public, max-age=${CACHE_MAX_AGE_MANIFEST}, must-revalidate`;
+
+/** Cache-Control for the service worker — must never be cached. */
+export const CACHE_CONTROL_SERVICE_WORKER = 'no-cache, no-store, must-revalidate';
+
+/** Cache-Control for the SPA HTML shell — revalidate on every navigation. */
+export const CACHE_CONTROL_HTML = 'no-cache, must-revalidate';
+
+// ---------------------------------------------------------------------------
+// Asset classification helpers
+// ---------------------------------------------------------------------------
+
+/** File extensions considered immutable when served under `/assets/`. */
+const HASHED_ASSET_EXTENSIONS = new Set(['.js', '.css', '.wasm', '.map']);
+
+/** File extensions for static resources that are NOT content-hashed. */
+const STATIC_FILE_EXTENSIONS = new Set([
+  '.ico',
+  '.png',
+  '.svg',
+  '.webp',
+  '.woff2',
+  '.woff',
+  '.ttf',
+  '.xml',
+  '.txt',
+]);
+
+/**
+ * Classify a request path into a cache policy category.
+ *
+ * @param path - The URL pathname (e.g. `/assets/main-a1b2c3.js`).
+ * @returns A cache policy identifier used to select the correct Cache-Control
+ *   header and service-worker caching strategy.
+ */
+export type CacheCategory = 'immutable' | 'static' | 'manifest' | 'service-worker' | 'html' | 'api';
+
+export function classifyCachePolicy(path: string): CacheCategory {
+  // Service worker must always revalidate
+  if (path === '/sw.js') {
+    return 'service-worker';
+  }
+
+  // PWA manifest
+  if (path === '/manifest.json') {
+    return 'manifest';
+  }
+
+  // API routes are not cached at the CDN layer
+  if (path.startsWith('/rest/') || path.startsWith('/auth/') || path.startsWith('/functions/')) {
+    return 'api';
+  }
+
+  // Hashed assets under /assets/
+  if (path.startsWith('/assets/')) {
+    const ext = getExtension(path);
+    if (HASHED_ASSET_EXTENSIONS.has(ext)) {
+      return 'immutable';
+    }
+    // Images/fonts in /assets/ are also immutable (Vite hashes them)
+    return 'immutable';
+  }
+
+  // Non-hashed static files
+  const ext = getExtension(path);
+  if (STATIC_FILE_EXTENSIONS.has(ext)) {
+    return 'static';
+  }
+
+  // Everything else falls through to the SPA shell
+  return 'html';
+}
+
+/**
+ * Return the appropriate Cache-Control header value for a given path.
+ *
+ * @param path - The URL pathname.
+ * @returns The Cache-Control header string, or `null` for API routes (which
+ *   are handled by the upstream service).
+ */
+export function getCacheControlHeader(path: string): string | null {
+  const category = classifyCachePolicy(path);
+  switch (category) {
+    case 'immutable':
+      return CACHE_CONTROL_IMMUTABLE;
+    case 'static':
+      return CACHE_CONTROL_STATIC;
+    case 'manifest':
+      return CACHE_CONTROL_MANIFEST;
+    case 'service-worker':
+      return CACHE_CONTROL_SERVICE_WORKER;
+    case 'html':
+      return CACHE_CONTROL_HTML;
+    case 'api':
+      return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Security header definitions
+// ---------------------------------------------------------------------------
+
+/**
+ * Security headers that Caddy applies to all responses.
+ * Exported so the service worker and tests can validate consistency.
+ */
+export const SECURITY_HEADERS: Readonly<Record<string, string>> = {
+  'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload',
+  'X-Content-Type-Options': 'nosniff',
+  'X-Frame-Options': 'DENY',
+  'X-XSS-Protection': '1; mode=block',
+  'Referrer-Policy': 'strict-origin-when-cross-origin',
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Extract the file extension from a URL path (lowercased, including the dot). */
+function getExtension(path: string): string {
+  // Strip query string and fragment
+  const cleaned = path.split('?')[0].split('#')[0];
+  const lastDot = cleaned.lastIndexOf('.');
+  if (lastDot === -1 || lastDot === cleaned.length - 1) {
+    return '';
+  }
+  return cleaned.slice(lastDot).toLowerCase();
+}

--- a/apps/web/src/lib/cdn/caddy-config-validator.test.ts
+++ b/apps/web/src/lib/cdn/caddy-config-validator.test.ts
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { hasCompression, hasSecurityHeader, parseCaddyDirectives } from './caddy-config-validator';
+import {
+  CACHE_CONTROL_HTML,
+  CACHE_CONTROL_IMMUTABLE,
+  CACHE_CONTROL_MANIFEST,
+  CACHE_CONTROL_SERVICE_WORKER,
+} from './cache-policy';
+
+// ---------------------------------------------------------------------------
+// Load the actual Caddyfile from the deploy directory
+// ---------------------------------------------------------------------------
+
+const CADDYFILE_PATH = resolve(__dirname, '../../../../../deploy/Caddyfile');
+const caddyfileContent = readFileSync(CADDYFILE_PATH, 'utf-8');
+
+// ---------------------------------------------------------------------------
+// Parser tests
+// ---------------------------------------------------------------------------
+
+describe('parseCaddyDirectives', () => {
+  it('extracts route-level handle blocks', () => {
+    const directives = parseCaddyDirectives(caddyfileContent);
+    const routes = directives.map((d) => d.route);
+
+    expect(routes).toContain('/sw.js');
+    expect(routes).toContain('/manifest.json');
+    expect(routes).toContain('/assets/*');
+  });
+
+  it('extracts Cache-Control headers from route blocks', () => {
+    const directives = parseCaddyDirectives(caddyfileContent);
+    const swDirective = directives.find((d) => d.route === '/sw.js');
+    const manifestDirective = directives.find((d) => d.route === '/manifest.json');
+    const assetsDirective = directives.find((d) => d.route === '/assets/*');
+
+    expect(swDirective?.cacheControl).toBeDefined();
+    expect(manifestDirective?.cacheControl).toBeDefined();
+    expect(assetsDirective?.cacheControl).toBeDefined();
+  });
+
+  it('detects file_server usage in static routes', () => {
+    const directives = parseCaddyDirectives(caddyfileContent);
+    const swDirective = directives.find((d) => d.route === '/sw.js');
+    const assetsDirective = directives.find((d) => d.route === '/assets/*');
+
+    expect(swDirective?.hasFileServer).toBe(true);
+    expect(assetsDirective?.hasFileServer).toBe(true);
+  });
+
+  it('detects try_files in the SPA fallback route', () => {
+    const directives = parseCaddyDirectives(caddyfileContent);
+    const fallback = directives.find((d) => d.route === '/*');
+
+    expect(fallback?.hasTryFiles).toBe(true);
+  });
+
+  it('detects reverse_proxy in API routes', () => {
+    const directives = parseCaddyDirectives(caddyfileContent);
+    const restRoute = directives.find((d) => d.route === '/rest/*');
+    const authRoute = directives.find((d) => d.route === '/auth/*');
+    const functionsRoute = directives.find((d) => d.route === '/functions/*');
+
+    expect(restRoute?.hasReverseProxy).toBe(true);
+    expect(authRoute?.hasReverseProxy).toBe(true);
+    expect(functionsRoute?.hasReverseProxy).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Caddy ↔ TypeScript cache policy synchronisation
+// ---------------------------------------------------------------------------
+
+describe('Caddy ↔ TypeScript cache policy sync', () => {
+  it('service worker Cache-Control matches TypeScript constant', () => {
+    const directives = parseCaddyDirectives(caddyfileContent);
+    const swDirective = directives.find((d) => d.route === '/sw.js');
+
+    expect(swDirective?.cacheControl).toBe(CACHE_CONTROL_SERVICE_WORKER);
+  });
+
+  it('manifest Cache-Control matches TypeScript constant', () => {
+    const directives = parseCaddyDirectives(caddyfileContent);
+    const manifestDirective = directives.find((d) => d.route === '/manifest.json');
+
+    expect(manifestDirective?.cacheControl).toBe(CACHE_CONTROL_MANIFEST);
+  });
+
+  it('hashed assets Cache-Control matches TypeScript constant', () => {
+    const directives = parseCaddyDirectives(caddyfileContent);
+    const assetsDirective = directives.find((d) => d.route === '/assets/*');
+
+    expect(assetsDirective?.cacheControl).toBe(CACHE_CONTROL_IMMUTABLE);
+  });
+
+  it('SPA fallback Cache-Control matches TypeScript constant', () => {
+    const directives = parseCaddyDirectives(caddyfileContent);
+    const fallback = directives.find((d) => d.route === '/*');
+
+    expect(fallback?.cacheControl).toBe(CACHE_CONTROL_HTML);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Compression
+// ---------------------------------------------------------------------------
+
+describe('Compression', () => {
+  it('Caddyfile enables gzip and/or zstd compression', () => {
+    expect(hasCompression(caddyfileContent)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Security headers
+// ---------------------------------------------------------------------------
+
+describe('Security headers in Caddyfile', () => {
+  it('sets Strict-Transport-Security', () => {
+    expect(hasSecurityHeader(caddyfileContent, 'Strict-Transport-Security')).toBe(true);
+  });
+
+  it('sets X-Content-Type-Options', () => {
+    expect(hasSecurityHeader(caddyfileContent, 'X-Content-Type-Options')).toBe(true);
+  });
+
+  it('sets X-Frame-Options', () => {
+    expect(hasSecurityHeader(caddyfileContent, 'X-Frame-Options')).toBe(true);
+  });
+
+  it('sets Referrer-Policy', () => {
+    expect(hasSecurityHeader(caddyfileContent, 'Referrer-Policy')).toBe(true);
+  });
+
+  it('sets Content-Security-Policy', () => {
+    expect(hasSecurityHeader(caddyfileContent, 'Content-Security-Policy')).toBe(true);
+  });
+
+  it('sets Permissions-Policy', () => {
+    expect(hasSecurityHeader(caddyfileContent, 'Permissions-Policy')).toBe(true);
+  });
+
+  it('removes Server header', () => {
+    expect(caddyfileContent).toContain('-Server');
+  });
+
+  it('CSP disallows eval', () => {
+    // The CSP should not contain unsafe-eval
+    const cspLine = caddyfileContent
+      .split('\n')
+      .find((line) => line.includes('Content-Security-Policy'));
+    expect(cspLine).toBeDefined();
+    expect(cspLine).not.toContain('unsafe-eval');
+  });
+
+  it('CSP allows worker-src self for service worker', () => {
+    const cspLine = caddyfileContent
+      .split('\n')
+      .find((line) => line.includes('Content-Security-Policy'));
+    expect(cspLine).toContain("worker-src 'self'");
+  });
+});

--- a/apps/web/src/lib/cdn/caddy-config-validator.ts
+++ b/apps/web/src/lib/cdn/caddy-config-validator.ts
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Caddy configuration validator.
+ *
+ * Provides a simple line-by-line parser that extracts cache policy directives
+ * and route patterns from the Caddyfile, enabling tests to verify that the
+ * Caddy config and TypeScript cache-policy module stay in sync.
+ *
+ * This is intentionally a lightweight structural check — it does NOT fully
+ * parse the Caddyfile format, just enough to validate cache-control headers
+ * and route presence.
+ *
+ * References: issue #897
+ * @module lib/cdn/caddy-config-validator
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A directive extracted from the Caddyfile. */
+export interface CaddyDirective {
+  /** The route pattern (e.g. `/assets/*`, `/sw.js`). */
+  route: string;
+  /** The Cache-Control header value, if one is specified for this route. */
+  cacheControl?: string;
+  /** Whether this route uses `file_server`. */
+  hasFileServer: boolean;
+  /** Whether this route uses `try_files` (SPA fallback). */
+  hasTryFiles: boolean;
+  /** Whether this route proxies to an upstream service. */
+  hasReverseProxy: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a Caddyfile string and extract route-level directives.
+ *
+ * @param caddyfileContent - The raw text of a Caddyfile.
+ * @returns An array of extracted directives, one per `handle` / `handle_path` block.
+ */
+export function parseCaddyDirectives(caddyfileContent: string): CaddyDirective[] {
+  const directives: CaddyDirective[] = [];
+  const lines = caddyfileContent.split('\n');
+
+  let currentDirective: CaddyDirective | null = null;
+  let braceDepth = 0;
+  let inHandleBlock = false;
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+
+    // Skip comments and empty lines
+    if (line === '' || line.startsWith('#')) {
+      continue;
+    }
+
+    // Track handle/handle_path blocks
+    const handleMatch = line.match(/^handle(?:_path)?\s+(\/\S+)/);
+    const handleDefaultMatch = line.match(/^handle\s*\{/);
+
+    if (handleMatch) {
+      currentDirective = {
+        route: handleMatch[1],
+        hasFileServer: false,
+        hasTryFiles: false,
+        hasReverseProxy: false,
+      };
+      inHandleBlock = true;
+      braceDepth = 0;
+      if (line.includes('{')) {
+        braceDepth++;
+      }
+      continue;
+    }
+
+    if (handleDefaultMatch) {
+      currentDirective = {
+        route: '/*',
+        hasFileServer: false,
+        hasTryFiles: false,
+        hasReverseProxy: false,
+      };
+      inHandleBlock = true;
+      braceDepth = 1;
+      continue;
+    }
+
+    if (inHandleBlock && currentDirective) {
+      if (line.includes('{')) {
+        braceDepth++;
+      }
+      if (line.includes('}')) {
+        braceDepth--;
+        if (braceDepth <= 0) {
+          directives.push(currentDirective);
+          currentDirective = null;
+          inHandleBlock = false;
+          continue;
+        }
+      }
+
+      // Extract Cache-Control header
+      const cacheControlMatch = line.match(/header\s+Cache-Control\s+"([^"]+)"/);
+      if (cacheControlMatch) {
+        currentDirective.cacheControl = cacheControlMatch[1];
+      }
+
+      // Track file_server usage
+      if (line === 'file_server' || line.startsWith('file_server')) {
+        currentDirective.hasFileServer = true;
+      }
+
+      // Track try_files usage
+      if (line.startsWith('try_files')) {
+        currentDirective.hasTryFiles = true;
+      }
+
+      // Track reverse_proxy usage
+      if (line.startsWith('reverse_proxy')) {
+        currentDirective.hasReverseProxy = true;
+      }
+    }
+  }
+
+  return directives;
+}
+
+/**
+ * Check whether the Caddyfile enables compression (gzip/zstd).
+ *
+ * @param caddyfileContent - The raw text of a Caddyfile.
+ * @returns `true` if an `encode` directive is present.
+ */
+export function hasCompression(caddyfileContent: string): boolean {
+  return caddyfileContent.split('\n').some((line) => {
+    const trimmed = line.trim();
+    return trimmed.startsWith('encode ') && (trimmed.includes('gzip') || trimmed.includes('zstd'));
+  });
+}
+
+/**
+ * Check whether the Caddyfile contains a specific security header.
+ *
+ * @param caddyfileContent - The raw text of a Caddyfile.
+ * @param headerName - The header name to search for (e.g. `Strict-Transport-Security`).
+ * @returns `true` if the header is set in the Caddyfile.
+ */
+export function hasSecurityHeader(caddyfileContent: string, headerName: string): boolean {
+  return caddyfileContent.includes(headerName);
+}

--- a/apps/web/src/lib/cdn/index.ts
+++ b/apps/web/src/lib/cdn/index.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Barrel export for CDN/caching utilities.
+ *
+ * @module lib/cdn
+ */
+
+export {
+  CACHE_MAX_AGE_IMMUTABLE,
+  CACHE_MAX_AGE_STATIC,
+  CACHE_MAX_AGE_MANIFEST,
+  CACHE_MAX_AGE_NO_CACHE,
+  CACHE_CONTROL_IMMUTABLE,
+  CACHE_CONTROL_STATIC,
+  CACHE_CONTROL_MANIFEST,
+  CACHE_CONTROL_SERVICE_WORKER,
+  CACHE_CONTROL_HTML,
+  SECURITY_HEADERS,
+  classifyCachePolicy,
+  getCacheControlHeader,
+} from './cache-policy';
+
+export type { CacheCategory } from './cache-policy';
+
+export { parseCaddyDirectives, hasCompression, hasSecurityHeader } from './caddy-config-validator';
+
+export type { CaddyDirective } from './caddy-config-validator';

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -108,6 +108,9 @@ ALLOWED_ORIGINS=https://YOUR_DOMAIN_HERE
 # Path to edge functions source (relative to docker-compose.yml)
 EDGE_FUNCTIONS_PATH=../services/api/supabase/functions
 
+# Path to the web app build output (relative to docker-compose.yml)
+WEB_DIST_PATH=../apps/web/dist
+
 # ---------------------------------------------------------------------------
 # PowerSync (optional — for offline-first sync)
 # ---------------------------------------------------------------------------

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,24 +1,32 @@
 # =============================================================================
-# Finance App — Caddy Reverse Proxy Configuration
+# Finance App — Caddy Reverse Proxy & Static File Serving Configuration
 # =============================================================================
 #
 # Provides automatic HTTPS via Let's Encrypt and routes requests to the
-# appropriate backend service based on the URL path.
+# appropriate backend service based on the URL path.  Also serves the
+# Finance PWA static build with CDN-friendly cache headers.
 #
 # Route mapping:
 #   /rest/*          → PostgREST (API)
 #   /auth/*          → GoTrue (authentication)
 #   /functions/*     → Edge Functions (Deno)
 #   /health          → Edge Functions health check
+#   /assets/*        → Immutable hashed static assets (1-year cache)
+#   /sw.js           → Service worker (no-cache, always revalidate)
+#   /manifest.json   → PWA manifest (short cache, revalidate)
+#   /*               → SPA index.html fallback
 #
-# Issue: #268
+# Issues: #268, #897
 # =============================================================================
 
 {$DOMAIN} {
 	# TLS with Let's Encrypt
 	tls {$TLS_EMAIL}
 
-	# Security headers
+	# Enable compression for text-based assets
+	encode zstd gzip
+
+	# Security headers (applied to all responses)
 	header {
 		# HSTS — enforce HTTPS for 1 year, including subdomains
 		Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
@@ -35,8 +43,11 @@
 		# Referrer policy
 		Referrer-Policy "strict-origin-when-cross-origin"
 
-		# Content Security Policy
-		Content-Security-Policy "default-src 'self'; connect-src 'self' https:; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'"
+		# Permissions-Policy — restrict sensitive browser APIs
+		Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(self)"
+
+		# Content Security Policy — strict, no inline scripts, no eval
+		Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self'; connect-src 'self' https:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; worker-src 'self'"
 
 		# Remove server identification
 		-Server
@@ -82,10 +93,56 @@
 	}
 
 	# -------------------------------------------------------------------------
-	# Default — return 404 for unmatched routes
+	# Service Worker — must always be re-validated so updates propagate
+	# -------------------------------------------------------------------------
+	handle /sw.js {
+		header Cache-Control "no-cache, no-store, must-revalidate"
+		header Service-Worker-Allowed "/"
+		root * /srv/web
+		file_server
+	}
+
+	# -------------------------------------------------------------------------
+	# PWA Manifest — short cache with revalidation
+	# -------------------------------------------------------------------------
+	handle /manifest.json {
+		header Cache-Control "public, max-age=3600, must-revalidate"
+		root * /srv/web
+		file_server
+	}
+
+	# -------------------------------------------------------------------------
+	# Hashed static assets — immutable, aggressive 1-year cache
+	# Vite outputs to /assets/ with content-hash filenames.
+	# -------------------------------------------------------------------------
+	handle /assets/* {
+		header Cache-Control "public, max-age=31536000, immutable"
+		root * /srv/web
+		file_server
+	}
+
+	# -------------------------------------------------------------------------
+	# Other static files (robots.txt, 404.html, icons, etc.)
+	# Short cache with revalidation for non-hashed files.
+	# -------------------------------------------------------------------------
+	@staticFiles {
+		path *.ico *.png *.svg *.webp *.woff2 *.woff *.ttf *.xml *.txt
+	}
+	handle @staticFiles {
+		header Cache-Control "public, max-age=86400, must-revalidate"
+		root * /srv/web
+		file_server
+	}
+
+	# -------------------------------------------------------------------------
+	# SPA fallback — serve index.html for all unmatched routes
+	# The PWA handles client-side routing via react-router-dom.
 	# -------------------------------------------------------------------------
 	handle {
-		respond "Not Found" 404
+		root * /srv/web
+		try_files {path} /index.html
+		header Cache-Control "no-cache, must-revalidate"
+		file_server
 	}
 
 	# Access logging

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -17,7 +17,7 @@
 #   80   — HTTP  (redirects to HTTPS)
 #   443  — HTTPS (automatic Let's Encrypt via Caddy)
 #
-# Issue: #268
+# Issues: #268, #897
 # =============================================================================
 
 services:
@@ -268,6 +268,7 @@ services:
       TLS_EMAIL: ${TLS_EMAIL}
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - ${WEB_DIST_PATH:-../apps/web/dist}:/srv/web:ro
       - caddy_data:/data
       - caddy_config:/config
     healthcheck:


### PR DESCRIPTION
## Summary
Configure the Caddy reverse proxy to serve the Finance PWA as a static site with CDN-friendly cache headers, compression, and SPA fallback routing.

## Changes
- **deploy/Caddyfile**: Add SPA fallback via \	ry_files\, immutable cache for hashed assets (1yr), no-cache for service worker and HTML, short cache for manifest, gzip+zstd compression, stricter CSP with \worker-src 'self'\, and \Permissions-Policy\ header
- **deploy/docker-compose.yml**: Mount web build output (\/srv/web\) into the Caddy container
- **deploy/.env.example**: Add \WEB_DIST_PATH\ configuration variable
- **apps/web/src/lib/cdn/cache-policy.ts**: TypeScript module defining cache categories, Cache-Control header values, and classification helpers — ensures app-side caching strategy stays in sync with Caddy
- **apps/web/src/lib/cdn/caddy-config-validator.ts**: Lightweight Caddyfile parser for extracting route-level directives in tests
- **apps/web/src/lib/cdn/cache-policy.test.ts**: 37 tests covering cache constants, classification, and header generation
- **apps/web/src/lib/cdn/caddy-config-validator.test.ts**: 19 tests validating Caddyfile structure, Caddy↔TS sync, compression, and security headers

## Testing
- 56 Vitest unit tests all passing
- Full web test suite unaffected (73 test files, all green)
- TypeScript type-check clean
- ESLint + Prettier clean

Closes #897