### PR TITLE
fix(packages): resolve detekt code scanning alerts (#1557)

### DIFF
--- a/packages/core/src/commonMain/kotlin/com/finance/core/budget/BudgetRolloverCalculator.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/budget/BudgetRolloverCalculator.kt
@@ -103,7 +103,7 @@ object BudgetRolloverCalculator {
      */
     fun calculateEffectiveBudget(
         budget: Budget,
-        currentPeriodTransactions: List<Transaction>,
+        @Suppress("unused") currentPeriodTransactions: List<Transaction>,
         previousPeriodTransactions: List<Transaction>,
         referenceDate: LocalDate,
     ): EffectiveBudget {

--- a/packages/core/src/commonMain/kotlin/com/finance/core/featureflags/FeatureFlagSyncManager.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/featureflags/FeatureFlagSyncManager.kt
@@ -102,14 +102,15 @@ class FeatureFlagSyncManager(
             return (cached.value as? FeatureFlagValue.BooleanValue)?.value ?: default
         }
 
-        val flag = provider.getFlag(key) ?: return default
-        val result = evaluateWithRollout(flag, context, default)
-        val flagValue = FeatureFlagValue.BooleanValue(result)
-
-        // Cache the evaluation.
-        _cache.value = _cache.value + (key to CachedFlagResult(key, flagValue, clock.now()))
-
-        return result
+        val flag = provider.getFlag(key)
+        return if (flag != null) {
+            evaluateWithRollout(flag, context, default).also { result ->
+                val flagValue = FeatureFlagValue.BooleanValue(result)
+                _cache.value = _cache.value + (key to CachedFlagResult(key, flagValue, clock.now()))
+            }
+        } else {
+            default
+        }
     }
 
     /**
@@ -119,16 +120,12 @@ class FeatureFlagSyncManager(
      * @param context Evaluation context.
      * @return The resolved value, or `null` if the flag is unknown.
      */
-    fun evaluate(key: FeatureFlagKey, context: EvaluationContext): FeatureFlagValue? {
-        val cached = _cache.value[key]
-        if (cached != null) return cached.value
-
-        val flag = provider.getFlag(key) ?: return null
-        val value = FeatureFlagEngine.evaluate(flag, context)
-
-        _cache.value = _cache.value + (key to CachedFlagResult(key, value, clock.now()))
-        return value
-    }
+    fun evaluate(key: FeatureFlagKey, context: EvaluationContext): FeatureFlagValue? =
+        _cache.value[key]?.value ?: provider.getFlag(key)?.let { flag ->
+            val value = FeatureFlagEngine.evaluate(flag, context)
+            _cache.value = _cache.value + (key to CachedFlagResult(key, value, clock.now()))
+            value
+        }
 
     /**
      * Observe a boolean flag reactively. Emits a new value whenever the
@@ -167,24 +164,25 @@ class FeatureFlagSyncManager(
      * If the flag is disabled, returns [default]. Otherwise evaluates targeting rules,
      * then checks rollout percentage if present.
      */
-    private fun evaluateWithRollout(flag: FeatureFlag, context: EvaluationContext, default: Boolean): Boolean {
-        if (!flag.enabled) return default
-
-        // Standard targeting-rule evaluation.
-        val baseResult = FeatureFlagEngine.evaluateBoolean(flag, context, default)
-
-        // If the flag didn't match any rule and returned the default, skip rollout.
-        if (!baseResult) return false
-
-        // Check for rollout percentage in context attributes.
-        val rolloutAttr = context.getAttribute("rolloutPercentage")
-        val userId = context.getAttribute("userId")
-
-        if (rolloutAttr != null && userId != null) {
-            val percentage = rolloutAttr.toIntOrNull() ?: return baseResult
-            return RolloutEvaluator.isInRollout(userId, flag.key.value, percentage)
+    private fun evaluateWithRollout(
+        flag: FeatureFlag,
+        context: EvaluationContext,
+        default: Boolean,
+    ): Boolean = when {
+        !flag.enabled -> default
+        else -> {
+            val baseResult = FeatureFlagEngine.evaluateBoolean(flag, context, default)
+            if (!baseResult) {
+                false
+            } else {
+                val percentage = context.getAttribute("rolloutPercentage")?.toIntOrNull()
+                val userId = context.getAttribute("userId")
+                if (percentage != null && userId != null) {
+                    RolloutEvaluator.isInRollout(userId, flag.key.value, percentage)
+                } else {
+                    baseResult
+                }
+            }
         }
-
-        return baseResult
     }
 }

--- a/packages/core/src/commonMain/kotlin/com/finance/core/featureflags/RolloutEvaluator.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/featureflags/RolloutEvaluator.kt
@@ -25,11 +25,11 @@ object RolloutEvaluator {
         require(rolloutPercentage in 0..100) {
             "rolloutPercentage must be 0-100, was $rolloutPercentage"
         }
-        if (rolloutPercentage == 0) return false
-        if (rolloutPercentage == 100) return true
-
-        val bucket = computeBucket(userId, flagKey)
-        return bucket < rolloutPercentage
+        return when (rolloutPercentage) {
+            0 -> false
+            100 -> true
+            else -> computeBucket(userId, flagKey) < rolloutPercentage
+        }
     }
 
     /**

--- a/packages/core/src/commonTest/kotlin/com/finance/core/RecurringBillDueDateTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/RecurringBillDueDateTest.kt
@@ -15,6 +15,7 @@ import kotlin.test.*
  * calculation, month-end edge cases, leap year handling, end date
  * boundaries, recurring rule linking, and bill reminder scheduling.
  */
+@Suppress("LargeClass") // Test suite intentionally groups all recurring-bill scenarios for discoverability
 class RecurringBillDueDateTest {
 
     @BeforeTest

--- a/packages/core/src/commonTest/kotlin/com/finance/core/prediction/WatchlistPredictiveBalanceTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/prediction/WatchlistPredictiveBalanceTest.kt
@@ -17,6 +17,7 @@ import kotlin.test.*
  *
  * Covers issue #1376.
  */
+@Suppress("LargeClass") // Test suite intentionally groups all predictive-balance scenarios for discoverability
 class WatchlistPredictiveBalanceTest {
 
     @BeforeTest

--- a/packages/sync/src/commonTest/kotlin/com/finance/sync/powersync/SyncConflictResolutionTest.kt
+++ b/packages/sync/src/commonTest/kotlin/com/finance/sync/powersync/SyncConflictResolutionTest.kt
@@ -31,6 +31,7 @@ class SyncConflictResolutionTest {
 
     // ── Helper ──────────────────────────────────────────────────
 
+    @Suppress("LongParameterList") // Test helper — many defaults make call-sites concise
     private fun conflict(
         tableName: String = "transactions",
         recordId: String = "rec-1",

--- a/packages/sync/src/jsMain/kotlin/com/finance/sync/crypto/KeyDerivation.js.kt
+++ b/packages/sync/src/jsMain/kotlin/com/finance/sync/crypto/KeyDerivation.js.kt
@@ -120,7 +120,7 @@ actual class PlatformKeyDerivation actual constructor() {
             val block = u.copyOf()
 
             // U2 .. Uc: accumulate XOR
-            for (_j in 2..iterations) {
+            repeat(iterations - 1) {
                 u = hmacSha256WithPaddedKey(ipadKey, opadKey, u)
                 for (k in block.indices) {
                     block[k] = (block[k].toInt() xor u[k].toInt()).toByte()


### PR DESCRIPTION
## Summary
Fix 9 detekt code scanning alerts in shared packages (core, sync).

## Changes
- **ReturnCount** (alerts #3682-#3684): Refactor FeatureFlagSyncManager.isEnabled, .evaluate, and .evaluateWithRollout to use expression bodies and when expressions, reducing return count to ≤2
- **ReturnCount** (alert #3681): Refactor RolloutEvaluator.isInRollout to use when expression
- **UnusedParameter** (alert #3680): Suppress unused currentPeriodTransactions in BudgetRolloverCalculator.calculateEffectiveBudget (kept for API stability)
- **UnusedPrivateProperty** (alert #3675): Replace unused loop variable _j with epeat() in KeyDerivation.js.kt`n- **LargeClass** (alerts #3685, #3687): Add @Suppress("LargeClass") to RecurringBillDueDateTest and WatchlistPredictiveBalanceTest — splitting would reduce test readability
- **LongParameterList** (alert #3686): Add @Suppress("LongParameterList") to SyncConflictResolutionTest.conflict() helper

Closes #1557