### PR TITLE
fix(deploy): edge-functions dep on rest must use service_started (#1246)

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -241,7 +241,7 @@ services:
       start_period: 15s
     depends_on:
       rest:
-        condition: service_healthy
+        condition: service_started
     command: start --main-service /home/deno/functions/main
     deploy:
       resources:


### PR DESCRIPTION
## Summary

edge-functions still depended on rest with `condition: service_healthy`, but rest's health check was disabled in PR #1264. This caused edge-functions to fail to start.

## Changes

- Changed edge-functions dependency on rest from `service_healthy` to `service_started`

## Issues

Closes #1246
