### PR TITLE
fix(web): precache route chunks, loading skeleton, import page navigation

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -22,6 +22,8 @@ const PAGE_TITLES: Record<string, string> = {
   '/achievements': 'Achievements',
   '/watchlists': 'Watchlists',
   '/settings': 'Settings',
+  '/import': 'Import',
+  '/import/wizard': 'Import Wizard',
 };
 
 /** Routes that are wrapped in AppLayout (authenticated main app pages). */
@@ -40,6 +42,8 @@ const AUTHENTICATED_ROUTES = new Set([
   '/achievements',
   '/watchlists',
   '/settings',
+  '/import',
+  '/import/wizard',
 ]);
 
 /**

--- a/apps/web/src/accessibility/__tests__/wcag-audit.test.ts
+++ b/apps/web/src/accessibility/__tests__/wcag-audit.test.ts
@@ -178,8 +178,8 @@ describe('Service Worker Caching', () => {
   });
 
   it('should pre-cache app shell on install', () => {
-    expect(swCode).toContain('APP_SHELL');
-    expect(swCode).toContain('cache.addAll(APP_SHELL)');
+    expect(swCode).toContain('PRECACHE_MANIFEST');
+    expect(swCode).toContain("cache.addAll(['/', '/index.html', '/manifest.json'])");
   });
 
   it('should purge stale caches on activate', () => {

--- a/apps/web/src/components/layout/AppLayout.test.tsx
+++ b/apps/web/src/components/layout/AppLayout.test.tsx
@@ -44,9 +44,7 @@ vi.mock('../common', () => ({
   SyncStatusBar: () => <div data-testid="sync-status-bar">Sync Status</div>,
 }));
 
-vi.mock('../OfflineBanner', () => ({
-  OfflineBanner: () => <div data-testid="offline-banner">Offline Banner</div>,
-}));
+// OfflineBanner removed — SyncStatusBar handles offline state
 
 vi.mock('../common/InstallBanner', () => ({
   InstallBanner: () => <div data-testid="install-banner">Install Banner</div>,
@@ -160,10 +158,10 @@ describe('AppLayout', () => {
     expect(screen.getByTestId('update-banner')).toBeInTheDocument();
   });
 
-  it('renders the OfflineBanner', () => {
+  it('renders without the removed OfflineBanner (offline state handled by SyncStatusBar)', () => {
     render(<AppLayout {...defaultProps} />);
 
-    expect(screen.getByTestId('offline-banner')).toBeInTheDocument();
+    expect(screen.queryByTestId('offline-banner')).not.toBeInTheDocument();
   });
 
   it('renders the InstallBanner', () => {

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -3,7 +3,6 @@
 import React, { useCallback, useState } from 'react';
 
 import { KeyboardShortcutsModal, UpdateBanner, SyncStatusBar } from '../common';
-import { OfflineBanner } from '../OfflineBanner';
 import { ConflictResolutionDialog } from '../common/ConflictResolutionDialog';
 import { useKeyboardShortcuts } from '../../hooks';
 import { useEscapeBack } from '../../hooks/useEscapeBack';
@@ -64,7 +63,6 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
       />
       <div className="app-shell">
         <UpdateBanner />
-        <OfflineBanner />
         <SyncStatusBar />
         <header className="app-header" aria-label="App header">
           <h1 className="app-header__title">{pageTitle}</h1>

--- a/apps/web/src/pages/DataImportWizardPage.tsx
+++ b/apps/web/src/pages/DataImportWizardPage.tsx
@@ -128,10 +128,10 @@ export function DataImportWizardPage() {
   const currentStepIndex = steps.indexOf(step);
 
   return (
-    <main className="import-wizard" aria-labelledby="import-wizard-title">
-      <h1 id="import-wizard-title" className="import-wizard__title">
+    <div className="import-wizard" aria-labelledby="import-wizard-title">
+      <h2 id="import-wizard-title" className="import-wizard__title">
         Import Transactions
-      </h1>
+      </h2>
 
       {/* Step indicator */}
       <nav className="import-wizard__steps" aria-label="Import wizard progress">
@@ -430,7 +430,7 @@ export function DataImportWizardPage() {
           </button>
         </section>
       )}
-    </main>
+    </div>
   );
 }
 

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -6,6 +6,7 @@ import { Routes, Route, Navigate, useNavigate } from 'react-router-dom';
 
 import { ProtectedRoute, useAuth } from './auth/auth-context';
 import { RouteErrorBoundary } from './components/common';
+import './styles/route-loader.css';
 
 /*
  * Lazy-loaded route pages - each is code-split into its own chunk.
@@ -39,12 +40,27 @@ const CreateBill = lazy(() => import('./pages/CreateBillPage'));
 
 /**
  * Loading fallback shown while a lazy route chunk is being fetched.
- * Uses a semantic element and ARIA live region so screen readers
- * announce the loading state.
+ * Renders a shimmer skeleton layout matching the app shell structure.
+ * Uses CSS-only animations (no JS deps) and ARIA live region for
+ * screen reader announcements.
  */
 const PageLoader: FC = () => (
-  <div role="status" aria-live="polite" aria-label="Loading page">
-    <p>Loading...</p>
+  <div
+    className="route-loader"
+    role="status"
+    aria-live="polite"
+    aria-label="Loading page"
+    aria-busy="true"
+  >
+    <div className="route-loader__header" />
+    <div className="route-loader__content">
+      <div className="route-loader__line route-loader__line--wide" />
+      <div className="route-loader__line route-loader__line--medium" />
+      <div className="route-loader__line route-loader__line--narrow" />
+      <div className="route-loader__block" />
+      <div className="route-loader__line route-loader__line--wide" />
+      <div className="route-loader__line route-loader__line--medium" />
+    </div>
   </div>
 );
 

--- a/apps/web/src/styles/route-loader.css
+++ b/apps/web/src/styles/route-loader.css
@@ -1,0 +1,93 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/**
+ * Route-level loading skeleton shown in Suspense fallback.
+ * CSS-only shimmer animation with design token integration.
+ */
+
+.route-loader {
+  display: flex;
+  flex-direction: column;
+  padding: var(--spacing-4, 16px);
+  min-height: 300px;
+  gap: var(--spacing-4, 16px);
+}
+
+.route-loader__header {
+  height: 32px;
+  width: 40%;
+  border-radius: var(--border-radius-sm, 4px);
+  background: linear-gradient(
+    90deg,
+    var(--semantic-background-secondary, #e5e7eb) 25%,
+    var(--semantic-background-elevated, #f3f4f6) 50%,
+    var(--semantic-background-secondary, #e5e7eb) 75%
+  );
+  background-size: 200% 100%;
+  animation: route-loader-shimmer 1.5s ease-in-out infinite;
+}
+
+.route-loader__content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3, 12px);
+}
+
+.route-loader__line {
+  height: 16px;
+  border-radius: var(--border-radius-sm, 4px);
+  background: linear-gradient(
+    90deg,
+    var(--semantic-background-secondary, #e5e7eb) 25%,
+    var(--semantic-background-elevated, #f3f4f6) 50%,
+    var(--semantic-background-secondary, #e5e7eb) 75%
+  );
+  background-size: 200% 100%;
+  animation: route-loader-shimmer 1.5s ease-in-out infinite;
+}
+
+.route-loader__line--wide {
+  width: 80%;
+}
+
+.route-loader__line--medium {
+  width: 55%;
+}
+
+.route-loader__line--narrow {
+  width: 30%;
+}
+
+.route-loader__block {
+  height: 120px;
+  width: 100%;
+  border-radius: var(--border-radius-md, 8px);
+  background: linear-gradient(
+    90deg,
+    var(--semantic-background-secondary, #e5e7eb) 25%,
+    var(--semantic-background-elevated, #f3f4f6) 50%,
+    var(--semantic-background-secondary, #e5e7eb) 75%
+  );
+  background-size: 200% 100%;
+  animation: route-loader-shimmer 1.5s ease-in-out infinite;
+}
+
+@keyframes route-loader-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+/* Reduced motion preference */
+@media (prefers-reduced-motion: reduce) {
+  .route-loader__header,
+  .route-loader__line,
+  .route-loader__block {
+    animation: none;
+    background: var(--semantic-background-secondary, #e5e7eb);
+    background-size: auto;
+  }
+}

--- a/apps/web/src/sw/service-worker.ts
+++ b/apps/web/src/sw/service-worker.ts
@@ -37,12 +37,15 @@ const STATIC_CACHE = `finance-static-${CACHE_VERSION}`;
 const API_CACHE = `finance-api-${CACHE_VERSION}`;
 
 /**
- * App-shell resources to pre-cache during installation.
+ * Build-time precache manifest.
  *
- * These URLs are cache-first and guarantee the app loads offline.
- * Update this list whenever the build output changes.
+ * At build time, Vite injects __PRECACHE_MANIFEST__ with all generated
+ * JS/CSS chunk paths (populated by the sw-precache-manifest plugin).
+ * This ensures lazy route chunks are available offline even before first visit.
  */
-const APP_SHELL: string[] = ['/', '/index.html', '/manifest.json'];
+declare const __PRECACHE_MANIFEST__: string[];
+const PRECACHE_MANIFEST: string[] =
+  typeof __PRECACHE_MANIFEST__ !== 'undefined' ? __PRECACHE_MANIFEST__ : [];
 
 /**
  * File-extension patterns that qualify for cache-first treatment.
@@ -55,7 +58,21 @@ const STATIC_EXTENSIONS = /\.(js|css|woff2?|ttf|otf|eot|png|jpe?g|gif|svg|ico|we
 // ---------------------------------------------------------------------------
 
 self.addEventListener('install', (event: ExtendableEvent) => {
-  event.waitUntil(caches.open(STATIC_CACHE).then((cache) => cache.addAll(APP_SHELL)));
+  event.waitUntil(
+    caches.open(STATIC_CACHE).then(async (cache) => {
+      // Always precache core app shell
+      await cache.addAll(['/', '/index.html', '/manifest.json']);
+      // Precache build chunks individually — a single failure should not
+      // block installation (e.g. dev mode without manifest).
+      await Promise.allSettled(
+        PRECACHE_MANIFEST.map((url) =>
+          cache.add(url).catch(() => {
+            /* non-critical: chunk will be cached on first visit */
+          }),
+        ),
+      );
+    }),
+  );
 });
 
 // ---------------------------------------------------------------------------
@@ -109,9 +126,9 @@ self.addEventListener('fetch', (event: FetchEvent) => {
     return;
   }
 
-  // Navigation requests (HTML) -> cache-first (SPA)
+  // Navigation requests (HTML) -> network-first with app-shell fallback (SPA)
   if (request.mode === 'navigate') {
-    event.respondWith(cacheFirst(request, '/index.html'));
+    event.respondWith(navigationHandler(request));
     return;
   }
 
@@ -185,6 +202,33 @@ self.addEventListener('message', (event: ExtendableMessageEvent) => {
 // ---------------------------------------------------------------------------
 // Caching strategies
 // ---------------------------------------------------------------------------
+
+/**
+ * **Navigation handler**: try network first for HTML navigations,
+ * fall back to the cached app shell (`/index.html`) for offline SPA routing.
+ */
+async function navigationHandler(request: Request): Promise<Response> {
+  try {
+    const response = await fetch(request);
+    if (response.ok) {
+      const cache = await caches.open(STATIC_CACHE);
+      await cache.put(request, response.clone());
+    }
+    return response;
+  } catch {
+    // Offline — serve the cached app shell so the SPA router can handle the path
+    const cache = await caches.open(STATIC_CACHE);
+    const cached = await cache.match('/index.html');
+    if (cached) {
+      return cached;
+    }
+    return new Response('Offline -- app shell not cached', {
+      status: 503,
+      statusText: 'Service Unavailable',
+      headers: { 'Content-Type': 'text/plain' },
+    });
+  }
+}
 
 /**
  * **Cache-first**: serve from cache if available, otherwise fetch from

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -42,9 +42,50 @@ function copySqlJsWasm(): Plugin {
   };
 }
 
+/**
+ * Vite plugin that injects a precache manifest into the service worker.
+ *
+ * During production builds, this plugin collects all generated JS and CSS
+ * asset paths from the Rollup bundle and defines `__PRECACHE_MANIFEST__`
+ * as a global constant in the service worker entry, enabling offline-first
+ * precaching of all route chunks during SW installation.
+ */
+function swPrecacheManifest(): Plugin {
+  return {
+    name: 'sw-precache-manifest',
+    apply: 'build',
+    generateBundle(_options, bundle) {
+      // Collect all JS and CSS asset paths from the build output
+      const assetPaths: string[] = [];
+      for (const [fileName, chunk] of Object.entries(bundle)) {
+        if (fileName === 'sw.js') continue; // Don't precache the SW itself
+        if (fileName.endsWith('.js') || fileName.endsWith('.css')) {
+          assetPaths.push(`/${fileName}`);
+        }
+        // Also include CSS assets referenced by chunks
+        if (chunk.type === 'chunk' && chunk.viteMetadata?.importedCss) {
+          for (const css of chunk.viteMetadata.importedCss) {
+            const cssPath = `/${css}`;
+            if (!assetPaths.includes(cssPath)) {
+              assetPaths.push(cssPath);
+            }
+          }
+        }
+      }
+
+      // Inject the manifest into the service worker bundle
+      const swEntry = bundle['sw.js'];
+      if (swEntry && swEntry.type === 'chunk') {
+        const manifest = JSON.stringify(assetPaths);
+        swEntry.code = `var __PRECACHE_MANIFEST__ = ${manifest};\n${swEntry.code}`;
+      }
+    },
+  };
+}
+
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), copySqlJsWasm()],
+  plugins: [react(), copySqlJsWasm(), swPrecacheManifest()],
 
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

Fixes offline PWA reliability, improves loading UX, and integrates import pages into the app shell.

## Changes

- **Service Worker precaching** (#1510): Added Vite build plugin that injects all JS/CSS chunk paths into the service worker as __PRECACHE_MANIFEST__. The SW install event now precaches all route chunks (resilient — individual failures don't block installation). Added network-first navigation handler that falls back to the cached app shell for offline SPA routing.
- **Remove duplicate OfflineBanner** (#1510): Removed OfflineBanner from AppLayout since SyncStatusBar already handles offline state display as a compact indicator.
- **Loading skeleton** (#1466): Replaced plain 'Loading...' text Suspense fallback with a CSS-only shimmer skeleton (header placeholder + content lines + block). Respects \prefers-reduced-motion\. Proper ARIA live region for screen reader announcements.
- **Import page navigation** (#1467): Added \/import\ and \/import/wizard\ to AUTHENTICATED_ROUTES and PAGE_TITLES so they render inside AppLayout with sidebar, bottom nav, and breadcrumbs.
- **Import page design consistency** (#1480): Fixed DataImportWizardPage semantic structure — changed \<main>\ to \<div>\ (AppLayout already provides \<main>\), adjusted heading level from h1 to h2 to avoid conflict with AppLayout's h1 page title.

## Issues

Closes #1510
Closes #1466
Closes #1467
Closes #1480