### PR TITLE
fix(web): CSP worker-src, bill creation, page errors, and export

### DIFF
--- a/apps/web/src/hooks/useBills.ts
+++ b/apps/web/src/hooks/useBills.ts
@@ -154,8 +154,14 @@ export function useBills(): UseBillsResult {
       const result = getAllBills(db);
       setBills(result);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load bills.');
-      setBills([]);
+      // If the table doesn't exist yet, treat it as empty (not an error).
+      const message = err instanceof Error ? err.message : '';
+      if (message.includes('no such table')) {
+        setBills([]);
+      } else {
+        setError(err instanceof Error ? err.message : 'Failed to load bills.');
+        setBills([]);
+      }
     } finally {
       setLoading(false);
     }

--- a/apps/web/src/hooks/useInvestments.ts
+++ b/apps/web/src/hooks/useInvestments.ts
@@ -124,8 +124,14 @@ export function useInvestments(): UseInvestmentsResult {
       const result = getAllInvestments(db);
       setInvestments(result);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load investments.');
-      setInvestments([]);
+      // If the table doesn't exist yet, treat it as empty (not an error).
+      const message = err instanceof Error ? err.message : '';
+      if (message.includes('no such table')) {
+        setInvestments([]);
+      } else {
+        setError(err instanceof Error ? err.message : 'Failed to load investments.');
+        setInvestments([]);
+      }
     } finally {
       setLoading(false);
     }

--- a/apps/web/src/pages/CreateBillPage.tsx
+++ b/apps/web/src/pages/CreateBillPage.tsx
@@ -8,9 +8,23 @@
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import { useDatabase } from '../db/DatabaseProvider';
+import { queryOne, type Row } from '../db/sqlite-wasm';
 import { useBills } from '../hooks';
 import type { BillFrequency } from '../kmp/bridge';
 import type { CreateBillInput } from '../db/repositories/bills';
+
+/** Resolve the first available household ID from the local database. */
+function getFirstHouseholdId(db: ReturnType<typeof useDatabase>): string | null {
+  const row = queryOne<Row>(
+    db,
+    'SELECT id FROM household WHERE deleted_at IS NULL ORDER BY created_at ASC LIMIT 1',
+  );
+  if (row && typeof row.id === 'string') {
+    return row.id;
+  }
+  return null;
+}
 
 /** Form validation error shape. */
 interface FormErrors {
@@ -52,6 +66,7 @@ function validate(fields: {
 /** Create bill page component. */
 export const CreateBillPage: React.FC = () => {
   const navigate = useNavigate();
+  const db = useDatabase();
   const { createBill } = useBills();
 
   const nameRef = useRef<HTMLInputElement>(null);
@@ -90,8 +105,15 @@ export const CreateBillPage: React.FC = () => {
       setSubmitting(true);
 
       try {
+        const householdId = getFirstHouseholdId(db);
+        if (!householdId) {
+          setSubmitError('No household found. Please create a household before adding bills.');
+          setSubmitting(false);
+          return;
+        }
+
         const input: CreateBillInput = {
-          householdId: crypto.randomUUID(), // TODO: derive from auth context
+          householdId,
           name: name.trim(),
           payee: payee.trim(),
           amount: { amount: Math.round(parseFloat(amount) * 100) },

--- a/apps/web/src/pages/TransactionsPage.tsx
+++ b/apps/web/src/pages/TransactionsPage.tsx
@@ -19,6 +19,50 @@ import type { Transaction } from '../kmp/bridge';
 
 const ALL_CATEGORIES_FILTER = '__all__';
 
+/** Escape a value for safe CSV inclusion. */
+function escapeCsvValue(value: string): string {
+  if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+/** Export transactions to CSV and trigger a browser download. */
+function exportTransactionsCsv(
+  transactions: Transaction[],
+  categoryNames: Map<string, string>,
+  accountNames: Map<string, string>,
+): void {
+  const headers = ['date', 'payee', 'amount', 'category', 'account', 'notes'];
+  const rows = transactions.map((t) => {
+    const amount = (t.type === 'EXPENSE' ? -Math.abs(t.amount.amount) : t.amount.amount) / 100;
+    return [
+      escapeCsvValue(t.date),
+      escapeCsvValue(t.payee ?? ''),
+      amount.toFixed(2),
+      escapeCsvValue(
+        t.categoryId ? (categoryNames.get(t.categoryId) ?? 'Uncategorized') : 'Uncategorized',
+      ),
+      escapeCsvValue(accountNames.get(t.accountId) ?? 'Unknown'),
+      escapeCsvValue(t.note ?? ''),
+    ].join(',');
+  });
+
+  const csv = [headers.join(','), ...rows].join('\n');
+  const blob = new Blob([csv], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = `transactions-${new Date().toISOString().slice(0, 10)}.csv`;
+  anchor.style.display = 'none';
+  document.body.appendChild(anchor);
+  anchor.click();
+  setTimeout(() => {
+    URL.revokeObjectURL(url);
+    document.body.removeChild(anchor);
+  }, 100);
+}
+
 function getTransactionDisplayAmount(transaction: Transaction): number {
   if (transaction.type === 'EXPENSE') {
     return -Math.abs(transaction.amount.amount);
@@ -195,6 +239,16 @@ export const TransactionsPage: React.FC = () => {
           style={{ marginRight: 'var(--spacing-2)' }}
         >
           <span aria-hidden="true">📥</span> Import CSV
+        </button>
+        <button
+          type="button"
+          className="add-button"
+          onClick={() => exportTransactionsCsv(transactions, categoryNames, accountNames)}
+          aria-label="Export transactions as CSV"
+          disabled={transactions.length === 0}
+          style={{ marginRight: 'var(--spacing-2)' }}
+        >
+          <span aria-hidden="true">📤</span> Export CSV
         </button>
         <button
           type="button"

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -119,6 +119,7 @@ export default defineConfig({
         "img-src 'self' data: blob:",
         "font-src 'self'",
         "connect-src 'self' ws://localhost:*",
+        "worker-src 'self' blob:",
         "frame-ancestors 'none'",
         "base-uri 'self'",
         "form-action 'self'",


### PR DESCRIPTION
## Summary

Fixes standalone web bugs: CSP directive, bill creation failure, page errors, and CSV export.

## Changes

- Add `worker-src 'self' blob:` directive to CSP in vite.config.ts
- Fix bill creation to derive householdId from user context (local DB query) instead of random UUID
- Fix Bills page error handling: treat missing table as empty state instead of error screen
- Fix Investments page error handling: treat missing table as empty state instead of error screen
- Add Export CSV button to TransactionsPage with browser download functionality

## Issues

Closes #1454
Closes #1507
Closes #1457
Closes #1456
Closes #1511