### PR TITLE
fix(deps): force Apache Commons, protobuf, and JDOM to safe versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,3 +22,31 @@ detekt {
     ignoreFailures = true
     buildUponDefaultConfig = true
 }
+
+// Force vulnerable transitive dependencies to safe versions
+allprojects {
+    configurations.all {
+        resolutionStrategy.eachDependency {
+            if (requested.group == "org.apache.commons" && requested.name == "commons-compress") {
+                useVersion(libs.versions.commons.compress.get())
+                because("Fix CVE-2024-25710 (DoS infinite loop) and CVE-2024-26308 (OOM)")
+            }
+            if (requested.group == "commons-io" && requested.name == "commons-io") {
+                useVersion(libs.versions.commons.io.get())
+                because("Fix CVE-2024-47554 (DoS via XmlStreamReader)")
+            }
+            if (requested.group == "org.apache.httpcomponents" && requested.name == "httpclient") {
+                useVersion(libs.versions.httpcomponents.httpclient.get())
+                because("Fix CVE-2020-13956 (XSS in Apache HttpComponents)")
+            }
+            if (requested.group == "com.google.protobuf" && requested.name == "protobuf-java") {
+                useVersion(libs.versions.protobuf.java.get())
+                because("Fix CVE-2024-7254 (DoS via protobuf-java)")
+            }
+            if (requested.group == "org.jdom" && requested.name == "jdom2") {
+                useVersion(libs.versions.jdom2.get())
+                because("Fix CVE-2021-33813 (XXE Injection in JDOM2)")
+            }
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,13 @@ kover = "0.9.1"
 paparazzi = "1.3.5"
 compose-multiplatform = "1.7.3"
 
+# Security: forced transitive dependency versions
+commons-compress = "1.27.1"
+commons-io = "2.18.0"
+httpcomponents-httpclient = "4.5.14"
+protobuf-java = "4.29.3"
+jdom2 = "2.0.6.1"
+
 # Android / Compose
 android-compileSdk = "35"
 android-minSdk = "28"


### PR DESCRIPTION
## Summary

Force Apache Commons, protobuf-java, and JDOM2 transitive dependencies to latest safe versions via Gradle resolution strategy, fixing 6 Dependabot security alerts.

## Changes

- Added version entries to \gradle/libs.versions.toml\ for commons-compress (1.27.1), commons-io (2.18.0), httpcomponents-httpclient (4.5.14), protobuf-java (4.29.3), and jdom2 (2.0.6.1)
- Added \llprojects { configurations.all { resolutionStrategy.eachDependency } }\ block in root \uild.gradle.kts\ to force all transitive resolutions to safe versions

## Alerts Fixed (6)

| CVE | Library | Severity | Type |
|-----|---------|----------|------|
| CVE-2024-25710 | commons-compress | Medium | DoS infinite loop |
| CVE-2024-26308 | commons-compress | Medium | OOM |
| CVE-2024-47554 | commons-io | High | DoS via XmlStreamReader |
| CVE-2020-13956 | httpcomponents httpclient | Medium | XSS |
| CVE-2024-7254 | protobuf-java | High | DoS |
| CVE-2021-33813 | jdom2 | High | XXE Injection |

## Testing

- [x] \:packages:core:compileKotlinJvm\ passes
- [x] \:packages:sync:compileKotlinJvm\ passes
- [x] \:apps:windows:compileKotlin\ passes
- [x] Prettier format check passes
- [x] ESLint passes with zero warnings

Closes #1290