### PR TITLE
chore(ci): align env vars — remove STAGING_/PROD_ prefixes, scope by GitHub Environment (#1279)

### DIFF
--- a/.github/workflows/canary-deploy.yml
+++ b/.github/workflows/canary-deploy.yml
@@ -154,9 +154,9 @@ jobs:
           NODE_ENV: production
           VITE_APP_VERSION: ${{ needs.prepare.outputs.version }}-canary
           VITE_ENVIRONMENT: canary
-          VITE_SUPABASE_URL: ${{ secrets.PROD_SUPABASE_URL }}
-          VITE_SUPABASE_ANON_KEY: ${{ secrets.PROD_SUPABASE_ANON_KEY }}
-          VITE_POWERSYNC_URL: ${{ secrets.PROD_POWERSYNC_URL }}
+          VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          VITE_POWERSYNC_URL: ${{ secrets.POWERSYNC_URL }}
         run: |
           npm run build -w packages/design-tokens
           npm run build -w apps/web
@@ -419,22 +419,23 @@ jobs:
       - name: Promote backend to production
         if: needs.prepare.outputs.deploy_backend == 'true'
         env:
-          PROD_HOST: ${{ secrets.PROD_HOST }}
-          PROD_SSH_KEY: ${{ secrets.PROD_SSH_KEY }}
-          PROD_USER: ${{ secrets.PROD_USER }}
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PATH: ${{ vars.DEPLOY_PATH || '~/finance' }}
         run: |
-          if [ -z "$PROD_HOST" ]; then
-            echo "::warning::PROD_HOST not configured — skipping backend promotion"
+          if [ -z "$DEPLOY_HOST" ]; then
+            echo "::warning::DEPLOY_HOST not configured — skipping backend promotion"
             exit 0
           fi
 
           mkdir -p ~/.ssh
-          echo "$PROD_SSH_KEY" > ~/.ssh/deploy_key
+          echo "$DEPLOY_SSH_KEY" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -H "$PROD_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+          ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null
 
-          ssh -i ~/.ssh/deploy_key "$PROD_USER@$PROD_HOST" << DEPLOY
-            cd /opt/finance
+          ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" << DEPLOY
+            cd $DEPLOY_PATH
             git fetch origin
             git checkout ${{ needs.prepare.outputs.sha }}
             docker compose -f deploy/docker-compose.yml pull

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -149,9 +149,9 @@ jobs:
           NODE_ENV: production
           VITE_APP_VERSION: ${{ needs.prepare.outputs.version }}
           VITE_ENVIRONMENT: production
-          VITE_SUPABASE_URL: ${{ secrets.PROD_SUPABASE_URL }}
-          VITE_SUPABASE_ANON_KEY: ${{ secrets.PROD_SUPABASE_ANON_KEY }}
-          VITE_POWERSYNC_URL: ${{ secrets.PROD_POWERSYNC_URL }}
+          VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          VITE_POWERSYNC_URL: ${{ secrets.POWERSYNC_URL }}
         run: npm run build -w apps/web
 
       - name: Type check
@@ -195,9 +195,9 @@ jobs:
           NODE_ENV: production
           VITE_APP_VERSION: ${{ needs.prepare.outputs.version }}
           VITE_ENVIRONMENT: production
-          VITE_SUPABASE_URL: ${{ secrets.PROD_SUPABASE_URL }}
-          VITE_SUPABASE_ANON_KEY: ${{ secrets.PROD_SUPABASE_ANON_KEY }}
-          VITE_POWERSYNC_URL: ${{ secrets.PROD_POWERSYNC_URL }}
+          VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          VITE_POWERSYNC_URL: ${{ secrets.POWERSYNC_URL }}
         run: |
           npm run build -w packages/design-tokens
           npm run build -w apps/web
@@ -243,14 +243,15 @@ jobs:
 
       - name: Deploy to production server
         env:
-          PROD_HOST: ${{ secrets.PROD_HOST }}
-          PROD_SSH_KEY: ${{ secrets.PROD_SSH_KEY }}
-          PROD_USER: ${{ secrets.PROD_USER }}
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PATH: ${{ vars.DEPLOY_PATH || '~/finance' }}
         run: |
-          if [ -z "$PROD_HOST" ]; then
-            echo "::warning::PROD_HOST not configured — skipping backend deployment"
+          if [ -z "$DEPLOY_HOST" ]; then
+            echo "::warning::DEPLOY_HOST not configured — skipping backend deployment"
             echo "### ⚠️ Backend Production Skipped" >> "$GITHUB_STEP_SUMMARY"
-            echo "Configure PROD_HOST, PROD_SSH_KEY, and PROD_USER secrets." >> "$GITHUB_STEP_SUMMARY"
+            echo "Configure DEPLOY_HOST, DEPLOY_SSH_KEY, and DEPLOY_USER secrets." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 
@@ -259,13 +260,13 @@ jobs:
 
           # Set up SSH
           mkdir -p ~/.ssh
-          echo "$PROD_SSH_KEY" > ~/.ssh/deploy_key
+          echo "$DEPLOY_SSH_KEY" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -H "$PROD_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+          ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null
 
           # Deploy: checkout specific version, rebuild containers
-          ssh -i ~/.ssh/deploy_key "$PROD_USER@$PROD_HOST" << DEPLOY
-            cd /opt/finance
+          ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" << DEPLOY
+            cd $DEPLOY_PATH
             git fetch origin
             git checkout $SHA
             docker compose -f deploy/docker-compose.yml pull
@@ -275,7 +276,7 @@ jobs:
           DEPLOY
 
           echo "### 🐳 Backend Production Deployed" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Host:** \`$PROD_HOST\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Host:** \`$DEPLOY_HOST\`" >> "$GITHUB_STEP_SUMMARY"
           echo "**Version:** \`$VERSION\`" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Clean up SSH key

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -106,9 +106,9 @@ jobs:
           NODE_ENV: production
           VITE_APP_VERSION: ${{ needs.pre-deploy-checks.outputs.sha_short }}
           VITE_ENVIRONMENT: staging
-          VITE_SUPABASE_URL: ${{ secrets.STAGING_SUPABASE_URL }}
-          VITE_SUPABASE_ANON_KEY: ${{ secrets.STAGING_SUPABASE_ANON_KEY }}
-          VITE_POWERSYNC_URL: ${{ secrets.STAGING_POWERSYNC_URL }}
+          VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          VITE_POWERSYNC_URL: ${{ secrets.POWERSYNC_URL }}
         run: npm run build -w apps/web
 
       - name: Deploy to Vercel (staging)
@@ -152,29 +152,30 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # Staging backend deployment is SSH-based to the staging server.
-      # This step is a template — configure STAGING_SSH_KEY and STAGING_HOST.
+      # Secrets are scoped to the "staging" GitHub Environment.
       - name: Deploy to staging server
         env:
-          STAGING_HOST: ${{ secrets.STAGING_HOST }}
-          STAGING_SSH_KEY: ${{ secrets.STAGING_SSH_KEY }}
-          STAGING_USER: ${{ secrets.STAGING_USER }}
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PATH: ${{ vars.DEPLOY_PATH || '~/finance' }}
         run: |
-          if [ -z "$STAGING_HOST" ]; then
-            echo "::warning::STAGING_HOST not configured — skipping backend deployment"
+          if [ -z "$DEPLOY_HOST" ]; then
+            echo "::warning::DEPLOY_HOST not configured — skipping backend deployment"
             echo "### ⚠️ Backend Staging Skipped" >> "$GITHUB_STEP_SUMMARY"
-            echo "Configure STAGING_HOST, STAGING_SSH_KEY, and STAGING_USER secrets." >> "$GITHUB_STEP_SUMMARY"
+            echo "Configure DEPLOY_HOST, DEPLOY_SSH_KEY, and DEPLOY_USER secrets." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 
           # Set up SSH key
           mkdir -p ~/.ssh
-          echo "$STAGING_SSH_KEY" > ~/.ssh/deploy_key
+          echo "$DEPLOY_SSH_KEY" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -H "$STAGING_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+          ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null
 
           # Deploy via SSH: pull latest, rebuild containers
-          ssh -i ~/.ssh/deploy_key "$STAGING_USER@$STAGING_HOST" << 'DEPLOY'
-            cd /opt/finance
+          ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" << DEPLOY
+            cd $DEPLOY_PATH
             git pull origin main
             docker compose -f deploy/docker-compose.yml pull
             docker compose -f deploy/docker-compose.yml up -d --remove-orphans
@@ -183,7 +184,7 @@ jobs:
 
           echo "### 🐳 Backend Staging Deployed" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Host:** \`$STAGING_HOST\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Host:** \`$DEPLOY_HOST\`" >> "$GITHUB_STEP_SUMMARY"
           echo "**Commit:** \`${{ needs.pre-deploy-checks.outputs.sha_short }}\`" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Clean up SSH key

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -5,6 +5,9 @@
 VITE_SUPABASE_URL=https://your-project.supabase.co
 VITE_SUPABASE_ANON_KEY=your-supabase-anon-key
 
+# PowerSync Configuration (offline-first sync engine)
+VITE_POWERSYNC_URL=https://your-powersync-instance.powersync.com
+
 # Auth Endpoints
 VITE_LOGIN_ENDPOINT=/api/auth/login
 VITE_REFRESH_ENDPOINT=/api/auth/refresh

--- a/docs/deployment-pipeline.md
+++ b/docs/deployment-pipeline.md
@@ -72,25 +72,29 @@ Manual re-deploy: **Actions → Deploy — Staging → Run workflow**
 
 ### Staging Server (Backend)
 
-| Secret                      | Description                 |
-| --------------------------- | --------------------------- |
-| `STAGING_HOST`              | Staging server hostname     |
-| `STAGING_SSH_KEY`           | SSH private key for staging |
-| `STAGING_USER`              | SSH username for staging    |
-| `STAGING_SUPABASE_URL`      | Staging Supabase URL        |
-| `STAGING_SUPABASE_ANON_KEY` | Staging Supabase anon key   |
-| `STAGING_POWERSYNC_URL`     | Staging PowerSync URL       |
+Scoped to the `staging` GitHub Environment:
+
+| Secret              | Description                              |
+| ------------------- | ---------------------------------------- |
+| `DEPLOY_HOST`       | Staging server hostname                  |
+| `DEPLOY_SSH_KEY`    | SSH private key for staging              |
+| `DEPLOY_USER`       | SSH username for staging                 |
+| `SUPABASE_URL`      | Supabase URL (e.g. `https://staging...`) |
+| `SUPABASE_ANON_KEY` | Supabase anon key                        |
+| `POWERSYNC_URL`     | PowerSync URL                            |
 
 ### Production Server (Backend)
 
-| Secret                   | Description                    |
-| ------------------------ | ------------------------------ |
-| `PROD_HOST`              | Production server hostname     |
-| `PROD_SSH_KEY`           | SSH private key for production |
-| `PROD_USER`              | SSH username for production    |
-| `PROD_SUPABASE_URL`      | Production Supabase URL        |
-| `PROD_SUPABASE_ANON_KEY` | Production Supabase anon key   |
-| `PROD_POWERSYNC_URL`     | Production PowerSync URL       |
+Scoped to the `production` GitHub Environment:
+
+| Secret              | Description                                 |
+| ------------------- | ------------------------------------------- |
+| `DEPLOY_HOST`       | Production server hostname                  |
+| `DEPLOY_SSH_KEY`    | SSH private key for production              |
+| `DEPLOY_USER`       | SSH username for production                 |
+| `SUPABASE_URL`      | Supabase URL (e.g. `https://finance.ex...`) |
+| `SUPABASE_ANON_KEY` | Supabase anon key                           |
+| `POWERSYNC_URL`     | PowerSync URL                               |
 
 ## GitHub Environment Setup
 


### PR DESCRIPTION
## Summary

Standardizes GitHub Actions secret naming by removing environment prefixes (`STAGING_`, `PROD_`) and scoping secrets by GitHub Environment instead. This is the standard pattern — same secret name, different values per environment.

## Changes

### Workflow files
- **deploy-staging.yml**: `STAGING_SUPABASE_URL` → `SUPABASE_URL`, `STAGING_HOST` → `DEPLOY_HOST`, etc.
- **deploy-production.yml**: `PROD_SUPABASE_URL` → `SUPABASE_URL`, `PROD_HOST` → `DEPLOY_HOST`, etc.
- **canary-deploy.yml**: Same renames for production promote job
- All workflows: Added configurable `DEPLOY_PATH` variable (defaults to `~/finance`), fixing hardcoded `/opt/finance`

### Documentation
- **docs/deployment-pipeline.md**: Updated secret name tables with environment scoping
- **deploy/.env.example**: Removed obsolete `POWERSYNC_SUPABASE_PROJECT_ID` and `POWERSYNC_JWKS_URI`
- **apps/web/.env.example**: Added missing `VITE_POWERSYNC_URL`

### GitHub Environments (already applied)
- **production**: Set `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `POWERSYNC_URL`, `DEPLOY_HOST`, `DEPLOY_SSH_KEY`, `DEPLOY_USER` + `DEPLOY_PATH` variable
- **staging**: Already had `SUPABASE_URL`, `SUPABASE_ANON_KEY` — deploy secrets pending staging server setup

### VPS cleanup (already applied)
- Removed obsolete `POWERSYNC_SUPABASE_PROJECT_ID` and `POWERSYNC_JWKS_URI` from `.env`

## Before/After

| Before (anti-pattern) | After (standard) | Scoped by |
|---|---|---|
| `STAGING_SUPABASE_URL` | `SUPABASE_URL` | GitHub Environment: staging |
| `PROD_SUPABASE_URL` | `SUPABASE_URL` | GitHub Environment: production |
| `STAGING_HOST` | `DEPLOY_HOST` | GitHub Environment: staging |
| `PROD_HOST` | `DEPLOY_HOST` | GitHub Environment: production |
| `/opt/finance` (hardcoded) | `DEPLOY_PATH` variable | GitHub Environment variable |

Closes #1279