### PR TITLE
chore(tooling): add .prettierignore entries for non-JS source files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -12,3 +12,19 @@ node_modules/
 packages/design-tokens/build/
 kotlin-js-store/
 .github/workflow-templates/
+
+# Kotlin — Prettier has no parser for .kt/.kts files
+*.kt
+*.kts
+
+# Swift — Prettier has no parser for .swift files
+*.swift
+
+# Caddy server config — no Prettier parser
+Caddyfile
+Caddyfile.*
+
+# Environment files — contain KEY=VALUE pairs, not parseable
+*.env
+*.env.*
+.env*

--- a/package.json
+++ b/package.json
@@ -39,9 +39,6 @@
     ],
     "*.{json,yaml,yml,md,css,html}": [
       "prettier --write"
-    ],
-    "*.{kt,kts}": [
-      "prettier --write"
     ]
   },
   "keywords": [


### PR DESCRIPTION
## Summary

Add .prettierignore entries for file types that Prettier cannot parse, eliminating noisy parser errors during format checks and git hooks.

## Changes

### \.prettierignore\
Added entries for:
- **\*.kt\, \*.kts\** — Kotlin files (no Prettier parser)
- **\*.swift\** — Swift files (no Prettier parser)
- **\Caddyfile\, \Caddyfile.*\** — Caddy server config (no parser)
- **\*.env\, \*.env.*\, \.env*\** — Environment files (KEY=VALUE, not parseable)

### \package.json\
- Removed \*.{kt,kts}\ from \lint-staged\ — was triggering \prettier --write\ on Kotlin files which Prettier cannot parse, causing confusing errors during git commit hooks.

## Impact
- Eliminates parser error noise in CI (\lint-format.yml\) and local \
pm run format:check\
- Fixes \lint-staged\ hook failures when committing Kotlin files
- No functional changes to formatting of supported files

Closes #959