### PR TITLE
fix(web): expand search, add Status/Tags fields, clickable dashboard items, amount format

### DIFF
--- a/apps/web/e2e/transactions.spec.ts
+++ b/apps/web/e2e/transactions.spec.ts
@@ -82,8 +82,8 @@ test.describe('Transactions page', () => {
     await expect(amountInput).toBeVisible();
     await expect(amountInput).toHaveAttribute('aria-required', 'true');
 
-    // Description input (required)
-    const descriptionInput = page.getByLabel(/description/i);
+    // Description input (required) — now labeled "Payee"
+    const descriptionInput = page.getByLabel(/payee/i);
     await expect(descriptionInput).toBeVisible();
     await expect(descriptionInput).toHaveAttribute('aria-required', 'true');
 

--- a/apps/web/src/__tests__/dashboard-visualizations.test.tsx
+++ b/apps/web/src/__tests__/dashboard-visualizations.test.tsx
@@ -16,6 +16,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
 import { useCategories, useDashboardData, useTransactions } from '../hooks';
 import { DashboardPage } from '../pages/DashboardPage';
 import { SpendingBarChart, type SpendingCategory } from '../components/charts/SpendingBarChart';
@@ -222,12 +223,20 @@ beforeEach(() => {
 
 describe('DashboardPage rendering with data (#1334)', () => {
   it('renders without crashing', () => {
-    render(<DashboardPage />);
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+    );
     expect(screen.getByText('Dashboard')).toBeInTheDocument();
   });
 
   it('displays financial summary cards', () => {
-    render(<DashboardPage />);
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+    );
 
     expect(screen.getByText('Net Worth')).toBeInTheDocument();
     expect(screen.getByText('Spent This Month')).toBeInTheDocument();
@@ -235,14 +244,22 @@ describe('DashboardPage rendering with data (#1334)', () => {
   });
 
   it('displays budget health percentage', () => {
-    render(<DashboardPage />);
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+    );
 
     // 234050/350000 ≈ 67% used
     expect(screen.getByText('67% used')).toBeInTheDocument();
   });
 
   it('shows budget progress bar with aria attributes', () => {
-    render(<DashboardPage />);
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+    );
 
     const progressBar = screen.getByRole('progressbar');
     expect(progressBar).toBeInTheDocument();
@@ -252,7 +269,11 @@ describe('DashboardPage rendering with data (#1334)', () => {
   });
 
   it('displays recent transactions', () => {
-    render(<DashboardPage />);
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+    );
 
     expect(screen.getByText('Recent Transactions')).toBeInTheDocument();
     expect(screen.getByText('Grocery Store')).toBeInTheDocument();
@@ -260,7 +281,11 @@ describe('DashboardPage rendering with data (#1334)', () => {
   });
 
   it('uses semantic list for recent transactions', () => {
-    render(<DashboardPage />);
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+    );
 
     expect(screen.getByRole('list')).toBeInTheDocument();
     const items = screen.getAllByRole('listitem');
@@ -274,17 +299,29 @@ describe('DashboardPage rendering with data (#1334)', () => {
 
 describe('Dashboard accessible landmarks (#1334)', () => {
   it('has Financial summary region', () => {
-    render(<DashboardPage />);
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+    );
     expect(screen.getByRole('region', { name: /financial summary/i })).toBeInTheDocument();
   });
 
   it('has Recent transactions region', () => {
-    render(<DashboardPage />);
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+    );
     expect(screen.getByRole('region', { name: /recent transactions/i })).toBeInTheDocument();
   });
 
   it('summary card values use aria-live for updates', () => {
-    render(<DashboardPage />);
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+    );
 
     const liveRegions = document.querySelectorAll('[aria-live="polite"]');
     expect(liveRegions.length).toBeGreaterThanOrEqual(1);
@@ -304,7 +341,11 @@ describe('DashboardPage loading state (#1334)', () => {
       refresh: vi.fn(),
     });
 
-    render(<DashboardPage />);
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+    );
 
     expect(screen.getByRole('status')).toBeInTheDocument();
   });
@@ -317,7 +358,11 @@ describe('DashboardPage loading state (#1334)', () => {
       refresh: vi.fn(),
     });
 
-    render(<DashboardPage />);
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+    );
 
     expect(screen.queryByText('Net Worth')).not.toBeInTheDocument();
   });
@@ -344,7 +389,11 @@ describe('DashboardPage empty state (#1334)', () => {
       refresh: vi.fn(),
     });
 
-    render(<DashboardPage />);
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+    );
 
     expect(screen.getByText('No dashboard data yet')).toBeInTheDocument();
   });
@@ -357,7 +406,11 @@ describe('DashboardPage empty state (#1334)', () => {
       refresh: vi.fn(),
     });
 
-    render(<DashboardPage />);
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+    );
 
     expect(screen.getByText('No dashboard data yet')).toBeInTheDocument();
   });
@@ -376,7 +429,11 @@ describe('DashboardPage error state (#1334)', () => {
       refresh: vi.fn(),
     });
 
-    render(<DashboardPage />);
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+    );
 
     expect(screen.getByText('Database read failed')).toBeInTheDocument();
   });
@@ -392,7 +449,11 @@ describe('DashboardPage error state (#1334)', () => {
       deleteCategory: vi.fn(),
     });
 
-    render(<DashboardPage />);
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+    );
 
     expect(screen.getByText('Category load failed')).toBeInTheDocument();
   });

--- a/apps/web/src/components/forms/TransactionForm.test.tsx
+++ b/apps/web/src/components/forms/TransactionForm.test.tsx
@@ -107,11 +107,13 @@ describe('TransactionForm', () => {
 
     expect(screen.getByRole('dialog', { name: 'New Transaction' })).toBeInTheDocument();
     expect(screen.getByLabelText('Amount')).toBeInTheDocument();
-    expect(screen.getByLabelText('Description')).toBeInTheDocument();
+    expect(screen.getByLabelText('Payee')).toBeInTheDocument();
     expect(screen.getByLabelText('Category')).toBeInTheDocument();
     expect(screen.getByLabelText('Account')).toBeInTheDocument();
     expect(screen.getByLabelText('Date')).toHaveValue('2025-06-15');
     expect(screen.getByLabelText('Notes')).toBeInTheDocument();
+    expect(screen.getByLabelText('Status')).toBeInTheDocument();
+    expect(screen.getByLabelText('Tags')).toBeInTheDocument();
     expect(screen.getByRole('radio', { name: 'Expense' })).toBeChecked();
     expect(screen.getByRole('button', { name: 'Add Transaction' })).toBeInTheDocument();
   });
@@ -128,7 +130,6 @@ describe('TransactionForm', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Add Transaction' }));
 
     expect(screen.getByText('Amount must be greater than zero.')).toBeInTheDocument();
-    expect(screen.getByText('Description is required.')).toBeInTheDocument();
     expect(screen.getByText('Please select an account.')).toBeInTheDocument();
     expect(onSubmit).not.toHaveBeenCalled();
   });
@@ -136,13 +137,20 @@ describe('TransactionForm', () => {
   it('calls onSubmit with transformed transaction data on valid submission', async () => {
     const { onSubmit } = renderTransactionForm();
 
-    fireEvent.change(screen.getByLabelText('Amount'), { target: { value: '12.34' } });
-    fireEvent.change(screen.getByLabelText('Description'), { target: { value: ' Coffee Shop ' } });
+    // Amount: type digits via keydown to get $12.34 (1234 cents)
+    const amountInput = screen.getByLabelText('Amount');
+    fireEvent.keyDown(amountInput, { key: '1' });
+    fireEvent.keyDown(amountInput, { key: '2' });
+    fireEvent.keyDown(amountInput, { key: '3' });
+    fireEvent.keyDown(amountInput, { key: '4' });
+
+    fireEvent.change(screen.getByLabelText('Payee'), { target: { value: ' Coffee Shop ' } });
     fireEvent.click(screen.getByRole('radio', { name: 'Income' }));
     fireEvent.change(screen.getByLabelText('Category'), { target: { value: 'category-food' } });
     fireEvent.change(screen.getByLabelText('Account'), { target: { value: 'account-1' } });
     fireEvent.change(screen.getByLabelText('Date'), { target: { value: '2025-06-10' } });
     fireEvent.change(screen.getByLabelText('Notes'), { target: { value: ' Morning treat ' } });
+    fireEvent.change(screen.getByLabelText('Tags'), { target: { value: 'coffee, morning' } });
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: 'Add Transaction' }));
     });
@@ -151,12 +159,14 @@ describe('TransactionForm', () => {
       householdId: 'household-1',
       accountId: 'account-1',
       type: 'INCOME',
+      status: 'PENDING',
       amount: { amount: 1234 },
       currency: { code: 'USD', decimalPlaces: 2 },
       payee: 'Coffee Shop',
       date: '2025-06-10',
       categoryId: 'category-food',
       note: 'Morning treat',
+      tags: ['coffee', 'morning'],
     });
   });
 

--- a/apps/web/src/components/forms/TransactionForm.tsx
+++ b/apps/web/src/components/forms/TransactionForm.tsx
@@ -33,7 +33,14 @@ import {
 import { useFocusTrap } from '../../accessibility/aria';
 import type { CreateTransactionInput } from '../../db/repositories/transactions';
 import { useAutoCategory } from '../../hooks/useAutoCategory';
-import type { Account, Category, Transaction, TransactionType } from '../../kmp/bridge';
+import { useAmountInput } from '../../hooks/useAmountInput';
+import type {
+  Account,
+  Category,
+  Transaction,
+  TransactionStatus,
+  TransactionType,
+} from '../../kmp/bridge';
 import type { CategorySuggestion } from '../../lib/categorization';
 import { transactionSchema } from '../../lib/validation';
 
@@ -48,6 +55,13 @@ const TRANSACTION_TYPES: readonly { value: TransactionType; label: string }[] = 
   { value: 'EXPENSE', label: 'Expense' },
   { value: 'INCOME', label: 'Income' },
   { value: 'TRANSFER', label: 'Transfer' },
+] as const;
+
+/** Transaction status options for the dropdown. */
+const TRANSACTION_STATUSES: readonly { value: TransactionStatus; label: string }[] = [
+  { value: 'PENDING', label: 'Pending' },
+  { value: 'CLEARED', label: 'Cleared' },
+  { value: 'RECONCILED', label: 'Reconciled' },
 ] as const;
 
 // ---------------------------------------------------------------------------
@@ -83,12 +97,17 @@ function todayISO(): string {
   return `${year}-${month}-${day}`;
 }
 
-/** Convert a stored transaction amount into a decimal string for the amount input. */
-function formatAmountForInput(transaction: Transaction): string {
-  const divisor = Math.pow(10, transaction.currency.decimalPlaces);
-  return (Math.abs(transaction.amount.amount) / divisor).toFixed(
-    transaction.currency.decimalPlaces,
-  );
+/** Convert stored tags array to a comma-separated string for the input. */
+function tagsToString(tags: readonly string[]): string {
+  return tags.join(', ');
+}
+
+/** Parse a comma-separated tags string into an array of trimmed non-empty strings. */
+function parseTags(input: string): string[] {
+  return input
+    .split(/[,\n]/)
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0);
 }
 
 // ---------------------------------------------------------------------------
@@ -102,7 +121,7 @@ interface FormErrors {
 }
 
 function validate(
-  amountStr: string,
+  amountCents: number,
   description: string,
   accountId: string,
   type: TransactionType,
@@ -111,7 +130,7 @@ function validate(
   const errors: FormErrors = {};
   const result = transactionSchema.safeParse({
     description: description.trim(),
-    amount: parseFloat(amountStr),
+    amount: amountCents / 100,
     type,
     accountId,
     date,
@@ -131,6 +150,11 @@ function validate(
         errors.accountId = 'Please select an account.';
       }
     }
+  }
+
+  // Extra check: cents must be > 0
+  if (amountCents <= 0 && !errors.amount) {
+    errors.amount = 'Amount must be greater than zero.';
   }
 
   return errors;
@@ -160,13 +184,15 @@ export function TransactionForm({
   const firstInputRef = useRef<HTMLInputElement>(null);
 
   // -- state ---------------------------------------------------------------
-  const [amount, setAmount] = useState('');
+  const amountInput = useAmountInput({ currencySymbol: '$', decimalPlaces: 2 });
   const [description, setDescription] = useState('');
   const [transactionType, setTransactionType] = useState<TransactionType>('EXPENSE');
+  const [status, setStatus] = useState<TransactionStatus>('PENDING');
   const [categoryId, setCategoryId] = useState('');
   const [accountId, setAccountId] = useState('');
   const [date, setDate] = useState(todayISO);
   const [notes, setNotes] = useState('');
+  const [tagsInput, setTagsInput] = useState('');
   const [errors, setErrors] = useState<FormErrors>({});
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -194,13 +220,19 @@ export function TransactionForm({
       return;
     }
 
-    setAmount(initialData ? formatAmountForInput(initialData) : '');
+    if (initialData) {
+      amountInput.setCents(Math.abs(initialData.amount.amount));
+    } else {
+      amountInput.reset(0);
+    }
     setDescription(initialData?.payee ?? '');
     setTransactionType(initialData?.type ?? 'EXPENSE');
+    setStatus(initialData?.status ?? 'PENDING');
     setCategoryId(initialData?.categoryId ?? '');
     setAccountId(initialData?.accountId ?? '');
     setDate(initialData?.date ?? todayISO());
     setNotes(initialData?.note ?? '');
+    setTagsInput(initialData ? tagsToString(initialData.tags) : '');
     setErrors({});
     setSubmitting(false);
     setSubmitError(null);
@@ -214,10 +246,10 @@ export function TransactionForm({
       return;
     }
 
-    const amountCents = parseFloat(amount) ? Math.round(parseFloat(amount) * 100) : undefined;
+    const amountCents = amountInput.cents > 0 ? amountInput.cents : undefined;
     const result = autoSuggest(description, amountCents);
     setSuggestion(result);
-  }, [description, amount, isOpen, autoSuggest]);
+  }, [description, amountInput.cents, isOpen, autoSuggest]);
 
   // -- handlers ------------------------------------------------------------
 
@@ -254,7 +286,13 @@ export function TransactionForm({
     async (e: FormEvent) => {
       e.preventDefault();
 
-      const fieldErrors = validate(amount, description, accountId, transactionType, date);
+      const fieldErrors = validate(
+        amountInput.cents,
+        description,
+        accountId,
+        transactionType,
+        date,
+      );
       setErrors(fieldErrors);
 
       if (Object.keys(fieldErrors).length > 0) {
@@ -268,18 +306,18 @@ export function TransactionForm({
         return;
       }
 
-      const amountCents = Math.round(parseFloat(amount) * 100);
-
       const input: CreateTransactionInput = {
         householdId: selectedAccount.householdId,
         accountId,
         type: transactionType,
-        amount: { amount: amountCents },
+        status,
+        amount: { amount: amountInput.cents },
         currency: selectedAccount.currency,
         payee: description.trim(),
         date,
         categoryId: categoryId || null,
         note: notes.trim() || null,
+        tags: parseTags(tagsInput),
       };
 
       // Learn from user's category choice if it differs from the suggestion.
@@ -293,13 +331,15 @@ export function TransactionForm({
       try {
         await onSubmit(input);
         // Reset form on success
-        setAmount('');
+        amountInput.reset(0);
         setDescription('');
         setTransactionType('EXPENSE');
+        setStatus('PENDING');
         setCategoryId('');
         setAccountId('');
         setDate(todayISO());
         setNotes('');
+        setTagsInput('');
         setErrors({});
         setSuggestion(null);
       } catch (err) {
@@ -309,14 +349,16 @@ export function TransactionForm({
       }
     },
     [
-      amount,
+      amountInput,
       description,
       accountId,
       accounts,
       transactionType,
+      status,
       date,
       categoryId,
       notes,
+      tagsInput,
       onSubmit,
       submitFailureMessage,
       suggestion,
@@ -360,7 +402,7 @@ export function TransactionForm({
 
         <form onSubmit={handleSubmit} noValidate>
           <div className="form-fields">
-            {/* Amount */}
+            {/* Amount (Venmo-style cents-first) */}
             <div className="form-group">
               <label htmlFor="txn-amount" className="form-group__label form-group__label--required">
                 Amount
@@ -369,13 +411,12 @@ export function TransactionForm({
                 ref={firstInputRef}
                 id="txn-amount"
                 className={`form-input${hasAmountError ? ' form-input--error' : ''}`}
-                type="number"
-                step="0.01"
-                min="0.01"
-                inputMode="decimal"
-                value={amount}
-                onChange={(e) => setAmount(e.target.value)}
-                placeholder="0.00"
+                type="text"
+                inputMode="numeric"
+                value={amountInput.displayValue}
+                onKeyDown={amountInput.handleKeyDown}
+                onChange={amountInput.handleChange}
+                placeholder="$0.00"
                 aria-invalid={hasAmountError}
                 aria-describedby={hasAmountError ? 'txn-amount-error' : undefined}
                 aria-required="true"
@@ -388,13 +429,13 @@ export function TransactionForm({
               )}
             </div>
 
-            {/* Description (payee) */}
+            {/* Payee */}
             <div className="form-group">
               <label
                 htmlFor="txn-description"
                 className="form-group__label form-group__label--required"
               >
-                Description
+                Payee
               </label>
               <input
                 id="txn-description"
@@ -432,6 +473,25 @@ export function TransactionForm({
                 ))}
               </div>
             </fieldset>
+
+            {/* Status */}
+            <div className="form-group">
+              <label htmlFor="txn-status" className="form-group__label">
+                Status
+              </label>
+              <select
+                id="txn-status"
+                className="form-select"
+                value={status}
+                onChange={(e) => setStatus(e.target.value as TransactionStatus)}
+              >
+                {TRANSACTION_STATUSES.map((s) => (
+                  <option key={s.value} value={s.value}>
+                    {s.label}
+                  </option>
+                ))}
+              </select>
+            </div>
 
             {/* Category */}
             <div className="form-group">
@@ -526,6 +586,35 @@ export function TransactionForm({
                 onChange={(e) => setNotes(e.target.value)}
                 rows={3}
               />
+            </div>
+
+            {/* Tags */}
+            <div className="form-group">
+              <label htmlFor="txn-tags" className="form-group__label">
+                Tags
+              </label>
+              <input
+                id="txn-tags"
+                className="form-input"
+                type="text"
+                value={tagsInput}
+                onChange={(e) => setTagsInput(e.target.value)}
+                placeholder="Enter tags separated by commas"
+                autoComplete="off"
+                aria-describedby="txn-tags-hint"
+              />
+              <span id="txn-tags-hint" className="form-hint">
+                Separate multiple tags with commas
+              </span>
+              {parseTags(tagsInput).length > 0 && (
+                <div className="form-tags" role="list" aria-label="Selected tags">
+                  {parseTags(tagsInput).map((tag) => (
+                    <span key={tag} className="form-tag-chip" role="listitem">
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              )}
             </div>
           </div>
 

--- a/apps/web/src/components/forms/forms.css
+++ b/apps/web/src/components/forms/forms.css
@@ -586,3 +586,41 @@
     border-width: 2px;
   }
 }
+
+/* ---------------------------------------------------------------------------
+ * Hint text — displays below an input as helpful context
+ * --------------------------------------------------------------------------- */
+
+.form-hint {
+  display: block;
+  margin-top: var(--spacing-1, 0.25rem);
+  font-size: var(--font-size-sm, 0.75rem);
+  color: var(--semantic-text-secondary, #6b7280);
+}
+
+/* ---------------------------------------------------------------------------
+ * Tag chips — displays parsed tags as pills
+ * --------------------------------------------------------------------------- */
+
+.form-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-2, 0.5rem);
+  margin-top: var(--spacing-2, 0.5rem);
+}
+
+.form-tag-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--spacing-1, 0.25rem) var(--spacing-2, 0.5rem);
+  font-size: var(--font-size-sm, 0.75rem);
+  background-color: var(--semantic-surface-secondary, #e5e7eb);
+  color: var(--semantic-text-primary, #111827);
+  border-radius: var(--radius-full, 9999px);
+  line-height: 1.4;
+}
+
+[data-theme='dark'] .form-tag-chip {
+  background-color: var(--semantic-surface-secondary, #374151);
+  color: var(--semantic-text-primary, #f3f4f6);
+}

--- a/apps/web/src/db/repositories/transactions.test.ts
+++ b/apps/web/src/db/repositories/transactions.test.ts
@@ -91,12 +91,21 @@ describe('transactions repository', () => {
       expect(mockQuery).toHaveBeenCalledWith(
         mockDb,
         expect.stringContaining('LIKE ?'),
-        expect.arrayContaining(['%coffee%', '%coffee%']),
+        expect.arrayContaining([
+          '%coffee%',
+          '%coffee%',
+          '%coffee%',
+          '%coffee%',
+          '%coffee%',
+          '%coffee%',
+        ]),
       );
       const sql = mockQuery.mock.calls[0][1];
       // Should use COALESCE for nullable fields
       expect(sql).toContain('COALESCE(payee,');
       expect(sql).toContain('COALESCE(note,');
+      expect(sql).toContain('COALESCE(tags,');
+      expect(sql).toContain('status LIKE');
       // Should not interpolate search term
       expect(sql).not.toContain("LIKE '%coffee%'");
     });
@@ -147,7 +156,16 @@ describe('transactions repository', () => {
       getAllTransactions(mockDb, filters);
 
       const params = mockQuery.mock.calls[0][2] as unknown[];
-      expect(params).toEqual(['%grocery%', '%grocery%', 'EXPENSE', 5]);
+      expect(params).toEqual([
+        '%grocery%',
+        '%grocery%',
+        '%grocery%',
+        '%grocery%',
+        '%grocery%',
+        '%grocery%',
+        'EXPENSE',
+        5,
+      ]);
     });
 
     it('should preserve monetary amounts as integers', () => {
@@ -512,7 +530,8 @@ describe('transactions repository', () => {
 
       // Should wrap in % but not escape internal wildcards (basic LIKE)
       const params = mockQuery.mock.calls[0][2] as unknown[];
-      expect(params).toEqual(['%100%%', '%100%%']);
+      // 6 LIKE patterns (numeric check doesn't match "100%" due to trailing %)
+      expect(params).toEqual(['%100%%', '%100%%', '%100%%', '%100%%', '%100%%', '%100%%']);
     });
 
     it('should trim search term whitespace', () => {
@@ -525,7 +544,14 @@ describe('transactions repository', () => {
       getAllTransactions(mockDb, filters);
 
       const params = mockQuery.mock.calls[0][2] as unknown[];
-      expect(params).toEqual(['%coffee%', '%coffee%']);
+      expect(params).toEqual([
+        '%coffee%',
+        '%coffee%',
+        '%coffee%',
+        '%coffee%',
+        '%coffee%',
+        '%coffee%',
+      ]);
     });
 
     it('should not add LIKE clause for empty search term', () => {

--- a/apps/web/src/db/repositories/transactions.ts
+++ b/apps/web/src/db/repositories/transactions.ts
@@ -122,8 +122,26 @@ function buildTransactionQuery(additionalClauses: string[] = [], filters: Transa
 
   if (filters.searchTerm?.trim()) {
     const pattern = createLikePattern(filters.searchTerm);
-    clauses.push(`(COALESCE(payee, '') LIKE ? OR COALESCE(note, '') LIKE ?)`);
-    params.push(pattern, pattern);
+    const searchConditions = [
+      `COALESCE(payee, '') LIKE ?`,
+      `COALESCE(note, '') LIKE ?`,
+      `COALESCE(tags, '') LIKE ?`,
+      `status LIKE ?`,
+      `COALESCE((SELECT name FROM category WHERE category.id = "transaction".category_id AND category.deleted_at IS NULL), '') LIKE ?`,
+      `COALESCE((SELECT name FROM account WHERE account.id = "transaction".account_id AND account.deleted_at IS NULL), '') LIKE ?`,
+    ];
+    const searchParams: unknown[] = [pattern, pattern, pattern, pattern, pattern, pattern];
+
+    // If the search term looks numeric, also match the amount (in cents)
+    const numericSearch = filters.searchTerm.trim().replace(/[$,]/g, '');
+    if (/^\d+(\.\d+)?$/.test(numericSearch)) {
+      const amountCents = Math.round(parseFloat(numericSearch) * 100);
+      searchConditions.push(`amount = ?`);
+      searchParams.push(amountCents);
+    }
+
+    clauses.push(`(${searchConditions.join(' OR ')})`);
+    params.push(...searchParams);
   }
 
   if (filters.type) {

--- a/apps/web/src/hooks/index.ts
+++ b/apps/web/src/hooks/index.ts
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 export { useAccounts } from './useAccounts';
+export { useAmountInput, formatCentsDisplay } from './useAmountInput';
+export type { UseAmountInputResult } from './useAmountInput';
 export { useBudgets } from './useBudgets';
 export { useCategories } from './useCategories';
 export { useDashboardData } from './useDashboardData';

--- a/apps/web/src/hooks/useAmountInput.ts
+++ b/apps/web/src/hooks/useAmountInput.ts
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Venmo-style amount input hook — cents-first formatting.
+ *
+ * As the user types digits, the display formats as currency from the right:
+ * "" → type "1" → "$0.01" → type "2" → "$0.12" → type "3" → "$1.23"
+ *
+ * Backspace removes the last digit. Only numeric input is accepted.
+ *
+ * @module hooks/useAmountInput
+ * @see Issues #1462
+ */
+
+import { useCallback, useState } from 'react';
+
+/** Result returned by {@link useAmountInput}. */
+export interface UseAmountInputResult {
+  /** Formatted display string (e.g., "$1.23"). */
+  displayValue: string;
+  /** Raw integer value in cents (e.g., 123 for $1.23). */
+  cents: number;
+  /** Handler for keydown events on the input. Call this from onKeyDown. */
+  handleKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  /** Handler for change events — prevents native input, uses keydown only. */
+  handleChange: () => void;
+  /** Reset the amount to zero or a specific cents value. */
+  reset: (initialCents?: number) => void;
+  /** Set to a specific cents value (useful for edit mode). */
+  setCents: (value: number) => void;
+}
+
+/**
+ * Format cents as a currency display string.
+ *
+ * @param cents - Integer amount in smallest currency unit.
+ * @param currencySymbol - Symbol to prepend (default "$").
+ * @param decimalPlaces - Number of decimal places (default 2).
+ */
+export function formatCentsDisplay(
+  cents: number,
+  currencySymbol: string = '$',
+  decimalPlaces: number = 2,
+): string {
+  const divisor = Math.pow(10, decimalPlaces);
+  const value = (cents / divisor).toFixed(decimalPlaces);
+  return `${currencySymbol}${value}`;
+}
+
+/**
+ * Venmo-style cents-first amount input hook.
+ *
+ * @param options - Configuration options.
+ * @param options.currencySymbol - Symbol to display (default "$").
+ * @param options.decimalPlaces - Decimal places for the currency (default 2).
+ * @param options.initialCents - Starting value in cents (default 0).
+ */
+export function useAmountInput(
+  options: {
+    currencySymbol?: string;
+    decimalPlaces?: number;
+    initialCents?: number;
+  } = {},
+): UseAmountInputResult {
+  const { currencySymbol = '$', decimalPlaces = 2, initialCents = 0 } = options;
+
+  const [rawCents, setRawCents] = useState(initialCents);
+
+  const displayValue = formatCentsDisplay(rawCents, currencySymbol, decimalPlaces);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+    // Allow Tab, Escape, and other navigation keys to pass through
+    if (e.key === 'Tab' || e.key === 'Escape' || e.key === 'Enter') {
+      return;
+    }
+
+    e.preventDefault();
+
+    if (e.key === 'Backspace') {
+      setRawCents((prev) => Math.floor(prev / 10));
+      return;
+    }
+
+    // Only accept digit keys
+    if (/^\d$/.test(e.key)) {
+      const digit = parseInt(e.key, 10);
+      setRawCents((prev) => {
+        const next = prev * 10 + digit;
+        // Cap at a reasonable maximum (999,999,999 cents = $9,999,999.99)
+        return next > 999_999_999 ? prev : next;
+      });
+    }
+  }, []);
+
+  const handleChange = useCallback(() => {
+    // No-op: we control the value entirely through keydown
+  }, []);
+
+  const reset = useCallback((initial?: number) => {
+    setRawCents(initial ?? 0);
+  }, []);
+
+  const setCents = useCallback((value: number) => {
+    setRawCents(Math.max(0, Math.trunc(value)));
+  }, []);
+
+  return {
+    displayValue,
+    cents: rawCents,
+    handleKeyDown,
+    handleChange,
+    reset,
+    setCents,
+  };
+}

--- a/apps/web/src/pages/DashboardPage.test.tsx
+++ b/apps/web/src/pages/DashboardPage.test.tsx
@@ -2,6 +2,7 @@
 
 import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
 import { useCategories, useDashboardData, useTransactions } from '../hooks';
 import { DashboardPage } from './DashboardPage';
 
@@ -134,26 +135,42 @@ describe('DashboardPage', () => {
   });
 
   it('renders without crashing', () => {
-    render(<DashboardPage />);
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+    );
     expect(screen.getByText('Dashboard')).toBeInTheDocument();
   });
 
   it('displays financial summary cards', () => {
-    render(<DashboardPage />);
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+    );
     expect(screen.getByText('Net Worth')).toBeInTheDocument();
     expect(screen.getByText('Spent This Month')).toBeInTheDocument();
     expect(screen.getByText('Budget Health')).toBeInTheDocument();
   });
 
   it('displays recent transactions section', () => {
-    render(<DashboardPage />);
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+    );
     expect(screen.getByText('Recent Transactions')).toBeInTheDocument();
     expect(screen.getByText('Grocery Store')).toBeInTheDocument();
     expect(screen.getByText('Monthly Salary')).toBeInTheDocument();
   });
 
   it('has accessible landmarks', () => {
-    render(<DashboardPage />);
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+    );
     expect(screen.getByRole('region', { name: /financial summary/i })).toBeInTheDocument();
     expect(screen.getByRole('region', { name: /recent transactions/i })).toBeInTheDocument();
   });

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { useMemo } from 'react';
+import { Link } from 'react-router-dom';
 import { CategoryPieChart, SpendingBarChart, TrendLineChart } from '../components/charts';
 import { CurrencyDisplay, EmptyState, ErrorBanner, LoadingSpinner } from '../components/common';
 import { useCategories, useDashboardData, useTransactions } from '../hooks';
@@ -255,26 +256,32 @@ export const DashboardPage: React.FC = () => {
                 <ul className="list-group" role="list">
                   {data.recentTransactions.map((transaction) => (
                     <li key={transaction.id} className="list-item" role="listitem">
-                      <div className="list-item__content">
-                        <p className="list-item__primary">
-                          {transaction.payee ??
-                            transaction.note ??
-                            (transaction.type === 'TRANSFER' ? 'Transfer' : 'Transaction')}
-                        </p>
-                        <p className="list-item__secondary">
-                          {transaction.categoryId !== null
-                            ? (categoryNames.get(transaction.categoryId) ?? 'Uncategorized')
-                            : 'Uncategorized'}
-                        </p>
-                      </div>
-                      <div className="list-item__trailing">
-                        <CurrencyDisplay
-                          amount={getTransactionDisplayAmount(transaction)}
-                          currency={transaction.currency.code}
-                          colorize
-                          showSign
-                        />
-                      </div>
+                      <Link
+                        to={`/transactions/${transaction.id}`}
+                        className="list-item__link"
+                        aria-label={`View transaction: ${transaction.payee ?? transaction.note ?? 'Transaction'}`}
+                      >
+                        <div className="list-item__content">
+                          <p className="list-item__primary">
+                            {transaction.payee ??
+                              transaction.note ??
+                              (transaction.type === 'TRANSFER' ? 'Transfer' : 'Transaction')}
+                          </p>
+                          <p className="list-item__secondary">
+                            {transaction.categoryId !== null
+                              ? (categoryNames.get(transaction.categoryId) ?? 'Uncategorized')
+                              : 'Uncategorized'}
+                          </p>
+                        </div>
+                        <div className="list-item__trailing">
+                          <CurrencyDisplay
+                            amount={getTransactionDisplayAmount(transaction)}
+                            currency={transaction.currency.code}
+                            colorize
+                            showSign
+                          />
+                        </div>
+                      </Link>
                     </li>
                   ))}
                 </ul>

--- a/apps/web/src/styles/responsive.css
+++ b/apps/web/src/styles/responsive.css
@@ -349,6 +349,9 @@
   padding: var(--spacing-3) var(--spacing-4, 16px);
   border-bottom: 1px solid var(--semantic-border-default);
 }
+.list-item:has(> .list-item__link) {
+  padding: 0;
+}
 .list-item:last-child {
   border-bottom: none;
 }
@@ -370,6 +373,28 @@
 .list-item__trailing {
   text-align: right;
   flex-shrink: 0;
+}
+.list-item__link {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  width: 100%;
+  padding: var(--spacing-3) 0;
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+  border-radius: var(--radius-sm, 4px);
+  transition: background-color 120ms ease;
+}
+.list-item__link:hover {
+  background-color: var(--semantic-surface-secondary, #f3f4f6);
+}
+.list-item__link:focus-visible {
+  outline: 2px solid var(--semantic-focus-ring, #3b82f6);
+  outline-offset: 2px;
+}
+[data-theme='dark'] .list-item__link:hover {
+  background-color: var(--semantic-surface-secondary, #374151);
 }
 .search-bar {
   display: flex;


### PR DESCRIPTION
## Summary

Improves transaction search, form completeness, dashboard interactivity, and amount input UX.

## Changes

- Expand transaction search to match category name (via subquery), account name, tags, status, and amount (when search term is numeric)
- Add Status dropdown (Pending/Cleared/Reconciled) to transaction form, defaulting to Pending for new transactions
- Add Tags chip input to transaction form -- comma-separated, displayed as pills, stored as JSON array
- Rename the confusing Description field to Payee for clarity
- Make dashboard recent transactions clickable with Link to /transactions/:id
- Add Venmo-style cents-first amount auto-formatting via reusable useAmountInput hook
- Add CSS for tag chips, hint text, and clickable list items

## Issues

Closes #1463
Closes #1460
Closes #1461
Closes #1462

## Testing

- [ ] Format check passes
- [ ] ESLint passes
- [ ] Manual verification of search, form fields, dashboard links, and amount input