### PR TITLE
feat(web): spending watchlists with proactive alerts

### DIFF
--- a/apps/web/src/hooks/index.ts
+++ b/apps/web/src/hooks/index.ts
@@ -44,3 +44,11 @@ export type {
   MonthComparison,
   Recommendation,
 } from './useInsights';
+export { useSpendingWatchlists } from './useSpendingWatchlists';
+export type {
+  UseSpendingWatchlistsResult,
+  Watchlist,
+  WatchlistAlert,
+  AlertLevel,
+  CreateWatchlistInput,
+} from './useSpendingWatchlists';

--- a/apps/web/src/hooks/useSpendingWatchlists.ts
+++ b/apps/web/src/hooks/useSpendingWatchlists.ts
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * React hook for managing spending watchlists with proactive alerts.
+ *
+ * A "watchlist" is a user-defined spending threshold on a category.
+ * When spending reaches warning (80%) or critical (100%) levels,
+ * the hook emits alert states that the UI can render as notifications.
+ *
+ * Watchlist data is persisted in localStorage for offline-first support.
+ * Spending totals are computed from the local SQLite-WASM database.
+ *
+ * Usage:
+ * ```tsx
+ * const { watchlists, alerts, addWatchlist, removeWatchlist } = useSpendingWatchlists();
+ * ```
+ *
+ * References: issue #316
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useDatabase } from '../db/DatabaseProvider';
+import { getTransactionsByCategory } from '../db/repositories/transactions';
+import type { SyncId, Transaction } from '../kmp/bridge';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A user-defined spending threshold for a category. */
+export interface Watchlist {
+  /** Unique identifier (UUID). */
+  readonly id: string;
+  /** Category to monitor. */
+  readonly categoryId: SyncId;
+  /** Category display name (cached for offline display). */
+  readonly categoryName: string;
+  /** Spending threshold in cents. */
+  readonly thresholdCents: number;
+  /** Period for spending calculation. */
+  readonly period: 'monthly' | 'weekly';
+  /** Whether alerts are enabled. */
+  readonly alertsEnabled: boolean;
+  /** Created timestamp. */
+  readonly createdAt: string;
+}
+
+/** Alert severity level. */
+export type AlertLevel = 'info' | 'warning' | 'critical';
+
+/** A proactive alert for a watchlist that has reached a threshold. */
+export interface WatchlistAlert {
+  /** The watchlist that triggered this alert. */
+  readonly watchlist: Watchlist;
+  /** Current spending in cents for the period. */
+  readonly spentCents: number;
+  /** Percentage of threshold reached (0-100+). */
+  readonly percentage: number;
+  /** Alert severity. */
+  readonly level: AlertLevel;
+  /** Human-readable message. */
+  readonly message: string;
+}
+
+/** Input for creating a new watchlist. */
+export interface CreateWatchlistInput {
+  readonly categoryId: SyncId;
+  readonly categoryName: string;
+  readonly thresholdCents: number;
+  readonly period?: 'monthly' | 'weekly';
+  readonly alertsEnabled?: boolean;
+}
+
+/** Shape returned by {@link useSpendingWatchlists}. */
+export interface UseSpendingWatchlistsResult {
+  /** All configured watchlists. */
+  watchlists: Watchlist[];
+  /** Active alerts for watchlists that have reached thresholds. */
+  alerts: WatchlistAlert[];
+  /** `true` while computing spending totals. */
+  loading: boolean;
+  /** Human-readable error message, or `null`. */
+  error: string | null;
+  /** Add a new watchlist. Returns the created watchlist. */
+  addWatchlist: (input: CreateWatchlistInput) => Watchlist;
+  /** Remove a watchlist by ID. */
+  removeWatchlist: (watchlistId: string) => void;
+  /** Update the threshold for an existing watchlist. */
+  updateThreshold: (watchlistId: string, newThresholdCents: number) => void;
+  /** Toggle alerts for a watchlist. */
+  toggleAlerts: (watchlistId: string) => void;
+  /** Dismiss an alert (hides it until spending changes). */
+  dismissAlert: (watchlistId: string) => void;
+  /** Refresh spending calculations. */
+  refresh: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Storage
+// ---------------------------------------------------------------------------
+
+const STORAGE_KEY = 'finance-spending-watchlists';
+
+function loadWatchlists(): Watchlist[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    return JSON.parse(raw) as Watchlist[];
+  } catch {
+    return [];
+  }
+}
+
+function saveWatchlists(watchlists: Watchlist[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(watchlists));
+  } catch {
+    // Storage may be unavailable.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Period helpers
+// ---------------------------------------------------------------------------
+
+function getPeriodBounds(period: 'monthly' | 'weekly'): { startDate: string; endDate: string } {
+  const now = new Date();
+  const pad = (v: number) => String(v).padStart(2, '0');
+
+  if (period === 'monthly') {
+    const start = new Date(now.getFullYear(), now.getMonth(), 1);
+    const end = new Date(now.getFullYear(), now.getMonth() + 1, 0);
+    return {
+      startDate: `${start.getFullYear()}-${pad(start.getMonth() + 1)}-${pad(start.getDate())}`,
+      endDate: `${end.getFullYear()}-${pad(end.getMonth() + 1)}-${pad(end.getDate())}`,
+    };
+  }
+
+  // Weekly: Monday to Sunday
+  const day = now.getDay();
+  const monday = new Date(now);
+  monday.setDate(now.getDate() - ((day + 6) % 7));
+  const sunday = new Date(monday);
+  sunday.setDate(monday.getDate() + 6);
+
+  return {
+    startDate: `${monday.getFullYear()}-${pad(monday.getMonth() + 1)}-${pad(monday.getDate())}`,
+    endDate: `${sunday.getFullYear()}-${pad(sunday.getMonth() + 1)}-${pad(sunday.getDate())}`,
+  };
+}
+
+function computeSpending(transactions: Transaction[]): number {
+  return transactions.reduce(
+    (sum, t) => (t.type === 'EXPENSE' ? sum + Math.abs(t.amount.amount) : sum),
+    0,
+  );
+}
+
+function getAlertLevel(percentage: number): AlertLevel {
+  if (percentage >= 100) return 'critical';
+  if (percentage >= 80) return 'warning';
+  return 'info';
+}
+
+function buildAlertMessage(watchlist: Watchlist, percentage: number, spentCents: number): string {
+  const spentDollars = (spentCents / 100).toFixed(2);
+  const thresholdDollars = (watchlist.thresholdCents / 100).toFixed(2);
+
+  if (percentage >= 100) {
+    return `${watchlist.categoryName}: $${spentDollars} spent — exceeded $${thresholdDollars} limit!`;
+  }
+  if (percentage >= 80) {
+    return `${watchlist.categoryName}: $${spentDollars} of $${thresholdDollars} (${Math.round(percentage)}%) — approaching limit`;
+  }
+  return `${watchlist.categoryName}: $${spentDollars} of $${thresholdDollars} (${Math.round(percentage)}%)`;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useSpendingWatchlists(): UseSpendingWatchlistsResult {
+  const db = useDatabase();
+  const [watchlists, setWatchlists] = useState<Watchlist[]>(loadWatchlists);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshToken, setRefreshToken] = useState(0);
+  const [dismissedIds, setDismissedIds] = useState<Set<string>>(new Set());
+
+  // Persist watchlists whenever they change.
+  useEffect(() => {
+    saveWatchlists(watchlists);
+  }, [watchlists]);
+
+  // Compute alerts from spending data.
+  const alerts = useMemo<WatchlistAlert[]>(() => {
+    if (watchlists.length === 0) return [];
+
+    try {
+      setLoading(true);
+      const results: WatchlistAlert[] = [];
+
+      for (const wl of watchlists) {
+        if (!wl.alertsEnabled || dismissedIds.has(wl.id)) continue;
+
+        const { startDate, endDate } = getPeriodBounds(wl.period);
+        const transactions = getTransactionsByCategory(db, wl.categoryId, {
+          type: 'EXPENSE',
+        }).filter((t) => t.date >= startDate && t.date <= endDate);
+
+        const spentCents = computeSpending(transactions);
+        const percentage = wl.thresholdCents > 0 ? (spentCents / wl.thresholdCents) * 100 : 0;
+
+        if (percentage >= 50) {
+          results.push({
+            watchlist: wl,
+            spentCents,
+            percentage,
+            level: getAlertLevel(percentage),
+            message: buildAlertMessage(wl, percentage, spentCents),
+          });
+        }
+      }
+
+      setLoading(false);
+      return results.sort((a, b) => b.percentage - a.percentage);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to compute spending alerts.');
+      setLoading(false);
+      return [];
+    }
+  }, [db, watchlists, dismissedIds, refreshToken]);
+
+  const addWatchlist = useCallback((input: CreateWatchlistInput): Watchlist => {
+    const newWl: Watchlist = {
+      id: crypto.randomUUID(),
+      categoryId: input.categoryId,
+      categoryName: input.categoryName,
+      thresholdCents: input.thresholdCents,
+      period: input.period ?? 'monthly',
+      alertsEnabled: input.alertsEnabled ?? true,
+      createdAt: new Date().toISOString(),
+    };
+
+    setWatchlists((prev) => [...prev, newWl]);
+    return newWl;
+  }, []);
+
+  const removeWatchlist = useCallback((watchlistId: string) => {
+    setWatchlists((prev) => prev.filter((wl) => wl.id !== watchlistId));
+  }, []);
+
+  const updateThreshold = useCallback((watchlistId: string, newThresholdCents: number) => {
+    setWatchlists((prev) =>
+      prev.map((wl) => (wl.id === watchlistId ? { ...wl, thresholdCents: newThresholdCents } : wl)),
+    );
+  }, []);
+
+  const toggleAlerts = useCallback((watchlistId: string) => {
+    setWatchlists((prev) =>
+      prev.map((wl) => (wl.id === watchlistId ? { ...wl, alertsEnabled: !wl.alertsEnabled } : wl)),
+    );
+  }, []);
+
+  const dismissAlert = useCallback((watchlistId: string) => {
+    setDismissedIds((prev) => new Set([...prev, watchlistId]));
+  }, []);
+
+  const refresh = useCallback(() => {
+    setDismissedIds(new Set());
+    setRefreshToken((t) => t + 1);
+  }, []);
+
+  return {
+    watchlists,
+    alerts,
+    loading,
+    error,
+    addWatchlist,
+    removeWatchlist,
+    updateThreshold,
+    toggleAlerts,
+    dismissAlert,
+    refresh,
+  };
+}

--- a/apps/web/src/pages/WatchlistsPage.test.tsx
+++ b/apps/web/src/pages/WatchlistsPage.test.tsx
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { WatchlistsPage } from './WatchlistsPage';
+import { useCategories } from '../hooks/useCategories';
+import { useSpendingWatchlists } from '../hooks/useSpendingWatchlists';
+import type { WatchlistAlert } from '../hooks/useSpendingWatchlists';
+
+vi.mock('../hooks/useCategories', () => ({
+  useCategories: vi.fn(),
+}));
+
+vi.mock('../hooks/useSpendingWatchlists', () => ({
+  useSpendingWatchlists: vi.fn(),
+}));
+
+const mockedUseCategories = vi.mocked(useCategories);
+const mockedUseSpendingWatchlists = vi.mocked(useSpendingWatchlists);
+
+const syncMetadata = {
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-01T00:00:00Z',
+  deletedAt: null,
+  syncVersion: 1,
+  isSynced: true,
+};
+
+describe('WatchlistsPage', () => {
+  beforeEach(() => {
+    mockedUseCategories.mockReturnValue({
+      categories: [
+        {
+          id: 'cat-food',
+          householdId: 'h1',
+          name: 'Food',
+          icon: null,
+          color: null,
+          parentId: null,
+          isIncome: false,
+          isSystem: false,
+          sortOrder: 1,
+          ...syncMetadata,
+        },
+        {
+          id: 'cat-transport',
+          householdId: 'h1',
+          name: 'Transport',
+          icon: null,
+          color: null,
+          parentId: null,
+          isIncome: false,
+          isSystem: false,
+          sortOrder: 2,
+          ...syncMetadata,
+        },
+      ],
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+      createCategory: vi.fn(),
+      updateCategory: vi.fn(),
+      deleteCategory: vi.fn(),
+    });
+
+    mockedUseSpendingWatchlists.mockReturnValue({
+      watchlists: [],
+      alerts: [],
+      loading: false,
+      error: null,
+      addWatchlist: vi.fn(),
+      removeWatchlist: vi.fn(),
+      updateThreshold: vi.fn(),
+      toggleAlerts: vi.fn(),
+      dismissAlert: vi.fn(),
+      refresh: vi.fn(),
+    });
+  });
+
+  it('renders the page heading', () => {
+    render(<WatchlistsPage />);
+    expect(screen.getByText('Spending Watchlists')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no watchlists exist', () => {
+    render(<WatchlistsPage />);
+    expect(screen.getByText('No watchlists yet')).toBeInTheDocument();
+  });
+
+  it('renders the add watchlist button', () => {
+    render(<WatchlistsPage />);
+    expect(screen.getByRole('button', { name: /add new spending watchlist/i })).toBeInTheDocument();
+  });
+
+  it('opens add form when button is clicked', () => {
+    render(<WatchlistsPage />);
+    fireEvent.click(screen.getByRole('button', { name: /add new spending watchlist/i }));
+    expect(screen.getByRole('dialog', { name: /add spending watchlist/i })).toBeInTheDocument();
+    expect(screen.getByLabelText('Category')).toBeInTheDocument();
+    expect(screen.getByLabelText('Spending Limit ($)')).toBeInTheDocument();
+  });
+
+  it('displays watchlist items when they exist', () => {
+    mockedUseSpendingWatchlists.mockReturnValue({
+      watchlists: [
+        {
+          id: 'wl-1',
+          categoryId: 'cat-food',
+          categoryName: 'Food',
+          thresholdCents: 50000,
+          period: 'monthly',
+          alertsEnabled: true,
+          createdAt: '2025-01-01T00:00:00Z',
+        },
+      ],
+      alerts: [],
+      loading: false,
+      error: null,
+      addWatchlist: vi.fn(),
+      removeWatchlist: vi.fn(),
+      updateThreshold: vi.fn(),
+      toggleAlerts: vi.fn(),
+      dismissAlert: vi.fn(),
+      refresh: vi.fn(),
+    });
+
+    render(<WatchlistsPage />);
+    expect(screen.getByText('Food')).toBeInTheDocument();
+    expect(screen.getByText('monthly')).toBeInTheDocument();
+  });
+
+  it('displays alert cards when alerts are active', () => {
+    const alerts: WatchlistAlert[] = [
+      {
+        watchlist: {
+          id: 'wl-1',
+          categoryId: 'cat-food',
+          categoryName: 'Food',
+          thresholdCents: 50000,
+          period: 'monthly',
+          alertsEnabled: true,
+          createdAt: '2025-01-01T00:00:00Z',
+        },
+        spentCents: 45000,
+        percentage: 90,
+        level: 'warning',
+        message: 'Food: $450.00 of $500.00 (90%) — approaching limit',
+      },
+    ];
+
+    mockedUseSpendingWatchlists.mockReturnValue({
+      watchlists: [alerts[0].watchlist],
+      alerts,
+      loading: false,
+      error: null,
+      addWatchlist: vi.fn(),
+      removeWatchlist: vi.fn(),
+      updateThreshold: vi.fn(),
+      toggleAlerts: vi.fn(),
+      dismissAlert: vi.fn(),
+      refresh: vi.fn(),
+    });
+
+    render(<WatchlistsPage />);
+    expect(screen.getByText('Active Alerts')).toBeInTheDocument();
+    expect(screen.getByText(/approaching limit/)).toBeInTheDocument();
+  });
+
+  it('calls dismissAlert when dismiss button is clicked', () => {
+    const dismissAlert = vi.fn();
+    const alerts: WatchlistAlert[] = [
+      {
+        watchlist: {
+          id: 'wl-1',
+          categoryId: 'cat-food',
+          categoryName: 'Food',
+          thresholdCents: 50000,
+          period: 'monthly',
+          alertsEnabled: true,
+          createdAt: '2025-01-01T00:00:00Z',
+        },
+        spentCents: 55000,
+        percentage: 110,
+        level: 'critical',
+        message: 'Food: $550.00 spent — exceeded $500.00 limit!',
+      },
+    ];
+
+    mockedUseSpendingWatchlists.mockReturnValue({
+      watchlists: [alerts[0].watchlist],
+      alerts,
+      loading: false,
+      error: null,
+      addWatchlist: vi.fn(),
+      removeWatchlist: vi.fn(),
+      updateThreshold: vi.fn(),
+      toggleAlerts: vi.fn(),
+      dismissAlert,
+      refresh: vi.fn(),
+    });
+
+    render(<WatchlistsPage />);
+    fireEvent.click(screen.getByRole('button', { name: /dismiss food alert/i }));
+    expect(dismissAlert).toHaveBeenCalledWith('wl-1');
+  });
+
+  it('has accessible landmarks', () => {
+    const alerts: WatchlistAlert[] = [
+      {
+        watchlist: {
+          id: 'wl-1',
+          categoryId: 'cat-food',
+          categoryName: 'Food',
+          thresholdCents: 50000,
+          period: 'monthly',
+          alertsEnabled: true,
+          createdAt: '2025-01-01T00:00:00Z',
+        },
+        spentCents: 45000,
+        percentage: 90,
+        level: 'warning',
+        message: 'Food: $450.00 of $500.00 (90%) — approaching limit',
+      },
+    ];
+
+    mockedUseSpendingWatchlists.mockReturnValue({
+      watchlists: [alerts[0].watchlist],
+      alerts,
+      loading: false,
+      error: null,
+      addWatchlist: vi.fn(),
+      removeWatchlist: vi.fn(),
+      updateThreshold: vi.fn(),
+      toggleAlerts: vi.fn(),
+      dismissAlert: vi.fn(),
+      refresh: vi.fn(),
+    });
+
+    render(<WatchlistsPage />);
+    expect(screen.getByRole('region', { name: /spending alerts/i })).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: /configured watchlists/i })).toBeInTheDocument();
+  });
+
+  it('shows loading spinner while loading', () => {
+    mockedUseSpendingWatchlists.mockReturnValue({
+      watchlists: [],
+      alerts: [],
+      loading: true,
+      error: null,
+      addWatchlist: vi.fn(),
+      removeWatchlist: vi.fn(),
+      updateThreshold: vi.fn(),
+      toggleAlerts: vi.fn(),
+      dismissAlert: vi.fn(),
+      refresh: vi.fn(),
+    });
+
+    render(<WatchlistsPage />);
+    expect(screen.getByText('Loading watchlists')).toBeInTheDocument();
+  });
+
+  it('shows error banner on error', () => {
+    mockedUseSpendingWatchlists.mockReturnValue({
+      watchlists: [],
+      alerts: [],
+      loading: false,
+      error: 'Something went wrong',
+      addWatchlist: vi.fn(),
+      removeWatchlist: vi.fn(),
+      updateThreshold: vi.fn(),
+      toggleAlerts: vi.fn(),
+      dismissAlert: vi.fn(),
+      refresh: vi.fn(),
+    });
+
+    render(<WatchlistsPage />);
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+  });
+
+  it('alert cards have role="alert" for screen readers', () => {
+    const alerts: WatchlistAlert[] = [
+      {
+        watchlist: {
+          id: 'wl-1',
+          categoryId: 'cat-food',
+          categoryName: 'Food',
+          thresholdCents: 50000,
+          period: 'monthly',
+          alertsEnabled: true,
+          createdAt: '2025-01-01T00:00:00Z',
+        },
+        spentCents: 55000,
+        percentage: 110,
+        level: 'critical',
+        message: 'Food: $550.00 spent — exceeded $500.00 limit!',
+      },
+    ];
+
+    mockedUseSpendingWatchlists.mockReturnValue({
+      watchlists: [alerts[0].watchlist],
+      alerts,
+      loading: false,
+      error: null,
+      addWatchlist: vi.fn(),
+      removeWatchlist: vi.fn(),
+      updateThreshold: vi.fn(),
+      toggleAlerts: vi.fn(),
+      dismissAlert: vi.fn(),
+      refresh: vi.fn(),
+    });
+
+    render(<WatchlistsPage />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/WatchlistsPage.tsx
+++ b/apps/web/src/pages/WatchlistsPage.tsx
@@ -1,0 +1,380 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Spending Watchlists Page
+ *
+ * Displays user-configured spending watchlists with proactive alerts.
+ * Users can add, edit, and remove watchlists that monitor category
+ * spending against defined thresholds.
+ *
+ * Accessibility:
+ *   - Alert notifications use role="alert" for screen reader announcements
+ *   - All forms use proper label associations
+ *   - Keyboard-accessible add/remove/edit controls
+ *   - Responsive mobile-first layout
+ *
+ * References: issue #316
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  CurrencyDisplay,
+  EmptyState,
+  ErrorBanner,
+  LoadingSpinner,
+  ConfirmDialog,
+} from '../components/common';
+import { useCategories } from '../hooks/useCategories';
+import {
+  useSpendingWatchlists,
+  type AlertLevel,
+  type CreateWatchlistInput,
+  type Watchlist,
+  type WatchlistAlert,
+} from '../hooks/useSpendingWatchlists';
+
+import '../styles/watchlists.css';
+
+// ---------------------------------------------------------------------------
+// Subcomponents
+// ---------------------------------------------------------------------------
+
+const ALERT_ARIA_LABELS: Record<AlertLevel, string> = {
+  info: 'Information',
+  warning: 'Warning',
+  critical: 'Critical alert',
+};
+
+interface AlertCardProps {
+  alert: WatchlistAlert;
+  onDismiss: (id: string) => void;
+}
+
+const AlertCard: React.FC<AlertCardProps> = ({ alert, onDismiss }) => (
+  <div
+    className={`watchlist-alert watchlist-alert--${alert.level}`}
+    role="alert"
+    aria-label={`${ALERT_ARIA_LABELS[alert.level]}: ${alert.message}`}
+  >
+    <div className="watchlist-alert__content">
+      <span className="watchlist-alert__icon" aria-hidden="true">
+        {alert.level === 'critical' ? '🚨' : alert.level === 'warning' ? '⚠️' : 'ℹ️'}
+      </span>
+      <div className="watchlist-alert__text">
+        <p className="watchlist-alert__message">{alert.message}</p>
+        <div
+          className="watchlist-alert__progress"
+          role="progressbar"
+          aria-valuenow={Math.min(Math.round(alert.percentage), 100)}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={`${Math.round(alert.percentage)}% of spending limit`}
+        >
+          <div
+            className={`watchlist-alert__progress-fill watchlist-alert__progress-fill--${alert.level}`}
+            style={{ width: `${Math.min(alert.percentage, 100)}%` }}
+          />
+        </div>
+      </div>
+    </div>
+    <button
+      type="button"
+      className="watchlist-alert__dismiss"
+      onClick={() => onDismiss(alert.watchlist.id)}
+      aria-label={`Dismiss ${alert.watchlist.categoryName} alert`}
+    >
+      ✕
+    </button>
+  </div>
+);
+
+interface WatchlistItemProps {
+  watchlist: Watchlist;
+  currentSpent: number;
+  onRemove: (id: string) => void;
+  onToggleAlerts: (id: string) => void;
+}
+
+const WatchlistItem: React.FC<WatchlistItemProps> = ({
+  watchlist,
+  currentSpent,
+  onRemove,
+  onToggleAlerts,
+}) => {
+  const percentage =
+    watchlist.thresholdCents > 0 ? (currentSpent / watchlist.thresholdCents) * 100 : 0;
+
+  return (
+    <li className="watchlist-item" role="listitem">
+      <div className="watchlist-item__header">
+        <h4 className="watchlist-item__name">{watchlist.categoryName}</h4>
+        <span className="watchlist-item__period">{watchlist.period}</span>
+      </div>
+      <div className="watchlist-item__spending">
+        <CurrencyDisplay amount={currentSpent} /> of{' '}
+        <CurrencyDisplay amount={watchlist.thresholdCents} />
+        <span className="watchlist-item__percentage"> ({Math.round(percentage)}%)</span>
+      </div>
+      <div
+        className="watchlist-item__bar"
+        role="progressbar"
+        aria-valuenow={Math.min(Math.round(percentage), 100)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={`${watchlist.categoryName}: ${Math.round(percentage)}% of limit`}
+      >
+        <div
+          className={`watchlist-item__bar-fill ${percentage >= 100 ? 'watchlist-item__bar-fill--critical' : percentage >= 80 ? 'watchlist-item__bar-fill--warning' : ''}`}
+          style={{ width: `${Math.min(percentage, 100)}%` }}
+        />
+      </div>
+      <div className="watchlist-item__actions">
+        <button
+          type="button"
+          className="watchlist-item__toggle"
+          onClick={() => onToggleAlerts(watchlist.id)}
+          aria-label={`${watchlist.alertsEnabled ? 'Disable' : 'Enable'} alerts for ${watchlist.categoryName}`}
+          aria-pressed={watchlist.alertsEnabled}
+        >
+          {watchlist.alertsEnabled ? '🔔 Alerts on' : '🔕 Alerts off'}
+        </button>
+        <button
+          type="button"
+          className="watchlist-item__remove"
+          onClick={() => onRemove(watchlist.id)}
+          aria-label={`Remove ${watchlist.categoryName} watchlist`}
+        >
+          Remove
+        </button>
+      </div>
+    </li>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Page component
+// ---------------------------------------------------------------------------
+
+export const WatchlistsPage: React.FC = () => {
+  const {
+    watchlists,
+    alerts,
+    loading,
+    error,
+    addWatchlist,
+    removeWatchlist,
+    toggleAlerts,
+    dismissAlert,
+    refresh,
+  } = useSpendingWatchlists();
+
+  const { categories, loading: categoriesLoading } = useCategories();
+
+  const [isAddFormOpen, setIsAddFormOpen] = useState(false);
+  const [selectedCategoryId, setSelectedCategoryId] = useState('');
+  const [thresholdInput, setThresholdInput] = useState('');
+  const [periodInput, setPeriodInput] = useState<'monthly' | 'weekly'>('monthly');
+  const [removingWatchlist, setRemovingWatchlist] = useState<Watchlist | null>(null);
+
+  // Filter out categories that already have watchlists.
+  const availableCategories = useMemo(
+    () =>
+      categories.filter(
+        (cat) => !cat.isIncome && !watchlists.some((wl) => wl.categoryId === cat.id),
+      ),
+    [categories, watchlists],
+  );
+
+  // Compute current spending per watchlist (for display).
+  const spendingMap = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const alert of alerts) {
+      map.set(alert.watchlist.id, alert.spentCents);
+    }
+    return map;
+  }, [alerts]);
+
+  const handleAddSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+
+      const category = categories.find((c) => c.id === selectedCategoryId);
+      if (!category || !thresholdInput) return;
+
+      const thresholdCents = Math.round(parseFloat(thresholdInput) * 100);
+      if (Number.isNaN(thresholdCents) || thresholdCents <= 0) return;
+
+      const input: CreateWatchlistInput = {
+        categoryId: category.id,
+        categoryName: category.name,
+        thresholdCents,
+        period: periodInput,
+      };
+
+      addWatchlist(input);
+      setIsAddFormOpen(false);
+      setSelectedCategoryId('');
+      setThresholdInput('');
+    },
+    [addWatchlist, categories, periodInput, selectedCategoryId, thresholdInput],
+  );
+
+  const handleConfirmRemove = useCallback(() => {
+    if (removingWatchlist) {
+      removeWatchlist(removingWatchlist.id);
+      setRemovingWatchlist(null);
+    }
+  }, [removeWatchlist, removingWatchlist]);
+
+  const isLoading = loading || categoriesLoading;
+
+  return (
+    <>
+      <div className="page-header-with-actions">
+        <h2
+          style={{
+            fontSize: 'var(--type-scale-headline-font-size)',
+            fontWeight: 'var(--type-scale-headline-font-weight)',
+          }}
+        >
+          Spending Watchlists
+        </h2>
+        <button
+          type="button"
+          className="add-button"
+          onClick={() => setIsAddFormOpen(true)}
+          aria-label="Add new spending watchlist"
+        >
+          <span aria-hidden="true">+</span> Add Watchlist
+        </button>
+      </div>
+
+      {/* Active alerts */}
+      {alerts.length > 0 && (
+        <section className="page-section" aria-label="Spending alerts">
+          <h3 className="page-section__title">Active Alerts</h3>
+          <div className="watchlist-alerts" role="log" aria-label="Spending alert notifications">
+            {alerts.map((alert) => (
+              <AlertCard key={alert.watchlist.id} alert={alert} onDismiss={dismissAlert} />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Watchlist items */}
+      {isLoading ? (
+        <div style={{ display: 'flex', justifyContent: 'center', padding: 'var(--spacing-8) 0' }}>
+          <LoadingSpinner label="Loading watchlists" />
+        </div>
+      ) : error ? (
+        <ErrorBanner message={error} onRetry={refresh} />
+      ) : watchlists.length === 0 ? (
+        <EmptyState
+          title="No watchlists yet"
+          description="Set up spending limits on categories to get proactive alerts when you're approaching your budget."
+        />
+      ) : (
+        <section className="page-section" aria-label="Configured watchlists">
+          <h3 className="page-section__title">Your Watchlists</h3>
+          <div className="card">
+            <ul className="watchlist-list" role="list">
+              {watchlists.map((wl) => (
+                <WatchlistItem
+                  key={wl.id}
+                  watchlist={wl}
+                  currentSpent={spendingMap.get(wl.id) ?? 0}
+                  onRemove={() => setRemovingWatchlist(wl)}
+                  onToggleAlerts={toggleAlerts}
+                />
+              ))}
+            </ul>
+          </div>
+        </section>
+      )}
+
+      {/* Add watchlist form (inline) */}
+      {isAddFormOpen && (
+        <div
+          className="watchlist-form-overlay"
+          role="dialog"
+          aria-label="Add spending watchlist"
+          aria-modal="true"
+        >
+          <form className="watchlist-form card" onSubmit={handleAddSubmit}>
+            <h3 className="watchlist-form__title">Add Watchlist</h3>
+            <div className="watchlist-form__field">
+              <label htmlFor="wl-category">Category</label>
+              <select
+                id="wl-category"
+                value={selectedCategoryId}
+                onChange={(e) => setSelectedCategoryId(e.target.value)}
+                required
+                aria-required="true"
+              >
+                <option value="">Select category…</option>
+                {availableCategories.map((cat) => (
+                  <option key={cat.id} value={cat.id}>
+                    {cat.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="watchlist-form__field">
+              <label htmlFor="wl-threshold">Spending Limit ($)</label>
+              <input
+                id="wl-threshold"
+                type="number"
+                min="0.01"
+                step="0.01"
+                value={thresholdInput}
+                onChange={(e) => setThresholdInput(e.target.value)}
+                required
+                aria-required="true"
+                placeholder="e.g. 500.00"
+              />
+            </div>
+            <div className="watchlist-form__field">
+              <label htmlFor="wl-period">Period</label>
+              <select
+                id="wl-period"
+                value={periodInput}
+                onChange={(e) => setPeriodInput(e.target.value as 'monthly' | 'weekly')}
+              >
+                <option value="monthly">Monthly</option>
+                <option value="weekly">Weekly</option>
+              </select>
+            </div>
+            <div className="watchlist-form__actions">
+              <button type="submit" className="watchlist-form__submit">
+                Add
+              </button>
+              <button
+                type="button"
+                className="watchlist-form__cancel"
+                onClick={() => setIsAddFormOpen(false)}
+              >
+                Cancel
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      <ConfirmDialog
+        isOpen={removingWatchlist !== null}
+        title="Remove Watchlist"
+        message={
+          removingWatchlist
+            ? `Remove the "${removingWatchlist.categoryName}" spending watchlist?`
+            : ''
+        }
+        confirmLabel="Remove"
+        cancelLabel="Cancel"
+        onConfirm={handleConfirmRemove}
+        onCancel={() => setRemovingWatchlist(null)}
+      />
+    </>
+  );
+};
+
+export default WatchlistsPage;

--- a/apps/web/src/pages/index.ts
+++ b/apps/web/src/pages/index.ts
@@ -15,3 +15,4 @@ export { InsightsPage } from './InsightsPage';
 export { LoginPage } from './LoginPage';
 export { NotFoundPage } from './NotFoundPage';
 export { SignupPage } from './SignupPage';
+export { WatchlistsPage } from './WatchlistsPage';

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -25,6 +25,7 @@ const Settings = lazy(() => import('./pages/SettingsPage'));
 const Login = lazy(() => import('./pages/LoginPage'));
 const Signup = lazy(() => import('./pages/SignupPage'));
 const NotFound = lazy(() => import('./pages/NotFoundPage'));
+const Watchlists = lazy(() => import('./pages/WatchlistsPage'));
 
 /**
  * Loading fallback shown while a lazy route chunk is being fetched.
@@ -208,6 +209,16 @@ export const AppRoutes: FC = () => (
         <AuthenticatedRoute>
           <Suspense fallback={<PageLoader />}>
             <Settings />
+          </Suspense>
+        </AuthenticatedRoute>
+      }
+    />
+    <Route
+      path="/watchlists"
+      element={
+        <AuthenticatedRoute>
+          <Suspense fallback={<PageLoader />}>
+            <Watchlists />
           </Suspense>
         </AuthenticatedRoute>
       }

--- a/apps/web/src/styles/watchlists.css
+++ b/apps/web/src/styles/watchlists.css
@@ -1,0 +1,323 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/* -------------------------------------------------------------------
+ * Spending Watchlists styles
+ *
+ * Mobile-first responsive layout with design token support.
+ * ------------------------------------------------------------------- */
+
+/* Alerts */
+.watchlist-alerts {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3, 12px);
+}
+
+.watchlist-alert {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-3, 12px);
+  padding: var(--spacing-3, 12px) var(--spacing-4, 16px);
+  border-radius: var(--border-radius-md, 8px);
+  border: 1px solid;
+}
+
+.watchlist-alert--info {
+  background-color: var(--color-blue-50, #eff6ff);
+  border-color: var(--color-blue-200, #bfdbfe);
+  color: var(--color-blue-800, #1e40af);
+}
+
+.watchlist-alert--warning {
+  background-color: var(--color-amber-50, #fffbeb);
+  border-color: var(--color-amber-200, #fde68a);
+  color: var(--color-amber-800, #92400e);
+}
+
+.watchlist-alert--critical {
+  background-color: var(--color-red-50, #fef2f2);
+  border-color: var(--color-red-200, #fecaca);
+  color: var(--color-red-800, #991b1b);
+}
+
+.watchlist-alert__content {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-2, 8px);
+  flex: 1;
+}
+
+.watchlist-alert__icon {
+  flex-shrink: 0;
+  font-size: 1.25rem;
+}
+
+.watchlist-alert__text {
+  flex: 1;
+  min-width: 0;
+}
+
+.watchlist-alert__message {
+  font-size: var(--type-scale-body-font-size, 0.875rem);
+  font-weight: 500;
+  margin-bottom: var(--spacing-2, 8px);
+}
+
+.watchlist-alert__progress {
+  height: 6px;
+  border-radius: var(--border-radius-full, 9999px);
+  background-color: rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+}
+
+.watchlist-alert__progress-fill {
+  height: 100%;
+  border-radius: inherit;
+  transition: width var(--duration-normal, 200ms) ease;
+}
+
+.watchlist-alert__progress-fill--info {
+  background-color: var(--color-blue-500, #3b82f6);
+}
+
+.watchlist-alert__progress-fill--warning {
+  background-color: var(--color-amber-500, #f59e0b);
+}
+
+.watchlist-alert__progress-fill--critical {
+  background-color: var(--color-red-500, #ef4444);
+}
+
+.watchlist-alert__dismiss {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: inherit;
+  opacity: 0.6;
+  cursor: pointer;
+  padding: var(--spacing-1, 4px);
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.watchlist-alert__dismiss:hover {
+  opacity: 1;
+}
+
+.watchlist-alert__dismiss:focus-visible {
+  outline: 2px solid var(--semantic-border-focus, #3b82f6);
+  outline-offset: 2px;
+}
+
+/* Watchlist list */
+.watchlist-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.watchlist-item {
+  padding: var(--spacing-4, 16px);
+  border-bottom: 1px solid var(--semantic-border-default, #e5e7eb);
+}
+
+.watchlist-item:last-child {
+  border-bottom: none;
+}
+
+.watchlist-item__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing-2, 8px);
+}
+
+.watchlist-item__name {
+  font-size: var(--type-scale-body-font-size, 0.875rem);
+  font-weight: 600;
+}
+
+.watchlist-item__period {
+  font-size: var(--type-scale-caption-font-size, 0.75rem);
+  color: var(--semantic-text-secondary, #6b7280);
+  text-transform: capitalize;
+}
+
+.watchlist-item__spending {
+  font-size: var(--type-scale-caption-font-size, 0.75rem);
+  color: var(--semantic-text-secondary, #6b7280);
+  margin-bottom: var(--spacing-2, 8px);
+}
+
+.watchlist-item__percentage {
+  font-weight: 600;
+}
+
+.watchlist-item__bar {
+  height: 8px;
+  border-radius: var(--border-radius-full, 9999px);
+  background-color: var(--color-gray-200, #e5e7eb);
+  overflow: hidden;
+  margin-bottom: var(--spacing-3, 12px);
+}
+
+.watchlist-item__bar-fill {
+  height: 100%;
+  border-radius: inherit;
+  background-color: var(--semantic-status-positive, #22c55e);
+  transition: width var(--duration-normal, 200ms) ease;
+}
+
+.watchlist-item__bar-fill--warning {
+  background-color: var(--semantic-status-warning, #f59e0b);
+}
+
+.watchlist-item__bar-fill--critical {
+  background-color: var(--semantic-status-negative, #ef4444);
+}
+
+.watchlist-item__actions {
+  display: flex;
+  gap: var(--spacing-2, 8px);
+  flex-wrap: wrap;
+}
+
+.watchlist-item__toggle,
+.watchlist-item__remove {
+  padding: var(--spacing-1, 4px) var(--spacing-2, 8px);
+  border: 1px solid var(--semantic-border-default, #e5e7eb);
+  border-radius: var(--border-radius-sm, 4px);
+  background: none;
+  font-size: var(--type-scale-caption-font-size, 0.75rem);
+  cursor: pointer;
+  color: var(--semantic-text-primary, inherit);
+}
+
+.watchlist-item__toggle:hover,
+.watchlist-item__remove:hover {
+  background-color: var(--semantic-background-elevated, #f3f4f6);
+}
+
+.watchlist-item__toggle:focus-visible,
+.watchlist-item__remove:focus-visible {
+  outline: 2px solid var(--semantic-border-focus, #3b82f6);
+  outline-offset: 2px;
+}
+
+.watchlist-item__remove {
+  color: var(--semantic-status-negative, #ef4444);
+  border-color: var(--semantic-status-negative, #ef4444);
+}
+
+/* Add form overlay */
+.watchlist-form-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.4);
+  z-index: 50;
+  padding: var(--spacing-4, 16px);
+}
+
+.watchlist-form {
+  width: 100%;
+  max-width: 400px;
+  padding: var(--spacing-6, 24px);
+}
+
+.watchlist-form__title {
+  font-size: var(--type-scale-title-font-size, 1.125rem);
+  font-weight: 600;
+  margin-bottom: var(--spacing-4, 16px);
+}
+
+.watchlist-form__field {
+  margin-bottom: var(--spacing-3, 12px);
+}
+
+.watchlist-form__field label {
+  display: block;
+  font-size: var(--type-scale-caption-font-size, 0.75rem);
+  font-weight: 500;
+  color: var(--semantic-text-secondary, #6b7280);
+  margin-bottom: var(--spacing-1, 4px);
+}
+
+.watchlist-form__field input,
+.watchlist-form__field select {
+  width: 100%;
+  padding: var(--spacing-2, 8px) var(--spacing-3, 12px);
+  border: 1px solid var(--semantic-border-default, #e5e7eb);
+  border-radius: var(--border-radius-sm, 4px);
+  font-size: var(--type-scale-body-font-size, 0.875rem);
+  background-color: var(--semantic-background-primary, #fff);
+  color: var(--semantic-text-primary, inherit);
+}
+
+.watchlist-form__field input:focus,
+.watchlist-form__field select:focus {
+  outline: 2px solid var(--semantic-border-focus, #3b82f6);
+  outline-offset: 0;
+}
+
+.watchlist-form__actions {
+  display: flex;
+  gap: var(--spacing-2, 8px);
+  justify-content: flex-end;
+  margin-top: var(--spacing-4, 16px);
+}
+
+.watchlist-form__submit {
+  padding: var(--spacing-2, 8px) var(--spacing-4, 16px);
+  background-color: var(--semantic-interactive-default, #3b82f6);
+  color: #fff;
+  border: none;
+  border-radius: var(--border-radius-sm, 4px);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.watchlist-form__submit:focus-visible {
+  outline: 2px solid var(--semantic-border-focus, #3b82f6);
+  outline-offset: 2px;
+}
+
+.watchlist-form__cancel {
+  padding: var(--spacing-2, 8px) var(--spacing-4, 16px);
+  background: none;
+  border: 1px solid var(--semantic-border-default, #e5e7eb);
+  border-radius: var(--border-radius-sm, 4px);
+  cursor: pointer;
+  color: var(--semantic-text-primary, inherit);
+}
+
+.watchlist-form__cancel:focus-visible {
+  outline: 2px solid var(--semantic-border-focus, #3b82f6);
+  outline-offset: 2px;
+}
+
+/* Dark mode */
+[data-theme='dark'] .watchlist-alert--info {
+  background-color: rgba(59, 130, 246, 0.12);
+  color: var(--color-blue-200, #bfdbfe);
+}
+
+[data-theme='dark'] .watchlist-alert--warning {
+  background-color: rgba(245, 158, 11, 0.12);
+  color: var(--color-amber-200, #fde68a);
+}
+
+[data-theme='dark'] .watchlist-alert--critical {
+  background-color: rgba(239, 68, 68, 0.12);
+  color: var(--color-red-200, #fecaca);
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .watchlist-alert__progress-fill,
+  .watchlist-item__bar-fill {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Closes #316

## Changes
- **useSpendingWatchlists hook**: Full watchlist management with localStorage persistence, period-based spending computation, and tiered alert levels (info/warning/critical at 50%/80%/100%)
- **WatchlistsPage**: Complete page with alert cards (role='alert'), watchlist list with progress bars, add/remove dialogs, category/threshold/period configuration
- **Route wiring**: Lazy-loaded /watchlists route added to router
- **Accessible UI**: role='alert' for notifications, aria-pressed for toggle buttons, proper label associations, keyboard-accessible controls
- **Responsive CSS**: Mobile-first watchlist styles with dark mode and reduced motion support

## Testing
- 11 tests covering page rendering, empty states, alert display, form interaction, dismiss behavior, accessibility landmarks, loading/error states
- All tests passing