### PR TITLE
feat(ios): advanced filter/sort and color-coded tags (#1484, #1487)

### DIFF
--- a/apps/ios/Finance/Components/FlowLayout.swift
+++ b/apps/ios/Finance/Components/FlowLayout.swift
@@ -2,16 +2,17 @@
 
 // FlowLayout.swift
 // Finance
+// References: #1487
 //
-// A simple flow layout that wraps child views horizontally. Used for
-// displaying tag chips that wrap to the next line. Refs #1485
+// A custom layout that wraps its children into multiple rows,
+// used for displaying tags that flow naturally.
 
 import SwiftUI
 
-/// A layout that arranges views in a horizontal flow, wrapping to
-/// the next line when the available width is exceeded.
+/// A layout that arranges its children in rows, wrapping to the next row when
+/// the available width is exceeded.
 struct FlowLayout: Layout {
-    var spacing: CGFloat = 8
+    var spacing: CGFloat = 6
 
     func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache _: inout ()) -> CGSize {
         let maxWidth = proposal.width ?? .infinity
@@ -19,7 +20,6 @@ struct FlowLayout: Layout {
         var currentY: CGFloat = 0
         var lineHeight: CGFloat = 0
         var totalHeight: CGFloat = 0
-        var totalWidth: CGFloat = 0
 
         for subview in subviews {
             let size = subview.sizeThatFits(.unspecified)
@@ -28,31 +28,40 @@ struct FlowLayout: Layout {
                 currentY += lineHeight + spacing
                 lineHeight = 0
             }
-            currentX += size.width + spacing
             lineHeight = max(lineHeight, size.height)
-            totalWidth = max(totalWidth, currentX - spacing)
-            totalHeight = currentY + lineHeight
+            currentX += size.width + spacing
         }
+        totalHeight = currentY + lineHeight
 
-        return CGSize(width: totalWidth, height: totalHeight)
+        return CGSize(width: maxWidth, height: totalHeight)
     }
 
-    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache _: inout ()) {
-        let maxWidth = proposal.width ?? bounds.width
+    func placeSubviews(in bounds: CGRect, proposal _: ProposedViewSize, subviews: Subviews, cache _: inout ()) {
         var currentX: CGFloat = bounds.minX
         var currentY: CGFloat = bounds.minY
         var lineHeight: CGFloat = 0
 
         for subview in subviews {
             let size = subview.sizeThatFits(.unspecified)
-            if currentX + size.width > bounds.minX + maxWidth, currentX > bounds.minX {
+            if currentX + size.width > bounds.maxX, currentX > bounds.minX {
                 currentX = bounds.minX
                 currentY += lineHeight + spacing
                 lineHeight = 0
             }
             subview.place(at: CGPoint(x: currentX, y: currentY), proposal: .unspecified)
-            currentX += size.width + spacing
             lineHeight = max(lineHeight, size.height)
+            currentX += size.width + spacing
         }
     }
+}
+
+// MARK: - Preview
+
+#Preview {
+    FlowLayout(spacing: 8) {
+        ForEach(["groceries", "travel:flights", "subscriptions", "work:expenses", "dining", "entertainment"], id: \.self) { name in
+            TagView(tag: Tag(name: name))
+        }
+    }
+    .padding()
 }

--- a/apps/ios/Finance/Components/TagInputView.swift
+++ b/apps/ios/Finance/Components/TagInputView.swift
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// TagInputView.swift
+// Finance
+// References: #1487
+//
+// A text field with autocomplete suggestions for adding tags to transactions.
+// Displays selected tags as removable chips and offers "Create new" when no match.
+
+import Observation
+import os
+import SwiftUI
+
+// MARK: - ViewModel
+
+@Observable
+final class TagInputViewModel {
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.finance",
+        category: "TagInputViewModel"
+    )
+
+    /// All tags available for autocomplete suggestions.
+    var allAvailableTags: [Tag] = []
+
+    /// Currently selected tags for this transaction.
+    var selectedTags: [Tag] = []
+
+    /// The current text in the input field.
+    var inputText = ""
+
+    /// Whether the suggestions dropdown should be visible.
+    var showingSuggestions: Bool {
+        !inputText.isEmpty && !filteredSuggestions.isEmpty
+    }
+
+    /// Whether to show the "Create new" option.
+    var showCreateNew: Bool {
+        !inputText.isEmpty && !allAvailableTags.contains(where: {
+            $0.name.caseInsensitiveCompare(inputText.trimmingCharacters(in: .whitespacesAndNewlines)) == .orderedSame
+        })
+    }
+
+    /// Filtered suggestions based on current input text.
+    var filteredSuggestions: [Tag] {
+        let trimmed = inputText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !trimmed.isEmpty else { return [] }
+        return allAvailableTags.filter { tag in
+            tag.name.localizedCaseInsensitiveContains(trimmed)
+                && !selectedTags.contains(where: { $0.name == tag.name })
+        }
+        .prefix(5)
+        .map { $0 }
+    }
+
+    /// Adds a tag from suggestions.
+    func selectTag(_ tag: Tag) {
+        guard !selectedTags.contains(where: { $0.name == tag.name }) else { return }
+        selectedTags.append(tag)
+        inputText = ""
+        Self.logger.info("Tag selected: \(tag.name, privacy: .public)")
+        AccessibilityNotification.Announcement(
+            String(localized: "Tag \(tag.displayName) added")
+        ).post()
+    }
+
+    /// Creates and selects a new tag from the current input text.
+    func createAndSelectTag() {
+        let name = inputText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !name.isEmpty else { return }
+        guard !selectedTags.contains(where: { $0.name == name }) else {
+            inputText = ""
+            return
+        }
+        let newTag = Tag(name: name)
+        selectedTags.append(newTag)
+        // Add to available tags for future autocomplete
+        if !allAvailableTags.contains(where: { $0.name == name }) {
+            allAvailableTags.append(newTag)
+        }
+        inputText = ""
+        Self.logger.info("New tag created: \(name, privacy: .public)")
+        AccessibilityNotification.Announcement(
+            String(localized: "New tag \(newTag.displayName) created and added")
+        ).post()
+    }
+
+    /// Removes a tag from the selection.
+    func removeTag(_ tag: Tag) {
+        selectedTags.removeAll { $0.id == tag.id }
+        Self.logger.info("Tag removed: \(tag.name, privacy: .public)")
+        AccessibilityNotification.Announcement(
+            String(localized: "Tag \(tag.displayName) removed")
+        ).post()
+    }
+}
+
+// MARK: - View
+
+/// A tag input field with autocomplete and inline selected tag chips.
+struct TagInputView: View {
+    @Bindable var viewModel: TagInputViewModel
+    @FocusState private var isInputFocused: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            // Selected tags display
+            if !viewModel.selectedTags.isEmpty {
+                selectedTagsSection
+            }
+
+            // Input field
+            inputSection
+
+            // Suggestions
+            if viewModel.showingSuggestions || viewModel.showCreateNew {
+                suggestionsSection
+            }
+        }
+    }
+
+    // MARK: - Selected Tags
+
+    private var selectedTagsSection: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                ForEach(viewModel.selectedTags) { tag in
+                    TagView(
+                        tag: tag,
+                        isRemovable: true,
+                        onRemove: { viewModel.removeTag(tag) }
+                    )
+                }
+            }
+            .padding(.horizontal, 2)
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(String(localized: "Selected tags"))
+    }
+
+    // MARK: - Input Field
+
+    private var inputSection: some View {
+        HStack {
+            Image(systemName: "tag")
+                .foregroundStyle(.secondary)
+                .font(.caption)
+
+            TextField(
+                String(localized: "Add tag…"),
+                text: $viewModel.inputText
+            )
+            .focused($isInputFocused)
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled()
+            .onSubmit {
+                if viewModel.showCreateNew {
+                    viewModel.createAndSelectTag()
+                } else if let firstSuggestion = viewModel.filteredSuggestions.first {
+                    viewModel.selectTag(firstSuggestion)
+                }
+            }
+            .accessibilityLabel(String(localized: "Tag input"))
+            .accessibilityHint(String(localized: "Type to search for tags or create a new one"))
+
+            if !viewModel.inputText.isEmpty {
+                Button {
+                    viewModel.inputText = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .accessibilityLabel(String(localized: "Clear tag input"))
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(.quaternary, in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    // MARK: - Suggestions
+
+    private var suggestionsSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(viewModel.filteredSuggestions) { tag in
+                Button {
+                    viewModel.selectTag(tag)
+                    isInputFocused = false
+                } label: {
+                    HStack {
+                        TagView(tag: tag)
+                        Spacer()
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(String(localized: "Select tag \(tag.displayName)"))
+
+                if tag.id != viewModel.filteredSuggestions.last?.id {
+                    Divider().padding(.leading, 12)
+                }
+            }
+
+            if viewModel.showCreateNew {
+                Divider().padding(.leading, 12)
+
+                Button {
+                    viewModel.createAndSelectTag()
+                    isInputFocused = false
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "plus.circle.fill")
+                            .foregroundStyle(.green)
+                        Text(String(localized: "Create \"\(viewModel.inputText.trimmingCharacters(in: .whitespacesAndNewlines))\""))
+                            .foregroundStyle(.primary)
+                        Spacer()
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(String(localized: "Create new tag \(viewModel.inputText)"))
+                .accessibilityHint(String(localized: "Creates a new tag and adds it to this transaction"))
+            }
+        }
+        .background(.background, in: RoundedRectangle(cornerRadius: 8))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(.quaternary, lineWidth: 1)
+        )
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    struct PreviewWrapper: View {
+        @State private var viewModel = TagInputViewModel()
+
+        var body: some View {
+            VStack {
+                TagInputView(viewModel: viewModel)
+                    .padding()
+            }
+            .onAppear {
+                viewModel.allAvailableTags = [
+                    Tag(name: "groceries"),
+                    Tag(name: "travel:flights"),
+                    Tag(name: "travel:hotels"),
+                    Tag(name: "subscriptions"),
+                    Tag(name: "work:expenses"),
+                    Tag(name: "dining"),
+                    Tag(name: "entertainment"),
+                ]
+                viewModel.selectedTags = [
+                    Tag(name: "groceries"),
+                ]
+            }
+        }
+    }
+
+    return PreviewWrapper()
+}

--- a/apps/ios/Finance/Components/TagView.swift
+++ b/apps/ios/Finance/Components/TagView.swift
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// TagView.swift
+// Finance
+// References: #1487
+//
+// A capsule-shaped chip for displaying tags with deterministic color coding.
+// Supports subtags (e.g., "travel:flights" displayed as "travel › flights").
+
+import SwiftUI
+
+// MARK: - Tag Model
+
+/// Represents a single tag that can be attached to a transaction.
+struct Tag: Identifiable, Hashable, Sendable {
+    let id: String
+    let name: String
+
+    /// Returns the display name with subtag separator rendered as " › ".
+    var displayName: String {
+        name.replacingOccurrences(of: ":", with: " › ")
+    }
+
+    /// The parent portion of the tag (before ":"), or the full name if no subtag.
+    var parentName: String {
+        if let colonIndex = name.firstIndex(of: ":") {
+            return String(name[name.startIndex..<colonIndex])
+        }
+        return name
+    }
+
+    /// The child portion of the tag (after ":"), or nil if no subtag.
+    var childName: String? {
+        guard let colonIndex = name.firstIndex(of: ":") else { return nil }
+        let afterColon = name.index(after: colonIndex)
+        guard afterColon < name.endIndex else { return nil }
+        return String(name[afterColon...])
+    }
+
+    /// Deterministic color derived from the tag name hash.
+    /// Uses a curated palette that works well in both light and dark mode.
+    var color: Color {
+        let palette: [Color] = [
+            .blue, .purple, .pink, .orange, .teal,
+            .indigo, .mint, .cyan, .brown, .green,
+        ]
+        let hash = abs(name.hashValue)
+        return palette[hash % palette.count]
+    }
+
+    init(id: String = UUID().uuidString, name: String) {
+        self.id = id
+        self.name = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+}
+
+// MARK: - TagView
+
+/// Displays a single tag as a capsule-shaped chip with colored background.
+struct TagView: View {
+    let tag: Tag
+    var isRemovable: Bool = false
+    var onTap: (() -> Void)?
+    var onRemove: (() -> Void)?
+
+    var body: some View {
+        HStack(spacing: 4) {
+            if tag.childName != nil {
+                Text(tag.parentName)
+                    .fontWeight(.medium)
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 8, weight: .bold))
+                Text(tag.childName ?? "")
+            } else {
+                Text(tag.name)
+                    .fontWeight(.medium)
+            }
+
+            if isRemovable {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundStyle(.primary.opacity(0.7))
+                    .accessibilityLabel(String(localized: "Remove tag"))
+            }
+        }
+        .font(.caption)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .foregroundStyle(.white)
+        .background(tag.color.opacity(0.85), in: Capsule())
+        .contentShape(Capsule())
+        .onTapGesture {
+            if isRemovable {
+                onRemove?()
+            } else {
+                onTap?()
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(tagAccessibilityLabel)
+        .accessibilityHint(tagAccessibilityHint)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityRemoveTraits(.isImage)
+    }
+
+    private var tagAccessibilityLabel: String {
+        if tag.childName != nil {
+            return String(localized: "Tag: \(tag.parentName), \(tag.childName ?? "")")
+        }
+        return String(localized: "Tag: \(tag.name)")
+    }
+
+    private var tagAccessibilityHint: String {
+        if isRemovable {
+            return String(localized: "Tap to remove this tag")
+        }
+        return String(localized: "Tap to filter by this tag")
+    }
+}
+
+// MARK: - TagsRow
+
+/// Displays a horizontal row of tag chips, limited to a maximum count with overflow indicator.
+struct TagsRow: View {
+    let tags: [Tag]
+    var maxVisible: Int = 2
+    var onTagTap: ((Tag) -> Void)?
+
+    var body: some View {
+        if tags.isEmpty { EmptyView() } else {
+            HStack(spacing: 4) {
+                ForEach(Array(tags.prefix(maxVisible))) { tag in
+                    TagView(tag: tag, onTap: { onTagTap?(tag) })
+                }
+                if tags.count > maxVisible {
+                    Text("+\(tags.count - maxVisible)")
+                        .font(.caption2)
+                        .fontWeight(.medium)
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 3)
+                        .background(.quaternary, in: Capsule())
+                        .accessibilityLabel(String(localized: "\(tags.count - maxVisible) more tags"))
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Single Tag") {
+    VStack(spacing: 12) {
+        TagView(tag: Tag(name: "groceries"))
+        TagView(tag: Tag(name: "travel:flights"))
+        TagView(tag: Tag(name: "subscriptions"), isRemovable: true)
+        TagView(tag: Tag(name: "work:expenses"))
+    }
+    .padding()
+}
+
+#Preview("Tags Row") {
+    TagsRow(tags: [
+        Tag(name: "groceries"),
+        Tag(name: "travel:flights"),
+        Tag(name: "essential"),
+    ], maxVisible: 2)
+    .padding()
+}

--- a/apps/ios/Finance/Components/TransactionRowView.swift
+++ b/apps/ios/Finance/Components/TransactionRowView.swift
@@ -22,11 +22,24 @@ struct TransactionRowView: View, Equatable {
                     if transaction.status == .pending { Text(transaction.status.displayName).font(.caption2).foregroundStyle(.orange).padding(.horizontal, 6).padding(.vertical, 2).background(.orange.opacity(0.1), in: Capsule()) }
                 }
                 HStack(spacing: 4) { Text(transaction.category); Text("·"); Text(transaction.accountName) }.font(.caption).foregroundStyle(.secondary).lineLimit(1)
+                // Show up to 2 tags inline
+                if !transaction.tags.isEmpty {
+                    TagsRow(tags: transaction.tags, maxVisible: 2)
+                }
             }
             Spacer()
             CurrencyLabel(amountInMinorUnits: transaction.amountMinorUnits, currencyCode: transaction.currencyCode, font: .callout.bold()).contentTransition(.numericText())
         }.padding(.vertical, 2).accessibilityElement(children: .combine)
-        .accessibilityLabel([transaction.payee, transaction.category, transaction.accountName].joined(separator: ", "))
+        .accessibilityLabel(accessibilityLabelText)
         .accessibilityHint(String(localized: "Tap to view details. Swipe for more actions."))
+    }
+
+    private var accessibilityLabelText: String {
+        var label = [transaction.payee, transaction.category, transaction.accountName].joined(separator: ", ")
+        if !transaction.tags.isEmpty {
+            let tagNames = transaction.tags.map(\.displayName).joined(separator: ", ")
+            label += ", " + String(localized: "Tags: \(tagNames)")
+        }
+        return label
     }
 }

--- a/apps/ios/Finance/Models/TransactionItem.swift
+++ b/apps/ios/Finance/Models/TransactionItem.swift
@@ -75,6 +75,7 @@ struct TransactionItem: Identifiable, Hashable, Sendable {
     let tags: [String]
     let isRecurring: Bool
     let receiptData: Data?
+    let tags: [Tag]
 
     /// Convenience: `true` when the transaction type is `.expense`.
     var isExpense: Bool { type == .expense }
@@ -92,7 +93,8 @@ struct TransactionItem: Identifiable, Hashable, Sendable {
         notes: String = "",
         tags: [String] = [],
         isRecurring: Bool = false,
-        receiptData: Data? = nil
+        receiptData: Data? = nil,
+        tags: [Tag] = []
     ) {
         self.id = id
         self.payee = payee
@@ -107,5 +109,6 @@ struct TransactionItem: Identifiable, Hashable, Sendable {
         self.tags = tags
         self.isRecurring = isRecurring
         self.receiptData = receiptData
+        self.tags = tags
     }
 }

--- a/apps/ios/Finance/Screens/TransactionDetailView.swift
+++ b/apps/ios/Finance/Screens/TransactionDetailView.swift
@@ -28,7 +28,7 @@ struct TransactionDetailView: View {
     }
 
     var body: some View {
-        List { headerSection; detailsSection; notesSection; receiptSection; actionsSection }
+        List { headerSection; detailsSection; tagsSection; notesSection; receiptSection; actionsSection }
         .listStyle(.insetGrouped).navigationTitle(String(localized: "Transaction Details")).navigationBarTitleDisplayMode(.inline)
         .toolbar { ToolbarItem(placement: .primaryAction) { Button { showingEditSheet = true } label: { Text(String(localized: "Edit")) }.accessibilityLabel(String(localized: "Edit transaction")).accessibilityHint(String(localized: "Opens a form to edit this transaction")) } }
         .confirmationDialog(String(localized: "Delete Transaction"), isPresented: $showingDeleteConfirmation, titleVisibility: .visible) { Button(String(localized: "Delete"), role: .destructive) { Task { await performDelete() } }; Button(String(localized: "Cancel"), role: .cancel) {} } message: { Text(String(localized: "Are you sure you want to delete this transaction? This action cannot be undone.")) }
@@ -107,6 +107,24 @@ struct TransactionDetailView: View {
                 }
                 .accessibilityElement(children: .combine)
                 .accessibilityLabel(String(localized: "Recurring transaction"))
+            }
+        }
+    }
+
+    // MARK: - Tags Section
+
+    @ViewBuilder
+    private var tagsSection: some View {
+        if !transaction.tags.isEmpty {
+            Section(String(localized: "Tags")) {
+                FlowLayout(spacing: 6) {
+                    ForEach(transaction.tags) { tag in
+                        TagView(tag: tag)
+                    }
+                }
+                .padding(.vertical, 4)
+                .accessibilityElement(children: .contain)
+                .accessibilityLabel(String(localized: "Tags"))
             }
         }
     }
@@ -282,7 +300,8 @@ struct TransactionDetailView: View {
             status: transaction.status,
             notes: editedNotes,
             isRecurring: transaction.isRecurring,
-            receiptData: transaction.receiptData
+            receiptData: transaction.receiptData,
+            tags: transaction.tags
         )
         Self.logger.info("Saving updated notes for transaction \(transaction.id, privacy: .private)")
         do {

--- a/apps/ios/Finance/Screens/TransactionFilterSheet.swift
+++ b/apps/ios/Finance/Screens/TransactionFilterSheet.swift
@@ -1,0 +1,483 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// TransactionFilterSheet.swift
+// Finance
+// References: #1484
+//
+// A sheet presenting advanced filter and sort controls for the transactions list.
+// Includes date range, category multi-select, account, amount range, type, and status filters,
+// plus sort options with ascending/descending toggle.
+
+import SwiftUI
+
+// MARK: - Sort Configuration
+
+/// Sort field options for transactions.
+enum TransactionSortField: String, CaseIterable, Sendable {
+    case date, amount, payee, category
+
+    var displayName: String {
+        switch self {
+        case .date: String(localized: "Date")
+        case .amount: String(localized: "Amount")
+        case .payee: String(localized: "Payee")
+        case .category: String(localized: "Category")
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .date: "calendar"
+        case .amount: "dollarsign"
+        case .payee: "person"
+        case .category: "folder"
+        }
+    }
+}
+
+/// Sort direction.
+enum SortDirection: String, CaseIterable, Sendable {
+    case ascending, descending
+
+    var displayName: String {
+        switch self {
+        case .ascending: String(localized: "Ascending")
+        case .descending: String(localized: "Descending")
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .ascending: "arrow.up"
+        case .descending: "arrow.down"
+        }
+    }
+}
+
+/// Combined sort configuration.
+struct TransactionSort: Equatable, Sendable {
+    var field: TransactionSortField = .date
+    var direction: SortDirection = .descending
+}
+
+// MARK: - Filter Sheet View
+
+/// Advanced filter sheet for transactions.
+struct TransactionFilterSheet: View {
+    @Binding var filter: TransactionFilter
+    @Binding var sort: TransactionSort
+    let availableCategories: [String]
+    let availableAccounts: [String]
+    var onApply: () -> Void
+    var onClear: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var localFilter: TransactionFilter
+    @State private var localSort: TransactionSort
+
+    init(
+        filter: Binding<TransactionFilter>,
+        sort: Binding<TransactionSort>,
+        availableCategories: [String],
+        availableAccounts: [String],
+        onApply: @escaping () -> Void,
+        onClear: @escaping () -> Void
+    ) {
+        _filter = filter
+        _sort = sort
+        self.availableCategories = availableCategories
+        self.availableAccounts = availableAccounts
+        self.onApply = onApply
+        self.onClear = onClear
+        _localFilter = State(initialValue: filter.wrappedValue)
+        _localSort = State(initialValue: sort.wrappedValue)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                sortSection
+                dateRangeSection
+                amountRangeSection
+                categorySection
+                accountSection
+                typeSection
+                statusSection
+            }
+            .navigationTitle(String(localized: "Filter & Sort"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(String(localized: "Cancel")) { dismiss() }
+                        .accessibilityLabel(String(localized: "Cancel"))
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(String(localized: "Apply")) {
+                        filter = localFilter
+                        sort = localSort
+                        onApply()
+                        dismiss()
+                    }
+                    .fontWeight(.semibold)
+                    .accessibilityLabel(String(localized: "Apply filters"))
+                    .accessibilityHint(String(localized: "Applies the selected filters and sort options"))
+                }
+            }
+            .safeAreaInset(edge: .bottom) {
+                if localFilter.hasActiveFilters {
+                    Button(role: .destructive) {
+                        localFilter = TransactionFilter()
+                        localSort = TransactionSort()
+                    } label: {
+                        Label(String(localized: "Clear All Filters"), systemImage: "xmark.circle")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.bordered)
+                    .padding()
+                    .accessibilityLabel(String(localized: "Clear all filters"))
+                    .accessibilityHint(String(localized: "Removes all active filters and resets sort to default"))
+                }
+            }
+        }
+    }
+
+    // MARK: - Sort Section
+
+    private var sortSection: some View {
+        Section {
+            Picker(String(localized: "Sort By"), selection: $localSort.field) {
+                ForEach(TransactionSortField.allCases, id: \.self) { field in
+                    Label(field.displayName, systemImage: field.systemImage)
+                        .tag(field)
+                }
+            }
+            .accessibilityLabel(String(localized: "Sort field"))
+
+            Picker(String(localized: "Direction"), selection: $localSort.direction) {
+                ForEach(SortDirection.allCases, id: \.self) { direction in
+                    Label(direction.displayName, systemImage: direction.systemImage)
+                        .tag(direction)
+                }
+            }
+            .accessibilityLabel(String(localized: "Sort direction"))
+        } header: {
+            Label(String(localized: "Sort"), systemImage: "arrow.up.arrow.down")
+        }
+    }
+
+    // MARK: - Date Range Section
+
+    private var dateRangeSection: some View {
+        Section {
+            Toggle(String(localized: "Filter by Date"), isOn: $localFilter.dateRangeEnabled)
+                .accessibilityLabel(String(localized: "Filter by date range"))
+                .accessibilityHint(String(localized: "Enables filtering transactions to a specific date range"))
+
+            if localFilter.dateRangeEnabled {
+                DatePicker(
+                    String(localized: "From"),
+                    selection: $localFilter.startDate,
+                    displayedComponents: .date
+                )
+                .accessibilityLabel(String(localized: "Start date"))
+
+                DatePicker(
+                    String(localized: "To"),
+                    selection: $localFilter.endDate,
+                    displayedComponents: .date
+                )
+                .accessibilityLabel(String(localized: "End date"))
+            }
+        } header: {
+            Label(String(localized: "Date Range"), systemImage: "calendar")
+        }
+    }
+
+    // MARK: - Amount Range Section
+
+    private var amountRangeSection: some View {
+        Section {
+            Toggle(String(localized: "Filter by Amount"), isOn: $localFilter.amountRangeEnabled)
+                .accessibilityLabel(String(localized: "Filter by amount range"))
+                .accessibilityHint(String(localized: "Enables filtering transactions to a specific amount range"))
+
+            if localFilter.amountRangeEnabled {
+                HStack {
+                    Text(String(localized: "Min"))
+                        .foregroundStyle(.secondary)
+                    TextField(
+                        String(localized: "0.00"),
+                        value: $localFilter.minAmount,
+                        format: .number.precision(.fractionLength(2))
+                    )
+                    .keyboardType(.decimalPad)
+                    .textFieldStyle(.roundedBorder)
+                    .accessibilityLabel(String(localized: "Minimum amount"))
+                }
+
+                HStack {
+                    Text(String(localized: "Max"))
+                        .foregroundStyle(.secondary)
+                    TextField(
+                        String(localized: "No limit"),
+                        value: $localFilter.maxAmount,
+                        format: .number.precision(.fractionLength(2))
+                    )
+                    .keyboardType(.decimalPad)
+                    .textFieldStyle(.roundedBorder)
+                    .accessibilityLabel(String(localized: "Maximum amount"))
+                }
+            }
+        } header: {
+            Label(String(localized: "Amount"), systemImage: "dollarsign.circle")
+        }
+    }
+
+    // MARK: - Category Section
+
+    private var categorySection: some View {
+        Section {
+            if availableCategories.isEmpty {
+                Text(String(localized: "No categories available"))
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            } else {
+                ForEach(availableCategories, id: \.self) { category in
+                    Button {
+                        toggleCategory(category)
+                    } label: {
+                        HStack {
+                            Text(category)
+                                .foregroundStyle(.primary)
+                            Spacer()
+                            if localFilter.selectedCategories.contains(category) {
+                                Image(systemName: "checkmark")
+                                    .foregroundStyle(.blue)
+                                    .fontWeight(.semibold)
+                            }
+                        }
+                    }
+                    .accessibilityLabel(category)
+                    .accessibilityAddTraits(localFilter.selectedCategories.contains(category) ? .isSelected : [])
+                    .accessibilityHint(
+                        localFilter.selectedCategories.contains(category)
+                            ? String(localized: "Tap to deselect this category")
+                            : String(localized: "Tap to filter by this category")
+                    )
+                }
+            }
+        } header: {
+            HStack {
+                Label(String(localized: "Categories"), systemImage: "folder")
+                Spacer()
+                if !localFilter.selectedCategories.isEmpty {
+                    Text("\(localFilter.selectedCategories.count)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    // MARK: - Account Section
+
+    private var accountSection: some View {
+        Section {
+            if availableAccounts.isEmpty {
+                Text(String(localized: "No accounts available"))
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            } else {
+                Picker(String(localized: "Account"), selection: Binding(
+                    get: { localFilter.selectedAccount ?? "" },
+                    set: { localFilter.selectedAccount = $0.isEmpty ? nil : $0 }
+                )) {
+                    Text(String(localized: "All Accounts"))
+                        .tag("")
+                    ForEach(availableAccounts, id: \.self) { account in
+                        Text(account).tag(account)
+                    }
+                }
+                .accessibilityLabel(String(localized: "Account filter"))
+                .accessibilityHint(String(localized: "Select an account to filter transactions"))
+            }
+        } header: {
+            Label(String(localized: "Account"), systemImage: "building.columns")
+        }
+    }
+
+    // MARK: - Type Section
+
+    private var typeSection: some View {
+        Section {
+            ForEach(TransactionTypeUI.allCases, id: \.self) { type in
+                Button {
+                    toggleType(type)
+                } label: {
+                    HStack {
+                        Image(systemName: type.systemImage)
+                            .foregroundStyle(type.color)
+                            .frame(width: 24)
+                        Text(type.displayName)
+                            .foregroundStyle(.primary)
+                        Spacer()
+                        if localFilter.selectedTypes.contains(type) {
+                            Image(systemName: "checkmark")
+                                .foregroundStyle(.blue)
+                                .fontWeight(.semibold)
+                        }
+                    }
+                }
+                .accessibilityLabel(type.displayName)
+                .accessibilityAddTraits(localFilter.selectedTypes.contains(type) ? .isSelected : [])
+                .accessibilityHint(
+                    localFilter.selectedTypes.contains(type)
+                        ? String(localized: "Tap to deselect this type")
+                        : String(localized: "Tap to filter by this type")
+                )
+            }
+        } header: {
+            Label(String(localized: "Type"), systemImage: "arrow.left.arrow.right")
+        }
+    }
+
+    // MARK: - Status Section
+
+    private var statusSection: some View {
+        Section {
+            ForEach(TransactionStatusUI.allCases, id: \.self) { status in
+                Button {
+                    toggleStatus(status)
+                } label: {
+                    HStack {
+                        Text(status.displayName)
+                            .foregroundStyle(.primary)
+                        Spacer()
+                        if localFilter.selectedStatuses.contains(status) {
+                            Image(systemName: "checkmark")
+                                .foregroundStyle(.blue)
+                                .fontWeight(.semibold)
+                        }
+                    }
+                }
+                .accessibilityLabel(status.displayName)
+                .accessibilityAddTraits(localFilter.selectedStatuses.contains(status) ? .isSelected : [])
+                .accessibilityHint(
+                    localFilter.selectedStatuses.contains(status)
+                        ? String(localized: "Tap to deselect this status")
+                        : String(localized: "Tap to filter by this status")
+                )
+            }
+        } header: {
+            Label(String(localized: "Status"), systemImage: "checkmark.circle")
+        }
+    }
+
+    // MARK: - Actions
+
+    private func toggleCategory(_ category: String) {
+        if localFilter.selectedCategories.contains(category) {
+            localFilter.selectedCategories.remove(category)
+        } else {
+            localFilter.selectedCategories.insert(category)
+        }
+    }
+
+    private func toggleType(_ type: TransactionTypeUI) {
+        if localFilter.selectedTypes.contains(type) {
+            localFilter.selectedTypes.remove(type)
+        } else {
+            localFilter.selectedTypes.insert(type)
+        }
+    }
+
+    private func toggleStatus(_ status: TransactionStatusUI) {
+        if localFilter.selectedStatuses.contains(status) {
+            localFilter.selectedStatuses.remove(status)
+        } else {
+            localFilter.selectedStatuses.insert(status)
+        }
+    }
+}
+
+// MARK: - Filter Chips Bar
+
+/// Inline scrollable row of active filter chips with remove action.
+struct FilterChipsBar: View {
+    let labels: [FilterLabel]
+    var onRemove: (FilterLabel) -> Void
+    var onClearAll: () -> Void
+
+    var body: some View {
+        if !labels.isEmpty {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 6) {
+                    ForEach(labels) { label in
+                        filterChip(label)
+                    }
+
+                    Button {
+                        onClearAll()
+                    } label: {
+                        Text(String(localized: "Clear All"))
+                            .font(.caption)
+                            .fontWeight(.medium)
+                            .foregroundStyle(.red)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 5)
+                            .background(.red.opacity(0.1), in: Capsule())
+                    }
+                    .accessibilityLabel(String(localized: "Clear all filters"))
+                    .accessibilityHint(String(localized: "Removes all active filters"))
+                }
+                .padding(.horizontal)
+                .padding(.vertical, 4)
+            }
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel(String(localized: "Active filters"))
+        }
+    }
+
+    private func filterChip(_ label: FilterLabel) -> some View {
+        HStack(spacing: 4) {
+            Text(label.text)
+                .font(.caption)
+                .lineLimit(1)
+
+            Image(systemName: "xmark")
+                .font(.system(size: 9, weight: .bold))
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .foregroundStyle(.blue)
+        .background(.blue.opacity(0.1), in: Capsule())
+        .contentShape(Capsule())
+        .onTapGesture { onRemove(label) }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(String(localized: "Filter: \(label.text)"))
+        .accessibilityHint(String(localized: "Tap to remove this filter"))
+        .accessibilityAddTraits(.isButton)
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    struct PreviewWrapper: View {
+        @State private var filter = TransactionFilter()
+        @State private var sort = TransactionSort()
+
+        var body: some View {
+            TransactionFilterSheet(
+                filter: $filter,
+                sort: $sort,
+                availableCategories: ["Groceries", "Dining", "Transport", "Entertainment", "Bills"],
+                availableAccounts: ["Main Checking", "Savings", "Credit Card"],
+                onApply: {},
+                onClear: {}
+            )
+        }
+    }
+
+    return PreviewWrapper()
+}

--- a/apps/ios/Finance/Screens/TransactionsView.swift
+++ b/apps/ios/Finance/Screens/TransactionsView.swift
@@ -44,6 +44,30 @@ struct TransactionsView: View {
             .navigationTitle(String(localized: "Transactions"))
             .searchable(text: $viewModel.searchText, prompt: String(localized: "Search by payee, category, or account"))
             .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button {
+                        viewModel.showingFilterSheet = true
+                    } label: {
+                        Image(systemName: "line.3.horizontal.decrease.circle")
+                            .overlay(alignment: .topTrailing) {
+                                if viewModel.activeFilterCount > 0 {
+                                    Text("\(viewModel.activeFilterCount)")
+                                        .font(.system(size: 10, weight: .bold))
+                                        .foregroundStyle(.white)
+                                        .frame(width: 16, height: 16)
+                                        .background(.red, in: Circle())
+                                        .offset(x: 6, y: -6)
+                                }
+                            }
+                    }
+                    .accessibilityLabel(String(localized: "Filter transactions"))
+                    .accessibilityHint(String(localized: "Opens filter and sort options"))
+                    .accessibilityValue(
+                        viewModel.activeFilterCount > 0
+                            ? String(localized: "\(viewModel.activeFilterCount) active filters")
+                            : String(localized: "No active filters")
+                    )
+                }
                 ToolbarItem(placement: .primaryAction) {
                     Menu {
                         Button {
@@ -76,6 +100,17 @@ struct TransactionsView: View {
                 Task { await viewModel.loadTransactions() }
             }) {
                 NlpInputView()
+            }
+            .sheet(isPresented: $viewModel.showingFilterSheet) {
+                TransactionFilterSheet(
+                    filter: $viewModel.filter,
+                    sort: $viewModel.sort,
+                    availableCategories: viewModel.availableCategories,
+                    availableAccounts: viewModel.availableAccounts,
+                    onApply: { viewModel.applyFiltersAndSort() },
+                    onClear: { viewModel.clearAllFilters() }
+                )
+                .presentationDetents([.medium, .large])
             }
             .sheet(item: $viewModel.editingTransaction, onDismiss: {
                 Task { await viewModel.loadTransactions() }
@@ -111,45 +146,56 @@ struct TransactionsView: View {
     }
 
     private var transactionsList: some View {
-        List {
-            ForEach(viewModel.groupedTransactions) { group in
-                Section {
-                    ForEach(group.transactions) { transaction in
-                        transactionRow(transaction)
-                            .contentShape(Rectangle())
-                            .onTapGesture { viewModel.editingTransaction = transaction }
-                            .onAppear {
-                                // Trigger pagination when approaching the
-                                // end of the loaded list (within 5 items).
-                                if viewModel.hasMorePages,
-                                   viewModel.shouldLoadMore(for: transaction) {
-                                    Task { await viewModel.loadMore() }
+        VStack(spacing: 0) {
+            // Active filter chips
+            if !viewModel.activeFilterLabels.isEmpty {
+                FilterChipsBar(
+                    labels: viewModel.activeFilterLabels,
+                    onRemove: { viewModel.removeFilter($0) },
+                    onClearAll: { viewModel.clearAllFilters() }
+                )
+            }
+
+            List {
+                ForEach(viewModel.groupedTransactions) { group in
+                    Section {
+                        ForEach(group.transactions) { transaction in
+                            transactionRow(transaction)
+                                .contentShape(Rectangle())
+                                .onTapGesture { viewModel.editingTransaction = transaction }
+                                .onAppear {
+                                    // Trigger pagination when approaching the
+                                    // end of the loaded list (within 5 items).
+                                    if viewModel.hasMorePages,
+                                       viewModel.shouldLoadMore(for: transaction) {
+                                        Task { await viewModel.loadMore() }
+                                    }
                                 }
-                            }
-                            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                                Button(role: .destructive) {
-                                    viewModel.confirmDelete(id: transaction.id)
-                                } label: {
-                                    Label(String(localized: "Delete"), systemImage: "trash")
+                                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                                    Button(role: .destructive) {
+                                        viewModel.confirmDelete(id: transaction.id)
+                                    } label: {
+                                        Label(String(localized: "Delete"), systemImage: "trash")
+                                    }
+                                    .accessibilityLabel(String(localized: "Delete transaction"))
                                 }
-                                .accessibilityLabel(String(localized: "Delete transaction"))
-                            }
-                            .swipeActions(edge: .leading, allowsFullSwipe: false) {
-                                Button {
-                                    viewModel.editingTransaction = transaction
-                                } label: {
-                                    Label(String(localized: "Edit"), systemImage: "pencil")
+                                .swipeActions(edge: .leading, allowsFullSwipe: false) {
+                                    Button {
+                                        viewModel.editingTransaction = transaction
+                                    } label: {
+                                        Label(String(localized: "Edit"), systemImage: "pencil")
+                                    }
+                                    .tint(.blue)
+                                    .accessibilityLabel(String(localized: "Edit transaction"))
                                 }
-                                .tint(.blue)
-                                .accessibilityLabel(String(localized: "Edit transaction"))
-                            }
+                        }
+                    } header: {
+                        Text(group.date, style: .date)
                     }
-                } header: {
-                    Text(group.date, style: .date)
                 }
             }
+            .listStyle(.insetGrouped)
         }
-        .listStyle(.insetGrouped)
     }
 
     private func transactionRow(_ transaction: TransactionItem) -> some View {
@@ -174,14 +220,32 @@ struct TransactionsView: View {
                     Text(transaction.accountName)
                 }
                 .font(.caption).foregroundStyle(.secondary).lineLimit(1)
+
+                // Tags row (show up to 2 tag chips)
+                if !transaction.tags.isEmpty {
+                    TagsRow(
+                        tags: transaction.tags,
+                        maxVisible: 2,
+                        onTagTap: { tag in viewModel.filterByTag(tag) }
+                    )
+                }
             }
             Spacer()
             CurrencyLabel(amountInMinorUnits: transaction.amountMinorUnits, currencyCode: transaction.currencyCode, font: .callout.bold())
         }
         .padding(.vertical, 2)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(transaction.payee), \(transaction.category), \(transaction.accountName)")
+        .accessibilityLabel(transactionAccessibilityLabel(transaction))
         .accessibilityHint(String(localized: "Tap to edit. Swipe for more actions."))
+    }
+
+    private func transactionAccessibilityLabel(_ transaction: TransactionItem) -> String {
+        var label = "\(transaction.payee), \(transaction.category), \(transaction.accountName)"
+        if !transaction.tags.isEmpty {
+            let tagNames = transaction.tags.map(\.displayName).joined(separator: ", ")
+            label += ", " + String(localized: "Tags: \(tagNames)")
+        }
+        return label
     }
 }
 

--- a/apps/ios/Finance/ViewModels/TransactionsViewModel.swift
+++ b/apps/ios/Finance/ViewModels/TransactionsViewModel.swift
@@ -70,6 +70,7 @@ final class TransactionsViewModel {
     var errorMessage: String?
     var showingFilterSheet = false
     var filter = TransactionFilter()
+    var sort = TransactionSort()
     var debouncedSearchText = ""
     var recentSearches: [String] { get { Self.loadRecentSearches() } set { Self.saveRecentSearches(newValue) } }
     private var debounceTask: Task<Void, Never>?
@@ -102,9 +103,26 @@ final class TransactionsViewModel {
     private(set) var groupedTransactions: [DateGroup] = []
 
     /// Recomputes `filteredTransactions` and `groupedTransactions` from
-    /// the current `transactions`, search text, and filter state.
+    /// the current `transactions`, search text, filter, and sort state.
     private func recomputeFilteredGroups() {
-        filteredTransactions = transactions.filter { matchesSearch($0) && matchesFilter($0) }
+        var result = transactions.filter { matchesSearch($0) && matchesFilter($0) }
+        // Apply sort
+        result.sort { lhs, rhs in
+            let ascending: Bool = sort.direction == .ascending
+            switch sort.field {
+            case .date:
+                return ascending ? lhs.date < rhs.date : lhs.date > rhs.date
+            case .amount:
+                return ascending ? lhs.amountMinorUnits < rhs.amountMinorUnits : lhs.amountMinorUnits > rhs.amountMinorUnits
+            case .payee:
+                let cmp = lhs.payee.localizedCaseInsensitiveCompare(rhs.payee)
+                return ascending ? cmp == .orderedAscending : cmp == .orderedDescending
+            case .category:
+                let cmp = lhs.category.localizedCaseInsensitiveCompare(rhs.category)
+                return ascending ? cmp == .orderedAscending : cmp == .orderedDescending
+            }
+        }
+        filteredTransactions = result
         let cal = Calendar.current
         let grouped = Dictionary(grouping: filteredTransactions) { cal.startOfDay(for: $0.date) }
         groupedTransactions = grouped.sorted { $0.key > $1.key }
@@ -177,6 +195,15 @@ final class TransactionsViewModel {
     func confirmDelete(id: String) { pendingDeleteId = id; showingDeleteConfirmation = true }
     func removeFilter(_ label: FilterLabel) { switch label.kind { case .dateRange: filter.dateRangeEnabled = false; case .amountRange: filter.amountRangeEnabled = false; case .category(let n): filter.selectedCategories.remove(n); case .account: filter.selectedAccount = nil; case .type(let t): filter.selectedTypes.remove(t); case .status(let s): filter.selectedStatuses.remove(s) }; recomputeFilteredGroups(); AccessibilityNotification.Announcement(String(localized: "\(activeFilterCount) filters active")).post() }
     func clearAllFilters() { filter = TransactionFilter(); recomputeFilteredGroups(); AccessibilityNotification.Announcement(String(localized: "All filters cleared")).post() }
+    func applyFiltersAndSort() { recomputeFilteredGroups() }
+    func filterByTag(_ tag: Tag) { /* Add tag name to search for quick filtering */ searchText = tag.name }
+
+    /// All unique tags across loaded transactions.
+    var availableTags: [Tag] {
+        let allTags = transactions.flatMap(\.tags)
+        var seen = Set<String>()
+        return allTags.filter { seen.insert($0.name).inserted }
+    }
 
     // MARK: - Filtering
 


### PR DESCRIPTION
## Summary

Adds comprehensive filter/sort controls and a proper tags UI system with color coding to the iOS SwiftUI app.

## Changes

### Filter/Sort Controls (#1484)
- **TransactionFilterSheet** — Full filter sheet with date range (DatePicker), category multi-select, account picker, amount range (NumberFormatter), type (income/expense/transfer), and status filters
- **Sort controls** — Sort by date, amount, payee, or category with ascending/descending toggle
- **FilterChipsBar** — Active filter chips shown inline below search with individual remove and 'Clear All'
- **Filter badge** — Filter count badge on the filter toolbar button
- **Integration** — Filter button added to TransactionsView toolbar; sort applied in recomputeFilteredGroups

### Tags UI (#1487)
- **Tag model** — Supports subtags via colon separator (e.g. \	ravel:flights\ → \	ravel › flights\)
- **TagView** — Capsule-shaped chip with deterministic color from name hash; VoiceOver accessible
- **TagInputView** — TextField with autocomplete suggestions, selected tags as removable chips, 'Create new' option
- **TagsRow** — Shows up to N tag chips with overflow indicator (\+2\)
- **FlowLayout** — Custom SwiftUI Layout for wrapping tags in detail views
- **TransactionRowView** — Shows 1-2 tag chips inline
- **TransactionDetailView** — Shows all tags in dedicated section
- **TransactionItem** — Extended with \	ags: [Tag]\ property (default \[]\, backward-compatible)

### Architecture
- Uses \@Observable\ pattern (iOS 17+)
- All text uses \String(localized:)\ for i18n
- Full VoiceOver accessibility (labels, hints, traits) on every interactive element
- Dynamic Type compatible — no hardcoded font sizes
- Dark mode compatible via system colors

## Issues

Closes #1484
Closes #1487