### PR TITLE
feat(ios): gamification system with achievements, streaks, and milestones (#242)

### DIFF
--- a/apps/ios/Finance/Models/GamificationModels.swift
+++ b/apps/ios/Finance/Models/GamificationModels.swift
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// GamificationModels.swift
+// Finance
+//
+// Data models for the gamification system — achievements, badges,
+// streaks, milestones, and progress tracking.
+//
+// References: #242
+
+import SwiftUI
+
+// MARK: - Achievement Category
+
+/// Broad grouping for achievements.
+enum AchievementCategory: String, CaseIterable, Sendable, Codable {
+    case tracking
+    case budgeting
+    case saving
+    case streaks
+    case milestones
+
+    var displayName: String {
+        switch self {
+        case .tracking: String(localized: "Tracking")
+        case .budgeting: String(localized: "Budgeting")
+        case .saving: String(localized: "Saving")
+        case .streaks: String(localized: "Streaks")
+        case .milestones: String(localized: "Milestones")
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .tracking: "list.bullet.clipboard"
+        case .budgeting: "chart.pie"
+        case .saving: "leaf"
+        case .streaks: "flame"
+        case .milestones: "flag.checkered"
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .tracking: FinanceColors.interactive
+        case .budgeting: Color(hex: "#805AD5") ?? .purple
+        case .saving: FinanceColors.statusPositive
+        case .streaks: FinanceColors.statusWarning
+        case .milestones: Color(hex: "#DD6B20") ?? .orange
+        }
+    }
+}
+
+// MARK: - Achievement Tier
+
+/// Rarity/difficulty tier for achievements.
+enum AchievementTier: String, CaseIterable, Sendable, Codable {
+    case bronze
+    case silver
+    case gold
+    case platinum
+
+    var displayName: String {
+        switch self {
+        case .bronze: String(localized: "Bronze")
+        case .silver: String(localized: "Silver")
+        case .gold: String(localized: "Gold")
+        case .platinum: String(localized: "Platinum")
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .bronze: Color(hex: "#CD7F32") ?? .brown
+        case .silver: Color(hex: "#C0C0C0") ?? .gray
+        case .gold: Color(hex: "#FFD700") ?? .yellow
+        case .platinum: Color(hex: "#E5E4E2") ?? .white
+        }
+    }
+
+    var points: Int {
+        switch self {
+        case .bronze: 10
+        case .silver: 25
+        case .gold: 50
+        case .platinum: 100
+        }
+    }
+}
+
+// MARK: - Achievement
+
+/// A single unlockable achievement/badge.
+struct Achievement: Identifiable, Sendable, Codable {
+    let id: String
+    let title: String
+    let description: String
+    let category: AchievementCategory
+    let tier: AchievementTier
+    let systemImage: String
+    let requiredCount: Int
+    var currentCount: Int
+    var isUnlocked: Bool
+    var unlockedAt: Date?
+
+    /// Progress toward unlocking (0.0–1.0).
+    var progress: Double {
+        guard requiredCount > 0 else { return isUnlocked ? 1.0 : 0.0 }
+        return min(1.0, Double(currentCount) / Double(requiredCount))
+    }
+
+    init(
+        id: String,
+        title: String,
+        description: String,
+        category: AchievementCategory,
+        tier: AchievementTier,
+        systemImage: String,
+        requiredCount: Int,
+        currentCount: Int = 0,
+        isUnlocked: Bool = false,
+        unlockedAt: Date? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.description = description
+        self.category = category
+        self.tier = tier
+        self.systemImage = systemImage
+        self.requiredCount = requiredCount
+        self.currentCount = currentCount
+        self.isUnlocked = isUnlocked
+        self.unlockedAt = unlockedAt
+    }
+}
+
+// MARK: - Streak
+
+/// Tracks consecutive-day activity.
+struct ActivityStreak: Sendable, Codable {
+    var currentDays: Int
+    var longestDays: Int
+    var lastActiveDate: Date?
+
+    var isActiveToday: Bool {
+        guard let last = lastActiveDate else { return false }
+        return Calendar.current.isDateInToday(last)
+    }
+
+    init(currentDays: Int = 0, longestDays: Int = 0, lastActiveDate: Date? = nil) {
+        self.currentDays = currentDays
+        self.longestDays = longestDays
+        self.lastActiveDate = lastActiveDate
+    }
+}
+
+// MARK: - Gamification Profile
+
+/// Aggregate gamification state for a user.
+struct GamificationProfile: Sendable, Codable {
+    var totalPoints: Int
+    var level: Int
+    var achievements: [Achievement]
+    var streak: ActivityStreak
+
+    /// Points needed for next level.
+    var pointsForNextLevel: Int { (level + 1) * 100 }
+
+    /// Progress toward the next level (0.0–1.0).
+    var levelProgress: Double {
+        let threshold = pointsForNextLevel
+        guard threshold > 0 else { return 0 }
+        let pointsInLevel = totalPoints - (level * 100)
+        return min(1.0, Double(pointsInLevel) / Double(100))
+    }
+
+    /// Achievements that have been unlocked.
+    var unlockedAchievements: [Achievement] {
+        achievements.filter(\.isUnlocked)
+    }
+
+    /// Achievements still locked.
+    var lockedAchievements: [Achievement] {
+        achievements.filter { !$0.isUnlocked }
+    }
+
+    init(
+        totalPoints: Int = 0,
+        level: Int = 1,
+        achievements: [Achievement] = [],
+        streak: ActivityStreak = ActivityStreak()
+    ) {
+        self.totalPoints = totalPoints
+        self.level = level
+        self.achievements = achievements
+        self.streak = streak
+    }
+}

--- a/apps/ios/Finance/Screens/AchievementsView.swift
+++ b/apps/ios/Finance/Screens/AchievementsView.swift
@@ -1,0 +1,361 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// AchievementsView.swift
+// Finance
+//
+// Gamification screen showing achievements, badges, streaks, level
+// progress, and milestone tracking.
+//
+// Uses @Observable, Swift haptics, and full accessibility support.
+//
+// References: #242
+
+import SwiftUI
+
+struct AchievementsView: View {
+    @State private var viewModel = GamificationViewModel()
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                LazyVStack(spacing: 20) {
+                    profileHeader
+                    streakSection
+                    categoryFilter
+                    achievementsGrid
+                }
+                .padding()
+            }
+            .navigationTitle(String(localized: "Achievements"))
+            .task {
+                await viewModel.loadProfile()
+            }
+            .refreshable {
+                await viewModel.loadProfile()
+            }
+            .overlay {
+                if viewModel.showUnlockAnimation, let achievement = viewModel.newlyUnlocked {
+                    achievementUnlockOverlay(achievement)
+                }
+            }
+            .alert(
+                String(localized: "Error"),
+                isPresented: .init(
+                    get: { viewModel.showError },
+                    set: { if !$0 { viewModel.dismissError() } }
+                )
+            ) {
+                Button(String(localized: "OK"), role: .cancel) {}
+            } message: {
+                Text(viewModel.errorMessage ?? "")
+            }
+        }
+    }
+
+    // MARK: - Profile Header
+
+    private var profileHeader: some View {
+        VStack(spacing: 16) {
+            // Level badge
+            ZStack {
+                Circle()
+                    .fill(FinanceColors.interactive.gradient)
+                    .frame(width: 80, height: 80)
+
+                Text("\(viewModel.profile.level)")
+                    .font(.title)
+                    .fontWeight(.bold)
+                    .foregroundStyle(.white)
+            }
+            .accessibilityHidden(true)
+
+            Text(String(localized: "Level \(viewModel.profile.level)"))
+                .font(.title2)
+                .fontWeight(.bold)
+
+            // Points and progress
+            VStack(spacing: 8) {
+                ProgressView(value: viewModel.profile.levelProgress) {
+                    HStack {
+                        Text(String(localized: "\(viewModel.profile.totalPoints) points"))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Text(String(localized: "\(viewModel.profile.pointsForNextLevel) to next level"))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .tint(FinanceColors.interactive)
+            }
+
+            // Stats row
+            HStack(spacing: 24) {
+                statPill(
+                    value: "\(viewModel.profile.unlockedAchievements.count)",
+                    label: String(localized: "Unlocked")
+                )
+                statPill(
+                    value: String(format: "%.0f%%", viewModel.completionPercent),
+                    label: String(localized: "Complete")
+                )
+                statPill(
+                    value: "\(viewModel.profile.streak.currentDays)",
+                    label: String(localized: "Day Streak")
+                )
+            }
+        }
+        .padding()
+        .background(FinanceColors.backgroundElevated)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .shadow(color: .black.opacity(0.06), radius: 4, y: 2)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            String(localized: "Level \(viewModel.profile.level), \(viewModel.profile.totalPoints) points, \(viewModel.profile.unlockedAchievements.count) achievements unlocked, \(viewModel.profile.streak.currentDays) day streak")
+        )
+    }
+
+    private func statPill(value: String, label: String) -> some View {
+        VStack(spacing: 4) {
+            Text(value)
+                .font(.headline)
+                .fontWeight(.bold)
+            Text(label)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(label): \(value)")
+    }
+
+    // MARK: - Streak Section
+
+    private var streakSection: some View {
+        HStack(spacing: 16) {
+            Image(systemName: "flame.fill")
+                .font(.title2)
+                .foregroundStyle(
+                    viewModel.profile.streak.currentDays > 0
+                        ? FinanceColors.statusWarning
+                        : .secondary
+                )
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(String(localized: "Current Streak"))
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+
+                Text(String(localized: "\(viewModel.profile.streak.currentDays) days"))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            VStack(alignment: .trailing, spacing: 2) {
+                Text(String(localized: "Best"))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Text(String(localized: "\(viewModel.profile.streak.longestDays) days"))
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+            }
+        }
+        .padding()
+        .background(FinanceColors.backgroundElevated)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            String(localized: "Streak: \(viewModel.profile.streak.currentDays) days current, \(viewModel.profile.streak.longestDays) days best")
+        )
+    }
+
+    // MARK: - Category Filter
+
+    private var categoryFilter: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                filterChip(
+                    label: String(localized: "All"),
+                    isSelected: viewModel.selectedCategory == nil
+                ) {
+                    viewModel.selectedCategory = nil
+                }
+
+                ForEach(AchievementCategory.allCases, id: \.self) { category in
+                    filterChip(
+                        label: category.displayName,
+                        icon: category.systemImage,
+                        isSelected: viewModel.selectedCategory == category
+                    ) {
+                        viewModel.selectedCategory = category
+                    }
+                }
+            }
+            .padding(.horizontal, 4)
+        }
+        .accessibilityLabel(String(localized: "Achievement category filter"))
+    }
+
+    private func filterChip(
+        label: String,
+        icon: String? = nil,
+        isSelected: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 4) {
+                if let icon {
+                    Image(systemName: icon)
+                        .font(.caption2)
+                }
+                Text(label)
+                    .font(.caption)
+                    .fontWeight(.medium)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(isSelected ? FinanceColors.interactive : FinanceColors.backgroundSecondary)
+            .foregroundStyle(isSelected ? .white : FinanceColors.textPrimary)
+            .clipShape(Capsule())
+        }
+        .accessibilityLabel(label)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    // MARK: - Achievements Grid
+
+    private var achievementsGrid: some View {
+        LazyVGrid(columns: [
+            GridItem(.flexible()),
+            GridItem(.flexible()),
+        ], spacing: 12) {
+            ForEach(viewModel.filteredAchievements) { achievement in
+                achievementCard(achievement)
+            }
+        }
+    }
+
+    private func achievementCard(_ achievement: Achievement) -> some View {
+        VStack(spacing: 10) {
+            ZStack {
+                Circle()
+                    .fill(
+                        achievement.isUnlocked
+                            ? achievement.tier.color.gradient
+                            : Color.secondary.opacity(0.2).gradient
+                    )
+                    .frame(width: 56, height: 56)
+
+                Image(systemName: achievement.systemImage)
+                    .font(.title3)
+                    .foregroundStyle(
+                        achievement.isUnlocked ? .white : .secondary
+                    )
+            }
+            .accessibilityHidden(true)
+
+            Text(achievement.title)
+                .font(.caption)
+                .fontWeight(.semibold)
+                .multilineTextAlignment(.center)
+                .lineLimit(2)
+
+            Text(achievement.description)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .lineLimit(2)
+
+            if !achievement.isUnlocked {
+                ProgressView(value: achievement.progress)
+                    .tint(achievement.category.color)
+
+                Text(String(localized: "\(achievement.currentCount)/\(achievement.requiredCount)"))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            } else {
+                HStack(spacing: 4) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.caption2)
+                    Text(achievement.tier.displayName)
+                        .font(.caption2)
+                        .fontWeight(.medium)
+                }
+                .foregroundStyle(achievement.tier.color)
+            }
+        }
+        .padding()
+        .background(FinanceColors.backgroundElevated)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .shadow(color: .black.opacity(0.04), radius: 2, y: 1)
+        .opacity(achievement.isUnlocked ? 1.0 : 0.7)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            achievement.isUnlocked
+                ? String(localized: "\(achievement.title), unlocked, \(achievement.tier.displayName) tier")
+                : String(localized: "\(achievement.title), locked, \(achievement.currentCount) of \(achievement.requiredCount) complete")
+        )
+        .accessibilityHint(achievement.description)
+    }
+
+    // MARK: - Unlock Overlay
+
+    private func achievementUnlockOverlay(_ achievement: Achievement) -> some View {
+        ZStack {
+            Color.black.opacity(0.5)
+                .ignoresSafeArea()
+                .onTapGesture {
+                    viewModel.showUnlockAnimation = false
+                }
+
+            VStack(spacing: 20) {
+                Image(systemName: "trophy.fill")
+                    .font(.system(size: 60))
+                    .foregroundStyle(achievement.tier.color)
+
+                Text(String(localized: "Achievement Unlocked!"))
+                    .font(.title2)
+                    .fontWeight(.bold)
+
+                Text(achievement.title)
+                    .font(.headline)
+
+                Text(achievement.description)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+
+                Text(String(localized: "+\(achievement.tier.points) points"))
+                    .font(.title3)
+                    .fontWeight(.bold)
+                    .foregroundStyle(FinanceColors.interactive)
+
+                Button(String(localized: "Awesome!")) {
+                    viewModel.showUnlockAnimation = false
+                }
+                .buttonStyle(.borderedProminent)
+                .accessibilityLabel(String(localized: "Dismiss achievement notification"))
+            }
+            .padding(32)
+            .background(FinanceColors.backgroundElevated)
+            .clipShape(RoundedRectangle(cornerRadius: 20))
+            .shadow(radius: 20)
+            .padding(40)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            String(localized: "Achievement unlocked: \(achievement.title). \(achievement.description). Plus \(achievement.tier.points) points.")
+        )
+        .accessibilityAddTraits(.isModal)
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Achievements") {
+    AchievementsView()
+}

--- a/apps/ios/Finance/Services/GamificationService.swift
+++ b/apps/ios/Finance/Services/GamificationService.swift
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// GamificationService.swift
+// Finance
+//
+// On-device gamification engine that tracks achievements, streaks,
+// and milestones. State is persisted in UserDefaults (non-sensitive
+// progress data). Achievement definitions are static; progress is
+// computed from repository data.
+//
+// References: #242
+
+import Foundation
+import os
+
+// MARK: - GamificationProviding Protocol
+
+/// Abstraction for the gamification engine.
+protocol GamificationProviding: Sendable {
+    func loadProfile() -> GamificationProfile
+    func evaluateAchievements(
+        transactionCount: Int,
+        budgetCount: Int,
+        goalCount: Int,
+        completedGoals: Int,
+        onBudgetCount: Int,
+        savingsRatePercent: Double
+    ) -> GamificationProfile
+    func recordActivity()
+    func resetProfile()
+}
+
+// MARK: - GamificationService
+
+/// Manages the gamification system — achievements, streaks, and points.
+///
+/// All data is stored in UserDefaults as non-sensitive progress metadata.
+/// Achievement definitions are hard-coded; progress is evaluated against
+/// current financial data from repositories.
+final class GamificationService: GamificationProviding, @unchecked Sendable {
+
+    static let shared = GamificationService()
+
+    private static let profileKey = "gamification.profile"
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
+        category: "GamificationService"
+    )
+
+    private let defaults: UserDefaults
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    // MARK: - Public API
+
+    /// Loads the current gamification profile from persistence.
+    func loadProfile() -> GamificationProfile {
+        guard let data = defaults.data(forKey: Self.profileKey),
+              let profile = try? decoder.decode(GamificationProfile.self, from: data)
+        else {
+            return GamificationProfile(achievements: Self.allAchievements)
+        }
+        return profile
+    }
+
+    /// Evaluates achievements against current financial metrics and returns updated profile.
+    func evaluateAchievements(
+        transactionCount: Int,
+        budgetCount: Int,
+        goalCount: Int,
+        completedGoals: Int,
+        onBudgetCount: Int,
+        savingsRatePercent: Double
+    ) -> GamificationProfile {
+        var profile = loadProfile()
+
+        // Ensure all achievement definitions exist
+        let existingIds = Set(profile.achievements.map(\.id))
+        for achievement in Self.allAchievements where !existingIds.contains(achievement.id) {
+            profile.achievements.append(achievement)
+        }
+
+        // Evaluate each achievement
+        for i in profile.achievements.indices {
+            let achievement = profile.achievements[i]
+            guard !achievement.isUnlocked else { continue }
+
+            let newCount: Int
+            switch achievement.id {
+            // Tracking achievements
+            case "first_transaction": newCount = min(1, transactionCount)
+            case "ten_transactions": newCount = min(10, transactionCount)
+            case "hundred_transactions": newCount = min(100, transactionCount)
+            case "thousand_transactions": newCount = min(1000, transactionCount)
+
+            // Budget achievements
+            case "first_budget": newCount = min(1, budgetCount)
+            case "budget_keeper": newCount = min(3, onBudgetCount)
+            case "budget_master": newCount = min(5, onBudgetCount)
+
+            // Saving achievements
+            case "first_goal": newCount = min(1, goalCount)
+            case "goal_achiever": newCount = min(1, completedGoals)
+            case "goal_crusher": newCount = min(5, completedGoals)
+            case "saver_20": newCount = savingsRatePercent >= 20 ? 1 : 0
+            case "saver_50": newCount = savingsRatePercent >= 50 ? 1 : 0
+
+            // Streak achievements
+            case "streak_7": newCount = min(7, profile.streak.currentDays)
+            case "streak_30": newCount = min(30, profile.streak.currentDays)
+            case "streak_100": newCount = min(100, profile.streak.currentDays)
+            case "streak_365": newCount = min(365, profile.streak.currentDays)
+
+            default: newCount = achievement.currentCount
+            }
+
+            profile.achievements[i].currentCount = newCount
+
+            if newCount >= achievement.requiredCount && !achievement.isUnlocked {
+                profile.achievements[i].isUnlocked = true
+                profile.achievements[i].unlockedAt = Date()
+                profile.totalPoints += achievement.tier.points
+                Self.logger.info(
+                    "Achievement unlocked: \(achievement.id, privacy: .public) (+\(achievement.tier.points, privacy: .public) pts)"
+                )
+            }
+        }
+
+        // Recalculate level
+        profile.level = max(1, profile.totalPoints / 100 + 1)
+
+        saveProfile(profile)
+        return profile
+    }
+
+    /// Records daily activity for streak tracking.
+    func recordActivity() {
+        var profile = loadProfile()
+        let calendar = Calendar.current
+        let today = Date()
+
+        if let lastActive = profile.streak.lastActiveDate {
+            if calendar.isDateInToday(lastActive) {
+                // Already active today — no change
+                return
+            } else if calendar.isDateInYesterday(lastActive) {
+                // Consecutive day
+                profile.streak.currentDays += 1
+            } else {
+                // Streak broken
+                profile.streak.currentDays = 1
+            }
+        } else {
+            profile.streak.currentDays = 1
+        }
+
+        profile.streak.lastActiveDate = today
+        profile.streak.longestDays = max(
+            profile.streak.longestDays,
+            profile.streak.currentDays
+        )
+
+        saveProfile(profile)
+        Self.logger.debug(
+            "Activity recorded, streak: \(profile.streak.currentDays, privacy: .public) days"
+        )
+    }
+
+    /// Resets the entire gamification profile.
+    func resetProfile() {
+        defaults.removeObject(forKey: Self.profileKey)
+        Self.logger.info("Gamification profile reset")
+    }
+
+    // MARK: - Persistence
+
+    private func saveProfile(_ profile: GamificationProfile) {
+        guard let data = try? encoder.encode(profile) else { return }
+        defaults.set(data, forKey: Self.profileKey)
+    }
+
+    // MARK: - Achievement Definitions
+
+    static let allAchievements: [Achievement] = [
+        // Tracking
+        Achievement(
+            id: "first_transaction", title: String(localized: "First Step"),
+            description: String(localized: "Log your first transaction"),
+            category: .tracking, tier: .bronze, systemImage: "pencil.line",
+            requiredCount: 1
+        ),
+        Achievement(
+            id: "ten_transactions", title: String(localized: "Getting Started"),
+            description: String(localized: "Log 10 transactions"),
+            category: .tracking, tier: .bronze, systemImage: "list.bullet",
+            requiredCount: 10
+        ),
+        Achievement(
+            id: "hundred_transactions", title: String(localized: "Committed Tracker"),
+            description: String(localized: "Log 100 transactions"),
+            category: .tracking, tier: .silver, systemImage: "star",
+            requiredCount: 100
+        ),
+        Achievement(
+            id: "thousand_transactions", title: String(localized: "Transaction Master"),
+            description: String(localized: "Log 1,000 transactions"),
+            category: .tracking, tier: .gold, systemImage: "star.fill",
+            requiredCount: 1000
+        ),
+
+        // Budgeting
+        Achievement(
+            id: "first_budget", title: String(localized: "Budget Beginner"),
+            description: String(localized: "Create your first budget"),
+            category: .budgeting, tier: .bronze, systemImage: "chart.pie",
+            requiredCount: 1
+        ),
+        Achievement(
+            id: "budget_keeper", title: String(localized: "Budget Keeper"),
+            description: String(localized: "Stay within budget for 3 categories"),
+            category: .budgeting, tier: .silver, systemImage: "checkmark.shield",
+            requiredCount: 3
+        ),
+        Achievement(
+            id: "budget_master", title: String(localized: "Budget Master"),
+            description: String(localized: "Stay within budget for 5 categories"),
+            category: .budgeting, tier: .gold, systemImage: "crown",
+            requiredCount: 5
+        ),
+
+        // Saving
+        Achievement(
+            id: "first_goal", title: String(localized: "Goal Setter"),
+            description: String(localized: "Create your first savings goal"),
+            category: .saving, tier: .bronze, systemImage: "target",
+            requiredCount: 1
+        ),
+        Achievement(
+            id: "goal_achiever", title: String(localized: "Goal Achiever"),
+            description: String(localized: "Complete your first savings goal"),
+            category: .saving, tier: .silver, systemImage: "checkmark.circle",
+            requiredCount: 1
+        ),
+        Achievement(
+            id: "goal_crusher", title: String(localized: "Goal Crusher"),
+            description: String(localized: "Complete 5 savings goals"),
+            category: .saving, tier: .gold, systemImage: "trophy",
+            requiredCount: 5
+        ),
+        Achievement(
+            id: "saver_20", title: String(localized: "Smart Saver"),
+            description: String(localized: "Achieve a 20% savings rate"),
+            category: .saving, tier: .silver, systemImage: "leaf",
+            requiredCount: 1
+        ),
+        Achievement(
+            id: "saver_50", title: String(localized: "Super Saver"),
+            description: String(localized: "Achieve a 50% savings rate"),
+            category: .saving, tier: .platinum, systemImage: "leaf.fill",
+            requiredCount: 1
+        ),
+
+        // Streaks
+        Achievement(
+            id: "streak_7", title: String(localized: "Week Warrior"),
+            description: String(localized: "7-day activity streak"),
+            category: .streaks, tier: .bronze, systemImage: "flame",
+            requiredCount: 7
+        ),
+        Achievement(
+            id: "streak_30", title: String(localized: "Monthly Master"),
+            description: String(localized: "30-day activity streak"),
+            category: .streaks, tier: .silver, systemImage: "flame.fill",
+            requiredCount: 30
+        ),
+        Achievement(
+            id: "streak_100", title: String(localized: "Century Club"),
+            description: String(localized: "100-day activity streak"),
+            category: .streaks, tier: .gold, systemImage: "100.circle",
+            requiredCount: 100
+        ),
+        Achievement(
+            id: "streak_365", title: String(localized: "Year of Discipline"),
+            description: String(localized: "365-day activity streak"),
+            category: .streaks, tier: .platinum, systemImage: "calendar.badge.checkmark",
+            requiredCount: 365
+        ),
+    ]
+}

--- a/apps/ios/Finance/ViewModels/GamificationViewModel.swift
+++ b/apps/ios/Finance/ViewModels/GamificationViewModel.swift
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// GamificationViewModel.swift
+// Finance
+//
+// ViewModel for the Achievements/Gamification screen. Evaluates
+// achievements against current financial data and exposes profile
+// state for the view layer.
+//
+// Uses @Observable and structured concurrency.
+//
+// References: #242
+
+import Observation
+import os
+import SwiftUI
+
+@Observable
+final class GamificationViewModel {
+    private let gamificationService: GamificationProviding
+    private let transactionRepository: TransactionRepository
+    private let budgetRepository: BudgetRepository
+    private let goalRepository: GoalRepository
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
+        category: "GamificationViewModel"
+    )
+
+    // MARK: - Published State
+
+    var profile: GamificationProfile = GamificationProfile()
+    var isLoading = false
+    var errorMessage: String?
+    var selectedCategory: AchievementCategory?
+    var showUnlockAnimation = false
+    var newlyUnlocked: Achievement?
+
+    var showError: Bool { errorMessage != nil }
+    func dismissError() { errorMessage = nil }
+
+    /// Filtered achievements based on selected category.
+    var filteredAchievements: [Achievement] {
+        guard let category = selectedCategory else {
+            return profile.achievements
+        }
+        return profile.achievements.filter { $0.category == category }
+    }
+
+    /// Achievement completion percentage.
+    var completionPercent: Double {
+        guard !profile.achievements.isEmpty else { return 0 }
+        return Double(profile.unlockedAchievements.count) / Double(profile.achievements.count) * 100
+    }
+
+    // MARK: - Init
+
+    init(
+        gamificationService: GamificationProviding = GamificationService.shared,
+        transactionRepository: TransactionRepository = RepositoryProvider.shared.transactions,
+        budgetRepository: BudgetRepository = RepositoryProvider.shared.budgets,
+        goalRepository: GoalRepository = RepositoryProvider.shared.goals
+    ) {
+        self.gamificationService = gamificationService
+        self.transactionRepository = transactionRepository
+        self.budgetRepository = budgetRepository
+        self.goalRepository = goalRepository
+    }
+
+    // MARK: - Data Loading
+
+    func loadProfile() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        // Record daily activity
+        gamificationService.recordActivity()
+
+        do {
+            async let transactions = transactionRepository.getTransactions()
+            async let budgets = budgetRepository.getBudgets()
+            async let goals = goalRepository.getGoals()
+
+            let (txns, budgetList, goalList) = try await (transactions, budgets, goals)
+
+            let previousUnlocked = Set(profile.unlockedAchievements.map(\.id))
+
+            profile = gamificationService.evaluateAchievements(
+                transactionCount: txns.count,
+                budgetCount: budgetList.count,
+                goalCount: goalList.count,
+                completedGoals: goalList.filter { $0.isComplete }.count,
+                onBudgetCount: budgetList.filter { $0.progress < 1.0 }.count,
+                savingsRatePercent: computeSavingsRate(transactions: txns)
+            )
+
+            // Check for newly unlocked achievements
+            let newUnlocked = profile.unlockedAchievements.filter {
+                !previousUnlocked.contains($0.id)
+            }
+            if let first = newUnlocked.first {
+                newlyUnlocked = first
+                showUnlockAnimation = true
+            }
+
+            Self.logger.debug(
+                "Profile loaded: level \(self.profile.level, privacy: .public), \(self.profile.totalPoints, privacy: .public) pts, \(self.profile.unlockedAchievements.count, privacy: .public) unlocked"
+            )
+        } catch {
+            errorMessage = String(localized: "Failed to load achievements.")
+            Self.logger.error("Gamification load failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func computeSavingsRate(transactions: [TransactionItem]) -> Double {
+        let calendar = Calendar.current
+        let now = Date()
+        let thisMonth = transactions.filter {
+            calendar.isDate($0.date, equalTo: now, toGranularity: .month)
+        }
+
+        let income = thisMonth.filter { $0.type == .income }
+            .reduce(Int64(0)) { $0 + abs($1.amountMinorUnits) }
+        let spending = thisMonth.filter { $0.type == .expense }
+            .reduce(Int64(0)) { $0 + abs($1.amountMinorUnits) }
+
+        guard income > 0 else { return 0 }
+        return Double(income - spending) / Double(income) * 100
+    }
+}

--- a/apps/ios/Tests/GamificationViewModelTests.swift
+++ b/apps/ios/Tests/GamificationViewModelTests.swift
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// GamificationViewModelTests.swift
+// FinanceTests
+//
+// Unit tests for GamificationViewModel and GamificationService.
+//
+// References: #242
+
+import Foundation
+import SwiftUI
+import Testing
+@testable import FinanceApp
+
+// MARK: - Stub Gamification Service
+
+final class StubGamificationService: GamificationProviding, @unchecked Sendable {
+    var profileToReturn = GamificationProfile(achievements: GamificationService.allAchievements)
+    var activityRecorded = false
+    var resetCalled = false
+
+    func loadProfile() -> GamificationProfile {
+        profileToReturn
+    }
+
+    func evaluateAchievements(
+        transactionCount: Int,
+        budgetCount: Int,
+        goalCount: Int,
+        completedGoals: Int,
+        onBudgetCount: Int,
+        savingsRatePercent: Double
+    ) -> GamificationProfile {
+        // Simulate unlocking first_transaction when count >= 1
+        var profile = profileToReturn
+        if transactionCount >= 1 {
+            if let idx = profile.achievements.firstIndex(where: { $0.id == "first_transaction" }) {
+                profile.achievements[idx].isUnlocked = true
+                profile.achievements[idx].unlockedAt = Date()
+                profile.achievements[idx].currentCount = 1
+                profile.totalPoints += profile.achievements[idx].tier.points
+            }
+        }
+        return profile
+    }
+
+    func recordActivity() {
+        activityRecorded = true
+    }
+
+    func resetProfile() {
+        resetCalled = true
+    }
+}
+
+// MARK: - GamificationViewModel Tests
+
+@Suite("GamificationViewModel Tests")
+struct GamificationViewModelTests {
+
+    @Test("Loads profile and records activity")
+    @MainActor
+    func loadsProfile() async {
+        let service = StubGamificationService()
+        let vm = GamificationViewModel(
+            gamificationService: service,
+            transactionRepository: StubTransactionRepository(),
+            budgetRepository: StubBudgetRepository(),
+            goalRepository: StubGoalRepository()
+        )
+
+        await vm.loadProfile()
+
+        #expect(service.activityRecorded)
+        #expect(!vm.isLoading)
+    }
+
+    @Test("Detects newly unlocked achievement")
+    @MainActor
+    func detectsNewUnlock() async {
+        let service = StubGamificationService()
+        let txnRepo = StubTransactionRepository()
+        txnRepo.transactionsToReturn = [SampleData.expenseTransaction]
+
+        let vm = GamificationViewModel(
+            gamificationService: service,
+            transactionRepository: txnRepo,
+            budgetRepository: StubBudgetRepository(),
+            goalRepository: StubGoalRepository()
+        )
+
+        await vm.loadProfile()
+
+        #expect(vm.profile.unlockedAchievements.contains { $0.id == "first_transaction" })
+    }
+
+    @Test("Filters by category")
+    @MainActor
+    func filtersByCategory() async {
+        let service = StubGamificationService()
+        let vm = GamificationViewModel(
+            gamificationService: service,
+            transactionRepository: StubTransactionRepository(),
+            budgetRepository: StubBudgetRepository(),
+            goalRepository: StubGoalRepository()
+        )
+
+        await vm.loadProfile()
+
+        vm.selectedCategory = nil
+        #expect(vm.filteredAchievements.count == vm.profile.achievements.count)
+
+        vm.selectedCategory = .tracking
+        #expect(vm.filteredAchievements.allSatisfy { $0.category == .tracking })
+    }
+
+    @Test("Handles repository errors gracefully")
+    @MainActor
+    func handlesErrors() async {
+        let service = StubGamificationService()
+        let repo = StubTransactionRepository()
+        repo.errorToThrow = TestError.simulated
+
+        let vm = GamificationViewModel(
+            gamificationService: service,
+            transactionRepository: repo,
+            budgetRepository: StubBudgetRepository(),
+            goalRepository: StubGoalRepository()
+        )
+
+        await vm.loadProfile()
+
+        #expect(vm.errorMessage != nil)
+    }
+
+    @Test("Calculates completion percentage")
+    @MainActor
+    func completionPercent() async {
+        let service = StubGamificationService()
+        var profile = GamificationProfile(achievements: [
+            Achievement(id: "a", title: "A", description: "A", category: .tracking,
+                       tier: .bronze, systemImage: "star", requiredCount: 1,
+                       currentCount: 1, isUnlocked: true),
+            Achievement(id: "b", title: "B", description: "B", category: .tracking,
+                       tier: .bronze, systemImage: "star", requiredCount: 10),
+        ])
+        service.profileToReturn = profile
+
+        let vm = GamificationViewModel(
+            gamificationService: service,
+            transactionRepository: StubTransactionRepository(),
+            budgetRepository: StubBudgetRepository(),
+            goalRepository: StubGoalRepository()
+        )
+
+        await vm.loadProfile()
+
+        // After evaluation, first_transaction might be unlocked too
+        // but we know at least 'a' is unlocked out of total
+        #expect(vm.completionPercent > 0)
+    }
+}
+
+// MARK: - GamificationService Tests
+
+@Suite("GamificationService Tests")
+struct GamificationServiceTests {
+
+    @Test("Records activity and starts streak")
+    func recordsActivity() {
+        let defaults = UserDefaults(suiteName: "test.gamification.streak")!
+        defer { defaults.removePersistentDomain(forName: "test.gamification.streak") }
+        let service = GamificationService(defaults: defaults)
+
+        service.recordActivity()
+        let profile = service.loadProfile()
+
+        #expect(profile.streak.currentDays == 1)
+        #expect(profile.streak.isActiveToday)
+    }
+
+    @Test("Evaluates and unlocks first transaction achievement")
+    func unlocksFirstTransaction() {
+        let defaults = UserDefaults(suiteName: "test.gamification.unlock")!
+        defer { defaults.removePersistentDomain(forName: "test.gamification.unlock") }
+        let service = GamificationService(defaults: defaults)
+
+        let profile = service.evaluateAchievements(
+            transactionCount: 1,
+            budgetCount: 0,
+            goalCount: 0,
+            completedGoals: 0,
+            onBudgetCount: 0,
+            savingsRatePercent: 0
+        )
+
+        let achievement = profile.achievements.first { $0.id == "first_transaction" }
+        #expect(achievement?.isUnlocked == true)
+        #expect(profile.totalPoints > 0)
+    }
+
+    @Test("Reset clears profile")
+    func resetClearsProfile() {
+        let defaults = UserDefaults(suiteName: "test.gamification.reset")!
+        defer { defaults.removePersistentDomain(forName: "test.gamification.reset") }
+        let service = GamificationService(defaults: defaults)
+
+        _ = service.evaluateAchievements(
+            transactionCount: 100,
+            budgetCount: 5,
+            goalCount: 3,
+            completedGoals: 1,
+            onBudgetCount: 3,
+            savingsRatePercent: 30
+        )
+
+        service.resetProfile()
+        let profile = service.loadProfile()
+
+        #expect(profile.totalPoints == 0)
+    }
+}


### PR DESCRIPTION
## Summary

Implements a gamification system for the iOS app with achievements, badges, streaks, and milestone tracking to increase user engagement with financial tracking habits.

### Changes
- **GamificationModels** — \Achievement\, \AchievementCategory\ (5 categories), \AchievementTier\ (bronze/silver/gold/platinum), \ActivityStreak\, \GamificationProfile\ — all Codable for UserDefaults persistence
- **GamificationService** — On-device achievement engine with 16 achievements:
  - *Tracking*: First Step, Getting Started (10), Committed Tracker (100), Transaction Master (1000)
  - *Budgeting*: Budget Beginner, Budget Keeper (3 on-track), Budget Master (5 on-track)
  - *Saving*: Goal Setter, Goal Achiever, Goal Crusher (5), Smart Saver (20%), Super Saver (50%)
  - *Streaks*: Week Warrior (7d), Monthly Master (30d), Century Club (100d), Year of Discipline (365d)
- **GamificationViewModel** — @Observable with parallel data loading, new-unlock detection
- **AchievementsView** — Full SwiftUI screen:
  - Profile header with level badge, progress bar, point totals
  - Streak tracker (current + best)
  - Category filter chips with horizontal scroll
  - 2-column achievement grid with progress indicators
  - Achievement unlock celebration overlay
- **Full accessibility** — VoiceOver labels/hints, element combining, modal traits, Dynamic Type, dark mode
- **Unit tests** — 8 test cases for ViewModel and Service

### Architecture
- Codable profile persisted in UserDefaults (non-sensitive progress metadata)
- Protocol-based \GamificationProviding\ for testability
- Point/level system: bronze (10pts), silver (25pts), gold (50pts), platinum (100pts), level = points/100 + 1

Closes #242