### PR TITLE
feat(ios): family/household collaboration features

### DIFF
--- a/apps/ios/Finance/Models/HouseholdModels.swift
+++ b/apps/ios/Finance/Models/HouseholdModels.swift
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// HouseholdModels.swift
+// Finance
+//
+// Data models for family/household collaboration features.
+// Supports household creation, member management, shared accounts,
+// and activity feeds.
+//
+// References: #270
+
+import SwiftUI
+
+// MARK: - Household
+
+/// A household unit for shared financial management.
+struct HouseholdItem: Identifiable, Sendable {
+    let id: String
+    let name: String
+    let createdAt: Date
+    let members: [HouseholdMember]
+    let inviteCode: String?
+
+    /// Number of active members.
+    var activeMemberCount: Int {
+        members.filter { $0.status == .active }.count
+    }
+}
+
+// MARK: - Household Member
+
+/// A member of a household with a defined role.
+struct HouseholdMember: Identifiable, Hashable, Sendable {
+    let id: String
+    let displayName: String
+    let email: String
+    let role: HouseholdRole
+    let status: MemberStatus
+    let avatarInitials: String
+    let joinedAt: Date
+
+    /// The color assigned to this member for chart differentiation.
+    var color: Color {
+        let colors: [Color] = [
+            ChartColorPalette.blue, ChartColorPalette.purple,
+            ChartColorPalette.magenta, ChartColorPalette.orange,
+            ChartColorPalette.gold, ChartColorPalette.teal,
+        ]
+        let hash = abs(id.hashValue)
+        return colors[hash % colors.count]
+    }
+}
+
+/// Role within a household determining permission levels.
+enum HouseholdRole: String, CaseIterable, Sendable {
+    case owner, admin, member, viewer
+
+    var displayName: String {
+        switch self {
+        case .owner: String(localized: "Owner")
+        case .admin: String(localized: "Admin")
+        case .member: String(localized: "Member")
+        case .viewer: String(localized: "Viewer")
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .owner: "crown"
+        case .admin: "person.badge.key"
+        case .member: "person"
+        case .viewer: "eye"
+        }
+    }
+
+    /// Whether this role can create transactions and budgets.
+    var canEdit: Bool {
+        switch self {
+        case .owner, .admin, .member: true
+        case .viewer: false
+        }
+    }
+
+    /// Whether this role can manage members and settings.
+    var canManage: Bool {
+        switch self {
+        case .owner, .admin: true
+        case .member, .viewer: false
+        }
+    }
+}
+
+/// Membership status within a household.
+enum MemberStatus: String, Sendable {
+    case active, invited, removed
+
+    var displayName: String {
+        switch self {
+        case .active: String(localized: "Active")
+        case .invited: String(localized: "Invited")
+        case .removed: String(localized: "Removed")
+        }
+    }
+}
+
+// MARK: - Shared Account
+
+/// An account shared between household members.
+struct SharedAccountItem: Identifiable, Sendable {
+    let id: String
+    let account: AccountItem
+    let sharedWith: [HouseholdMember]
+    let permissions: SharedPermission
+}
+
+/// Permission level for a shared account.
+enum SharedPermission: String, CaseIterable, Sendable {
+    case readOnly, contribute, fullAccess
+
+    var displayName: String {
+        switch self {
+        case .readOnly: String(localized: "View Only")
+        case .contribute: String(localized: "Can Add Transactions")
+        case .fullAccess: String(localized: "Full Access")
+        }
+    }
+}
+
+// MARK: - Activity Feed
+
+/// An activity entry in the household feed.
+struct HouseholdActivity: Identifiable, Sendable {
+    let id: String
+    let memberName: String
+    let action: ActivityAction
+    let description: String
+    let timestamp: Date
+    let amountMinorUnits: Int64?
+    let currencyCode: String?
+}
+
+/// Types of household activity actions.
+enum ActivityAction: String, Sendable {
+    case transactionCreated, budgetUpdated, goalContributed
+    case memberJoined, memberInvited, accountShared
+
+    var systemImage: String {
+        switch self {
+        case .transactionCreated: "arrow.left.arrow.right"
+        case .budgetUpdated: "chart.pie"
+        case .goalContributed: "target"
+        case .memberJoined: "person.badge.plus"
+        case .memberInvited: "envelope"
+        case .accountShared: "person.2"
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .transactionCreated: String(localized: "Transaction")
+        case .budgetUpdated: String(localized: "Budget Update")
+        case .goalContributed: String(localized: "Goal Contribution")
+        case .memberJoined: String(localized: "Member Joined")
+        case .memberInvited: String(localized: "Invitation Sent")
+        case .accountShared: String(localized: "Account Shared")
+        }
+    }
+}

--- a/apps/ios/Finance/Repositories/HouseholdRepository.swift
+++ b/apps/ios/Finance/Repositories/HouseholdRepository.swift
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// HouseholdRepository.swift
+// Finance
+//
+// Protocol defining the data-access contract for household collaboration.
+// Implementations can back this with KMP bridge calls or stub data.
+//
+// References: #270
+
+import Foundation
+
+/// Data-access contract for household collaboration features.
+///
+/// All methods are `async throws` to support network-backed operations
+/// for real-time household sync.
+protocol HouseholdRepository: Sendable {
+
+    /// Returns the current user's household, if any.
+    func getHousehold() async throws -> HouseholdItem?
+
+    /// Creates a new household with the current user as owner.
+    func createHousehold(name: String) async throws -> HouseholdItem
+
+    /// Generates an invite code for the household.
+    func generateInviteCode(householdId: String) async throws -> String
+
+    /// Joins a household using an invite code.
+    func joinHousehold(inviteCode: String) async throws -> HouseholdItem
+
+    /// Removes a member from the household. Requires admin/owner role.
+    func removeMember(householdId: String, memberId: String) async throws
+
+    /// Updates a member's role. Requires owner role.
+    func updateMemberRole(
+        householdId: String,
+        memberId: String,
+        newRole: HouseholdRole
+    ) async throws
+
+    /// Leaves the current household.
+    func leaveHousehold(householdId: String) async throws
+
+    /// Returns the activity feed for the household.
+    func getActivityFeed(
+        householdId: String,
+        limit: Int
+    ) async throws -> [HouseholdActivity]
+}

--- a/apps/ios/Finance/Screens/HouseholdView.swift
+++ b/apps/ios/Finance/Screens/HouseholdView.swift
@@ -1,0 +1,408 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// HouseholdView.swift
+// Finance
+//
+// Household management screen supporting creation, member management,
+// invite sharing, and activity feed display.
+//
+// References: #270
+
+import SwiftUI
+
+struct HouseholdView: View {
+    @State private var viewModel: HouseholdViewModel
+    @State private var showCreateSheet = false
+    @State private var newHouseholdName = ""
+    @State private var confirmLeave = false
+
+    init(repository: HouseholdRepository) {
+        _viewModel = State(initialValue: HouseholdViewModel(repository: repository))
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if viewModel.isLoading && viewModel.household == nil {
+                    ProgressView(String(localized: "Loading…"))
+                        .accessibilityLabel(String(localized: "Loading household"))
+                } else if let household = viewModel.household {
+                    householdContent(household)
+                } else {
+                    noHouseholdView
+                }
+            }
+            .navigationTitle(String(localized: "Household"))
+            .task {
+                await viewModel.loadHousehold()
+            }
+            .refreshable {
+                await viewModel.loadHousehold()
+            }
+            .alert(
+                String(localized: "Error"),
+                isPresented: .init(
+                    get: { viewModel.showError },
+                    set: { if !$0 { viewModel.dismissError() } }
+                )
+            ) {
+                Button(String(localized: "OK"), role: .cancel) {}
+            } message: {
+                Text(viewModel.errorMessage ?? "")
+            }
+            .sheet(isPresented: $showCreateSheet) {
+                createHouseholdSheet
+            }
+            .sheet(isPresented: $viewModel.showJoinSheet) {
+                joinHouseholdSheet
+            }
+            .sheet(isPresented: $viewModel.showInviteSheet) {
+                inviteSheet
+            }
+            .confirmationDialog(
+                String(localized: "Leave Household"),
+                isPresented: $confirmLeave,
+                titleVisibility: .visible
+            ) {
+                Button(String(localized: "Leave"), role: .destructive) {
+                    Task { await viewModel.leaveHousehold() }
+                }
+            } message: {
+                Text(String(localized: "You will lose access to all shared accounts and data."))
+            }
+        }
+    }
+
+    // MARK: - No Household
+
+    private var noHouseholdView: some View {
+        VStack(spacing: 24) {
+            EmptyStateView(
+                systemImage: "person.2.circle",
+                title: String(localized: "No Household"),
+                message: String(localized: "Create or join a household to share finances with family.")
+            )
+
+            VStack(spacing: 12) {
+                Button {
+                    showCreateSheet = true
+                } label: {
+                    Label(String(localized: "Create Household"), systemImage: "plus.circle")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .accessibilityLabel(String(localized: "Create a new household"))
+                .accessibilityHint(String(localized: "Opens the household creation form"))
+
+                Button {
+                    viewModel.showJoinSheet = true
+                } label: {
+                    Label(String(localized: "Join with Code"), systemImage: "ticket")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .accessibilityLabel(String(localized: "Join existing household"))
+                .accessibilityHint(String(localized: "Enter an invite code to join"))
+            }
+            .padding(.horizontal, 40)
+        }
+    }
+
+    // MARK: - Household Content
+
+    @ViewBuilder
+    private func householdContent(_ household: HouseholdItem) -> some View {
+        List {
+            // Members section
+            Section {
+                ForEach(household.members.filter { $0.status != .removed }) { member in
+                    memberRow(member)
+                }
+            } header: {
+                HStack {
+                    Text(String(localized: "Members"))
+                    Spacer()
+                    Text(String(localized: "\(household.activeMemberCount) active"))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(
+                    String(localized: "Members section, \(household.activeMemberCount) active")
+                )
+            }
+
+            // Activity feed section
+            if !viewModel.activityFeed.isEmpty {
+                Section {
+                    ForEach(viewModel.activityFeed) { activity in
+                        activityRow(activity)
+                    }
+                } header: {
+                    Text(String(localized: "Recent Activity"))
+                        .accessibilityAddTraits(.isHeader)
+                }
+            }
+
+            // Actions section
+            Section {
+                if viewModel.canManageMembers {
+                    Button {
+                        Task { await viewModel.generateInvite() }
+                    } label: {
+                        Label(
+                            String(localized: "Invite Member"),
+                            systemImage: "person.badge.plus"
+                        )
+                    }
+                    .accessibilityLabel(String(localized: "Invite a new member"))
+                    .accessibilityHint(String(localized: "Generates an invite code to share"))
+                }
+
+                Button(role: .destructive) {
+                    confirmLeave = true
+                } label: {
+                    Label(
+                        String(localized: "Leave Household"),
+                        systemImage: "rectangle.portrait.and.arrow.right"
+                    )
+                }
+                .accessibilityLabel(String(localized: "Leave this household"))
+                .accessibilityHint(String(localized: "You will lose access to shared data"))
+            }
+        }
+    }
+
+    // MARK: - Member Row
+
+    private func memberRow(_ member: HouseholdMember) -> some View {
+        HStack(spacing: 12) {
+            Text(member.avatarInitials)
+                .font(.headline)
+                .foregroundStyle(.white)
+                .frame(width: 40, height: 40)
+                .background(member.color)
+                .clipShape(Circle())
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(member.displayName)
+                    .font(.body)
+
+                HStack(spacing: 4) {
+                    Image(systemName: member.role.systemImage)
+                        .font(.caption2)
+                    Text(member.role.displayName)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .accessibilityHidden(true)
+            }
+
+            Spacer()
+
+            if member.status == .invited {
+                Text(String(localized: "Pending"))
+                    .font(.caption)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 2)
+                    .background(.orange.opacity(0.15))
+                    .clipShape(Capsule())
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            String(localized: "\(member.displayName), \(member.role.displayName)")
+        )
+        .accessibilityValue(member.status.displayName)
+        .contextMenu {
+            if viewModel.canManageMembers && member.role != .owner {
+                Button(role: .destructive) {
+                    Task { await viewModel.removeMember(member.id) }
+                } label: {
+                    Label(String(localized: "Remove"), systemImage: "person.badge.minus")
+                }
+                .accessibilityLabel(String(localized: "Remove \(member.displayName)"))
+            }
+        }
+    }
+
+    // MARK: - Activity Row
+
+    private func activityRow(_ activity: HouseholdActivity) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: activity.action.systemImage)
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .frame(width: 32, height: 32)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(activity.memberName)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+
+                Text(activity.description)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+
+            Spacer()
+
+            VStack(alignment: .trailing, spacing: 2) {
+                if let amount = activity.amountMinorUnits,
+                   let currency = activity.currencyCode {
+                    Text(viewModel.formatCurrency(amount, currencyCode: currency))
+                        .font(.caption)
+                        .fontWeight(.medium)
+                }
+
+                Text(activity.timestamp.formatted(.relative(presentation: .named)))
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            String(localized: "\(activity.memberName): \(activity.description)")
+        )
+    }
+
+    // MARK: - Create Sheet
+
+    private var createHouseholdSheet: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextField(
+                        String(localized: "Household Name"),
+                        text: $newHouseholdName
+                    )
+                    .accessibilityLabel(String(localized: "Household name"))
+                    .accessibilityHint(String(localized: "Enter a name for your household"))
+                } footer: {
+                    Text(String(localized: "Choose a name that your family members will recognize."))
+                }
+            }
+            .navigationTitle(String(localized: "Create Household"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(String(localized: "Cancel")) {
+                        showCreateSheet = false
+                    }
+                    .accessibilityLabel(String(localized: "Cancel"))
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(String(localized: "Create")) {
+                        Task {
+                            await viewModel.createHousehold(name: newHouseholdName)
+                            showCreateSheet = false
+                        }
+                    }
+                    .disabled(newHouseholdName.trimmingCharacters(in: .whitespaces).isEmpty)
+                    .accessibilityLabel(String(localized: "Create household"))
+                }
+            }
+        }
+    }
+
+    // MARK: - Join Sheet
+
+    private var joinHouseholdSheet: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextField(
+                        String(localized: "Invite Code"),
+                        text: $viewModel.joinCode
+                    )
+                    .textContentType(.oneTimeCode)
+                    .autocorrectionDisabled()
+                    .accessibilityLabel(String(localized: "Invite code"))
+                    .accessibilityHint(String(localized: "Enter the code shared with you"))
+                } footer: {
+                    Text(String(localized: "Ask a household member for the invite code."))
+                }
+            }
+            .navigationTitle(String(localized: "Join Household"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(String(localized: "Cancel")) {
+                        viewModel.showJoinSheet = false
+                    }
+                    .accessibilityLabel(String(localized: "Cancel"))
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(String(localized: "Join")) {
+                        Task { await viewModel.joinHousehold() }
+                    }
+                    .disabled(viewModel.joinCode.isEmpty)
+                    .accessibilityLabel(String(localized: "Join household"))
+                }
+            }
+        }
+    }
+
+    // MARK: - Invite Sheet
+
+    private var inviteSheet: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                Image(systemName: "person.badge.plus")
+                    .font(.system(size: 48))
+                    .foregroundStyle(.accent)
+                    .accessibilityHidden(true)
+
+                Text(String(localized: "Share this code"))
+                    .font(.headline)
+
+                if let code = viewModel.inviteCode {
+                    Text(code)
+                        .font(.system(.title, design: .monospaced))
+                        .fontWeight(.bold)
+                        .padding()
+                        .background(.fill.secondary)
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                        .accessibilityLabel(String(localized: "Invite code"))
+                        .accessibilityValue(code)
+                }
+
+                Text(String(localized: "Anyone with this code can join your household."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+
+                if let code = viewModel.inviteCode {
+                    ShareLink(
+                        item: code,
+                        subject: Text(String(localized: "Join my Finance household")),
+                        message: Text(String(localized: "Use this code to join: \(code)"))
+                    ) {
+                        Label(String(localized: "Share Code"), systemImage: "square.and.arrow.up")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .accessibilityLabel(String(localized: "Share invite code"))
+                }
+            }
+            .padding()
+            .navigationTitle(String(localized: "Invite"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(String(localized: "Done")) {
+                        viewModel.showInviteSheet = false
+                    }
+                    .accessibilityLabel(String(localized: "Done"))
+                }
+            }
+        }
+    }
+}
+
+#Preview("Household View") {
+    HouseholdView(repository: StubHouseholdRepository())
+}

--- a/apps/ios/Finance/ViewModels/HouseholdViewModel.swift
+++ b/apps/ios/Finance/ViewModels/HouseholdViewModel.swift
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// HouseholdViewModel.swift
+// Finance
+//
+// ViewModel for household management — creation, member management,
+// invite codes, and activity feed display.
+//
+// References: #270
+
+import Observation
+import os
+import SwiftUI
+
+@Observable
+final class HouseholdViewModel {
+    private let repository: HouseholdRepository
+    private let formatter: any SwiftExportFormatterModule
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
+        category: "HouseholdViewModel"
+    )
+
+    // MARK: - State
+
+    var household: HouseholdItem?
+    var activityFeed: [HouseholdActivity] = []
+    var isLoading = false
+    var errorMessage: String?
+    var inviteCode: String?
+    var showInviteSheet = false
+    var showJoinSheet = false
+    var joinCode = ""
+
+    var showError: Bool { errorMessage != nil }
+    func dismissError() { errorMessage = nil }
+
+    /// Whether the current user has a household.
+    var hasHousehold: Bool { household != nil }
+
+    /// Current user's role in the household.
+    var currentUserRole: HouseholdRole? {
+        household?.members.first { $0.status == .active }?.role
+    }
+
+    /// Whether the current user can manage members.
+    var canManageMembers: Bool {
+        currentUserRole?.canManage ?? false
+    }
+
+    // MARK: - Init
+
+    init(
+        repository: HouseholdRepository,
+        formatter: any SwiftExportFormatterModule = SwiftExportBridgeProvider.shared.formatter
+    ) {
+        self.repository = repository
+        self.formatter = formatter
+    }
+
+    // MARK: - Data Loading
+
+    func loadHousehold() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            household = try await repository.getHousehold()
+            if let householdId = household?.id {
+                activityFeed = try await repository.getActivityFeed(
+                    householdId: householdId,
+                    limit: 20
+                )
+            }
+            Self.logger.debug(
+                "Household loaded: \(self.household?.name ?? "none", privacy: .public)"
+            )
+        } catch {
+            errorMessage = String(localized: "Failed to load household data.")
+            Self.logger.error("Household load failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    func createHousehold(name: String) async {
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            household = try await repository.createHousehold(name: name)
+            Self.logger.info("Household created: \(name, privacy: .public)")
+        } catch {
+            errorMessage = String(localized: "Failed to create household.")
+            Self.logger.error("Household creation failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    func generateInvite() async {
+        guard let householdId = household?.id else { return }
+
+        do {
+            inviteCode = try await repository.generateInviteCode(householdId: householdId)
+            showInviteSheet = true
+        } catch {
+            errorMessage = String(localized: "Failed to generate invite code.")
+            Self.logger.error("Invite generation failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    func joinHousehold() async {
+        guard !joinCode.isEmpty else { return }
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            household = try await repository.joinHousehold(inviteCode: joinCode)
+            joinCode = ""
+            showJoinSheet = false
+            Self.logger.info("Joined household via invite code")
+        } catch {
+            errorMessage = String(localized: "Invalid or expired invite code.")
+            Self.logger.error("Join failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    func removeMember(_ memberId: String) async {
+        guard let householdId = household?.id else { return }
+
+        do {
+            try await repository.removeMember(
+                householdId: householdId,
+                memberId: memberId
+            )
+            await loadHousehold()
+        } catch {
+            errorMessage = String(localized: "Failed to remove member.")
+            Self.logger.error("Remove member failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    func leaveHousehold() async {
+        guard let householdId = household?.id else { return }
+
+        do {
+            try await repository.leaveHousehold(householdId: householdId)
+            household = nil
+            activityFeed = []
+        } catch {
+            errorMessage = String(localized: "Failed to leave household.")
+            Self.logger.error("Leave household failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    // MARK: - Formatting
+
+    func formatCurrency(_ amountMinorUnits: Int64, currencyCode: String) -> String {
+        formatter.format(
+            amountMinorUnits: amountMinorUnits,
+            currencyCode: currencyCode,
+            showSign: false
+        )
+    }
+}

--- a/apps/ios/Tests/HouseholdViewModelTests.swift
+++ b/apps/ios/Tests/HouseholdViewModelTests.swift
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// HouseholdViewModelTests.swift
+// FinanceTests
+//
+// Tests for HouseholdViewModel — household CRUD, member management,
+// invite codes, and activity feed loading.
+//
+// References: #270
+
+import XCTest
+@testable import FinanceApp
+
+// MARK: - Stub Household Repository
+
+final class StubHouseholdRepository: HouseholdRepository, @unchecked Sendable {
+    var householdToReturn: HouseholdItem?
+    var activityToReturn: [HouseholdActivity] = []
+    var errorToThrow: Error?
+    private(set) var createdHouseholdNames: [String] = []
+    private(set) var removedMemberIds: [String] = []
+    private(set) var leftHouseholdIds: [String] = []
+    private(set) var joinedCodes: [String] = []
+
+    func getHousehold() async throws -> HouseholdItem? {
+        if let error = errorToThrow { throw error }
+        return householdToReturn
+    }
+
+    func createHousehold(name: String) async throws -> HouseholdItem {
+        if let error = errorToThrow { throw error }
+        createdHouseholdNames.append(name)
+        return HouseholdItem(
+            id: "h-new", name: name, createdAt: .now,
+            members: [SampleHouseholdData.ownerMember],
+            inviteCode: nil
+        )
+    }
+
+    func generateInviteCode(householdId: String) async throws -> String {
+        if let error = errorToThrow { throw error }
+        return "INVITE-ABC123"
+    }
+
+    func joinHousehold(inviteCode: String) async throws -> HouseholdItem {
+        if let error = errorToThrow { throw error }
+        joinedCodes.append(inviteCode)
+        return SampleHouseholdData.household
+    }
+
+    func removeMember(householdId: String, memberId: String) async throws {
+        if let error = errorToThrow { throw error }
+        removedMemberIds.append(memberId)
+    }
+
+    func updateMemberRole(
+        householdId: String,
+        memberId: String,
+        newRole: HouseholdRole
+    ) async throws {
+        if let error = errorToThrow { throw error }
+    }
+
+    func leaveHousehold(householdId: String) async throws {
+        if let error = errorToThrow { throw error }
+        leftHouseholdIds.append(householdId)
+    }
+
+    func getActivityFeed(
+        householdId: String,
+        limit: Int
+    ) async throws -> [HouseholdActivity] {
+        if let error = errorToThrow { throw error }
+        return activityToReturn
+    }
+}
+
+// MARK: - Sample Household Data
+
+enum SampleHouseholdData {
+    static let ownerMember = HouseholdMember(
+        id: "m1", displayName: "Alice", email: "alice@example.com",
+        role: .owner, status: .active, avatarInitials: "AL",
+        joinedAt: Date(timeIntervalSince1970: 1_700_000_000)
+    )
+
+    static let memberTwo = HouseholdMember(
+        id: "m2", displayName: "Bob", email: "bob@example.com",
+        role: .member, status: .active, avatarInitials: "BO",
+        joinedAt: Date(timeIntervalSince1970: 1_700_100_000)
+    )
+
+    static let invitedMember = HouseholdMember(
+        id: "m3", displayName: "Charlie", email: "charlie@example.com",
+        role: .viewer, status: .invited, avatarInitials: "CH",
+        joinedAt: Date(timeIntervalSince1970: 1_700_200_000)
+    )
+
+    static let household = HouseholdItem(
+        id: "h1", name: "Smith Family",
+        createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+        members: [ownerMember, memberTwo, invitedMember],
+        inviteCode: nil
+    )
+
+    static let sampleActivity = HouseholdActivity(
+        id: "act1", memberName: "Bob",
+        action: .transactionCreated,
+        description: "Added grocery expense",
+        timestamp: Date(timeIntervalSince1970: 1_700_300_000),
+        amountMinorUnits: 85_40,
+        currencyCode: "USD"
+    )
+}
+
+// MARK: - Tests
+
+final class HouseholdViewModelTests: XCTestCase {
+
+    @MainActor
+    private func makeViewModel(
+        household: HouseholdItem? = SampleHouseholdData.household,
+        activity: [HouseholdActivity] = [SampleHouseholdData.sampleActivity],
+        error: Error? = nil
+    ) -> (HouseholdViewModel, StubHouseholdRepository) {
+        let repo = StubHouseholdRepository()
+        repo.householdToReturn = household
+        repo.activityToReturn = activity
+        repo.errorToThrow = error
+        let vm = HouseholdViewModel(repository: repo)
+        return (vm, repo)
+    }
+
+    @MainActor
+    func testLoadHouseholdPopulatesData() async {
+        let (vm, _) = makeViewModel()
+
+        await vm.loadHousehold()
+
+        XCTAssertNotNil(vm.household)
+        XCTAssertEqual(vm.household?.name, "Smith Family")
+        XCTAssertFalse(vm.activityFeed.isEmpty)
+        XCTAssertFalse(vm.isLoading)
+        XCTAssertNil(vm.errorMessage)
+    }
+
+    @MainActor
+    func testLoadHouseholdWithNoHousehold() async {
+        let (vm, _) = makeViewModel(household: nil, activity: [])
+
+        await vm.loadHousehold()
+
+        XCTAssertNil(vm.household)
+        XCTAssertFalse(vm.hasHousehold)
+        XCTAssertTrue(vm.activityFeed.isEmpty)
+    }
+
+    @MainActor
+    func testLoadHouseholdErrorSetsMessage() async {
+        let (vm, _) = makeViewModel(error: TestError.simulated)
+
+        await vm.loadHousehold()
+
+        XCTAssertNotNil(vm.errorMessage)
+        XCTAssertNil(vm.household)
+    }
+
+    @MainActor
+    func testCreateHouseholdSetsData() async {
+        let (vm, repo) = makeViewModel(household: nil, activity: [])
+
+        await vm.createHousehold(name: "New Family")
+
+        XCTAssertNotNil(vm.household)
+        XCTAssertEqual(repo.createdHouseholdNames, ["New Family"])
+    }
+
+    @MainActor
+    func testGenerateInviteSetsCode() async {
+        let (vm, _) = makeViewModel()
+        await vm.loadHousehold()
+
+        await vm.generateInvite()
+
+        XCTAssertEqual(vm.inviteCode, "INVITE-ABC123")
+        XCTAssertTrue(vm.showInviteSheet)
+    }
+
+    @MainActor
+    func testJoinHouseholdSetsData() async {
+        let (vm, repo) = makeViewModel(household: nil, activity: [])
+        vm.joinCode = "TEST-CODE"
+
+        await vm.joinHousehold()
+
+        XCTAssertNotNil(vm.household)
+        XCTAssertEqual(repo.joinedCodes, ["TEST-CODE"])
+        XCTAssertFalse(vm.showJoinSheet)
+    }
+
+    @MainActor
+    func testJoinHouseholdEmptyCodeDoesNothing() async {
+        let (vm, repo) = makeViewModel(household: nil, activity: [])
+        vm.joinCode = ""
+
+        await vm.joinHousehold()
+
+        XCTAssertTrue(repo.joinedCodes.isEmpty)
+    }
+
+    @MainActor
+    func testRemoveMember() async {
+        let (vm, repo) = makeViewModel()
+        await vm.loadHousehold()
+
+        await vm.removeMember("m2")
+
+        XCTAssertEqual(repo.removedMemberIds, ["m2"])
+    }
+
+    @MainActor
+    func testLeaveHousehold() async {
+        let (vm, repo) = makeViewModel()
+        await vm.loadHousehold()
+
+        await vm.leaveHousehold()
+
+        XCTAssertNil(vm.household)
+        XCTAssertTrue(vm.activityFeed.isEmpty)
+        XCTAssertEqual(repo.leftHouseholdIds, ["h1"])
+    }
+
+    @MainActor
+    func testCanManageMembers() async {
+        let (vm, _) = makeViewModel()
+        await vm.loadHousehold()
+
+        // Owner role can manage
+        XCTAssertTrue(vm.canManageMembers)
+    }
+
+    @MainActor
+    func testActiveMemberCount() {
+        let household = SampleHouseholdData.household
+        // owner + memberTwo = 2 active, invitedMember is .invited
+        XCTAssertEqual(household.activeMemberCount, 2)
+    }
+
+    @MainActor
+    func testHouseholdRolePermissions() {
+        XCTAssertTrue(HouseholdRole.owner.canEdit)
+        XCTAssertTrue(HouseholdRole.owner.canManage)
+        XCTAssertTrue(HouseholdRole.admin.canEdit)
+        XCTAssertTrue(HouseholdRole.admin.canManage)
+        XCTAssertTrue(HouseholdRole.member.canEdit)
+        XCTAssertFalse(HouseholdRole.member.canManage)
+        XCTAssertFalse(HouseholdRole.viewer.canEdit)
+        XCTAssertFalse(HouseholdRole.viewer.canManage)
+    }
+
+    @MainActor
+    func testDismissErrorClearsMessage() async {
+        let (vm, _) = makeViewModel(error: TestError.simulated)
+        await vm.loadHousehold()
+
+        XCTAssertTrue(vm.showError)
+        vm.dismissError()
+        XCTAssertFalse(vm.showError)
+    }
+}


### PR DESCRIPTION
## Summary
Implements the iOS portion of family/household collaboration, enabling users to create households, invite members, manage roles, and view shared activity feeds.

## Changes
- **HouseholdModels.swift**: Models for Household, HouseholdMember, HouseholdRole, MemberStatus, SharedAccountItem, SharedPermission, HouseholdActivity, ActivityAction
- **HouseholdRepository.swift**: Protocol for household CRUD, invite codes, member management, and activity feed
- **HouseholdViewModel.swift**: @Observable ViewModel with create, join, invite, remove, leave operations
- **HouseholdView.swift**: Full SwiftUI screen with member list, activity feed, create/join/invite sheets
- **HouseholdViewModelTests.swift**: 13 unit tests with stub repository

## Key Design Decisions
- Role-based permissions: owner > admin > member > viewer
- ShareLink integration for invite code sharing (iOS native share sheet)
- Context menus for member management (admin/owner only)
- ConfirmationDialog for destructive actions (leave household)
- IBM CVD-safe color palette for member avatar colors
- Activity feed with relative timestamps

## Accessibility
- All interactive elements have accessibility labels and hints
- Member rows combine children for VoiceOver
- Role and status conveyed through text, not just icons
- Dynamic Type supported throughout

Closes #270