### PR TITLE
fix(deploy): increase PostgREST health check timing (#1246)

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -89,8 +89,8 @@ services:
       test: ['CMD-SHELL', 'curl -sf http://localhost:3000/ready || exit 1']
       interval: 15s
       timeout: 5s
-      retries: 5
-      start_period: 10s
+      retries: 10
+      start_period: 30s
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary

PostgREST needs more startup time on first boot. The previous 10s start_period caused false-negative health checks, preventing Caddy and edge-functions from starting.

## Fix

- `start_period`: 10s → 30s
- `retries`: 5 → 10

Closes #1246