### PR TITLE
fix(windows): add auth guard and budget/goal edit/delete

### DIFF
--- a/apps/windows/src/main/kotlin/com/finance/desktop/FinanceApp.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/FinanceApp.kt
@@ -3,15 +3,23 @@
 package com.finance.desktop
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
 import com.finance.desktop.components.ShortcutHandler
 import com.finance.desktop.di.koinGet
 import com.finance.desktop.navigation.Screen
@@ -39,6 +47,7 @@ import com.finance.desktop.tray.FinanceSystemTray
 import com.finance.desktop.tray.QuickAddTransactionManager
 import com.finance.desktop.screens.auth.LoginScreen
 import com.finance.desktop.screens.gdpr.GdprConsentDialog
+import com.finance.desktop.data.repository.AuthRepository
 import com.finance.desktop.viewmodel.AuthViewModel
 import com.finance.desktop.viewmodel.GdprConsentViewModel
 
@@ -52,13 +61,24 @@ import com.finance.desktop.viewmodel.GdprConsentViewModel
  * entry (activated via Ctrl+Shift+V). The [QuickAddTransactionDialog] is
  * triggered from the system tray context menu.
  *
+ * ## Authentication Guard
+ *
+ * The auth guard ensures that authenticated users never see login/signup
+ * screens. During startup a splash/loading screen is shown while the auth
+ * state resolves, preventing any flash of the login screen. If a deep link
+ * points to login/signup while authenticated, the user is redirected to the
+ * dashboard.
+ *
  * ## Authentication Flow
  *
- * 1. [AuthViewModel] checks Windows Hello availability and stored credentials
- * 2. If authentication is required, [LockScreen] is shown
- * 3. User authenticates via Windows Hello (biometric → PIN fallback)
- * 4. On success, the main app content is rendered
- * 5. Auto-lock returns to the lock screen after inactivity
+ * 1. Show loading splash while auth state resolves
+ * 2. [AuthViewModel] checks Windows Hello availability and stored credentials
+ * 3. [AuthRepository.isAuthenticated] is consulted for session-level auth
+ * 4. If authenticated (session or Windows Hello), go directly to dashboard
+ * 5. If authentication is required, [LockScreen] is shown
+ * 6. User authenticates via Windows Hello (biometric → PIN fallback)
+ * 7. On success, the main app content is rendered
+ * 8. Auto-lock returns to the lock screen after inactivity
  *
  * @param shortcutHandler The [ShortcutHandler] wired to the application
  *   window's [onPreviewKeyEvent], enabling Ctrl+1 through Ctrl+8 shortcuts.
@@ -74,6 +94,8 @@ fun FinanceApp(
 ) {
     val authViewModel = koinGet<AuthViewModel>()
     val authState by authViewModel.uiState.collectAsState()
+    val authRepository = koinGet<AuthRepository>()
+    val sessionAuthenticated by authRepository.isAuthenticated.collectAsState()
     val gdprViewModel = koinGet<GdprConsentViewModel>()
     val gdprState by gdprViewModel.uiState.collectAsState()
 
@@ -84,6 +106,13 @@ fun FinanceApp(
                 .semantics { contentDescription = "Finance application" },
             color = MaterialTheme.colorScheme.background,
         ) {
+            // ── Layer 0: Splash screen while auth state resolves ──
+            // Prevents flash of login screen during startup
+            if (authState.isAuthenticating && !authState.isAuthenticated && !sessionAuthenticated) {
+                SplashLoadingScreen()
+                return@Surface
+            }
+
             // ── Layer 1: GDPR consent dialog (first run) ──
             if (gdprState.showConsentDialog) {
                 GdprConsentDialog(
@@ -96,8 +125,12 @@ fun FinanceApp(
                 return@Surface
             }
 
-            // ── Layer 2: Auth gate ──
-            if (authState.requiresAuth && !authState.isAuthenticated) {
+            // ── Auth Guard: If user has an active session, always show main app ──
+            // This ensures deep links to login/signup are redirected to dashboard
+            val isFullyAuthenticated = authState.isAuthenticated || sessionAuthenticated
+
+            if (!isFullyAuthenticated && authState.requiresAuth) {
+                // ── Layer 2: Auth gate — only shown when NOT authenticated ──
                 if (authState.isWindowsHelloAvailable) {
                     // Windows Hello lock screen
                     LockScreen(
@@ -151,6 +184,35 @@ fun FinanceApp(
                     )
                 }
             }
+        }
+    }
+}
+
+/**
+ * Splash/loading screen shown during auth state resolution.
+ *
+ * Prevents any flash of login/signup screens while the auth system
+ * determines whether the user has an active session.
+ */
+@Composable
+private fun SplashLoadingScreen() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .semantics { contentDescription = "Loading Finance application" },
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(48.dp),
+                color = MaterialTheme.colorScheme.primary,
+            )
+            Spacer(Modifier.height(16.dp))
+            Text(
+                text = "Finance",
+                style = MaterialTheme.typography.headlineMedium,
+                color = MaterialTheme.colorScheme.onBackground,
+            )
         }
     }
 }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/BudgetRepository.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/BudgetRepository.kt
@@ -10,5 +10,6 @@ interface BudgetRepository {
     fun observeAll(householdId: SyncId): Flow<List<Budget>>
     fun observeActive(householdId: SyncId): Flow<List<Budget>>
     suspend fun insert(entity: Budget)
+    suspend fun update(entity: Budget)
     suspend fun delete(id: SyncId)
 }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/GoalRepository.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/GoalRepository.kt
@@ -11,4 +11,7 @@ interface GoalRepository {
     fun observeAll(householdId: SyncId): Flow<List<Goal>>
     fun observeActive(householdId: SyncId): Flow<List<Goal>>
     suspend fun updateProgress(id: SyncId, currentAmount: Cents)
+    suspend fun insert(entity: Goal)
+    suspend fun update(entity: Goal)
+    suspend fun delete(id: SyncId)
 }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/impl/InMemoryBudgetRepository.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/impl/InMemoryBudgetRepository.kt
@@ -13,6 +13,7 @@ class InMemoryBudgetRepository : BudgetRepository {
     override fun observeAll(householdId: SyncId) = store.map { it.filter { b -> b.deletedAt == null } }
     override fun observeActive(householdId: SyncId) = observeAll(householdId)
     override suspend fun insert(entity: Budget) { store.update { it + entity } }
+    override suspend fun update(entity: Budget) { val now = Clock.System.now(); store.update { l -> l.map { if (it.id == entity.id) entity.copy(updatedAt = now) else it } } }
     override suspend fun delete(id: SyncId) { val now = Clock.System.now(); store.update { l -> l.map { if (it.id == id) it.copy(deletedAt = now) else it } } }
 }
 

--- a/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/impl/InMemoryGoalRepository.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/impl/InMemoryGoalRepository.kt
@@ -15,6 +15,9 @@ class InMemoryGoalRepository : GoalRepository {
     override suspend fun updateProgress(id: SyncId, currentAmount: Cents) {
         val now = Clock.System.now(); store.update { l -> l.map { if (it.id == id) it.copy(currentAmount = currentAmount, updatedAt = now) else it } }
     }
+    override suspend fun insert(entity: Goal) { store.update { it + entity } }
+    override suspend fun update(entity: Goal) { val now = Clock.System.now(); store.update { l -> l.map { if (it.id == entity.id) entity.copy(updatedAt = now) else it } } }
+    override suspend fun delete(id: SyncId) { val now = Clock.System.now(); store.update { l -> l.map { if (it.id == id) it.copy(deletedAt = now) else it } } }
 }
 
 private fun createSampleGoals(): List<Goal> {

--- a/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/impl/sqldelight/SqlDelightBudgetRepository.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/impl/sqldelight/SqlDelightBudgetRepository.kt
@@ -61,6 +61,25 @@ class SqlDelightBudgetRepository(
         refreshCache()
     }
 
+    override suspend fun update(entity: Budget) = withContext(Dispatchers.IO) {
+        val now = Clock.System.now()
+        queries.update(
+            category_id = entity.categoryId.value,
+            name = entity.name,
+            amount = entity.amount.amount,
+            currency = entity.currency.code,
+            period = entity.period.name,
+            start_date = entity.startDate.toString(),
+            end_date = entity.endDate?.toString(),
+            is_rollover = if (entity.isRollover) 1L else 0L,
+            updated_at = now.toString(),
+            sync_version = entity.syncVersion + 1,
+            is_synced = 0L,
+            id = entity.id.value,
+        )
+        refreshCache()
+    }
+
     override suspend fun delete(id: SyncId) = withContext(Dispatchers.IO) {
         val now = Clock.System.now()
         queries.softDelete(

--- a/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/impl/sqldelight/SqlDelightGoalRepository.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/impl/sqldelight/SqlDelightGoalRepository.kt
@@ -55,6 +55,58 @@ class SqlDelightGoalRepository(
             refreshCache()
         }
 
+    override suspend fun insert(entity: Goal) = withContext(Dispatchers.IO) {
+        queries.insert(
+            id = entity.id.value,
+            household_id = entity.householdId.value,
+            owner_id = entity.ownerId.value,
+            name = entity.name,
+            target_amount = entity.targetAmount.amount,
+            current_amount = entity.currentAmount.amount,
+            currency = entity.currency.code,
+            target_date = entity.targetDate?.toString(),
+            status = entity.status.name,
+            icon = entity.icon,
+            color = entity.color,
+            account_id = entity.accountId?.value,
+            created_at = entity.createdAt.toString(),
+            updated_at = entity.updatedAt.toString(),
+            sync_version = entity.syncVersion,
+            is_synced = if (entity.isSynced) 1L else 0L,
+        )
+        refreshCache()
+    }
+
+    override suspend fun update(entity: Goal) = withContext(Dispatchers.IO) {
+        val now = Clock.System.now()
+        queries.update(
+            name = entity.name,
+            target_amount = entity.targetAmount.amount,
+            current_amount = entity.currentAmount.amount,
+            currency = entity.currency.code,
+            target_date = entity.targetDate?.toString(),
+            status = entity.status.name,
+            icon = entity.icon,
+            color = entity.color,
+            account_id = entity.accountId?.value,
+            updated_at = now.toString(),
+            sync_version = entity.syncVersion + 1,
+            is_synced = 0L,
+            id = entity.id.value,
+        )
+        refreshCache()
+    }
+
+    override suspend fun delete(id: SyncId) = withContext(Dispatchers.IO) {
+        val now = Clock.System.now()
+        queries.softDelete(
+            deleted_at = now.toString(),
+            updated_at = now.toString(),
+            id = id.value,
+        )
+        refreshCache()
+    }
+
     private fun refreshCache() {
         try {
             val rows = queries.selectAll().executeAsList()

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/BudgetsScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/BudgetsScreen.kt
@@ -10,26 +10,42 @@ import androidx.compose.foundation.ContextMenuItem
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.PieChart
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -48,6 +64,7 @@ import com.finance.desktop.di.koinGet
 import com.finance.desktop.theme.FinanceDesktopTheme
 import com.finance.desktop.viewmodel.BudgetItemUi
 import com.finance.desktop.viewmodel.BudgetsViewModel
+import com.finance.models.BudgetPeriod
 
 // =============================================================================
 // Budgets Screen — Grid of Budget Cards (KMP shared logic)
@@ -65,6 +82,7 @@ import com.finance.desktop.viewmodel.BudgetsViewModel
  * - Animated progress ring with utilization percentage
  * - Spent / limit amounts and remaining balance
  * - Color-coded health indicator (green/amber/red)
+ * - Edit (pencil) and Delete (trash) icon buttons
  *
  * Right-click context menus provide Edit and Delete actions.
  * Narrator reads category, amounts, and health status.
@@ -86,6 +104,47 @@ fun BudgetsScreen(modifier: Modifier = Modifier) {
             )
         }
         return
+    }
+
+    // ── Edit Dialog ──
+    if (state.editingBudgetId != null) {
+        BudgetEditDialog(
+            name = state.editName,
+            amount = state.editAmount,
+            period = state.editPeriod,
+            onNameChange = { viewModel.updateEditName(it) },
+            onAmountChange = { viewModel.updateEditAmount(it) },
+            onPeriodChange = { viewModel.updateEditPeriod(it) },
+            onSave = { viewModel.saveEdit() },
+            onDismiss = { viewModel.cancelEdit() },
+        )
+    }
+
+    // ── Delete Confirmation Dialog ──
+    if (state.deletingBudgetId != null) {
+        val budgetName = state.budgets.find { it.id == state.deletingBudgetId }?.name ?: "this budget"
+        AlertDialog(
+            onDismissRequest = { viewModel.cancelDelete() },
+            title = { Text("Delete Budget") },
+            text = {
+                Text(
+                    "Are you sure you want to delete \"$budgetName\"? This action cannot be undone.",
+                    modifier = Modifier.semantics {
+                        contentDescription = "Confirm deletion of budget $budgetName"
+                    },
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = { viewModel.executeDelete() }) {
+                    Text("Delete", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { viewModel.cancelDelete() }) {
+                    Text("Cancel")
+                }
+            },
+        )
     }
 
     Column(
@@ -147,11 +206,99 @@ fun BudgetsScreen(modifier: Modifier = Modifier) {
                 verticalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.lg),
             ) {
                 items(state.budgets, key = { it.id }) { budget ->
-                    BudgetCard(budget)
+                    BudgetCard(
+                        budget = budget,
+                        onEdit = { viewModel.startEdit(budget.id) },
+                        onDelete = { viewModel.confirmDelete(budget.id) },
+                    )
                 }
             }
         }
     }
+}
+
+// =============================================================================
+// Budget Edit Dialog
+// =============================================================================
+
+/**
+ * Dialog for editing a budget's name, amount, and period.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun BudgetEditDialog(
+    name: String,
+    amount: String,
+    period: BudgetPeriod,
+    onNameChange: (String) -> Unit,
+    onAmountChange: (String) -> Unit,
+    onPeriodChange: (BudgetPeriod) -> Unit,
+    onSave: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var periodExpanded by remember { mutableStateOf(false) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Edit Budget") },
+        text = {
+            Column(
+                modifier = Modifier.semantics {
+                    contentDescription = "Edit budget form"
+                },
+            ) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = onNameChange,
+                    label = { Text("Budget Name") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(12.dp))
+                OutlinedTextField(
+                    value = amount,
+                    onValueChange = onAmountChange,
+                    label = { Text("Amount ($)") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(12.dp))
+                ExposedDropdownMenuBox(
+                    expanded = periodExpanded,
+                    onExpandedChange = { periodExpanded = it },
+                ) {
+                    OutlinedTextField(
+                        value = period.name.lowercase().replaceFirstChar { it.uppercase() },
+                        onValueChange = {},
+                        readOnly = true,
+                        label = { Text("Period") },
+                        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = periodExpanded) },
+                        modifier = Modifier.menuAnchor().fillMaxWidth(),
+                    )
+                    ExposedDropdownMenu(
+                        expanded = periodExpanded,
+                        onDismissRequest = { periodExpanded = false },
+                    ) {
+                        BudgetPeriod.entries.forEach { p ->
+                            DropdownMenuItem(
+                                text = { Text(p.name.lowercase().replaceFirstChar { it.uppercase() }) },
+                                onClick = {
+                                    onPeriodChange(p)
+                                    periodExpanded = false
+                                },
+                            )
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onSave) { Text("Save") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        },
+    )
 }
 
 // =============================================================================
@@ -160,7 +307,11 @@ fun BudgetsScreen(modifier: Modifier = Modifier) {
 
 @Composable
 @Suppress("LongMethod") // Budget item composable
-private fun BudgetCard(budget: BudgetItemUi) {
+private fun BudgetCard(
+    budget: BudgetItemUi,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+) {
     val healthColor = when (budget.health) {
         BudgetHealth.OVER -> MaterialTheme.colorScheme.error
         BudgetHealth.WARNING -> Color(0xFFFF9800)
@@ -181,10 +332,10 @@ private fun BudgetCard(budget: BudgetItemUi) {
     ContextMenuArea(
         items = {
             listOf(
-                ContextMenuItem("Edit Budget") { /* edit */ },
+                ContextMenuItem("Edit Budget") { onEdit() },
                 ContextMenuItem("View Transactions") { /* view transactions for category */ },
                 ContextMenuItem("Reset Budget") { /* reset */ },
-                ContextMenuItem("Delete Budget") { /* delete */ },
+                ContextMenuItem("Delete Budget") { onDelete() },
             )
         },
     ) {
@@ -207,6 +358,39 @@ private fun BudgetCard(budget: BudgetItemUi) {
                 modifier = Modifier.padding(FinanceDesktopTheme.spacing.xxl),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
+                // Action buttons row: Edit + Delete
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    IconButton(
+                        onClick = onEdit,
+                        modifier = Modifier.semantics {
+                            contentDescription = "Edit budget ${budget.name}"
+                        },
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Edit,
+                            contentDescription = "Edit",
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.size(18.dp),
+                        )
+                    }
+                    IconButton(
+                        onClick = onDelete,
+                        modifier = Modifier.semantics {
+                            contentDescription = "Delete budget ${budget.name}"
+                        },
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Delete,
+                            contentDescription = "Delete",
+                            tint = MaterialTheme.colorScheme.error,
+                            modifier = Modifier.size(18.dp),
+                        )
+                    }
+                }
+
                 // Category name + period
                 Text(
                     text = budget.name,

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/GoalsScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/GoalsScreen.kt
@@ -21,15 +21,21 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.automirrored.filled.TrendingUp
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -64,6 +70,7 @@ import com.finance.desktop.viewmodel.GoalsViewModel
  * - Animated horizontal progress bar
  * - Current / target amounts
  * - Deadline info (if set)
+ * - Edit (pencil) and Delete (trash) icon buttons
  *
  * Right-click context menus provide Edit, Contribute, and Delete actions.
  * Narrator reads goal name, progress percentage, amounts, and deadline.
@@ -85,6 +92,47 @@ fun GoalsScreen(modifier: Modifier = Modifier) {
             )
         }
         return
+    }
+
+    // ── Edit Dialog ──
+    if (state.editingGoalId != null) {
+        GoalEditDialog(
+            name = state.editName,
+            targetAmount = state.editTargetAmount,
+            currentAmount = state.editCurrentAmount,
+            onNameChange = { viewModel.updateEditName(it) },
+            onTargetAmountChange = { viewModel.updateEditTargetAmount(it) },
+            onCurrentAmountChange = { viewModel.updateEditCurrentAmount(it) },
+            onSave = { viewModel.saveEdit() },
+            onDismiss = { viewModel.cancelEdit() },
+        )
+    }
+
+    // ── Delete Confirmation Dialog ──
+    if (state.deletingGoalId != null) {
+        val goalName = state.goals.find { it.id == state.deletingGoalId }?.name ?: "this goal"
+        AlertDialog(
+            onDismissRequest = { viewModel.cancelDelete() },
+            title = { Text("Delete Goal") },
+            text = {
+                Text(
+                    "Are you sure you want to delete \"$goalName\"? This action cannot be undone.",
+                    modifier = Modifier.semantics {
+                        contentDescription = "Confirm deletion of goal $goalName"
+                    },
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = { viewModel.executeDelete() }) {
+                    Text("Delete", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { viewModel.cancelDelete() }) {
+                    Text("Cancel")
+                }
+            },
+        )
     }
 
     Column(
@@ -146,11 +194,76 @@ fun GoalsScreen(modifier: Modifier = Modifier) {
                 verticalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.lg),
             ) {
                 items(state.goals, key = { it.id }) { goal ->
-                    GoalCard(goal)
+                    GoalCard(
+                        goal = goal,
+                        onEdit = { viewModel.startEdit(goal.id) },
+                        onDelete = { viewModel.confirmDelete(goal.id) },
+                    )
                 }
             }
         }
     }
+}
+
+// =============================================================================
+// Goal Edit Dialog
+// =============================================================================
+
+/**
+ * Dialog for editing a goal's name, target amount, and current amount.
+ */
+@Composable
+private fun GoalEditDialog(
+    name: String,
+    targetAmount: String,
+    currentAmount: String,
+    onNameChange: (String) -> Unit,
+    onTargetAmountChange: (String) -> Unit,
+    onCurrentAmountChange: (String) -> Unit,
+    onSave: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Edit Goal") },
+        text = {
+            Column(
+                modifier = Modifier.semantics {
+                    contentDescription = "Edit goal form"
+                },
+            ) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = onNameChange,
+                    label = { Text("Goal Name") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(12.dp))
+                OutlinedTextField(
+                    value = targetAmount,
+                    onValueChange = onTargetAmountChange,
+                    label = { Text("Target Amount ($)") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(12.dp))
+                OutlinedTextField(
+                    value = currentAmount,
+                    onValueChange = onCurrentAmountChange,
+                    label = { Text("Current Amount ($)") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onSave) { Text("Save") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        },
+    )
 }
 
 // =============================================================================
@@ -159,7 +272,11 @@ fun GoalsScreen(modifier: Modifier = Modifier) {
 
 @Composable
 @Suppress("LongMethod") // Goal detail composable
-private fun GoalCard(goal: GoalItemUi) {
+private fun GoalCard(
+    goal: GoalItemUi,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+) {
     val progressColor = when {
         goal.progress >= 0.75f -> Color(0xFF2E7D32)
         goal.progress >= 0.40f -> MaterialTheme.colorScheme.primary
@@ -177,9 +294,9 @@ private fun GoalCard(goal: GoalItemUi) {
         items = {
             listOf(
                 ContextMenuItem("Add Contribution") { /* contribute */ },
-                ContextMenuItem("Edit Goal") { /* edit */ },
+                ContextMenuItem("Edit Goal") { onEdit() },
                 ContextMenuItem("View History") { /* history */ },
-                ContextMenuItem("Delete Goal") { /* delete */ },
+                ContextMenuItem("Delete Goal") { onDelete() },
             )
         },
     ) {
@@ -201,13 +318,16 @@ private fun GoalCard(goal: GoalItemUi) {
             Column(
                 modifier = Modifier.padding(FinanceDesktopTheme.spacing.xxl),
             ) {
-                // Header row: icon + name + percentage
+                // Header row: icon + name + percentage + action buttons
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.weight(1f),
+                    ) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.TrendingUp,
                             contentDescription = null,
@@ -229,6 +349,33 @@ private fun GoalCard(goal: GoalItemUi) {
                         fontWeight = FontWeight.Bold,
                         color = progressColor,
                     )
+                    Spacer(Modifier.width(8.dp))
+                    IconButton(
+                        onClick = onEdit,
+                        modifier = Modifier.semantics {
+                            contentDescription = "Edit goal ${goal.name}"
+                        },
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Edit,
+                            contentDescription = "Edit",
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.size(18.dp),
+                        )
+                    }
+                    IconButton(
+                        onClick = onDelete,
+                        modifier = Modifier.semantics {
+                            contentDescription = "Delete goal ${goal.name}"
+                        },
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Delete,
+                            contentDescription = "Delete",
+                            tint = MaterialTheme.colorScheme.error,
+                            modifier = Modifier.size(18.dp),
+                        )
+                    }
                 }
 
                 Spacer(Modifier.height(FinanceDesktopTheme.spacing.lg))

--- a/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/BudgetsViewModel.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/BudgetsViewModel.kt
@@ -42,6 +42,11 @@ data class BudgetItemUi(
 data class BudgetsUiState(
     val isLoading: Boolean = true,
     val budgets: List<BudgetItemUi> = emptyList(),
+    val editingBudgetId: String? = null,
+    val deletingBudgetId: String? = null,
+    val editName: String = "",
+    val editAmount: String = "",
+    val editPeriod: BudgetPeriod = BudgetPeriod.MONTHLY,
 )
 
 /**
@@ -51,6 +56,8 @@ data class BudgetsUiState(
  * per-budget spending status using [BudgetCalculator] from `packages/core`.
  * Transactions are fetched from [TransactionRepository] and filtered by
  * each budget's category to produce accurate utilization numbers.
+ *
+ * Supports edit and delete operations with confirmation dialogs.
  */
 class BudgetsViewModel(
     private val budgetRepository: BudgetRepository,
@@ -62,6 +69,9 @@ class BudgetsViewModel(
 
     private val hid = SyncId("d1")
 
+    /** Cached raw budgets for edit operations. */
+    private var rawBudgets: List<Budget> = emptyList()
+
     init {
         loadBudgets()
     }
@@ -69,6 +79,7 @@ class BudgetsViewModel(
     private fun loadBudgets() {
         viewModelScope.launch {
             val budgets = budgetRepository.observeAll(hid).first()
+            rawBudgets = budgets
             val transactions = transactionRepository.observeAll(hid).first()
             val today = Clock.System.now()
                 .toLocalDateTime(TimeZone.currentSystemDefault()).date
@@ -111,10 +122,82 @@ class BudgetsViewModel(
                 )
             }
 
-            _uiState.value = BudgetsUiState(
+            _uiState.value = _uiState.value.copy(
                 isLoading = false,
                 budgets = items,
             )
+        }
+    }
+
+    /**
+     * Opens the edit dialog for a budget, pre-filling the current values.
+     */
+    fun startEdit(budgetId: String) {
+        val budget = rawBudgets.find { it.id.value == budgetId } ?: return
+        _uiState.value = _uiState.value.copy(
+            editingBudgetId = budgetId,
+            editName = budget.name,
+            editAmount = (budget.amount.amount / 100.0).toString(),
+            editPeriod = budget.period,
+        )
+    }
+
+    /** Cancels the edit dialog. */
+    fun cancelEdit() {
+        _uiState.value = _uiState.value.copy(editingBudgetId = null)
+    }
+
+    /** Updates the edit form name field. */
+    fun updateEditName(name: String) {
+        _uiState.value = _uiState.value.copy(editName = name)
+    }
+
+    /** Updates the edit form amount field. */
+    fun updateEditAmount(amount: String) {
+        _uiState.value = _uiState.value.copy(editAmount = amount)
+    }
+
+    /** Updates the edit form period field. */
+    fun updateEditPeriod(period: BudgetPeriod) {
+        _uiState.value = _uiState.value.copy(editPeriod = period)
+    }
+
+    /** Saves the edited budget to the repository. */
+    fun saveEdit() {
+        val editingId = _uiState.value.editingBudgetId ?: return
+        val budget = rawBudgets.find { it.id.value == editingId } ?: return
+        val amountCents = ((_uiState.value.editAmount.toDoubleOrNull() ?: 0.0) * 100).toLong()
+
+        viewModelScope.launch {
+            budgetRepository.update(
+                budget.copy(
+                    name = _uiState.value.editName,
+                    amount = com.finance.models.types.Cents(amountCents),
+                    period = _uiState.value.editPeriod,
+                ),
+            )
+            _uiState.value = _uiState.value.copy(editingBudgetId = null)
+            loadBudgets()
+        }
+    }
+
+    /** Shows the delete confirmation dialog for a budget. */
+    fun confirmDelete(budgetId: String) {
+        _uiState.value = _uiState.value.copy(deletingBudgetId = budgetId)
+    }
+
+    /** Cancels the delete confirmation. */
+    fun cancelDelete() {
+        _uiState.value = _uiState.value.copy(deletingBudgetId = null)
+    }
+
+    /** Deletes the budget from the repository after confirmation. */
+    fun executeDelete() {
+        val deletingId = _uiState.value.deletingBudgetId ?: return
+        viewModelScope.launch {
+            budgetRepository.delete(SyncId(deletingId))
+            _uiState.value = _uiState.value.copy(deletingBudgetId = null)
+            loadBudgets()
         }
     }
 }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/GoalsViewModel.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/GoalsViewModel.kt
@@ -33,6 +33,11 @@ data class GoalItemUi(
 data class GoalsUiState(
     val isLoading: Boolean = true,
     val goals: List<GoalItemUi> = emptyList(),
+    val editingGoalId: String? = null,
+    val deletingGoalId: String? = null,
+    val editName: String = "",
+    val editTargetAmount: String = "",
+    val editCurrentAmount: String = "",
 )
 
 /**
@@ -41,6 +46,8 @@ data class GoalsUiState(
  * Loads savings goals from the KMP shared [GoalRepository] and maps
  * them to display-ready [GoalItemUi] instances. Progress is computed
  * by the KMP [Goal.progress] property — no duplicate logic here.
+ *
+ * Supports edit and delete operations with confirmation dialogs.
  */
 class GoalsViewModel(
     private val goalRepository: GoalRepository,
@@ -51,6 +58,9 @@ class GoalsViewModel(
 
     private val hid = SyncId("d1")
 
+    /** Cached raw goals for edit operations. */
+    private var rawGoals: List<Goal> = emptyList()
+
     init {
         loadGoals()
     }
@@ -58,6 +68,7 @@ class GoalsViewModel(
     private fun loadGoals() {
         viewModelScope.launch {
             val goals = goalRepository.observeAll(hid).first()
+            rawGoals = goals
             val currency = Currency.USD
 
             val items = goals.map { goal ->
@@ -76,10 +87,83 @@ class GoalsViewModel(
                 )
             }
 
-            _uiState.value = GoalsUiState(
+            _uiState.value = _uiState.value.copy(
                 isLoading = false,
                 goals = items,
             )
+        }
+    }
+
+    /**
+     * Opens the edit dialog for a goal, pre-filling the current values.
+     */
+    fun startEdit(goalId: String) {
+        val goal = rawGoals.find { it.id.value == goalId } ?: return
+        _uiState.value = _uiState.value.copy(
+            editingGoalId = goalId,
+            editName = goal.name,
+            editTargetAmount = (goal.targetAmount.amount / 100.0).toString(),
+            editCurrentAmount = (goal.currentAmount.amount / 100.0).toString(),
+        )
+    }
+
+    /** Cancels the edit dialog. */
+    fun cancelEdit() {
+        _uiState.value = _uiState.value.copy(editingGoalId = null)
+    }
+
+    /** Updates the edit form name field. */
+    fun updateEditName(name: String) {
+        _uiState.value = _uiState.value.copy(editName = name)
+    }
+
+    /** Updates the edit form target amount field. */
+    fun updateEditTargetAmount(amount: String) {
+        _uiState.value = _uiState.value.copy(editTargetAmount = amount)
+    }
+
+    /** Updates the edit form current amount field. */
+    fun updateEditCurrentAmount(amount: String) {
+        _uiState.value = _uiState.value.copy(editCurrentAmount = amount)
+    }
+
+    /** Saves the edited goal to the repository. */
+    fun saveEdit() {
+        val editingId = _uiState.value.editingGoalId ?: return
+        val goal = rawGoals.find { it.id.value == editingId } ?: return
+        val targetCents = ((_uiState.value.editTargetAmount.toDoubleOrNull() ?: 0.0) * 100).toLong()
+        val currentCents = ((_uiState.value.editCurrentAmount.toDoubleOrNull() ?: 0.0) * 100).toLong()
+
+        viewModelScope.launch {
+            goalRepository.update(
+                goal.copy(
+                    name = _uiState.value.editName,
+                    targetAmount = com.finance.models.types.Cents(targetCents),
+                    currentAmount = com.finance.models.types.Cents(currentCents),
+                ),
+            )
+            _uiState.value = _uiState.value.copy(editingGoalId = null)
+            loadGoals()
+        }
+    }
+
+    /** Shows the delete confirmation dialog for a goal. */
+    fun confirmDelete(goalId: String) {
+        _uiState.value = _uiState.value.copy(deletingGoalId = goalId)
+    }
+
+    /** Cancels the delete confirmation. */
+    fun cancelDelete() {
+        _uiState.value = _uiState.value.copy(deletingGoalId = null)
+    }
+
+    /** Deletes the goal from the repository after confirmation. */
+    fun executeDelete() {
+        val deletingId = _uiState.value.deletingGoalId ?: return
+        viewModelScope.launch {
+            goalRepository.delete(SyncId(deletingId))
+            _uiState.value = _uiState.value.copy(deletingGoalId = null)
+            loadGoals()
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes Windows app auth flow and adds CRUD functionality to budget/goal screens.

## Changes

- Add auth state check (AuthRepository.isAuthenticated + AuthViewModel) to prevent showing login/signup when authenticated
- Add splash/loading screen during auth state resolution to prevent flash of login screen
- If user has active session, always route to main app regardless of deep link target
- Add edit functionality (AlertDialog with pre-filled form) to budget detail cards
- Add delete with confirmation AlertDialog to budget detail cards
- Add edit functionality (AlertDialog with pre-filled form) to goal detail cards
- Add delete with confirmation AlertDialog to goal detail cards
- Add Edit (pencil) and Delete (trash) icon buttons to budget and goal cards
- Wire context menu Edit/Delete actions to ViewModel operations
- Add update() and delete() methods to GoalRepository interface and implementations
- Add update() method to BudgetRepository interface and SqlDelight implementation
- Full Narrator accessibility: contentDescription on all action buttons and dialogs

## Issues

Closes #1498
Closes #1497