### PR TITLE
fix(deploy): tighten CSP connect-src and remove unnecessary proxy headers (#1307)

### DIFF
--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -17,7 +17,7 @@
 #   /manifest.json   → PWA manifest (short cache, revalidate)
 #   /*               → SPA index.html fallback
 #
-# Issues: #268, #897
+# Issues: #268, #897, #1307
 # =============================================================================
 
 {$DOMAIN} {
@@ -48,7 +48,7 @@
 		Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(self)"
 
 		# Content Security Policy — strict, no inline scripts, no eval
-		Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self'; connect-src 'self' https:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; worker-src 'self'"
+		Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; worker-src 'self'"
 
 		# Remove server identification
 		-Server
@@ -60,7 +60,6 @@
 	# -------------------------------------------------------------------------
 	handle_path /rest/v1/* {
 		reverse_proxy rest:3000 {
-			header_up X-Forwarded-Proto {scheme}
 			header_up X-Real-IP {remote_host}
 		}
 	}
@@ -71,7 +70,6 @@
 	# -------------------------------------------------------------------------
 	handle_path /auth/v1/* {
 		reverse_proxy auth:9999 {
-			header_up X-Forwarded-Proto {scheme}
 			header_up X-Real-IP {remote_host}
 		}
 	}
@@ -81,7 +79,6 @@
 	# -------------------------------------------------------------------------
 	handle_path /sync/* {
 		reverse_proxy powersync:8080 {
-			header_up X-Forwarded-Proto {scheme}
 			header_up X-Real-IP {remote_host}
 		}
 	}
@@ -92,7 +89,6 @@
 	# -------------------------------------------------------------------------
 	handle_path /functions/v1/* {
 		reverse_proxy edge-functions:9000 {
-			header_up X-Forwarded-Proto {scheme}
 			header_up X-Real-IP {remote_host}
 		}
 	}

--- a/deploy/Caddyfile.staging
+++ b/deploy/Caddyfile.staging
@@ -5,7 +5,7 @@
 # Same as production Caddyfile but uses Let's Encrypt Staging CA to avoid
 # hitting rate limits during frequent re-deployments.
 #
-# Issues: #883
+# Issues: #883, #1307
 # =============================================================================
 
 {
@@ -25,7 +25,7 @@
 		X-Frame-Options "DENY"
 		X-XSS-Protection "1; mode=block"
 		Referrer-Policy "strict-origin-when-cross-origin"
-		Content-Security-Policy "default-src 'self'; connect-src 'self' https:; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'"
+		Content-Security-Policy "default-src 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'"
 		-Server
 	}
 
@@ -34,7 +34,6 @@
 	# -------------------------------------------------------------------------
 	handle_path /rest/v1/* {
 		reverse_proxy rest:3000 {
-			header_up X-Forwarded-Proto {scheme}
 			header_up X-Real-IP {remote_host}
 		}
 	}
@@ -44,7 +43,6 @@
 	# -------------------------------------------------------------------------
 	handle_path /auth/v1/* {
 		reverse_proxy auth:9999 {
-			header_up X-Forwarded-Proto {scheme}
 			header_up X-Real-IP {remote_host}
 		}
 	}
@@ -54,7 +52,6 @@
 	# -------------------------------------------------------------------------
 	handle_path /sync/* {
 		reverse_proxy powersync:8080 {
-			header_up X-Forwarded-Proto {scheme}
 			header_up X-Real-IP {remote_host}
 		}
 	}
@@ -64,7 +61,6 @@
 	# -------------------------------------------------------------------------
 	handle_path /functions/v1/* {
 		reverse_proxy edge-functions:9000 {
-			header_up X-Forwarded-Proto {scheme}
 			header_up X-Real-IP {remote_host}
 		}
 	}


### PR DESCRIPTION
## Summary

Tighten Content-Security-Policy headers in both production and staging Caddyfiles to eliminate data exfiltration risk, and remove deprecated Caddy v2.9+ proxy headers that generate warnings.

## Changes

### CSP Hardening
- **\connect-src 'self' https:\** → **\connect-src 'self'\** — the blanket \https:\ allowed fetch/XHR to *any* HTTPS endpoint, enabling XSS-based data exfiltration of financial data. All backend services (PostgREST, GoTrue, PowerSync, Edge Functions) are routed through Caddy's reverse proxy on the same origin, so \'self'\ is sufficient.
- **\img-src 'self' data: blob: https:\** → **\img-src 'self' data: blob:\** — removed blanket \https:\ for images; the app does not load external images.

### Caddy v2.9+ Cleanup
- Removed \header_up X-Forwarded-Proto {scheme}\ from all 4 \everse_proxy\ blocks in both files — Caddy v2.9+ automatically forwards this header, so the manual directive is unnecessary and generates deprecation warnings.

### Both Files Updated
- \deploy/Caddyfile\ (production)
- \deploy/Caddyfile.staging\ (staging)

## Security Impact

This change significantly reduces the attack surface for XSS-based data exfiltration in a financial application. Previously, any XSS could send user financial data to any HTTPS endpoint. Now, \connect-src 'self'\ restricts all fetch/XHR to the app's own domain.

## Issues

Closes #1307