### PR TITLE
fix(deploy): use native Deno.serve, add edge-functions internet access, create auth schema (#1246)

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -254,6 +254,7 @@ services:
           memory: 64M
     networks:
       - finance-internal
+      - finance-external
 
   # ---------------------------------------------------------------------------
   # PowerSync — offline-first sync engine (#881)

--- a/deploy/volumes/db/init/00-init-roles.sh
+++ b/deploy/volumes/db/init/00-init-roles.sh
@@ -66,6 +66,15 @@ else
         GRANT service_role TO authenticator;
         GRANT supabase_admin TO postgres;
 
+        -- Create schemas required by Supabase services
+        CREATE SCHEMA IF NOT EXISTS auth AUTHORIZATION supabase_auth_admin;
+        CREATE SCHEMA IF NOT EXISTS extensions;
+
+        -- Grant schema usage
+        GRANT USAGE ON SCHEMA auth TO supabase_auth_admin, service_role, postgres;
+        GRANT ALL ON SCHEMA auth TO supabase_auth_admin;
+        ALTER ROLE supabase_auth_admin SET search_path = 'auth';
+
         -- Set passwords
         ALTER ROLE authenticator SET statement_timeout = '8s';
         ALTER ROLE supabase_admin WITH PASSWORD current_setting('app.settings.jwt_secret', true);

--- a/services/api/supabase/functions/main/index.ts
+++ b/services/api/supabase/functions/main/index.ts
@@ -6,13 +6,13 @@
  * Required by supabase/edge-runtime as the `--main-service` handler.
  * Provides a minimal health-check responder and routes requests.
  *
+ * Uses native Deno.serve() — no URL imports needed at boot time.
+ *
  * Issues: #1246
  */
 
-import { serve } from 'https://deno.land/std@0.208.0/http/server.ts';
-
-serve(async (req: Request): Promise<Response> => {
-  const url = new URL(req.url);
+Deno.serve((_req: Request): Response => {
+  const url = new URL(_req.url);
 
   // Health check for the edge-runtime itself
   if (url.pathname === '/health-check' || url.pathname === '/') {


### PR DESCRIPTION
## Summary

Fixes the remaining container crash-loops for auth (GoTrue) and edge-functions.

## Changes

- **Edge Functions**: Replace \deno.land\ URL import with native \Deno.serve()\ — eliminates internet dependency at boot time (was causing \ailed to read path\ errors)
- **Edge Functions**: Add \inance-external\ network so edge functions can make outbound HTTP calls
- **Init Script**: Add \uth\ and \xtensions\ schema creation for future clean deployments

## Deploy Instructions

**After merging**, on the VPS:
\\\ash
cd ~/finance && git pull origin main
cd deploy && docker compose down && docker compose up -d
docker compose ps
\\\

The auth schema SQL was already run manually on the live DB.

## Issues

Closes #1246