### PR TITLE
fix(api): verify and tighten Edge Function CORS enforcement (#1325)

### DIFF
--- a/services/api/supabase/functions/_shared/cors.test.ts
+++ b/services/api/supabase/functions/_shared/cors.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /**
- * Tests for `_shared/cors.ts` (#533).
+ * Tests for `_shared/cors.ts` (#533, #1325).
  *
  * Validates origin-validated CORS header generation and
  * preflight request handling.
@@ -30,6 +30,7 @@ function getCorsHeadersForTest(request: Request, allowedOrigins: string[]): Reco
     'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, accept',
     'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
     'Access-Control-Max-Age': '86400',
+    Vary: 'Origin',
   };
 }
 
@@ -112,6 +113,40 @@ Deno.test('getCorsHeaders — includes required CORS headers', () => {
   assertEquals(headers['Access-Control-Max-Age'], '86400');
 });
 
+Deno.test('getCorsHeaders — includes Vary: Origin header', () => {
+  const allowedOrigins = ['https://app.finance.example.com'];
+  const req = createMockRequest({
+    headers: { Origin: 'https://app.finance.example.com' },
+  });
+
+  const headers = getCorsHeadersForTest(req, allowedOrigins);
+
+  assertEquals(headers['Vary'], 'Origin');
+});
+
+Deno.test('getCorsHeaders — Vary: Origin present even for disallowed origins', () => {
+  const allowedOrigins = ['https://app.finance.example.com'];
+  const req = createMockRequest({
+    headers: { Origin: 'https://evil.example.com' },
+  });
+
+  const headers = getCorsHeadersForTest(req, allowedOrigins);
+
+  assertEquals(headers['Vary'], 'Origin');
+});
+
+Deno.test('getCorsHeaders — does not include Access-Control-Allow-Credentials', () => {
+  const allowedOrigins = ['https://app.finance.example.com'];
+  const req = createMockRequest({
+    headers: { Origin: 'https://app.finance.example.com' },
+  });
+
+  const headers = getCorsHeadersForTest(req, allowedOrigins);
+
+  // Credentials header is intentionally omitted — we use Bearer tokens, not cookies
+  assertEquals(headers['Access-Control-Allow-Credentials'], undefined);
+});
+
 Deno.test('getCorsHeaders — Allow-Methods includes all HTTP verbs', () => {
   const allowedOrigins = ['https://app.finance.example.com'];
   const req = createMockRequest({
@@ -169,4 +204,13 @@ Deno.test('handleCorsPreflightRequest — rejects disallowed origin in preflight
   const response = handleCorsPreflightForTest(req, allowedOrigins);
 
   assertEquals(response.headers.get('Access-Control-Allow-Origin'), '');
+});
+
+Deno.test('handleCorsPreflightRequest — includes Vary: Origin in preflight', () => {
+  const allowedOrigins = ['https://app.finance.example.com'];
+  const req = createCorsPreflightRequest('https://app.finance.example.com');
+
+  const response = handleCorsPreflightForTest(req, allowedOrigins);
+
+  assertEquals(response.headers.get('Vary'), 'Origin');
 });

--- a/services/api/supabase/functions/_shared/cors.ts
+++ b/services/api/supabase/functions/_shared/cors.ts
@@ -1,14 +1,40 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /**
- * CORS headers helper for Supabase Edge Functions (#98, #353).
+ * CORS headers helper for Supabase Edge Functions (#98, #353, #1325).
  *
  * Provides consistent, origin-validated CORS configuration across all
  * Edge Functions. Allowed origins are read from the ALLOWED_ORIGINS
  * environment variable (comma-separated).
  *
- * Security (P-1 fix): Never uses wildcard '*'. Only explicitly allowed
- * origins receive a valid Access-Control-Allow-Origin header.
+ * ## CORS Policy (Security Audit #1325)
+ *
+ * - **Origin validation**: Strict allowlist from `ALLOWED_ORIGINS` env var.
+ *   Never uses wildcard `*`. Only explicitly listed origins receive a valid
+ *   `Access-Control-Allow-Origin` header; all others get an empty value.
+ *
+ * - **Credentials**: `Access-Control-Allow-Credentials` is intentionally
+ *   NOT set. This app uses Bearer tokens via the `Authorization` header
+ *   (not cookies), so credential-mode CORS is unnecessary. This also
+ *   prevents the browser from sending ambient credentials (cookies) to
+ *   the API, reducing CSRF risk.
+ *
+ * - **Allowed headers**: `authorization`, `x-client-info`, `apikey`,
+ *   `content-type`, `accept` — the minimum set needed by Supabase clients.
+ *
+ * - **Allowed methods**: `GET`, `POST`, `PUT`, `DELETE`, `OPTIONS`.
+ *
+ * - **Preflight caching**: `Access-Control-Max-Age: 86400` (24 hours)
+ *   reduces preflight round-trips for repeat requests.
+ *
+ * - **`Vary: Origin`**: Always included so CDNs and proxies do not serve
+ *   a cached CORS response for origin A to a request from origin B.
+ *
+ * - **Exempt functions**: `auth-webhook` (server-to-server, no browser
+ *   access) and `main` (internal edge-runtime health probe) intentionally
+ *   do not use CORS headers.
+ *
+ * @module
  */
 
 /** Parsed origin allowlist from environment. */
@@ -31,6 +57,7 @@ export function getCorsHeaders(request: Request): Record<string, string> {
     'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, accept',
     'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
     'Access-Control-Max-Age': '86400',
+    Vary: 'Origin',
   };
 }
 

--- a/services/api/supabase/functions/_shared/webhook.test.ts
+++ b/services/api/supabase/functions/_shared/webhook.test.ts
@@ -92,6 +92,7 @@ const testCorsHeaders: Record<string, string> = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, accept',
   'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
   'Access-Control-Max-Age': '86400',
+  Vary: 'Origin',
 };
 
 function jsonRes(data: Record<string, unknown>, status = 200): Response {

--- a/services/api/supabase/functions/_test_helpers/assertions.ts
+++ b/services/api/supabase/functions/_test_helpers/assertions.ts
@@ -90,6 +90,12 @@ export function assertCorsHeaders(response: Response): void {
     true,
     'Response should include Access-Control-Allow-Origin header',
   );
+  const vary = response.headers.get('Vary');
+  assertEquals(
+    vary !== null && vary.includes('Origin'),
+    true,
+    'Response should include Vary: Origin header for correct CDN/proxy caching',
+  );
 }
 
 /**

--- a/services/api/supabase/functions/account-deletion/index.test.ts
+++ b/services/api/supabase/functions/account-deletion/index.test.ts
@@ -47,6 +47,7 @@ const testCorsHeaders: Record<string, string> = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, accept',
   'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
   'Access-Control-Max-Age': '86400',
+  Vary: 'Origin',
 };
 
 /** Tracks which operations were performed during a test. */

--- a/services/api/supabase/functions/admin-dashboard/index.test.ts
+++ b/services/api/supabase/functions/admin-dashboard/index.test.ts
@@ -44,6 +44,7 @@ const testCorsHeaders: Record<string, string> = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, accept',
   'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
   'Access-Control-Max-Age': '86400',
+  Vary: 'Origin',
 };
 
 // ---------------------------------------------------------------------------

--- a/services/api/supabase/functions/consent-management/index.test.ts
+++ b/services/api/supabase/functions/consent-management/index.test.ts
@@ -39,6 +39,7 @@ const testCorsHeaders: Record<string, string> = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, accept',
   'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
   'Access-Control-Max-Age': '86400',
+  Vary: 'Origin',
 };
 
 interface MockConsentDeps {

--- a/services/api/supabase/functions/data-export/index.test.ts
+++ b/services/api/supabase/functions/data-export/index.test.ts
@@ -44,6 +44,7 @@ const testCorsHeaders: Record<string, string> = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, accept',
   'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
   'Access-Control-Max-Age': '86400',
+  Vary: 'Origin',
 };
 
 function resolveExportFormat(req: Request): ExportFormat | null {

--- a/services/api/supabase/functions/health-check/index.test.ts
+++ b/services/api/supabase/functions/health-check/index.test.ts
@@ -46,6 +46,7 @@ const testCorsHeaders: Record<string, string> = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, accept',
   'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
   'Access-Control-Max-Age': '86400',
+  Vary: 'Origin',
 };
 
 /**

--- a/services/api/supabase/functions/household-invite/index.test.ts
+++ b/services/api/supabase/functions/household-invite/index.test.ts
@@ -55,6 +55,7 @@ const testCorsHeaders: Record<string, string> = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, accept',
   'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
   'Access-Control-Max-Age': '86400',
+  Vary: 'Origin',
 };
 
 function jsonRes(data: Record<string, unknown>, status = 200): Response {

--- a/services/api/supabase/functions/passkey-authenticate/index.test.ts
+++ b/services/api/supabase/functions/passkey-authenticate/index.test.ts
@@ -53,6 +53,7 @@ const testCorsHeaders: Record<string, string> = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, accept',
   'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
   'Access-Control-Max-Age': '86400',
+  Vary: 'Origin',
 };
 
 function jsonRes(data: Record<string, unknown>, status = 200): Response {

--- a/services/api/supabase/functions/passkey-register/index.test.ts
+++ b/services/api/supabase/functions/passkey-register/index.test.ts
@@ -35,6 +35,7 @@ const testCorsHeaders: Record<string, string> = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, accept',
   'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
   'Access-Control-Max-Age': '86400',
+  Vary: 'Origin',
 };
 
 /**


### PR DESCRIPTION
## Summary

Security audit of Edge Function CORS enforcement per issue #1325. Verified all 29 Edge Functions and the shared CORS handler for correct origin validation, preflight handling, and header consistency.

## Threat Model: CORS Enforcement

**Assets**: API endpoints handling sensitive financial data (accounts, transactions, budgets)
**Entry Points**: Browser-initiated cross-origin requests to all Edge Functions
**Trust Boundaries**: Browser origin → Edge Function API

| Threat | STRIDE Category | Severity | Mitigation |
|--------|----------------|----------|------------|
| CORS wildcard allows any origin | Tampering / Info Disclosure | CRITICAL | Strict allowlist from ALLOWED_ORIGINS env var (already in place) |
| Cache poisoning via missing Vary header | Info Disclosure | MEDIUM | Added \Vary: Origin\ header (**this PR**) |
| Cookie-based CSRF via credentials | Tampering | HIGH | \Access-Control-Allow-Credentials\ intentionally omitted (Bearer tokens only) |

## Security Audit Findings

### ✅ PASS — Origin Validation
All 27 browser-facing Edge Functions use the shared \getCorsHeaders()\ / \handleCorsPreflightRequest()\ from \_shared/cors.ts\. Origins are validated against an explicit allowlist from the \ALLOWED_ORIGINS\ environment variable. No wildcard \*\ is ever used.

### ✅ PASS — Preflight Handling
All browser-facing functions check \eq.method === 'OPTIONS'\ and return a 204 with proper CORS headers via the shared handler.

### ✅ PASS — Credentials Policy
\Access-Control-Allow-Credentials\ is intentionally NOT set. The app uses Bearer tokens via the \Authorization\ header, not cookies. This eliminates ambient credential (cookie) CSRF risk.

### ✅ PASS — Exempt Functions
- \uth-webhook\: Server-to-server webhook (Supabase → Edge Function), no browser access, no CORS needed.
- \main\: Internal edge-runtime health probe, no CORS needed.

### 🔧 FIXED — Missing \Vary: Origin\ Header
The CORS handler returned different \Access-Control-Allow-Origin\ values based on the request's \Origin\ header, but did not include \Vary: Origin\. This could cause CDNs or proxies to cache the wrong CORS response, potentially blocking legitimate origins or (in theory) leaking a valid CORS response to an unauthorized origin. Now fixed.

## Changes

- \_shared/cors.ts\: Add \Vary: 'Origin'\ to all CORS responses; add comprehensive CORS policy JSDoc
- \_shared/cors.test.ts\: Add tests for \Vary: Origin\ presence (allowed + disallowed origins), \Credentials\ intentional omission
- \_test_helpers/assertions.ts\: Update \ssertCorsHeaders()\ to verify \Vary: Origin\
- 9 test files: Add \Vary: 'Origin'\ to \	estCorsHeaders\ fixtures for consistency

## Testing

- [x] All CORS tests updated and passing locally
- [x] Format check passes (\
pm run format:check\)
- [x] Lint passes (\
px eslint . --max-warnings 0\)

Closes #1325