### PR TITLE
feat(windows): enhance NLP transaction input with inline preview, per-field confidence, quick-fix UI, merchant chips, locale-aware parsing, and recent history (#1143)

### DIFF
--- a/apps/windows/src/main/kotlin/com/finance/desktop/di/ViewModelModule.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/di/ViewModelModule.kt
@@ -39,4 +39,5 @@ val viewModelModule = module {
     single { TipsViewModel(get(), get(), get()) }
     single { GamificationViewModel(get(), get()) }
     single { CurrencyViewModel(get(), get()) }
+    single { NaturalLanguageViewModel(get(), get()) }
 }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/NaturalLanguageScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/NaturalLanguageScreen.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -22,6 +24,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AutoAwesome
@@ -29,11 +32,16 @@ import androidx.compose.material.icons.filled.CalendarToday
 import androidx.compose.material.icons.filled.Category
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Error
+import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Payment
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Send
 import androidx.compose.material.icons.filled.Store
+import androidx.compose.material.icons.filled.SwapVert
+import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -44,14 +52,17 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -61,17 +72,21 @@ import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.finance.desktop.di.koinGet
 import com.finance.desktop.theme.FinanceDesktopTheme
+import com.finance.desktop.viewmodel.EditingField
+import com.finance.desktop.viewmodel.FieldConfidence
 import com.finance.desktop.viewmodel.NaturalLanguageUiState
 import com.finance.desktop.viewmodel.NaturalLanguageViewModel
 import com.finance.desktop.viewmodel.NlSuggestion
 import com.finance.desktop.viewmodel.ParsedTransaction
+import com.finance.desktop.viewmodel.RecentNlpInput
 import com.finance.models.TransactionType
 
 // =============================================================================
-// Natural Language Input Screen — Sprint 21 (#237)
+// Natural Language Input Screen — Sprint 21 (#237) + Enhancement (#1143)
 // =============================================================================
 
 /**
@@ -79,130 +94,238 @@ import com.finance.models.TransactionType
  *
  * A smart text field that parses free-form input like
  * "Spent $42.50 at Whole Foods on groceries yesterday" into structured
- * transaction data. Shows a live parsing preview, autocomplete suggestions,
- * and a confidence indicator.
+ * transaction data. Features:
+ * - Inline parsing preview with per-field confidence indicators
+ * - Merchant suggestion chips from transaction history
+ * - Multi-language / locale-aware amount and date parsing
+ * - Quick-fix UI — click any parsed field to correct it
+ * - Recent NLP inputs history for quick reuse
  *
- * Narrator reads input field, parsed fields, suggestions, and confidence.
+ * Narrator reads input field, parsed fields, suggestions, confidence, and
+ * quick-fix editing state. All interactive elements have contentDescription.
  */
 @Composable
 fun NaturalLanguageScreen(modifier: Modifier = Modifier) {
     val viewModel = koinGet<NaturalLanguageViewModel>()
     val state by viewModel.uiState.collectAsState()
 
-    Column(
+    LazyColumn(
         modifier = modifier
             .fillMaxSize()
             .padding(FinanceDesktopTheme.spacing.xxl)
             .semantics { contentDescription = "Natural Language Input screen" },
+        verticalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.lg),
     ) {
         // Header
-        Text(
-            text = "Quick Add Transaction",
-            style = MaterialTheme.typography.titleLarge,
-            fontWeight = FontWeight.SemiBold,
-            modifier = Modifier.semantics {
-                heading()
-                contentDescription = "Quick Add Transaction heading"
-            },
-        )
-        Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
-        Text(
-            text = "Describe a transaction in plain English",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        Spacer(Modifier.height(FinanceDesktopTheme.spacing.xxl))
+        item {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column {
+                    Text(
+                        text = "Quick Add Transaction",
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.semantics {
+                            heading()
+                            contentDescription = "Quick Add Transaction heading"
+                        },
+                    )
+                    Spacer(Modifier.height(FinanceDesktopTheme.spacing.xs))
+                    Text(
+                        text = "Describe a transaction in plain English (or your language)",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                // Recent history toggle
+                if (state.recentInputs.isNotEmpty()) {
+                    IconButton(
+                        onClick = { viewModel.toggleRecentInputs() },
+                        modifier = Modifier.semantics {
+                            contentDescription = if (state.showRecentInputs) "Hide recent inputs"
+                            else "Show recent inputs history"
+                            role = Role.Button
+                        },
+                    ) {
+                        Icon(
+                            Icons.Filled.History,
+                            contentDescription = null,
+                            tint = if (state.showRecentInputs) MaterialTheme.colorScheme.primary
+                            else MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+        }
 
         // Input field with suggestions
-        NlInputField(
-            text = state.inputText,
-            onTextChange = viewModel::updateInput,
-            onClear = viewModel::clearInput,
-            suggestions = state.suggestions,
-            showSuggestions = state.showSuggestions,
-            onSuggestionClick = viewModel::applySuggestion,
-            onDismissSuggestions = viewModel::dismissSuggestions,
-        )
-
-        Spacer(Modifier.height(FinanceDesktopTheme.spacing.xxl))
-
-        // Status messages
-        AnimatedVisibility(
-            visible = state.successMessage != null,
-            enter = fadeIn() + slideInVertically(),
-            exit = fadeOut() + slideOutVertically(),
-        ) {
-            Surface(
-                shape = RoundedCornerShape(8.dp),
-                color = Color(0xFF2E7D32).copy(alpha = 0.12f),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .semantics { contentDescription = state.successMessage ?: "" },
-            ) {
-                Row(
-                    modifier = Modifier.padding(FinanceDesktopTheme.spacing.lg),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Icon(
-                        Icons.Filled.Check,
-                        contentDescription = null,
-                        tint = Color(0xFF2E7D32),
-                    )
-                    Spacer(Modifier.width(FinanceDesktopTheme.spacing.md))
-                    Text(
-                        text = state.successMessage ?: "",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = Color(0xFF2E7D32),
-                    )
-                }
-            }
-        }
-
-        AnimatedVisibility(
-            visible = state.errorMessage != null,
-            enter = fadeIn() + slideInVertically(),
-            exit = fadeOut() + slideOutVertically(),
-        ) {
-            Surface(
-                shape = RoundedCornerShape(8.dp),
-                color = MaterialTheme.colorScheme.errorContainer,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .semantics { contentDescription = state.errorMessage ?: "" },
-            ) {
-                Row(
-                    modifier = Modifier.padding(FinanceDesktopTheme.spacing.lg),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Icon(
-                        Icons.Filled.Error,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.error,
-                    )
-                    Spacer(Modifier.width(FinanceDesktopTheme.spacing.md))
-                    Text(
-                        text = state.errorMessage ?: "",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onErrorContainer,
-                    )
-                }
-            }
-        }
-
-        // Parsed preview
-        state.parsedTransaction?.let { parsed ->
-            Spacer(Modifier.height(FinanceDesktopTheme.spacing.xxl))
-            ParsedPreviewCard(
-                parsed = parsed,
-                isProcessing = state.isProcessing,
-                onConfirm = viewModel::createTransaction,
+        item {
+            NlInputField(
+                text = state.inputText,
+                onTextChange = viewModel::updateInput,
+                onClear = viewModel::clearInput,
+                suggestions = state.suggestions,
+                showSuggestions = state.showSuggestions,
+                onSuggestionClick = viewModel::applySuggestion,
+                onDismissSuggestions = viewModel::dismissSuggestions,
             )
         }
 
-        Spacer(Modifier.height(FinanceDesktopTheme.spacing.xxl))
+        // Merchant suggestion chips
+        if (state.inputText.isNotBlank() && state.recentPayees.isNotEmpty()) {
+            item {
+                MerchantSuggestionChips(
+                    payees = state.recentPayees.take(6),
+                    onChipClick = { payee ->
+                        val text = state.inputText
+                        val updated = if (text.contains("at ", ignoreCase = true)) text
+                        else "$text at $payee"
+                        viewModel.updateInput(updated)
+                    },
+                )
+            }
+        }
+
+        // Status messages
+        item {
+            AnimatedVisibility(
+                visible = state.successMessage != null,
+                enter = fadeIn() + slideInVertically(),
+                exit = fadeOut() + slideOutVertically(),
+            ) {
+                Surface(
+                    shape = RoundedCornerShape(8.dp),
+                    color = Color(0xFF2E7D32).copy(alpha = 0.12f),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .semantics { contentDescription = state.successMessage ?: "" },
+                ) {
+                    Row(
+                        modifier = Modifier.padding(FinanceDesktopTheme.spacing.lg),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(Icons.Filled.Check, contentDescription = null, tint = Color(0xFF2E7D32))
+                        Spacer(Modifier.width(FinanceDesktopTheme.spacing.md))
+                        Text(
+                            text = state.successMessage ?: "",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = Color(0xFF2E7D32),
+                        )
+                    }
+                }
+            }
+
+            AnimatedVisibility(
+                visible = state.errorMessage != null,
+                enter = fadeIn() + slideInVertically(),
+                exit = fadeOut() + slideOutVertically(),
+            ) {
+                Surface(
+                    shape = RoundedCornerShape(8.dp),
+                    color = MaterialTheme.colorScheme.errorContainer,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .semantics { contentDescription = state.errorMessage ?: "" },
+                ) {
+                    Row(
+                        modifier = Modifier.padding(FinanceDesktopTheme.spacing.lg),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            Icons.Filled.Error,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.error,
+                        )
+                        Spacer(Modifier.width(FinanceDesktopTheme.spacing.md))
+                        Text(
+                            text = state.errorMessage ?: "",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onErrorContainer,
+                        )
+                    }
+                }
+            }
+        }
+
+        // Parsed preview with per-field confidence and quick-fix
+        state.parsedTransaction?.let { parsed ->
+            item {
+                ParsedPreviewCard(
+                    parsed = parsed,
+                    isProcessing = state.isProcessing,
+                    editingField = state.editingField,
+                    editFieldValue = state.editFieldValue,
+                    onConfirm = viewModel::createTransaction,
+                    onFieldClick = viewModel::startEditingField,
+                    onEditValueChange = viewModel::updateEditFieldValue,
+                    onEditConfirm = viewModel::confirmFieldEdit,
+                    onEditCancel = viewModel::cancelFieldEdit,
+                )
+            }
+        }
+
+        // Recent NLP inputs history
+        if (state.showRecentInputs && state.recentInputs.isNotEmpty()) {
+            item {
+                RecentInputsPanel(
+                    recentInputs = state.recentInputs,
+                    onReuse = viewModel::reuseRecentInput,
+                )
+            }
+        }
 
         // Hint examples
-        ExampleHints()
+        item {
+            ExampleHints()
+        }
+    }
+}
+
+// ─── Merchant suggestion chips ───────────────────────────────────────────────
+
+/**
+ * Row of suggestion chips showing recent merchants for quick auto-complete.
+ * Narrator reads each chip as "Suggest merchant: {name}".
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun MerchantSuggestionChips(
+    payees: List<String>,
+    onChipClick: (String) -> Unit,
+) {
+    Column {
+        Text(
+            text = "Suggested Merchants",
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.semantics { heading() },
+        )
+        Spacer(Modifier.height(FinanceDesktopTheme.spacing.xs))
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.sm),
+            verticalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.xs),
+        ) {
+            payees.forEach { payee ->
+                AssistChip(
+                    onClick = { onChipClick(payee) },
+                    label = { Text(payee) },
+                    leadingIcon = {
+                        Icon(
+                            Icons.Filled.Store,
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp),
+                        )
+                    },
+                    modifier = Modifier.semantics {
+                        contentDescription = "Suggest merchant: $payee"
+                        role = Role.Button
+                    },
+                )
+            }
+        }
     }
 }
 
@@ -310,13 +433,28 @@ private fun NlInputField(
     }
 }
 
-// ─── Parsed preview card ─────────────────────────────────────────────────────
+// ─── Parsed preview card with per-field confidence + quick-fix ───────────────
 
+/**
+ * Enhanced parsed preview card showing:
+ * - Overall confidence bar
+ * - Per-field confidence indicators (colored dots)
+ * - Click-to-edit (quick-fix) on any parsed field
+ * - Inline edit mode with confirm/cancel
+ *
+ * Narrator reads the full preview, per-field confidence, and edit state.
+ */
 @Composable
 private fun ParsedPreviewCard(
     parsed: ParsedTransaction,
     isProcessing: Boolean,
+    editingField: EditingField,
+    editFieldValue: String,
     onConfirm: () -> Unit,
+    onFieldClick: (EditingField) -> Unit,
+    onEditValueChange: (String) -> Unit,
+    onEditConfirm: () -> Unit,
+    onEditCancel: () -> Unit,
 ) {
     val confidenceColor = when {
         parsed.confidence >= 0.7f -> Color(0xFF2E7D32)
@@ -336,17 +474,18 @@ private fun ParsedPreviewCard(
             .semantics {
                 contentDescription = buildString {
                     append("Parsed transaction preview. ")
-                    append("Confidence: $pct percent. ")
+                    append("Overall confidence: $pct percent. ")
                     parsed.amount?.let { append("Amount: ${it.amount / 100.0}. ") }
                     parsed.payee?.let { append("Payee: $it. ") }
                     parsed.category?.let { append("Category: $it. ") }
                     parsed.date?.let { append("Date: $it. ") }
-                    append("Type: ${parsed.type.name}.")
+                    append("Type: ${parsed.type.name}. ")
+                    append("Click any field to correct it.")
                 }
             },
     ) {
         Column(modifier = Modifier.padding(FinanceDesktopTheme.spacing.xxl)) {
-            // Title + confidence
+            // Title + overall confidence
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,
@@ -378,43 +517,78 @@ private fun ParsedPreviewCard(
                 }
             }
 
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
+            Text(
+                text = "Click any field to correct it",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
             Spacer(Modifier.height(FinanceDesktopTheme.spacing.lg))
             HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
             Spacer(Modifier.height(FinanceDesktopTheme.spacing.lg))
 
-            // Parsed fields grid
+            // Parsed fields grid with per-field confidence and quick-fix
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.xxl),
             ) {
-                ParsedField(
+                EditableParsedField(
                     icon = Icons.Filled.Payment,
                     label = "Amount",
                     value = parsed.amount?.let {
                         "$${String.format("%.2f", it.amount / 100.0)}"
                     } ?: "—",
                     isPresent = parsed.amount != null,
+                    fieldConfidence = parsed.amountConfidence,
+                    isEditing = editingField == EditingField.AMOUNT,
+                    editValue = editFieldValue,
+                    onFieldClick = { onFieldClick(EditingField.AMOUNT) },
+                    onEditValueChange = onEditValueChange,
+                    onEditConfirm = onEditConfirm,
+                    onEditCancel = onEditCancel,
                     modifier = Modifier.weight(1f),
                 )
-                ParsedField(
+                EditableParsedField(
                     icon = Icons.Filled.Store,
                     label = "Payee",
                     value = parsed.payee ?: "—",
                     isPresent = parsed.payee != null,
+                    fieldConfidence = parsed.payeeConfidence,
+                    isEditing = editingField == EditingField.PAYEE,
+                    editValue = editFieldValue,
+                    onFieldClick = { onFieldClick(EditingField.PAYEE) },
+                    onEditValueChange = onEditValueChange,
+                    onEditConfirm = onEditConfirm,
+                    onEditCancel = onEditCancel,
                     modifier = Modifier.weight(1f),
                 )
-                ParsedField(
+                EditableParsedField(
                     icon = Icons.Filled.Category,
                     label = "Category",
                     value = parsed.category ?: "—",
                     isPresent = parsed.category != null,
+                    fieldConfidence = parsed.categoryConfidence,
+                    isEditing = editingField == EditingField.CATEGORY,
+                    editValue = editFieldValue,
+                    onFieldClick = { onFieldClick(EditingField.CATEGORY) },
+                    onEditValueChange = onEditValueChange,
+                    onEditConfirm = onEditConfirm,
+                    onEditCancel = onEditCancel,
                     modifier = Modifier.weight(1f),
                 )
-                ParsedField(
+                EditableParsedField(
                     icon = Icons.Filled.CalendarToday,
                     label = "Date",
                     value = parsed.date?.toString() ?: "Today",
                     isPresent = parsed.date != null,
+                    fieldConfidence = parsed.dateConfidence,
+                    isEditing = editingField == EditingField.DATE,
+                    editValue = editFieldValue,
+                    onFieldClick = { onFieldClick(EditingField.DATE) },
+                    onEditValueChange = onEditValueChange,
+                    onEditConfirm = onEditConfirm,
+                    onEditCancel = onEditCancel,
                     modifier = Modifier.weight(1f),
                 )
             }
@@ -427,25 +601,49 @@ private fun ParsedPreviewCard(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Surface(
-                    shape = RoundedCornerShape(12.dp),
-                    color = if (parsed.type == TransactionType.EXPENSE)
-                        MaterialTheme.colorScheme.errorContainer
-                    else Color(0xFF2E7D32).copy(alpha = 0.12f),
-                ) {
-                    Text(
-                        text = parsed.type.name.lowercase().replaceFirstChar { it.uppercase() },
-                        style = MaterialTheme.typography.labelLarge,
-                        fontWeight = FontWeight.SemiBold,
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Surface(
+                        shape = RoundedCornerShape(12.dp),
                         color = if (parsed.type == TransactionType.EXPENSE)
-                            MaterialTheme.colorScheme.onErrorContainer
-                        else Color(0xFF2E7D32),
-                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
-                    )
+                            MaterialTheme.colorScheme.errorContainer
+                        else Color(0xFF2E7D32).copy(alpha = 0.12f),
+                        modifier = Modifier.clickable { onFieldClick(EditingField.TYPE) }
+                            .semantics {
+                                contentDescription = "Transaction type: ${parsed.type.name}. Click to change."
+                                role = Role.Button
+                            },
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(
+                                text = parsed.type.name.lowercase()
+                                    .replaceFirstChar { it.uppercase() },
+                                style = MaterialTheme.typography.labelLarge,
+                                fontWeight = FontWeight.SemiBold,
+                                color = if (parsed.type == TransactionType.EXPENSE)
+                                    MaterialTheme.colorScheme.onErrorContainer
+                                else Color(0xFF2E7D32),
+                            )
+                            Spacer(Modifier.width(4.dp))
+                            Icon(
+                                Icons.Filled.SwapVert,
+                                contentDescription = null,
+                                modifier = Modifier.size(14.dp),
+                                tint = if (parsed.type == TransactionType.EXPENSE)
+                                    MaterialTheme.colorScheme.onErrorContainer
+                                else Color(0xFF2E7D32),
+                            )
+                        }
+                    }
+                    Spacer(Modifier.width(FinanceDesktopTheme.spacing.md))
+                    ConfidenceDot(parsed.typeConfidence)
                 }
                 Button(
                     onClick = onConfirm,
-                    enabled = parsed.amount != null && !isProcessing,
+                    enabled = parsed.amount != null && !isProcessing &&
+                        editingField == EditingField.NONE,
                     modifier = Modifier.semantics {
                         contentDescription = "Create transaction"
                         role = Role.Button
@@ -467,12 +665,28 @@ private fun ParsedPreviewCard(
     }
 }
 
+// ─── Editable parsed field with confidence dot ───────────────────────────────
+
+/**
+ * A parsed field that shows a confidence indicator dot and supports
+ * click-to-edit (quick-fix). When clicked, an inline text field appears
+ * for the user to correct the value.
+ *
+ * Narrator reads field label, value, confidence level, and edit state.
+ */
 @Composable
-private fun ParsedField(
+private fun EditableParsedField(
     icon: ImageVector,
     label: String,
     value: String,
     isPresent: Boolean,
+    fieldConfidence: FieldConfidence,
+    isEditing: Boolean,
+    editValue: String,
+    onFieldClick: () -> Unit,
+    onEditValueChange: (String) -> Unit,
+    onEditConfirm: () -> Unit,
+    onEditCancel: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val contentColor = if (isPresent)
@@ -480,11 +694,28 @@ private fun ParsedField(
     else
         MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
 
+    val confidenceText = when (fieldConfidence) {
+        FieldConfidence.HIGH -> "high confidence"
+        FieldConfidence.MEDIUM -> "medium confidence"
+        FieldConfidence.LOW -> "low confidence"
+        FieldConfidence.NONE -> "not detected"
+    }
+
     Column(
-        modifier = modifier.semantics {
-            contentDescription = "$label: $value"
-        },
+        modifier = modifier
+            .clip(RoundedCornerShape(8.dp))
+            .clickable(enabled = !isEditing) { onFieldClick() }
+            .background(
+                if (isEditing) MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+                else Color.Transparent,
+            )
+            .padding(FinanceDesktopTheme.spacing.sm)
+            .semantics {
+                contentDescription = "$label: $value, $confidenceText. Click to edit."
+                role = Role.Button
+            },
     ) {
+        // Label row with confidence dot
         Row(verticalAlignment = Alignment.CenterVertically) {
             Icon(
                 imageVector = icon,
@@ -498,14 +729,190 @@ private fun ParsedField(
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
+            Spacer(Modifier.width(FinanceDesktopTheme.spacing.xs))
+            ConfidenceDot(fieldConfidence)
         }
         Spacer(Modifier.height(FinanceDesktopTheme.spacing.xs))
-        Text(
-            text = value,
-            style = MaterialTheme.typography.bodyLarge,
-            fontWeight = if (isPresent) FontWeight.SemiBold else FontWeight.Normal,
-            color = contentColor,
-        )
+
+        if (isEditing) {
+            // Inline edit mode
+            OutlinedTextField(
+                value = editValue,
+                onValueChange = onEditValueChange,
+                singleLine = true,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics { contentDescription = "Edit $label value" },
+                textStyle = MaterialTheme.typography.bodyMedium,
+            )
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.xs))
+            Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                IconButton(
+                    onClick = onEditConfirm,
+                    modifier = Modifier
+                        .size(28.dp)
+                        .semantics {
+                            contentDescription = "Confirm $label edit"
+                            role = Role.Button
+                        },
+                ) {
+                    Icon(
+                        Icons.Filled.Check,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                        tint = Color(0xFF2E7D32),
+                    )
+                }
+                IconButton(
+                    onClick = onEditCancel,
+                    modifier = Modifier
+                        .size(28.dp)
+                        .semantics {
+                            contentDescription = "Cancel $label edit"
+                            role = Role.Button
+                        },
+                ) {
+                    Icon(
+                        Icons.Filled.Close,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                        tint = MaterialTheme.colorScheme.error,
+                    )
+                }
+            }
+        } else {
+            // Display mode with edit hint
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = value,
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = if (isPresent) FontWeight.SemiBold else FontWeight.Normal,
+                    color = contentColor,
+                    modifier = Modifier.weight(1f),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Icon(
+                    Icons.Filled.Edit,
+                    contentDescription = null,
+                    modifier = Modifier.size(12.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                )
+            }
+        }
+    }
+}
+
+// ─── Confidence dot indicator ────────────────────────────────────────────────
+
+/**
+ * Small colored dot indicating the confidence level of a parsed field.
+ * Green = high, yellow = medium, red = low, gray = not detected.
+ */
+@Composable
+private fun ConfidenceDot(confidence: FieldConfidence) {
+    val color = when (confidence) {
+        FieldConfidence.HIGH -> Color(0xFF2E7D32)
+        FieldConfidence.MEDIUM -> Color(0xFFF9A825)
+        FieldConfidence.LOW -> MaterialTheme.colorScheme.error
+        FieldConfidence.NONE -> MaterialTheme.colorScheme.outlineVariant
+    }
+    val label = when (confidence) {
+        FieldConfidence.HIGH -> "High confidence"
+        FieldConfidence.MEDIUM -> "Medium confidence"
+        FieldConfidence.LOW -> "Low confidence"
+        FieldConfidence.NONE -> "Not detected"
+    }
+    Box(
+        modifier = Modifier
+            .size(8.dp)
+            .clip(CircleShape)
+            .background(color)
+            .semantics { contentDescription = label },
+    )
+}
+
+// ─── Recent NLP inputs history panel ─────────────────────────────────────────
+
+/**
+ * Expandable panel showing recently submitted NLP inputs.
+ * The user can click any entry to reuse it in the input field.
+ *
+ * Narrator reads each entry as "Recent input: {text}, {amount}".
+ */
+@Composable
+private fun RecentInputsPanel(
+    recentInputs: List<RecentNlpInput>,
+    onReuse: (RecentNlpInput) -> Unit,
+) {
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(FinanceDesktopTheme.spacing.lg)) {
+            Text(
+                text = "Recent Inputs",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.semantics {
+                    heading()
+                    contentDescription = "Recent NLP inputs history"
+                },
+            )
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
+
+            recentInputs.forEachIndexed { index, input ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(8.dp))
+                        .clickable { onReuse(input) }
+                        .padding(
+                            horizontal = FinanceDesktopTheme.spacing.md,
+                            vertical = FinanceDesktopTheme.spacing.sm,
+                        )
+                        .semantics {
+                            contentDescription = "Recent input: ${input.rawInput}, ${input.amount}. Click to reuse."
+                            role = Role.Button
+                        },
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = input.rawInput,
+                            style = MaterialTheme.typography.bodyMedium,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        Row {
+                            input.payee?.let {
+                                Text(
+                                    text = it,
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.primary,
+                                )
+                                Spacer(Modifier.width(FinanceDesktopTheme.spacing.sm))
+                            }
+                            Text(
+                                text = input.amount,
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                    Icon(
+                        Icons.Filled.History,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                if (index < recentInputs.lastIndex) {
+                    HorizontalDivider(
+                        modifier = Modifier.padding(horizontal = FinanceDesktopTheme.spacing.md),
+                        color = MaterialTheme.colorScheme.outlineVariant,
+                    )
+                }
+            }
+        }
     }
 }
 
@@ -532,6 +939,8 @@ private fun ExampleHints() {
                 "Earned \$3,500 from salary",
                 "Coffee at Starbucks \$5.75",
                 "\$25 Amazon for books",
+                "Gasté €15,50 en café ayer",
+                "Payé 30€ à Carrefour pour courses",
             )
             examples.forEach { example ->
                 Text(

--- a/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/NaturalLanguageViewModel.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/NaturalLanguageViewModel.kt
@@ -15,12 +15,38 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.datetime.*
+import java.text.DecimalFormat
+import java.text.DecimalFormatSymbols
+import java.text.NumberFormat
+import java.util.Locale
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Natural Language Input ViewModel — Sprint 21 (#237)
+// Natural Language Input ViewModel — Sprint 21 (#237) + Enhancement (#1143)
 // ─────────────────────────────────────────────────────────────────────────────
 
-/** Parsed result from a natural language input string. */
+/** Confidence level for a single parsed field. */
+enum class FieldConfidence {
+    /** The field was parsed with high reliability (exact match or strong signal). */
+    HIGH,
+
+    /** The field was parsed but may need user review. */
+    MEDIUM,
+
+    /** The field was guessed from weak signals and likely needs correction. */
+    LOW,
+
+    /** The field was not detected in the input. */
+    NONE,
+}
+
+/** Per-field parse result with individual confidence. */
+data class ParsedField<T>(
+    val value: T?,
+    val confidence: FieldConfidence,
+    val source: String = "",
+)
+
+/** Parsed result from a natural language input string with per-field confidence. */
 data class ParsedTransaction(
     val amount: Cents?,
     val currency: Currency,
@@ -30,12 +56,28 @@ data class ParsedTransaction(
     val type: TransactionType,
     val confidence: Float,
     val rawInput: String,
+    val amountConfidence: FieldConfidence = FieldConfidence.NONE,
+    val payeeConfidence: FieldConfidence = FieldConfidence.NONE,
+    val categoryConfidence: FieldConfidence = FieldConfidence.NONE,
+    val dateConfidence: FieldConfidence = FieldConfidence.NONE,
+    val typeConfidence: FieldConfidence = FieldConfidence.NONE,
 )
 
 /** Autocomplete suggestion for the NL input field. */
 data class NlSuggestion(
     val text: String,
     val type: String, // "payee", "category", "amount"
+)
+
+/** The field currently being edited via the quick-fix UI. */
+enum class EditingField { AMOUNT, PAYEE, CATEGORY, DATE, TYPE, NONE }
+
+/** A recent NLP input that was successfully submitted. */
+data class RecentNlpInput(
+    val rawInput: String,
+    val payee: String?,
+    val amount: String,
+    val timestamp: Instant,
 )
 
 data class NaturalLanguageUiState(
@@ -48,14 +90,25 @@ data class NaturalLanguageUiState(
     val availableCategories: List<String> = emptyList(),
     val successMessage: String? = null,
     val errorMessage: String? = null,
+    val editingField: EditingField = EditingField.NONE,
+    val editFieldValue: String = "",
+    val recentInputs: List<RecentNlpInput> = emptyList(),
+    val showRecentInputs: Boolean = false,
+    val userLocale: Locale = Locale.getDefault(),
 )
 
 /**
  * ViewModel for the Natural Language Transaction Input feature.
  *
  * Parses free-text input like "Spent $42.50 at Whole Foods on groceries yesterday"
- * into structured transaction data. Provides autocomplete suggestions based on
- * known payees and categories. Transaction creation delegates to [TransactionRepository].
+ * into structured transaction data. Provides:
+ * - Inline parsing preview with per-field confidence indicators
+ * - Merchant suggestion chips from transaction history
+ * - Multi-language / locale-aware amount and date parsing
+ * - Quick-fix UI to correct misparsed fields inline
+ * - Recent NLP inputs history for quick reuse
+ *
+ * Transaction creation delegates to [TransactionRepository].
  */
 class NaturalLanguageViewModel(
     private val transactionRepository: TransactionRepository,
@@ -66,6 +119,9 @@ class NaturalLanguageViewModel(
     val uiState: StateFlow<NaturalLanguageUiState> = _uiState.asStateFlow()
 
     private val hid = SyncId("d1")
+
+    /** Maximum number of recent inputs to retain. */
+    private val maxRecentInputs = 10
 
     init {
         loadSuggestionData()
@@ -85,6 +141,7 @@ class NaturalLanguageViewModel(
         }
     }
 
+    /** Updates the input text and re-parses in real time. */
     fun updateInput(text: String) {
         _uiState.value = _uiState.value.copy(
             inputText = text,
@@ -108,11 +165,12 @@ class NaturalLanguageViewModel(
             showSuggestions = suggestions.isNotEmpty(),
         )
 
-        // Parse the input
-        val parsed = parseInput(text)
+        // Parse the input with locale awareness
+        val parsed = parseInput(text, _uiState.value.userLocale)
         _uiState.value = _uiState.value.copy(parsedTransaction = parsed)
     }
 
+    /** Applies a selected suggestion to the input text. */
     fun applySuggestion(suggestion: NlSuggestion) {
         val currentText = _uiState.value.inputText
         val newText = when (suggestion.type) {
@@ -130,10 +188,12 @@ class NaturalLanguageViewModel(
         _uiState.value = _uiState.value.copy(showSuggestions = false)
     }
 
+    /** Dismisses the suggestion dropdown. */
     fun dismissSuggestions() {
         _uiState.value = _uiState.value.copy(showSuggestions = false)
     }
 
+    /** Creates a transaction from the parsed input and records to recent history. */
     fun createTransaction() {
         val parsed = _uiState.value.parsedTransaction
         if (parsed == null || parsed.amount == null) {
@@ -166,10 +226,21 @@ class NaturalLanguageViewModel(
 
             transactionRepository.insert(txn)
 
+            // Add to recent history
+            val recentEntry = RecentNlpInput(
+                rawInput = parsed.rawInput,
+                payee = parsed.payee,
+                amount = formatCents(parsed.amount, parsed.currency),
+                timestamp = now,
+            )
+            val updatedRecent = (listOf(recentEntry) + _uiState.value.recentInputs)
+                .take(maxRecentInputs)
+
             _uiState.value = _uiState.value.copy(
                 isProcessing = false,
                 inputText = "",
                 parsedTransaction = null,
+                recentInputs = updatedRecent,
                 successMessage = "Transaction created: ${parsed.payee ?: "Unknown"} for ${formatCents(parsed.amount, parsed.currency)}",
             )
 
@@ -179,6 +250,7 @@ class NaturalLanguageViewModel(
         }
     }
 
+    /** Clears the input field and resets all parse state. */
     fun clearInput() {
         _uiState.value = _uiState.value.copy(
             inputText = "",
@@ -187,73 +259,280 @@ class NaturalLanguageViewModel(
             showSuggestions = false,
             errorMessage = null,
             successMessage = null,
+            editingField = EditingField.NONE,
+            editFieldValue = "",
         )
     }
 
-    // ── Parsing logic ────────────────────────────────────────────────────────
+    // ── Quick-fix field editing ──────────────────────────────────────────────
 
-    private fun parseInput(text: String): ParsedTransaction {
-        val lower = text.lowercase().trim()
-        var confidence = 0.0f
+    /**
+     * Begins editing a parsed field via the quick-fix UI.
+     * The current value is pre-populated for the user to correct.
+     */
+    fun startEditingField(field: EditingField) {
+        val parsed = _uiState.value.parsedTransaction ?: return
+        val currentValue = when (field) {
+            EditingField.AMOUNT -> parsed.amount?.let {
+                String.format("%.2f", it.amount / 100.0)
+            } ?: ""
+            EditingField.PAYEE -> parsed.payee ?: ""
+            EditingField.CATEGORY -> parsed.category ?: ""
+            EditingField.DATE -> parsed.date?.toString() ?: ""
+            EditingField.TYPE -> parsed.type.name.lowercase()
+            EditingField.NONE -> ""
+        }
+        _uiState.value = _uiState.value.copy(
+            editingField = field,
+            editFieldValue = currentValue,
+        )
+    }
 
-        // Parse amount (e.g. $42.50, 42.50, $42)
-        val amountRegex = Regex("""\$?(\d+(?:\.\d{1,2})?)""")
-        val amountMatch = amountRegex.find(lower)
-        val amount = amountMatch?.groupValues?.get(1)?.let {
-            val cents = (it.toDouble() * 100).toLong()
-            confidence += 0.4f
-            Cents(cents)
+    /** Updates the in-progress quick-fix field value. */
+    fun updateEditFieldValue(value: String) {
+        _uiState.value = _uiState.value.copy(editFieldValue = value)
+    }
+
+    /** Applies the quick-fix correction to the parsed transaction. */
+    fun confirmFieldEdit() {
+        val parsed = _uiState.value.parsedTransaction ?: return
+        val value = _uiState.value.editFieldValue.trim()
+        val field = _uiState.value.editingField
+
+        val updated = when (field) {
+            EditingField.AMOUNT -> {
+                val cents = value.toDoubleOrNull()?.let { Cents((it * 100).toLong()) }
+                parsed.copy(
+                    amount = cents ?: parsed.amount,
+                    amountConfidence = if (cents != null) FieldConfidence.HIGH else parsed.amountConfidence,
+                )
+            }
+            EditingField.PAYEE -> parsed.copy(
+                payee = value.ifBlank { null },
+                payeeConfidence = if (value.isNotBlank()) FieldConfidence.HIGH else FieldConfidence.NONE,
+            )
+            EditingField.CATEGORY -> parsed.copy(
+                category = value.ifBlank { null },
+                categoryConfidence = if (value.isNotBlank()) FieldConfidence.HIGH else FieldConfidence.NONE,
+            )
+            EditingField.DATE -> {
+                val date = try { LocalDate.parse(value) } catch (_: Exception) { parsed.date }
+                parsed.copy(
+                    date = date,
+                    dateConfidence = if (date != null) FieldConfidence.HIGH else parsed.dateConfidence,
+                )
+            }
+            EditingField.TYPE -> {
+                val type = when (value.lowercase()) {
+                    "income" -> TransactionType.INCOME
+                    "expense" -> TransactionType.EXPENSE
+                    else -> parsed.type
+                }
+                parsed.copy(type = type, typeConfidence = FieldConfidence.HIGH)
+            }
+            EditingField.NONE -> parsed
         }
 
-        // Parse type (spent, paid, earned, received)
-        val isIncome = lower.contains("earned") || lower.contains("received") ||
-            lower.contains("income") || lower.contains("got paid")
-        val type = if (isIncome) TransactionType.INCOME else TransactionType.EXPENSE
-        if (lower.contains("spent") || lower.contains("paid") || isIncome) {
-            confidence += 0.1f
-        }
+        _uiState.value = _uiState.value.copy(
+            parsedTransaction = updated,
+            editingField = EditingField.NONE,
+            editFieldValue = "",
+        )
+    }
+
+    /** Cancels the quick-fix edit without applying changes. */
+    fun cancelFieldEdit() {
+        _uiState.value = _uiState.value.copy(
+            editingField = EditingField.NONE,
+            editFieldValue = "",
+        )
+    }
+
+    // ── Recent inputs history ───────────────────────────────────────────────
+
+    /** Toggles visibility of the recent inputs panel. */
+    fun toggleRecentInputs() {
+        _uiState.value = _uiState.value.copy(
+            showRecentInputs = !_uiState.value.showRecentInputs,
+        )
+    }
+
+    /** Reuses a recent input by copying it into the input field. */
+    fun reuseRecentInput(input: RecentNlpInput) {
+        updateInput(input.rawInput)
+        _uiState.value = _uiState.value.copy(showRecentInputs = false)
+    }
+
+    // ── Parsing logic (locale-aware) ────────────────────────────────────────
+
+    private fun parseInput(text: String, locale: Locale): ParsedTransaction {
+        val lower = text.lowercase(locale).trim()
+        var overallConfidence = 0.0f
+
+        // Parse amount with locale-aware number formats
+        val amountResult = parseAmount(lower, locale)
+        if (amountResult.value != null) overallConfidence += 0.4f
+
+        // Parse type (spent, paid, earned, received — multi-language keywords)
+        val typeResult = parseType(lower, locale)
+        if (typeResult.confidence != FieldConfidence.NONE) overallConfidence += 0.1f
 
         // Parse payee (after "at" or "to" or "from")
-        val payeeRegex = Regex("""(?:at|to|from)\s+([A-Za-z][A-Za-z\s']+?)(?:\s+(?:on|for|yesterday|today|\d)|\s*$)""")
-        val payeeMatch = payeeRegex.find(lower)
-        val payee = payeeMatch?.groupValues?.get(1)?.trim()?.split(' ')
-            ?.joinToString(" ") { it.replaceFirstChar { c -> c.uppercase() } }
-        if (payee != null) confidence += 0.2f
+        val payeeResult = parsePayee(lower)
+        if (payeeResult.value != null) overallConfidence += 0.2f
 
         // Parse category (after "on" or "for")
-        val catRegex = Regex("""(?:on|for)\s+([a-z]+(?:\s+[a-z]+)?)""")
-        val catMatch = catRegex.find(lower)
-        val category = catMatch?.groupValues?.get(1)?.trim()?.replaceFirstChar { it.uppercase() }
-        if (category != null) confidence += 0.15f
+        val categoryResult = parseCategory(lower)
+        if (categoryResult.value != null) overallConfidence += 0.15f
 
-        // Parse date
-        val today = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
-        val date = when {
-            lower.contains("yesterday") -> {
-                confidence += 0.15f
-                today.minus(1, DateTimeUnit.DAY)
-            }
-            lower.contains("today") -> {
-                confidence += 0.15f
-                today
-            }
-            lower.contains("last week") -> {
-                confidence += 0.1f
-                today.minus(7, DateTimeUnit.DAY)
-            }
-            else -> null
-        }
+        // Parse date with locale-aware patterns
+        val dateResult = parseDate(lower, locale)
+        if (dateResult.value != null) overallConfidence += 0.15f
 
         return ParsedTransaction(
-            amount = amount,
+            amount = amountResult.value,
             currency = Currency.USD,
-            payee = payee,
-            category = category,
-            date = date,
-            type = type,
-            confidence = confidence.coerceIn(0f, 1f),
+            payee = payeeResult.value,
+            category = categoryResult.value,
+            date = dateResult.value,
+            type = typeResult.value ?: TransactionType.EXPENSE,
+            confidence = overallConfidence.coerceIn(0f, 1f),
             rawInput = text,
+            amountConfidence = amountResult.confidence,
+            payeeConfidence = payeeResult.confidence,
+            categoryConfidence = categoryResult.confidence,
+            dateConfidence = dateResult.confidence,
+            typeConfidence = typeResult.confidence,
         )
+    }
+
+    /**
+     * Parses an amount from the input, supporting locale-specific decimal
+     * separators (e.g. "42,50" in European locales, "42.50" in US).
+     */
+    private fun parseAmount(text: String, locale: Locale): ParsedField<Cents> {
+        // Try locale-specific currency symbols first
+        val symbols = DecimalFormatSymbols.getInstance(locale)
+        val decSep = symbols.decimalSeparator
+        val grpSep = symbols.groupingSeparator
+
+        // Match common patterns: $42.50, €42,50, 42.50, 1,200.50, 1.200,50
+        val patterns = listOf(
+            Regex("""[\$€£¥]?\s*(\d{1,3}(?:[${Regex.escape(grpSep.toString())}]\d{3})*(?:[${Regex.escape(decSep.toString())}]\d{1,2})?)"""),
+            Regex("""\$?(\d+(?:\.\d{1,2})?)"""),
+            Regex("""(\d+(?:,\d{1,2})?)"""),
+        )
+
+        for (pattern in patterns) {
+            val match = pattern.find(text) ?: continue
+            val raw = match.groupValues[1]
+                .replace(grpSep.toString(), "")
+                .replace(decSep, '.')
+            val value = raw.toDoubleOrNull() ?: continue
+            if (value > 0) {
+                val cents = Cents((value * 100).toLong())
+                val conf = if (text.contains("$") || text.contains("€") || text.contains("£"))
+                    FieldConfidence.HIGH else FieldConfidence.MEDIUM
+                return ParsedField(cents, conf, match.value)
+            }
+        }
+        return ParsedField(null, FieldConfidence.NONE)
+    }
+
+    /** Parses the transaction type from keywords. */
+    private fun parseType(text: String, locale: Locale): ParsedField<TransactionType> {
+        // English keywords
+        val incomeKeywords = listOf("earned", "received", "income", "got paid", "salary", "refund")
+        val expenseKeywords = listOf("spent", "paid", "bought", "purchased", "cost")
+
+        // Spanish keywords
+        val incomeKeywordsEs = listOf("ganado", "recibido", "ingreso", "salario")
+        val expenseKeywordsEs = listOf("gastado", "pagado", "comprado", "compré")
+
+        // French keywords
+        val incomeKeywordsFr = listOf("gagné", "reçu", "revenu", "salaire")
+        val expenseKeywordsFr = listOf("dépensé", "payé", "acheté")
+
+        val allIncome = incomeKeywords + incomeKeywordsEs + incomeKeywordsFr
+        val allExpense = expenseKeywords + expenseKeywordsEs + expenseKeywordsFr
+
+        return when {
+            allIncome.any { text.contains(it) } ->
+                ParsedField(TransactionType.INCOME, FieldConfidence.HIGH)
+            allExpense.any { text.contains(it) } ->
+                ParsedField(TransactionType.EXPENSE, FieldConfidence.HIGH)
+            else -> ParsedField(TransactionType.EXPENSE, FieldConfidence.LOW)
+        }
+    }
+
+    /** Parses payee from preposition patterns (at/to/from). */
+    private fun parsePayee(text: String): ParsedField<String> {
+        val payeeRegex = Regex("""(?:at|to|from|en|à|chez)\s+([A-Za-zÀ-ÿ][A-Za-zÀ-ÿ\s']+?)(?:\s+(?:on|for|yesterday|today|para|pour|\d)|\s*$)""")
+        val match = payeeRegex.find(text) ?: return ParsedField(null, FieldConfidence.NONE)
+        val payee = match.groupValues[1].trim().split(' ')
+            .joinToString(" ") { it.replaceFirstChar { c -> c.uppercase() } }
+
+        // Check if payee matches a known merchant for higher confidence
+        val isKnown = _uiState.value.recentPayees.any { it.equals(payee, ignoreCase = true) }
+        val conf = if (isKnown) FieldConfidence.HIGH else FieldConfidence.MEDIUM
+        return ParsedField(payee, conf, match.value)
+    }
+
+    /** Parses category from preposition patterns (on/for). */
+    private fun parseCategory(text: String): ParsedField<String> {
+        val catRegex = Regex("""(?:on|for|para|pour)\s+([a-zà-ÿ]+(?:\s+[a-zà-ÿ]+)?)""")
+        val match = catRegex.find(text) ?: return ParsedField(null, FieldConfidence.NONE)
+        val category = match.groupValues[1].trim().replaceFirstChar { it.uppercase() }
+
+        // Check if category matches a known category
+        val isKnown = _uiState.value.availableCategories.any { it.equals(category, ignoreCase = true) }
+        val conf = if (isKnown) FieldConfidence.HIGH else FieldConfidence.LOW
+        return ParsedField(category, conf, match.value)
+    }
+
+    /** Parses date from relative keywords and locale-aware date patterns. */
+    private fun parseDate(text: String, locale: Locale): ParsedField<LocalDate> {
+        val today = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
+
+        // Relative date keywords (English + Spanish + French)
+        val dateKeywords = mapOf(
+            "yesterday" to today.minus(1, DateTimeUnit.DAY),
+            "today" to today,
+            "last week" to today.minus(7, DateTimeUnit.DAY),
+            "ayer" to today.minus(1, DateTimeUnit.DAY),
+            "hoy" to today,
+            "hier" to today.minus(1, DateTimeUnit.DAY),
+            "aujourd'hui" to today,
+        )
+
+        for ((keyword, date) in dateKeywords) {
+            if (text.contains(keyword)) {
+                return ParsedField(date, FieldConfidence.HIGH, keyword)
+            }
+        }
+
+        // Try explicit date patterns: MM/DD, DD/MM, YYYY-MM-DD
+        val isoMatch = Regex("""\d{4}-\d{2}-\d{2}""").find(text)
+        if (isoMatch != null) {
+            val date = try { LocalDate.parse(isoMatch.value) } catch (_: Exception) { null }
+            if (date != null) return ParsedField(date, FieldConfidence.HIGH, isoMatch.value)
+        }
+
+        val slashMatch = Regex("""(\d{1,2})/(\d{1,2})(?:/(\d{2,4}))?""").find(text)
+        if (slashMatch != null) {
+            val a = slashMatch.groupValues[1].toIntOrNull() ?: return ParsedField(null, FieldConfidence.NONE)
+            val b = slashMatch.groupValues[2].toIntOrNull() ?: return ParsedField(null, FieldConfidence.NONE)
+            val year = slashMatch.groupValues[3].toIntOrNull()?.let {
+                if (it < 100) 2000 + it else it
+            } ?: today.year
+
+            // Locale-based: US = MM/DD, most others = DD/MM
+            val (month, day) = if (locale.country == "US") a to b else b to a
+            val date = try { LocalDate(year, month, day) } catch (_: Exception) { null }
+            if (date != null) return ParsedField(date, FieldConfidence.MEDIUM, slashMatch.value)
+        }
+
+        return ParsedField(null, FieldConfidence.NONE)
     }
 
     private fun generateSuggestions(text: String): List<NlSuggestion> {
@@ -262,15 +541,15 @@ class NaturalLanguageViewModel(
 
         val suggestions = mutableListOf<NlSuggestion>()
 
-        // Payee suggestions
+        // Payee suggestions — match prefix and also fuzzy contains
         _uiState.value.recentPayees
-            .filter { it.lowercase().startsWith(lastWord) }
+            .filter { it.lowercase().startsWith(lastWord) || it.lowercase().contains(lastWord) }
             .take(3)
             .forEach { suggestions.add(NlSuggestion(it, "payee")) }
 
         // Category suggestions
         _uiState.value.availableCategories
-            .filter { it.lowercase().startsWith(lastWord) }
+            .filter { it.lowercase().startsWith(lastWord) || it.lowercase().contains(lastWord) }
             .take(3)
             .forEach { suggestions.add(NlSuggestion(it, "category")) }
 


### PR DESCRIPTION
## Summary

Enhances the existing Natural Language Transaction Input screen on Windows Desktop with six new capabilities:

1. Inline parsing preview - Real-time per-field confidence indicators (colored dots) show parsing reliability as the user types
2. Merchant suggestion chips - Auto-complete chips showing recent merchants from transaction history
3. Multi-language input - Locale-aware amount parsing (US, European formats) and date parsing; multi-language keywords (English/Spanish/French)
4. Per-field confidence - Each parsed field has its own FieldConfidence level (HIGH/MEDIUM/LOW/NONE)
5. Quick-fix UI - Click any parsed field to correct it inline with a text field and confirm/cancel buttons
6. Recent NLP inputs history - Toggleable panel showing recently submitted inputs for quick reuse

## Changes

- NaturalLanguageViewModel.kt: Added FieldConfidence, EditingField, RecentNlpInput types; refactored parser into locale-aware sub-parsers; added quick-fix and history methods
- NaturalLanguageScreen.kt: Added MerchantSuggestionChips, EditableParsedField, ConfidenceDot, RecentInputsPanel composables; full Narrator accessibility
- ViewModelModule.kt: Registered NaturalLanguageViewModel in Koin (was missing)

## Accessibility

- All composables have semantics contentDescription for Narrator
- Confidence dots announce their level
- Quick-fix edit mode announces field name and state
- Heading semantics on section headers

Closes #1143