### PR TITLE
feat(windows): performance monitoring and APM instrumentation (#304)

### DIFF
--- a/apps/windows/src/main/kotlin/com/finance/desktop/FinanceApp.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/FinanceApp.kt
@@ -19,6 +19,7 @@ import com.finance.desktop.navigation.SidebarNavigation
 import com.finance.desktop.screens.AccountsScreen
 import com.finance.desktop.screens.BudgetsScreen
 import com.finance.desktop.screens.DashboardScreen
+import com.finance.desktop.screens.DiagnosticsScreen
 import com.finance.desktop.screens.GoalsScreen
 import com.finance.desktop.screens.LockScreen
 import com.finance.desktop.screens.SettingsScreen
@@ -78,6 +79,7 @@ fun FinanceApp(shortcutHandler: ShortcutHandler) {
                             Screen.Transactions -> TransactionsScreen()
                             Screen.Budgets -> BudgetsScreen()
                             Screen.Goals -> GoalsScreen()
+                            Screen.Diagnostics -> DiagnosticsScreen()
                             Screen.Settings -> SettingsScreen()
                         }
                     }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/Main.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/Main.kt
@@ -12,21 +12,36 @@ import androidx.compose.ui.window.rememberWindowState
 import com.finance.desktop.components.rememberShortcutHandler
 import com.finance.desktop.di.appModules
 import com.finance.desktop.notifications.DesktopNotificationManager
+import com.finance.desktop.performance.PerformanceMonitor
+import com.finance.desktop.performance.PerformanceTracker
+import com.finance.desktop.performance.timed
 import com.finance.desktop.widgets.WidgetRegistrationManager
 import org.koin.core.context.GlobalContext
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 
 fun main() {
-    startKoin {
-        modules(appModules)
+    PerformanceTracker.recordAppStart()
+
+    timed("koin_init") {
+        startKoin {
+            modules(appModules)
+        }
     }
 
-    DesktopNotificationManager.initialise()
+    timed("notifications_init") {
+        DesktopNotificationManager.initialise()
+    }
 
     // Initialise Windows 11 Widget Board integration
     val widgetManager = GlobalContext.get().get<WidgetRegistrationManager>()
-    widgetManager.initialize()
+    timed("widget_init") {
+        widgetManager.initialize()
+    }
+
+    // Start background performance monitoring
+    PerformanceMonitor.start()
+    PerformanceTracker.recordFirstInteractive()
 
     application {
         val windowState = rememberWindowState(
@@ -38,6 +53,7 @@ fun main() {
 
         Window(
             onCloseRequest = {
+                PerformanceMonitor.stop()
                 widgetManager.dispose()
                 DesktopNotificationManager.dispose()
                 stopKoin()

--- a/apps/windows/src/main/kotlin/com/finance/desktop/di/ViewModelModule.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/di/ViewModelModule.kt
@@ -28,4 +28,5 @@ val viewModelModule = module {
     single { AuthViewModel(get(), get()) }
     single { WidgetViewModel(get()) }
     single { VoiceTransactionViewModel(get(), get(), get()) }
+    single { DiagnosticsViewModel() }
 }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/navigation/SidebarNavigation.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/navigation/SidebarNavigation.kt
@@ -29,6 +29,7 @@ import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.PieChart
 import androidx.compose.material.icons.filled.Receipt
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -76,7 +77,8 @@ enum class Screen(
     Transactions("Transactions", Icons.Filled.Receipt, Key.Three, "Ctrl+3"),
     Budgets("Budgets", Icons.Filled.PieChart, Key.Four, "Ctrl+4"),
     Goals("Goals", Icons.Filled.Star, Key.Five, "Ctrl+5"),
-    Settings("Settings", Icons.Filled.Settings, Key.Six, "Ctrl+6"),
+    Diagnostics("Diagnostics", Icons.Filled.Speed, Key.Six, "Ctrl+6"),
+    Settings("Settings", Icons.Filled.Settings, Key.Seven, "Ctrl+7"),
 }
 
 /** Width of the sidebar when expanded. */

--- a/apps/windows/src/main/kotlin/com/finance/desktop/performance/PerformanceInstrumentation.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/performance/PerformanceInstrumentation.kt
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.performance
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import java.util.logging.Logger
+
+/**
+ * Composable effect that records first-render timing for a screen.
+ *
+ * Call this at the top of each screen composable to automatically track
+ * when the screen first becomes visible:
+ *
+ * ```kotlin
+ * @Composable
+ * fun DashboardScreen() {
+ *     TrackScreenRender("dashboard")
+ *     // … rest of screen …
+ * }
+ * ```
+ *
+ * The metric is recorded as `screen.<name>.first_render`.
+ */
+@Composable
+fun TrackScreenRender(screenName: String) {
+    LaunchedEffect(screenName) {
+        PerformanceTracker.markStart("screen.$screenName.first_render")
+        // The first frame after LaunchedEffect runs is the render frame
+        kotlinx.coroutines.yield()
+        PerformanceTracker.markEnd("screen.$screenName.first_render", MetricCategory.RENDER)
+    }
+}
+
+/**
+ * Wraps a suspend block with automatic performance timing.
+ *
+ * Records the duration of [block] under the given [metricName]:
+ *
+ * ```kotlin
+ * val accounts = timedSuspend("repo.accounts.load") {
+ *     accountRepository.observeAll(hid).first()
+ * }
+ * ```
+ */
+suspend fun <T> timedSuspend(
+    metricName: String,
+    category: MetricCategory = MetricCategory.DATA_ACCESS,
+    block: suspend () -> T,
+): T {
+    val startNanos = System.nanoTime()
+    return try {
+        block()
+    } finally {
+        val durationMs = (System.nanoTime() - startNanos) / 1_000_000
+        PerformanceTracker.record(metricName, durationMs, category)
+    }
+}
+
+/**
+ * Wraps a synchronous block with automatic performance timing.
+ */
+inline fun <T> timed(
+    metricName: String,
+    category: MetricCategory = MetricCategory.GENERAL,
+    block: () -> T,
+): T {
+    val startNanos = System.nanoTime()
+    return try {
+        block()
+    } finally {
+        val durationMs = (System.nanoTime() - startNanos) / 1_000_000
+        PerformanceTracker.record(metricName, durationMs, category)
+    }
+}
+
+/**
+ * Background service that periodically captures memory snapshots and
+ * checks for performance budget violations.
+ *
+ * Start this during app initialization:
+ * ```kotlin
+ * PerformanceMonitor.start()
+ * ```
+ */
+object PerformanceMonitor {
+
+    private val logger: Logger = Logger.getLogger(PerformanceMonitor::class.java.name)
+
+    /** Interval between memory snapshots. */
+    private const val SNAPSHOT_INTERVAL_MS = 30_000L // 30 seconds
+
+    /** Memory warning threshold in MB. */
+    private const val MEMORY_WARNING_THRESHOLD_MB = 400L
+
+    /** Cold start warning threshold in milliseconds. */
+    const val COLD_START_WARNING_MS = 3000L
+
+    /** Screen render warning threshold in milliseconds. */
+    const val SCREEN_RENDER_WARNING_MS = 500L
+
+    private var isRunning = false
+
+    /**
+     * Starts the periodic background monitoring.
+     */
+    fun start() {
+        if (isRunning) return
+        isRunning = true
+
+        CoroutineScope(Dispatchers.Default).launch {
+            logger.info("Performance monitor started")
+            while (isActive && isRunning) {
+                PerformanceTracker.captureMemorySnapshot()
+
+                // Check for memory pressure
+                val runtime = Runtime.getRuntime()
+                val usedMb = (runtime.totalMemory() - runtime.freeMemory()) / (1024 * 1024)
+                if (usedMb > MEMORY_WARNING_THRESHOLD_MB) {
+                    logger.warning("High memory usage: ${usedMb}MB (threshold: ${MEMORY_WARNING_THRESHOLD_MB}MB)")
+                }
+
+                delay(SNAPSHOT_INTERVAL_MS)
+            }
+        }
+    }
+
+    /**
+     * Stops the periodic background monitoring.
+     */
+    fun stop() {
+        isRunning = false
+        logger.info("Performance monitor stopped")
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/performance/PerformanceTracker.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/performance/PerformanceTracker.kt
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.performance
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.logging.Logger
+
+/**
+ * Lightweight APM (Application Performance Monitoring) tracker for the
+ * Finance Windows desktop client.
+ *
+ * Captures and stores performance metrics including:
+ * - **Startup timing**: cold-start and per-phase breakdown
+ * - **Screen render timing**: first render and recomposition counts
+ * - **Repository latency**: time for data-access operations
+ * - **Memory snapshots**: JVM heap usage over time
+ * - **Frame rate**: approximate composition frame durations
+ *
+ * All metrics are stored in memory with configurable retention (default
+ * 500 entries). No data leaves the device — this is a debug/diagnostics
+ * tool surfaced in the Settings → Diagnostics screen.
+ *
+ * ## Thread Safety
+ *
+ * Uses [ConcurrentHashMap] and [CopyOnWriteArrayList] for lock-free
+ * concurrent access from UI, IO, and Default coroutine dispatchers.
+ *
+ * ## Usage
+ *
+ * ```kotlin
+ * PerformanceTracker.markStart("screen.dashboard.render")
+ * // … compose the screen …
+ * PerformanceTracker.markEnd("screen.dashboard.render")
+ * ```
+ */
+object PerformanceTracker {
+
+    private val logger: Logger = Logger.getLogger(PerformanceTracker::class.java.name)
+
+    /** Maximum number of metric entries retained in memory. */
+    private const val MAX_ENTRIES = 500
+
+    /** Pending start timestamps keyed by span name. */
+    private val pendingSpans = ConcurrentHashMap<String, Long>()
+
+    /** Completed metric entries. */
+    private val _metrics = CopyOnWriteArrayList<MetricEntry>()
+
+    /** Startup phase timings. */
+    private val _startupPhases = CopyOnWriteArrayList<StartupPhase>()
+
+    /** Memory snapshots over time. */
+    private val _memorySnapshots = CopyOnWriteArrayList<MemorySnapshot>()
+
+    /** Application cold-start timestamp (set once). */
+    private var appStartTimeMs: Long = 0L
+
+    /** Time when the first screen became interactive. */
+    private var firstInteractiveTimeMs: Long = 0L
+
+    /**
+     * Call once at the very beginning of `main()` to record the cold-start
+     * baseline timestamp.
+     */
+    fun recordAppStart() {
+        appStartTimeMs = System.currentTimeMillis()
+        logger.fine("App start recorded at $appStartTimeMs")
+    }
+
+    /**
+     * Call when the first screen has rendered and is interactive.
+     */
+    fun recordFirstInteractive() {
+        firstInteractiveTimeMs = System.currentTimeMillis()
+        val coldStartMs = firstInteractiveTimeMs - appStartTimeMs
+        addMetric(MetricEntry("app.cold_start", coldStartMs, MetricCategory.STARTUP))
+        logger.fine("First interactive in ${coldStartMs}ms")
+    }
+
+    /**
+     * Records a named startup phase with its duration.
+     */
+    fun recordStartupPhase(name: String, durationMs: Long) {
+        _startupPhases.add(StartupPhase(name, durationMs))
+        addMetric(MetricEntry("startup.$name", durationMs, MetricCategory.STARTUP))
+    }
+
+    /**
+     * Marks the beginning of a timed span.
+     */
+    fun markStart(spanName: String) {
+        pendingSpans[spanName] = System.nanoTime()
+    }
+
+    /**
+     * Marks the end of a timed span and records the duration.
+     */
+    fun markEnd(spanName: String, category: MetricCategory = MetricCategory.RENDER) {
+        val startNanos = pendingSpans.remove(spanName) ?: return
+        val durationMs = (System.nanoTime() - startNanos) / 1_000_000
+        addMetric(MetricEntry(spanName, durationMs, category))
+    }
+
+    /**
+     * Records a pre-computed duration metric.
+     */
+    fun record(name: String, durationMs: Long, category: MetricCategory = MetricCategory.GENERAL) {
+        addMetric(MetricEntry(name, durationMs, category))
+    }
+
+    /**
+     * Captures a snapshot of current JVM memory usage.
+     */
+    fun captureMemorySnapshot() {
+        val runtime = Runtime.getRuntime()
+        val snapshot = MemorySnapshot(
+            timestampMs = System.currentTimeMillis(),
+            usedMb = (runtime.totalMemory() - runtime.freeMemory()) / (1024 * 1024),
+            totalMb = runtime.totalMemory() / (1024 * 1024),
+            maxMb = runtime.maxMemory() / (1024 * 1024),
+        )
+        _memorySnapshots.add(snapshot)
+        if (_memorySnapshots.size > MAX_ENTRIES) {
+            _memorySnapshots.removeAt(0)
+        }
+    }
+
+    // ── Query API ──────────────────────────────────────────────────────────
+
+    /** All recorded metrics. */
+    val metrics: List<MetricEntry> get() = _metrics.toList()
+
+    /** Startup phase breakdown. */
+    val startupPhases: List<StartupPhase> get() = _startupPhases.toList()
+
+    /** Memory usage over time. */
+    val memorySnapshots: List<MemorySnapshot> get() = _memorySnapshots.toList()
+
+    /** Cold-start duration in milliseconds (0 if not yet recorded). */
+    val coldStartMs: Long
+        get() = if (firstInteractiveTimeMs > 0 && appStartTimeMs > 0) {
+            firstInteractiveTimeMs - appStartTimeMs
+        } else {
+            0L
+        }
+
+    /** Average duration for a named metric across all samples. */
+    fun averageMs(name: String): Long {
+        val matching = _metrics.filter { it.name == name }
+        return if (matching.isNotEmpty()) matching.map { it.durationMs }.average().toLong() else 0L
+    }
+
+    /** P95 duration for a named metric. */
+    fun p95Ms(name: String): Long {
+        val sorted = _metrics.filter { it.name == name }.map { it.durationMs }.sorted()
+        return if (sorted.isNotEmpty()) sorted[(sorted.size * 0.95).toInt().coerceAtMost(sorted.size - 1)] else 0L
+    }
+
+    /** All unique metric names. */
+    fun metricNames(): Set<String> = _metrics.map { it.name }.toSet()
+
+    /** Clears all recorded metrics (for diagnostics reset). */
+    fun reset() {
+        _metrics.clear()
+        _startupPhases.clear()
+        _memorySnapshots.clear()
+        pendingSpans.clear()
+        logger.info("Performance metrics reset")
+    }
+
+    private fun addMetric(entry: MetricEntry) {
+        _metrics.add(entry)
+        if (_metrics.size > MAX_ENTRIES) {
+            _metrics.removeAt(0)
+        }
+    }
+}
+
+/**
+ * A single performance metric data point.
+ */
+data class MetricEntry(
+    val name: String,
+    val durationMs: Long,
+    val category: MetricCategory,
+    val timestampMs: Long = System.currentTimeMillis(),
+)
+
+/**
+ * Categories for organizing metrics.
+ */
+enum class MetricCategory(val displayName: String) {
+    STARTUP("Startup"),
+    RENDER("Screen Render"),
+    DATA_ACCESS("Data Access"),
+    SYNC("Sync"),
+    GENERAL("General"),
+}
+
+/**
+ * A named phase during application startup.
+ */
+data class StartupPhase(
+    val name: String,
+    val durationMs: Long,
+)
+
+/**
+ * A snapshot of JVM memory usage at a point in time.
+ */
+data class MemorySnapshot(
+    val timestampMs: Long,
+    val usedMb: Long,
+    val totalMb: Long,
+    val maxMb: Long,
+)

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/DiagnosticsScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/DiagnosticsScreen.kt
@@ -1,0 +1,508 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Memory
+import androidx.compose.material.icons.filled.Speed
+import androidx.compose.material.icons.filled.Timer
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.finance.desktop.di.koinGet
+import com.finance.desktop.theme.FinanceDesktopTheme
+import com.finance.desktop.viewmodel.AlertSeverity
+import com.finance.desktop.viewmodel.DiagnosticsViewModel
+import com.finance.desktop.viewmodel.MetricCategorySummary
+import com.finance.desktop.viewmodel.PerformanceAlert
+
+// =============================================================================
+// Diagnostics Screen — Performance monitoring dashboard
+// =============================================================================
+
+/**
+ * Performance diagnostics screen for the desktop Finance application.
+ *
+ * Displays real-time APM metrics including:
+ * - Cold start time and startup phase breakdown
+ * - Per-category metric summaries (average, P95, max)
+ * - Memory usage with heap utilization
+ * - Performance alerts for budget violations
+ * - Recent metric entries log
+ *
+ * Auto-refreshes every 5 seconds via [DiagnosticsViewModel].
+ * Narrator reads all metric values and alert descriptions.
+ */
+@Composable
+fun DiagnosticsScreen(modifier: Modifier = Modifier) {
+    val viewModel = koinGet<DiagnosticsViewModel>()
+    val state by viewModel.uiState.collectAsState()
+
+    LazyColumn(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(FinanceDesktopTheme.spacing.xxl)
+            .semantics { contentDescription = "Performance Diagnostics screen" },
+        verticalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.lg),
+    ) {
+        // ── Header ──
+        item {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column {
+                    Text(
+                        text = "Performance Diagnostics",
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.semantics {
+                            heading()
+                            contentDescription = "Performance Diagnostics heading"
+                        },
+                    )
+                    Text(
+                        text = "${state.totalMetricCount} metrics recorded · Auto-refreshing",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Button(
+                    onClick = { viewModel.resetMetrics() },
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.errorContainer,
+                        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                    ),
+                    modifier = Modifier.semantics {
+                        contentDescription = "Reset all performance metrics"
+                    },
+                ) {
+                    Icon(Icons.Filled.Delete, contentDescription = null, modifier = Modifier.size(16.dp))
+                    Spacer(Modifier.width(FinanceDesktopTheme.spacing.sm))
+                    Text("Reset Metrics")
+                }
+            }
+        }
+
+        // ── Alerts ──
+        if (state.alerts.isNotEmpty()) {
+            item {
+                Text(
+                    text = "Performance Alerts",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.semantics { heading() },
+                )
+            }
+            items(state.alerts, key = { it.metricName }) { alert ->
+                AlertCard(alert)
+            }
+        }
+
+        // ── Startup + Memory summary row ──
+        item {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.lg),
+            ) {
+                StartupCard(
+                    coldStartMs = state.coldStartMs,
+                    phases = state.startupPhases,
+                    modifier = Modifier.weight(1f),
+                )
+                MemoryCard(
+                    latestMemory = state.latestMemory,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+
+        // ── Category summaries ──
+        item {
+            Text(
+                text = "Metric Categories",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.semantics { heading() },
+            )
+        }
+
+        if (state.categorySummaries.isEmpty()) {
+            item {
+                Text(
+                    text = "No metrics recorded yet. Navigate around the app to generate data.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        } else {
+            items(state.categorySummaries, key = { it.category.name }) { summary ->
+                CategorySummaryCard(summary)
+            }
+        }
+
+        // ── Recent metrics log ──
+        item {
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
+            Text(
+                text = "Recent Metrics (last 20)",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.semantics { heading() },
+            )
+        }
+
+        items(state.recentMetrics, key = { "${it.name}-${it.timestampMs}" }) { metric ->
+            MetricLogRow(metric)
+        }
+    }
+}
+
+// =============================================================================
+// Sub-composables
+// =============================================================================
+
+@Composable
+private fun AlertCard(alert: PerformanceAlert) {
+    val containerColor = when (alert.severity) {
+        AlertSeverity.CRITICAL -> MaterialTheme.colorScheme.errorContainer
+        AlertSeverity.WARNING -> MaterialTheme.colorScheme.tertiaryContainer
+    }
+    val contentColor = when (alert.severity) {
+        AlertSeverity.CRITICAL -> MaterialTheme.colorScheme.onErrorContainer
+        AlertSeverity.WARNING -> MaterialTheme.colorScheme.onTertiaryContainer
+    }
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics {
+                contentDescription = "${alert.severity.displayName}: ${alert.message}"
+            },
+        colors = CardDefaults.cardColors(containerColor = containerColor),
+    ) {
+        Row(
+            modifier = Modifier.padding(FinanceDesktopTheme.spacing.lg),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                Icons.Filled.Warning,
+                contentDescription = null,
+                tint = contentColor,
+                modifier = Modifier.size(20.dp),
+            )
+            Spacer(Modifier.width(FinanceDesktopTheme.spacing.md))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = alert.severity.displayName,
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = contentColor,
+                )
+                Text(
+                    text = alert.message,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = contentColor,
+                )
+            }
+            Text(
+                text = "${alert.actualMs}ms / ${alert.budgetMs}ms",
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = contentColor,
+            )
+        }
+    }
+}
+
+@Composable
+private fun StartupCard(
+    coldStartMs: Long,
+    phases: List<com.finance.desktop.performance.StartupPhase>,
+    modifier: Modifier = Modifier,
+) {
+    ElevatedCard(
+        modifier = modifier.semantics {
+            contentDescription = "Cold start time: ${coldStartMs} milliseconds"
+        },
+    ) {
+        Column(modifier = Modifier.padding(FinanceDesktopTheme.spacing.lg)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    Icons.Filled.Timer,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(20.dp),
+                )
+                Spacer(Modifier.width(FinanceDesktopTheme.spacing.sm))
+                Text(
+                    text = "Startup",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.md))
+            Text(
+                text = "${coldStartMs}ms",
+                style = MaterialTheme.typography.headlineLarge,
+                fontWeight = FontWeight.Bold,
+                color = if (coldStartMs > 3000) MaterialTheme.colorScheme.error
+                else MaterialTheme.colorScheme.primary,
+            )
+            Text(
+                text = "Cold start time",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            if (phases.isNotEmpty()) {
+                Spacer(Modifier.height(FinanceDesktopTheme.spacing.md))
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
+                phases.forEach { phase ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 2.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                    ) {
+                        Text(
+                            text = phase.name,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Text(
+                            text = "${phase.durationMs}ms",
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.Medium,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MemoryCard(
+    latestMemory: com.finance.desktop.performance.MemorySnapshot?,
+    modifier: Modifier = Modifier,
+) {
+    ElevatedCard(
+        modifier = modifier.semantics {
+            contentDescription = if (latestMemory != null) {
+                "Memory usage: ${latestMemory.usedMb} of ${latestMemory.maxMb} megabytes"
+            } else {
+                "Memory: no data yet"
+            }
+        },
+    ) {
+        Column(modifier = Modifier.padding(FinanceDesktopTheme.spacing.lg)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    Icons.Filled.Memory,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.secondary,
+                    modifier = Modifier.size(20.dp),
+                )
+                Spacer(Modifier.width(FinanceDesktopTheme.spacing.sm))
+                Text(
+                    text = "Memory",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.md))
+
+            if (latestMemory != null) {
+                Text(
+                    text = "${latestMemory.usedMb}MB",
+                    style = MaterialTheme.typography.headlineLarge,
+                    fontWeight = FontWeight.Bold,
+                    color = if (latestMemory.usedMb > 400) MaterialTheme.colorScheme.error
+                    else MaterialTheme.colorScheme.secondary,
+                )
+                Text(
+                    text = "of ${latestMemory.maxMb}MB max heap",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(FinanceDesktopTheme.spacing.md))
+                val utilization = latestMemory.usedMb.toFloat() / latestMemory.maxMb.toFloat()
+                LinearProgressIndicator(
+                    progress = { utilization.coerceIn(0f, 1f) },
+                    modifier = Modifier.fillMaxWidth().height(8.dp),
+                    color = if (utilization > 0.8f) MaterialTheme.colorScheme.error
+                    else MaterialTheme.colorScheme.secondary,
+                    trackColor = MaterialTheme.colorScheme.surfaceVariant,
+                    strokeCap = StrokeCap.Round,
+                )
+                Spacer(Modifier.height(FinanceDesktopTheme.spacing.xs))
+                Text(
+                    text = "${(utilization * 100).toInt()}% heap utilization",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else {
+                Text(
+                    text = "Waiting for data…",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CategorySummaryCard(summary: MetricCategorySummary) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics {
+                contentDescription = "${summary.category.displayName}: " +
+                    "${summary.count} samples, avg ${summary.averageMs}ms, P95 ${summary.p95Ms}ms"
+            },
+    ) {
+        Column(modifier = Modifier.padding(FinanceDesktopTheme.spacing.lg)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        Icons.Filled.Speed,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(18.dp),
+                    )
+                    Spacer(Modifier.width(FinanceDesktopTheme.spacing.sm))
+                    Text(
+                        text = summary.category.displayName,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
+                Text(
+                    text = "${summary.count} samples",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.md))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly,
+            ) {
+                MetricStat("Avg", "${summary.averageMs}ms")
+                MetricStat("P95", "${summary.p95Ms}ms")
+                MetricStat("Max", "${summary.maxMs}ms")
+            }
+            if (summary.names.isNotEmpty()) {
+                Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
+                Text(
+                    text = summary.names.joinToString(", "),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MetricStat(label: String, value: String) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(
+            text = value,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun MetricLogRow(metric: com.finance.desktop.performance.MetricEntry) {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics {
+                contentDescription = "${metric.name}: ${metric.durationMs}ms (${metric.category.displayName})"
+            },
+        tonalElevation = 1.dp,
+        shape = MaterialTheme.shapes.small,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(
+                    horizontal = FinanceDesktopTheme.spacing.md,
+                    vertical = FinanceDesktopTheme.spacing.sm,
+                ),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = metric.name,
+                    style = MaterialTheme.typography.bodySmall,
+                    fontWeight = FontWeight.Medium,
+                )
+                Text(
+                    text = metric.category.displayName,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Text(
+                text = "${metric.durationMs}ms",
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = if (metric.durationMs > 500) MaterialTheme.colorScheme.error
+                else MaterialTheme.colorScheme.onSurface,
+            )
+        }
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/DiagnosticsViewModel.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/DiagnosticsViewModel.kt
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.viewmodel
+
+import com.finance.desktop.performance.MemorySnapshot
+import com.finance.desktop.performance.MetricCategory
+import com.finance.desktop.performance.MetricEntry
+import com.finance.desktop.performance.PerformanceMonitor
+import com.finance.desktop.performance.PerformanceTracker
+import com.finance.desktop.performance.StartupPhase
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+/**
+ * Summary statistics for a metric category.
+ */
+data class MetricCategorySummary(
+    val category: MetricCategory,
+    val count: Int,
+    val averageMs: Long,
+    val p95Ms: Long,
+    val maxMs: Long,
+    val names: List<String>,
+)
+
+/**
+ * A performance alert indicating a budget violation.
+ */
+data class PerformanceAlert(
+    val severity: AlertSeverity,
+    val message: String,
+    val metricName: String,
+    val actualMs: Long,
+    val budgetMs: Long,
+)
+
+enum class AlertSeverity(val displayName: String) {
+    WARNING("Warning"),
+    CRITICAL("Critical"),
+}
+
+/**
+ * UI state for the performance diagnostics screen.
+ */
+data class DiagnosticsUiState(
+    val coldStartMs: Long = 0L,
+    val startupPhases: List<StartupPhase> = emptyList(),
+    val categorySummaries: List<MetricCategorySummary> = emptyList(),
+    val recentMetrics: List<MetricEntry> = emptyList(),
+    val latestMemory: MemorySnapshot? = null,
+    val memoryHistory: List<MemorySnapshot> = emptyList(),
+    val alerts: List<PerformanceAlert> = emptyList(),
+    val totalMetricCount: Int = 0,
+)
+
+/**
+ * ViewModel for the Performance Diagnostics screen.
+ *
+ * Periodically polls [PerformanceTracker] for updated metrics and
+ * computes summary statistics, alerts, and memory usage data.
+ * Refresh interval is 5 seconds to keep the dashboard up to date
+ * without excessive CPU usage.
+ */
+class DiagnosticsViewModel : DesktopViewModel() {
+
+    private val _uiState = MutableStateFlow(DiagnosticsUiState())
+    val uiState: StateFlow<DiagnosticsUiState> = _uiState.asStateFlow()
+
+    init {
+        startPolling()
+    }
+
+    fun resetMetrics() {
+        PerformanceTracker.reset()
+        refreshState()
+    }
+
+    private fun startPolling() {
+        viewModelScope.launch {
+            while (isActive) {
+                refreshState()
+                delay(5_000)
+            }
+        }
+    }
+
+    private fun refreshState() {
+        val metrics = PerformanceTracker.metrics
+        val memorySnapshots = PerformanceTracker.memorySnapshots
+
+        // Category summaries
+        val categorySummaries = MetricCategory.entries.mapNotNull { category ->
+            val categoryMetrics = metrics.filter { it.category == category }
+            if (categoryMetrics.isEmpty()) return@mapNotNull null
+
+            val names = categoryMetrics.map { it.name }.distinct()
+            val durations = categoryMetrics.map { it.durationMs }
+
+            MetricCategorySummary(
+                category = category,
+                count = categoryMetrics.size,
+                averageMs = durations.average().toLong(),
+                p95Ms = durations.sorted().let { sorted ->
+                    sorted[(sorted.size * 0.95).toInt().coerceAtMost(sorted.size - 1)]
+                },
+                maxMs = durations.max(),
+                names = names,
+            )
+        }
+
+        // Performance alerts
+        val alerts = mutableListOf<PerformanceAlert>()
+
+        val coldStartMs = PerformanceTracker.coldStartMs
+        if (coldStartMs > PerformanceMonitor.COLD_START_WARNING_MS) {
+            alerts.add(
+                PerformanceAlert(
+                    severity = if (coldStartMs > 5000) AlertSeverity.CRITICAL else AlertSeverity.WARNING,
+                    message = "Cold start took ${coldStartMs}ms (budget: ${PerformanceMonitor.COLD_START_WARNING_MS}ms)",
+                    metricName = "app.cold_start",
+                    actualMs = coldStartMs,
+                    budgetMs = PerformanceMonitor.COLD_START_WARNING_MS,
+                ),
+            )
+        }
+
+        // Check screen render times
+        PerformanceTracker.metricNames()
+            .filter { it.startsWith("screen.") && it.endsWith(".first_render") }
+            .forEach { name ->
+                val avg = PerformanceTracker.averageMs(name)
+                if (avg > PerformanceMonitor.SCREEN_RENDER_WARNING_MS) {
+                    alerts.add(
+                        PerformanceAlert(
+                            severity = AlertSeverity.WARNING,
+                            message = "$name averages ${avg}ms (budget: ${PerformanceMonitor.SCREEN_RENDER_WARNING_MS}ms)",
+                            metricName = name,
+                            actualMs = avg,
+                            budgetMs = PerformanceMonitor.SCREEN_RENDER_WARNING_MS,
+                        ),
+                    )
+                }
+            }
+
+        _uiState.value = DiagnosticsUiState(
+            coldStartMs = coldStartMs,
+            startupPhases = PerformanceTracker.startupPhases,
+            categorySummaries = categorySummaries,
+            recentMetrics = metrics.takeLast(20).reversed(),
+            latestMemory = memorySnapshots.lastOrNull(),
+            memoryHistory = memorySnapshots.takeLast(20),
+            alerts = alerts,
+            totalMetricCount = metrics.size,
+        )
+    }
+}


### PR DESCRIPTION
## Summary
Adds comprehensive APM (Application Performance Monitoring) to the Windows desktop client.

### Changes
- **PerformanceTracker**: Thread-safe singleton for recording metrics
  - Span-based timing (markStart/markEnd)
  - Startup phase recording with cold-start measurement
  - Memory snapshots with JVM heap tracking
  - Configurable retention (500 entries)
- **PerformanceInstrumentation**: Composable and coroutine helpers
  - \TrackScreenRender\ composable for automatic first-render timing
  - \	imedSuspend\ / \	imed\ wrappers for repository/sync calls
  - \PerformanceMonitor\ background service (30s memory snapshots)
- **Main.kt Startup Instrumentation**: 
  - Cold-start baseline timestamp at app start
  - Phase timing: Koin init, notifications init, widget init
  - Background monitor auto-starts; stops on window close
- **DiagnosticsViewModel**: Auto-refreshing (5s) with category summaries
  - Avg/P95/Max per category (Startup, Render, Data Access, Sync, General)
  - Performance alerts for budget violations (cold start > 3s, render > 500ms)
  - Memory pressure warnings (> 400MB)
- **DiagnosticsScreen**: Full diagnostics dashboard
  - Startup card with cold-start time and phase breakdown
  - Memory card with heap utilization progress bar
  - Category summary cards with Avg/P95/Max stats
  - Alert banners for performance budget violations
  - Recent metrics log (last 20 entries)
  - Reset button to clear all metrics
- **Navigation**: Diagnostics screen at Ctrl+6

### Architecture
- PerformanceTracker (static singleton) — no DI needed, available everywhere
- DiagnosticsViewModel → PerformanceTracker polling loop
- ConcurrentHashMap + CopyOnWriteArrayList for thread safety

Closes #304