### PR TITLE
feat(android): financial insights dashboard (#1064)

### DIFF
--- a/apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt
@@ -31,6 +31,7 @@ import com.finance.android.ui.streak.StreakViewModel
 import com.finance.android.ui.streak.TransactionBackedStreakRepository
 import com.finance.android.ui.theme.ThemePreferenceManager
 import com.finance.android.ui.tips.TipsViewModel
+import com.finance.android.ui.insights.InsightsViewModel
 import com.finance.android.ui.viewmodel.AccountCreateViewModel
 import com.finance.android.ui.viewmodel.AccountEditViewModel
 import com.finance.android.ui.viewmodel.AnalyticsViewModel
@@ -152,4 +153,7 @@ val appModule = module {
 
     // ── Tips ─────────────────────────────────────────────────────────
     viewModelOf(::TipsViewModel)
+
+    // ── Insights ─────────────────────────────────────────────────────
+    viewModelOf(::InsightsViewModel)
 }

--- a/apps/android/src/main/kotlin/com/finance/android/ui/insights/InsightsScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/insights/InsightsScreen.kt
@@ -1,0 +1,557 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.insights
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDownward
+import androidx.compose.material.icons.filled.ArrowUpward
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Remove
+import androidx.compose.material.icons.filled.TrendingDown
+import androidx.compose.material.icons.filled.TrendingUp
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.finance.android.ui.theme.FinanceTheme
+import com.finance.core.insights.HealthAssessment
+import com.finance.core.insights.TrendDirection
+import org.koin.compose.viewmodel.koinViewModel
+
+/** Chart color palette for spending category breakdown. */
+private val chartColors = listOf(
+    Color(0xFF2196F3), Color(0xFF4CAF50), Color(0xFFFF9800),
+    Color(0xFFE91E63), Color(0xFF9C27B0), Color(0xFF00BCD4),
+    Color(0xFF795548), Color(0xFFFF5722), Color(0xFF607D8B),
+    Color(0xFF3F51B5),
+)
+
+/**
+ * Financial Insights Dashboard screen (#241).
+ *
+ * Displays spending category breakdown, trends, income vs expense
+ * summary, financial health score, and recommendations.
+ */
+@Composable
+fun InsightsScreen(
+    modifier: Modifier = Modifier,
+    viewModel: InsightsViewModel = koinViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+
+    if (state.isLoading) {
+        Box(
+            modifier = modifier
+                .fillMaxSize()
+                .semantics { contentDescription = "Loading insights" },
+            contentAlignment = Alignment.Center,
+        ) {
+            CircularProgressIndicator(
+                modifier = Modifier.semantics { contentDescription = "Loading indicator" },
+            )
+        }
+        return
+    }
+
+    InsightsContent(state = state, modifier = modifier)
+}
+
+@Composable
+internal fun InsightsContent(
+    state: InsightsUiState,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        // Health score hero card
+        item(key = "health-score") {
+            HealthScoreCard(
+                score = state.healthScore,
+                assessment = state.healthAssessment,
+            )
+        }
+
+        // Income vs expense summary
+        state.incomeExpense?.let { summary ->
+            item(key = "income-expense") {
+                IncomeExpenseCard(summary = summary)
+            }
+        }
+
+        // Spending breakdown header
+        if (state.categoryBreakdown.isNotEmpty()) {
+            item(key = "breakdown-header") {
+                Text(
+                    text = "Spending Breakdown",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.semantics {
+                        heading()
+                        contentDescription = "Spending Breakdown section"
+                    },
+                )
+            }
+
+            // Donut chart
+            item(key = "donut-chart") {
+                SpendingDonutChart(categories = state.categoryBreakdown)
+            }
+
+            // Category list
+            items(state.categoryBreakdown, key = { it.name }) { category ->
+                CategoryBreakdownItem(category = category)
+            }
+        }
+
+        // Trends
+        if (state.categoryTrends.isNotEmpty()) {
+            item(key = "trends-header") {
+                Text(
+                    text = "Spending Trends",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.semantics {
+                        heading()
+                        contentDescription = "Spending Trends section"
+                    },
+                )
+            }
+
+            items(state.categoryTrends, key = { it.name }) { trend ->
+                TrendItem(trend = trend)
+            }
+        }
+
+        // Health components
+        if (state.healthComponents.isNotEmpty()) {
+            item(key = "health-header") {
+                Text(
+                    text = "Health Score Breakdown",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.semantics {
+                        heading()
+                        contentDescription = "Health Score Breakdown section"
+                    },
+                )
+            }
+
+            items(state.healthComponents, key = { it.name }) { component ->
+                HealthComponentItem(component = component)
+            }
+        }
+
+        // Recommendations
+        if (state.recommendations.isNotEmpty()) {
+            item(key = "recs-header") {
+                Text(
+                    text = "Recommendations",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.semantics {
+                        heading()
+                        contentDescription = "Recommendations section"
+                    },
+                )
+            }
+
+            items(state.recommendations) { rec ->
+                RecommendationItem(text = rec)
+            }
+        }
+
+        item(key = "spacer") { Spacer(Modifier.height(80.dp)) }
+    }
+}
+
+// ── Health Score Card ────────────────────────────────────────────────
+
+@Composable
+private fun HealthScoreCard(score: Int, assessment: HealthAssessment) {
+    val scoreColor = when (assessment) {
+        HealthAssessment.EXCELLENT -> Color(0xFF2E7D32)
+        HealthAssessment.GOOD -> Color(0xFF4CAF50)
+        HealthAssessment.FAIR -> Color(0xFFFF9800)
+        HealthAssessment.NEEDS_ATTENTION -> Color(0xFFFF5722)
+        HealthAssessment.CRITICAL -> Color(0xFFC62828)
+    }
+    val assessmentLabel = when (assessment) {
+        HealthAssessment.EXCELLENT -> "Excellent"
+        HealthAssessment.GOOD -> "Good"
+        HealthAssessment.FAIR -> "Fair"
+        HealthAssessment.NEEDS_ATTENTION -> "Needs Attention"
+        HealthAssessment.CRITICAL -> "Critical"
+    }
+    val animatedProgress by animateFloatAsState(
+        targetValue = score / 100f,
+        animationSpec = tween(1000),
+        label = "health-score",
+    )
+
+    ElevatedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics {
+                contentDescription = "Financial health score: $score out of 100, $assessmentLabel"
+            },
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+        ),
+    ) {
+        Column(
+            Modifier.padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = "Financial Health",
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+            Spacer(Modifier.height(16.dp))
+            Box(Modifier.size(120.dp), contentAlignment = Alignment.Center) {
+                val trackColor = MaterialTheme.colorScheme.surfaceVariant
+                Canvas(Modifier.size(120.dp)) {
+                    val sw = 10.dp.toPx()
+                    val arcSize = Size(size.width - sw, size.height - sw)
+                    val topLeft = Offset(sw / 2, sw / 2)
+                    drawArc(trackColor, -90f, 360f, false, topLeft, arcSize, style = Stroke(sw, cap = StrokeCap.Round))
+                    drawArc(scoreColor, -90f, animatedProgress * 360f, false, topLeft, arcSize, style = Stroke(sw, cap = StrokeCap.Round))
+                }
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(
+                        text = "$score",
+                        style = MaterialTheme.typography.headlineLarge,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                    )
+                    Text(
+                        text = assessmentLabel,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = scoreColor,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
+            }
+        }
+    }
+}
+
+// ── Income vs Expense Card ───────────────────────────────────────────
+
+@Composable
+private fun IncomeExpenseCard(summary: IncomeExpenseUi) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics {
+                contentDescription = "Income: ${summary.incomeFormatted}. " +
+                    "Expenses: ${summary.expenseFormatted}. " +
+                    "Net: ${summary.netCashFlowFormatted}. " +
+                    "Savings rate: ${summary.savingsRateFormatted}."
+            },
+    ) {
+        Column(Modifier.padding(16.dp)) {
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                IncomeExpenseColumn(label = "Income", amount = summary.incomeFormatted, color = Color(0xFF2E7D32))
+                IncomeExpenseColumn(label = "Expenses", amount = summary.expenseFormatted, color = MaterialTheme.colorScheme.error)
+                IncomeExpenseColumn(
+                    label = "Net",
+                    amount = summary.netCashFlowFormatted,
+                    color = if (summary.isPositiveCashFlow) Color(0xFF2E7D32) else MaterialTheme.colorScheme.error,
+                )
+            }
+            Spacer(Modifier.height(12.dp))
+            Row(
+                Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    Icons.Filled.Favorite,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(16.dp),
+                )
+                Spacer(Modifier.width(4.dp))
+                Text(
+                    text = "Savings Rate: ${summary.savingsRateFormatted}",
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun IncomeExpenseColumn(label: String, amount: String, color: Color) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text(amount, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold, color = color)
+    }
+}
+
+// ── Spending Donut Chart ─────────────────────────────────────────────
+
+@Composable
+private fun SpendingDonutChart(categories: List<CategorySpendingUi>) {
+    Box(
+        Modifier
+            .fillMaxWidth()
+            .height(180.dp)
+            .semantics {
+                contentDescription = "Spending breakdown chart with ${categories.size} categories"
+            },
+        contentAlignment = Alignment.Center,
+    ) {
+        Canvas(Modifier.size(160.dp)) {
+            val sw = 24.dp.toPx()
+            val arcSize = Size(size.width - sw, size.height - sw)
+            val topLeft = Offset(sw / 2, sw / 2)
+            var startAngle = -90f
+
+            categories.forEach { cat ->
+                val sweep = (cat.percentage / 100.0 * 360.0).toFloat()
+                val color = chartColors[cat.colorIndex % chartColors.size]
+                drawArc(color, startAngle, sweep, false, topLeft, arcSize, style = Stroke(sw, cap = StrokeCap.Butt))
+                startAngle += sweep
+            }
+        }
+    }
+}
+
+// ── Category Breakdown Item ──────────────────────────────────────────
+
+@Composable
+private fun CategoryBreakdownItem(category: CategorySpendingUi) {
+    val changeText = category.changePercent?.let { pct ->
+        val sign = if (pct > 0) "+" else ""
+        "$sign${pct.toInt()}% vs last month"
+    } ?: "New this month"
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics {
+                contentDescription = "${category.name}: ${category.amountFormatted}, " +
+                    "${category.percentage.toInt()}% of total. $changeText"
+            },
+    ) {
+        Row(
+            Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // Color dot
+            Canvas(Modifier.size(12.dp)) {
+                drawCircle(chartColors[category.colorIndex % chartColors.size])
+            }
+            Spacer(Modifier.width(12.dp))
+            Column(Modifier.weight(1f)) {
+                Text(category.name, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium)
+                Text(changeText, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            Column(horizontalAlignment = Alignment.End) {
+                Text(category.amountFormatted, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.SemiBold)
+                Text("${category.percentage.toInt()}%", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+        }
+    }
+}
+
+// ── Trend Item ───────────────────────────────────────────────────────
+
+@Composable
+private fun TrendItem(trend: CategoryTrendUi) {
+    val (icon, trendLabel, trendColor) = when (trend.direction) {
+        TrendDirection.INCREASING -> Triple(Icons.Filled.TrendingUp, "Increasing", MaterialTheme.colorScheme.error)
+        TrendDirection.DECREASING -> Triple(Icons.Filled.TrendingDown, "Decreasing", Color(0xFF2E7D32))
+        TrendDirection.STABLE -> Triple(Icons.Filled.Remove, "Stable", MaterialTheme.colorScheme.onSurfaceVariant)
+    }
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics {
+                contentDescription = "${trend.name}: $trendLabel. Average ${trend.averageFormatted} per month."
+            },
+    ) {
+        Row(
+            Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(icon, contentDescription = null, tint = trendColor, modifier = Modifier.size(20.dp))
+            Spacer(Modifier.width(12.dp))
+            Column(Modifier.weight(1f)) {
+                Text(trend.name, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium)
+                Text(trendLabel, style = MaterialTheme.typography.labelSmall, color = trendColor)
+            }
+            Text(
+                text = "${trend.averageFormatted}/mo",
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+        }
+    }
+}
+
+// ── Health Component Item ────────────────────────────────────────────
+
+@Composable
+private fun HealthComponentItem(component: HealthComponentUi) {
+    val progressColor = when {
+        component.score >= 70 -> Color(0xFF2E7D32)
+        component.score >= 40 -> Color(0xFFFF9800)
+        else -> MaterialTheme.colorScheme.error
+    }
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics {
+                contentDescription = "${component.name}: score ${component.score} out of 100. ${component.explanation}"
+            },
+    ) {
+        Column(Modifier.padding(12.dp)) {
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Text(component.name, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium)
+                Text("${component.score}/100", style = MaterialTheme.typography.labelMedium, color = progressColor, fontWeight = FontWeight.SemiBold)
+            }
+            Spacer(Modifier.height(8.dp))
+            LinearProgressIndicator(
+                progress = { component.score / 100f },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(6.dp)
+                    .clip(RoundedCornerShape(3.dp)),
+                color = progressColor,
+                trackColor = MaterialTheme.colorScheme.surfaceVariant,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = component.explanation,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+// ── Recommendation Item ──────────────────────────────────────────────
+
+@Composable
+private fun RecommendationItem(text: String) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics { contentDescription = "Recommendation: $text" },
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+        ),
+    ) {
+        Row(Modifier.padding(12.dp), verticalAlignment = Alignment.Top) {
+            Icon(
+                Icons.Filled.ArrowUpward,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onTertiaryContainer,
+                modifier = Modifier.size(18.dp),
+            )
+            Spacer(Modifier.width(8.dp))
+            Text(
+                text = text,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onTertiaryContainer,
+            )
+        }
+    }
+}
+
+// ── Previews ─────────────────────────────────────────────────────────
+
+@Preview(showBackground = true, showSystemUi = true, name = "Insights - Light")
+@Preview(
+    showBackground = true,
+    showSystemUi = true,
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+    name = "Insights - Dark",
+)
+@Composable
+private fun InsightsScreenPreview() {
+    FinanceTheme(dynamicColor = false) {
+        InsightsContent(
+            state = InsightsUiState(
+                isLoading = false,
+                healthScore = 72,
+                healthAssessment = HealthAssessment.GOOD,
+                incomeExpense = IncomeExpenseUi(
+                    incomeFormatted = "$5,200.00",
+                    expenseFormatted = "$3,800.00",
+                    netCashFlowFormatted = "+$1,400.00",
+                    savingsRateFormatted = "27%",
+                    isPositiveCashFlow = true,
+                ),
+                categoryBreakdown = listOf(
+                    CategorySpendingUi("Groceries", "$680", 24.0, 1, -5.0, "$715", 0),
+                    CategorySpendingUi("Dining", "$420", 15.0, 2, 12.0, "$375", 1),
+                    CategorySpendingUi("Transport", "$280", 10.0, 3, null, "$0", 2),
+                ),
+                categoryTrends = listOf(
+                    CategoryTrendUi("Groceries", TrendDirection.DECREASING, "$700", -5.0),
+                    CategoryTrendUi("Dining", TrendDirection.INCREASING, "$390", 12.0),
+                    CategoryTrendUi("Transport", TrendDirection.STABLE, "$275", 2.0),
+                ),
+                healthComponents = listOf(
+                    HealthComponentUi("Savings Rate", 80, "Excellent savings rate of 27%"),
+                    HealthComponentUi("Budget Adherence", 75, "3 of 4 budgets within limit"),
+                    HealthComponentUi("Debt Ratio", 65, "Healthy debt level (28% ratio)"),
+                ),
+                recommendations = listOf(
+                    "Your dining spending is trending up — consider setting a tighter budget",
+                ),
+            ),
+        )
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/insights/InsightsViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/insights/InsightsViewModel.kt
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.insights
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.finance.android.auth.HouseholdIdProvider
+import com.finance.android.data.repository.AccountRepository
+import com.finance.android.data.repository.BudgetRepository
+import com.finance.android.data.repository.CategoryRepository
+import com.finance.android.data.repository.TransactionRepository
+import com.finance.core.currency.CurrencyFormatter
+import com.finance.core.insights.CategoryAnalysis
+import com.finance.core.insights.CategoryTrend
+import com.finance.core.insights.FinancialHealthScore
+import com.finance.core.insights.HealthAssessment
+import com.finance.core.insights.IncomeExpenseSummary
+import com.finance.core.insights.InsightsEngine
+import com.finance.core.insights.TrendDirection
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+/**
+ * UI model for a single category in the spending breakdown.
+ */
+data class CategorySpendingUi(
+    val name: String,
+    val amountFormatted: String,
+    val percentage: Double,
+    val rank: Int,
+    val changePercent: Double?,
+    val priorAmountFormatted: String,
+    val colorIndex: Int,
+)
+
+/**
+ * UI model for a category trend.
+ */
+data class CategoryTrendUi(
+    val name: String,
+    val direction: TrendDirection,
+    val averageFormatted: String,
+    val changePercent: Double?,
+)
+
+/**
+ * UI model for the income vs expense summary.
+ */
+data class IncomeExpenseUi(
+    val incomeFormatted: String,
+    val expenseFormatted: String,
+    val netCashFlowFormatted: String,
+    val savingsRateFormatted: String,
+    val isPositiveCashFlow: Boolean,
+)
+
+/**
+ * UI model for a health score component.
+ */
+data class HealthComponentUi(
+    val name: String,
+    val score: Int,
+    val explanation: String,
+)
+
+/**
+ * Complete UI state for the Financial Insights Dashboard (#241).
+ */
+data class InsightsUiState(
+    val isLoading: Boolean = true,
+    val categoryBreakdown: List<CategorySpendingUi> = emptyList(),
+    val categoryTrends: List<CategoryTrendUi> = emptyList(),
+    val incomeExpense: IncomeExpenseUi? = null,
+    val healthScore: Int = 0,
+    val healthAssessment: HealthAssessment = HealthAssessment.FAIR,
+    val healthComponents: List<HealthComponentUi> = emptyList(),
+    val recommendations: List<String> = emptyList(),
+    val currency: Currency = Currency.USD,
+)
+
+/**
+ * ViewModel for the Financial Insights Dashboard (#241).
+ *
+ * Delegates to KMP [InsightsEngine] for all analytics computations.
+ *
+ * @param householdIdProvider Provides the authenticated household ID.
+ * @param transactionRepository Source for transaction data.
+ * @param accountRepository Source for account data.
+ * @param budgetRepository Source for budget data.
+ * @param categoryRepository Source for category metadata.
+ */
+class InsightsViewModel(
+    private val householdIdProvider: HouseholdIdProvider,
+    private val transactionRepository: TransactionRepository,
+    private val accountRepository: AccountRepository,
+    private val budgetRepository: BudgetRepository,
+    private val categoryRepository: CategoryRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(InsightsUiState())
+    val uiState: StateFlow<InsightsUiState> = _uiState.asStateFlow()
+
+    init {
+        loadInsights()
+    }
+
+    fun refresh() {
+        loadInsights()
+    }
+
+    private fun loadInsights() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+
+            val householdId = householdIdProvider.householdId.value ?: run {
+                Timber.w("No household ID available — skipping insights load")
+                _uiState.update { it.copy(isLoading = false) }
+                return@launch
+            }
+
+            try {
+                val transactions = transactionRepository.observeAll(householdId).first()
+                val accounts = accountRepository.observeAll(householdId).first()
+                val budgets = budgetRepository.observeAll(householdId).first()
+                val categories = categoryRepository.observeAll(householdId).first()
+                val categoryMap = categories.associateBy { it.id }
+                val currency = Currency.USD
+
+                // Category analysis
+                val analysis = InsightsEngine.categoryAnalysis(transactions)
+                val categoryBreakdown = analysis.mapIndexed { index, cat ->
+                    val name = categoryMap[cat.categoryId]?.name ?: "Unknown"
+                    CategorySpendingUi(
+                        name = name,
+                        amountFormatted = CurrencyFormatter.format(cat.totalSpent, currency),
+                        percentage = cat.percentOfTotal,
+                        rank = cat.rank,
+                        changePercent = cat.changePercent,
+                        priorAmountFormatted = CurrencyFormatter.format(cat.priorPeriodAmount, currency),
+                        colorIndex = index,
+                    )
+                }
+
+                // Category trends
+                val trends = InsightsEngine.categoryTrends(transactions)
+                val categoryTrends = trends.take(5).map { trend ->
+                    val name = categoryMap[trend.categoryId]?.name ?: "Unknown"
+                    CategoryTrendUi(
+                        name = name,
+                        direction = trend.direction,
+                        averageFormatted = CurrencyFormatter.format(trend.averageMonthly, currency),
+                        changePercent = trend.overallChangePercent,
+                    )
+                }
+
+                // Income vs expense
+                val summary = InsightsEngine.incomeExpenseSummary(transactions)
+                val incomeExpense = IncomeExpenseUi(
+                    incomeFormatted = CurrencyFormatter.format(summary.totalIncome, currency),
+                    expenseFormatted = CurrencyFormatter.format(summary.totalExpenses, currency),
+                    netCashFlowFormatted = CurrencyFormatter.format(summary.netCashFlow, currency, showSign = true),
+                    savingsRateFormatted = "${summary.savingsRate.toInt()}%",
+                    isPositiveCashFlow = summary.netCashFlow.isPositive(),
+                )
+
+                // Health score
+                val healthScore = InsightsEngine.calculateHealthScore(transactions, accounts, budgets)
+                val healthComponents = healthScore.components.map { component ->
+                    HealthComponentUi(
+                        name = component.name,
+                        score = component.score,
+                        explanation = component.explanation,
+                    )
+                }
+
+                // Recommendations from health components with low scores
+                val recommendations = healthScore.components
+                    .filter { it.score < 50 }
+                    .map { it.explanation }
+
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        categoryBreakdown = categoryBreakdown,
+                        categoryTrends = categoryTrends,
+                        incomeExpense = incomeExpense,
+                        healthScore = healthScore.overallScore,
+                        healthAssessment = healthScore.assessment,
+                        healthComponents = healthComponents,
+                        recommendations = recommendations,
+                        currency = currency,
+                    )
+                }
+
+                Timber.d(
+                    "Insights loaded: categories=%d, trends=%d, healthScore=%d",
+                    categoryBreakdown.size,
+                    categoryTrends.size,
+                    healthScore.overallScore,
+                )
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to load financial insights")
+                _uiState.update { it.copy(isLoading = false) }
+            }
+        }
+    }
+}

--- a/apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceNavHost.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceNavHost.kt
@@ -44,6 +44,7 @@ import com.finance.android.ui.education.FinancialGlossaryScreen
 import com.finance.android.ui.expertise.ExpertiseTierScreen
 import com.finance.android.ui.learning.LearningPathsScreen
 import com.finance.android.ui.nlp.NlpTransactionScreen
+import com.finance.android.ui.insights.InsightsScreen
 import timber.log.Timber
 
 /** Base URI for all deep link patterns declared in AndroidManifest.xml. */
@@ -123,6 +124,9 @@ sealed class Route(val route: String) {
 
     /** Analytics / Spending Trends screen. */
     data object Analytics : Route("analytics")
+
+    /** Financial Insights Dashboard screen (#241). */
+    data object Insights : Route("insights")
 
     /** "Can I Afford This?" affordability check screen (#377). */
     data object Affordability : Route("affordability")
@@ -288,6 +292,10 @@ fun FinanceNavHost(
 
         composable(Route.Analytics.route) {
             AnalyticsScreen()
+        }
+
+        composable(Route.Insights.route) {
+            InsightsScreen()
         }
 
         composable(Route.Affordability.route) {

--- a/apps/android/src/test/kotlin/com/finance/android/ui/insights/InsightsUiStateTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/ui/insights/InsightsUiStateTest.kt
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.android.ui.insights
+
+import com.finance.core.insights.HealthAssessment
+import com.finance.core.insights.TrendDirection
+import com.finance.models.types.Currency
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [InsightsUiState] and related UI models.
+ */
+class InsightsUiStateTest {
+
+    @Test
+    fun `default state is loading`() {
+        val state = InsightsUiState()
+        assertTrue(state.isLoading)
+        assertTrue(state.categoryBreakdown.isEmpty())
+        assertTrue(state.categoryTrends.isEmpty())
+        assertNull(state.incomeExpense)
+        assertEquals(0, state.healthScore)
+        assertEquals(HealthAssessment.FAIR, state.healthAssessment)
+    }
+
+    @Test
+    fun `CategorySpendingUi preserves percentage`() {
+        val category = CategorySpendingUi(
+            name = "Groceries",
+            amountFormatted = "$500",
+            percentage = 25.0,
+            rank = 1,
+            changePercent = -5.0,
+            priorAmountFormatted = "$525",
+            colorIndex = 0,
+        )
+        assertEquals(25.0, category.percentage, 0.01)
+        assertEquals(1, category.rank)
+    }
+
+    @Test
+    fun `IncomeExpenseUi tracks positive cash flow`() {
+        val positive = IncomeExpenseUi(
+            incomeFormatted = "$5000",
+            expenseFormatted = "$3000",
+            netCashFlowFormatted = "+$2000",
+            savingsRateFormatted = "40%",
+            isPositiveCashFlow = true,
+        )
+        assertTrue(positive.isPositiveCashFlow)
+
+        val negative = positive.copy(isPositiveCashFlow = false)
+        assertTrue(!negative.isPositiveCashFlow)
+    }
+
+    @Test
+    fun `CategoryTrendUi captures direction`() {
+        val trend = CategoryTrendUi(
+            name = "Dining",
+            direction = TrendDirection.INCREASING,
+            averageFormatted = "$400",
+            changePercent = 15.0,
+        )
+        assertEquals(TrendDirection.INCREASING, trend.direction)
+    }
+
+    @Test
+    fun `HealthComponentUi stores score`() {
+        val component = HealthComponentUi(
+            name = "Savings Rate",
+            score = 80,
+            explanation = "Excellent savings",
+        )
+        assertEquals(80, component.score)
+    }
+
+    @Test
+    fun `loaded state carries correct currency`() {
+        val state = InsightsUiState(
+            isLoading = false,
+            currency = Currency.USD,
+        )
+        assertEquals(Currency.USD, state.currency)
+    }
+}


### PR DESCRIPTION
## Summary
Insights screen with spending category breakdown, month-over-month trends, savings rate, financial health score, and actionable recommendations.

## Changes
- **InsightsViewModel**: loads data, delegates to KMP InsightsEngine
- **InsightsScreen**: health score hero card, income/expense card, donut chart, category breakdown, trend list, health components, recommendations
- Material 3 cards with animated health score ring
- Chart color palette for category breakdown visualization
- Full TalkBack accessibility on all cards and sections
- Navigation: Route.Insights added to FinanceNavHost
- Koin wiring in AppModule

## Testing
- Unit tests for InsightsUiState and UI models
- Compose Preview annotations

Closes #1064