### PR TITLE
fix(web): persist demo session across page refresh (#1506)

### DIFF
--- a/apps/web/src/auth/auth-context.tsx
+++ b/apps/web/src/auth/auth-context.tsx
@@ -47,11 +47,13 @@ import {
 } from './token-storage';
 
 import {
+  clearDemoSession,
   demoDeleteAccount,
   demoLogin,
   demoRefreshToken,
   demoSignup,
   isDemoMode,
+  restoreDemoSession,
 } from './demo-auth';
 
 // ---------------------------------------------------------------------------
@@ -168,20 +170,45 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
 
   useEffect(() => {
     if (demoModeActive) {
-      // In demo mode, use a no-op refresh endpoint and skip WebAuthn
+      // In demo mode, skip WebAuthn and use localStorage-based session
+      // persistence instead of the HttpOnly cookie refresh flow.
       initTokenManager({
         refreshEndpoint: '',
         onSessionExpired: () => {
           setUser(null);
           clearTokens();
+          clearDemoSession();
           config.onUnauthenticated?.();
         },
       });
+
+      // Attempt to restore demo session from localStorage (#1506)
+      const savedEmail = restoreDemoSession();
+      if (savedEmail) {
+        const token = demoRefreshToken(savedEmail);
+        if (token) {
+          setAccessToken(token);
+          const payload = parseTokenPayload(token);
+          if (payload) {
+            setUser({
+              id: payload.sub ?? '',
+              email: payload.email ?? '',
+              hasPasskey: false,
+            });
+          }
+        }
+      }
+
       setIsLoading(false);
       return;
     }
 
     // Initialise token manager
+    // NOTE: In production (Supabase configured), the backend sets an HttpOnly
+    // refresh cookie on login. `tryRestoreSession` calls `executeRefresh()`
+    // which posts to the refresh endpoint with credentials: 'include', allowing
+    // the browser to send the cookie. This correctly restores the session on
+    // page refresh without storing tokens in localStorage.
     initTokenManager({
       refreshEndpoint: config.refreshEndpoint,
       onSessionExpired: () => {
@@ -362,6 +389,9 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
     } finally {
       clearTokens();
       setUser(null);
+      if (demoModeActive) {
+        clearDemoSession();
+      }
       config.onUnauthenticated?.();
     }
   }, [config, demoModeActive]);
@@ -433,6 +463,7 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
             email: result.user.email,
             hasPasskey: false,
           });
+          // demoLogin already calls persistDemoSession
           return;
         }
 

--- a/apps/web/src/auth/demo-auth.test.ts
+++ b/apps/web/src/auth/demo-auth.test.ts
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  clearDemoSession,
+  demoLogin,
+  demoRefreshToken,
+  demoSignup,
+  isDemoMode,
+  persistDemoSession,
+  restoreDemoSession,
+} from './demo-auth';
+
+// ---------------------------------------------------------------------------
+// Mock Web Crypto API for Node/Vitest environment
+// ---------------------------------------------------------------------------
+
+const mockDigest = vi.fn(async (_algo: string, data: ArrayBuffer) => {
+  // Simple deterministic fake hash for testing
+  const bytes = new Uint8Array(data);
+  const result = new Uint8Array(32);
+  for (let i = 0; i < bytes.length; i++) {
+    result[i % 32] = (result[i % 32]! + bytes[i]!) & 0xff;
+  }
+  return result.buffer;
+});
+
+Object.defineProperty(globalThis, 'crypto', {
+  value: {
+    subtle: { digest: mockDigest },
+    randomUUID: () => 'test-uuid-1234',
+  },
+  writable: true,
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('demo-auth', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  describe('isDemoMode', () => {
+    it('returns true for empty URL', () => {
+      expect(isDemoMode('')).toBe(true);
+    });
+
+    it('returns true for placeholder URL', () => {
+      expect(isDemoMode('https://placeholder.supabase.co')).toBe(true);
+    });
+
+    it('returns false for a real URL', () => {
+      expect(isDemoMode('https://myproject.supabase.co')).toBe(false);
+    });
+  });
+
+  describe('session persistence', () => {
+    it('persistDemoSession stores email in localStorage', () => {
+      persistDemoSession('test@example.com');
+      expect(localStorage.getItem('finance_demo_session')).toBe('test@example.com');
+    });
+
+    it('persistDemoSession normalizes email to lowercase', () => {
+      persistDemoSession('Test@Example.COM');
+      expect(localStorage.getItem('finance_demo_session')).toBe('test@example.com');
+    });
+
+    it('restoreDemoSession retrieves stored email', () => {
+      localStorage.setItem('finance_demo_session', 'user@test.com');
+      expect(restoreDemoSession()).toBe('user@test.com');
+    });
+
+    it('restoreDemoSession returns null when no session exists', () => {
+      expect(restoreDemoSession()).toBeNull();
+    });
+
+    it('clearDemoSession removes the stored session', () => {
+      localStorage.setItem('finance_demo_session', 'user@test.com');
+      clearDemoSession();
+      expect(localStorage.getItem('finance_demo_session')).toBeNull();
+    });
+  });
+
+  describe('demoLogin', () => {
+    it('persists session on successful login', async () => {
+      await demoSignup('login@test.com', 'password123');
+      await demoLogin('login@test.com', 'password123');
+
+      expect(restoreDemoSession()).toBe('login@test.com');
+    });
+
+    it('returns a valid token and user info', async () => {
+      await demoSignup('user@test.com', 'pass');
+      const result = await demoLogin('user@test.com', 'pass');
+
+      expect(result.accessToken).toContain('.');
+      expect(result.user.email).toBe('user@test.com');
+      expect(result.user.id).toContain('demo-');
+    });
+
+    it('throws on incorrect password', async () => {
+      await demoSignup('user@test.com', 'pass');
+      await expect(demoLogin('user@test.com', 'wrong')).rejects.toThrow('Incorrect password.');
+    });
+
+    it('throws on unknown email', async () => {
+      await expect(demoLogin('nobody@test.com', 'pass')).rejects.toThrow(
+        'No account found for that email.',
+      );
+    });
+  });
+
+  describe('demoRefreshToken', () => {
+    it('returns a token for a valid email', () => {
+      const token = demoRefreshToken('user@test.com');
+      expect(token).not.toBeNull();
+      expect(token!.split('.')).toHaveLength(3);
+    });
+
+    it('returns null for null email', () => {
+      expect(demoRefreshToken(null)).toBeNull();
+    });
+  });
+});

--- a/apps/web/src/auth/demo-auth.ts
+++ b/apps/web/src/auth/demo-auth.ts
@@ -30,6 +30,9 @@ interface DemoUser {
 
 const STORAGE_KEY = 'finance_demo_users';
 
+/** Key for persisting the active demo session email across page refreshes. */
+const DEMO_SESSION_KEY = 'finance_demo_session';
+
 /** Token lifetime in seconds (1 hour). */
 const TOKEN_LIFETIME_SECONDS = 3600;
 
@@ -95,6 +98,49 @@ function generateDemoToken(email: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// Session Persistence Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Persist the active demo user's email in localStorage.
+ *
+ * SECURITY NOTE: This is acceptable because demo mode tokens are fake
+ * (unsigned, local-only). Production mode NEVER stores tokens or session
+ * identifiers in localStorage — it relies on HttpOnly cookies.
+ */
+export function persistDemoSession(email: string): void {
+  try {
+    localStorage.setItem(DEMO_SESSION_KEY, email.toLowerCase().trim());
+  } catch {
+    // Storage quota exceeded or private browsing — session won't persist
+  }
+}
+
+/**
+ * Retrieve the stored demo session email, if any.
+ *
+ * @returns The email of the previously logged-in demo user, or `null`.
+ */
+export function restoreDemoSession(): string | null {
+  try {
+    return localStorage.getItem(DEMO_SESSION_KEY);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Clear the persisted demo session (used on logout).
+ */
+export function clearDemoSession(): void {
+  try {
+    localStorage.removeItem(DEMO_SESSION_KEY);
+  } catch {
+    // Ignore — nothing to clean up
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -156,6 +202,9 @@ export async function demoLogin(
 
   const token = generateDemoToken(userByEmail.email);
   const sub = `demo-${userByEmail.email.replace(/[^a-zA-Z0-9]/g, '-')}`;
+
+  // Persist the session so it survives page refresh (#1506)
+  persistDemoSession(userByEmail.email);
 
   return {
     accessToken: token,


### PR DESCRIPTION
## Summary

Fixes session lost on page refresh in demo mode by persisting the demo user email in localStorage and restoring the session on app mount.

## Root Cause

In demo mode, uth-context.tsx set efreshEndpoint: '' which caused 	ryRestoreSession() → refreshAccessToken() → executeRefresh() to fetch an empty URL — always failing. The result: demo mode had NO session persistence across page refresh.

## Changes

- **demo-auth.ts**: Add persistDemoSession(), estoreDemoSession(), and clearDemoSession() functions using localStorage
- **demo-auth.ts**: demoLogin() now calls persistDemoSession(email) on successful login
- **uth-context.tsx**: Demo mode initialization now calls estoreDemoSession() and regenerates a fresh token if a session exists
- **uth-context.tsx**: Logout clears the demo session via clearDemoSession()`n- **demo-auth.test.ts**: New test coverage for session persistence functions and login flow

## Security Notes

- **Demo mode only** — localStorage is acceptable because tokens are fake (unsigned, local-only)
- **Production mode** — continues to use HttpOnly cookie + refresh endpoint (no localStorage for tokens)
- No changes to the production auth architecture

## Issues

Closes #1506