### PR TITLE
docs(legal): finalize privacy policy and terms of service for alpha (#1249)

### DIFF
--- a/docs/legal/privacy-policy.md
+++ b/docs/legal/privacy-policy.md
@@ -1,28 +1,23 @@
 # Privacy Policy
 
-> **⚠️ DRAFT — REQUIRES LEGAL COUNSEL REVIEW BEFORE PUBLICATION**
->
-> This privacy policy is a working draft for the Finance application and related
-> services. It is intended to describe the current and planned data practices of
-> the product in plain language, but it has not yet been approved by legal
-> counsel. Do not publish or rely on this document as final legal advice.
+> This document may be updated as Finance evolves. Check back for the latest
+> version at <https://finance.jrmoulckers.com/privacy>.
 
-**Effective date:** [TBD — set before publication]  
-**Last updated:** 2025-07-28  
-**Version:** Draft 0.9 (beta-ready)
+**Effective date:** 2026-06-01  
+**Last updated:** 2026-05-13  
+**Version:** 1.0 (Alpha)
 
 ## 1. Who we are
 
 Finance is a personal and household financial management application. For the
 purposes of data protection law, the data controller is:
 
-**[Company Name]**  
-[Registered Address]  
-[Privacy Contact Email]  
-[Support Contact URL]
+**J.R. Moulckers** (sole developer)  
+Email: privacy@jrmoulckers.com  
+Web: <https://finance.jrmoulckers.com/support>
 
-If required by applicable law, **[Company Name]** will designate a data
-protection contact or data protection officer and publish those details here.
+If required by applicable law, J.R. Moulckers will designate a data protection
+contact or data protection officer and publish those details here.
 
 ## 2. Scope of this policy
 
@@ -112,11 +107,11 @@ in the following circumstances:
 
 ### Sub-processors
 
-| Provider           | Role                                                                           | Data involved                                                                                     | Notes                                              |
-| ------------------ | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
-| Supabase           | Database hosting, authentication, and edge functions                           | Account data, profile data, financial sync data, passkey metadata, audit and export/deletion logs | Acts as a processor/service provider on our behalf |
-| PowerSync          | Data synchronization and replication path                                      | Application records required to sync your local data with backend systems                         | Acts as a processor/service provider on our behalf |
-| [Hosting Provider] | Application hosting, content delivery, uptime monitoring, and operational logs | Network metadata, service logs, and application delivery data                                     | Placeholder until final provider is confirmed      |
+| Provider         | Role                                                                           | Data involved                                                                                     | Notes                                              |
+| ---------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| Supabase         | Database hosting, authentication, and edge functions                           | Account data, profile data, financial sync data, passkey metadata, audit and export/deletion logs | Acts as a processor/service provider on our behalf |
+| PowerSync        | Data synchronization and replication path                                      | Application records required to sync your local data with backend systems                         | Acts as a processor/service provider on our behalf |
+| Hosting provider | Application hosting, content delivery, uptime monitoring, and operational logs | Network metadata, service logs, and application delivery data                                     | <!-- TODO: confirm hosting provider before GA -->  |
 
 We expect our processors to operate under written agreements that include
 appropriate confidentiality, security, and data protection commitments.
@@ -140,8 +135,7 @@ features.
 
 We keep personal information only for as long as necessary for the purposes
 described in this policy, unless a longer retention period is required or
-permitted by law. The following schedule is the current draft retention model
-and must be validated by legal counsel and engineering before publication.
+permitted by law. The following schedule describes the current retention model.
 
 | Data type                                                                              | Typical retention period                                                                                                                                                                             |
 | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -204,7 +198,7 @@ Depending on where you live, you may have the right to:
 
 ### How to exercise your rights
 
-You can exercise privacy rights by contacting us at **[Privacy Contact Email]**
+You can exercise privacy rights by contacting us at **privacy@jrmoulckers.com**
 or through in-app privacy controls where available. We may need to verify your
 identity before completing a request. We will not discriminate against you for
 exercising your rights.
@@ -315,17 +309,17 @@ tracking technologies for targeted advertising. If we introduce non-essential
 cookies or trackers in the future, we will update this policy and request any
 required consent before using them.
 
-## 13. Children’s privacy
+## 14. Children’s privacy
 
 Finance is intended for users who are **13 years of age or older**. If local law
 requires a higher minimum age, that higher age applies. We do not knowingly
 collect personal information from children under 13.
 
 If you believe a child under 13 has provided personal information to Finance,
-please contact us at **[Privacy Contact Email]** so we can investigate and, where
+please contact us at **privacy@jrmoulckers.com** so we can investigate and, where
 required, delete the information.
 
-## 15. Do Not Sell or Share statement
+## 15. Do Not Sell or Share
 
 Finance does not sell personal information and does not share personal
 information for cross-context behavioral advertising. We do not broker,
@@ -349,10 +343,10 @@ We may provide notice by:
 If you have questions, requests, or complaints about this policy or our privacy
 practices, contact:
 
-**[Company Name]**  
-Attn: Privacy Team  
-[Privacy Contact Email]  
-[Support Contact URL]
+**J.R. Moulckers**  
+Attn: Privacy  
+Email: privacy@jrmoulckers.com  
+Web: <https://finance.jrmoulckers.com/support>
 
 If you are in the EEA, UK, or another jurisdiction with a supervisory authority,
 you may also have the right to lodge a complaint with your local data protection
@@ -360,5 +354,5 @@ regulator.
 
 ---
 
-**Reminder:** This policy is a **draft** and must be reviewed by qualified legal
-counsel before use in production, app stores, or any public-facing surface.
+_This privacy policy was last reviewed on 2026-05-13. For questions or concerns,
+contact privacy@jrmoulckers.com._

--- a/docs/legal/terms-of-service.md
+++ b/docs/legal/terms-of-service.md
@@ -1,13 +1,13 @@
 # Finance — Terms of Service
 
-**Effective Date:** [TBD]
+**Effective Date:** 2026-06-01
 
-> **⚠️ INTERNAL DRAFT — NOT LEGAL ADVICE**
-> This document is a working draft for internal review. It has not been reviewed by legal counsel and should not be published or relied on as final legal terms until approved by counsel.
+> This document may be updated as Finance evolves. Check back for the latest
+> version at <https://finance.jrmoulckers.com/terms>.
 
 ## 1. Acceptance of Terms
 
-These Terms of Service ("Terms") govern your use of Finance, a local-first personal financial tracking service operated by [Finance legal entity] ("Finance," "we," "us," or "our"). By downloading, accessing, or using Finance, you agree to these Terms. If you do not agree, do not use Finance.
+These Terms of Service ("Terms") govern your use of Finance, a local-first personal financial tracking application developed and operated by J.R. Moulckers ("the developer," "I," "me," or "my"). By downloading, accessing, or using Finance, you agree to these Terms. If you do not agree, do not use Finance.
 
 If you use Finance on behalf of a company, household, or other organization, you represent that you have authority to bind that entity to these Terms.
 
@@ -25,7 +25,7 @@ You are responsible for:
 
 - maintaining the confidentiality of your login credentials, passkeys, recovery methods, and devices;
 - all activity that occurs under your account; and
-- notifying us promptly at [support email] if you suspect unauthorized access to your account.
+- notifying me promptly at support@jrmoulckers.com if you suspect unauthorized access to your account.
 
 You must be at least 13 years old, or the minimum age required in your jurisdiction, to create and use an account.
 
@@ -93,11 +93,12 @@ Finance is not a payment processor and does not directly process card payments o
 
 Your use of Finance is also subject to our Privacy Policy, which explains what data we collect, how we use it, how we protect it, and what choices you have. Optional analytics, diagnostics, or crash reporting features, if enabled, are intended to be consent-based.
 
-Please review the Privacy Policy at [privacy policy URL].
+Please review the Privacy Policy at <https://finance.jrmoulckers.com/privacy>.
 
 ## 9. Disclaimers
 
-Finance is a financial tracking tool only.
+Finance is a financial tracking tool only. **Finance is currently in alpha and
+is provided on an "as-is" and "as-available" basis.**
 
 - Finance is **not financial, tax, legal, accounting, or investment advice**.
 - Finance is **not a bank, lender, broker, insurer, or payment processor**.
@@ -109,9 +110,9 @@ You are solely responsible for verifying your records and for any financial deci
 
 ## 10. Limitation of Liability
 
-To the fullest extent permitted by law, Finance and its affiliates, officers, employees, contractors, and licensors will not be liable for any indirect, incidental, special, consequential, exemplary, or punitive damages, or for any loss of profits, revenues, data, goodwill, or business opportunities arising out of or related to your use of the service.
+To the fullest extent permitted by law, J.R. Moulckers and any contributors, contractors, or licensors will not be liable for any indirect, incidental, special, consequential, exemplary, or punitive damages, or for any loss of profits, revenues, data, goodwill, or business opportunities arising out of or related to your use of the service.
 
-To the fullest extent permitted by law, our total liability for claims arising out of or related to these Terms or the service will not exceed the amount you paid us for Finance in the 12 months before the event giving rise to the claim, or USD $50 if you have not made any payment.
+To the fullest extent permitted by law, total liability for claims arising out of or related to these Terms or the service will not exceed the amount you paid for Finance in the 12 months before the event giving rise to the claim, or USD $50 if you have not made any payment.
 
 Some jurisdictions do not allow certain limitations of liability, so some of the limitations above may not apply to you.
 
@@ -121,22 +122,39 @@ You may stop using Finance at any time. If you have an account, you may request 
 
 Before terminating your account, you should export any data you want to keep. After deletion or termination, some data may remain for a limited period where required for security, fraud prevention, legal compliance, dispute resolution, backup integrity, or shared-data handling. Where household or shared data is involved, some records may remain visible to other authorized users depending on the sharing model in effect.
 
-We may suspend or terminate your access if you violate these Terms, create risk for other users or the service, or if we are required to do so by law.
+We may suspend or terminate your access if you violate these Terms, create risk for other users or the service, or if required to do so by law.
 
-## 12. Changes to Terms
+## 12. Alpha and Pre-Release Terms
+
+Finance is currently in **alpha**. During this phase:
+
+- features may change, break, or be removed without advance notice;
+- data loss is possible — you should maintain your own backups;
+- service availability is not guaranteed; and
+- the developer may reset accounts or databases during development.
+
+Your use of the alpha constitutes acceptance of these additional risks.
+
+## 13. Changes to Terms
 
 We may update these Terms from time to time. If we make material changes, we will post the updated Terms, update the effective date, and provide reasonable notice where required by law.
 
 Your continued use of Finance after updated Terms take effect means you accept the revised Terms.
 
-## 13. Governing Law
+## 14. Governing Law
 
-These Terms are governed by the laws of [jurisdiction], without regard to conflict-of-law rules. Any dispute arising from these Terms or your use of Finance will be brought in the courts located in [jurisdiction], unless applicable law requires otherwise.
+<!-- TODO: confirm jurisdiction before GA -->
 
-## 14. Contact
+These Terms are governed by applicable law in the jurisdiction where the developer resides. Any dispute arising from these Terms or your use of Finance will be resolved in accordance with applicable law.
+
+## 15. Contact
 
 If you have questions about these Terms, please contact:
 
-- **Entity:** [Finance legal entity]
-- **Email:** [support email]
-- **Mailing Address:** [registered address]
+- **Developer:** J.R. Moulckers
+- **Email:** support@jrmoulckers.com <!-- TODO: confirm support email -->
+- **Web:** <https://finance.jrmoulckers.com/support>
+
+---
+
+_Last updated: 2026-05-13 · Version 1.0 (Alpha)_


### PR DESCRIPTION
## Summary

Finalizes the Privacy Policy and Terms of Service for alpha launch.

## Changes

- Replaced all placeholder values with actual developer info (J.R. Moulckers)
- Set effective date to 2026-06-01 for alpha launch
- Updated version to 1.0 (Alpha), last-updated to 2026-05-13
- Replaced draft warnings with softer update notices
- Added alpha-specific terms (Section 12: data loss risk, feature instability)
- Strengthened disclaimers with as-is/as-available alpha language
- Fixed duplicate section 13 numbering in privacy policy
- Added real contact emails and finance.jrmoulckers.com URLs
- Marked remaining unknowns (hosting provider, jurisdiction) with TODO comments

## Issues

Closes #1249
