### PR TITLE
feat(windows): enhance report builder with template picker, category filter, chart rendering, saved reports, scheduled toggle, and share export (#1115)

### DIFF
--- a/apps/windows/src/main/kotlin/com/finance/desktop/di/ViewModelModule.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/di/ViewModelModule.kt
@@ -33,7 +33,7 @@ val viewModelModule = module {
     single { DiagnosticsViewModel() }
     single { WidgetBoardViewModel(get()) }
     single { HealthScoreViewModel(get(), get(), get(), get()) }
-    single { ReportBuilderViewModel(get(), get()) }
+    single { ReportBuilderViewModel(get(), get(), get()) }
     single { BudgetNegotiationViewModel(get(), get()) }
     single { EntitlementViewModel(get(), get(), get()) }
     single { TipsViewModel(get(), get(), get()) }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/ReportBuilderScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/ReportBuilderScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -24,11 +26,17 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.TrendingDown
 import androidx.compose.material.icons.automirrored.filled.TrendingUp
 import androidx.compose.material.icons.filled.Assessment
+import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.PictureAsPdf
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Save
+import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.TableChart
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -39,13 +47,16 @@ import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -63,27 +74,33 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.finance.desktop.components.BarDataPoint
+import com.finance.desktop.components.FinanceBarChart
 import com.finance.desktop.di.koinGet
 import com.finance.desktop.theme.FinanceDesktopTheme
 import com.finance.desktop.viewmodel.DateRangePreset
 import com.finance.desktop.viewmodel.ExportFormat
 import com.finance.desktop.viewmodel.ReportBuilderUiState
 import com.finance.desktop.viewmodel.ReportBuilderViewModel
+import com.finance.desktop.viewmodel.ReportChartPoint
 import com.finance.desktop.viewmodel.ReportPreviewRow
 import com.finance.desktop.viewmodel.ReportSummary
+import com.finance.desktop.viewmodel.ReportTemplate
 import com.finance.desktop.viewmodel.ReportType
+import com.finance.desktop.viewmodel.SavedReport
 
 // =============================================================================
-// Custom Report Builder Screen — Sprint 20 (#303)
+// Custom Report Builder Screen — Sprint 20 (#303) + Enhancement (#1115)
 // =============================================================================
 
 /**
  * Custom Report Builder with a side-by-side configuration + preview layout.
  *
- * Left pane: Report type, date range, account filter, export format.
- * Right pane: Preview table with generated report data and summary statistics.
+ * Left pane: Template picker, report type, date range, category/account filter,
+ *            export format, saved reports, scheduled toggle.
+ * Right pane: Chart visualization, preview table, summary statistics.
  *
- * Narrator reads report configuration, preview data, and export status.
+ * Narrator reads report configuration, preview data, charts, and export status.
  * High contrast colours adapt via [MaterialTheme.colorScheme].
  */
 @Composable
@@ -100,17 +117,29 @@ fun ReportBuilderScreen(modifier: Modifier = Modifier) {
         // ── Left: Configuration panel ──
         ReportConfigPanel(
             state = state,
+            onTemplateChange = viewModel::selectTemplate,
             onReportTypeChange = viewModel::setReportType,
             onDatePresetChange = viewModel::setDateRangePreset,
             onStartDateChange = viewModel::setStartDate,
             onEndDateChange = viewModel::setEndDate,
             onToggleAccount = viewModel::toggleAccountSelection,
+            onToggleCategory = viewModel::toggleCategorySelection,
+            onSelectAllCategories = viewModel::selectAllCategories,
+            onDeselectAllCategories = viewModel::deselectAllCategories,
             onToggleTransfers = viewModel::toggleIncludeTransfers,
             onExportFormatChange = viewModel::setExportFormat,
             onGenerate = viewModel::generatePreview,
             onExport = viewModel::exportReport,
+            onToggleScheduled = viewModel::toggleScheduled,
+            onSaveReport = viewModel::showSaveDialog,
+            onToggleSavedReports = viewModel::toggleSavedReports,
+            onLoadSavedReport = viewModel::loadSavedReport,
+            onDeleteSavedReport = viewModel::deleteSavedReport,
+            onSaveDialogNameChange = viewModel::updateSaveReportName,
+            onSaveDialogConfirm = viewModel::saveReport,
+            onSaveDialogDismiss = viewModel::hideSaveDialog,
             modifier = Modifier
-                .width(360.dp)
+                .width(380.dp)
                 .fillMaxHeight(),
         )
 
@@ -121,7 +150,7 @@ fun ReportBuilderScreen(modifier: Modifier = Modifier) {
             color = MaterialTheme.colorScheme.outlineVariant,
         )
 
-        // ── Right: Preview pane ──
+        // ── Right: Preview pane with charts ──
         ReportPreviewPanel(
             state = state,
             modifier = Modifier
@@ -133,18 +162,31 @@ fun ReportBuilderScreen(modifier: Modifier = Modifier) {
 
 // ─── Configuration panel ─────────────────────────────────────────────────────
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun ReportConfigPanel(
     state: ReportBuilderUiState,
+    onTemplateChange: (ReportTemplate) -> Unit,
     onReportTypeChange: (ReportType) -> Unit,
     onDatePresetChange: (DateRangePreset) -> Unit,
     onStartDateChange: (String) -> Unit,
     onEndDateChange: (String) -> Unit,
     onToggleAccount: (String) -> Unit,
+    onToggleCategory: (String) -> Unit,
+    onSelectAllCategories: () -> Unit,
+    onDeselectAllCategories: () -> Unit,
     onToggleTransfers: () -> Unit,
     onExportFormatChange: (ExportFormat) -> Unit,
     onGenerate: () -> Unit,
     onExport: () -> Unit,
+    onToggleScheduled: () -> Unit,
+    onSaveReport: () -> Unit,
+    onToggleSavedReports: () -> Unit,
+    onLoadSavedReport: (SavedReport) -> Unit,
+    onDeleteSavedReport: (String) -> Unit,
+    onSaveDialogNameChange: (String) -> Unit,
+    onSaveDialogConfirm: () -> Unit,
+    onSaveDialogDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     LazyColumn(
@@ -152,49 +194,127 @@ private fun ReportConfigPanel(
         verticalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.lg),
     ) {
         item {
-            Text(
-                text = "Report Builder",
-                style = MaterialTheme.typography.titleLarge,
-                fontWeight = FontWeight.SemiBold,
-                modifier = Modifier.semantics {
-                    heading()
-                    contentDescription = "Report Builder configuration"
-                },
-            )
-            Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
-            Text(
-                text = "Configure and generate custom financial reports",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column {
+                    Text(
+                        text = "Report Builder",
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.semantics {
+                            heading()
+                            contentDescription = "Report Builder configuration"
+                        },
+                    )
+                    Spacer(Modifier.height(FinanceDesktopTheme.spacing.xs))
+                    Text(
+                        text = "Configure and generate custom financial reports",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                // Saved reports button
+                if (state.savedReports.isNotEmpty()) {
+                    IconButton(
+                        onClick = onToggleSavedReports,
+                        modifier = Modifier.semantics {
+                            contentDescription = if (state.showSavedReports) "Hide saved reports"
+                            else "Show saved reports"
+                            role = Role.Button
+                        },
+                    ) {
+                        Icon(
+                            Icons.Filled.Bookmark,
+                            contentDescription = null,
+                            tint = if (state.showSavedReports) MaterialTheme.colorScheme.primary
+                            else MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
         }
 
-        // Report type
+        // Saved reports list
+        if (state.showSavedReports && state.savedReports.isNotEmpty()) {
+            item {
+                SavedReportsSection(
+                    savedReports = state.savedReports,
+                    onLoad = onLoadSavedReport,
+                    onDelete = onDeleteSavedReport,
+                )
+            }
+        }
+
+        // Save dialog
+        if (state.showSaveDialog) {
+            item {
+                SaveReportDialog(
+                    name = state.saveReportName,
+                    onNameChange = onSaveDialogNameChange,
+                    onConfirm = onSaveDialogConfirm,
+                    onDismiss = onSaveDialogDismiss,
+                )
+            }
+        }
+
+        // Template picker
         item {
-            SectionHeader("Report Type")
+            SectionHeader("Report Template")
             Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
-            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                ReportType.entries.forEach { type ->
-                    val label = type.name.replace('_', ' ').lowercase()
-                        .split(' ').joinToString(" ") { it.replaceFirstChar { c -> c.uppercase() } }
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable { onReportTypeChange(type) }
-                            .padding(vertical = 4.dp)
-                            .semantics {
-                                role = Role.RadioButton
-                                selected = state.reportType == type
-                                contentDescription = "$label report type"
-                            },
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        RadioButton(
-                            selected = state.reportType == type,
-                            onClick = { onReportTypeChange(type) },
-                        )
-                        Spacer(Modifier.width(FinanceDesktopTheme.spacing.sm))
-                        Text(text = label, style = MaterialTheme.typography.bodyMedium)
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.sm),
+                verticalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.sm),
+            ) {
+                ReportTemplate.entries.forEach { template ->
+                    val label = when (template) {
+                        ReportTemplate.MONTHLY_SUMMARY -> "Monthly Summary"
+                        ReportTemplate.CATEGORY_BREAKDOWN -> "Category Breakdown"
+                        ReportTemplate.TREND_ANALYSIS -> "Trend Analysis"
+                        ReportTemplate.CUSTOM -> "Custom"
+                    }
+                    FilterChip(
+                        selected = state.selectedTemplate == template,
+                        onClick = { onTemplateChange(template) },
+                        label = { Text(label) },
+                        modifier = Modifier.semantics {
+                            contentDescription = "$label template"
+                        },
+                    )
+                }
+            }
+        }
+
+        // Report type (only show for Custom template)
+        if (state.selectedTemplate == ReportTemplate.CUSTOM) {
+            item {
+                SectionHeader("Report Type")
+                Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
+                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    ReportType.entries.forEach { type ->
+                        val label = type.name.replace('_', ' ').lowercase()
+                            .split(' ').joinToString(" ") { it.replaceFirstChar { c -> c.uppercase() } }
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { onReportTypeChange(type) }
+                                .padding(vertical = 4.dp)
+                                .semantics {
+                                    role = Role.RadioButton
+                                    selected = state.reportType == type
+                                    contentDescription = "$label report type"
+                                },
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            RadioButton(
+                                selected = state.reportType == type,
+                                onClick = { onReportTypeChange(type) },
+                            )
+                            Spacer(Modifier.width(FinanceDesktopTheme.spacing.sm))
+                            Text(text = label, style = MaterialTheme.typography.bodyMedium)
+                        }
                     }
                 }
             }
@@ -205,8 +325,8 @@ private fun ReportConfigPanel(
             SectionHeader("Date Range")
             Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
             FlowRow(
-                horizontalSpacing = FinanceDesktopTheme.spacing.sm,
-                verticalSpacing = FinanceDesktopTheme.spacing.sm,
+                horizontalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.sm),
+                verticalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.sm),
             ) {
                 DateRangePreset.entries.forEach { preset ->
                     val label = preset.name.replace('_', ' ').lowercase()
@@ -244,6 +364,50 @@ private fun ReportConfigPanel(
                         .weight(1f)
                         .semantics { contentDescription = "End date: ${state.endDate}" },
                 )
+            }
+        }
+
+        // Category filter (multi-select)
+        item {
+            SectionHeader("Categories")
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.sm),
+            ) {
+                TextButton(
+                    onClick = onSelectAllCategories,
+                    modifier = Modifier.semantics {
+                        contentDescription = "Select all categories"
+                        role = Role.Button
+                    },
+                ) { Text("Select All") }
+                TextButton(
+                    onClick = onDeselectAllCategories,
+                    modifier = Modifier.semantics {
+                        contentDescription = "Deselect all categories"
+                        role = Role.Button
+                    },
+                ) { Text("Clear") }
+            }
+            state.availableCategories.forEach { (id, name) ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { onToggleCategory(id) }
+                        .padding(vertical = 2.dp)
+                        .semantics {
+                            role = Role.Checkbox
+                            contentDescription = "$name category filter"
+                        },
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Checkbox(
+                        checked = id in state.selectedCategoryIds,
+                        onCheckedChange = { onToggleCategory(id) },
+                    )
+                    Spacer(Modifier.width(FinanceDesktopTheme.spacing.sm))
+                    Text(text = name, style = MaterialTheme.typography.bodyMedium)
+                }
             }
         }
 
@@ -291,7 +455,7 @@ private fun ReportConfigPanel(
             }
         }
 
-        // Export format
+        // Export format with Share option
         item {
             SectionHeader("Export Format")
             Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
@@ -302,18 +466,58 @@ private fun ReportConfigPanel(
                         onClick = { onExportFormatChange(format) },
                         label = { Text(format.name) },
                         leadingIcon = {
-                            Icon(
-                                if (format == ExportFormat.PDF) Icons.Filled.PictureAsPdf
-                                else Icons.Filled.TableChart,
-                                contentDescription = null,
-                                modifier = Modifier.size(16.dp),
-                            )
+                            val icon = when (format) {
+                                ExportFormat.PDF -> Icons.Filled.PictureAsPdf
+                                ExportFormat.CSV -> Icons.Filled.TableChart
+                                ExportFormat.SHARE -> Icons.Filled.Share
+                            }
+                            Icon(icon, contentDescription = null, modifier = Modifier.size(16.dp))
                         },
                         modifier = Modifier.semantics {
                             contentDescription = "Export as ${format.name}"
                         },
                     )
                 }
+            }
+        }
+
+        // Scheduled report toggle
+        item {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onToggleScheduled() }
+                    .padding(vertical = FinanceDesktopTheme.spacing.sm)
+                    .semantics {
+                        contentDescription = if (state.isScheduled)
+                            "Scheduled report enabled. Click to disable."
+                        else "Schedule this report. Click to enable."
+                        role = Role.Switch
+                    },
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        Icons.Filled.Schedule,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(20.dp),
+                    )
+                    Spacer(Modifier.width(FinanceDesktopTheme.spacing.sm))
+                    Column {
+                        Text("Schedule Report", style = MaterialTheme.typography.bodyMedium)
+                        Text(
+                            "Auto-generate on selected interval",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+                Switch(
+                    checked = state.isScheduled,
+                    onCheckedChange = { onToggleScheduled() },
+                )
             }
         }
 
@@ -376,6 +580,166 @@ private fun ReportConfigPanel(
                     )
                 }
             }
+
+            // Save report button
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
+            OutlinedButton(
+                onClick = onSaveReport,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics {
+                        contentDescription = "Save report configuration"
+                        role = Role.Button
+                    },
+            ) {
+                Icon(Icons.Filled.Save, contentDescription = null)
+                Spacer(Modifier.width(FinanceDesktopTheme.spacing.sm))
+                Text("Save Report")
+            }
+        }
+    }
+}
+
+// ─── Saved reports section ───────────────────────────────────────────────────
+
+/**
+ * List of saved report configurations. Each entry can be loaded or deleted.
+ * Narrator reads the report name and creation date.
+ */
+@Composable
+private fun SavedReportsSection(
+    savedReports: List<SavedReport>,
+    onLoad: (SavedReport) -> Unit,
+    onDelete: (String) -> Unit,
+) {
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(FinanceDesktopTheme.spacing.lg)) {
+            Text(
+                text = "Saved Reports",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.semantics {
+                    heading()
+                    contentDescription = "Saved report configurations"
+                },
+            )
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
+
+            savedReports.forEachIndexed { index, report ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { onLoad(report) }
+                        .padding(vertical = FinanceDesktopTheme.spacing.sm)
+                        .semantics {
+                            contentDescription = "Saved report: ${report.name}. Click to load."
+                            role = Role.Button
+                        },
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text(
+                                text = report.name,
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontWeight = FontWeight.Medium,
+                            )
+                            if (report.isScheduled) {
+                                Spacer(Modifier.width(FinanceDesktopTheme.spacing.sm))
+                                Icon(
+                                    Icons.Filled.Schedule,
+                                    contentDescription = "Scheduled",
+                                    modifier = Modifier.size(14.dp),
+                                    tint = MaterialTheme.colorScheme.primary,
+                                )
+                            }
+                        }
+                        val templateLabel = when (report.template) {
+                            ReportTemplate.MONTHLY_SUMMARY -> "Monthly Summary"
+                            ReportTemplate.CATEGORY_BREAKDOWN -> "Category Breakdown"
+                            ReportTemplate.TREND_ANALYSIS -> "Trend Analysis"
+                            ReportTemplate.CUSTOM -> "Custom"
+                        }
+                        Text(
+                            text = "$templateLabel · ${report.startDate} – ${report.endDate}",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    IconButton(
+                        onClick = { onDelete(report.id) },
+                        modifier = Modifier.semantics {
+                            contentDescription = "Delete saved report ${report.name}"
+                            role = Role.Button
+                        },
+                    ) {
+                        Icon(
+                            Icons.Filled.Delete,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.error,
+                            modifier = Modifier.size(18.dp),
+                        )
+                    }
+                }
+                if (index < savedReports.lastIndex) {
+                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                }
+            }
+        }
+    }
+}
+
+// ─── Save report dialog ──────────────────────────────────────────────────────
+
+@Composable
+private fun SaveReportDialog(
+    name: String,
+    onNameChange: (String) -> Unit,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(FinanceDesktopTheme.spacing.lg)) {
+            Text(
+                text = "Save Report Configuration",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.semantics { heading() },
+            )
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.md))
+            OutlinedTextField(
+                value = name,
+                onValueChange = onNameChange,
+                label = { Text("Report Name") },
+                placeholder = { Text("e.g. Monthly Summary - Q1") },
+                singleLine = true,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics { contentDescription = "Report name input" },
+            )
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.md))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                TextButton(
+                    onClick = onDismiss,
+                    modifier = Modifier.semantics {
+                        contentDescription = "Cancel save"
+                        role = Role.Button
+                    },
+                ) { Text("Cancel") }
+                Spacer(Modifier.width(FinanceDesktopTheme.spacing.sm))
+                Button(
+                    onClick = onConfirm,
+                    enabled = name.isNotBlank(),
+                    modifier = Modifier.semantics {
+                        contentDescription = "Confirm save report"
+                        role = Role.Button
+                    },
+                ) { Text("Save") }
+            }
         }
     }
 }
@@ -424,18 +788,25 @@ private fun ReportPreviewPanel(
                 }
             }
         } else {
-            // Summary cards
-            state.summary?.let { summary ->
-                ReportSummaryCards(summary)
-                Spacer(Modifier.height(FinanceDesktopTheme.spacing.xxl))
-            }
-
-            // Data table
             LazyColumn(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.sm),
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.lg),
             ) {
-                // Table header
+                // Summary cards
+                state.summary?.let { summary ->
+                    item {
+                        ReportSummaryCards(summary)
+                    }
+                }
+
+                // Chart visualization
+                if (state.chartData.isNotEmpty()) {
+                    item {
+                        ReportChartSection(state.chartData)
+                    }
+                }
+
+                // Data table header
                 item {
                     Row(
                         modifier = Modifier
@@ -473,6 +844,48 @@ private fun ReportPreviewPanel(
                     ReportDataRow(row)
                 }
             }
+        }
+    }
+}
+
+// ─── Chart section ───────────────────────────────────────────────────────────
+
+/**
+ * Renders a bar chart of the report data using [FinanceBarChart].
+ * Narrator reads the chart title and data summary.
+ */
+@Composable
+private fun ReportChartSection(chartData: List<ReportChartPoint>) {
+    ElevatedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics {
+                contentDescription = "Report chart showing ${chartData.size} categories"
+            },
+    ) {
+        Column(modifier = Modifier.padding(FinanceDesktopTheme.spacing.lg)) {
+            Text(
+                text = "Spending by Category",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.semantics { heading() },
+            )
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.md))
+            FinanceBarChart(
+                data = chartData.map { point ->
+                    BarDataPoint(
+                        label = point.label,
+                        value = point.value,
+                        color = if (point.isIncome) Color(0xFF2E7D32)
+                        else MaterialTheme.colorScheme.error,
+                        formattedValue = point.formattedValue,
+                    )
+                },
+                title = "",
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(200.dp),
+            )
         }
     }
 }
@@ -611,26 +1024,4 @@ private fun SectionHeader(title: String) {
             contentDescription = "$title section"
         },
     )
-}
-
-/**
- * Simple flow-row layout that wraps children horizontally.
- * Compose Desktop doesn't ship FlowRow yet; this approximates it with Column+Row.
- */
-@Composable
-private fun FlowRow(
-    horizontalSpacing: androidx.compose.ui.unit.Dp = 0.dp,
-    verticalSpacing: androidx.compose.ui.unit.Dp = 0.dp,
-    content: @Composable () -> Unit,
-) {
-    // Use built-in Compose flow layout when available.
-    // For now, wrap in a simple Column that places items in rows.
-    Column(verticalArrangement = Arrangement.spacedBy(verticalSpacing)) {
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(horizontalSpacing),
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            content()
-        }
-    }
 }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/ReportBuilderViewModel.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/ReportBuilderViewModel.kt
@@ -3,6 +3,7 @@
 package com.finance.desktop.viewmodel
 
 import com.finance.desktop.data.repository.AccountRepository
+import com.finance.desktop.data.repository.CategoryRepository
 import com.finance.desktop.data.repository.TransactionRepository
 import com.finance.core.currency.CurrencyFormatter
 import com.finance.models.TransactionType
@@ -17,7 +18,7 @@ import kotlinx.coroutines.launch
 import kotlinx.datetime.*
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Custom Report Builder UI State — Sprint 20 (#303)
+// Custom Report Builder UI State — Sprint 20 (#303) + Enhancement (#1115)
 // ─────────────────────────────────────────────────────────────────────────────
 
 /** Report type the user can generate. */
@@ -27,7 +28,22 @@ enum class ReportType { INCOME_EXPENSE, SPENDING_BY_CATEGORY, NET_WORTH_TREND, C
 enum class DateRangePreset { LAST_7_DAYS, LAST_30_DAYS, THIS_MONTH, LAST_MONTH, THIS_QUARTER, THIS_YEAR, CUSTOM }
 
 /** Export format for report output. */
-enum class ExportFormat { PDF, CSV }
+enum class ExportFormat { PDF, CSV, SHARE }
+
+/** Report template with pre-configured settings. */
+enum class ReportTemplate {
+    /** Monthly income vs expenses summary. */
+    MONTHLY_SUMMARY,
+
+    /** Breakdown of spending by category with percentages. */
+    CATEGORY_BREAKDOWN,
+
+    /** Multi-month trend analysis. */
+    TREND_ANALYSIS,
+
+    /** Fully custom report with manual configuration. */
+    CUSTOM,
+}
 
 /** A single row in the report preview table. */
 data class ReportPreviewRow(
@@ -45,6 +61,30 @@ data class ReportSummary(
     val transactionCount: Int,
 )
 
+/** A chart data point for the report preview chart. */
+data class ReportChartPoint(
+    val label: String,
+    val value: Float,
+    val formattedValue: String,
+    val isIncome: Boolean,
+)
+
+/** A saved report configuration for later reuse. */
+data class SavedReport(
+    val id: String,
+    val name: String,
+    val template: ReportTemplate,
+    val reportType: ReportType,
+    val dateRangePreset: DateRangePreset,
+    val startDate: String,
+    val endDate: String,
+    val selectedAccountIds: Set<String>,
+    val selectedCategoryIds: Set<String>,
+    val includeTransfers: Boolean,
+    val createdAt: Instant,
+    val isScheduled: Boolean = false,
+)
+
 data class ReportBuilderUiState(
     val isLoading: Boolean = false,
     val reportType: ReportType = ReportType.INCOME_EXPENSE,
@@ -53,24 +93,35 @@ data class ReportBuilderUiState(
     val endDate: String = "",
     val selectedAccountIds: Set<String> = emptySet(),
     val availableAccounts: List<Pair<String, String>> = emptyList(), // id, name
+    val selectedCategoryIds: Set<String> = emptySet(),
+    val availableCategories: List<Pair<String, String>> = emptyList(), // id, name
     val includeTransfers: Boolean = false,
     val previewRows: List<ReportPreviewRow> = emptyList(),
     val summary: ReportSummary? = null,
+    val chartData: List<ReportChartPoint> = emptyList(),
     val isPreviewReady: Boolean = false,
     val isExporting: Boolean = false,
     val exportSuccess: Boolean = false,
     val exportFormat: ExportFormat = ExportFormat.PDF,
+    val selectedTemplate: ReportTemplate = ReportTemplate.CUSTOM,
+    val savedReports: List<SavedReport> = emptyList(),
+    val showSavedReports: Boolean = false,
+    val saveReportName: String = "",
+    val showSaveDialog: Boolean = false,
+    val isScheduled: Boolean = false,
 )
 
 /**
  * ViewModel for the Custom Report Builder.
  *
- * Manages report configuration (type, date range, filters), generates a
- * preview of the data, and handles export to PDF/CSV format.
+ * Manages report configuration (template, type, date range, category/account filters),
+ * generates a preview of the data with chart-ready points, handles export to
+ * PDF/CSV/Share format, and supports saving/loading report configurations.
  */
 class ReportBuilderViewModel(
     private val accountRepository: AccountRepository,
     private val transactionRepository: TransactionRepository,
+    private val categoryRepository: CategoryRepository,
 ) : DesktopViewModel() {
 
     private val _uiState = MutableStateFlow(ReportBuilderUiState())
@@ -80,6 +131,7 @@ class ReportBuilderViewModel(
 
     init {
         loadAccounts()
+        loadCategories()
     }
 
     private fun loadAccounts() {
@@ -97,8 +149,69 @@ class ReportBuilderViewModel(
         }
     }
 
+    private fun loadCategories() {
+        viewModelScope.launch {
+            val categories = categoryRepository.observeAll(hid).first()
+            _uiState.value = _uiState.value.copy(
+                availableCategories = categories.map { it.id.value to it.name },
+                selectedCategoryIds = categories.map { it.id.value }.toSet(),
+            )
+        }
+    }
+
+    // ── Template selection ───────────────────────────────────────────────────
+
+    /**
+     * Selects a report template and auto-configures report type and date range.
+     */
+    fun selectTemplate(template: ReportTemplate) {
+        val today = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
+        when (template) {
+            ReportTemplate.MONTHLY_SUMMARY -> {
+                _uiState.value = _uiState.value.copy(
+                    selectedTemplate = template,
+                    reportType = ReportType.INCOME_EXPENSE,
+                    dateRangePreset = DateRangePreset.THIS_MONTH,
+                    startDate = LocalDate(today.year, today.month, 1).toString(),
+                    endDate = today.toString(),
+                    isPreviewReady = false,
+                )
+            }
+            ReportTemplate.CATEGORY_BREAKDOWN -> {
+                _uiState.value = _uiState.value.copy(
+                    selectedTemplate = template,
+                    reportType = ReportType.SPENDING_BY_CATEGORY,
+                    dateRangePreset = DateRangePreset.THIS_MONTH,
+                    startDate = LocalDate(today.year, today.month, 1).toString(),
+                    endDate = today.toString(),
+                    isPreviewReady = false,
+                )
+            }
+            ReportTemplate.TREND_ANALYSIS -> {
+                _uiState.value = _uiState.value.copy(
+                    selectedTemplate = template,
+                    reportType = ReportType.NET_WORTH_TREND,
+                    dateRangePreset = DateRangePreset.THIS_YEAR,
+                    startDate = LocalDate(today.year, 1, 1).toString(),
+                    endDate = today.toString(),
+                    isPreviewReady = false,
+                )
+            }
+            ReportTemplate.CUSTOM -> {
+                _uiState.value = _uiState.value.copy(
+                    selectedTemplate = template,
+                    isPreviewReady = false,
+                )
+            }
+        }
+    }
+
     fun setReportType(type: ReportType) {
-        _uiState.value = _uiState.value.copy(reportType = type, isPreviewReady = false)
+        _uiState.value = _uiState.value.copy(
+            reportType = type,
+            selectedTemplate = ReportTemplate.CUSTOM,
+            isPreviewReady = false,
+        )
     }
 
     fun setDateRangePreset(preset: DateRangePreset) {
@@ -150,6 +263,31 @@ class ReportBuilderViewModel(
         _uiState.value = _uiState.value.copy(selectedAccountIds = updated, isPreviewReady = false)
     }
 
+    // ── Category filter ─────────────────────────────────────────────────────
+
+    /** Toggles a category in the multi-select filter. */
+    fun toggleCategorySelection(categoryId: String) {
+        val current = _uiState.value.selectedCategoryIds
+        val updated = if (categoryId in current) current - categoryId else current + categoryId
+        _uiState.value = _uiState.value.copy(selectedCategoryIds = updated, isPreviewReady = false)
+    }
+
+    /** Selects all categories. */
+    fun selectAllCategories() {
+        _uiState.value = _uiState.value.copy(
+            selectedCategoryIds = _uiState.value.availableCategories.map { it.first }.toSet(),
+            isPreviewReady = false,
+        )
+    }
+
+    /** Deselects all categories. */
+    fun deselectAllCategories() {
+        _uiState.value = _uiState.value.copy(
+            selectedCategoryIds = emptySet(),
+            isPreviewReady = false,
+        )
+    }
+
     fun toggleIncludeTransfers() {
         _uiState.value = _uiState.value.copy(
             includeTransfers = !_uiState.value.includeTransfers,
@@ -161,6 +299,16 @@ class ReportBuilderViewModel(
         _uiState.value = _uiState.value.copy(exportFormat = format)
     }
 
+    // ── Scheduled reports ───────────────────────────────────────────────────
+
+    /** Toggles the scheduled report flag. */
+    fun toggleScheduled() {
+        _uiState.value = _uiState.value.copy(isScheduled = !_uiState.value.isScheduled)
+    }
+
+    // ── Preview generation ──────────────────────────────────────────────────
+
+    /** Generates the report preview with data rows and chart points. */
     fun generatePreview() {
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isLoading = true)
@@ -171,9 +319,14 @@ class ReportBuilderViewModel(
             val startDate = try { LocalDate.parse(_uiState.value.startDate) } catch (_: Exception) { return@launch }
             val endDate = try { LocalDate.parse(_uiState.value.endDate) } catch (_: Exception) { return@launch }
 
+            val selectedCategories = _uiState.value.selectedCategoryIds
+
             val filtered = transactions.filter { txn ->
                 txn.date in startDate..endDate &&
-                    txn.accountId.value in _uiState.value.selectedAccountIds
+                    txn.accountId.value in _uiState.value.selectedAccountIds &&
+                    (selectedCategories.isEmpty() ||
+                        txn.categoryId?.value in selectedCategories ||
+                        (txn.categoryId == null && "Uncategorized" in selectedCategories))
             }
 
             val income = filtered.filter { it.type == TransactionType.INCOME }
@@ -186,6 +339,7 @@ class ReportBuilderViewModel(
                 (totalIncome.amount + totalExpenses.amount).toFloat() else 1f
 
             val rows = mutableListOf<ReportPreviewRow>()
+            val chartPoints = mutableListOf<ReportChartPoint>()
 
             // Group by category
             val byCat = filtered.groupBy { it.categoryId?.value ?: "Uncategorized" }
@@ -193,11 +347,21 @@ class ReportBuilderViewModel(
                 .forEach { (catId, txns) ->
                     val catTotal = Cents(txns.sumOf { it.amount.amount })
                     val isIncome = txns.firstOrNull()?.type == TransactionType.INCOME
+                    val formatted = CurrencyFormatter.format(catTotal, currency)
+                    val pct = catTotal.amount.toFloat() / grandTotal
                     rows.add(
                         ReportPreviewRow(
                             label = catId,
-                            amount = CurrencyFormatter.format(catTotal, currency),
-                            percentage = catTotal.amount.toFloat() / grandTotal,
+                            amount = formatted,
+                            percentage = pct,
+                            isIncome = isIncome,
+                        ),
+                    )
+                    chartPoints.add(
+                        ReportChartPoint(
+                            label = catId,
+                            value = catTotal.amount.toFloat() / 100f,
+                            formattedValue = formatted,
                             isIncome = isIncome,
                         ),
                     )
@@ -207,6 +371,7 @@ class ReportBuilderViewModel(
                 isLoading = false,
                 isPreviewReady = true,
                 previewRows = rows,
+                chartData = chartPoints,
                 summary = ReportSummary(
                     totalIncome = CurrencyFormatter.format(totalIncome, currency),
                     totalExpenses = CurrencyFormatter.format(totalExpenses, currency),
@@ -217,6 +382,9 @@ class ReportBuilderViewModel(
         }
     }
 
+    // ── Export ───────────────────────────────────────────────────────────────
+
+    /** Exports the current report in the selected format (PDF/CSV/Share). */
     fun exportReport() {
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isExporting = true)
@@ -228,5 +396,80 @@ class ReportBuilderViewModel(
             kotlinx.coroutines.delay(3000)
             _uiState.value = _uiState.value.copy(exportSuccess = false)
         }
+    }
+
+    // ── Saved reports ───────────────────────────────────────────────────────
+
+    /** Shows the save report dialog. */
+    fun showSaveDialog() {
+        _uiState.value = _uiState.value.copy(showSaveDialog = true, saveReportName = "")
+    }
+
+    /** Hides the save report dialog. */
+    fun hideSaveDialog() {
+        _uiState.value = _uiState.value.copy(showSaveDialog = false, saveReportName = "")
+    }
+
+    /** Updates the name for the report being saved. */
+    fun updateSaveReportName(name: String) {
+        _uiState.value = _uiState.value.copy(saveReportName = name)
+    }
+
+    /** Saves the current report configuration for later reuse. */
+    fun saveReport() {
+        val state = _uiState.value
+        val name = state.saveReportName.trim()
+        if (name.isBlank()) return
+
+        val saved = SavedReport(
+            id = "rpt-${Clock.System.now().toEpochMilliseconds()}",
+            name = name,
+            template = state.selectedTemplate,
+            reportType = state.reportType,
+            dateRangePreset = state.dateRangePreset,
+            startDate = state.startDate,
+            endDate = state.endDate,
+            selectedAccountIds = state.selectedAccountIds,
+            selectedCategoryIds = state.selectedCategoryIds,
+            includeTransfers = state.includeTransfers,
+            createdAt = Clock.System.now(),
+            isScheduled = state.isScheduled,
+        )
+        _uiState.value = state.copy(
+            savedReports = state.savedReports + saved,
+            showSaveDialog = false,
+            saveReportName = "",
+        )
+    }
+
+    /** Loads a saved report configuration into the builder. */
+    fun loadSavedReport(report: SavedReport) {
+        _uiState.value = _uiState.value.copy(
+            selectedTemplate = report.template,
+            reportType = report.reportType,
+            dateRangePreset = report.dateRangePreset,
+            startDate = report.startDate,
+            endDate = report.endDate,
+            selectedAccountIds = report.selectedAccountIds,
+            selectedCategoryIds = report.selectedCategoryIds,
+            includeTransfers = report.includeTransfers,
+            isScheduled = report.isScheduled,
+            showSavedReports = false,
+            isPreviewReady = false,
+        )
+    }
+
+    /** Deletes a saved report. */
+    fun deleteSavedReport(reportId: String) {
+        _uiState.value = _uiState.value.copy(
+            savedReports = _uiState.value.savedReports.filter { it.id != reportId },
+        )
+    }
+
+    /** Toggles the saved reports list visibility. */
+    fun toggleSavedReports() {
+        _uiState.value = _uiState.value.copy(
+            showSavedReports = !_uiState.value.showSavedReports,
+        )
     }
 }


### PR DESCRIPTION
## Summary

Enhances the existing Custom Report Builder UI on Windows Desktop with seven new capabilities:

1. Report template picker - Pre-configured templates (Monthly Summary, Category Breakdown, Trend Analysis, Custom) that auto-set report type and date range
2. Category filter (multi-select) - Filter report data by categories with Select All / Clear toggles
3. Chart rendering - Bar chart visualization using existing FinanceBarChart component, showing spending by category with income/expense coloring
4. Report preview - Full scrollable preview with summary cards, chart, and data table in a unified LazyColumn
5. Export options - Added SHARE format alongside PDF and CSV
6. Saved reports list - Save, load, and delete report configurations; persisted in ViewModel state
7. Scheduled report toggle - Switch to mark a report for auto-generation on a recurring interval

## Changes

### ViewModel (ReportBuilderViewModel.kt)
- Added CategoryRepository dependency for category filter data
- Added ReportTemplate enum (MONTHLY_SUMMARY, CATEGORY_BREAKDOWN, TREND_ANALYSIS, CUSTOM)
- Added ReportChartPoint data class for chart-ready data
- Added SavedReport data class with full configuration persistence
- Extended ReportBuilderUiState with category filters, chart data, saved reports, save dialog, and schedule toggle
- Added selectTemplate() with auto-configuration of report type + date range
- Added category filter methods: toggleCategorySelection(), selectAllCategories(), deselectAllCategories()
- Added saved report methods: showSaveDialog(), saveReport(), loadSavedReport(), deleteSavedReport(), toggleSavedReports()
- Added toggleScheduled() for scheduled report flag
- Enhanced generatePreview() to produce chart data points and filter by selected categories
- Added SHARE export format option

### Screen (ReportBuilderScreen.kt)
- Added template picker section with FilterChip row
- Added category filter section with multi-select checkboxes and Select All / Clear buttons
- Added ReportChartSection composable using FinanceBarChart for bar chart visualization
- Added SavedReportsSection composable showing saved configurations with load/delete
- Added SaveReportDialog composable for naming and saving report configs
- Added scheduled report toggle with Switch and description
- Added Save Report button in action section
- Replaced custom FlowRow with official ExperimentalLayoutApi FlowRow
- Unified preview panel into single LazyColumn with chart + summary + data table
- Full Narrator accessibility on all new elements

### DI (ViewModelModule.kt)
- Updated ReportBuilderViewModel registration to inject CategoryRepository (3 params)

## Accessibility

- All new composables have semantics contentDescription for Narrator
- Template chips, category filters, saved report entries all have role annotations
- Scheduled toggle has Switch role and descriptive label
- Save dialog has heading semantics and input descriptions
- Chart section announces category count

Closes #1115