### PR TITLE
fix(auth): secure passkey authentication session flow (#1310)

### DIFF
--- a/apps/web/src/auth/auth-context.tsx
+++ b/apps/web/src/auth/auth-context.tsx
@@ -259,58 +259,38 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
     [config.loginEndpoint],
   );
 
-  const loginWithPasskey = useCallback(
-    async (email?: string): Promise<void> => {
-      setError(null);
-      setIsLoading(true);
+  const loginWithPasskey = useCallback(async (email?: string): Promise<void> => {
+    setError(null);
+    setIsLoading(true);
 
-      try {
-        const result = await authenticateWithPasskey(email);
+    try {
+      const result = await authenticateWithPasskey(email);
 
-        // After passkey verification, exchange for a session token.
-        // The backend returns a session via Set-Cookie + access_token.
-        const sessionResponse = await fetch(
-          `${config.supabaseUrl}/functions/v1/passkey-authenticate?step=session`,
-          {
-            method: 'POST',
-            credentials: 'include',
-            headers: {
-              'Content-Type': 'application/json',
-              apikey: config.supabaseAnonKey,
-            },
-            body: JSON.stringify({ user_id: result.userId }),
-          },
-        );
-
-        if (sessionResponse.ok) {
-          const sessionData = (await sessionResponse.json()) as {
-            access_token: string;
-            user: { id: string; email: string };
-          };
-          setAccessToken(sessionData.access_token);
-          setUser({
-            id: sessionData.user.id,
-            email: sessionData.user.email,
-            hasPasskey: true,
-          });
-        } else {
-          // Fallback: use the user_id from the passkey result
-          setUser({
-            id: result.userId,
-            email: email ?? '',
-            hasPasskey: true,
-          });
-        }
-      } catch (err) {
-        const message = err instanceof Error ? err.message : 'Passkey authentication failed';
-        setError(message);
-        throw err;
-      } finally {
-        setIsLoading(false);
+      // The verify step returns a full Supabase session (access_token,
+      // refresh_token, user). No separate session-minting call is needed —
+      // binding session issuance to the WebAuthn ceremony eliminates the
+      // CSRF risk of a detached session endpoint (#1310).
+      if (result.accessToken) {
+        setAccessToken(result.accessToken);
+        setUser({
+          id: result.userId,
+          email: result.email ?? email ?? '',
+          hasPasskey: true,
+        });
+      } else {
+        // Defensive fallback — should not occur with a correctly
+        // configured server, but avoids a blank screen if the server
+        // response shape changes.
+        throw new Error('Passkey verification succeeded but no session token was returned.');
       }
-    },
-    [config.supabaseUrl, config.supabaseAnonKey],
-  );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Passkey authentication failed';
+      setError(message);
+      throw err;
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
 
   const registerNewPasskey = useCallback(async (): Promise<void> => {
     setError(null);

--- a/apps/web/src/auth/webauthn.ts
+++ b/apps/web/src/auth/webauthn.ts
@@ -39,6 +39,14 @@ export interface RegistrationResult {
 export interface AuthenticationResult {
   verified: boolean;
   userId: string;
+  /** Access token from the minted session (set when the server returns a full session). */
+  accessToken?: string;
+  /** Refresh token from the minted session. */
+  refreshToken?: string;
+  /** Token expiry in seconds. */
+  expiresIn?: number;
+  /** User email from the minted session. */
+  email?: string;
 }
 
 /** Registration options returned by the server (PublicKeyCredentialCreationOptionsJSON). */
@@ -386,18 +394,28 @@ export async function authenticateWithPasskey(email?: string): Promise<Authentic
     clientExtensionResults: credential.getClientExtensionResults(),
   };
 
-  // Step 5: Send assertion to server for verification
+  // Step 5: Send assertion to server for verification.
+  // The verify step returns a full Supabase session (access_token,
+  // refresh_token, user) — no separate session-minting call is needed.
   const result = await callEdgeFunction<{
     verified: boolean;
     user_id: string;
+    access_token?: string;
+    refresh_token?: string;
+    expires_in?: number;
+    user?: { id: string; email?: string };
   }>('passkey-authenticate', 'verify', assertionBody);
 
-  if (!result.verified) {
+  if (!result.verified && !result.access_token) {
     throw new Error('Server rejected the authentication.');
   }
 
   return {
-    verified: result.verified,
-    userId: result.user_id,
+    verified: result.verified ?? true,
+    userId: result.user?.id ?? result.user_id,
+    accessToken: result.access_token,
+    refreshToken: result.refresh_token,
+    expiresIn: result.expires_in,
+    email: result.user?.email,
   };
 }

--- a/services/api/supabase/functions/passkey-register/index.ts
+++ b/services/api/supabase/functions/passkey-register/index.ts
@@ -168,24 +168,64 @@ serve(async (req: Request): Promise<Response> => {
 
       const body = await req.json();
 
-      // Retrieve stored challenge
-      const { data: challenges, error: challengeError } = await supabaseAdmin
-        .from('webauthn_challenges')
-        .select('*')
-        .eq('user_id', user.id)
-        .eq('type', 'registration')
-        .gt('expires_at', new Date().toISOString())
-        .order('created_at', { ascending: false })
-        .limit(1);
-
-      if (challengeError || !challenges || challenges.length === 0) {
-        return new Response(JSON.stringify({ error: 'No valid challenge found' }), {
+      // ── Scoped challenge lookup (#1310, API-9) ─────────────────────
+      // Extract the challenge from clientDataJSON so we look up by exact
+      // value — never "the most recent challenge for this user".
+      if (!body.response?.clientDataJSON) {
+        return new Response(JSON.stringify({ error: 'Missing clientDataJSON in response' }), {
           status: 400,
           headers: { ...getCorsHeaders(req), 'Content-Type': 'application/json' },
         });
       }
 
-      const expectedChallenge = challenges[0].challenge;
+      const clientDataBytes = Uint8Array.from(
+        atob(
+          body.response.clientDataJSON
+            .replace(/-/g, '+')
+            .replace(/_/g, '/')
+            .padEnd(
+              body.response.clientDataJSON.length +
+                ((4 - (body.response.clientDataJSON.length % 4)) % 4),
+              '=',
+            ),
+        ),
+        (c: string) => c.charCodeAt(0),
+      );
+      const clientData = JSON.parse(new TextDecoder().decode(clientDataBytes));
+      const submittedChallenge = clientData.challenge as string | undefined;
+
+      if (!submittedChallenge) {
+        return new Response(JSON.stringify({ error: 'Missing challenge in client data' }), {
+          status: 400,
+          headers: { ...getCorsHeaders(req), 'Content-Type': 'application/json' },
+        });
+      }
+
+      // Look up by exact challenge value + user + type + not-expired
+      const { data: challengeRow, error: challengeError } = await supabaseAdmin
+        .from('webauthn_challenges')
+        .select('*')
+        .eq('challenge', submittedChallenge)
+        .eq('user_id', user.id)
+        .eq('type', 'registration')
+        .gt('expires_at', new Date().toISOString())
+        .single();
+
+      if (challengeError || !challengeRow) {
+        return new Response(
+          JSON.stringify({ error: 'Challenge not found, expired, or already used' }),
+          {
+            status: 400,
+            headers: { ...getCorsHeaders(req), 'Content-Type': 'application/json' },
+          },
+        );
+      }
+
+      // Delete challenge immediately — one-time use regardless of
+      // whether verification succeeds (#1310, API-9).
+      await supabaseAdmin.from('webauthn_challenges').delete().eq('id', challengeRow.id);
+
+      const expectedChallenge = challengeRow.challenge as string;
 
       const verification: VerifiedRegistrationResponse = await verifyRegistrationResponse({
         response: body,
@@ -223,9 +263,6 @@ serve(async (req: Request): Promise<Response> => {
           headers: { ...getCorsHeaders(req), 'Content-Type': 'application/json' },
         });
       }
-
-      // Clean up used challenge
-      await supabaseAdmin.from('webauthn_challenges').delete().eq('id', challenges[0].id);
 
       logger.info('Passkey registration verified', {
         httpStatus: 201,


### PR DESCRIPTION
## Summary

Secures the passkey authentication flow by eliminating a redundant, CSRF-vulnerable session-minting endpoint call and ensuring session tokens are properly captured from the WebAuthn verification step.

## Threat Model

| Threat | STRIDE | Severity | Mitigation |
|--------|--------|----------|------------|
| Redundant \?step=session\ call with \credentials: 'include'\ and no CSRF token | CSRF | **HIGH** | Removed — verify step already returns full session |
| Client discards session tokens from verify response | Broken Auth | **CRITICAL** | Updated \AuthenticationResult\ to capture \ccess_token\, \efresh_token\ |
| Registration challenge lookup uses 'most recent' pattern | Tampering | **MEDIUM** | Scoped lookup by challenge value extracted from \clientDataJSON\ (API-9 parity) |

## Changes

### \pps/web/src/auth/webauthn.ts\
- Expanded \AuthenticationResult\ interface to include \ccessToken\, \efreshToken\, \xpiresIn\, and \mail\
- Updated \uthenticateWithPasskey()\ to capture full session response from the verify step instead of only \{ verified, user_id }\

### \pps/web/src/auth/auth-context.tsx\
- **Removed** the redundant \etch(passkey-authenticate?step=session)\ call that:
  - Used \credentials: 'include'\ without CSRF protection
  - Called a non-existent server endpoint (always returned 400)
  - Fell through to a tokenless fallback, leaving the user unauthenticated
- Now uses session tokens directly from the \uthenticateWithPasskey()\ result
- Throws a clear error if the server doesn't return a session token

### \services/api/supabase/functions/passkey-register/index.ts\
- Applied the same scoped challenge lookup fix from passkey-authenticate (#362, API-9)
- Challenge is now looked up by exact value extracted from \clientDataJSON\ instead of 'most recent for user'
- Challenge is deleted **before** verification (one-time use, prevents replay)

## Security Verification

- [x] No sensitive data in logs/errors
- [x] All queries are parameterized (Supabase client)
- [x] Authentication checks present on passkey-register (JWT required)
- [x] Challenge is one-time use (deleted before verification)
- [x] Session user ID is validated against credential owner (existing server check)
- [x] No \credentials: 'include'\ without CSRF protection remaining
- [x] Rate limiting in place on both endpoints

## Issues

Closes #1310