### PR TITLE
feat(web): passkey-first auth — biometric setup prompt after signup (#1445)

### DIFF
--- a/apps/web/src/auth/auth-context.tsx
+++ b/apps/web/src/auth/auth-context.tsx
@@ -56,6 +56,12 @@ import {
   restoreDemoSession,
 } from './demo-auth';
 
+import {
+  incrementLoginCount,
+  setHasRegisteredPasskey,
+  shouldShowPasskeyPrompt,
+} from '../lib/passkey-preferences';
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -107,6 +113,10 @@ export interface AuthContextValue extends AuthActions {
   webAuthnSupported: boolean;
   /** Whether the app is running in demo mode (no backend configured). */
   isDemoMode: boolean;
+  /** Whether the passkey setup prompt should be shown. */
+  showPasskeyPrompt: boolean;
+  /** Dismiss the passkey setup prompt. */
+  dismissPasskeyPrompt: () => void;
 }
 
 /** Configuration for the AuthProvider. */
@@ -160,9 +170,15 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [webAuthnSupported] = useState(() => isWebAuthnSupported());
+  const [showPasskeyPrompt, setShowPasskeyPrompt] = useState(false);
 
   const demoModeActive = isDemoMode(config.supabaseUrl);
   const isAuthenticated = user !== null && hasValidToken();
+
+  /** Dismiss the passkey prompt (hides it without changing preferences). */
+  const dismissPasskeyPrompt = useCallback(() => {
+    setShowPasskeyPrompt(false);
+  }, []);
 
   // -----------------------------------------------------------------------
   // Initialisation
@@ -271,6 +287,17 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
   // Auth Actions
   // -----------------------------------------------------------------------
 
+  /**
+   * Check whether the passkey setup prompt should appear after login/signup.
+   * Increments the login counter and evaluates the prompt state.
+   */
+  function triggerPasskeyPromptCheck(): void {
+    incrementLoginCount();
+    if (webAuthnSupported && shouldShowPasskeyPrompt()) {
+      setShowPasskeyPrompt(true);
+    }
+  }
+
   const loginWithEmail = useCallback(
     async (email: string, password: string): Promise<void> => {
       setError(null);
@@ -285,6 +312,7 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
             email: result.user.email,
             hasPasskey: false,
           });
+          triggerPasskeyPromptCheck();
           return;
         }
 
@@ -313,6 +341,7 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
           email: data.user.email,
           hasPasskey: data.user.has_passkey ?? false,
         });
+        triggerPasskeyPromptCheck();
       } catch (err) {
         const message = err instanceof Error ? err.message : 'An unexpected error occurred';
         setError(message);
@@ -368,8 +397,10 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
 
       await registerPasskey(token);
 
-      // Update user state to reflect passkey registration
+      // Update user state and localStorage to reflect passkey registration
       setUser((prev) => (prev ? { ...prev, hasPasskey: true } : null));
+      setHasRegisteredPasskey();
+      setShowPasskeyPrompt(false);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Passkey registration failed';
       setError(message);
@@ -464,6 +495,7 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
             hasPasskey: false,
           });
           // demoLogin already calls persistDemoSession
+          triggerPasskeyPromptCheck();
           return;
         }
 
@@ -500,6 +532,7 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
             email: data.user.email,
             hasPasskey: data.user.has_passkey ?? false,
           });
+          triggerPasskeyPromptCheck();
         }
         // If auto-login fails, the signup still succeeded — caller can
         // decide to redirect to login or show a message.
@@ -552,6 +585,8 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
       error,
       webAuthnSupported,
       isDemoMode: demoModeActive,
+      showPasskeyPrompt,
+      dismissPasskeyPrompt,
       loginWithEmail,
       loginWithPasskey,
       loginWithOAuth,
@@ -568,6 +603,8 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
       error,
       webAuthnSupported,
       demoModeActive,
+      showPasskeyPrompt,
+      dismissPasskeyPrompt,
       loginWithEmail,
       loginWithPasskey,
       loginWithOAuth,

--- a/apps/web/src/components/auth/PasskeySetupPrompt.test.tsx
+++ b/apps/web/src/components/auth/PasskeySetupPrompt.test.tsx
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { PasskeySetupPrompt } from './PasskeySetupPrompt';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const registerNewPasskeyMock = vi.fn();
+
+vi.mock('../../auth/auth-context', () => ({
+  useAuth: () => ({
+    registerNewPasskey: registerNewPasskeyMock,
+  }),
+}));
+
+vi.mock('../../lib/passkey-preferences', () => ({
+  setPasskeyPromptState: vi.fn(),
+  setHasRegisteredPasskey: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderPrompt(isOpen = true, onClose = vi.fn()) {
+  return {
+    onClose,
+    ...render(<PasskeySetupPrompt isOpen={isOpen} onClose={onClose} />),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PasskeySetupPrompt', () => {
+  beforeEach(() => {
+    registerNewPasskeyMock.mockReset();
+  });
+
+  it('renders nothing when isOpen is false', () => {
+    renderPrompt(false);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('renders the dialog when isOpen is true', () => {
+    renderPrompt(true);
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText(/secure your account/i)).toBeInTheDocument();
+  });
+
+  it('renders three action buttons', () => {
+    renderPrompt(true);
+
+    expect(screen.getByRole('button', { name: /set up now/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /remind me later/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /skip/i })).toBeInTheDocument();
+  });
+
+  it('has proper ARIA attributes', () => {
+    renderPrompt(true);
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby', 'passkey-prompt-title');
+    expect(dialog).toHaveAttribute('aria-describedby', 'passkey-prompt-description');
+  });
+
+  it('calls onClose when "Remind Me Later" is clicked', async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderPrompt(true);
+
+    await user.click(screen.getByRole('button', { name: /remind me later/i }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when "Skip" is clicked', async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderPrompt(true);
+
+    await user.click(screen.getByRole('button', { name: /skip/i }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls registerNewPasskey when "Set Up Now" is clicked', async () => {
+    const user = userEvent.setup();
+    registerNewPasskeyMock.mockResolvedValue(undefined);
+
+    renderPrompt(true);
+
+    await user.click(screen.getByRole('button', { name: /set up now/i }));
+
+    expect(registerNewPasskeyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows error when registration fails', async () => {
+    const user = userEvent.setup();
+    registerNewPasskeyMock.mockRejectedValue(new Error('Credential creation was cancelled'));
+
+    renderPrompt(true);
+
+    await user.click(screen.getByRole('button', { name: /set up now/i }));
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Credential creation was cancelled');
+  });
+
+  it('disables buttons during registration', async () => {
+    // Make registerNewPasskey hang (never resolve)
+    registerNewPasskeyMock.mockReturnValue(new Promise(() => {}));
+
+    const user = userEvent.setup();
+    renderPrompt(true);
+
+    await user.click(screen.getByRole('button', { name: /set up now/i }));
+
+    expect(screen.getByRole('button', { name: /setting up/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /remind me later/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /skip/i })).toBeDisabled();
+  });
+
+  it('shows biometric-specific messaging', () => {
+    renderPrompt(true);
+
+    // The exact label depends on the test environment's user agent, but
+    // the description should always mention signing in faster
+    expect(screen.getByText(/sign in faster/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/auth/PasskeySetupPrompt.tsx
+++ b/apps/web/src/components/auth/PasskeySetupPrompt.tsx
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * PasskeySetupPrompt (#1445)
+ *
+ * Modal dialog that prompts users to set up passkey-based biometric
+ * authentication after their first login or signup.
+ *
+ * Features:
+ *   - Platform-aware messaging (Windows Hello, Touch ID, Face ID, biometrics)
+ *   - Three actions: Set Up Now, Remind Me Later, Skip
+ *   - Only shows when platform authenticator is available
+ *   - Accessible modal with focus trapping and ARIA attributes
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { useAuth } from '../../auth/auth-context';
+import { setHasRegisteredPasskey, setPasskeyPromptState } from '../../lib/passkey-preferences';
+
+import './passkey-setup-prompt.css';
+
+// ---------------------------------------------------------------------------
+// Platform Detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect the platform-appropriate biometric label.
+ *
+ * @returns A user-friendly name for the platform authenticator.
+ */
+function getPlatformBiometricLabel(): string {
+  const ua = navigator.userAgent;
+
+  if (/Windows/i.test(ua)) {
+    return 'Windows Hello';
+  }
+
+  // iPad can report as Macintosh, so check for touch support
+  if (/iPad|Macintosh/i.test(ua) && navigator.maxTouchPoints > 0) {
+    return 'Face ID';
+  }
+
+  if (/iPhone/i.test(ua)) {
+    // Modern iPhones use Face ID; older ones use Touch ID.
+    // We can't reliably detect which, so default to Face ID.
+    return 'Face ID';
+  }
+
+  if (/Macintosh|Mac OS/i.test(ua)) {
+    return 'Touch ID';
+  }
+
+  if (/Android/i.test(ua)) {
+    return 'biometrics';
+  }
+
+  return 'biometrics';
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface PasskeySetupPromptProps {
+  /** Whether the modal is open. */
+  isOpen: boolean;
+  /** Called when the modal should close (after any action). */
+  onClose: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/**
+ * PasskeySetupPrompt — modal dialog encouraging passkey registration.
+ *
+ * Renders a friendly prompt with platform-specific biometric messaging.
+ * On "Set Up Now", calls `registerNewPasskey()` from the auth context.
+ *
+ * @example
+ * ```tsx
+ * <PasskeySetupPrompt isOpen={showPrompt} onClose={() => setShowPrompt(false)} />
+ * ```
+ */
+export function PasskeySetupPrompt({ isOpen, onClose }: PasskeySetupPromptProps) {
+  const { registerNewPasskey } = useAuth();
+  const panelRef = useRef<HTMLDivElement>(null);
+  const primaryButtonRef = useRef<HTMLButtonElement>(null);
+
+  const [isRegistering, setIsRegistering] = useState(false);
+  const [registrationError, setRegistrationError] = useState<string | null>(null);
+
+  const biometricLabel = getPlatformBiometricLabel();
+
+  // -----------------------------------------------------------------------
+  // Focus management
+  // -----------------------------------------------------------------------
+
+  useEffect(() => {
+    if (isOpen) {
+      // Focus the primary button on open
+      requestAnimationFrame(() => {
+        primaryButtonRef.current?.focus();
+      });
+    }
+  }, [isOpen]);
+
+  // Trap focus within the dialog
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const panel = panelRef.current;
+    if (!panel) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && !isRegistering) {
+        handleRemindLater();
+        return;
+      }
+
+      if (event.key !== 'Tab') return;
+
+      const focusable = panel.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      );
+
+      if (focusable.length === 0) return;
+
+      const first = focusable[0]!;
+      const last = focusable[focusable.length - 1]!;
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, isRegistering]);
+
+  // -----------------------------------------------------------------------
+  // Handlers
+  // -----------------------------------------------------------------------
+
+  const handleSetUpNow = useCallback(async () => {
+    setIsRegistering(true);
+    setRegistrationError(null);
+
+    try {
+      await registerNewPasskey();
+      setHasRegisteredPasskey();
+      onClose();
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : 'Passkey registration failed. Please try again.';
+      setRegistrationError(message);
+    } finally {
+      setIsRegistering(false);
+    }
+  }, [registerNewPasskey, onClose]);
+
+  const handleRemindLater = useCallback(() => {
+    setPasskeyPromptState('remind');
+    onClose();
+  }, [onClose]);
+
+  const handleSkip = useCallback(() => {
+    setPasskeyPromptState('skipped');
+    onClose();
+  }, [onClose]);
+
+  // -----------------------------------------------------------------------
+  // Render
+  // -----------------------------------------------------------------------
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="passkey-prompt" role="presentation">
+      {/* Backdrop */}
+      <div
+        className="passkey-prompt__backdrop"
+        onClick={isRegistering ? undefined : handleRemindLater}
+        aria-hidden="true"
+      />
+
+      {/* Dialog panel */}
+      <div
+        ref={panelRef}
+        className="passkey-prompt__panel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="passkey-prompt-title"
+        aria-describedby="passkey-prompt-description"
+      >
+        {/* Icon */}
+        <div className="passkey-prompt__icon" aria-hidden="true">
+          🔐
+        </div>
+
+        {/* Title */}
+        <h2 id="passkey-prompt-title" className="passkey-prompt__title">
+          Secure your account with {biometricLabel}
+        </h2>
+
+        {/* Description */}
+        <p id="passkey-prompt-description" className="passkey-prompt__description">
+          Sign in faster and more securely using {biometricLabel} instead of your password. Your
+          biometric data never leaves your device.
+        </p>
+
+        {/* Error banner */}
+        {registrationError && (
+          <div className="passkey-prompt__error" role="alert">
+            {registrationError}
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="passkey-prompt__actions">
+          <button
+            ref={primaryButtonRef}
+            type="button"
+            className="passkey-prompt__button passkey-prompt__button--primary"
+            onClick={() => {
+              void handleSetUpNow();
+            }}
+            disabled={isRegistering}
+            aria-busy={isRegistering}
+          >
+            {isRegistering ? 'Setting up…' : 'Set Up Now'}
+          </button>
+
+          <button
+            type="button"
+            className="passkey-prompt__button passkey-prompt__button--secondary"
+            onClick={handleRemindLater}
+            disabled={isRegistering}
+          >
+            Remind Me Later
+          </button>
+
+          <button
+            type="button"
+            className="passkey-prompt__button passkey-prompt__button--text"
+            onClick={handleSkip}
+            disabled={isRegistering}
+          >
+            Skip
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/auth/passkey-setup-prompt.css
+++ b/apps/web/src/components/auth/passkey-setup-prompt.css
@@ -1,0 +1,209 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/**
+ * Styles for the PasskeySetupPrompt modal (#1445).
+ *
+ * Uses design-token custom properties for consistency with the rest
+ * of the app. Supports dark mode, reduced motion, and high contrast.
+ */
+
+/* ─── Overlay ────────────────────────────────────────────────────────────── */
+
+.passkey-prompt {
+  position: fixed;
+  inset: 0;
+  z-index: 300;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-4);
+}
+
+.passkey-prompt__backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: -1;
+}
+
+/* ─── Dialog panel ───────────────────────────────────────────────────────── */
+
+.passkey-prompt__panel {
+  position: relative;
+  width: 100%;
+  max-width: 420px;
+  padding: var(--spacing-6);
+  background: var(--semantic-background-primary);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-lg, var(--border-radius-md));
+  box-shadow: var(--shadow-lg, 0 10px 25px rgba(0, 0, 0, 0.15));
+  text-align: center;
+  animation: passkey-prompt-enter var(--duration-normal, 200ms) var(--easing-out, ease-out);
+}
+
+@keyframes passkey-prompt-enter {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.98);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* ─── Icon ───────────────────────────────────────────────────────────────── */
+
+.passkey-prompt__icon {
+  font-size: 3rem;
+  line-height: 1;
+  margin-bottom: var(--spacing-3);
+}
+
+/* ─── Title & description ────────────────────────────────────────────────── */
+
+.passkey-prompt__title {
+  font-size: var(--type-scale-title-font-size, 1.25rem);
+  font-weight: var(--font-weight-semibold, 600);
+  color: var(--semantic-text-primary);
+  margin: 0 0 var(--spacing-2);
+}
+
+.passkey-prompt__description {
+  font-size: var(--type-scale-body-font-size, 1rem);
+  color: var(--semantic-text-secondary);
+  margin: 0 0 var(--spacing-5);
+  line-height: var(--type-scale-body-line-height, 1.5);
+}
+
+/* ─── Error banner ───────────────────────────────────────────────────────── */
+
+.passkey-prompt__error {
+  padding: var(--spacing-3);
+  border-radius: var(--border-radius-md);
+  background: var(--color-red-50, #fef2f2);
+  color: var(--semantic-status-negative);
+  font-size: var(--type-scale-caption-font-size, 0.875rem);
+  margin-bottom: var(--spacing-4);
+}
+
+/* ─── Action buttons ─────────────────────────────────────────────────────── */
+
+.passkey-prompt__actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+}
+
+.passkey-prompt__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 44px;
+  padding: var(--spacing-2) var(--spacing-4);
+  border-radius: var(--border-radius-md);
+  font: inherit;
+  font-weight: var(--font-weight-medium, 500);
+  cursor: pointer;
+  transition:
+    background-color var(--duration-fast, 100ms) ease,
+    border-color var(--duration-fast, 100ms) ease;
+}
+
+.passkey-prompt__button:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+}
+
+.passkey-prompt__button:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+/* Primary — "Set Up Now" */
+.passkey-prompt__button--primary {
+  background: var(--semantic-interactive-default);
+  border: 1px solid var(--semantic-interactive-default);
+  color: var(--semantic-text-inverse);
+  font-weight: var(--font-weight-semibold, 600);
+}
+
+.passkey-prompt__button--primary:hover:not(:disabled) {
+  background: var(--semantic-interactive-hover);
+  border-color: var(--semantic-interactive-hover);
+}
+
+/* Secondary — "Remind Me Later" */
+.passkey-prompt__button--secondary {
+  background: transparent;
+  border: 1px solid var(--semantic-border-default);
+  color: var(--semantic-text-primary);
+}
+
+.passkey-prompt__button--secondary:hover:not(:disabled) {
+  background: var(--semantic-background-secondary, rgba(0, 0, 0, 0.04));
+  border-color: var(--semantic-border-hover, var(--semantic-border-default));
+}
+
+/* Text — "Skip" */
+.passkey-prompt__button--text {
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size, 0.875rem);
+}
+
+.passkey-prompt__button--text:hover:not(:disabled) {
+  color: var(--semantic-text-primary);
+  text-decoration: underline;
+}
+
+/* ─── Responsive ─────────────────────────────────────────────────────────── */
+
+@media (max-width: 480px) {
+  .passkey-prompt {
+    padding: var(--spacing-3);
+  }
+
+  .passkey-prompt__panel {
+    padding: var(--spacing-5);
+  }
+}
+
+/* ─── Reduced motion ─────────────────────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .passkey-prompt__panel {
+    animation: none;
+  }
+
+  .passkey-prompt__button {
+    transition: none;
+  }
+}
+
+/* ─── High contrast ──────────────────────────────────────────────────────── */
+
+@media (prefers-contrast: more) {
+  .passkey-prompt__panel {
+    border-width: 2px;
+  }
+
+  .passkey-prompt__button--secondary {
+    border-width: 2px;
+  }
+}
+
+/* ─── Dark mode ──────────────────────────────────────────────────────────── */
+
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme='light']) .passkey-prompt__error {
+    background: rgba(239, 68, 68, 0.12);
+  }
+
+  html:not([data-theme='light']) .passkey-prompt__button--secondary:hover:not(:disabled) {
+    background: rgba(255, 255, 255, 0.06);
+  }
+}

--- a/apps/web/src/lib/passkey-preferences.test.ts
+++ b/apps/web/src/lib/passkey-preferences.test.ts
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  clearPasskeyPreferences,
+  getLoginCount,
+  getPasskeyPromptState,
+  hasRegisteredPasskey,
+  incrementLoginCount,
+  setHasRegisteredPasskey,
+  setPasskeyPromptState,
+  shouldShowPasskeyPrompt,
+} from './passkey-preferences';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('passkey-preferences', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  // -----------------------------------------------------------------------
+  // getPasskeyPromptState / setPasskeyPromptState
+  // -----------------------------------------------------------------------
+
+  describe('getPasskeyPromptState', () => {
+    it('returns "show" by default', () => {
+      expect(getPasskeyPromptState()).toBe('show');
+    });
+
+    it('returns "remind" after being set', () => {
+      setPasskeyPromptState('remind');
+      expect(getPasskeyPromptState()).toBe('remind');
+    });
+
+    it('returns "skipped" after being set', () => {
+      setPasskeyPromptState('skipped');
+      expect(getPasskeyPromptState()).toBe('skipped');
+    });
+  });
+
+  describe('setPasskeyPromptState', () => {
+    it('resets login count when set to "remind"', () => {
+      incrementLoginCount();
+      incrementLoginCount();
+      expect(getLoginCount()).toBe(2);
+
+      setPasskeyPromptState('remind');
+      expect(getLoginCount()).toBe(0);
+    });
+
+    it('does not reset login count when set to "skipped"', () => {
+      incrementLoginCount();
+      incrementLoginCount();
+
+      setPasskeyPromptState('skipped');
+      expect(getLoginCount()).toBe(2);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // incrementLoginCount / getLoginCount
+  // -----------------------------------------------------------------------
+
+  describe('incrementLoginCount', () => {
+    it('starts at 0 and increments', () => {
+      expect(getLoginCount()).toBe(0);
+      expect(incrementLoginCount()).toBe(1);
+      expect(incrementLoginCount()).toBe(2);
+      expect(incrementLoginCount()).toBe(3);
+      expect(getLoginCount()).toBe(3);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // hasRegisteredPasskey / setHasRegisteredPasskey
+  // -----------------------------------------------------------------------
+
+  describe('hasRegisteredPasskey', () => {
+    it('returns false by default', () => {
+      expect(hasRegisteredPasskey()).toBe(false);
+    });
+
+    it('returns true after setHasRegisteredPasskey()', () => {
+      setHasRegisteredPasskey();
+      expect(hasRegisteredPasskey()).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // shouldShowPasskeyPrompt
+  // -----------------------------------------------------------------------
+
+  describe('shouldShowPasskeyPrompt', () => {
+    it('returns true for new users (default state)', () => {
+      expect(shouldShowPasskeyPrompt()).toBe(true);
+    });
+
+    it('returns false when user has registered a passkey', () => {
+      setHasRegisteredPasskey();
+      expect(shouldShowPasskeyPrompt()).toBe(false);
+    });
+
+    it('returns false when user chose "Skip"', () => {
+      setPasskeyPromptState('skipped');
+      expect(shouldShowPasskeyPrompt()).toBe(false);
+    });
+
+    it('returns false when "remind" and login count < 3', () => {
+      setPasskeyPromptState('remind');
+      incrementLoginCount();
+      incrementLoginCount();
+      expect(shouldShowPasskeyPrompt()).toBe(false);
+    });
+
+    it('returns true when "remind" and login count >= 3', () => {
+      setPasskeyPromptState('remind');
+      incrementLoginCount();
+      incrementLoginCount();
+      incrementLoginCount();
+      expect(shouldShowPasskeyPrompt()).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // clearPasskeyPreferences
+  // -----------------------------------------------------------------------
+
+  describe('clearPasskeyPreferences', () => {
+    it('resets all preferences', () => {
+      setPasskeyPromptState('skipped');
+      setHasRegisteredPasskey();
+      incrementLoginCount();
+
+      clearPasskeyPreferences();
+
+      expect(getPasskeyPromptState()).toBe('show');
+      expect(hasRegisteredPasskey()).toBe(false);
+      expect(getLoginCount()).toBe(0);
+    });
+  });
+});

--- a/apps/web/src/lib/passkey-preferences.ts
+++ b/apps/web/src/lib/passkey-preferences.ts
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Passkey Preference Tracking (#1445)
+ *
+ * Manages localStorage-based state for the passkey setup prompt:
+ *   - Whether to show, remind later, or skip the prompt
+ *   - Login count tracking for "remind me later" logic
+ *   - Whether the user has a registered passkey
+ *
+ * All data is stored in localStorage — no server round-trips needed.
+ */
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const STORAGE_KEY_PROMPT_STATE = 'finance:passkey-prompt-state';
+const STORAGE_KEY_LOGIN_COUNT = 'finance:passkey-login-count';
+const STORAGE_KEY_HAS_PASSKEY = 'finance:has-registered-passkey';
+
+/** Number of logins before re-prompting after "Remind Me Later". */
+const REMIND_AFTER_LOGINS = 3;
+
+// ---------------------------------------------------------------------------
+// Prompt State
+// ---------------------------------------------------------------------------
+
+/** Possible states for the passkey setup prompt. */
+export type PasskeyPromptState = 'show' | 'remind' | 'skipped';
+
+/**
+ * Get the current passkey prompt state.
+ *
+ * - `'show'` — prompt should be displayed (default for new users)
+ * - `'remind'` — user chose "Remind Me Later"; re-prompt after 3 logins
+ * - `'skipped'` — user chose "Skip"; never prompt again
+ *
+ * @returns The current prompt state.
+ */
+export function getPasskeyPromptState(): PasskeyPromptState {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY_PROMPT_STATE);
+    if (stored === 'remind' || stored === 'skipped') {
+      return stored;
+    }
+  } catch {
+    // localStorage unavailable — default to show
+  }
+  return 'show';
+}
+
+/**
+ * Set the passkey prompt state.
+ *
+ * When set to `'remind'`, the login counter is reset so the prompt
+ * re-appears after {@link REMIND_AFTER_LOGINS} additional logins.
+ *
+ * @param state - The new prompt state.
+ */
+export function setPasskeyPromptState(state: 'remind' | 'skipped'): void {
+  try {
+    localStorage.setItem(STORAGE_KEY_PROMPT_STATE, state);
+    if (state === 'remind') {
+      // Reset login counter when user chooses "Remind Me Later"
+      localStorage.setItem(STORAGE_KEY_LOGIN_COUNT, '0');
+    }
+  } catch {
+    // localStorage unavailable — silently fail
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Login Count
+// ---------------------------------------------------------------------------
+
+/**
+ * Increment the login count and return the new value.
+ *
+ * Used to track how many logins have occurred since the user chose
+ * "Remind Me Later". When the count reaches {@link REMIND_AFTER_LOGINS},
+ * the prompt state should be checked again.
+ *
+ * @returns The updated login count.
+ */
+export function incrementLoginCount(): number {
+  try {
+    const current = parseInt(localStorage.getItem(STORAGE_KEY_LOGIN_COUNT) ?? '0', 10);
+    const next = (isNaN(current) ? 0 : current) + 1;
+    localStorage.setItem(STORAGE_KEY_LOGIN_COUNT, String(next));
+    return next;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Get the current login count without incrementing.
+ *
+ * @returns The current login count.
+ */
+export function getLoginCount(): number {
+  try {
+    const value = parseInt(localStorage.getItem(STORAGE_KEY_LOGIN_COUNT) ?? '0', 10);
+    return isNaN(value) ? 0 : value;
+  } catch {
+    return 0;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Passkey Registration Flag
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether the user has a registered passkey (localStorage flag).
+ *
+ * This is a client-side cache — the server is the source of truth, but
+ * this avoids a network call on every page load.
+ *
+ * @returns `true` if the user has previously registered a passkey.
+ */
+export function hasRegisteredPasskey(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY_HAS_PASSKEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Mark that the user has successfully registered a passkey.
+ */
+export function setHasRegisteredPasskey(): void {
+  try {
+    localStorage.setItem(STORAGE_KEY_HAS_PASSKEY, 'true');
+  } catch {
+    // localStorage unavailable — silently fail
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Derived Logic
+// ---------------------------------------------------------------------------
+
+/**
+ * Determine whether the passkey setup prompt should be shown right now.
+ *
+ * The prompt is shown when:
+ *   1. The user hasn't already registered a passkey.
+ *   2. The prompt state is `'show'`, OR the state is `'remind'` and
+ *      the login count has reached the threshold.
+ *   3. The prompt state is NOT `'skipped'`.
+ *
+ * @returns `true` if the prompt should be displayed.
+ */
+export function shouldShowPasskeyPrompt(): boolean {
+  if (hasRegisteredPasskey()) {
+    return false;
+  }
+
+  const state = getPasskeyPromptState();
+
+  if (state === 'skipped') {
+    return false;
+  }
+
+  if (state === 'remind') {
+    return getLoginCount() >= REMIND_AFTER_LOGINS;
+  }
+
+  // state === 'show'
+  return true;
+}
+
+/**
+ * Clear all passkey preference data from localStorage.
+ * Useful for logout / account deletion.
+ */
+export function clearPasskeyPreferences(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY_PROMPT_STATE);
+    localStorage.removeItem(STORAGE_KEY_LOGIN_COUNT);
+    localStorage.removeItem(STORAGE_KEY_HAS_PASSKEY);
+  } catch {
+    // localStorage unavailable — silently fail
+  }
+}

--- a/apps/web/src/pages/LoginPage.test.tsx
+++ b/apps/web/src/pages/LoginPage.test.tsx
@@ -16,10 +16,20 @@ const authState = vi.hoisted(() => ({
   user: null,
   webAuthnSupported: true,
   isDemoMode: false,
+  showPasskeyPrompt: false,
+  dismissPasskeyPrompt: vi.fn(),
 }));
 
 vi.mock('../auth/auth-context', () => ({
   useAuth: () => authState,
+}));
+
+vi.mock('../components/auth/PasskeySetupPrompt', () => ({
+  PasskeySetupPrompt: () => null,
+}));
+
+vi.mock('../lib/passkey-preferences', () => ({
+  hasRegisteredPasskey: () => false,
 }));
 
 vi.mock('react-router-dom', async () => {
@@ -44,6 +54,8 @@ describe('LoginPage', () => {
     authState.error = null;
     authState.user = null;
     authState.webAuthnSupported = true;
+    authState.showPasskeyPrompt = false;
+    authState.dismissPasskeyPrompt.mockReset();
     navigateMock.mockReset();
   });
 

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -4,7 +4,9 @@ import React, { useEffect, useId, useRef, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
 import { useAuth } from '../auth/auth-context';
+import { PasskeySetupPrompt } from '../components/auth/PasskeySetupPrompt';
 import { LoadingSpinner } from '../components/common/LoadingSpinner';
+import { hasRegisteredPasskey } from '../lib/passkey-preferences';
 import { loginSchema } from '../lib/validation';
 
 import '../components/forms/forms.css';
@@ -29,12 +31,17 @@ export const LoginPage: React.FC = () => {
     error,
     webAuthnSupported,
     isDemoMode,
+    showPasskeyPrompt,
+    dismissPasskeyPrompt,
   } = useAuth();
 
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [fieldErrors, setFieldErrors] = useState<LoginFieldErrors>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  /** Whether the user has a passkey registered (drives layout priority). */
+  const passkeyPrimary = webAuthnSupported && hasRegisteredPasskey();
 
   const uid = useId();
   const emailId = `${uid}-email`;
@@ -152,6 +159,32 @@ export const LoginPage: React.FC = () => {
           </div>
         )}
 
+        {/* ── Passkey-first layout: biometric primary when passkey exists ── */}
+        {passkeyPrimary && (
+          <div className="auth-actions" style={{ marginBottom: 'var(--spacing-4)' }}>
+            <button
+              type="button"
+              className="auth-submit"
+              onClick={handlePasskeyLogin}
+              disabled={isBusy}
+              aria-busy={isBusy}
+            >
+              {isBusy ? (
+                <>
+                  <LoadingSpinner size={20} label="Signing in" />
+                  <span>Signing in...</span>
+                </>
+              ) : (
+                '🔐 Sign in with biometrics'
+              )}
+            </button>
+
+            <div className="auth-divider" aria-hidden="true">
+              <span className="auth-divider__text">or sign in with email</span>
+            </div>
+          </div>
+        )}
+
         <form className="auth-form" onSubmit={handleEmailLogin} aria-label="Sign in" noValidate>
           <div className="form-fields">
             <div className="form-group">
@@ -218,8 +251,17 @@ export const LoginPage: React.FC = () => {
           </div>
 
           <div className="auth-actions">
-            <button type="submit" className="auth-submit" disabled={isBusy} aria-busy={isBusy}>
-              {isBusy ? (
+            <button
+              type="submit"
+              className={
+                passkeyPrimary
+                  ? 'form-button form-button--secondary auth-passkey-button'
+                  : 'auth-submit'
+              }
+              disabled={isBusy}
+              aria-busy={isBusy}
+            >
+              {isBusy && !passkeyPrimary ? (
                 <>
                   <LoadingSpinner size={20} label="Signing in" />
                   <span>Signing in...</span>
@@ -229,7 +271,8 @@ export const LoginPage: React.FC = () => {
               )}
             </button>
 
-            {webAuthnSupported ? (
+            {/* Show passkey as secondary when no passkey registered yet */}
+            {webAuthnSupported && !passkeyPrimary ? (
               <>
                 <div className="auth-divider" aria-hidden="true">
                   <span className="auth-divider__text">or</span>
@@ -331,6 +374,9 @@ export const LoginPage: React.FC = () => {
           </Link>
         </p>
       </section>
+
+      {/* Passkey setup prompt modal */}
+      <PasskeySetupPrompt isOpen={showPasskeyPrompt} onClose={dismissPasskeyPrompt} />
     </main>
   );
 };


### PR DESCRIPTION
## Summary

Implements passkey-first authentication: prompts biometric setup after signup, reorders login page to show passkey as primary when available.

## Changes

- **PasskeySetupPrompt modal** — appears after first login/signup with platform-aware messaging (Windows Hello, Touch ID, Face ID, biometrics). Three actions: Set Up Now (calls registerPasskey), Remind Me Later (re-prompts after 3 logins), Skip (never prompt again).
- **Login page reordered** — when user has a registered passkey, biometric sign-in becomes the primary (large) button, email/password becomes secondary.
- **Passkey preference tracking** (\passkey-preferences.ts\) — localStorage-based state management for prompt state, login count, and registration flag.
- **Auth context integration** — \showPasskeyPrompt\ and \dismissPasskeyPrompt\ exposed via context; trigger logic fires after successful login/signup.
- **Accessible modal** — ARIA dialog with focus trapping, keyboard support (Escape), proper labelling, reduced motion/high contrast support.

## New Files

| File | Purpose |
|------|---------|
| \components/auth/PasskeySetupPrompt.tsx\ | Modal component with platform detection |
| \components/auth/passkey-setup-prompt.css\ | Modal styles with dark mode, responsive, a11y |
| \lib/passkey-preferences.ts\ | localStorage preference tracking |
| \lib/passkey-preferences.test.ts\ | 14 unit tests for preference logic |
| \components/auth/PasskeySetupPrompt.test.tsx\ | 10 render tests for the prompt |

## Modified Files

| File | Change |
|------|--------|
| \uth/auth-context.tsx\ | Added showPasskeyPrompt state, dismissPasskeyPrompt callback, triggerPasskeyPromptCheck after login/signup, setHasRegisteredPasskey on passkey registration |
| \pages/LoginPage.tsx\ | Passkey-first layout when passkey exists, PasskeySetupPrompt integration |
| \pages/LoginPage.test.tsx\ | Updated mocks for new auth context fields |

## Testing

- 29 tests pass (14 preference tracking + 10 prompt component + 5 login page)
- All existing tests (SignupPage, SettingsPage) continue to pass

## Issues

Closes #1445