### PR TITLE
fix(web): add budget/goal edit/delete, fix pie chart labels, fix card grid

### DIFF
--- a/apps/web/src/components/charts/CategoryPieChart.tsx
+++ b/apps/web/src/components/charts/CategoryPieChart.tsx
@@ -2,6 +2,10 @@
 
 /**
  * CategoryPieChart — custom D3.js pie chart for category breakdowns.
+ *
+ * Renders a pie chart with a responsive legend (side on desktop, below on
+ * mobile) instead of inline text labels which overlap with many categories.
+ *
  * @module components/charts/CategoryPieChart
  */
 import { type FC, useCallback, useEffect, useId, useRef } from 'react';
@@ -30,6 +34,7 @@ export const CategoryPieChart: FC<CategoryPieChartProps> = ({
   const chartId = useId();
   const svgRef = useRef<SVGSVGElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const total = data.reduce((sum, d) => sum + d.value, 0);
   const description = buildChartDescription(
     'Pie chart',
     data.map((d) => ({ label: d.name, value: d.value })),
@@ -54,7 +59,6 @@ export const CategoryPieChart: FC<CategoryPieChartProps> = ({
       .sort(null)
       .padAngle(0.02);
     const arc = d3.arc<d3.PieArcDatum<CategorySlice>>().innerRadius(0).outerRadius(radius);
-    const total = data.reduce((sum, d) => sum + d.value, 0);
     const slices = g
       .selectAll<SVGPathElement, d3.PieArcDatum<CategorySlice>>('path')
       .data(pie(data))
@@ -95,23 +99,7 @@ export const CategoryPieChart: FC<CategoryPieChartProps> = ({
           return (t: number) => arc(i(t)) ?? '';
         });
     }
-    const labelArc = d3
-      .arc<d3.PieArcDatum<CategorySlice>>()
-      .innerRadius(radius * 0.6)
-      .outerRadius(radius * 0.6);
-    g.selectAll<SVGTextElement, d3.PieArcDatum<CategorySlice>>('text')
-      .data(pie(data))
-      .enter()
-      .append('text')
-      .attr('transform', (d) => `translate(${labelArc.centroid(d)})`)
-      .attr('text-anchor', 'middle')
-      .attr('dy', '0.35em')
-      .attr('fill', 'var(--semantic-text-primary, #111827)')
-      .attr('font-size', '11px')
-      .attr('font-weight', '500')
-      .attr('aria-hidden', 'true')
-      .text((d) => (d.data.value / total > 0.05 ? d.data.name : ''));
-  }, [data, currency, width, height, reducedMotion]);
+  }, [data, currency, width, height, reducedMotion, total]);
 
   useEffect(() => {
     renderChart();
@@ -146,16 +134,36 @@ export const CategoryPieChart: FC<CategoryPieChartProps> = ({
       <p id={`${chartId}-desc`} className="sr-only">
         {description}
       </p>
-      <svg
-        ref={svgRef}
-        width={width}
-        height={height}
-        viewBox={`0 0 ${width} ${height}`}
-        role="img"
-        aria-labelledby={`${chartId}-title`}
-        aria-describedby={`${chartId}-desc`}
-        onKeyDown={handleKeyDown}
-      />
+      <div className="pie-chart-layout">
+        <svg
+          ref={svgRef}
+          width={width}
+          height={height}
+          viewBox={`0 0 ${width} ${height}`}
+          role="img"
+          aria-labelledby={`${chartId}-title`}
+          aria-describedby={`${chartId}-desc`}
+          onKeyDown={handleKeyDown}
+        />
+        <ul className="pie-chart-legend" aria-label="Category legend">
+          {data.map((slice, i) => {
+            const percent = total > 0 ? ((slice.value / total) * 100).toFixed(1) : '0.0';
+            return (
+              <li key={slice.name} className="pie-chart-legend__item">
+                <span
+                  className="pie-chart-legend__swatch"
+                  style={{ backgroundColor: CHART_COLORS[i % CHART_COLORS.length] }}
+                  aria-hidden="true"
+                />
+                <span className="pie-chart-legend__name">{slice.name}</span>
+                <span className="pie-chart-legend__value">
+                  {formatChartCurrency(slice.value, currency)} ({percent}%)
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
     </div>
   );
 };

--- a/apps/web/src/pages/BudgetDetailPage.test.tsx
+++ b/apps/web/src/pages/BudgetDetailPage.test.tsx
@@ -12,6 +12,10 @@ vi.mock('../hooks', () => ({
   useCategories: vi.fn(),
 }));
 
+vi.mock('../components/forms', () => ({
+  BudgetForm: () => null,
+}));
+
 const mockedUseBudgets = vi.mocked(useBudgets);
 const mockedUseCategories = vi.mocked(useCategories);
 

--- a/apps/web/src/pages/BudgetDetailPage.tsx
+++ b/apps/web/src/pages/BudgetDetailPage.tsx
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import React, { useMemo } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import React, { useCallback, useMemo, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 
-import { CurrencyDisplay, ErrorBanner, LoadingSpinner } from '../components/common';
+import { ConfirmDialog, CurrencyDisplay, ErrorBanner, LoadingSpinner } from '../components/common';
+import { BudgetForm } from '../components/forms';
+import type { CreateBudgetInput } from '../db/repositories/budgets';
 import { useBudgets, useCategories } from '../hooks';
+import type { Budget } from '../kmp/bridge';
+import '../styles/pages.css';
 
 const PERIOD_LABELS: Record<string, string> = {
   WEEKLY: 'Weekly',
@@ -34,8 +38,12 @@ function getBudgetIcon(iconName: string | null | undefined): string {
 /** Detail view for a single budget route. */
 export const BudgetDetailPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
 
-  const { budgets, loading, error, refresh } = useBudgets();
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [deletingBudget, setDeletingBudget] = useState<Budget | null>(null);
+
+  const { budgets, loading, error, refresh, updateBudget, deleteBudget } = useBudgets();
   const { categories, loading: categoriesLoading } = useCategories();
 
   const isLoading = loading || categoriesLoading;
@@ -46,6 +54,31 @@ export const BudgetDetailPage: React.FC = () => {
     () => (budget ? (categories.find((c) => c.id === budget.categoryId) ?? null) : null),
     [budget, categories],
   );
+
+  const handleCloseForm = useCallback(() => {
+    setIsFormOpen(false);
+  }, []);
+
+  const handleFormSubmit = useCallback(
+    async (data: CreateBudgetInput) => {
+      if (!budget) return;
+      const updated = updateBudget(budget.id, data);
+      if (updated === null) {
+        throw new Error('Failed to update budget.');
+      }
+      setIsFormOpen(false);
+    },
+    [budget, updateBudget],
+  );
+
+  const handleDeleteConfirm = useCallback(() => {
+    if (!deletingBudget) return;
+    const deleted = deleteBudget(deletingBudget.id);
+    if (deleted) {
+      setDeletingBudget(null);
+      navigate('/budgets', { replace: true });
+    }
+  }, [deleteBudget, deletingBudget, navigate]);
 
   if (isLoading) {
     return (
@@ -111,16 +144,28 @@ export const BudgetDetailPage: React.FC = () => {
         ← Back to Budgets
       </Link>
 
-      <div style={{ marginBottom: 'var(--spacing-4)' }}>
-        <h2
-          style={{
-            fontSize: 'var(--type-scale-headline-font-size)',
-            fontWeight: 'var(--type-scale-headline-font-weight)',
-            margin: 0,
-          }}
-        >
+      <div className="page-header">
+        <h2 className="page-heading">
           <span aria-hidden="true">{getBudgetIcon(category?.icon)}</span> {budget.name}
         </h2>
+        <div className="page-actions">
+          <button
+            type="button"
+            className="form-button form-button--secondary"
+            onClick={() => setIsFormOpen(true)}
+            aria-label={`Edit ${budget.name}`}
+          >
+            ✏️ Edit
+          </button>
+          <button
+            type="button"
+            className="form-button confirm-dialog__confirm confirm-dialog__confirm--danger"
+            onClick={() => setDeletingBudget(budget)}
+            aria-label={`Delete ${budget.name}`}
+          >
+            🗑️ Delete
+          </button>
+        </div>
       </div>
 
       <article
@@ -265,6 +310,27 @@ export const BudgetDetailPage: React.FC = () => {
           </div>
         </div>
       </section>
+
+      <BudgetForm
+        isOpen={isFormOpen}
+        onCancel={handleCloseForm}
+        onSubmit={handleFormSubmit}
+        categories={categories}
+        initialData={budget}
+      />
+
+      <ConfirmDialog
+        isOpen={deletingBudget !== null}
+        title="Delete Budget"
+        message={
+          deletingBudget
+            ? `Are you sure you want to delete this budget? This will remove "${deletingBudget.name}" from your budgets list.`
+            : ''
+        }
+        confirmLabel="Delete"
+        onConfirm={handleDeleteConfirm}
+        onCancel={() => setDeletingBudget(null)}
+      />
     </>
   );
 };

--- a/apps/web/src/pages/GoalDetailPage.test.tsx
+++ b/apps/web/src/pages/GoalDetailPage.test.tsx
@@ -11,6 +11,10 @@ vi.mock('../hooks', () => ({
   useGoals: vi.fn(),
 }));
 
+vi.mock('../components/forms', () => ({
+  GoalForm: () => null,
+}));
+
 const mockedUseGoals = vi.mocked(useGoals);
 
 const syncMetadata = {

--- a/apps/web/src/pages/GoalDetailPage.tsx
+++ b/apps/web/src/pages/GoalDetailPage.tsx
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import React from 'react';
-import { Link, useParams } from 'react-router-dom';
+import React, { useCallback, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 
-import { CurrencyDisplay, ErrorBanner, LoadingSpinner } from '../components/common';
+import { ConfirmDialog, CurrencyDisplay, ErrorBanner, LoadingSpinner } from '../components/common';
+import { GoalForm } from '../components/forms';
+import type { CreateGoalInput } from '../db/repositories/goals';
 import { useGoals } from '../hooks';
+import type { Goal } from '../kmp/bridge';
+import '../styles/pages.css';
 
 function getGoalIcon(iconName: string | null | undefined): string {
   switch (iconName) {
@@ -24,10 +28,39 @@ function getGoalIcon(iconName: string | null | undefined): string {
 /** Detail view for a single goal route. */
 export const GoalDetailPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
 
-  const { goals, loading, error, refresh } = useGoals();
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [deletingGoal, setDeletingGoal] = useState<Goal | null>(null);
+
+  const { goals, loading, error, refresh, updateGoal, deleteGoal } = useGoals();
 
   const goal = id ? (goals.find((g) => g.id === id) ?? null) : null;
+
+  const handleCloseForm = useCallback(() => {
+    setIsFormOpen(false);
+  }, []);
+
+  const handleFormSubmit = useCallback(
+    async (data: CreateGoalInput) => {
+      if (!goal) return;
+      const updated = updateGoal(goal.id, data);
+      if (updated === null) {
+        throw new Error('Failed to update goal.');
+      }
+      setIsFormOpen(false);
+    },
+    [goal, updateGoal],
+  );
+
+  const handleDeleteConfirm = useCallback(() => {
+    if (!deletingGoal) return;
+    const deleted = deleteGoal(deletingGoal.id);
+    if (deleted) {
+      setDeletingGoal(null);
+      navigate('/goals', { replace: true });
+    }
+  }, [deleteGoal, deletingGoal, navigate]);
 
   if (loading) {
     return (
@@ -115,16 +148,28 @@ export const GoalDetailPage: React.FC = () => {
         ← Back to Goals
       </Link>
 
-      <div style={{ marginBottom: 'var(--spacing-4)' }}>
-        <h2
-          style={{
-            fontSize: 'var(--type-scale-headline-font-size)',
-            fontWeight: 'var(--type-scale-headline-font-weight)',
-            margin: 0,
-          }}
-        >
+      <div className="page-header">
+        <h2 className="page-heading">
           <span aria-hidden="true">{getGoalIcon(goal.icon)}</span> {goal.name}
         </h2>
+        <div className="page-actions">
+          <button
+            type="button"
+            className="form-button form-button--secondary"
+            onClick={() => setIsFormOpen(true)}
+            aria-label={`Edit ${goal.name}`}
+          >
+            ✏️ Edit
+          </button>
+          <button
+            type="button"
+            className="form-button confirm-dialog__confirm confirm-dialog__confirm--danger"
+            onClick={() => setDeletingGoal(goal)}
+            aria-label={`Delete ${goal.name}`}
+          >
+            🗑️ Delete
+          </button>
+        </div>
       </div>
 
       <article
@@ -226,6 +271,26 @@ export const GoalDetailPage: React.FC = () => {
           </div>
         </div>
       </section>
+
+      <GoalForm
+        isOpen={isFormOpen}
+        onCancel={handleCloseForm}
+        onSubmit={handleFormSubmit}
+        initialData={goal}
+      />
+
+      <ConfirmDialog
+        isOpen={deletingGoal !== null}
+        title="Delete Goal"
+        message={
+          deletingGoal
+            ? `Are you sure you want to delete this goal? This will remove "${deletingGoal.name}" from your goals list.`
+            : ''
+        }
+        confirmLabel="Delete"
+        onConfirm={handleDeleteConfirm}
+        onCancel={() => setDeletingGoal(null)}
+      />
     </>
   );
 };

--- a/apps/web/src/styles/responsive-breakpoints.css
+++ b/apps/web/src/styles/responsive-breakpoints.css
@@ -48,36 +48,32 @@
 .card-grid {
   display: grid;
   gap: var(--layout-card-gap, var(--spacing-4, 16px));
-  grid-template-columns: 1fr;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
 }
 
 @media (min-width: 640px) {
-  .card-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
   .card-grid--3 {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
   }
 
   .card-grid--4 {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
   }
 }
 
 @media (min-width: 1024px) {
   .card-grid--3 {
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
   }
 
   .card-grid--4 {
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
   }
 }
 
 @media (min-width: 1440px) {
   .card-grid--4 {
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
   }
 }
 

--- a/apps/web/src/styles/responsive.css
+++ b/apps/web/src/styles/responsive.css
@@ -285,6 +285,12 @@
   grid-template-columns: 1fr;
   gap: var(--layout-card-gap);
 }
+
+.card-grid > .card {
+  display: flex;
+  flex-direction: column;
+  min-height: 120px;
+}
 .page-section {
   margin-bottom: var(--spacing-6);
 }
@@ -860,4 +866,68 @@
   .card {
     border-width: 2px;
   }
+}
+
+/* -------------------------------------------------------------------
+ * Pie chart legend (replaces inline SVG labels to avoid overlap)
+ * ------------------------------------------------------------------- */
+
+.pie-chart-layout {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-4);
+}
+
+@media (min-width: 768px) {
+  .pie-chart-layout {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+}
+
+.pie-chart-legend {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-2);
+}
+
+@media (min-width: 768px) {
+  .pie-chart-legend {
+    flex-direction: column;
+    flex-wrap: nowrap;
+    max-width: 240px;
+  }
+}
+
+.pie-chart-legend__item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  font-size: var(--type-scale-caption-font-size, 0.75rem);
+  color: var(--semantic-text-primary);
+}
+
+.pie-chart-legend__swatch {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: var(--radius-xs, 2px);
+  flex-shrink: 0;
+}
+
+.pie-chart-legend__name {
+  font-weight: var(--font-weight-medium, 500);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 120px;
+}
+
+.pie-chart-legend__value {
+  color: var(--semantic-text-secondary);
+  white-space: nowrap;
 }


### PR DESCRIPTION
## Summary

Adds edit/delete functionality to budget and goal detail pages, replaces overlapping pie chart labels with a legend, and fixes card grid responsive alignment.

## Changes

- Add Edit button (opens BudgetForm/GoalForm modal with pre-filled data) and Delete button (with ConfirmDialog) to BudgetDetailPage
- Add Edit and Delete to GoalDetailPage with the same pattern
- Replace inline pie chart SVG text labels with a responsive color-swatch legend (side on desktop, below on mobile)
- Fix card grid alignment with CSS Grid \uto-fill\ and \minmax(280px, 1fr)\ for graceful 3→2→1 column transitions
- Add \min-height\ to cards in grid for consistent vertical alignment

## Accessibility

- Delete confirmation uses existing ConfirmDialog with focus trapping and Escape handling
- Edit/Delete buttons have \ria-label\ with entity name
- Legend uses semantic \<ul>\ with \ria-label\
- All patterns follow existing AccountDetailPage conventions

## Issues

Closes #1474
Closes #1470
Closes #1475