### PR TITLE
feat(ios): expand search, form fields, feedback button, amount format

### DIFF
--- a/apps/ios/Finance/Components/FlowLayout.swift
+++ b/apps/ios/Finance/Components/FlowLayout.swift
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// FlowLayout.swift
+// Finance
+//
+// A simple flow layout that wraps child views horizontally. Used for
+// displaying tag chips that wrap to the next line. Refs #1485
+
+import SwiftUI
+
+/// A layout that arranges views in a horizontal flow, wrapping to
+/// the next line when the available width is exceeded.
+struct FlowLayout: Layout {
+    var spacing: CGFloat = 8
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache _: inout ()) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        var currentX: CGFloat = 0
+        var currentY: CGFloat = 0
+        var lineHeight: CGFloat = 0
+        var totalHeight: CGFloat = 0
+        var totalWidth: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if currentX + size.width > maxWidth, currentX > 0 {
+                currentX = 0
+                currentY += lineHeight + spacing
+                lineHeight = 0
+            }
+            currentX += size.width + spacing
+            lineHeight = max(lineHeight, size.height)
+            totalWidth = max(totalWidth, currentX - spacing)
+            totalHeight = currentY + lineHeight
+        }
+
+        return CGSize(width: totalWidth, height: totalHeight)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache _: inout ()) {
+        let maxWidth = proposal.width ?? bounds.width
+        var currentX: CGFloat = bounds.minX
+        var currentY: CGFloat = bounds.minY
+        var lineHeight: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if currentX + size.width > bounds.minX + maxWidth, currentX > bounds.minX {
+                currentX = bounds.minX
+                currentY += lineHeight + spacing
+                lineHeight = 0
+            }
+            subview.place(at: CGPoint(x: currentX, y: currentY), proposal: .unspecified)
+            currentX += size.width + spacing
+            lineHeight = max(lineHeight, size.height)
+        }
+    }
+}

--- a/apps/ios/Finance/Components/TagChipView.swift
+++ b/apps/ios/Finance/Components/TagChipView.swift
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// TagChipView.swift
+// Finance
+//
+// A removable capsule/chip view for displaying tags. Used in the
+// transaction create/edit form for tag management. Refs #1485
+
+import SwiftUI
+
+/// A small capsule view representing a tag with a remove button.
+struct TagChipView: View {
+    let text: String
+    let onRemove: () -> Void
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Text(text)
+                .font(.subheadline)
+                .lineLimit(1)
+            Button {
+                onRemove()
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(String(localized: "Remove tag \(text)"))
+            .accessibilityHint(String(localized: "Removes this tag from the transaction"))
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(Color(.systemGray5), in: Capsule())
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(String(localized: "Tag: \(text)"))
+        .accessibilityRemoveTraits(.isButton)
+        .accessibilityAddTraits(.isStaticText)
+    }
+}
+
+#Preview {
+    HStack {
+        TagChipView(text: "groceries") {}
+        TagChipView(text: "recurring") {}
+    }
+    .padding()
+}

--- a/apps/ios/Finance/Models/TransactionItem.swift
+++ b/apps/ios/Finance/Models/TransactionItem.swift
@@ -72,6 +72,7 @@ struct TransactionItem: Identifiable, Hashable, Sendable {
     let type: TransactionTypeUI
     let status: TransactionStatusUI
     let notes: String
+    let tags: [String]
     let isRecurring: Bool
     let receiptData: Data?
 
@@ -89,6 +90,7 @@ struct TransactionItem: Identifiable, Hashable, Sendable {
         type: TransactionTypeUI = .expense,
         status: TransactionStatusUI = .cleared,
         notes: String = "",
+        tags: [String] = [],
         isRecurring: Bool = false,
         receiptData: Data? = nil
     ) {
@@ -102,6 +104,7 @@ struct TransactionItem: Identifiable, Hashable, Sendable {
         self.type = type
         self.status = status
         self.notes = notes
+        self.tags = tags
         self.isRecurring = isRecurring
         self.receiptData = receiptData
     }

--- a/apps/ios/Finance/Screens/FeedbackView.swift
+++ b/apps/ios/Finance/Screens/FeedbackView.swift
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// FeedbackView.swift
+// Finance
+//
+// In-app feedback and bug report sheet. Captures type (Bug, Feedback,
+// Suggestion), description, and device context. Stores locally for alpha;
+// backend integration planned. Refs #1488
+
+import os
+import SwiftUI
+
+// MARK: - Feedback Type
+
+/// The category of feedback being submitted.
+enum FeedbackType: String, CaseIterable, Sendable {
+    case bug = "Bug"
+    case feedback = "Feedback"
+    case suggestion = "Suggestion"
+
+    var displayName: String {
+        switch self {
+        case .bug: String(localized: "Bug Report")
+        case .feedback: String(localized: "Feedback")
+        case .suggestion: String(localized: "Suggestion")
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .bug: "ladybug"
+        case .feedback: "bubble.left"
+        case .suggestion: "lightbulb"
+        }
+    }
+}
+
+// MARK: - FeedbackViewModel
+
+@Observable
+final class FeedbackViewModel {
+    var feedbackType: FeedbackType = .bug
+    var descriptionText = ""
+    var isSaving = false
+    var showingConfirmation = false
+    var errorMessage: String?
+
+    /// Device info auto-captured for context.
+    var deviceInfo: String {
+        let device = UIDevice.current
+        let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+        let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "?"
+        return "\(device.systemName) \(device.systemVersion), App \(appVersion) (\(buildNumber))"
+    }
+
+    var canSubmit: Bool {
+        !descriptionText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
+        category: "FeedbackViewModel"
+    )
+
+    /// Saves feedback locally. TODO: Integrate with backend API.
+    func submit() async -> Bool {
+        guard canSubmit else { return false }
+        isSaving = true
+        defer { isSaving = false }
+
+        let entry = FeedbackEntry(
+            id: UUID().uuidString,
+            type: feedbackType.rawValue,
+            description: descriptionText,
+            deviceInfo: deviceInfo,
+            createdAt: Date()
+        )
+
+        // Store locally for alpha — append to existing feedback
+        var existing = Self.loadLocalFeedback()
+        existing.append(entry)
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        guard let data = try? encoder.encode(existing) else {
+            errorMessage = String(localized: "Failed to save feedback.")
+            Self.logger.error("Failed to encode feedback entry")
+            return false
+        }
+
+        UserDefaults.standard.set(data, forKey: Self.feedbackStorageKey)
+        Self.logger.info("Feedback saved locally: type=\(entry.type, privacy: .public)")
+        showingConfirmation = true
+        return true
+    }
+
+    // MARK: - Local Storage
+
+    private static let feedbackStorageKey = "finance_local_feedback"
+
+    private static func loadLocalFeedback() -> [FeedbackEntry] {
+        guard let data = UserDefaults.standard.data(forKey: feedbackStorageKey) else { return [] }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return (try? decoder.decode([FeedbackEntry].self, from: data)) ?? []
+    }
+}
+
+// MARK: - FeedbackEntry
+
+/// A locally stored feedback entry.
+private struct FeedbackEntry: Codable, Sendable {
+    let id: String
+    let type: String
+    let description: String
+    let deviceInfo: String
+    let createdAt: Date
+}
+
+// MARK: - FeedbackView
+
+/// A sheet for submitting bug reports, feedback, or suggestions.
+struct FeedbackView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var viewModel = FeedbackViewModel()
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section(String(localized: "Type")) {
+                    Picker(String(localized: "Feedback Type"), selection: $viewModel.feedbackType) {
+                        ForEach(FeedbackType.allCases, id: \.rawValue) { type in
+                            Label(type.displayName, systemImage: type.systemImage)
+                                .tag(type)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .accessibilityLabel(String(localized: "Feedback type"))
+                    .accessibilityHint(String(localized: "Select whether this is a bug report, feedback, or suggestion"))
+                }
+
+                Section(String(localized: "Description")) {
+                    TextEditor(text: $viewModel.descriptionText)
+                        .frame(minHeight: 120)
+                        .accessibilityLabel(String(localized: "Description"))
+                        .accessibilityHint(String(localized: "Describe the issue or suggestion in detail"))
+                    if viewModel.descriptionText.isEmpty {
+                        Text(String(localized: "Please describe what you experienced or what you'd like to see improved."))
+                            .foregroundStyle(.tertiary)
+                            .font(.subheadline)
+                            .allowsHitTesting(false)
+                            .accessibilityHidden(true)
+                    }
+                }
+
+                Section(String(localized: "Device Info")) {
+                    Text(viewModel.deviceInfo)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .accessibilityLabel(String(localized: "Device information: \(viewModel.deviceInfo)"))
+                }
+            }
+            .navigationTitle(String(localized: "Send Feedback"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(String(localized: "Cancel")) { dismiss() }
+                        .accessibilityLabel(String(localized: "Cancel"))
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(String(localized: "Submit")) {
+                        Task {
+                            if await viewModel.submit() {
+                                // Dismiss after brief confirmation
+                                try? await Task.sleep(for: .seconds(1))
+                                dismiss()
+                            }
+                        }
+                    }
+                    .disabled(!viewModel.canSubmit || viewModel.isSaving)
+                    .accessibilityLabel(String(localized: "Submit feedback"))
+                    .accessibilityHint(String(localized: "Sends your feedback"))
+                }
+            }
+            .alert(String(localized: "Thank You!"), isPresented: $viewModel.showingConfirmation) {
+                Button(String(localized: "OK"), role: .cancel) { dismiss() }
+            } message: {
+                Text(String(localized: "Your feedback has been saved. We'll review it soon."))
+            }
+            .alert(String(localized: "Error"), isPresented: Binding(
+                get: { viewModel.errorMessage != nil },
+                set: { if !$0 { viewModel.errorMessage = nil } }
+            )) {
+                Button(String(localized: "OK"), role: .cancel) {}
+            } message: {
+                if let msg = viewModel.errorMessage {
+                    Text(msg)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    FeedbackView()
+}

--- a/apps/ios/Finance/Screens/SettingsView.swift
+++ b/apps/ios/Finance/Screens/SettingsView.swift
@@ -317,6 +317,14 @@ struct SettingsView: View {
             }
             .accessibilityLabel(String(localized: "App version \(viewModel.appVersion), build \(viewModel.buildNumber)"))
 
+            Button {
+                viewModel.showingFeedback = true
+            } label: {
+                Label(String(localized: "Send Feedback"), systemImage: "envelope")
+            }
+            .accessibilityLabel(String(localized: "Send Feedback"))
+            .accessibilityHint(String(localized: "Opens a form to report bugs or suggest improvements"))
+
             NavigationLink {
                 AboutView()
             } label: {
@@ -332,6 +340,9 @@ struct SettingsView: View {
             }
             .accessibilityLabel(String(localized: "Acknowledgments"))
             .accessibilityHint(String(localized: "Opens the open source acknowledgments"))
+        }
+        .sheet(isPresented: $viewModel.showingFeedback) {
+            FeedbackView()
         }
     }
 }

--- a/apps/ios/Finance/Screens/TransactionCreateView.swift
+++ b/apps/ios/Finance/Screens/TransactionCreateView.swift
@@ -130,12 +130,39 @@ struct TransactionCreateView: View {
             Section(String(localized: "Amount")) {
                 HStack {
                     Text(currencySymbol).font(.title2).foregroundStyle(.secondary)
-                    TextField(String(localized: "0.00"), text: $viewModel.amountText)
-                        .font(.title2).keyboardType(.decimalPad)
-                        .accessibilityIdentifier("transaction_amount_field")
+                    Text(viewModel.formattedAmount)
+                        .font(.title2.monospacedDigit())
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .contentShape(Rectangle())
+                        .accessibilityIdentifier("transaction_amount_display")
                         .accessibilityLabel(String(localized: "Transaction amount"))
-                        .accessibilityHint(String(localized: "Enter the amount in dollars"))
+                        .accessibilityValue(String(localized: "\(currencySymbol)\(viewModel.formattedAmount)"))
                 }
+                // Venmo-style digit pad (#1486)
+                LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 3), spacing: 12) {
+                    ForEach(["1", "2", "3", "4", "5", "6", "7", "8", "9", "", "0", "⌫"], id: \.self) { key in
+                        if key.isEmpty {
+                            Color.clear.frame(height: 44)
+                        } else {
+                            Button {
+                                if key == "⌫" {
+                                    viewModel.removeLastAmountDigit()
+                                } else {
+                                    viewModel.appendAmountDigit(key.first!)
+                                }
+                            } label: {
+                                Text(key)
+                                    .font(.title3.weight(.medium))
+                                    .frame(maxWidth: .infinity, minHeight: 44)
+                                    .background(Color(.systemGray6), in: RoundedRectangle(cornerRadius: 8))
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel(key == "⌫" ? String(localized: "Delete") : key)
+                            .accessibilityHint(key == "⌫" ? String(localized: "Removes the last digit") : String(localized: "Adds digit \(key) to the amount"))
+                        }
+                    }
+                }
+                .padding(.vertical, 8)
             }
             Section(String(localized: "Payee")) {
                 TextField(String(localized: "Who was this payment to?"), text: $viewModel.payee)
@@ -159,6 +186,43 @@ struct TransactionCreateView: View {
                     }
                 }
                 .accessibilityLabel(String(localized: "Category"))
+            }
+            Section(String(localized: "Status")) {
+                Picker(String(localized: "Status"), selection: $viewModel.selectedStatus) {
+                    Text(TransactionStatusUI.pending.displayName).tag(TransactionStatusUI.pending)
+                    Text(TransactionStatusUI.cleared.displayName).tag(TransactionStatusUI.cleared)
+                    Text(TransactionStatusUI.reconciled.displayName).tag(TransactionStatusUI.reconciled)
+                }
+                .accessibilityLabel(String(localized: "Transaction status"))
+                .accessibilityHint(String(localized: "Select the clearance status of this transaction"))
+            }
+            Section(String(localized: "Tags")) {
+                // Existing tags as removable capsules
+                if !viewModel.tags.isEmpty {
+                    FlowLayout(spacing: 8) {
+                        ForEach(Array(viewModel.tags.enumerated()), id: \.offset) { index, tag in
+                            TagChipView(text: tag) {
+                                viewModel.removeTag(at: index)
+                            }
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+                HStack {
+                    TextField(String(localized: "Add a tag..."), text: $viewModel.currentTagText)
+                        .onSubmit { viewModel.addTag() }
+                        .accessibilityLabel(String(localized: "Tag input"))
+                        .accessibilityHint(String(localized: "Type a tag name and press return to add it"))
+                    Button {
+                        viewModel.addTag()
+                    } label: {
+                        Image(systemName: "plus.circle.fill")
+                            .foregroundStyle(.blue)
+                    }
+                    .disabled(viewModel.currentTagText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    .accessibilityLabel(String(localized: "Add tag"))
+                    .accessibilityHint(String(localized: "Adds the entered text as a tag"))
+                }
             }
             Section(String(localized: "Date")) {
                 DatePicker(String(localized: "Date"), selection: $viewModel.date, displayedComponents: .date)
@@ -192,7 +256,13 @@ struct TransactionCreateView: View {
                    let category = viewModel.categories.first(where: { $0.id == categoryId }) {
                     LabeledContent(String(localized: "Category")) { Text(category.name) }
                 }
+                LabeledContent(String(localized: "Status")) { Text(viewModel.selectedStatus.displayName) }
                 LabeledContent(String(localized: "Date")) { Text(viewModel.date, style: .date) }
+                if !viewModel.tags.isEmpty {
+                    LabeledContent(String(localized: "Tags")) {
+                        Text(viewModel.tags.joined(separator: ", ")).foregroundStyle(.secondary)
+                    }
+                }
                 if !viewModel.note.isEmpty {
                     LabeledContent(String(localized: "Note")) { Text(viewModel.note).foregroundStyle(.secondary) }
                 }

--- a/apps/ios/Finance/ViewModels/SettingsViewModel.swift
+++ b/apps/ios/Finance/ViewModels/SettingsViewModel.swift
@@ -122,6 +122,9 @@ final class SettingsViewModel {
     var showingBiometricError = false
     var errorMessage: String?
 
+    /// Controls visibility of the feedback sheet.
+    var showingFeedback = false
+
     /// Whether a general error alert should be presented.
     var showError: Bool { errorMessage != nil }
 

--- a/apps/ios/Finance/ViewModels/TransactionCreateViewModel.swift
+++ b/apps/ios/Finance/ViewModels/TransactionCreateViewModel.swift
@@ -48,6 +48,13 @@ final class TransactionCreateViewModel {
     var isSaving = false
     var showingValidationError = false
     var validationMessage = ""
+    var selectedStatus: TransactionStatusUI = .pending
+    var tags: [String] = []
+    var currentTagText = ""
+
+    /// Venmo-style amount: stores raw digit input (no decimals).
+    /// e.g. user types "1", "2", "3" → amountCents = 123 → displays "$1.23"
+    var amountCents: Int = 0
 
     /// Category auto-suggested by the KMP CategorizationEngine based on payee.
     var suggestedCategoryId: String?
@@ -66,12 +73,50 @@ final class TransactionCreateViewModel {
     var canAdvance: Bool {
         switch currentStep {
         case .type: true
-        case .details: !amountText.isEmpty && selectedAccountId != nil && !payee.isEmpty
+        case .details: amountCents > 0 && selectedAccountId != nil && !payee.isEmpty
         case .review: true
         }
     }
 
-    var amountMinorUnits: Int64 { Int64((Double(amountText) ?? 0) * 100) }
+    var amountMinorUnits: Int64 { Int64(amountCents) }
+
+    /// Formatted display string for the Venmo-style amount input.
+    var formattedAmount: String {
+        let dollars = amountCents / 100
+        let cents = amountCents % 100
+        return String(format: "%d.%02d", dollars, cents)
+    }
+
+    /// Appends a digit to the amount (Venmo-style cents-first input).
+    func appendAmountDigit(_ digit: Character) {
+        guard digit.isNumber else { return }
+        let newCents = amountCents * 10 + (Int(String(digit)) ?? 0)
+        // Cap at $999,999.99
+        guard newCents <= 99_999_999 else { return }
+        amountCents = newCents
+    }
+
+    /// Removes the last digit from the amount (backspace).
+    func removeLastAmountDigit() {
+        amountCents = amountCents / 10
+    }
+
+    /// Adds the current tag text as a tag.
+    func addTag() {
+        let trimmed = currentTagText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !tags.contains(trimmed) else {
+            currentTagText = ""
+            return
+        }
+        tags.append(trimmed)
+        currentTagText = ""
+    }
+
+    /// Removes a tag at the specified index.
+    func removeTag(at index: Int) {
+        guard tags.indices.contains(index) else { return }
+        tags.remove(at: index)
+    }
 
     /// Navigation title for the form.
     var navigationTitle: String {
@@ -99,10 +144,12 @@ final class TransactionCreateViewModel {
         if let transaction {
             // Pre-fill fields from the existing transaction
             transactionType = transaction.type
-            amountText = Self.formatAmountForEditing(abs(transaction.amountMinorUnits))
+            amountCents = Int(abs(transaction.amountMinorUnits))
             payee = transaction.payee
             date = transaction.date
             currencyCode = transaction.currencyCode
+            selectedStatus = transaction.status
+            tags = transaction.tags
             // Category and account IDs are resolved after loadData()
         }
     }
@@ -161,7 +208,8 @@ final class TransactionCreateViewModel {
             currencyCode: currencyCode,
             date: date,
             type: transactionType,
-            status: editingTransaction?.status ?? .pending
+            status: selectedStatus,
+            tags: tags
         )
 
         do {
@@ -186,7 +234,7 @@ final class TransactionCreateViewModel {
 
     private func validate() -> Bool {
         // Basic client-side validation
-        if amountText.isEmpty || (Double(amountText) ?? 0) <= 0 {
+        if amountCents <= 0 {
             validationMessage = String(localized: "Please enter a valid amount.")
             showingValidationError = true
             return false
@@ -217,7 +265,7 @@ final class TransactionCreateViewModel {
             date: Calendar.current.dateComponents([.year, .month, .day], from: date),
             transferAccountId: nil,
             isRecurring: false,
-            tags: [],
+            tags: tags,
             createdAt: .now,
             updatedAt: .now,
             deletedAt: nil,
@@ -240,10 +288,4 @@ final class TransactionCreateViewModel {
     }
 
     // MARK: - Helpers
-
-    /// Formats minor units to a decimal string for editing (e.g., 2550 → "25.50").
-    private static func formatAmountForEditing(_ minorUnits: Int64) -> String {
-        let value = Double(minorUnits) / 100.0
-        return String(format: "%.2f", value)
-    }
 }

--- a/apps/ios/Finance/ViewModels/TransactionsViewModel.swift
+++ b/apps/ios/Finance/ViewModels/TransactionsViewModel.swift
@@ -180,7 +180,33 @@ final class TransactionsViewModel {
 
     // MARK: - Filtering
 
-    private func matchesSearch(_ t: TransactionItem) -> Bool { guard !debouncedSearchText.isEmpty else { return true }; return t.payee.localizedCaseInsensitiveContains(debouncedSearchText) || t.category.localizedCaseInsensitiveContains(debouncedSearchText) || t.accountName.localizedCaseInsensitiveContains(debouncedSearchText) }
+    private func matchesSearch(_ t: TransactionItem) -> Bool {
+        guard !debouncedSearchText.isEmpty else { return true }
+        let query = debouncedSearchText
+        // #1483: Match against all relevant fields
+        if t.payee.localizedCaseInsensitiveContains(query) { return true }
+        if t.category.localizedCaseInsensitiveContains(query) { return true }
+        if t.accountName.localizedCaseInsensitiveContains(query) { return true }
+        if t.status.displayName.localizedCaseInsensitiveContains(query) { return true }
+        if t.type.displayName.localizedCaseInsensitiveContains(query) { return true }
+        // Match tags
+        if t.tags.contains(where: { $0.localizedCaseInsensitiveContains(query) }) { return true }
+        // Match formatted amount (e.g. "12.50")
+        let amountStr = String(format: "%.2f", Double(abs(t.amountMinorUnits)) / 100.0)
+        if amountStr.contains(query) { return true }
+        // Match date (short format)
+        if Self.searchDateFormatter.string(from: t.date).localizedCaseInsensitiveContains(query) { return true }
+        // Match notes
+        if !t.notes.isEmpty, t.notes.localizedCaseInsensitiveContains(query) { return true }
+        return false
+    }
+
+    /// Date formatter used for search matching against transaction dates.
+    private static nonisolated(unsafe) let searchDateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .medium
+        return f
+    }()
     private func matchesFilter(_ t: TransactionItem) -> Bool {
         if filter.dateRangeEnabled { let start = Calendar.current.startOfDay(for: filter.startDate); let end = Calendar.current.date(byAdding: .day, value: 1, to: Calendar.current.startOfDay(for: filter.endDate)) ?? filter.endDate; guard t.date >= start && t.date < end else { return false } }
         if filter.amountRangeEnabled { let absAmt = abs(Double(t.amountMinorUnits)) / 100.0; if let min = filter.minAmount, absAmt < min { return false }; if let max = filter.maxAmount, absAmt > max { return false } }


### PR DESCRIPTION
## Summary

Comprehensive iOS UX improvements addressing four issues: search breadth, form completeness, user feedback, and amount input UX.

## Changes

- **Search (#1483)**: Expand transaction search to match all fields — payee, category, tags, account name, status, type, amount, date, and notes (case-insensitive)
- **Form fields (#1485)**: Add Status picker (Pending/Cleared/Reconciled) and Tags chip input (type + return to add, tap X to remove) to transaction create/edit form
- **Feedback (#1488)**: Add Send Feedback button in Settings → About section, presenting a sheet with type picker (Bug/Feedback/Suggestion), multi-line description, and auto-captured device info. Stored locally for alpha (TODO: backend integration)
- **Amount format (#1486)**: Replace free-text amount field with Venmo-style cents-first digit pad. Type '123' → displays '\.23'. Backspace removes last digit. Capped at \,999.99

## New Files

- \pps/ios/Finance/Components/TagChipView.swift\ — Removable capsule tag component
- \pps/ios/Finance/Components/FlowLayout.swift\ — Horizontal wrapping layout for tags
- \pps/ios/Finance/Screens/FeedbackView.swift\ — Feedback sheet with view model

## Accessibility

- All new interactive elements have \.accessibilityLabel()\ and \.accessibilityHint()\
- Digit pad buttons individually labeled for VoiceOver
- Tag chips announce removal actions
- Status picker and tag input fully accessible

## Issues

Closes #1483
Closes #1485
Closes #1488
Closes #1486