### PR TITLE
fix(web): harden SQLite-WASM initialization and storage fallback (#1332)

### DIFF
--- a/apps/web/src/components/DataExport.test.tsx
+++ b/apps/web/src/components/DataExport.test.tsx
@@ -6,7 +6,7 @@ import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { DataExport } from './DataExport';
 import type { SqliteDb } from '../db/sqlite-wasm';
-import { DatabaseContext } from '../db/DatabaseProvider';
+import { DatabaseContext, type DatabaseContextValue } from '../db/DatabaseProvider';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -120,8 +120,20 @@ afterEach(() => {
 describe('DataExport', () => {
   // Helper to create test wrapper with database context
   const createTestWrapper = (db: SqliteDb | null) => {
+    const contextValue: DatabaseContextValue | null = db
+      ? {
+          db,
+          diagnostics: {
+            backend: 'indexeddb',
+            opfsAvailable: false,
+            didFallback: false,
+            quotaBytes: null,
+            usageBytes: null,
+          },
+        }
+      : null;
     const TestWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-      <DatabaseContext.Provider value={db}>{children}</DatabaseContext.Provider>
+      <DatabaseContext.Provider value={contextValue}>{children}</DatabaseContext.Provider>
     );
     return TestWrapper;
   };

--- a/apps/web/src/components/forms/AccountForm.stories.tsx
+++ b/apps/web/src/components/forms/AccountForm.stories.tsx
@@ -3,7 +3,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { fn } from 'storybook/test';
 import type { Account } from '../../kmp/bridge';
-import { DatabaseContext } from '../../db/DatabaseProvider';
+import { DatabaseContext, type DatabaseContextValue } from '../../db/DatabaseProvider';
 import type { SqliteDb } from '../../db/sqlite-wasm';
 import { AccountForm } from './AccountForm';
 
@@ -18,6 +18,17 @@ const mockDb: SqliteDb = {
   selectAll: fn().mockReturnValue([]),
   selectOne: fn().mockReturnValue({ id: 'hh-1' }),
   close: fn().mockResolvedValue(undefined),
+};
+
+const mockDbContext: DatabaseContextValue = {
+  db: mockDb,
+  diagnostics: {
+    backend: 'indexeddb',
+    opfsAvailable: false,
+    didFallback: false,
+    quotaBytes: null,
+    usageBytes: null,
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -76,7 +87,7 @@ const meta: Meta<typeof AccountForm> = {
   },
   decorators: [
     (Story) => (
-      <DatabaseContext.Provider value={mockDb}>
+      <DatabaseContext.Provider value={mockDbContext}>
         <div style={{ width: '100%', minWidth: 360, maxWidth: 480 }}>
           <Story />
         </div>

--- a/apps/web/src/components/forms/GoalForm.stories.tsx
+++ b/apps/web/src/components/forms/GoalForm.stories.tsx
@@ -3,7 +3,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { fn } from 'storybook/test';
 import type { Goal } from '../../kmp/bridge';
-import { DatabaseContext } from '../../db/DatabaseProvider';
+import { DatabaseContext, type DatabaseContextValue } from '../../db/DatabaseProvider';
 import type { SqliteDb } from '../../db/sqlite-wasm';
 import { GoalForm } from './GoalForm';
 
@@ -18,6 +18,17 @@ const mockDb: SqliteDb = {
   selectAll: fn().mockReturnValue([]),
   selectOne: fn().mockReturnValue({ id: 'hh-1' }),
   close: fn().mockResolvedValue(undefined),
+};
+
+const mockDbContext: DatabaseContextValue = {
+  db: mockDb,
+  diagnostics: {
+    backend: 'indexeddb',
+    opfsAvailable: false,
+    didFallback: false,
+    quotaBytes: null,
+    usageBytes: null,
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -78,7 +89,7 @@ const meta: Meta<typeof GoalForm> = {
   },
   decorators: [
     (Story) => (
-      <DatabaseContext.Provider value={mockDb}>
+      <DatabaseContext.Provider value={mockDbContext}>
         <div style={{ width: '100%', minWidth: 360, maxWidth: 480 }}>
           <Story />
         </div>

--- a/apps/web/src/db/DatabaseProvider.tsx
+++ b/apps/web/src/db/DatabaseProvider.tsx
@@ -3,19 +3,57 @@
 import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from 'react';
 import { ErrorBanner, LoadingSpinner } from '../components/common';
 import { seedDatabase } from './seed';
-import { initDatabase, type SqliteDb } from './sqlite-wasm';
+import {
+  initDatabaseWithDiagnostics,
+  getUserFriendlyStorageMessage,
+  StorageError,
+  type SqliteDb,
+  type StorageDiagnostics,
+  type StorageErrorCode,
+} from './sqlite-wasm';
 import '../styles/pages.css';
 
+/** Context value providing the database instance and diagnostics. */
+export interface DatabaseContextValue {
+  /** The initialised SQLite-WASM database instance. */
+  db: SqliteDb;
+  /** Storage diagnostics from initialisation. */
+  diagnostics: StorageDiagnostics;
+}
+
 /** React context that stores the shared SQLite-WASM database instance. */
-export const DatabaseContext = createContext<SqliteDb | null>(null);
+export const DatabaseContext = createContext<DatabaseContextValue | null>(null);
 DatabaseContext.displayName = 'DatabaseContext';
 
 interface DatabaseProviderProps {
   children: ReactNode;
 }
 
-function getErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : 'Failed to initialize the local database.';
+/** Structured error state for the provider UI. */
+interface InitError {
+  /** Machine-readable error code. */
+  code: StorageErrorCode;
+  /** User-friendly error message. */
+  message: string;
+  /** Technical detail for diagnostics (not shown to users by default). */
+  detail: string | null;
+}
+
+function toInitError(error: unknown): InitError {
+  if (error instanceof StorageError) {
+    return {
+      code: error.code,
+      message: error.message,
+      detail: error.cause instanceof Error ? error.cause.message : null,
+    };
+  }
+  const message =
+    error instanceof Error ? error.message : 'Failed to initialize the local database.';
+  return {
+    code: 'UNKNOWN',
+    message,
+    detail: null,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -44,6 +82,14 @@ const E2E_STUB_DB: SqliteDb = {
   close: async () => {},
 };
 
+const E2E_STUB_DIAGNOSTICS: StorageDiagnostics = {
+  backend: 'indexeddb',
+  opfsAvailable: false,
+  didFallback: false,
+  quotaBytes: null,
+  usageBytes: null,
+};
+
 /** Initialize SQLite-WASM and provide the database instance to descendants. */
 export function DatabaseProvider({ children }: DatabaseProviderProps) {
   // Skip real DB init in E2E tests — WASM binaries aren't in the static
@@ -52,9 +98,11 @@ export function DatabaseProvider({ children }: DatabaseProviderProps) {
     () => typeof window !== 'undefined' && window.__PLAYWRIGHT_E2E__ === true,
   );
 
-  const [db, setDb] = useState<SqliteDb | null>(isE2E ? E2E_STUB_DB : null);
+  const [ctxValue, setCtxValue] = useState<DatabaseContextValue | null>(
+    isE2E ? { db: E2E_STUB_DB, diagnostics: E2E_STUB_DIAGNOSTICS } : null,
+  );
   const [isLoading, setIsLoading] = useState(!isE2E);
-  const [error, setError] = useState<string | null>(null);
+  const [initError, setInitError] = useState<InitError | null>(null);
   const [reloadToken, setReloadToken] = useState(0);
 
   const retryInitialization = useCallback(() => {
@@ -70,11 +118,13 @@ export function DatabaseProvider({ children }: DatabaseProviderProps) {
 
     const initializeDatabase = async () => {
       setIsLoading(true);
-      setError(null);
-      setDb(null);
+      setInitError(null);
+      setCtxValue(null);
 
       try {
-        initializedDb = await initDatabase();
+        const result = await initDatabaseWithDiagnostics();
+        initializedDb = result.db;
+
         await seedDatabase(initializedDb);
 
         if (isDisposed) {
@@ -83,7 +133,7 @@ export function DatabaseProvider({ children }: DatabaseProviderProps) {
           return;
         }
 
-        setDb(initializedDb);
+        setCtxValue({ db: initializedDb, diagnostics: result.diagnostics });
       } catch (initializationError) {
         if (initializedDb) {
           try {
@@ -95,7 +145,7 @@ export function DatabaseProvider({ children }: DatabaseProviderProps) {
         }
 
         if (!isDisposed) {
-          setError(getErrorMessage(initializationError));
+          setInitError(toInitError(initializationError));
         }
       } finally {
         if (!isDisposed) {
@@ -123,18 +173,25 @@ export function DatabaseProvider({ children }: DatabaseProviderProps) {
     );
   }
 
-  if (error || !db) {
+  if (initError || !ctxValue) {
+    const errorCode = initError?.code ?? 'UNKNOWN';
+    const errorMessage = initError?.message ?? getUserFriendlyStorageMessage('UNKNOWN');
+
     return (
-      <div className="page-error-wrapper">
-        <ErrorBanner
-          message={error ?? 'The database is unavailable.'}
-          onRetry={retryInitialization}
-        />
+      <div className="page-error-wrapper page-error-wrapper--centered" role="alert">
+        <ErrorBanner message={errorMessage} onRetry={retryInitialization} />
+        {initError?.detail && (
+          <details className="db-error-details">
+            <summary className="db-error-details__summary">Technical details</summary>
+            <p className="db-error-details__code">Error code: {errorCode}</p>
+            <p className="db-error-details__code">{initError.detail}</p>
+          </details>
+        )}
       </div>
     );
   }
 
-  return <DatabaseContext.Provider value={db}>{children}</DatabaseContext.Provider>;
+  return <DatabaseContext.Provider value={ctxValue}>{children}</DatabaseContext.Provider>;
 }
 
 /** Access the shared SQLite-WASM database instance from React context. */
@@ -144,5 +201,11 @@ export function useDatabase(): SqliteDb {
     throw new Error('useDatabase must be used within a DatabaseProvider');
   }
 
-  return context;
+  return context.db;
+}
+
+/** Access storage diagnostics from the initialization. */
+export function useStorageDiagnostics(): StorageDiagnostics | null {
+  const context = useContext(DatabaseContext);
+  return context?.diagnostics ?? null;
 }

--- a/apps/web/src/db/__tests__/DatabaseProvider.test.tsx
+++ b/apps/web/src/db/__tests__/DatabaseProvider.test.tsx
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { DatabaseProvider, useDatabase, useStorageDiagnostics } from '../DatabaseProvider';
+import { StorageError, type StorageDiagnostics, type SqliteDb } from '../sqlite-wasm';
+
+// Mock the sqlite-wasm module — we test provider behavior, not real WASM
+vi.mock('../sqlite-wasm', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../sqlite-wasm')>();
+  return {
+    ...actual,
+    initDatabaseWithDiagnostics: vi.fn(),
+  };
+});
+
+// Mock seed to avoid actual DB operations
+vi.mock('../seed', () => ({
+  seedDatabase: vi.fn().mockResolvedValue(undefined),
+}));
+
+const { initDatabaseWithDiagnostics } = await import('../sqlite-wasm');
+
+const mockDb: SqliteDb = {
+  exec: vi.fn(),
+  selectAll: vi.fn().mockReturnValue([]),
+  selectOne: vi.fn().mockReturnValue(null),
+  close: vi.fn().mockResolvedValue(undefined),
+};
+
+const mockDiagnostics: StorageDiagnostics = {
+  backend: 'opfs',
+  opfsAvailable: true,
+  didFallback: false,
+  quotaBytes: 1_000_000_000,
+  usageBytes: 50_000,
+};
+
+/** Test component that consumes useDatabase. */
+function DbConsumer() {
+  const db = useDatabase();
+  return <div data-testid="db-ready">{db ? 'Database ready' : 'No database'}</div>;
+}
+
+/** Test component that consumes useStorageDiagnostics. */
+function DiagnosticsConsumer() {
+  const diag = useStorageDiagnostics();
+  if (!diag) return <div data-testid="no-diag">No diagnostics</div>;
+  return <div data-testid="diag-backend">{diag.backend}</div>;
+}
+
+describe('DatabaseProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset E2E flag
+    if (typeof window !== 'undefined') {
+      delete window.__PLAYWRIGHT_E2E__;
+    }
+  });
+
+  it('renders loading state initially', async () => {
+    // Never resolve — keep in loading state
+    (initDatabaseWithDiagnostics as Mock).mockReturnValue(new Promise(() => {}));
+
+    render(
+      <DatabaseProvider>
+        <DbConsumer />
+      </DatabaseProvider>,
+    );
+
+    const statusElements = screen.getAllByRole('status');
+    expect(statusElements.length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Initializing database')).toBeInTheDocument();
+  });
+
+  it('renders children when init succeeds', async () => {
+    (initDatabaseWithDiagnostics as Mock).mockResolvedValue({
+      db: mockDb,
+      diagnostics: mockDiagnostics,
+    });
+
+    render(
+      <DatabaseProvider>
+        <DbConsumer />
+      </DatabaseProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('db-ready')).toHaveTextContent('Database ready');
+    });
+  });
+
+  it('renders error banner when init fails with StorageError', async () => {
+    const storageError = new StorageError(
+      'WASM_LOAD_FAILED',
+      'Failed to load the database engine. Please check your network connection and reload the page.',
+      { cause: new Error('fetch failed'), backend: 'opfs', fallbackAttempted: true },
+    );
+    (initDatabaseWithDiagnostics as Mock).mockRejectedValue(storageError);
+
+    render(
+      <DatabaseProvider>
+        <DbConsumer />
+      </DatabaseProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('alert').length).toBeGreaterThanOrEqual(1);
+    });
+
+    expect(screen.getByText(/database engine/i)).toBeInTheDocument();
+    // Technical details should be available
+    expect(screen.getByText('Technical details')).toBeInTheDocument();
+  });
+
+  it('renders error banner when init fails with generic error', async () => {
+    (initDatabaseWithDiagnostics as Mock).mockRejectedValue(
+      new Error('Something unexpected happened'),
+    );
+
+    render(
+      <DatabaseProvider>
+        <DbConsumer />
+      </DatabaseProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('alert').length).toBeGreaterThanOrEqual(1);
+    });
+
+    expect(screen.getByText('Something unexpected happened')).toBeInTheDocument();
+  });
+
+  it('retry button re-triggers initialization', async () => {
+    let callCount = 0;
+    (initDatabaseWithDiagnostics as Mock).mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        throw new StorageError('INDEXEDDB_FAILED', 'Browser storage is unavailable.', {
+          backend: 'indexeddb',
+        });
+      }
+      return { db: mockDb, diagnostics: mockDiagnostics };
+    });
+
+    const user = userEvent.setup();
+
+    render(
+      <DatabaseProvider>
+        <DbConsumer />
+      </DatabaseProvider>,
+    );
+
+    // Wait for error state
+    await waitFor(() => {
+      expect(screen.getAllByRole('alert').length).toBeGreaterThanOrEqual(1);
+    });
+
+    // Click retry
+    await user.click(screen.getByRole('button', { name: /retry/i }));
+
+    // Should now succeed
+    await waitFor(() => {
+      expect(screen.getByTestId('db-ready')).toHaveTextContent('Database ready');
+    });
+
+    expect(callCount).toBe(2);
+  });
+
+  it('exposes diagnostics via useStorageDiagnostics', async () => {
+    (initDatabaseWithDiagnostics as Mock).mockResolvedValue({
+      db: mockDb,
+      diagnostics: { ...mockDiagnostics, backend: 'indexeddb' },
+    });
+
+    render(
+      <DatabaseProvider>
+        <DiagnosticsConsumer />
+      </DatabaseProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('diag-backend')).toHaveTextContent('indexeddb');
+    });
+  });
+
+  it('skips WASM init in E2E mode', async () => {
+    window.__PLAYWRIGHT_E2E__ = true;
+
+    render(
+      <DatabaseProvider>
+        <DbConsumer />
+      </DatabaseProvider>,
+    );
+
+    // Should render immediately without calling init
+    expect(screen.getByTestId('db-ready')).toHaveTextContent('Database ready');
+    expect(initDatabaseWithDiagnostics).not.toHaveBeenCalled();
+  });
+
+  it('shows quota exceeded error with actionable message', async () => {
+    const quotaError = new StorageError(
+      'QUOTA_EXCEEDED',
+      'Storage space is full. Please free up space by clearing unused site data in your browser settings.',
+      { backend: 'indexeddb' },
+    );
+    (initDatabaseWithDiagnostics as Mock).mockRejectedValue(quotaError);
+
+    render(
+      <DatabaseProvider>
+        <DbConsumer />
+      </DatabaseProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('alert').length).toBeGreaterThanOrEqual(1);
+    });
+
+    expect(screen.getByText(/storage space is full/i)).toBeInTheDocument();
+  });
+});
+
+describe('useDatabase', () => {
+  it('throws when used outside DatabaseProvider', () => {
+    function Orphan() {
+      useDatabase();
+      return null;
+    }
+
+    // Suppress React error boundary console output
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => {
+      render(<Orphan />);
+    }).toThrow('useDatabase must be used within a DatabaseProvider');
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/apps/web/src/db/__tests__/sqlite-wasm.test.ts
+++ b/apps/web/src/db/__tests__/sqlite-wasm.test.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect } from 'vitest';
+import { StorageError, getUserFriendlyStorageMessage, type StorageErrorCode } from '../sqlite-wasm';
+
+describe('StorageError', () => {
+  it('creates an error with a code, message, and backend', () => {
+    const error = new StorageError('WASM_LOAD_FAILED', 'WASM failed', {
+      backend: 'opfs',
+      fallbackAttempted: false,
+    });
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(StorageError);
+    expect(error.name).toBe('StorageError');
+    expect(error.code).toBe('WASM_LOAD_FAILED');
+    expect(error.message).toBe('WASM failed');
+    expect(error.backend).toBe('opfs');
+    expect(error.fallbackAttempted).toBe(false);
+  });
+
+  it('preserves the cause chain', () => {
+    const rootCause = new TypeError('WebAssembly.instantiate failed');
+    const error = new StorageError('WASM_LOAD_FAILED', 'Failed to load', {
+      cause: rootCause,
+      backend: 'opfs',
+    });
+
+    expect(error.cause).toBe(rootCause);
+  });
+
+  it('defaults backend to null and fallbackAttempted to false', () => {
+    const error = new StorageError('UNKNOWN', 'Something broke');
+
+    expect(error.backend).toBeNull();
+    expect(error.fallbackAttempted).toBe(false);
+  });
+
+  it('tracks when a fallback was attempted', () => {
+    const error = new StorageError('INDEXEDDB_FAILED', 'IndexedDB failed', {
+      backend: 'indexeddb',
+      fallbackAttempted: true,
+    });
+
+    expect(error.fallbackAttempted).toBe(true);
+    expect(error.backend).toBe('indexeddb');
+  });
+});
+
+describe('getUserFriendlyStorageMessage', () => {
+  const codes: StorageErrorCode[] = [
+    'WASM_LOAD_FAILED',
+    'OPFS_UNAVAILABLE',
+    'OPFS_INIT_FAILED',
+    'INDEXEDDB_FAILED',
+    'QUOTA_EXCEEDED',
+    'MIGRATION_FAILED',
+    'UNKNOWN',
+  ];
+
+  it.each(codes)('returns a non-empty string for code "%s"', (code) => {
+    const message = getUserFriendlyStorageMessage(code);
+    expect(message).toBeTruthy();
+    expect(typeof message).toBe('string');
+    expect(message.length).toBeGreaterThan(10);
+  });
+
+  it('returns a message that does not expose technical jargon for WASM_LOAD_FAILED', () => {
+    const message = getUserFriendlyStorageMessage('WASM_LOAD_FAILED');
+    expect(message).toContain('database engine');
+    expect(message).not.toContain('WebAssembly');
+    expect(message).not.toContain('WASM');
+  });
+
+  it('mentions storage for QUOTA_EXCEEDED', () => {
+    const message = getUserFriendlyStorageMessage('QUOTA_EXCEEDED');
+    expect(message.toLowerCase()).toContain('storage');
+    expect(message.toLowerCase()).toContain('full');
+  });
+
+  it('provides actionable guidance for INDEXEDDB_FAILED', () => {
+    const message = getUserFriendlyStorageMessage('INDEXEDDB_FAILED');
+    expect(message.toLowerCase()).toContain('browser');
+  });
+});

--- a/apps/web/src/db/sqlite-wasm.ts
+++ b/apps/web/src/db/sqlite-wasm.ts
@@ -22,7 +22,70 @@
 /** Supported SQLite VFS backends. */
 export type StorageBackend = 'opfs' | 'indexeddb';
 
-/** A single row returned by a query ΓÇö column-name ΓåÆ value. */
+/** Error codes for storage initialization failures. */
+export type StorageErrorCode =
+  | 'WASM_LOAD_FAILED'
+  | 'OPFS_UNAVAILABLE'
+  | 'OPFS_INIT_FAILED'
+  | 'INDEXEDDB_FAILED'
+  | 'QUOTA_EXCEEDED'
+  | 'MIGRATION_FAILED'
+  | 'UNKNOWN';
+
+/**
+ * Structured error for storage initialization failures.
+ *
+ * Provides an error code for programmatic handling and a user-friendly
+ * message suitable for display in the UI.
+ */
+export class StorageError extends Error {
+  /** Machine-readable error code for programmatic handling. */
+  readonly code: StorageErrorCode;
+  /** The storage backend that was being used when the error occurred. */
+  readonly backend: StorageBackend | null;
+  /** Whether a fallback to another backend was attempted. */
+  readonly fallbackAttempted: boolean;
+
+  constructor(
+    code: StorageErrorCode,
+    message: string,
+    options?: {
+      cause?: unknown;
+      backend?: StorageBackend | null;
+      fallbackAttempted?: boolean;
+    },
+  ) {
+    super(message, { cause: options?.cause });
+    this.name = 'StorageError';
+    this.code = code;
+    this.backend = options?.backend ?? null;
+    this.fallbackAttempted = options?.fallbackAttempted ?? false;
+  }
+}
+
+/** Diagnostic information about the storage initialization. */
+export interface StorageDiagnostics {
+  /** Which backend is active. */
+  backend: StorageBackend;
+  /** Whether OPFS was available during detection. */
+  opfsAvailable: boolean;
+  /** Whether a fallback from OPFS to IndexedDB occurred. */
+  didFallback: boolean;
+  /** Estimated storage quota in bytes, if available. */
+  quotaBytes: number | null;
+  /** Estimated storage usage in bytes, if available. */
+  usageBytes: number | null;
+}
+
+/** Result of a successful database initialization. */
+export interface StorageInitResult {
+  /** The initialized database instance. */
+  db: SqliteDb;
+  /** Diagnostic information about the initialization. */
+  diagnostics: StorageDiagnostics;
+}
+
+/** A single row returned by a query — column-name → value. */
 export type Row = Record<string, unknown>;
 
 /** Typed query-result wrapper. */
@@ -313,9 +376,93 @@ export async function detectBackend(): Promise<StorageBackend> {
       return 'opfs';
     }
   } catch {
-    // OPFS not usable ΓÇö fall through
+    // OPFS not usable — fall through
   }
   return 'indexeddb';
+}
+
+/**
+ * Query the browser's storage quota estimate.
+ *
+ * Returns `{ quota, usage }` in bytes, or `null` values when the
+ * StorageManager API is unavailable.
+ */
+export async function getStorageEstimate(): Promise<{
+  quotaBytes: number | null;
+  usageBytes: number | null;
+}> {
+  try {
+    if (typeof navigator !== 'undefined' && navigator.storage?.estimate) {
+      const estimate = await navigator.storage.estimate();
+      return {
+        quotaBytes: estimate.quota ?? null,
+        usageBytes: estimate.usage ?? null,
+      };
+    }
+  } catch {
+    // StorageManager not available
+  }
+  return { quotaBytes: null, usageBytes: null };
+}
+
+/**
+ * Returns a user-friendly message for a given storage error code.
+ */
+export function getUserFriendlyStorageMessage(code: StorageErrorCode): string {
+  switch (code) {
+    case 'WASM_LOAD_FAILED':
+      return 'Failed to load the database engine. Please check your network connection and reload the page.';
+    case 'OPFS_UNAVAILABLE':
+      return 'Your browser does not support the required storage features. The app will use a fallback storage method.';
+    case 'OPFS_INIT_FAILED':
+      return 'Failed to initialize persistent storage. Falling back to alternative storage.';
+    case 'INDEXEDDB_FAILED':
+      return 'Browser storage is unavailable. Please check that your browser allows site data and that storage is not full.';
+    case 'QUOTA_EXCEEDED':
+      return 'Storage space is full. Please free up space by clearing unused site data in your browser settings.';
+    case 'MIGRATION_FAILED':
+      return 'Failed to update the database schema. Please try clearing site data and reloading.';
+    case 'UNKNOWN':
+    default:
+      return 'An unexpected error occurred while setting up local storage. Please reload the page.';
+  }
+}
+
+/** Classify an unknown error into a StorageErrorCode. */
+function classifyError(err: unknown): StorageErrorCode {
+  if (err instanceof StorageError) {
+    return err.code;
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  const name = err instanceof Error ? err.name : '';
+
+  if (name === 'QuotaExceededError' || message.includes('quota')) {
+    return 'QUOTA_EXCEEDED';
+  }
+  if (
+    message.includes('OPFS') ||
+    message.includes('createSyncAccessHandle') ||
+    message.includes('OriginPrivateFileSystem')
+  ) {
+    return 'OPFS_INIT_FAILED';
+  }
+  if (
+    message.includes('IndexedDB') ||
+    message.includes('indexedDB') ||
+    name === 'InvalidStateError'
+  ) {
+    return 'INDEXEDDB_FAILED';
+  }
+  if (
+    message.includes('WebAssembly') ||
+    message.includes('wasm') ||
+    message.includes('WASM') ||
+    message.includes('CompileError') ||
+    message.includes('instantiate')
+  ) {
+    return 'WASM_LOAD_FAILED';
+  }
+  return 'UNKNOWN';
 }
 
 // ---------------------------------------------------------------------------
@@ -329,59 +476,202 @@ export async function detectBackend(): Promise<StorageBackend> {
  * 2. Loads the wa-sqlite or sql.js WASM module.
  * 3. Opens or creates the database file.
  * 4. Runs any pending migrations.
- * 5. Returns a thin wrapper implementing {@link SqliteDb}.
+ * 5. Returns the database wrapper and diagnostic information.
+ *
+ * If OPFS initialization fails at runtime (even after detection succeeds),
+ * the function automatically falls back to IndexedDB before giving up.
+ *
+ * Throws {@link StorageError} with a machine-readable `code` on failure.
  *
  * Usage:
  * ```ts
- * const db = await initDatabase();
- * const accounts = query<Account>(db, 'SELECT * FROM account WHERE deleted_at IS NULL');
+ * const { db, diagnostics } = await initDatabaseWithDiagnostics();
  * ```
  */
-export async function initDatabase(): Promise<SqliteDb> {
-  const backend = await detectBackend();
+export async function initDatabaseWithDiagnostics(): Promise<StorageInitResult> {
+  const detectedBackend = await detectBackend();
+  const opfsAvailable = detectedBackend === 'opfs';
+  let didFallback = false;
 
-  // Dynamic import ΓÇö keeps wa-sqlite out of the main bundle
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let sqlite3: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let db: any;
+  let activeBackend: StorageBackend = detectedBackend;
 
-  if (backend === 'opfs') {
+  // --- Phase 1: Try the detected backend ---
+  if (detectedBackend === 'opfs') {
+    try {
+      ({ sqlite3, db } = await initOpfsBackend());
+    } catch {
+      // OPFS detected but failed at runtime — try IndexedDB fallback
+      didFallback = true;
+      activeBackend = 'indexeddb';
+      try {
+        ({ sqlite3, db } = await initIndexedDbBackend());
+      } catch (idbError) {
+        const code = classifyError(idbError);
+        throw new StorageError(code, getUserFriendlyStorageMessage(code), {
+          cause: idbError,
+          backend: 'indexeddb',
+          fallbackAttempted: true,
+        });
+      }
+    }
+  } else {
+    try {
+      ({ sqlite3, db } = await initIndexedDbBackend());
+    } catch (idbError) {
+      const code = classifyError(idbError);
+      throw new StorageError(code, getUserFriendlyStorageMessage(code), {
+        cause: idbError,
+        backend: 'indexeddb',
+        fallbackAttempted: false,
+      });
+    }
+  }
+
+  // --- Phase 2: Configure pragmas ---
+  try {
+    execRaw(sqlite3, db, 'PRAGMA journal_mode = WAL;', activeBackend);
+    execRaw(sqlite3, db, 'PRAGMA foreign_keys = ON;', activeBackend);
+  } catch (pragmaError) {
+    throw new StorageError('UNKNOWN', 'Failed to configure the database engine.', {
+      cause: pragmaError,
+      backend: activeBackend,
+      fallbackAttempted: didFallback,
+    });
+  }
+
+  // --- Phase 3: Run migrations ---
+  try {
+    await runMigrations(sqlite3, db, activeBackend);
+  } catch (migrationError) {
+    const code = migrationError instanceof StorageError ? migrationError.code : 'MIGRATION_FAILED';
+    throw new StorageError(code, getUserFriendlyStorageMessage('MIGRATION_FAILED'), {
+      cause: migrationError,
+      backend: activeBackend,
+      fallbackAttempted: didFallback,
+    });
+  }
+
+  // --- Phase 4: Persist IndexedDB if needed ---
+  if (activeBackend === 'indexeddb') {
+    try {
+      await persistToIndexedDB(DB_NAME, exportDatabase(sqlite3, db, activeBackend));
+    } catch (persistError) {
+      const code = classifyError(persistError);
+      throw new StorageError(code, getUserFriendlyStorageMessage(code), {
+        cause: persistError,
+        backend: 'indexeddb',
+        fallbackAttempted: didFallback,
+      });
+    }
+  }
+
+  // --- Phase 5: Gather diagnostics ---
+  const storageEstimate = await getStorageEstimate();
+
+  const wrapper = createDbWrapper(sqlite3, db, activeBackend);
+  return {
+    db: wrapper,
+    diagnostics: {
+      backend: activeBackend,
+      opfsAvailable,
+      didFallback,
+      quotaBytes: storageEstimate.quotaBytes,
+      usageBytes: storageEstimate.usageBytes,
+    },
+  };
+}
+
+/**
+ * Initialises the Finance SQLite database (legacy convenience wrapper).
+ *
+ * Returns only the {@link SqliteDb} instance.  Use
+ * {@link initDatabaseWithDiagnostics} when you need storage diagnostics.
+ */
+export async function initDatabase(): Promise<SqliteDb> {
+  const { db } = await initDatabaseWithDiagnostics();
+  return db;
+}
+
+// ---------------------------------------------------------------------------
+// Backend-specific initializers
+// ---------------------------------------------------------------------------
+
+/** Initialise wa-sqlite with OPFS VFS. */
+async function initOpfsBackend(): Promise<{
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  sqlite3: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  db: any;
+}> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let wasmModule: any;
+  try {
     const { default: SQLiteESMFactory } = await import(
       /* webpackChunkName: "wa-sqlite" */ 'wa-sqlite'
     );
+    wasmModule = await SQLiteESMFactory();
+  } catch (err) {
+    throw new StorageError('WASM_LOAD_FAILED', getUserFriendlyStorageMessage('WASM_LOAD_FAILED'), {
+      cause: err,
+      backend: 'opfs',
+    });
+  }
+
+  try {
     const { OriginPrivateFileSystemVFS } = await import(
       /* webpackChunkName: "wa-sqlite-vfs" */ 'wa-sqlite/src/examples/OriginPrivateFileSystemVFS.js'
     );
+    const vfs = await OriginPrivateFileSystemVFS.create(DB_NAME, wasmModule);
+    wasmModule.vfs_register(vfs, /* makeDefault */ true);
+    const dbHandle = await wasmModule.open_v2(DB_NAME);
+    return { sqlite3: wasmModule, db: dbHandle };
+  } catch (err) {
+    const code = classifyError(err);
+    throw new StorageError(
+      code === 'UNKNOWN' ? 'OPFS_INIT_FAILED' : code,
+      getUserFriendlyStorageMessage('OPFS_INIT_FAILED'),
+      { cause: err, backend: 'opfs' },
+    );
+  }
+}
 
-    const module = await SQLiteESMFactory();
-    sqlite3 = module;
-
-    const vfs = await OriginPrivateFileSystemVFS.create(DB_NAME, module);
-    module.vfs_register(vfs, /* makeDefault */ true);
-    db = await module.open_v2(DB_NAME);
-  } else {
+/** Initialise sql.js with IndexedDB persistence. */
+async function initIndexedDbBackend(): Promise<{
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  sqlite3: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  db: any;
+}> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let SQL: any;
+  try {
     const initSqlJs = (await import(/* webpackChunkName: "sql-js" */ 'sql.js')).default;
-
-    const SQL = await initSqlJs({
+    SQL = await initSqlJs({
       locateFile: (file: string) => `/assets/sql-wasm/${file}`,
     });
+  } catch (err) {
+    throw new StorageError('WASM_LOAD_FAILED', getUserFriendlyStorageMessage('WASM_LOAD_FAILED'), {
+      cause: err,
+      backend: 'indexeddb',
+    });
+  }
 
+  try {
     const savedBuffer = await loadFromIndexedDB(DB_NAME);
-    db = savedBuffer ? new SQL.Database(new Uint8Array(savedBuffer)) : new SQL.Database();
-    sqlite3 = SQL;
+    const db = savedBuffer ? new SQL.Database(new Uint8Array(savedBuffer)) : new SQL.Database();
+    return { sqlite3: SQL, db };
+  } catch (err) {
+    const code = classifyError(err);
+    throw new StorageError(
+      code === 'UNKNOWN' ? 'INDEXEDDB_FAILED' : code,
+      getUserFriendlyStorageMessage(code === 'UNKNOWN' ? 'INDEXEDDB_FAILED' : code),
+      { cause: err, backend: 'indexeddb' },
+    );
   }
-
-  execRaw(sqlite3, db, 'PRAGMA journal_mode = WAL;', backend);
-  execRaw(sqlite3, db, 'PRAGMA foreign_keys = ON;', backend);
-
-  await runMigrations(sqlite3, db, backend);
-
-  if (backend === 'indexeddb') {
-    await persistToIndexedDB(DB_NAME, exportDatabase(sqlite3, db, backend));
-  }
-
-  return createDbWrapper(sqlite3, db, backend);
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/styles/pages.css
+++ b/apps/web/src/styles/pages.css
@@ -45,6 +45,29 @@
   padding: var(--spacing-6);
 }
 
+.page-error-wrapper--centered {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+/* Database error diagnostics */
+.db-error-details {
+  margin-top: var(--spacing-3);
+  padding: var(--spacing-3);
+  font-size: var(--font-size-sm, 0.875rem);
+  color: var(--semantic-text-secondary, #666);
+}
+
+.db-error-details__summary {
+  cursor: pointer;
+}
+
+.db-error-details__code {
+  margin-top: var(--spacing-2);
+  font-family: monospace;
+  word-break: break-word;
+}
+
 /* Net worth / summary text */
 .page-summary {
   margin-bottom: var(--spacing-6);


### PR DESCRIPTION
## Summary

Hardens SQLite-WASM initialization and storage fallback in the web app to handle edge cases: WASM binary loading failures, OPFS unavailability, storage quota exceeded, and IndexedDB fallback failures.

## Changes

### Core (apps/web/src/db/sqlite-wasm.ts)
- StorageError class with typed error codes (WASM_LOAD_FAILED, OPFS_UNAVAILABLE, OPFS_INIT_FAILED, INDEXEDDB_FAILED, QUOTA_EXCEEDED, MIGRATION_FAILED, UNKNOWN)
- initDatabaseWithDiagnostics() returning StorageInitResult with db + StorageDiagnostics
- Automatic OPFS-to-IndexedDB fallback when OPFS runtime init fails
- getUserFriendlyStorageMessage() for actionable error messages
- classifyError() to map unknown errors to StorageErrorCode
- getStorageEstimate() for storage quota diagnostics
- Phase-based init with isolated error handling per phase

### Provider (apps/web/src/db/DatabaseProvider.tsx)
- Structured error UI with expandable technical details
- DatabaseContextValue providing both db and diagnostics
- useStorageDiagnostics() hook for downstream diagnostic access

### Tests
- sqlite-wasm.test.ts: 14 unit tests for StorageError and getUserFriendlyStorageMessage
- DatabaseProvider.test.tsx: 9 integration tests for error/loading/success states
- DataExport.test.tsx: Updated to match new context shape

## Issues

Closes #1332

## Testing

- [x] All 1619 web tests pass (123 test files)
- [x] Prettier formatting clean
- [x] ESLint clean (0 warnings)
- [x] Backward-compatible: useDatabase() still returns SqliteDb