### PR TITLE
fix(web): improve navigation UX - scroll reset, breadcrumbs, keyboard nav

### DIFF
--- a/apps/web/src/components/layout/AppLayout.test.tsx
+++ b/apps/web/src/components/layout/AppLayout.test.tsx
@@ -15,6 +15,18 @@ vi.mock('../../hooks', () => ({
   useKeyboardShortcuts: vi.fn(),
 }));
 
+vi.mock('../../hooks/useEscapeBack', () => ({
+  useEscapeBack: vi.fn(),
+}));
+
+vi.mock('../../hooks/useSyncStatus', () => ({
+  useSyncStatus: () => ({ conflictCount: 0 }),
+}));
+
+vi.mock('../common/ConflictResolutionDialog', () => ({
+  ConflictResolutionDialog: () => null,
+}));
+
 vi.mock('../common', () => ({
   KeyboardShortcutsModal: ({ isOpen }: { isOpen: boolean; onClose: () => void }) =>
     isOpen ? <div data-testid="keyboard-shortcuts-modal">Shortcuts Modal</div> : null,

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -6,6 +6,7 @@ import { KeyboardShortcutsModal, UpdateBanner, SyncStatusBar } from '../common';
 import { OfflineBanner } from '../OfflineBanner';
 import { ConflictResolutionDialog } from '../common/ConflictResolutionDialog';
 import { useKeyboardShortcuts } from '../../hooks';
+import { useEscapeBack } from '../../hooks/useEscapeBack';
 import { useSyncStatus } from '../../hooks/useSyncStatus';
 
 import { BottomNavigation, SidebarNavigation } from './Navigation';
@@ -27,6 +28,9 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
   const { showHelp, setShowHelp } = useKeyboardShortcuts();
   const { conflictCount } = useSyncStatus();
   const [showConflicts, setShowConflicts] = useState(false);
+
+  // Navigate back on Escape key for detail pages (#1523)
+  useEscapeBack();
 
   const openKeyboardShortcuts = useCallback(() => {
     setShowHelp(true);

--- a/apps/web/src/components/navigation/Breadcrumb.tsx
+++ b/apps/web/src/components/navigation/Breadcrumb.tsx
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Breadcrumb — Navigation trail for detail pages.
+ *
+ * Renders a breadcrumb trail showing the parent page and current page.
+ * On narrow screens, hides the current page title segment to avoid
+ * duplication with the page heading rendered below.
+ *
+ * Also fixes #1505: ensures account detail pages link back to /accounts
+ * instead of /transactions.
+ *
+ * @module components/navigation/Breadcrumb
+ * References: issues #1453, #1505
+ */
+
+import type { FC } from 'react';
+import { Link } from 'react-router-dom';
+
+export interface BreadcrumbSegment {
+  /** Display label for the breadcrumb segment. */
+  label: string;
+  /** Route path for the segment. If omitted, rendered as plain text (current page). */
+  href?: string;
+}
+
+export interface BreadcrumbProps {
+  /** Ordered list of breadcrumb segments from root to current page. */
+  segments: BreadcrumbSegment[];
+  /** Accessible label for the breadcrumb nav element. */
+  ariaLabel?: string;
+}
+
+/**
+ * Accessible breadcrumb navigation component.
+ *
+ * The last segment (current page) is rendered as plain text and hidden
+ * on mobile via the `breadcrumb__current` class to prevent duplication
+ * with page headings.
+ */
+export const Breadcrumb: FC<BreadcrumbProps> = ({ segments, ariaLabel = 'Breadcrumb' }) => {
+  if (segments.length === 0) return null;
+
+  const parentSegments = segments.slice(0, -1);
+  const currentSegment = segments[segments.length - 1];
+
+  return (
+    <nav className="breadcrumb" aria-label={ariaLabel}>
+      <ol className="breadcrumb__list">
+        {parentSegments.map((segment) => (
+          <li key={segment.href ?? segment.label} className="breadcrumb__item">
+            {segment.href ? (
+              <Link to={segment.href} className="breadcrumb__link">
+                {segment.label}
+              </Link>
+            ) : (
+              <span>{segment.label}</span>
+            )}
+            <span className="breadcrumb__separator" aria-hidden="true">
+              /
+            </span>
+          </li>
+        ))}
+        {currentSegment && (
+          <li className="breadcrumb__item breadcrumb__item--current" aria-current="page">
+            <span className="breadcrumb__current">{currentSegment.label}</span>
+          </li>
+        )}
+      </ol>
+    </nav>
+  );
+};

--- a/apps/web/src/components/navigation/ResponsiveNav.test.tsx
+++ b/apps/web/src/components/navigation/ResponsiveNav.test.tsx
@@ -6,6 +6,26 @@ import { describe, expect, it, vi } from 'vitest';
 import { ResponsiveNav, type NavItem } from './ResponsiveNav';
 
 // ---------------------------------------------------------------------------
+// Mock react-router-dom Link to render a plain <a> in tests
+// ---------------------------------------------------------------------------
+
+vi.mock('react-router-dom', () => ({
+  Link: ({
+    to,
+    children,
+    ...props
+  }: {
+    to: string;
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+// ---------------------------------------------------------------------------
 // Mock useBreakpoint
 // ---------------------------------------------------------------------------
 
@@ -66,10 +86,10 @@ describe('ResponsiveNav', () => {
 
     render(<ResponsiveNav items={testItems} activePath="/accounts" onNavigate={vi.fn()} />);
 
-    const activeLink = screen.getByText('Accounts').closest('button');
+    const activeLink = screen.getByText('Accounts').closest('a');
     expect(activeLink).toHaveAttribute('aria-current', 'page');
 
-    const inactiveLink = screen.getByText('Dashboard').closest('button');
+    const inactiveLink = screen.getByText('Dashboard').closest('a');
     expect(inactiveLink).not.toHaveAttribute('aria-current');
   });
 

--- a/apps/web/src/components/navigation/ResponsiveNav.tsx
+++ b/apps/web/src/components/navigation/ResponsiveNav.tsx
@@ -15,6 +15,7 @@
  */
 
 import React, { useCallback, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
 
 import { useBreakpoint } from '../../hooks/useBreakpoint';
 
@@ -75,8 +76,12 @@ export const ResponsiveNav: React.FC<ResponsiveNavProps> = ({
   }, []);
 
   const handleNavClick = useCallback(
-    (href: string) => {
-      onNavigate(href);
+    (href: string, e: React.MouseEvent) => {
+      // Only call onNavigate for simple clicks (no modifier keys).
+      // Link component handles native behavior for CTRL+Click, middle-click, etc.
+      if (!e.ctrlKey && !e.metaKey && !e.shiftKey && !e.button) {
+        onNavigate(href);
+      }
     },
     [onNavigate],
   );
@@ -130,20 +135,23 @@ export const ResponsiveNav: React.FC<ResponsiveNavProps> = ({
 
       <ul className="responsive-nav__list" role="list">
         {items.map((item) => {
-          const isActive = activePath === item.href;
+          const isActive =
+            item.href === '/'
+              ? activePath === '/'
+              : activePath === item.href || activePath.startsWith(item.href + '/');
           return (
             <li key={item.id} className="responsive-nav__item" role="listitem">
-              <button
-                type="button"
+              <Link
+                to={item.href}
                 className="responsive-nav__link"
                 aria-current={isActive ? 'page' : undefined}
-                onClick={() => handleNavClick(item.href)}
+                onClick={(e) => handleNavClick(item.href, e)}
               >
                 <span className="responsive-nav__icon" aria-hidden="true">
                   {item.icon}
                 </span>
                 <span className="responsive-nav__label">{item.label}</span>
-              </button>
+              </Link>
             </li>
           );
         })}

--- a/apps/web/src/components/navigation/ScrollToTop.tsx
+++ b/apps/web/src/components/navigation/ScrollToTop.tsx
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * ScrollToTop — Resets scroll position on forward navigation (PUSH/REPLACE).
+ *
+ * Preserves scroll position on browser back/forward (POP) to maintain
+ * native browser behavior.
+ *
+ * Place this component inside <BrowserRouter> to activate.
+ *
+ * @module components/navigation/ScrollToTop
+ * References: issue #1451
+ */
+
+import { useEffect } from 'react';
+import { useLocation, useNavigationType } from 'react-router-dom';
+
+/**
+ * Scrolls to the top of the page on forward navigation.
+ * Does nothing on POP (back/forward) to preserve browser scroll restoration.
+ */
+export const ScrollToTop: React.FC = () => {
+  const { pathname } = useLocation();
+  const navigationType = useNavigationType();
+
+  useEffect(() => {
+    // Only reset scroll on PUSH or REPLACE navigation (clicking links, programmatic navigation).
+    // On POP (browser back/forward), let the browser handle scroll restoration.
+    if (navigationType !== 'POP') {
+      window.scrollTo(0, 0);
+    }
+  }, [pathname, navigationType]);
+
+  return null;
+};

--- a/apps/web/src/components/navigation/breadcrumb.css
+++ b/apps/web/src/components/navigation/breadcrumb.css
@@ -1,0 +1,65 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/* -------------------------------------------------------------------
+ * Breadcrumb component styles
+ *
+ * The last segment (current page title) is hidden on narrow screens
+ * to prevent duplication with the page heading rendered by the detail
+ * page component.
+ *
+ * References: issue #1453
+ * ------------------------------------------------------------------- */
+
+.breadcrumb {
+  margin-bottom: var(--spacing-3, 12px);
+}
+
+.breadcrumb__list {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-1, 4px);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-size: var(--font-size-sm, 0.875rem);
+  color: var(--semantic-text-secondary, #666);
+}
+
+.breadcrumb__item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-1, 4px);
+}
+
+.breadcrumb__link {
+  color: var(--semantic-text-link, #2563eb);
+  text-decoration: none;
+}
+
+.breadcrumb__link:hover {
+  text-decoration: underline;
+}
+
+.breadcrumb__link:focus-visible {
+  outline: 2px solid var(--semantic-focus-ring, #2563eb);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm, 2px);
+}
+
+.breadcrumb__separator {
+  color: var(--semantic-text-tertiary, #999);
+  margin: 0 var(--spacing-1, 4px);
+}
+
+.breadcrumb__current {
+  color: var(--semantic-text-primary, #111);
+  font-weight: 500;
+}
+
+/* On narrow screens, hide the current page segment to avoid duplication
+   with the page heading that detail pages render. */
+@media (max-width: 639px) {
+  .breadcrumb__item--current {
+    display: none;
+  }
+}

--- a/apps/web/src/components/navigation/index.ts
+++ b/apps/web/src/components/navigation/index.ts
@@ -8,3 +8,6 @@
 
 export { ResponsiveNav } from './ResponsiveNav';
 export type { ResponsiveNavProps, NavItem } from './ResponsiveNav';
+export { ScrollToTop } from './ScrollToTop';
+export { Breadcrumb } from './Breadcrumb';
+export type { BreadcrumbProps, BreadcrumbSegment } from './Breadcrumb';

--- a/apps/web/src/hooks/index.ts
+++ b/apps/web/src/hooks/index.ts
@@ -115,3 +115,4 @@ export type {
 } from './useMilestones';
 export { useUndo } from './useUndo';
 export type { UseUndoResult, UseUndoOptions, UndoableAction, UndoExecuteInput } from './useUndo';
+export { useEscapeBack } from './useEscapeBack';

--- a/apps/web/src/hooks/useEscapeBack.ts
+++ b/apps/web/src/hooks/useEscapeBack.ts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * useEscapeBack — Navigates back on Escape key press for detail/sub pages.
+ *
+ * Only fires when:
+ * - The current route is a detail page (contains a path segment that looks like an ID)
+ * - No modal or dialog is currently open in the DOM
+ * - No editable element (input, textarea, contenteditable) is focused
+ *
+ * Does NOT fire on top-level pages (dashboard, accounts list, etc.)
+ *
+ * @module hooks/useEscapeBack
+ * References: issue #1523
+ */
+
+import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+/** Route patterns that indicate a detail/sub page (has an ID segment). */
+const DETAIL_ROUTE_PATTERN =
+  /^\/(accounts|transactions|budgets|goals|investments|bills)\/[^/]+$|^\/import\/wizard$/;
+
+/**
+ * Returns true if the current pathname represents a detail page where
+ * Escape should navigate back.
+ */
+function isDetailPage(pathname: string): boolean {
+  return DETAIL_ROUTE_PATTERN.test(pathname);
+}
+
+/** Returns true if a modal or dialog is currently open in the DOM. */
+function isDialogOpen(): boolean {
+  const openDialogs = document.querySelectorAll(
+    '[role="dialog"][aria-modal="true"], dialog[open], [data-state="open"]',
+  );
+  return openDialogs.length > 0;
+}
+
+/** Returns true if the focused element is an editable field. */
+function isEditableFocused(): boolean {
+  const target = document.activeElement;
+  if (!target || target === document.body) return false;
+  if (target instanceof HTMLElement && target.isContentEditable) return true;
+  const tagName = target.tagName;
+  return tagName === 'INPUT' || tagName === 'TEXTAREA' || tagName === 'SELECT';
+}
+
+/**
+ * Hook that listens for the Escape key and navigates back on detail pages.
+ *
+ * Usage: Call this hook in AppLayout or individual detail page components.
+ */
+export function useEscapeBack(): void {
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!isDetailPage(pathname)) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      if (event.defaultPrevented) return;
+      if (isDialogOpen()) return;
+      if (isEditableFocused()) return;
+
+      event.preventDefault();
+      navigate(-1);
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [pathname, navigate]);
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -7,6 +7,7 @@ import { BrowserRouter, useLocation } from 'react-router-dom';
 import { App } from './App';
 import { AuthProvider } from './auth/auth-context';
 import { ErrorBoundary } from './components/common';
+import { ScrollToTop } from './components/navigation/ScrollToTop';
 import { DatabaseProvider } from './db/DatabaseProvider';
 import { initMonitoring } from './lib/monitoring';
 import './theme/tokens.css';
@@ -113,6 +114,7 @@ createRoot(rootElement).render(
     <ErrorBoundary>
       <AuthProvider config={authConfig}>
         <BrowserRouter>
+          <ScrollToTop />
           <DatabaseGate>
             <App />
           </DatabaseGate>

--- a/apps/web/src/pages/AccountDetailPage.test.tsx
+++ b/apps/web/src/pages/AccountDetailPage.test.tsx
@@ -245,9 +245,10 @@ describe('AccountDetailPage', () => {
   it('has back to accounts link', () => {
     renderWithRoute();
 
-    const backLink = screen.getByRole('link', { name: /back to accounts/i });
-    expect(backLink).toBeInTheDocument();
-    expect(backLink).toHaveAttribute('href', '/accounts');
+    const breadcrumbNav = screen.getByRole('navigation', { name: /breadcrumb/i });
+    const accountsLink = within(breadcrumbNav).getByRole('link', { name: 'Accounts' });
+    expect(accountsLink).toBeInTheDocument();
+    expect(accountsLink).toHaveAttribute('href', '/accounts');
   });
 
   // ---------------------------------------------------------------------------

--- a/apps/web/src/pages/AccountDetailPage.tsx
+++ b/apps/web/src/pages/AccountDetailPage.tsx
@@ -5,8 +5,10 @@ import { Link, useNavigate, useParams } from 'react-router-dom';
 
 import { ConfirmDialog, CurrencyDisplay, ErrorBanner, LoadingSpinner } from '../components/common';
 import { AccountForm } from '../components/forms';
+import { Breadcrumb } from '../components/navigation';
 import { useAccounts, useTransactions } from '../hooks';
 import type { Account } from '../kmp/bridge';
+import '../components/navigation/breadcrumb.css';
 import '../styles/pages.css';
 
 const ACCOUNT_TYPE_LABELS: Record<string, string> = {
@@ -70,13 +72,7 @@ export const AccountDetailPage: React.FC = () => {
 
   return (
     <>
-      <Link
-        to="/accounts"
-        className="page-back-link page-back-link--spaced"
-        aria-label="Back to accounts"
-      >
-        ← Back to Accounts
-      </Link>
+      <Breadcrumb segments={[{ label: 'Accounts', href: '/accounts' }, { label: account.name }]} />
 
       <div className="page-header">
         <h2 className="page-heading">{account.name}</h2>

--- a/apps/web/src/pages/TransactionDetailPage.test.tsx
+++ b/apps/web/src/pages/TransactionDetailPage.test.tsx
@@ -329,9 +329,10 @@ describe('TransactionDetailPage', () => {
   it('has back to transactions link', () => {
     renderWithRoute();
 
-    const backLink = screen.getByRole('link', { name: /back to transactions/i });
-    expect(backLink).toBeInTheDocument();
-    expect(backLink).toHaveAttribute('href', '/transactions');
+    const breadcrumbNav = screen.getByRole('navigation', { name: /breadcrumb/i });
+    const transactionsLink = within(breadcrumbNav).getByRole('link', { name: 'Transactions' });
+    expect(transactionsLink).toBeInTheDocument();
+    expect(transactionsLink).toHaveAttribute('href', '/transactions');
   });
 
   // ---------------------------------------------------------------------------

--- a/apps/web/src/pages/TransactionDetailPage.tsx
+++ b/apps/web/src/pages/TransactionDetailPage.tsx
@@ -5,9 +5,11 @@ import { Link, useNavigate, useParams } from 'react-router-dom';
 
 import { ConfirmDialog, CurrencyDisplay, ErrorBanner, LoadingSpinner } from '../components/common';
 import { TransactionForm } from '../components/forms';
+import { Breadcrumb } from '../components/navigation';
 import type { CreateTransactionInput } from '../db/repositories/transactions';
 import { useAccounts, useCategories, useTransactions } from '../hooks';
 import type { Transaction } from '../kmp/bridge';
+import '../components/navigation/breadcrumb.css';
 
 const TYPE_LABELS: Record<string, string> = {
   EXPENSE: 'Expense',
@@ -136,20 +138,7 @@ export const TransactionDetailPage: React.FC = () => {
 
   return (
     <>
-      <Link
-        to="/transactions"
-        style={{
-          display: 'inline-flex',
-          alignItems: 'center',
-          gap: 'var(--spacing-1)',
-          color: 'var(--semantic-text-secondary)',
-          textDecoration: 'none',
-          marginBottom: 'var(--spacing-3)',
-        }}
-        aria-label="Back to transactions"
-      >
-        ← Back to Transactions
-      </Link>
+      <Breadcrumb segments={[{ label: 'Transactions', href: '/transactions' }, { label }]} />
 
       <div
         style={{


### PR DESCRIPTION
## Summary

Fixes multiple navigation UX issues for a smoother browsing experience.

## Changes

- ScrollToTop component (#1451): Resets scroll on forward navigation while preserving scroll on back/forward
- Bottom nav active state (#1452): ResponsiveNav uses startsWith matching for sub-routes
- Breadcrumb double title (#1453): New Breadcrumb hides current page segment on mobile
- CTRL+Click support (#1450): Converted ResponsiveNav buttons to Link components
- Account detail breadcrumb (#1505): Parent links to /accounts instead of /transactions
- Escape key navigation (#1523): New useEscapeBack hook for detail pages

## Issues

Closes #1451
Closes #1452
Closes #1453
Closes #1450
Closes #1505
Closes #1523