### PR TITLE
fix(api): migration housekeeping — down migrations and timestamp dedup (#1322, #1323)

### DIFF
--- a/services/api/supabase/migrations/20260316000002_fix_invitation_rls.sql
+++ b/services/api/supabase/migrations/20260316000002_fix_invitation_rls.sql
@@ -1,6 +1,6 @@
 -- SPDX-License-Identifier: BUSL-1.1
 
--- Migration: 20260316000001_fix_invitation_rls
+-- Migration: 20260316000002_fix_invitation_rls
 -- Description: Restrict household_invitations UPDATE to owner + invited-user accept
 -- Security Finding: H-2 (High) — API Security Audit v2
 -- Issues: #375

--- a/services/api/supabase/migrations/20260325000002_read_only_rate_limit_status.sql
+++ b/services/api/supabase/migrations/20260325000002_read_only_rate_limit_status.sql
@@ -1,6 +1,6 @@
 -- SPDX-License-Identifier: BUSL-1.1
 
--- Migration: 20260325000001_read_only_rate_limit_status
+-- Migration: 20260325000002_read_only_rate_limit_status
 -- Description: Add read-only rate limit status RPC for abuse detection (#781)
 -- Issue: #781
 --

--- a/services/api/supabase/migrations/20260328000002_recurring_idempotency.sql
+++ b/services/api/supabase/migrations/20260328000002_recurring_idempotency.sql
@@ -1,6 +1,6 @@
 -- SPDX-License-Identifier: BUSL-1.1
 
--- Migration: 20260328000001_recurring_idempotency
+-- Migration: 20260328000002_recurring_idempotency
 -- Description: Add idempotency tracking for recurring transaction generation
 -- Issues: #1047
 --

--- a/services/api/supabase/migrations/20260328000003_notification_triggers.sql
+++ b/services/api/supabase/migrations/20260328000003_notification_triggers.sql
@@ -1,6 +1,6 @@
 -- SPDX-License-Identifier: BUSL-1.1
 
--- Migration: 20260328000002_notification_triggers
+-- Migration: 20260328000003_notification_triggers
 -- Description: Add notifications table and trigger detection functions
 -- Issues: #1051
 --

--- a/services/api/supabase/migrations/20260328000004_referral_tracking.sql
+++ b/services/api/supabase/migrations/20260328000004_referral_tracking.sql
@@ -1,6 +1,6 @@
 -- SPDX-License-Identifier: BUSL-1.1
 
--- Migration: 20260328000002_referral_tracking
+-- Migration: 20260328000004_referral_tracking
 -- Description: Create referrals table for referral code generation, tracking, and rewards
 -- Issues: #sprint-7
 --
@@ -16,7 +16,7 @@
 --   - Duplicate referrals prevented by unique index
 --   - Monetary rewards stored as BIGINT cents
 --
--- DOWN migration: services/api/supabase/migrations/down/20260328000002_referral_tracking.down.sql
+-- DOWN migration: services/api/supabase/migrations/down/20260328000004_referral_tracking.down.sql
 
 -- =============================================================================
 -- UP

--- a/services/api/supabase/migrations/20260328000005_report_generation.sql
+++ b/services/api/supabase/migrations/20260328000005_report_generation.sql
@@ -1,6 +1,6 @@
 -- SPDX-License-Identifier: BUSL-1.1
 
--- Migration: 20260328000003_report_generation
+-- Migration: 20260328000005_report_generation
 -- Description: Create report_configs and scheduled_reports tables for report generation service
 -- Issues: #sprint-8
 --
@@ -14,7 +14,7 @@
 --   - Report queries execute through RLS so users only see their household data
 --   - Config stored as JSONB with strict validation in Edge Function
 --
--- DOWN migration: services/api/supabase/migrations/down/20260328000003_report_generation.down.sql
+-- DOWN migration: services/api/supabase/migrations/down/20260328000005_report_generation.down.sql
 
 -- =============================================================================
 -- UP

--- a/services/api/supabase/migrations/20260328000006_exchange_rates.sql
+++ b/services/api/supabase/migrations/20260328000006_exchange_rates.sql
@@ -1,6 +1,6 @@
 -- SPDX-License-Identifier: BUSL-1.1
 
--- Migration: 20260328000004_exchange_rates
+-- Migration: 20260328000006_exchange_rates
 -- Description: Create exchange_rates table for multi-currency support
 -- Issues: #sprint-9
 --
@@ -22,7 +22,7 @@
 --   - Only service role can insert/update (Edge Function)
 --   - No household scoping needed — rates are global
 --
--- DOWN migration: services/api/supabase/migrations/down/20260328000004_exchange_rates.down.sql
+-- DOWN migration: services/api/supabase/migrations/down/20260328000006_exchange_rates.down.sql
 
 -- =============================================================================
 -- UP

--- a/services/api/supabase/migrations/20260328000007_bill_detection.sql
+++ b/services/api/supabase/migrations/20260328000007_bill_detection.sql
@@ -1,6 +1,6 @@
 -- SPDX-License-Identifier: BUSL-1.1
 
--- Migration: 20260328000005_bill_detection
+-- Migration: 20260328000007_bill_detection
 -- Description: Create detected_bills table for recurring bill detection
 -- Issues: #sprint-10
 --
@@ -15,7 +15,7 @@
 --   - Monetary values stored as BIGINT (cents) with ISO 4217 currency_code
 --   - owner_id tracks who triggered the detection
 --
--- DOWN migration: services/api/supabase/migrations/down/20260328000005_bill_detection.down.sql
+-- DOWN migration: services/api/supabase/migrations/down/20260328000007_bill_detection.down.sql
 
 -- =============================================================================
 -- UP

--- a/services/api/supabase/migrations/20260328000008_data_import_pipeline.sql
+++ b/services/api/supabase/migrations/20260328000008_data_import_pipeline.sql
@@ -1,6 +1,6 @@
 -- SPDX-License-Identifier: BUSL-1.1
 
--- Migration: 20260328000006_data_import_pipeline
+-- Migration: 20260328000008_data_import_pipeline
 -- Description: Create import_jobs table for tracking CSV import processing
 -- Issues: #sprint-11
 --
@@ -16,7 +16,7 @@
 --   - Only the import creator can view/manage their import jobs
 --   - Monetary values from imports stored as BIGINT (cents)
 --
--- DOWN migration: services/api/supabase/migrations/down/20260328000006_data_import_pipeline.down.sql
+-- DOWN migration: services/api/supabase/migrations/down/20260328000008_data_import_pipeline.down.sql
 
 -- =============================================================================
 -- UP

--- a/services/api/supabase/migrations/down/20260316000002_fix_invitation_rls.down.sql
+++ b/services/api/supabase/migrations/down/20260316000002_fix_invitation_rls.down.sql
@@ -1,6 +1,6 @@
 -- SPDX-License-Identifier: BUSL-1.1
 
--- DOWN Migration: 20260316000001_fix_invitation_rls
+-- DOWN Migration: 20260316000002_fix_invitation_rls
 -- Description: Revert invitation RLS to the original permissive UPDATE policy
 -- Issues: #893
 

--- a/services/api/supabase/migrations/down/20260325000002_read_only_rate_limit_status.down.sql
+++ b/services/api/supabase/migrations/down/20260325000002_read_only_rate_limit_status.down.sql
@@ -1,6 +1,6 @@
 -- SPDX-License-Identifier: BUSL-1.1
 
--- DOWN Migration: 20260325000001_read_only_rate_limit_status
+-- DOWN Migration: 20260325000002_read_only_rate_limit_status
 -- Description: Drop the read-only rate limit status RPC
 -- Issues: #893
 

--- a/services/api/supabase/migrations/down/20260326000001_production_readiness.down.sql
+++ b/services/api/supabase/migrations/down/20260326000001_production_readiness.down.sql
@@ -1,0 +1,12 @@
+-- SPDX-License-Identifier: BUSL-1.1
+
+-- DOWN Migration: 20260326000001_production_readiness
+-- Description: Drop production readiness verification functions
+-- Issues: #1322
+--
+-- Reverts: verify_rls_status(), verify_schema_integrity(), production_health_summary()
+-- These are diagnostic functions with no schema dependencies — safe to drop.
+
+DROP FUNCTION IF EXISTS public.production_health_summary();
+DROP FUNCTION IF EXISTS public.verify_schema_integrity();
+DROP FUNCTION IF EXISTS public.verify_rls_status();

--- a/services/api/supabase/migrations/down/20260326000002_add_transfer_recurring_to_transactions.down.sql
+++ b/services/api/supabase/migrations/down/20260326000002_add_transfer_recurring_to_transactions.down.sql
@@ -1,0 +1,13 @@
+-- SPDX-License-Identifier: BUSL-1.1
+
+-- DOWN Migration: 20260326000002_add_transfer_recurring_to_transactions
+-- Description: Remove transfer_transaction_id and recurring_rule_id from transactions
+-- Issues: #1322
+--
+-- Reverts the two new nullable FK columns and their indexes.
+-- Data in these columns will be lost on rollback.
+
+DROP INDEX IF EXISTS idx_transactions_recurring_rule;
+DROP INDEX IF EXISTS idx_transactions_transfer_pair;
+ALTER TABLE transactions DROP COLUMN IF EXISTS recurring_rule_id;
+ALTER TABLE transactions DROP COLUMN IF EXISTS transfer_transaction_id;

--- a/services/api/supabase/migrations/down/20260326000003_add_rollover_to_budgets.down.sql
+++ b/services/api/supabase/migrations/down/20260326000003_add_rollover_to_budgets.down.sql
@@ -1,0 +1,9 @@
+-- SPDX-License-Identifier: BUSL-1.1
+
+-- DOWN Migration: 20260326000003_add_rollover_to_budgets
+-- Description: Remove is_rollover column from budgets
+-- Issues: #1322
+--
+-- Reverts the is_rollover boolean column. Any rollover configuration will be lost.
+
+ALTER TABLE budgets DROP COLUMN IF EXISTS is_rollover;

--- a/services/api/supabase/migrations/down/20260326000004_add_account_status_to_goals.down.sql
+++ b/services/api/supabase/migrations/down/20260326000004_add_account_status_to_goals.down.sql
@@ -1,0 +1,14 @@
+-- SPDX-License-Identifier: BUSL-1.1
+
+-- DOWN Migration: 20260326000004_add_account_status_to_goals
+-- Description: Remove account_id and status columns from goals
+-- Issues: #1322
+--
+-- Reverts the account_id FK, status enum column, CHECK constraint, and indexes.
+-- Goal-to-account links and lifecycle status will be lost on rollback.
+
+DROP INDEX IF EXISTS idx_goals_status;
+DROP INDEX IF EXISTS idx_goals_account;
+ALTER TABLE goals DROP CONSTRAINT IF EXISTS chk_goals_status;
+ALTER TABLE goals DROP COLUMN IF EXISTS status;
+ALTER TABLE goals DROP COLUMN IF EXISTS account_id;

--- a/services/api/supabase/migrations/down/20260326000005_standardize_owner_id.down.sql
+++ b/services/api/supabase/migrations/down/20260326000005_standardize_owner_id.down.sql
@@ -1,0 +1,32 @@
+-- SPDX-License-Identifier: BUSL-1.1
+
+-- DOWN Migration: 20260326000005_standardize_owner_id
+-- Description: Remove owner_id from all sync-enabled tables
+-- Issues: #1322
+--
+-- Reverts owner_id columns, indexes, and owner-based SELECT RLS policies.
+-- Must be run IN ORDER: policies first, then indexes, then columns.
+
+-- 1. Drop owner-based SELECT policies
+DROP POLICY IF EXISTS recurring_templates_select_owner ON recurring_transaction_templates;
+DROP POLICY IF EXISTS goals_select_owner ON goals;
+DROP POLICY IF EXISTS budgets_select_owner ON budgets;
+DROP POLICY IF EXISTS transactions_select_owner ON transactions;
+DROP POLICY IF EXISTS categories_select_owner ON categories;
+DROP POLICY IF EXISTS accounts_select_owner ON accounts;
+
+-- 2. Drop indexes
+DROP INDEX IF EXISTS idx_recurring_templates_owner;
+DROP INDEX IF EXISTS idx_goals_owner;
+DROP INDEX IF EXISTS idx_budgets_owner;
+DROP INDEX IF EXISTS idx_transactions_owner;
+DROP INDEX IF EXISTS idx_categories_owner;
+DROP INDEX IF EXISTS idx_accounts_owner;
+
+-- 3. Drop columns
+ALTER TABLE recurring_transaction_templates DROP COLUMN IF EXISTS owner_id;
+ALTER TABLE goals DROP COLUMN IF EXISTS owner_id;
+ALTER TABLE budgets DROP COLUMN IF EXISTS owner_id;
+ALTER TABLE transactions DROP COLUMN IF EXISTS owner_id;
+ALTER TABLE categories DROP COLUMN IF EXISTS owner_id;
+ALTER TABLE accounts DROP COLUMN IF EXISTS owner_id;

--- a/services/api/supabase/migrations/down/20260326000006_sync_optimization.down.sql
+++ b/services/api/supabase/migrations/down/20260326000006_sync_optimization.down.sql
@@ -1,12 +1,16 @@
 -- SPDX-License-Identifier: BUSL-1.1
 
--- Down migration for: 20260328000001_recurring_idempotency
--- Reverts idempotency tracking for recurring transaction generation (#1047)
+-- DOWN Migration: 20260326000006_sync_optimization
+-- Description: Remove sync optimization objects (schema version, materialized view, updated generate function)
+-- Issues: #1322
+--
+-- Reverts:
+--   1. Restores generate_recurring_transactions to the version from 20260323000002
+--      (without recurring_rule_id/owner_id population)
+--   2. Drops the household financial summary materialized view and refresh function
+--   3. Drops the schema version function
 
--- 3. Drop monitoring helper
-DROP FUNCTION IF EXISTS public.get_recurring_status();
-
--- 2. Restore previous generate_recurring_transactions (from 20260326000006)
+-- 4. Restore original generate_recurring_transactions (from 20260323000002)
 CREATE OR REPLACE FUNCTION public.generate_recurring_transactions(
     p_as_of_date DATE DEFAULT CURRENT_DATE
 )
@@ -33,14 +37,12 @@ BEGIN
             household_id, account_id, category_id,
             amount_cents, currency_code, type,
             payee, note, date,
-            is_recurring, status,
-            recurring_rule_id, owner_id
+            is_recurring, status
         ) VALUES (
             template.household_id, template.account_id, template.category_id,
             template.amount_cents, template.currency_code, template.type,
             template.payee, template.note, template.next_due_date,
-            true, 'CLEARED',
-            template.id, template.owner_id
+            true, 'CLEARED'
         );
 
         next_date := CASE template.frequency
@@ -78,5 +80,11 @@ $$;
 GRANT EXECUTE ON FUNCTION public.generate_recurring_transactions(DATE) TO service_role;
 REVOKE EXECUTE ON FUNCTION public.generate_recurring_transactions(DATE) FROM PUBLIC;
 
--- 1. Drop idempotency tracking table
-DROP TABLE IF EXISTS recurring_generation_log;
+-- 3. Drop refresh function
+DROP FUNCTION IF EXISTS public.refresh_household_summary();
+
+-- 2. Drop materialized view
+DROP MATERIALIZED VIEW IF EXISTS household_financial_summary;
+
+-- 1. Drop schema version function
+DROP FUNCTION IF EXISTS public.get_schema_version();

--- a/services/api/supabase/migrations/down/20260328000002_recurring_idempotency.down.sql
+++ b/services/api/supabase/migrations/down/20260328000002_recurring_idempotency.down.sql
@@ -1,0 +1,82 @@
+-- SPDX-License-Identifier: BUSL-1.1
+
+-- Down migration for: 20260328000002_recurring_idempotency
+-- Reverts idempotency tracking for recurring transaction generation (#1047)
+
+-- 3. Drop monitoring helper
+DROP FUNCTION IF EXISTS public.get_recurring_status();
+
+-- 2. Restore previous generate_recurring_transactions (from 20260326000006)
+CREATE OR REPLACE FUNCTION public.generate_recurring_transactions(
+    p_as_of_date DATE DEFAULT CURRENT_DATE
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    template RECORD;
+    generated_count INTEGER := 0;
+    next_date DATE;
+BEGIN
+    FOR template IN
+        SELECT * FROM recurring_transaction_templates
+        WHERE deleted_at IS NULL
+          AND is_active = true
+          AND next_due_date <= p_as_of_date
+          AND (end_date IS NULL OR next_due_date <= end_date)
+        ORDER BY next_due_date ASC
+        FOR UPDATE SKIP LOCKED
+    LOOP
+        INSERT INTO transactions (
+            household_id, account_id, category_id,
+            amount_cents, currency_code, type,
+            payee, note, date,
+            is_recurring, status,
+            recurring_rule_id, owner_id
+        ) VALUES (
+            template.household_id, template.account_id, template.category_id,
+            template.amount_cents, template.currency_code, template.type,
+            template.payee, template.note, template.next_due_date,
+            true, 'CLEARED',
+            template.id, template.owner_id
+        );
+
+        next_date := CASE template.frequency
+            WHEN 'daily'     THEN template.next_due_date + INTERVAL '1 day'
+            WHEN 'weekly'    THEN template.next_due_date + INTERVAL '1 week'
+            WHEN 'biweekly'  THEN template.next_due_date + INTERVAL '2 weeks'
+            WHEN 'monthly'   THEN template.next_due_date + INTERVAL '1 month'
+            WHEN 'quarterly' THEN template.next_due_date + INTERVAL '3 months'
+            WHEN 'yearly'    THEN template.next_due_date + INTERVAL '1 year'
+        END;
+
+        IF template.end_date IS NOT NULL AND next_date > template.end_date THEN
+            UPDATE recurring_transaction_templates
+            SET is_active = false,
+                last_generated_date = template.next_due_date
+            WHERE id = template.id;
+        ELSE
+            UPDATE recurring_transaction_templates
+            SET last_generated_date = template.next_due_date,
+                next_due_date = next_date
+            WHERE id = template.id;
+        END IF;
+
+        generated_count := generated_count + 1;
+    END LOOP;
+
+    RETURN jsonb_build_object(
+        'generated_count', generated_count,
+        'as_of_date', p_as_of_date,
+        'generated_at', now()
+    );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.generate_recurring_transactions(DATE) TO service_role;
+REVOKE EXECUTE ON FUNCTION public.generate_recurring_transactions(DATE) FROM PUBLIC;
+
+-- 1. Drop idempotency tracking table
+DROP TABLE IF EXISTS recurring_generation_log;

--- a/services/api/supabase/migrations/down/20260328000003_notification_triggers.down.sql
+++ b/services/api/supabase/migrations/down/20260328000003_notification_triggers.down.sql
@@ -1,6 +1,6 @@
 -- SPDX-License-Identifier: BUSL-1.1
 
--- Down migration for: 20260328000002_notification_triggers
+-- Down migration for: 20260328000003_notification_triggers
 -- Reverts notification triggers and notifications table (#1051)
 
 DROP FUNCTION IF EXISTS public.detect_unusual_spending();

--- a/services/api/supabase/migrations/down/20260328000004_referral_tracking.down.sql
+++ b/services/api/supabase/migrations/down/20260328000004_referral_tracking.down.sql
@@ -1,6 +1,6 @@
 -- SPDX-License-Identifier: BUSL-1.1
 
--- DOWN Migration: 20260328000002_referral_tracking
+-- DOWN Migration: 20260328000004_referral_tracking
 -- Description: Drop referrals table and all related objects
 -- Issues: #sprint-7
 

--- a/services/api/supabase/migrations/down/20260328000005_report_generation.down.sql
+++ b/services/api/supabase/migrations/down/20260328000005_report_generation.down.sql
@@ -1,6 +1,6 @@
 -- SPDX-License-Identifier: BUSL-1.1
 
--- DOWN Migration: 20260328000003_report_generation
+-- DOWN Migration: 20260328000005_report_generation
 -- Description: Drop report_configs and scheduled_reports tables
 -- Issues: #sprint-8
 

--- a/services/api/supabase/migrations/down/20260328000006_exchange_rates.down.sql
+++ b/services/api/supabase/migrations/down/20260328000006_exchange_rates.down.sql
@@ -1,6 +1,6 @@
 -- SPDX-License-Identifier: BUSL-1.1
 
--- DOWN Migration: 20260328000004_exchange_rates
+-- DOWN Migration: 20260328000006_exchange_rates
 -- Description: Drop exchange_rates table and all related objects
 -- Issues: #sprint-9
 

--- a/services/api/supabase/migrations/down/20260328000007_bill_detection.down.sql
+++ b/services/api/supabase/migrations/down/20260328000007_bill_detection.down.sql
@@ -1,6 +1,6 @@
 -- SPDX-License-Identifier: BUSL-1.1
 
--- DOWN Migration: 20260328000005_bill_detection
+-- DOWN Migration: 20260328000007_bill_detection
 -- Description: Drop detected_bills table and all related objects
 -- Issues: #sprint-10
 

--- a/services/api/supabase/migrations/down/20260328000008_data_import_pipeline.down.sql
+++ b/services/api/supabase/migrations/down/20260328000008_data_import_pipeline.down.sql
@@ -1,6 +1,6 @@
 -- SPDX-License-Identifier: BUSL-1.1
 
--- DOWN Migration: 20260328000006_data_import_pipeline
+-- DOWN Migration: 20260328000008_data_import_pipeline
 -- Description: Drop import_jobs table and all related objects
 -- Issues: #sprint-11
 

--- a/services/api/supabase/migrations/down/README.md
+++ b/services/api/supabase/migrations/down/README.md
@@ -1,6 +1,6 @@
 # Reverse (Down) Migrations
 
-**Issue:** #893
+**Issues:** #893, #1322, #1323
 
 ---
 
@@ -29,7 +29,7 @@ Apply down migrations in **reverse order**:
 
 ```bash
 # Example: roll back the last 3 migrations
-psql -f down/20260325000001_read_only_rate_limit_status.down.sql
+psql -f down/20260325000002_read_only_rate_limit_status.down.sql
 psql -f down/20260325000001_enhanced_cleanup_and_balance.down.sql
 psql -f down/20260324000004_webhook_infrastructure.down.sql
 ```
@@ -50,24 +50,66 @@ done
 
 Each down migration matches its up migration with a `.down.sql` suffix:
 
-| Up Migration                                      | Down Migration                                              |
-| ------------------------------------------------- | ----------------------------------------------------------- |
-| `20260306000001_initial_schema.sql`               | `down/20260306000001_initial_schema.down.sql`               |
-| `20260306000002_rls_policies.sql`                 | `down/20260306000002_rls_policies.down.sql`                 |
-| `20260306000003_auth_config.sql`                  | `down/20260306000003_auth_config.down.sql`                  |
-| `20260307000001_monitoring.sql`                   | `down/20260307000001_monitoring.down.sql`                   |
-| `20260315000001_export_audit_log.sql`             | `down/20260315000001_export_audit_log.down.sql`             |
-| `20260316000001_edge_function_security.sql`       | `down/20260316000001_edge_function_security.down.sql`       |
-| `20260316000001_fix_invitation_rls.sql`           | `down/20260316000001_fix_invitation_rls.down.sql`           |
-| `20260323000001_cleanup_and_balance_triggers.sql` | `down/20260323000001_cleanup_and_balance_triggers.down.sql` |
-| `20260323000002_recurring_transactions.sql`       | `down/20260323000002_recurring_transactions.down.sql`       |
-| `20260323000003_rate_limits.sql`                  | `down/20260323000003_rate_limits.down.sql`                  |
-| `20260324000001_notification_infrastructure.sql`  | `down/20260324000001_notification_infrastructure.down.sql`  |
-| `20260324000002_performance_indexes.sql`          | `down/20260324000002_performance_indexes.down.sql`          |
-| `20260324000003_automated_maintenance.sql`        | `down/20260324000003_automated_maintenance.down.sql`        |
-| `20260324000004_webhook_infrastructure.sql`       | `down/20260324000004_webhook_infrastructure.down.sql`       |
-| `20260325000001_enhanced_cleanup_and_balance.sql` | `down/20260325000001_enhanced_cleanup_and_balance.down.sql` |
-| `20260325000001_read_only_rate_limit_status.sql`  | `down/20260325000001_read_only_rate_limit_status.down.sql`  |
+| Up Migration                                                | Down Migration                                                        |
+| ----------------------------------------------------------- | --------------------------------------------------------------------- |
+| `20260306000001_initial_schema.sql`                         | `down/20260306000001_initial_schema.down.sql`                         |
+| `20260306000002_rls_policies.sql`                           | `down/20260306000002_rls_policies.down.sql`                           |
+| `20260306000003_auth_config.sql`                            | `down/20260306000003_auth_config.down.sql`                            |
+| `20260307000001_monitoring.sql`                             | `down/20260307000001_monitoring.down.sql`                             |
+| `20260315000001_export_audit_log.sql`                       | `down/20260315000001_export_audit_log.down.sql`                       |
+| `20260316000001_edge_function_security.sql`                 | `down/20260316000001_edge_function_security.down.sql`                 |
+| `20260316000002_fix_invitation_rls.sql`                     | `down/20260316000002_fix_invitation_rls.down.sql`                     |
+| `20260323000001_cleanup_and_balance_triggers.sql`           | `down/20260323000001_cleanup_and_balance_triggers.down.sql`           |
+| `20260323000002_recurring_transactions.sql`                 | `down/20260323000002_recurring_transactions.down.sql`                 |
+| `20260323000003_rate_limits.sql`                            | `down/20260323000003_rate_limits.down.sql`                            |
+| `20260324000001_notification_infrastructure.sql`            | `down/20260324000001_notification_infrastructure.down.sql`            |
+| `20260324000002_performance_indexes.sql`                    | `down/20260324000002_performance_indexes.down.sql`                    |
+| `20260324000003_automated_maintenance.sql`                  | `down/20260324000003_automated_maintenance.down.sql`                  |
+| `20260324000004_webhook_infrastructure.sql`                 | `down/20260324000004_webhook_infrastructure.down.sql`                 |
+| `20260325000001_enhanced_cleanup_and_balance.sql`           | `down/20260325000001_enhanced_cleanup_and_balance.down.sql`           |
+| `20260325000002_read_only_rate_limit_status.sql`            | `down/20260325000002_read_only_rate_limit_status.down.sql`            |
+| `20260326000001_production_readiness.sql`                   | `down/20260326000001_production_readiness.down.sql`                   |
+| `20260326000002_add_transfer_recurring_to_transactions.sql` | `down/20260326000002_add_transfer_recurring_to_transactions.down.sql` |
+| `20260326000003_add_rollover_to_budgets.sql`                | `down/20260326000003_add_rollover_to_budgets.down.sql`                |
+| `20260326000004_add_account_status_to_goals.sql`            | `down/20260326000004_add_account_status_to_goals.down.sql`            |
+| `20260326000005_standardize_owner_id.sql`                   | `down/20260326000005_standardize_owner_id.down.sql`                   |
+| `20260326000006_sync_optimization.sql`                      | `down/20260326000006_sync_optimization.down.sql`                      |
+| `20260327000001_launch_readiness_dashboard.sql`             | `down/20260327000001_launch_readiness_dashboard.down.sql`             |
+| `20260327000002_bank_connections.sql`                       | `down/20260327000002_bank_connections.down.sql`                       |
+| `20260327000003_spending_forecast.sql`                      | `down/20260327000003_spending_forecast.down.sql`                      |
+| `20260327000004_anomaly_detection.sql`                      | `down/20260327000004_anomaly_detection.down.sql`                      |
+| `20260328000001_family_plan_subscriptions.sql`              | `down/20260328000001_family_plan_subscriptions.down.sql`              |
+| `20260328000002_recurring_idempotency.sql`                  | `down/20260328000002_recurring_idempotency.down.sql`                  |
+| `20260328000003_notification_triggers.sql`                  | `down/20260328000003_notification_triggers.down.sql`                  |
+| `20260328000004_referral_tracking.sql`                      | `down/20260328000004_referral_tracking.down.sql`                      |
+| `20260328000005_report_generation.sql`                      | `down/20260328000005_report_generation.down.sql`                      |
+| `20260328000006_exchange_rates.sql`                         | `down/20260328000006_exchange_rates.down.sql`                         |
+| `20260328000007_bill_detection.sql`                         | `down/20260328000007_bill_detection.down.sql`                         |
+| `20260328000008_data_import_pipeline.sql`                   | `down/20260328000008_data_import_pipeline.down.sql`                   |
+| `20260329000001_gdpr_consent_capture.sql`                   | `down/20260329000001_gdpr_consent_capture.down.sql`                   |
+| `20260329000002_crypto_shredding.sql`                       | `down/20260329000002_crypto_shredding.down.sql`                       |
+| `20260329000003_rate_limit_enhancement.sql`                 | `down/20260329000003_rate_limit_enhancement.down.sql`                 |
+| `20260329000004_webhook_security_hardening.sql`             | `down/20260329000004_webhook_security_hardening.down.sql`             |
+| `20260330000001_investment_tables.sql`                      | `down/20260330000001_investment_tables.down.sql`                      |
+| `20260330000002_exchange_rates_enhancements.sql`            | `down/20260330000002_exchange_rates_enhancements.down.sql`            |
+| `20260330000003_bill_detection_enhancements.sql`            | `down/20260330000003_bill_detection_enhancements.down.sql`            |
+| `20260330000004_report_generation_enhancements.sql`         | `down/20260330000004_report_generation_enhancements.down.sql`         |
+
+## Timestamp Deduplication (#1323)
+
+The following migrations were renamed to resolve duplicate timestamps:
+
+| Original Name                                | New Name                                     | Reason                          |
+| -------------------------------------------- | -------------------------------------------- | ------------------------------- |
+| `20260316000001_fix_invitation_rls`          | `20260316000002_fix_invitation_rls`          | Collided with edge_fn_security  |
+| `20260325000001_read_only_rate_limit_status` | `20260325000002_read_only_rate_limit_status` | Collided with enhanced_cleanup  |
+| `20260328000001_recurring_idempotency`       | `20260328000002_recurring_idempotency`       | Collided with family_plan_subs  |
+| `20260328000002_notification_triggers`       | `20260328000003_notification_triggers`       | Cascade from above              |
+| `20260328000002_referral_tracking`           | `20260328000004_referral_tracking`           | Collided with notification_trig |
+| `20260328000003_report_generation`           | `20260328000005_report_generation`           | Cascade from above              |
+| `20260328000004_exchange_rates`              | `20260328000006_exchange_rates`              | Cascade from above              |
+| `20260328000005_bill_detection`              | `20260328000007_bill_detection`              | Cascade from above              |
+| `20260328000006_data_import_pipeline`        | `20260328000008_data_import_pipeline`        | Cascade from above              |
 
 ## Safety Notes
 


### PR DESCRIPTION
## Summary

Migration housekeeping: resolve duplicate timestamps and add missing down (rollback) migrations for schema-alignment work.

## Changes

### Duplicate timestamp resolution (#1323)

4 timestamp collisions resolved by renaming the second file in each pair and cascade-renaming dependents:

| Original Timestamp | Collision | Resolution |
|---|---|---|
| \20260316000001\ | \dge_function_security\ vs \ix_invitation_rls\ | \ix_invitation_rls\ → \20260316000002\ |
| \20260325000001\ | \nhanced_cleanup\ vs \ead_only_rate_limit_status\ | \ead_only_rate_limit_status\ → \20260325000002\ |
| \20260328000001\ | \amily_plan_subscriptions\ vs \ecurring_idempotency\ | \ecurring_idempotency\ → \20260328000002\ |
| \20260328000002\ | \
otification_triggers\ vs \eferral_tracking\ | Cascade: 000002-000006 → 000003-000008 |

9 up-migration files and 9 down-migration files renamed (with internal header comments updated).

### Missing down migrations (#1322)

6 new down-migration files created for the \20260326\ schema-alignment batch:

- \20260326000001_production_readiness.down.sql\ — drops verification functions
- \20260326000002_add_transfer_recurring_to_transactions.down.sql\ — removes transfer_transaction_id + recurring_rule_id columns
- \20260326000003_add_rollover_to_budgets.down.sql\ — removes is_rollover column
- \20260326000004_add_account_status_to_goals.down.sql\ — removes account_id + status columns and CHECK constraint
- \20260326000005_standardize_owner_id.down.sql\ — removes owner_id columns, indexes, and RLS policies from 6 tables
- \20260326000006_sync_optimization.down.sql\ — drops materialized view, schema version function, restores original generate_recurring_transactions

### Documentation

- Updated \down/README.md\ with complete migration mapping table (42 migrations) and deduplication changelog.

## Verification

- ✅ All 42 up-migration files have unique timestamps (zero collisions)
- ✅ All 42 up-migration files have a corresponding \.down.sql\ file
- ✅ No effective schema changes — only file renames and new down-migration files
- ✅ All down migrations use \IF EXISTS\/\IF NOT EXISTS\ for idempotency

## Issues

Closes #1322
Closes #1323