### PR TITLE
feat(ios): contextual financial tips with context-aware guidance (#320)

### DIFF
--- a/apps/ios/Finance/Components/FinancialTipCard.swift
+++ b/apps/ios/Finance/Components/FinancialTipCard.swift
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// FinancialTipCard.swift
+// Finance
+//
+// Reusable card component for displaying a single contextual financial tip.
+// Supports dismiss action, VoiceOver, Dynamic Type, and dark mode.
+//
+// References: #320
+
+import SwiftUI
+
+// MARK: - Financial Tip Card
+
+/// A card view displaying a single financial tip with category indicator,
+/// title, body, optional action, and a dismiss button.
+///
+/// Fully accessible: combines elements for VoiceOver, supports Dynamic Type,
+/// and provides a custom dismiss action.
+struct FinancialTipCard: View {
+    let tip: FinancialTip
+    let onDismiss: () -> Void
+    let onAction: (() -> Void)?
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    init(
+        tip: FinancialTip,
+        onDismiss: @escaping () -> Void,
+        onAction: (() -> Void)? = nil
+    ) {
+        self.tip = tip
+        self.onDismiss = onDismiss
+        self.onAction = onAction
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Header: icon + category + dismiss
+            HStack(spacing: 8) {
+                Image(systemName: tip.systemImage)
+                    .font(.subheadline)
+                    .foregroundStyle(tip.category.color)
+                    .accessibilityHidden(true)
+
+                Text(tip.category.displayName)
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(tip.category.color)
+                    .textCase(.uppercase)
+
+                Spacer()
+
+                Button {
+                    if reduceMotion {
+                        onDismiss()
+                    } else {
+                        withAnimation(.easeInOut(duration: 0.3)) {
+                            onDismiss()
+                        }
+                    }
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.body)
+                        .foregroundStyle(.secondary)
+                }
+                .accessibilityLabel(String(localized: "Dismiss tip"))
+                .accessibilityHint(String(localized: "Hides this financial tip"))
+            }
+
+            // Title
+            Text(tip.title)
+                .font(.headline)
+                .foregroundStyle(FinanceColors.textPrimary)
+
+            // Body
+            Text(tip.body)
+                .font(.subheadline)
+                .foregroundStyle(FinanceColors.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            // Optional action button
+            if let actionLabel = tip.actionLabel, let onAction {
+                Button(action: onAction) {
+                    Text(actionLabel)
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+                .accessibilityLabel(actionLabel)
+            }
+        }
+        .padding()
+        .background(FinanceColors.backgroundElevated)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .shadow(color: .black.opacity(0.06), radius: 3, y: 2)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(
+            String(localized: "\(tip.category.displayName) tip: \(tip.title)")
+        )
+        .accessibilityHint(tip.body)
+        .accessibilityAction(named: String(localized: "Dismiss")) {
+            onDismiss()
+        }
+        .accessibilityIdentifier("financial_tip_card_\(tip.id)")
+    }
+}
+
+// MARK: - Financial Tips Section
+
+/// A section that displays a vertical list of contextual financial tips.
+///
+/// Use this component inside any screen's `ScrollView` or `List` to show
+/// context-appropriate tips. Tips auto-load via `.task {}` and respect
+/// dismiss state.
+struct FinancialTipsSection: View {
+    @State private var viewModel: FinancialTipsViewModel
+    let context: TipContext
+    let onAction: ((FinancialTip) -> Void)?
+
+    init(
+        context: TipContext,
+        viewModel: FinancialTipsViewModel = FinancialTipsViewModel(),
+        onAction: ((FinancialTip) -> Void)? = nil
+    ) {
+        self.context = context
+        _viewModel = State(initialValue: viewModel)
+        self.onAction = onAction
+    }
+
+    var body: some View {
+        Group {
+            if !viewModel.tips.isEmpty {
+                VStack(alignment: .leading, spacing: 12) {
+                    Label(
+                        String(localized: "Tips for You"),
+                        systemImage: "lightbulb"
+                    )
+                    .font(.headline)
+                    .foregroundStyle(FinanceColors.textPrimary)
+                    .accessibilityAddTraits(.isHeader)
+
+                    ForEach(viewModel.tips) { tip in
+                        FinancialTipCard(
+                            tip: tip,
+                            onDismiss: {
+                                viewModel.dismissTip(tip)
+                            },
+                            onAction: tip.actionLabel != nil ? {
+                                onAction?(tip)
+                            } : nil
+                        )
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+        }
+        .task {
+            await viewModel.loadTips(for: context)
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Tip Card") {
+    FinancialTipCard(
+        tip: FinancialTip(
+            id: "preview_tip",
+            title: "Try the 50/30/20 Rule",
+            body: "Allocate 50% of income to needs, 30% to wants, and 20% to savings.",
+            category: .budgeting,
+            applicableContexts: [.dashboard],
+            priority: 10
+        ),
+        onDismiss: {}
+    )
+    .padding()
+}
+
+#Preview("Tips Section") {
+    ScrollView {
+        FinancialTipsSection(context: .dashboard)
+            .padding()
+    }
+}

--- a/apps/ios/Finance/Models/FinancialTip.swift
+++ b/apps/ios/Finance/Models/FinancialTip.swift
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// FinancialTip.swift
+// Finance
+//
+// Model for contextual financial tips displayed throughout the app.
+// Tips are context-aware — they adapt to the user's current view,
+// spending patterns, budget status, and goal progress.
+//
+// References: #320
+
+import SwiftUI
+
+// MARK: - Tip Context
+
+/// The screen or user action that triggers a contextual tip.
+enum TipContext: String, CaseIterable, Sendable {
+    case dashboard
+    case transactions
+    case budgets
+    case goals
+    case accounts
+    case overspending
+    case savingsGoalProgress
+    case newUser
+
+    var displayName: String {
+        switch self {
+        case .dashboard: String(localized: "Dashboard")
+        case .transactions: String(localized: "Transactions")
+        case .budgets: String(localized: "Budgets")
+        case .goals: String(localized: "Goals")
+        case .accounts: String(localized: "Accounts")
+        case .overspending: String(localized: "Overspending Alert")
+        case .savingsGoalProgress: String(localized: "Savings Progress")
+        case .newUser: String(localized: "Getting Started")
+        }
+    }
+}
+
+// MARK: - Tip Category
+
+/// Broad classification of financial advice.
+enum TipCategory: String, CaseIterable, Sendable {
+    case saving
+    case budgeting
+    case spending
+    case investing
+    case general
+
+    var displayName: String {
+        switch self {
+        case .saving: String(localized: "Saving")
+        case .budgeting: String(localized: "Budgeting")
+        case .spending: String(localized: "Spending")
+        case .investing: String(localized: "Investing")
+        case .general: String(localized: "General")
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .saving: "leaf"
+        case .budgeting: "chart.pie"
+        case .spending: "creditcard"
+        case .investing: "chart.line.uptrend.xyaxis"
+        case .general: "lightbulb"
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .saving: FinanceColors.statusPositive
+        case .budgeting: FinanceColors.interactive
+        case .spending: FinanceColors.statusWarning
+        case .investing: Color(hex: "#805AD5") ?? .purple
+        case .general: FinanceColors.statusInfo
+        }
+    }
+}
+
+// MARK: - Financial Tip
+
+/// A single contextual financial tip.
+///
+/// Tips are matched to contexts via ``applicableContexts`` and can be
+/// conditionally displayed based on the user's financial state (e.g.,
+/// only show budget tips when a budget exists).
+struct FinancialTip: Identifiable, Hashable, Sendable {
+    let id: String
+    let title: String
+    let body: String
+    let category: TipCategory
+    let applicableContexts: Set<TipContext>
+    let systemImage: String
+    let actionLabel: String?
+    let priority: Int
+
+    /// Whether this tip has been dismissed by the user.
+    /// Managed externally by ``FinancialTipService``.
+    var isDismissed: Bool = false
+
+    init(
+        id: String,
+        title: String,
+        body: String,
+        category: TipCategory,
+        applicableContexts: Set<TipContext>,
+        systemImage: String? = nil,
+        actionLabel: String? = nil,
+        priority: Int = 0
+    ) {
+        self.id = id
+        self.title = title
+        self.body = body
+        self.category = category
+        self.applicableContexts = applicableContexts
+        self.systemImage = systemImage ?? category.systemImage
+        self.actionLabel = actionLabel
+        self.priority = priority
+    }
+
+    // Hashable — identity is the tip ID.
+    static func == (lhs: FinancialTip, rhs: FinancialTip) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+}

--- a/apps/ios/Finance/Services/FinancialTipService.swift
+++ b/apps/ios/Finance/Services/FinancialTipService.swift
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// FinancialTipService.swift
+// Finance
+//
+// On-device service that generates context-aware financial tips based on
+// the user's spending patterns, budget status, and goal progress.
+// Tip dismissals are persisted in UserDefaults (non-sensitive boolean flags).
+//
+// References: #320
+
+import Foundation
+import os
+
+// MARK: - FinancialTipProviding Protocol
+
+/// Abstraction for financial tip generation — testable without side effects.
+protocol FinancialTipProviding: Sendable {
+    func tips(
+        for context: TipContext,
+        budgets: [BudgetItem],
+        goals: [GoalItem],
+        transactions: [TransactionItem]
+    ) -> [FinancialTip]
+
+    func dismissTip(id: String)
+    func isDismissed(id: String) -> Bool
+    func resetDismissals()
+}
+
+// MARK: - FinancialTipService
+
+/// Generates and manages contextual financial tips.
+///
+/// Tips are selected based on the current context plus optional financial
+/// state signals (over-budget categories, goal progress, etc.). Dismissed
+/// tips are tracked in `UserDefaults` under a namespaced key prefix.
+///
+/// > Note: Dismissed-tip IDs are non-sensitive UI preferences — Keychain
+/// >   storage is not required.
+final class FinancialTipService: FinancialTipProviding, @unchecked Sendable {
+
+    // MARK: - Singleton
+
+    static let shared = FinancialTipService()
+
+    // MARK: - Constants
+
+    /// UserDefaults key prefix for dismissed tip tracking.
+    private static let dismissedKeyPrefix = "financialTip.dismissed."
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
+        category: "FinancialTipService"
+    )
+
+    // MARK: - Private State
+
+    private let defaults: UserDefaults
+
+    // MARK: - Init
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    // MARK: - Public API
+
+    /// Returns context-appropriate tips, filtered by financial state and dismissals.
+    ///
+    /// - Parameters:
+    ///   - context: The screen or action triggering the tip request.
+    ///   - budgets: Current budget items for conditional tips.
+    ///   - goals: Current goal items for conditional tips.
+    ///   - transactions: Recent transactions for conditional tips.
+    /// - Returns: An array of tips sorted by priority (highest first), excluding dismissed tips.
+    func tips(
+        for context: TipContext,
+        budgets: [BudgetItem],
+        goals: [GoalItem],
+        transactions: [TransactionItem]
+    ) -> [FinancialTip] {
+        var candidates = allTips.filter { $0.applicableContexts.contains(context) }
+
+        // Add dynamic tips based on financial state.
+        candidates.append(contentsOf: dynamicTips(
+            for: context,
+            budgets: budgets,
+            goals: goals,
+            transactions: transactions
+        ))
+
+        // Filter dismissed and sort by priority.
+        let result = candidates
+            .filter { !isDismissed(id: $0.id) }
+            .sorted { $0.priority > $1.priority }
+
+        Self.logger.debug(
+            "Generated \(result.count, privacy: .public) tips for context \(context.rawValue, privacy: .public)"
+        )
+
+        return result
+    }
+
+    /// Marks a tip as dismissed so it won't appear again.
+    func dismissTip(id: String) {
+        defaults.set(true, forKey: Self.dismissedKeyPrefix + id)
+        Self.logger.info("Dismissed tip: \(id, privacy: .public)")
+    }
+
+    /// Checks whether a tip has been dismissed.
+    func isDismissed(id: String) -> Bool {
+        defaults.bool(forKey: Self.dismissedKeyPrefix + id)
+    }
+
+    /// Resets all tip dismissals.
+    func resetDismissals() {
+        let keys = defaults.dictionaryRepresentation().keys.filter {
+            $0.hasPrefix(Self.dismissedKeyPrefix)
+        }
+        for key in keys {
+            defaults.removeObject(forKey: key)
+        }
+        Self.logger.info("Reset all tip dismissals (\(keys.count, privacy: .public) tips)")
+    }
+
+    // MARK: - Static Tip Catalog
+
+    /// The full catalog of pre-authored financial tips.
+    private var allTips: [FinancialTip] {
+        [
+            // Dashboard tips
+            FinancialTip(
+                id: "tip_50_30_20",
+                title: String(localized: "Try the 50/30/20 Rule"),
+                body: String(localized: "Allocate 50% of income to needs, 30% to wants, and 20% to savings. It's a simple framework to balance your spending."),
+                category: .budgeting,
+                applicableContexts: [.dashboard, .budgets],
+                priority: 10
+            ),
+            FinancialTip(
+                id: "tip_emergency_fund",
+                title: String(localized: "Build an Emergency Fund"),
+                body: String(localized: "Aim to save 3–6 months of essential expenses. Start small — even $50/month adds up over time."),
+                category: .saving,
+                applicableContexts: [.dashboard, .goals, .newUser],
+                priority: 9
+            ),
+            FinancialTip(
+                id: "tip_automate_savings",
+                title: String(localized: "Automate Your Savings"),
+                body: String(localized: "Set up automatic transfers to your savings account on payday. You'll save consistently without having to think about it."),
+                category: .saving,
+                applicableContexts: [.dashboard, .accounts],
+                priority: 8
+            ),
+
+            // Transaction tips
+            FinancialTip(
+                id: "tip_categorize_spending",
+                title: String(localized: "Categorize Every Transaction"),
+                body: String(localized: "Consistent categorization reveals your true spending patterns. Review uncategorized transactions weekly for the best insights."),
+                category: .spending,
+                applicableContexts: [.transactions],
+                priority: 7
+            ),
+            FinancialTip(
+                id: "tip_review_recurring",
+                title: String(localized: "Audit Recurring Charges"),
+                body: String(localized: "Review your subscriptions quarterly. The average person has 12 recurring subscriptions — canceling unused ones can save hundreds yearly."),
+                category: .spending,
+                applicableContexts: [.transactions, .accounts],
+                systemImage: "repeat",
+                priority: 8
+            ),
+
+            // Budget tips
+            FinancialTip(
+                id: "tip_zero_based_budget",
+                title: String(localized: "Try Zero-Based Budgeting"),
+                body: String(localized: "Give every dollar a job. Assign all income to specific categories until you reach zero — this ensures nothing slips through."),
+                category: .budgeting,
+                applicableContexts: [.budgets],
+                priority: 6
+            ),
+            FinancialTip(
+                id: "tip_budget_buffer",
+                title: String(localized: "Add a 10% Buffer"),
+                body: String(localized: "Life is unpredictable. Adding a small buffer to each budget category prevents frustration from minor overruns."),
+                category: .budgeting,
+                applicableContexts: [.budgets],
+                priority: 5
+            ),
+
+            // Goal tips
+            FinancialTip(
+                id: "tip_smart_goals",
+                title: String(localized: "Set SMART Financial Goals"),
+                body: String(localized: "Make goals Specific, Measurable, Achievable, Relevant, and Time-bound. \"Save $5,000 for vacation by December\" beats \"save more money.\""),
+                category: .saving,
+                applicableContexts: [.goals],
+                priority: 7
+            ),
+            FinancialTip(
+                id: "tip_visualize_progress",
+                title: String(localized: "Visualize Your Progress"),
+                body: String(localized: "Tracking progress toward goals boosts motivation. Check your goal dashboard weekly to stay engaged and adjust course if needed."),
+                category: .general,
+                applicableContexts: [.goals, .dashboard],
+                priority: 4
+            ),
+
+            // Account tips
+            FinancialTip(
+                id: "tip_high_yield_savings",
+                title: String(localized: "Consider High-Yield Savings"),
+                body: String(localized: "High-yield savings accounts can earn 10–20× more interest than traditional ones. Your emergency fund should be working for you."),
+                category: .saving,
+                applicableContexts: [.accounts],
+                priority: 6
+            ),
+            FinancialTip(
+                id: "tip_pay_yourself_first",
+                title: String(localized: "Pay Yourself First"),
+                body: String(localized: "Before paying bills or spending, move a set amount to savings. Treat savings as a non-negotiable expense."),
+                category: .saving,
+                applicableContexts: [.accounts, .dashboard],
+                priority: 7
+            ),
+
+            // New user tips
+            FinancialTip(
+                id: "tip_start_tracking",
+                title: String(localized: "Start Tracking Today"),
+                body: String(localized: "The first step to financial health is awareness. Log your transactions daily for one week to understand where your money goes."),
+                category: .general,
+                applicableContexts: [.newUser, .dashboard],
+                systemImage: "sparkles",
+                priority: 10
+            ),
+        ]
+    }
+
+    // MARK: - Dynamic Tips
+
+    /// Generates tips based on the user's current financial state.
+    private func dynamicTips(
+        for context: TipContext,
+        budgets: [BudgetItem],
+        goals: [GoalItem],
+        transactions: [TransactionItem]
+    ) -> [FinancialTip] {
+        var tips: [FinancialTip] = []
+
+        // Over-budget warning tip
+        let overBudgetCategories = budgets.filter { $0.progress >= 1.0 }
+        if !overBudgetCategories.isEmpty {
+            let names = overBudgetCategories.map(\.name).joined(separator: ", ")
+            tips.append(FinancialTip(
+                id: "tip_dynamic_over_budget",
+                title: String(localized: "Over Budget Alert"),
+                body: String(localized: "You've exceeded your budget in: \(names). Consider reducing discretionary spending for the rest of the month."),
+                category: .budgeting,
+                applicableContexts: [context, .budgets, .dashboard, .overspending],
+                systemImage: "exclamationmark.triangle",
+                priority: 15
+            ))
+        }
+
+        // Near-budget warning (75%+)
+        let nearBudgetCategories = budgets.filter { $0.progress >= 0.75 && $0.progress < 1.0 }
+        if !nearBudgetCategories.isEmpty {
+            let names = nearBudgetCategories.map(\.name).joined(separator: ", ")
+            tips.append(FinancialTip(
+                id: "tip_dynamic_near_budget",
+                title: String(localized: "Approaching Budget Limit"),
+                body: String(localized: "You're nearing the limit in: \(names). Plan your remaining spending carefully this period."),
+                category: .budgeting,
+                applicableContexts: [context, .budgets, .dashboard],
+                systemImage: "gauge.with.dots.needle.67percent",
+                priority: 12
+            ))
+        }
+
+        // Goal nearly complete
+        let nearCompleteGoals = goals.filter {
+            $0.status == .active && $0.progress >= 0.80 && $0.progress < 1.0
+        }
+        for goal in nearCompleteGoals {
+            let percentLeft = Int((1.0 - goal.progress) * 100)
+            tips.append(FinancialTip(
+                id: "tip_dynamic_goal_near_\(goal.id)",
+                title: String(localized: "Almost There!"),
+                body: String(localized: "\"\(goal.name)\" is \(percentLeft)% away from completion. A small push could get you across the finish line!"),
+                category: .saving,
+                applicableContexts: [context, .goals, .dashboard, .savingsGoalProgress],
+                systemImage: "star.fill",
+                priority: 14
+            ))
+        }
+
+        // No budgets set
+        if budgets.isEmpty && (context == .dashboard || context == .budgets) {
+            tips.append(FinancialTip(
+                id: "tip_dynamic_no_budgets",
+                title: String(localized: "Create Your First Budget"),
+                body: String(localized: "Budgets help you control spending. Start with your top 3 expense categories and set realistic monthly limits."),
+                category: .budgeting,
+                applicableContexts: [context],
+                actionLabel: String(localized: "Create Budget"),
+                priority: 11
+            ))
+        }
+
+        // No goals set
+        if goals.isEmpty && (context == .dashboard || context == .goals) {
+            tips.append(FinancialTip(
+                id: "tip_dynamic_no_goals",
+                title: String(localized: "Set a Financial Goal"),
+                body: String(localized: "Goals give purpose to your savings. Whether it's an emergency fund or a vacation, start with one meaningful goal."),
+                category: .saving,
+                applicableContexts: [context],
+                actionLabel: String(localized: "Create Goal"),
+                priority: 11
+            ))
+        }
+
+        return tips
+    }
+}

--- a/apps/ios/Finance/ViewModels/FinancialTipsViewModel.swift
+++ b/apps/ios/Finance/ViewModels/FinancialTipsViewModel.swift
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// FinancialTipsViewModel.swift
+// Finance
+//
+// ViewModel for contextual financial tips. Loads tips from the
+// FinancialTipService based on the current screen context and
+// user's financial state.
+//
+// Uses @Observable (Observation framework) and structured concurrency.
+//
+// References: #320
+
+import Observation
+import os
+import SwiftUI
+
+@Observable
+final class FinancialTipsViewModel {
+    private let tipService: FinancialTipProviding
+    private let transactionRepository: TransactionRepository
+    private let budgetRepository: BudgetRepository
+    private let goalRepository: GoalRepository
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
+        category: "FinancialTipsViewModel"
+    )
+
+    // MARK: - Published State
+
+    /// Currently displayed tips for the active context.
+    var tips: [FinancialTip] = []
+
+    /// The active tip context.
+    var context: TipContext = .dashboard
+
+    /// Whether tips are loading.
+    var isLoading = false
+
+    /// Error message if tip loading fails.
+    var errorMessage: String?
+
+    /// The maximum number of tips to display.
+    var maxTips: Int = 3
+
+    // MARK: - Init
+
+    init(
+        tipService: FinancialTipProviding = FinancialTipService.shared,
+        transactionRepository: TransactionRepository = RepositoryProvider.shared.transactions,
+        budgetRepository: BudgetRepository = RepositoryProvider.shared.budgets,
+        goalRepository: GoalRepository = RepositoryProvider.shared.goals
+    ) {
+        self.tipService = tipService
+        self.transactionRepository = transactionRepository
+        self.budgetRepository = budgetRepository
+        self.goalRepository = goalRepository
+    }
+
+    // MARK: - Data Loading
+
+    /// Loads tips for the given context, enriched with the user's financial data.
+    func loadTips(for context: TipContext) async {
+        self.context = context
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            async let budgets = budgetRepository.getBudgets()
+            async let goals = goalRepository.getGoals()
+            async let transactions = transactionRepository.getRecentTransactions(limit: 50)
+
+            let (loadedBudgets, loadedGoals, loadedTransactions) = try await (
+                budgets, goals, transactions
+            )
+
+            tips = Array(
+                tipService.tips(
+                    for: context,
+                    budgets: loadedBudgets,
+                    goals: loadedGoals,
+                    transactions: loadedTransactions
+                ).prefix(maxTips)
+            )
+
+            Self.logger.debug(
+                "Loaded \(self.tips.count, privacy: .public) tips for \(context.rawValue, privacy: .public)"
+            )
+        } catch {
+            // Tips are advisory — failures should not block the user.
+            errorMessage = error.localizedDescription
+            tips = []
+            Self.logger.error(
+                "Tip loading failed: \(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+
+    /// Dismisses a tip and removes it from the current list.
+    func dismissTip(_ tip: FinancialTip) {
+        tipService.dismissTip(id: tip.id)
+        withAnimation(.easeInOut(duration: 0.3)) {
+            tips.removeAll { $0.id == tip.id }
+        }
+        Self.logger.info("User dismissed tip: \(tip.id, privacy: .public)")
+    }
+
+    /// Resets all tip dismissals and reloads.
+    func resetAllDismissals() async {
+        tipService.resetDismissals()
+        await loadTips(for: context)
+    }
+}

--- a/apps/ios/Tests/FinancialTipsViewModelTests.swift
+++ b/apps/ios/Tests/FinancialTipsViewModelTests.swift
@@ -1,0 +1,271 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// FinancialTipsViewModelTests.swift
+// FinanceTests
+//
+// Unit tests for FinancialTipsViewModel and FinancialTipService.
+//
+// References: #320
+
+import Foundation
+import SwiftUI
+import Testing
+@testable import FinanceApp
+
+// MARK: - Stub Tip Service
+
+/// Test double for FinancialTipProviding.
+final class StubFinancialTipService: FinancialTipProviding, @unchecked Sendable {
+    var tipsToReturn: [FinancialTip] = []
+    var dismissedIds: Set<String> = []
+
+    func tips(
+        for context: TipContext,
+        budgets: [BudgetItem],
+        goals: [GoalItem],
+        transactions: [TransactionItem]
+    ) -> [FinancialTip] {
+        tipsToReturn.filter { $0.applicableContexts.contains(context) && !dismissedIds.contains($0.id) }
+    }
+
+    func dismissTip(id: String) {
+        dismissedIds.insert(id)
+    }
+
+    func isDismissed(id: String) -> Bool {
+        dismissedIds.contains(id)
+    }
+
+    func resetDismissals() {
+        dismissedIds.removeAll()
+    }
+}
+
+// MARK: - FinancialTipsViewModel Tests
+
+@Suite("FinancialTipsViewModel Tests")
+struct FinancialTipsViewModelTests {
+
+    private func makeViewModel(
+        tips: [FinancialTip] = [],
+        budgets: [BudgetItem] = [],
+        goals: [GoalItem] = [],
+        transactions: [TransactionItem] = []
+    ) -> (FinancialTipsViewModel, StubFinancialTipService) {
+        let tipService = StubFinancialTipService()
+        tipService.tipsToReturn = tips
+
+        let budgetRepo = StubBudgetRepository()
+        budgetRepo.budgetsToReturn = budgets
+
+        let goalRepo = StubGoalRepository()
+        goalRepo.goalsToReturn = goals
+
+        let transactionRepo = StubTransactionRepository()
+        transactionRepo.transactionsToReturn = transactions
+
+        let vm = FinancialTipsViewModel(
+            tipService: tipService,
+            transactionRepository: transactionRepo,
+            budgetRepository: budgetRepo,
+            goalRepository: goalRepo
+        )
+        return (vm, tipService)
+    }
+
+    @Test("Loads tips for given context")
+    @MainActor
+    func loadsTipsForContext() async {
+        let tip = FinancialTip(
+            id: "test_tip",
+            title: "Test",
+            body: "Body",
+            category: .saving,
+            applicableContexts: [.dashboard],
+            priority: 5
+        )
+        let (vm, _) = makeViewModel(tips: [tip])
+
+        await vm.loadTips(for: .dashboard)
+
+        #expect(vm.tips.count == 1)
+        #expect(vm.tips.first?.id == "test_tip")
+        #expect(vm.context == .dashboard)
+    }
+
+    @Test("Filters tips by context")
+    @MainActor
+    func filtersByContext() async {
+        let dashboardTip = FinancialTip(
+            id: "dash",
+            title: "D",
+            body: "DB",
+            category: .general,
+            applicableContexts: [.dashboard],
+            priority: 5
+        )
+        let goalTip = FinancialTip(
+            id: "goal",
+            title: "G",
+            body: "GB",
+            category: .saving,
+            applicableContexts: [.goals],
+            priority: 5
+        )
+        let (vm, _) = makeViewModel(tips: [dashboardTip, goalTip])
+
+        await vm.loadTips(for: .goals)
+
+        #expect(vm.tips.count == 1)
+        #expect(vm.tips.first?.id == "goal")
+    }
+
+    @Test("Respects maxTips limit")
+    @MainActor
+    func respectsMaxTips() async {
+        let tips = (0..<10).map { i in
+            FinancialTip(
+                id: "tip_\(i)",
+                title: "Tip \(i)",
+                body: "Body",
+                category: .general,
+                applicableContexts: [.dashboard],
+                priority: i
+            )
+        }
+        let (vm, _) = makeViewModel(tips: tips)
+        vm.maxTips = 3
+
+        await vm.loadTips(for: .dashboard)
+
+        #expect(vm.tips.count == 3)
+    }
+
+    @Test("Dismiss removes tip from list")
+    @MainActor
+    func dismissRemovesTip() async {
+        let tip = FinancialTip(
+            id: "dismissable",
+            title: "Bye",
+            body: "Gone",
+            category: .general,
+            applicableContexts: [.dashboard],
+            priority: 5
+        )
+        let (vm, service) = makeViewModel(tips: [tip])
+
+        await vm.loadTips(for: .dashboard)
+        #expect(vm.tips.count == 1)
+
+        vm.dismissTip(tip)
+
+        #expect(vm.tips.isEmpty)
+        #expect(service.isDismissed(id: "dismissable"))
+    }
+
+    @Test("Reset dismissals restores tips")
+    @MainActor
+    func resetRestoresTips() async {
+        let tip = FinancialTip(
+            id: "reset_test",
+            title: "Reset",
+            body: "Me",
+            category: .general,
+            applicableContexts: [.dashboard],
+            priority: 5
+        )
+        let (vm, _) = makeViewModel(tips: [tip])
+
+        await vm.loadTips(for: .dashboard)
+        vm.dismissTip(tip)
+        #expect(vm.tips.isEmpty)
+
+        await vm.resetAllDismissals()
+        #expect(vm.tips.count == 1)
+    }
+
+    @Test("Handles repository errors gracefully")
+    @MainActor
+    func handlesErrors() async {
+        let tipService = StubFinancialTipService()
+        let budgetRepo = StubBudgetRepository()
+        budgetRepo.errorToThrow = TestError.simulated
+        let goalRepo = StubGoalRepository()
+        let transactionRepo = StubTransactionRepository()
+
+        let vm = FinancialTipsViewModel(
+            tipService: tipService,
+            transactionRepository: transactionRepo,
+            budgetRepository: budgetRepo,
+            goalRepository: goalRepo
+        )
+
+        await vm.loadTips(for: .dashboard)
+
+        #expect(vm.tips.isEmpty)
+        #expect(vm.errorMessage != nil)
+    }
+}
+
+// MARK: - FinancialTipService Tests
+
+@Suite("FinancialTipService Tests")
+struct FinancialTipServiceTests {
+
+    @Test("Generates tips for dashboard context")
+    func generatesForDashboard() {
+        let service = FinancialTipService(defaults: UserDefaults(suiteName: "test.tips.dash")!)
+        defer { UserDefaults(suiteName: "test.tips.dash")?.removePersistentDomain(forName: "test.tips.dash") }
+
+        let tips = service.tips(
+            for: .dashboard,
+            budgets: SampleData.allBudgets,
+            goals: SampleData.allGoals,
+            transactions: SampleData.allTransactions
+        )
+
+        #expect(!tips.isEmpty)
+    }
+
+    @Test("Generates dynamic over-budget tip")
+    func generatesOverBudgetTip() {
+        let service = FinancialTipService(defaults: UserDefaults(suiteName: "test.tips.ob")!)
+        defer { UserDefaults(suiteName: "test.tips.ob")?.removePersistentDomain(forName: "test.tips.ob") }
+
+        let tips = service.tips(
+            for: .budgets,
+            budgets: [SampleData.overBudget],
+            goals: [],
+            transactions: []
+        )
+
+        let overBudgetTip = tips.first { $0.id == "tip_dynamic_over_budget" }
+        #expect(overBudgetTip != nil)
+    }
+
+    @Test("Dismissal persists")
+    func dismissalPersists() {
+        let defaults = UserDefaults(suiteName: "test.tips.dismiss")!
+        defer { defaults.removePersistentDomain(forName: "test.tips.dismiss") }
+        let service = FinancialTipService(defaults: defaults)
+
+        #expect(!service.isDismissed(id: "some_tip"))
+
+        service.dismissTip(id: "some_tip")
+        #expect(service.isDismissed(id: "some_tip"))
+    }
+
+    @Test("Reset clears all dismissals")
+    func resetClearsAll() {
+        let defaults = UserDefaults(suiteName: "test.tips.reset")!
+        defer { defaults.removePersistentDomain(forName: "test.tips.reset") }
+        let service = FinancialTipService(defaults: defaults)
+
+        service.dismissTip(id: "tip_a")
+        service.dismissTip(id: "tip_b")
+        service.resetDismissals()
+
+        #expect(!service.isDismissed(id: "tip_a"))
+        #expect(!service.isDismissed(id: "tip_b"))
+    }
+}


### PR DESCRIPTION
## Summary

Implements contextual financial tips for the iOS app, providing context-aware financial guidance based on the user's current screen and financial state.

### Changes
- **FinancialTip model** — TipContext enum (dashboard, transactions, budgets, goals, accounts, etc.) and TipCategory enum (saving, budgeting, spending, investing, general) with SF Symbols and semantic colors
- **FinancialTipService** — On-device tip engine with a static catalog of 12+ pre-authored tips plus dynamic tips generated from financial state (over-budget alerts, near-complete goal nudges, empty-state guidance)
- **FinancialTipsViewModel** — @Observable ViewModel with structured concurrency, parallel data loading, and graceful error handling
- **FinancialTipCard** — Reusable SwiftUI card component with dismiss animation, optional action button
- **FinancialTipsSection** — Drop-in section component for any screen with .task{} auto-loading
- **Full accessibility** — VoiceOver labels/hints, custom dismiss actions, Dynamic Type, dark mode
- **Unit tests** — 7 test cases covering loading, filtering, dismissal, reset, and error handling

### Architecture
- Tips are generated on-device (privacy-first, no analytics)
- Dismissals persisted in UserDefaults (non-sensitive boolean flags)
- Protocol-based TipService for testability
- Integrates with existing RepositoryProvider for financial state

Closes #320