### PR TITLE
fix(web): add missing routes, auth guards, and sidebar improvements

### DIFF
--- a/apps/web/e2e/responsive.spec.ts
+++ b/apps/web/e2e/responsive.spec.ts
@@ -143,8 +143,8 @@ test.describe('Mobile viewport (375px)', () => {
     const bottomNav = page.locator('nav.bottom-nav');
     const navButtons = bottomNav.getByRole('button');
 
-    // Expect the 7 nav items: Dashboard, Accounts, Transactions, Budgets, Goals, Investments, Bills
-    await expect(navButtons).toHaveCount(7);
+    // Expect the 5 primary nav items for mobile: Dashboard, Accounts, Transactions, Budgets, Goals
+    await expect(navButtons).toHaveCount(5);
   });
 
   test('form dialog is full-screen on small mobile', async ({ authenticatedPage: page }) => {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -14,16 +14,31 @@ const PAGE_TITLES: Record<string, string> = {
   '/transactions': 'Transactions',
   '/budgets': 'Budgets',
   '/goals': 'Goals',
+  '/insights': 'Insights',
+  '/household': 'Household',
+  '/investments': 'Investments',
+  '/bills': 'Bills',
+  '/report-builder': 'Report Builder',
+  '/achievements': 'Achievements',
+  '/watchlists': 'Watchlists',
   '/settings': 'Settings',
 };
 
 /** Routes that are wrapped in AppLayout (authenticated main app pages). */
 const AUTHENTICATED_ROUTES = new Set([
+  '/',
   '/dashboard',
   '/accounts',
   '/transactions',
   '/budgets',
   '/goals',
+  '/insights',
+  '/household',
+  '/investments',
+  '/bills',
+  '/report-builder',
+  '/achievements',
+  '/watchlists',
   '/settings',
 ]);
 

--- a/apps/web/src/components/layout/AppLayout.test.tsx
+++ b/apps/web/src/components/layout/AppLayout.test.tsx
@@ -11,6 +11,16 @@ vi.mock('../../accessibility/CognitiveAccessibilityProvider', () => ({
   SIMPLIFIED_NAV_PATHS: new Set(['/', '/dashboard', '/transactions', '/budgets', '/settings']),
 }));
 
+vi.mock('../../auth/auth-context', () => ({
+  useAuth: () => ({
+    isAuthenticated: true,
+    isLoading: false,
+    user: { id: 'test-user', email: 'test@example.com', hasPasskey: false },
+    error: null,
+    logout: vi.fn(),
+  }),
+}));
+
 vi.mock('../../hooks', () => ({
   useKeyboardShortcuts: vi.fn(),
 }));

--- a/apps/web/src/components/layout/Navigation.test.tsx
+++ b/apps/web/src/components/layout/Navigation.test.tsx
@@ -11,25 +11,35 @@ vi.mock('../../accessibility/CognitiveAccessibilityProvider', () => ({
   SIMPLIFIED_NAV_PATHS: new Set(['/', '/dashboard', '/transactions', '/budgets', '/settings']),
 }));
 
+vi.mock('../../auth/auth-context', () => ({
+  useAuth: () => ({
+    isAuthenticated: true,
+    isLoading: false,
+    user: { id: 'test-user', email: 'test@example.com', hasPasskey: false },
+    error: null,
+    logout: vi.fn(),
+  }),
+}));
+
 import { BottomNavigation, SidebarNavigation, NAV_ITEMS } from './Navigation';
 
 describe('BottomNavigation', () => {
   const defaultProps = {
-    activePath: '/',
+    activePath: '/dashboard',
     onNavigate: vi.fn(),
   };
 
-  it('renders 7 navigation items', () => {
+  it('renders 5 navigation items for mobile', () => {
     render(<BottomNavigation {...defaultProps} />);
 
     const buttons = screen.getAllByRole('button');
-    expect(buttons).toHaveLength(7);
+    expect(buttons).toHaveLength(5);
   });
 
-  it('renders all expected nav item labels', () => {
+  it('renders the first 5 expected nav item labels', () => {
     render(<BottomNavigation {...defaultProps} />);
 
-    for (const item of NAV_ITEMS) {
+    for (const item of NAV_ITEMS.slice(0, 5)) {
       expect(screen.getByRole('button', { name: item.label })).toBeInTheDocument();
     }
   });
@@ -71,7 +81,7 @@ describe('BottomNavigation', () => {
 
 describe('SidebarNavigation', () => {
   const defaultProps = {
-    activePath: '/',
+    activePath: '/dashboard',
     onNavigate: vi.fn(),
   };
 
@@ -169,8 +179,20 @@ describe('SidebarNavigation', () => {
   it('renders nav items in a list', () => {
     render(<SidebarNavigation {...defaultProps} />);
 
-    const list = screen.getByRole('list');
-    const listItems = within(list).getAllByRole('listitem');
+    const lists = screen.getAllByRole('list');
+    const listItems = within(lists[0]).getAllByRole('listitem');
     expect(listItems).toHaveLength(NAV_ITEMS.length);
+  });
+
+  it('renders a Sign Out button', () => {
+    render(<SidebarNavigation {...defaultProps} />);
+
+    expect(screen.getByRole('button', { name: 'Sign out' })).toBeInTheDocument();
+  });
+
+  it('renders a More toggle button', () => {
+    render(<SidebarNavigation {...defaultProps} />);
+
+    expect(screen.getByRole('button', { name: /More/ })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/layout/Navigation.tsx
+++ b/apps/web/src/components/layout/Navigation.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import React from 'react';
+import React, { useState } from 'react';
+import { useAuth } from '../../auth/auth-context';
 
 export interface NavItem {
   path: string;
@@ -8,12 +9,13 @@ export interface NavItem {
   icon: React.ReactNode;
 }
 
+/** Primary navigation items shown in the main nav section. */
 export const NAV_ITEMS: NavItem[] = [
   {
-    path: '/',
+    path: '/dashboard',
     label: 'Dashboard',
     icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true">
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
         <path d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-4 0a1 1 0 01-1-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 01-1 1h-2z" />
       </svg>
     ),
@@ -22,7 +24,7 @@ export const NAV_ITEMS: NavItem[] = [
     path: '/accounts',
     label: 'Accounts',
     icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true">
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
         <path d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" />
       </svg>
     ),
@@ -31,7 +33,7 @@ export const NAV_ITEMS: NavItem[] = [
     path: '/transactions',
     label: 'Transactions',
     icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true">
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
         <path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
       </svg>
     ),
@@ -40,7 +42,7 @@ export const NAV_ITEMS: NavItem[] = [
     path: '/budgets',
     label: 'Budgets',
     icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true">
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
         <path d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17" />
       </svg>
     ),
@@ -49,7 +51,7 @@ export const NAV_ITEMS: NavItem[] = [
     path: '/goals',
     label: 'Goals',
     icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true">
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
         <path d="M13 10V3L4 14h7v7l9-11h-7z" />
       </svg>
     ),
@@ -58,7 +60,7 @@ export const NAV_ITEMS: NavItem[] = [
     path: '/investments',
     label: 'Investments',
     icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true">
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
         <path d="M3 17l6-6 4 4 8-8" />
         <path d="M17 7h4v4" />
       </svg>
@@ -68,10 +70,60 @@ export const NAV_ITEMS: NavItem[] = [
     path: '/bills',
     label: 'Bills',
     icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true">
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
         <path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2" />
         <path d="M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
         <path d="M9 14l2 2 4-4" />
+      </svg>
+    ),
+  },
+  {
+    path: '/insights',
+    label: 'Insights',
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+      </svg>
+    ),
+  },
+  {
+    path: '/household',
+    label: 'Household',
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+      </svg>
+    ),
+  },
+];
+
+/** Secondary navigation items shown in a collapsible "More" section. */
+export const MORE_NAV_ITEMS: NavItem[] = [
+  {
+    path: '/report-builder',
+    label: 'Report Builder',
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path d="M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+      </svg>
+    ),
+  },
+  {
+    path: '/achievements',
+    label: 'Achievements',
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
+      </svg>
+    ),
+  },
+  {
+    path: '/watchlists',
+    label: 'Watchlists',
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+        <path d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
       </svg>
     ),
   },
@@ -83,9 +135,10 @@ export interface NavigationProps {
   onOpenShortcuts?: () => void;
 }
 
+/** Bottom navigation for mobile viewports. */
 export const BottomNavigation: React.FC<NavigationProps> = ({ activePath, onNavigate }) => (
   <nav className="bottom-nav" aria-label="Main navigation">
-    {NAV_ITEMS.map((item) => {
+    {NAV_ITEMS.slice(0, 5).map((item) => {
       const isActive = activePath === item.path;
       return (
         <button
@@ -104,38 +157,101 @@ export const BottomNavigation: React.FC<NavigationProps> = ({ activePath, onNavi
   </nav>
 );
 
+/** Sidebar navigation for desktop viewports with pinned footer. */
 export const SidebarNavigation: React.FC<NavigationProps> = ({
   activePath,
   onNavigate,
   onOpenShortcuts,
 }) => {
+  const { logout } = useAuth();
+  const [moreExpanded, setMoreExpanded] = useState(false);
   const isSettingsActive = activePath === '/settings';
+
+  const handleSignOut = async () => {
+    await logout();
+  };
 
   return (
     <aside className="app-sidebar" aria-label="Main navigation">
       <div className="app-sidebar__header">
         <span className="app-sidebar__logo">Finance</span>
       </div>
-      <nav className="app-sidebar__nav" aria-label="Primary">
-        <ul className="sidebar-nav__list" role="list">
-          {NAV_ITEMS.map((item) => {
-            const isActive = activePath === item.path;
-            return (
-              <li key={item.path} role="listitem">
-                <button
-                  type="button"
-                  className={`sidebar-nav__item${isActive ? ' sidebar-nav__item--active' : ''}`}
-                  aria-current={isActive ? 'page' : undefined}
-                  onClick={() => onNavigate(item.path)}
-                >
-                  <span className="sidebar-nav__item-icon">{item.icon}</span>
-                  <span>{item.label}</span>
-                </button>
-              </li>
-            );
-          })}
-        </ul>
-      </nav>
+
+      {/* Scrollable navigation section */}
+      <div className="app-sidebar__scrollable">
+        <nav className="app-sidebar__nav" aria-label="Primary">
+          <ul className="sidebar-nav__list" role="list">
+            {NAV_ITEMS.map((item) => {
+              const isActive = activePath === item.path;
+              return (
+                <li key={item.path} role="listitem">
+                  <button
+                    type="button"
+                    className={`sidebar-nav__item${isActive ? ' sidebar-nav__item--active' : ''}`}
+                    aria-current={isActive ? 'page' : undefined}
+                    onClick={() => onNavigate(item.path)}
+                  >
+                    <span className="sidebar-nav__item-icon">{item.icon}</span>
+                    <span>{item.label}</span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </nav>
+
+        {/* Collapsible "More" section */}
+        <div className="app-sidebar__more">
+          <button
+            type="button"
+            className="sidebar-nav__item sidebar-nav__item--more-toggle"
+            aria-expanded={moreExpanded}
+            aria-controls="sidebar-more-section"
+            onClick={() => setMoreExpanded((prev) => !prev)}
+          >
+            <span className="sidebar-nav__item-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path d="M5 12h.01M12 12h.01M19 12h.01M6 12a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0z" />
+              </svg>
+            </span>
+            <span>More</span>
+            <span
+              className={`sidebar-nav__item-chevron${moreExpanded ? ' sidebar-nav__item-chevron--expanded' : ''}`}
+              aria-hidden="true"
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path d="M19 9l-7 7-7-7" />
+              </svg>
+            </span>
+          </button>
+          {moreExpanded && (
+            <ul
+              id="sidebar-more-section"
+              className="sidebar-nav__list sidebar-nav__list--nested"
+              role="list"
+            >
+              {MORE_NAV_ITEMS.map((item) => {
+                const isActive = activePath === item.path;
+                return (
+                  <li key={item.path} role="listitem">
+                    <button
+                      type="button"
+                      className={`sidebar-nav__item${isActive ? ' sidebar-nav__item--active' : ''}`}
+                      aria-current={isActive ? 'page' : undefined}
+                      onClick={() => onNavigate(item.path)}
+                    >
+                      <span className="sidebar-nav__item-icon">{item.icon}</span>
+                      <span>{item.label}</span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      {/* Pinned footer — always visible without scrolling */}
       <div className="app-sidebar__footer">
         {onOpenShortcuts ? (
           <button
@@ -159,7 +275,26 @@ export const SidebarNavigation: React.FC<NavigationProps> = ({
           aria-current={isSettingsActive ? 'page' : undefined}
           onClick={() => onNavigate('/settings')}
         >
+          <span className="sidebar-nav__item-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.573-1.066z" />
+              <path d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+            </svg>
+          </span>
           <span>Settings</span>
+        </button>
+        <button
+          type="button"
+          className="sidebar-nav__item sidebar-nav__item--sign-out"
+          onClick={handleSignOut}
+          aria-label="Sign out"
+        >
+          <span className="sidebar-nav__item-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+            </svg>
+          </span>
+          <span>Sign Out</span>
         </button>
       </div>
     </aside>

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -29,6 +29,8 @@ const Login = lazy(() => import('./pages/LoginPage'));
 const Signup = lazy(() => import('./pages/SignupPage'));
 const NotFound = lazy(() => import('./pages/NotFoundPage'));
 const Watchlists = lazy(() => import('./pages/WatchlistsPage'));
+const Household = lazy(() => import('./pages/HouseholdPage'));
+const ReportBuilder = lazy(() => import('./pages/ReportBuilderPage'));
 const Investments = lazy(() => import('./pages/InvestmentsPage'));
 const InvestmentDetail = lazy(() => import('./pages/InvestmentDetailPage'));
 const Bills = lazy(() => import('./pages/BillsPage'));
@@ -86,6 +88,24 @@ const RootRedirect: FC = () => {
 };
 
 /**
+ * Redirects authenticated users away from public-only routes (login, signup).
+ * If the user is already logged in, they are sent to the dashboard.
+ */
+const RedirectIfAuthenticated: FC<{ children: ReactNode }> = ({ children }) => {
+  const { isAuthenticated, isLoading } = useAuth();
+
+  if (isLoading) {
+    return <PageLoader />;
+  }
+
+  if (isAuthenticated) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  return <>{children}</>;
+};
+
+/**
  * Application route definitions.
  *
  * Route structure mirrors the mobile app tabs:
@@ -99,17 +119,21 @@ export const AppRoutes: FC = () => (
     <Route
       path="/login"
       element={
-        <RouteBoundary name="Login">
-          <Login />
-        </RouteBoundary>
+        <RedirectIfAuthenticated>
+          <RouteBoundary name="Login">
+            <Login />
+          </RouteBoundary>
+        </RedirectIfAuthenticated>
       }
     />
     <Route
       path="/signup"
       element={
-        <RouteBoundary name="Sign Up">
-          <Signup />
-        </RouteBoundary>
+        <RedirectIfAuthenticated>
+          <RouteBoundary name="Sign Up">
+            <Signup />
+          </RouteBoundary>
+        </RedirectIfAuthenticated>
       }
     />
 
@@ -219,6 +243,26 @@ export const AppRoutes: FC = () => (
         <AuthenticatedRoute>
           <RouteBoundary name="Insights">
             <Insights />
+          </RouteBoundary>
+        </AuthenticatedRoute>
+      }
+    />
+    <Route
+      path="/household"
+      element={
+        <AuthenticatedRoute>
+          <RouteBoundary name="Household">
+            <Household />
+          </RouteBoundary>
+        </AuthenticatedRoute>
+      }
+    />
+    <Route
+      path="/report-builder"
+      element={
+        <AuthenticatedRoute>
+          <RouteBoundary name="Report Builder">
+            <ReportBuilder />
           </RouteBoundary>
         </AuthenticatedRoute>
       }


### PR DESCRIPTION
## Summary

Fixes routing for all feature pages, adds auth guards for login/signup, and improves sidebar UX with pinned footer and sign-out button.

## Changes

- Fix dashboard nav link from \/\ to \/dashboard\ (eliminates redirect flash)
- Add \/\ to AUTHENTICATED_ROUTES so root renders with AppLayout before redirect
- Add \/insights\, \/household\, \/report-builder\, \/achievements\, \/watchlists\ to AUTHENTICATED_ROUTES
- Add route definitions for \/household\ and \/report-builder\ in routes.tsx
- Add nav items for Insights and Household in main nav
- Add collapsible More section with Report Builder, Achievements, Watchlists
- Redirect authenticated users away from \/login\ and \/signup\ via RedirectIfAuthenticated guard
- Pin Settings, Shortcuts, Sign Out to sidebar bottom (flex-shrink:0 footer)
- Add scrollable top section (flex-1, overflow-y:auto) for nav items
- Add Sign Out button with distinct styling calling \logout()\ from auth context

## Issues

Closes #1522
Closes #1508
Closes #1524
Closes #1482
Closes #1459
Closes #1440
Closes #1441