### PR TITLE
fix(deploy): mount /etc/passwd for PostgREST libpq (#1246)

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -82,6 +82,8 @@ services:
       PGRST_DB_USE_LEGACY_GUCS: 'false'
       PGRST_DB_MAX_ROWS: 1000
       PGRST_SERVER_PORT: 3000
+    volumes:
+      - /etc/passwd:/etc/passwd:ro
     healthcheck:
       test: ['CMD-SHELL', 'curl -sf http://localhost:3000/ready || exit 1']
       interval: 15s


### PR DESCRIPTION
## Summary

Fixes PostgREST container failing with `could not look up local user ID 1000: No such file or directory` error.

## Problem

PostgREST's libpq calls `getpwuid()` to resolve the current OS user, but the minimal container image lacks `/etc/passwd` entry for UID 1000.

## Fix

Mount host `/etc/passwd` as read-only into the rest container. This provides the user lookup without modifying the container.

## Also check

If POSTGRES_PASSWORD contains special characters (`/`, `+`, `=`, `@`), they need URL-encoding in the connection URI.

Closes #1246