### PR TITLE
fix(deploy): disable PostgREST health check and relax caddy deps (#1246)

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -87,11 +87,7 @@ services:
     volumes:
       - /etc/passwd:/etc/passwd:ro
     healthcheck:
-      test: ['CMD-SHELL', 'curl -sf http://localhost:3001/ready || exit 1']
-      interval: 15s
-      timeout: 5s
-      retries: 5
-      start_period: 15s
+      disable: true
     depends_on:
       db:
         condition: service_healthy
@@ -382,13 +378,13 @@ services:
       start_period: 10s
     depends_on:
       rest:
-        condition: service_healthy
+        condition: service_started
       auth:
-        condition: service_healthy
+        condition: service_started
       edge-functions:
-        condition: service_healthy
+        condition: service_started
       powersync:
-        condition: service_healthy
+        condition: service_started
     deploy:
       resources:
         limits:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -83,14 +83,15 @@ services:
       PGRST_DB_USE_LEGACY_GUCS: 'false'
       PGRST_DB_MAX_ROWS: 1000
       PGRST_SERVER_PORT: 3000
+      PGRST_ADMIN_SERVER_PORT: 3001
     volumes:
       - /etc/passwd:/etc/passwd:ro
     healthcheck:
-      test: ['CMD-SHELL', 'curl -sf http://localhost:3000/ready || exit 1']
+      test: ['CMD-SHELL', 'curl -sf http://localhost:3001/ready || exit 1']
       interval: 15s
       timeout: 5s
-      retries: 10
-      start_period: 30s
+      retries: 5
+      start_period: 15s
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary

PostgREST container image does not include curl, so the curl-based health check always failed with exit code 127. This blocked caddy and other dependent containers from starting.

## Changes

- Disabled PostgREST health check (container has internal retry logic)
- Relaxed caddy dependencies from service_healthy to service_started

## Issues

Closes #1246
