### PR TITLE
chore(api): clean up speculative Edge Functions (#1390)

### DIFF
--- a/services/api/supabase/functions/admin-dashboard/index.ts
+++ b/services/api/supabase/functions/admin-dashboard/index.ts
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 
+// TODO(alpha): SPECULATIVE — Internal admin tool, not wired to any client
+// UI. Has tests. Useful for ops but not part of the alpha user-facing
+// surface. Consider deploying for internal use only. (#1390)
+
 /**
  * Admin Dashboard Edge Function (#684)
  *

--- a/services/api/supabase/functions/anomaly-detection/index.ts
+++ b/services/api/supabase/functions/anomaly-detection/index.ts
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 
+// TODO(alpha): SPECULATIVE — Not wired to any client. Has tests but no UI
+// integration. Post-alpha feature for unusual transaction detection. Exclude
+// from alpha deployment. (#1390)
+
 /**
  * Anomaly Detection Edge Function (#323)
  *

--- a/services/api/supabase/functions/bank-connection/index.ts
+++ b/services/api/supabase/functions/bank-connection/index.ts
@@ -1,5 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 
+// TODO(alpha): SPECULATIVE — Not wired to any client. Has tests but depends
+// on Plaid/MX provider integration (PLAID_CLIENT_ID, PLAID_SECRET, etc.)
+// that is not configured. Post-alpha feature. Exclude from alpha
+// deployment. (#1390)
+
 /**
  * Bank Connection API Edge Function (#265)
  *

--- a/services/api/supabase/functions/bank-webhook/index.ts
+++ b/services/api/supabase/functions/bank-webhook/index.ts
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 
+// TODO(alpha): SPECULATIVE — Not wired to any client. No tests. Webhook
+// signature verification is stubbed (Plaid JWT, MX HMAC). Depends on
+// bank-connection being active. Exclude from alpha deployment. (#1390)
+
 /**
  * Bank Webhook Handler Edge Function (#265)
  *

--- a/services/api/supabase/functions/check-notifications/index.ts
+++ b/services/api/supabase/functions/check-notifications/index.ts
@@ -1,5 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 
+// TODO(alpha): SPECULATIVE — Not wired to any client. No tests. Depends on
+// notifications table, cron-based detection RPCs (detect_budget_threshold_notifications,
+// detect_goal_milestone_notifications, detect_unusual_spending) that may not
+// exist yet. Exclude from alpha deployment. (#1390)
+
 /**
  * Check Notifications Edge Function (#1051)
  *

--- a/services/api/supabase/functions/consent-management/index.ts
+++ b/services/api/supabase/functions/consent-management/index.ts
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 
+// TODO(alpha): SPECULATIVE — Not wired to any client. Has tests. GDPR
+// consent management is important but needs UI integration before
+// deployment. Keep for near-term post-alpha work. (#1390)
+
 /**
  * Consent Management Edge Function (#1100 — GDPR Critical)
  *

--- a/services/api/supabase/functions/detect-bills/index.ts
+++ b/services/api/supabase/functions/detect-bills/index.ts
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 
+// TODO(alpha): SPECULATIVE — Not wired to any client. Has tests but no UI
+// integration. Bill detection is a post-alpha feature. Exclude from alpha
+// deployment. (#1390)
+
 /**
  * Bill Detection Engine Edge Function (#sprint-10)
  *

--- a/services/api/supabase/functions/family-plan/index.ts
+++ b/services/api/supabase/functions/family-plan/index.ts
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 
+// TODO(alpha): SPECULATIVE — Not wired to any client. No tests. Depends on
+// family_plan_subscriptions table and payment provider integration that do
+// not exist yet. Exclude from alpha deployment. (#1390)
+
 /**
  * Family Plan Subscription Management Edge Function (#sprint-6)
  *

--- a/services/api/supabase/functions/generate-report/index.ts
+++ b/services/api/supabase/functions/generate-report/index.ts
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 
+// TODO(alpha): SPECULATIVE — Not wired to any client. Has tests but report
+// generation (PDF/CSV export) is a post-alpha feature. Exclude from alpha
+// deployment. (#1390)
+
 /**
  * Report Generation Edge Function (#sprint-8)
  *

--- a/services/api/supabase/functions/household-analytics/index.ts
+++ b/services/api/supabase/functions/household-analytics/index.ts
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 
+// TODO(alpha): SPECULATIVE — Not wired to any client. No tests. Analytics
+// queries depend on RPC functions that may not exist yet. Exclude from
+// alpha deployment; revisit when household analytics UI is built. (#1390)
+
 /**
  * Household Analytics Edge Function (#1052)
  *

--- a/services/api/supabase/functions/import-data/index.ts
+++ b/services/api/supabase/functions/import-data/index.ts
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 
+// TODO(alpha): SPECULATIVE — Not wired to any client. No tests. CSV import
+// pipeline is feature-complete in code but has no UI integration. Exclude
+// from alpha deployment; revisit when import UI is built. (#1390)
+
 /**
  * Data Import Pipeline Edge Function (#sprint-11)
  *

--- a/services/api/supabase/functions/investment-sync/index.ts
+++ b/services/api/supabase/functions/investment-sync/index.ts
@@ -1,5 +1,10 @@
 ﻿// SPDX-License-Identifier: BUSL-1.1
 
+// TODO(alpha): SPECULATIVE — Not wired to any client. No tests. Provider
+// integration stubs (Plaid Investments, Yodlee) are unimplemented. Exclude
+// from alpha deployment; revisit post-launch when investment tracking is
+// prioritized. (#1390)
+
 /**
  * Investment Data Sync Edge Function (#sprint-backend-1)
  *

--- a/services/api/supabase/functions/launch-readiness/index.ts
+++ b/services/api/supabase/functions/launch-readiness/index.ts
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 
+// TODO(alpha): SPECULATIVE — Internal admin tool for launch readiness
+// checks. Has tests. Not wired to any client UI. Useful for pre-launch
+// validation but not part of the alpha user surface. (#1390)
+
 /**
  * Launch Readiness Dashboard Edge Function (#894)
  *

--- a/services/api/supabase/functions/manage-webhooks/index.ts
+++ b/services/api/supabase/functions/manage-webhooks/index.ts
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 
+// TODO(alpha): SPECULATIVE — Not wired to any client. No tests. Depends on
+// webhook_endpoints table. Webhook system is not wired end-to-end. Exclude
+// from alpha deployment. (#1390)
+
 /**
  * Manage Webhooks Edge Function (#683)
  *

--- a/services/api/supabase/functions/send-notification/index.ts
+++ b/services/api/supabase/functions/send-notification/index.ts
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 
+// TODO(alpha): SPECULATIVE — Not wired to any client. No tests. Depends on
+// notification_log table and SMTP configuration. Exclude from alpha
+// deployment; revisit when notification system is built end-to-end. (#1390)
+
 /**
  * Send Notification Edge Function (#685)
  *

--- a/services/api/supabase/functions/spending-forecast/index.ts
+++ b/services/api/supabase/functions/spending-forecast/index.ts
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 
+// TODO(alpha): SPECULATIVE — Not wired to any client. Has tests but depends
+// on get_spending_forecast() and get_spending_summary() RPCs that may not
+// exist yet. Post-alpha feature. Exclude from alpha deployment. (#1390)
+
 /**
  * Spending Forecast Edge Function (#328)
  *

--- a/services/api/supabase/functions/verify-device-attestation/index.ts
+++ b/services/api/supabase/functions/verify-device-attestation/index.ts
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 
+// TODO(alpha): STUB — All platform verification functions return
+// { valid: false }. Not wired to any client. No tests. Exclude from
+// alpha deployment; implement when device attestation is prioritized. (#1390)
+
 /**
  * Edge Function: verify-device-attestation (#331)
  *


### PR DESCRIPTION
## Summary

Audits all 28 Edge Functions in \services/api/supabase/functions/\ and marks 17 speculative or stub functions with \TODO(alpha)\ comments identifying their status and what blocks alpha deployment.

No functions are removed — this is a documentation-only change that clearly identifies the alpha surface area for contributors.

## Edge Function Inventory

### Active Alpha Surface (12 functions)
| Function | Client Refs | OpenAPI | Tests |
|----------|-------------|---------|-------|
| \health-check\ | Web, Caddyfile | ✅ | ✅ |
| \passkey-authenticate\ | Web | ✅ | ✅ |
| \passkey-register\ | Web | ✅ | ✅ |
| \household-invite\ | Web | ✅ | ✅ |
| \data-export\ | Web | ✅ | ✅ |
| \xchange-rates\ | Android, Web | — | ✅ |
| \eferral\ | Android, Web, Windows, KMP | — | — |
| \uth-webhook\ | — | ✅ | ✅ |
| \ccount-deletion\ | — | ✅ | ✅ |
| \sync-health-report\ | — | ✅ | — |
| \process-recurring\ | deploy/.env | ✅ | — |
| \main\ | Runtime entry point | — | — |

### Speculative — Has Tests, No Client (8 functions, marked TODO)
| Function | Status | Reason |
|----------|--------|--------|
| \dmin-dashboard\ | Internal admin tool | No client UI |
| \launch-readiness\ | Internal admin tool | No client UI |
| \nomaly-detection\ | Post-alpha feature | No client UI |
| \detect-bills\ | Post-alpha feature | No client UI |
| \spending-forecast\ | Post-alpha feature | Depends on RPCs |
| \ank-connection\ | Post-alpha feature | Needs provider keys |
| \generate-report\ | Post-alpha feature | No client UI |
| \consent-management\ | Near-term post-alpha | GDPR, needs UI |

### Speculative — No Tests, No Client (7 functions, marked TODO)
| Function | Status | Reason |
|----------|--------|--------|
| \household-analytics\ | Post-alpha | Depends on RPCs |
| \check-notifications\ | Post-alpha | Depends on cron RPCs |
| \send-notification\ | Post-alpha | Depends on SMTP |
| \manage-webhooks\ | Post-alpha | Webhook system not wired |
| \import-data\ | Post-alpha | No import UI |
| \amily-plan\ | Post-alpha | No subscription system |
| \ank-webhook\ | Post-alpha | Signature verification stubbed |

### Stubs (2 functions, marked TODO)
| Function | Status | Reason |
|----------|--------|--------|
| \investment-sync\ | Stub | Provider TODOs, returns placeholders |
| \erify-device-attestation\ | Stub | All verifiers return \{ valid: false }\ |

## Changes

- Added \// TODO(alpha): SPECULATIVE\ or \// TODO(alpha): STUB\ header comments to 17 Edge Functions
- Each comment identifies: status, missing dependencies, and recommendation

## Issues

Closes #1390
