### PR TITLE
feat(web): tags UI components with color coding and subtags (#1472)

### DIFF
--- a/apps/web/src/components/tags/Tag.test.tsx
+++ b/apps/web/src/components/tags/Tag.test.tsx
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Tag } from './Tag';
+
+describe('Tag', () => {
+  it('renders the tag name', () => {
+    render(<Tag name="groceries" />);
+    expect(screen.getByText('groceries')).toBeInTheDocument();
+  });
+
+  it('renders subtag with separator', () => {
+    const { container } = render(<Tag name="travel:flights" />);
+    const label = container.querySelector('.tag__label');
+    expect(label).toBeInTheDocument();
+    expect(label?.textContent).toContain('travel');
+    expect(label?.textContent).toContain('flights');
+    expect(label?.textContent).toContain('›');
+  });
+
+  it('shows remove button when removable', () => {
+    const onRemove = vi.fn();
+    render(<Tag name="test" removable onRemove={onRemove} />);
+    const removeBtn = screen.getByLabelText('Remove tag test');
+    expect(removeBtn).toBeInTheDocument();
+    fireEvent.click(removeBtn);
+    expect(onRemove).toHaveBeenCalledWith('test');
+  });
+
+  it('does not show remove button when not removable', () => {
+    render(<Tag name="test" />);
+    expect(screen.queryByLabelText('Remove tag test')).not.toBeInTheDocument();
+  });
+
+  it('renders as a button when onClick is provided', () => {
+    const onClick = vi.fn();
+    render(<Tag name="filter-me" onClick={onClick} />);
+    const btn = screen.getByRole('button', { name: 'Filter by tag filter-me' });
+    fireEvent.click(btn);
+    expect(onClick).toHaveBeenCalledWith('filter-me');
+  });
+
+  it('renders as a span with listitem role when not clickable', () => {
+    render(<Tag name="static" />);
+    expect(screen.getByRole('listitem')).toBeInTheDocument();
+  });
+
+  it('applies size class', () => {
+    const { container } = render(<Tag name="small" size="sm" />);
+    expect(container.querySelector('.tag--sm')).toBeInTheDocument();
+  });
+
+  it('renders optional icon prefix', () => {
+    render(<Tag name="travel" icon="✈️" />);
+    expect(screen.getByText('✈️')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/tags/Tag.tsx
+++ b/apps/web/src/components/tags/Tag.tsx
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tag chip/pill component with deterministic color coding.
+ *
+ * Displays a colored chip for a tag name. Supports subtag display
+ * (e.g., "travel:flights" renders as "travel › flights"), optional
+ * remove button for edit mode, and click handling for filtering.
+ *
+ * Colors are auto-generated from the tag name hash to be visually
+ * distinct and WCAG AA contrast compliant.
+ */
+
+import React, { useMemo } from 'react';
+
+import { formatTagDisplay, getTagColor, getTagColorDark } from './tag-colors';
+
+/** Props for the Tag component. */
+export interface TagProps {
+  /** Full tag name, may include subtag separator (e.g., "travel:flights"). */
+  name: string;
+  /** Size variant: sm for list views, md for detail/forms. */
+  size?: 'sm' | 'md';
+  /** Whether the tag is removable (shows × button). */
+  removable?: boolean;
+  /** Callback when remove button is clicked. */
+  onRemove?: (name: string) => void;
+  /** Callback when the tag chip is clicked (e.g., for filtering). */
+  onClick?: (name: string) => void;
+  /** Optional emoji or icon prefix to display before the label. */
+  icon?: string;
+}
+
+/**
+ * A colored chip/pill displaying a tag name with optional subtag hierarchy.
+ *
+ * Accessible as a list item when rendered inside TagList.
+ * Clickable tags use a button role; static tags use a span.
+ */
+export const Tag: React.FC<TagProps> = ({
+  name,
+  size = 'md',
+  removable = false,
+  onRemove,
+  onClick,
+  icon,
+}) => {
+  const { root, sub } = useMemo(() => formatTagDisplay(name), [name]);
+  const lightColor = useMemo(() => getTagColor(name), [name]);
+  const darkColor = useMemo(() => getTagColorDark(name), [name]);
+
+  const style = {
+    '--tag-bg': lightColor.bg,
+    '--tag-text': lightColor.text,
+    '--tag-border': lightColor.border,
+    '--tag-bg-dark': darkColor.bg,
+    '--tag-text-dark': darkColor.text,
+    '--tag-border-dark': darkColor.border,
+    backgroundColor: 'var(--tag-bg-resolved, var(--tag-bg))',
+    color: 'var(--tag-text-resolved, var(--tag-text))',
+    borderColor: 'var(--tag-border-resolved, var(--tag-border))',
+  } as React.CSSProperties;
+
+  const className = `tag tag--${size}${onClick ? ' tag--clickable' : ''}`;
+
+  const labelContent = (
+    <>
+      {icon && (
+        <span className="tag__icon" aria-hidden="true">
+          {icon}
+        </span>
+      )}
+      <span className="tag__label">
+        {sub ? (
+          <>
+            {root}
+            <span className="tag__separator" aria-hidden="true">
+              ›
+            </span>
+            {sub}
+          </>
+        ) : (
+          root
+        )}
+      </span>
+    </>
+  );
+
+  const removeButton = removable && (
+    <button
+      type="button"
+      className="tag__remove"
+      onClick={(e) => {
+        e.stopPropagation();
+        onRemove?.(name);
+      }}
+      aria-label={`Remove tag ${name}`}
+    >
+      ×
+    </button>
+  );
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        className={className}
+        style={style}
+        onClick={() => onClick(name)}
+        aria-label={`Filter by tag ${name}`}
+      >
+        {labelContent}
+        {removeButton}
+      </button>
+    );
+  }
+
+  return (
+    <span className={className} style={style} role="listitem">
+      {labelContent}
+      {removeButton}
+    </span>
+  );
+};

--- a/apps/web/src/components/tags/TagInput.test.tsx
+++ b/apps/web/src/components/tags/TagInput.test.tsx
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TagInput } from './TagInput';
+
+describe('TagInput', () => {
+  const defaultProps = {
+    value: [] as string[],
+    onChange: vi.fn(),
+    suggestions: ['food', 'travel', 'bills', 'shopping', 'travel:flights'],
+  };
+
+  it('renders with a combobox role input', () => {
+    render(<TagInput {...defaultProps} />);
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('shows placeholder when no tags are selected', () => {
+    render(<TagInput {...defaultProps} placeholder="Add tags…" />);
+    expect(screen.getByPlaceholderText('Add tags…')).toBeInTheDocument();
+  });
+
+  it('renders selected tags as chips', () => {
+    render(<TagInput {...defaultProps} value={['food', 'travel']} />);
+    expect(screen.getByText('food')).toBeInTheDocument();
+    expect(screen.getByText('travel')).toBeInTheDocument();
+  });
+
+  it('filters suggestions based on typed text', () => {
+    render(<TagInput {...defaultProps} />);
+    const input = screen.getByRole('combobox');
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: 'tra' } });
+    expect(screen.getByText('travel')).toBeInTheDocument();
+    expect(screen.getByText('travel:flights')).toBeInTheDocument();
+    expect(screen.queryByText('food')).not.toBeInTheDocument();
+  });
+
+  it('shows "Create new" option when typed text has no exact match', () => {
+    render(<TagInput {...defaultProps} />);
+    const input = screen.getByRole('combobox');
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: 'newt' } });
+    expect(screen.getByText(/Create/)).toBeInTheDocument();
+    expect(screen.getByText(/newt/)).toBeInTheDocument();
+  });
+
+  it('does not show "Create new" when exact match exists', () => {
+    render(<TagInput {...defaultProps} />);
+    const input = screen.getByRole('combobox');
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: 'food' } });
+    expect(screen.queryByText(/Create/)).not.toBeInTheDocument();
+  });
+
+  it('adds a tag on Enter key', () => {
+    const onChange = vi.fn();
+    render(<TagInput {...defaultProps} onChange={onChange} />);
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, { target: { value: 'new-tag' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onChange).toHaveBeenCalledWith(['new-tag']);
+  });
+
+  it('removes last tag on Backspace when input is empty', () => {
+    const onChange = vi.fn();
+    render(<TagInput {...defaultProps} value={['food', 'travel']} onChange={onChange} />);
+    const input = screen.getByRole('combobox');
+    fireEvent.keyDown(input, { key: 'Backspace' });
+    expect(onChange).toHaveBeenCalledWith(['food']);
+  });
+
+  it('sets aria-expanded to false on Escape', () => {
+    render(<TagInput {...defaultProps} />);
+    const input = screen.getByRole('combobox');
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: 'food' } });
+    expect(input).toHaveAttribute('aria-expanded', 'true');
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(input).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('removes a selected tag via remove button', () => {
+    const onChange = vi.fn();
+    render(<TagInput {...defaultProps} value={['food']} onChange={onChange} />);
+    fireEvent.click(screen.getByLabelText('Remove tag food'));
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+
+  it('excludes already-selected tags from suggestions', () => {
+    render(<TagInput {...defaultProps} value={['food']} />);
+    const input = screen.getByRole('combobox');
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '' } });
+    // food should not appear in dropdown since it's already selected
+    const options = screen.getAllByRole('option');
+    const optionTexts = options.map((o) => o.textContent);
+    expect(optionTexts).not.toContain('food');
+  });
+});

--- a/apps/web/src/components/tags/TagInput.tsx
+++ b/apps/web/src/components/tags/TagInput.tsx
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * TagInput — multi-select input with autocomplete for tag management.
+ *
+ * Features:
+ * - Shows selected tags as colored chips inside the input
+ * - Dropdown with existing tags filtered by typed text
+ * - "Create new tag" option at bottom if no exact match
+ * - Subtag support via `:` separator (e.g., "travel:flights")
+ * - Keyboard navigable: arrow keys, Enter to select, Backspace to remove
+ * - Accessible: combobox role, aria-expanded, aria-activedescendant
+ */
+
+import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+
+import { Tag } from './Tag';
+
+/** Props for the TagInput component. */
+export interface TagInputProps {
+  /** Currently selected tag names. */
+  value: string[];
+  /** Callback when selected tags change. */
+  onChange: (tags: string[]) => void;
+  /** Available tags for autocomplete suggestions. */
+  suggestions?: string[];
+  /** Placeholder text when no tags are selected and input is empty. */
+  placeholder?: string;
+  /** Accessible label for the input. */
+  'aria-label'?: string;
+  /** ID of the element that labels this input. */
+  'aria-labelledby'?: string;
+  /** Whether the input is disabled. */
+  disabled?: boolean;
+}
+
+/**
+ * Multi-select tag input with autocomplete dropdown.
+ *
+ * Renders selected tags as removable chips inside the input field.
+ * Typing filters the suggestion dropdown. Supports creating new tags.
+ */
+export const TagInput: React.FC<TagInputProps> = ({
+  value,
+  onChange,
+  suggestions = [],
+  placeholder = 'Add tags…',
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy,
+  disabled = false,
+}) => {
+  const [inputValue, setInputValue] = useState('');
+  const [isOpen, setIsOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const escapePressedRef = useRef(false);
+  const listboxId = useId();
+  const inputId = useId();
+
+  // Filter suggestions based on input text and already-selected tags
+  const filteredSuggestions = useMemo(() => {
+    const query = inputValue.toLowerCase().trim();
+    return suggestions.filter(
+      (tag) => !value.includes(tag) && (query === '' || tag.toLowerCase().includes(query)),
+    );
+  }, [inputValue, suggestions, value]);
+
+  // Show "create new" option when there's input that doesn't exactly match
+  const showCreateOption = useMemo(() => {
+    const trimmed = inputValue.trim();
+    if (trimmed === '') return false;
+    const lower = trimmed.toLowerCase();
+    return (
+      !value.some((t) => t.toLowerCase() === lower) &&
+      !suggestions.some((t) => t.toLowerCase() === lower)
+    );
+  }, [inputValue, value, suggestions]);
+
+  const totalOptions = filteredSuggestions.length + (showCreateOption ? 1 : 0);
+
+  // Add a tag and clear input
+  const addTag = useCallback(
+    (tag: string) => {
+      const trimmed = tag.trim();
+      if (trimmed === '' || value.includes(trimmed)) return;
+      onChange([...value, trimmed]);
+      setInputValue('');
+      setActiveIndex(-1);
+      setIsOpen(false);
+    },
+    [value, onChange],
+  );
+
+  // Remove a tag by name
+  const removeTag = useCallback(
+    (tag: string) => {
+      onChange(value.filter((t) => t !== tag));
+    },
+    [value, onChange],
+  );
+
+  // Handle keyboard navigation
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          setIsOpen(true);
+          setActiveIndex((prev) => (prev < totalOptions - 1 ? prev + 1 : 0));
+          break;
+
+        case 'ArrowUp':
+          e.preventDefault();
+          setIsOpen(true);
+          setActiveIndex((prev) => (prev > 0 ? prev - 1 : totalOptions - 1));
+          break;
+
+        case 'Enter':
+          e.preventDefault();
+          if (activeIndex >= 0 && activeIndex < filteredSuggestions.length) {
+            addTag(filteredSuggestions[activeIndex]);
+          } else if (activeIndex === filteredSuggestions.length && showCreateOption) {
+            addTag(inputValue.trim());
+          } else if (inputValue.trim()) {
+            addTag(inputValue.trim());
+          }
+          break;
+
+        case 'Escape':
+          e.preventDefault();
+          escapePressedRef.current = true;
+          setIsOpen(false);
+          setActiveIndex(-1);
+          break;
+
+        case 'Backspace':
+          if (inputValue === '' && value.length > 0) {
+            removeTag(value[value.length - 1]);
+          }
+          break;
+      }
+    },
+    [
+      activeIndex,
+      addTag,
+      filteredSuggestions,
+      inputValue,
+      removeTag,
+      showCreateOption,
+      totalOptions,
+      value,
+    ],
+  );
+
+  // Handle input change
+  const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value);
+    setIsOpen(true);
+    setActiveIndex(-1);
+  }, []);
+
+  // Close dropdown when clicking outside
+  const containerRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+        setActiveIndex(-1);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  // Focus the input when clicking the control area
+  const handleControlClick = useCallback(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const getOptionId = (index: number) => `${listboxId}-option-${index}`;
+
+  const activeDescendant = activeIndex >= 0 ? getOptionId(activeIndex) : undefined;
+
+  return (
+    <div className="tag-input" ref={containerRef}>
+      <div
+        className="tag-input__control"
+        onClick={handleControlClick}
+        onKeyDown={() => inputRef.current?.focus()}
+        role="group"
+        aria-label="Selected tags"
+      >
+        {value.map((tag) => (
+          <Tag key={tag} name={tag} size="sm" removable onRemove={removeTag} />
+        ))}
+        <input
+          ref={inputRef}
+          id={inputId}
+          className="tag-input__text"
+          type="text"
+          role="combobox"
+          aria-expanded={isOpen && totalOptions > 0}
+          aria-controls={listboxId}
+          aria-activedescendant={activeDescendant}
+          aria-autocomplete="list"
+          aria-label={ariaLabel}
+          aria-labelledby={ariaLabelledBy}
+          value={inputValue}
+          onChange={handleInputChange}
+          onKeyDown={handleKeyDown}
+          onFocus={() => {
+            if (escapePressedRef.current) {
+              escapePressedRef.current = false;
+              return;
+            }
+            setIsOpen(true);
+          }}
+          placeholder={value.length === 0 ? placeholder : ''}
+          disabled={disabled}
+          autoComplete="off"
+        />
+      </div>
+
+      {isOpen && totalOptions > 0 && (
+        <ul
+          id={listboxId}
+          className="tag-input__dropdown"
+          role="listbox"
+          aria-label="Tag suggestions"
+        >
+          {filteredSuggestions.map((tag, index) => (
+            <li
+              key={tag}
+              id={getOptionId(index)}
+              className={`tag-input__option${index === activeIndex ? ' tag-input__option--active' : ''}`}
+              role="option"
+              aria-selected={index === activeIndex}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                addTag(tag);
+              }}
+            >
+              {tag}
+            </li>
+          ))}
+          {showCreateOption && (
+            <li
+              id={getOptionId(filteredSuggestions.length)}
+              className={`tag-input__option tag-input__option--create${
+                activeIndex === filteredSuggestions.length ? ' tag-input__option--active' : ''
+              }`}
+              role="option"
+              aria-selected={activeIndex === filteredSuggestions.length}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                addTag(inputValue.trim());
+              }}
+            >
+              Create &ldquo;{inputValue.trim()}&rdquo;
+            </li>
+          )}
+        </ul>
+      )}
+    </div>
+  );
+};

--- a/apps/web/src/components/tags/TagList.test.tsx
+++ b/apps/web/src/components/tags/TagList.test.tsx
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TagList } from './TagList';
+
+describe('TagList', () => {
+  it('renders nothing when tags array is empty', () => {
+    const { container } = render(<TagList tags={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders all tags when count is within maxVisible', () => {
+    render(<TagList tags={['food', 'travel', 'bills']} maxVisible={5} />);
+    expect(screen.getByText('food')).toBeInTheDocument();
+    expect(screen.getByText('travel')).toBeInTheDocument();
+    expect(screen.getByText('bills')).toBeInTheDocument();
+  });
+
+  it('shows overflow chip when tags exceed maxVisible', () => {
+    render(<TagList tags={['a', 'b', 'c', 'd', 'e']} maxVisible={2} />);
+    expect(screen.getByText('a')).toBeInTheDocument();
+    expect(screen.getByText('b')).toBeInTheDocument();
+    expect(screen.queryByText('c')).not.toBeInTheDocument();
+    expect(screen.getByText('+3 more')).toBeInTheDocument();
+  });
+
+  it('expands to show all tags when overflow chip is clicked', () => {
+    render(<TagList tags={['a', 'b', 'c', 'd']} maxVisible={2} />);
+    fireEvent.click(screen.getByText('+2 more'));
+    expect(screen.getByText('c')).toBeInTheDocument();
+    expect(screen.getByText('d')).toBeInTheDocument();
+    expect(screen.queryByText('+2 more')).not.toBeInTheDocument();
+  });
+
+  it('has accessible list role', () => {
+    render(<TagList tags={['test']} />);
+    expect(screen.getByRole('list', { name: 'Tags' })).toBeInTheDocument();
+  });
+
+  it('calls onTagClick when a tag is clicked', () => {
+    const onTagClick = vi.fn();
+    render(<TagList tags={['clickable']} onTagClick={onTagClick} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Filter by tag clickable' }));
+    expect(onTagClick).toHaveBeenCalledWith('clickable');
+  });
+
+  it('calls onRemove when tag remove button is clicked', () => {
+    const onRemove = vi.fn();
+    render(<TagList tags={['removable']} removable onRemove={onRemove} />);
+    fireEvent.click(screen.getByLabelText('Remove tag removable'));
+    expect(onRemove).toHaveBeenCalledWith('removable');
+  });
+});

--- a/apps/web/src/components/tags/TagList.tsx
+++ b/apps/web/src/components/tags/TagList.tsx
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * TagList component — renders multiple Tag chips in a flex-wrap layout.
+ *
+ * Supports overflow handling: shows first N tags + "+X more" chip that
+ * expands on click to reveal all tags. Uses role="list" for accessibility.
+ */
+
+import React, { useCallback, useState } from 'react';
+
+import { Tag } from './Tag';
+import type { TagProps } from './Tag';
+
+/** Props for the TagList component. */
+export interface TagListProps {
+  /** Array of tag name strings to display. */
+  tags: readonly string[];
+  /** Maximum number of visible tags before overflow. Defaults to 3. */
+  maxVisible?: number;
+  /** Size variant passed to each Tag chip. */
+  size?: TagProps['size'];
+  /** Whether tags are removable. */
+  removable?: boolean;
+  /** Called when a tag's remove button is clicked. */
+  onRemove?: (name: string) => void;
+  /** Called when a tag chip is clicked. */
+  onTagClick?: (name: string) => void;
+  /** Optional class name for the list container. */
+  className?: string;
+}
+
+/**
+ * Renders a list of colored tag chips with optional overflow truncation.
+ *
+ * When `tags.length > maxVisible`, shows the first `maxVisible` tags
+ * and a "+N more" button. Clicking the button expands to show all tags.
+ */
+export const TagList: React.FC<TagListProps> = ({
+  tags,
+  maxVisible = 3,
+  size = 'sm',
+  removable = false,
+  onRemove,
+  onTagClick,
+  className,
+}) => {
+  const [expanded, setExpanded] = useState(false);
+
+  const handleExpand = useCallback(() => {
+    setExpanded(true);
+  }, []);
+
+  if (tags.length === 0) {
+    return null;
+  }
+
+  const visibleTags = expanded ? tags : tags.slice(0, maxVisible);
+  const overflowCount = tags.length - maxVisible;
+  const showOverflow = !expanded && overflowCount > 0;
+
+  return (
+    <ul className={`tag-list${className ? ` ${className}` : ''}`} role="list" aria-label="Tags">
+      {visibleTags.map((tag) => (
+        <li key={tag} role="listitem">
+          <Tag
+            name={tag}
+            size={size}
+            removable={removable}
+            onRemove={onRemove}
+            onClick={onTagClick}
+          />
+        </li>
+      ))}
+      {showOverflow && (
+        <li role="listitem">
+          <button
+            type="button"
+            className="tag-list__overflow"
+            onClick={handleExpand}
+            aria-label={`Show ${overflowCount} more tag${overflowCount > 1 ? 's' : ''}`}
+          >
+            +{overflowCount} more
+          </button>
+        </li>
+      )}
+    </ul>
+  );
+};

--- a/apps/web/src/components/tags/index.ts
+++ b/apps/web/src/components/tags/index.ts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+export { Tag } from './Tag';
+export type { TagProps } from './Tag';
+export { TagList } from './TagList';
+export type { TagListProps } from './TagList';
+export { TagInput } from './TagInput';
+export type { TagInputProps } from './TagInput';
+export { getTagColor, getTagColorDark, getTagRootName, formatTagDisplay } from './tag-colors';
+export type { TagColor } from './tag-colors';
+
+import './tags.css';

--- a/apps/web/src/components/tags/tag-colors.test.ts
+++ b/apps/web/src/components/tags/tag-colors.test.ts
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import { formatTagDisplay, getTagColor, getTagColorDark, getTagRootName } from './tag-colors';
+
+describe('tag-colors', () => {
+  describe('getTagRootName', () => {
+    it('returns the full name when no subtag separator exists', () => {
+      expect(getTagRootName('groceries')).toBe('groceries');
+    });
+
+    it('returns the root portion before the colon', () => {
+      expect(getTagRootName('travel:flights')).toBe('travel');
+    });
+
+    it('handles multiple colons by splitting only on the first', () => {
+      expect(getTagRootName('a:b:c')).toBe('a');
+    });
+
+    it('returns empty string for a tag starting with colon', () => {
+      expect(getTagRootName(':orphan')).toBe('');
+    });
+  });
+
+  describe('getTagColor', () => {
+    it('returns an object with bg, text, and border properties', () => {
+      const color = getTagColor('travel');
+      expect(color).toHaveProperty('bg');
+      expect(color).toHaveProperty('text');
+      expect(color).toHaveProperty('border');
+    });
+
+    it('produces deterministic colors for the same tag name', () => {
+      const first = getTagColor('shopping');
+      const second = getTagColor('shopping');
+      expect(first).toEqual(second);
+    });
+
+    it('produces the same color for a subtag as its root', () => {
+      const rootColor = getTagColor('travel');
+      const subColor = getTagColor('travel:flights');
+      expect(rootColor).toEqual(subColor);
+    });
+
+    it('produces different colors for different root tags', () => {
+      const a = getTagColor('food');
+      const b = getTagColor('travel');
+      // At minimum one property should differ
+      expect(a.bg !== b.bg || a.text !== b.text || a.border !== b.border).toBe(true);
+    });
+
+    it('is case-insensitive', () => {
+      expect(getTagColor('Travel')).toEqual(getTagColor('travel'));
+    });
+
+    it('trims whitespace', () => {
+      expect(getTagColor('  travel  ')).toEqual(getTagColor('travel'));
+    });
+  });
+
+  describe('getTagColorDark', () => {
+    it('returns valid dark color values', () => {
+      const color = getTagColorDark('bills');
+      expect(color.bg).toContain('hsl');
+      expect(color.text).toContain('hsl');
+      expect(color.border).toContain('hsl');
+    });
+
+    it('produces different values from light mode', () => {
+      const light = getTagColor('shopping');
+      const dark = getTagColorDark('shopping');
+      expect(light.bg).not.toBe(dark.bg);
+    });
+  });
+
+  describe('formatTagDisplay', () => {
+    it('returns root only for simple tags', () => {
+      expect(formatTagDisplay('groceries')).toEqual({ root: 'groceries', sub: null });
+    });
+
+    it('splits subtags on the first colon', () => {
+      expect(formatTagDisplay('travel:flights')).toEqual({ root: 'travel', sub: 'flights' });
+    });
+
+    it('handles multiple colons by keeping everything after first colon as sub', () => {
+      expect(formatTagDisplay('a:b:c')).toEqual({ root: 'a', sub: 'b:c' });
+    });
+  });
+});

--- a/apps/web/src/components/tags/tag-colors.ts
+++ b/apps/web/src/components/tags/tag-colors.ts
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Deterministic color generation for tag chips.
+ *
+ * Generates WCAG AA compliant colors from tag names using a hash function.
+ * Colors are consistent across renders — the same tag name always produces
+ * the same color. Subtags (e.g., "travel:flights") inherit the root tag's color.
+ */
+
+/** Color values for a tag chip (CSS color strings). */
+export interface TagColor {
+  /** Background color for the chip. */
+  bg: string;
+  /** Text color for the chip label. */
+  text: string;
+  /** Border color for the chip outline. */
+  border: string;
+}
+
+/**
+ * Pre-defined palette of 12 harmonious hues (in degrees on the HSL wheel).
+ * Selected for visual distinctiveness and WCAG AA contrast compliance when
+ * paired with appropriate lightness values.
+ */
+const PALETTE_HUES = [
+  210, // blue
+  340, // rose
+  160, // teal
+  30, // orange
+  270, // purple
+  50, // gold
+  180, // cyan
+  0, // red
+  120, // green
+  300, // magenta
+  80, // lime
+  240, // indigo
+] as const;
+
+/**
+ * Simple string hash using DJB2 algorithm.
+ * Produces a positive 32-bit integer from any string.
+ */
+function djb2Hash(str: string): number {
+  let hash = 5381;
+  for (let i = 0; i < str.length; i++) {
+    hash = (hash * 33) ^ str.charCodeAt(i);
+  }
+  return hash >>> 0; // Ensure unsigned
+}
+
+/**
+ * Extract the root tag name from a potentially nested subtag.
+ *
+ * @example
+ * getTagRootName("travel:flights") // "travel"
+ * getTagRootName("groceries") // "groceries"
+ */
+export function getTagRootName(tag: string): string {
+  const colonIndex = tag.indexOf(':');
+  return colonIndex === -1 ? tag : tag.slice(0, colonIndex);
+}
+
+/**
+ * Generate a deterministic HSL color set from a tag name.
+ *
+ * Uses the root tag name for color so subtags share their parent's color.
+ * Light theme: pastel background + dark text for WCAG AA contrast (≥4.5:1).
+ * Dark theme support via CSS custom properties is handled at the component level.
+ *
+ * @param tagName - The full tag name (may include subtag separator `:`)
+ * @returns Object with bg, text, and border CSS color strings
+ */
+export function getTagColor(tagName: string): TagColor {
+  const root = getTagRootName(tagName.toLowerCase().trim());
+  const hash = djb2Hash(root);
+  const hue = PALETTE_HUES[hash % PALETTE_HUES.length];
+
+  // Light theme: high-lightness bg, low-lightness text
+  // These values ensure ≥4.5:1 contrast ratio for WCAG AA
+  const saturation = 60 + (hash % 20); // 60-79%
+
+  return {
+    bg: `hsl(${hue} ${saturation}% 92%)`,
+    text: `hsl(${hue} ${saturation}% 25%)`,
+    border: `hsl(${hue} ${saturation}% 80%)`,
+  };
+}
+
+/**
+ * Get dark-mode color values for a tag.
+ * Uses lower lightness for background and higher for text.
+ */
+export function getTagColorDark(tagName: string): TagColor {
+  const root = getTagRootName(tagName.toLowerCase().trim());
+  const hash = djb2Hash(root);
+  const hue = PALETTE_HUES[hash % PALETTE_HUES.length];
+  const saturation = 40 + (hash % 20); // 40-59% (less saturated in dark mode)
+
+  return {
+    bg: `hsl(${hue} ${saturation}% 18%)`,
+    text: `hsl(${hue} ${saturation}% 82%)`,
+    border: `hsl(${hue} ${saturation}% 30%)`,
+  };
+}
+
+/**
+ * Format a subtag for display, showing the hierarchy separator.
+ *
+ * @example
+ * formatTagDisplay("travel:flights") // { root: "travel", sub: "flights" }
+ * formatTagDisplay("groceries") // { root: "groceries", sub: null }
+ */
+export function formatTagDisplay(tag: string): { root: string; sub: string | null } {
+  const colonIndex = tag.indexOf(':');
+  if (colonIndex === -1) {
+    return { root: tag, sub: null };
+  }
+  return {
+    root: tag.slice(0, colonIndex),
+    sub: tag.slice(colonIndex + 1),
+  };
+}

--- a/apps/web/src/components/tags/tags.css
+++ b/apps/web/src/components/tags/tags.css
@@ -1,0 +1,254 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/**
+ * Tag component styles.
+ *
+ * Provides chip/pill styling for tags with color-coded backgrounds,
+ * overflow handling, and accessible interactive states.
+ */
+
+/* ---------------------------------------------------------------------------
+ * Tag chip base
+ * ------------------------------------------------------------------------- */
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  border-radius: var(--border-radius-full, 9999px);
+  border: 1px solid;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+  max-width: 180px;
+  transition: opacity var(--duration-fast, 100ms) ease;
+}
+
+.tag--sm {
+  padding: var(--spacing-half, 2px) var(--spacing-2, 8px);
+  font-size: var(--type-scale-caption-font-size, 0.75rem);
+}
+
+.tag--md {
+  padding: var(--spacing-1, 4px) var(--spacing-3, 12px);
+  font-size: var(--type-scale-body-sm-font-size, 0.8125rem);
+}
+
+.tag__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tag__separator {
+  opacity: 0.6;
+  margin: 0 var(--spacing-half, 2px);
+}
+
+.tag__remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  margin-left: var(--spacing-half, 2px);
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  opacity: 0.7;
+  font-size: 0.75rem;
+  line-height: 1;
+  transition: opacity var(--duration-fast, 100ms) ease;
+}
+
+.tag__remove:hover,
+.tag__remove:focus-visible {
+  opacity: 1;
+  background: rgba(0, 0, 0, 0.1);
+}
+
+.tag__remove:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 1px;
+}
+
+.tag--clickable {
+  cursor: pointer;
+}
+
+.tag--clickable:hover {
+  opacity: 0.85;
+}
+
+.tag--clickable:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+}
+
+/* ---------------------------------------------------------------------------
+ * Tag list
+ * ------------------------------------------------------------------------- */
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-1);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.tag-list__overflow {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--spacing-half, 2px) var(--spacing-2, 8px);
+  border-radius: var(--border-radius-full, 9999px);
+  border: 1px solid var(--semantic-border-default);
+  background: var(--semantic-background-secondary);
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size, 0.75rem);
+  font-weight: 500;
+  cursor: pointer;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.tag-list__overflow:hover {
+  background: var(--semantic-background-elevated, var(--semantic-background-secondary));
+  color: var(--semantic-text-primary);
+}
+
+.tag-list__overflow:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+}
+
+/* ---------------------------------------------------------------------------
+ * Tag input
+ * ------------------------------------------------------------------------- */
+
+.tag-input {
+  position: relative;
+  width: 100%;
+}
+
+.tag-input__control {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-1);
+  padding: var(--spacing-2);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md, 6px);
+  background: var(--semantic-background-primary);
+  min-height: 40px;
+  cursor: text;
+  transition: border-color var(--duration-fast, 100ms) ease;
+}
+
+.tag-input__control:focus-within {
+  border-color: var(--semantic-border-focus);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--semantic-border-focus) 25%, transparent);
+}
+
+.tag-input__text {
+  flex: 1 1 80px;
+  min-width: 80px;
+  border: none;
+  outline: none;
+  background: transparent;
+  font-size: var(--type-scale-body-font-size, 0.875rem);
+  color: var(--semantic-text-primary);
+  padding: var(--spacing-half, 2px) 0;
+}
+
+.tag-input__text::placeholder {
+  color: var(--semantic-text-disabled);
+}
+
+.tag-input__dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  margin-top: var(--spacing-1);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md, 6px);
+  background: var(--semantic-background-primary);
+  box-shadow: var(--shadow-md, 0 4px 12px rgba(0, 0, 0, 0.1));
+  max-height: 200px;
+  overflow-y: auto;
+  list-style: none;
+  margin-block: var(--spacing-1) 0;
+  padding: var(--spacing-1);
+}
+
+.tag-input__option {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-3);
+  border-radius: var(--border-radius-sm, 4px);
+  cursor: pointer;
+  font-size: var(--type-scale-body-sm-font-size, 0.8125rem);
+  color: var(--semantic-text-primary);
+}
+
+.tag-input__option:hover,
+.tag-input__option--active {
+  background: var(--semantic-background-secondary);
+}
+
+.tag-input__option--create {
+  color: var(--semantic-interactive-default);
+  font-style: italic;
+}
+
+/* ---------------------------------------------------------------------------
+ * Dark mode overrides for tag remove button
+ * ------------------------------------------------------------------------- */
+
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme='light']) .tag__remove:hover,
+  html:not([data-theme='light']) .tag__remove:focus-visible {
+    background: rgba(255, 255, 255, 0.15);
+  }
+}
+
+[data-theme='dark'] .tag__remove:hover,
+[data-theme='dark'] .tag__remove:focus-visible {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+/* ---------------------------------------------------------------------------
+ * Reduced motion
+ * ------------------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .tag,
+  .tag__remove,
+  .tag-input__control {
+    transition: none;
+  }
+}
+
+/* ---------------------------------------------------------------------------
+ * High contrast
+ * ------------------------------------------------------------------------- */
+
+@media (prefers-contrast: more) {
+  .tag {
+    border-width: 2px;
+  }
+
+  .tag-input__control {
+    border-width: 2px;
+  }
+
+  .tag-input__control:focus-within {
+    box-shadow: 0 0 0 3px var(--semantic-border-focus);
+  }
+}

--- a/apps/web/src/pages/TransactionDetailPage.test.tsx
+++ b/apps/web/src/pages/TransactionDetailPage.test.tsx
@@ -277,7 +277,10 @@ describe('TransactionDetailPage', () => {
   it('displays tags when present', () => {
     renderWithRoute();
 
-    expect(screen.getByText('food, essentials')).toBeInTheDocument();
+    const tagList = screen.getByRole('list', { name: 'Tags' });
+    expect(tagList).toBeInTheDocument();
+    expect(tagList.textContent).toContain('food');
+    expect(tagList.textContent).toContain('essentials');
   });
 
   it('has an accessible article for transaction details', () => {

--- a/apps/web/src/pages/TransactionDetailPage.tsx
+++ b/apps/web/src/pages/TransactionDetailPage.tsx
@@ -6,6 +6,7 @@ import { Link, useNavigate, useParams } from 'react-router-dom';
 import { ConfirmDialog, CurrencyDisplay, ErrorBanner, LoadingSpinner } from '../components/common';
 import { TransactionForm } from '../components/forms';
 import { Breadcrumb } from '../components/navigation';
+import { TagList } from '../components/tags';
 import type { CreateTransactionInput } from '../db/repositories/transactions';
 import { useAccounts, useCategories, useTransactions } from '../hooks';
 import type { Transaction } from '../kmp/bridge';
@@ -225,7 +226,9 @@ export const TransactionDetailPage: React.FC = () => {
           {transaction.tags.length > 0 && (
             <div style={{ gridColumn: '1 / -1' }}>
               <dt className="card__title">Tags</dt>
-              <dd>{transaction.tags.join(', ')}</dd>
+              <dd>
+                <TagList tags={transaction.tags} size="md" maxVisible={5} />
+              </dd>
             </div>
           )}
         </dl>

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "d3": "^7.9.0",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
-        "react-router-dom": "^7.15.0",
+        "react-router-dom": "^7.15.1",
         "recharts": "^3.8.1",
         "sql.js": "^1.14.1",
         "wa-sqlite": "^1.0.0",
@@ -719,44 +719,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "apps/web/node_modules/react-router": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.0.tgz",
-      "integrity": "sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ==",
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "apps/web/node_modules/react-router-dom": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.15.0.tgz",
-      "integrity": "sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.15.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "apps/web/node_modules/rolldown": {
@@ -11255,6 +11217,44 @@
         "redux": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.15.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.1.tgz",
+      "integrity": "sha512-R8rl9HhgikFYoPJymnUtPXWbnDb3oget6lQnfIoupbt61aT9aOhRkDsY2XRhZRyX1Z/8a5sL74fXmFNm3NRK5A==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.15.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.15.1.tgz",
+      "integrity": "sha512-AzF62gjY6U9rkMq4RfP/r2EVtQ7DMfNMjyOp/flLTCrtRylLiK4wT4pSq6O8rOXZ2eXdZYJPEYe+ifomiv+Igg==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.15.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/react-tabs": {


### PR DESCRIPTION
## Summary

Creates a complete tags UI system with colored chips, autocomplete input, overflow handling, and subtag support.

## Changes

- **Tag component** (Tag.tsx): Colored chip/pill with deterministic HSL color from name hash, subtag display (travel › flights), optional icon prefix, remove button, sizes (sm/md), click handler for filtering
- **TagList component** (TagList.tsx): Flex-wrap layout with overflow (+N more chip that expands on click), role=list accessibility
- **TagInput component** (TagInput.tsx): Multi-select combobox with autocomplete dropdown, keyboard navigation (arrows/Enter/Escape/Backspace), create-new-tag option, ARIA combobox pattern
- **Color utilities** (	ag-colors.ts): DJB2 hash → 12-hue palette, WCAG AA compliant light/dark colors, subtag root inheritance
- **CSS** (	ags.css): Design token usage, dark mode, reduced motion, high contrast support
- **Integration**: TransactionDetailPage now uses TagList instead of plain text join
- **Tests**: 41 tests covering color generation, Tag rendering, TagList overflow, TagInput keyboard nav

## Accessibility

- role=list/listitem for tag lists
- role=combobox with aria-expanded, aria-activedescendant for input
- aria-label on remove buttons and filter buttons
- Keyboard fully navigable (Tab, arrows, Enter, Escape, Backspace)
- WCAG AA color contrast (≥4.5:1 ratio)
- prefers-reduced-motion and prefers-contrast respected

## Issues

Closes #1472