### PR TITLE
feat(ci): add Kotlin/detekt linting workflow

### DIFF
--- a/.github/workflows/kotlin-lint.yml
+++ b/.github/workflows/kotlin-lint.yml
@@ -1,0 +1,116 @@
+# =============================================================================
+# Kotlin Lint — detekt static analysis for all Kotlin/KMP modules
+# =============================================================================
+#
+# Runs detekt on PRs and pushes to main that touch Kotlin or Gradle files.
+# Uploads SARIF results to GitHub Code Scanning for inline annotations.
+#
+# Issue: #958
+# =============================================================================
+
+name: Kotlin Lint
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/*.kt'
+      - '**/*.kts'
+      - '**/build.gradle*'
+      - 'gradle/**'
+      - 'settings.gradle*'
+      - 'gradle.properties'
+      - 'config/detekt/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - '**/*.kt'
+      - '**/*.kts'
+      - '**/build.gradle*'
+      - 'gradle/**'
+      - 'settings.gradle*'
+      - 'gradle.properties'
+      - 'config/detekt/**'
+
+concurrency:
+  group: kotlin-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+  pull-requests: read
+
+env:
+  GRADLE_OPTS: >-
+    -Xmx2g
+    -XX:MaxMetaspaceSize=512m
+    -Dorg.gradle.daemon=false
+
+jobs:
+  detekt:
+    name: detekt Analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+
+      - name: Run detekt
+        id: detekt
+        run: |
+          DETEKT_START=$SECONDS
+          ./gradlew detekt \
+            --parallel --build-cache --stacktrace \
+            --continue
+          echo "duration=$(( SECONDS - DETEKT_START ))" >> "$GITHUB_OUTPUT"
+
+      - name: Upload SARIF to GitHub Code Scanning
+        if: always() && (success() || failure())
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        continue-on-error: true
+        with:
+          sarif_file: build/reports/detekt/
+          category: detekt
+          wait-for-processing: false
+
+      - name: Upload detekt reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: detekt-reports
+          path: |
+            **/build/reports/detekt/
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: CI Summary
+        if: always()
+        run: |
+          echo "### 🔍 Kotlin Lint (detekt) Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Metric | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|--------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Duration | ${{ steps.detekt.outputs.duration || 'N/A' }}s |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Gradle cache | ${{ github.ref == 'refs/heads/main' && 'read-write' || 'read-only' }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| SARIF upload | ${{ steps.detekt.outcome == 'success' && '✅' || '⚠️' }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Detekt findings (if any) appear in the **Security → Code scanning** tab." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Add a dedicated GitHub Actions workflow (\kotlin-lint.yml\) for Kotlin static analysis using detekt.

## Changes

- **New workflow**: \.github/workflows/kotlin-lint.yml\
  - Runs detekt on all Kotlin/KMP modules
  - Triggers on PRs and pushes to main touching \*.kt\, \*.kts\, or Gradle files
  - Uploads SARIF results to GitHub Code Scanning for inline annotations
  - Uses pinned action versions (SHA) matching existing CI conventions
  - Gradle cache: read-only on PRs, read-write on main
  - Includes CI summary with duration and cache metrics

## Existing Infrastructure

- Uses existing \config/detekt/detekt.yml\ configuration
- detekt plugin already declared in root \uild.gradle.kts\ and version catalog (\1.23.7\)
- Follows same patterns as \ci.yml\, \ndroid-ci.yml\ (JDK 21, Android SDK, Gradle setup)

## CI Checks

- [x] Prettier format check
- [x] ESLint (zero warnings)

Closes #958