### PR TITLE
fix(web): WASM loading, CSP, SW scope, rollback safety, auto-login (#1436, #1438)

### DIFF
--- a/apps/web/src/__tests__/auth-flows.test.tsx
+++ b/apps/web/src/__tests__/auth-flows.test.tsx
@@ -286,8 +286,11 @@ describe('Signup flow (#1331)', () => {
     expect(authState.signupWithEmail).toHaveBeenCalledWith('new@example.com', 'password123');
   });
 
-  it('shows success message after successful signup', async () => {
-    authState.signupWithEmail.mockResolvedValue(undefined);
+  it('redirects to /dashboard when isAuthenticated becomes true after signup', async () => {
+    authState.signupWithEmail.mockImplementation(() => {
+      authState.isAuthenticated = true;
+      return Promise.resolve();
+    });
     renderSignupPage();
 
     fireEvent.change(screen.getByLabelText('Email'), {
@@ -304,9 +307,7 @@ describe('Signup flow (#1331)', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Sign up' }));
     });
 
-    await waitFor(() => {
-      expect(screen.getByText('Account created! Please sign in.')).toBeInTheDocument();
-    });
+    expect(navigateMock).toHaveBeenCalledWith('/dashboard');
   });
 
   it('shows error banner when signup fails', async () => {

--- a/apps/web/src/auth/auth-context.tsx
+++ b/apps/web/src/auth/auth-context.tsx
@@ -390,6 +390,14 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
       try {
         if (demoModeActive) {
           await demoSignup(email, password);
+          // Auto-login after demo signup
+          const result = await demoLogin(email, password);
+          setAccessToken(result.accessToken);
+          setUser({
+            id: result.user.id,
+            email: result.user.email,
+            hasPasskey: false,
+          });
           return;
         }
 
@@ -406,6 +414,29 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
           };
           throw new Error(body.error ?? 'Signup failed');
         }
+
+        // Auto-login: use the same credentials to establish a session
+        const loginResponse = await fetch(config.loginEndpoint, {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, password }),
+        });
+
+        if (loginResponse.ok) {
+          const data = (await loginResponse.json()) as {
+            access_token: string;
+            user: { id: string; email: string; has_passkey?: boolean };
+          };
+          setAccessToken(data.access_token);
+          setUser({
+            id: data.user.id,
+            email: data.user.email,
+            hasPasskey: data.user.has_passkey ?? false,
+          });
+        }
+        // If auto-login fails, the signup still succeeded — caller can
+        // decide to redirect to login or show a message.
       } catch (err) {
         const message = err instanceof Error ? err.message : 'An unexpected error occurred';
         setError(message);
@@ -414,7 +445,7 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
         setIsLoading(false);
       }
     },
-    [config.signupEndpoint, demoModeActive],
+    [config.loginEndpoint, config.signupEndpoint, demoModeActive],
   );
 
   const loginWithOAuth = useCallback(

--- a/apps/web/src/db/seed.ts
+++ b/apps/web/src/db/seed.ts
@@ -492,7 +492,11 @@ export async function seedDatabase(db: SqliteDb): Promise<void> {
 
     execute(db, 'COMMIT');
   } catch (error) {
-    execute(db, 'ROLLBACK');
+    try {
+      execute(db, 'ROLLBACK');
+    } catch {
+      // ROLLBACK may fail if SQLite already auto-rolled back the transaction.
+    }
     throw error;
   }
 }

--- a/apps/web/src/db/sqlite-wasm.ts
+++ b/apps/web/src/db/sqlite-wasm.ts
@@ -821,7 +821,11 @@ async function runMigrations(
 
       execRaw(driver, db, 'COMMIT;', backend);
     } catch (err) {
-      execRaw(driver, db, 'ROLLBACK;', backend);
+      try {
+        execRaw(driver, db, 'ROLLBACK;', backend);
+      } catch {
+        // ROLLBACK may fail if SQLite already auto-rolled back the transaction.
+      }
       throw new Error(
         `Migration v${migration.version} (${migration.label}) failed: ${err instanceof Error ? err.message : String(err)}`,
         { cause: err },

--- a/apps/web/src/pages/SignupPage.test.tsx
+++ b/apps/web/src/pages/SignupPage.test.tsx
@@ -112,8 +112,11 @@ describe('SignupPage', () => {
     expect(authState.signupWithEmail).toHaveBeenCalledWith('alex@example.com', 'password123');
   });
 
-  it('shows success message after successful signup', async () => {
-    authState.signupWithEmail.mockResolvedValue(undefined);
+  it('redirects to /dashboard when isAuthenticated becomes true after signup', async () => {
+    authState.signupWithEmail.mockImplementation(() => {
+      authState.isAuthenticated = true;
+      return Promise.resolve();
+    });
     renderSignupPage();
     fillValidForm();
 
@@ -121,33 +124,8 @@ describe('SignupPage', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Sign up' }));
     });
 
-    await waitFor(() => {
-      expect(screen.getByText('Account created! Please sign in.')).toBeInTheDocument();
-    });
-  });
-
-  it('redirects to /login after 2 seconds on successful signup', async () => {
-    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
-    authState.signupWithEmail.mockResolvedValue(undefined);
-    renderSignupPage();
-    fillValidForm();
-
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: 'Sign up' }));
-    });
-
-    // Success message is visible; redirect has not fired yet.
-    expect(screen.getByText('Account created! Please sign in.')).toBeInTheDocument();
-    expect(navigateMock).not.toHaveBeenCalled();
-
-    // Advance the 2-second redirect timer.
-    act(() => {
-      vi.advanceTimersByTime(2000);
-    });
-
-    expect(navigateMock).toHaveBeenCalledWith('/login');
-
-    vi.useRealTimers();
+    // The component re-renders with isAuthenticated = true and navigates.
+    expect(navigateMock).toHaveBeenCalledWith('/dashboard');
   });
 
   it('shows error banner when signup fails', async () => {

--- a/apps/web/src/pages/SignupPage.tsx
+++ b/apps/web/src/pages/SignupPage.tsx
@@ -6,11 +6,11 @@
  * This page is rendered outside of `AppLayout` and reuses the shared
  * auth-card layout from `auth.css`.
  *
- * On successful registration the user sees a confirmation message and is
- * automatically redirected to `/login` after two seconds.
+ * On successful registration the user is automatically logged in and
+ * redirected to the dashboard.
  */
 
-import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useId, useMemo, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
 import { useAuth } from '../auth/auth-context';
@@ -21,9 +21,6 @@ import '../styles/auth.css';
 
 /** Minimum password length enforced by client-side validation. */
 const MIN_PASSWORD_LENGTH = 8;
-
-/** Duration (ms) before auto-redirecting to /login after successful signup. */
-const REDIRECT_DELAY_MS = 2000;
 
 interface SignupFieldErrors {
   email?: string;
@@ -44,7 +41,13 @@ interface SubmitMessage {
  */
 export const SignupPage: React.FC = () => {
   const navigate = useNavigate();
-  const { signupWithEmail, error: authError, isLoading, isDemoMode: demoMode } = useAuth();
+  const {
+    signupWithEmail,
+    error: authError,
+    isLoading,
+    isDemoMode: demoMode,
+    isAuthenticated,
+  } = useAuth();
 
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -62,17 +65,12 @@ export const SignupPage: React.FC = () => {
   const passwordErrorId = `${uid}-password-error`;
   const confirmPasswordErrorId = `${uid}-confirm-password-error`;
 
-  /** Ref to the pending redirect timer so it can be cancelled on unmount. */
-  const redirectTimerRef = useRef<number | null>(null);
-
-  // Cancel any pending redirect when the component unmounts.
+  // Redirect to dashboard once the user is authenticated (auto-login after signup)
   useEffect(() => {
-    return () => {
-      if (redirectTimerRef.current !== null) {
-        window.clearTimeout(redirectTimerRef.current);
-      }
-    };
-  }, []);
+    if (isAuthenticated) {
+      navigate('/dashboard');
+    }
+  }, [isAuthenticated, navigate]);
 
   const confirmPasswordError = useMemo(() => {
     if (fieldErrors.confirmPassword) {
@@ -143,16 +141,8 @@ export const SignupPage: React.FC = () => {
 
       try {
         await signupWithEmail(email.trim(), password);
-
-        setSubmitMessage({
-          type: 'info',
-          text: 'Account created! Please sign in.',
-        });
-
-        // Redirect to login after a short delay so the user can read the message.
-        redirectTimerRef.current = window.setTimeout(() => {
-          navigate('/login');
-        }, REDIRECT_DELAY_MS);
+        // Auto-login is handled by signupWithEmail — the useEffect above
+        // will redirect to /dashboard once isAuthenticated becomes true.
       } catch (err) {
         setSubmitMessage({
           type: 'error',

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -7,29 +7,36 @@ import react from '@vitejs/plugin-react';
 import { defineConfig, type Plugin } from 'vite';
 
 /**
- * Vite plugin that copies sql.js WASM binary to the public assets directory.
+ * Vite plugin that copies sql.js WASM binaries to the public assets directory.
  *
  * sql.js uses `locateFile` to fetch its WASM binary at runtime via a network
  * request. The binary must be served as a static asset at the path specified
- * in `initIndexedDbBackend()` (`/assets/sql-wasm/sql-wasm.wasm`).
+ * in `initIndexedDbBackend()` (`/assets/sql-wasm/<file>`).
+ *
+ * The browser build of sql.js (used by Vite's pre-bundler) requests
+ * `sql-wasm-browser.wasm`, while the generic build requests `sql-wasm.wasm`.
+ * We copy both to handle either resolution path.
  */
 function copySqlJsWasm(): Plugin {
-  const srcPath = resolve(__dirname, '../../node_modules/sql.js/dist/sql-wasm.wasm');
+  const srcDir = resolve(__dirname, '../../node_modules/sql.js/dist');
   const destDir = resolve(__dirname, 'public/assets/sql-wasm');
-  const destPath = resolve(destDir, 'sql-wasm.wasm');
+  const wasmFiles = ['sql-wasm.wasm', 'sql-wasm-browser.wasm'];
 
   return {
     name: 'copy-sql-js-wasm',
     buildStart() {
-      if (!existsSync(srcPath)) {
-        this.warn('sql.js WASM binary not found — IndexedDB fallback will fail at runtime.');
-        return;
-      }
       if (!existsSync(destDir)) {
         mkdirSync(destDir, { recursive: true });
       }
-      if (!existsSync(destPath)) {
-        copyFileSync(srcPath, destPath);
+      for (const file of wasmFiles) {
+        const src = resolve(srcDir, file);
+        const dest = resolve(destDir, file);
+        if (existsSync(src) && !existsSync(dest)) {
+          copyFileSync(src, dest);
+        }
+      }
+      if (!wasmFiles.some((f) => existsSync(resolve(srcDir, f)))) {
+        this.warn('sql.js WASM binaries not found — IndexedDB fallback will fail at runtime.');
       }
     },
   };
@@ -107,7 +114,7 @@ export default defineConfig({
       // Strict CSP - no inline scripts, no eval
       'Content-Security-Policy': [
         "default-src 'self'",
-        "script-src 'self' 'unsafe-inline'",
+        "script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'",
         "style-src 'self' 'unsafe-inline'",
         "img-src 'self' data: blob:",
         "font-src 'self'",
@@ -119,6 +126,8 @@ export default defineConfig({
       'X-Content-Type-Options': 'nosniff',
       'X-Frame-Options': 'DENY',
       'Referrer-Policy': 'strict-origin-when-cross-origin',
+      // Allow service worker registered from /src/sw/ to control the entire app
+      'Service-Worker-Allowed': '/',
     },
   },
 });


### PR DESCRIPTION
## Summary

Fixes multiple runtime issues discovered during local E2E testing of the web alpha:

1. **WASM binary not found** — Vite's pre-bundled sql.js requests \sql-wasm-browser.wasm\, but the copy plugin only provided \sql-wasm.wasm\. Added both filenames.
2. **CSP blocking WebAssembly** — Added \'wasm-unsafe-eval'\ to \script-src\ Content Security Policy.
3. **Service Worker scope error** — Added \Service-Worker-Allowed: '/'\ response header.
4. **SQLite rollback masking errors** — Wrapped explicit ROLLBACK in try/catch so the original error propagates when SQLite auto-rolls back.
5. **Auto-login after signup** — \signupWithEmail\ now auto-logs in after registration (both demo and real auth paths). SignupPage redirects to dashboard on authentication.

## Changes

- \pps/web/vite.config.ts\ — copy both WASM files, CSP fix, SW header
- \pps/web/src/db/seed.ts\ — safe ROLLBACK in catch block
- \pps/web/src/db/sqlite-wasm.ts\ — safe ROLLBACK in migration runner
- \pps/web/src/auth/auth-context.tsx\ — auto-login after signup
- \pps/web/src/pages/SignupPage.tsx\ — redirect to dashboard on auth
- \pps/web/src/pages/SignupPage.test.tsx\ — updated tests

## Testing

- [x] All 15 auth tests pass (5 LoginPage + 10 SignupPage)
- [x] Prettier format check clean
- [x] ESLint zero warnings

## Issues

Closes #1438
Refs #1436