### PR TITLE
fix(deploy): write PowerSync config to /tmp/ (container /app/ is read-only) (#1276)

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -320,9 +320,9 @@ services:
             'sync_rules:',
             '  path: /sync-rules/sync-rules.yaml'
           ].join('\n');
-          fs.writeFileSync('/app/powersync.yaml', lines);
-          console.log('Generated /app/powersync.yaml');
-        " && exec node service/lib/entry.js start
+          fs.writeFileSync('/tmp/powersync.yaml', lines);
+          console.log('Generated /tmp/powersync.yaml');
+        " && exec node service/lib/entry.js start --config-path /tmp/powersync.yaml
     volumes:
       - ${POWERSYNC_SYNC_RULES_PATH:-../services/api/powersync}:/sync-rules:ro
     healthcheck:


### PR DESCRIPTION
## Summary

Quick follow-up to #1277 — the PowerSync container runs as non-root user \web\ and \/app/\ is owned by root, so writing the generated config to \/app/powersync.yaml\ fails with \EACCES\.

## Fix

- Write to \/tmp/powersync.yaml\ (world-writable) instead
- Pass \--config-path /tmp/powersync.yaml\ to the start command

Verified working on production VPS.

## Issues

Closes #1276
