### PR TITLE
feat(kmp): add bill reminder shared models and scheduling engine (#1120)

### DIFF
--- a/packages/core/src/commonMain/kotlin/com/finance/core/recurring/BillCalendar.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/recurring/BillCalendar.kt
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.recurring
+
+import com.finance.models.types.Cents
+import com.finance.models.types.SyncId
+import kotlinx.datetime.LocalDate
+import kotlinx.serialization.Serializable
+
+/**
+ * A day in the bill calendar with all bills due on that date.
+ *
+ * @property date The calendar date.
+ * @property bills List of bills due on this date.
+ * @property totalAmount Sum of all bill amounts for this date in their original currencies.
+ */
+@Serializable
+data class BillCalendarDay(
+    val date: LocalDate,
+    val bills: List<BillCalendarEntry>,
+    val totalAmount: Cents,
+) {
+    /** Number of bills due on this date. */
+    val billCount: Int get() = bills.size
+
+    /** `true` if any bill on this date is overdue. */
+    val hasOverdue: Boolean get() = bills.any { it.isOverdue }
+}
+
+/**
+ * A single bill entry in the calendar.
+ *
+ * @property ruleId The recurring transaction rule for this bill.
+ * @property merchant The payee/merchant name.
+ * @property amount The expected bill amount.
+ * @property dueDate The due date.
+ * @property isPaid `true` if a matching transaction has been recorded for this cycle.
+ * @property isOverdue `true` if the due date has passed without payment.
+ */
+@Serializable
+data class BillCalendarEntry(
+    val ruleId: SyncId,
+    val merchant: String,
+    val amount: Cents,
+    val dueDate: LocalDate,
+    val isPaid: Boolean = false,
+    val isOverdue: Boolean = false,
+)
+
+/**
+ * Monthly calendar view data for bills.
+ *
+ * @property year The calendar year.
+ * @property month The calendar month (1–12).
+ * @property days List of days with bills (only days that have bills are included).
+ * @property totalDue Total amount due across all bills this month.
+ * @property totalPaid Total amount already paid this month.
+ * @property billCount Total number of bills this month.
+ */
+@Serializable
+data class BillCalendarMonth(
+    val year: Int,
+    val month: Int,
+    val days: List<BillCalendarDay>,
+    val totalDue: Cents,
+    val totalPaid: Cents,
+    val billCount: Int,
+) {
+    /** Amount remaining to be paid this month. */
+    val totalRemaining: Cents get() = totalDue - totalPaid
+
+    /** Fraction of bills paid (0.0–1.0). */
+    val paidFraction: Double get() = if (billCount > 0) {
+        days.sumOf { day -> day.bills.count { it.isPaid } }.toDouble() / billCount
+    } else {
+        0.0
+    }
+}
+
+/**
+ * Bill confirmation flow states for auto-detected bills.
+ */
+@Serializable
+enum class BillConfirmationAction {
+    /** User confirms this is a recurring bill. */
+    ACCEPT,
+
+    /** User rejects — this is not a recurring bill. */
+    REJECT,
+
+    /** User wants to review later. */
+    SNOOZE,
+}
+
+/**
+ * An auto-detected bill presented to the user for confirmation.
+ *
+ * @property ruleId The auto-detected recurring rule to confirm.
+ * @property merchant Detected merchant name.
+ * @property amount Detected average amount.
+ * @property frequency Detected recurrence frequency.
+ * @property confidence Detection confidence in `[0.0, 1.0]`.
+ * @property recentDates Recent transaction dates that contributed to detection.
+ * @property action User's decision (null if not yet decided).
+ */
+@Serializable
+data class BillConfirmation(
+    val ruleId: SyncId,
+    val merchant: String,
+    val amount: Cents,
+    val frequency: RecurrenceFrequency,
+    val confidence: Double,
+    val recentDates: List<LocalDate>,
+    val action: BillConfirmationAction? = null,
+) {
+    init {
+        require(confidence in 0.0..1.0) { "Confidence must be in [0.0, 1.0], was $confidence" }
+    }
+
+    /** `true` if the user has taken an action on this confirmation. */
+    val isResolved: Boolean get() = action != null
+}
+
+/**
+ * Tracks amount changes for a recurring bill across cycles.
+ *
+ * @property ruleId The recurring rule being tracked.
+ * @property merchant The merchant name.
+ * @property currentAmount The most recent bill amount.
+ * @property previousAmount The previous cycle's amount.
+ * @property amountChange The change in cents (positive = increase, negative = decrease).
+ * @property changePercentage The percentage change.
+ * @property history Recent amounts for trend analysis.
+ */
+@Serializable
+data class BillAmountChange(
+    val ruleId: SyncId,
+    val merchant: String,
+    val currentAmount: Cents,
+    val previousAmount: Cents,
+    val amountChange: Cents,
+    val changePercentage: Double,
+    val history: List<BillAmountRecord>,
+) {
+    /** `true` if the amount increased from the previous cycle. */
+    val isIncrease: Boolean get() = amountChange.isPositive()
+
+    /** `true` if the amount decreased from the previous cycle. */
+    val isDecrease: Boolean get() = amountChange.isNegative()
+
+    /** `true` if the change exceeds 10% (potential billing error or rate change). */
+    val isSignificant: Boolean get() = kotlin.math.abs(changePercentage) > 10.0
+}
+
+/**
+ * A single historical bill amount record.
+ *
+ * @property date The date the bill was paid.
+ * @property amount The amount paid.
+ */
+@Serializable
+data class BillAmountRecord(
+    val date: LocalDate,
+    val amount: Cents,
+)

--- a/packages/core/src/commonMain/kotlin/com/finance/core/recurring/BillReminder.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/recurring/BillReminder.kt
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.recurring
+
+import com.finance.models.types.SyncId
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.serialization.Serializable
+
+/**
+ * Notification preference for bill reminders.
+ */
+@Serializable
+enum class ReminderNotificationType {
+    /** Push notification. */
+    PUSH,
+
+    /** In-app notification only. */
+    IN_APP,
+
+    /** Both push and in-app. */
+    BOTH,
+
+    /** No notification (silent). */
+    NONE,
+}
+
+/**
+ * A bill reminder configuration tied to a [RecurringTransactionRule].
+ *
+ * Defines when and how the user should be notified about an upcoming bill.
+ * The reminder fires at `dueDate - offsetDays` at the specified time.
+ *
+ * @property id Unique identifier for this reminder.
+ * @property ruleId The [RecurringTransactionRule] this reminder is for.
+ * @property ownerId Authenticated user who owns this reminder.
+ * @property offsetDays Number of days before the due date to fire the reminder.
+ *                      `0` means on the due date, `3` means 3 days before.
+ * @property reminderTime Time of day to fire the reminder (hour:minute).
+ * @property notificationType How to notify the user.
+ * @property isEnabled Whether this reminder is active.
+ * @property lastFiredDate The date this reminder last fired (for deduplication).
+ */
+@Serializable
+data class BillReminder(
+    val id: SyncId,
+    val ruleId: SyncId,
+    val ownerId: SyncId,
+    val offsetDays: Int = 3,
+    val reminderTime: ReminderTime = ReminderTime(9, 0),
+    val notificationType: ReminderNotificationType = ReminderNotificationType.PUSH,
+    val isEnabled: Boolean = true,
+    val lastFiredDate: LocalDate? = null,
+) {
+    init {
+        require(offsetDays >= 0) { "offsetDays must be non-negative, was $offsetDays" }
+    }
+}
+
+/**
+ * Time of day for a reminder, without timezone (user's local time).
+ *
+ * @property hour Hour in 24-hour format (0–23).
+ * @property minute Minute (0–59).
+ */
+@Serializable
+data class ReminderTime(
+    val hour: Int,
+    val minute: Int,
+) {
+    init {
+        require(hour in 0..23) { "Hour must be 0–23, was $hour" }
+        require(minute in 0..59) { "Minute must be 0–59, was $minute" }
+    }
+
+    /** Formatted as "HH:mm". */
+    override fun toString(): String = "${hour.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}"
+}
+
+/**
+ * Calculated next reminder notification time.
+ *
+ * @property ruleId The recurring rule this notification is for.
+ * @property reminderId The bill reminder configuration.
+ * @property dueDate The bill's due date.
+ * @property notificationDate The date the reminder should fire.
+ * @property notificationTime The time of day for the notification.
+ * @property merchant The merchant name (for notification content).
+ */
+@Serializable
+data class ScheduledNotification(
+    val ruleId: SyncId,
+    val reminderId: SyncId,
+    val dueDate: LocalDate,
+    val notificationDate: LocalDate,
+    val notificationTime: ReminderTime,
+    val merchant: String,
+)

--- a/packages/core/src/commonMain/kotlin/com/finance/core/recurring/BillReminderEngine.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/recurring/BillReminderEngine.kt
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.recurring
+
+import com.finance.models.types.Cents
+import com.finance.models.types.SyncId
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.minus
+import kotlinx.datetime.number
+import kotlinx.datetime.plus
+
+/**
+ * Engine for bill reminder scheduling, calendar generation, and amount change tracking.
+ *
+ * All functions are pure and deterministic — no side effects, no I/O.
+ * Platform notification scheduling (actual OS-level alarms) is the
+ * caller's responsibility; this engine only computes the data.
+ */
+object BillReminderEngine {
+
+    // ═════════════════════════════════════════════════════════════════
+    // Reminder Scheduling
+    // ═════════════════════════════════════════════════════════════════
+
+    /**
+     * Calculate the next notification times for a set of bill reminders.
+     *
+     * For each rule+reminder pair, computes when the notification should fire
+     * based on the rule's next due date and the reminder's offset.
+     *
+     * @param rules Active recurring transaction rules.
+     * @param reminders Bill reminder configurations keyed by rule ID.
+     * @param today Reference date for filtering (only future notifications returned).
+     * @return Sorted list of [ScheduledNotification]s in chronological order.
+     */
+    fun scheduleNotifications(
+        rules: List<RecurringTransactionRule>,
+        reminders: Map<SyncId, BillReminder>,
+        today: LocalDate,
+    ): List<ScheduledNotification> {
+        val notifications = mutableListOf<ScheduledNotification>()
+
+        for (rule in rules) {
+            if (!rule.isConfirmed) continue
+            val reminder = reminders[rule.id] ?: continue
+            if (!reminder.isEnabled) continue
+
+            val notificationDate = rule.nextDueDate.minus(reminder.offsetDays, DateTimeUnit.DAY)
+
+            // Only include future or today's notifications
+            if (notificationDate >= today) {
+                notifications.add(
+                    ScheduledNotification(
+                        ruleId = rule.id,
+                        reminderId = reminder.id,
+                        dueDate = rule.nextDueDate,
+                        notificationDate = notificationDate,
+                        notificationTime = reminder.reminderTime,
+                        merchant = rule.merchant,
+                    ),
+                )
+            }
+        }
+
+        return notifications.sortedBy { it.notificationDate }
+    }
+
+    /**
+     * Calculate notification times for the next N occurrences of a rule.
+     *
+     * @param rule The recurring transaction rule.
+     * @param reminder The bill reminder configuration.
+     * @param from Start date for occurrence generation.
+     * @param count Number of future occurrences to generate.
+     * @return List of [ScheduledNotification]s for the next [count] occurrences.
+     */
+    fun scheduleNextN(
+        rule: RecurringTransactionRule,
+        reminder: BillReminder,
+        from: LocalDate,
+        count: Int,
+    ): List<ScheduledNotification> {
+        require(count > 0) { "Count must be positive, was $count" }
+
+        val endDate = from.plus(365 * 2, DateTimeUnit.DAY) // 2-year horizon
+        val occurrences = RecurringTransactionEngine.generateUpcoming(
+            rule.recurrenceRule, from, endDate,
+        ).take(count)
+
+        return occurrences.map { dueDate ->
+            val notifDate = dueDate.minus(reminder.offsetDays, DateTimeUnit.DAY)
+            ScheduledNotification(
+                ruleId = rule.id,
+                reminderId = reminder.id,
+                dueDate = dueDate,
+                notificationDate = notifDate,
+                notificationTime = reminder.reminderTime,
+                merchant = rule.merchant,
+            )
+        }
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // Bill Calendar
+    // ═════════════════════════════════════════════════════════════════
+
+    /**
+     * Generate a monthly bill calendar view.
+     *
+     * Computes all bill occurrences for the specified month, marks paid/overdue
+     * status, and aggregates totals.
+     *
+     * @param rules Active recurring transaction rules.
+     * @param year Calendar year.
+     * @param month Calendar month (1–12).
+     * @param today Reference date for overdue detection.
+     * @param paidBills Set of (ruleId, dueDate) pairs for bills already paid.
+     * @return [BillCalendarMonth] with all bills for the month.
+     */
+    fun generateMonthlyCalendar(
+        rules: List<RecurringTransactionRule>,
+        year: Int,
+        month: Int,
+        today: LocalDate,
+        paidBills: Set<Pair<SyncId, LocalDate>> = emptySet(),
+    ): BillCalendarMonth {
+        val firstDay = LocalDate(year, month, 1)
+        val lastDay = lastDayOfMonth(year, month)
+
+        val dayMap = mutableMapOf<LocalDate, MutableList<BillCalendarEntry>>()
+
+        for (rule in rules) {
+            if (!rule.isConfirmed) continue
+
+            val occurrences = RecurringTransactionEngine.generateUpcoming(
+                rule.recurrenceRule, firstDay, lastDay,
+            )
+
+            for (dueDate in occurrences) {
+                val isPaid = Pair(rule.id, dueDate) in paidBills
+                val isOverdue = !isPaid && dueDate < today
+
+                val entry = BillCalendarEntry(
+                    ruleId = rule.id,
+                    merchant = rule.merchant,
+                    amount = rule.amount,
+                    dueDate = dueDate,
+                    isPaid = isPaid,
+                    isOverdue = isOverdue,
+                )
+
+                dayMap.getOrPut(dueDate) { mutableListOf() }.add(entry)
+            }
+        }
+
+        val days = dayMap.entries.sortedBy { it.key }.map { (date, bills) ->
+            BillCalendarDay(
+                date = date,
+                bills = bills,
+                totalAmount = Cents(bills.sumOf { it.amount.amount }),
+            )
+        }
+
+        val allBills = days.flatMap { it.bills }
+        val totalDue = Cents(allBills.sumOf { it.amount.amount })
+        val totalPaid = Cents(allBills.filter { it.isPaid }.sumOf { it.amount.amount })
+
+        return BillCalendarMonth(
+            year = year,
+            month = month,
+            days = days,
+            totalDue = totalDue,
+            totalPaid = totalPaid,
+            billCount = allBills.size,
+        )
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // Bill Amount Tracking
+    // ═════════════════════════════════════════════════════════════════
+
+    /**
+     * Detect amount changes for a recurring bill by comparing recent payments.
+     *
+     * @param ruleId The recurring rule ID.
+     * @param merchant The merchant name.
+     * @param history Chronologically ordered list of recent bill amounts.
+     * @return [BillAmountChange] if there's been a change, or `null` if
+     *         history is too short (< 2 records) or amounts are unchanged.
+     */
+    fun detectAmountChange(
+        ruleId: SyncId,
+        merchant: String,
+        history: List<BillAmountRecord>,
+    ): BillAmountChange? {
+        if (history.size < 2) return null
+
+        val sorted = history.sortedBy { it.date }
+        val current = sorted.last()
+        val previous = sorted[sorted.size - 2]
+
+        if (current.amount == previous.amount) return null
+
+        val change = current.amount - previous.amount
+        val percentChange = if (previous.amount.amount != 0L) {
+            (change.amount.toDouble() / previous.amount.abs().amount) * 100.0
+        } else {
+            0.0
+        }
+
+        return BillAmountChange(
+            ruleId = ruleId,
+            merchant = merchant,
+            currentAmount = current.amount,
+            previousAmount = previous.amount,
+            amountChange = change,
+            changePercentage = percentChange,
+            history = sorted,
+        )
+    }
+
+    /**
+     * Detect amount changes across all tracked bills.
+     *
+     * @param billHistories Map of rule ID to list of amount records.
+     * @param rules Active rules for merchant name lookup.
+     * @return List of [BillAmountChange]s for bills with detected changes.
+     */
+    fun detectAllAmountChanges(
+        billHistories: Map<SyncId, List<BillAmountRecord>>,
+        rules: List<RecurringTransactionRule>,
+    ): List<BillAmountChange> {
+        val ruleMap = rules.associateBy { it.id }
+        return billHistories.mapNotNull { (ruleId, history) ->
+            val rule = ruleMap[ruleId] ?: return@mapNotNull null
+            detectAmountChange(ruleId, rule.merchant, history)
+        }
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // Internal helpers
+    // ═════════════════════════════════════════════════════════════════
+
+    private fun lastDayOfMonth(year: Int, month: Int): LocalDate {
+        val daysInMonth = when (month) {
+            1 -> 31; 2 -> if (isLeapYear(year)) 29 else 28; 3 -> 31
+            4 -> 30; 5 -> 31; 6 -> 30; 7 -> 31; 8 -> 31
+            9 -> 30; 10 -> 31; 11 -> 30; 12 -> 31
+            else -> throw IllegalArgumentException("Invalid month: $month")
+        }
+        return LocalDate(year, month, daysInMonth)
+    }
+
+    private fun isLeapYear(year: Int): Boolean =
+        (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/recurring/RecurringTransactionRule.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/recurring/RecurringTransactionRule.kt
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.recurring
+
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.serialization.Serializable
+
+/**
+ * A recurring transaction rule defining a repeating bill or income.
+ *
+ * This model represents the full metadata for a recurring bill/transaction,
+ * including merchant, amount, frequency, and notification preferences.
+ * It extends the scheduling concept from [RecurrenceRule] with financial
+ * context needed for bill management.
+ *
+ * @property id Unique identifier for this rule.
+ * @property ownerId Authenticated user who owns this rule.
+ * @property householdId Household this rule belongs to.
+ * @property merchant The payee/merchant name for this recurring bill.
+ * @property amount Expected bill amount in cents.
+ * @property currency Currency for the bill amount.
+ * @property accountId Account to charge/credit.
+ * @property categoryId Category for generated transactions.
+ * @property recurrenceRule The scheduling rule (frequency, interval, start/end).
+ * @property nextDueDate The next upcoming due date.
+ * @property isAutoDetected `true` if this rule was auto-detected from transaction history.
+ * @property isConfirmed `true` if the user has confirmed this rule (relevant for auto-detected rules).
+ * @property note Optional user note.
+ * @property createdAt Record creation timestamp.
+ * @property updatedAt Last modification timestamp.
+ * @property deletedAt Soft-delete timestamp.
+ * @property syncVersion Sync versioning for conflict resolution.
+ * @property isSynced Whether this record has been synced to the server.
+ */
+@Serializable
+data class RecurringTransactionRule(
+    val id: SyncId,
+    val ownerId: SyncId,
+    val householdId: SyncId,
+    val merchant: String,
+    val amount: Cents,
+    val currency: Currency,
+    val accountId: SyncId,
+    val categoryId: SyncId? = null,
+    val recurrenceRule: RecurrenceRule,
+    val nextDueDate: LocalDate,
+    val isAutoDetected: Boolean = false,
+    val isConfirmed: Boolean = true,
+    val note: String? = null,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+    val deletedAt: Instant? = null,
+    val syncVersion: Long = 0,
+    val isSynced: Boolean = false,
+) {
+    init {
+        require(merchant.isNotBlank()) { "Merchant name cannot be blank" }
+        require(amount.amount != 0L) { "Bill amount cannot be zero" }
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/recurring/BillReminderEngineTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/recurring/BillReminderEngineTest.kt
@@ -1,0 +1,526 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.recurring
+
+import com.finance.models.types.Cents
+import com.finance.models.types.Currency
+import com.finance.models.types.SyncId
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class BillReminderEngineTest {
+
+    private val fixedInstant: Instant = Instant.parse("2024-06-15T12:00:00Z")
+    private val today = LocalDate(2024, 6, 15)
+
+    private fun createRule(
+        id: String = "rule-1",
+        merchant: String = "Netflix",
+        amount: Long = 1599L,
+        frequency: RecurrenceFrequency = RecurrenceFrequency.MONTHLY,
+        startDate: LocalDate = LocalDate(2024, 1, 15),
+        nextDueDate: LocalDate = LocalDate(2024, 7, 15),
+        isConfirmed: Boolean = true,
+    ): RecurringTransactionRule = RecurringTransactionRule(
+        id = SyncId(id),
+        ownerId = SyncId("owner-1"),
+        householdId = SyncId("household-1"),
+        merchant = merchant,
+        amount = Cents(amount),
+        currency = Currency.USD,
+        accountId = SyncId("account-1"),
+        recurrenceRule = RecurrenceRule(
+            id = SyncId("recurrence-$id"),
+            frequency = frequency,
+            startDate = startDate,
+        ),
+        nextDueDate = nextDueDate,
+        isConfirmed = isConfirmed,
+        createdAt = fixedInstant,
+        updatedAt = fixedInstant,
+    )
+
+    private fun createReminder(
+        id: String = "reminder-1",
+        ruleId: String = "rule-1",
+        offsetDays: Int = 3,
+        isEnabled: Boolean = true,
+    ): BillReminder = BillReminder(
+        id = SyncId(id),
+        ruleId = SyncId(ruleId),
+        ownerId = SyncId("owner-1"),
+        offsetDays = offsetDays,
+        isEnabled = isEnabled,
+    )
+
+    // ═════════════════════════════════════════════════════════════════
+    // Recurring Transaction Rule
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun recurringTransactionRule_creation() {
+        val rule = createRule()
+        assertEquals("Netflix", rule.merchant)
+        assertEquals(Cents(1599L), rule.amount)
+        assertTrue(rule.isConfirmed)
+    }
+
+    @Test
+    fun recurringTransactionRule_serializable() {
+        val rule = createRule()
+        assertNotNull(rule.id)
+        assertNotNull(rule.ownerId)
+        assertNotNull(rule.householdId)
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // Bill Reminder
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun billReminder_creation() {
+        val reminder = createReminder()
+        assertEquals(3, reminder.offsetDays)
+        assertTrue(reminder.isEnabled)
+        assertEquals(ReminderNotificationType.PUSH, reminder.notificationType)
+    }
+
+    @Test
+    fun reminderTime_formatting() {
+        assertEquals("09:00", ReminderTime(9, 0).toString())
+        assertEquals("14:30", ReminderTime(14, 30).toString())
+        assertEquals("00:05", ReminderTime(0, 5).toString())
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // Notification Scheduling
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun scheduleNotifications_calculatesCorrectDate() {
+        val rule = createRule(nextDueDate = LocalDate(2024, 7, 15))
+        val reminder = createReminder(offsetDays = 3)
+
+        val notifications = BillReminderEngine.scheduleNotifications(
+            rules = listOf(rule),
+            reminders = mapOf(SyncId("rule-1") to reminder),
+            today = today,
+        )
+
+        assertEquals(1, notifications.size)
+        assertEquals(LocalDate(2024, 7, 12), notifications[0].notificationDate) // 15 - 3 = 12
+        assertEquals(LocalDate(2024, 7, 15), notifications[0].dueDate)
+        assertEquals("Netflix", notifications[0].merchant)
+    }
+
+    @Test
+    fun scheduleNotifications_zeroOffset_notifiesOnDueDate() {
+        val rule = createRule(nextDueDate = LocalDate(2024, 7, 15))
+        val reminder = createReminder(offsetDays = 0)
+
+        val notifications = BillReminderEngine.scheduleNotifications(
+            rules = listOf(rule),
+            reminders = mapOf(SyncId("rule-1") to reminder),
+            today = today,
+        )
+
+        assertEquals(1, notifications.size)
+        assertEquals(LocalDate(2024, 7, 15), notifications[0].notificationDate)
+    }
+
+    @Test
+    fun scheduleNotifications_skipsPastNotifications() {
+        val rule = createRule(nextDueDate = LocalDate(2024, 6, 10)) // past due
+        val reminder = createReminder(offsetDays = 3)
+
+        val notifications = BillReminderEngine.scheduleNotifications(
+            rules = listOf(rule),
+            reminders = mapOf(SyncId("rule-1") to reminder),
+            today = today,
+        )
+
+        assertEquals(0, notifications.size)
+    }
+
+    @Test
+    fun scheduleNotifications_skipsUnconfirmedRules() {
+        val rule = createRule(isConfirmed = false, nextDueDate = LocalDate(2024, 7, 15))
+        val reminder = createReminder()
+
+        val notifications = BillReminderEngine.scheduleNotifications(
+            rules = listOf(rule),
+            reminders = mapOf(SyncId("rule-1") to reminder),
+            today = today,
+        )
+
+        assertEquals(0, notifications.size)
+    }
+
+    @Test
+    fun scheduleNotifications_skipsDisabledReminders() {
+        val rule = createRule(nextDueDate = LocalDate(2024, 7, 15))
+        val reminder = createReminder(isEnabled = false)
+
+        val notifications = BillReminderEngine.scheduleNotifications(
+            rules = listOf(rule),
+            reminders = mapOf(SyncId("rule-1") to reminder),
+            today = today,
+        )
+
+        assertEquals(0, notifications.size)
+    }
+
+    @Test
+    fun scheduleNotifications_multipleRules_sortedChronologically() {
+        val rule1 = createRule(id = "rule-1", merchant = "Netflix", nextDueDate = LocalDate(2024, 7, 20))
+        val rule2 = createRule(id = "rule-2", merchant = "Spotify", nextDueDate = LocalDate(2024, 7, 10))
+
+        val reminders = mapOf(
+            SyncId("rule-1") to createReminder(id = "rem-1", ruleId = "rule-1", offsetDays = 3),
+            SyncId("rule-2") to createReminder(id = "rem-2", ruleId = "rule-2", offsetDays = 1),
+        )
+
+        val notifications = BillReminderEngine.scheduleNotifications(
+            rules = listOf(rule1, rule2),
+            reminders = reminders,
+            today = today,
+        )
+
+        assertEquals(2, notifications.size)
+        // Spotify: July 10 - 1 = July 9... wait, that's before today (June 15)
+        // Let me fix: Spotify due July 10, offset 1 → notify July 9 which is > June 15
+        assertEquals("Spotify", notifications[0].merchant)
+        assertEquals("Netflix", notifications[1].merchant)
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // Schedule Next N
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun scheduleNextN_generatesCorrectCount() {
+        val rule = createRule(nextDueDate = LocalDate(2024, 7, 15))
+        val reminder = createReminder(offsetDays = 3)
+
+        val notifications = BillReminderEngine.scheduleNextN(
+            rule, reminder, from = LocalDate(2024, 7, 1), count = 3,
+        )
+
+        assertEquals(3, notifications.size)
+        // Monthly from July 15: Jul 15, Aug 15, Sep 15
+        assertEquals(LocalDate(2024, 7, 12), notifications[0].notificationDate)
+        assertEquals(LocalDate(2024, 8, 12), notifications[1].notificationDate)
+        assertEquals(LocalDate(2024, 9, 12), notifications[2].notificationDate)
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // Bill Calendar
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun monthlyCalendar_generatesCorrectBills() {
+        val rule1 = createRule(id = "rule-1", merchant = "Netflix", amount = 1599)
+        val rule2 = createRule(
+            id = "rule-2", merchant = "Rent", amount = 150000,
+            startDate = LocalDate(2024, 1, 1),
+            frequency = RecurrenceFrequency.MONTHLY,
+        )
+
+        val calendar = BillReminderEngine.generateMonthlyCalendar(
+            rules = listOf(rule1, rule2),
+            year = 2024,
+            month = 7,
+            today = today,
+        )
+
+        assertEquals(2024, calendar.year)
+        assertEquals(7, calendar.month)
+        assertTrue(calendar.billCount >= 2) // At least Netflix + Rent in July
+    }
+
+    @Test
+    fun monthlyCalendar_marksPaidBills() {
+        val rule = createRule(nextDueDate = LocalDate(2024, 7, 15))
+
+        val paidBills = setOf(Pair(SyncId("rule-1"), LocalDate(2024, 7, 15)))
+
+        val calendar = BillReminderEngine.generateMonthlyCalendar(
+            rules = listOf(rule),
+            year = 2024,
+            month = 7,
+            today = today,
+            paidBills = paidBills,
+        )
+
+        val billDay = calendar.days.firstOrNull { it.date == LocalDate(2024, 7, 15) }
+        assertNotNull(billDay)
+        assertTrue(billDay.bills.all { it.isPaid })
+    }
+
+    @Test
+    fun monthlyCalendar_marksOverdueBills() {
+        val rule = createRule(
+            startDate = LocalDate(2024, 6, 1),
+            nextDueDate = LocalDate(2024, 6, 1),
+        )
+
+        val calendar = BillReminderEngine.generateMonthlyCalendar(
+            rules = listOf(rule),
+            year = 2024,
+            month = 6,
+            today = today, // June 15 — bill on June 1 is overdue
+        )
+
+        val overdueDay = calendar.days.firstOrNull { it.date == LocalDate(2024, 6, 1) }
+        assertNotNull(overdueDay)
+        assertTrue(overdueDay.hasOverdue)
+    }
+
+    @Test
+    fun monthlyCalendar_calculatesTotals() {
+        val rule1 = createRule(id = "rule-1", amount = 1000)
+        val rule2 = createRule(
+            id = "rule-2", amount = 2000,
+            startDate = LocalDate(2024, 1, 20),
+        )
+
+        val paidBills = setOf(Pair(SyncId("rule-1"), LocalDate(2024, 7, 15)))
+
+        val calendar = BillReminderEngine.generateMonthlyCalendar(
+            rules = listOf(rule1, rule2),
+            year = 2024,
+            month = 7,
+            today = today,
+            paidBills = paidBills,
+        )
+
+        assertEquals(Cents(3000L), calendar.totalDue) // 1000 + 2000
+        assertEquals(Cents(1000L), calendar.totalPaid) // Only rule-1 paid
+        assertEquals(Cents(2000L), calendar.totalRemaining)
+    }
+
+    @Test
+    fun monthlyCalendar_skipsUnconfirmedRules() {
+        val rule = createRule(isConfirmed = false)
+
+        val calendar = BillReminderEngine.generateMonthlyCalendar(
+            rules = listOf(rule),
+            year = 2024,
+            month = 7,
+            today = today,
+        )
+
+        assertEquals(0, calendar.billCount)
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // Bill Confirmation Flow
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun billConfirmation_creation() {
+        val confirmation = BillConfirmation(
+            ruleId = SyncId("rule-1"),
+            merchant = "Netflix",
+            amount = Cents(1599L),
+            frequency = RecurrenceFrequency.MONTHLY,
+            confidence = 0.85,
+            recentDates = listOf(
+                LocalDate(2024, 4, 15),
+                LocalDate(2024, 5, 15),
+                LocalDate(2024, 6, 15),
+            ),
+        )
+
+        assertFalse(confirmation.isResolved)
+        assertEquals(0.85, confirmation.confidence)
+    }
+
+    @Test
+    fun billConfirmation_accept() {
+        val confirmation = BillConfirmation(
+            ruleId = SyncId("rule-1"),
+            merchant = "Netflix",
+            amount = Cents(1599L),
+            frequency = RecurrenceFrequency.MONTHLY,
+            confidence = 0.9,
+            recentDates = emptyList(),
+            action = BillConfirmationAction.ACCEPT,
+        )
+
+        assertTrue(confirmation.isResolved)
+        assertEquals(BillConfirmationAction.ACCEPT, confirmation.action)
+    }
+
+    @Test
+    fun billConfirmation_reject() {
+        val confirmation = BillConfirmation(
+            ruleId = SyncId("rule-1"),
+            merchant = "One-time Purchase",
+            amount = Cents(9999L),
+            frequency = RecurrenceFrequency.MONTHLY,
+            confidence = 0.3,
+            recentDates = emptyList(),
+            action = BillConfirmationAction.REJECT,
+        )
+
+        assertTrue(confirmation.isResolved)
+        assertEquals(BillConfirmationAction.REJECT, confirmation.action)
+    }
+
+    @Test
+    fun billConfirmation_snooze() {
+        val confirmation = BillConfirmation(
+            ruleId = SyncId("rule-1"),
+            merchant = "Maybe Recurring",
+            amount = Cents(5000L),
+            frequency = RecurrenceFrequency.MONTHLY,
+            confidence = 0.6,
+            recentDates = emptyList(),
+            action = BillConfirmationAction.SNOOZE,
+        )
+
+        assertTrue(confirmation.isResolved)
+        assertEquals(BillConfirmationAction.SNOOZE, confirmation.action)
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // Bill Amount Tracking
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun detectAmountChange_noChange() {
+        val history = listOf(
+            BillAmountRecord(LocalDate(2024, 5, 15), Cents(1599L)),
+            BillAmountRecord(LocalDate(2024, 6, 15), Cents(1599L)),
+        )
+
+        val result = BillReminderEngine.detectAmountChange(
+            SyncId("rule-1"), "Netflix", history,
+        )
+
+        assertNull(result) // No change
+    }
+
+    @Test
+    fun detectAmountChange_increase() {
+        val history = listOf(
+            BillAmountRecord(LocalDate(2024, 5, 15), Cents(1599L)),
+            BillAmountRecord(LocalDate(2024, 6, 15), Cents(1799L)),
+        )
+
+        val result = BillReminderEngine.detectAmountChange(
+            SyncId("rule-1"), "Netflix", history,
+        )
+
+        assertNotNull(result)
+        assertTrue(result.isIncrease)
+        assertFalse(result.isDecrease)
+        assertEquals(Cents(200L), result.amountChange)
+        assertEquals(Cents(1799L), result.currentAmount)
+        assertEquals(Cents(1599L), result.previousAmount)
+    }
+
+    @Test
+    fun detectAmountChange_decrease() {
+        val history = listOf(
+            BillAmountRecord(LocalDate(2024, 5, 15), Cents(2000L)),
+            BillAmountRecord(LocalDate(2024, 6, 15), Cents(1500L)),
+        )
+
+        val result = BillReminderEngine.detectAmountChange(
+            SyncId("rule-1"), "Service", history,
+        )
+
+        assertNotNull(result)
+        assertFalse(result.isIncrease)
+        assertTrue(result.isDecrease)
+    }
+
+    @Test
+    fun detectAmountChange_significantIncrease() {
+        val history = listOf(
+            BillAmountRecord(LocalDate(2024, 5, 15), Cents(1000L)),
+            BillAmountRecord(LocalDate(2024, 6, 15), Cents(1500L)), // 50% increase
+        )
+
+        val result = BillReminderEngine.detectAmountChange(
+            SyncId("rule-1"), "Service", history,
+        )
+
+        assertNotNull(result)
+        assertTrue(result.isSignificant) // > 10% change
+    }
+
+    @Test
+    fun detectAmountChange_tooShortHistory() {
+        val history = listOf(
+            BillAmountRecord(LocalDate(2024, 6, 15), Cents(1599L)),
+        )
+
+        val result = BillReminderEngine.detectAmountChange(
+            SyncId("rule-1"), "Netflix", history,
+        )
+
+        assertNull(result)
+    }
+
+    @Test
+    fun detectAllAmountChanges_multipleRules() {
+        val rules = listOf(
+            createRule(id = "rule-1", merchant = "Netflix", amount = 1799),
+            createRule(id = "rule-2", merchant = "Spotify", amount = 999),
+        )
+
+        val histories = mapOf(
+            SyncId("rule-1") to listOf(
+                BillAmountRecord(LocalDate(2024, 5, 15), Cents(1599L)),
+                BillAmountRecord(LocalDate(2024, 6, 15), Cents(1799L)),
+            ),
+            SyncId("rule-2") to listOf(
+                BillAmountRecord(LocalDate(2024, 5, 15), Cents(999L)),
+                BillAmountRecord(LocalDate(2024, 6, 15), Cents(999L)),
+            ),
+        )
+
+        val changes = BillReminderEngine.detectAllAmountChanges(histories, rules)
+
+        assertEquals(1, changes.size) // Only Netflix changed
+        assertEquals("Netflix", changes[0].merchant)
+    }
+
+    // ═════════════════════════════════════════════════════════════════
+    // Bill Calendar Month calculations
+    // ═════════════════════════════════════════════════════════════════
+
+    @Test
+    fun billCalendarMonth_paidFraction() {
+        val month = BillCalendarMonth(
+            year = 2024,
+            month = 7,
+            days = listOf(
+                BillCalendarDay(
+                    date = LocalDate(2024, 7, 15),
+                    bills = listOf(
+                        BillCalendarEntry(SyncId("r1"), "A", Cents(100L), LocalDate(2024, 7, 15), isPaid = true),
+                        BillCalendarEntry(SyncId("r2"), "B", Cents(200L), LocalDate(2024, 7, 15), isPaid = false),
+                    ),
+                    totalAmount = Cents(300L),
+                ),
+            ),
+            totalDue = Cents(300L),
+            totalPaid = Cents(100L),
+            billCount = 2,
+        )
+
+        assertEquals(0.5, month.paidFraction)
+        assertEquals(Cents(200L), month.totalRemaining)
+    }
+}


### PR DESCRIPTION
## Summary

Implement KMP shared layer for bill reminders and recurring transaction management. Extends the existing `recurring/` package with bill-specific models, notification scheduling, calendar views, confirmation flows, and amount change tracking.

## Changes

- **RecurringTransactionRule.kt**: Full recurring bill model with merchant, amount, frequency, auto-detection flag, and confirmation state
- **BillReminder.kt**: Reminder configuration (offset days, notification type, ReminderTime), ScheduledNotification model
- **BillCalendar.kt**: Monthly calendar view models (BillCalendarMonth/Day/Entry), BillConfirmation flow (accept/reject/snooze), BillAmountChange tracking
- **BillReminderEngine.kt**: Pure-function engine for notification scheduling, monthly calendar generation, and amount change detection
- **BillReminderEngineTest.kt**: 30+ tests covering scheduling, calendar, confirmation flow, and amount tracking

## Technical Notes

- All monetary values use `Cents` (Long) — no floating-point
- All dates use `kotlinx-datetime` — no java.time in commonMain
- All models annotated with `@Serializable` for sync support
- Builds on existing `RecurrenceRule` and `RecurringTransactionEngine`  
- Pure functions only — no I/O, fully deterministic and testable

Closes #1120