### PR TITLE
feat(android): expertise tier system — adaptive UI by user skill level (#379)

### DIFF
--- a/apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt
@@ -22,6 +22,8 @@ import com.finance.android.ui.screens.BiometricAvailabilityChecker
 import com.finance.android.ui.screens.DefaultBiometricAvailabilityChecker
 import com.finance.android.ui.screens.SettingsViewModel
 import com.finance.android.ui.screens.affordability.AffordabilityViewModel
+import com.finance.android.ui.expertise.ExpertiseTierManager
+import com.finance.android.ui.expertise.ExpertiseTierViewModel
 import com.finance.android.ui.streak.StreakRepository
 import com.finance.android.ui.streak.StreakViewModel
 import com.finance.android.ui.streak.TransactionBackedStreakRepository
@@ -97,6 +99,11 @@ val appModule = module {
     /** Theme preference manager — provides reactive theme state for the whole app. */
     single { ThemePreferenceManager(get()) }
 
+    // ── Expertise tier ──────────────────────────────────────────────────
+
+    /** Expertise tier manager — persists and provides the user's skill level (#379). */
+    single { ExpertiseTierManager(get()) }
+
     // ── Streak tracking ───────────────────────────────────────────────
 
     /** Streak repository — derives logging dates from the transaction repository. */
@@ -136,4 +143,5 @@ val appModule = module {
     viewModelOf(::StreakViewModel)
     viewModelOf(::NotificationSettingsViewModel)
     viewModelOf(::AffordabilityViewModel)
+    viewModelOf(::ExpertiseTierViewModel)
 }

--- a/apps/android/src/main/kotlin/com/finance/android/ui/expertise/AdaptiveExpertise.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/expertise/AdaptiveExpertise.kt
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.expertise
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+
+/**
+ * Adaptive UI wrapper that conditionally renders content based on the
+ * user's expertise tier (#379).
+ *
+ * Place these composables around sections of your UI that should adapt
+ * to the user's skill level.
+ */
+
+/**
+ * Only renders [content] if the current tier matches [minimumTier] or above.
+ *
+ * Example usage:
+ * ```
+ * WhenExpertiseAtLeast(ExpertiseTier.INTERMEDIATE, tierManager) {
+ *     DebtToIncomeRatioCard(...)
+ * }
+ * ```
+ *
+ * @param minimumTier The minimum tier required to see this content.
+ * @param tierManager The [ExpertiseTierManager] providing the current tier.
+ * @param content The composable to conditionally render.
+ */
+@Composable
+fun WhenExpertiseAtLeast(
+    minimumTier: ExpertiseTier,
+    tierManager: ExpertiseTierManager,
+    content: @Composable () -> Unit,
+) {
+    val currentTier by tierManager.currentTier.collectAsState()
+    if (currentTier.ordinal >= minimumTier.ordinal) {
+        content()
+    }
+}
+
+/**
+ * Renders different content based on the user's expertise tier.
+ *
+ * Example:
+ * ```
+ * AdaptiveByTier(tierManager,
+ *     beginner = { SimpleBudgetCard() },
+ *     intermediate = { DetailedBudgetCard() },
+ *     advanced = { AdvancedBudgetAnalytics() },
+ * )
+ * ```
+ *
+ * @param tierManager The [ExpertiseTierManager] providing the current tier.
+ * @param beginner Content for beginner users.
+ * @param intermediate Content for intermediate users.
+ * @param advanced Content for advanced users.
+ */
+@Composable
+fun AdaptiveByTier(
+    tierManager: ExpertiseTierManager,
+    beginner: @Composable () -> Unit = {},
+    intermediate: @Composable () -> Unit = beginner,
+    advanced: @Composable () -> Unit = intermediate,
+) {
+    val currentTier by tierManager.currentTier.collectAsState()
+    when (currentTier) {
+        ExpertiseTier.BEGINNER -> beginner()
+        ExpertiseTier.INTERMEDIATE -> intermediate()
+        ExpertiseTier.ADVANCED -> advanced()
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/expertise/ExpertiseTier.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/expertise/ExpertiseTier.kt
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.expertise
+
+/**
+ * User expertise tier for adaptive UI (#379).
+ *
+ * Determines how much detail, jargon, and complexity the app surfaces.
+ * Users can self-select their tier or let the app infer it from usage
+ * patterns.
+ *
+ * @property displayName Human-readable tier name.
+ * @property description Brief description of what this tier means.
+ */
+enum class ExpertiseTier(
+    val displayName: String,
+    val description: String,
+) {
+    /**
+     * New to personal finance. Shows simplified views, extensive tooltips,
+     * guided workflows, and avoids jargon.
+     */
+    BEGINNER(
+        displayName = "Beginner",
+        description = "New to personal finance — simplified views with helpful guidance",
+    ),
+
+    /**
+     * Understands basic budgeting and saving. Shows standard detail
+     * with optional tooltips.
+     */
+    INTERMEDIATE(
+        displayName = "Intermediate",
+        description = "Comfortable with budgeting basics — balanced detail level",
+    ),
+
+    /**
+     * Experienced with financial planning. Shows full detail, advanced
+     * metrics, and power-user features.
+     */
+    ADVANCED(
+        displayName = "Advanced",
+        description = "Experienced with finance — full detail and advanced features",
+    ),
+}
+
+/**
+ * Feature visibility rules per expertise tier (#379).
+ *
+ * Encapsulates which UI elements, metrics, and features are visible
+ * at each tier level. This is a pure data model — no Android or
+ * Compose dependencies.
+ *
+ * @property tier The expertise tier these rules apply to.
+ * @property showDetailedMetrics Whether to show advanced metrics (debt-to-income, etc.).
+ * @property showTooltipsByDefault Whether tooltips auto-show or require tap.
+ * @property showAdvancedCharts Whether to show complex chart types (candlestick, etc.).
+ * @property showSimplifiedLabels Whether to use simplified labels instead of technical terms.
+ * @property maxBudgetCategories Suggested max categories to show without "show more".
+ * @property showGuidedWorkflows Whether to show step-by-step guided flows.
+ * @property showProjections Whether to show future projections and forecasts.
+ */
+data class TierFeatureConfig(
+    val tier: ExpertiseTier,
+    val showDetailedMetrics: Boolean,
+    val showTooltipsByDefault: Boolean,
+    val showAdvancedCharts: Boolean,
+    val showSimplifiedLabels: Boolean,
+    val maxBudgetCategories: Int,
+    val showGuidedWorkflows: Boolean,
+    val showProjections: Boolean,
+)
+
+/**
+ * Resolves [TierFeatureConfig] for a given [ExpertiseTier].
+ *
+ * Pure function — no side effects, easily testable.
+ */
+object ExpertiseTierConfig {
+
+    fun configFor(tier: ExpertiseTier): TierFeatureConfig = when (tier) {
+        ExpertiseTier.BEGINNER -> TierFeatureConfig(
+            tier = tier,
+            showDetailedMetrics = false,
+            showTooltipsByDefault = true,
+            showAdvancedCharts = false,
+            showSimplifiedLabels = true,
+            maxBudgetCategories = 5,
+            showGuidedWorkflows = true,
+            showProjections = false,
+        )
+        ExpertiseTier.INTERMEDIATE -> TierFeatureConfig(
+            tier = tier,
+            showDetailedMetrics = true,
+            showTooltipsByDefault = false,
+            showAdvancedCharts = false,
+            showSimplifiedLabels = false,
+            maxBudgetCategories = 10,
+            showGuidedWorkflows = false,
+            showProjections = true,
+        )
+        ExpertiseTier.ADVANCED -> TierFeatureConfig(
+            tier = tier,
+            showDetailedMetrics = true,
+            showTooltipsByDefault = false,
+            showAdvancedCharts = true,
+            showSimplifiedLabels = false,
+            maxBudgetCategories = 20,
+            showGuidedWorkflows = false,
+            showProjections = true,
+        )
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/expertise/ExpertiseTierManager.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/expertise/ExpertiseTierManager.kt
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.expertise
+
+import android.content.SharedPreferences
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import timber.log.Timber
+
+/**
+ * Manages persistence and retrieval of the user's expertise tier (#379).
+ *
+ * Stores the selected tier in SharedPreferences and exposes it as a
+ * reactive [StateFlow] for Compose UI consumption.
+ *
+ * @param sharedPreferences The app's SharedPreferences instance.
+ */
+class ExpertiseTierManager(
+    private val sharedPreferences: SharedPreferences,
+) {
+
+    private val _currentTier = MutableStateFlow(loadTier())
+    val currentTier: StateFlow<ExpertiseTier> = _currentTier.asStateFlow()
+
+    /**
+     * The current [TierFeatureConfig] derived from the active tier.
+     */
+    val currentConfig: TierFeatureConfig
+        get() = ExpertiseTierConfig.configFor(_currentTier.value)
+
+    /**
+     * Updates the user's expertise tier and persists it.
+     */
+    fun setTier(tier: ExpertiseTier) {
+        sharedPreferences.edit()
+            .putString(PREF_KEY_TIER, tier.name)
+            .apply()
+        _currentTier.value = tier
+        Timber.d("Expertise tier updated to %s", tier.name)
+    }
+
+    private fun loadTier(): ExpertiseTier {
+        val stored = sharedPreferences.getString(PREF_KEY_TIER, null)
+        return if (stored != null) {
+            try {
+                ExpertiseTier.valueOf(stored)
+            } catch (_: IllegalArgumentException) {
+                Timber.w("Unknown expertise tier '%s', defaulting to BEGINNER", stored)
+                ExpertiseTier.BEGINNER
+            }
+        } else {
+            ExpertiseTier.BEGINNER
+        }
+    }
+
+    companion object {
+        private const val PREF_KEY_TIER = "expertise_tier"
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/expertise/ExpertiseTierScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/expertise/ExpertiseTierScreen.kt
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.expertise
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.TrendingUp
+import androidx.compose.material.icons.filled.AutoGraph
+import androidx.compose.material.icons.filled.School
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.finance.android.ui.theme.FinanceTheme
+import org.koin.compose.viewmodel.koinViewModel
+
+/**
+ * Expertise tier selection screen (#379).
+ *
+ * Allows users to self-select their financial expertise level, which
+ * adapts the UI complexity throughout the app.
+ *
+ * @param onBack Navigation callback.
+ * @param viewModel The [ExpertiseTierViewModel].
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ExpertiseTierScreen(
+    onBack: () -> Unit = {},
+    modifier: Modifier = Modifier,
+    viewModel: ExpertiseTierViewModel = koinViewModel(),
+) {
+    val currentTier by viewModel.currentTier.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        "Your Experience Level",
+                        modifier = Modifier.semantics {
+                            heading()
+                            contentDescription = "Your Experience Level screen"
+                        },
+                    )
+                },
+                navigationIcon = {
+                    IconButton(
+                        onClick = onBack,
+                        modifier = Modifier.semantics { contentDescription = "Navigate back" },
+                    ) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                },
+            )
+        },
+        modifier = modifier,
+    ) { padding ->
+        ExpertiseTierContent(
+            currentTier = currentTier,
+            availableTiers = viewModel.availableTiers,
+            onTierSelected = viewModel::selectTier,
+            modifier = Modifier.padding(padding),
+        )
+    }
+}
+
+@Composable
+internal fun ExpertiseTierContent(
+    currentTier: ExpertiseTier,
+    availableTiers: List<ExpertiseTier>,
+    onTierSelected: (ExpertiseTier) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Text(
+            text = "Choose how much detail you'd like to see. You can change this anytime in Settings.",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.semantics {
+                contentDescription = "Choose how much detail you'd like to see. You can change this anytime in Settings."
+            },
+        )
+
+        Spacer(Modifier.height(8.dp))
+
+        availableTiers.forEach { tier ->
+            TierCard(
+                tier = tier,
+                isSelected = tier == currentTier,
+                onClick = { onTierSelected(tier) },
+            )
+        }
+
+        Spacer(Modifier.height(16.dp))
+
+        // Feature preview for current tier
+        val config = ExpertiseTierConfig.configFor(currentTier)
+        FeaturePreviewCard(config)
+
+        Spacer(Modifier.height(80.dp))
+    }
+}
+
+@Composable
+private fun TierCard(
+    tier: ExpertiseTier,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+) {
+    val containerColor by animateColorAsState(
+        targetValue = if (isSelected) MaterialTheme.colorScheme.primaryContainer
+        else MaterialTheme.colorScheme.surface,
+        label = "tier-card-color",
+    )
+    val borderColor by animateColorAsState(
+        targetValue = if (isSelected) MaterialTheme.colorScheme.primary
+        else MaterialTheme.colorScheme.outline,
+        label = "tier-card-border",
+    )
+
+    Card(
+        onClick = onClick,
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics {
+                contentDescription = "${tier.displayName}: ${tier.description}. ${if (isSelected) "Currently selected" else "Tap to select"}"
+                selected = isSelected
+            },
+        colors = CardDefaults.cardColors(containerColor = containerColor),
+        border = BorderStroke(
+            width = if (isSelected) 2.dp else 1.dp,
+            color = borderColor,
+        ),
+    ) {
+        Row(
+            modifier = Modifier.padding(20.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = iconForTier(tier),
+                contentDescription = null,
+                tint = if (isSelected) MaterialTheme.colorScheme.primary
+                else MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(32.dp),
+            )
+            Spacer(Modifier.width(16.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = tier.displayName,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = if (isSelected) MaterialTheme.colorScheme.onPrimaryContainer
+                    else MaterialTheme.colorScheme.onSurface,
+                )
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = tier.description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (isSelected) MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
+                    else MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            if (isSelected) {
+                Icon(
+                    Icons.Filled.Star,
+                    contentDescription = "Selected",
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(24.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun FeaturePreviewCard(config: TierFeatureConfig) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics {
+                contentDescription = "Feature preview for ${config.tier.displayName} tier"
+            },
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = "What you'll see",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.semantics { heading() },
+            )
+            Spacer(Modifier.height(12.dp))
+            FeatureRow("Detailed metrics", config.showDetailedMetrics)
+            FeatureRow("Auto-show tooltips", config.showTooltipsByDefault)
+            FeatureRow("Advanced charts", config.showAdvancedCharts)
+            FeatureRow("Simplified labels", config.showSimplifiedLabels)
+            FeatureRow("Guided workflows", config.showGuidedWorkflows)
+            FeatureRow("Future projections", config.showProjections)
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = "Budget categories shown: up to ${config.maxBudgetCategories}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.semantics {
+                    contentDescription = "Budget categories shown: up to ${config.maxBudgetCategories}"
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun FeatureRow(label: String, enabled: Boolean) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 2.dp)
+            .semantics { contentDescription = "$label: ${if (enabled) "enabled" else "disabled"}" },
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = if (enabled) "✓" else "—",
+            style = MaterialTheme.typography.bodySmall,
+            color = if (enabled) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline,
+            modifier = Modifier.width(24.dp),
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodySmall,
+            color = if (enabled) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+private fun iconForTier(tier: ExpertiseTier): ImageVector = when (tier) {
+    ExpertiseTier.BEGINNER -> Icons.Filled.School
+    ExpertiseTier.INTERMEDIATE -> Icons.AutoMirrored.Filled.TrendingUp
+    ExpertiseTier.ADVANCED -> Icons.Filled.AutoGraph
+}
+
+// ── Previews ────────────────────────────────────────────────────────────
+
+@Preview(showBackground = true, showSystemUi = true, name = "Expertise Tier - Beginner")
+@Composable
+private fun ExpertiseTierBeginnerPreview() {
+    FinanceTheme(dynamicColor = false) {
+        ExpertiseTierContent(
+            currentTier = ExpertiseTier.BEGINNER,
+            availableTiers = ExpertiseTier.entries,
+            onTierSelected = {},
+        )
+    }
+}
+
+@Preview(showBackground = true, showSystemUi = true, name = "Expertise Tier - Advanced")
+@Composable
+private fun ExpertiseTierAdvancedPreview() {
+    FinanceTheme(dynamicColor = false) {
+        ExpertiseTierContent(
+            currentTier = ExpertiseTier.ADVANCED,
+            availableTiers = ExpertiseTier.entries,
+            onTierSelected = {},
+        )
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/expertise/ExpertiseTierViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/expertise/ExpertiseTierViewModel.kt
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.expertise
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.StateFlow
+import timber.log.Timber
+
+/**
+ * ViewModel for the expertise tier selection and adaptive UI (#379).
+ *
+ * Exposes the current tier and feature config as reactive state, and
+ * provides methods to change the user's tier.
+ *
+ * @param expertiseTierManager Manages tier persistence and retrieval.
+ */
+class ExpertiseTierViewModel(
+    private val expertiseTierManager: ExpertiseTierManager,
+) : ViewModel() {
+
+    /** The currently selected expertise tier. */
+    val currentTier: StateFlow<ExpertiseTier> = expertiseTierManager.currentTier
+
+    /** Available tiers for the tier selector UI. */
+    val availableTiers: List<ExpertiseTier> = ExpertiseTier.entries
+
+    /**
+     * Returns the [TierFeatureConfig] for the current tier.
+     */
+    fun currentConfig(): TierFeatureConfig = expertiseTierManager.currentConfig
+
+    /**
+     * Updates the user's expertise tier.
+     */
+    fun selectTier(tier: ExpertiseTier) {
+        Timber.d("User selected expertise tier: %s", tier.name)
+        expertiseTierManager.setTier(tier)
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceNavHost.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceNavHost.kt
@@ -41,6 +41,7 @@ import com.finance.android.ui.screens.TransactionDetailScreen
 import com.finance.android.ui.screens.TransactionsScreen
 import com.finance.android.ui.screens.affordability.AffordabilityScreen
 import com.finance.android.ui.education.FinancialGlossaryScreen
+import com.finance.android.ui.expertise.ExpertiseTierScreen
 import timber.log.Timber
 
 /** Base URI for all deep link patterns declared in AndroidManifest.xml. */
@@ -126,6 +127,9 @@ sealed class Route(val route: String) {
 
     /** Financial Glossary screen - contextual education tooltips (#378). */
     data object FinancialGlossary : Route("glossary")
+
+    /** Expertise tier selection screen (#379). */
+    data object ExpertiseTier : Route("expertise-tier")
 
     /**
      * Transaction detail deep link destination.
@@ -289,6 +293,12 @@ fun FinanceNavHost(
 
         composable(Route.FinancialGlossary.route) {
             FinancialGlossaryScreen(
+                onBack = { navController.popBackStack() },
+            )
+        }
+
+        composable(Route.ExpertiseTier.route) {
+            ExpertiseTierScreen(
                 onBack = { navController.popBackStack() },
             )
         }

--- a/apps/android/src/test/kotlin/com/finance/android/ui/expertise/ExpertiseTierConfigTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/ui/expertise/ExpertiseTierConfigTest.kt
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.expertise
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for the expertise tier system (#379).
+ *
+ * Validates tier configurations, feature visibility rules, and
+ * the progression logic between tiers.
+ */
+class ExpertiseTierConfigTest {
+
+    // ── Beginner tier tests ─────────────────────────────────────────
+
+    @Test
+    fun `beginner tier hides detailed metrics`() {
+        val config = ExpertiseTierConfig.configFor(ExpertiseTier.BEGINNER)
+        assertFalse(config.showDetailedMetrics)
+    }
+
+    @Test
+    fun `beginner tier shows tooltips by default`() {
+        val config = ExpertiseTierConfig.configFor(ExpertiseTier.BEGINNER)
+        assertTrue(config.showTooltipsByDefault)
+    }
+
+    @Test
+    fun `beginner tier hides advanced charts`() {
+        val config = ExpertiseTierConfig.configFor(ExpertiseTier.BEGINNER)
+        assertFalse(config.showAdvancedCharts)
+    }
+
+    @Test
+    fun `beginner tier shows simplified labels`() {
+        val config = ExpertiseTierConfig.configFor(ExpertiseTier.BEGINNER)
+        assertTrue(config.showSimplifiedLabels)
+    }
+
+    @Test
+    fun `beginner tier shows guided workflows`() {
+        val config = ExpertiseTierConfig.configFor(ExpertiseTier.BEGINNER)
+        assertTrue(config.showGuidedWorkflows)
+    }
+
+    @Test
+    fun `beginner tier limits budget categories to 5`() {
+        val config = ExpertiseTierConfig.configFor(ExpertiseTier.BEGINNER)
+        assertEquals(5, config.maxBudgetCategories)
+    }
+
+    @Test
+    fun `beginner tier hides projections`() {
+        val config = ExpertiseTierConfig.configFor(ExpertiseTier.BEGINNER)
+        assertFalse(config.showProjections)
+    }
+
+    // ── Intermediate tier tests ─────────────────────────────────────
+
+    @Test
+    fun `intermediate tier shows detailed metrics`() {
+        val config = ExpertiseTierConfig.configFor(ExpertiseTier.INTERMEDIATE)
+        assertTrue(config.showDetailedMetrics)
+    }
+
+    @Test
+    fun `intermediate tier does not auto-show tooltips`() {
+        val config = ExpertiseTierConfig.configFor(ExpertiseTier.INTERMEDIATE)
+        assertFalse(config.showTooltipsByDefault)
+    }
+
+    @Test
+    fun `intermediate tier hides advanced charts`() {
+        val config = ExpertiseTierConfig.configFor(ExpertiseTier.INTERMEDIATE)
+        assertFalse(config.showAdvancedCharts)
+    }
+
+    @Test
+    fun `intermediate tier shows projections`() {
+        val config = ExpertiseTierConfig.configFor(ExpertiseTier.INTERMEDIATE)
+        assertTrue(config.showProjections)
+    }
+
+    @Test
+    fun `intermediate tier allows 10 budget categories`() {
+        val config = ExpertiseTierConfig.configFor(ExpertiseTier.INTERMEDIATE)
+        assertEquals(10, config.maxBudgetCategories)
+    }
+
+    // ── Advanced tier tests ─────────────────────────────────────────
+
+    @Test
+    fun `advanced tier shows all features`() {
+        val config = ExpertiseTierConfig.configFor(ExpertiseTier.ADVANCED)
+        assertTrue(config.showDetailedMetrics)
+        assertTrue(config.showAdvancedCharts)
+        assertTrue(config.showProjections)
+    }
+
+    @Test
+    fun `advanced tier allows 20 budget categories`() {
+        val config = ExpertiseTierConfig.configFor(ExpertiseTier.ADVANCED)
+        assertEquals(20, config.maxBudgetCategories)
+    }
+
+    @Test
+    fun `advanced tier does not show simplified labels`() {
+        val config = ExpertiseTierConfig.configFor(ExpertiseTier.ADVANCED)
+        assertFalse(config.showSimplifiedLabels)
+    }
+
+    @Test
+    fun `advanced tier does not show guided workflows`() {
+        val config = ExpertiseTierConfig.configFor(ExpertiseTier.ADVANCED)
+        assertFalse(config.showGuidedWorkflows)
+    }
+
+    // ── Cross-tier tests ────────────────────────────────────────────
+
+    @Test
+    fun `every tier has a config`() {
+        ExpertiseTier.entries.forEach { tier ->
+            val config = ExpertiseTierConfig.configFor(tier)
+            assertEquals(tier, config.tier)
+        }
+    }
+
+    @Test
+    fun `budget categories increase with tier level`() {
+        val beginner = ExpertiseTierConfig.configFor(ExpertiseTier.BEGINNER)
+        val intermediate = ExpertiseTierConfig.configFor(ExpertiseTier.INTERMEDIATE)
+        val advanced = ExpertiseTierConfig.configFor(ExpertiseTier.ADVANCED)
+        assertTrue(beginner.maxBudgetCategories < intermediate.maxBudgetCategories)
+        assertTrue(intermediate.maxBudgetCategories < advanced.maxBudgetCategories)
+    }
+
+    @Test
+    fun `tier display names are not empty`() {
+        ExpertiseTier.entries.forEach { tier ->
+            assertTrue(tier.displayName.isNotBlank(), "Empty displayName for $tier")
+            assertTrue(tier.description.isNotBlank(), "Empty description for $tier")
+        }
+    }
+
+    @Test
+    fun `tier ordinals follow beginner to advanced progression`() {
+        assertTrue(ExpertiseTier.BEGINNER.ordinal < ExpertiseTier.INTERMEDIATE.ordinal)
+        assertTrue(ExpertiseTier.INTERMEDIATE.ordinal < ExpertiseTier.ADVANCED.ordinal)
+    }
+}


### PR DESCRIPTION
## Summary
Implements the **expertise tier system** for Android (#379) — adaptive UI that adjusts complexity based on user skill level.

### Changes
- **ExpertiseTier enum**: BEGINNER / INTERMEDIATE / ADVANCED with human-readable display names and descriptions
- **TierFeatureConfig**: Per-tier visibility rules controlling metrics, charts, tooltips, labels, workflows, projections, and budget category limits
- **ExpertiseTierConfig**: Pure resolver mapping tiers to feature configurations
- **ExpertiseTierManager**: SharedPreferences-backed persistence with reactive StateFlow
- **ExpertiseTierViewModel**: Reactive tier state and selection actions for Compose
- **ExpertiseTierScreen**: Material 3 tier selection cards with animated color states, feature preview panel, and full TalkBack accessibility
- **AdaptiveExpertise composables**: \WhenExpertiseAtLeast\ and \AdaptiveByTier\ wrapper composables for conditional UI rendering

### Tier Progression
| Feature | Beginner | Intermediate | Advanced |
|---------|----------|-------------|----------|
| Detailed metrics | ✗ | ✓ | ✓ |
| Auto-show tooltips | ✓ | ✗ | ✗ |
| Advanced charts | ✗ | ✗ | ✓ |
| Simplified labels | ✓ | ✗ | ✗ |
| Guided workflows | ✓ | ✗ | ✗ |
| Projections | ✗ | ✓ | ✓ |
| Max categories | 5 | 10 | 20 |

### Tests
20 unit tests covering all tier configs, progression ordering, and feature boundaries.

Closes #379