### PR TITLE
ci(security): fix intermittent CodeQL Java/Kotlin analysis (#1281)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -51,12 +51,11 @@ jobs:
       - if: github.event_name != 'pull_request' || steps.changes.outputs.kotlin == 'true'
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
       # Compile JVM targets only — Android SDK is unavailable in this CI environment.
-      # jvmMainClasses produces the class files CodeQL needs to analyze Kotlin code.
+      # clean + --no-build-cache ensures kotlinc actually runs so CodeQL's tracer can observe it.
       - if: github.event_name != 'pull_request' || steps.changes.outputs.kotlin == 'true'
-        run: ./gradlew jvmMainClasses --no-daemon
+        run: ./gradlew clean compileKotlinJvm --no-daemon --no-build-cache
       - if: github.event_name != 'pull_request' || steps.changes.outputs.kotlin == 'true'
         uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
-        continue-on-error: true
         with:
           category: '/language:java-kotlin'
 


### PR DESCRIPTION
## Summary

Fixes the intermittent CodeQL Java/Kotlin analysis failures by ensuring Gradle actually invokes the Kotlin compiler on every run.

## Changes

- Replace `jvmMainClasses` with `clean compileKotlinJvm --no-build-cache` to prevent UP-TO-DATE caching from starving CodeQL's tracer
- Remove redundant `continue-on-error: true` on the analyze step (job-level `continue-on-error: true` on line 21 already handles this)
- Update build step comment to reflect the new command

## Root Cause

Gradle build caching could skip actual `kotlinc` invocations when outputs were UP-TO-DATE, causing CodeQL's tracer to find no Java/Kotlin code to analyze. The fix ensures:
- `clean` removes any cached build outputs
- `--no-build-cache` prevents Gradle remote cache from skipping compilation
- `compileKotlinJvm` is more targeted than `jvmMainClasses`

Closes #1281