### PR TITLE
fix(deploy): add listen_addresses for postgres networking (#1246)

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -55,6 +55,7 @@ services:
     shm_size: 128mb
     command: >
       postgres
+      -c listen_addresses='*'
       -c wal_level=logical
       -c max_wal_senders=10
       -c max_replication_slots=10


### PR DESCRIPTION
## Summary

Fixes PostgREST/GoTrue 'Connection refused' errors when connecting to the PostgreSQL container.

## Problem

PostgreSQL defaults to `listen_addresses = 'localhost'`, only accepting connections on 127.0.0.1. Other containers (rest, auth) connect via Docker's internal network (172.x.x.x), which gets refused.

## Fix

Added `-c listen_addresses='*'` to the postgres command so it accepts connections on all interfaces, including the Docker bridge network.

Closes #1246