### PR TITLE
fix(deploy): harden infrastructure exposure and restrict PostgREST schemas (#1306)

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -17,7 +17,10 @@
 #   80   — HTTP  (redirects to HTTPS)
 #   443  — HTTPS (automatic Let's Encrypt via Caddy)
 #
-# Issues: #268, #897
+# Security: PostgreSQL is NOT exposed to the host. All services connect via
+# the Docker 'finance-internal' bridge network. See #1306.
+#
+# Issues: #268, #897, #1306, #1316
 # =============================================================================
 
 services:
@@ -27,8 +30,9 @@ services:
   db:
     image: supabase/postgres:15.8.1.060
     restart: unless-stopped
-    ports:
-      - '${POSTGRES_PORT:-5432}:5432'
+    # No host port exposure — all services connect via Docker 'finance-internal'
+    # network. Exposing PostgreSQL to the host bypasses Caddy TLS, Edge Function
+    # auth, and all RLS policies. See #1306.
     environment:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB:-postgres}
@@ -82,7 +86,7 @@ services:
     restart: unless-stopped
     environment:
       PGRST_DB_URI: postgres://authenticator:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-postgres}
-      PGRST_DB_SCHEMAS: public,auth,storage
+      PGRST_DB_SCHEMAS: public
       PGRST_DB_ANON_ROLE: anon
       PGRST_JWT_SECRET: ${JWT_SECRET}
       PGRST_DB_USE_LEGACY_GUCS: 'false'
@@ -283,11 +287,21 @@ services:
   # The entrypoint generates it from env vars using the mounted template.
   #
   # Ports: 8080 (API) — internal only, routed through Caddy at /sync/*
+  #
+  # TODO(#1306): PowerSync currently connects as supabase_admin (superuser).
+  # Create a dedicated 'powersync_replication' PostgreSQL role with only:
+  #   - REPLICATION privilege (for logical replication)
+  #   - SELECT on all sync-enabled tables (for initial snapshot)
+  #   - USAGE on the public schema
+  # Then update PS_PG_URI below to use that role instead of supabase_admin.
+  # Migration: services/api/supabase/migrations/YYYYMMDDHHMMSS_powersync_role.sql
   powersync:
     image: journeyapps/powersync-service:latest
     restart: unless-stopped
     environment:
       # These env vars are used by the startup script to generate powersync.yaml
+      # TODO(#1306): Replace supabase_admin with a dedicated powersync_replication
+      # role once the migration is created (see comment block above).
       PS_PG_URI: postgres://supabase_admin:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-postgres}
       PS_PG_SLOT: ${POWERSYNC_SLOT_NAME:-powersync}
       PS_PG_PUBLICATION: ${POWERSYNC_PUBLICATION:-powersync}
@@ -304,7 +318,7 @@ services:
             '  connections:',
             '    - type: postgresql',
             '      uri: ' + process.env.PS_PG_URI,
-            '      sslmode: disable',
+            '      sslmode: disable',  // Acceptable: traffic stays on Docker bridge network (finance-internal). For production deployments outside Docker, upgrade to sslmode: require or verify-full.
             '      slot_name: ' + process.env.PS_PG_SLOT,
             '      publication_name: ' + process.env.PS_PG_PUBLICATION,
             '',


### PR DESCRIPTION
## Summary

Hardens the Docker Compose stack by:
1. Removing PostgreSQL port exposure to the host (was bypassing all RLS)
2. Restricting PostgREST to public schema only (was exposing auth/storage)
3. Documenting PowerSync superuser usage and SSL mode

Closes #1306
Closes #1316

## Changes

- Removed `ports:` from db service — all services connect via Docker internal network
- Changed `PGRST_DB_SCHEMAS` from `public,auth,storage` to `public`
- Updated header comment to reflect only ports 80/443 exposed, added security note
- Added TODO comments for dedicated PowerSync replication role migration
- Documented `sslmode: disable` as acceptable for Docker bridge network isolation

## Security Impact

**Fix 1 (Critical):** PostgreSQL was exposed on host port 5432, allowing anyone with network access to connect directly — bypassing Caddy TLS, Edge Function auth, and all RLS policies. Now only accessible via Docker internal network.

**Fix 2 (High):** PostgREST was exposing `auth` and `storage` schemas, allowing direct REST API access to sensitive tables like `auth.users`. Now restricted to `public` schema only.

**Fix 3 (Documentation):** PowerSync connects as `supabase_admin` (superuser) with `sslmode: disable`. Added TODOs for a dedicated least-privilege role and SSL documentation.

## Testing

- [ ] All services still connect via Docker internal network (`finance-internal`)
- [ ] PostgREST only serves public schema
- [ ] No external PostgreSQL access possible
- [ ] `docker compose config` validates successfully