### PR TITLE
feat(web): add report builder templates, charts, and saved reports (#1113)

### DIFF
--- a/apps/web/src/hooks/index.ts
+++ b/apps/web/src/hooks/index.ts
@@ -64,3 +64,14 @@ export { useInvestments } from './useInvestments';
 export type { UseInvestmentsResult, PortfolioSummary } from './useInvestments';
 export { useBills } from './useBills';
 export type { UseBillsResult, BillsSummary } from './useBills';
+export { useReportBuilder } from './useReportBuilder';
+export type {
+  UseReportBuilderResult,
+  ReportConfig,
+  ReportField,
+  ReportPreview,
+  ReportTemplate,
+  ChartType,
+  DatePreset,
+  SavedReport,
+} from './useReportBuilder';

--- a/apps/web/src/hooks/useReportBuilder.ts
+++ b/apps/web/src/hooks/useReportBuilder.ts
@@ -3,15 +3,22 @@
 /**
  * React hook for the custom report builder.
  *
- * Manages report configuration with draggable fields, date range filters,
- * category/account filters, and export preview (PDF/CSV).
+ * Manages report configuration with:
+ * - Report template picker (monthly summary, category breakdown, trend, custom)
+ * - Date range presets + custom picker
+ * - Category/account multi-select filters
+ * - Chart type selection (bar, line, pie)
+ * - Preview with tabular + chart data
+ * - Export (PDF, CSV, email)
+ * - Saved reports with localStorage persistence
+ * - Scheduled report toggle
  *
  * Usage:
  * ```tsx
- * const { config, addField, removeField, reorderFields, generatePreview } = useReportBuilder();
+ * const { config, applyTemplate, generatePreview, savedReports } = useReportBuilder();
  * ```
  *
- * References: issue #303
+ * References: issue #303, #1113
  */
 
 import { useCallback, useMemo, useState } from 'react';
@@ -41,29 +48,72 @@ export interface ReportField {
   readonly sortOrder: number;
 }
 
-export type ExportFormat = 'csv' | 'pdf';
+export type ExportFormat = 'csv' | 'pdf' | 'email';
 
 export type GroupBy = 'none' | 'category' | 'account' | 'month' | 'week';
 
+export type ChartType = 'bar' | 'line' | 'pie' | 'none';
+
+export type ReportTemplate = 'monthly-summary' | 'category-breakdown' | 'trend-analysis' | 'custom';
+
+export type DatePreset =
+  | 'this-month'
+  | 'last-month'
+  | 'this-quarter'
+  | 'last-quarter'
+  | 'ytd'
+  | 'last-year'
+  | 'custom';
+
 export interface ReportConfig {
   readonly name: string;
+  readonly template: ReportTemplate;
   readonly fields: ReportField[];
   readonly startDate: LocalDate | null;
   readonly endDate: LocalDate | null;
+  readonly datePreset: DatePreset;
   readonly categoryIds: SyncId[];
   readonly accountIds: SyncId[];
   readonly groupBy: GroupBy;
+  readonly chartType: ChartType;
   readonly exportFormat: ExportFormat;
+  readonly isScheduled: boolean;
+  readonly scheduleFrequency: 'weekly' | 'monthly' | 'quarterly';
 }
 
 export interface ReportPreviewRow {
   [key: string]: string | number;
 }
 
+/** Chart data point for Recharts rendering. */
+export interface ChartDataPoint {
+  readonly name: string;
+  readonly value: number;
+}
+
 export interface ReportPreview {
   readonly headers: string[];
   readonly rows: ReportPreviewRow[];
   readonly totalRows: number;
+  readonly chartData: ChartDataPoint[];
+  readonly summary: ReportSummary;
+}
+
+/** Summary statistics for the report preview. */
+export interface ReportSummary {
+  readonly totalIncome: number;
+  readonly totalExpenses: number;
+  readonly netAmount: number;
+  readonly transactionCount: number;
+}
+
+/** A saved report configuration. */
+export interface SavedReport {
+  readonly id: string;
+  readonly name: string;
+  readonly config: ReportConfig;
+  readonly createdAt: number;
+  readonly updatedAt: number;
 }
 
 export interface UseReportBuilderResult {
@@ -89,20 +139,38 @@ export interface UseReportBuilderResult {
   toggleFieldVisibility: (fieldId: string) => void;
   /** Set date range filter. */
   setDateRange: (startDate: LocalDate | null, endDate: LocalDate | null) => void;
+  /** Apply a date preset (this month, last quarter, etc.). */
+  applyDatePreset: (preset: DatePreset) => void;
   /** Set category filter. */
   setCategoryFilter: (categoryIds: SyncId[]) => void;
   /** Set account filter. */
   setAccountFilter: (accountIds: SyncId[]) => void;
   /** Set grouping mode. */
   setGroupBy: (groupBy: GroupBy) => void;
+  /** Set chart type for visualization. */
+  setChartType: (chartType: ChartType) => void;
   /** Set export format. */
   setExportFormat: (format: ExportFormat) => void;
+  /** Apply a report template (sets fields, grouping, chart type). */
+  applyTemplate: (template: ReportTemplate) => void;
+  /** Toggle scheduled report on/off. */
+  setScheduled: (scheduled: boolean) => void;
+  /** Set scheduled report frequency. */
+  setScheduleFrequency: (freq: 'weekly' | 'monthly' | 'quarterly') => void;
   /** Generate preview data. */
   generatePreview: () => void;
   /** Export the report in the selected format. Returns a data URL. */
   exportReport: () => string | null;
   /** Reset configuration to defaults. */
   resetConfig: () => void;
+  /** List of saved reports. */
+  savedReports: SavedReport[];
+  /** Save the current configuration as a named report. */
+  saveReport: () => void;
+  /** Load a saved report by ID. */
+  loadReport: (reportId: string) => void;
+  /** Delete a saved report by ID. */
+  deleteSavedReport: (reportId: string) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -124,14 +192,130 @@ const DEFAULT_FIELDS: ReportField[] = [
 function createDefaultConfig(): ReportConfig {
   return {
     name: 'Custom Report',
+    template: 'custom',
     fields: DEFAULT_FIELDS,
     startDate: null,
     endDate: null,
+    datePreset: 'this-month',
     categoryIds: [],
     accountIds: [],
     groupBy: 'none',
+    chartType: 'none',
     exportFormat: 'csv',
+    isScheduled: false,
+    scheduleFrequency: 'monthly',
   };
+}
+
+// ---------------------------------------------------------------------------
+// Template configurations
+// ---------------------------------------------------------------------------
+
+function getTemplateConfig(template: ReportTemplate): Partial<ReportConfig> {
+  switch (template) {
+    case 'monthly-summary':
+      return {
+        name: 'Monthly Summary',
+        template: 'monthly-summary',
+        groupBy: 'month',
+        chartType: 'bar',
+        datePreset: 'this-month',
+        fields: DEFAULT_FIELDS.map((f) =>
+          ['date', 'payee', 'amount', 'category'].includes(f.type)
+            ? { ...f, visible: true }
+            : { ...f, visible: false },
+        ),
+      };
+    case 'category-breakdown':
+      return {
+        name: 'Category Breakdown',
+        template: 'category-breakdown',
+        groupBy: 'category',
+        chartType: 'pie',
+        datePreset: 'this-month',
+        fields: DEFAULT_FIELDS.map((f) =>
+          ['category', 'amount'].includes(f.type)
+            ? { ...f, visible: true }
+            : { ...f, visible: false },
+        ),
+      };
+    case 'trend-analysis':
+      return {
+        name: 'Trend Analysis',
+        template: 'trend-analysis',
+        groupBy: 'month',
+        chartType: 'line',
+        datePreset: 'ytd',
+        fields: DEFAULT_FIELDS.map((f) =>
+          ['date', 'amount', 'category'].includes(f.type)
+            ? { ...f, visible: true }
+            : { ...f, visible: false },
+        ),
+      };
+    case 'custom':
+    default:
+      return {
+        name: 'Custom Report',
+        template: 'custom',
+      };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Date preset helpers
+// ---------------------------------------------------------------------------
+
+function formatDate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+function getDatePresetRange(preset: DatePreset): { start: string | null; end: string | null } {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = now.getMonth();
+
+  switch (preset) {
+    case 'this-month':
+      return {
+        start: formatDate(new Date(year, month, 1)),
+        end: formatDate(new Date(year, month + 1, 0)),
+      };
+    case 'last-month':
+      return {
+        start: formatDate(new Date(year, month - 1, 1)),
+        end: formatDate(new Date(year, month, 0)),
+      };
+    case 'this-quarter': {
+      const qStart = Math.floor(month / 3) * 3;
+      return {
+        start: formatDate(new Date(year, qStart, 1)),
+        end: formatDate(new Date(year, qStart + 3, 0)),
+      };
+    }
+    case 'last-quarter': {
+      const lqStart = Math.floor(month / 3) * 3 - 3;
+      return {
+        start: formatDate(new Date(year, lqStart, 1)),
+        end: formatDate(new Date(year, lqStart + 3, 0)),
+      };
+    }
+    case 'ytd':
+      return {
+        start: formatDate(new Date(year, 0, 1)),
+        end: formatDate(now),
+      };
+    case 'last-year':
+      return {
+        start: formatDate(new Date(year - 1, 0, 1)),
+        end: formatDate(new Date(year - 1, 11, 31)),
+      };
+    case 'custom':
+    default:
+      return { start: null, end: null };
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -223,7 +407,37 @@ function generateMockPreview(config: ReportConfig): ReportPreview {
     return mapped;
   });
 
-  return { headers, rows, totalRows: rows.length };
+  // Generate chart data grouped by category
+  const chartMap = new Map<string, number>();
+  for (const row of sampleData) {
+    const existing = chartMap.get(row.category) ?? 0;
+    chartMap.set(row.category, existing + Math.abs(row.amount));
+  }
+  const chartData: ChartDataPoint[] = Array.from(chartMap.entries()).map(([name, value]) => ({
+    name,
+    value,
+  }));
+
+  // Summary stats
+  const totalIncome = sampleData
+    .filter((r) => r.type === 'INCOME')
+    .reduce((sum, r) => sum + r.amount, 0);
+  const totalExpenses = sampleData
+    .filter((r) => r.type === 'EXPENSE')
+    .reduce((sum, r) => sum + Math.abs(r.amount), 0);
+
+  return {
+    headers,
+    rows,
+    totalRows: rows.length,
+    chartData,
+    summary: {
+      totalIncome,
+      totalExpenses,
+      netAmount: totalIncome - totalExpenses,
+      transactionCount: sampleData.length,
+    },
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -250,6 +464,32 @@ function generateCsvExport(preview: ReportPreview): string {
 }
 
 // ---------------------------------------------------------------------------
+// Saved reports storage
+// ---------------------------------------------------------------------------
+
+const SAVED_REPORTS_KEY = 'finance-saved-reports';
+
+function loadSavedReports(): SavedReport[] {
+  try {
+    const stored = localStorage.getItem(SAVED_REPORTS_KEY);
+    if (stored) {
+      return JSON.parse(stored) as SavedReport[];
+    }
+  } catch {
+    // Ignore parse errors
+  }
+  return [];
+}
+
+function persistSavedReports(reports: SavedReport[]): void {
+  try {
+    localStorage.setItem(SAVED_REPORTS_KEY, JSON.stringify(reports));
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------
 
@@ -258,6 +498,7 @@ export function useReportBuilder(): UseReportBuilderResult {
   const [preview, setPreview] = useState<ReportPreview | null>(null);
   const [generating, setGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [savedReports, setSavedReports] = useState<SavedReport[]>(loadSavedReports);
 
   const availableFields = useMemo(() => config.fields.filter((f) => !f.visible), [config.fields]);
 
@@ -314,7 +555,12 @@ export function useReportBuilder(): UseReportBuilderResult {
   }, []);
 
   const setDateRange = useCallback((startDate: LocalDate | null, endDate: LocalDate | null) => {
-    setConfig((prev) => ({ ...prev, startDate, endDate }));
+    setConfig((prev) => ({ ...prev, startDate, endDate, datePreset: 'custom' as DatePreset }));
+  }, []);
+
+  const applyDatePreset = useCallback((preset: DatePreset) => {
+    const { start, end } = getDatePresetRange(preset);
+    setConfig((prev) => ({ ...prev, datePreset: preset, startDate: start, endDate: end }));
   }, []);
 
   const setCategoryFilter = useCallback((categoryIds: SyncId[]) => {
@@ -329,9 +575,36 @@ export function useReportBuilder(): UseReportBuilderResult {
     setConfig((prev) => ({ ...prev, groupBy }));
   }, []);
 
+  const setChartType = useCallback((chartType: ChartType) => {
+    setConfig((prev) => ({ ...prev, chartType }));
+  }, []);
+
   const setExportFormat = useCallback((exportFormat: ExportFormat) => {
     setConfig((prev) => ({ ...prev, exportFormat }));
   }, []);
+
+  const applyTemplate = useCallback((template: ReportTemplate) => {
+    const templateConfig = getTemplateConfig(template);
+    const { start, end } = getDatePresetRange(templateConfig.datePreset ?? 'this-month');
+    setConfig((prev) => ({
+      ...prev,
+      ...templateConfig,
+      startDate: start,
+      endDate: end,
+    }));
+    setPreview(null);
+  }, []);
+
+  const setScheduled = useCallback((isScheduled: boolean) => {
+    setConfig((prev) => ({ ...prev, isScheduled }));
+  }, []);
+
+  const setScheduleFrequency = useCallback(
+    (scheduleFrequency: 'weekly' | 'monthly' | 'quarterly') => {
+      setConfig((prev) => ({ ...prev, scheduleFrequency }));
+    },
+    [],
+  );
 
   const generatePreview = useCallback(() => {
     setGenerating(true);
@@ -357,19 +630,68 @@ export function useReportBuilder(): UseReportBuilderResult {
       if (config.exportFormat === 'csv') {
         return generateCsvExport(preview);
       }
+      if (config.exportFormat === 'email') {
+        // Email export — placeholder for mailto integration
+        return `mailto:?subject=${encodeURIComponent(config.name)}&body=${encodeURIComponent('Report data attached.')}`;
+      }
       // PDF export would use a library — return placeholder
       return `data:application/pdf;base64,placeholder`;
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to export report.');
       return null;
     }
-  }, [preview, config.exportFormat]);
+  }, [preview, config.exportFormat, config.name]);
 
   const resetConfig = useCallback(() => {
     setConfig(createDefaultConfig());
     setPreview(null);
     setError(null);
   }, []);
+
+  const saveReport = useCallback(() => {
+    const now = Date.now();
+    const existing = savedReports.find((r) => r.name === config.name);
+
+    if (existing) {
+      const updated = savedReports.map((r) =>
+        r.id === existing.id ? { ...r, config, updatedAt: now } : r,
+      );
+      setSavedReports(updated);
+      persistSavedReports(updated);
+    } else {
+      const newReport: SavedReport = {
+        id: crypto.randomUUID(),
+        name: config.name,
+        config,
+        createdAt: now,
+        updatedAt: now,
+      };
+      const updated = [newReport, ...savedReports];
+      setSavedReports(updated);
+      persistSavedReports(updated);
+    }
+  }, [config, savedReports]);
+
+  const loadReport = useCallback(
+    (reportId: string) => {
+      const report = savedReports.find((r) => r.id === reportId);
+      if (report) {
+        setConfig(report.config);
+        setPreview(null);
+        setError(null);
+      }
+    },
+    [savedReports],
+  );
+
+  const deleteSavedReport = useCallback(
+    (reportId: string) => {
+      const updated = savedReports.filter((r) => r.id !== reportId);
+      setSavedReports(updated);
+      persistSavedReports(updated);
+    },
+    [savedReports],
+  );
 
   return {
     config,
@@ -383,12 +705,21 @@ export function useReportBuilder(): UseReportBuilderResult {
     reorderFields,
     toggleFieldVisibility,
     setDateRange,
+    applyDatePreset,
     setCategoryFilter,
     setAccountFilter,
     setGroupBy,
+    setChartType,
     setExportFormat,
+    applyTemplate,
+    setScheduled,
+    setScheduleFrequency,
     generatePreview,
     exportReport,
     resetConfig,
+    savedReports,
+    saveReport,
+    loadReport,
+    deleteSavedReport,
   };
 }

--- a/apps/web/src/pages/ReportBuilderPage.css
+++ b/apps/web/src/pages/ReportBuilderPage.css
@@ -2,7 +2,7 @@
 
 /**
  * Styles for the Custom Report Builder page.
- * References: issue #303
+ * References: issue #303, #1113
  */
 
 .report-builder {
@@ -18,6 +18,11 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+}
+
+.report-builder__header-actions {
+  display: flex;
+  gap: var(--spacing-2);
 }
 
 .report-builder__title {
@@ -53,6 +58,87 @@
   color: var(--semantic-text-secondary);
   font-size: var(--type-scale-caption-font-size);
   margin-bottom: var(--spacing-3);
+}
+
+/* Template picker grid */
+.report-template-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: var(--spacing-3);
+}
+
+.report-template-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+  padding: var(--spacing-4);
+  background: var(--semantic-background-secondary);
+  border: 2px solid transparent;
+  border-radius: var(--border-radius-md);
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+  transition: border-color var(--duration-fast, 100ms) ease;
+}
+
+.report-template-card:hover {
+  border-color: var(--semantic-border-default);
+}
+
+.report-template-card--active {
+  border-color: var(--semantic-interactive-default);
+  background: var(--semantic-background-elevated);
+}
+
+.report-template-card:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+}
+
+.report-template-card__name {
+  font-weight: var(--font-weight-semibold);
+  font-size: var(--type-scale-body-font-size);
+  color: var(--semantic-text-primary);
+}
+
+.report-template-card__desc {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+/* Date presets */
+.report-date-presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-3);
+}
+
+.report-date-preset {
+  padding: var(--spacing-1) var(--spacing-3);
+  background: var(--semantic-background-secondary);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-full, 9999px);
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-primary);
+  cursor: pointer;
+  font-family: inherit;
+  transition: background-color var(--duration-fast, 100ms) ease;
+}
+
+.report-date-preset:hover {
+  background: var(--semantic-background-elevated);
+}
+
+.report-date-preset--active {
+  background: var(--semantic-interactive-default);
+  color: var(--semantic-text-inverse);
+  border-color: transparent;
+}
+
+.report-date-preset:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
 }
 
 /* Inputs */
@@ -203,6 +289,119 @@
   color: var(--semantic-text-primary);
 }
 
+/* Schedule toggle */
+.report-schedule-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-4);
+}
+
+.report-toggle-label {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  cursor: pointer;
+}
+
+.report-toggle-input {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--semantic-interactive-default);
+}
+
+.report-toggle-text {
+  font-size: var(--type-scale-body-font-size);
+  color: var(--semantic-text-primary);
+}
+
+.report-schedule-freq {
+  width: auto;
+  min-width: 140px;
+}
+
+/* Chart container */
+.report-chart-container {
+  min-height: 300px;
+}
+
+/* Summary grid */
+.report-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: var(--spacing-4);
+}
+
+.report-summary-stat {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+  padding: var(--spacing-3);
+  background: var(--semantic-background-secondary);
+  border-radius: var(--border-radius-md);
+}
+
+.report-summary-stat__label {
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-medium);
+  color: var(--semantic-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.report-summary-stat__value {
+  font-size: var(--type-scale-title-font-size);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-primary);
+}
+
+.report-summary-stat__value--positive {
+  color: var(--semantic-status-positive);
+}
+
+.report-summary-stat__value--negative {
+  color: var(--semantic-status-negative);
+}
+
+/* Saved reports list */
+.report-saved-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.report-saved-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-3);
+  background: var(--semantic-background-secondary);
+  border-radius: var(--border-radius-md);
+}
+
+.report-saved-item__info {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.report-saved-item__name {
+  font-weight: var(--font-weight-medium);
+  color: var(--semantic-text-primary);
+}
+
+.report-saved-item__date {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+.report-saved-item__actions {
+  display: flex;
+  gap: var(--spacing-2);
+}
+
 /* Buttons */
 .report-button {
   display: inline-flex;
@@ -241,6 +440,21 @@
 
 .report-button--secondary:hover:not(:disabled) {
   background: var(--semantic-background-secondary);
+}
+
+.report-button--sm {
+  padding: var(--spacing-1) var(--spacing-3);
+  min-height: 32px;
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.report-button--danger {
+  color: var(--semantic-status-negative);
+  border-color: var(--semantic-status-negative);
+}
+
+.report-button--danger:hover:not(:disabled) {
+  background: rgba(239, 68, 68, 0.1);
 }
 
 .report-button:disabled {
@@ -316,8 +530,32 @@
     grid-template-columns: 1fr;
   }
 
+  .report-template-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .report-summary-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
   .report-actions {
     flex-direction: column;
+  }
+
+  .report-builder__header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--spacing-2);
+  }
+
+  .report-date-presets {
+    gap: var(--spacing-1);
+  }
+
+  .report-saved-item {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--spacing-2);
   }
 }
 
@@ -336,7 +574,9 @@
 @media (prefers-reduced-motion: reduce) {
   .report-field-item,
   .report-chip,
-  .report-button {
+  .report-button,
+  .report-template-card,
+  .report-date-preset {
     transition: none;
   }
 }
@@ -355,5 +595,13 @@
   .report-table th,
   .report-table td {
     border-bottom-width: 2px;
+  }
+
+  .report-template-card {
+    border-width: 3px;
+  }
+
+  .report-date-preset {
+    border-width: 2px;
   }
 }

--- a/apps/web/src/pages/ReportBuilderPage.test.tsx
+++ b/apps/web/src/pages/ReportBuilderPage.test.tsx
@@ -11,10 +11,38 @@ vi.mock('../hooks/useReportBuilder', () => ({
   useReportBuilder: vi.fn(),
 }));
 
+vi.mock('recharts', () => ({
+  BarChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="bar-chart">{children}</div>
+  ),
+  Bar: () => null,
+  LineChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="line-chart">{children}</div>
+  ),
+  Line: () => null,
+  PieChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="pie-chart">{children}</div>
+  ),
+  Pie: () => null,
+  Cell: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Legend: () => null,
+}));
+
+vi.mock('../components/charts/chart-palette', () => ({
+  CHART_COLORS: ['#4F46E5'],
+  formatChartCurrency: (v: number) => `$${(v / 100).toFixed(2)}`,
+}));
+
 const mockedUseReportBuilder = vi.mocked(useReportBuilder);
 
 const defaultConfig: ReportConfig = {
   name: 'Custom Report',
+  template: 'custom',
   fields: [
     { id: 'field-date', type: 'date', label: 'Date', visible: true, sortOrder: 0 },
     { id: 'field-payee', type: 'payee', label: 'Payee', visible: true, sortOrder: 1 },
@@ -23,10 +51,14 @@ const defaultConfig: ReportConfig = {
   ],
   startDate: null,
   endDate: null,
+  datePreset: 'this-month',
   categoryIds: [],
   accountIds: [],
   groupBy: 'none',
+  chartType: 'none',
   exportFormat: 'csv',
+  isScheduled: false,
+  scheduleFrequency: 'monthly',
 };
 
 function mockResult(overrides: Partial<UseReportBuilderResult> = {}): UseReportBuilderResult {
@@ -44,13 +76,22 @@ function mockResult(overrides: Partial<UseReportBuilderResult> = {}): UseReportB
     reorderFields: vi.fn(),
     toggleFieldVisibility: vi.fn(),
     setDateRange: vi.fn(),
+    applyDatePreset: vi.fn(),
     setCategoryFilter: vi.fn(),
     setAccountFilter: vi.fn(),
     setGroupBy: vi.fn(),
+    setChartType: vi.fn(),
     setExportFormat: vi.fn(),
+    applyTemplate: vi.fn(),
+    setScheduled: vi.fn(),
+    setScheduleFrequency: vi.fn(),
     generatePreview: vi.fn(),
     exportReport: vi.fn(),
     resetConfig: vi.fn(),
+    savedReports: [],
+    saveReport: vi.fn(),
+    loadReport: vi.fn(),
+    deleteSavedReport: vi.fn(),
     ...overrides,
   };
 }
@@ -94,9 +135,8 @@ describe('ReportBuilderPage', () => {
     mockedUseReportBuilder.mockReturnValue(mockResult());
 
     render(<ReportBuilderPage />);
-    expect(screen.getByLabelText('Start Date')).toBeInTheDocument();
-    expect(screen.getByLabelText('End Date')).toBeInTheDocument();
     expect(screen.getByLabelText('Group By')).toBeInTheDocument();
+    expect(screen.getByLabelText('Chart Type')).toBeInTheDocument();
     expect(screen.getByLabelText('Export Format')).toBeInTheDocument();
   });
 
@@ -114,6 +154,13 @@ describe('ReportBuilderPage', () => {
           headers: ['Date', 'Payee', 'Amount'],
           rows: [{ Date: '2025-01-15', Payee: 'Store', Amount: -4520 }],
           totalRows: 1,
+          chartData: [{ name: 'Groceries', value: 4520 }],
+          summary: {
+            totalIncome: 0,
+            totalExpenses: 4520,
+            netAmount: -4520,
+            transactionCount: 1,
+          },
         },
       }),
     );
@@ -142,11 +189,121 @@ describe('ReportBuilderPage', () => {
           headers: ['Date'],
           rows: [{ Date: '2025-01-15' }],
           totalRows: 1,
+          chartData: [],
+          summary: {
+            totalIncome: 0,
+            totalExpenses: 0,
+            netAmount: 0,
+            transactionCount: 1,
+          },
         },
       }),
     );
 
     rerender(<ReportBuilderPage />);
     expect(screen.getByRole('button', { name: /export.*csv/i })).toBeInTheDocument();
+  });
+
+  it('renders template picker cards', () => {
+    mockedUseReportBuilder.mockReturnValue(mockResult());
+
+    render(<ReportBuilderPage />);
+    expect(screen.getByText('Monthly Summary')).toBeInTheDocument();
+    expect(screen.getByText('Category Breakdown')).toBeInTheDocument();
+    expect(screen.getByText('Trend Analysis')).toBeInTheDocument();
+    expect(screen.getByText('Custom Report')).toBeInTheDocument();
+  });
+
+  it('renders date preset buttons', () => {
+    mockedUseReportBuilder.mockReturnValue(mockResult());
+
+    render(<ReportBuilderPage />);
+    expect(screen.getByRole('button', { name: 'This Month' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Last Month' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Year to Date' })).toBeInTheDocument();
+  });
+
+  it('renders schedule toggle', () => {
+    mockedUseReportBuilder.mockReturnValue(mockResult());
+
+    render(<ReportBuilderPage />);
+    expect(screen.getByLabelText(/enable scheduled report/i)).toBeInTheDocument();
+  });
+
+  it('shows save button', () => {
+    mockedUseReportBuilder.mockReturnValue(mockResult());
+
+    render(<ReportBuilderPage />);
+    expect(screen.getByRole('button', { name: /save current report/i })).toBeInTheDocument();
+  });
+
+  it('renders saved reports when available', () => {
+    mockedUseReportBuilder.mockReturnValue(
+      mockResult({
+        savedReports: [
+          {
+            id: 'report-1',
+            name: 'My Monthly Report',
+            config: defaultConfig,
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+          },
+        ],
+      }),
+    );
+
+    render(<ReportBuilderPage />);
+    expect(screen.getByText('Saved Reports')).toBeInTheDocument();
+    expect(screen.getByText('My Monthly Report')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /load report.*my monthly/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /delete report.*my monthly/i })).toBeInTheDocument();
+  });
+
+  it('renders summary when preview exists', () => {
+    mockedUseReportBuilder.mockReturnValue(
+      mockResult({
+        preview: {
+          headers: ['Date'],
+          rows: [{ Date: '2025-01-15' }],
+          totalRows: 1,
+          chartData: [],
+          summary: {
+            totalIncome: 350000,
+            totalExpenses: 22970,
+            netAmount: 327030,
+            transactionCount: 5,
+          },
+        },
+      }),
+    );
+
+    render(<ReportBuilderPage />);
+    expect(screen.getByText('Summary')).toBeInTheDocument();
+    expect(screen.getByText('Income')).toBeInTheDocument();
+    expect(screen.getByText('Expenses')).toBeInTheDocument();
+    expect(screen.getByText('Net')).toBeInTheDocument();
+  });
+
+  it('renders bar chart when chart type is bar', () => {
+    mockedUseReportBuilder.mockReturnValue(
+      mockResult({
+        config: { ...defaultConfig, chartType: 'bar' },
+        preview: {
+          headers: ['Date'],
+          rows: [{ Date: '2025-01-15' }],
+          totalRows: 1,
+          chartData: [{ name: 'Groceries', value: 4520 }],
+          summary: {
+            totalIncome: 0,
+            totalExpenses: 4520,
+            netAmount: -4520,
+            transactionCount: 1,
+          },
+        },
+      }),
+    );
+
+    render(<ReportBuilderPage />);
+    expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/ReportBuilderPage.tsx
+++ b/apps/web/src/pages/ReportBuilderPage.tsx
@@ -3,17 +3,40 @@
 /**
  * Custom Report Builder page.
  *
- * Drag-and-drop report configuration, date range filters,
- * category/account filters, PDF/CSV export preview.
+ * Template picker, date range presets, category filters,
+ * Recharts chart rendering (bar/line/pie), saved reports,
+ * scheduled report toggle, PDF/CSV/email export.
  *
- * References: issue #303
+ * References: issue #303, #1113
  */
 
 import { useCallback, useRef, useState } from 'react';
 import type { DragEvent } from 'react';
+import {
+  BarChart,
+  Bar,
+  LineChart,
+  Line,
+  PieChart,
+  Pie,
+  Cell,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from 'recharts';
 
 import { useReportBuilder } from '../hooks/useReportBuilder';
-import type { ExportFormat, GroupBy } from '../hooks/useReportBuilder';
+import type {
+  ExportFormat,
+  GroupBy,
+  ChartType,
+  ReportTemplate,
+  DatePreset,
+} from '../hooks/useReportBuilder';
+import { CHART_COLORS, formatChartCurrency } from '../components/charts/chart-palette';
 
 import './ReportBuilderPage.css';
 
@@ -32,6 +55,39 @@ const GROUP_OPTIONS: readonly { value: GroupBy; label: string }[] = [
 const FORMAT_OPTIONS: readonly { value: ExportFormat; label: string }[] = [
   { value: 'csv', label: 'CSV' },
   { value: 'pdf', label: 'PDF' },
+  { value: 'email', label: 'Email' },
+];
+
+const CHART_OPTIONS: readonly { value: ChartType; label: string }[] = [
+  { value: 'none', label: 'No Chart' },
+  { value: 'bar', label: 'Bar Chart' },
+  { value: 'line', label: 'Line Chart' },
+  { value: 'pie', label: 'Pie Chart' },
+];
+
+const TEMPLATE_OPTIONS: readonly { value: ReportTemplate; label: string; description: string }[] = [
+  {
+    value: 'monthly-summary',
+    label: 'Monthly Summary',
+    description: 'Overview of income and expenses by month',
+  },
+  {
+    value: 'category-breakdown',
+    label: 'Category Breakdown',
+    description: 'Spending distribution across categories',
+  },
+  { value: 'trend-analysis', label: 'Trend Analysis', description: 'Spending trends over time' },
+  { value: 'custom', label: 'Custom Report', description: 'Build your own report from scratch' },
+];
+
+const DATE_PRESET_OPTIONS: readonly { value: DatePreset; label: string }[] = [
+  { value: 'this-month', label: 'This Month' },
+  { value: 'last-month', label: 'Last Month' },
+  { value: 'this-quarter', label: 'This Quarter' },
+  { value: 'last-quarter', label: 'Last Quarter' },
+  { value: 'ytd', label: 'Year to Date' },
+  { value: 'last-year', label: 'Last Year' },
+  { value: 'custom', label: 'Custom Range' },
 ];
 
 // ---------------------------------------------------------------------------
@@ -50,11 +106,20 @@ export function ReportBuilderPage() {
     removeField,
     reorderFields,
     setDateRange,
+    applyDatePreset,
     setGroupBy,
+    setChartType,
     setExportFormat,
+    applyTemplate,
+    setScheduled,
+    setScheduleFrequency,
     generatePreview,
     exportReport,
     resetConfig,
+    savedReports,
+    saveReport,
+    loadReport,
+    deleteSavedReport,
   } = useReportBuilder();
 
   const [dragIndex, setDragIndex] = useState<number | null>(null);
@@ -100,17 +165,20 @@ export function ReportBuilderPage() {
   const handleExport = useCallback(() => {
     const url = exportReport();
     if (url) {
-      setExportUrl(url);
-      // Trigger download via hidden link
-      setTimeout(() => downloadRef.current?.click(), 100);
+      if (config.exportFormat === 'email') {
+        window.open(url, '_blank');
+      } else {
+        setExportUrl(url);
+        setTimeout(() => downloadRef.current?.click(), 100);
+      }
     }
-  }, [exportReport]);
+  }, [exportReport, config.exportFormat]);
 
   // -- Format amount for display -------------------------------------------
 
   const formatValue = (key: string, value: string | number): string => {
     if ((key === 'Amount' || key === 'Running Balance') && typeof value === 'number') {
-      return `$${(value / 100).toFixed(2)}`;
+      return formatChartCurrency(value, 'USD');
     }
     return String(value);
   };
@@ -127,14 +195,45 @@ export function ReportBuilderPage() {
         <h1 id="report-builder-title" className="report-builder__title">
           Custom Report Builder
         </h1>
-        <button
-          className="report-button report-button--secondary"
-          onClick={resetConfig}
-          aria-label="Reset report configuration"
-        >
-          Reset
-        </button>
+        <div className="report-builder__header-actions">
+          <button
+            className="report-button report-button--secondary"
+            onClick={saveReport}
+            aria-label="Save current report"
+          >
+            Save
+          </button>
+          <button
+            className="report-button report-button--secondary"
+            onClick={resetConfig}
+            aria-label="Reset report configuration"
+          >
+            Reset
+          </button>
+        </div>
       </header>
+
+      {/* Template Picker */}
+      <section className="report-card" aria-labelledby="template-title">
+        <h2 id="template-title" className="report-card__title">
+          Report Template
+        </h2>
+        <div className="report-template-grid" role="radiogroup" aria-label="Select report template">
+          {TEMPLATE_OPTIONS.map((tmpl) => (
+            <button
+              key={tmpl.value}
+              className={`report-template-card ${config.template === tmpl.value ? 'report-template-card--active' : ''}`}
+              role="radio"
+              aria-checked={config.template === tmpl.value}
+              onClick={() => applyTemplate(tmpl.value)}
+              aria-label={`${tmpl.label}: ${tmpl.description}`}
+            >
+              <span className="report-template-card__name">{tmpl.label}</span>
+              <span className="report-template-card__desc">{tmpl.description}</span>
+            </button>
+          ))}
+        </div>
+      </section>
 
       {/* Report Name */}
       <section className="report-card" aria-labelledby="report-name-label">
@@ -214,39 +313,62 @@ export function ReportBuilderPage() {
         )}
       </section>
 
-      {/* Filters */}
+      {/* Date Range */}
+      <section className="report-card" aria-labelledby="date-range-title">
+        <h2 id="date-range-title" className="report-card__title">
+          Date Range
+        </h2>
+
+        <div className="report-date-presets" role="group" aria-label="Date range presets">
+          {DATE_PRESET_OPTIONS.map((preset) => (
+            <button
+              key={preset.value}
+              className={`report-date-preset ${config.datePreset === preset.value ? 'report-date-preset--active' : ''}`}
+              onClick={() => applyDatePreset(preset.value)}
+              aria-pressed={config.datePreset === preset.value}
+            >
+              {preset.label}
+            </button>
+          ))}
+        </div>
+
+        {config.datePreset === 'custom' && (
+          <div className="report-filters-grid">
+            <div className="report-filter-group">
+              <label htmlFor="report-start-date" className="report-filter-group__label">
+                Start Date
+              </label>
+              <input
+                id="report-start-date"
+                className="report-input"
+                type="date"
+                value={config.startDate ?? ''}
+                onChange={(e) => setDateRange(e.target.value || null, config.endDate)}
+              />
+            </div>
+            <div className="report-filter-group">
+              <label htmlFor="report-end-date" className="report-filter-group__label">
+                End Date
+              </label>
+              <input
+                id="report-end-date"
+                className="report-input"
+                type="date"
+                value={config.endDate ?? ''}
+                onChange={(e) => setDateRange(config.startDate, e.target.value || null)}
+              />
+            </div>
+          </div>
+        )}
+      </section>
+
+      {/* Filters & Chart */}
       <section className="report-card" aria-labelledby="filters-title">
         <h2 id="filters-title" className="report-card__title">
-          Filters
+          Filters & Visualization
         </h2>
 
         <div className="report-filters-grid">
-          <div className="report-filter-group">
-            <label htmlFor="report-start-date" className="report-filter-group__label">
-              Start Date
-            </label>
-            <input
-              id="report-start-date"
-              className="report-input"
-              type="date"
-              value={config.startDate ?? ''}
-              onChange={(e) => setDateRange(e.target.value || null, config.endDate)}
-            />
-          </div>
-
-          <div className="report-filter-group">
-            <label htmlFor="report-end-date" className="report-filter-group__label">
-              End Date
-            </label>
-            <input
-              id="report-end-date"
-              className="report-input"
-              type="date"
-              value={config.endDate ?? ''}
-              onChange={(e) => setDateRange(config.startDate, e.target.value || null)}
-            />
-          </div>
-
           <div className="report-filter-group">
             <label htmlFor="report-group-by" className="report-filter-group__label">
               Group By
@@ -258,6 +380,24 @@ export function ReportBuilderPage() {
               onChange={(e) => setGroupBy(e.target.value as GroupBy)}
             >
               {GROUP_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="report-filter-group">
+            <label htmlFor="report-chart-type" className="report-filter-group__label">
+              Chart Type
+            </label>
+            <select
+              id="report-chart-type"
+              className="report-select"
+              value={config.chartType}
+              onChange={(e) => setChartType(e.target.value as ChartType)}
+            >
+              {CHART_OPTIONS.map((opt) => (
                 <option key={opt.value} value={opt.value}>
                   {opt.label}
                 </option>
@@ -282,6 +422,42 @@ export function ReportBuilderPage() {
               ))}
             </select>
           </div>
+        </div>
+      </section>
+
+      {/* Schedule Toggle */}
+      <section className="report-card" aria-labelledby="schedule-title">
+        <h2 id="schedule-title" className="report-card__title">
+          Schedule
+        </h2>
+        <div className="report-schedule-row">
+          <label className="report-toggle-label" htmlFor="report-schedule-toggle">
+            <input
+              id="report-schedule-toggle"
+              type="checkbox"
+              checked={config.isScheduled}
+              onChange={(e) => setScheduled(e.target.checked)}
+              className="report-toggle-input"
+              aria-label="Enable scheduled report"
+            />
+            <span className="report-toggle-text">
+              {config.isScheduled ? 'Scheduled' : 'Not Scheduled'}
+            </span>
+          </label>
+          {config.isScheduled && (
+            <select
+              className="report-select report-schedule-freq"
+              value={config.scheduleFrequency}
+              onChange={(e) =>
+                setScheduleFrequency(e.target.value as 'weekly' | 'monthly' | 'quarterly')
+              }
+              aria-label="Schedule frequency"
+            >
+              <option value="weekly">Weekly</option>
+              <option value="monthly">Monthly</option>
+              <option value="quarterly">Quarterly</option>
+            </select>
+          )}
         </div>
       </section>
 
@@ -320,6 +496,55 @@ export function ReportBuilderPage() {
         </a>
       )}
 
+      {/* Chart Preview */}
+      {preview && config.chartType !== 'none' && (
+        <section className="report-card" aria-labelledby="chart-title">
+          <h2 id="chart-title" className="report-card__title">
+            Chart
+          </h2>
+          <div
+            className="report-chart-container"
+            role="figure"
+            aria-label={`${config.chartType} chart of report data`}
+          >
+            <ReportChart chartType={config.chartType} data={preview.chartData} />
+          </div>
+        </section>
+      )}
+
+      {/* Summary */}
+      {preview && (
+        <section className="report-card" aria-labelledby="summary-title">
+          <h2 id="summary-title" className="report-card__title">
+            Summary
+          </h2>
+          <div className="report-summary-grid" role="group" aria-label="Report summary statistics">
+            <div className="report-summary-stat">
+              <span className="report-summary-stat__label">Income</span>
+              <span className="report-summary-stat__value report-summary-stat__value--positive">
+                {formatChartCurrency(preview.summary.totalIncome, 'USD')}
+              </span>
+            </div>
+            <div className="report-summary-stat">
+              <span className="report-summary-stat__label">Expenses</span>
+              <span className="report-summary-stat__value report-summary-stat__value--negative">
+                {formatChartCurrency(preview.summary.totalExpenses, 'USD')}
+              </span>
+            </div>
+            <div className="report-summary-stat">
+              <span className="report-summary-stat__label">Net</span>
+              <span className="report-summary-stat__value">
+                {formatChartCurrency(preview.summary.netAmount, 'USD')}
+              </span>
+            </div>
+            <div className="report-summary-stat">
+              <span className="report-summary-stat__label">Transactions</span>
+              <span className="report-summary-stat__value">{preview.summary.transactionCount}</span>
+            </div>
+          </div>
+        </section>
+      )}
+
       {/* Preview Table */}
       {preview && (
         <section className="report-card" aria-labelledby="preview-title">
@@ -355,8 +580,132 @@ export function ReportBuilderPage() {
           </div>
         </section>
       )}
+
+      {/* Saved Reports */}
+      {savedReports.length > 0 && (
+        <section className="report-card" aria-labelledby="saved-reports-title">
+          <h2 id="saved-reports-title" className="report-card__title">
+            Saved Reports
+          </h2>
+          <ul className="report-saved-list" role="list" aria-label="Saved reports">
+            {savedReports.map((report) => (
+              <li key={report.id} className="report-saved-item" role="listitem">
+                <div className="report-saved-item__info">
+                  <span className="report-saved-item__name">{report.name}</span>
+                  <span className="report-saved-item__date">
+                    {new Date(report.updatedAt).toLocaleDateString()}
+                  </span>
+                </div>
+                <div className="report-saved-item__actions">
+                  <button
+                    className="report-button report-button--secondary report-button--sm"
+                    onClick={() => loadReport(report.id)}
+                    aria-label={`Load report: ${report.name}`}
+                  >
+                    Load
+                  </button>
+                  <button
+                    className="report-button report-button--secondary report-button--sm report-button--danger"
+                    onClick={() => deleteSavedReport(report.id)}
+                    aria-label={`Delete report: ${report.name}`}
+                  >
+                    Delete
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
     </main>
   );
+}
+
+// ---------------------------------------------------------------------------
+// ReportChart sub-component (Recharts)
+// ---------------------------------------------------------------------------
+
+interface ReportChartProps {
+  chartType: ChartType;
+  data: readonly { name: string; value: number }[];
+}
+
+function ReportChart({ chartType, data }: ReportChartProps) {
+  const currency = 'USD';
+
+  if (chartType === 'bar') {
+    return (
+      <ResponsiveContainer width="100%" height={300}>
+        <BarChart data={[...data]} margin={{ top: 8, right: 16, bottom: 8, left: 16 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="var(--semantic-border-default, #E5E7EB)" />
+          <XAxis dataKey="name" tick={{ fontSize: 12 }} />
+          <YAxis tickFormatter={(v: number) => formatChartCurrency(v, currency)} width={80} />
+          <Tooltip formatter={(value) => formatChartCurrency(Number(value ?? 0), currency)} />
+          <Bar dataKey="value">
+            {data.map((entry, index) => (
+              <Cell
+                key={entry.name}
+                fill={CHART_COLORS[index % CHART_COLORS.length]}
+                role="listitem"
+                aria-label={`${entry.name}: ${formatChartCurrency(entry.value, currency)}`}
+              />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    );
+  }
+
+  if (chartType === 'line') {
+    return (
+      <ResponsiveContainer width="100%" height={300}>
+        <LineChart data={[...data]} margin={{ top: 8, right: 16, bottom: 8, left: 16 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="var(--semantic-border-default, #E5E7EB)" />
+          <XAxis dataKey="name" tick={{ fontSize: 12 }} />
+          <YAxis tickFormatter={(v: number) => formatChartCurrency(v, currency)} width={80} />
+          <Tooltip formatter={(value) => formatChartCurrency(Number(value ?? 0), currency)} />
+          <Line
+            type="monotone"
+            dataKey="value"
+            stroke={CHART_COLORS[0]}
+            strokeWidth={2}
+            dot={{ r: 4 }}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    );
+  }
+
+  if (chartType === 'pie') {
+    return (
+      <ResponsiveContainer width="100%" height={300}>
+        <PieChart>
+          <Pie
+            data={[...data]}
+            dataKey="value"
+            nameKey="name"
+            cx="50%"
+            cy="50%"
+            outerRadius={100}
+            label
+          >
+            {data.map((entry, index) => (
+              <Cell
+                key={entry.name}
+                fill={CHART_COLORS[index % CHART_COLORS.length]}
+                role="listitem"
+                aria-label={`${entry.name}: ${formatChartCurrency(entry.value, currency)}`}
+              />
+            ))}
+          </Pie>
+          <Tooltip formatter={(value) => formatChartCurrency(Number(value ?? 0), currency)} />
+          <Legend />
+        </PieChart>
+      </ResponsiveContainer>
+    );
+  }
+
+  return null;
 }
 
 export default ReportBuilderPage;

--- a/apps/web/src/pages/index.ts
+++ b/apps/web/src/pages/index.ts
@@ -23,3 +23,4 @@ export { InvestmentDetailPage } from './InvestmentDetailPage';
 export { BillsPage } from './BillsPage';
 export { BillDetailPage } from './BillDetailPage';
 export { CreateBillPage } from './CreateBillPage';
+export { ReportBuilderPage } from './ReportBuilderPage';


### PR DESCRIPTION
## Summary

Enhances the Custom Report Builder page with report templates, Recharts chart rendering, date range presets, saved reports, scheduled report toggle, and email export option.

## Changes

- **Report template picker**: Monthly Summary, Category Breakdown, Trend Analysis, and Custom templates — each auto-configures fields, grouping, and chart type
- **Date range presets**: This Month, Last Month, This Quarter, Last Quarter, Year to Date, Last Year, and Custom with date pickers
- **Chart rendering**: Recharts-powered bar, line, and pie charts integrated into preview
- **Summary statistics**: Income, Expenses, Net, and Transaction Count shown after preview generation
- **Export options**: CSV (data URL download), PDF (placeholder), and Email (mailto link)
- **Saved reports**: localStorage-backed list of saved report configs with Load/Delete actions
- **Scheduled report toggle**: Enable/disable with weekly, monthly, or quarterly frequency
- **WCAG 2.2 AA**: Full keyboard nav, ARIA roles/labels, focus management, reduced motion support, high contrast mode
- **Tests**: Extended test suite covering templates, date presets, charts (mocked Recharts), saved reports, schedule toggle, summary stats

## Issues

Closes #1113

## Testing

- [x] All existing tests pass
- [x] New tests for templates, date presets, charts, saved reports, schedule
- [x] Keyboard navigation verified
- [x] Screen reader labels verified (ARIA roles, labels)