### PR TITLE
fix(ios): prevent auth screens when authenticated (#1489)

### DIFF
--- a/apps/ios/Finance/ContentView.swift
+++ b/apps/ios/Finance/ContentView.swift
@@ -1,14 +1,25 @@
 // SPDX-License-Identifier: BUSL-1.1
+import os
 import SwiftUI
 
-/// Root view of the Finance application.
+/// Root view of the Finance application (authenticated shell).
 ///
 /// Hosts the `MainTabView` and injects infrastructure services
 /// (deep linking, network monitoring) into the SwiftUI environment
 /// for consumption by child views.
+///
+/// This view is ONLY shown when the user is authenticated. The
+/// ``AuthGateView`` ensures unauthenticated users never reach this view.
+/// Deep links targeting auth screens are intercepted and redirected to
+/// the dashboard. (#1489)
 struct ContentView: View {
     @Bindable var deepLinkHandler: DeepLinkHandler
     @State var networkMonitor: NetworkMonitor
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
+        category: "ContentView"
+    )
 
     init(
         deepLinkHandler: DeepLinkHandler = DeepLinkHandler(),
@@ -24,6 +35,15 @@ struct ContentView: View {
         )
         .environment(networkMonitor)
         .environment(deepLinkHandler)
+        .onChange(of: deepLinkHandler.currentDeepLink) { _, newLink in
+            guard let newLink else { return }
+            // Redirect auth deep links — user is already authenticated (#1489)
+            if case .authCallback = newLink {
+                Self.logger.info("Auth deep link received while authenticated — redirecting to dashboard")
+                deepLinkHandler.completeAuthCallback()
+                deepLinkHandler.selectedTab = .dashboard
+            }
+        }
     }
 }
 

--- a/apps/ios/Finance/Screens/AuthGateView.swift
+++ b/apps/ios/Finance/Screens/AuthGateView.swift
@@ -8,7 +8,10 @@
 // This view sits between the app entry point and ContentView, ensuring
 // all data views have a valid auth context.
 //
-// References: #650
+// Prevents authenticated users from ever seeing login/signup screens (#1489).
+// Deep links targeting auth screens while authenticated are redirected to main.
+//
+// References: #650, #1489
 
 import os
 import SwiftUI
@@ -20,12 +23,20 @@ import SwiftUI
 /// On launch, checks for an existing Keychain session. If found, refreshes
 /// the token and proceeds to the main app. If not, shows ``LoginView``.
 ///
+/// The view uses a splash/loading state to prevent any flash of the login
+/// screen during session restoration. Only transitions to auth or main
+/// content AFTER the auth state is definitively known.
+///
 /// Auth tokens are always stored in the Keychain — never in UserDefaults.
 struct AuthGateView: View {
 
     @State private var authService: AuthenticationService
     @Bindable var deepLinkHandler: DeepLinkHandler
     @State var networkMonitor: NetworkMonitor
+
+    /// Tracks whether the initial session check has completed to prevent
+    /// showing login UI before we know the definitive auth state.
+    @State private var hasCompletedInitialCheck = false
 
     private static let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
@@ -43,41 +54,105 @@ struct AuthGateView: View {
     }
 
     var body: some View {
-        Group {
-            switch authService.state {
-            case .loading:
-                loadingView
+        ZStack {
+            switch resolvedState {
+            case .splash:
+                splashView
+                    .transition(.opacity)
             case .authenticated:
                 ContentView(
                     deepLinkHandler: deepLinkHandler,
                     networkMonitor: networkMonitor
                 )
                 .environment(authService)
-            case .unauthenticated, .error:
+                .transition(.opacity)
+            case .unauthenticated:
                 LoginView()
                     .environment(authService)
+                    .transition(.opacity)
             }
         }
+        .animation(.easeInOut(duration: 0.3), value: resolvedState)
         .task {
             await authService.checkExistingSession()
+            hasCompletedInitialCheck = true
+            Self.logger.info("Initial session check complete, state: \(String(describing: authService.state))")
+        }
+        .onChange(of: authService.isAuthenticated) { _, isAuthenticated in
+            if isAuthenticated {
+                redirectAuthDeepLinks()
+            }
         }
     }
 
-    // MARK: - Loading View
+    // MARK: - Resolved State
+
+    /// The definitive view state, ensuring we never show login UI before
+    /// the auth session check completes.
+    private var resolvedState: ResolvedAuthState {
+        // Always show splash until initial check completes — prevents flash of login
+        guard hasCompletedInitialCheck else {
+            return .splash
+        }
+
+        switch authService.state {
+        case .loading:
+            return .splash
+        case .authenticated:
+            return .authenticated
+        case .unauthenticated, .error:
+            return .unauthenticated
+        }
+    }
+
+    // MARK: - Deep Link Auth Redirect
+
+    /// Redirects auth-related deep links to the main app when authenticated.
+    ///
+    /// If the user is authenticated and a deep link targets an auth screen
+    /// (e.g. `/auth/callback`), we consume it and redirect to dashboard.
+    private func redirectAuthDeepLinks() {
+        if case .authCallback = deepLinkHandler.currentDeepLink {
+            Self.logger.info("Redirecting auth deep link — user already authenticated")
+            deepLinkHandler.completeAuthCallback()
+            deepLinkHandler.selectedTab = .dashboard
+        }
+    }
+
+    // MARK: - Splash View
 
     @ViewBuilder
-    private var loadingView: some View {
-        VStack(spacing: 16) {
+    private var splashView: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "banknote")
+                .font(.system(size: 60))
+                .foregroundStyle(.tint)
+                .accessibilityHidden(true)
+
             ProgressView()
-                .scaleEffect(1.5)
-            Text(String(localized: "Checking session..."))
+                .controlSize(.regular)
+
+            Text(String(localized: "Loading..."))
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(.systemBackground))
         .accessibilityElement(children: .combine)
-        .accessibilityLabel(String(localized: "Checking your authentication session"))
+        .accessibilityLabel(String(localized: "Finance is loading, please wait"))
     }
+}
+
+// MARK: - ResolvedAuthState
+
+/// Internal state enum for the auth gate view transitions.
+///
+/// Separates the concept of "still determining auth" (splash) from
+/// the service's `.loading` state to prevent flash of login screen.
+private enum ResolvedAuthState: Equatable {
+    case splash
+    case authenticated
+    case unauthenticated
 }
 
 #Preview("Authenticated") {


### PR DESCRIPTION
## Summary

Fixes iOS app to never show login/signup screens when user is already authenticated.

## Changes

- Add splash/loading state during auth session restoration (no flash of login screen)
- Rewrite AuthGateView with ResolvedAuthState enum state machine
- Add smooth opacity transitions between auth states
- Intercept auth deep links while authenticated and redirect to dashboard
- Add structured os.Logger logging

## Issues

Closes #1489