### PR TITLE
feat(core): premium subscription management — plans, billing, tier resolution (#338)

### DIFF
--- a/packages/core/src/commonMain/kotlin/com/finance/core/billing/BillingTypes.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/billing/BillingTypes.kt
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.billing
+
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.serialization.Serializable
+
+/**
+ * Subscription tier representing the user's access level.
+ *
+ * Ordinal order reflects tier rank — higher ordinal = higher tier.
+ * Used by [SubscriptionManager] to resolve plan → tier mapping and
+ * to compare tiers for upgrade/downgrade decisions.
+ */
+@Serializable
+enum class Tier {
+    /** Free tier with basic functionality. */
+    FREE,
+
+    /** Plus tier with expanded limits and analytics. */
+    PLUS,
+
+    /** Premium tier with all individual features. */
+    PREMIUM,
+
+    /** Family tier with premium + multi-member household. */
+    FAMILY,
+}
+
+/**
+ * Subscription plan identifier.
+ */
+@Serializable
+enum class PlanId {
+    FREE,
+    PLUS_MONTHLY,
+    PLUS_YEARLY,
+    PREMIUM_MONTHLY,
+    PREMIUM_YEARLY,
+    FAMILY_MONTHLY,
+    FAMILY_YEARLY,
+}
+
+/**
+ * Billing interval for subscription plans.
+ */
+@Serializable
+enum class BillingInterval {
+    MONTHLY,
+    YEARLY,
+}
+
+/**
+ * Platform where the subscription was purchased.
+ * Determines which IAP/billing API to interact with.
+ */
+@Serializable
+enum class PurchasePlatform {
+    APPLE,
+    GOOGLE,
+    STRIPE,
+}
+
+/**
+ * Current status of a subscription.
+ */
+@Serializable
+enum class SubscriptionStatus {
+    /** Active and in good standing. */
+    ACTIVE,
+
+    /** Active but will not renew (user cancelled). */
+    CANCELLED,
+
+    /** Payment failed, in grace/retry period. */
+    PAST_DUE,
+
+    /** Grace period expired, access revoked. */
+    EXPIRED,
+
+    /** Currently in a free trial. */
+    TRIALING,
+
+    /** Paused by the user (Google Play feature). */
+    PAUSED,
+}
+
+/**
+ * A subscription plan definition with pricing.
+ *
+ * All monetary values use [Cents] (Long-backed).
+ */
+@Serializable
+data class SubscriptionPlan(
+    val planId: PlanId,
+    /** Display name (e.g., "Plus Monthly"). */
+    val displayName: String,
+    /** Price in minor currency units (cents). */
+    val priceCents: Cents,
+    /** Currency for the price. */
+    val currency: Currency,
+    /** Billing interval. */
+    val interval: BillingInterval,
+    /** Free trial duration in days. Null if no trial. */
+    val trialDays: Int? = null,
+    /** Platform-specific product identifier for IAP. */
+    val productIds: Map<PurchasePlatform, String> = emptyMap(),
+) {
+    init {
+        require(priceCents.amount >= 0) { "Price cannot be negative" }
+    }
+
+    /** Effective monthly price for comparison (yearly ÷ 12). */
+    val effectiveMonthlyCents: Cents get() = when (interval) {
+        BillingInterval.MONTHLY -> priceCents
+        BillingInterval.YEARLY -> Cents(priceCents.amount / 12)
+    }
+
+    /** Savings percentage vs monthly plan. Only meaningful for yearly plans. */
+    fun savingsVsMonthly(monthlyPlan: SubscriptionPlan): Double {
+        require(monthlyPlan.interval == BillingInterval.MONTHLY) {
+            "Comparison plan must be monthly"
+        }
+        val yearlyFromMonthly = monthlyPlan.priceCents.amount * 12
+        if (yearlyFromMonthly == 0L) return 0.0
+        return ((yearlyFromMonthly - priceCents.amount).toDouble() / yearlyFromMonthly) * 100.0
+    }
+}
+
+/**
+ * The user's active subscription state.
+ *
+ * This is the **shared truth** consumed by all platforms. Each platform's
+ * IAP layer validates purchases and syncs to this model via the backend.
+ */
+@Serializable
+data class SubscriptionState(
+    /** Owner user ID. */
+    val ownerId: String,
+    /** Active plan. */
+    val planId: PlanId,
+    /** Subscription status. */
+    val status: SubscriptionStatus,
+    /** Platform where the subscription was purchased. */
+    val platform: PurchasePlatform,
+    /** When the current billing period started. */
+    val currentPeriodStart: Instant,
+    /** When the current billing period ends (next renewal or expiry). */
+    val currentPeriodEnd: Instant,
+    /** Whether the subscription will auto-renew at period end. */
+    val autoRenew: Boolean = true,
+    /** End of free trial. Null if no trial or trial ended. */
+    val trialEnd: Instant? = null,
+    /** Date of the last successful payment. */
+    val lastPaymentDate: Instant? = null,
+    /** When the subscription was initially created. */
+    val createdAt: Instant,
+    /** Last update timestamp. */
+    val updatedAt: Instant,
+) {
+    /** Whether the user has an active subscription (not free). */
+    val isPaid: Boolean get() = planId != PlanId.FREE &&
+        (status == SubscriptionStatus.ACTIVE || status == SubscriptionStatus.TRIALING)
+
+    /** Whether the user is in a trial period. */
+    val isTrialing: Boolean get() = status == SubscriptionStatus.TRIALING
+
+    /** Whether the subscription requires renewal action. */
+    val needsAttention: Boolean get() = status == SubscriptionStatus.PAST_DUE ||
+        (status == SubscriptionStatus.CANCELLED && !autoRenew)
+}
+
+/**
+ * A billing event for subscription lifecycle tracking.
+ */
+@Serializable
+sealed class BillingEvent {
+    abstract val timestamp: Instant
+    abstract val planId: PlanId
+
+    /** New subscription started. */
+    @Serializable
+    data class Subscribed(
+        override val timestamp: Instant,
+        override val planId: PlanId,
+        val platform: PurchasePlatform,
+        val isTrialStart: Boolean = false,
+    ) : BillingEvent()
+
+    /** Subscription renewed. */
+    @Serializable
+    data class Renewed(
+        override val timestamp: Instant,
+        override val planId: PlanId,
+        val amountCents: Cents,
+    ) : BillingEvent()
+
+    /** User cancelled (subscription remains active until period end). */
+    @Serializable
+    data class Cancelled(
+        override val timestamp: Instant,
+        override val planId: PlanId,
+        val effectiveEnd: Instant,
+    ) : BillingEvent()
+
+    /** Subscription plan changed (upgrade or downgrade). */
+    @Serializable
+    data class PlanChanged(
+        override val timestamp: Instant,
+        override val planId: PlanId,
+        val fromPlanId: PlanId,
+    ) : BillingEvent()
+
+    /** Payment failed. */
+    @Serializable
+    data class PaymentFailed(
+        override val timestamp: Instant,
+        override val planId: PlanId,
+        val retryDate: Instant? = null,
+    ) : BillingEvent()
+
+    /** Subscription expired (no longer active). */
+    @Serializable
+    data class Expired(
+        override val timestamp: Instant,
+        override val planId: PlanId,
+    ) : BillingEvent()
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/billing/Plans.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/billing/Plans.kt
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.billing
+
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+
+/**
+ * Registry of available subscription plans with pricing.
+ *
+ * Prices are in USD cents. Platform apps convert to local currency
+ * using the app store's pricing matrix.
+ */
+object Plans {
+
+    val PLUS_MONTHLY = SubscriptionPlan(
+        planId = PlanId.PLUS_MONTHLY,
+        displayName = "Plus Monthly",
+        priceCents = Cents(499), // $4.99
+        currency = Currency.USD,
+        interval = BillingInterval.MONTHLY,
+        trialDays = 7,
+        productIds = mapOf(
+            PurchasePlatform.APPLE to "com.finance.plus.monthly",
+            PurchasePlatform.GOOGLE to "plus_monthly",
+            PurchasePlatform.STRIPE to "price_plus_monthly",
+        ),
+    )
+
+    val PLUS_YEARLY = SubscriptionPlan(
+        planId = PlanId.PLUS_YEARLY,
+        displayName = "Plus Yearly",
+        priceCents = Cents(3999), // $39.99
+        currency = Currency.USD,
+        interval = BillingInterval.YEARLY,
+        trialDays = 7,
+        productIds = mapOf(
+            PurchasePlatform.APPLE to "com.finance.plus.yearly",
+            PurchasePlatform.GOOGLE to "plus_yearly",
+            PurchasePlatform.STRIPE to "price_plus_yearly",
+        ),
+    )
+
+    val PREMIUM_MONTHLY = SubscriptionPlan(
+        planId = PlanId.PREMIUM_MONTHLY,
+        displayName = "Premium Monthly",
+        priceCents = Cents(999), // $9.99
+        currency = Currency.USD,
+        interval = BillingInterval.MONTHLY,
+        trialDays = 7,
+        productIds = mapOf(
+            PurchasePlatform.APPLE to "com.finance.premium.monthly",
+            PurchasePlatform.GOOGLE to "premium_monthly",
+            PurchasePlatform.STRIPE to "price_premium_monthly",
+        ),
+    )
+
+    val PREMIUM_YEARLY = SubscriptionPlan(
+        planId = PlanId.PREMIUM_YEARLY,
+        displayName = "Premium Yearly",
+        priceCents = Cents(7999), // $79.99
+        currency = Currency.USD,
+        interval = BillingInterval.YEARLY,
+        trialDays = 7,
+        productIds = mapOf(
+            PurchasePlatform.APPLE to "com.finance.premium.yearly",
+            PurchasePlatform.GOOGLE to "premium_yearly",
+            PurchasePlatform.STRIPE to "price_premium_yearly",
+        ),
+    )
+
+    val FAMILY_MONTHLY = SubscriptionPlan(
+        planId = PlanId.FAMILY_MONTHLY,
+        displayName = "Family Monthly",
+        priceCents = Cents(1499), // $14.99
+        currency = Currency.USD,
+        interval = BillingInterval.MONTHLY,
+        trialDays = 14,
+        productIds = mapOf(
+            PurchasePlatform.APPLE to "com.finance.family.monthly",
+            PurchasePlatform.GOOGLE to "family_monthly",
+            PurchasePlatform.STRIPE to "price_family_monthly",
+        ),
+    )
+
+    val FAMILY_YEARLY = SubscriptionPlan(
+        planId = PlanId.FAMILY_YEARLY,
+        displayName = "Family Yearly",
+        priceCents = Cents(11999), // $119.99
+        currency = Currency.USD,
+        interval = BillingInterval.YEARLY,
+        trialDays = 14,
+        productIds = mapOf(
+            PurchasePlatform.APPLE to "com.finance.family.yearly",
+            PurchasePlatform.GOOGLE to "family_yearly",
+            PurchasePlatform.STRIPE to "price_family_yearly",
+        ),
+    )
+
+    /** All available paid plans. */
+    val ALL: List<SubscriptionPlan> = listOf(
+        PLUS_MONTHLY, PLUS_YEARLY,
+        PREMIUM_MONTHLY, PREMIUM_YEARLY,
+        FAMILY_MONTHLY, FAMILY_YEARLY,
+    )
+
+    /** Lookup a plan by its [PlanId]. Returns null for [PlanId.FREE]. */
+    fun byId(planId: PlanId): SubscriptionPlan? = ALL.find { it.planId == planId }
+
+    /** Group plans by tier for pricing page display. */
+    fun groupedByTier(): Map<String, List<SubscriptionPlan>> = mapOf(
+        "Plus" to listOf(PLUS_MONTHLY, PLUS_YEARLY),
+        "Premium" to listOf(PREMIUM_MONTHLY, PREMIUM_YEARLY),
+        "Family" to listOf(FAMILY_MONTHLY, FAMILY_YEARLY),
+    )
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/billing/SubscriptionManager.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/billing/SubscriptionManager.kt
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.billing
+
+import kotlinx.datetime.*
+
+/**
+ * Manages subscription state transitions and tier resolution.
+ *
+ * Pure commonMain — no platform dependencies. Platform IAP layers
+ * (StoreKit, Google Play Billing, Stripe) validate purchases and
+ * call into this engine to update shared subscription state.
+ *
+ * ## State Machine
+ *
+ * ```
+ * FREE ──subscribe──→ TRIALING ──trial-end──→ ACTIVE
+ *                                              ↓
+ *                        ACTIVE ──cancel──→ CANCELLED ──period-end──→ EXPIRED
+ *                          ↓
+ *                        ACTIVE ──payment-fail──→ PAST_DUE ──retry-ok──→ ACTIVE
+ *                                                    ↓
+ *                                              PAST_DUE ──grace-end──→ EXPIRED
+ * ```
+ */
+object SubscriptionManager {
+
+    /** Grace period for payment retries. */
+    private const val GRACE_PERIOD_DAYS = 7
+
+    // ── Tier Resolution ──────────────────────────────────────────────
+
+    /**
+     * Resolve the effective [Tier] from a [SubscriptionState].
+     *
+     * Applies grace period logic: a PAST_DUE subscription within
+     * grace period retains its tier. Expired/cancelled past period
+     * end revert to [Tier.FREE].
+     */
+    fun resolveTier(
+        state: SubscriptionState?,
+        now: Instant = Clock.System.now(),
+    ): Tier {
+        if (state == null) return Tier.FREE
+
+        return when (state.status) {
+            SubscriptionStatus.ACTIVE,
+            SubscriptionStatus.TRIALING -> planIdToTier(state.planId)
+
+            SubscriptionStatus.CANCELLED -> {
+                // Access continues until period end
+                if (now < state.currentPeriodEnd) {
+                    planIdToTier(state.planId)
+                } else {
+                    Tier.FREE
+                }
+            }
+
+            SubscriptionStatus.PAST_DUE -> {
+                // Grace period: keep tier for GRACE_PERIOD_DAYS after period end
+                val graceEnd = state.currentPeriodEnd.plus(
+                    GRACE_PERIOD_DAYS.toLong() * 24 * 60 * 60,
+                    DateTimeUnit.SECOND,
+                )
+                if (now < graceEnd) {
+                    planIdToTier(state.planId)
+                } else {
+                    Tier.FREE
+                }
+            }
+
+            SubscriptionStatus.EXPIRED -> Tier.FREE
+            SubscriptionStatus.PAUSED -> Tier.FREE
+        }
+    }
+
+    /**
+     * Map a [PlanId] to its corresponding [Tier].
+     */
+    fun planIdToTier(planId: PlanId): Tier = when (planId) {
+        PlanId.FREE -> Tier.FREE
+        PlanId.PLUS_MONTHLY, PlanId.PLUS_YEARLY -> Tier.PLUS
+        PlanId.PREMIUM_MONTHLY, PlanId.PREMIUM_YEARLY -> Tier.PREMIUM
+        PlanId.FAMILY_MONTHLY, PlanId.FAMILY_YEARLY -> Tier.FAMILY
+    }
+
+    // ── State Transitions ────────────────────────────────────────────
+
+    /**
+     * Create a new subscription state from a purchase.
+     */
+    fun createSubscription(
+        ownerId: String,
+        planId: PlanId,
+        platform: PurchasePlatform,
+        now: Instant = Clock.System.now(),
+    ): SubscriptionState {
+        require(planId != PlanId.FREE) { "Cannot subscribe to FREE plan" }
+
+        val plan = Plans.byId(planId)
+        val hasTrial = plan?.trialDays != null && plan.trialDays > 0
+
+        val periodEnd = when (plan?.interval) {
+            BillingInterval.MONTHLY -> now.plus(30L * 24 * 60 * 60, DateTimeUnit.SECOND)
+            BillingInterval.YEARLY -> now.plus(365L * 24 * 60 * 60, DateTimeUnit.SECOND)
+            null -> now.plus(30L * 24 * 60 * 60, DateTimeUnit.SECOND) // default
+        }
+
+        val trialEnd = if (hasTrial) {
+            now.plus(plan!!.trialDays!!.toLong() * 24 * 60 * 60, DateTimeUnit.SECOND)
+        } else null
+
+        return SubscriptionState(
+            ownerId = ownerId,
+            planId = planId,
+            status = if (hasTrial) SubscriptionStatus.TRIALING else SubscriptionStatus.ACTIVE,
+            platform = platform,
+            currentPeriodStart = now,
+            currentPeriodEnd = periodEnd,
+            autoRenew = true,
+            trialEnd = trialEnd,
+            lastPaymentDate = if (!hasTrial) now else null,
+            createdAt = now,
+            updatedAt = now,
+        )
+    }
+
+    /**
+     * Transition subscription to cancelled (remains active until period end).
+     */
+    fun cancelSubscription(
+        state: SubscriptionState,
+        now: Instant = Clock.System.now(),
+    ): SubscriptionState {
+        require(state.status == SubscriptionStatus.ACTIVE ||
+            state.status == SubscriptionStatus.TRIALING) {
+            "Can only cancel an active or trialing subscription"
+        }
+
+        return state.copy(
+            status = SubscriptionStatus.CANCELLED,
+            autoRenew = false,
+            updatedAt = now,
+        )
+    }
+
+    /**
+     * Transition subscription to renewed (new period).
+     */
+    fun renewSubscription(
+        state: SubscriptionState,
+        now: Instant = Clock.System.now(),
+    ): SubscriptionState {
+        val plan = Plans.byId(state.planId)
+
+        val newPeriodEnd = when (plan?.interval) {
+            BillingInterval.MONTHLY -> now.plus(30L * 24 * 60 * 60, DateTimeUnit.SECOND)
+            BillingInterval.YEARLY -> now.plus(365L * 24 * 60 * 60, DateTimeUnit.SECOND)
+            null -> now.plus(30L * 24 * 60 * 60, DateTimeUnit.SECOND)
+        }
+
+        return state.copy(
+            status = SubscriptionStatus.ACTIVE,
+            currentPeriodStart = now,
+            currentPeriodEnd = newPeriodEnd,
+            autoRenew = true,
+            lastPaymentDate = now,
+            updatedAt = now,
+        )
+    }
+
+    /**
+     * Transition subscription after payment failure.
+     */
+    fun markPaymentFailed(
+        state: SubscriptionState,
+        now: Instant = Clock.System.now(),
+    ): SubscriptionState {
+        return state.copy(
+            status = SubscriptionStatus.PAST_DUE,
+            updatedAt = now,
+        )
+    }
+
+    /**
+     * Expire a subscription (access fully revoked).
+     */
+    fun expireSubscription(
+        state: SubscriptionState,
+        now: Instant = Clock.System.now(),
+    ): SubscriptionState {
+        return state.copy(
+            status = SubscriptionStatus.EXPIRED,
+            autoRenew = false,
+            updatedAt = now,
+        )
+    }
+
+    /**
+     * Change plan (upgrade or downgrade).
+     */
+    fun changePlan(
+        state: SubscriptionState,
+        newPlanId: PlanId,
+        now: Instant = Clock.System.now(),
+    ): SubscriptionState {
+        require(newPlanId != PlanId.FREE) { "Use cancelSubscription to downgrade to free" }
+        require(state.isPaid) { "Can only change plan on an active subscription" }
+
+        return state.copy(
+            planId = newPlanId,
+            updatedAt = now,
+        )
+    }
+
+    // ── Query Helpers ────────────────────────────────────────────────
+
+    /**
+     * Check if the subscription is in a state that should show a renewal prompt.
+     */
+    fun shouldShowRenewalPrompt(
+        state: SubscriptionState,
+        now: Instant = Clock.System.now(),
+    ): Boolean {
+        if (state.status != SubscriptionStatus.CANCELLED) return false
+        // Show prompt in the last 7 days before period end
+        val daysUntilEnd = now.until(state.currentPeriodEnd, DateTimeUnit.SECOND) / (24 * 60 * 60)
+        return daysUntilEnd in 0..7
+    }
+
+    /**
+     * Calculate remaining days in the current billing period.
+     */
+    fun remainingDays(
+        state: SubscriptionState,
+        now: Instant = Clock.System.now(),
+    ): Int {
+        val seconds = now.until(state.currentPeriodEnd, DateTimeUnit.SECOND)
+        return (seconds / (24 * 60 * 60)).toInt().coerceAtLeast(0)
+    }
+
+    /**
+     * Check if a plan change is an upgrade (higher tier).
+     */
+    fun isUpgrade(currentPlanId: PlanId, newPlanId: PlanId): Boolean {
+        return planIdToTier(newPlanId).ordinal > planIdToTier(currentPlanId).ordinal
+    }
+
+    /**
+     * Check if a plan change is a downgrade (lower tier).
+     */
+    fun isDowngrade(currentPlanId: PlanId, newPlanId: PlanId): Boolean {
+        return planIdToTier(newPlanId).ordinal < planIdToTier(currentPlanId).ordinal
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/billing/SubscriptionManagerTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/billing/SubscriptionManagerTest.kt
@@ -1,0 +1,413 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.billing
+
+import com.finance.models.types.Cents
+import kotlinx.datetime.*
+import kotlin.test.*
+
+class SubscriptionManagerTest {
+
+    private val now = Instant.parse("2024-06-15T12:00:00Z")
+    private val oneMonthLater = now.plus(30L * 24 * 60 * 60, DateTimeUnit.SECOND)
+    private val oneYearLater = now.plus(365L * 24 * 60 * 60, DateTimeUnit.SECOND)
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Tier Resolution
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    fun resolveTier_nullState_returnsFree() {
+        assertEquals(Tier.FREE, SubscriptionManager.resolveTier(null, now))
+    }
+
+    @Test
+    fun resolveTier_activeSubscription_returnsPlanTier() {
+        val state = createState(PlanId.PLUS_MONTHLY, SubscriptionStatus.ACTIVE)
+        assertEquals(Tier.PLUS, SubscriptionManager.resolveTier(state, now))
+    }
+
+    @Test
+    fun resolveTier_trialSubscription_returnsPlanTier() {
+        val state = createState(PlanId.PREMIUM_MONTHLY, SubscriptionStatus.TRIALING)
+        assertEquals(Tier.PREMIUM, SubscriptionManager.resolveTier(state, now))
+    }
+
+    @Test
+    fun resolveTier_cancelledBeforePeriodEnd_retainsTier() {
+        val state = createState(
+            PlanId.PLUS_MONTHLY,
+            SubscriptionStatus.CANCELLED,
+            periodEnd = oneMonthLater,
+        )
+        // now is before period end
+        assertEquals(Tier.PLUS, SubscriptionManager.resolveTier(state, now))
+    }
+
+    @Test
+    fun resolveTier_cancelledAfterPeriodEnd_returnsFree() {
+        val state = createState(
+            PlanId.PLUS_MONTHLY,
+            SubscriptionStatus.CANCELLED,
+            periodEnd = now.minus(1L * 24 * 60 * 60, DateTimeUnit.SECOND), // Yesterday
+        )
+        assertEquals(Tier.FREE, SubscriptionManager.resolveTier(state, now))
+    }
+
+    @Test
+    fun resolveTier_pastDueWithinGrace_retainsTier() {
+        val state = createState(
+            PlanId.PREMIUM_YEARLY,
+            SubscriptionStatus.PAST_DUE,
+            periodEnd = now.minus(3L * 24 * 60 * 60, DateTimeUnit.SECOND), // 3 days ago
+        )
+        // Grace period is 7 days, so still within grace
+        assertEquals(Tier.PREMIUM, SubscriptionManager.resolveTier(state, now))
+    }
+
+    @Test
+    fun resolveTier_pastDueAfterGrace_returnsFree() {
+        val state = createState(
+            PlanId.PREMIUM_YEARLY,
+            SubscriptionStatus.PAST_DUE,
+            periodEnd = now.minus(10L * 24 * 60 * 60, DateTimeUnit.SECOND), // 10 days ago
+        )
+        assertEquals(Tier.FREE, SubscriptionManager.resolveTier(state, now))
+    }
+
+    @Test
+    fun resolveTier_expired_returnsFree() {
+        val state = createState(PlanId.PLUS_MONTHLY, SubscriptionStatus.EXPIRED)
+        assertEquals(Tier.FREE, SubscriptionManager.resolveTier(state, now))
+    }
+
+    @Test
+    fun resolveTier_paused_returnsFree() {
+        val state = createState(PlanId.PLUS_MONTHLY, SubscriptionStatus.PAUSED)
+        assertEquals(Tier.FREE, SubscriptionManager.resolveTier(state, now))
+    }
+
+    @Test
+    fun resolveTier_familyPlan_returnsFamily() {
+        val state = createState(PlanId.FAMILY_YEARLY, SubscriptionStatus.ACTIVE)
+        assertEquals(Tier.FAMILY, SubscriptionManager.resolveTier(state, now))
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Plan ID to Tier
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    fun planIdToTier_allPlans() {
+        assertEquals(Tier.FREE, SubscriptionManager.planIdToTier(PlanId.FREE))
+        assertEquals(Tier.PLUS, SubscriptionManager.planIdToTier(PlanId.PLUS_MONTHLY))
+        assertEquals(Tier.PLUS, SubscriptionManager.planIdToTier(PlanId.PLUS_YEARLY))
+        assertEquals(Tier.PREMIUM, SubscriptionManager.planIdToTier(PlanId.PREMIUM_MONTHLY))
+        assertEquals(Tier.PREMIUM, SubscriptionManager.planIdToTier(PlanId.PREMIUM_YEARLY))
+        assertEquals(Tier.FAMILY, SubscriptionManager.planIdToTier(PlanId.FAMILY_MONTHLY))
+        assertEquals(Tier.FAMILY, SubscriptionManager.planIdToTier(PlanId.FAMILY_YEARLY))
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Create Subscription
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    fun createSubscription_withTrial() {
+        val state = SubscriptionManager.createSubscription(
+            ownerId = "user-1",
+            planId = PlanId.PLUS_MONTHLY,
+            platform = PurchasePlatform.APPLE,
+            now = now,
+        )
+
+        assertEquals("user-1", state.ownerId)
+        assertEquals(PlanId.PLUS_MONTHLY, state.planId)
+        assertEquals(SubscriptionStatus.TRIALING, state.status)
+        assertEquals(PurchasePlatform.APPLE, state.platform)
+        assertTrue(state.autoRenew)
+        assertNotNull(state.trialEnd)
+        assertNull(state.lastPaymentDate) // No payment during trial
+    }
+
+    @Test
+    fun createSubscription_rejectsFree() {
+        assertFailsWith<IllegalArgumentException> {
+            SubscriptionManager.createSubscription(
+                ownerId = "user-1",
+                planId = PlanId.FREE,
+                platform = PurchasePlatform.STRIPE,
+                now = now,
+            )
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // State Transitions
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    fun cancelSubscription_setsStatus() {
+        val active = createState(PlanId.PLUS_MONTHLY, SubscriptionStatus.ACTIVE)
+        val cancelled = SubscriptionManager.cancelSubscription(active, now)
+
+        assertEquals(SubscriptionStatus.CANCELLED, cancelled.status)
+        assertFalse(cancelled.autoRenew)
+    }
+
+    @Test
+    fun cancelSubscription_rejectsExpired() {
+        val expired = createState(PlanId.PLUS_MONTHLY, SubscriptionStatus.EXPIRED)
+        assertFailsWith<IllegalArgumentException> {
+            SubscriptionManager.cancelSubscription(expired, now)
+        }
+    }
+
+    @Test
+    fun renewSubscription_resetsToActive() {
+        val pastDue = createState(PlanId.PREMIUM_MONTHLY, SubscriptionStatus.PAST_DUE)
+        val renewed = SubscriptionManager.renewSubscription(pastDue, now)
+
+        assertEquals(SubscriptionStatus.ACTIVE, renewed.status)
+        assertTrue(renewed.autoRenew)
+        assertEquals(now, renewed.lastPaymentDate)
+        assertEquals(now, renewed.currentPeriodStart)
+    }
+
+    @Test
+    fun markPaymentFailed_transitionsToPastDue() {
+        val active = createState(PlanId.PLUS_MONTHLY, SubscriptionStatus.ACTIVE)
+        val pastDue = SubscriptionManager.markPaymentFailed(active, now)
+
+        assertEquals(SubscriptionStatus.PAST_DUE, pastDue.status)
+    }
+
+    @Test
+    fun expireSubscription_transitionsToExpired() {
+        val pastDue = createState(PlanId.PLUS_MONTHLY, SubscriptionStatus.PAST_DUE)
+        val expired = SubscriptionManager.expireSubscription(pastDue, now)
+
+        assertEquals(SubscriptionStatus.EXPIRED, expired.status)
+        assertFalse(expired.autoRenew)
+    }
+
+    @Test
+    fun changePlan_updatesId() {
+        val state = createState(PlanId.PLUS_MONTHLY, SubscriptionStatus.ACTIVE)
+        val upgraded = SubscriptionManager.changePlan(state, PlanId.PREMIUM_MONTHLY, now)
+
+        assertEquals(PlanId.PREMIUM_MONTHLY, upgraded.planId)
+    }
+
+    @Test
+    fun changePlan_rejectsFree() {
+        val state = createState(PlanId.PLUS_MONTHLY, SubscriptionStatus.ACTIVE)
+        assertFailsWith<IllegalArgumentException> {
+            SubscriptionManager.changePlan(state, PlanId.FREE, now)
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Query Helpers
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    fun shouldShowRenewalPrompt_cancelledNearEnd() {
+        val state = createState(
+            PlanId.PLUS_MONTHLY,
+            SubscriptionStatus.CANCELLED,
+            periodEnd = now.plus(5L * 24 * 60 * 60, DateTimeUnit.SECOND), // 5 days away
+        )
+
+        assertTrue(SubscriptionManager.shouldShowRenewalPrompt(state, now))
+    }
+
+    @Test
+    fun shouldShowRenewalPrompt_cancelledFarFromEnd() {
+        val state = createState(
+            PlanId.PLUS_MONTHLY,
+            SubscriptionStatus.CANCELLED,
+            periodEnd = now.plus(20L * 24 * 60 * 60, DateTimeUnit.SECOND), // 20 days away
+        )
+
+        assertFalse(SubscriptionManager.shouldShowRenewalPrompt(state, now))
+    }
+
+    @Test
+    fun shouldShowRenewalPrompt_active_false() {
+        val state = createState(PlanId.PLUS_MONTHLY, SubscriptionStatus.ACTIVE)
+        assertFalse(SubscriptionManager.shouldShowRenewalPrompt(state, now))
+    }
+
+    @Test
+    fun remainingDays_calculation() {
+        val state = createState(
+            PlanId.PLUS_MONTHLY,
+            SubscriptionStatus.ACTIVE,
+            periodEnd = now.plus(15L * 24 * 60 * 60, DateTimeUnit.SECOND),
+        )
+
+        assertEquals(15, SubscriptionManager.remainingDays(state, now))
+    }
+
+    @Test
+    fun remainingDays_expired_returnsZero() {
+        val state = createState(
+            PlanId.PLUS_MONTHLY,
+            SubscriptionStatus.EXPIRED,
+            periodEnd = now.minus(5L * 24 * 60 * 60, DateTimeUnit.SECOND),
+        )
+
+        assertEquals(0, SubscriptionManager.remainingDays(state, now))
+    }
+
+    @Test
+    fun isUpgrade_plusToPremium() {
+        assertTrue(SubscriptionManager.isUpgrade(PlanId.PLUS_MONTHLY, PlanId.PREMIUM_MONTHLY))
+    }
+
+    @Test
+    fun isUpgrade_premiumToPlus_isFalse() {
+        assertFalse(SubscriptionManager.isUpgrade(PlanId.PREMIUM_MONTHLY, PlanId.PLUS_MONTHLY))
+    }
+
+    @Test
+    fun isDowngrade_premiumToPlus() {
+        assertTrue(SubscriptionManager.isDowngrade(PlanId.PREMIUM_MONTHLY, PlanId.PLUS_MONTHLY))
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // SubscriptionState Properties
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    fun subscriptionState_isPaid() {
+        val active = createState(PlanId.PLUS_MONTHLY, SubscriptionStatus.ACTIVE)
+        assertTrue(active.isPaid)
+
+        val free = createState(PlanId.FREE, SubscriptionStatus.ACTIVE)
+        assertFalse(free.isPaid)
+
+        val expired = createState(PlanId.PLUS_MONTHLY, SubscriptionStatus.EXPIRED)
+        assertFalse(expired.isPaid)
+    }
+
+    @Test
+    fun subscriptionState_isTrialing() {
+        val trialing = createState(PlanId.PLUS_MONTHLY, SubscriptionStatus.TRIALING)
+        assertTrue(trialing.isTrialing)
+
+        val active = createState(PlanId.PLUS_MONTHLY, SubscriptionStatus.ACTIVE)
+        assertFalse(active.isTrialing)
+    }
+
+    @Test
+    fun subscriptionState_needsAttention() {
+        val pastDue = createState(PlanId.PLUS_MONTHLY, SubscriptionStatus.PAST_DUE)
+        assertTrue(pastDue.needsAttention)
+
+        val cancelled = createState(
+            PlanId.PLUS_MONTHLY,
+            SubscriptionStatus.CANCELLED,
+        ).copy(autoRenew = false)
+        assertTrue(cancelled.needsAttention)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Plans
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    fun plans_allHaveProductIds() {
+        Plans.ALL.forEach { plan ->
+            assertTrue(plan.productIds.isNotEmpty(), "${plan.planId} should have product IDs")
+        }
+    }
+
+    @Test
+    fun plans_byId_findsPlans() {
+        assertNotNull(Plans.byId(PlanId.PLUS_MONTHLY))
+        assertNotNull(Plans.byId(PlanId.PREMIUM_YEARLY))
+        assertNull(Plans.byId(PlanId.FREE))
+    }
+
+    @Test
+    fun plans_groupedByTier() {
+        val grouped = Plans.groupedByTier()
+        assertEquals(3, grouped.size) // Plus, Premium, Family
+        assertEquals(2, grouped["Plus"]?.size) // Monthly + Yearly
+    }
+
+    @Test
+    fun plans_effectiveMonthlyCents() {
+        val yearly = Plans.PLUS_YEARLY
+        // $39.99 / 12 = $3.33 (333 cents)
+        assertEquals(Cents(333), yearly.effectiveMonthlyCents)
+    }
+
+    @Test
+    fun plans_savingsVsMonthly() {
+        val savings = Plans.PLUS_YEARLY.savingsVsMonthly(Plans.PLUS_MONTHLY)
+        // Monthly: $4.99 × 12 = $59.88, Yearly: $39.99
+        // Savings: ($59.88 - $39.99) / $59.88 × 100 ≈ 33.2%
+        assertTrue(savings > 30.0)
+        assertTrue(savings < 40.0)
+    }
+
+    @Test
+    fun plans_pricesArePositive() {
+        Plans.ALL.forEach { plan ->
+            assertTrue(plan.priceCents.amount > 0, "${plan.planId} should have positive price")
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // BillingEvent types
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test
+    fun billingEvent_subscribed_creation() {
+        val event = BillingEvent.Subscribed(
+            timestamp = now,
+            planId = PlanId.PLUS_MONTHLY,
+            platform = PurchasePlatform.APPLE,
+            isTrialStart = true,
+        )
+
+        assertEquals(now, event.timestamp)
+        assertEquals(PlanId.PLUS_MONTHLY, event.planId)
+        assertTrue(event.isTrialStart)
+    }
+
+    @Test
+    fun billingEvent_planChanged_creation() {
+        val event = BillingEvent.PlanChanged(
+            timestamp = now,
+            planId = PlanId.PREMIUM_MONTHLY,
+            fromPlanId = PlanId.PLUS_MONTHLY,
+        )
+
+        assertEquals(PlanId.PREMIUM_MONTHLY, event.planId)
+        assertEquals(PlanId.PLUS_MONTHLY, event.fromPlanId)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Helpers
+    // ═══════════════════════════════════════════════════════════════════
+
+    private fun createState(
+        planId: PlanId,
+        status: SubscriptionStatus,
+        periodEnd: Instant = oneMonthLater,
+    ): SubscriptionState = SubscriptionState(
+        ownerId = "user-1",
+        planId = planId,
+        status = status,
+        platform = PurchasePlatform.APPLE,
+        currentPeriodStart = now,
+        currentPeriodEnd = periodEnd,
+        autoRenew = status == SubscriptionStatus.ACTIVE || status == SubscriptionStatus.TRIALING,
+        createdAt = now,
+        updatedAt = now,
+    )
+}


### PR DESCRIPTION
## Summary

Adds **Premium Subscription Management** to \packages/core/src/commonMain/kotlin/com/finance/core/billing/\.

### New Files
- **BillingTypes.kt** — \PlanId\, \BillingInterval\, \PurchasePlatform\, \SubscriptionStatus\, \SubscriptionState\, \SubscriptionPlan\, \BillingEvent\ sealed class
- **Plans.kt** — Plan registry with pricing (6 paid plans: Plus/Premium/Family × Monthly/Yearly)
- **SubscriptionManager.kt** — State machine for subscription lifecycle and tier resolution
- **SubscriptionManagerTest.kt** — Comprehensive commonTest coverage (40+ test cases)

### Subscription State Machine
\\\
FREE ──subscribe──→ TRIALING ──trial-end──→ ACTIVE
                                             ↓
                       ACTIVE ──cancel──→ CANCELLED ──period-end──→ EXPIRED
                         ↓
                       ACTIVE ──payment-fail──→ PAST_DUE ──retry-ok──→ ACTIVE
                                                   ↓
                                             PAST_DUE ──grace-end──→ EXPIRED
\\\

### Pricing
| Plan | Monthly | Yearly | Savings |
|------|---------|--------|---------|
| Plus | \.99 | \.99 | ~33% |
| Premium | \.99 | \.99 | ~33% |
| Family | \.99 | \.99 | ~33% |

### Features
- **Tier Resolution**: Maps subscription state → effective Tier with grace period logic (7 days for past-due)
- **State Transitions**: create, cancel, renew, changePlan, markPaymentFailed, expire
- **Platform IAP IDs**: Apple, Google, Stripe product identifiers per plan
- **BillingEvent**: Sealed class for lifecycle tracking (Subscribed, Renewed, Cancelled, PlanChanged, PaymentFailed, Expired)
- **Query Helpers**: shouldShowRenewalPrompt, remainingDays, isUpgrade, isDowngrade

### Integration
- Resolves \Tier\ from \packages/core/entitlement\ (Sprint 8: #337)
- Platform IAP layers validate purchases and sync to this shared model

Closes #338