### PR TITLE
feat(web): advanced filter/sort controls and transaction edit panel (#1464, #1479)

### DIFF
--- a/apps/web/e2e/transactions.spec.ts
+++ b/apps/web/e2e/transactions.spec.ts
@@ -36,17 +36,16 @@ test.describe('Transactions page', () => {
     await expect(searchInput).toHaveAttribute('placeholder', /search/i);
   });
 
-  test('shows filter chips including "All"', async ({ authenticatedPage: page }) => {
+  test('shows filter controls with toggle button', async ({ authenticatedPage: page }) => {
     await page.goto('/transactions');
 
-    // Category filter group
-    const filterGroup = page.getByRole('group', { name: /category filter/i });
-    await expect(filterGroup).toBeVisible();
+    // Advanced filter toggle button should be visible
+    const filterToggle = page.getByRole('button', { name: /filters/i });
+    await expect(filterToggle).toBeVisible();
 
-    // The "All" filter chip should be present and pressed by default
-    const allChip = filterGroup.getByRole('button', { name: 'All' });
-    await expect(allChip).toBeVisible();
-    await expect(allChip).toHaveAttribute('aria-pressed', 'true');
+    // Sort controls should be visible
+    const sortSelect = page.getByLabel(/sort field/i);
+    await expect(sortSelect).toBeVisible();
   });
 
   test('shows the Add Transaction button', async ({ authenticatedPage: page }) => {

--- a/apps/web/src/components/transactions/TransactionEditPanel.test.tsx
+++ b/apps/web/src/components/transactions/TransactionEditPanel.test.tsx
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for TransactionEditPanel component.
+ * References: issue #1479
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+import { TransactionEditPanel } from './TransactionEditPanel';
+import type { Account, Category, Transaction } from '../../kmp/bridge';
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+const mockTransaction: Transaction = {
+  id: 'txn-1',
+  householdId: 'h1',
+  accountId: 'acc-1',
+  categoryId: 'cat-1',
+  type: 'EXPENSE',
+  status: 'CLEARED',
+  amount: { amount: 2500 },
+  currency: { code: 'USD', decimalPlaces: 2 },
+  payee: 'Grocery Store',
+  note: 'Weekly groceries',
+  date: '2024-03-15',
+  transferAccountId: null,
+  transferTransactionId: null,
+  isRecurring: false,
+  recurringRuleId: null,
+  tags: [],
+  createdAt: '2024-03-15T10:00:00Z',
+  updatedAt: '2024-03-15T10:00:00Z',
+  deletedAt: null,
+  syncVersion: 1,
+  isSynced: true,
+};
+
+const mockAccounts: Account[] = [
+  {
+    id: 'acc-1',
+    householdId: 'h1',
+    name: 'Checking',
+    type: 'CHECKING',
+    currency: { code: 'USD', decimalPlaces: 2 },
+    currentBalance: { amount: 100000 },
+    isArchived: false,
+    sortOrder: 0,
+    icon: null,
+    color: null,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    deletedAt: null,
+    syncVersion: 1,
+    isSynced: true,
+  },
+] as Account[];
+
+const mockCategories: Category[] = [
+  {
+    id: 'cat-1',
+    householdId: 'h1',
+    name: 'Food',
+    icon: null,
+    color: null,
+    parentId: null,
+    sortOrder: 0,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    deletedAt: null,
+    syncVersion: 1,
+    isSynced: true,
+  },
+] as unknown as Category[];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TransactionEditPanel', () => {
+  it('renders nothing when transaction is null', () => {
+    const { container } = render(
+      <TransactionEditPanel
+        transaction={null}
+        accounts={mockAccounts}
+        categories={mockCategories}
+        onSave={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders the edit panel dialog when transaction is provided', () => {
+    render(
+      <TransactionEditPanel
+        transaction={mockTransaction}
+        accounts={mockAccounts}
+        categories={mockCategories}
+        onSave={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Edit Transaction')).toBeInTheDocument();
+  });
+
+  it('pre-fills form fields with transaction data', () => {
+    render(
+      <TransactionEditPanel
+        transaction={mockTransaction}
+        accounts={mockAccounts}
+        categories={mockCategories}
+        onSave={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const payeeInput = screen.getByLabelText(/payee/i) as HTMLInputElement;
+    expect(payeeInput.value).toBe('Grocery Store');
+
+    const amountInput = screen.getByLabelText(/amount/i) as HTMLInputElement;
+    expect(amountInput.value).toBe('25.00');
+
+    const dateInput = screen.getByLabelText(/date/i) as HTMLInputElement;
+    expect(dateInput.value).toBe('2024-03-15');
+  });
+
+  it('calls onClose when close button is clicked', () => {
+    const onClose = vi.fn();
+    render(
+      <TransactionEditPanel
+        transaction={mockTransaction}
+        accounts={mockAccounts}
+        categories={mockCategories}
+        onSave={vi.fn()}
+        onClose={onClose}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText(/close edit panel/i));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('calls onClose when cancel button is clicked', () => {
+    const onClose = vi.fn();
+    render(
+      <TransactionEditPanel
+        transaction={mockTransaction}
+        accounts={mockAccounts}
+        categories={mockCategories}
+        onSave={vi.fn()}
+        onClose={onClose}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('calls onClose when backdrop is clicked', () => {
+    const onClose = vi.fn();
+    render(
+      <TransactionEditPanel
+        transaction={mockTransaction}
+        accounts={mockAccounts}
+        categories={mockCategories}
+        onSave={vi.fn()}
+        onClose={onClose}
+      />,
+    );
+
+    const backdrop = document.querySelector('.edit-panel-backdrop');
+    expect(backdrop).not.toBeNull();
+    fireEvent.click(backdrop!);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('calls onClose when Escape key is pressed', () => {
+    const onClose = vi.fn();
+    render(
+      <TransactionEditPanel
+        transaction={mockTransaction}
+        accounts={mockAccounts}
+        categories={mockCategories}
+        onSave={vi.fn()}
+        onClose={onClose}
+      />,
+    );
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('has proper aria attributes for accessibility', () => {
+    render(
+      <TransactionEditPanel
+        transaction={mockTransaction}
+        accounts={mockAccounts}
+        categories={mockCategories}
+        onSave={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby', 'edit-panel-title');
+  });
+});

--- a/apps/web/src/components/transactions/TransactionEditPanel.tsx
+++ b/apps/web/src/components/transactions/TransactionEditPanel.tsx
@@ -1,0 +1,331 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * TransactionEditPanel — Slide-over panel for editing transactions.
+ *
+ * Desktop: slide-over drawer from the right side.
+ * Mobile: full-screen modal.
+ * Includes focus trapping, backdrop click-to-close, and Escape key handling.
+ *
+ * @module components/transactions/TransactionEditPanel
+ * References: issue #1479
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+import { useFocusTrap } from '../../accessibility/aria';
+import type { Account, Category, Transaction } from '../../kmp/bridge';
+import type { CreateTransactionInput } from '../../db/repositories/transactions';
+import './transaction-edit-panel.css';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface TransactionEditPanelProps {
+  /** The transaction to edit. If null, the panel is hidden. */
+  transaction: Transaction | null;
+  /** Available accounts for the form. */
+  accounts: Account[];
+  /** Available categories for the form. */
+  categories: Category[];
+  /** Callback on save. */
+  onSave: (id: string, data: CreateTransactionInput) => Promise<void>;
+  /** Callback to close the panel. */
+  onClose: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export const TransactionEditPanel: React.FC<TransactionEditPanelProps> = ({
+  transaction,
+  accounts,
+  categories,
+  onSave,
+  onClose,
+}) => {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const isOpen = transaction !== null;
+
+  useFocusTrap(panelRef, { active: isOpen });
+
+  // Form state
+  const [payee, setPayee] = useState('');
+  const [amount, setAmount] = useState('');
+  const [date, setDate] = useState('');
+  const [type, setType] = useState<'EXPENSE' | 'INCOME' | 'TRANSFER'>('EXPENSE');
+  const [categoryId, setCategoryId] = useState('');
+  const [accountId, setAccountId] = useState('');
+  const [note, setNote] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // Populate form when transaction changes
+  useEffect(() => {
+    if (transaction) {
+      setPayee(transaction.payee ?? '');
+      setAmount((Math.abs(transaction.amount.amount) / 100).toFixed(2));
+      setDate(transaction.date);
+      setType(transaction.type);
+      setCategoryId(transaction.categoryId ?? '');
+      setAccountId(transaction.accountId);
+      setNote(transaction.note ?? '');
+      setSubmitError(null);
+    }
+  }, [transaction]);
+
+  // Escape key closes
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && !event.defaultPrevented) {
+        event.preventDefault();
+        onClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
+
+  const handleBackdropClick = useCallback(() => {
+    if (!submitting) {
+      onClose();
+    }
+  }, [submitting, onClose]);
+
+  const handleSubmit = useCallback(
+    async (event: React.FormEvent) => {
+      event.preventDefault();
+      if (!transaction) return;
+
+      setSubmitting(true);
+      setSubmitError(null);
+
+      try {
+        const data: CreateTransactionInput = {
+          householdId: transaction.householdId,
+          accountId,
+          categoryId: categoryId || null,
+          type,
+          amount: { amount: Math.round(parseFloat(amount) * 100) },
+          currency: transaction.currency,
+          payee: payee || null,
+          note: note || null,
+          date,
+          status: transaction.status,
+        };
+
+        await onSave(transaction.id, data);
+      } catch (err) {
+        setSubmitError(err instanceof Error ? err.message : 'Failed to save transaction.');
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [transaction, accountId, categoryId, type, amount, payee, note, date, onSave],
+  );
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="edit-panel-overlay" role="presentation">
+      <div className="edit-panel-backdrop" onClick={handleBackdropClick} aria-hidden="true" />
+      <div
+        ref={panelRef}
+        className="edit-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="edit-panel-title"
+      >
+        <header className="edit-panel__header">
+          <h2 id="edit-panel-title" className="edit-panel__title">
+            Edit Transaction
+          </h2>
+          <button
+            type="button"
+            className="edit-panel__close"
+            onClick={onClose}
+            aria-label="Close edit panel"
+            disabled={submitting}
+          >
+            <span aria-hidden="true">✕</span>
+          </button>
+        </header>
+
+        <form className="edit-panel__body" onSubmit={handleSubmit}>
+          {submitError && (
+            <div className="form-banner-error" role="alert">
+              {submitError}
+            </div>
+          )}
+
+          <div className="form-fields">
+            {/* Payee */}
+            <div className="form-group">
+              <label className="form-group__label" htmlFor="edit-panel-payee">
+                Payee
+              </label>
+              <input
+                id="edit-panel-payee"
+                type="text"
+                className="form-input"
+                value={payee}
+                onChange={(e) => setPayee(e.target.value)}
+                disabled={submitting}
+              />
+            </div>
+
+            {/* Amount */}
+            <div className="form-group">
+              <label
+                className="form-group__label form-group__label--required"
+                htmlFor="edit-panel-amount"
+              >
+                Amount
+              </label>
+              <input
+                id="edit-panel-amount"
+                type="number"
+                className="form-input"
+                value={amount}
+                onChange={(e) => setAmount(e.target.value)}
+                min="0"
+                step="0.01"
+                required
+                aria-required="true"
+                disabled={submitting}
+              />
+            </div>
+
+            {/* Date */}
+            <div className="form-group">
+              <label
+                className="form-group__label form-group__label--required"
+                htmlFor="edit-panel-date"
+              >
+                Date
+              </label>
+              <input
+                id="edit-panel-date"
+                type="date"
+                className="form-input"
+                value={date}
+                onChange={(e) => setDate(e.target.value)}
+                required
+                aria-required="true"
+                disabled={submitting}
+              />
+            </div>
+
+            {/* Type */}
+            <fieldset className="form-radio-group">
+              <legend className="form-radio-group__legend">Type</legend>
+              <div className="form-radio-group__options">
+                {(['EXPENSE', 'INCOME', 'TRANSFER'] as const).map((t) => (
+                  <label key={t} className="form-radio-option">
+                    <input
+                      type="radio"
+                      name="edit-panel-type"
+                      value={t}
+                      checked={type === t}
+                      onChange={() => setType(t)}
+                      disabled={submitting}
+                    />
+                    <span className="form-radio-option__label">
+                      {t.charAt(0) + t.slice(1).toLowerCase()}
+                    </span>
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+
+            {/* Category */}
+            <div className="form-group">
+              <label className="form-group__label" htmlFor="edit-panel-category">
+                Category
+              </label>
+              <select
+                id="edit-panel-category"
+                className="form-select"
+                value={categoryId}
+                onChange={(e) => setCategoryId(e.target.value)}
+                disabled={submitting}
+              >
+                <option value="">Uncategorized</option>
+                {categories.map((cat) => (
+                  <option key={cat.id} value={cat.id}>
+                    {cat.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* Account */}
+            <div className="form-group">
+              <label
+                className="form-group__label form-group__label--required"
+                htmlFor="edit-panel-account"
+              >
+                Account
+              </label>
+              <select
+                id="edit-panel-account"
+                className="form-select"
+                value={accountId}
+                onChange={(e) => setAccountId(e.target.value)}
+                required
+                aria-required="true"
+                disabled={submitting}
+              >
+                {accounts.map((acc) => (
+                  <option key={acc.id} value={acc.id}>
+                    {acc.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* Note */}
+            <div className="form-group">
+              <label className="form-group__label" htmlFor="edit-panel-note">
+                Note
+              </label>
+              <textarea
+                id="edit-panel-note"
+                className="form-textarea"
+                value={note}
+                onChange={(e) => setNote(e.target.value)}
+                rows={3}
+                disabled={submitting}
+              />
+            </div>
+          </div>
+        </form>
+
+        <footer className="edit-panel__footer">
+          <button
+            type="button"
+            className="form-button form-button--secondary"
+            onClick={onClose}
+            disabled={submitting}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="form-button form-button--primary"
+            onClick={handleSubmit}
+            disabled={submitting}
+            aria-busy={submitting}
+          >
+            {submitting ? 'Saving…' : 'Save'}
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+};

--- a/apps/web/src/components/transactions/TransactionFilters.test.tsx
+++ b/apps/web/src/components/transactions/TransactionFilters.test.tsx
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for TransactionFilters component.
+ * References: issue #1464
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+import { TransactionFilters, EMPTY_FILTERS, countActiveFilters } from './TransactionFilters';
+import type { AdvancedFilters } from './TransactionFilters';
+import type { Account, Category } from '../../kmp/bridge';
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+const mockCategories: Category[] = [
+  {
+    id: 'cat-1',
+    householdId: 'h1',
+    name: 'Food',
+    icon: null,
+    color: null,
+    parentId: null,
+    sortOrder: 0,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    deletedAt: null,
+    syncVersion: 1,
+    isSynced: true,
+  },
+  {
+    id: 'cat-2',
+    householdId: 'h1',
+    name: 'Transport',
+    icon: null,
+    color: null,
+    parentId: null,
+    sortOrder: 1,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    deletedAt: null,
+    syncVersion: 1,
+    isSynced: true,
+  },
+] as unknown as Category[];
+
+const mockAccounts: Account[] = [
+  {
+    id: 'acc-1',
+    householdId: 'h1',
+    name: 'Checking',
+    type: 'CHECKING',
+    currency: { code: 'USD', decimalPlaces: 2 },
+    currentBalance: { amount: 100000 },
+    isArchived: false,
+    sortOrder: 0,
+    icon: null,
+    color: null,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    deletedAt: null,
+    syncVersion: 1,
+    isSynced: true,
+  },
+] as Account[];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TransactionFilters', () => {
+  it('renders toggle button with correct label', () => {
+    render(
+      <TransactionFilters
+        filters={EMPTY_FILTERS}
+        onChange={vi.fn()}
+        isOpen={false}
+        onToggle={vi.fn()}
+        categories={mockCategories}
+        accounts={mockAccounts}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: /filters/i })).toBeInTheDocument();
+  });
+
+  it('shows badge when filters are active', () => {
+    const filtersWithType: AdvancedFilters = { ...EMPTY_FILTERS, types: ['EXPENSE'] };
+    render(
+      <TransactionFilters
+        filters={filtersWithType}
+        onChange={vi.fn()}
+        isOpen={false}
+        onToggle={vi.fn()}
+        categories={mockCategories}
+        accounts={mockAccounts}
+      />,
+    );
+
+    expect(screen.getByText('1')).toBeInTheDocument();
+  });
+
+  it('calls onToggle when toggle button is clicked', () => {
+    const onToggle = vi.fn();
+    render(
+      <TransactionFilters
+        filters={EMPTY_FILTERS}
+        onChange={vi.fn()}
+        isOpen={false}
+        onToggle={onToggle}
+        categories={mockCategories}
+        accounts={mockAccounts}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /filters/i }));
+    expect(onToggle).toHaveBeenCalledOnce();
+  });
+
+  it('renders the panel when isOpen is true', () => {
+    render(
+      <TransactionFilters
+        filters={EMPTY_FILTERS}
+        onChange={vi.fn()}
+        isOpen={true}
+        onToggle={vi.fn()}
+        categories={mockCategories}
+        accounts={mockAccounts}
+      />,
+    );
+
+    expect(screen.getByRole('region', { name: /advanced filters/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/from date/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/to date/i)).toBeInTheDocument();
+  });
+
+  it('does not render the panel when isOpen is false', () => {
+    render(
+      <TransactionFilters
+        filters={EMPTY_FILTERS}
+        onChange={vi.fn()}
+        isOpen={false}
+        onToggle={vi.fn()}
+        categories={mockCategories}
+        accounts={mockAccounts}
+      />,
+    );
+
+    expect(screen.queryByRole('region', { name: /advanced filters/i })).not.toBeInTheDocument();
+  });
+
+  it('calls onChange when a type toggle is clicked', () => {
+    const onChange = vi.fn();
+    render(
+      <TransactionFilters
+        filters={EMPTY_FILTERS}
+        onChange={onChange}
+        isOpen={true}
+        onToggle={vi.fn()}
+        categories={mockCategories}
+        accounts={mockAccounts}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /expense/i }));
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ types: ['EXPENSE'] }));
+  });
+
+  it('shows active filter chips and allows removal', () => {
+    const onChange = vi.fn();
+    const filtersWithDate: AdvancedFilters = { ...EMPTY_FILTERS, startDate: '2024-01-01' };
+    render(
+      <TransactionFilters
+        filters={filtersWithDate}
+        onChange={onChange}
+        isOpen={false}
+        onToggle={vi.fn()}
+        categories={mockCategories}
+        accounts={mockAccounts}
+      />,
+    );
+
+    expect(screen.getByText(/from: 2024-01-01/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText(/remove filter/i));
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ startDate: '' }));
+  });
+
+  it('shows clear all button when filters are active', () => {
+    const onChange = vi.fn();
+    const filtersWithType: AdvancedFilters = { ...EMPTY_FILTERS, types: ['INCOME'] };
+    render(
+      <TransactionFilters
+        filters={filtersWithType}
+        onChange={onChange}
+        isOpen={true}
+        onToggle={vi.fn()}
+        categories={mockCategories}
+        accounts={mockAccounts}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /clear all/i }));
+    expect(onChange).toHaveBeenCalledWith(EMPTY_FILTERS);
+  });
+});
+
+describe('countActiveFilters', () => {
+  it('returns 0 for empty filters', () => {
+    expect(countActiveFilters(EMPTY_FILTERS)).toBe(0);
+  });
+
+  it('counts each active filter dimension', () => {
+    const filters: AdvancedFilters = {
+      ...EMPTY_FILTERS,
+      startDate: '2024-01-01',
+      types: ['EXPENSE'],
+      amountMin: '10',
+    };
+    expect(countActiveFilters(filters)).toBe(3);
+  });
+});

--- a/apps/web/src/components/transactions/TransactionFilters.tsx
+++ b/apps/web/src/components/transactions/TransactionFilters.tsx
@@ -1,0 +1,437 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * TransactionFilters — Collapsible advanced filter panel for transactions.
+ *
+ * Provides filters for: date range, category, account, amount range,
+ * type (income/expense/transfer), and status (pending/cleared).
+ * Filters compose with AND logic. Active filters are shown as removable chips.
+ *
+ * @module components/transactions/TransactionFilters
+ * References: issue #1464
+ */
+
+import React, { useCallback, useId } from 'react';
+
+import type { Account, Category, TransactionStatus, TransactionType } from '../../kmp/bridge';
+import './transaction-filters.css';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** All possible filter state managed by this component. */
+export interface AdvancedFilters {
+  startDate: string;
+  endDate: string;
+  categoryIds: string[];
+  accountIds: string[];
+  amountMin: string;
+  amountMax: string;
+  types: TransactionType[];
+  statuses: TransactionStatus[];
+}
+
+/** Default (empty) filter state. */
+export const EMPTY_FILTERS: AdvancedFilters = {
+  startDate: '',
+  endDate: '',
+  categoryIds: [],
+  accountIds: [],
+  amountMin: '',
+  amountMax: '',
+  types: [],
+  statuses: [],
+};
+
+export interface TransactionFiltersProps {
+  /** Current filter state. */
+  filters: AdvancedFilters;
+  /** Callback when any filter changes. */
+  onChange: (filters: AdvancedFilters) => void;
+  /** Whether the panel is expanded. */
+  isOpen: boolean;
+  /** Toggle panel open/closed. */
+  onToggle: () => void;
+  /** Available categories for multi-select. */
+  categories: Category[];
+  /** Available accounts for multi-select. */
+  accounts: Account[];
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Count how many filters are currently active. */
+export function countActiveFilters(filters: AdvancedFilters): number {
+  let count = 0;
+  if (filters.startDate) count++;
+  if (filters.endDate) count++;
+  if (filters.categoryIds.length > 0) count++;
+  if (filters.accountIds.length > 0) count++;
+  if (filters.amountMin) count++;
+  if (filters.amountMax) count++;
+  if (filters.types.length > 0) count++;
+  if (filters.statuses.length > 0) count++;
+  return count;
+}
+
+/** Get human-readable chip descriptions for active filters. */
+export function getActiveFilterChips(
+  filters: AdvancedFilters,
+  categories: Category[],
+  accounts: Account[],
+): { key: string; label: string }[] {
+  const chips: { key: string; label: string }[] = [];
+
+  if (filters.startDate) {
+    chips.push({ key: 'startDate', label: `From: ${filters.startDate}` });
+  }
+  if (filters.endDate) {
+    chips.push({ key: 'endDate', label: `To: ${filters.endDate}` });
+  }
+  if (filters.categoryIds.length > 0) {
+    const names = filters.categoryIds
+      .map((id) => categories.find((c) => c.id === id)?.name ?? id)
+      .join(', ');
+    chips.push({ key: 'categories', label: `Categories: ${names}` });
+  }
+  if (filters.accountIds.length > 0) {
+    const names = filters.accountIds
+      .map((id) => accounts.find((a) => a.id === id)?.name ?? id)
+      .join(', ');
+    chips.push({ key: 'accounts', label: `Accounts: ${names}` });
+  }
+  if (filters.amountMin) {
+    chips.push({ key: 'amountMin', label: `Min: $${filters.amountMin}` });
+  }
+  if (filters.amountMax) {
+    chips.push({ key: 'amountMax', label: `Max: $${filters.amountMax}` });
+  }
+  if (filters.types.length > 0) {
+    chips.push({ key: 'types', label: `Type: ${filters.types.join(', ')}` });
+  }
+  if (filters.statuses.length > 0) {
+    chips.push({ key: 'statuses', label: `Status: ${filters.statuses.join(', ')}` });
+  }
+
+  return chips;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+const TRANSACTION_TYPES: TransactionType[] = ['INCOME', 'EXPENSE', 'TRANSFER'];
+const TRANSACTION_STATUSES: TransactionStatus[] = ['PENDING', 'CLEARED'];
+
+export const TransactionFilters: React.FC<TransactionFiltersProps> = ({
+  filters,
+  onChange,
+  isOpen,
+  onToggle,
+  categories,
+  accounts,
+}) => {
+  const idPrefix = useId();
+  const activeCount = countActiveFilters(filters);
+
+  const handleFieldChange = useCallback(
+    (field: keyof AdvancedFilters, value: AdvancedFilters[keyof AdvancedFilters]) => {
+      onChange({ ...filters, [field]: value });
+    },
+    [filters, onChange],
+  );
+
+  const handleTypeToggle = useCallback(
+    (type: TransactionType) => {
+      const current = filters.types;
+      const next = current.includes(type) ? current.filter((t) => t !== type) : [...current, type];
+      onChange({ ...filters, types: next });
+    },
+    [filters, onChange],
+  );
+
+  const handleStatusToggle = useCallback(
+    (status: TransactionStatus) => {
+      const current = filters.statuses;
+      const next = current.includes(status)
+        ? current.filter((s) => s !== status)
+        : [...current, status];
+      onChange({ ...filters, statuses: next });
+    },
+    [filters, onChange],
+  );
+
+  const handleClearAll = useCallback(() => {
+    onChange(EMPTY_FILTERS);
+  }, [onChange]);
+
+  const handleRemoveChip = useCallback(
+    (key: string) => {
+      const updated = { ...filters };
+      switch (key) {
+        case 'startDate':
+          updated.startDate = '';
+          break;
+        case 'endDate':
+          updated.endDate = '';
+          break;
+        case 'categories':
+          updated.categoryIds = [];
+          break;
+        case 'accounts':
+          updated.accountIds = [];
+          break;
+        case 'amountMin':
+          updated.amountMin = '';
+          break;
+        case 'amountMax':
+          updated.amountMax = '';
+          break;
+        case 'types':
+          updated.types = [];
+          break;
+        case 'statuses':
+          updated.statuses = [];
+          break;
+      }
+      onChange(updated);
+    },
+    [filters, onChange],
+  );
+
+  const handleCategoryChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      const selected = Array.from(event.target.selectedOptions, (opt) => opt.value);
+      handleFieldChange('categoryIds', selected);
+    },
+    [handleFieldChange],
+  );
+
+  const handleAccountChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      const selected = Array.from(event.target.selectedOptions, (opt) => opt.value);
+      handleFieldChange('accountIds', selected);
+    },
+    [handleFieldChange],
+  );
+
+  const chips = getActiveFilterChips(filters, categories, accounts);
+
+  return (
+    <div className="transaction-filters">
+      <button
+        type="button"
+        className="transaction-filters-toggle"
+        onClick={onToggle}
+        aria-expanded={isOpen}
+        aria-controls={`${idPrefix}-panel`}
+        aria-label={`Filters${activeCount > 0 ? `, ${activeCount} active` : ''}`}
+      >
+        <span aria-hidden="true">⚙️</span>
+        Filters
+        {activeCount > 0 && (
+          <span className="transaction-filters-toggle__badge" aria-hidden="true">
+            {activeCount}
+          </span>
+        )}
+      </button>
+
+      {isOpen && (
+        <div
+          id={`${idPrefix}-panel`}
+          className="transaction-filters-panel"
+          role="region"
+          aria-label="Advanced filters"
+        >
+          {/* Date range */}
+          <div className="transaction-filters-panel__group">
+            <label className="transaction-filters-panel__label" htmlFor={`${idPrefix}-start-date`}>
+              From date
+            </label>
+            <input
+              id={`${idPrefix}-start-date`}
+              type="date"
+              className="transaction-filters-panel__input"
+              value={filters.startDate}
+              onChange={(e) => handleFieldChange('startDate', e.target.value)}
+            />
+          </div>
+
+          <div className="transaction-filters-panel__group">
+            <label className="transaction-filters-panel__label" htmlFor={`${idPrefix}-end-date`}>
+              To date
+            </label>
+            <input
+              id={`${idPrefix}-end-date`}
+              type="date"
+              className="transaction-filters-panel__input"
+              value={filters.endDate}
+              onChange={(e) => handleFieldChange('endDate', e.target.value)}
+            />
+          </div>
+
+          {/* Category multi-select */}
+          <div className="transaction-filters-panel__group">
+            <label className="transaction-filters-panel__label" htmlFor={`${idPrefix}-categories`}>
+              Categories
+            </label>
+            <select
+              id={`${idPrefix}-categories`}
+              className="transaction-filters-panel__input"
+              multiple
+              value={filters.categoryIds}
+              onChange={handleCategoryChange}
+              aria-label="Select categories"
+              size={3}
+            >
+              {categories.map((cat) => (
+                <option key={cat.id} value={cat.id}>
+                  {cat.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Account multi-select */}
+          <div className="transaction-filters-panel__group">
+            <label className="transaction-filters-panel__label" htmlFor={`${idPrefix}-accounts`}>
+              Accounts
+            </label>
+            <select
+              id={`${idPrefix}-accounts`}
+              className="transaction-filters-panel__input"
+              multiple
+              value={filters.accountIds}
+              onChange={handleAccountChange}
+              aria-label="Select accounts"
+              size={3}
+            >
+              {accounts.map((acc) => (
+                <option key={acc.id} value={acc.id}>
+                  {acc.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Amount range */}
+          <div className="transaction-filters-panel__group">
+            <label className="transaction-filters-panel__label" htmlFor={`${idPrefix}-amount-min`}>
+              Min amount ($)
+            </label>
+            <input
+              id={`${idPrefix}-amount-min`}
+              type="number"
+              className="transaction-filters-panel__input"
+              value={filters.amountMin}
+              onChange={(e) => handleFieldChange('amountMin', e.target.value)}
+              placeholder="0.00"
+              min="0"
+              step="0.01"
+            />
+          </div>
+
+          <div className="transaction-filters-panel__group">
+            <label className="transaction-filters-panel__label" htmlFor={`${idPrefix}-amount-max`}>
+              Max amount ($)
+            </label>
+            <input
+              id={`${idPrefix}-amount-max`}
+              type="number"
+              className="transaction-filters-panel__input"
+              value={filters.amountMax}
+              onChange={(e) => handleFieldChange('amountMax', e.target.value)}
+              placeholder="0.00"
+              min="0"
+              step="0.01"
+            />
+          </div>
+
+          {/* Type toggles */}
+          <div className="transaction-filters-panel__group">
+            <span className="transaction-filters-panel__label" id={`${idPrefix}-type-label`}>
+              Type
+            </span>
+            <div
+              className="transaction-type-toggles"
+              role="group"
+              aria-labelledby={`${idPrefix}-type-label`}
+            >
+              {TRANSACTION_TYPES.map((type) => (
+                <button
+                  key={type}
+                  type="button"
+                  className={`transaction-type-toggle${filters.types.includes(type) ? ' transaction-type-toggle--active' : ''}`}
+                  onClick={() => handleTypeToggle(type)}
+                  aria-pressed={filters.types.includes(type)}
+                >
+                  {type.charAt(0) + type.slice(1).toLowerCase()}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Status toggles */}
+          <div className="transaction-filters-panel__group">
+            <span className="transaction-filters-panel__label" id={`${idPrefix}-status-label`}>
+              Status
+            </span>
+            <div
+              className="transaction-type-toggles"
+              role="group"
+              aria-labelledby={`${idPrefix}-status-label`}
+            >
+              {TRANSACTION_STATUSES.map((status) => (
+                <button
+                  key={status}
+                  type="button"
+                  className={`transaction-type-toggle${filters.statuses.includes(status) ? ' transaction-type-toggle--active' : ''}`}
+                  onClick={() => handleStatusToggle(status)}
+                  aria-pressed={filters.statuses.includes(status)}
+                >
+                  {status.charAt(0) + status.slice(1).toLowerCase()}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Clear all */}
+          {activeCount > 0 && (
+            <div className="transaction-filters-panel__actions">
+              <button
+                type="button"
+                className="transaction-filters-panel__clear"
+                onClick={handleClearAll}
+                aria-label="Clear all filters"
+              >
+                Clear all
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Active filter chips */}
+      {chips.length > 0 && (
+        <div className="transaction-active-filters" role="list" aria-label="Active filters">
+          {chips.map((chip) => (
+            <span key={chip.key} className="transaction-active-filter-chip" role="listitem">
+              {chip.label}
+              <button
+                type="button"
+                className="transaction-active-filter-chip__remove"
+                onClick={() => handleRemoveChip(chip.key)}
+                aria-label={`Remove filter: ${chip.label}`}
+              >
+                ✕
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/web/src/components/transactions/TransactionSort.test.tsx
+++ b/apps/web/src/components/transactions/TransactionSort.test.tsx
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for TransactionSort component.
+ * References: issue #1464
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+import { TransactionSort, DEFAULT_SORT } from './TransactionSort';
+
+describe('TransactionSort', () => {
+  it('renders sort field select and direction button', () => {
+    render(<TransactionSort sort={DEFAULT_SORT} onChange={vi.fn()} />);
+
+    expect(screen.getByLabelText(/sort field/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/sort direction/i)).toBeInTheDocument();
+  });
+
+  it('displays the current sort field', () => {
+    render(<TransactionSort sort={{ field: 'amount', direction: 'asc' }} onChange={vi.fn()} />);
+
+    const select = screen.getByLabelText(/sort field/i) as HTMLSelectElement;
+    expect(select.value).toBe('amount');
+  });
+
+  it('calls onChange with new field when select changes', () => {
+    const onChange = vi.fn();
+    render(<TransactionSort sort={DEFAULT_SORT} onChange={onChange} />);
+
+    fireEvent.change(screen.getByLabelText(/sort field/i), { target: { value: 'payee' } });
+    expect(onChange).toHaveBeenCalledWith({ field: 'payee', direction: 'desc' });
+  });
+
+  it('toggles direction on button click', () => {
+    const onChange = vi.fn();
+    render(<TransactionSort sort={{ field: 'date', direction: 'desc' }} onChange={onChange} />);
+
+    fireEvent.click(screen.getByLabelText(/sort direction/i));
+    expect(onChange).toHaveBeenCalledWith({ field: 'date', direction: 'asc' });
+  });
+
+  it('shows ascending arrow when direction is asc', () => {
+    render(<TransactionSort sort={{ field: 'date', direction: 'asc' }} onChange={vi.fn()} />);
+
+    expect(screen.getByText('↑')).toBeInTheDocument();
+  });
+
+  it('shows descending arrow when direction is desc', () => {
+    render(<TransactionSort sort={{ field: 'date', direction: 'desc' }} onChange={vi.fn()} />);
+
+    expect(screen.getByText('↓')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/transactions/TransactionSort.tsx
+++ b/apps/web/src/components/transactions/TransactionSort.tsx
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * TransactionSort — Sort controls for the transactions list.
+ *
+ * Allows sorting by date, amount, payee, or category with
+ * ascending/descending direction toggle.
+ *
+ * @module components/transactions/TransactionSort
+ * References: issue #1464
+ */
+
+import React, { useCallback, useId } from 'react';
+
+import './transaction-filters.css';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Fields that transactions can be sorted by. */
+export type SortField = 'date' | 'amount' | 'payee' | 'category';
+
+/** Sort direction. */
+export type SortDirection = 'asc' | 'desc';
+
+/** Sort configuration. */
+export interface SortConfig {
+  field: SortField;
+  direction: SortDirection;
+}
+
+/** Default sort: newest first. */
+export const DEFAULT_SORT: SortConfig = {
+  field: 'date',
+  direction: 'desc',
+};
+
+export interface TransactionSortProps {
+  /** Current sort configuration. */
+  sort: SortConfig;
+  /** Callback when sort changes. */
+  onChange: (sort: SortConfig) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+const SORT_FIELD_LABELS: Record<SortField, string> = {
+  date: 'Date',
+  amount: 'Amount',
+  payee: 'Payee',
+  category: 'Category',
+};
+
+export const TransactionSort: React.FC<TransactionSortProps> = ({ sort, onChange }) => {
+  const idPrefix = useId();
+
+  const handleFieldChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      onChange({ ...sort, field: event.target.value as SortField });
+    },
+    [sort, onChange],
+  );
+
+  const handleDirectionToggle = useCallback(() => {
+    onChange({ ...sort, direction: sort.direction === 'asc' ? 'desc' : 'asc' });
+  }, [sort, onChange]);
+
+  return (
+    <div className="transaction-sort" role="group" aria-label="Sort transactions">
+      <label htmlFor={`${idPrefix}-sort-field`} className="sr-only">
+        Sort by
+      </label>
+      <select
+        id={`${idPrefix}-sort-field`}
+        className="transaction-sort__select"
+        value={sort.field}
+        onChange={handleFieldChange}
+        aria-label="Sort field"
+      >
+        {(Object.entries(SORT_FIELD_LABELS) as [SortField, string][]).map(([value, label]) => (
+          <option key={value} value={value}>
+            {label}
+          </option>
+        ))}
+      </select>
+      <button
+        type="button"
+        className="transaction-sort__direction"
+        onClick={handleDirectionToggle}
+        aria-label={`Sort direction: ${sort.direction === 'asc' ? 'ascending' : 'descending'}. Click to toggle.`}
+        title={sort.direction === 'asc' ? 'Ascending' : 'Descending'}
+      >
+        <span aria-hidden="true">{sort.direction === 'asc' ? '↑' : '↓'}</span>
+      </button>
+    </div>
+  );
+};

--- a/apps/web/src/components/transactions/index.ts
+++ b/apps/web/src/components/transactions/index.ts
@@ -2,3 +2,9 @@
 
 export { QuickEntry } from './QuickEntry';
 export type { QuickEntryProps } from './QuickEntry';
+export { TransactionFilters, EMPTY_FILTERS, countActiveFilters } from './TransactionFilters';
+export type { AdvancedFilters, TransactionFiltersProps } from './TransactionFilters';
+export { TransactionSort, DEFAULT_SORT } from './TransactionSort';
+export type { SortConfig, SortField, SortDirection, TransactionSortProps } from './TransactionSort';
+export { TransactionEditPanel } from './TransactionEditPanel';
+export type { TransactionEditPanelProps } from './TransactionEditPanel';

--- a/apps/web/src/components/transactions/transaction-edit-panel.css
+++ b/apps/web/src/components/transactions/transaction-edit-panel.css
@@ -1,0 +1,200 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/**
+ * Styles for TransactionEditPanel slide-over drawer.
+ * Desktop: right-side slide-over panel.
+ * Mobile: full-screen modal.
+ */
+
+/* ---------------------------------------------------------------------------
+ * Overlay container
+ * ------------------------------------------------------------------------- */
+
+.edit-panel-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 300;
+  display: flex;
+  justify-content: flex-end;
+}
+
+/* ---------------------------------------------------------------------------
+ * Backdrop
+ * ------------------------------------------------------------------------- */
+
+.edit-panel-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: -1;
+  animation: edit-panel-backdrop-enter var(--duration-normal, 200ms) ease-out;
+}
+
+@keyframes edit-panel-backdrop-enter {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+/* ---------------------------------------------------------------------------
+ * Panel (desktop: slide from right)
+ * ------------------------------------------------------------------------- */
+
+.edit-panel {
+  position: relative;
+  width: 100%;
+  max-width: 480px;
+  height: 100%;
+  background: var(--semantic-background-primary);
+  border-left: 1px solid var(--semantic-border-default);
+  box-shadow: var(--shadow-lg, -4px 0 25px rgba(0, 0, 0, 0.1));
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: edit-panel-slide-in var(--duration-normal, 200ms) var(--easing-out, ease-out);
+}
+
+@keyframes edit-panel-slide-in {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+/* ---------------------------------------------------------------------------
+ * Panel header
+ * ------------------------------------------------------------------------- */
+
+.edit-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-4) var(--spacing-5);
+  border-bottom: 1px solid var(--semantic-border-default);
+  flex-shrink: 0;
+}
+
+.edit-panel__title {
+  font-size: var(--type-scale-title-font-size);
+  font-weight: var(--type-scale-title-font-weight);
+  color: var(--semantic-text-primary);
+  margin: 0;
+}
+
+.edit-panel__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: var(--border-radius-md);
+  background: transparent;
+  color: var(--semantic-text-secondary);
+  font-size: 1.25rem;
+  cursor: pointer;
+  transition: background-color var(--duration-fast, 100ms) ease;
+}
+
+.edit-panel__close:hover {
+  background: var(--semantic-background-secondary);
+  color: var(--semantic-text-primary);
+}
+
+.edit-panel__close:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+}
+
+/* ---------------------------------------------------------------------------
+ * Panel body (scrollable form area)
+ * ------------------------------------------------------------------------- */
+
+.edit-panel__body {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--spacing-5);
+}
+
+/* ---------------------------------------------------------------------------
+ * Panel footer (save/cancel actions)
+ * ------------------------------------------------------------------------- */
+
+.edit-panel__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-3);
+  padding: var(--spacing-4) var(--spacing-5);
+  border-top: 1px solid var(--semantic-border-default);
+  flex-shrink: 0;
+}
+
+/* ---------------------------------------------------------------------------
+ * Mobile: full screen
+ * ------------------------------------------------------------------------- */
+
+@media (max-width: 767px) {
+  .edit-panel {
+    max-width: 100%;
+    border-left: none;
+    animation: edit-panel-slide-up var(--duration-normal, 200ms) var(--easing-out, ease-out);
+  }
+
+  @keyframes edit-panel-slide-up {
+    from {
+      transform: translateY(100%);
+    }
+    to {
+      transform: translateY(0);
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------------
+ * Dark mode
+ * ------------------------------------------------------------------------- */
+
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme='light']) .edit-panel-backdrop {
+    background: rgba(0, 0, 0, 0.6);
+  }
+}
+
+[data-theme='dark'] .edit-panel-backdrop {
+  background: rgba(0, 0, 0, 0.6);
+}
+
+/* ---------------------------------------------------------------------------
+ * Reduced motion
+ * ------------------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .edit-panel,
+  .edit-panel-backdrop {
+    animation: none;
+  }
+
+  .edit-panel__close {
+    transition: none;
+  }
+}
+
+/* ---------------------------------------------------------------------------
+ * High contrast
+ * ------------------------------------------------------------------------- */
+
+@media (prefers-contrast: more) {
+  .edit-panel {
+    border-left-width: 2px;
+  }
+
+  .edit-panel__header,
+  .edit-panel__footer {
+    border-width: 2px;
+  }
+}

--- a/apps/web/src/components/transactions/transaction-filters.css
+++ b/apps/web/src/components/transactions/transaction-filters.css
@@ -1,0 +1,353 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/**
+ * Styles for TransactionFilters and TransactionSort components.
+ * Uses design tokens for consistent theming.
+ */
+
+/* ---------------------------------------------------------------------------
+ * Filter panel toggle
+ * ------------------------------------------------------------------------- */
+
+.transaction-filters-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-primary);
+  color: var(--semantic-text-primary);
+  font-size: var(--type-scale-body-font-size);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  transition: background-color var(--duration-fast, 100ms) ease;
+}
+
+.transaction-filters-toggle:hover {
+  background: var(--semantic-background-secondary);
+}
+
+.transaction-filters-toggle:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+}
+
+.transaction-filters-toggle__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.25rem;
+  height: 1.25rem;
+  padding: 0 var(--spacing-1);
+  border-radius: 999px;
+  background: var(--semantic-interactive-default);
+  color: var(--semantic-text-inverse);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-semibold);
+}
+
+/* ---------------------------------------------------------------------------
+ * Filter panel (collapsible)
+ * ------------------------------------------------------------------------- */
+
+.transaction-filters-panel {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: var(--spacing-4);
+  padding: var(--spacing-4);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-secondary);
+  margin-top: var(--spacing-3);
+  animation: filters-panel-enter var(--duration-normal, 200ms) var(--easing-out, ease-out);
+}
+
+@keyframes filters-panel-enter {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.transaction-filters-panel__group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.transaction-filters-panel__label {
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.transaction-filters-panel__row {
+  display: flex;
+  gap: var(--spacing-2);
+  align-items: center;
+}
+
+.transaction-filters-panel__input {
+  width: 100%;
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-primary);
+  color: var(--semantic-text-primary);
+  font-size: var(--type-scale-body-font-size);
+  font-family: inherit;
+}
+
+.transaction-filters-panel__input:focus {
+  outline: none;
+  border-color: var(--semantic-border-focus);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+}
+
+.transaction-filters-panel__actions {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--spacing-2);
+}
+
+.transaction-filters-panel__clear {
+  padding: var(--spacing-2) var(--spacing-3);
+  border: none;
+  border-radius: var(--border-radius-md);
+  background: transparent;
+  color: var(--semantic-status-negative);
+  font-size: var(--type-scale-body-font-size);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.transaction-filters-panel__clear:hover {
+  background: rgba(239, 68, 68, 0.08);
+}
+
+.transaction-filters-panel__clear:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+}
+
+/* ---------------------------------------------------------------------------
+ * Type toggle buttons
+ * ------------------------------------------------------------------------- */
+
+.transaction-type-toggles {
+  display: flex;
+  gap: var(--spacing-1);
+  flex-wrap: wrap;
+}
+
+.transaction-type-toggle {
+  padding: var(--spacing-1) var(--spacing-2);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-primary);
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  transition:
+    background-color var(--duration-fast, 100ms) ease,
+    border-color var(--duration-fast, 100ms) ease;
+}
+
+.transaction-type-toggle:hover {
+  background: var(--semantic-background-secondary);
+}
+
+.transaction-type-toggle:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+}
+
+.transaction-type-toggle--active {
+  background: var(--semantic-interactive-default);
+  color: var(--semantic-text-inverse);
+  border-color: var(--semantic-interactive-default);
+}
+
+.transaction-type-toggle--active:hover {
+  background: var(--semantic-interactive-hover);
+  border-color: var(--semantic-interactive-hover);
+}
+
+/* ---------------------------------------------------------------------------
+ * Active filter chips
+ * ------------------------------------------------------------------------- */
+
+.transaction-active-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-2);
+  margin-top: var(--spacing-3);
+}
+
+.transaction-active-filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  padding: var(--spacing-1) var(--spacing-2);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: 999px;
+  background: var(--semantic-background-secondary);
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-primary);
+}
+
+.transaction-active-filter-chip__remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  height: 1rem;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--semantic-text-secondary);
+  font-size: 0.75rem;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.transaction-active-filter-chip__remove:hover {
+  background: var(--semantic-status-negative);
+  color: var(--semantic-text-inverse);
+}
+
+.transaction-active-filter-chip__remove:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 1px;
+}
+
+/* ---------------------------------------------------------------------------
+ * Sort controls
+ * ------------------------------------------------------------------------- */
+
+.transaction-sort {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
+.transaction-sort__select {
+  padding: var(--spacing-2) var(--spacing-3);
+  padding-right: 2rem;
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-primary);
+  color: var(--semantic-text-primary);
+  font-size: var(--type-scale-body-font-size);
+  font-family: inherit;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath d='M3 5l3 3 3-3' fill='none' stroke='%23666' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.5rem center;
+}
+
+.transaction-sort__select:focus {
+  outline: none;
+  border-color: var(--semantic-border-focus);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+}
+
+.transaction-sort__direction {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-primary);
+  color: var(--semantic-text-primary);
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background-color var(--duration-fast, 100ms) ease;
+}
+
+.transaction-sort__direction:hover {
+  background: var(--semantic-background-secondary);
+}
+
+.transaction-sort__direction:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+}
+
+/* ---------------------------------------------------------------------------
+ * Controls bar (filter + sort row)
+ * ------------------------------------------------------------------------- */
+
+.transaction-controls-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+  flex-wrap: wrap;
+  margin-bottom: var(--spacing-4);
+}
+
+.transaction-controls-bar__left {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+}
+
+/* ---------------------------------------------------------------------------
+ * Responsive
+ * ------------------------------------------------------------------------- */
+
+@media (max-width: 480px) {
+  .transaction-filters-panel {
+    grid-template-columns: 1fr;
+  }
+
+  .transaction-controls-bar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .transaction-controls-bar__left {
+    justify-content: space-between;
+  }
+}
+
+/* ---------------------------------------------------------------------------
+ * Reduced motion
+ * ------------------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .transaction-filters-panel {
+    animation: none;
+  }
+
+  .transaction-filters-toggle,
+  .transaction-type-toggle,
+  .transaction-sort__direction {
+    transition: none;
+  }
+}
+
+/* ---------------------------------------------------------------------------
+ * High contrast
+ * ------------------------------------------------------------------------- */
+
+@media (prefers-contrast: more) {
+  .transaction-filters-panel__input,
+  .transaction-sort__select,
+  .transaction-filters-toggle,
+  .transaction-sort__direction {
+    border-width: 2px;
+  }
+}

--- a/apps/web/src/pages/TransactionsPage.test.tsx
+++ b/apps/web/src/pages/TransactionsPage.test.tsx
@@ -28,6 +28,29 @@ vi.mock('../components/forms', () => ({
     ) : null,
 }));
 
+// Mock the transactions sub-components to avoid complex internal dependencies.
+vi.mock('../components/transactions', () => ({
+  TransactionFilters: () => <div data-testid="transaction-filters">Filters</div>,
+  TransactionSort: () => <div data-testid="transaction-sort">Sort</div>,
+  TransactionEditPanel: ({ transaction }: { transaction: { payee: string } | null }) =>
+    transaction ? (
+      <div role="dialog" aria-label="Edit panel">
+        Edit: {transaction.payee}
+      </div>
+    ) : null,
+  EMPTY_FILTERS: {
+    startDate: '',
+    endDate: '',
+    categoryIds: [],
+    accountIds: [],
+    amountMin: '',
+    amountMax: '',
+    types: [],
+    statuses: [],
+  },
+  DEFAULT_SORT: { field: 'date', direction: 'desc' },
+}));
+
 const mockedUseTransactions = vi.mocked(useTransactions);
 const mockedUseCategories = vi.mocked(useCategories);
 const mockedUseAccounts = vi.mocked(useAccounts);
@@ -207,15 +230,14 @@ describe('TransactionsPage', () => {
     expect(screen.getByRole('searchbox', { name: /search transactions/i })).toBeInTheDocument();
   });
 
-  it('displays category filter chips', () => {
+  it('displays filter and sort controls', () => {
     render(
       <MemoryRouter>
         <TransactionsPage />
       </MemoryRouter>,
     );
-    expect(screen.getByRole('button', { name: 'All' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Food' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Income' })).toBeInTheDocument();
+    expect(screen.getByTestId('transaction-filters')).toBeInTheDocument();
+    expect(screen.getByTestId('transaction-sort')).toBeInTheDocument();
   });
 
   it('displays transaction descriptions', () => {
@@ -252,7 +274,7 @@ describe('TransactionsPage', () => {
     expect(screen.getAllByRole('button', { name: /^delete /i })).toHaveLength(3);
   });
 
-  it('clicking edit opens the form', () => {
+  it('clicking edit opens the edit panel', () => {
     render(
       <MemoryRouter>
         <TransactionsPage />
@@ -261,7 +283,7 @@ describe('TransactionsPage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /edit grocery store/i }));
 
-    expect(screen.getByRole('dialog', { name: /transaction form/i })).toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: /edit panel/i })).toBeInTheDocument();
   });
 
   it('clicking delete opens ConfirmDialog', () => {

--- a/apps/web/src/pages/TransactionsPage.tsx
+++ b/apps/web/src/pages/TransactionsPage.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { useCallback, useMemo, useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 
 import {
   ConfirmDialog,
@@ -11,13 +11,64 @@ import {
   LoadingSpinner,
 } from '../components/common';
 import { TransactionForm } from '../components/forms';
+import {
+  TransactionFilters,
+  TransactionSort,
+  TransactionEditPanel,
+  DEFAULT_SORT,
+} from '../components/transactions';
+import type { AdvancedFilters } from '../components/transactions';
+import type { SortConfig, SortField } from '../components/transactions';
 import type { CreateTransactionInput } from '../db/repositories/transactions';
 import { useAccounts } from '../hooks/useAccounts';
 import { useCategories } from '../hooks/useCategories';
 import { useTransactions } from '../hooks/useTransactions';
 import type { Transaction } from '../kmp/bridge';
 
-const ALL_CATEGORIES_FILTER = '__all__';
+// ---------------------------------------------------------------------------
+// URL param helpers for filter/sort persistence
+// ---------------------------------------------------------------------------
+
+function filtersFromParams(params: URLSearchParams): AdvancedFilters {
+  return {
+    startDate: params.get('startDate') ?? '',
+    endDate: params.get('endDate') ?? '',
+    categoryIds: params.get('categoryIds') ? params.get('categoryIds')!.split(',') : [],
+    accountIds: params.get('accountIds') ? params.get('accountIds')!.split(',') : [],
+    amountMin: params.get('amountMin') ?? '',
+    amountMax: params.get('amountMax') ?? '',
+    types: params.get('types') ? (params.get('types')!.split(',') as AdvancedFilters['types']) : [],
+    statuses: params.get('statuses')
+      ? (params.get('statuses')!.split(',') as AdvancedFilters['statuses'])
+      : [],
+  };
+}
+
+function filtersToParams(filters: AdvancedFilters): Record<string, string> {
+  const result: Record<string, string> = {};
+  if (filters.startDate) result.startDate = filters.startDate;
+  if (filters.endDate) result.endDate = filters.endDate;
+  if (filters.categoryIds.length > 0) result.categoryIds = filters.categoryIds.join(',');
+  if (filters.accountIds.length > 0) result.accountIds = filters.accountIds.join(',');
+  if (filters.amountMin) result.amountMin = filters.amountMin;
+  if (filters.amountMax) result.amountMax = filters.amountMax;
+  if (filters.types.length > 0) result.types = filters.types.join(',');
+  if (filters.statuses.length > 0) result.statuses = filters.statuses.join(',');
+  return result;
+}
+
+function sortFromParams(params: URLSearchParams): SortConfig {
+  const field = params.get('sortField') as SortField | null;
+  const direction = params.get('sortDir') as 'asc' | 'desc' | null;
+  return {
+    field: field ?? DEFAULT_SORT.field,
+    direction: direction ?? DEFAULT_SORT.direction,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// CSV export helpers
+// ---------------------------------------------------------------------------
 
 /** Escape a value for safe CSV inclusion. */
 function escapeCsvValue(value: string): string {
@@ -63,11 +114,14 @@ function exportTransactionsCsv(
   }, 100);
 }
 
+// ---------------------------------------------------------------------------
+// Transaction display helpers
+// ---------------------------------------------------------------------------
+
 function getTransactionDisplayAmount(transaction: Transaction): number {
   if (transaction.type === 'EXPENSE') {
     return -Math.abs(transaction.amount.amount);
   }
-
   return transaction.amount.amount;
 }
 
@@ -79,31 +133,127 @@ function getTransactionLabel(transaction: Transaction): string {
   );
 }
 
+// ---------------------------------------------------------------------------
+// Sort logic
+// ---------------------------------------------------------------------------
+
+function sortTransactions(
+  transactions: Transaction[],
+  sort: SortConfig,
+  categoryNames: Map<string, string>,
+): Transaction[] {
+  const sorted = [...transactions].sort((a, b) => {
+    let comparison = 0;
+
+    switch (sort.field) {
+      case 'date':
+        comparison = a.date.localeCompare(b.date);
+        break;
+      case 'amount':
+        comparison = Math.abs(a.amount.amount) - Math.abs(b.amount.amount);
+        break;
+      case 'payee':
+        comparison = (a.payee ?? '').localeCompare(b.payee ?? '');
+        break;
+      case 'category': {
+        const catA = a.categoryId ? (categoryNames.get(a.categoryId) ?? '') : '';
+        const catB = b.categoryId ? (categoryNames.get(b.categoryId) ?? '') : '';
+        comparison = catA.localeCompare(catB);
+        break;
+      }
+    }
+
+    if (sort.direction === 'desc') comparison = -comparison;
+
+    // Secondary sort: always by date descending for non-date primary sorts
+    if (comparison === 0 && sort.field !== 'date') {
+      comparison = b.date.localeCompare(a.date);
+    }
+
+    return comparison;
+  });
+
+  return sorted;
+}
+
+// ---------------------------------------------------------------------------
+// Local filtering (advanced filters applied on top of hook results)
+// ---------------------------------------------------------------------------
+
+function applyAdvancedFilters(
+  transactions: Transaction[],
+  filters: AdvancedFilters,
+): Transaction[] {
+  let result = transactions;
+
+  if (filters.categoryIds.length > 0) {
+    result = result.filter(
+      (t) => t.categoryId !== null && filters.categoryIds.includes(t.categoryId),
+    );
+  }
+
+  if (filters.accountIds.length > 0) {
+    result = result.filter((t) => filters.accountIds.includes(t.accountId));
+  }
+
+  if (filters.amountMin) {
+    const minCents = Math.round(parseFloat(filters.amountMin) * 100);
+    result = result.filter((t) => Math.abs(t.amount.amount) >= minCents);
+  }
+
+  if (filters.amountMax) {
+    const maxCents = Math.round(parseFloat(filters.amountMax) * 100);
+    result = result.filter((t) => Math.abs(t.amount.amount) <= maxCents);
+  }
+
+  if (filters.types.length > 0) {
+    result = result.filter((t) => filters.types.includes(t.type));
+  }
+
+  if (filters.statuses.length > 0) {
+    result = result.filter((t) => filters.statuses.includes(t.status));
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Page Component
+// ---------------------------------------------------------------------------
+
 export const TransactionsPage: React.FC = () => {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [query, setQuery] = useState('');
-  const [selectedCategoryId, setSelectedCategoryId] = useState(ALL_CATEGORIES_FILTER);
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [editingTransaction, setEditingTransaction] = useState<Transaction | null>(null);
+  const [editPanelTransaction, setEditPanelTransaction] = useState<Transaction | null>(null);
   const [deletingTransaction, setDeletingTransaction] = useState<Transaction | null>(null);
+  const [filtersOpen, setFiltersOpen] = useState(false);
 
-  const filters = useMemo(
+  // Get filters/sort from URL params
+  const advancedFilters = useMemo(() => filtersFromParams(searchParams), [searchParams]);
+  const sortConfig = useMemo(() => sortFromParams(searchParams), [searchParams]);
+
+  // Build hook filters from URL params + search query
+  const hookFilters = useMemo(
     () => ({
       searchTerm: query.trim() || undefined,
-      categoryId: selectedCategoryId === ALL_CATEGORIES_FILTER ? undefined : selectedCategoryId,
+      startDate: advancedFilters.startDate || undefined,
+      endDate: advancedFilters.endDate || undefined,
     }),
-    [query, selectedCategoryId],
+    [query, advancedFilters.startDate, advancedFilters.endDate],
   );
 
   const {
-    transactions,
+    transactions: rawTransactions,
     loading,
     error,
     refresh: refreshTransactions,
     createTransaction,
     updateTransaction,
     deleteTransaction,
-  } = useTransactions(filters);
+  } = useTransactions(hookFilters);
   const {
     categories,
     loading: categoriesLoading,
@@ -125,14 +275,74 @@ export const TransactionsPage: React.FC = () => {
     refreshAccounts();
   };
 
+  const categoryNames = useMemo(
+    () => new Map(categories.map((category) => [category.id, category.name])),
+    [categories],
+  );
+  const accountNames = useMemo(
+    () => new Map(accounts.map((account) => [account.id, account.name])),
+    [accounts],
+  );
+
+  // Apply advanced local filters, then sort
+  const transactions = useMemo(() => {
+    const filtered = applyAdvancedFilters(rawTransactions, advancedFilters);
+    return sortTransactions(filtered, sortConfig, categoryNames);
+  }, [rawTransactions, advancedFilters, sortConfig, categoryNames]);
+
+  // Group by date for display
+  const groupedTransactions = useMemo(() => {
+    const groups = new Map<string, Transaction[]>();
+
+    for (const transaction of transactions) {
+      const existingTransactions = groups.get(transaction.date);
+      if (existingTransactions) {
+        existingTransactions.push(transaction);
+      } else {
+        groups.set(transaction.date, [transaction]);
+      }
+    }
+
+    return Array.from(groups, ([date, datedTransactions]) => ({
+      date,
+      label: new Date(`${date}T00:00:00`).toLocaleDateString('en-US', {
+        weekday: 'long',
+        month: 'short',
+        day: 'numeric',
+      }),
+      transactions: datedTransactions,
+    }));
+  }, [transactions]);
+
+  // Filter/Sort handlers
+  const handleFiltersChange = useCallback(
+    (newFilters: AdvancedFilters) => {
+      const params = { ...filtersToParams(newFilters) };
+      if (sortConfig.field !== DEFAULT_SORT.field) params.sortField = sortConfig.field;
+      if (sortConfig.direction !== DEFAULT_SORT.direction) params.sortDir = sortConfig.direction;
+      setSearchParams(params, { replace: true });
+    },
+    [sortConfig, setSearchParams],
+  );
+
+  const handleSortChange = useCallback(
+    (newSort: SortConfig) => {
+      const params = { ...filtersToParams(advancedFilters) };
+      if (newSort.field !== DEFAULT_SORT.field) params.sortField = newSort.field;
+      if (newSort.direction !== DEFAULT_SORT.direction) params.sortDir = newSort.direction;
+      setSearchParams(params, { replace: true });
+    },
+    [advancedFilters, setSearchParams],
+  );
+
+  // Form handlers
   const handleOpenCreateForm = useCallback(() => {
     setEditingTransaction(null);
     setIsFormOpen(true);
   }, []);
 
   const handleEditTransaction = useCallback((transaction: Transaction) => {
-    setEditingTransaction(transaction);
-    setIsFormOpen(true);
+    setEditPanelTransaction(transaction);
   }, []);
 
   const handleFormCancel = useCallback(() => {
@@ -166,6 +376,22 @@ export const TransactionsPage: React.FC = () => {
     ],
   );
 
+  const handleEditPanelSave = useCallback(
+    async (id: string, data: CreateTransactionInput): Promise<void> => {
+      const result = updateTransaction(id, data);
+      if (result === null) {
+        throw new Error('Failed to update transaction. Please try again.');
+      }
+      setEditPanelTransaction(null);
+      refreshTransactions();
+    },
+    [updateTransaction, refreshTransactions],
+  );
+
+  const handleEditPanelClose = useCallback(() => {
+    setEditPanelTransaction(null);
+  }, []);
+
   const handleDeleteConfirm = useCallback(() => {
     if (deletingTransaction === null) {
       return;
@@ -178,47 +404,16 @@ export const TransactionsPage: React.FC = () => {
     }
   }, [deleteTransaction, deletingTransaction, refreshTransactions]);
 
-  const categoryFilters = useMemo(
-    () => [
-      { id: ALL_CATEGORIES_FILTER, name: 'All' },
-      ...categories.map((category) => ({ id: category.id, name: category.name })),
-    ],
-    [categories],
-  );
-
-  const categoryNames = useMemo(
-    () => new Map(categories.map((category) => [category.id, category.name])),
-    [categories],
-  );
-  const accountNames = useMemo(
-    () => new Map(accounts.map((account) => [account.id, account.name])),
-    [accounts],
-  );
-
-  const groupedTransactions = useMemo(() => {
-    const groups = new Map<string, Transaction[]>();
-
-    for (const transaction of transactions) {
-      const existingTransactions = groups.get(transaction.date);
-      if (existingTransactions) {
-        existingTransactions.push(transaction);
-      } else {
-        groups.set(transaction.date, [transaction]);
-      }
-    }
-
-    return Array.from(groups, ([date, datedTransactions]) => ({
-      date,
-      label: new Date(`${date}T00:00:00`).toLocaleDateString('en-US', {
-        weekday: 'long',
-        month: 'short',
-        day: 'numeric',
-      }),
-      transactions: datedTransactions,
-    }));
-  }, [transactions]);
-
-  const hasActiveFilters = filters.searchTerm !== undefined || filters.categoryId !== undefined;
+  const hasActiveFilters =
+    query.trim() !== '' ||
+    advancedFilters.startDate !== '' ||
+    advancedFilters.endDate !== '' ||
+    advancedFilters.categoryIds.length > 0 ||
+    advancedFilters.accountIds.length > 0 ||
+    advancedFilters.amountMin !== '' ||
+    advancedFilters.amountMax !== '' ||
+    advancedFilters.types.length > 0 ||
+    advancedFilters.statuses.length > 0;
 
   return (
     <>
@@ -259,6 +454,7 @@ export const TransactionsPage: React.FC = () => {
           <span aria-hidden="true">+</span> Add Transaction
         </button>
       </div>
+
       <div className="search-bar" role="search">
         <input
           type="search"
@@ -269,24 +465,22 @@ export const TransactionsPage: React.FC = () => {
           aria-label="Search transactions"
         />
       </div>
-      <div
-        className="filter-chips"
-        role="group"
-        aria-label="Category filter"
-        style={{ marginBottom: 'var(--spacing-4)' }}
-      >
-        {categoryFilters.map((category) => (
-          <button
-            key={category.id}
-            type="button"
-            className={`filter-chip${selectedCategoryId === category.id ? ' filter-chip--active' : ''}`}
-            onClick={() => setSelectedCategoryId(category.id)}
-            aria-pressed={selectedCategoryId === category.id}
-          >
-            {category.name}
-          </button>
-        ))}
+
+      {/* Filter/Sort controls */}
+      <div className="transaction-controls-bar">
+        <div className="transaction-controls-bar__left">
+          <TransactionFilters
+            filters={advancedFilters}
+            onChange={handleFiltersChange}
+            isOpen={filtersOpen}
+            onToggle={() => setFiltersOpen((o) => !o)}
+            categories={categories}
+            accounts={accounts}
+          />
+        </div>
+        <TransactionSort sort={sortConfig} onChange={handleSortChange} />
       </div>
+
       {isLoading ? (
         <div style={{ display: 'flex', justifyContent: 'center', padding: 'var(--spacing-8) 0' }}>
           <LoadingSpinner label="Loading transactions" />
@@ -298,7 +492,7 @@ export const TransactionsPage: React.FC = () => {
           title={hasActiveFilters ? 'No transactions found' : 'No transactions yet'}
           description={
             hasActiveFilters
-              ? 'Try adjusting your search or category filters.'
+              ? 'Try adjusting your search or filters.'
               : 'Transactions you add will appear here.'
           }
         />
@@ -369,6 +563,7 @@ export const TransactionsPage: React.FC = () => {
           ))}
         </div>
       )}
+
       <TransactionForm
         isOpen={isFormOpen}
         accounts={accounts}
@@ -377,6 +572,15 @@ export const TransactionsPage: React.FC = () => {
         onSubmit={handleTransactionSubmit}
         onCancel={handleFormCancel}
       />
+
+      <TransactionEditPanel
+        transaction={editPanelTransaction}
+        accounts={accounts}
+        categories={categories}
+        onSave={handleEditPanelSave}
+        onClose={handleEditPanelClose}
+      />
+
       <ConfirmDialog
         isOpen={deletingTransaction !== null}
         title="Delete Transaction"

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -204,6 +204,14 @@ export const AppRoutes: FC = () => (
       }
     />
     <Route
+      path="/transactions/:id/edit"
+      element={
+        <AuthenticatedRoute>
+          <Navigate to="/transactions" replace />
+        </AuthenticatedRoute>
+      }
+    />
+    <Route
       path="/budgets"
       element={
         <AuthenticatedRoute>


### PR DESCRIPTION
## Summary

Adds comprehensive filter/sort controls to the transactions page and replaces full-page edit with a slide-over panel for improved UX.

## Changes

- **TransactionFilters** component: collapsible panel with date range, category (multi-select), account (multi-select), amount range, type toggles, status toggles, active filter count badge, removable filter chips, and clear-all
- **TransactionSort** component: sort by date/amount/payee/category with asc/desc direction toggle; secondary sort always by date
- **TransactionEditPanel**: slide-over drawer from right (desktop), full-screen modal (mobile), pre-filled form, focus trap, backdrop click/Escape to close
- Filter and sort state persisted in URL search params for shareability
- Updated TransactionsPage to integrate all new components
- Added fallback route \/transactions/:id/edit\ that redirects to list
- Unit tests for all new components

## Accessibility

- All interactive elements keyboard accessible (Tab, Enter, Escape)
- Focus trapping in edit panel
- ARIA attributes: \ria-expanded\, \ria-controls\, \ria-pressed\, \ria-modal\, \ria-labelledby\, \ole=dialog\, \ole=region\
- Screen reader text for filter counts and sort direction
- Respects \prefers-reduced-motion\ and \prefers-contrast: more\

## Design

- Uses CSS custom properties (design tokens) exclusively
- Responsive: mobile-first with breakpoint adaptations
- Dark mode support via semantic color tokens

## Issues

Closes #1464
Closes #1479