### PR TITLE
feat(windows): financial insights dashboard (#1055)

### DIFF
--- a/apps/windows/src/main/kotlin/com/finance/desktop/FinanceApp.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/FinanceApp.kt
@@ -23,6 +23,7 @@ import com.finance.desktop.screens.DashboardScreen
 import com.finance.desktop.screens.DiagnosticsScreen
 import com.finance.desktop.screens.GoalsScreen
 import com.finance.desktop.screens.HealthScoreScreen
+import com.finance.desktop.screens.InsightsScreen
 import com.finance.desktop.screens.LockScreen
 import com.finance.desktop.screens.ReportBuilderScreen
 import com.finance.desktop.screens.QuickAddTransactionDialog
@@ -123,6 +124,7 @@ fun FinanceApp(
                             Screen.Widgets -> WidgetBoardScreen()
                             Screen.Upgrade -> UpgradeScreen()
                             Screen.Tips -> TipsScreen()
+                            Screen.Insights -> InsightsScreen()
                             Screen.Diagnostics -> DiagnosticsScreen()
                             Screen.HealthScore -> HealthScoreScreen()
                             Screen.Reports -> ReportBuilderScreen()

--- a/apps/windows/src/main/kotlin/com/finance/desktop/di/ViewModelModule.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/di/ViewModelModule.kt
@@ -37,4 +37,5 @@ val viewModelModule = module {
     single { BudgetNegotiationViewModel(get(), get()) }
     single { EntitlementViewModel(get(), get(), get()) }
     single { TipsViewModel(get(), get(), get()) }
+    single { InsightsViewModel(get(), get(), get()) }
 }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/navigation/SidebarNavigation.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/navigation/SidebarNavigation.kt
@@ -31,6 +31,7 @@ import androidx.compose.material.icons.filled.Groups
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.PieChart
 import androidx.compose.material.icons.filled.Receipt
+import androidx.compose.material.icons.filled.Insights
 import androidx.compose.material.icons.filled.Lightbulb
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Speed
@@ -85,6 +86,7 @@ enum class Screen(
     Goals("Goals", Icons.Filled.Star, Key.Five, "Ctrl+5"),
     Upgrade("Upgrade", Icons.Filled.WorkspacePremium, Key.Six, "Ctrl+6"),
     Tips("Tips", Icons.Filled.Lightbulb, Key.T, "Ctrl+T"),
+    Insights("Insights", Icons.Filled.Insights, Key.I, "Ctrl+I"),
     Widgets("Widgets", Icons.Filled.Widgets, Key.Seven, "Ctrl+7"),
     HealthScore("Health Score", Icons.Filled.Favorite, Key.Eight, "Ctrl+8"),
     Reports("Reports", Icons.Filled.Assessment, Key.Nine, "Ctrl+9"),

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/InsightsScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/InsightsScreen.kt
@@ -1,0 +1,642 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.screens
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.TrendingDown
+import androidx.compose.material.icons.automirrored.filled.TrendingUp
+import androidx.compose.material.icons.filled.Analytics
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Remove
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.finance.core.analytics.Trend
+import com.finance.desktop.di.koinGet
+import com.finance.desktop.theme.FinanceDesktopTheme
+import com.finance.desktop.viewmodel.CategorySpendingUi
+import com.finance.desktop.viewmodel.InsightsTab
+import com.finance.desktop.viewmodel.InsightsViewModel
+import com.finance.desktop.viewmodel.MonthlyComparisonUi
+import com.finance.desktop.viewmodel.NetWorthPointUi
+import com.finance.desktop.viewmodel.SpendingInsightUi
+
+// ── Chart color palette ──────────────────────────────────────────────
+
+private val chartColors = listOf(
+    Color(0xFF3B82F6), // Blue
+    Color(0xFF22C55E), // Green
+    Color(0xFFF59E0B), // Amber
+    Color(0xFFEF4444), // Red
+    Color(0xFF8B5CF6), // Purple
+    Color(0xFF06B6D4), // Cyan
+    Color(0xFFF97316), // Orange
+    Color(0xFFEC4899), // Pink
+)
+
+/**
+ * Financial Insights Dashboard.
+ *
+ * Multi-panel layout with spending breakdown pie chart, income vs. expense
+ * bar chart, category trends, and net worth line chart. Consumes KMP shared
+ * [ReportGenerator] analytics through [InsightsViewModel].
+ *
+ * Narrator accessibility: heading semantics, content descriptions on all
+ * charts and data points, tab navigation support.
+ */
+@Composable
+fun InsightsScreen(modifier: Modifier = Modifier) {
+    val viewModel = koinGet<InsightsViewModel>()
+    val state by viewModel.uiState.collectAsState()
+
+    if (state.isLoading) {
+        Box(
+            modifier = modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center,
+        ) {
+            CircularProgressIndicator(
+                modifier = Modifier.semantics {
+                    contentDescription = "Loading insights"
+                },
+            )
+        }
+        return
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(FinanceDesktopTheme.spacing.xxl)
+            .semantics { contentDescription = "Financial Insights screen" },
+    ) {
+        // ── Header ──
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Filled.Analytics,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(28.dp),
+                )
+                Spacer(Modifier.width(FinanceDesktopTheme.spacing.md))
+                Text(
+                    text = "Financial Insights",
+                    style = MaterialTheme.typography.headlineLarge,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.semantics { heading() },
+                )
+            }
+            IconButton(
+                onClick = { viewModel.refresh() },
+                modifier = Modifier.semantics {
+                    contentDescription = "Refresh insights"
+                },
+            ) {
+                Icon(Icons.Filled.Refresh, contentDescription = null)
+            }
+        }
+
+        Spacer(Modifier.height(FinanceDesktopTheme.spacing.lg))
+
+        // ── Tab bar ──
+        val tabs = InsightsTab.entries
+        TabRow(
+            selectedTabIndex = tabs.indexOf(state.selectedTab),
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        ) {
+            tabs.forEach { tab ->
+                Tab(
+                    selected = state.selectedTab == tab,
+                    onClick = { viewModel.selectTab(tab) },
+                    text = {
+                        Text(
+                            text = tab.name.lowercase().replaceFirstChar { it.uppercase() },
+                            fontWeight = if (state.selectedTab == tab) FontWeight.SemiBold
+                            else FontWeight.Normal,
+                        )
+                    },
+                    modifier = Modifier.semantics {
+                        contentDescription = "${tab.name} tab"
+                    },
+                )
+            }
+        }
+
+        Spacer(Modifier.height(FinanceDesktopTheme.spacing.xxl))
+
+        // ── Tab content ──
+        when (state.selectedTab) {
+            InsightsTab.OVERVIEW -> OverviewTab(state.categorySpending, state.monthlyComparisons, state.totalSpendingFormatted)
+            InsightsTab.CATEGORIES -> CategoriesTab(state.categorySpending, state.totalSpendingFormatted)
+            InsightsTab.TRENDS -> TrendsTab(state.spendingInsights, state.netWorthHistory)
+        }
+    }
+}
+
+// ── Overview tab ─────────────────────────────────────────────────────
+
+@Composable
+private fun OverviewTab(
+    categorySpending: List<CategorySpendingUi>,
+    monthlyComparisons: List<MonthlyComparisonUi>,
+    totalSpendingFormatted: String,
+) {
+    Row(
+        modifier = Modifier.fillMaxSize(),
+        horizontalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.xxl),
+    ) {
+        // Left: donut chart + category list
+        Column(
+            modifier = Modifier.weight(1f).fillMaxHeight(),
+            verticalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.lg),
+        ) {
+            ElevatedCard(
+                modifier = Modifier.fillMaxWidth().semantics {
+                    contentDescription = "Spending breakdown: $totalSpendingFormatted total this month"
+                },
+            ) {
+                Column(
+                    modifier = Modifier.padding(FinanceDesktopTheme.spacing.xxl),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Text(
+                        text = "Spending This Month",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.semantics { heading() },
+                    )
+                    Spacer(Modifier.height(FinanceDesktopTheme.spacing.lg))
+                    DonutChart(
+                        items = categorySpending,
+                        centerLabel = totalSpendingFormatted,
+                        modifier = Modifier.size(180.dp),
+                    )
+                }
+            }
+
+            // Category legend
+            LazyColumn(
+                verticalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.xs),
+            ) {
+                items(categorySpending) { cat ->
+                    CategoryLegendRow(cat)
+                }
+            }
+        }
+
+        // Right: income vs expense bars
+        Column(
+            modifier = Modifier.weight(1f).fillMaxHeight(),
+        ) {
+            ElevatedCard(modifier = Modifier.fillMaxSize()) {
+                Column(modifier = Modifier.padding(FinanceDesktopTheme.spacing.xxl)) {
+                    Text(
+                        text = "Income vs. Expenses",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.semantics { heading() },
+                    )
+                    Spacer(Modifier.height(FinanceDesktopTheme.spacing.lg))
+                    IncomeExpenseChart(
+                        comparisons = monthlyComparisons,
+                        modifier = Modifier.fillMaxWidth().weight(1f),
+                    )
+                    Spacer(Modifier.height(FinanceDesktopTheme.spacing.md))
+                    // Legend
+                    Row(horizontalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.lg)) {
+                        LegendDot(Color(0xFF22C55E), "Income")
+                        LegendDot(Color(0xFFEF4444), "Expenses")
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ── Categories tab ───────────────────────────────────────────────────
+
+@Composable
+private fun CategoriesTab(
+    categorySpending: List<CategorySpendingUi>,
+    totalSpendingFormatted: String,
+) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        Text(
+            text = "Category Breakdown — $totalSpendingFormatted total",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.semantics { heading() },
+        )
+        Spacer(Modifier.height(FinanceDesktopTheme.spacing.lg))
+        LazyColumn(
+            verticalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.sm),
+        ) {
+            items(categorySpending) { cat ->
+                CategoryBarRow(cat)
+            }
+        }
+    }
+}
+
+// ── Trends tab ───────────────────────────────────────────────────────
+
+@Composable
+private fun TrendsTab(
+    insights: List<SpendingInsightUi>,
+    netWorthHistory: List<NetWorthPointUi>,
+) {
+    Row(
+        modifier = Modifier.fillMaxSize(),
+        horizontalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.xxl),
+    ) {
+        // Left: spending insights
+        Column(modifier = Modifier.weight(1f).fillMaxHeight()) {
+            Text(
+                text = "Spending Trends",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.semantics { heading() },
+            )
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.md))
+            if (insights.isEmpty()) {
+                Text(
+                    text = "Not enough data for trends yet.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else {
+                LazyColumn(
+                    verticalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.sm),
+                ) {
+                    items(insights) { insight ->
+                        InsightRow(insight)
+                    }
+                }
+            }
+        }
+
+        // Right: net worth chart
+        Column(modifier = Modifier.weight(1f).fillMaxHeight()) {
+            ElevatedCard(modifier = Modifier.fillMaxSize()) {
+                Column(modifier = Modifier.padding(FinanceDesktopTheme.spacing.xxl)) {
+                    Text(
+                        text = "Net Worth Over Time",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.semantics { heading() },
+                    )
+                    Spacer(Modifier.height(FinanceDesktopTheme.spacing.lg))
+                    NetWorthLineChart(
+                        points = netWorthHistory,
+                        modifier = Modifier.fillMaxWidth().weight(1f),
+                    )
+                }
+            }
+        }
+    }
+}
+
+// ── Chart composables ────────────────────────────────────────────────
+
+/**
+ * Donut (ring) chart showing category spending proportions.
+ */
+@Composable
+private fun DonutChart(
+    items: List<CategorySpendingUi>,
+    centerLabel: String,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier, contentAlignment = Alignment.Center) {
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            val strokeWidth = 28.dp.toPx()
+            val radius = (size.minDimension - strokeWidth) / 2
+            val center = Offset(size.width / 2, size.height / 2)
+            val arcSize = Size(radius * 2, radius * 2)
+            val topLeft = Offset(center.x - radius, center.y - radius)
+
+            var startAngle = -90f
+            items.forEach { item ->
+                val sweep = item.percentage / 100f * 360f
+                val color = chartColors[item.colorIndex % chartColors.size]
+                drawArc(
+                    color = color,
+                    startAngle = startAngle,
+                    sweepAngle = sweep,
+                    useCenter = false,
+                    topLeft = topLeft,
+                    size = arcSize,
+                    style = Stroke(width = strokeWidth, cap = StrokeCap.Butt),
+                )
+                startAngle += sweep
+            }
+
+            // Gap ring
+            if (items.isEmpty()) {
+                drawArc(
+                    color = Color.LightGray,
+                    startAngle = 0f,
+                    sweepAngle = 360f,
+                    useCenter = false,
+                    topLeft = topLeft,
+                    size = arcSize,
+                    style = Stroke(width = strokeWidth, cap = StrokeCap.Butt),
+                )
+            }
+        }
+        Text(
+            text = centerLabel,
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+        )
+    }
+}
+
+/**
+ * Grouped bar chart for income vs. expenses over months.
+ */
+@Composable
+private fun IncomeExpenseChart(
+    comparisons: List<MonthlyComparisonUi>,
+    modifier: Modifier = Modifier,
+) {
+    val incomeColor = Color(0xFF22C55E)
+    val expenseColor = Color(0xFFEF4444)
+
+    val accessibilityText = comparisons.joinToString("; ") {
+        "${it.label}: income ${it.incomeFormatted}, expense ${it.expenseFormatted}"
+    }
+
+    Canvas(
+        modifier = modifier.semantics {
+            contentDescription = "Income vs Expense chart. $accessibilityText"
+        },
+    ) {
+        if (comparisons.isEmpty()) return@Canvas
+        val maxVal = comparisons.maxOf { maxOf(it.incomeAmount, it.expenseAmount) }
+            .coerceAtLeast(1)
+        val barGroupWidth = size.width / comparisons.size
+        val barWidth = barGroupWidth * 0.3f
+        val gap = barGroupWidth * 0.05f
+
+        comparisons.forEachIndexed { index, mc ->
+            val x = index * barGroupWidth + barGroupWidth * 0.15f
+            val incomeHeight = (mc.incomeAmount.toFloat() / maxVal) * size.height * 0.85f
+            val expenseHeight = (mc.expenseAmount.toFloat() / maxVal) * size.height * 0.85f
+
+            // Income bar
+            drawRect(
+                color = incomeColor,
+                topLeft = Offset(x, size.height - incomeHeight),
+                size = Size(barWidth, incomeHeight),
+            )
+            // Expense bar
+            drawRect(
+                color = expenseColor,
+                topLeft = Offset(x + barWidth + gap, size.height - expenseHeight),
+                size = Size(barWidth, expenseHeight),
+            )
+        }
+    }
+}
+
+/**
+ * Line chart for net worth over time.
+ */
+@Composable
+private fun NetWorthLineChart(
+    points: List<NetWorthPointUi>,
+    modifier: Modifier = Modifier,
+) {
+    val lineColor = MaterialTheme.colorScheme.primary
+    val accessibilityText = points.joinToString("; ") {
+        "${it.label}: ${it.formatted}"
+    }
+
+    Canvas(
+        modifier = modifier.semantics {
+            contentDescription = "Net worth chart. $accessibilityText"
+        },
+    ) {
+        if (points.size < 2) return@Canvas
+        val minVal = points.minOf { it.amount }
+        val maxVal = points.maxOf { it.amount }
+        val range = (maxVal - minVal).coerceAtLeast(1)
+
+        val path = Path()
+        points.forEachIndexed { index, point ->
+            val x = index.toFloat() / (points.size - 1) * size.width
+            val y = size.height - ((point.amount - minVal).toFloat() / range * size.height * 0.85f + size.height * 0.075f)
+            if (index == 0) path.moveTo(x, y) else path.lineTo(x, y)
+        }
+
+        drawPath(
+            path = path,
+            color = lineColor,
+            style = Stroke(width = 3.dp.toPx(), cap = StrokeCap.Round),
+        )
+
+        // Draw data points
+        points.forEachIndexed { index, point ->
+            val x = index.toFloat() / (points.size - 1) * size.width
+            val y = size.height - ((point.amount - minVal).toFloat() / range * size.height * 0.85f + size.height * 0.075f)
+            drawCircle(color = lineColor, radius = 5.dp.toPx(), center = Offset(x, y))
+        }
+    }
+}
+
+// ── Row composables ──────────────────────────────────────────────────
+
+@Composable
+private fun CategoryLegendRow(cat: CategorySpendingUi) {
+    val color = chartColors[cat.colorIndex % chartColors.size]
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = FinanceDesktopTheme.spacing.sm, vertical = 2.dp)
+            .semantics {
+                contentDescription = "${cat.categoryName}: ${cat.amountFormatted}, ${cat.percentage.toInt()}%"
+            },
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Canvas(Modifier.size(12.dp)) {
+            drawCircle(color = color)
+        }
+        Spacer(Modifier.width(FinanceDesktopTheme.spacing.sm))
+        Text(
+            text = cat.categoryName,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.weight(1f),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Text(
+            text = "${cat.percentage.toInt()}%",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.width(FinanceDesktopTheme.spacing.sm))
+        Text(
+            text = cat.amountFormatted,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Medium,
+        )
+    }
+}
+
+@Composable
+private fun CategoryBarRow(cat: CategorySpendingUi) {
+    val color = chartColors[cat.colorIndex % chartColors.size]
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(FinanceDesktopTheme.spacing.lg)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    text = cat.categoryName,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                )
+                Text(
+                    text = "${cat.amountFormatted} (${cat.percentage.toInt()}%)",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
+            // Progress bar
+            Canvas(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(8.dp)
+                    .semantics {
+                        contentDescription = "${cat.categoryName}: ${cat.percentage.toInt()}% of total spending"
+                    },
+            ) {
+                drawRoundRect(
+                    color = color.copy(alpha = 0.2f),
+                    size = size,
+                    cornerRadius = androidx.compose.ui.geometry.CornerRadius(4.dp.toPx()),
+                )
+                drawRoundRect(
+                    color = color,
+                    size = Size(size.width * cat.percentage / 100f, size.height),
+                    cornerRadius = androidx.compose.ui.geometry.CornerRadius(4.dp.toPx()),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun InsightRow(insight: SpendingInsightUi) {
+    val trendColor = when (insight.trend) {
+        Trend.UP -> MaterialTheme.colorScheme.error
+        Trend.DOWN -> Color(0xFF22C55E)
+        Trend.STABLE -> MaterialTheme.colorScheme.onSurfaceVariant
+    }
+    val trendIcon = when (insight.trend) {
+        Trend.UP -> Icons.AutoMirrored.Filled.TrendingUp
+        Trend.DOWN -> Icons.AutoMirrored.Filled.TrendingDown
+        Trend.STABLE -> Icons.Filled.Remove
+    }
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics {
+                contentDescription = "${insight.categoryName}: ${insight.percentChange} change, " +
+                    "current ${insight.currentFormatted}, previous ${insight.previousFormatted}"
+            },
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(FinanceDesktopTheme.spacing.md),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = trendIcon,
+                contentDescription = null,
+                tint = trendColor,
+                modifier = Modifier.size(20.dp),
+            )
+            Spacer(Modifier.width(FinanceDesktopTheme.spacing.md))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = insight.categoryName,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                )
+                Text(
+                    text = "${insight.previousFormatted} → ${insight.currentFormatted}",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Text(
+                text = insight.percentChange,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = trendColor,
+            )
+        }
+    }
+}
+
+@Composable
+private fun LegendDot(color: Color, label: String) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Canvas(Modifier.size(10.dp)) { drawCircle(color = color) }
+        Spacer(Modifier.width(4.dp))
+        Text(text = label, style = MaterialTheme.typography.labelSmall)
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/InsightsViewModel.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/InsightsViewModel.kt
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.viewmodel
+
+import com.finance.core.analytics.MonthlyComparison
+import com.finance.core.analytics.ReportGenerator
+import com.finance.core.analytics.SpendingInsight
+import com.finance.core.analytics.Trend
+import com.finance.core.currency.CurrencyFormatter
+import com.finance.desktop.data.repository.AccountRepository
+import com.finance.desktop.data.repository.CategoryRepository
+import com.finance.desktop.data.repository.TransactionRepository
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+// ── UI models ────────────────────────────────────────────────────────
+
+data class CategorySpendingUi(
+    val categoryName: String,
+    val amountFormatted: String,
+    val amountCents: Long,
+    val percentage: Float,
+    val colorIndex: Int,
+)
+
+data class MonthlyComparisonUi(
+    val label: String,
+    val incomeFormatted: String,
+    val expenseFormatted: String,
+    val netFormatted: String,
+    val incomeAmount: Long,
+    val expenseAmount: Long,
+    val netAmount: Long,
+)
+
+data class SpendingInsightUi(
+    val categoryName: String,
+    val currentFormatted: String,
+    val previousFormatted: String,
+    val percentChange: String,
+    val trend: Trend,
+)
+
+data class NetWorthPointUi(
+    val label: String,
+    val amount: Long,
+    val formatted: String,
+)
+
+data class InsightsUiState(
+    val isLoading: Boolean = true,
+    val categorySpending: List<CategorySpendingUi> = emptyList(),
+    val monthlyComparisons: List<MonthlyComparisonUi> = emptyList(),
+    val spendingInsights: List<SpendingInsightUi> = emptyList(),
+    val netWorthHistory: List<NetWorthPointUi> = emptyList(),
+    val totalSpendingFormatted: String = "",
+    val selectedTab: InsightsTab = InsightsTab.OVERVIEW,
+)
+
+enum class InsightsTab { OVERVIEW, CATEGORIES, TRENDS }
+
+/**
+ * ViewModel for the Financial Insights Dashboard.
+ *
+ * Delegates heavy analytics to the KMP shared [ReportGenerator] from
+ * `packages/core/analytics/`, then maps results to UI-friendly models
+ * for Compose Desktop collection.
+ */
+class InsightsViewModel(
+    private val accountRepository: AccountRepository,
+    private val transactionRepository: TransactionRepository,
+    private val categoryRepository: CategoryRepository,
+) : DesktopViewModel() {
+
+    private val _uiState = MutableStateFlow(InsightsUiState())
+    val uiState: StateFlow<InsightsUiState> = _uiState.asStateFlow()
+
+    private val householdId = SyncId("d1")
+    private val currency = Currency.USD
+
+    init {
+        loadInsights()
+    }
+
+    fun selectTab(tab: InsightsTab) {
+        _uiState.value = _uiState.value.copy(selectedTab = tab)
+    }
+
+    fun refresh() {
+        loadInsights()
+    }
+
+    private fun loadInsights() {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isLoading = true)
+
+            val accounts = accountRepository.observeAll(householdId).first()
+            val transactions = transactionRepository.observeAll(householdId).first()
+            val categories = categoryRepository.observeAll(householdId).first()
+            val today = Clock.System.now()
+                .toLocalDateTime(TimeZone.currentSystemDefault()).date
+
+            val categoryMap = categories.associateBy { it.id }
+
+            // ── Category spending breakdown (current month) ──
+            val monthStart = kotlinx.datetime.LocalDate(today.year, today.month, 1)
+            val dateRange = ReportGenerator.DateRange(monthStart, today)
+            val categorySpending = ReportGenerator.spendingByCategory(transactions, dateRange)
+            val totalSpending = categorySpending.values.sumOf { it.amount }
+            val categorySpendingUi = categorySpending.entries
+                .sortedByDescending { it.value.amount }
+                .mapIndexed { index, (catId, cents) ->
+                    val pct = if (totalSpending > 0) {
+                        (cents.amount.toFloat() / totalSpending * 100)
+                    } else 0f
+                    CategorySpendingUi(
+                        categoryName = categoryMap[catId]?.name ?: "Unknown",
+                        amountFormatted = CurrencyFormatter.format(cents, currency),
+                        amountCents = cents.amount,
+                        percentage = pct,
+                        colorIndex = index % 8,
+                    )
+                }
+
+            // ── Income vs. Expense (last 6 months) ──
+            val monthlyComparisons = ReportGenerator.incomeVsExpense(transactions, 6, today)
+            val monthlyUi = monthlyComparisons.map { mc ->
+                val monthLabel = "${mc.month.name.take(3)} ${mc.year}"
+                MonthlyComparisonUi(
+                    label = monthLabel,
+                    incomeFormatted = CurrencyFormatter.format(mc.income, currency),
+                    expenseFormatted = CurrencyFormatter.format(mc.expense, currency),
+                    netFormatted = CurrencyFormatter.format(mc.net, currency),
+                    incomeAmount = mc.income.amount,
+                    expenseAmount = mc.expense.amount,
+                    netAmount = mc.net.amount,
+                )
+            }
+
+            // ── Spending insights (month-over-month per category) ──
+            val insights = ReportGenerator.spendingInsights(transactions, today)
+            val insightsUi = insights.take(10).map { insight ->
+                SpendingInsightUi(
+                    categoryName = categoryMap[insight.categoryId]?.name ?: "Unknown",
+                    currentFormatted = CurrencyFormatter.format(insight.currentMonth, currency),
+                    previousFormatted = CurrencyFormatter.format(insight.previousMonth, currency),
+                    percentChange = insight.percentChange?.let {
+                        val sign = if (it >= 0) "+" else ""
+                        "$sign${it.toInt()}%"
+                    } ?: "New",
+                    trend = insight.trend,
+                )
+            }
+
+            // ── Net worth history (last 6 months) ──
+            val nwHistory = ReportGenerator.netWorthOverTime(
+                accounts, transactions, 6, today,
+            )
+            val nwUi = nwHistory.map { snapshot ->
+                val label = "${snapshot.date.month.name.take(3)} ${snapshot.date.year}"
+                NetWorthPointUi(
+                    label = label,
+                    amount = snapshot.netWorth.amount,
+                    formatted = CurrencyFormatter.format(snapshot.netWorth, currency),
+                )
+            }
+
+            _uiState.value = InsightsUiState(
+                isLoading = false,
+                categorySpending = categorySpendingUi,
+                monthlyComparisons = monthlyUi,
+                spendingInsights = insightsUi,
+                netWorthHistory = nwUi,
+                totalSpendingFormatted = CurrencyFormatter.format(Cents(totalSpending), currency),
+                selectedTab = _uiState.value.selectedTab,
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Build a multi-panel financial insights dashboard with custom Compose Desktop charts.

### Changes
- **InsightsViewModel**: Delegates analytics to KMP shared ReportGenerator, maps results to UI models
- **InsightsScreen**: Three-tab layout (Overview, Categories, Trends)
  - **Overview**: Donut chart for category spending breakdown + grouped bar chart for income vs expenses (6 months)
  - **Categories**: Full category list with proportional bars and percentages
  - **Trends**: Month-over-month spending change indicators + net worth line chart
- **Custom Canvas Charts**: DonutChart, IncomeExpenseChart, NetWorthLineChart with accessibility
- **Koin DI**: InsightsViewModel registered with AccountRepository, TransactionRepository, CategoryRepository
- **Navigation**: Insights tab added to sidebar (Ctrl+6)
- **Narrator**: Chart semantic descriptions, tab announcements, heading hierarchy

Closes #1055