### PR TITLE
fix(deploy): set POSTGRES_USER=supabase_admin and use correct service roles (#1246)

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -24,7 +24,7 @@ TLS_EMAIL=YOUR_EMAIL_HERE
 # ---------------------------------------------------------------------------
 POSTGRES_PASSWORD=YOUR_STRONG_PASSWORD_HERE
 POSTGRES_DB=postgres
-POSTGRES_USER=postgres
+POSTGRES_USER=supabase_admin
 POSTGRES_PORT=5432
 
 # ---------------------------------------------------------------------------

--- a/deploy/.env.staging.example
+++ b/deploy/.env.staging.example
@@ -28,7 +28,7 @@ TLS_EMAIL=YOUR_EMAIL_HERE
 # Generate with: openssl rand -base64 24
 POSTGRES_PASSWORD=YOUR_STAGING_POSTGRES_PASSWORD_HERE
 POSTGRES_DB=postgres
-POSTGRES_USER=postgres
+POSTGRES_USER=supabase_admin
 POSTGRES_PORT=5432
 
 # ---------------------------------------------------------------------------

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -116,7 +116,7 @@ npm install -g supabase
 for migration in ../services/api/supabase/migrations/*.sql; do
   echo "Applying: $migration"
   docker compose exec -T db psql \
-    -U "${POSTGRES_USER:-postgres}" \
+    -U "${POSTGRES_USER:-supabase_admin}" \
     -d "${POSTGRES_DB:-postgres}" \
     -f - < "$migration"
 done
@@ -245,20 +245,20 @@ docker compose ps
 
 ### Optional
 
-| Variable                  | Default                              | Description                          |
-| ------------------------- | ------------------------------------ | ------------------------------------ |
-| `POSTGRES_DB`             | `postgres`                           | Database name                        |
-| `POSTGRES_USER`           | `postgres`                           | Database superuser name              |
-| `POSTGRES_PORT`           | `5432`                               | Host port for direct database access |
-| `JWT_EXPIRY`              | `3600`                               | JWT lifetime in seconds              |
-| `AUTH_RATE_LIMIT_EMAIL`   | `30`                                 | Max email sends per hour             |
-| `AUTH_RATE_LIMIT_REFRESH` | `150`                                | Max token refreshes per hour         |
-| `MAILER_AUTOCONFIRM`      | `false`                              | Skip email confirmation (testing)    |
-| `AUTH_REDIRECT_URLS`      | —                                    | Allowed OAuth redirect URLs          |
-| `EDGE_FUNCTIONS_PATH`     | `../services/api/supabase/functions` | Path to Edge Functions source        |
-| `BACKUP_RETENTION_DAYS`   | `30`                                 | Number of daily backups to keep      |
-| `POWERSYNC_URL`           | —                                    | PowerSync instance URL (optional)    |
-| `POWERSYNC_PUBLIC_KEY`    | —                                    | PowerSync public key (optional)      |
+| Variable                  | Default                              | Description                                                                      |
+| ------------------------- | ------------------------------------ | -------------------------------------------------------------------------------- |
+| `POSTGRES_DB`             | `postgres`                           | Database name                                                                    |
+| `POSTGRES_USER`           | `supabase_admin`                     | Database superuser name (must be supabase_admin for the supabase/postgres image) |
+| `POSTGRES_PORT`           | `5432`                               | Host port for direct database access                                             |
+| `JWT_EXPIRY`              | `3600`                               | JWT lifetime in seconds                                                          |
+| `AUTH_RATE_LIMIT_EMAIL`   | `30`                                 | Max email sends per hour                                                         |
+| `AUTH_RATE_LIMIT_REFRESH` | `150`                                | Max token refreshes per hour                                                     |
+| `MAILER_AUTOCONFIRM`      | `false`                              | Skip email confirmation (testing)                                                |
+| `AUTH_REDIRECT_URLS`      | —                                    | Allowed OAuth redirect URLs                                                      |
+| `EDGE_FUNCTIONS_PATH`     | `../services/api/supabase/functions` | Path to Edge Functions source                                                    |
+| `BACKUP_RETENTION_DAYS`   | `30`                                 | Number of daily backups to keep                                                  |
+| `POWERSYNC_URL`           | —                                    | PowerSync instance URL (optional)                                                |
+| `POWERSYNC_PUBLIC_KEY`    | —                                    | PowerSync public key (optional)                                                  |
 
 ---
 

--- a/deploy/backup/.env.backup.example
+++ b/deploy/backup/.env.backup.example
@@ -16,7 +16,7 @@
 POSTGRES_HOST=localhost
 POSTGRES_PORT=5432
 POSTGRES_DB=postgres
-POSTGRES_USER=postgres
+POSTGRES_USER=supabase_admin
 PGPASSWORD=YOUR_POSTGRES_PASSWORD_HERE
 
 # ---------------------------------------------------------------------------

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -32,17 +32,19 @@ services:
     environment:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB:-postgres}
-      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      # MUST be supabase_admin — the image's migrate.sh connects as this user
+      POSTGRES_USER: supabase_admin
       JWT_SECRET: ${JWT_SECRET}
       JWT_EXP: ${JWT_EXPIRY:-3600}
     volumes:
       - pgdata:/var/lib/postgresql/data
       - ./volumes/db/backups:/backups
-      # Match official supabase/supabase docker setup: mount SQL into init-scripts/
+      # Mounted into init-scripts/ where the image's migrate.sh processes them
+      - ./volumes/db/webhooks.sql:/docker-entrypoint-initdb.d/init-scripts/98-webhooks.sql:ro
       - ./volumes/db/roles.sql:/docker-entrypoint-initdb.d/init-scripts/99-roles.sql:ro
       - ./volumes/db/jwt.sql:/docker-entrypoint-initdb.d/init-scripts/99-jwt.sql:ro
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-postgres}']
+      test: ['CMD-SHELL', 'pg_isready -U supabase_admin -d ${POSTGRES_DB:-postgres}']
       interval: 10s
       timeout: 5s
       retries: 10
@@ -79,7 +81,7 @@ services:
     image: postgrest/postgrest:v12.2.12
     restart: unless-stopped
     environment:
-      PGRST_DB_URI: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-postgres}
+      PGRST_DB_URI: postgres://authenticator:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-postgres}
       PGRST_DB_SCHEMAS: public,auth,storage
       PGRST_DB_ANON_ROLE: anon
       PGRST_JWT_SECRET: ${JWT_SECRET}
@@ -122,7 +124,7 @@ services:
 
       # Database
       GOTRUE_DB_DRIVER: postgres
-      GOTRUE_DB_DATABASE_URL: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-postgres}?sslmode=disable
+      GOTRUE_DB_DATABASE_URL: postgres://supabase_auth_admin:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-postgres}?sslmode=disable
 
       # JWT
       GOTRUE_JWT_SECRET: ${JWT_SECRET}
@@ -195,7 +197,7 @@ services:
       PG_META_DB_HOST: db
       PG_META_DB_PORT: 5432
       PG_META_DB_NAME: ${POSTGRES_DB:-postgres}
-      PG_META_DB_USER: ${POSTGRES_USER:-postgres}
+      PG_META_DB_USER: supabase_admin
       PG_META_DB_PASSWORD: ${POSTGRES_PASSWORD}
     healthcheck:
       test:
@@ -227,7 +229,7 @@ services:
     environment:
       SUPABASE_URL: http://rest:3000
       SUPABASE_SERVICE_ROLE_KEY: ${SERVICE_ROLE_KEY}
-      SUPABASE_DB_URL: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-postgres}
+      SUPABASE_DB_URL: postgres://supabase_admin:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-postgres}
       JWT_SECRET: ${JWT_SECRET}
       ALLOWED_ORIGINS: ${ALLOWED_ORIGINS}
       AUTH_WEBHOOK_SECRET: ${AUTH_WEBHOOK_SECRET}
@@ -285,7 +287,7 @@ services:
           "replication": {
             "connections": [{
               "type": "postgresql",
-              "uri": "postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-postgres}",
+              "uri": "postgres://supabase_admin:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-postgres}",
               "slot_name": "${POWERSYNC_SLOT_NAME:-powersync}",
               "publication_name": "${POWERSYNC_PUBLICATION:-powersync}"
             }]

--- a/deploy/volumes/db/webhooks.sql
+++ b/deploy/volumes/db/webhooks.sql
@@ -1,0 +1,156 @@
+-- Supabase webhooks and functions schema (from official supabase/supabase docker setup)
+BEGIN;
+  CREATE EXTENSION IF NOT EXISTS pg_net SCHEMA extensions;
+  CREATE SCHEMA supabase_functions AUTHORIZATION supabase_admin;
+  GRANT USAGE ON SCHEMA supabase_functions TO postgres, anon, authenticated, service_role;
+  ALTER DEFAULT PRIVILEGES IN SCHEMA supabase_functions GRANT ALL ON TABLES TO postgres, anon, authenticated, service_role;
+  ALTER DEFAULT PRIVILEGES IN SCHEMA supabase_functions GRANT ALL ON FUNCTIONS TO postgres, anon, authenticated, service_role;
+  ALTER DEFAULT PRIVILEGES IN SCHEMA supabase_functions GRANT ALL ON SEQUENCES TO postgres, anon, authenticated, service_role;
+
+  CREATE TABLE supabase_functions.migrations (
+    version text PRIMARY KEY,
+    inserted_at timestamptz NOT NULL DEFAULT NOW()
+  );
+  INSERT INTO supabase_functions.migrations (version) VALUES ('initial');
+
+  CREATE TABLE supabase_functions.hooks (
+    id bigserial PRIMARY KEY,
+    hook_table_id integer NOT NULL,
+    hook_name text NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT NOW(),
+    request_id bigint
+  );
+  CREATE INDEX supabase_functions_hooks_request_id_idx ON supabase_functions.hooks USING btree (request_id);
+  CREATE INDEX supabase_functions_hooks_h_table_id_h_name_idx ON supabase_functions.hooks USING btree (hook_table_id, hook_name);
+  COMMENT ON TABLE supabase_functions.hooks IS 'Supabase Functions Hooks: Audit trail for triggered hooks.';
+
+  CREATE FUNCTION supabase_functions.http_request()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+    DECLARE
+      request_id bigint;
+      payload jsonb;
+      url text := TG_ARGV[0]::text;
+      method text := TG_ARGV[1]::text;
+      headers jsonb DEFAULT '{}'::jsonb;
+      params jsonb DEFAULT '{}'::jsonb;
+      timeout_ms integer DEFAULT 1000;
+    BEGIN
+      IF url IS NULL OR url = 'null' THEN
+        RAISE EXCEPTION 'url argument is missing';
+      END IF;
+      IF method IS NULL OR method = 'null' THEN
+        RAISE EXCEPTION 'method argument is missing';
+      END IF;
+      IF TG_ARGV[2] IS NULL OR TG_ARGV[2] = 'null' THEN
+        headers = '{"Content-Type": "application/json"}'::jsonb;
+      ELSE
+        headers = TG_ARGV[2]::jsonb;
+      END IF;
+      IF TG_ARGV[3] IS NULL OR TG_ARGV[3] = 'null' THEN
+        params = '{}'::jsonb;
+      ELSE
+        params = TG_ARGV[3]::jsonb;
+      END IF;
+      IF TG_ARGV[4] IS NULL OR TG_ARGV[4] = 'null' THEN
+        timeout_ms = 1000;
+      ELSE
+        timeout_ms = TG_ARGV[4]::integer;
+      END IF;
+      CASE
+        WHEN method = 'GET' THEN
+          SELECT http_get INTO request_id FROM net.http_get(url, params, headers, timeout_ms);
+        WHEN method = 'POST' THEN
+          payload = jsonb_build_object(
+            'old_record', OLD, 'record', NEW, 'type', TG_OP,
+            'table', TG_TABLE_NAME, 'schema', TG_TABLE_SCHEMA
+          );
+          SELECT http_post INTO request_id FROM net.http_post(url, payload, params, headers, timeout_ms);
+        ELSE
+          RAISE EXCEPTION 'method argument % is invalid', method;
+      END CASE;
+      INSERT INTO supabase_functions.hooks (hook_table_id, hook_name, request_id)
+        VALUES (TG_RELID, TG_NAME, request_id);
+      RETURN NEW;
+    END
+  $function$;
+
+  DO $$
+  BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'supabase_functions_admin') THEN
+      CREATE USER supabase_functions_admin NOINHERIT CREATEROLE LOGIN NOREPLICATION;
+    END IF;
+  END $$;
+
+  GRANT ALL PRIVILEGES ON SCHEMA supabase_functions TO supabase_functions_admin;
+  GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA supabase_functions TO supabase_functions_admin;
+  GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA supabase_functions TO supabase_functions_admin;
+  ALTER USER supabase_functions_admin SET search_path = "supabase_functions";
+  ALTER table "supabase_functions".migrations OWNER TO supabase_functions_admin;
+  ALTER table "supabase_functions".hooks OWNER TO supabase_functions_admin;
+  ALTER function "supabase_functions".http_request() OWNER TO supabase_functions_admin;
+  GRANT supabase_functions_admin TO postgres;
+
+  DO $$
+  BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'supabase_pg_net_admin') THEN
+      REASSIGN OWNED BY supabase_pg_net_admin TO supabase_admin;
+      DROP OWNED BY supabase_pg_net_admin;
+      DROP ROLE supabase_pg_net_admin;
+    END IF;
+  END $$;
+
+  DO $$
+  BEGIN
+    IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_net') THEN
+      GRANT USAGE ON SCHEMA net TO supabase_functions_admin, postgres, anon, authenticated, service_role;
+      ALTER function net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) SECURITY DEFINER;
+      ALTER function net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) SECURITY DEFINER;
+      ALTER function net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) SET search_path = net;
+      ALTER function net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) SET search_path = net;
+      REVOKE ALL ON FUNCTION net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) FROM PUBLIC;
+      REVOKE ALL ON FUNCTION net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) FROM PUBLIC;
+      GRANT EXECUTE ON FUNCTION net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) TO supabase_functions_admin, postgres, anon, authenticated, service_role;
+      GRANT EXECUTE ON FUNCTION net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) TO supabase_functions_admin, postgres, anon, authenticated, service_role;
+    END IF;
+  END $$;
+
+  CREATE OR REPLACE FUNCTION extensions.grant_pg_net_access()
+  RETURNS event_trigger
+  LANGUAGE plpgsql
+  AS $$
+  BEGIN
+    IF EXISTS (
+      SELECT 1 FROM pg_event_trigger_ddl_commands() AS ev
+      JOIN pg_extension AS ext ON ev.objid = ext.oid
+      WHERE ext.extname = 'pg_net'
+    ) THEN
+      GRANT USAGE ON SCHEMA net TO supabase_functions_admin, postgres, anon, authenticated, service_role;
+      ALTER function net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) SECURITY DEFINER;
+      ALTER function net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) SECURITY DEFINER;
+      ALTER function net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) SET search_path = net;
+      ALTER function net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) SET search_path = net;
+      REVOKE ALL ON FUNCTION net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) FROM PUBLIC;
+      REVOKE ALL ON FUNCTION net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) FROM PUBLIC;
+      GRANT EXECUTE ON FUNCTION net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) TO supabase_functions_admin, postgres, anon, authenticated, service_role;
+      GRANT EXECUTE ON FUNCTION net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) TO supabase_functions_admin, postgres, anon, authenticated, service_role;
+    END IF;
+  END;
+  $$;
+  COMMENT ON FUNCTION extensions.grant_pg_net_access IS 'Grants access to pg_net';
+
+  DO $$
+  BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_event_trigger WHERE evtname = 'issue_pg_net_access') THEN
+      CREATE EVENT TRIGGER issue_pg_net_access ON ddl_command_end WHEN TAG IN ('CREATE EXTENSION')
+      EXECUTE PROCEDURE extensions.grant_pg_net_access();
+    END IF;
+  END $$;
+
+  INSERT INTO supabase_functions.migrations (version) VALUES ('20210809183423_update_grants');
+  ALTER function supabase_functions.http_request() SECURITY DEFINER;
+  ALTER function supabase_functions.http_request() SET search_path = supabase_functions;
+  REVOKE ALL ON FUNCTION supabase_functions.http_request() FROM PUBLIC;
+  GRANT EXECUTE ON FUNCTION supabase_functions.http_request() TO postgres, anon, authenticated, service_role;
+COMMIT;


### PR DESCRIPTION
## Summary

Root cause fix for the auth crash-loop. The supabase/postgres:15.8.1.060 image's Dockerfile sets ENV POSTGRES_USER=supabase_admin. Its migrate.sh script connects as supabase_admin to bootstrap all roles, schemas, and types. Our compose was overriding this to postgres, so initdb created the wrong superuser and the entire initialization chain failed.

## Changes

- POSTGRES_USER: supabase_admin — matches what the image expects
- Auth connects as supabase_auth_admin (official standard)
- PostgREST connects as authenticator (official standard)
- Meta connects as supabase_admin (official standard)
- Edge-functions and PowerSync connect as supabase_admin
- Added webhooks.sql for supabase_functions schema (required by edge-runtime)
- Updated .env.example, .env.staging.example, backup config, and README

## After Merge — VPS Deployment Steps

1. Update .env: change POSTGRES_USER=postgres to POSTGRES_USER=supabase_admin
2. Pull: cd ~/finance && git pull origin main
3. Redeploy with volume wipe: cd deploy && docker compose down -v && docker compose up -d
4. Verify: sleep 30 && docker compose ps && docker compose logs auth --tail 10

> docker compose down -v is required to wipe the postgres data volume so initdb re-runs with the correct superuser.

## Issues

Closes #1246

## Testing

- [ ] CI passes (lint, format, security scanning)
- [ ] Deploy on VPS with docker compose down -v && docker compose up -d
- [ ] Auth container starts without crash-loop
- [ ] curl https://finance.jrmoulckers.com/auth/v1/health returns healthy
