### PR TITLE
feat(android): contextual financial tips on dashboard (#1063)

### DIFF
--- a/apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt
@@ -30,6 +30,7 @@ import com.finance.android.ui.streak.StreakRepository
 import com.finance.android.ui.streak.StreakViewModel
 import com.finance.android.ui.streak.TransactionBackedStreakRepository
 import com.finance.android.ui.theme.ThemePreferenceManager
+import com.finance.android.ui.tips.TipsViewModel
 import com.finance.android.ui.viewmodel.AccountCreateViewModel
 import com.finance.android.ui.viewmodel.AccountEditViewModel
 import com.finance.android.ui.viewmodel.AnalyticsViewModel
@@ -148,4 +149,7 @@ val appModule = module {
     viewModelOf(::ExpertiseTierViewModel)
     viewModelOf(::LearningPathViewModel)
     viewModelOf(::NlpTransactionViewModel)
+
+    // ── Tips ─────────────────────────────────────────────────────────
+    viewModelOf(::TipsViewModel)
 }

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/DashboardScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/DashboardScreen.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.finance.android.ui.data.SampleData
 import com.finance.android.ui.theme.FinanceTheme
+import com.finance.android.ui.tips.TipsSection
 import com.finance.android.ui.viewmodel.BudgetStatusUi
 import com.finance.android.ui.viewmodel.DashboardUiState
 import com.finance.android.ui.viewmodel.DashboardViewModel
@@ -114,6 +115,7 @@ internal fun DashboardContent(
             item(key = "spending") { SpendingSummaryRow(state.todaySpendingFormatted, state.monthlySpendingFormatted) }
             item(key = "affordability") { AffordabilityCheckCard(onAffordabilityCheck) }
             item(key = "insights") { InsightsCard(onViewInsights) }
+            item(key = "tips") { TipsSection() }
             if (state.budgetStatuses.isNotEmpty()) {
                 item(key = "budget-hdr") {
                     Text("Budget Health", style = MaterialTheme.typography.titleMedium,

--- a/apps/android/src/main/kotlin/com/finance/android/ui/tips/TipsSection.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/tips/TipsSection.kt
@@ -1,0 +1,298 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.tips
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Lightbulb
+import androidx.compose.material.icons.filled.PieChart
+import androidx.compose.material.icons.filled.Savings
+import androidx.compose.material.icons.filled.ShoppingCart
+import androidx.compose.material.icons.filled.TrendingUp
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.finance.android.ui.theme.FinanceTheme
+import com.finance.core.tips.FinancialTip
+import com.finance.core.tips.TipCategory
+import com.finance.core.tips.TipPriority
+import org.koin.compose.viewmodel.koinViewModel
+
+/**
+ * Dashboard tips section showing contextual financial tips (#320).
+ *
+ * Displays a horizontally scrolling row of tip cards. High-priority
+ * tips are emphasized with accent colors. Each card is dismissible.
+ *
+ * Fully accessible: TalkBack announces tip content, dismiss button
+ * has clear content description.
+ */
+@Composable
+fun TipsSection(
+    modifier: Modifier = Modifier,
+    viewModel: TipsViewModel = koinViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+
+    TipsSectionContent(
+        tips = state.visibleTips,
+        isLoading = state.isLoading,
+        onDismiss = viewModel::dismissTip,
+        modifier = modifier,
+    )
+}
+
+@Composable
+internal fun TipsSectionContent(
+    tips: List<FinancialTip>,
+    isLoading: Boolean,
+    onDismiss: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (isLoading || tips.isEmpty()) return
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = "Financial Tips",
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.semantics {
+                heading()
+                contentDescription = "Financial Tips section"
+            },
+        )
+        Spacer(Modifier.height(8.dp))
+        LazyRow(
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            contentPadding = PaddingValues(horizontal = 4.dp),
+        ) {
+            items(tips, key = { it.id }) { tip ->
+                AnimatedVisibility(
+                    visible = true,
+                    enter = fadeIn() + slideInVertically(),
+                    exit = fadeOut() + slideOutVertically(),
+                ) {
+                    TipCard(
+                        tip = tip,
+                        onDismiss = { onDismiss(tip.id) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Individual tip card displaying a financial insight.
+ *
+ * High-priority tips use error container colors to draw attention.
+ * Medium-priority tips use tertiary container. Low-priority tips
+ * use the default surface variant.
+ */
+@Composable
+internal fun TipCard(
+    tip: FinancialTip,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val containerColor = when (tip.priority) {
+        TipPriority.HIGH -> MaterialTheme.colorScheme.errorContainer
+        TipPriority.MEDIUM -> MaterialTheme.colorScheme.tertiaryContainer
+        TipPriority.LOW -> MaterialTheme.colorScheme.surfaceVariant
+    }
+    val contentColor = when (tip.priority) {
+        TipPriority.HIGH -> MaterialTheme.colorScheme.onErrorContainer
+        TipPriority.MEDIUM -> MaterialTheme.colorScheme.onTertiaryContainer
+        TipPriority.LOW -> MaterialTheme.colorScheme.onSurfaceVariant
+    }
+    val icon = tipCategoryIcon(tip.category)
+    val priorityLabel = when (tip.priority) {
+        TipPriority.HIGH -> "High priority"
+        TipPriority.MEDIUM -> "Medium priority"
+        TipPriority.LOW -> "Tip"
+    }
+
+    ElevatedCard(
+        modifier = modifier
+            .width(280.dp)
+            .semantics {
+                contentDescription = "$priorityLabel: ${tip.title}. ${tip.description}"
+            },
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = containerColor,
+        ),
+    ) {
+        Column(Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.Top,
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Icon(
+                        imageVector = icon,
+                        contentDescription = null,
+                        tint = contentColor,
+                        modifier = Modifier.size(20.dp),
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        text = tip.title,
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        color = contentColor,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                IconButton(
+                    onClick = onDismiss,
+                    modifier = Modifier
+                        .size(32.dp)
+                        .semantics {
+                            contentDescription = "Dismiss tip: ${tip.title}"
+                        },
+                ) {
+                    Icon(
+                        Icons.Filled.Close,
+                        contentDescription = null,
+                        tint = contentColor.copy(alpha = 0.6f),
+                        modifier = Modifier.size(16.dp),
+                    )
+                }
+            }
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = tip.description,
+                style = MaterialTheme.typography.bodySmall,
+                color = contentColor.copy(alpha = 0.85f),
+                maxLines = 3,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = tipCategoryLabel(tip.category),
+                style = MaterialTheme.typography.labelSmall,
+                color = contentColor.copy(alpha = 0.5f),
+            )
+        }
+    }
+}
+
+/** Map tip categories to Material Icons. */
+private fun tipCategoryIcon(category: TipCategory): ImageVector = when (category) {
+    TipCategory.BUDGET -> Icons.Filled.PieChart
+    TipCategory.SPENDING -> Icons.Filled.ShoppingCart
+    TipCategory.SAVINGS -> Icons.Filled.Savings
+    TipCategory.INCOME -> Icons.Filled.TrendingUp
+    TipCategory.GENERAL -> Icons.Filled.Lightbulb
+}
+
+/** Human-readable labels for tip categories. */
+private fun tipCategoryLabel(category: TipCategory): String = when (category) {
+    TipCategory.BUDGET -> "Budget"
+    TipCategory.SPENDING -> "Spending"
+    TipCategory.SAVINGS -> "Savings"
+    TipCategory.INCOME -> "Income"
+    TipCategory.GENERAL -> "General"
+}
+
+// ── Previews ─────────────────────────────────────────────────────────
+
+@Preview(showBackground = true, name = "Tips Section - Light")
+@Preview(
+    showBackground = true,
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+    name = "Tips Section - Dark",
+)
+@Composable
+private fun TipsSectionPreview() {
+    FinanceTheme(dynamicColor = false) {
+        TipsSectionContent(
+            tips = listOf(
+                FinancialTip(
+                    id = "budget-over-1",
+                    title = "Budget exceeded: Dining",
+                    description = "You've spent \$380 of your \$300 Dining budget. Consider adjusting spending.",
+                    category = TipCategory.BUDGET,
+                    priority = TipPriority.HIGH,
+                    actionHint = "navigate:budgets",
+                ),
+                FinancialTip(
+                    id = "goal-almost-1",
+                    title = "Almost there: Vacation",
+                    description = "You're 92% toward your Vacation goal! Just \$160 to go.",
+                    category = TipCategory.SAVINGS,
+                    priority = TipPriority.MEDIUM,
+                    actionHint = "navigate:goals",
+                ),
+                FinancialTip(
+                    id = "savings-streak-3",
+                    title = "Great savings streak!",
+                    description = "You've had positive cash flow for 3 consecutive months.",
+                    category = TipCategory.SAVINGS,
+                    priority = TipPriority.LOW,
+                ),
+            ),
+            isLoading = false,
+            onDismiss = {},
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Tip Card - High Priority")
+@Composable
+private fun TipCardHighPreview() {
+    FinanceTheme(dynamicColor = false) {
+        TipCard(
+            tip = FinancialTip(
+                id = "low-savings-rate",
+                title = "Savings rate needs attention",
+                description = "Your savings rate this month is 3%. Experts recommend 10-20%.",
+                category = TipCategory.SAVINGS,
+                priority = TipPriority.HIGH,
+            ),
+            onDismiss = {},
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/tips/TipsViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/tips/TipsViewModel.kt
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.tips
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.finance.android.auth.HouseholdIdProvider
+import com.finance.android.data.repository.AccountRepository
+import com.finance.android.data.repository.BudgetRepository
+import com.finance.android.data.repository.CategoryRepository
+import com.finance.android.data.repository.GoalRepository
+import com.finance.android.data.repository.TransactionRepository
+import com.finance.core.tips.FinancialContext
+import com.finance.core.tips.FinancialTip
+import com.finance.core.tips.FinancialTipsEngine
+import com.finance.core.tips.TipCategory
+import com.finance.core.tips.TipPriority
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+/**
+ * UI state for the contextual financial tips feature (#320).
+ *
+ * @property tips The list of generated tips to display.
+ * @property isLoading Whether tip generation is in progress.
+ * @property dismissedTipIds Set of tip IDs the user has dismissed this session.
+ */
+data class TipsUiState(
+    val tips: List<FinancialTip> = emptyList(),
+    val isLoading: Boolean = true,
+    val dismissedTipIds: Set<String> = emptySet(),
+) {
+    /** Visible tips after filtering out dismissed ones. */
+    val visibleTips: List<FinancialTip>
+        get() = tips.filter { it.id !in dismissedTipIds }
+
+    /** High-priority tip suitable for the dashboard hero card. */
+    val heroTip: FinancialTip?
+        get() = visibleTips.firstOrNull { it.priority == TipPriority.HIGH }
+
+    /** Number of visible tips. */
+    val visibleCount: Int get() = visibleTips.size
+}
+
+/**
+ * ViewModel for the contextual financial tips feature (#320).
+ *
+ * Loads the user's financial data from repositories, builds a
+ * [FinancialContext], and delegates to the KMP [FinancialTipsEngine]
+ * to generate context-aware tips.
+ *
+ * @param householdIdProvider Provides the authenticated household ID.
+ * @param transactionRepository Source for transaction data.
+ * @param budgetRepository Source for budget data.
+ * @param goalRepository Source for goal data.
+ * @param accountRepository Source for account data.
+ * @param categoryRepository Source for category data.
+ */
+class TipsViewModel(
+    private val householdIdProvider: HouseholdIdProvider,
+    private val transactionRepository: TransactionRepository,
+    private val budgetRepository: BudgetRepository,
+    private val goalRepository: GoalRepository,
+    private val accountRepository: AccountRepository,
+    private val categoryRepository: CategoryRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(TipsUiState())
+    val uiState: StateFlow<TipsUiState> = _uiState.asStateFlow()
+
+    init {
+        loadTips()
+    }
+
+    /** Refresh tips with latest financial data. */
+    fun refresh() {
+        loadTips()
+    }
+
+    /** Dismiss a tip for the current session. */
+    fun dismissTip(tipId: String) {
+        _uiState.update { state ->
+            state.copy(dismissedTipIds = state.dismissedTipIds + tipId)
+        }
+        Timber.d("Tip dismissed: %s", tipId)
+    }
+
+    private fun loadTips() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+
+            val householdId = householdIdProvider.householdId.value ?: run {
+                Timber.w("No household ID available — skipping tips generation")
+                _uiState.update { it.copy(isLoading = false) }
+                return@launch
+            }
+
+            try {
+                val transactions = transactionRepository.observeAll(householdId).first()
+                val budgets = budgetRepository.observeAll(householdId).first()
+                val goals = goalRepository.observeAll(householdId).first()
+                val accounts = accountRepository.observeAll(householdId).first()
+                val categories = categoryRepository.observeAll(householdId).first()
+
+                val context = FinancialContext(
+                    transactions = transactions,
+                    budgets = budgets,
+                    goals = goals,
+                    accounts = accounts,
+                    categories = categories,
+                )
+
+                val tips = FinancialTipsEngine.generateTips(context)
+
+                _uiState.update { state ->
+                    state.copy(
+                        tips = tips,
+                        isLoading = false,
+                    )
+                }
+
+                Timber.d(
+                    "Tips generated: %d total, %d high priority",
+                    tips.size,
+                    tips.count { it.priority == TipPriority.HIGH },
+                )
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to generate financial tips")
+                _uiState.update { it.copy(isLoading = false) }
+            }
+        }
+    }
+}

--- a/apps/android/src/test/kotlin/com/finance/android/ui/tips/TipsUiStateTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/ui/tips/TipsUiStateTest.kt
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.tips
+
+import com.finance.core.tips.FinancialTip
+import com.finance.core.tips.TipCategory
+import com.finance.core.tips.TipPriority
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [TipsUiState] filtering and computed properties.
+ */
+class TipsUiStateTest {
+
+    private val highTip = FinancialTip(
+        id = "budget-over-1",
+        title = "Budget exceeded",
+        description = "Over budget on dining",
+        category = TipCategory.BUDGET,
+        priority = TipPriority.HIGH,
+    )
+
+    private val mediumTip = FinancialTip(
+        id = "goal-almost-1",
+        title = "Almost there",
+        description = "Goal nearly complete",
+        category = TipCategory.SAVINGS,
+        priority = TipPriority.MEDIUM,
+    )
+
+    private val lowTip = FinancialTip(
+        id = "savings-streak",
+        title = "Great streak",
+        description = "Positive cash flow 3 months",
+        category = TipCategory.SAVINGS,
+        priority = TipPriority.LOW,
+    )
+
+    @Test
+    fun `visibleTips filters out dismissed tips`() {
+        val state = TipsUiState(
+            tips = listOf(highTip, mediumTip, lowTip),
+            dismissedTipIds = setOf("goal-almost-1"),
+        )
+
+        assertEquals(2, state.visibleTips.size)
+        assertTrue(state.visibleTips.none { it.id == "goal-almost-1" })
+    }
+
+    @Test
+    fun `heroTip returns first high priority visible tip`() {
+        val state = TipsUiState(
+            tips = listOf(lowTip, mediumTip, highTip),
+        )
+
+        assertEquals(highTip, state.heroTip)
+    }
+
+    @Test
+    fun `heroTip returns null when no high priority tips`() {
+        val state = TipsUiState(
+            tips = listOf(lowTip, mediumTip),
+        )
+
+        assertNull(state.heroTip)
+    }
+
+    @Test
+    fun `heroTip skips dismissed high priority tips`() {
+        val state = TipsUiState(
+            tips = listOf(highTip, mediumTip),
+            dismissedTipIds = setOf("budget-over-1"),
+        )
+
+        assertNull(state.heroTip)
+    }
+
+    @Test
+    fun `visibleCount reflects dismissals`() {
+        val state = TipsUiState(
+            tips = listOf(highTip, mediumTip, lowTip),
+            dismissedTipIds = setOf("budget-over-1", "savings-streak"),
+        )
+
+        assertEquals(1, state.visibleCount)
+    }
+
+    @Test
+    fun `empty tips produces empty visibleTips`() {
+        val state = TipsUiState(tips = emptyList())
+
+        assertTrue(state.visibleTips.isEmpty())
+        assertNull(state.heroTip)
+        assertEquals(0, state.visibleCount)
+    }
+}


### PR DESCRIPTION
## Summary
Display context-aware financial tips using Material 3 cards on the dashboard.

## Changes
- **TipsViewModel**: loads financial data, delegates to KMP FinancialTipsEngine
- **TipsSection**: horizontally scrolling tip cards with priority colors
- **TipCard**: individual card with dismiss, category icon, a11y support
- **TipsUiState**: computed visibleTips, heroTip, dismissal filtering
- Dashboard integration: tips section between insights and budget health
- Koin wiring in AppModule
- Unit tests for TipsUiState

## Testing
- Unit tests for TipsUiState filtering and computed properties
- Compose Preview annotations for light/dark mode

Closes #1063