### PR TITLE
fix(deps): force Bouncy Castle and jose4j to safe versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,9 @@ detekt {
 }
 
 // Force vulnerable transitive dependencies to safe versions
+val bouncyCastleVersion = libs.versions.bouncy.castle.get()
+val jose4jVersion = libs.versions.jose4j.get()
+
 allprojects {
     configurations.all {
         resolutionStrategy.eachDependency {
@@ -62,6 +65,14 @@ allprojects {
             if (requested.group == "org.jdom" && requested.name == "jdom2") {
                 useVersion(libs.versions.jdom2.get())
                 because("Fix CVE-2021-33813 (XXE Injection in JDOM2)")
+            }
+            if (requested.group == "org.bouncycastle") {
+                useVersion(bouncyCastleVersion)
+                because("Fix 9 Dependabot alerts for Bouncy Castle CVEs (timing, crypto, DoS, LDAP injection)")
+            }
+            if (requested.group == "org.bitbucket.b_c" && requested.name == "jose4j") {
+                useVersion(jose4jVersion)
+                because("Fix 4 Dependabot alerts for jose4j CVEs (DoS, weak crypto, chosen ciphertext)")
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,8 @@ commons-io = "2.18.0"
 httpcomponents-httpclient = "4.5.14"
 protobuf-java = "4.29.3"
 jdom2 = "2.0.6.1"
+bouncy-castle = "1.80"
+jose4j = "0.9.6"
 
 # Android / Compose
 android-compileSdk = "35"


### PR DESCRIPTION
## Summary

Force Bouncy Castle and jose4j transitive dependencies to latest safe versions via Gradle resolution strategy, fixing 13 Dependabot security alerts.

## Changes

- Added \ouncy-castle = \"1.80\"\ and \jose4j = \"0.9.6\"\ version entries to \gradle/libs.versions.toml\`n- Added \esolutionStrategy.eachDependency\ in root \uild.gradle.kts\ \llprojects {}\ block to force all transitive Bouncy Castle and jose4j dependencies to safe versions

## Bouncy Castle (9 alerts fixed)

- CVE-2026-5598 (high): Covert Timing Channel
- CVE-2026-0636 (medium): LDAP Injection
- CVE-2026-5588 (medium): Broken/Risky Crypto Algorithm
- CVE-2025-8916 (medium): Excessive Allocation
- CVE-2025-8885 (medium): Excessive Allocation
- CVE-2024-30172 (medium): Infinite loop on crafted signature
- CVE-2024-30171 (medium): RSA timing side-channel (Marvin Attack)
- CVE-2024-29857 (medium): High CPU on certificate parsing
- CVE-2024-34447 (medium): DNS poisoning

## jose4j (4 alerts fixed)

- CVE-2023-51775 (medium): DoS via crafted JWE
- CVE-2023-31582 (high): Weak cryptographic algorithm
- CVE-2024-29371 (high): DoS via compressed JWE content
- No CVE (medium): Chosen Ciphertext Attack

## Testing

- [x] \:packages:core:compileKotlinJvm\ — passes
- [x] \:packages:sync:compileKotlinJvm\ — passes
- [x] \:apps:windows:compileKotlin\ — passes

Closes #1291