### PR TITLE
feat(windows): system tray integration with quick actions (#1058)

### DIFF
--- a/apps/windows/src/main/kotlin/com/finance/desktop/FinanceApp.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/FinanceApp.kt
@@ -24,11 +24,14 @@ import com.finance.desktop.screens.GoalsScreen
 import com.finance.desktop.screens.HealthScoreScreen
 import com.finance.desktop.screens.LockScreen
 import com.finance.desktop.screens.ReportBuilderScreen
+import com.finance.desktop.screens.QuickAddTransactionDialog
 import com.finance.desktop.screens.SettingsScreen
 import com.finance.desktop.screens.TransactionsScreen
 import com.finance.desktop.screens.VoiceTransactionOverlay
 import com.finance.desktop.screens.WidgetBoardScreen
 import com.finance.desktop.theme.FinanceDesktopTheme
+import com.finance.desktop.tray.FinanceSystemTray
+import com.finance.desktop.tray.QuickAddTransactionManager
 import com.finance.desktop.viewmodel.AuthViewModel
 
 /**
@@ -38,7 +41,8 @@ import com.finance.desktop.viewmodel.AuthViewModel
  * gates access behind Windows Hello authentication when configured. Once
  * authenticated, renders the sidebar navigation shell with all core screens.
  * The [VoiceTransactionOverlay] is layered on top for voice-driven transaction
- * entry (activated via Ctrl+Shift+V).
+ * entry (activated via Ctrl+Shift+V). The [QuickAddTransactionDialog] is
+ * triggered from the system tray context menu.
  *
  * ## Authentication Flow
  *
@@ -49,10 +53,16 @@ import com.finance.desktop.viewmodel.AuthViewModel
  * 5. Auto-lock returns to the lock screen after inactivity
  *
  * @param shortcutHandler The [ShortcutHandler] wired to the application
- *   window's [onPreviewKeyEvent], enabling Ctrl+1 through Ctrl+6 shortcuts.
+ *   window's [onPreviewKeyEvent], enabling Ctrl+1 through Ctrl+8 shortcuts.
+ * @param quickAddManager Manager for system tray quick-add transaction.
+ * @param systemTray The system tray integration for notifications.
  */
 @Composable
-fun FinanceApp(shortcutHandler: ShortcutHandler) {
+fun FinanceApp(
+    shortcutHandler: ShortcutHandler,
+    quickAddManager: QuickAddTransactionManager,
+    systemTray: FinanceSystemTray,
+) {
     val authViewModel = koinGet<AuthViewModel>()
     val authState by authViewModel.uiState.collectAsState()
 
@@ -92,6 +102,12 @@ fun FinanceApp(shortcutHandler: ShortcutHandler) {
 
                     // Voice transaction overlay — rendered on top of all content
                     VoiceTransactionOverlay()
+
+                    // Quick-add transaction dialog — triggered from system tray
+                    QuickAddTransactionDialog(
+                        quickAddManager = quickAddManager,
+                        systemTray = systemTray,
+                    )
                 }
             }
         }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/Main.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/Main.kt
@@ -15,6 +15,9 @@ import com.finance.desktop.notifications.DesktopNotificationManager
 import com.finance.desktop.performance.PerformanceMonitor
 import com.finance.desktop.performance.PerformanceTracker
 import com.finance.desktop.performance.timed
+import com.finance.desktop.tray.FinanceSystemTray
+import com.finance.desktop.tray.QuickAddTransactionManager
+import com.finance.desktop.tray.TrayActionHandler
 import com.finance.desktop.widgets.WidgetRegistrationManager
 import org.koin.core.context.GlobalContext
 import org.koin.core.context.startKoin
@@ -39,6 +42,10 @@ fun main() {
         widgetManager.initialize()
     }
 
+    // Initialise system tray integration
+    val systemTray = GlobalContext.get().get<FinanceSystemTray>()
+    val quickAddManager = GlobalContext.get().get<QuickAddTransactionManager>()
+
     // Start background performance monitoring
     PerformanceMonitor.start()
     PerformanceTracker.recordFirstInteractive()
@@ -51,9 +58,38 @@ fun main() {
 
         val shortcutHandler = rememberShortcutHandler()
 
+        // Initialise tray with action handler
+        timed("tray_init") {
+            systemTray.initialise(
+                handler = object : TrayActionHandler {
+                    override fun onQuickAddTransaction() {
+                        quickAddManager.show()
+                    }
+
+                    override fun onOpenApp() {
+                        // Bring window to front (WindowState is managed by Compose)
+                        windowState.isMinimized = false
+                    }
+
+                    override fun onShowSummary() {
+                        systemTray.showDailySummary()
+                    }
+                },
+                onQuit = {
+                    PerformanceMonitor.stop()
+                    systemTray.dispose()
+                    widgetManager.dispose()
+                    DesktopNotificationManager.dispose()
+                    stopKoin()
+                    exitApplication()
+                },
+            )
+        }
+
         Window(
             onCloseRequest = {
                 PerformanceMonitor.stop()
+                systemTray.dispose()
                 widgetManager.dispose()
                 DesktopNotificationManager.dispose()
                 stopKoin()
@@ -63,7 +99,7 @@ fun main() {
             state = windowState,
             onPreviewKeyEvent = { shortcutHandler.onKeyEvent(it) },
         ) {
-            FinanceApp(shortcutHandler)
+            FinanceApp(shortcutHandler, quickAddManager, systemTray)
         }
     }
 }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/di/PlatformModule.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/di/PlatformModule.kt
@@ -5,6 +5,8 @@ package com.finance.desktop.di
 import com.finance.desktop.notifications.DesktopNotificationManager
 import com.finance.desktop.voice.VoiceCommandManager
 import com.finance.desktop.voice.VoiceCommandParser
+import com.finance.desktop.tray.FinanceSystemTray
+import com.finance.desktop.tray.QuickAddTransactionManager
 import com.finance.desktop.widgets.WidgetContentRenderer
 import com.finance.desktop.widgets.WidgetDataProvider
 import com.finance.desktop.widgets.WidgetRegistrationManager
@@ -39,4 +41,8 @@ val platformModule = module {
     // ── Voice / Cortana integration ──
     single { VoiceCommandManager.create() }
     single { VoiceCommandParser() }
+
+    // ── System tray integration ──
+    single { FinanceSystemTray(get(), get(), get()) }
+    single { QuickAddTransactionManager(get()) }
 }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/QuickAddTransactionDialog.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/QuickAddTransactionDialog.kt
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.TrendingDown
+import androidx.compose.material.icons.automirrored.filled.TrendingUp
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.finance.desktop.theme.FinanceDesktopTheme
+import com.finance.desktop.tray.FinanceSystemTray
+import com.finance.desktop.tray.QuickAddTransactionManager
+import kotlinx.coroutines.launch
+
+/**
+ * Quick-add transaction dialog shown from the system tray.
+ *
+ * Minimal form with payee, amount, and expense/income toggle.
+ * Saves through the repository layer and shows a tray notification
+ * on success.
+ *
+ * Narrator: all fields have labels, chips announce selection state,
+ * error messages are announced, save/cancel buttons are labeled.
+ */
+@Composable
+fun QuickAddTransactionDialog(
+    quickAddManager: QuickAddTransactionManager,
+    systemTray: FinanceSystemTray,
+) {
+    val state by quickAddManager.state.collectAsState()
+    val scope = rememberCoroutineScope()
+
+    if (!state.isVisible) return
+
+    AlertDialog(
+        onDismissRequest = { quickAddManager.hide() },
+        title = {
+            Text(
+                text = "Quick Add Transaction",
+                fontWeight = FontWeight.SemiBold,
+            )
+        },
+        text = {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics {
+                        contentDescription = "Quick add transaction form"
+                    },
+            ) {
+                // Type toggle
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.sm),
+                ) {
+                    FilterChip(
+                        selected = state.isExpense,
+                        onClick = { if (!state.isExpense) quickAddManager.toggleType() },
+                        label = { Text("Expense") },
+                        leadingIcon = {
+                            Icon(
+                                Icons.AutoMirrored.Filled.TrendingDown,
+                                contentDescription = null,
+                                tint = if (state.isExpense) MaterialTheme.colorScheme.error else Color.Unspecified,
+                            )
+                        },
+                        modifier = Modifier.semantics {
+                            contentDescription = "Expense type${if (state.isExpense) ", selected" else ""}"
+                        },
+                    )
+                    FilterChip(
+                        selected = !state.isExpense,
+                        onClick = { if (state.isExpense) quickAddManager.toggleType() },
+                        label = { Text("Income") },
+                        leadingIcon = {
+                            Icon(
+                                Icons.AutoMirrored.Filled.TrendingUp,
+                                contentDescription = null,
+                                tint = if (!state.isExpense) Color(0xFF22C55E) else Color.Unspecified,
+                            )
+                        },
+                        modifier = Modifier.semantics {
+                            contentDescription = "Income type${if (!state.isExpense) ", selected" else ""}"
+                        },
+                    )
+                }
+
+                Spacer(Modifier.height(FinanceDesktopTheme.spacing.lg))
+
+                // Payee field
+                OutlinedTextField(
+                    value = state.payee,
+                    onValueChange = { quickAddManager.updatePayee(it) },
+                    label = { Text("Payee") },
+                    placeholder = { Text("e.g. Grocery store") },
+                    singleLine = true,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .semantics {
+                            contentDescription = "Payee name"
+                        },
+                )
+
+                Spacer(Modifier.height(FinanceDesktopTheme.spacing.md))
+
+                // Amount field
+                OutlinedTextField(
+                    value = state.amount,
+                    onValueChange = { quickAddManager.updateAmount(it) },
+                    label = { Text("Amount (\$)") },
+                    placeholder = { Text("0.00") },
+                    singleLine = true,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .semantics {
+                            contentDescription = "Transaction amount in dollars"
+                        },
+                )
+
+                // Error message
+                if (state.errorMessage != null) {
+                    Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
+                    Text(
+                        text = state.errorMessage!!,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.semantics {
+                            contentDescription = "Error: ${state.errorMessage}"
+                        },
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = {
+                    scope.launch {
+                        val result = quickAddManager.save()
+                        if (result != null) {
+                            systemTray.showQuickAddConfirmation(result.first, result.second)
+                        }
+                    }
+                },
+                enabled = !state.isSaving,
+            ) {
+                if (state.isSaving) {
+                    CircularProgressIndicator(
+                        modifier = Modifier
+                            .padding(end = 8.dp)
+                            .then(Modifier.height(16.dp).width(16.dp)),
+                        strokeWidth = 2.dp,
+                    )
+                }
+                Text("Save")
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = { quickAddManager.hide() },
+                enabled = !state.isSaving,
+            ) {
+                Text("Cancel")
+            }
+        },
+        modifier = Modifier.semantics {
+            contentDescription = "Quick add transaction dialog. " +
+                "Enter payee and amount to quickly log a transaction."
+        },
+    )
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/tray/FinanceSystemTray.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/tray/FinanceSystemTray.kt
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.tray
+
+import com.finance.core.budget.BudgetCalculator
+import com.finance.core.budget.BudgetHealth
+import com.finance.core.currency.CurrencyFormatter
+import com.finance.desktop.data.repository.AccountRepository
+import com.finance.desktop.data.repository.BudgetRepository
+import com.finance.desktop.data.repository.TransactionRepository
+import com.finance.models.TransactionType
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import java.awt.AWTException
+import java.awt.MenuItem
+import java.awt.PopupMenu
+import java.awt.SystemTray
+import java.awt.Toolkit
+import java.awt.TrayIcon
+import java.awt.TrayIcon.MessageType
+import java.awt.event.ActionEvent
+import java.util.logging.Level
+import java.util.logging.Logger
+
+/**
+ * Callback interface for system tray quick actions.
+ */
+interface TrayActionHandler {
+    /** User clicked "Quick Add Transaction" in the tray menu. */
+    fun onQuickAddTransaction()
+
+    /** User clicked "Open Finance" or double-clicked the tray icon. */
+    fun onOpenApp()
+
+    /** User clicked "Show Summary". */
+    fun onShowSummary()
+}
+
+/**
+ * Windows system tray integration with quick actions.
+ *
+ * Provides:
+ * - Tray icon with context menu (Quick Add, Daily Summary, Open, Quit)
+ * - Daily summary notifications showing today's spending and budget health
+ * - Budget alert notifications when budgets are exceeded or near limit
+ * - Double-click to open / focus the application window
+ *
+ * Uses [java.awt.SystemTray] API for native Windows integration. The tray
+ * icon produces standard Windows 10/11 toast notifications that appear in
+ * the Action Center.
+ *
+ * Thread safety: all public methods are safe to call from any thread.
+ * Internal AWT operations are dispatched to the EDT automatically.
+ */
+class FinanceSystemTray(
+    private val accountRepository: AccountRepository,
+    private val transactionRepository: TransactionRepository,
+    private val budgetRepository: BudgetRepository,
+) {
+
+    private val logger = Logger.getLogger("FinanceSystemTray")
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val householdId = SyncId("d1")
+
+    @Volatile
+    private var trayIcon: TrayIcon? = null
+
+    @Volatile
+    private var actionHandler: TrayActionHandler? = null
+
+    @Volatile
+    private var isInitialised = false
+
+    // ── Lifecycle ────────────────────────────────────────────────────
+
+    /**
+     * Initialise the system tray icon with context menu.
+     *
+     * Must be called once during application startup, after Koin is
+     * initialised. If the system tray is unsupported, degrades silently.
+     *
+     * @param handler Callback for user interactions.
+     * @param onQuit  Called when the user selects "Quit" from the tray menu.
+     */
+    @Synchronized
+    fun initialise(handler: TrayActionHandler, onQuit: () -> Unit) {
+        if (isInitialised) {
+            logger.fine("FinanceSystemTray already initialised.")
+            return
+        }
+
+        if (!SystemTray.isSupported()) {
+            logger.warning("SystemTray not supported. Tray features disabled.")
+            return
+        }
+
+        actionHandler = handler
+
+        try {
+            val popup = buildPopupMenu(handler, onQuit)
+            val image = loadTrayImage()
+            val icon = TrayIcon(image, "Finance — Personal Finance Tracker").apply {
+                isImageAutoSize = true
+                popupMenu = popup
+                addActionListener { handler.onOpenApp() }
+            }
+
+            SystemTray.getSystemTray().add(icon)
+            trayIcon = icon
+            isInitialised = true
+            logger.info("FinanceSystemTray initialised successfully.")
+        } catch (e: AWTException) {
+            logger.log(Level.WARNING, "Failed to add system tray icon: ${e.message}", e)
+        }
+    }
+
+    /**
+     * Remove the tray icon and release resources.
+     */
+    @Synchronized
+    fun dispose() {
+        scope.cancel()
+        trayIcon?.let { icon ->
+            try {
+                SystemTray.getSystemTray().remove(icon)
+            } catch (e: Exception) {
+                logger.log(Level.FINE, "Error removing tray icon", e)
+            }
+        }
+        trayIcon = null
+        actionHandler = null
+        isInitialised = false
+        logger.info("FinanceSystemTray disposed.")
+    }
+
+    // ── Notifications ────────────────────────────────────────────────
+
+    /**
+     * Show a daily spending summary as a toast notification.
+     *
+     * Fetches today's transactions and budget status, then displays
+     * a summary notification with spending total and budget alerts.
+     */
+    fun showDailySummary() {
+        scope.launch {
+            try {
+                val today = currentDate()
+                val transactions = transactionRepository.observeAll(householdId).first()
+                val accounts = accountRepository.observeAll(householdId).first()
+                val budgets = budgetRepository.observeAll(householdId).first()
+                val currency = Currency.USD
+
+                val todayExpenses = transactions.filter {
+                    it.type == TransactionType.EXPENSE && it.date == today
+                }
+                val todayTotal = Cents(todayExpenses.sumOf { it.amount.abs().amount })
+                val txnCount = todayExpenses.size
+                val formattedTotal = CurrencyFormatter.format(todayTotal, currency)
+
+                // Check budget health
+                val budgetAlerts = budgets.mapNotNull { budget ->
+                    val catTxns = transactions.filter { it.categoryId == budget.categoryId }
+                    val status = BudgetCalculator.calculateStatus(budget, catTxns, today)
+                    when (status.healthLevel) {
+                        BudgetHealth.OVER -> "${budget.name}: over budget"
+                        BudgetHealth.WARNING -> "${budget.name}: nearing limit"
+                        BudgetHealth.HEALTHY -> null
+                    }
+                }
+
+                val body = buildString {
+                    append("Today's spending: $formattedTotal ($txnCount transactions)")
+                    if (budgetAlerts.isNotEmpty()) {
+                        append("\n\n⚠️ Budget alerts:\n")
+                        budgetAlerts.forEach { append("• $it\n") }
+                    }
+                }
+
+                val messageType = when {
+                    budgetAlerts.any { "over" in it } -> MessageType.WARNING
+                    budgetAlerts.isNotEmpty() -> MessageType.INFO
+                    else -> MessageType.INFO
+                }
+
+                showNotification("Daily Summary", body.trim(), messageType)
+            } catch (e: Exception) {
+                logger.log(Level.WARNING, "Failed to generate daily summary", e)
+            }
+        }
+    }
+
+    /**
+     * Show a budget alert notification for a specific budget.
+     */
+    fun showBudgetAlert(budgetName: String, percentUsed: Int) {
+        val (title, body, type) = when {
+            percentUsed >= 100 -> Triple(
+                "Budget Exceeded",
+                "$budgetName has exceeded its limit ($percentUsed% used).",
+                MessageType.ERROR,
+            )
+            percentUsed >= 90 -> Triple(
+                "Budget Warning",
+                "$budgetName is at $percentUsed% of its limit.",
+                MessageType.WARNING,
+            )
+            else -> Triple(
+                "Budget Update",
+                "$budgetName is at $percentUsed%.",
+                MessageType.INFO,
+            )
+        }
+        showNotification(title, body, type)
+    }
+
+    /**
+     * Show a generic notification via the tray icon.
+     */
+    fun showNotification(title: String, body: String, type: MessageType = MessageType.INFO) {
+        val icon = trayIcon
+        if (icon == null) {
+            logger.fine("Notification suppressed (tray icon not available): $title")
+            return
+        }
+
+        val truncated = if (body.length > 256) body.take(255) + "…" else body
+        try {
+            icon.displayMessage(title, truncated, type)
+        } catch (e: Exception) {
+            logger.log(Level.WARNING, "Failed to show notification: $title", e)
+        }
+    }
+
+    // ── Quick add support ────────────────────────────────────────────
+
+    /**
+     * Show a confirmation notification after quick-adding a transaction.
+     */
+    fun showQuickAddConfirmation(payee: String, amount: String) {
+        showNotification(
+            "Transaction Added",
+            "$amount at $payee added successfully.",
+            MessageType.INFO,
+        )
+    }
+
+    // ── Internal ─────────────────────────────────────────────────────
+
+    private fun buildPopupMenu(handler: TrayActionHandler, onQuit: () -> Unit): PopupMenu {
+        return PopupMenu("Finance").apply {
+            // Quick Add Transaction
+            add(MenuItem("Quick Add Transaction").apply {
+                addActionListener { handler.onQuickAddTransaction() }
+            })
+
+            addSeparator()
+
+            // Daily Summary
+            add(MenuItem("Show Daily Summary").apply {
+                addActionListener { showDailySummary() }
+            })
+
+            addSeparator()
+
+            // Open App
+            add(MenuItem("Open Finance").apply {
+                addActionListener { handler.onOpenApp() }
+            })
+
+            addSeparator()
+
+            // Quit
+            add(MenuItem("Quit").apply {
+                addActionListener { onQuit() }
+            })
+        }
+    }
+
+    private fun loadTrayImage(): java.awt.Image {
+        val url = FinanceSystemTray::class.java.getResource("/icons/finance-tray.png")
+        if (url != null) {
+            return Toolkit.getDefaultToolkit().getImage(url)
+        }
+        // Fallback: 16x16 transparent image
+        return java.awt.image.BufferedImage(16, 16, java.awt.image.BufferedImage.TYPE_INT_ARGB)
+    }
+
+    private fun currentDate(): LocalDate =
+        Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/tray/QuickAddTransactionManager.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/tray/QuickAddTransactionManager.kt
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.tray
+
+import com.finance.core.currency.CurrencyFormatter
+import com.finance.desktop.data.repository.TransactionRepository
+import com.finance.models.Transaction
+import com.finance.models.TransactionType
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+/**
+ * State for the quick-add transaction popup.
+ */
+data class QuickAddState(
+    val isVisible: Boolean = false,
+    val payee: String = "",
+    val amount: String = "",
+    val isExpense: Boolean = true,
+    val isSaving: Boolean = false,
+    val errorMessage: String? = null,
+)
+
+/**
+ * Manager for quick-add transaction from the system tray.
+ *
+ * Handles the state for the quick-add popup window and persists
+ * transactions through the repository layer.
+ */
+class QuickAddTransactionManager(
+    private val transactionRepository: TransactionRepository,
+) {
+
+    private val _state = MutableStateFlow(QuickAddState())
+    val state: StateFlow<QuickAddState> = _state.asStateFlow()
+
+    private val householdId = SyncId("d1")
+    private val ownerId = SyncId("owner1")
+    private val defaultAccountId = SyncId("acc1")
+
+    fun show() {
+        _state.value = QuickAddState(isVisible = true)
+    }
+
+    fun hide() {
+        _state.value = QuickAddState(isVisible = false)
+    }
+
+    fun updatePayee(payee: String) {
+        _state.value = _state.value.copy(payee = payee, errorMessage = null)
+    }
+
+    fun updateAmount(amount: String) {
+        // Only allow numeric input with optional decimal
+        val filtered = amount.filter { it.isDigit() || it == '.' }
+        _state.value = _state.value.copy(amount = filtered, errorMessage = null)
+    }
+
+    fun toggleType() {
+        _state.value = _state.value.copy(isExpense = !_state.value.isExpense)
+    }
+
+    /**
+     * Persist the transaction and return success/failure.
+     * Returns the formatted amount string on success, null on failure.
+     */
+    suspend fun save(): Pair<String, String>? {
+        val current = _state.value
+
+        if (current.payee.isBlank()) {
+            _state.value = current.copy(errorMessage = "Payee is required")
+            return null
+        }
+
+        val amountDouble = current.amount.toDoubleOrNull()
+        if (amountDouble == null || amountDouble <= 0) {
+            _state.value = current.copy(errorMessage = "Enter a valid amount")
+            return null
+        }
+
+        _state.value = current.copy(isSaving = true)
+
+        return try {
+            val cents = Cents.fromDollars(amountDouble)
+            val now = Clock.System.now()
+            val today = now.toLocalDateTime(TimeZone.currentSystemDefault()).date
+
+            val transaction = Transaction(
+                id = SyncId("quick-${now.toEpochMilliseconds()}"),
+                householdId = householdId,
+                ownerId = ownerId,
+                accountId = defaultAccountId,
+                type = if (current.isExpense) TransactionType.EXPENSE else TransactionType.INCOME,
+                amount = if (current.isExpense) Cents(-cents.amount) else cents,
+                currency = Currency.USD,
+                payee = current.payee,
+                date = today,
+                createdAt = now,
+                updatedAt = now,
+            )
+
+            transactionRepository.insert(transaction)
+
+            val formatted = CurrencyFormatter.format(cents, Currency.USD)
+            _state.value = QuickAddState(isVisible = false)
+            current.payee to formatted
+        } catch (e: Exception) {
+            _state.value = current.copy(
+                isSaving = false,
+                errorMessage = "Failed to save: ${e.message}",
+            )
+            null
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Windows-native system tray icon with quick-add transaction, daily summary notification, and budget alerts.

### Changes
- **FinanceSystemTray**: Full tray icon lifecycle management with AWT SystemTray API
  - Context menu: Quick Add Transaction, Show Daily Summary, Open Finance, Quit
  - Daily summary notification: today's spending total + budget health alerts
  - Budget alert notifications with escalating severity (info → warning → error)
  - Double-click tray icon to focus/restore the application window
- **QuickAddTransactionManager**: State manager for the quick-add popup
  - Payee and amount fields with validation
  - Expense/income toggle
  - Persists through TransactionRepository
  - Toast confirmation on success
- **QuickAddTransactionDialog**: Accessible Compose Desktop dialog
  - FilterChips for transaction type selection
  - OutlinedTextFields with labels and placeholders
  - Error display and save progress indicator
- **Koin DI**: FinanceSystemTray + QuickAddTransactionManager in platformModule
- **Main.kt**: Tray initialised with handler, disposed on shutdown
- **FinanceApp**: Dialog layered on top of main content

Closes #1058