### PR TITLE
chore(deps): fix Dependabot vulnerability alerts (#1434)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,6 +50,10 @@ allprojects {
                 useVersion(libs.versions.commons.compress.get())
                 because("Fix CVE-2024-25710 (DoS infinite loop) and CVE-2024-26308 (OOM)")
             }
+            if (requested.group == "org.apache.commons" && requested.name == "commons-lang3") {
+                useVersion(libs.versions.commons.lang3.get())
+                because("Fix CVE-2024-51503 (LDAP injection via NumberUtils)")
+            }
             if (requested.group == "commons-io" && requested.name == "commons-io") {
                 useVersion(libs.versions.commons.io.get())
                 because("Fix CVE-2024-47554 (DoS via XmlStreamReader)")
@@ -68,7 +72,7 @@ allprojects {
             }
             if (requested.group == "org.bouncycastle") {
                 useVersion(bouncyCastleVersion)
-                because("Fix 9 Dependabot alerts for Bouncy Castle CVEs (timing, crypto, DoS, LDAP injection)")
+                because("Fix Dependabot alerts for Bouncy Castle CVEs (timing, crypto, DoS, LDAP injection, covert channels)")
             }
             if (requested.group == "org.bitbucket.b_c" && requested.name == "jose4j") {
                 useVersion(jose4jVersion)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,12 +17,13 @@ compose-multiplatform = "1.7.3"
 netty = "4.1.133.Final"
 
 # Security: forced transitive dependency versions
+commons-lang3 = "3.18.0"
 commons-compress = "1.27.1"
 commons-io = "2.18.0"
 httpcomponents-httpclient = "4.5.14"
 protobuf-java = "4.29.3"
 jdom2 = "2.0.6.1"
-bouncy-castle = "1.80"
+bouncy-castle = "1.84"
 jose4j = "0.9.6"
 
 # Android / Compose


### PR DESCRIPTION
## Summary

Addresses 40 open Dependabot security alerts (15 high, 23 moderate, 2 low) by updating forced transitive dependency versions.

## Changes

### Version bumps:
- **Bouncy Castle** 1.80 → **1.84** — fixes covert timing channel vulnerability (alert #67) and 8 other BC alerts
- **commons-lang3** added at **3.18.0** — fixes LDAP injection via NumberUtils (alert #79, new force)

### Already resolved by existing \esolutionStrategy\ (38 alerts):
These were already forced to patched versions in \uild.gradle.kts\ but Dependabot doesn't recognize Gradle's \esolutionStrategy.eachDependency\. After merge, the dependency graph submission should auto-close these:

| Package | Forced Version | Alerts |
|---------|---------------|--------|
| Netty (all modules) | 4.1.133.Final | ~21 alerts (HTTP/2, smuggling, DoS, decompression bombs) |
| jose4j | 0.9.6 | 4 alerts (weak crypto, DoS, chosen ciphertext) |
| protobuf-java | 4.29.3 | 1 alert (DoS) |
| jdom2 | 2.0.6.1 | 1 alert (XXE injection) |
| commons-io | 2.18.0 | 1 alert (DoS via XmlStreamReader) |
| commons-compress | 1.27.1 | 2 alerts (DoS infinite loop, OOM) |

## Issues

Closes #1434

## Testing

- Format check passes (\
pm run format:check\)
- Gradle resolution strategies are applied at build time via \llprojects { configurations.all { resolutionStrategy } }\
- CI will verify the build still compiles with updated versions