### PR TITLE
feat(web): bulk transaction editing

### DIFF
--- a/apps/web/src/components/forms/BulkEditToolbar.test.tsx
+++ b/apps/web/src/components/forms/BulkEditToolbar.test.tsx
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { BulkEditToolbar } from './BulkEditToolbar';
+import type { BulkEditToolbarProps } from './BulkEditToolbar';
+
+const syncMetadata = {
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-01T00:00:00Z',
+  deletedAt: null,
+  syncVersion: 1,
+  isSynced: true,
+};
+
+const defaultCategories = [
+  {
+    id: 'cat-1',
+    householdId: 'h1',
+    name: 'Food',
+    icon: null,
+    color: null,
+    parentId: null,
+    isIncome: false,
+    isSystem: false,
+    sortOrder: 1,
+    ...syncMetadata,
+  },
+  {
+    id: 'cat-2',
+    householdId: 'h1',
+    name: 'Transport',
+    icon: null,
+    color: null,
+    parentId: null,
+    isIncome: false,
+    isSystem: false,
+    sortOrder: 2,
+    ...syncMetadata,
+  },
+];
+
+function renderToolbar(overrides: Partial<BulkEditToolbarProps> = {}) {
+  const defaultProps: BulkEditToolbarProps = {
+    selectionCount: 3,
+    totalCount: 10,
+    categories: defaultCategories,
+    onSelectAll: vi.fn(),
+    onClearSelection: vi.fn(),
+    onBulkUpdate: vi.fn().mockReturnValue({ successCount: 3, failureCount: 0, errors: [] }),
+    onBulkDelete: vi.fn().mockReturnValue({ successCount: 3, failureCount: 0, errors: [] }),
+    ...overrides,
+  };
+
+  return render(<BulkEditToolbar {...defaultProps} />);
+}
+
+describe('BulkEditToolbar', () => {
+  it('renders nothing when selectionCount is 0', () => {
+    const { container } = renderToolbar({ selectionCount: 0 });
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the toolbar with selection count', () => {
+    renderToolbar();
+    expect(screen.getByText('3 selected')).toBeInTheDocument();
+  });
+
+  it('has toolbar role with accessible label', () => {
+    renderToolbar();
+    expect(screen.getByRole('toolbar', { name: /bulk edit/i })).toBeInTheDocument();
+  });
+
+  it('shows Select All button when not all selected', () => {
+    renderToolbar({ selectionCount: 3, totalCount: 10 });
+    expect(screen.getByRole('button', { name: /select all/i })).toBeInTheDocument();
+  });
+
+  it('shows Deselect All button when all selected', () => {
+    renderToolbar({ selectionCount: 10, totalCount: 10 });
+    expect(screen.getByRole('button', { name: /deselect all/i })).toBeInTheDocument();
+  });
+
+  it('calls onSelectAll when Select All is clicked', () => {
+    const onSelectAll = vi.fn();
+    renderToolbar({ onSelectAll, selectionCount: 3, totalCount: 10 });
+    fireEvent.click(screen.getByRole('button', { name: /select all/i }));
+    expect(onSelectAll).toHaveBeenCalledOnce();
+  });
+
+  it('calls onClearSelection when cancel is clicked', () => {
+    const onClearSelection = vi.fn();
+    renderToolbar({ onClearSelection });
+    fireEvent.click(screen.getByRole('button', { name: /cancel bulk selection/i }));
+    expect(onClearSelection).toHaveBeenCalledOnce();
+  });
+
+  it('opens category picker on click', () => {
+    renderToolbar();
+    fireEvent.click(screen.getByRole('button', { name: /change category/i }));
+    expect(screen.getByRole('listbox', { name: /select category/i })).toBeInTheDocument();
+    expect(screen.getByText('Food')).toBeInTheDocument();
+    expect(screen.getByText('Transport')).toBeInTheDocument();
+  });
+
+  it('calls onBulkUpdate with category when selected', () => {
+    const onBulkUpdate = vi.fn().mockReturnValue({ successCount: 3, failureCount: 0, errors: [] });
+    renderToolbar({ onBulkUpdate });
+    fireEvent.click(screen.getByRole('button', { name: /change category/i }));
+    fireEvent.click(screen.getByText('Food'));
+    expect(onBulkUpdate).toHaveBeenCalledWith({ categoryId: 'cat-1' });
+  });
+
+  it('shows delete confirmation on delete click', () => {
+    renderToolbar();
+    fireEvent.click(screen.getByRole('button', { name: /delete 3 selected/i }));
+    expect(screen.getByText(/Delete 3 transactions\?/)).toBeInTheDocument();
+  });
+
+  it('calls onBulkDelete on confirm', () => {
+    const onBulkDelete = vi.fn().mockReturnValue({ successCount: 3, failureCount: 0, errors: [] });
+    renderToolbar({ onBulkDelete });
+    fireEvent.click(screen.getByRole('button', { name: /delete 3 selected/i }));
+    fireEvent.click(screen.getByRole('button', { name: /confirm delete/i }));
+    expect(onBulkDelete).toHaveBeenCalledOnce();
+  });
+
+  it('shows success toast after bulk operation', () => {
+    const onBulkUpdate = vi.fn().mockReturnValue({ successCount: 3, failureCount: 0, errors: [] });
+    renderToolbar({ onBulkUpdate });
+    fireEvent.click(screen.getByRole('button', { name: /change category/i }));
+    fireEvent.click(screen.getByText('Food'));
+    expect(screen.getByRole('status')).toHaveTextContent('Updated category for 3 transactions');
+  });
+
+  it('shows failure count in toast when some fail', () => {
+    const onBulkUpdate = vi
+      .fn()
+      .mockReturnValue({ successCount: 2, failureCount: 1, errors: ['err'] });
+    renderToolbar({ onBulkUpdate });
+    fireEvent.click(screen.getByRole('button', { name: /change category/i }));
+    fireEvent.click(screen.getByText('Food'));
+    expect(screen.getByRole('status')).toHaveTextContent('1 failed');
+  });
+
+  it('has Uncategorized option in category picker', () => {
+    renderToolbar();
+    fireEvent.click(screen.getByRole('button', { name: /change category/i }));
+    expect(screen.getByText('Uncategorized')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/forms/BulkEditToolbar.tsx
+++ b/apps/web/src/components/forms/BulkEditToolbar.tsx
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * BulkEditToolbar — floating action bar for bulk transaction operations.
+ *
+ * Appears when one or more transactions are selected. Provides:
+ *   - Selection count display
+ *   - Category reassignment
+ *   - Bulk delete with confirmation
+ *   - Select all / Deselect all toggle
+ *
+ * Accessibility:
+ *   - role="toolbar" with aria-label
+ *   - Keyboard-accessible controls
+ *   - aria-live region for operation results
+ *
+ * References: issue #318
+ */
+
+import React, { useCallback, useState } from 'react';
+import type { Category, SyncId } from '../../kmp/bridge';
+import type { BulkUpdateFields, BulkOperationResult } from '../../hooks/useBulkTransactions';
+
+import '../../styles/bulk-edit.css';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface BulkEditToolbarProps {
+  /** Number of selected transactions. */
+  selectionCount: number;
+  /** Total number of transactions in the list. */
+  totalCount: number;
+  /** Available categories for reassignment. */
+  categories: Category[];
+  /** Select all transactions. */
+  onSelectAll: () => void;
+  /** Clear all selections. */
+  onClearSelection: () => void;
+  /** Apply bulk field updates. */
+  onBulkUpdate: (fields: BulkUpdateFields) => BulkOperationResult;
+  /** Bulk delete selected transactions. */
+  onBulkDelete: () => BulkOperationResult;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export const BulkEditToolbar: React.FC<BulkEditToolbarProps> = ({
+  selectionCount,
+  totalCount,
+  categories,
+  onSelectAll,
+  onClearSelection,
+  onBulkUpdate,
+  onBulkDelete,
+}) => {
+  const [showCategoryPicker, setShowCategoryPicker] = useState(false);
+  const [operationResult, setOperationResult] = useState<string | null>(null);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  const allSelected = selectionCount === totalCount && totalCount > 0;
+
+  const handleCategoryChange = useCallback(
+    (categoryId: SyncId | null) => {
+      const result = onBulkUpdate({ categoryId });
+      setShowCategoryPicker(false);
+      setOperationResult(
+        `Updated category for ${result.successCount} transaction${result.successCount !== 1 ? 's' : ''}${result.failureCount > 0 ? ` (${result.failureCount} failed)` : ''}`,
+      );
+      setTimeout(() => setOperationResult(null), 4000);
+    },
+    [onBulkUpdate],
+  );
+
+  const handleBulkDelete = useCallback(() => {
+    const result = onBulkDelete();
+    setShowDeleteConfirm(false);
+    setOperationResult(
+      `Deleted ${result.successCount} transaction${result.successCount !== 1 ? 's' : ''}${result.failureCount > 0 ? ` (${result.failureCount} failed)` : ''}`,
+    );
+    setTimeout(() => setOperationResult(null), 4000);
+  }, [onBulkDelete]);
+
+  if (selectionCount === 0) return null;
+
+  return (
+    <div className="bulk-edit-toolbar" role="toolbar" aria-label="Bulk edit actions">
+      <div className="bulk-edit-toolbar__info">
+        <span className="bulk-edit-toolbar__count" aria-live="polite">
+          {selectionCount} selected
+        </span>
+        <button
+          type="button"
+          className="bulk-edit-toolbar__toggle"
+          onClick={allSelected ? onClearSelection : onSelectAll}
+          aria-label={allSelected ? 'Deselect all transactions' : 'Select all transactions'}
+        >
+          {allSelected ? 'Deselect All' : 'Select All'}
+        </button>
+      </div>
+
+      <div className="bulk-edit-toolbar__actions">
+        {/* Category reassignment */}
+        <div className="bulk-edit-toolbar__action-group">
+          <button
+            type="button"
+            className="bulk-edit-toolbar__button"
+            onClick={() => setShowCategoryPicker(!showCategoryPicker)}
+            aria-expanded={showCategoryPicker}
+            aria-label="Change category for selected transactions"
+          >
+            <span aria-hidden="true">📁</span> Category
+          </button>
+          {showCategoryPicker && (
+            <div
+              className="bulk-edit-toolbar__dropdown"
+              role="listbox"
+              aria-label="Select category"
+            >
+              <button
+                type="button"
+                className="bulk-edit-toolbar__dropdown-item"
+                role="option"
+                aria-selected={false}
+                onClick={() => handleCategoryChange(null)}
+              >
+                Uncategorized
+              </button>
+              {categories.map((cat) => (
+                <button
+                  key={cat.id}
+                  type="button"
+                  className="bulk-edit-toolbar__dropdown-item"
+                  role="option"
+                  aria-selected={false}
+                  onClick={() => handleCategoryChange(cat.id)}
+                >
+                  {cat.name}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Bulk delete */}
+        {!showDeleteConfirm ? (
+          <button
+            type="button"
+            className="bulk-edit-toolbar__button bulk-edit-toolbar__button--danger"
+            onClick={() => setShowDeleteConfirm(true)}
+            aria-label={`Delete ${selectionCount} selected transactions`}
+          >
+            <span aria-hidden="true">🗑️</span> Delete
+          </button>
+        ) : (
+          <div
+            className="bulk-edit-toolbar__confirm"
+            role="alertdialog"
+            aria-label="Confirm deletion"
+          >
+            <span className="bulk-edit-toolbar__confirm-text">
+              Delete {selectionCount} transaction{selectionCount !== 1 ? 's' : ''}?
+            </span>
+            <button
+              type="button"
+              className="bulk-edit-toolbar__button bulk-edit-toolbar__button--danger"
+              onClick={handleBulkDelete}
+              aria-label="Confirm delete"
+            >
+              Confirm
+            </button>
+            <button
+              type="button"
+              className="bulk-edit-toolbar__button"
+              onClick={() => setShowDeleteConfirm(false)}
+              aria-label="Cancel delete"
+            >
+              Cancel
+            </button>
+          </div>
+        )}
+
+        {/* Clear selection */}
+        <button
+          type="button"
+          className="bulk-edit-toolbar__button"
+          onClick={onClearSelection}
+          aria-label="Cancel bulk selection"
+        >
+          ✕
+        </button>
+      </div>
+
+      {/* Operation result toast */}
+      {operationResult && (
+        <div className="bulk-edit-toolbar__toast" role="status" aria-live="polite">
+          {operationResult}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default BulkEditToolbar;

--- a/apps/web/src/components/forms/index.ts
+++ b/apps/web/src/components/forms/index.ts
@@ -16,3 +16,5 @@ export { TransactionForm } from './TransactionForm';
 export type { TransactionFormProps } from './TransactionForm';
 export { QuickEntry } from './QuickEntry';
 export type { QuickEntryProps } from './QuickEntry';
+export { BulkEditToolbar } from './BulkEditToolbar';
+export type { BulkEditToolbarProps } from './BulkEditToolbar';

--- a/apps/web/src/hooks/index.ts
+++ b/apps/web/src/hooks/index.ts
@@ -29,3 +29,9 @@ export { useQuickEntry } from './useQuickEntry';
 export type { UseQuickEntryResult } from './useQuickEntry';
 export { useWidgetLayout } from './useWidgetLayout';
 export type { UseWidgetLayoutResult } from './useWidgetLayout';
+export { useBulkTransactions } from './useBulkTransactions';
+export type {
+  UseBulkTransactionsResult,
+  BulkUpdateFields,
+  BulkOperationResult,
+} from './useBulkTransactions';

--- a/apps/web/src/hooks/useBulkTransactions.ts
+++ b/apps/web/src/hooks/useBulkTransactions.ts
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * React hook for bulk transaction editing.
+ *
+ * Manages selection state for multiple transactions and provides
+ * bulk operations: update category, update tags, and bulk delete.
+ *
+ * Usage:
+ * ```tsx
+ * const { selectedIds, toggleSelection, selectAll, clearSelection,
+ *         bulkUpdateCategory, bulkDelete, selectionCount } = useBulkTransactions(transactions);
+ * ```
+ *
+ * References: issue #318
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+import { useDatabase } from '../db/DatabaseProvider';
+import {
+  updateTransaction as repoUpdateTransaction,
+  deleteTransaction as repoDeleteTransaction,
+} from '../db/repositories/transactions';
+import type { SyncId, Transaction, TransactionType } from '../kmp/bridge';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Fields that can be bulk-updated across selected transactions. */
+export interface BulkUpdateFields {
+  categoryId?: SyncId | null;
+  tags?: readonly string[];
+  type?: TransactionType;
+  status?: 'PENDING' | 'CLEARED' | 'RECONCILED' | 'VOID';
+}
+
+/** Result of a bulk operation. */
+export interface BulkOperationResult {
+  /** Number of transactions successfully modified. */
+  successCount: number;
+  /** Number of transactions that failed. */
+  failureCount: number;
+  /** Error messages from failed operations. */
+  errors: string[];
+}
+
+/** Shape returned by {@link useBulkTransactions}. */
+export interface UseBulkTransactionsResult {
+  /** Set of currently selected transaction IDs. */
+  selectedIds: ReadonlySet<SyncId>;
+  /** Number of selected transactions. */
+  selectionCount: number;
+  /** Whether bulk mode is active (any selections exist). */
+  isBulkMode: boolean;
+  /** Toggle selection for a single transaction. */
+  toggleSelection: (transactionId: SyncId) => void;
+  /** Select all provided transactions. */
+  selectAll: () => void;
+  /** Clear all selections. */
+  clearSelection: () => void;
+  /** Check if a transaction is selected. */
+  isSelected: (transactionId: SyncId) => boolean;
+  /** Bulk update fields on all selected transactions. */
+  bulkUpdate: (fields: BulkUpdateFields) => BulkOperationResult;
+  /** Bulk soft-delete all selected transactions. */
+  bulkDelete: () => BulkOperationResult;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useBulkTransactions(
+  transactions: Transaction[],
+  onComplete?: () => void,
+): UseBulkTransactionsResult {
+  const db = useDatabase();
+  const [selectedIds, setSelectedIds] = useState<Set<SyncId>>(new Set());
+
+  const selectionCount = selectedIds.size;
+  const isBulkMode = selectionCount > 0;
+
+  const toggleSelection = useCallback((transactionId: SyncId) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(transactionId)) {
+        next.delete(transactionId);
+      } else {
+        next.add(transactionId);
+      }
+      return next;
+    });
+  }, []);
+
+  const selectAll = useCallback(() => {
+    setSelectedIds(new Set(transactions.map((t) => t.id)));
+  }, [transactions]);
+
+  const clearSelection = useCallback(() => {
+    setSelectedIds(new Set());
+  }, []);
+
+  const isSelected = useCallback(
+    (transactionId: SyncId) => selectedIds.has(transactionId),
+    [selectedIds],
+  );
+
+  const bulkUpdate = useCallback(
+    (fields: BulkUpdateFields): BulkOperationResult => {
+      let successCount = 0;
+      let failureCount = 0;
+      const errors: string[] = [];
+
+      for (const txId of selectedIds) {
+        try {
+          const result = repoUpdateTransaction(db, txId, {
+            categoryId: fields.categoryId,
+            tags: fields.tags,
+            type: fields.type,
+            status: fields.status,
+          });
+          if (result) {
+            successCount++;
+          } else {
+            failureCount++;
+            errors.push(`Transaction ${txId}: not found or already deleted`);
+          }
+        } catch (err) {
+          failureCount++;
+          errors.push(
+            `Transaction ${txId}: ${err instanceof Error ? err.message : 'Unknown error'}`,
+          );
+        }
+      }
+
+      setSelectedIds(new Set());
+      onComplete?.();
+
+      return { successCount, failureCount, errors };
+    },
+    [db, selectedIds, onComplete],
+  );
+
+  const bulkDelete = useCallback((): BulkOperationResult => {
+    let successCount = 0;
+    let failureCount = 0;
+    const errors: string[] = [];
+
+    for (const txId of selectedIds) {
+      try {
+        const deleted = repoDeleteTransaction(db, txId);
+        if (deleted) {
+          successCount++;
+        } else {
+          failureCount++;
+          errors.push(`Transaction ${txId}: not found or already deleted`);
+        }
+      } catch (err) {
+        failureCount++;
+        errors.push(`Transaction ${txId}: ${err instanceof Error ? err.message : 'Unknown error'}`);
+      }
+    }
+
+    setSelectedIds(new Set());
+    onComplete?.();
+
+    return { successCount, failureCount, errors };
+  }, [db, selectedIds, onComplete]);
+
+  // Memoize the read-only view of selected IDs.
+  const readonlySelectedIds = useMemo(() => selectedIds as ReadonlySet<SyncId>, [selectedIds]);
+
+  return {
+    selectedIds: readonlySelectedIds,
+    selectionCount,
+    isBulkMode,
+    toggleSelection,
+    selectAll,
+    clearSelection,
+    isSelected,
+    bulkUpdate,
+    bulkDelete,
+  };
+}

--- a/apps/web/src/styles/bulk-edit.css
+++ b/apps/web/src/styles/bulk-edit.css
@@ -1,0 +1,222 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/* -------------------------------------------------------------------
+ * Bulk Edit Toolbar styles
+ *
+ * Floating action bar for bulk transaction operations.
+ * Mobile-first, responsive design with design token support.
+ * ------------------------------------------------------------------- */
+
+.bulk-edit-toolbar {
+  position: sticky;
+  bottom: var(--spacing-4, 16px);
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-3, 12px);
+  padding: var(--spacing-3, 12px) var(--spacing-4, 16px);
+  background-color: var(--semantic-background-elevated, #fff);
+  border: 1px solid var(--semantic-border-default, #e5e7eb);
+  border-radius: var(--border-radius-lg, 12px);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  flex-wrap: wrap;
+}
+
+.bulk-edit-toolbar__info {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2, 8px);
+}
+
+.bulk-edit-toolbar__count {
+  font-size: var(--type-scale-body-font-size, 0.875rem);
+  font-weight: 600;
+  color: var(--semantic-interactive-default, #3b82f6);
+}
+
+.bulk-edit-toolbar__toggle {
+  padding: var(--spacing-1, 4px) var(--spacing-2, 8px);
+  border: 1px solid var(--semantic-border-default, #e5e7eb);
+  border-radius: var(--border-radius-sm, 4px);
+  background: none;
+  font-size: var(--type-scale-caption-font-size, 0.75rem);
+  cursor: pointer;
+  color: var(--semantic-text-primary, inherit);
+}
+
+.bulk-edit-toolbar__toggle:hover {
+  background-color: var(--semantic-background-secondary, #f9fafb);
+}
+
+.bulk-edit-toolbar__toggle:focus-visible {
+  outline: 2px solid var(--semantic-border-focus, #3b82f6);
+  outline-offset: 2px;
+}
+
+.bulk-edit-toolbar__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2, 8px);
+  flex-wrap: wrap;
+}
+
+.bulk-edit-toolbar__action-group {
+  position: relative;
+}
+
+.bulk-edit-toolbar__button {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1, 4px);
+  padding: var(--spacing-2, 8px) var(--spacing-3, 12px);
+  border: 1px solid var(--semantic-border-default, #e5e7eb);
+  border-radius: var(--border-radius-sm, 4px);
+  background: none;
+  font-size: var(--type-scale-caption-font-size, 0.75rem);
+  font-weight: 500;
+  cursor: pointer;
+  color: var(--semantic-text-primary, inherit);
+  white-space: nowrap;
+}
+
+.bulk-edit-toolbar__button:hover {
+  background-color: var(--semantic-background-secondary, #f9fafb);
+}
+
+.bulk-edit-toolbar__button:focus-visible {
+  outline: 2px solid var(--semantic-border-focus, #3b82f6);
+  outline-offset: 2px;
+}
+
+.bulk-edit-toolbar__button--danger {
+  color: var(--semantic-status-negative, #ef4444);
+  border-color: var(--semantic-status-negative, #ef4444);
+}
+
+.bulk-edit-toolbar__button--danger:hover {
+  background-color: var(--color-red-50, #fef2f2);
+}
+
+/* Dropdown */
+.bulk-edit-toolbar__dropdown {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  min-width: 200px;
+  max-height: 300px;
+  overflow-y: auto;
+  background-color: var(--semantic-background-elevated, #fff);
+  border: 1px solid var(--semantic-border-default, #e5e7eb);
+  border-radius: var(--border-radius-md, 8px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  margin-bottom: var(--spacing-1, 4px);
+  z-index: 50;
+}
+
+.bulk-edit-toolbar__dropdown-item {
+  display: block;
+  width: 100%;
+  padding: var(--spacing-2, 8px) var(--spacing-3, 12px);
+  border: none;
+  background: none;
+  text-align: start;
+  font-size: var(--type-scale-body-font-size, 0.875rem);
+  cursor: pointer;
+  color: var(--semantic-text-primary, inherit);
+}
+
+.bulk-edit-toolbar__dropdown-item:hover {
+  background-color: var(--semantic-background-secondary, #f9fafb);
+}
+
+.bulk-edit-toolbar__dropdown-item:focus-visible {
+  outline: 2px solid var(--semantic-border-focus, #3b82f6);
+  outline-offset: -2px;
+}
+
+/* Confirm inline */
+.bulk-edit-toolbar__confirm {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2, 8px);
+}
+
+.bulk-edit-toolbar__confirm-text {
+  font-size: var(--type-scale-caption-font-size, 0.75rem);
+  font-weight: 500;
+  color: var(--semantic-status-negative, #ef4444);
+}
+
+/* Toast */
+.bulk-edit-toolbar__toast {
+  position: absolute;
+  top: calc(-1 * var(--spacing-8, 32px) - var(--spacing-2, 8px));
+  left: 50%;
+  transform: translateX(-50%);
+  padding: var(--spacing-2, 8px) var(--spacing-4, 16px);
+  background-color: var(--color-green-600, #16a34a);
+  color: #fff;
+  border-radius: var(--border-radius-sm, 4px);
+  font-size: var(--type-scale-caption-font-size, 0.75rem);
+  font-weight: 500;
+  white-space: nowrap;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+/* Checkbox for transaction selection */
+.bulk-select-checkbox {
+  width: 20px;
+  height: 20px;
+  accent-color: var(--semantic-interactive-default, #3b82f6);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.bulk-select-checkbox:focus-visible {
+  outline: 2px solid var(--semantic-border-focus, #3b82f6);
+  outline-offset: 2px;
+}
+
+/* Mobile: stack toolbar vertically */
+@media (max-width: 639px) {
+  .bulk-edit-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+    bottom: 0;
+    border-radius: var(--border-radius-lg, 12px) var(--border-radius-lg, 12px) 0 0;
+    margin-inline: calc(-1 * var(--spacing-4, 16px));
+  }
+
+  .bulk-edit-toolbar__actions {
+    justify-content: center;
+  }
+}
+
+/* Dark mode */
+[data-theme='dark'] .bulk-edit-toolbar {
+  background-color: var(--semantic-background-elevated, #1f2937);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+}
+
+[data-theme='dark'] .bulk-edit-toolbar__dropdown {
+  background-color: var(--semantic-background-elevated, #1f2937);
+}
+
+[data-theme='dark'] .bulk-edit-toolbar__button--danger:hover {
+  background-color: rgba(239, 68, 68, 0.12);
+}
+
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme='light']) .bulk-edit-toolbar {
+    background-color: var(--semantic-background-elevated, #1f2937);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  }
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .bulk-edit-toolbar__toast {
+    animation: none;
+  }
+}


### PR DESCRIPTION
Closes #318

## Changes
- **useBulkTransactions hook**: Selection state management (toggle, select all, clear), bulk update (category, tags, type, status), bulk soft-delete with operation result tracking
- **BulkEditToolbar component**: Floating sticky toolbar with selection count, Select All/Deselect All, category picker dropdown (listbox), bulk delete with inline confirmation, operation result toast
- **Accessible UI**: role='toolbar' with aria-label, aria-expanded for category picker, role='alertdialog' for delete confirmation, role='status' for toast notifications, all keyboard-accessible
- **Responsive CSS**: Mobile-first sticky toolbar with dark mode, print, and reduced motion support

## Testing
- 14 tests for BulkEditToolbar: rendering, selection, category picker, delete confirmation, toast messages, accessibility roles
- All tests passing