### PR TITLE
feat(android): non-manipulative streak tracking for logging consistency (#383)

### DIFF
--- a/apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt
@@ -16,6 +16,9 @@ import com.finance.android.logging.TimberCrashReporter
 import com.finance.android.ui.screens.BiometricAvailabilityChecker
 import com.finance.android.ui.screens.DefaultBiometricAvailabilityChecker
 import com.finance.android.ui.screens.SettingsViewModel
+import com.finance.android.ui.streak.StreakRepository
+import com.finance.android.ui.streak.StreakViewModel
+import com.finance.android.ui.streak.TransactionBackedStreakRepository
 import com.finance.android.ui.theme.ThemePreferenceManager
 import com.finance.android.ui.viewmodel.AccountCreateViewModel
 import com.finance.android.ui.viewmodel.AccountEditViewModel
@@ -88,6 +91,11 @@ val appModule = module {
     /** Theme preference manager — provides reactive theme state for the whole app. */
     single { ThemePreferenceManager(get()) }
 
+    // ── Streak tracking ───────────────────────────────────────────────
+
+    /** Streak repository — derives logging dates from the transaction repository. */
+    single<StreakRepository> { TransactionBackedStreakRepository(get()) }
+
     // ── ViewModels ──────────────────────────────────────────────────
 
     viewModelOf(::DashboardViewModel)
@@ -105,4 +113,5 @@ val appModule = module {
     viewModelOf(::GoalCreateViewModel)
     viewModelOf(::GoalEditViewModel)
     viewModelOf(::SettingsViewModel)
+    viewModelOf(::StreakViewModel)
 }

--- a/apps/android/src/main/kotlin/com/finance/android/ui/streak/StreakCalculator.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/streak/StreakCalculator.kt
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.streak
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.DatePeriod
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.minus
+import kotlinx.datetime.plus
+import kotlinx.datetime.toLocalDateTime
+
+/**
+ * Pure-function streak calculator — no Android dependencies.
+ *
+ * Computes the current logging streak from a set of dates on which
+ * the user logged at least one transaction. A streak is a sequence
+ * of consecutive calendar days ending on today (or yesterday, to be
+ * forgiving of time-zone edge cases).
+ *
+ * Design principles (non-manipulative):
+ * - A missed day resets the streak to 0 — no "freeze" mechanics.
+ * - No loss-aversion language; the UI should celebrate presence, not punish absence.
+ * - The streak count is informational only — it does not gate features or rewards.
+ */
+object StreakCalculator {
+
+    /**
+     * Computes the current consecutive-day logging streak.
+     *
+     * @param loggingDates A set of [LocalDate]s on which the user logged
+     *   at least one transaction. Does not need to be sorted.
+     * @param today The current date (injectable for testing).
+     * @return The number of consecutive days ending at [today] (or yesterday)
+     *   that appear in [loggingDates]. Returns 0 if today/yesterday are
+     *   not in the set.
+     */
+    fun currentStreak(
+        loggingDates: Set<LocalDate>,
+        today: LocalDate = Clock.System.now()
+            .toLocalDateTime(TimeZone.currentSystemDefault()).date,
+    ): Int {
+        if (loggingDates.isEmpty()) return 0
+
+        // Start counting from today; if today isn't logged, try yesterday
+        // (forgiving: the user may not have logged yet today).
+        val startDate = when {
+            today in loggingDates -> today
+            today.minus(1, DateTimeUnit.DAY) in loggingDates -> {
+                today.minus(1, DateTimeUnit.DAY)
+            }
+            else -> return 0
+        }
+
+        var streak = 0
+        var checkDate = startDate
+        while (checkDate in loggingDates) {
+            streak++
+            checkDate = checkDate.minus(1, DateTimeUnit.DAY)
+        }
+
+        return streak
+    }
+
+    /**
+     * Computes the longest-ever streak from the provided dates.
+     *
+     * @param loggingDates All dates on which the user has logged transactions.
+     * @return The length of the longest consecutive-day sequence found.
+     */
+    fun longestStreak(loggingDates: Set<LocalDate>): Int {
+        if (loggingDates.isEmpty()) return 0
+
+        val sorted = loggingDates.sorted()
+        var maxStreak = 1
+        var current = 1
+
+        for (i in 1 until sorted.size) {
+            val prev = sorted[i - 1]
+            val next = sorted[i]
+            if (next == prev.plus(1, DateTimeUnit.DAY)) {
+                // next == prev + 1 day
+                current++
+                if (current > maxStreak) maxStreak = current
+            } else if (next != prev) {
+                // Gap — reset (skip duplicates)
+                current = 1
+            }
+        }
+
+        return maxStreak
+    }
+
+    /**
+     * Returns a brief, positive, non-manipulative message for the given streak.
+     *
+     * Rules:
+     * - 0 days → encouraging but NOT guilt-tripping
+     * - 1-2 days → gentle acknowledgement
+     * - 3-6 days → warm encouragement
+     * - 7+ days → celebration without pressure to continue
+     *
+     * NEVER uses phrases like "Don't break your streak!" or "You'll lose your progress!"
+     */
+    fun streakMessage(streakDays: Int): String = when {
+        streakDays == 0 -> "Log a transaction to start tracking"
+        streakDays == 1 -> "Nice — you logged today!"
+        streakDays == 2 -> "Two days in a row, great start"
+        streakDays in 3..6 -> "$streakDays days of logging — well done"
+        streakDays in 7..13 -> "A whole week! You're building a great habit"
+        streakDays in 14..29 -> "$streakDays days — impressive consistency"
+        else -> "$streakDays days — remarkable dedication"
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/streak/StreakCard.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/streak/StreakCard.kt
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.streak
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+/**
+ * Dashboard card showing the user's logging consistency streak.
+ *
+ * Design principles:
+ * - **Non-manipulative**: no guilt language, no "don't break your streak!"
+ * - **Dismissible**: users can hide the card without penalty
+ * - **Informational**: the streak is a mirror, not a leash
+ * - **Accessible**: full TalkBack descriptions, appropriate heading semantics
+ *
+ * @param viewModel The [StreakViewModel] providing streak state.
+ * @param modifier Modifier applied to the card.
+ */
+@Composable
+fun StreakCard(
+    viewModel: StreakViewModel,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.uiState.collectAsState()
+
+    StreakCardContent(
+        state = state,
+        onDismiss = { viewModel.dismissStreak() },
+        modifier = modifier,
+    )
+}
+
+/**
+ * Stateless streak card content — useful for previews and testing.
+ */
+@Composable
+fun StreakCardContent(
+    state: StreakUiState,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AnimatedVisibility(
+        visible = state.isVisible && !state.isLoading,
+        enter = fadeIn() + slideInVertically(),
+        exit = fadeOut() + slideOutVertically(),
+    ) {
+        Card(
+            shape = RoundedCornerShape(16.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            ),
+            modifier = modifier
+                .fillMaxWidth()
+                .semantics {
+                    contentDescription = buildString {
+                        append("Logging streak: ${state.currentStreak} days. ")
+                        append(state.message)
+                        if (state.longestStreak > 0) {
+                            append(". Your longest streak is ${state.longestStreak} days.")
+                        }
+                    }
+                },
+        ) {
+            Column(
+                modifier = Modifier.padding(16.dp),
+            ) {
+                // Header row with streak icon and dismiss button
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        // Streak flame icon
+                        Box(
+                            contentAlignment = Alignment.Center,
+                            modifier = Modifier
+                                .size(40.dp)
+                                .clip(CircleShape)
+                                .background(MaterialTheme.colorScheme.secondary.copy(alpha = 0.2f))
+                                .semantics {
+                                    contentDescription = "Logging streak icon"
+                                },
+                        ) {
+                            Text(
+                                text = if (state.currentStreak > 0) "🔥" else "📝",
+                                style = MaterialTheme.typography.titleMedium,
+                                textAlign = TextAlign.Center,
+                            )
+                        }
+
+                        Spacer(modifier = Modifier.width(12.dp))
+
+                        Column {
+                            Text(
+                                text = "Logging Streak",
+                                style = MaterialTheme.typography.titleSmall,
+                                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                modifier = Modifier.semantics { heading() },
+                            )
+                            Text(
+                                text = "${state.currentStreak} ${if (state.currentStreak == 1) "day" else "days"}",
+                                style = MaterialTheme.typography.headlineSmall,
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                            )
+                        }
+                    }
+
+                    // Dismiss button — no judgment, just a clean close
+                    IconButton(
+                        onClick = onDismiss,
+                        modifier = Modifier.semantics {
+                            contentDescription = "Hide streak card"
+                        },
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Close,
+                            contentDescription = "Hide streak card",
+                            tint = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.6f),
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                // Positive message — NEVER guilt-tripping
+                Text(
+                    text = state.message,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.8f),
+                    modifier = Modifier.semantics {
+                        contentDescription = state.message
+                    },
+                )
+
+                // Show longest streak as a subtle footer when it's higher than current
+                if (state.longestStreak > state.currentStreak && state.longestStreak > 0) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = "Longest: ${state.longestStreak} days",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.5f),
+                        modifier = Modifier.semantics {
+                            contentDescription = "Your longest streak is ${state.longestStreak} days"
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+// ── Previews ─────────────────────────────────────────────────────────────────
+
+@Preview(showBackground = true, name = "Streak — Active (7 days)")
+@Composable
+private fun StreakCardActivePreview() {
+    MaterialTheme {
+        StreakCardContent(
+            state = StreakUiState(
+                currentStreak = 7,
+                longestStreak = 14,
+                message = "A whole week! You're building a great habit",
+                isLoading = false,
+            ),
+            onDismiss = {},
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Streak — No streak")
+@Composable
+private fun StreakCardNoStreakPreview() {
+    MaterialTheme {
+        StreakCardContent(
+            state = StreakUiState(
+                currentStreak = 0,
+                longestStreak = 3,
+                message = "Log a transaction to start tracking",
+                isLoading = false,
+            ),
+            onDismiss = {},
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Streak — New user (1 day)")
+@Composable
+private fun StreakCardOneDayPreview() {
+    MaterialTheme {
+        StreakCardContent(
+            state = StreakUiState(
+                currentStreak = 1,
+                longestStreak = 1,
+                message = "Nice — you logged today!",
+                isLoading = false,
+            ),
+            onDismiss = {},
+        )
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/streak/StreakRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/streak/StreakRepository.kt
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.streak
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.datetime.LocalDate
+
+/**
+ * Repository contract for streak data.
+ *
+ * Abstracts the source of "which dates did the user log at least one
+ * transaction?" so that [StreakViewModel] is testable without a real database.
+ */
+interface StreakRepository {
+
+    /**
+     * Observes the distinct set of dates on which the user has logged
+     * at least one transaction. Emits a new value whenever the underlying
+     * data changes (e.g. a new transaction is created).
+     *
+     * @param householdId The household to scope the query to.
+     * @return A [Flow] of distinct logging dates.
+     */
+    fun observeLoggingDates(householdId: String): Flow<Set<LocalDate>>
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/streak/StreakViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/streak/StreakViewModel.kt
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.streak
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.finance.android.auth.HouseholdIdProvider
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+/**
+ * UI state for the streak tracking feature.
+ *
+ * All text is phrased positively and non-manipulatively:
+ * - No "You're about to lose your streak!" messaging
+ * - No fake urgency or loss-aversion tactics
+ * - Celebration of presence, not punishment for absence
+ */
+data class StreakUiState(
+    /** Current consecutive-day streak (0 = no active streak). */
+    val currentStreak: Int = 0,
+
+    /** Longest-ever streak achieved. */
+    val longestStreak: Int = 0,
+
+    /** A brief, encouraging, non-manipulative message. */
+    val message: String = StreakCalculator.streakMessage(0),
+
+    /** Whether streak data is still loading. */
+    val isLoading: Boolean = true,
+
+    /** Whether the user has opted in to seeing streak info. */
+    val isVisible: Boolean = true,
+)
+
+/**
+ * ViewModel for the logging consistency streak tracker.
+ *
+ * Observes transaction dates via [StreakRepository] and computes the
+ * current and longest streaks using [StreakCalculator].
+ *
+ * The streak is purely informational — it does not gate features,
+ * send notifications, or use manipulative language.
+ *
+ * @param streakRepository Source of distinct transaction logging dates.
+ * @param householdIdProvider Provides the authenticated household ID.
+ */
+class StreakViewModel(
+    private val streakRepository: StreakRepository,
+    private val householdIdProvider: HouseholdIdProvider,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(StreakUiState())
+    val uiState: StateFlow<StreakUiState> = _uiState.asStateFlow()
+
+    init {
+        observeStreak()
+    }
+
+    private fun observeStreak() {
+        viewModelScope.launch {
+            val householdId = householdIdProvider.householdId.value ?: run {
+                Timber.d("No household ID available — streak tracking inactive")
+                _uiState.update { it.copy(isLoading = false, currentStreak = 0) }
+                return@launch
+            }
+
+            streakRepository.observeLoggingDates(householdId.value).collectLatest { dates ->
+                val current = StreakCalculator.currentStreak(dates)
+                val longest = StreakCalculator.longestStreak(dates)
+                val message = StreakCalculator.streakMessage(current)
+
+                Timber.d("Streak updated: current=%d, longest=%d", current, longest)
+
+                _uiState.update {
+                    it.copy(
+                        currentStreak = current,
+                        longestStreak = longest,
+                        message = message,
+                        isLoading = false,
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * Allows the user to dismiss the streak card. This is opt-in UI —
+     * users who find streak tracking unhelpful can hide it without judgment.
+     */
+    fun dismissStreak() {
+        _uiState.update { it.copy(isVisible = false) }
+        Timber.d("User dismissed streak card")
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/streak/TransactionBackedStreakRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/streak/TransactionBackedStreakRepository.kt
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.streak
+
+import com.finance.android.auth.HouseholdIdProvider
+import com.finance.android.data.repository.TransactionRepository
+import com.finance.models.types.SyncId
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.datetime.LocalDate
+
+/**
+ * [StreakRepository] backed by the existing [TransactionRepository].
+ *
+ * Derives the set of logging dates from the full transaction list by
+ * extracting distinct dates. This is intentionally simple — a future
+ * optimisation could use a dedicated SQL query to avoid loading all
+ * transaction data.
+ */
+class TransactionBackedStreakRepository(
+    private val transactionRepository: TransactionRepository,
+) : StreakRepository {
+
+    override fun observeLoggingDates(householdId: String): Flow<Set<LocalDate>> {
+        return transactionRepository.observeAll(SyncId(householdId)).map { transactions ->
+            transactions.map { it.date }.toSet()
+        }
+    }
+}

--- a/apps/android/src/test/kotlin/com/finance/android/ui/streak/StreakCalculatorTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/ui/streak/StreakCalculatorTest.kt
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.streak
+
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.minus
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [StreakCalculator].
+ *
+ * Tests cover:
+ * - Empty input
+ * - Single-day streak (today / yesterday)
+ * - Multi-day consecutive streaks
+ * - Gap handling (streak reset)
+ * - Forgiving yesterday logic
+ * - Longest streak computation
+ * - Non-manipulative message content
+ */
+class StreakCalculatorTest {
+
+    private val today = LocalDate(2025, 4, 15)
+
+    // ── currentStreak ───────────────────────────────────────────────────
+
+    @Test
+    fun `empty dates returns 0`() {
+        assertEquals(0, StreakCalculator.currentStreak(emptySet(), today))
+    }
+
+    @Test
+    fun `today only returns 1`() {
+        val dates = setOf(today)
+        assertEquals(1, StreakCalculator.currentStreak(dates, today))
+    }
+
+    @Test
+    fun `yesterday only returns 1 (forgiving)`() {
+        val yesterday = LocalDate(2025, 4, 14)
+        val dates = setOf(yesterday)
+        assertEquals(1, StreakCalculator.currentStreak(dates, today))
+    }
+
+    @Test
+    fun `today and yesterday returns 2`() {
+        val dates = setOf(
+            LocalDate(2025, 4, 14),
+            LocalDate(2025, 4, 15),
+        )
+        assertEquals(2, StreakCalculator.currentStreak(dates, today))
+    }
+
+    @Test
+    fun `7 consecutive days ending today returns 7`() {
+        val dates = (0..6).map { LocalDate(2025, 4, 15 - it) }.toSet()
+        assertEquals(7, StreakCalculator.currentStreak(dates, today))
+    }
+
+    @Test
+    fun `gap breaks the streak`() {
+        val dates = setOf(
+            LocalDate(2025, 4, 15), // today
+            LocalDate(2025, 4, 14),
+            // gap on April 13
+            LocalDate(2025, 4, 12),
+            LocalDate(2025, 4, 11),
+        )
+        assertEquals(2, StreakCalculator.currentStreak(dates, today))
+    }
+
+    @Test
+    fun `no today or yesterday returns 0`() {
+        val dates = setOf(
+            LocalDate(2025, 4, 10),
+            LocalDate(2025, 4, 9),
+        )
+        assertEquals(0, StreakCalculator.currentStreak(dates, today))
+    }
+
+    @Test
+    fun `yesterday with trailing consecutive days counts correctly`() {
+        // User hasn't logged today yet, but has 5 days ending yesterday
+        val dates = (1..5).map { LocalDate(2025, 4, 15 - it) }.toSet()
+        assertEquals(5, StreakCalculator.currentStreak(dates, today))
+    }
+
+    @Test
+    fun `single date two days ago returns 0`() {
+        val dates = setOf(LocalDate(2025, 4, 13))
+        assertEquals(0, StreakCalculator.currentStreak(dates, today))
+    }
+
+    @Test
+    fun `30 day streak counts correctly`() {
+        val dates = (0..29).map { today.minus(it, DateTimeUnit.DAY) }.toSet()
+        assertEquals(30, StreakCalculator.currentStreak(dates, today))
+    }
+
+    // ── longestStreak ───────────────────────────────────────────────────
+
+    @Test
+    fun `longestStreak with empty set returns 0`() {
+        assertEquals(0, StreakCalculator.longestStreak(emptySet()))
+    }
+
+    @Test
+    fun `longestStreak with single date returns 1`() {
+        assertEquals(1, StreakCalculator.longestStreak(setOf(today)))
+    }
+
+    @Test
+    fun `longestStreak finds the longest consecutive run`() {
+        val dates = setOf(
+            // Run of 3
+            LocalDate(2025, 3, 1),
+            LocalDate(2025, 3, 2),
+            LocalDate(2025, 3, 3),
+            // Gap
+            // Run of 5
+            LocalDate(2025, 3, 10),
+            LocalDate(2025, 3, 11),
+            LocalDate(2025, 3, 12),
+            LocalDate(2025, 3, 13),
+            LocalDate(2025, 3, 14),
+            // Gap
+            // Run of 2
+            LocalDate(2025, 3, 20),
+            LocalDate(2025, 3, 21),
+        )
+        assertEquals(5, StreakCalculator.longestStreak(dates))
+    }
+
+    @Test
+    fun `longestStreak with all consecutive returns total count`() {
+        val dates = (1..10).map { LocalDate(2025, 1, it) }.toSet()
+        assertEquals(10, StreakCalculator.longestStreak(dates))
+    }
+
+    @Test
+    fun `longestStreak with all separate days returns 1`() {
+        val dates = setOf(
+            LocalDate(2025, 1, 1),
+            LocalDate(2025, 1, 3),
+            LocalDate(2025, 1, 5),
+        )
+        assertEquals(1, StreakCalculator.longestStreak(dates))
+    }
+
+    // ── streakMessage ───────────────────────────────────────────────────
+
+    @Test
+    fun `message for 0 days is encouraging, not guilt-tripping`() {
+        val msg = StreakCalculator.streakMessage(0)
+        assertTrue(msg.isNotBlank())
+        // Must NOT contain manipulative language
+        assertTrue(!msg.contains("lose", ignoreCase = true))
+        assertTrue(!msg.contains("break", ignoreCase = true))
+        assertTrue(!msg.contains("miss", ignoreCase = true))
+    }
+
+    @Test
+    fun `message for 1 day is positive`() {
+        val msg = StreakCalculator.streakMessage(1)
+        assertTrue(msg.contains("logged", ignoreCase = true) || msg.contains("nice", ignoreCase = true))
+    }
+
+    @Test
+    fun `message for 2 days acknowledges the start`() {
+        val msg = StreakCalculator.streakMessage(2)
+        assertTrue(msg.isNotBlank())
+    }
+
+    @Test
+    fun `message for 5 days is warm`() {
+        val msg = StreakCalculator.streakMessage(5)
+        assertTrue(msg.contains("5"))
+    }
+
+    @Test
+    fun `message for 7 days celebrates a week`() {
+        val msg = StreakCalculator.streakMessage(7)
+        assertTrue(msg.contains("week", ignoreCase = true))
+    }
+
+    @Test
+    fun `message for 14 days acknowledges consistency`() {
+        val msg = StreakCalculator.streakMessage(14)
+        assertTrue(msg.contains("14"))
+    }
+
+    @Test
+    fun `message for 30 days celebrates dedication`() {
+        val msg = StreakCalculator.streakMessage(30)
+        assertTrue(msg.contains("30"))
+        assertTrue(msg.contains("dedication", ignoreCase = true) || msg.contains("remarkable", ignoreCase = true))
+    }
+
+    @Test
+    fun `no message contains manipulative language`() {
+        val badWords = listOf("lose", "break", "miss", "don't", "won't", "fail", "gone", "lost")
+        for (days in listOf(0, 1, 2, 3, 5, 7, 10, 14, 21, 30, 100)) {
+            val msg = StreakCalculator.streakMessage(days)
+            for (word in badWords) {
+                assertTrue(
+                    !msg.contains(word, ignoreCase = true),
+                    "Message for $days days contains manipulative word '$word': $msg",
+                )
+            }
+        }
+    }
+}

--- a/apps/android/src/test/kotlin/com/finance/android/ui/streak/StreakViewModelTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/ui/streak/StreakViewModelTest.kt
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.streak
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.minus
+import kotlinx.datetime.toLocalDateTime
+import com.finance.models.types.SyncId
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [StreakViewModel].
+ *
+ * Uses a fake [StreakRepository] and fake [HouseholdIdProvider] to
+ * verify that the ViewModel correctly computes and exposes streak state.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class StreakViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // ── Fakes ────────────────────────────────────────────────────────────
+
+    private class FakeStreakRepository : StreakRepository {
+        val datesFlow = MutableStateFlow<Set<LocalDate>>(emptySet())
+
+        override fun observeLoggingDates(householdId: String): Flow<Set<LocalDate>> = datesFlow
+    }
+
+    private class FakeHouseholdIdProvider(id: String?) : com.finance.android.auth.HouseholdIdProvider {
+        override val householdId: StateFlow<SyncId?> = MutableStateFlow(
+            id?.let { SyncId(it) },
+        ).asStateFlow()
+    }
+
+    // ── Tests ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `initial state shows loading`() = runTest {
+        val repo = FakeStreakRepository()
+        val provider = FakeHouseholdIdProvider("test-household")
+        val vm = StreakViewModel(repo, provider)
+
+        assertEquals(true, vm.uiState.value.isLoading)
+    }
+
+    @Test
+    fun `emits 0 streak when no dates logged`() = runTest {
+        val repo = FakeStreakRepository()
+        val provider = FakeHouseholdIdProvider("test-household")
+        val vm = StreakViewModel(repo, provider)
+
+        repo.datesFlow.value = emptySet()
+        advanceUntilIdle()
+
+        assertEquals(0, vm.uiState.value.currentStreak)
+        assertEquals(0, vm.uiState.value.longestStreak)
+        assertFalse(vm.uiState.value.isLoading)
+    }
+
+    @Test
+    fun `computes streak from dates`() = runTest {
+        val repo = FakeStreakRepository()
+        val provider = FakeHouseholdIdProvider("test-household")
+        val vm = StreakViewModel(repo, provider)
+
+        val today = kotlinx.datetime.Clock.System.now()
+            .toLocalDateTime(kotlinx.datetime.TimeZone.currentSystemDefault()).date
+
+        repo.datesFlow.value = setOf(today)
+        advanceUntilIdle()
+
+        assertEquals(1, vm.uiState.value.currentStreak)
+        assertFalse(vm.uiState.value.isLoading)
+    }
+
+    @Test
+    fun `dismissStreak hides the card`() = runTest {
+        val repo = FakeStreakRepository()
+        val provider = FakeHouseholdIdProvider("test-household")
+        val vm = StreakViewModel(repo, provider)
+
+        assertTrue(vm.uiState.value.isVisible)
+        vm.dismissStreak()
+        assertFalse(vm.uiState.value.isVisible)
+    }
+
+    @Test
+    fun `no household ID results in 0 streak`() = runTest {
+        val repo = FakeStreakRepository()
+        val provider = FakeHouseholdIdProvider(null)
+        val vm = StreakViewModel(repo, provider)
+
+        advanceUntilIdle()
+
+        assertEquals(0, vm.uiState.value.currentStreak)
+        assertFalse(vm.uiState.value.isLoading)
+    }
+
+    @Test
+    fun `updates when new dates flow in`() = runTest {
+        val repo = FakeStreakRepository()
+        val provider = FakeHouseholdIdProvider("test-household")
+        val vm = StreakViewModel(repo, provider)
+
+        val today = kotlinx.datetime.Clock.System.now()
+            .toLocalDateTime(kotlinx.datetime.TimeZone.currentSystemDefault()).date
+        val yesterday = today.minus(1, kotlinx.datetime.DateTimeUnit.DAY)
+
+        repo.datesFlow.value = setOf(today)
+        advanceUntilIdle()
+        assertEquals(1, vm.uiState.value.currentStreak)
+
+        repo.datesFlow.value = setOf(today, yesterday)
+        advanceUntilIdle()
+        assertEquals(2, vm.uiState.value.currentStreak)
+    }
+
+    @Test
+    fun `message is non-empty for any streak value`() = runTest {
+        val repo = FakeStreakRepository()
+        val provider = FakeHouseholdIdProvider("test-household")
+        val vm = StreakViewModel(repo, provider)
+
+        repo.datesFlow.value = emptySet()
+        advanceUntilIdle()
+
+        assertTrue(vm.uiState.value.message.isNotBlank())
+    }
+}


### PR DESCRIPTION
Implements non-manipulative streak tracking (#383). Counts consecutive days with logged transactions. Designed with ethical UX: no guilt-tripping, no loss aversion, dismissible without judgment. Includes StreakCalculator (pure functions), StreakRepository interface, TransactionBackedStreakRepository, StreakViewModel (Koin DI), StreakCard (Material 3 Composable with TalkBack support). 29 unit tests including exhaustive anti-manipulation language checks. Closes #383