### PR TITLE
feat(ios): financial insights with spending analysis and recommendations (#241)

### DIFF
--- a/apps/ios/Finance/Models/InsightModels.swift
+++ b/apps/ios/Finance/Models/InsightModels.swift
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// InsightModels.swift
+// Finance
+//
+// Data models for the Financial Insights feature — spending analysis,
+// trend identification, and actionable recommendations.
+//
+// References: #241
+
+import SwiftUI
+
+// MARK: - Insight Type
+
+/// Classification of financial insights.
+enum InsightType: String, CaseIterable, Sendable {
+    case spendingTrend
+    case savingsOpportunity
+    case budgetPerformance
+    case incomeAnalysis
+    case categorySpike
+    case monthOverMonth
+
+    var displayName: String {
+        switch self {
+        case .spendingTrend: String(localized: "Spending Trend")
+        case .savingsOpportunity: String(localized: "Savings Opportunity")
+        case .budgetPerformance: String(localized: "Budget Performance")
+        case .incomeAnalysis: String(localized: "Income Analysis")
+        case .categorySpike: String(localized: "Category Spike")
+        case .monthOverMonth: String(localized: "Month-over-Month")
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .spendingTrend: "chart.line.downtrend.xyaxis"
+        case .savingsOpportunity: "leaf.arrow.circlepath"
+        case .budgetPerformance: "gauge.with.dots.needle.67percent"
+        case .incomeAnalysis: "arrow.down.left.circle"
+        case .categorySpike: "exclamationmark.arrow.triangle.2.circlepath"
+        case .monthOverMonth: "calendar.badge.clock"
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .spendingTrend: FinanceColors.statusWarning
+        case .savingsOpportunity: FinanceColors.statusPositive
+        case .budgetPerformance: FinanceColors.interactive
+        case .incomeAnalysis: FinanceColors.amountPositive
+        case .categorySpike: FinanceColors.statusNegative
+        case .monthOverMonth: Color(hex: "#805AD5") ?? .purple
+        }
+    }
+}
+
+// MARK: - Insight Severity
+
+/// How urgent or important an insight is.
+enum InsightSeverity: String, CaseIterable, Sendable {
+    case info
+    case suggestion
+    case warning
+    case critical
+
+    var displayName: String {
+        switch self {
+        case .info: String(localized: "Info")
+        case .suggestion: String(localized: "Suggestion")
+        case .warning: String(localized: "Warning")
+        case .critical: String(localized: "Critical")
+        }
+    }
+}
+
+// MARK: - Financial Insight
+
+/// A single actionable financial insight.
+struct FinancialInsight: Identifiable, Sendable {
+    let id: String
+    let type: InsightType
+    let severity: InsightSeverity
+    let title: String
+    let description: String
+    let detail: String?
+    let amountMinorUnits: Int64?
+    let percentChange: Double?
+    let relatedCategory: String?
+    let generatedAt: Date
+
+    init(
+        id: String = UUID().uuidString,
+        type: InsightType,
+        severity: InsightSeverity,
+        title: String,
+        description: String,
+        detail: String? = nil,
+        amountMinorUnits: Int64? = nil,
+        percentChange: Double? = nil,
+        relatedCategory: String? = nil,
+        generatedAt: Date = Date()
+    ) {
+        self.id = id
+        self.type = type
+        self.severity = severity
+        self.title = title
+        self.description = description
+        self.detail = detail
+        self.amountMinorUnits = amountMinorUnits
+        self.percentChange = percentChange
+        self.relatedCategory = relatedCategory
+        self.generatedAt = generatedAt
+    }
+}
+
+// MARK: - Spending Breakdown
+
+/// Spending aggregated by category for a given period.
+struct SpendingBreakdown: Identifiable, Sendable {
+    let id = UUID()
+    let categoryName: String
+    let categoryIcon: String
+    let amountMinorUnits: Int64
+    let percentOfTotal: Double
+    let color: Color
+}
+
+// MARK: - Insights Summary
+
+/// Aggregate result from the insights engine.
+struct InsightsSummary: Sendable {
+    let totalSpendingMinorUnits: Int64
+    let totalIncomeMinorUnits: Int64
+    let netCashFlowMinorUnits: Int64
+    let savingsRatePercent: Double
+    let spendingBreakdown: [SpendingBreakdown]
+    let insights: [FinancialInsight]
+    let monthlySpendingTrend: [MonthlyAmount]
+    let currencyCode: String
+}

--- a/apps/ios/Finance/Screens/InsightsView.swift
+++ b/apps/ios/Finance/Screens/InsightsView.swift
@@ -1,0 +1,383 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// InsightsView.swift
+// Finance
+//
+// Financial Insights screen showing spending analysis, category breakdown,
+// trend charts, and actionable recommendations.
+//
+// Uses Swift Charts, @Observable ViewModel, and full accessibility support.
+//
+// References: #241
+
+import Charts
+import SwiftUI
+
+struct InsightsView: View {
+    @State private var viewModel = InsightsViewModel()
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if viewModel.isLoading {
+                    ProgressView(String(localized: "Analyzing your finances…"))
+                        .accessibilityLabel(String(localized: "Loading financial insights"))
+                } else if let summary = viewModel.summary {
+                    insightsContent(summary)
+                } else {
+                    EmptyStateView(
+                        systemImage: "lightbulb",
+                        title: String(localized: "No Insights Yet"),
+                        message: String(localized: "Add transactions to see personalized financial insights and recommendations.")
+                    )
+                }
+            }
+            .navigationTitle(String(localized: "Insights"))
+            .task {
+                await viewModel.loadInsights()
+            }
+            .refreshable {
+                await viewModel.loadInsights()
+            }
+            .alert(
+                String(localized: "Error"),
+                isPresented: .init(
+                    get: { viewModel.showError },
+                    set: { if !$0 { viewModel.dismissError() } }
+                )
+            ) {
+                Button(String(localized: "OK"), role: .cancel) {}
+            } message: {
+                Text(viewModel.errorMessage ?? "")
+            }
+        }
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private func insightsContent(_ summary: InsightsSummary) -> some View {
+        ScrollView {
+            LazyVStack(spacing: 20) {
+                overviewCards(summary)
+                spendingBreakdownSection(summary)
+                trendChartSection(summary)
+                insightsListSection(summary)
+            }
+            .padding()
+        }
+    }
+
+    // MARK: - Overview Cards
+
+    @ViewBuilder
+    private func overviewCards(_ summary: InsightsSummary) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(String(localized: "This Month"))
+                .font(.headline)
+                .accessibilityAddTraits(.isHeader)
+
+            LazyVGrid(columns: [
+                GridItem(.flexible()),
+                GridItem(.flexible()),
+            ], spacing: 12) {
+                metricCard(
+                    title: String(localized: "Income"),
+                    value: viewModel.formatCurrency(summary.totalIncomeMinorUnits),
+                    icon: "arrow.down.left",
+                    color: FinanceColors.amountPositive
+                )
+                metricCard(
+                    title: String(localized: "Spending"),
+                    value: viewModel.formatCurrency(summary.totalSpendingMinorUnits),
+                    icon: "arrow.up.right",
+                    color: FinanceColors.amountNegative
+                )
+                metricCard(
+                    title: String(localized: "Net Cash Flow"),
+                    value: viewModel.formatSignedCurrency(summary.netCashFlowMinorUnits),
+                    icon: "arrow.left.arrow.right",
+                    color: summary.netCashFlowMinorUnits >= 0
+                        ? FinanceColors.amountPositive
+                        : FinanceColors.amountNegative
+                )
+                metricCard(
+                    title: String(localized: "Savings Rate"),
+                    value: String(format: "%.1f%%", summary.savingsRatePercent),
+                    icon: "leaf",
+                    color: summary.savingsRatePercent >= 20
+                        ? FinanceColors.statusPositive
+                        : FinanceColors.statusWarning
+                )
+            }
+        }
+    }
+
+    private func metricCard(
+        title: String,
+        value: String,
+        icon: String,
+        color: Color
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Image(systemName: icon)
+                .font(.caption)
+                .foregroundStyle(color)
+                .accessibilityHidden(true)
+
+            Text(value)
+                .font(.title3)
+                .fontWeight(.semibold)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(FinanceColors.backgroundElevated)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .shadow(color: .black.opacity(0.05), radius: 2, y: 1)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(title): \(value)")
+    }
+
+    // MARK: - Spending Breakdown
+
+    @ViewBuilder
+    private func spendingBreakdownSection(_ summary: InsightsSummary) -> some View {
+        if !summary.spendingBreakdown.isEmpty {
+            VStack(alignment: .leading, spacing: 12) {
+                Text(String(localized: "Spending by Category"))
+                    .font(.headline)
+                    .accessibilityAddTraits(.isHeader)
+
+                Chart(summary.spendingBreakdown) { item in
+                    SectorMark(
+                        angle: .value(
+                            String(localized: "Amount"),
+                            item.amountMinorUnits
+                        ),
+                        innerRadius: .ratio(0.618),
+                        angularInset: 1.5
+                    )
+                    .foregroundStyle(item.color)
+                    .cornerRadius(4)
+                    .annotation(position: .overlay) {
+                        if item.percentOfTotal > 10 {
+                            Text(String(format: "%.0f%%", item.percentOfTotal))
+                                .font(.caption2)
+                                .fontWeight(.bold)
+                                .foregroundStyle(.white)
+                        }
+                    }
+                }
+                .frame(height: 200)
+                .accessibilityLabel(String(localized: "Spending breakdown chart"))
+                .accessibilityHint(String(localized: "Shows spending distribution across categories"))
+
+                // Legend
+                ForEach(summary.spendingBreakdown) { item in
+                    HStack(spacing: 8) {
+                        Circle()
+                            .fill(item.color)
+                            .frame(width: 10, height: 10)
+                            .accessibilityHidden(true)
+
+                        Image(systemName: item.categoryIcon)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .frame(width: 20)
+                            .accessibilityHidden(true)
+
+                        Text(item.categoryName)
+                            .font(.subheadline)
+
+                        Spacer()
+
+                        Text(viewModel.formatCurrency(item.amountMinorUnits))
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+
+                        Text(String(format: "%.1f%%", item.percentOfTotal))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .frame(width: 44, alignment: .trailing)
+                    }
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel(
+                        String(localized: "\(item.categoryName): \(viewModel.formatCurrency(item.amountMinorUnits)), \(String(format: "%.1f", item.percentOfTotal)) percent")
+                    )
+                }
+            }
+        }
+    }
+
+    // MARK: - Trend Chart
+
+    @ViewBuilder
+    private func trendChartSection(_ summary: InsightsSummary) -> some View {
+        if !summary.monthlySpendingTrend.isEmpty {
+            VStack(alignment: .leading, spacing: 12) {
+                Text(String(localized: "Monthly Spending Trend"))
+                    .font(.headline)
+                    .accessibilityAddTraits(.isHeader)
+
+                Chart(summary.monthlySpendingTrend) { point in
+                    BarMark(
+                        x: .value(
+                            String(localized: "Month"),
+                            point.month, unit: .month
+                        ),
+                        y: .value(
+                            String(localized: "Spending"),
+                            Double(point.amountMinorUnits) / 100.0
+                        )
+                    )
+                    .foregroundStyle(FinanceColors.interactive.gradient)
+                    .cornerRadius(4)
+                }
+                .chartYAxis {
+                    AxisMarks(position: .leading) { value in
+                        if let amount = value.as(Double.self) {
+                            AxisValueLabel {
+                                Text(viewModel.formatCurrency(Int64(amount * 100)))
+                                    .font(.caption2)
+                            }
+                        }
+                        AxisGridLine()
+                    }
+                }
+                .chartXAxis {
+                    AxisMarks(values: .stride(by: .month)) { value in
+                        if let date = value.as(Date.self) {
+                            AxisValueLabel {
+                                Text(date.formatted(.dateTime.month(.abbreviated)))
+                                    .font(.caption2)
+                            }
+                        }
+                    }
+                }
+                .frame(height: 180)
+                .accessibilityLabel(String(localized: "Monthly spending trend chart"))
+                .accessibilityHint(String(localized: "Bar chart showing spending over the last 6 months"))
+            }
+        }
+    }
+
+    // MARK: - Insights List
+
+    @ViewBuilder
+    private func insightsListSection(_ summary: InsightsSummary) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text(String(localized: "Insights"))
+                    .font(.headline)
+                    .accessibilityAddTraits(.isHeader)
+
+                Spacer()
+
+                Picker(
+                    String(localized: "Filter"),
+                    selection: $viewModel.selectedFilter
+                ) {
+                    ForEach(InsightFilter.allCases, id: \.self) { filter in
+                        Text(filter.displayName).tag(filter)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .frame(maxWidth: 240)
+                .accessibilityLabel(String(localized: "Filter insights"))
+            }
+
+            if viewModel.filteredInsights.isEmpty {
+                Text(String(localized: "No insights match this filter."))
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .padding(.vertical, 8)
+            } else {
+                ForEach(viewModel.filteredInsights) { insight in
+                    insightRow(insight)
+                }
+            }
+        }
+    }
+
+    private func insightRow(_ insight: FinancialInsight) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: insight.type.systemImage)
+                .font(.title3)
+                .foregroundStyle(insight.type.color)
+                .frame(width: 32, height: 32)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text(insight.title)
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+
+                    Spacer()
+
+                    severityBadge(insight.severity)
+                }
+
+                Text(insight.description)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                if let change = insight.percentChange {
+                    HStack(spacing: 4) {
+                        Image(systemName: change >= 0 ? "arrow.up.right" : "arrow.down.right")
+                            .font(.caption2)
+                        Text(String(format: "%+.1f%%", change))
+                            .font(.caption)
+                            .fontWeight(.medium)
+                    }
+                    .foregroundStyle(change > 0 && insight.type == .categorySpike ? .red : .green)
+                    .accessibilityLabel(String(localized: "\(String(format: "%.1f", abs(change))) percent \(change >= 0 ? "increase" : "decrease")"))
+                }
+            }
+        }
+        .padding()
+        .background(FinanceColors.backgroundElevated)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .shadow(color: .black.opacity(0.04), radius: 2, y: 1)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            String(localized: "\(insight.severity.displayName) \(insight.type.displayName): \(insight.title)")
+        )
+        .accessibilityHint(insight.description)
+    }
+
+    private func severityBadge(_ severity: InsightSeverity) -> some View {
+        Text(severity.displayName)
+            .font(.caption2)
+            .fontWeight(.medium)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 2)
+            .background(severityColor(severity).opacity(0.15))
+            .foregroundStyle(severityColor(severity))
+            .clipShape(Capsule())
+            .accessibilityHidden(true) // Included in parent label
+    }
+
+    private func severityColor(_ severity: InsightSeverity) -> Color {
+        switch severity {
+        case .info: FinanceColors.statusInfo
+        case .suggestion: FinanceColors.statusPositive
+        case .warning: FinanceColors.statusWarning
+        case .critical: FinanceColors.statusNegative
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Insights View") {
+    InsightsView()
+}

--- a/apps/ios/Finance/Services/InsightsEngine.swift
+++ b/apps/ios/Finance/Services/InsightsEngine.swift
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// InsightsEngine.swift
+// Finance
+//
+// On-device engine that analyses transactions, budgets, and goals to
+// generate actionable financial insights. All computation happens locally
+// (privacy-first, no server calls).
+//
+// References: #241
+
+import Foundation
+import os
+
+// MARK: - InsightsEngineProtocol
+
+/// Abstraction for the insights computation engine.
+protocol InsightsEngineProtocol: Sendable {
+    func generateInsights(
+        transactions: [TransactionItem],
+        budgets: [BudgetItem],
+        goals: [GoalItem],
+        currencyCode: String
+    ) async -> InsightsSummary
+}
+
+// MARK: - InsightsEngine
+
+/// Computes financial insights from local transaction data.
+///
+/// The engine performs:
+/// 1. Spending breakdown by category
+/// 2. Month-over-month trend analysis
+/// 3. Savings rate calculation
+/// 4. Category spike detection
+/// 5. Budget performance scoring
+/// 6. Actionable recommendations
+final class InsightsEngine: InsightsEngineProtocol, @unchecked Sendable {
+
+    static let shared = InsightsEngine()
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
+        category: "InsightsEngine"
+    )
+
+    // MARK: - Public API
+
+    func generateInsights(
+        transactions: [TransactionItem],
+        budgets: [BudgetItem],
+        goals: [GoalItem],
+        currencyCode: String
+    ) async -> InsightsSummary {
+        let calendar = Calendar.current
+        let now = Date()
+
+        // Current month's transactions
+        let thisMonth = transactions.filter {
+            calendar.isDate($0.date, equalTo: now, toGranularity: .month)
+        }
+
+        // Last month's transactions
+        let lastMonthDate = calendar.date(byAdding: .month, value: -1, to: now) ?? now
+        let lastMonth = transactions.filter {
+            calendar.isDate($0.date, equalTo: lastMonthDate, toGranularity: .month)
+        }
+
+        // Core metrics
+        let totalSpending = thisMonth
+            .filter { $0.type == .expense }
+            .reduce(Int64(0)) { $0 + abs($1.amountMinorUnits) }
+
+        let totalIncome = thisMonth
+            .filter { $0.type == .income }
+            .reduce(Int64(0)) { $0 + abs($1.amountMinorUnits) }
+
+        let netCashFlow = totalIncome - totalSpending
+
+        let savingsRate: Double = totalIncome > 0
+            ? Double(netCashFlow) / Double(totalIncome) * 100.0
+            : 0
+
+        // Spending breakdown
+        let breakdown = computeBreakdown(expenses: thisMonth.filter { $0.type == .expense })
+
+        // Monthly trend (last 6 months)
+        let trend = computeMonthlyTrend(transactions: transactions, months: 6)
+
+        // Generate insights
+        var insights: [FinancialInsight] = []
+
+        insights.append(contentsOf: savingsRateInsights(savingsRate: savingsRate))
+        insights.append(contentsOf: categorySpikes(
+            thisMonth: thisMonth, lastMonth: lastMonth
+        ))
+        insights.append(contentsOf: budgetInsights(budgets: budgets))
+        insights.append(contentsOf: monthOverMonthInsights(
+            thisMonthSpending: totalSpending,
+            lastMonthTransactions: lastMonth
+        ))
+        insights.append(contentsOf: goalInsights(goals: goals))
+
+        // Sort by severity (critical first)
+        let severityOrder: [InsightSeverity] = [.critical, .warning, .suggestion, .info]
+        insights.sort { lhs, rhs in
+            let lhsIndex = severityOrder.firstIndex(of: lhs.severity) ?? 0
+            let rhsIndex = severityOrder.firstIndex(of: rhs.severity) ?? 0
+            return lhsIndex < rhsIndex
+        }
+
+        Self.logger.debug(
+            "Generated \(insights.count, privacy: .public) insights, savings rate: \(String(format: "%.1f", savingsRate), privacy: .public)%"
+        )
+
+        return InsightsSummary(
+            totalSpendingMinorUnits: totalSpending,
+            totalIncomeMinorUnits: totalIncome,
+            netCashFlowMinorUnits: netCashFlow,
+            savingsRatePercent: savingsRate,
+            spendingBreakdown: breakdown,
+            insights: insights,
+            monthlySpendingTrend: trend,
+            currencyCode: currencyCode
+        )
+    }
+
+    // MARK: - Breakdown
+
+    private func computeBreakdown(expenses: [TransactionItem]) -> [SpendingBreakdown] {
+        let grouped = Dictionary(grouping: expenses) { $0.category }
+        let total = expenses.reduce(Int64(0)) { $0 + abs($1.amountMinorUnits) }
+
+        guard total > 0 else { return [] }
+
+        let colors = FinanceColors.chart
+        return grouped
+            .map { (category, txns) in
+                let amount = txns.reduce(Int64(0)) { $0 + abs($1.amountMinorUnits) }
+                return (category: category, amount: amount)
+            }
+            .sorted { $0.amount > $1.amount }
+            .enumerated()
+            .map { index, item in
+                SpendingBreakdown(
+                    categoryName: item.category,
+                    categoryIcon: iconForCategory(item.category),
+                    amountMinorUnits: item.amount,
+                    percentOfTotal: Double(item.amount) / Double(total) * 100,
+                    color: colors[index % colors.count]
+                )
+            }
+    }
+
+    // MARK: - Monthly Trend
+
+    private func computeMonthlyTrend(
+        transactions: [TransactionItem],
+        months: Int
+    ) -> [MonthlyAmount] {
+        let calendar = Calendar.current
+        let now = Date()
+
+        return (0..<months).compactMap { offset in
+            guard let month = calendar.date(byAdding: .month, value: -offset, to: now) else {
+                return nil
+            }
+            let spending = transactions
+                .filter {
+                    $0.type == .expense &&
+                    calendar.isDate($0.date, equalTo: month, toGranularity: .month)
+                }
+                .reduce(Int64(0)) { $0 + abs($1.amountMinorUnits) }
+
+            return MonthlyAmount(month: month, amountMinorUnits: spending)
+        }
+        .reversed()
+    }
+
+    // MARK: - Insight Generators
+
+    private func savingsRateInsights(savingsRate: Double) -> [FinancialInsight] {
+        if savingsRate >= 20 {
+            return [FinancialInsight(
+                type: .savingsOpportunity,
+                severity: .info,
+                title: String(localized: "Great Savings Rate"),
+                description: String(localized: "You're saving \(String(format: "%.0f", savingsRate))% of your income this month — above the recommended 20%. Keep it up!"),
+                percentChange: savingsRate
+            )]
+        } else if savingsRate >= 0 {
+            return [FinancialInsight(
+                type: .savingsOpportunity,
+                severity: .suggestion,
+                title: String(localized: "Boost Your Savings"),
+                description: String(localized: "Your savings rate is \(String(format: "%.0f", savingsRate))%. Aim for 20% — even small increases compound significantly over time."),
+                percentChange: savingsRate
+            )]
+        } else {
+            return [FinancialInsight(
+                type: .savingsOpportunity,
+                severity: .warning,
+                title: String(localized: "Spending Exceeds Income"),
+                description: String(localized: "You're spending more than you earn this month. Review your expenses and identify areas to cut back."),
+                percentChange: savingsRate
+            )]
+        }
+    }
+
+    private func categorySpikes(
+        thisMonth: [TransactionItem],
+        lastMonth: [TransactionItem]
+    ) -> [FinancialInsight] {
+        let thisGrouped = Dictionary(grouping: thisMonth.filter { $0.type == .expense }) { $0.category }
+        let lastGrouped = Dictionary(grouping: lastMonth.filter { $0.type == .expense }) { $0.category }
+
+        var insights: [FinancialInsight] = []
+
+        for (category, txns) in thisGrouped {
+            let thisTotal = txns.reduce(Int64(0)) { $0 + abs($1.amountMinorUnits) }
+            let lastTotal = (lastGrouped[category] ?? [])
+                .reduce(Int64(0)) { $0 + abs($1.amountMinorUnits) }
+
+            guard lastTotal > 0 else { continue }
+
+            let change = Double(thisTotal - lastTotal) / Double(lastTotal) * 100
+
+            if change > 50 {
+                insights.append(FinancialInsight(
+                    type: .categorySpike,
+                    severity: change > 100 ? .warning : .suggestion,
+                    title: String(localized: "\(category) Spending Up \(String(format: "%.0f", change))%"),
+                    description: String(localized: "Your spending in \(category) has increased significantly compared to last month. Review recent transactions to ensure this is intentional."),
+                    percentChange: change,
+                    relatedCategory: category
+                ))
+            }
+        }
+
+        return insights
+    }
+
+    private func budgetInsights(budgets: [BudgetItem]) -> [FinancialInsight] {
+        var insights: [FinancialInsight] = []
+
+        let overBudget = budgets.filter { $0.progress >= 1.0 }
+        if !overBudget.isEmpty {
+            insights.append(FinancialInsight(
+                type: .budgetPerformance,
+                severity: .warning,
+                title: String(localized: "\(overBudget.count) Budget\(overBudget.count == 1 ? "" : "s") Exceeded"),
+                description: String(localized: "You've exceeded your limit in \(overBudget.map(\.name).joined(separator: ", ")). Consider adjusting your budget or reducing spending.")
+            ))
+        }
+
+        let onTrack = budgets.filter { $0.progress < 0.75 }
+        if !onTrack.isEmpty && overBudget.isEmpty {
+            insights.append(FinancialInsight(
+                type: .budgetPerformance,
+                severity: .info,
+                title: String(localized: "Budgets on Track"),
+                description: String(localized: "All your budgets are within healthy limits. Great discipline!")
+            ))
+        }
+
+        return insights
+    }
+
+    private func monthOverMonthInsights(
+        thisMonthSpending: Int64,
+        lastMonthTransactions: [TransactionItem]
+    ) -> [FinancialInsight] {
+        let lastMonthSpending = lastMonthTransactions
+            .filter { $0.type == .expense }
+            .reduce(Int64(0)) { $0 + abs($1.amountMinorUnits) }
+
+        guard lastMonthSpending > 0 else { return [] }
+
+        let change = Double(thisMonthSpending - lastMonthSpending) / Double(lastMonthSpending) * 100
+
+        if abs(change) > 10 {
+            return [FinancialInsight(
+                type: .monthOverMonth,
+                severity: change > 20 ? .warning : .info,
+                title: change > 0
+                    ? String(localized: "Spending Up \(String(format: "%.0f", change))% vs Last Month")
+                    : String(localized: "Spending Down \(String(format: "%.0f", abs(change)))% vs Last Month"),
+                description: change > 0
+                    ? String(localized: "Your spending is trending higher this month. Review your largest categories for potential savings.")
+                    : String(localized: "You've reduced spending compared to last month. Great progress on financial discipline!"),
+                percentChange: change
+            )]
+        }
+
+        return []
+    }
+
+    private func goalInsights(goals: [GoalItem]) -> [FinancialInsight] {
+        var insights: [FinancialInsight] = []
+
+        let activeGoals = goals.filter { $0.status == .active }
+        for goal in activeGoals {
+            if goal.progress >= 0.9 && goal.progress < 1.0 {
+                insights.append(FinancialInsight(
+                    type: .savingsOpportunity,
+                    severity: .info,
+                    title: String(localized: "\"\(goal.name)\" Nearly Complete"),
+                    description: String(localized: "You're \(String(format: "%.0f", goal.progress * 100))% of the way to your goal. A final push will get you there!"),
+                    percentChange: goal.progress * 100
+                ))
+            }
+        }
+
+        return insights
+    }
+
+    // MARK: - Helpers
+
+    private func iconForCategory(_ name: String) -> String {
+        let mapping: [String: String] = [
+            "Groceries": "cart", "Dining Out": "fork.knife",
+            "Transport": "car", "Entertainment": "film",
+            "Shopping": "bag", "Utilities": "bolt",
+            "Health": "heart", "Housing": "house",
+            "Travel": "airplane", "Education": "book",
+            "Income": "arrow.down.left", "Transfer": "arrow.left.arrow.right",
+        ]
+        return mapping[name] ?? "creditcard"
+    }
+}

--- a/apps/ios/Finance/ViewModels/InsightsViewModel.swift
+++ b/apps/ios/Finance/ViewModels/InsightsViewModel.swift
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// InsightsViewModel.swift
+// Finance
+//
+// ViewModel for the Financial Insights screen. Orchestrates the
+// InsightsEngine with repository data and exposes computed state
+// for the view layer.
+//
+// Uses @Observable and @MainActor for SwiftUI integration.
+//
+// References: #241
+
+import Observation
+import os
+import SwiftUI
+
+@Observable
+final class InsightsViewModel {
+    private let transactionRepository: TransactionRepository
+    private let budgetRepository: BudgetRepository
+    private let goalRepository: GoalRepository
+    private let engine: InsightsEngineProtocol
+    private let formatter: any SwiftExportFormatterModule
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
+        category: "InsightsViewModel"
+    )
+
+    // MARK: - Published State
+
+    var summary: InsightsSummary?
+    var isLoading = false
+    var errorMessage: String?
+
+    /// Filter for insight severity display.
+    var selectedFilter: InsightFilter = .all
+
+    var showError: Bool { errorMessage != nil }
+    func dismissError() { errorMessage = nil }
+
+    /// Filtered insights based on selected filter.
+    var filteredInsights: [FinancialInsight] {
+        guard let insights = summary?.insights else { return [] }
+        switch selectedFilter {
+        case .all: return insights
+        case .warnings: return insights.filter { $0.severity == .warning || $0.severity == .critical }
+        case .suggestions: return insights.filter { $0.severity == .suggestion }
+        case .info: return insights.filter { $0.severity == .info }
+        }
+    }
+
+    // MARK: - Init
+
+    init(
+        transactionRepository: TransactionRepository = RepositoryProvider.shared.transactions,
+        budgetRepository: BudgetRepository = RepositoryProvider.shared.budgets,
+        goalRepository: GoalRepository = RepositoryProvider.shared.goals,
+        engine: InsightsEngineProtocol = InsightsEngine.shared,
+        formatter: any SwiftExportFormatterModule = SwiftExportBridgeProvider.shared.formatter
+    ) {
+        self.transactionRepository = transactionRepository
+        self.budgetRepository = budgetRepository
+        self.goalRepository = goalRepository
+        self.engine = engine
+        self.formatter = formatter
+    }
+
+    // MARK: - Data Loading
+
+    func loadInsights() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            async let transactions = transactionRepository.getTransactions()
+            async let budgets = budgetRepository.getBudgets()
+            async let goals = goalRepository.getGoals()
+
+            let (txns, budgetList, goalList) = try await (transactions, budgets, goals)
+            let currencyCode = "USD" // TODO: derive from account
+
+            summary = await engine.generateInsights(
+                transactions: txns,
+                budgets: budgetList,
+                goals: goalList,
+                currencyCode: currencyCode
+            )
+
+            Self.logger.debug(
+                "Insights loaded: \(self.summary?.insights.count ?? 0, privacy: .public) insights"
+            )
+        } catch {
+            errorMessage = String(localized: "Failed to load insights. Please try again.")
+            Self.logger.error("Insights load failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    // MARK: - Formatting
+
+    func formatCurrency(_ amountMinorUnits: Int64) -> String {
+        let code = summary?.currencyCode ?? "USD"
+        return formatter.format(
+            amountMinorUnits: amountMinorUnits,
+            currencyCode: code,
+            showSign: false
+        )
+    }
+
+    func formatSignedCurrency(_ amountMinorUnits: Int64) -> String {
+        let code = summary?.currencyCode ?? "USD"
+        return formatter.format(
+            amountMinorUnits: amountMinorUnits,
+            currencyCode: code,
+            showSign: true
+        )
+    }
+}
+
+// MARK: - Insight Filter
+
+enum InsightFilter: String, CaseIterable, Sendable {
+    case all
+    case warnings
+    case suggestions
+    case info
+
+    var displayName: String {
+        switch self {
+        case .all: String(localized: "All")
+        case .warnings: String(localized: "Warnings")
+        case .suggestions: String(localized: "Suggestions")
+        case .info: String(localized: "Info")
+        }
+    }
+}

--- a/apps/ios/Tests/InsightsViewModelTests.swift
+++ b/apps/ios/Tests/InsightsViewModelTests.swift
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// InsightsViewModelTests.swift
+// FinanceTests
+//
+// Unit tests for InsightsViewModel and InsightsEngine.
+//
+// References: #241
+
+import Foundation
+import SwiftUI
+import Testing
+@testable import FinanceApp
+
+// MARK: - Stub Insights Engine
+
+final class StubInsightsEngine: InsightsEngineProtocol, @unchecked Sendable {
+    var summaryToReturn: InsightsSummary?
+
+    func generateInsights(
+        transactions: [TransactionItem],
+        budgets: [BudgetItem],
+        goals: [GoalItem],
+        currencyCode: String
+    ) async -> InsightsSummary {
+        summaryToReturn ?? InsightsSummary(
+            totalSpendingMinorUnits: 0,
+            totalIncomeMinorUnits: 0,
+            netCashFlowMinorUnits: 0,
+            savingsRatePercent: 0,
+            spendingBreakdown: [],
+            insights: [],
+            monthlySpendingTrend: [],
+            currencyCode: currencyCode
+        )
+    }
+}
+
+// MARK: - InsightsViewModel Tests
+
+@Suite("InsightsViewModel Tests")
+struct InsightsViewModelTests {
+
+    @Test("Loads insights successfully")
+    @MainActor
+    func loadsSuccessfully() async {
+        let engine = StubInsightsEngine()
+        engine.summaryToReturn = InsightsSummary(
+            totalSpendingMinorUnits: 150_000,
+            totalIncomeMinorUnits: 400_000,
+            netCashFlowMinorUnits: 250_000,
+            savingsRatePercent: 62.5,
+            spendingBreakdown: [],
+            insights: [
+                FinancialInsight(
+                    type: .savingsOpportunity,
+                    severity: .info,
+                    title: "Great Savings",
+                    description: "You're saving well."
+                ),
+            ],
+            monthlySpendingTrend: [],
+            currencyCode: "USD"
+        )
+
+        let vm = InsightsViewModel(
+            transactionRepository: StubTransactionRepository(),
+            budgetRepository: StubBudgetRepository(),
+            goalRepository: StubGoalRepository(),
+            engine: engine
+        )
+
+        await vm.loadInsights()
+
+        #expect(vm.summary != nil)
+        #expect(vm.summary?.totalSpendingMinorUnits == 150_000)
+        #expect(vm.summary?.insights.count == 1)
+        #expect(!vm.isLoading)
+    }
+
+    @Test("Handles repository error gracefully")
+    @MainActor
+    func handlesError() async {
+        let repo = StubTransactionRepository()
+        repo.errorToThrow = TestError.simulated
+
+        let vm = InsightsViewModel(
+            transactionRepository: repo,
+            budgetRepository: StubBudgetRepository(),
+            goalRepository: StubGoalRepository()
+        )
+
+        await vm.loadInsights()
+
+        #expect(vm.summary == nil)
+        #expect(vm.errorMessage != nil)
+        #expect(!vm.isLoading)
+    }
+
+    @Test("Filters insights by severity")
+    @MainActor
+    func filtersInsights() async {
+        let engine = StubInsightsEngine()
+        engine.summaryToReturn = InsightsSummary(
+            totalSpendingMinorUnits: 0,
+            totalIncomeMinorUnits: 0,
+            netCashFlowMinorUnits: 0,
+            savingsRatePercent: 0,
+            spendingBreakdown: [],
+            insights: [
+                FinancialInsight(type: .savingsOpportunity, severity: .info, title: "Info", description: ""),
+                FinancialInsight(type: .categorySpike, severity: .warning, title: "Warning", description: ""),
+                FinancialInsight(type: .budgetPerformance, severity: .suggestion, title: "Suggestion", description: ""),
+            ],
+            monthlySpendingTrend: [],
+            currencyCode: "USD"
+        )
+
+        let vm = InsightsViewModel(
+            transactionRepository: StubTransactionRepository(),
+            budgetRepository: StubBudgetRepository(),
+            goalRepository: StubGoalRepository(),
+            engine: engine
+        )
+
+        await vm.loadInsights()
+
+        vm.selectedFilter = .all
+        #expect(vm.filteredInsights.count == 3)
+
+        vm.selectedFilter = .warnings
+        #expect(vm.filteredInsights.count == 1)
+        #expect(vm.filteredInsights.first?.title == "Warning")
+
+        vm.selectedFilter = .info
+        #expect(vm.filteredInsights.count == 1)
+        #expect(vm.filteredInsights.first?.title == "Info")
+    }
+}
+
+// MARK: - InsightsEngine Tests
+
+@Suite("InsightsEngine Tests")
+struct InsightsEngineTests {
+
+    @Test("Generates insights from sample data")
+    func generatesInsights() async {
+        let engine = InsightsEngine.shared
+
+        let summary = await engine.generateInsights(
+            transactions: SampleData.allTransactions,
+            budgets: SampleData.allBudgets,
+            goals: SampleData.allGoals,
+            currencyCode: "USD"
+        )
+
+        #expect(!summary.insights.isEmpty)
+        #expect(summary.currencyCode == "USD")
+    }
+
+    @Test("Detects over-budget condition")
+    func detectsOverBudget() async {
+        let engine = InsightsEngine.shared
+
+        let summary = await engine.generateInsights(
+            transactions: [],
+            budgets: [SampleData.overBudget],
+            goals: [],
+            currencyCode: "USD"
+        )
+
+        let budgetInsight = summary.insights.first {
+            $0.type == .budgetPerformance && $0.severity == .warning
+        }
+        #expect(budgetInsight != nil)
+    }
+
+    @Test("Computes spending breakdown")
+    func computesBreakdown() async {
+        let engine = InsightsEngine.shared
+
+        // Create transactions dated this month so they get included
+        let now = Date()
+        let txns = [
+            TransactionItem(
+                id: "a", payee: "Store", category: "Groceries",
+                amountMinorUnits: -5000, currencyCode: "USD",
+                date: now, type: .expense
+            ),
+            TransactionItem(
+                id: "b", payee: "Gas", category: "Transport",
+                amountMinorUnits: -3000, currencyCode: "USD",
+                date: now, type: .expense
+            ),
+        ]
+
+        let summary = await engine.generateInsights(
+            transactions: txns,
+            budgets: [],
+            goals: [],
+            currencyCode: "USD"
+        )
+
+        #expect(summary.spendingBreakdown.count == 2)
+        #expect(summary.totalSpendingMinorUnits == 8000)
+    }
+}


### PR DESCRIPTION
## Summary

Implements a comprehensive Financial Insights screen for the iOS app, providing users with spending analysis, trend visualizations, and actionable financial recommendations.

### Changes
- **InsightModels** — \FinancialInsight\, \InsightType\ (6 types), \InsightSeverity\ (4 levels), \SpendingBreakdown\, \InsightsSummary\
- **InsightsEngine** — On-device analytics engine (privacy-first, no server calls):
  - Spending breakdown by category
  - Month-over-month trend analysis (6-month window)
  - Savings rate calculation with guidance thresholds
  - Category spike detection (flags 50%+ month-over-month increases)
  - Budget performance scoring (exceeded/on-track)
  - Goal completion tracking (90%+ alerts)
- **InsightsViewModel** — @Observable with structured concurrency, parallel data loading, severity-based filtering
- **InsightsView** — Full SwiftUI screen with:
  - 4 metric overview cards (income, spending, cash flow, savings rate)
  - Pie chart (SectorMark) for category spending breakdown with legend
  - Bar chart (BarMark) for 6-month spending trend
  - Filterable insights list (All/Warnings/Suggestions/Info)
  - Severity badges with semantic colors
- **Full accessibility** — VoiceOver labels/hints, chart descriptions, Dynamic Type, dark mode
- **Unit tests** — 6 test cases covering ViewModel loading, error handling, filtering, engine computation

### Architecture
- Protocol-based \InsightsEngineProtocol\ for testability
- All computation on-device (privacy-first)
- Integrates with RepositoryProvider and SwiftExportBridgeProvider

Closes #241