### PR TITLE
feat(web): add privacy dashboard, consent management, and local-only onboarding (#1641, #1636, #1612, #1621)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -26,6 +26,7 @@ const PAGE_TITLES: Record<string, string> = {
   '/settings': 'Settings',
   '/import': 'Import',
   '/import/wizard': 'Import Wizard',
+  '/privacy-dashboard': 'Privacy Dashboard',
 };
 
 /** Routes that are wrapped in AppLayout (authenticated main app pages). */
@@ -46,6 +47,7 @@ const AUTHENTICATED_ROUTES = new Set([
   '/settings',
   '/import',
   '/import/wizard',
+  '/privacy-dashboard',
 ]);
 
 /**

--- a/apps/web/src/components/gdpr/ConsentHistoryViewer.tsx
+++ b/apps/web/src/components/gdpr/ConsentHistoryViewer.tsx
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * ConsentHistoryViewer — displays a timeline of consent changes.
+ *
+ * Shows when each consent category was granted or withdrawn with
+ * timestamps, providing transparent proof of consent decisions.
+ *
+ * References: issue #1641 (granular consent management with proof)
+ */
+
+import React, { useCallback, useState } from 'react';
+import { useConsentHistory } from '../../hooks/useConsentHistory';
+import { CONSENT_LABELS, type ConsentCategory } from '../../lib/consent-storage';
+import type { ConsentEvent } from '../../lib/consent-history';
+import './consent-history.css';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Human-readable method label. */
+const METHOD_LABELS: Record<ConsentEvent['method'], string> = {
+  first_run: 'First Run',
+  settings: 'Settings',
+  banner: 'Consent Banner',
+  dashboard: 'Privacy Dashboard',
+  bulk: 'Bulk Action',
+};
+
+/** Format a date for display. */
+function formatDate(iso: string): string {
+  try {
+    const date = new Date(iso);
+    return date.toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export interface ConsentHistoryViewerProps {
+  /** Optional filter to show only specific categories. */
+  readonly filterCategory?: ConsentCategory;
+}
+
+/** Timeline view of consent changes with export capability. */
+export const ConsentHistoryViewer: React.FC<ConsentHistoryViewerProps> = ({ filterCategory }) => {
+  const { history, exportHistory } = useConsentHistory();
+  const [exportMessage, setExportMessage] = useState<string | null>(null);
+
+  const filteredHistory = filterCategory
+    ? history.filter((e) => e.category === filterCategory)
+    : history;
+
+  const handleExport = useCallback(() => {
+    try {
+      const data = exportHistory();
+      const blob = new Blob([data], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = `consent-history-${new Date().toISOString().slice(0, 10)}.json`;
+      anchor.style.display = 'none';
+      document.body.appendChild(anchor);
+      anchor.click();
+      setTimeout(() => {
+        URL.revokeObjectURL(url);
+        document.body.removeChild(anchor);
+      }, 100);
+      setExportMessage('Consent history exported successfully.');
+      setTimeout(() => setExportMessage(null), 4000);
+    } catch {
+      setExportMessage('Failed to export consent history.');
+    }
+  }, [exportHistory]);
+
+  return (
+    <section className="consent-history" aria-label="Consent history">
+      <div className="consent-history__header">
+        <h3 className="consent-history__title">Consent History</h3>
+        <button
+          type="button"
+          className="consent-history__export-btn"
+          onClick={handleExport}
+          aria-label="Export consent history as JSON"
+        >
+          Export History
+        </button>
+      </div>
+
+      {exportMessage && (
+        <div role="status" aria-live="polite" className="consent-history__status">
+          {exportMessage}
+        </div>
+      )}
+
+      {filteredHistory.length === 0 ? (
+        <p className="consent-history__empty">No consent changes recorded yet.</p>
+      ) : (
+        <ol className="consent-history__timeline" role="list" aria-label="Consent change timeline">
+          {filteredHistory.map((event) => (
+            <li
+              key={event.id}
+              className={`consent-history__event ${
+                event.granted
+                  ? 'consent-history__event--granted'
+                  : 'consent-history__event--withdrawn'
+              }`}
+              role="listitem"
+              aria-label={`${CONSENT_LABELS[event.category]} ${event.granted ? 'granted' : 'withdrawn'} on ${formatDate(event.timestamp)}`}
+            >
+              <span className="consent-history__event-indicator" aria-hidden="true">
+                {event.granted ? '✓' : '✕'}
+              </span>
+              <div className="consent-history__event-content">
+                <div className="consent-history__event-header">
+                  <span className="consent-history__event-category">
+                    {CONSENT_LABELS[event.category]}
+                  </span>
+                  <span
+                    className={`consent-history__event-badge ${
+                      event.granted
+                        ? 'consent-history__event-badge--granted'
+                        : 'consent-history__event-badge--withdrawn'
+                    }`}
+                  >
+                    {event.granted ? 'Granted' : 'Withdrawn'}
+                  </span>
+                </div>
+                <div className="consent-history__event-meta">
+                  <time dateTime={event.timestamp} className="consent-history__event-time">
+                    {formatDate(event.timestamp)}
+                  </time>
+                  <span className="consent-history__event-method">
+                    via {METHOD_LABELS[event.method]}
+                  </span>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ol>
+      )}
+    </section>
+  );
+};
+
+export default ConsentHistoryViewer;

--- a/apps/web/src/components/gdpr/PrivacyGate.test.tsx
+++ b/apps/web/src/components/gdpr/PrivacyGate.test.tsx
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for PrivacyGate component.
+ *
+ * Tests that features are gated behind consent with proper
+ * privacy explainers shown when consent is not granted.
+ *
+ * References: issue #1612
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PrivacyGate } from './PrivacyGate';
+import { useConsent } from '../../hooks/useConsent';
+import { useConsentHistory } from '../../hooks/useConsentHistory';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../../hooks/useConsent', () => ({
+  useConsent: vi.fn(),
+}));
+
+vi.mock('../../hooks/useConsentHistory', () => ({
+  useConsentHistory: vi.fn(),
+}));
+
+const mockedUseConsent = vi.mocked(useConsent);
+const mockedUseConsentHistory = vi.mocked(useConsentHistory);
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+const defaultConsentHistoryReturn = {
+  history: [],
+  loading: false,
+  recordChange: vi.fn(),
+  recordBulkChanges: vi.fn(),
+  exportHistory: vi.fn(),
+  clearHistory: vi.fn(),
+  refresh: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedUseConsentHistory.mockReturnValue(defaultConsentHistoryReturn);
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PrivacyGate', () => {
+  it('renders children when consent is granted', () => {
+    mockedUseConsent.mockReturnValue({
+      consent: {
+        categories: {
+          essential: true,
+          analytics: true,
+          error_reporting: false,
+          sync: false,
+          marketing: false,
+        },
+        timestamp: '',
+        policyVersion: '1.0.0',
+        method: 'settings',
+        hasCompletedFirstRun: true,
+      },
+      needsConsent: false,
+      hasCompleted: true,
+      updateCategory: vi.fn(),
+      acceptAll: vi.fn(),
+      rejectAll: vi.fn(),
+      savePreferences: vi.fn(),
+      refresh: vi.fn(),
+    });
+
+    render(
+      <PrivacyGate
+        requiredConsent="analytics"
+        featureName="Analytics Dashboard"
+        featureDescription="View usage stats."
+      >
+        <div data-testid="gated-content">Analytics Content</div>
+      </PrivacyGate>,
+    );
+
+    expect(screen.getByTestId('gated-content')).toBeDefined();
+  });
+
+  it('shows privacy explainer when consent is not granted', () => {
+    mockedUseConsent.mockReturnValue({
+      consent: {
+        categories: {
+          essential: true,
+          analytics: false,
+          error_reporting: false,
+          sync: false,
+          marketing: false,
+        },
+        timestamp: '',
+        policyVersion: '1.0.0',
+        method: 'settings',
+        hasCompletedFirstRun: true,
+      },
+      needsConsent: false,
+      hasCompleted: true,
+      updateCategory: vi.fn(),
+      acceptAll: vi.fn(),
+      rejectAll: vi.fn(),
+      savePreferences: vi.fn(),
+      refresh: vi.fn(),
+    });
+
+    render(
+      <PrivacyGate
+        requiredConsent="analytics"
+        featureName="Analytics Dashboard"
+        featureDescription="View usage statistics."
+        dataNeeded={['Usage patterns', 'Page views']}
+      >
+        <div data-testid="gated-content">Analytics Content</div>
+      </PrivacyGate>,
+    );
+
+    expect(screen.queryByTestId('gated-content')).toBeNull();
+    expect(screen.getByText('Analytics Dashboard')).toBeDefined();
+    expect(screen.getByText('View usage statistics.')).toBeDefined();
+    expect(screen.getByText('Usage patterns')).toBeDefined();
+    expect(screen.getByText('Page views')).toBeDefined();
+  });
+
+  it('shows custom fallback when provided', () => {
+    mockedUseConsent.mockReturnValue({
+      consent: {
+        categories: {
+          essential: true,
+          analytics: false,
+          error_reporting: false,
+          sync: false,
+          marketing: false,
+        },
+        timestamp: '',
+        policyVersion: '1.0.0',
+        method: 'settings',
+        hasCompletedFirstRun: true,
+      },
+      needsConsent: false,
+      hasCompleted: true,
+      updateCategory: vi.fn(),
+      acceptAll: vi.fn(),
+      rejectAll: vi.fn(),
+      savePreferences: vi.fn(),
+      refresh: vi.fn(),
+    });
+
+    render(
+      <PrivacyGate
+        requiredConsent="analytics"
+        featureName="Analytics"
+        featureDescription="Stats"
+        fallback={<div data-testid="custom-fallback">Custom Gate UI</div>}
+      >
+        <div>Content</div>
+      </PrivacyGate>,
+    );
+
+    expect(screen.getByTestId('custom-fallback')).toBeDefined();
+  });
+
+  it('calls updateCategory when enable button is clicked', () => {
+    const updateCategory = vi.fn();
+    mockedUseConsent.mockReturnValue({
+      consent: {
+        categories: {
+          essential: true,
+          analytics: false,
+          error_reporting: false,
+          sync: false,
+          marketing: false,
+        },
+        timestamp: '',
+        policyVersion: '1.0.0',
+        method: 'settings',
+        hasCompletedFirstRun: true,
+      },
+      needsConsent: false,
+      hasCompleted: true,
+      updateCategory,
+      acceptAll: vi.fn(),
+      rejectAll: vi.fn(),
+      savePreferences: vi.fn(),
+      refresh: vi.fn(),
+    });
+
+    render(
+      <PrivacyGate requiredConsent="analytics" featureName="Analytics" featureDescription="Stats">
+        <div>Content</div>
+      </PrivacyGate>,
+    );
+
+    const enableBtn = screen.getByRole('button', { name: /enable analytics/i });
+    fireEvent.click(enableBtn);
+    expect(updateCategory).toHaveBeenCalledWith('analytics', true);
+  });
+
+  it('records consent change in history when enabling', () => {
+    const recordChange = vi.fn();
+    mockedUseConsent.mockReturnValue({
+      consent: {
+        categories: {
+          essential: true,
+          sync: false,
+          analytics: false,
+          error_reporting: false,
+          marketing: false,
+        },
+        timestamp: '',
+        policyVersion: '1.0.0',
+        method: 'settings',
+        hasCompletedFirstRun: true,
+      },
+      needsConsent: false,
+      hasCompleted: true,
+      updateCategory: vi.fn(),
+      acceptAll: vi.fn(),
+      rejectAll: vi.fn(),
+      savePreferences: vi.fn(),
+      refresh: vi.fn(),
+    });
+    mockedUseConsentHistory.mockReturnValue({
+      ...defaultConsentHistoryReturn,
+      recordChange,
+    });
+
+    render(
+      <PrivacyGate requiredConsent="sync" featureName="Cloud Sync" featureDescription="Sync data.">
+        <div>Content</div>
+      </PrivacyGate>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /enable cloud sync/i }));
+    expect(recordChange).toHaveBeenCalledWith('sync', true, 'dashboard');
+  });
+});

--- a/apps/web/src/components/gdpr/PrivacyGate.tsx
+++ b/apps/web/src/components/gdpr/PrivacyGate.tsx
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * PrivacyGate — gates features behind consent with privacy-first disclosure.
+ *
+ * Wraps features that require specific consent categories. When the user
+ * has not consented, shows a privacy explainer describing what data the
+ * feature needs, instead of a blocked/empty UI.
+ *
+ * This implements progressive disclosure: users see what data a feature
+ * needs before deciding to enable it.
+ *
+ * Usage:
+ * ```tsx
+ * <PrivacyGate
+ *   requiredConsent="sync"
+ *   featureName="Cloud Sync"
+ *   featureDescription="Sync data across devices."
+ *   dataNeeded={['Account data', 'Transaction history']}
+ * >
+ *   <SyncSettings />
+ * </PrivacyGate>
+ * ```
+ *
+ * References: issue #1612 (cross-platform app privacy shell)
+ */
+
+import React, { useCallback } from 'react';
+import type { ReactNode } from 'react';
+import { useConsent } from '../../hooks/useConsent';
+import { useConsentHistory } from '../../hooks/useConsentHistory';
+import {
+  CONSENT_LABELS,
+  CONSENT_DESCRIPTIONS,
+  type ConsentCategory,
+} from '../../lib/consent-storage';
+import './privacy-gate.css';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface PrivacyGateProps {
+  /** The consent category required to access this feature. */
+  readonly requiredConsent: ConsentCategory;
+  /** Human-readable feature name. */
+  readonly featureName: string;
+  /** Description of the feature for the privacy explainer. */
+  readonly featureDescription: string;
+  /** List of data types this feature accesses. */
+  readonly dataNeeded?: readonly string[];
+  /** Content to render when consent is granted. */
+  readonly children: ReactNode;
+  /** Optional custom fallback when consent is not granted. */
+  readonly fallback?: ReactNode;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/** Gates a feature behind consent with a privacy-first explainer. */
+export const PrivacyGate: React.FC<PrivacyGateProps> = ({
+  requiredConsent,
+  featureName,
+  featureDescription,
+  dataNeeded = [],
+  children,
+  fallback,
+}) => {
+  const { consent, updateCategory } = useConsent();
+  const { recordChange } = useConsentHistory();
+  const isGranted = consent.categories[requiredConsent];
+
+  const handleEnable = useCallback(() => {
+    updateCategory(requiredConsent, true);
+    recordChange(requiredConsent, true, 'dashboard');
+  }, [requiredConsent, updateCategory, recordChange]);
+
+  if (isGranted) {
+    return <>{children}</>;
+  }
+
+  // Custom fallback takes precedence
+  if (fallback) {
+    return <>{fallback}</>;
+  }
+
+  // Default privacy explainer
+  return (
+    <section className="privacy-gate" aria-label={`${featureName} requires consent`}>
+      <div className="privacy-gate__card">
+        <div className="privacy-gate__icon" aria-hidden="true">
+          🔒
+        </div>
+
+        <h3 className="privacy-gate__title">{featureName}</h3>
+
+        <p className="privacy-gate__description">{featureDescription}</p>
+
+        <div className="privacy-gate__consent-info">
+          <h4 className="privacy-gate__consent-label">Requires:</h4>
+          <p className="privacy-gate__consent-name">{CONSENT_LABELS[requiredConsent]}</p>
+          <p className="privacy-gate__consent-description">
+            {CONSENT_DESCRIPTIONS[requiredConsent]}
+          </p>
+        </div>
+
+        {dataNeeded.length > 0 && (
+          <div className="privacy-gate__data-section">
+            <h4 className="privacy-gate__data-title">Data this feature accesses:</h4>
+            <ul className="privacy-gate__data-list" role="list">
+              {dataNeeded.map((item) => (
+                <li key={item} className="privacy-gate__data-item" role="listitem">
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <button
+          type="button"
+          className="privacy-gate__enable-btn"
+          onClick={handleEnable}
+          aria-label={`Enable ${CONSENT_LABELS[requiredConsent]} to use ${featureName}`}
+        >
+          Enable {CONSENT_LABELS[requiredConsent]}
+        </button>
+
+        <p className="privacy-gate__revoke-note">
+          You can withdraw consent at any time in Privacy Settings.
+        </p>
+      </div>
+    </section>
+  );
+};
+
+export default PrivacyGate;

--- a/apps/web/src/components/gdpr/consent-history.css
+++ b/apps/web/src/components/gdpr/consent-history.css
@@ -1,0 +1,187 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/* -------------------------------------------------------------------
+ * ConsentHistoryViewer component styles
+ *
+ * Timeline view of consent change events.
+ * ------------------------------------------------------------------- */
+
+.consent-history {
+  margin-top: var(--spacing-4);
+}
+
+.consent-history__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing-3);
+}
+
+.consent-history__title {
+  font-size: var(--type-scale-h3-font-size, 1.25rem);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-primary);
+  margin: 0;
+}
+
+.consent-history__export-btn {
+  padding: var(--spacing-1) var(--spacing-3);
+  border-radius: var(--border-radius-sm);
+  border: 1px solid var(--semantic-border-default);
+  background-color: var(--semantic-background-primary);
+  color: var(--semantic-interactive-default);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-medium, 500);
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.consent-history__export-btn:hover {
+  background-color: var(--semantic-background-secondary);
+}
+
+.consent-history__export-btn:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+}
+
+.consent-history__status {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-status-positive);
+  margin-bottom: var(--spacing-3);
+  padding: var(--spacing-2);
+  border-radius: var(--border-radius-sm);
+  background-color: var(--semantic-background-secondary);
+}
+
+.consent-history__empty {
+  font-size: var(--type-scale-body-font-size, 1rem);
+  color: var(--semantic-text-secondary);
+  text-align: center;
+  padding: var(--spacing-6) 0;
+}
+
+.consent-history__timeline {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.consent-history__event {
+  display: flex;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3);
+  border-left: 3px solid var(--semantic-border-default);
+  margin-bottom: var(--spacing-1);
+  transition: background-color 0.1s ease;
+}
+
+.consent-history__event:hover {
+  background-color: var(--semantic-background-secondary);
+}
+
+.consent-history__event--granted {
+  border-left-color: var(--semantic-status-positive);
+}
+
+.consent-history__event--withdrawn {
+  border-left-color: var(--semantic-status-negative);
+}
+
+.consent-history__event-indicator {
+  flex-shrink: 0;
+  width: 1.5rem;
+  height: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-bold, 700);
+}
+
+.consent-history__event--granted .consent-history__event-indicator {
+  background-color: var(--semantic-status-positive);
+  color: var(--semantic-text-inverse, #fff);
+}
+
+.consent-history__event--withdrawn .consent-history__event-indicator {
+  background-color: var(--semantic-status-negative);
+  color: var(--semantic-text-inverse, #fff);
+}
+
+.consent-history__event-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.consent-history__event-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing-1);
+}
+
+.consent-history__event-category {
+  font-size: var(--type-scale-body-font-size, 1rem);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-primary);
+}
+
+.consent-history__event-badge {
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-medium, 500);
+  padding: var(--spacing-0, 2px) var(--spacing-2);
+  border-radius: var(--border-radius-sm);
+}
+
+.consent-history__event-badge--granted {
+  background-color: rgba(34, 197, 94, 0.12);
+  color: var(--semantic-status-positive);
+}
+
+.consent-history__event-badge--withdrawn {
+  background-color: rgba(239, 68, 68, 0.12);
+  color: var(--semantic-status-negative);
+}
+
+.consent-history__event-meta {
+  display: flex;
+  gap: var(--spacing-2);
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+/* -------------------------------------------------------------------
+ * Reduced motion
+ * ------------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .consent-history__event,
+  .consent-history__export-btn {
+    transition: none;
+  }
+}
+
+/* -------------------------------------------------------------------
+ * Mobile
+ * ------------------------------------------------------------------- */
+
+@media (max-width: 480px) {
+  .consent-history__header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--spacing-2);
+  }
+
+  .consent-history__event-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--spacing-1);
+  }
+
+  .consent-history__event-meta {
+    flex-direction: column;
+    gap: var(--spacing-0, 2px);
+  }
+}

--- a/apps/web/src/components/gdpr/index.ts
+++ b/apps/web/src/components/gdpr/index.ts
@@ -2,7 +2,11 @@
 
 export { ConsentDialog } from './ConsentDialog';
 export type { ConsentDialogProps } from './ConsentDialog';
+export { ConsentHistoryViewer } from './ConsentHistoryViewer';
+export type { ConsentHistoryViewerProps } from './ConsentHistoryViewer';
 export { CrashReportingSettings } from './CrashReportingSettings';
 export type { CrashReportingSettingsProps } from './CrashReportingSettings';
+export { PrivacyGate } from './PrivacyGate';
+export type { PrivacyGateProps } from './PrivacyGate';
 export { PrivacySettings } from './PrivacySettings';
 export type { PrivacySettingsProps } from './PrivacySettings';

--- a/apps/web/src/components/gdpr/privacy-gate.css
+++ b/apps/web/src/components/gdpr/privacy-gate.css
@@ -1,0 +1,163 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/* -------------------------------------------------------------------
+ * PrivacyGate component styles
+ *
+ * Progressive disclosure UI for features gated behind consent.
+ * Uses design-token CSS custom properties throughout.
+ * ------------------------------------------------------------------- */
+
+.privacy-gate {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: var(--spacing-6);
+}
+
+.privacy-gate__card {
+  max-width: 480px;
+  width: 100%;
+  padding: var(--spacing-6);
+  border-radius: var(--card-border-radius, var(--border-radius-md));
+  border: 1px solid var(--semantic-border-default);
+  background-color: var(--semantic-background-elevated, var(--semantic-background-secondary));
+  box-shadow: var(--card-shadow, none);
+  text-align: center;
+}
+
+.privacy-gate__icon {
+  font-size: 2.5rem;
+  margin-bottom: var(--spacing-3);
+}
+
+.privacy-gate__title {
+  font-size: var(--type-scale-h3-font-size, 1.25rem);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-primary);
+  margin: 0 0 var(--spacing-2);
+}
+
+.privacy-gate__description {
+  font-size: var(--type-scale-body-font-size, 1rem);
+  color: var(--semantic-text-secondary);
+  margin: 0 0 var(--spacing-4);
+  line-height: 1.5;
+}
+
+.privacy-gate__consent-info {
+  padding: var(--spacing-3);
+  border-radius: var(--border-radius-sm);
+  background-color: var(--semantic-background-primary);
+  border: 1px solid var(--semantic-border-default);
+  margin-bottom: var(--spacing-4);
+  text-align: left;
+}
+
+.privacy-gate__consent-label {
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-secondary);
+  margin: 0 0 var(--spacing-1);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.privacy-gate__consent-name {
+  font-size: var(--type-scale-body-font-size, 1rem);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-primary);
+  margin: 0 0 var(--spacing-1);
+}
+
+.privacy-gate__consent-description {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+  margin: 0;
+  line-height: 1.4;
+}
+
+.privacy-gate__data-section {
+  text-align: left;
+  margin-bottom: var(--spacing-4);
+}
+
+.privacy-gate__data-title {
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-secondary);
+  margin: 0 0 var(--spacing-2);
+}
+
+.privacy-gate__data-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.privacy-gate__data-item {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+  padding: var(--spacing-1) 0;
+  padding-left: var(--spacing-3);
+  position: relative;
+}
+
+.privacy-gate__data-item::before {
+  content: '•';
+  position: absolute;
+  left: var(--spacing-1);
+  color: var(--semantic-interactive-default);
+}
+
+.privacy-gate__enable-btn {
+  display: inline-block;
+  padding: var(--spacing-2) var(--spacing-5);
+  border-radius: var(--border-radius-md);
+  border: none;
+  background-color: var(--semantic-interactive-default);
+  color: var(--semantic-text-inverse, #fff);
+  font-size: var(--type-scale-body-font-size, 1rem);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+  margin-bottom: var(--spacing-3);
+}
+
+.privacy-gate__enable-btn:hover {
+  background-color: var(--semantic-interactive-hover);
+}
+
+.privacy-gate__enable-btn:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+}
+
+.privacy-gate__revoke-note {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+  margin: 0;
+}
+
+/* -------------------------------------------------------------------
+ * Reduced motion
+ * ------------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .privacy-gate__enable-btn {
+    transition: none;
+  }
+}
+
+/* -------------------------------------------------------------------
+ * Mobile
+ * ------------------------------------------------------------------- */
+
+@media (max-width: 480px) {
+  .privacy-gate {
+    padding: var(--spacing-3);
+  }
+
+  .privacy-gate__card {
+    padding: var(--spacing-4);
+  }
+}

--- a/apps/web/src/hooks/index.ts
+++ b/apps/web/src/hooks/index.ts
@@ -151,3 +151,13 @@ export { useSpendingPace } from './useSpendingPace';
 export type { UseSpendingPaceResult } from './useSpendingPace';
 export { useTransactionConfirmation } from './useTransactionConfirmation';
 export type { UseTransactionConfirmationResult } from './useTransactionConfirmation';
+export { useConsentHistory } from './useConsentHistory';
+export type { UseConsentHistoryResult } from './useConsentHistory';
+export { useLocalOnlyMode } from './useLocalOnlyMode';
+export type { UseLocalOnlyModeResult } from './useLocalOnlyMode';
+export { usePrivacyDashboard } from './usePrivacyDashboard';
+export type {
+  UsePrivacyDashboardResult,
+  DataCategory,
+  StorageQuotaInfo,
+} from './usePrivacyDashboard';

--- a/apps/web/src/hooks/useConsentHistory.ts
+++ b/apps/web/src/hooks/useConsentHistory.ts
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * React hook for consent history with timestamped proof.
+ *
+ * Provides access to the consent audit log and actions for recording
+ * consent changes with full GDPR-compliant timestamping.
+ *
+ * Usage:
+ * ```tsx
+ * const { history, recordChange, exportHistory } = useConsentHistory();
+ * ```
+ *
+ * References: issue #1641 (granular consent management with proof)
+ */
+
+import { useCallback, useState } from 'react';
+import {
+  loadConsentHistory,
+  recordConsentChange,
+  recordBulkConsentChanges,
+  exportConsentHistory,
+  clearConsentHistory,
+  type ConsentEvent,
+} from '../lib/consent-history';
+import { CURRENT_POLICY_VERSION, type ConsentCategory } from '../lib/consent-storage';
+
+// ---------------------------------------------------------------------------
+// Public interface
+// ---------------------------------------------------------------------------
+
+/** Shape returned by {@link useConsentHistory}. */
+export interface UseConsentHistoryResult {
+  /** All consent change events, newest first. */
+  readonly history: ConsentEvent[];
+  /** Whether the history is loading. */
+  readonly loading: boolean;
+  /** Record a single consent change. */
+  readonly recordChange: (
+    category: ConsentCategory,
+    granted: boolean,
+    method?: ConsentEvent['method'],
+  ) => void;
+  /** Record multiple consent changes at once. */
+  readonly recordBulkChanges: (
+    changes: ReadonlyArray<{ category: ConsentCategory; granted: boolean }>,
+    method?: ConsentEvent['method'],
+  ) => void;
+  /** Export consent history as JSON string. */
+  readonly exportHistory: () => string;
+  /** Clear all history (for account deletion). */
+  readonly clearHistory: () => void;
+  /** Refresh history from storage. */
+  readonly refresh: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/** Manage consent history with timestamped proof. */
+export function useConsentHistory(): UseConsentHistoryResult {
+  const [history, setHistory] = useState<ConsentEvent[]>(() =>
+    loadConsentHistory().slice().reverse(),
+  );
+  const [loading] = useState(false);
+
+  const refresh = useCallback(() => {
+    setHistory(loadConsentHistory().slice().reverse());
+  }, []);
+
+  const recordChange = useCallback(
+    (category: ConsentCategory, granted: boolean, method: ConsentEvent['method'] = 'settings') => {
+      recordConsentChange(category, granted, method, CURRENT_POLICY_VERSION);
+      refresh();
+    },
+    [refresh],
+  );
+
+  const recordBulkChanges = useCallback(
+    (
+      changes: ReadonlyArray<{ category: ConsentCategory; granted: boolean }>,
+      method: ConsentEvent['method'] = 'bulk',
+    ) => {
+      recordBulkConsentChanges(changes, method, CURRENT_POLICY_VERSION);
+      refresh();
+    },
+    [refresh],
+  );
+
+  const doExportHistory = useCallback(() => {
+    return exportConsentHistory();
+  }, []);
+
+  const doClearHistory = useCallback(() => {
+    clearConsentHistory();
+    refresh();
+  }, [refresh]);
+
+  return {
+    history,
+    loading,
+    recordChange,
+    recordBulkChanges,
+    exportHistory: doExportHistory,
+    clearHistory: doClearHistory,
+    refresh,
+  };
+}

--- a/apps/web/src/hooks/useLocalOnlyMode.ts
+++ b/apps/web/src/hooks/useLocalOnlyMode.ts
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * React hook for local-only mode management.
+ *
+ * Tracks whether the user is operating in local-only mode (no account,
+ * no sync). Provides actions to enable/disable the mode and check
+ * feature availability.
+ *
+ * Usage:
+ * ```tsx
+ * const { isLocalOnly, enableLocalOnly, features } = useLocalOnlyMode();
+ * ```
+ *
+ * References: issue #1621 (local-only onboarding path)
+ */
+
+import { useCallback, useState } from 'react';
+import {
+  isLocalOnlyMode,
+  setLocalOnlyMode,
+  isOnboardingComplete,
+  setOnboardingComplete,
+  FEATURE_AVAILABILITY,
+  type FeatureAvailability,
+} from '../lib/local-only-mode';
+
+// ---------------------------------------------------------------------------
+// Public interface
+// ---------------------------------------------------------------------------
+
+/** Shape returned by {@link useLocalOnlyMode}. */
+export interface UseLocalOnlyModeResult {
+  /** Whether the user is in local-only mode. */
+  readonly isLocalOnly: boolean;
+  /** Whether the onboarding flow has been completed. */
+  readonly onboardingComplete: boolean;
+  /** Feature availability list for the current mode. */
+  readonly features: FeatureAvailability[];
+  /** Enable local-only mode. */
+  readonly enableLocalOnly: () => void;
+  /** Disable local-only mode (upgrade to account). */
+  readonly disableLocalOnly: () => void;
+  /** Mark onboarding as complete. */
+  readonly completeOnboarding: () => void;
+  /** Check if a specific feature is available in the current mode. */
+  readonly isFeatureAvailable: (featureId: string) => boolean;
+  /** Refresh state from storage. */
+  readonly refresh: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/** Manage local-only mode state. */
+export function useLocalOnlyMode(): UseLocalOnlyModeResult {
+  const [isLocalOnly, setIsLocalOnly] = useState(isLocalOnlyMode);
+  const [onboardingDone, setOnboardingDone] = useState(isOnboardingComplete);
+
+  const refresh = useCallback(() => {
+    setIsLocalOnly(isLocalOnlyMode());
+    setOnboardingDone(isOnboardingComplete());
+  }, []);
+
+  const enableLocalOnly = useCallback(() => {
+    setLocalOnlyMode(true);
+    setIsLocalOnly(true);
+  }, []);
+
+  const disableLocalOnly = useCallback(() => {
+    setLocalOnlyMode(false);
+    setIsLocalOnly(false);
+  }, []);
+
+  const completeOnboarding = useCallback(() => {
+    setOnboardingComplete(true);
+    setOnboardingDone(true);
+  }, []);
+
+  const isFeatureAvailable = useCallback(
+    (featureId: string): boolean => {
+      const feature = FEATURE_AVAILABILITY.find((f) => f.id === featureId);
+      if (!feature) return false;
+      if (isLocalOnly) return feature.availableLocalOnly;
+      return true;
+    },
+    [isLocalOnly],
+  );
+
+  return {
+    isLocalOnly,
+    onboardingComplete: onboardingDone,
+    features: FEATURE_AVAILABILITY,
+    enableLocalOnly,
+    disableLocalOnly,
+    completeOnboarding,
+    isFeatureAvailable,
+    refresh,
+  };
+}

--- a/apps/web/src/hooks/usePrivacyDashboard.ts
+++ b/apps/web/src/hooks/usePrivacyDashboard.ts
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * React hook for the Privacy Dashboard data inventory.
+ *
+ * Provides a breakdown of locally stored data categories, estimated
+ * storage usage, and descriptions of what data is stored for each
+ * category.
+ *
+ * Usage:
+ * ```tsx
+ * const { categories, totalStorageEstimate } = usePrivacyDashboard();
+ * ```
+ *
+ * References: issue #1636 (privacy dashboard with full data inventory)
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A data category stored locally. */
+export interface DataCategory {
+  /** Unique category identifier. */
+  readonly id: string;
+  /** Human-readable name. */
+  readonly name: string;
+  /** Description of what data is stored. */
+  readonly description: string;
+  /** Where the data is stored. */
+  readonly storageLocation: 'SQLite (OPFS)' | 'localStorage' | 'IndexedDB';
+  /** Whether this data ever leaves the device. */
+  readonly leavesDevice: boolean;
+  /** Condition under which data leaves the device (if applicable). */
+  readonly leavesDeviceCondition?: string;
+  /** Estimated storage in bytes (0 if not calculable). */
+  readonly estimatedBytes: number;
+  /** Icon name for the category. */
+  readonly icon: string;
+}
+
+/** Shape returned by {@link usePrivacyDashboard}. */
+export interface UsePrivacyDashboardResult {
+  /** Data categories with descriptions and storage info. */
+  readonly categories: DataCategory[];
+  /** Total estimated storage usage in bytes. */
+  readonly totalStorageEstimate: number;
+  /** Browser storage quota info (if available). */
+  readonly storageQuota: StorageQuotaInfo | null;
+  /** Whether data is loading. */
+  readonly loading: boolean;
+  /** Error message if estimation fails. */
+  readonly error: string | null;
+  /** Refresh storage estimates. */
+  readonly refresh: () => void;
+}
+
+/** Browser storage quota information. */
+export interface StorageQuotaInfo {
+  /** Total quota in bytes. */
+  readonly quota: number;
+  /** Currently used in bytes. */
+  readonly usage: number;
+  /** Usage as a percentage (0–100). */
+  readonly usagePercent: number;
+}
+
+// ---------------------------------------------------------------------------
+// Data category definitions
+// ---------------------------------------------------------------------------
+
+/** Static data category metadata. */
+const DATA_CATEGORY_DEFS: Omit<DataCategory, 'estimatedBytes'>[] = [
+  {
+    id: 'accounts',
+    name: 'Financial Accounts',
+    description:
+      'Bank accounts, credit cards, and cash accounts you track. Includes account names, types, balances, and currency settings.',
+    storageLocation: 'SQLite (OPFS)',
+    leavesDevice: false,
+    leavesDeviceCondition: 'Only if Cloud Sync is enabled',
+    icon: '🏦',
+  },
+  {
+    id: 'transactions',
+    name: 'Transactions',
+    description:
+      'Income and expense records with dates, amounts, categories, merchants, and notes. This is typically the largest data category.',
+    storageLocation: 'SQLite (OPFS)',
+    leavesDevice: false,
+    leavesDeviceCondition: 'Only if Cloud Sync is enabled',
+    icon: '💳',
+  },
+  {
+    id: 'budgets',
+    name: 'Budgets',
+    description:
+      'Monthly or custom-period budgets with spending limits per category. Tracks budget vs. actual spending.',
+    storageLocation: 'SQLite (OPFS)',
+    leavesDevice: false,
+    leavesDeviceCondition: 'Only if Cloud Sync is enabled',
+    icon: '📊',
+  },
+  {
+    id: 'goals',
+    name: 'Savings Goals',
+    description:
+      'Financial goals with target amounts, deadlines, and progress tracking. Links to funding accounts.',
+    storageLocation: 'SQLite (OPFS)',
+    leavesDevice: false,
+    leavesDeviceCondition: 'Only if Cloud Sync is enabled',
+    icon: '🎯',
+  },
+  {
+    id: 'categories',
+    name: 'Categories & Tags',
+    description:
+      'Custom spending categories and tags for organizing transactions. Includes auto-categorization rules.',
+    storageLocation: 'SQLite (OPFS)',
+    leavesDevice: false,
+    icon: '🏷️',
+  },
+  {
+    id: 'settings',
+    name: 'App Settings',
+    description:
+      'Your preferences: theme, currency, notification settings, privacy mode, and display options.',
+    storageLocation: 'localStorage',
+    leavesDevice: false,
+    icon: '⚙️',
+  },
+  {
+    id: 'consent',
+    name: 'Consent Records',
+    description:
+      'Timestamped records of your privacy consent choices. Required for GDPR compliance and your own audit trail.',
+    storageLocation: 'localStorage',
+    leavesDevice: false,
+    icon: '📋',
+  },
+  {
+    id: 'investments',
+    name: 'Investments',
+    description: 'Investment holdings, portfolio allocations, and performance history.',
+    storageLocation: 'SQLite (OPFS)',
+    leavesDevice: false,
+    leavesDeviceCondition: 'Only if Cloud Sync is enabled',
+    icon: '📈',
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Estimate localStorage usage for keys matching a prefix. */
+function estimateLocalStorageBytes(prefix: string): number {
+  try {
+    let total = 0;
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key && key.startsWith(prefix)) {
+        const value = localStorage.getItem(key);
+        // UTF-16: each character is 2 bytes
+        total += (key.length + (value?.length ?? 0)) * 2;
+      }
+    }
+    return total;
+  } catch {
+    return 0;
+  }
+}
+
+/** Estimate total localStorage usage. */
+function estimateTotalLocalStorageBytes(): number {
+  try {
+    let total = 0;
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key) {
+        const value = localStorage.getItem(key);
+        total += (key.length + (value?.length ?? 0)) * 2;
+      }
+    }
+    return total;
+  } catch {
+    return 0;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/** Privacy dashboard data inventory and storage usage. */
+export function usePrivacyDashboard(): UsePrivacyDashboardResult {
+  const [categories, setCategories] = useState<DataCategory[]>([]);
+  const [storageQuota, setStorageQuota] = useState<StorageQuotaInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshToken, setRefreshToken] = useState(0);
+
+  const refresh = useCallback(() => {
+    setRefreshToken((t) => t + 1);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function estimate() {
+      try {
+        setLoading(true);
+
+        // Estimate storage per category
+        const estimated: DataCategory[] = DATA_CATEGORY_DEFS.map((def) => {
+          let bytes = 0;
+
+          if (def.storageLocation === 'localStorage') {
+            if (def.id === 'consent') {
+              bytes =
+                estimateLocalStorageBytes('finance-gdpr-consent') +
+                estimateLocalStorageBytes('finance-consent-history');
+            } else if (def.id === 'settings') {
+              bytes =
+                estimateTotalLocalStorageBytes() -
+                estimateLocalStorageBytes('finance-gdpr-consent') -
+                estimateLocalStorageBytes('finance-consent-history');
+            }
+          }
+          // SQLite OPFS storage is estimated via the StorageManager API below.
+
+          return { ...def, estimatedBytes: bytes };
+        });
+
+        if (!cancelled) {
+          setCategories(estimated);
+        }
+
+        // Query browser StorageManager for quota info
+        if ('storage' in navigator && 'estimate' in navigator.storage) {
+          const est = await navigator.storage.estimate();
+          if (!cancelled && est.quota !== undefined && est.usage !== undefined) {
+            setStorageQuota({
+              quota: est.quota,
+              usage: est.usage,
+              usagePercent:
+                est.quota > 0 ? Math.round((est.usage / est.quota) * 100 * 100) / 100 : 0,
+            });
+          }
+        }
+
+        if (!cancelled) {
+          setLoading(false);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to estimate storage.');
+          setLoading(false);
+        }
+      }
+    }
+
+    void estimate();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshToken]);
+
+  const totalStorageEstimate = categories.reduce((sum, c) => sum + c.estimatedBytes, 0);
+
+  return {
+    categories,
+    totalStorageEstimate,
+    storageQuota,
+    loading,
+    error,
+    refresh,
+  };
+}

--- a/apps/web/src/lib/consent-history.test.ts
+++ b/apps/web/src/lib/consent-history.test.ts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for consent-history library.
+ *
+ * References: issue #1641
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  loadConsentHistory,
+  recordConsentChange,
+  recordBulkConsentChanges,
+  exportConsentHistory,
+  clearConsentHistory,
+} from './consent-history';
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('consent-history', () => {
+  describe('loadConsentHistory', () => {
+    it('returns empty array when no history exists', () => {
+      expect(loadConsentHistory()).toEqual([]);
+    });
+
+    it('returns empty array for invalid JSON', () => {
+      localStorage.setItem('finance-consent-history', 'not-json');
+      expect(loadConsentHistory()).toEqual([]);
+    });
+  });
+
+  describe('recordConsentChange', () => {
+    it('records a single consent change', () => {
+      const event = recordConsentChange('analytics', true, 'settings', '1.0.0');
+
+      expect(event.category).toBe('analytics');
+      expect(event.granted).toBe(true);
+      expect(event.method).toBe('settings');
+      expect(event.policyVersion).toBe('1.0.0');
+      expect(event.id).toBeDefined();
+      expect(event.timestamp).toBeDefined();
+    });
+
+    it('appends events to history', () => {
+      recordConsentChange('analytics', true, 'settings', '1.0.0');
+      recordConsentChange('sync', false, 'dashboard', '1.0.0');
+
+      const history = loadConsentHistory();
+      expect(history).toHaveLength(2);
+      expect(history[0].category).toBe('analytics');
+      expect(history[1].category).toBe('sync');
+    });
+  });
+
+  describe('recordBulkConsentChanges', () => {
+    it('records multiple changes at once', () => {
+      const events = recordBulkConsentChanges(
+        [
+          { category: 'analytics', granted: true },
+          { category: 'sync', granted: false },
+        ],
+        'bulk',
+        '1.0.0',
+      );
+
+      expect(events).toHaveLength(2);
+      expect(loadConsentHistory()).toHaveLength(2);
+    });
+
+    it('all events share the same timestamp', () => {
+      const events = recordBulkConsentChanges(
+        [
+          { category: 'analytics', granted: true },
+          { category: 'marketing', granted: true },
+        ],
+        'first_run',
+        '1.0.0',
+      );
+
+      expect(events[0].timestamp).toBe(events[1].timestamp);
+    });
+  });
+
+  describe('exportConsentHistory', () => {
+    it('exports history as JSON string', () => {
+      recordConsentChange('analytics', true, 'settings', '1.0.0');
+      const exported = exportConsentHistory();
+      const parsed = JSON.parse(exported);
+
+      expect(parsed.type).toBe('gdpr_consent_history');
+      expect(parsed.totalEvents).toBe(1);
+      expect(parsed.events).toHaveLength(1);
+      expect(parsed.exportedAt).toBeDefined();
+    });
+  });
+
+  describe('clearConsentHistory', () => {
+    it('removes all history', () => {
+      recordConsentChange('analytics', true, 'settings', '1.0.0');
+      expect(loadConsentHistory()).toHaveLength(1);
+
+      clearConsentHistory();
+      expect(loadConsentHistory()).toHaveLength(0);
+    });
+  });
+});

--- a/apps/web/src/lib/consent-history.ts
+++ b/apps/web/src/lib/consent-history.ts
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Consent History — timestamped audit log of all consent changes.
+ *
+ * Every consent change (grant or withdrawal) is recorded as an immutable
+ * event. This provides GDPR-compliant proof of consent with timestamps
+ * and supports the consent history viewer in the Privacy Dashboard.
+ *
+ * Storage: localStorage (same as consent-storage.ts — no server needed).
+ *
+ * References: issue #1641 (granular consent management with proof)
+ */
+
+import type { ConsentCategory } from './consent-storage';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A single consent change event. */
+export interface ConsentEvent {
+  /** Unique event ID. */
+  readonly id: string;
+  /** ISO-8601 timestamp of the change. */
+  readonly timestamp: string;
+  /** Which category was changed. */
+  readonly category: ConsentCategory;
+  /** The new value (true = granted, false = withdrawn). */
+  readonly granted: boolean;
+  /** How the change was made. */
+  readonly method: 'first_run' | 'settings' | 'banner' | 'dashboard' | 'bulk';
+  /** Privacy policy version at the time of the change. */
+  readonly policyVersion: string;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** localStorage key for consent history. */
+const CONSENT_HISTORY_KEY = 'finance-consent-history';
+
+/** Maximum history entries to retain (prevents unbounded growth). */
+const MAX_HISTORY_ENTRIES = 500;
+
+// ---------------------------------------------------------------------------
+// Storage functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Load the full consent history from localStorage.
+ *
+ * Returns an empty array if no history exists or parsing fails.
+ */
+export function loadConsentHistory(): ConsentEvent[] {
+  try {
+    const raw = localStorage.getItem(CONSENT_HISTORY_KEY);
+    if (!raw) return [];
+
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+
+    // Validate each entry has required fields
+    return parsed.filter(
+      (e: unknown): e is ConsentEvent =>
+        typeof e === 'object' &&
+        e !== null &&
+        'id' in e &&
+        'timestamp' in e &&
+        'category' in e &&
+        'granted' in e,
+    );
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Record a consent change event.
+ *
+ * Appends to the history log and trims if it exceeds the maximum size.
+ */
+export function recordConsentChange(
+  category: ConsentCategory,
+  granted: boolean,
+  method: ConsentEvent['method'],
+  policyVersion: string,
+): ConsentEvent {
+  const event: ConsentEvent = {
+    id: crypto.randomUUID(),
+    timestamp: new Date().toISOString(),
+    category,
+    granted,
+    method,
+    policyVersion,
+  };
+
+  const history = loadConsentHistory();
+  history.push(event);
+
+  // Trim oldest entries if over the limit
+  const trimmed =
+    history.length > MAX_HISTORY_ENTRIES ? history.slice(-MAX_HISTORY_ENTRIES) : history;
+
+  localStorage.setItem(CONSENT_HISTORY_KEY, JSON.stringify(trimmed));
+  return event;
+}
+
+/**
+ * Record multiple consent changes at once (e.g., "Accept All" or "Reject All").
+ */
+export function recordBulkConsentChanges(
+  changes: ReadonlyArray<{ category: ConsentCategory; granted: boolean }>,
+  method: ConsentEvent['method'],
+  policyVersion: string,
+): ConsentEvent[] {
+  const now = new Date().toISOString();
+  const events: ConsentEvent[] = changes.map((change) => ({
+    id: crypto.randomUUID(),
+    timestamp: now,
+    category: change.category,
+    granted: change.granted,
+    method,
+    policyVersion,
+  }));
+
+  const history = loadConsentHistory();
+  history.push(...events);
+
+  const trimmed =
+    history.length > MAX_HISTORY_ENTRIES ? history.slice(-MAX_HISTORY_ENTRIES) : history;
+
+  localStorage.setItem(CONSENT_HISTORY_KEY, JSON.stringify(trimmed));
+  return events;
+}
+
+/**
+ * Export consent history as a formatted JSON string for GDPR data portability.
+ */
+export function exportConsentHistory(): string {
+  const history = loadConsentHistory();
+  return JSON.stringify(
+    {
+      type: 'gdpr_consent_history',
+      exportedAt: new Date().toISOString(),
+      totalEvents: history.length,
+      events: history,
+    },
+    null,
+    2,
+  );
+}
+
+/**
+ * Clear all consent history (for account deletion / data erasure).
+ */
+export function clearConsentHistory(): void {
+  localStorage.removeItem(CONSENT_HISTORY_KEY);
+}

--- a/apps/web/src/lib/local-only-mode.ts
+++ b/apps/web/src/lib/local-only-mode.ts
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Local-Only Mode — manages the user's preference for local-only operation.
+ *
+ * When local-only mode is active:
+ *   - No cloud sync occurs
+ *   - No account creation is required
+ *   - All data stays in the browser's SQLite-WASM (OPFS)
+ *   - Core features (budgets, tracking, reporting) remain fully available
+ *
+ * The mode is persisted in localStorage and exposed via a React context.
+ *
+ * References: issue #1621 (local-only onboarding path)
+ */
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** localStorage key for local-only mode preference. */
+const LOCAL_ONLY_STORAGE_KEY = 'finance-local-only-mode';
+
+/** localStorage key for onboarding completion. */
+const ONBOARDING_COMPLETE_KEY = 'finance-onboarding-complete';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Features available in local-only mode vs. account mode. */
+export interface FeatureAvailability {
+  /** Feature identifier. */
+  readonly id: string;
+  /** Human-readable feature name. */
+  readonly name: string;
+  /** Short description. */
+  readonly description: string;
+  /** Available without an account (local-only). */
+  readonly availableLocalOnly: boolean;
+  /** Requires an account / sync. */
+  readonly requiresAccount: boolean;
+}
+
+/** All features with their availability in each mode. */
+export const FEATURE_AVAILABILITY: FeatureAvailability[] = [
+  {
+    id: 'accounts',
+    name: 'Account Tracking',
+    description: 'Track bank accounts, credit cards, and cash.',
+    availableLocalOnly: true,
+    requiresAccount: false,
+  },
+  {
+    id: 'transactions',
+    name: 'Transaction Management',
+    description: 'Record and categorize income and expenses.',
+    availableLocalOnly: true,
+    requiresAccount: false,
+  },
+  {
+    id: 'budgets',
+    name: 'Budget Planning',
+    description: 'Create budgets and track spending by category.',
+    availableLocalOnly: true,
+    requiresAccount: false,
+  },
+  {
+    id: 'goals',
+    name: 'Savings Goals',
+    description: 'Set and track financial goals.',
+    availableLocalOnly: true,
+    requiresAccount: false,
+  },
+  {
+    id: 'insights',
+    name: 'Spending Insights',
+    description: 'Analyze spending patterns and trends.',
+    availableLocalOnly: true,
+    requiresAccount: false,
+  },
+  {
+    id: 'reports',
+    name: 'Report Builder',
+    description: 'Generate custom financial reports.',
+    availableLocalOnly: true,
+    requiresAccount: false,
+  },
+  {
+    id: 'import',
+    name: 'Data Import',
+    description: 'Import transactions from CSV or bank exports.',
+    availableLocalOnly: true,
+    requiresAccount: false,
+  },
+  {
+    id: 'export',
+    name: 'Data Export',
+    description: 'Export all data as JSON or CSV.',
+    availableLocalOnly: true,
+    requiresAccount: false,
+  },
+  {
+    id: 'sync',
+    name: 'Cloud Sync',
+    description: 'Sync data across devices via secure cloud.',
+    availableLocalOnly: false,
+    requiresAccount: true,
+  },
+  {
+    id: 'household',
+    name: 'Household Sharing',
+    description: 'Share finances with family or partners.',
+    availableLocalOnly: false,
+    requiresAccount: true,
+  },
+  {
+    id: 'backup',
+    name: 'Automatic Backups',
+    description: 'Cloud-based automatic backup and restore.',
+    availableLocalOnly: false,
+    requiresAccount: true,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Storage functions
+// ---------------------------------------------------------------------------
+
+/** Check if the user has chosen local-only mode. */
+export function isLocalOnlyMode(): boolean {
+  try {
+    return localStorage.getItem(LOCAL_ONLY_STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+/** Set local-only mode preference. */
+export function setLocalOnlyMode(enabled: boolean): void {
+  try {
+    localStorage.setItem(LOCAL_ONLY_STORAGE_KEY, String(enabled));
+  } catch {
+    // localStorage unavailable — degrade gracefully.
+  }
+}
+
+/** Check if onboarding has been completed. */
+export function isOnboardingComplete(): boolean {
+  try {
+    return localStorage.getItem(ONBOARDING_COMPLETE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+/** Mark onboarding as complete. */
+export function setOnboardingComplete(complete: boolean): void {
+  try {
+    localStorage.setItem(ONBOARDING_COMPLETE_KEY, String(complete));
+  } catch {
+    // localStorage unavailable — degrade gracefully.
+  }
+}

--- a/apps/web/src/pages/OnboardingPage.css
+++ b/apps/web/src/pages/OnboardingPage.css
@@ -1,0 +1,303 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/* -------------------------------------------------------------------
+ * OnboardingPage styles
+ *
+ * Two-path onboarding: Local Only vs Create Account.
+ * Mobile-first, accessible, uses design tokens.
+ * ------------------------------------------------------------------- */
+
+.onboarding {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: var(--spacing-6) var(--spacing-4);
+  background-color: var(--semantic-background-primary);
+}
+
+.onboarding__container {
+  max-width: 900px;
+  width: 100%;
+}
+
+.onboarding__container--narrow {
+  max-width: 560px;
+}
+
+/* Header */
+.onboarding__header {
+  text-align: center;
+  margin-bottom: var(--spacing-6);
+}
+
+.onboarding__title {
+  font-size: var(--type-scale-h1-font-size, 2rem);
+  font-weight: var(--font-weight-bold, 700);
+  color: var(--semantic-text-primary);
+  margin: 0 0 var(--spacing-2);
+}
+
+.onboarding__subtitle {
+  font-size: var(--type-scale-body-font-size, 1rem);
+  color: var(--semantic-text-secondary);
+  margin: 0;
+  line-height: 1.5;
+}
+
+/* Path cards */
+.onboarding__paths {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: var(--spacing-4);
+  margin-bottom: var(--spacing-6);
+}
+
+.onboarding__path-card {
+  padding: var(--spacing-5);
+  border-radius: var(--card-border-radius, var(--border-radius-md));
+  border: 2px solid var(--semantic-border-default);
+  background-color: var(--semantic-background-elevated, var(--semantic-background-secondary));
+  text-align: center;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.onboarding__path-card:hover {
+  border-color: var(--semantic-interactive-default);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.onboarding__path-card--local {
+  border-color: var(--semantic-status-positive);
+}
+
+.onboarding__path-icon {
+  font-size: 2.5rem;
+  margin-bottom: var(--spacing-3);
+}
+
+.onboarding__path-title {
+  font-size: var(--type-scale-h2-font-size, 1.5rem);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-primary);
+  margin: 0 0 var(--spacing-2);
+}
+
+.onboarding__path-description {
+  font-size: var(--type-scale-body-font-size, 1rem);
+  color: var(--semantic-text-secondary);
+  margin: 0 0 var(--spacing-4);
+  line-height: 1.5;
+}
+
+.onboarding__path-features {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 var(--spacing-4);
+  text-align: left;
+}
+
+.onboarding__path-features li {
+  font-size: var(--type-scale-body-font-size, 1rem);
+  color: var(--semantic-text-primary);
+  padding: var(--spacing-1) 0;
+}
+
+.onboarding__path-btn {
+  display: inline-block;
+  width: 100%;
+  padding: var(--spacing-3) var(--spacing-5);
+  border-radius: var(--border-radius-md);
+  border: none;
+  font-size: var(--type-scale-body-font-size, 1rem);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+  margin-bottom: var(--spacing-2);
+}
+
+.onboarding__path-btn--primary {
+  background-color: var(--semantic-interactive-default);
+  color: var(--semantic-text-inverse, #fff);
+}
+
+.onboarding__path-btn--primary:hover {
+  background-color: var(--semantic-interactive-hover);
+}
+
+.onboarding__path-btn--secondary {
+  background-color: transparent;
+  color: var(--semantic-interactive-default);
+  border: 2px solid var(--semantic-interactive-default);
+}
+
+.onboarding__path-btn--secondary:hover {
+  background-color: var(--semantic-background-secondary);
+}
+
+.onboarding__path-btn:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+}
+
+.onboarding__path-note {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+  margin: 0;
+}
+
+/* Feature comparison table */
+.onboarding__comparison {
+  margin-bottom: var(--spacing-6);
+}
+
+.onboarding__comparison-title {
+  font-size: var(--type-scale-h2-font-size, 1.5rem);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-primary);
+  text-align: center;
+  margin: 0 0 var(--spacing-4);
+}
+
+.onboarding__comparison-table {
+  width: 100%;
+  border-collapse: collapse;
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-sm);
+  overflow: hidden;
+}
+
+.onboarding__table-header {
+  padding: var(--spacing-3);
+  text-align: center;
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-secondary);
+  background-color: var(--semantic-background-secondary);
+  border-bottom: 1px solid var(--semantic-border-default);
+}
+
+.onboarding__table-header:first-child {
+  text-align: left;
+}
+
+.onboarding__feature-row td {
+  padding: var(--spacing-2) var(--spacing-3);
+  border-bottom: 1px solid var(--semantic-border-default);
+}
+
+.onboarding__feature-name {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-0, 2px);
+}
+
+.onboarding__feature-title {
+  font-size: var(--type-scale-body-font-size, 1rem);
+  font-weight: var(--font-weight-medium, 500);
+  color: var(--semantic-text-primary);
+}
+
+.onboarding__feature-desc {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+.onboarding__feature-cell {
+  text-align: center;
+  width: 100px;
+}
+
+.onboarding__check {
+  color: var(--semantic-status-positive);
+  font-weight: var(--font-weight-bold, 700);
+}
+
+.onboarding__cross {
+  color: var(--semantic-text-secondary);
+}
+
+/* Privacy step */
+.onboarding__privacy-choices {
+  text-align: center;
+}
+
+.onboarding__privacy-note {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+  margin: 0 0 var(--spacing-4);
+  line-height: 1.4;
+}
+
+/* Complete step */
+.onboarding__complete {
+  text-align: center;
+  padding: var(--spacing-6) 0;
+}
+
+.onboarding__complete-icon {
+  font-size: 3rem;
+  margin-bottom: var(--spacing-4);
+}
+
+.onboarding__complete-details {
+  text-align: left;
+  max-width: 400px;
+  margin: var(--spacing-4) auto var(--spacing-6);
+}
+
+.onboarding__complete-item {
+  font-size: var(--type-scale-body-font-size, 1rem);
+  color: var(--semantic-text-primary);
+  margin: 0 0 var(--spacing-2);
+  line-height: 1.5;
+}
+
+/* -------------------------------------------------------------------
+ * Reduced motion
+ * ------------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .onboarding__path-card,
+  .onboarding__path-btn {
+    transition: none;
+  }
+}
+
+/* -------------------------------------------------------------------
+ * High contrast
+ * ------------------------------------------------------------------- */
+
+@media (prefers-contrast: more) {
+  .onboarding__path-card {
+    border-width: 3px;
+  }
+
+  .onboarding__comparison-table {
+    border-width: 2px;
+  }
+}
+
+/* -------------------------------------------------------------------
+ * Mobile
+ * ------------------------------------------------------------------- */
+
+@media (max-width: 480px) {
+  .onboarding {
+    padding: var(--spacing-4) var(--spacing-3);
+  }
+
+  .onboarding__paths {
+    grid-template-columns: 1fr;
+  }
+
+  .onboarding__comparison-table {
+    font-size: var(--type-scale-caption-font-size);
+  }
+
+  .onboarding__feature-desc {
+    display: none;
+  }
+}

--- a/apps/web/src/pages/OnboardingPage.test.tsx
+++ b/apps/web/src/pages/OnboardingPage.test.tsx
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for OnboardingPage.
+ *
+ * Tests the two-path onboarding flow: Local Only and Create Account.
+ *
+ * References: issue #1621
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import OnboardingPage from './OnboardingPage';
+import { useLocalOnlyMode } from '../hooks/useLocalOnlyMode';
+import { useConsent } from '../hooks/useConsent';
+import { useConsentHistory } from '../hooks/useConsentHistory';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('../hooks/useLocalOnlyMode', () => ({
+  useLocalOnlyMode: vi.fn(),
+}));
+
+vi.mock('../hooks/useConsent', () => ({
+  useConsent: vi.fn(),
+}));
+
+vi.mock('../hooks/useConsentHistory', () => ({
+  useConsentHistory: vi.fn(),
+}));
+
+const mockedUseLocalOnlyMode = vi.mocked(useLocalOnlyMode);
+const mockedUseConsent = vi.mocked(useConsent);
+const mockedUseConsentHistory = vi.mocked(useConsentHistory);
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+const defaultLocalOnlyReturn = {
+  isLocalOnly: false,
+  onboardingComplete: false,
+  features: [
+    {
+      id: 'accounts',
+      name: 'Account Tracking',
+      description: 'Track bank accounts.',
+      availableLocalOnly: true,
+      requiresAccount: false,
+    },
+    {
+      id: 'sync',
+      name: 'Cloud Sync',
+      description: 'Sync across devices.',
+      availableLocalOnly: false,
+      requiresAccount: true,
+    },
+  ],
+  enableLocalOnly: vi.fn(),
+  disableLocalOnly: vi.fn(),
+  completeOnboarding: vi.fn(),
+  isFeatureAvailable: vi.fn(() => true),
+  refresh: vi.fn(),
+};
+
+const defaultConsentReturn = {
+  consent: {
+    categories: {
+      essential: true,
+      analytics: false,
+      error_reporting: false,
+      sync: false,
+      marketing: false,
+    },
+    timestamp: '',
+    policyVersion: '1.0.0',
+    method: 'first_run' as const,
+    hasCompletedFirstRun: false,
+  },
+  needsConsent: true,
+  hasCompleted: false,
+  updateCategory: vi.fn(),
+  acceptAll: vi.fn(),
+  rejectAll: vi.fn(),
+  savePreferences: vi.fn(),
+  refresh: vi.fn(),
+};
+
+const defaultConsentHistoryReturn = {
+  history: [],
+  loading: false,
+  recordChange: vi.fn(),
+  recordBulkChanges: vi.fn(),
+  exportHistory: vi.fn(),
+  clearHistory: vi.fn(),
+  refresh: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedUseLocalOnlyMode.mockReturnValue(defaultLocalOnlyReturn);
+  mockedUseConsent.mockReturnValue(defaultConsentReturn);
+  mockedUseConsentHistory.mockReturnValue(defaultConsentHistoryReturn);
+});
+
+const renderWithRouter = (ui: React.ReactElement) => render(<MemoryRouter>{ui}</MemoryRouter>);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('OnboardingPage', () => {
+  it('renders the welcome title', () => {
+    renderWithRouter(<OnboardingPage />);
+    expect(screen.getByRole('heading', { name: /welcome to finance/i })).toBeDefined();
+  });
+
+  it('shows two path options: Local Only and Create Account', () => {
+    renderWithRouter(<OnboardingPage />);
+    expect(screen.getByRole('heading', { name: /local only/i })).toBeDefined();
+    expect(screen.getByRole('heading', { name: /create account/i })).toBeDefined();
+  });
+
+  it('navigates to signup when Create Account is clicked', () => {
+    renderWithRouter(<OnboardingPage />);
+    const accountBtn = screen.getByRole('button', { name: /create account/i });
+    fireEvent.click(accountBtn);
+    expect(mockNavigate).toHaveBeenCalledWith('/signup');
+  });
+
+  it('shows privacy preferences step when Local Only is clicked', () => {
+    renderWithRouter(<OnboardingPage />);
+    const localBtn = screen.getByRole('button', { name: /start local only/i });
+    fireEvent.click(localBtn);
+    expect(screen.getByRole('heading', { name: /privacy preferences/i })).toBeDefined();
+  });
+
+  it('renders feature comparison table', () => {
+    renderWithRouter(<OnboardingPage />);
+    expect(screen.getByText('Account Tracking')).toBeDefined();
+    expect(screen.getByText('Cloud Sync')).toBeDefined();
+  });
+
+  it('completes onboarding with essential-only privacy', () => {
+    const enableLocalOnly = vi.fn();
+    const completeOnboarding = vi.fn();
+    const rejectAll = vi.fn();
+
+    mockedUseLocalOnlyMode.mockReturnValue({
+      ...defaultLocalOnlyReturn,
+      enableLocalOnly,
+      completeOnboarding,
+    });
+
+    mockedUseConsent.mockReturnValue({
+      ...defaultConsentReturn,
+      rejectAll,
+    });
+
+    renderWithRouter(<OnboardingPage />);
+
+    // Step 1: Choose Local Only
+    fireEvent.click(screen.getByRole('button', { name: /start local only/i }));
+
+    // Step 2: Choose Essential Only
+    fireEvent.click(screen.getByRole('button', { name: /essential only/i }));
+
+    expect(rejectAll).toHaveBeenCalled();
+    expect(enableLocalOnly).toHaveBeenCalled();
+    expect(completeOnboarding).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/pages/OnboardingPage.tsx
+++ b/apps/web/src/pages/OnboardingPage.tsx
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * OnboardingPage — local-only onboarding path.
+ *
+ * Offers two clear paths:
+ *   1. Local Only — no account, no sync, all data stays on device
+ *   2. Create Account — sign up for cloud sync and sharing
+ *
+ * Clearly communicates what each path provides and what it doesn't.
+ * Local-only is positioned as a first-class option, not a fallback.
+ *
+ * References: issue #1621 (local-only onboarding path)
+ */
+
+import React, { useCallback, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useLocalOnlyMode } from '../hooks/useLocalOnlyMode';
+import { useConsent } from '../hooks/useConsent';
+import { useConsentHistory } from '../hooks/useConsentHistory';
+import type { FeatureAvailability } from '../lib/local-only-mode';
+import './OnboardingPage.css';
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+/** Feature comparison row. */
+const FeatureRow: React.FC<{
+  feature: FeatureAvailability;
+}> = ({ feature }) => (
+  <tr className="onboarding__feature-row">
+    <td className="onboarding__feature-name">
+      <span className="onboarding__feature-title">{feature.name}</span>
+      <span className="onboarding__feature-desc">{feature.description}</span>
+    </td>
+    <td
+      className="onboarding__feature-cell"
+      aria-label={
+        feature.availableLocalOnly ? 'Available in Local Only' : 'Not available in Local Only'
+      }
+    >
+      {feature.availableLocalOnly ? (
+        <span className="onboarding__check" aria-hidden="true">
+          ✓
+        </span>
+      ) : (
+        <span className="onboarding__cross" aria-hidden="true">
+          —
+        </span>
+      )}
+    </td>
+    <td className="onboarding__feature-cell" aria-label="Available with Account">
+      <span className="onboarding__check" aria-hidden="true">
+        ✓
+      </span>
+    </td>
+  </tr>
+);
+
+// ---------------------------------------------------------------------------
+// Main Component
+// ---------------------------------------------------------------------------
+
+/** Onboarding page with local-only and account paths. */
+const OnboardingPage: React.FC = () => {
+  const navigate = useNavigate();
+  const { features, enableLocalOnly, completeOnboarding } = useLocalOnlyMode();
+  const { acceptAll, rejectAll } = useConsent();
+  const { recordBulkChanges } = useConsentHistory();
+  const [step, setStep] = useState<'choose' | 'privacy' | 'complete'>('choose');
+
+  const handleLocalOnly = useCallback(() => {
+    setStep('privacy');
+  }, []);
+
+  const handleCreateAccount = useCallback(() => {
+    navigate('/signup');
+  }, [navigate]);
+
+  const handlePrivacyAcceptEssential = useCallback(() => {
+    rejectAll();
+    recordBulkChanges(
+      [
+        { category: 'analytics', granted: false },
+        { category: 'error_reporting', granted: false },
+        { category: 'sync', granted: false },
+        { category: 'marketing', granted: false },
+      ],
+      'first_run',
+    );
+    enableLocalOnly();
+    completeOnboarding();
+    setStep('complete');
+  }, [rejectAll, recordBulkChanges, enableLocalOnly, completeOnboarding]);
+
+  const handlePrivacyAcceptAll = useCallback(() => {
+    acceptAll();
+    recordBulkChanges(
+      [
+        { category: 'analytics', granted: true },
+        { category: 'error_reporting', granted: true },
+        { category: 'sync', granted: true },
+        { category: 'marketing', granted: true },
+      ],
+      'first_run',
+    );
+    enableLocalOnly();
+    completeOnboarding();
+    setStep('complete');
+  }, [acceptAll, recordBulkChanges, enableLocalOnly, completeOnboarding]);
+
+  const handleGoToDashboard = useCallback(() => {
+    navigate('/dashboard');
+  }, [navigate]);
+
+  // Step 1: Choose path
+  if (step === 'choose') {
+    return (
+      <main className="onboarding" aria-label="Get Started">
+        <div className="onboarding__container">
+          <header className="onboarding__header">
+            <h1 className="onboarding__title">Welcome to Finance</h1>
+            <p className="onboarding__subtitle">
+              Your personal finance tracker. Choose how you want to get started.
+            </p>
+          </header>
+
+          {/* Path cards */}
+          <div className="onboarding__paths">
+            {/* Local Only */}
+            <article className="onboarding__path-card onboarding__path-card--local">
+              <div className="onboarding__path-icon" aria-hidden="true">
+                🔒
+              </div>
+              <h2 className="onboarding__path-title">Local Only</h2>
+              <p className="onboarding__path-description">
+                Keep everything on this device. No account needed. No data ever leaves your browser.
+              </p>
+              <ul className="onboarding__path-features" role="list">
+                <li role="listitem">✓ Full budgeting & tracking</li>
+                <li role="listitem">✓ All data stays on device</li>
+                <li role="listitem">✓ No email required</li>
+                <li role="listitem">✓ Works completely offline</li>
+              </ul>
+              <button
+                type="button"
+                className="onboarding__path-btn onboarding__path-btn--primary"
+                onClick={handleLocalOnly}
+              >
+                Start Local Only
+              </button>
+              <p className="onboarding__path-note">
+                You can create an account later without losing any data.
+              </p>
+            </article>
+
+            {/* Account */}
+            <article className="onboarding__path-card onboarding__path-card--account">
+              <div className="onboarding__path-icon" aria-hidden="true">
+                ☁️
+              </div>
+              <h2 className="onboarding__path-title">Create Account</h2>
+              <p className="onboarding__path-description">
+                Sign up to sync across devices and share with household members.
+              </p>
+              <ul className="onboarding__path-features" role="list">
+                <li role="listitem">✓ Everything in Local Only</li>
+                <li role="listitem">✓ Sync across devices</li>
+                <li role="listitem">✓ Household sharing</li>
+                <li role="listitem">✓ Automatic cloud backups</li>
+              </ul>
+              <button
+                type="button"
+                className="onboarding__path-btn onboarding__path-btn--secondary"
+                onClick={handleCreateAccount}
+              >
+                Create Account
+              </button>
+            </article>
+          </div>
+
+          {/* Feature comparison table */}
+          <section className="onboarding__comparison" aria-label="Feature comparison">
+            <h2 className="onboarding__comparison-title">Feature Comparison</h2>
+            <table className="onboarding__comparison-table">
+              <thead>
+                <tr>
+                  <th scope="col" className="onboarding__table-header">
+                    Feature
+                  </th>
+                  <th scope="col" className="onboarding__table-header">
+                    Local Only
+                  </th>
+                  <th scope="col" className="onboarding__table-header">
+                    With Account
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {features.map((f) => (
+                  <FeatureRow key={f.id} feature={f} />
+                ))}
+              </tbody>
+            </table>
+          </section>
+        </div>
+      </main>
+    );
+  }
+
+  // Step 2: Privacy consent for local-only users
+  if (step === 'privacy') {
+    return (
+      <main className="onboarding" aria-label="Privacy Preferences">
+        <div className="onboarding__container onboarding__container--narrow">
+          <header className="onboarding__header">
+            <h1 className="onboarding__title">Privacy Preferences</h1>
+            <p className="onboarding__subtitle">
+              Even in local-only mode, you can choose to share anonymous usage data to help us
+              improve the app. This is entirely optional.
+            </p>
+          </header>
+
+          <div className="onboarding__privacy-choices">
+            <button
+              type="button"
+              className="onboarding__path-btn onboarding__path-btn--primary"
+              onClick={handlePrivacyAcceptEssential}
+            >
+              Essential Only — Maximum Privacy
+            </button>
+            <p className="onboarding__privacy-note">
+              No analytics, no error reporting, no sync. Your data never leaves this device.
+            </p>
+
+            <button
+              type="button"
+              className="onboarding__path-btn onboarding__path-btn--secondary"
+              onClick={handlePrivacyAcceptAll}
+            >
+              Help Improve Finance
+            </button>
+            <p className="onboarding__privacy-note">
+              Allow anonymous analytics and crash reporting. You can change this anytime in
+              Settings.
+            </p>
+          </div>
+        </div>
+      </main>
+    );
+  }
+
+  // Step 3: Complete
+  return (
+    <main className="onboarding" aria-label="Setup Complete">
+      <div className="onboarding__container onboarding__container--narrow">
+        <div className="onboarding__complete">
+          <div className="onboarding__complete-icon" aria-hidden="true">
+            🎉
+          </div>
+          <h1 className="onboarding__title">You&apos;re All Set!</h1>
+          <p className="onboarding__subtitle">
+            Your finance tracker is ready. All data is stored locally on this device.
+          </p>
+          <div className="onboarding__complete-details">
+            <p className="onboarding__complete-item">
+              🔒 <strong>Local-only mode</strong> — no data leaves your browser
+            </p>
+            <p className="onboarding__complete-item">
+              💾 <strong>SQLite storage</strong> — fast, reliable, offline-first
+            </p>
+            <p className="onboarding__complete-item">
+              🔄 <strong>Upgrade anytime</strong> — create an account later to enable sync
+            </p>
+          </div>
+          <button
+            type="button"
+            className="onboarding__path-btn onboarding__path-btn--primary"
+            onClick={handleGoToDashboard}
+          >
+            Go to Dashboard
+          </button>
+        </div>
+      </div>
+    </main>
+  );
+};
+
+export default OnboardingPage;

--- a/apps/web/src/pages/PrivacyDashboardPage.css
+++ b/apps/web/src/pages/PrivacyDashboardPage.css
@@ -1,0 +1,346 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/* -------------------------------------------------------------------
+ * PrivacyDashboardPage styles
+ *
+ * Full-page privacy dashboard with data inventory, consent management,
+ * and storage visualization.
+ * ------------------------------------------------------------------- */
+
+.privacy-dashboard {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: var(--spacing-4) var(--spacing-4) var(--spacing-8);
+}
+
+/* Header */
+.privacy-dashboard__header {
+  margin-bottom: var(--spacing-6);
+}
+
+.privacy-dashboard__title {
+  font-size: var(--type-scale-h1-font-size, 2rem);
+  font-weight: var(--font-weight-bold, 700);
+  color: var(--semantic-text-primary);
+  margin: 0 0 var(--spacing-2);
+}
+
+.privacy-dashboard__subtitle {
+  font-size: var(--type-scale-body-font-size, 1rem);
+  color: var(--semantic-text-secondary);
+  margin: 0;
+  line-height: 1.5;
+}
+
+/* Sections */
+.privacy-dashboard__section {
+  margin-bottom: var(--spacing-6);
+  padding: var(--spacing-5);
+  border-radius: var(--card-border-radius, var(--border-radius-md));
+  border: 1px solid var(--semantic-border-default);
+  background-color: var(--semantic-background-elevated, var(--semantic-background-secondary));
+  box-shadow: var(--card-shadow, none);
+}
+
+.privacy-dashboard__section-title {
+  font-size: var(--type-scale-h2-font-size, 1.5rem);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-primary);
+  margin: 0 0 var(--spacing-2);
+}
+
+.privacy-dashboard__section-description {
+  font-size: var(--type-scale-body-font-size, 1rem);
+  color: var(--semantic-text-secondary);
+  margin: 0 0 var(--spacing-4);
+  line-height: 1.5;
+}
+
+/* Storage bar */
+.privacy-dashboard__storage-overview {
+  margin-top: var(--spacing-3);
+}
+
+.privacy-dashboard__storage-bar {
+  height: 12px;
+  border-radius: 6px;
+  background-color: var(--semantic-background-primary);
+  border: 1px solid var(--semantic-border-default);
+  overflow: hidden;
+}
+
+.privacy-dashboard__storage-fill {
+  height: 100%;
+  border-radius: 6px;
+  background-color: var(--semantic-interactive-default);
+  transition: width 0.3s ease;
+}
+
+.privacy-dashboard__storage-labels {
+  display: flex;
+  justify-content: space-between;
+  margin-top: var(--spacing-2);
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+/* Data categories */
+.privacy-dashboard__categories {
+  display: grid;
+  gap: var(--spacing-3);
+}
+
+.privacy-dashboard__category-card {
+  display: flex;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3);
+  border-radius: var(--border-radius-sm);
+  border: 1px solid var(--semantic-border-default);
+  background-color: var(--semantic-background-primary);
+}
+
+.privacy-dashboard__category-icon {
+  font-size: 1.5rem;
+  flex-shrink: 0;
+  width: 2.5rem;
+  text-align: center;
+}
+
+.privacy-dashboard__category-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.privacy-dashboard__category-name {
+  font-size: var(--type-scale-body-font-size, 1rem);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-primary);
+  margin: 0 0 var(--spacing-1);
+}
+
+.privacy-dashboard__category-description {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+  margin: 0 0 var(--spacing-2);
+  line-height: 1.4;
+}
+
+.privacy-dashboard__category-meta {
+  display: flex;
+  gap: var(--spacing-3);
+  flex-wrap: wrap;
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+.privacy-dashboard__category-local {
+  color: var(--semantic-status-positive);
+}
+
+.privacy-dashboard__category-leaves {
+  color: var(--semantic-status-info);
+}
+
+/* Consent management */
+.privacy-dashboard__consent-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3);
+  border-bottom: 1px solid var(--semantic-border-default);
+}
+
+.privacy-dashboard__consent-item:last-of-type {
+  border-bottom: none;
+}
+
+.privacy-dashboard__consent-item--essential {
+  opacity: 0.7;
+}
+
+.privacy-dashboard__consent-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.privacy-dashboard__consent-label {
+  font-size: var(--type-scale-body-font-size, 1rem);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-primary);
+  cursor: pointer;
+}
+
+.privacy-dashboard__consent-required {
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-normal, 400);
+  color: var(--semantic-text-secondary);
+}
+
+.privacy-dashboard__consent-description {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+  margin: var(--spacing-1) 0 0;
+  line-height: 1.4;
+}
+
+.privacy-dashboard__consent-toggle {
+  flex-shrink: 0;
+  width: 1.25rem;
+  height: 1.25rem;
+  margin-top: var(--spacing-1);
+  cursor: pointer;
+}
+
+.privacy-dashboard__consent-toggle:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+}
+
+.privacy-dashboard__consent-timestamp {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+  margin-top: var(--spacing-3);
+}
+
+.privacy-dashboard__consent-actions {
+  display: flex;
+  gap: var(--spacing-3);
+  margin-top: var(--spacing-3);
+}
+
+.privacy-dashboard__action-btn {
+  padding: var(--spacing-2) var(--spacing-4);
+  border-radius: var(--border-radius-sm);
+  border: 1px solid var(--semantic-border-default);
+  background-color: var(--semantic-background-primary);
+  color: var(--semantic-interactive-default);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-medium, 500);
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.privacy-dashboard__action-btn:hover {
+  background-color: var(--semantic-background-secondary);
+}
+
+.privacy-dashboard__action-btn:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+}
+
+.privacy-dashboard__status {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-status-positive);
+  margin-top: var(--spacing-2);
+}
+
+/* Loading / error */
+.privacy-dashboard__loading {
+  text-align: center;
+  padding: var(--spacing-4);
+  color: var(--semantic-text-secondary);
+}
+
+.privacy-dashboard__error {
+  padding: var(--spacing-3);
+  border-radius: var(--border-radius-sm);
+  background-color: rgba(239, 68, 68, 0.08);
+  color: var(--semantic-status-negative);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+/* Data rights */
+.privacy-dashboard__rights {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: var(--spacing-3);
+}
+
+.privacy-dashboard__right-card {
+  padding: var(--spacing-4);
+  border-radius: var(--border-radius-sm);
+  border: 1px solid var(--semantic-border-default);
+  background-color: var(--semantic-background-primary);
+}
+
+.privacy-dashboard__right-title {
+  font-size: var(--type-scale-body-font-size, 1rem);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-primary);
+  margin: 0 0 var(--spacing-2);
+}
+
+.privacy-dashboard__right-description {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+  margin: 0 0 var(--spacing-3);
+  line-height: 1.4;
+}
+
+.privacy-dashboard__right-link {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-interactive-default);
+  text-decoration: none;
+  font-weight: var(--font-weight-medium, 500);
+}
+
+.privacy-dashboard__right-link:hover {
+  text-decoration: underline;
+}
+
+.privacy-dashboard__right-link:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+}
+
+/* -------------------------------------------------------------------
+ * Reduced motion
+ * ------------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .privacy-dashboard__storage-fill,
+  .privacy-dashboard__action-btn {
+    transition: none;
+  }
+}
+
+/* -------------------------------------------------------------------
+ * High contrast
+ * ------------------------------------------------------------------- */
+
+@media (prefers-contrast: more) {
+  .privacy-dashboard__section,
+  .privacy-dashboard__category-card,
+  .privacy-dashboard__right-card {
+    border-width: 2px;
+  }
+}
+
+/* -------------------------------------------------------------------
+ * Mobile
+ * ------------------------------------------------------------------- */
+
+@media (max-width: 480px) {
+  .privacy-dashboard {
+    padding: var(--spacing-3) var(--spacing-3) var(--spacing-6);
+  }
+
+  .privacy-dashboard__section {
+    padding: var(--spacing-3);
+  }
+
+  .privacy-dashboard__category-card {
+    flex-direction: column;
+  }
+
+  .privacy-dashboard__category-meta {
+    flex-direction: column;
+    gap: var(--spacing-1);
+  }
+
+  .privacy-dashboard__consent-actions {
+    flex-direction: column;
+  }
+}

--- a/apps/web/src/pages/PrivacyDashboardPage.test.tsx
+++ b/apps/web/src/pages/PrivacyDashboardPage.test.tsx
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for PrivacyDashboardPage.
+ *
+ * Mocks hooks (not repositories) per project conventions.
+ * Tests loading, error, empty, and data-present states.
+ *
+ * References: issue #1636
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PrivacyDashboardPage from './PrivacyDashboardPage';
+import { useConsent } from '../hooks/useConsent';
+import { useConsentHistory } from '../hooks/useConsentHistory';
+import { usePrivacyDashboard } from '../hooks/usePrivacyDashboard';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../hooks/useConsent', () => ({
+  useConsent: vi.fn(),
+}));
+
+vi.mock('../hooks/useConsentHistory', () => ({
+  useConsentHistory: vi.fn(),
+}));
+
+vi.mock('../hooks/usePrivacyDashboard', () => ({
+  usePrivacyDashboard: vi.fn(),
+}));
+
+vi.mock('../components/gdpr/ConsentHistoryViewer', () => ({
+  ConsentHistoryViewer: () => <div data-testid="consent-history-viewer">History</div>,
+}));
+
+const mockedUseConsent = vi.mocked(useConsent);
+const mockedUseConsentHistory = vi.mocked(useConsentHistory);
+const mockedUsePrivacyDashboard = vi.mocked(usePrivacyDashboard);
+
+// ---------------------------------------------------------------------------
+// Test setup
+// ---------------------------------------------------------------------------
+
+const mockConsent = {
+  categories: {
+    essential: true,
+    analytics: false,
+    error_reporting: true,
+    sync: false,
+    marketing: false,
+  },
+  timestamp: '2024-01-15T10:00:00.000Z',
+  policyVersion: '1.0.0',
+  method: 'settings' as const,
+  hasCompletedFirstRun: true,
+};
+
+const mockCategories = [
+  {
+    id: 'accounts',
+    name: 'Financial Accounts',
+    description: 'Bank accounts and credit cards.',
+    storageLocation: 'SQLite (OPFS)' as const,
+    leavesDevice: false,
+    icon: '🏦',
+    estimatedBytes: 0,
+  },
+  {
+    id: 'settings',
+    name: 'App Settings',
+    description: 'Your preferences.',
+    storageLocation: 'localStorage' as const,
+    leavesDevice: false,
+    icon: '⚙️',
+    estimatedBytes: 512,
+  },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  mockedUseConsent.mockReturnValue({
+    consent: mockConsent,
+    needsConsent: false,
+    hasCompleted: true,
+    updateCategory: vi.fn(),
+    acceptAll: vi.fn(),
+    rejectAll: vi.fn(),
+    savePreferences: vi.fn(),
+    refresh: vi.fn(),
+  });
+
+  mockedUseConsentHistory.mockReturnValue({
+    history: [],
+    loading: false,
+    recordChange: vi.fn(),
+    recordBulkChanges: vi.fn(),
+    exportHistory: vi.fn(),
+    clearHistory: vi.fn(),
+    refresh: vi.fn(),
+  });
+
+  mockedUsePrivacyDashboard.mockReturnValue({
+    categories: mockCategories,
+    totalStorageEstimate: 512,
+    storageQuota: { quota: 1073741824, usage: 5242880, usagePercent: 0.49 },
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PrivacyDashboardPage', () => {
+  it('renders the page title', () => {
+    render(<PrivacyDashboardPage />);
+    expect(screen.getByRole('heading', { name: /privacy dashboard/i })).toBeDefined();
+  });
+
+  it('displays storage usage bar', () => {
+    render(<PrivacyDashboardPage />);
+    expect(screen.getByRole('progressbar')).toBeDefined();
+  });
+
+  it('renders data category cards', () => {
+    render(<PrivacyDashboardPage />);
+    expect(screen.getByText('Financial Accounts')).toBeDefined();
+    expect(screen.getByText('App Settings')).toBeDefined();
+  });
+
+  it('displays consent toggles', () => {
+    render(<PrivacyDashboardPage />);
+    const analyticsCheckbox = screen.getByLabelText(/consent for Analytics/i);
+    expect(analyticsCheckbox).toBeDefined();
+  });
+
+  it('shows loading state', () => {
+    mockedUsePrivacyDashboard.mockReturnValue({
+      categories: [],
+      totalStorageEstimate: 0,
+      storageQuota: null,
+      loading: true,
+      error: null,
+      refresh: vi.fn(),
+    });
+
+    render(<PrivacyDashboardPage />);
+    expect(screen.getByText(/loading data inventory/i)).toBeDefined();
+  });
+
+  it('shows error state', () => {
+    mockedUsePrivacyDashboard.mockReturnValue({
+      categories: [],
+      totalStorageEstimate: 0,
+      storageQuota: null,
+      loading: false,
+      error: 'Something went wrong',
+      refresh: vi.fn(),
+    });
+
+    render(<PrivacyDashboardPage />);
+    expect(screen.getByRole('alert')).toBeDefined();
+  });
+
+  it('renders consent history viewer', () => {
+    render(<PrivacyDashboardPage />);
+    expect(screen.getByTestId('consent-history-viewer')).toBeDefined();
+  });
+
+  it('calls updateCategory when toggling consent', () => {
+    const updateCategory = vi.fn();
+    mockedUseConsent.mockReturnValue({
+      consent: mockConsent,
+      needsConsent: false,
+      hasCompleted: true,
+      updateCategory,
+      acceptAll: vi.fn(),
+      rejectAll: vi.fn(),
+      savePreferences: vi.fn(),
+      refresh: vi.fn(),
+    });
+
+    render(<PrivacyDashboardPage />);
+    const analyticsCheckbox = screen.getByLabelText(/consent for Analytics/i);
+    fireEvent.click(analyticsCheckbox);
+    expect(updateCategory).toHaveBeenCalledWith('analytics', true);
+  });
+
+  it('renders data rights section with links', () => {
+    render(<PrivacyDashboardPage />);
+    expect(screen.getByText(/export your data/i)).toBeDefined();
+    expect(screen.getByText(/delete your data/i)).toBeDefined();
+  });
+});

--- a/apps/web/src/pages/PrivacyDashboardPage.tsx
+++ b/apps/web/src/pages/PrivacyDashboardPage.tsx
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * PrivacyDashboardPage — comprehensive privacy dashboard.
+ *
+ * Shows:
+ *   - All locally stored data categories with descriptions
+ *   - Storage usage per category and overall
+ *   - Granular consent management with one-click withdrawal
+ *   - Consent history timeline with proof
+ *   - Links to export and delete functionality
+ *
+ * References:
+ *   - issue #1636 (privacy dashboard with full data inventory)
+ *   - issue #1641 (granular consent management with proof)
+ *   - issue #1612 (privacy-first app shell)
+ */
+
+import React, { useCallback, useState } from 'react';
+import { useConsent } from '../hooks/useConsent';
+import { useConsentHistory } from '../hooks/useConsentHistory';
+import { usePrivacyDashboard } from '../hooks/usePrivacyDashboard';
+import { ConsentHistoryViewer } from '../components/gdpr/ConsentHistoryViewer';
+import {
+  CONSENT_LABELS,
+  CONSENT_DESCRIPTIONS,
+  exportConsentRecord,
+  type ConsentCategory,
+} from '../lib/consent-storage';
+import './PrivacyDashboardPage.css';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Toggleable consent categories (essential is always on). */
+const TOGGLEABLE_CATEGORIES: ConsentCategory[] = [
+  'analytics',
+  'error_reporting',
+  'sync',
+  'marketing',
+];
+
+/** Format bytes to a human-readable string. */
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(1024));
+  const value = bytes / Math.pow(1024, i);
+  return `${value.toFixed(i > 0 ? 1 : 0)} ${units[i]}`;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/** Privacy Dashboard — full data inventory and consent management. */
+const PrivacyDashboardPage: React.FC = () => {
+  const { consent, updateCategory } = useConsent();
+  const { recordChange } = useConsentHistory();
+  const { categories, storageQuota, loading, error } = usePrivacyDashboard();
+  const [exportMessage, setExportMessage] = useState<string | null>(null);
+
+  const handleToggleConsent = useCallback(
+    (category: ConsentCategory) => {
+      const newValue = !consent.categories[category];
+      updateCategory(category, newValue);
+      recordChange(category, newValue, 'dashboard');
+    },
+    [consent.categories, updateCategory, recordChange],
+  );
+
+  const handleExportConsent = useCallback(() => {
+    try {
+      const data = exportConsentRecord();
+      const blob = new Blob([data], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = `consent-record-${new Date().toISOString().slice(0, 10)}.json`;
+      anchor.style.display = 'none';
+      document.body.appendChild(anchor);
+      anchor.click();
+      setTimeout(() => {
+        URL.revokeObjectURL(url);
+        document.body.removeChild(anchor);
+      }, 100);
+      setExportMessage('Consent record exported.');
+      setTimeout(() => setExportMessage(null), 4000);
+    } catch {
+      setExportMessage('Failed to export.');
+    }
+  }, []);
+
+  return (
+    <main className="privacy-dashboard" aria-label="Privacy Dashboard">
+      <header className="privacy-dashboard__header">
+        <h1 className="privacy-dashboard__title">Privacy Dashboard</h1>
+        <p className="privacy-dashboard__subtitle">
+          Full transparency into what data is stored on your device and how it is used.
+        </p>
+      </header>
+
+      {/* Storage Overview */}
+      {storageQuota && (
+        <section className="privacy-dashboard__section" aria-label="Storage usage">
+          <h2 className="privacy-dashboard__section-title">Storage Usage</h2>
+          <div className="privacy-dashboard__storage-overview">
+            <div
+              className="privacy-dashboard__storage-bar"
+              role="progressbar"
+              aria-valuenow={storageQuota.usagePercent}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label={`Storage: ${formatBytes(storageQuota.usage)} of ${formatBytes(storageQuota.quota)} used`}
+            >
+              <div
+                className="privacy-dashboard__storage-fill"
+                style={{ width: `${Math.min(storageQuota.usagePercent, 100)}%` }}
+              />
+            </div>
+            <div className="privacy-dashboard__storage-labels">
+              <span>{formatBytes(storageQuota.usage)} used</span>
+              <span>{formatBytes(storageQuota.quota)} total</span>
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* Data Inventory */}
+      <section className="privacy-dashboard__section" aria-label="Data inventory">
+        <h2 className="privacy-dashboard__section-title">What We Store</h2>
+        <p className="privacy-dashboard__section-description">
+          All your financial data is stored locally in your browser. Nothing leaves your device
+          unless you explicitly enable Cloud Sync.
+        </p>
+
+        {loading && (
+          <div role="status" aria-live="polite" className="privacy-dashboard__loading">
+            Loading data inventory…
+          </div>
+        )}
+
+        {error && (
+          <div role="alert" className="privacy-dashboard__error">
+            {error}
+          </div>
+        )}
+
+        {!loading && (
+          <div className="privacy-dashboard__categories">
+            {categories.map((category) => (
+              <article
+                key={category.id}
+                className="privacy-dashboard__category-card"
+                aria-label={category.name}
+              >
+                <div className="privacy-dashboard__category-icon" aria-hidden="true">
+                  {category.icon}
+                </div>
+                <div className="privacy-dashboard__category-content">
+                  <h3 className="privacy-dashboard__category-name">{category.name}</h3>
+                  <p className="privacy-dashboard__category-description">{category.description}</p>
+                  <div className="privacy-dashboard__category-meta">
+                    <span className="privacy-dashboard__category-storage">
+                      📦 {category.storageLocation}
+                    </span>
+                    {category.leavesDevice ? (
+                      <span className="privacy-dashboard__category-leaves">
+                        ☁️ {category.leavesDeviceCondition ?? 'May sync'}
+                      </span>
+                    ) : (
+                      <span className="privacy-dashboard__category-local">🔒 Stays on device</span>
+                    )}
+                    {category.estimatedBytes > 0 && (
+                      <span className="privacy-dashboard__category-size">
+                        {formatBytes(category.estimatedBytes)}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Consent Management */}
+      <section className="privacy-dashboard__section" aria-label="Consent management">
+        <h2 className="privacy-dashboard__section-title">Consent Management</h2>
+        <p className="privacy-dashboard__section-description">
+          Control exactly how your data is used. Toggle any category off to immediately withdraw
+          consent.
+        </p>
+
+        {/* Essential (always on) */}
+        <div className="privacy-dashboard__consent-item privacy-dashboard__consent-item--essential">
+          <div className="privacy-dashboard__consent-info">
+            <span className="privacy-dashboard__consent-label">
+              {CONSENT_LABELS.essential}
+              <span className="privacy-dashboard__consent-required"> (Required)</span>
+            </span>
+            <p className="privacy-dashboard__consent-description">
+              {CONSENT_DESCRIPTIONS.essential}
+            </p>
+          </div>
+          <input
+            type="checkbox"
+            checked
+            disabled
+            aria-label={`${CONSENT_LABELS.essential} — always required`}
+            className="privacy-dashboard__consent-toggle"
+          />
+        </div>
+
+        {/* Toggleable categories */}
+        {TOGGLEABLE_CATEGORIES.map((category) => (
+          <div key={category} className="privacy-dashboard__consent-item">
+            <div className="privacy-dashboard__consent-info">
+              <label htmlFor={`consent-${category}`} className="privacy-dashboard__consent-label">
+                {CONSENT_LABELS[category]}
+              </label>
+              <p className="privacy-dashboard__consent-description">
+                {CONSENT_DESCRIPTIONS[category]}
+              </p>
+            </div>
+            <input
+              id={`consent-${category}`}
+              type="checkbox"
+              checked={consent.categories[category]}
+              onChange={() => handleToggleConsent(category)}
+              aria-label={`${consent.categories[category] ? 'Withdraw' : 'Grant'} consent for ${CONSENT_LABELS[category]}`}
+              className="privacy-dashboard__consent-toggle"
+            />
+          </div>
+        ))}
+
+        {consent.timestamp && (
+          <p className="privacy-dashboard__consent-timestamp">
+            Last updated: {new Date(consent.timestamp).toLocaleString()}
+          </p>
+        )}
+
+        <div className="privacy-dashboard__consent-actions">
+          <button
+            type="button"
+            className="privacy-dashboard__action-btn"
+            onClick={handleExportConsent}
+            aria-label="Export consent record as JSON"
+          >
+            Export Consent Record
+          </button>
+        </div>
+
+        {exportMessage && (
+          <div role="status" aria-live="polite" className="privacy-dashboard__status">
+            {exportMessage}
+          </div>
+        )}
+      </section>
+
+      {/* Consent History */}
+      <section className="privacy-dashboard__section" aria-label="Consent history">
+        <ConsentHistoryViewer />
+      </section>
+
+      {/* Data Actions */}
+      <section className="privacy-dashboard__section" aria-label="Data actions">
+        <h2 className="privacy-dashboard__section-title">Your Data Rights</h2>
+        <div className="privacy-dashboard__rights">
+          <article className="privacy-dashboard__right-card">
+            <h3 className="privacy-dashboard__right-title">📥 Export Your Data</h3>
+            <p className="privacy-dashboard__right-description">
+              Download all your financial data in JSON or CSV format. This is your data — you can
+              take it with you at any time.
+            </p>
+            <a href="/settings" className="privacy-dashboard__right-link">
+              Go to Settings → Export
+            </a>
+          </article>
+          <article className="privacy-dashboard__right-card">
+            <h3 className="privacy-dashboard__right-title">🗑️ Delete Your Data</h3>
+            <p className="privacy-dashboard__right-description">
+              Permanently delete all your data from this device. If you have an account, you can
+              also request server-side deletion.
+            </p>
+            <a href="/settings" className="privacy-dashboard__right-link">
+              Go to Settings → Delete
+            </a>
+          </article>
+        </div>
+      </section>
+    </main>
+  );
+};
+
+export default PrivacyDashboardPage;

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -38,6 +38,8 @@ const Bills = lazy(() => import('./pages/BillsPage'));
 const BillDetail = lazy(() => import('./pages/BillDetailPage'));
 const CreateBill = lazy(() => import('./pages/CreateBillPage'));
 const Planning = lazy(() => import('./pages/PlanningPage'));
+const PrivacyDashboard = lazy(() => import('./pages/PrivacyDashboardPage'));
+const Onboarding = lazy(() => import('./pages/OnboardingPage'));
 
 /**
  * Loading fallback shown while a lazy route chunk is being fetched.
@@ -390,6 +392,24 @@ export const AppRoutes: FC = () => (
             <DataImportWizard />
           </RouteBoundary>
         </AuthenticatedRoute>
+      }
+    />
+    <Route
+      path="/privacy-dashboard"
+      element={
+        <AuthenticatedRoute>
+          <RouteBoundary name="Privacy Dashboard">
+            <PrivacyDashboard />
+          </RouteBoundary>
+        </AuthenticatedRoute>
+      }
+    />
+    <Route
+      path="/onboarding"
+      element={
+        <RouteBoundary name="Onboarding">
+          <Onboarding />
+        </RouteBoundary>
       }
     />
 


### PR DESCRIPTION
## Summary

Comprehensive privacy features for the Finance web app: granular consent management with timestamped proof, full data inventory dashboard, privacy-first app shell with progressive consent disclosure, and local-only onboarding path.

## Changes

### Libraries (apps/web/src/lib/)
- **consent-history.ts** — Timestamped audit log of all consent changes. Records every grant/withdrawal as an immutable event with policy version and method. Supports export as JSON for GDPR data portability.
- **local-only-mode.ts** — Manages local-only mode preference and onboarding state. Defines feature availability matrix (what works without an account vs. with an account).

### Hooks (apps/web/src/hooks/)
- **useConsentHistory** — Access consent audit log, record changes, export/clear history
- **useLocalOnlyMode** — Local-only mode state, feature availability checks, onboarding flow control
- **usePrivacyDashboard** — Data category inventory, storage usage estimation via StorageManager API

### Components (apps/web/src/components/gdpr/)
- **PrivacyGate** — Gates features behind consent. Shows a privacy explainer with progressive disclosure (what data is needed, why) instead of a blocked UI. One-click enable with consent history recording.
- **ConsentHistoryViewer** — Timeline view of all consent changes with timestamps, grant/withdrawal badges, and JSON export.

### Pages (apps/web/src/pages/)
- **PrivacyDashboardPage** — Full privacy dashboard with:
  - Storage usage bar (StorageManager API)
  - Data category cards (accounts, transactions, budgets, goals, categories, settings, consent, investments)
  - Per-category storage location and device-leaving status
  - Granular consent toggles with one-click withdrawal
  - Consent history timeline
  - Data rights section (export, delete links)
- **OnboardingPage** — Two-path onboarding:
  - **Local Only** — No account, no sync, all data stays on device. Full budgeting/tracking available.
  - **Create Account** — Sign up for cloud sync and sharing.
  - Feature comparison table
  - Privacy consent step with Essential Only vs. Help Improve options
  - Completion step with clear messaging

### Routes
- Added /privacy-dashboard (authenticated) and /onboarding (public) routes

## Accessibility
- All interactive elements have ARIA labels
- Consent toggles linked with labels via htmlFor
- Storage bar uses role=progressbar with aria-valuenow/min/max
- Timeline uses ordered list with role=list/listitem
- Feature comparison table uses proper th/scope
- Focus-visible outlines on all interactive elements
- role=status for status messages, role=alert for errors

## CSS
- All values use design token CSS custom properties
- Dark mode support via prefers-color-scheme and [data-theme]
- Reduced motion support via prefers-reduced-motion
- High contrast support via prefers-contrast
- Mobile-first with responsive breakpoints

## Testing
- 28 tests across 4 test files, all passing
- Mocks hooks (not repositories) per project conventions
- Tests cover: loading, error, empty, data-present states
- Tests cover: consent toggle, history recording, path navigation, onboarding flow

Closes #1641
Closes #1636
Closes #1612
Closes #1621

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>