### PR TITLE
chore(ops): configure Sentry error monitoring for all platforms (#1254)

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -145,6 +145,30 @@ POWERSYNC_SYNC_RULES_PATH=../services/api/powersync
 BACKUP_RETENTION_DAYS=30
 
 # ---------------------------------------------------------------------------
+# Sentry Error Monitoring (#1254)
+# ---------------------------------------------------------------------------
+# Create projects at https://sentry.io — one per platform.
+# DSNs are project-specific ingest URLs; auth token is org-level.
+# See docs/ops/monitoring-setup.md for full configuration guide.
+
+# Sentry organization slug (e.g. "finance-app")
+SENTRY_ORG=
+
+# Org-level auth token for source map / ProGuard / dSYM uploads
+# Generate at: https://sentry.io/settings/auth-tokens/
+# Scopes required: project:releases, org:ci
+SENTRY_AUTH_TOKEN=
+
+# Per-platform DSNs (each maps to a separate Sentry project)
+SENTRY_DSN_WEB=
+SENTRY_DSN_ANDROID=
+SENTRY_DSN_IOS=
+SENTRY_DSN_WINDOWS=
+
+# Environment tag sent with all events (production, staging, debug)
+SENTRY_ENVIRONMENT=production
+
+# ---------------------------------------------------------------------------
 # CI/CD Deployment (GitHub Actions secrets — not needed in .env)
 # ---------------------------------------------------------------------------
 # These values are configured as environment-scoped GitHub Secrets

--- a/deploy/.env.staging.example
+++ b/deploy/.env.staging.example
@@ -126,6 +126,23 @@ MONGO_PORT=27017
 POWERSYNC_SYNC_RULES_PATH=../services/api/powersync
 
 # ---------------------------------------------------------------------------
+# Sentry Error Monitoring (#1254)
+# ---------------------------------------------------------------------------
+# Staging Sentry DSNs — use separate Sentry projects from production
+# to keep staging noise out of production dashboards.
+# See docs/ops/monitoring-setup.md for full configuration guide.
+
+SENTRY_ORG=
+SENTRY_AUTH_TOKEN=
+
+SENTRY_DSN_WEB=
+SENTRY_DSN_ANDROID=
+SENTRY_DSN_IOS=
+SENTRY_DSN_WINDOWS=
+
+SENTRY_ENVIRONMENT=staging
+
+# ---------------------------------------------------------------------------
 # Backups
 # ---------------------------------------------------------------------------
 BACKUP_RETENTION_DAYS=7

--- a/docs/ops/monitoring-setup.md
+++ b/docs/ops/monitoring-setup.md
@@ -1,12 +1,299 @@
-# CI/CD Monitoring Setup
+# Monitoring Setup
 
-This document describes the CI/CD monitoring infrastructure for the Finance monorepo, including alerting rules, incident response, and dashboard configuration.
+This document covers the full monitoring setup for the Finance monorepo: CI/CD health monitoring and Sentry error tracking across all platforms.
 
-> **Related:** [CI Workflow](ci-workflow.md) | [Release Process](release-process.md) | [Deployment Runbook](deployment-runbook.md)
+> **Related:** [CI Workflow](ci-workflow.md) | [Release Process](release-process.md) | [Deployment Runbook](deployment-runbook.md) | [Observability ADR](../architecture/0020-observability-architecture.md)
 
 ---
 
-## Overview
+## Table of Contents
+
+- [Sentry Error Monitoring](#sentry-error-monitoring)
+  - [Overview](#overview)
+  - [1. Create Sentry Projects](#1-create-sentry-projects)
+  - [2. DSN Configuration](#2-dsn-configuration)
+  - [3. Privacy & Data Scrubbing](#3-privacy--data-scrubbing)
+  - [4. Environment Tagging](#4-environment-tagging)
+  - [5. Source Map Upload (Web)](#5-source-map-upload-web)
+  - [6. ProGuard Mapping Upload (Android)](#6-proguard-mapping-upload-android)
+  - [7. dSYM Upload (iOS)](#7-dsym-upload-ios)
+  - [8. Alert Rules](#8-alert-rules)
+  - [9. GitHub Actions Secrets](#9-github-actions-secrets)
+- [CI/CD Monitoring](#cicd-monitoring)
+
+---
+
+## Sentry Error Monitoring
+
+### Overview
+
+Finance uses [Sentry](https://sentry.io) for error tracking on all four platforms. The SDK wiring is already in the codebase — this section describes how to create projects, configure DSNs, and verify the privacy contract.
+
+**Architecture summary:**
+
+| Platform | SDK                        | DSN Source               | Config File                                        |
+| -------- | -------------------------- | ------------------------ | -------------------------------------------------- |
+| Web      | `@sentry/react`            | `VITE_SENTRY_DSN`        | `apps/web/src/lib/monitoring.ts`                   |
+| Android  | `io.sentry:sentry-android` | `BuildConfig.SENTRY_DSN` | `apps/android/src/main/kotlin/.../SentryConfig.kt` |
+| iOS      | `sentry-cocoa`             | `SENTRY_DSN` env / plist | (Planned — see iOS section below)                  |
+| Windows  | `Sentry.NET`               | `SENTRY_DSN` env         | (Planned — see Windows section below)              |
+
+All platforms share the same privacy contract enforced by the `CrashReporter` interface in `packages/core/`.
+
+### 1. Create Sentry Projects
+
+Create **one Sentry project per platform** in your Sentry organization. Using separate projects ensures platform-specific alert rules, release tracking, and symbol upload isolation.
+
+1. Go to [sentry.io](https://sentry.io) → **Settings** → **Projects** → **Create Project**
+2. Create four projects:
+
+   | Project Name      | Platform    | Team    |
+   | ----------------- | ----------- | ------- |
+   | `finance-web`     | React       | default |
+   | `finance-android` | Android     | default |
+   | `finance-ios`     | Apple (iOS) | default |
+   | `finance-windows` | .NET/WinUI  | default |
+
+3. For each project, go to **Settings** → **Client Keys (DSN)** and copy the DSN.
+
+> **Staging vs. Production:** Create separate projects (e.g., `finance-web-staging`) or use Sentry's environment filtering. Separate projects are recommended to avoid staging noise in production dashboards.
+
+### 2. DSN Configuration
+
+DSNs are **never hardcoded** in source. Each platform reads the DSN from environment variables.
+
+#### Self-hosted deployment (`deploy/`)
+
+Add DSNs to your `.env` file (see `deploy/.env.example`):
+
+```env
+SENTRY_DSN_WEB=https://examplePublicKey@o0.ingest.sentry.io/0
+SENTRY_DSN_ANDROID=https://examplePublicKey@o0.ingest.sentry.io/1
+SENTRY_DSN_IOS=https://examplePublicKey@o0.ingest.sentry.io/2
+SENTRY_DSN_WINDOWS=https://examplePublicKey@o0.ingest.sentry.io/3
+SENTRY_ORG=your-org-slug
+SENTRY_AUTH_TOKEN=sntrys_your_token_here
+SENTRY_ENVIRONMENT=production
+```
+
+#### Web (`apps/web/`)
+
+The web app reads `VITE_SENTRY_DSN` and `VITE_SENTRY_ENVIRONMENT` via Vite's env system:
+
+```env
+# apps/web/.env.local (not committed)
+VITE_SENTRY_DSN=https://examplePublicKey@o0.ingest.sentry.io/0
+VITE_SENTRY_ENVIRONMENT=development
+```
+
+#### Android (`apps/android/`)
+
+The Android app reads the DSN from `BuildConfig`, injected via Gradle:
+
+```properties
+# local.properties (not committed)
+SENTRY_DSN=https://examplePublicKey@o0.ingest.sentry.io/1
+```
+
+In CI, set `SENTRY_DSN` as a GitHub Actions secret.
+
+#### iOS (`apps/ios/`)
+
+When the Sentry iOS SDK is integrated:
+
+- Set `SENTRY_DSN` as an environment variable in the Xcode scheme (debug/release)
+- In CI (Fastlane), pass via `SENTRY_DSN` environment variable
+- Never add DSNs to `Info.plist` in source control
+
+#### Windows (`apps/windows/`)
+
+When the Sentry .NET SDK is integrated:
+
+- Read `SENTRY_DSN` from environment variables at startup
+- In CI, pass via GitHub Actions secrets
+
+### 3. Privacy & Data Scrubbing
+
+**All platforms enforce these rules** (via the `CrashReporter` interface and platform-specific `beforeSend` hooks):
+
+| Rule                    | Implementation                                         |
+| ----------------------- | ------------------------------------------------------ |
+| `sendDefaultPii: false` | Configured in SDK init on all platforms                |
+| No financial data       | `beforeSend` strips amounts, balances, account numbers |
+| No auth material        | Tokens, API keys, session IDs are redacted             |
+| No PII                  | Email, name, display name are never sent               |
+| Consent-gated           | Reporting is no-op until user opts in                  |
+| Pseudonymous IDs only   | User identification uses rotatable UUIDs               |
+
+#### Scrubbed key categories
+
+The following keys are stripped from all error context and breadcrumb data:
+
+- **PII keys:** `email`, `name`, `displayName`, `userName`, `payee`, `note`, `memo`, `description`
+- **Auth keys:** `token`, `accessToken`, `refreshToken`, `password`, `secret`, `apiKey`, `authorization`, `cookie`
+- **Financial keys:** `amount`, `balance`, `currentBalance`, `targetAmount`, `budgetAmount`, `total`, `price`, `accountNumber`, `routingNumber`
+
+#### Pattern-based scrubbing
+
+- Currency patterns (`$1,234.56`, `€100.00`, `£50`) → `[REDACTED_AMOUNT]`
+- Digit sequences (4+ digits, potential account numbers) → `[REDACTED_NUMBER]`
+
+#### Sentry server-side settings
+
+In addition to client-side scrubbing, enable these in each Sentry project under **Settings** → **Security & Privacy**:
+
+1. ✅ **Data Scrubber** — enabled
+2. ✅ **Scrub IP Addresses** — enabled
+3. ✅ **Sensitive Fields** — add: `amount`, `balance`, `accountNumber`, `routingNumber`, `payee`
+4. ❌ **Store Default PII** — disabled (must remain off)
+
+### 4. Environment Tagging
+
+Events are tagged with the deployment environment so you can filter dashboards and alerts:
+
+| Environment   | When used                              | Sentry behavior            |
+| ------------- | -------------------------------------- | -------------------------- |
+| `production`  | Live user builds                       | Full alerting, full volume |
+| `staging`     | Pre-release verification (staging VPS) | Reduced alerts             |
+| `development` | Local dev builds                       | No events sent             |
+
+**Debug builds should NOT send events to Sentry.** The SDK should only initialize when:
+
+1. The DSN is non-empty, AND
+2. The environment is `staging` or `production`, AND
+3. The user has granted monitoring consent
+
+This is already enforced in the web and Android implementations.
+
+### 5. Source Map Upload (Web)
+
+To get readable stack traces for production web errors, upload source maps to Sentry during the build:
+
+#### Option A: Vite plugin (recommended)
+
+```bash
+npm install --save-dev @sentry/vite-plugin
+```
+
+```ts
+// vite.config.ts — add to plugins array
+import { sentryVitePlugin } from '@sentry/vite-plugin';
+
+export default defineConfig({
+  build: {
+    sourcemap: 'hidden', // Generate maps but don't serve them publicly
+  },
+  plugins: [
+    react(),
+    sentryVitePlugin({
+      org: process.env.SENTRY_ORG,
+      project: 'finance-web',
+      authToken: process.env.SENTRY_AUTH_TOKEN,
+    }),
+  ],
+});
+```
+
+#### Option B: CLI upload in CI
+
+```yaml
+# In web-ci.yml or release.yml
+- name: Upload source maps to Sentry
+  run: |
+    npx @sentry/cli releases files ${{ github.sha }} upload-sourcemaps ./apps/web/dist
+  env:
+    SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+    SENTRY_PROJECT: finance-web
+    SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+```
+
+> **Note:** The current `vite.config.ts` has `sourcemap: false` for security. Change to `sourcemap: 'hidden'` when enabling Sentry source map uploads — this generates maps for upload without serving them publicly.
+
+### 6. ProGuard Mapping Upload (Android)
+
+For readable Android crash stack traces with ProGuard/R8 obfuscation:
+
+1. Add the Sentry Gradle plugin to `apps/android/build.gradle.kts`:
+
+   ```kotlin
+   plugins {
+       id("io.sentry.android.gradle") version "<latest>"
+   }
+
+   sentry {
+       org.set(System.getenv("SENTRY_ORG"))
+       projectName.set("finance-android")
+       authToken.set(System.getenv("SENTRY_AUTH_TOKEN"))
+       autoUploadProguardMapping.set(true)
+   }
+   ```
+
+2. In CI, set `SENTRY_ORG` and `SENTRY_AUTH_TOKEN` as GitHub Actions secrets.
+
+### 7. dSYM Upload (iOS)
+
+For readable iOS crash stack traces:
+
+#### Option A: Fastlane plugin (recommended)
+
+```ruby
+# apps/ios/fastlane/Fastfile
+lane :upload_dsyms do
+  sentry_upload_dsym(
+    org_slug: ENV['SENTRY_ORG'],
+    project_slug: 'finance-ios',
+    auth_token: ENV['SENTRY_AUTH_TOKEN'],
+    dsym_path: './build/Finance.app.dSYM.zip'
+  )
+end
+```
+
+Install the plugin: `fastlane add_plugin sentry`
+
+#### Option B: Sentry CLI
+
+```bash
+sentry-cli debug-files upload --org $SENTRY_ORG --project finance-ios ./build/Finance.app.dSYM.zip
+```
+
+### 8. Alert Rules
+
+Configure these alert rules in each Sentry project under **Alerts** → **Create Alert Rule**:
+
+#### Recommended alert rules
+
+| Alert                    | Condition                             | Action             |
+| ------------------------ | ------------------------------------- | ------------------ |
+| New issue spike          | When a new issue is seen 10+ times/hr | Notify via email   |
+| High error rate          | Error count > 50 in 1 hour            | Notify via Slack   |
+| Regression               | A resolved issue reoccurs             | Notify via email   |
+| Unhandled crash (mobile) | Unhandled exception detected          | Notify immediately |
+| Performance degradation  | P95 transaction duration > 3s         | Notify via Slack   |
+
+#### Environment-specific alerting
+
+- **Production:** All alerts active, immediate notification
+- **Staging:** Only "new issue spike" and "unhandled crash" active
+- **Development:** No alerts (events should not reach Sentry)
+
+### 9. GitHub Actions Secrets
+
+Add these secrets in **Settings** → **Secrets and variables** → **Actions**:
+
+| Secret               | Scope       | Description                                                 |
+| -------------------- | ----------- | ----------------------------------------------------------- |
+| `SENTRY_ORG`         | Repository  | Sentry organization slug                                    |
+| `SENTRY_AUTH_TOKEN`  | Repository  | Org-level auth token (scopes: `project:releases`, `org:ci`) |
+| `SENTRY_DSN_WEB`     | Environment | Web project DSN (scoped to `staging` / `production`)        |
+| `SENTRY_DSN_ANDROID` | Environment | Android project DSN (scoped to `staging` / `production`)    |
+| `SENTRY_DSN_IOS`     | Environment | iOS project DSN (scoped to `staging` / `production`)        |
+| `SENTRY_DSN_WINDOWS` | Environment | Windows project DSN (scoped to `staging` / `production`)    |
+
+> **Environment-scoped secrets:** Use GitHub Environments (`staging`, `production`) to scope DSNs so staging builds never send events to production Sentry projects.
+
+---
+
+## CI/CD Monitoring
 
 CI health is monitored through three complementary mechanisms:
 
@@ -14,7 +301,7 @@ CI health is monitored through three complementary mechanisms:
 2. **Local tooling** — `tools/ci-health-dashboard.js` for on-demand checks
 3. **GitHub Security tab** — CodeQL and dependency scanning results
 
-## Monitored Workflows
+### Monitored Workflows
 
 | Workflow               | Schedule             | What it monitors                                 |
 | ---------------------- | -------------------- | ------------------------------------------------ |
@@ -24,9 +311,9 @@ CI health is monitored through three complementary mechanisms:
 | `security.yml`         | Weekly (Mon 6AM UTC) | CodeQL SAST, secret detection                    |
 | `stale-detection.yml`  | On schedule          | Stale issues and PRs                             |
 
-## Alerting Rules
+### Alerting Rules
 
-### CI Pipeline Health
+#### CI Pipeline Health
 
 | Condition                     | Severity     | Action                                             |
 | ----------------------------- | ------------ | -------------------------------------------------- |
@@ -36,7 +323,7 @@ CI health is monitored through three complementary mechanisms:
 | Build time trend > +15%       | **Warning**  | Review recent dependency/config changes            |
 | Flaky test detected (re-runs) | **Medium**   | Add to flaky test tracking issue                   |
 
-### Dependency Security
+#### Dependency Security
 
 | Condition                         | Severity     | Action                        |
 | --------------------------------- | ------------ | ----------------------------- |
@@ -45,7 +332,7 @@ CI health is monitored through three complementary mechanisms:
 | Moderate CVE                      | **Medium**   | Fix in next sprint            |
 | GPL-3.0/AGPL-3.0 license detected | **High**     | Remove dependency immediately |
 
-### Build Performance
+#### Build Performance
 
 | Metric           | Budget      | Action on violation                    |
 | ---------------- | ----------- | -------------------------------------- |
@@ -54,7 +341,7 @@ CI health is monitored through three complementary mechanisms:
 | KMP build time   | Track trend | Investigate if P90 > 15min             |
 | npm install time | Track trend | Review dependency count                |
 
-## Local Dashboard
+### Local Dashboard
 
 Run the CI health dashboard locally:
 
@@ -72,7 +359,7 @@ node tools/ci-health-dashboard.js --alerts-only
 node tools/ci-health-dashboard.js --json
 ```
 
-## Fleet Monitoring
+### Fleet Monitoring
 
 For fleet (parallel agent) operations:
 
@@ -87,9 +374,9 @@ node tools/fleet-status.js --watch
 node tools/worktree-cleanup.js
 ```
 
-## Incident Response
+### Incident Response
 
-### CI Pipeline Failure
+#### CI Pipeline Failure
 
 1. **Identify**: Check `gh run list --workflow=<name> --status=failure`
 2. **Diagnose**: `gh run view <id> --log-failed`
@@ -97,7 +384,7 @@ node tools/worktree-cleanup.js
 4. **Fix**: Create a fix branch, push, verify CI passes
 5. **Prevent**: Add regression test, update monitoring thresholds
 
-### Build Performance Degradation
+#### Build Performance Degradation
 
 1. **Identify**: `node tools/build-analysis.js --recommend`
 2. **Diagnose**: Check Turbo cache hits, Gradle cache effectiveness
@@ -105,7 +392,7 @@ node tools/worktree-cleanup.js
 4. **Fix**: Optimize build config, split jobs, improve caching
 5. **Verify**: Run `node tools/performance-benchmark.js --compare`
 
-### Dependency Vulnerability
+#### Dependency Vulnerability
 
 1. **Identify**: `node tools/dependency-audit.js`
 2. **Assess**: Check CVE severity and exploitability
@@ -113,7 +400,7 @@ node tools/worktree-cleanup.js
 4. **Verify**: Re-run audit, check no regressions
 5. **Document**: Note in PR description which CVEs are resolved
 
-## Dashboard Metrics Reference
+### Dashboard Metrics Reference
 
 | Metric          | Source                 | Healthy         | Warning         | Critical      |
 | --------------- | ---------------------- | --------------- | --------------- | ------------- |
@@ -123,9 +410,9 @@ node tools/worktree-cleanup.js
 | npm audit       | `dependency-audit.yml` | 0 high/critical | moderate issues | high/critical |
 | CodeQL findings | `security.yml`         | 0 findings      | low severity    | high severity |
 
-## Configuration
+### Configuration
 
-### Environment Variables
+#### Environment Variables
 
 | Variable       | Purpose                 | Where                    |
 | -------------- | ----------------------- | ------------------------ |
@@ -133,7 +420,7 @@ node tools/worktree-cleanup.js
 | `TURBO_TEAM`   | Turbo team identifier   | GitHub Actions secret    |
 | `GITHUB_TOKEN` | GitHub API access       | Auto-provided in Actions |
 
-### Scheduled Workflow Cadence
+#### Scheduled Workflow Cadence
 
 All scheduled workflows run during low-activity hours (UTC mornings) to avoid impacting developer CI queues:
 


### PR DESCRIPTION
## Summary

Configures Sentry error monitoring for all platforms — env var placeholders and comprehensive setup documentation.

## Changes

- Added Sentry env vars to deploy/.env.example and deploy/.env.staging.example
- Rewrote docs/ops/monitoring-setup.md with full Sentry setup guide
- Covers all 4 platforms: web, android, ios, windows
- Documents privacy/scrubbing requirements, source map uploads, alert rules
- Existing app code (web, android) already has proper Sentry wiring — no code changes needed

## Issues

Closes #1254
