### PR TITLE
fix(deps): resolve 21 Netty transitive dependency vulnerabilities

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,22 @@ plugins {
     alias(libs.plugins.kotlin.jvm) apply false
 }
 
+// Force all transitive io.netty dependencies to the latest patched version.
+// Fixes 21 Dependabot security alerts (HTTP/2 attacks, request smuggling, DoS,
+// decompression bombs, CRLF injection) across Ktor, Compose Desktop, and
+// Gradle Develocity transitive dependency trees.
+val nettyVersion = libs.versions.netty.get()
+allprojects {
+    configurations.all {
+        resolutionStrategy.eachDependency {
+            if (requested.group == "io.netty") {
+                useVersion(nettyVersion)
+                because("Fix Dependabot security alerts for Netty CVEs (#1292)")
+            }
+        }
+    }
+}
+
 // Configure detekt for all Kotlin files in the project
 detekt {
     basePath = projectDir.absolutePath

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ turbine = "1.2.0"
 kover = "0.9.1"
 paparazzi = "1.3.5"
 compose-multiplatform = "1.7.3"
+netty = "4.1.133.Final"
 
 # Android / Compose
 android-compileSdk = "35"


### PR DESCRIPTION
## Summary

Force all \io.netty:*\ transitive dependencies to **4.1.133.Final** (latest safe version) via Gradle resolution strategy, fixing 21 Dependabot security alerts.

## Changes

- Added \
etty = "4.1.133.Final"\ version entry to \gradle/libs.versions.toml\
- Added \esolutionStrategy.eachDependency\ block in root \uild.gradle.kts\ to force all \io.netty\ group dependencies to the safe version

## How It Works

The \llprojects { configurations.all { resolutionStrategy.eachDependency { ... } } }\ block intercepts every dependency resolution across all subprojects. Any dependency with group \io.netty\ is forced to 4.1.133.Final, regardless of which transitive path introduced it (Ktor 3.0.3, Compose Desktop 1.7.3, or Gradle Develocity 4.3.2).

## Affected Netty Modules

| Module | CVE Count | Key Vulnerabilities |
|--------|-----------|-------------------|
| \
etty-codec-http\ | 12 | HTTP smuggling, OOM, CRLF injection |
| \
etty-codec-http2\ | 5 | HTTP/2 Rapid Reset, CONTINUATION flood, DDoS |
| \
etty-handler\ | 2 | SslHandler crash, SniHandler allocation |
| \
etty-common\ | 2 | DoS on Windows |
| \
etty-codec\ | 2 | Lz4 exhaustion, zip bomb DoS |
| \
etty-handler-proxy\ | 1 | HTTP Header Injection |

## Dependabot Alerts Fixed (21)

CVE-2026-42587, CVE-2026-42585, CVE-2026-42584, CVE-2026-42583, CVE-2026-42581, CVE-2026-42580, CVE-2026-42578, CVE-2026-41417, CVE-2026-33871, CVE-2026-33870, CVE-2025-67735, CVE-2025-58056, CVE-2025-58057, CVE-2025-55163, CVE-2025-25193, CVE-2024-47535, CVE-2025-24970, CVE-2024-29025, CVE-2023-34462, and HTTP/2 Rapid Reset (no CVE).

Closes #1292