### PR TITLE
feat(web): add household foundation - roles, invitations, account sharing, privacy boundaries (#1780, #1779, #1781, #1716, #1784, #1786)

### DIFF
--- a/apps/web/src/contexts/HouseholdContext.tsx
+++ b/apps/web/src/contexts/HouseholdContext.tsx
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Household Context — provides household state and permission checks
+ * to the entire component tree.
+ *
+ * This context is the single source of truth for:
+ * - Current household and membership info
+ * - Role-based permission checks
+ * - Privacy boundary enforcement (account visibility)
+ *
+ * Usage:
+ * ```tsx
+ * <HouseholdProvider userId="user-123">
+ *   <App />
+ * </HouseholdProvider>
+ *
+ * // In components:
+ * const { household, currentRole, hasPermission } = useHouseholdContext();
+ * ```
+ *
+ * References: issues #1780, #1716
+ */
+
+import { createContext, useCallback, useContext, useMemo, type FC, type ReactNode } from 'react';
+
+import type {
+  Household,
+  HouseholdMember,
+  HouseholdPermission,
+  HouseholdRole,
+  SyncId,
+} from '../kmp/bridge';
+import { ROLE_PERMISSIONS } from '../kmp/bridge';
+
+// ---------------------------------------------------------------------------
+// Context type
+// ---------------------------------------------------------------------------
+
+/** Shape of the household context value. */
+export interface HouseholdContextValue {
+  /** The current user's household, or null if not in a household. */
+  readonly household: Household | null;
+  /** The current user's household membership, or null. */
+  readonly currentMember: HouseholdMember | null;
+  /** The current user's role in the household, or null. */
+  readonly currentRole: HouseholdRole | null;
+  /** All members of the current household. */
+  readonly members: HouseholdMember[];
+  /** Whether the current user is the household owner. */
+  readonly isOwner: boolean;
+  /** Whether the current user is an admin or owner. */
+  readonly isAdminOrOwner: boolean;
+  /** Whether the current user belongs to a household. */
+  readonly isInHousehold: boolean;
+  /** Check if the current user has a specific permission. */
+  readonly hasPermission: (permission: HouseholdPermission) => boolean;
+  /** Check if the current user can manage the household (owner or admin). */
+  readonly canManage: boolean;
+  /** The authenticated user's ID. */
+  readonly userId: SyncId | null;
+}
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+const HouseholdContext = createContext<HouseholdContextValue | null>(null);
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+export interface HouseholdProviderProps {
+  readonly children: ReactNode;
+  /** The authenticated user's ID. */
+  readonly userId: SyncId | null;
+  /** Current household (loaded externally via useHousehold hook). */
+  readonly household: Household | null;
+  /** Current household members (loaded externally). */
+  readonly members: HouseholdMember[];
+}
+
+/**
+ * Provides household context to the component tree.
+ *
+ * Derives the current user's role and permissions from the household
+ * membership data. The provider does not load data itself — it receives
+ * pre-loaded data from the useHousehold hook.
+ */
+export const HouseholdProvider: FC<HouseholdProviderProps> = ({
+  children,
+  userId,
+  household,
+  members,
+}) => {
+  const currentMember = useMemo(
+    () => (userId ? (members.find((m) => m.userId === userId) ?? null) : null),
+    [userId, members],
+  );
+
+  const currentRole = currentMember?.role ?? null;
+
+  const isOwner = currentRole === 'OWNER';
+  const isAdminOrOwner = currentRole === 'OWNER' || currentRole === 'ADMIN';
+  const isInHousehold = currentMember !== null;
+
+  const hasPermission = useCallback(
+    (permission: HouseholdPermission): boolean => {
+      if (!currentRole) return false;
+      return ROLE_PERMISSIONS[currentRole].includes(permission);
+    },
+    [currentRole],
+  );
+
+  const canManage = isAdminOrOwner;
+
+  const contextValue = useMemo<HouseholdContextValue>(
+    () => ({
+      household,
+      currentMember,
+      currentRole,
+      members,
+      isOwner,
+      isAdminOrOwner,
+      isInHousehold,
+      hasPermission,
+      canManage,
+      userId,
+    }),
+    [
+      household,
+      currentMember,
+      currentRole,
+      members,
+      isOwner,
+      isAdminOrOwner,
+      isInHousehold,
+      hasPermission,
+      canManage,
+      userId,
+    ],
+  );
+
+  return <HouseholdContext.Provider value={contextValue}>{children}</HouseholdContext.Provider>;
+};
+
+// ---------------------------------------------------------------------------
+// Hooks
+// ---------------------------------------------------------------------------
+
+/**
+ * Access the household context.
+ *
+ * Must be called inside a `<HouseholdProvider>`.
+ *
+ * @throws Error if used outside the provider.
+ */
+export function useHouseholdContext(): HouseholdContextValue {
+  const ctx = useContext(HouseholdContext);
+  if (!ctx) {
+    throw new Error('useHouseholdContext must be used within a <HouseholdProvider>.');
+  }
+  return ctx;
+}
+
+/**
+ * Check if the current user has a specific household permission.
+ *
+ * Returns false when no provider is present (safe for shared components).
+ */
+export function useHouseholdPermission(permission: HouseholdPermission): boolean {
+  const ctx = useContext(HouseholdContext);
+  return ctx?.hasPermission(permission) ?? false;
+}

--- a/apps/web/src/contexts/index.ts
+++ b/apps/web/src/contexts/index.ts
@@ -8,3 +8,5 @@ export {
   MASKED_LABEL,
 } from './PrivacyModeContext';
 export type { PrivacyModeContextValue, PrivacyModeProviderProps } from './PrivacyModeContext';
+export { HouseholdProvider, useHouseholdContext, useHouseholdPermission } from './HouseholdContext';
+export type { HouseholdContextValue, HouseholdProviderProps } from './HouseholdContext';

--- a/apps/web/src/db/repositories/household.ts
+++ b/apps/web/src/db/repositories/household.ts
@@ -1,0 +1,732 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Household repository — CRUD operations for household, members, invitations,
+ * account sharing, shared budgets, and shared goals.
+ *
+ * All writes set `is_synced = 0` and `sync_version = 1` to flag records for
+ * future sync. Reads always filter `deleted_at IS NULL` (soft deletes).
+ *
+ * Monetary values are stored as integer cents.
+ *
+ * References: issues #1780, #1779, #1781, #1716, #1784, #1786
+ */
+
+import type {
+  AccountSharing,
+  AccountSharingMode,
+  Household,
+  HouseholdInvitation,
+  HouseholdMember,
+  HouseholdPermission,
+  HouseholdRole,
+  InvitationStatus,
+  SharedBudget,
+  SharedBudgetMode,
+  SharedGoal,
+  SyncId,
+  BudgetContribution,
+  GoalContribution,
+} from '../../kmp/bridge';
+import { ROLE_PERMISSIONS, cents } from '../../kmp/bridge';
+import { execute, query, queryOne, type Row, type SqliteDb } from '../sqlite-wasm';
+import {
+  SQLITE_NOW_EXPRESSION,
+  mapSyncMetadata,
+  optionalString,
+  requireNumber,
+  requireString,
+  toBoolean,
+} from './helpers';
+
+// ---------------------------------------------------------------------------
+// Table initialization
+// ---------------------------------------------------------------------------
+
+/**
+ * Create household-related tables if they don't already exist.
+ *
+ * Call this during database initialization to ensure the schema is ready.
+ */
+export function initHouseholdTables(db: SqliteDb): void {
+  execute(
+    db,
+    `CREATE TABLE IF NOT EXISTS household (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      owner_id TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      deleted_at TEXT,
+      sync_version INTEGER NOT NULL DEFAULT 1,
+      is_synced INTEGER NOT NULL DEFAULT 0
+    )`,
+    [],
+  );
+
+  execute(
+    db,
+    `CREATE TABLE IF NOT EXISTS household_member (
+      id TEXT PRIMARY KEY,
+      household_id TEXT NOT NULL,
+      user_id TEXT NOT NULL,
+      display_name TEXT,
+      role TEXT NOT NULL DEFAULT 'MEMBER',
+      joined_at TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      deleted_at TEXT,
+      sync_version INTEGER NOT NULL DEFAULT 1,
+      is_synced INTEGER NOT NULL DEFAULT 0,
+      FOREIGN KEY (household_id) REFERENCES household(id)
+    )`,
+    [],
+  );
+
+  execute(
+    db,
+    `CREATE TABLE IF NOT EXISTS household_invitation (
+      id TEXT PRIMARY KEY,
+      household_id TEXT NOT NULL,
+      invited_by TEXT NOT NULL,
+      email TEXT NOT NULL,
+      role TEXT NOT NULL DEFAULT 'MEMBER',
+      status TEXT NOT NULL DEFAULT 'PENDING',
+      invite_code TEXT NOT NULL,
+      expires_at TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      deleted_at TEXT,
+      sync_version INTEGER NOT NULL DEFAULT 1,
+      is_synced INTEGER NOT NULL DEFAULT 0,
+      FOREIGN KEY (household_id) REFERENCES household(id)
+    )`,
+    [],
+  );
+
+  execute(
+    db,
+    `CREATE TABLE IF NOT EXISTS account_sharing (
+      id TEXT PRIMARY KEY,
+      account_id TEXT NOT NULL,
+      household_id TEXT NOT NULL,
+      owner_id TEXT NOT NULL,
+      sharing_mode TEXT NOT NULL DEFAULT 'PRIVATE',
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      deleted_at TEXT,
+      sync_version INTEGER NOT NULL DEFAULT 1,
+      is_synced INTEGER NOT NULL DEFAULT 0,
+      FOREIGN KEY (household_id) REFERENCES household(id)
+    )`,
+    [],
+  );
+
+  execute(
+    db,
+    `CREATE TABLE IF NOT EXISTS shared_budget (
+      id TEXT PRIMARY KEY,
+      household_id TEXT NOT NULL,
+      budget_id TEXT NOT NULL,
+      mode TEXT NOT NULL DEFAULT 'CATEGORY',
+      is_active INTEGER NOT NULL DEFAULT 1,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      deleted_at TEXT,
+      sync_version INTEGER NOT NULL DEFAULT 1,
+      is_synced INTEGER NOT NULL DEFAULT 0,
+      FOREIGN KEY (household_id) REFERENCES household(id)
+    )`,
+    [],
+  );
+
+  execute(
+    db,
+    `CREATE TABLE IF NOT EXISTS shared_goal (
+      id TEXT PRIMARY KEY,
+      household_id TEXT NOT NULL,
+      goal_id TEXT NOT NULL,
+      is_shared INTEGER NOT NULL DEFAULT 1,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      deleted_at TEXT,
+      sync_version INTEGER NOT NULL DEFAULT 1,
+      is_synced INTEGER NOT NULL DEFAULT 0,
+      FOREIGN KEY (household_id) REFERENCES household(id)
+    )`,
+    [],
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Row mappers
+// ---------------------------------------------------------------------------
+
+function mapHousehold(row: Row): Household {
+  return {
+    id: requireString(row.id, 'household.id'),
+    name: requireString(row.name, 'household.name'),
+    ownerId: requireString(row.owner_id, 'household.owner_id'),
+    ...mapSyncMetadata(row),
+  };
+}
+
+function mapMember(row: Row): HouseholdMember {
+  return {
+    id: requireString(row.id, 'household_member.id'),
+    householdId: requireString(row.household_id, 'household_member.household_id'),
+    userId: requireString(row.user_id, 'household_member.user_id'),
+    displayName: optionalString(row.display_name),
+    role: requireString(row.role, 'household_member.role') as HouseholdRole,
+    joinedAt: requireString(row.joined_at, 'household_member.joined_at'),
+    ...mapSyncMetadata(row),
+  };
+}
+
+function mapInvitation(row: Row): HouseholdInvitation {
+  return {
+    id: requireString(row.id, 'household_invitation.id'),
+    householdId: requireString(row.household_id, 'household_invitation.household_id'),
+    invitedBy: requireString(row.invited_by, 'household_invitation.invited_by'),
+    email: requireString(row.email, 'household_invitation.email'),
+    role: requireString(row.role, 'household_invitation.role') as HouseholdRole,
+    status: requireString(row.status, 'household_invitation.status') as InvitationStatus,
+    inviteCode: requireString(row.invite_code, 'household_invitation.invite_code'),
+    expiresAt: requireString(row.expires_at, 'household_invitation.expires_at'),
+    ...mapSyncMetadata(row),
+  };
+}
+
+function mapAccountSharing(row: Row): AccountSharing {
+  return {
+    id: requireString(row.id, 'account_sharing.id'),
+    accountId: requireString(row.account_id, 'account_sharing.account_id'),
+    householdId: requireString(row.household_id, 'account_sharing.household_id'),
+    ownerId: requireString(row.owner_id, 'account_sharing.owner_id'),
+    sharingMode: requireString(
+      row.sharing_mode,
+      'account_sharing.sharing_mode',
+    ) as AccountSharingMode,
+    ...mapSyncMetadata(row),
+  };
+}
+
+function mapSharedBudget(row: Row): SharedBudget {
+  return {
+    id: requireString(row.id, 'shared_budget.id'),
+    householdId: requireString(row.household_id, 'shared_budget.household_id'),
+    budgetId: requireString(row.budget_id, 'shared_budget.budget_id'),
+    mode: requireString(row.mode, 'shared_budget.mode') as SharedBudgetMode,
+    isActive: toBoolean(row.is_active),
+    ...mapSyncMetadata(row),
+  };
+}
+
+function mapSharedGoal(row: Row): SharedGoal {
+  return {
+    id: requireString(row.id, 'shared_goal.id'),
+    householdId: requireString(row.household_id, 'shared_goal.household_id'),
+    goalId: requireString(row.goal_id, 'shared_goal.goal_id'),
+    isShared: toBoolean(row.is_shared),
+    ...mapSyncMetadata(row),
+  };
+}
+
+function _mapBudgetContribution(row: Row): BudgetContribution {
+  return {
+    memberId: requireString(row.member_id, 'budget_contribution.member_id'),
+    memberName: optionalString(row.member_name),
+    spentAmount: cents(requireNumber(row.spent_amount, 'budget_contribution.spent_amount')),
+  };
+}
+
+function _mapGoalContribution(row: Row): GoalContribution {
+  return {
+    memberId: requireString(row.member_id, 'goal_contribution.member_id'),
+    memberName: optionalString(row.member_name),
+    contributedAmount: cents(
+      requireNumber(row.contributed_amount, 'goal_contribution.contributed_amount'),
+    ),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Household CRUD
+// ---------------------------------------------------------------------------
+
+/** Input for creating a new household. */
+export interface CreateHouseholdInput {
+  name: string;
+  ownerId: SyncId;
+}
+
+/** Retrieve the household for a given owner. Returns null if none exists. */
+export function getHouseholdByOwner(db: SqliteDb, ownerId: SyncId): Household | null {
+  const row = queryOne(db, `SELECT * FROM household WHERE owner_id = ? AND deleted_at IS NULL`, [
+    ownerId,
+  ]);
+  return row ? mapHousehold(row) : null;
+}
+
+/** Retrieve a household by its ID. */
+export function getHouseholdById(db: SqliteDb, id: SyncId): Household | null {
+  const row = queryOne(db, `SELECT * FROM household WHERE id = ? AND deleted_at IS NULL`, [id]);
+  return row ? mapHousehold(row) : null;
+}
+
+/** Create a new household and add the creator as OWNER member. */
+export function createHousehold(db: SqliteDb, input: CreateHouseholdInput): Household {
+  const id = crypto.randomUUID();
+  const memberId = crypto.randomUUID();
+  const now = new Date().toISOString();
+
+  execute(
+    db,
+    `INSERT INTO household (id, name, owner_id, created_at, updated_at, sync_version, is_synced)
+     VALUES (?, ?, ?, ${SQLITE_NOW_EXPRESSION}, ${SQLITE_NOW_EXPRESSION}, 1, 0)`,
+    [id, input.name.trim(), input.ownerId],
+  );
+
+  execute(
+    db,
+    `INSERT INTO household_member (id, household_id, user_id, display_name, role, joined_at, created_at, updated_at, sync_version, is_synced)
+     VALUES (?, ?, ?, NULL, 'OWNER', ?, ${SQLITE_NOW_EXPRESSION}, ${SQLITE_NOW_EXPRESSION}, 1, 0)`,
+    [memberId, id, input.ownerId, now],
+  );
+
+  const row = queryOne(db, `SELECT * FROM household WHERE id = ?`, [id]);
+  return mapHousehold(row!);
+}
+
+// ---------------------------------------------------------------------------
+// Member CRUD
+// ---------------------------------------------------------------------------
+
+/** Retrieve all non-deleted members of a household. */
+export function getHouseholdMembers(db: SqliteDb, householdId: SyncId): HouseholdMember[] {
+  return query(
+    db,
+    `SELECT * FROM household_member WHERE household_id = ? AND deleted_at IS NULL ORDER BY joined_at ASC`,
+    [householdId],
+  ).rows.map(mapMember);
+}
+
+/** Update a member's role within the household. */
+export function updateMemberRole(
+  db: SqliteDb,
+  memberId: SyncId,
+  role: HouseholdRole,
+): HouseholdMember | null {
+  execute(
+    db,
+    `UPDATE household_member
+       SET role = ?, updated_at = ${SQLITE_NOW_EXPRESSION}, sync_version = 1, is_synced = 0
+     WHERE id = ? AND deleted_at IS NULL`,
+    [role, memberId],
+  );
+  const row = queryOne(db, `SELECT * FROM household_member WHERE id = ?`, [memberId]);
+  return row ? mapMember(row) : null;
+}
+
+/** Soft-delete a member from the household. */
+export function removeMember(db: SqliteDb, memberId: SyncId): boolean {
+  execute(
+    db,
+    `UPDATE household_member
+       SET deleted_at = ${SQLITE_NOW_EXPRESSION}, updated_at = ${SQLITE_NOW_EXPRESSION},
+           sync_version = 1, is_synced = 0
+     WHERE id = ? AND deleted_at IS NULL`,
+    [memberId],
+  );
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Invitation CRUD
+// ---------------------------------------------------------------------------
+
+/** Input for creating a new invitation. */
+export interface CreateInvitationInput {
+  householdId: SyncId;
+  invitedBy: SyncId;
+  email: string;
+  role: HouseholdRole;
+}
+
+/** Generate a short invite code (8 hex characters). */
+function generateInviteCode(): string {
+  const bytes = new Uint8Array(4);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/** Retrieve all non-deleted invitations for a household. */
+export function getHouseholdInvitations(db: SqliteDb, householdId: SyncId): HouseholdInvitation[] {
+  return query(
+    db,
+    `SELECT * FROM household_invitation WHERE household_id = ? AND deleted_at IS NULL ORDER BY created_at DESC`,
+    [householdId],
+  ).rows.map(mapInvitation);
+}
+
+/** Create a new invitation with a 7-day expiry. */
+export function createInvitation(db: SqliteDb, input: CreateInvitationInput): HouseholdInvitation {
+  const id = crypto.randomUUID();
+  const inviteCode = generateInviteCode();
+  const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+
+  execute(
+    db,
+    `INSERT INTO household_invitation (id, household_id, invited_by, email, role, status, invite_code, expires_at, created_at, updated_at, sync_version, is_synced)
+     VALUES (?, ?, ?, ?, ?, 'PENDING', ?, ?, ${SQLITE_NOW_EXPRESSION}, ${SQLITE_NOW_EXPRESSION}, 1, 0)`,
+    [
+      id,
+      input.householdId,
+      input.invitedBy,
+      input.email.trim().toLowerCase(),
+      input.role,
+      inviteCode,
+      expiresAt,
+    ],
+  );
+
+  const row = queryOne(db, `SELECT * FROM household_invitation WHERE id = ?`, [id]);
+  return mapInvitation(row!);
+}
+
+/** Accept a pending invitation by invite code. Creates a household member. */
+export function acceptInvitation(
+  db: SqliteDb,
+  inviteCode: string,
+  userId: SyncId,
+  displayName: string | null,
+): HouseholdMember | null {
+  const invRow = queryOne(
+    db,
+    `SELECT * FROM household_invitation
+     WHERE invite_code = ? AND status = 'PENDING' AND deleted_at IS NULL`,
+    [inviteCode],
+  );
+
+  if (!invRow) return null;
+
+  const invitation = mapInvitation(invRow);
+  const now = new Date();
+
+  // Check expiry
+  if (new Date(invitation.expiresAt) < now) {
+    execute(
+      db,
+      `UPDATE household_invitation
+         SET status = 'EXPIRED', updated_at = ${SQLITE_NOW_EXPRESSION}, sync_version = 1, is_synced = 0
+       WHERE id = ?`,
+      [invitation.id],
+    );
+    return null;
+  }
+
+  // Mark invitation as accepted
+  execute(
+    db,
+    `UPDATE household_invitation
+       SET status = 'ACCEPTED', updated_at = ${SQLITE_NOW_EXPRESSION}, sync_version = 1, is_synced = 0
+     WHERE id = ?`,
+    [invitation.id],
+  );
+
+  // Create the member with privacy-by-default: no accounts shared
+  const memberId = crypto.randomUUID();
+  execute(
+    db,
+    `INSERT INTO household_member (id, household_id, user_id, display_name, role, joined_at, created_at, updated_at, sync_version, is_synced)
+     VALUES (?, ?, ?, ?, ?, ?, ${SQLITE_NOW_EXPRESSION}, ${SQLITE_NOW_EXPRESSION}, 1, 0)`,
+    [memberId, invitation.householdId, userId, displayName, invitation.role, now.toISOString()],
+  );
+
+  const row = queryOne(db, `SELECT * FROM household_member WHERE id = ?`, [memberId]);
+  return row ? mapMember(row) : null;
+}
+
+/** Revoke a pending invitation (soft-delete). */
+export function revokeInvitation(db: SqliteDb, invitationId: SyncId): boolean {
+  execute(
+    db,
+    `UPDATE household_invitation
+       SET status = 'REVOKED', deleted_at = ${SQLITE_NOW_EXPRESSION},
+           updated_at = ${SQLITE_NOW_EXPRESSION}, sync_version = 1, is_synced = 0
+     WHERE id = ? AND status = 'PENDING' AND deleted_at IS NULL`,
+    [invitationId],
+  );
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Account Sharing (#1781, #1716)
+// ---------------------------------------------------------------------------
+
+/** Input for setting account sharing mode. */
+export interface SetAccountSharingInput {
+  accountId: SyncId;
+  householdId: SyncId;
+  ownerId: SyncId;
+  sharingMode: AccountSharingMode;
+}
+
+/** Get all account sharing settings for a household. */
+export function getAccountSharings(db: SqliteDb, householdId: SyncId): AccountSharing[] {
+  return query(db, `SELECT * FROM account_sharing WHERE household_id = ? AND deleted_at IS NULL`, [
+    householdId,
+  ]).rows.map(mapAccountSharing);
+}
+
+/** Get sharing mode for a specific account. Returns null if not configured (defaults to PRIVATE). */
+export function getAccountSharingByAccount(db: SqliteDb, accountId: SyncId): AccountSharing | null {
+  const row = queryOne(
+    db,
+    `SELECT * FROM account_sharing WHERE account_id = ? AND deleted_at IS NULL`,
+    [accountId],
+  );
+  return row ? mapAccountSharing(row) : null;
+}
+
+/** Set or update sharing mode for an account. Upsert pattern. */
+export function setAccountSharing(db: SqliteDb, input: SetAccountSharingInput): AccountSharing {
+  const existing = getAccountSharingByAccount(db, input.accountId);
+
+  if (existing) {
+    execute(
+      db,
+      `UPDATE account_sharing
+         SET sharing_mode = ?, updated_at = ${SQLITE_NOW_EXPRESSION},
+             sync_version = 1, is_synced = 0
+       WHERE id = ? AND deleted_at IS NULL`,
+      [input.sharingMode, existing.id],
+    );
+    const row = queryOne(db, `SELECT * FROM account_sharing WHERE id = ?`, [existing.id]);
+    return mapAccountSharing(row!);
+  }
+
+  const id = crypto.randomUUID();
+  execute(
+    db,
+    `INSERT INTO account_sharing (id, account_id, household_id, owner_id, sharing_mode, created_at, updated_at, sync_version, is_synced)
+     VALUES (?, ?, ?, ?, ?, ${SQLITE_NOW_EXPRESSION}, ${SQLITE_NOW_EXPRESSION}, 1, 0)`,
+    [id, input.accountId, input.householdId, input.ownerId, input.sharingMode],
+  );
+
+  const row = queryOne(db, `SELECT * FROM account_sharing WHERE id = ?`, [id]);
+  return mapAccountSharing(row!);
+}
+
+/**
+ * Check whether an account is visible to a given user within a household.
+ *
+ * Privacy boundary enforcement (#1716):
+ * - PRIVATE accounts are visible only to their owner
+ * - SHARED accounts are visible to all household members
+ * - Accounts with no sharing config default to PRIVATE (privacy-by-default)
+ */
+export function isAccountVisibleToUser(db: SqliteDb, accountId: SyncId, userId: SyncId): boolean {
+  const sharing = getAccountSharingByAccount(db, accountId);
+
+  // Default to PRIVATE — privacy-by-default
+  if (!sharing) return false;
+
+  if (sharing.sharingMode === 'SHARED') return true;
+
+  // PRIVATE — visible only to owner
+  return sharing.ownerId === userId;
+}
+
+/**
+ * Get all accounts visible to a user in a household context.
+ * Enforces privacy boundaries: only shared accounts + user's own private accounts.
+ */
+export function getVisibleAccountIds(db: SqliteDb, householdId: SyncId, userId: SyncId): SyncId[] {
+  return query(
+    db,
+    `SELECT account_id FROM account_sharing
+     WHERE household_id = ? AND deleted_at IS NULL
+       AND (sharing_mode = 'SHARED' OR owner_id = ?)`,
+    [householdId, userId],
+  ).rows.map((r: Row) => requireString(r.account_id, 'account_id'));
+}
+
+// ---------------------------------------------------------------------------
+// Shared Budgets (#1784)
+// ---------------------------------------------------------------------------
+
+/** Input for creating or updating a shared budget. */
+export interface SetSharedBudgetInput {
+  householdId: SyncId;
+  budgetId: SyncId;
+  mode: SharedBudgetMode;
+}
+
+/** Get all shared budgets for a household. */
+export function getSharedBudgets(db: SqliteDb, householdId: SyncId): SharedBudget[] {
+  return query(db, `SELECT * FROM shared_budget WHERE household_id = ? AND deleted_at IS NULL`, [
+    householdId,
+  ]).rows.map(mapSharedBudget);
+}
+
+/** Set or update a shared budget configuration. Upsert pattern. */
+export function setSharedBudget(db: SqliteDb, input: SetSharedBudgetInput): SharedBudget {
+  const existing = queryOne(
+    db,
+    `SELECT * FROM shared_budget WHERE budget_id = ? AND household_id = ? AND deleted_at IS NULL`,
+    [input.budgetId, input.householdId],
+  );
+
+  if (existing) {
+    execute(
+      db,
+      `UPDATE shared_budget
+         SET mode = ?, is_active = 1, updated_at = ${SQLITE_NOW_EXPRESSION},
+             sync_version = 1, is_synced = 0
+       WHERE id = ?`,
+      [input.mode, requireString(existing.id, 'shared_budget.id')],
+    );
+    const row = queryOne(db, `SELECT * FROM shared_budget WHERE id = ?`, [
+      requireString(existing.id, 'shared_budget.id'),
+    ]);
+    return mapSharedBudget(row!);
+  }
+
+  const id = crypto.randomUUID();
+  execute(
+    db,
+    `INSERT INTO shared_budget (id, household_id, budget_id, mode, is_active, created_at, updated_at, sync_version, is_synced)
+     VALUES (?, ?, ?, ?, 1, ${SQLITE_NOW_EXPRESSION}, ${SQLITE_NOW_EXPRESSION}, 1, 0)`,
+    [id, input.householdId, input.budgetId, input.mode],
+  );
+
+  const row = queryOne(db, `SELECT * FROM shared_budget WHERE id = ?`, [id]);
+  return mapSharedBudget(row!);
+}
+
+/** Deactivate (soft-delete) a shared budget. */
+export function removeSharedBudget(db: SqliteDb, sharedBudgetId: SyncId): boolean {
+  execute(
+    db,
+    `UPDATE shared_budget
+       SET is_active = 0, deleted_at = ${SQLITE_NOW_EXPRESSION},
+           updated_at = ${SQLITE_NOW_EXPRESSION}, sync_version = 1, is_synced = 0
+     WHERE id = ? AND deleted_at IS NULL`,
+    [sharedBudgetId],
+  );
+  return true;
+}
+
+/**
+ * Get budget contribution breakdown by member (stub).
+ *
+ * In production this joins transactions on shared accounts against
+ * budget categories. For now returns an empty array — real implementation
+ * requires transaction aggregation queries.
+ */
+export function getBudgetContributions(
+  _db: SqliteDb,
+  _sharedBudgetId: SyncId,
+): BudgetContribution[] {
+  // TODO: Implement transaction aggregation for contribution tracking
+  return [];
+}
+
+// ---------------------------------------------------------------------------
+// Shared Goals (#1786)
+// ---------------------------------------------------------------------------
+
+/** Input for sharing a goal with the household. */
+export interface SetSharedGoalInput {
+  householdId: SyncId;
+  goalId: SyncId;
+  isShared: boolean;
+}
+
+/** Get all shared goals for a household. */
+export function getSharedGoals(db: SqliteDb, householdId: SyncId): SharedGoal[] {
+  return query(
+    db,
+    `SELECT * FROM shared_goal WHERE household_id = ? AND deleted_at IS NULL AND is_shared = 1`,
+    [householdId],
+  ).rows.map(mapSharedGoal);
+}
+
+/** Set or update shared goal configuration. Upsert pattern. */
+export function setSharedGoal(db: SqliteDb, input: SetSharedGoalInput): SharedGoal {
+  const existing = queryOne(
+    db,
+    `SELECT * FROM shared_goal WHERE goal_id = ? AND household_id = ? AND deleted_at IS NULL`,
+    [input.goalId, input.householdId],
+  );
+
+  if (existing) {
+    execute(
+      db,
+      `UPDATE shared_goal
+         SET is_shared = ?, updated_at = ${SQLITE_NOW_EXPRESSION},
+             sync_version = 1, is_synced = 0
+       WHERE id = ?`,
+      [input.isShared ? 1 : 0, requireString(existing.id, 'shared_goal.id')],
+    );
+    const row = queryOne(db, `SELECT * FROM shared_goal WHERE id = ?`, [
+      requireString(existing.id, 'shared_goal.id'),
+    ]);
+    return mapSharedGoal(row!);
+  }
+
+  const id = crypto.randomUUID();
+  execute(
+    db,
+    `INSERT INTO shared_goal (id, household_id, goal_id, is_shared, created_at, updated_at, sync_version, is_synced)
+     VALUES (?, ?, ?, ?, ${SQLITE_NOW_EXPRESSION}, ${SQLITE_NOW_EXPRESSION}, 1, 0)`,
+    [id, input.householdId, input.goalId, input.isShared ? 1 : 0],
+  );
+
+  const row = queryOne(db, `SELECT * FROM shared_goal WHERE id = ?`, [id]);
+  return mapSharedGoal(row!);
+}
+
+/**
+ * Get goal contribution breakdown by member (stub).
+ *
+ * In production this joins transaction/deposit data against goal accounts.
+ * For now returns an empty array — real implementation requires
+ * transaction aggregation queries.
+ */
+export function getGoalContributions(_db: SqliteDb, _sharedGoalId: SyncId): GoalContribution[] {
+  // TODO: Implement contribution aggregation for shared goals
+  return [];
+}
+
+// ---------------------------------------------------------------------------
+// Permission helpers (#1780)
+// ---------------------------------------------------------------------------
+
+/** Check whether a role has a specific permission. */
+export function hasPermission(role: HouseholdRole, permission: HouseholdPermission): boolean {
+  return ROLE_PERMISSIONS[role].includes(permission);
+}
+
+/** Get all permissions for a role. */
+export function getPermissionsForRole(role: HouseholdRole): readonly HouseholdPermission[] {
+  return ROLE_PERMISSIONS[role];
+}
+
+/** Determine the role of a user within a household. Returns null if not a member. */
+export function getUserRole(
+  db: SqliteDb,
+  householdId: SyncId,
+  userId: SyncId,
+): HouseholdRole | null {
+  const row = queryOne(
+    db,
+    `SELECT role FROM household_member
+     WHERE household_id = ? AND user_id = ? AND deleted_at IS NULL`,
+    [householdId, userId],
+  );
+  return row ? (requireString(row.role, 'role') as HouseholdRole) : null;
+}

--- a/apps/web/src/db/repositories/index.ts
+++ b/apps/web/src/db/repositories/index.ts
@@ -8,3 +8,4 @@ export * from './categories';
 export * from './investments';
 export * from './investment-lots';
 export * from './bills';
+export * from './household';

--- a/apps/web/src/hooks/__tests__/household-permissions.test.ts
+++ b/apps/web/src/hooks/__tests__/household-permissions.test.ts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for household permission logic and privacy boundary enforcement.
+ *
+ * Validates:
+ * - Role-based permission checks (#1780)
+ * - Privacy-by-default for new members (#1779)
+ * - Account visibility enforcement (#1716)
+ * - Permission hierarchy (OWNER > ADMIN > MEMBER > VIEWER)
+ *
+ * References: issues #1780, #1779, #1716
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import type { HouseholdPermission, HouseholdRole } from '../../kmp/bridge';
+import { ROLE_PERMISSIONS } from '../../kmp/bridge';
+import { hasPermission, getPermissionsForRole } from '../../db/repositories/household';
+
+// ---------------------------------------------------------------------------
+// Role permission tests (#1780)
+// ---------------------------------------------------------------------------
+
+describe('Household Role Permissions', () => {
+  describe('OWNER role', () => {
+    it('has all permissions', () => {
+      const allPerms: HouseholdPermission[] = [
+        'MANAGE_MEMBERS',
+        'INVITE_MEMBERS',
+        'MANAGE_ROLES',
+        'VIEW_SHARED_ACCOUNTS',
+        'EDIT_SHARED_ACCOUNTS',
+        'CREATE_SHARED_BUDGETS',
+        'EDIT_SHARED_BUDGETS',
+        'VIEW_SHARED_BUDGETS',
+        'CREATE_SHARED_GOALS',
+        'EDIT_SHARED_GOALS',
+        'VIEW_SHARED_GOALS',
+        'ADD_TRANSACTIONS',
+      ];
+
+      for (const perm of allPerms) {
+        expect(hasPermission('OWNER', perm)).toBe(true);
+      }
+    });
+
+    it('has the most permissions of any role', () => {
+      const ownerPerms = getPermissionsForRole('OWNER');
+      const adminPerms = getPermissionsForRole('ADMIN');
+      const memberPerms = getPermissionsForRole('MEMBER');
+      const viewerPerms = getPermissionsForRole('VIEWER');
+
+      expect(ownerPerms.length).toBeGreaterThanOrEqual(adminPerms.length);
+      expect(adminPerms.length).toBeGreaterThanOrEqual(memberPerms.length);
+      expect(memberPerms.length).toBeGreaterThanOrEqual(viewerPerms.length);
+    });
+  });
+
+  describe('ADMIN role', () => {
+    it('can invite members and manage roles', () => {
+      expect(hasPermission('ADMIN', 'INVITE_MEMBERS')).toBe(true);
+      expect(hasPermission('ADMIN', 'MANAGE_ROLES')).toBe(true);
+    });
+
+    it('cannot manage members (OWNER-only)', () => {
+      expect(hasPermission('ADMIN', 'MANAGE_MEMBERS')).toBe(false);
+    });
+
+    it('can view and edit shared accounts', () => {
+      expect(hasPermission('ADMIN', 'VIEW_SHARED_ACCOUNTS')).toBe(true);
+      expect(hasPermission('ADMIN', 'EDIT_SHARED_ACCOUNTS')).toBe(true);
+    });
+  });
+
+  describe('MEMBER role', () => {
+    it('can view shared data and add transactions', () => {
+      expect(hasPermission('MEMBER', 'VIEW_SHARED_ACCOUNTS')).toBe(true);
+      expect(hasPermission('MEMBER', 'VIEW_SHARED_BUDGETS')).toBe(true);
+      expect(hasPermission('MEMBER', 'VIEW_SHARED_GOALS')).toBe(true);
+      expect(hasPermission('MEMBER', 'ADD_TRANSACTIONS')).toBe(true);
+    });
+
+    it('cannot edit shared accounts or create budgets', () => {
+      expect(hasPermission('MEMBER', 'EDIT_SHARED_ACCOUNTS')).toBe(false);
+      expect(hasPermission('MEMBER', 'CREATE_SHARED_BUDGETS')).toBe(false);
+      expect(hasPermission('MEMBER', 'INVITE_MEMBERS')).toBe(false);
+    });
+  });
+
+  describe('VIEWER role', () => {
+    it('can only view shared data', () => {
+      expect(hasPermission('VIEWER', 'VIEW_SHARED_ACCOUNTS')).toBe(true);
+      expect(hasPermission('VIEWER', 'VIEW_SHARED_BUDGETS')).toBe(true);
+      expect(hasPermission('VIEWER', 'VIEW_SHARED_GOALS')).toBe(true);
+    });
+
+    it('cannot add transactions or modify anything', () => {
+      expect(hasPermission('VIEWER', 'ADD_TRANSACTIONS')).toBe(false);
+      expect(hasPermission('VIEWER', 'EDIT_SHARED_ACCOUNTS')).toBe(false);
+      expect(hasPermission('VIEWER', 'CREATE_SHARED_BUDGETS')).toBe(false);
+      expect(hasPermission('VIEWER', 'INVITE_MEMBERS')).toBe(false);
+      expect(hasPermission('VIEWER', 'MANAGE_MEMBERS')).toBe(false);
+      expect(hasPermission('VIEWER', 'MANAGE_ROLES')).toBe(false);
+    });
+  });
+
+  describe('Permission hierarchy', () => {
+    it('each role is a strict subset of the role above it', () => {
+      const hierarchy: HouseholdRole[] = ['VIEWER', 'MEMBER', 'ADMIN', 'OWNER'];
+
+      for (let i = 0; i < hierarchy.length - 1; i++) {
+        const lowerPerms = new Set(ROLE_PERMISSIONS[hierarchy[i]]);
+        const higherPerms = new Set(ROLE_PERMISSIONS[hierarchy[i + 1]]);
+
+        // Every permission in the lower role must exist in the higher role
+        for (const perm of lowerPerms) {
+          expect(higherPerms.has(perm)).toBe(true);
+        }
+      }
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Privacy-by-default tests (#1779, #1716)
+// ---------------------------------------------------------------------------
+
+describe('Privacy-by-Default', () => {
+  it('ROLE_PERMISSIONS does not grant MANAGE_MEMBERS to non-owners', () => {
+    const nonOwnerRoles: HouseholdRole[] = ['ADMIN', 'MEMBER', 'VIEWER'];
+    for (const role of nonOwnerRoles) {
+      expect(ROLE_PERMISSIONS[role].includes('MANAGE_MEMBERS')).toBe(false);
+    }
+  });
+
+  it('all roles have defined permissions (no undefined entries)', () => {
+    const allRoles: HouseholdRole[] = ['OWNER', 'ADMIN', 'MEMBER', 'VIEWER'];
+    for (const role of allRoles) {
+      expect(ROLE_PERMISSIONS[role]).toBeDefined();
+      expect(Array.isArray(ROLE_PERMISSIONS[role])).toBe(true);
+      expect(ROLE_PERMISSIONS[role].length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/web/src/hooks/__tests__/useHousehold.test.ts
+++ b/apps/web/src/hooks/__tests__/useHousehold.test.ts
@@ -13,6 +13,10 @@ import { useHousehold } from '../useHousehold';
 let uuidCounter = 0;
 vi.stubGlobal('crypto', {
   randomUUID: () => `uuid-${++uuidCounter}`,
+  getRandomValues: (arr: Uint8Array) => {
+    for (let i = 0; i < arr.length; i++) arr[i] = i + 1;
+    return arr;
+  },
 });
 
 beforeEach(() => {
@@ -60,15 +64,15 @@ describe('useHousehold', () => {
     act(() => {
       invitation = result.current.inviteMember({
         email: 'partner@example.com',
-        role: 'PARTNER',
+        role: 'ADMIN',
       });
     });
 
     expect(invitation).not.toBeNull();
     expect(result.current.invitations).toHaveLength(1);
     expect(result.current.invitations[0]?.email).toBe('partner@example.com');
-    expect(result.current.invitations[0]?.role).toBe('PARTNER');
-    expect(result.current.invitations[0]?.status).toBe('pending');
+    expect(result.current.invitations[0]?.role).toBe('ADMIN');
+    expect(result.current.invitations[0]?.status).toBe('PENDING');
   });
 
   it('returns null when inviting without a household', () => {
@@ -106,7 +110,6 @@ describe('useHousehold', () => {
     });
 
     expect(revoked!).toBe(true);
-    expect(result.current.invitations).toHaveLength(0);
   });
 
   it('updates a member role', () => {
@@ -116,18 +119,17 @@ describe('useHousehold', () => {
       result.current.createHousehold({ name: 'Test' });
     });
 
-    // The first member is the owner — we cannot change owner role in this test,
-    // but we test the mechanism
+    // The first member is the owner — we test the mechanism
     const memberId = result.current.members[0]?.id;
     expect(memberId).toBeDefined();
 
     let updated: boolean;
     act(() => {
-      updated = result.current.updateMemberRole(memberId!, 'PARTNER');
+      updated = result.current.updateMemberRole(memberId!, 'ADMIN');
     });
 
     expect(updated!).toBe(true);
-    expect(result.current.members[0]?.role).toBe('PARTNER');
+    expect(result.current.members[0]?.role).toBe('ADMIN');
   });
 
   it('removes a member', () => {
@@ -148,21 +150,25 @@ describe('useHousehold', () => {
     expect(result.current.members).toHaveLength(0);
   });
 
-  it('toggles budget visibility', () => {
+  it('sets account sharing mode', () => {
     const { result } = renderHook(() => useHousehold());
 
     act(() => {
-      result.current.toggleBudgetVisibility('budget-1');
+      result.current.createHousehold({ name: 'Test' });
     });
-
-    expect(result.current.budgetVisibility).toHaveLength(1);
-    expect(result.current.budgetVisibility[0]?.isShared).toBe(true);
 
     act(() => {
-      result.current.toggleBudgetVisibility('budget-1');
+      result.current.setAccountSharing({ accountId: 'acct-1', sharingMode: 'SHARED' });
     });
 
-    expect(result.current.budgetVisibility[0]?.isShared).toBe(false);
+    expect(result.current.accountSharings).toHaveLength(1);
+    expect(result.current.accountSharings[0]?.sharingMode).toBe('SHARED');
+
+    act(() => {
+      result.current.setAccountSharing({ accountId: 'acct-1', sharingMode: 'PRIVATE' });
+    });
+
+    expect(result.current.accountSharings[0]?.sharingMode).toBe('PRIVATE');
   });
 
   it('persists household data to localStorage', () => {
@@ -179,5 +185,14 @@ describe('useHousehold', () => {
 
     expect(result2.current.household?.name).toBe('Persistent Family');
     expect(result2.current.members).toHaveLength(1);
+  });
+
+  it('checks permissions correctly', () => {
+    const { result } = renderHook(() => useHousehold());
+
+    expect(result.current.checkPermission('OWNER', 'MANAGE_MEMBERS')).toBe(true);
+    expect(result.current.checkPermission('VIEWER', 'MANAGE_MEMBERS')).toBe(false);
+    expect(result.current.checkPermission('MEMBER', 'ADD_TRANSACTIONS')).toBe(true);
+    expect(result.current.checkPermission('VIEWER', 'ADD_TRANSACTIONS')).toBe(false);
   });
 });

--- a/apps/web/src/hooks/index.ts
+++ b/apps/web/src/hooks/index.ts
@@ -161,3 +161,12 @@ export type {
   DataCategory,
   StorageQuotaInfo,
 } from './usePrivacyDashboard';
+export { useHousehold } from './useHousehold';
+export type {
+  UseHouseholdResult,
+  CreateHouseholdInput,
+  InviteMemberInput,
+  SetAccountSharingInput,
+  SetSharedBudgetInput,
+  SetSharedGoalInput,
+} from './useHousehold';

--- a/apps/web/src/hooks/useHousehold.ts
+++ b/apps/web/src/hooks/useHousehold.ts
@@ -3,86 +3,147 @@
 /**
  * React hook for household/family plan management.
  *
- * Provides household CRUD, member invitation, role management,
- * and shared vs personal budget toggling.
+ * Provides household CRUD, member invitation with privacy-by-default,
+ * role management, account sharing (mine/yours/ours), shared budgets
+ * with flex/category modes, shared goals, and permission checks.
  *
  * Usage:
  * ```tsx
- * const { household, members, inviteMember, updateRole } = useHousehold();
+ * const {
+ *   household,
+ *   members,
+ *   invitations,
+ *   accountSharings,
+ *   sharedBudgets,
+ *   sharedGoals,
+ *   inviteMember,
+ *   updateMemberRole,
+ *   setAccountSharing,
+ * } = useHousehold();
  * ```
  *
- * References: issue #339
+ * References: issues #1780, #1779, #1781, #1716, #1784, #1786
  */
 
 import { useCallback, useEffect, useState } from 'react';
 
-import type { Household, HouseholdMember, HouseholdRole, SyncId } from '../kmp/bridge';
+import type {
+  AccountSharing,
+  AccountSharingMode,
+  Household,
+  HouseholdInvitation,
+  HouseholdMember,
+  HouseholdPermission,
+  HouseholdRole,
+  SharedBudget,
+  SharedBudgetMode,
+  SharedGoal,
+  SyncId,
+} from '../kmp/bridge';
+import { ROLE_PERMISSIONS } from '../kmp/bridge';
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-export interface HouseholdInvitation {
-  readonly id: string;
-  readonly householdId: SyncId;
-  readonly email: string;
-  readonly role: HouseholdRole;
-  readonly status: 'pending' | 'accepted' | 'expired';
-  readonly createdAt: string;
-  readonly expiresAt: string;
-}
-
+/** Input for creating a new household. */
 export interface CreateHouseholdInput {
   name: string;
 }
 
+/** Input for inviting a member to the household. */
 export interface InviteMemberInput {
   email: string;
   role: HouseholdRole;
 }
 
-export interface BudgetVisibility {
+/** Input for setting account sharing mode. */
+export interface SetAccountSharingInput {
+  accountId: SyncId;
+  sharingMode: AccountSharingMode;
+}
+
+/** Input for configuring a shared budget. */
+export interface SetSharedBudgetInput {
   budgetId: SyncId;
+  mode: SharedBudgetMode;
+}
+
+/** Input for sharing/unsharing a goal. */
+export interface SetSharedGoalInput {
+  goalId: SyncId;
   isShared: boolean;
 }
 
+/** Complete return shape of the useHousehold hook. */
 export interface UseHouseholdResult {
   /** The current user's household, or null if none exists. */
   household: Household | null;
   /** All members of the current household. */
   members: HouseholdMember[];
-  /** Pending invitations for the household. */
+  /** All invitations for the household. */
   invitations: HouseholdInvitation[];
-  /** Budget visibility settings (shared vs personal). */
-  budgetVisibility: BudgetVisibility[];
+  /** Account sharing configurations. */
+  accountSharings: AccountSharing[];
+  /** Shared budget configurations. */
+  sharedBudgets: SharedBudget[];
+  /** Shared goal configurations. */
+  sharedGoals: SharedGoal[];
   /** True while loading data. */
   loading: boolean;
   /** Human-readable error message, or null. */
   error: string | null;
+
+  // -- Household management ---
   /** Create a new household. */
   createHousehold: (input: CreateHouseholdInput) => Household | null;
+
+  // -- Invitation flow (#1779) ---
   /** Invite a member to the household. */
   inviteMember: (input: InviteMemberInput) => HouseholdInvitation | null;
+  /** Accept an invitation by invite code. */
+  acceptInvitation: (inviteCode: string) => HouseholdMember | null;
   /** Revoke a pending invitation. */
-  revokeInvitation: (invitationId: string) => boolean;
+  revokeInvitation: (invitationId: SyncId) => boolean;
+
+  // -- Role management (#1780) ---
   /** Update a member's role. */
   updateMemberRole: (memberId: SyncId, role: HouseholdRole) => boolean;
   /** Remove a member from the household. */
   removeMember: (memberId: SyncId) => boolean;
-  /** Toggle a budget between shared and personal. */
-  toggleBudgetVisibility: (budgetId: SyncId) => boolean;
+  /** Check if a role has a specific permission. */
+  checkPermission: (role: HouseholdRole, permission: HouseholdPermission) => boolean;
+
+  // -- Account sharing (#1781, #1716) ---
+  /** Set sharing mode for an account (PRIVATE or SHARED). */
+  setAccountSharing: (input: SetAccountSharingInput) => AccountSharing | null;
+  /** Check if an account is visible to the current user. */
+  isAccountVisible: (accountId: SyncId) => boolean;
+
+  // -- Shared budgets (#1784) ---
+  /** Configure a shared budget with flex or category mode. */
+  setSharedBudget: (input: SetSharedBudgetInput) => SharedBudget | null;
+  /** Remove a shared budget configuration. */
+  removeSharedBudget: (sharedBudgetId: SyncId) => boolean;
+
+  // -- Shared goals (#1786) ---
+  /** Share or unshare a goal with the household. */
+  setSharedGoal: (input: SetSharedGoalInput) => SharedGoal | null;
+
   /** Refresh all household data. */
   refresh: () => void;
 }
 
 // ---------------------------------------------------------------------------
-// Simulated storage (local state — bridged to SQLite in production)
+// Simulated storage (local state — bridged to SQLite repositories in production)
 // ---------------------------------------------------------------------------
 
 const STORAGE_KEY_HOUSEHOLD = 'finance-household';
 const STORAGE_KEY_MEMBERS = 'finance-household-members';
 const STORAGE_KEY_INVITATIONS = 'finance-household-invitations';
-const STORAGE_KEY_BUDGET_VIS = 'finance-budget-visibility';
+const STORAGE_KEY_ACCOUNT_SHARINGS = 'finance-account-sharings';
+const STORAGE_KEY_SHARED_BUDGETS = 'finance-shared-budgets';
+const STORAGE_KEY_SHARED_GOALS = 'finance-shared-goals';
 
 function loadFromStorage<T>(key: string, fallback: T): T {
   try {
@@ -97,15 +158,37 @@ function saveToStorage<T>(key: string, value: T): void {
   localStorage.setItem(key, JSON.stringify(value));
 }
 
+/** Generate a short invite code (8 hex characters). */
+function generateInviteCode(): string {
+  const bytes = new Uint8Array(4);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
 // ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------
 
+/**
+ * Comprehensive household management hook.
+ *
+ * Covers all six household-related issues:
+ * - #1780: Roles and permissions (OWNER, ADMIN, MEMBER, VIEWER)
+ * - #1779: Invitation flow with privacy-by-default onboarding
+ * - #1781: Selective account sharing (mine/yours/ours)
+ * - #1716: "Mine only" privacy boundaries
+ * - #1784: Shared household budgets (flex + category modes)
+ * - #1786: Shared savings goals
+ */
 export function useHousehold(): UseHouseholdResult {
   const [household, setHousehold] = useState<Household | null>(null);
   const [members, setMembers] = useState<HouseholdMember[]>([]);
   const [invitations, setInvitations] = useState<HouseholdInvitation[]>([]);
-  const [budgetVisibility, setBudgetVisibility] = useState<BudgetVisibility[]>([]);
+  const [accountSharings, setAccountSharings] = useState<AccountSharing[]>([]);
+  const [sharedBudgets, setSharedBudgets] = useState<SharedBudget[]>([]);
+  const [sharedGoals, setSharedGoals] = useState<SharedGoal[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [refreshToken, setRefreshToken] = useState(0);
@@ -115,20 +198,18 @@ export function useHousehold(): UseHouseholdResult {
     setRefreshToken((t) => t + 1);
   }, []);
 
+  // -- Load data from storage on mount / refresh --
   useEffect(() => {
     setLoading(true);
     setError(null);
 
     try {
-      const hh = loadFromStorage<Household | null>(STORAGE_KEY_HOUSEHOLD, null);
-      const mems = loadFromStorage<HouseholdMember[]>(STORAGE_KEY_MEMBERS, []);
-      const invs = loadFromStorage<HouseholdInvitation[]>(STORAGE_KEY_INVITATIONS, []);
-      const vis = loadFromStorage<BudgetVisibility[]>(STORAGE_KEY_BUDGET_VIS, []);
-
-      setHousehold(hh);
-      setMembers(mems);
-      setInvitations(invs);
-      setBudgetVisibility(vis);
+      setHousehold(loadFromStorage<Household | null>(STORAGE_KEY_HOUSEHOLD, null));
+      setMembers(loadFromStorage<HouseholdMember[]>(STORAGE_KEY_MEMBERS, []));
+      setInvitations(loadFromStorage<HouseholdInvitation[]>(STORAGE_KEY_INVITATIONS, []));
+      setAccountSharings(loadFromStorage<AccountSharing[]>(STORAGE_KEY_ACCOUNT_SHARINGS, []));
+      setSharedBudgets(loadFromStorage<SharedBudget[]>(STORAGE_KEY_SHARED_BUDGETS, []));
+      setSharedGoals(loadFromStorage<SharedGoal[]>(STORAGE_KEY_SHARED_GOALS, []));
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load household data.');
     } finally {
@@ -136,6 +217,7 @@ export function useHousehold(): UseHouseholdResult {
     }
   }, [refreshToken]);
 
+  // -- Household creation --
   const createHousehold = useCallback((input: CreateHouseholdInput): Household | null => {
     try {
       const now = new Date().toISOString();
@@ -155,6 +237,7 @@ export function useHousehold(): UseHouseholdResult {
         id: crypto.randomUUID(),
         householdId: newHousehold.id,
         userId: ownerId,
+        displayName: null,
         role: 'OWNER',
         joinedAt: now,
         createdAt: now,
@@ -176,6 +259,7 @@ export function useHousehold(): UseHouseholdResult {
     }
   }, []);
 
+  // -- Invitation flow (#1779) --
   const inviteMember = useCallback(
     (input: InviteMemberInput): HouseholdInvitation | null => {
       if (!household) {
@@ -190,11 +274,17 @@ export function useHousehold(): UseHouseholdResult {
         const invitation: HouseholdInvitation = {
           id: crypto.randomUUID(),
           householdId: household.id,
+          invitedBy: household.ownerId,
           email: input.email.trim().toLowerCase(),
           role: input.role,
-          status: 'pending',
-          createdAt: now.toISOString(),
+          status: 'PENDING',
+          inviteCode: generateInviteCode(),
           expiresAt: expiresAt.toISOString(),
+          createdAt: now.toISOString(),
+          updatedAt: now.toISOString(),
+          deletedAt: null,
+          syncVersion: 1,
+          isSynced: false,
         };
 
         const updated = [...invitations, invitation];
@@ -209,11 +299,84 @@ export function useHousehold(): UseHouseholdResult {
     [household, invitations],
   );
 
-  const revokeInvitation = useCallback(
-    (invitationId: string): boolean => {
+  const acceptInvitation = useCallback(
+    (inviteCode: string): HouseholdMember | null => {
       try {
-        const updated = invitations.filter((inv) => inv.id !== invitationId);
-        if (updated.length === invitations.length) return false;
+        const invitation = invitations.find(
+          (inv) => inv.inviteCode === inviteCode && inv.status === 'PENDING',
+        );
+
+        if (!invitation) {
+          setError('Invalid or expired invitation code.');
+          return null;
+        }
+
+        // Check expiry
+        if (new Date(invitation.expiresAt) < new Date()) {
+          const updatedInvs = invitations.map((inv) =>
+            inv.id === invitation.id
+              ? { ...inv, status: 'EXPIRED' as const, updatedAt: new Date().toISOString() }
+              : inv,
+          );
+          saveToStorage(STORAGE_KEY_INVITATIONS, updatedInvs);
+          setInvitations(updatedInvs);
+          setError('This invitation has expired.');
+          return null;
+        }
+
+        const now = new Date().toISOString();
+
+        // Privacy-by-default: new member joins with no shared accounts
+        const newMember: HouseholdMember = {
+          id: crypto.randomUUID(),
+          householdId: invitation.householdId,
+          userId: crypto.randomUUID(),
+          displayName: null,
+          role: invitation.role,
+          joinedAt: now,
+          createdAt: now,
+          updatedAt: now,
+          deletedAt: null,
+          syncVersion: 1,
+          isSynced: false,
+        };
+
+        // Mark invitation as accepted
+        const updatedInvs = invitations.map((inv) =>
+          inv.id === invitation.id ? { ...inv, status: 'ACCEPTED' as const, updatedAt: now } : inv,
+        );
+
+        const updatedMembers = [...members, newMember];
+
+        saveToStorage(STORAGE_KEY_INVITATIONS, updatedInvs);
+        saveToStorage(STORAGE_KEY_MEMBERS, updatedMembers);
+        setInvitations(updatedInvs);
+        setMembers(updatedMembers);
+
+        return newMember;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to accept invitation.');
+        return null;
+      }
+    },
+    [invitations, members],
+  );
+
+  const revokeInvitation = useCallback(
+    (invitationId: SyncId): boolean => {
+      try {
+        const updated = invitations.map((inv) =>
+          inv.id === invitationId && inv.status === 'PENDING'
+            ? {
+                ...inv,
+                status: 'REVOKED' as const,
+                updatedAt: new Date().toISOString(),
+                deletedAt: new Date().toISOString(),
+              }
+            : inv,
+        );
+        const changed = updated.some((inv, i) => inv !== invitations[i]);
+        if (!changed) return false;
         saveToStorage(STORAGE_KEY_INVITATIONS, updated);
         setInvitations(updated);
         return true;
@@ -225,6 +388,7 @@ export function useHousehold(): UseHouseholdResult {
     [invitations],
   );
 
+  // -- Role management (#1780) --
   const updateMemberRole = useCallback(
     (memberId: SyncId, role: HouseholdRole): boolean => {
       try {
@@ -260,42 +424,203 @@ export function useHousehold(): UseHouseholdResult {
     [members],
   );
 
-  const toggleBudgetVisibility = useCallback(
-    (budgetId: SyncId): boolean => {
+  const checkPermission = useCallback(
+    (role: HouseholdRole, permission: HouseholdPermission): boolean => {
+      return ROLE_PERMISSIONS[role].includes(permission);
+    },
+    [],
+  );
+
+  // -- Account sharing (#1781, #1716) --
+  const setAccountSharingFn = useCallback(
+    (input: SetAccountSharingInput): AccountSharing | null => {
+      if (!household) {
+        setError('No household exists.');
+        return null;
+      }
+
       try {
-        const existing = budgetVisibility.find((bv) => bv.budgetId === budgetId);
-        let updated: BudgetVisibility[];
+        const now = new Date().toISOString();
+        const existing = accountSharings.find((as) => as.accountId === input.accountId);
+
         if (existing) {
-          updated = budgetVisibility.map((bv) =>
-            bv.budgetId === budgetId ? { ...bv, isShared: !bv.isShared } : bv,
+          const updated = accountSharings.map((as) =>
+            as.accountId === input.accountId
+              ? { ...as, sharingMode: input.sharingMode, updatedAt: now }
+              : as,
           );
-        } else {
-          updated = [...budgetVisibility, { budgetId, isShared: true }];
+          saveToStorage(STORAGE_KEY_ACCOUNT_SHARINGS, updated);
+          setAccountSharings(updated);
+          return updated.find((as) => as.accountId === input.accountId) ?? null;
         }
-        saveToStorage(STORAGE_KEY_BUDGET_VIS, updated);
-        setBudgetVisibility(updated);
+
+        const newSharing: AccountSharing = {
+          id: crypto.randomUUID(),
+          accountId: input.accountId,
+          householdId: household.id,
+          ownerId: household.ownerId,
+          sharingMode: input.sharingMode,
+          createdAt: now,
+          updatedAt: now,
+          deletedAt: null,
+          syncVersion: 1,
+          isSynced: false,
+        };
+
+        const updated = [...accountSharings, newSharing];
+        saveToStorage(STORAGE_KEY_ACCOUNT_SHARINGS, updated);
+        setAccountSharings(updated);
+        return newSharing;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to update account sharing.');
+        return null;
+      }
+    },
+    [household, accountSharings],
+  );
+
+  const isAccountVisible = useCallback(
+    (accountId: SyncId): boolean => {
+      const sharing = accountSharings.find((as) => as.accountId === accountId);
+      // Privacy-by-default: no sharing config means PRIVATE
+      if (!sharing) return false;
+      if (sharing.sharingMode === 'SHARED') return true;
+      // PRIVATE — only visible to owner
+      return sharing.ownerId === household?.ownerId;
+    },
+    [accountSharings, household],
+  );
+
+  // -- Shared budgets (#1784) --
+  const setSharedBudgetFn = useCallback(
+    (input: SetSharedBudgetInput): SharedBudget | null => {
+      if (!household) {
+        setError('No household exists.');
+        return null;
+      }
+
+      try {
+        const now = new Date().toISOString();
+        const existing = sharedBudgets.find((sb) => sb.budgetId === input.budgetId);
+
+        if (existing) {
+          const updated = sharedBudgets.map((sb) =>
+            sb.budgetId === input.budgetId
+              ? { ...sb, mode: input.mode, isActive: true, updatedAt: now }
+              : sb,
+          );
+          saveToStorage(STORAGE_KEY_SHARED_BUDGETS, updated);
+          setSharedBudgets(updated);
+          return updated.find((sb) => sb.budgetId === input.budgetId) ?? null;
+        }
+
+        const newSharedBudget: SharedBudget = {
+          id: crypto.randomUUID(),
+          householdId: household.id,
+          budgetId: input.budgetId,
+          mode: input.mode,
+          isActive: true,
+          createdAt: now,
+          updatedAt: now,
+          deletedAt: null,
+          syncVersion: 1,
+          isSynced: false,
+        };
+
+        const updated = [...sharedBudgets, newSharedBudget];
+        saveToStorage(STORAGE_KEY_SHARED_BUDGETS, updated);
+        setSharedBudgets(updated);
+        return newSharedBudget;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to set shared budget.');
+        return null;
+      }
+    },
+    [household, sharedBudgets],
+  );
+
+  const removeSharedBudget = useCallback(
+    (sharedBudgetId: SyncId): boolean => {
+      try {
+        const updated = sharedBudgets.filter((sb) => sb.id !== sharedBudgetId);
+        if (updated.length === sharedBudgets.length) return false;
+        saveToStorage(STORAGE_KEY_SHARED_BUDGETS, updated);
+        setSharedBudgets(updated);
         return true;
       } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to toggle budget visibility.');
+        setError(err instanceof Error ? err.message : 'Failed to remove shared budget.');
         return false;
       }
     },
-    [budgetVisibility],
+    [sharedBudgets],
+  );
+
+  // -- Shared goals (#1786) --
+  const setSharedGoalFn = useCallback(
+    (input: SetSharedGoalInput): SharedGoal | null => {
+      if (!household) {
+        setError('No household exists.');
+        return null;
+      }
+
+      try {
+        const now = new Date().toISOString();
+        const existing = sharedGoals.find((sg) => sg.goalId === input.goalId);
+
+        if (existing) {
+          const updated = sharedGoals.map((sg) =>
+            sg.goalId === input.goalId ? { ...sg, isShared: input.isShared, updatedAt: now } : sg,
+          );
+          saveToStorage(STORAGE_KEY_SHARED_GOALS, updated);
+          setSharedGoals(updated);
+          return updated.find((sg) => sg.goalId === input.goalId) ?? null;
+        }
+
+        const newSharedGoal: SharedGoal = {
+          id: crypto.randomUUID(),
+          householdId: household.id,
+          goalId: input.goalId,
+          isShared: input.isShared,
+          createdAt: now,
+          updatedAt: now,
+          deletedAt: null,
+          syncVersion: 1,
+          isSynced: false,
+        };
+
+        const updated = [...sharedGoals, newSharedGoal];
+        saveToStorage(STORAGE_KEY_SHARED_GOALS, updated);
+        setSharedGoals(updated);
+        return newSharedGoal;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to set shared goal.');
+        return null;
+      }
+    },
+    [household, sharedGoals],
   );
 
   return {
     household,
     members,
     invitations,
-    budgetVisibility,
+    accountSharings,
+    sharedBudgets,
+    sharedGoals,
     loading,
     error,
     createHousehold,
     inviteMember,
+    acceptInvitation,
     revokeInvitation,
     updateMemberRole,
     removeMember,
-    toggleBudgetVisibility,
+    checkPermission,
+    setAccountSharing: setAccountSharingFn,
+    isAccountVisible,
+    setSharedBudget: setSharedBudgetFn,
+    removeSharedBudget,
+    setSharedGoal: setSharedGoalFn,
     refresh,
   };
 }

--- a/apps/web/src/kmp/bridge.ts
+++ b/apps/web/src/kmp/bridge.ts
@@ -206,15 +206,139 @@ export interface Household extends SyncMetadata {
 }
 
 /** Maps to KMP `com.finance.models.HouseholdRole`. */
-export type HouseholdRole = 'OWNER' | 'PARTNER' | 'MEMBER' | 'VIEWER';
+export type HouseholdRole = 'OWNER' | 'ADMIN' | 'MEMBER' | 'VIEWER';
 
 /** Maps to KMP `com.finance.models.HouseholdMember`. */
 export interface HouseholdMember extends SyncMetadata {
   readonly id: SyncId;
   readonly householdId: SyncId;
   readonly userId: SyncId;
+  readonly displayName: string | null;
   readonly role: HouseholdRole;
   readonly joinedAt: Instant;
+}
+
+/**
+ * Permission capabilities that can be assigned per household role.
+ * Maps to KMP `com.finance.models.HouseholdPermission`.
+ */
+export type HouseholdPermission =
+  | 'MANAGE_MEMBERS'
+  | 'INVITE_MEMBERS'
+  | 'MANAGE_ROLES'
+  | 'VIEW_SHARED_ACCOUNTS'
+  | 'EDIT_SHARED_ACCOUNTS'
+  | 'CREATE_SHARED_BUDGETS'
+  | 'EDIT_SHARED_BUDGETS'
+  | 'VIEW_SHARED_BUDGETS'
+  | 'CREATE_SHARED_GOALS'
+  | 'EDIT_SHARED_GOALS'
+  | 'VIEW_SHARED_GOALS'
+  | 'ADD_TRANSACTIONS';
+
+/** Default permissions per household role. */
+export const ROLE_PERMISSIONS: Readonly<Record<HouseholdRole, readonly HouseholdPermission[]>> = {
+  OWNER: [
+    'MANAGE_MEMBERS',
+    'INVITE_MEMBERS',
+    'MANAGE_ROLES',
+    'VIEW_SHARED_ACCOUNTS',
+    'EDIT_SHARED_ACCOUNTS',
+    'CREATE_SHARED_BUDGETS',
+    'EDIT_SHARED_BUDGETS',
+    'VIEW_SHARED_BUDGETS',
+    'CREATE_SHARED_GOALS',
+    'EDIT_SHARED_GOALS',
+    'VIEW_SHARED_GOALS',
+    'ADD_TRANSACTIONS',
+  ],
+  ADMIN: [
+    'INVITE_MEMBERS',
+    'MANAGE_ROLES',
+    'VIEW_SHARED_ACCOUNTS',
+    'EDIT_SHARED_ACCOUNTS',
+    'CREATE_SHARED_BUDGETS',
+    'EDIT_SHARED_BUDGETS',
+    'VIEW_SHARED_BUDGETS',
+    'CREATE_SHARED_GOALS',
+    'EDIT_SHARED_GOALS',
+    'VIEW_SHARED_GOALS',
+    'ADD_TRANSACTIONS',
+  ],
+  MEMBER: ['VIEW_SHARED_ACCOUNTS', 'VIEW_SHARED_BUDGETS', 'VIEW_SHARED_GOALS', 'ADD_TRANSACTIONS'],
+  VIEWER: ['VIEW_SHARED_ACCOUNTS', 'VIEW_SHARED_BUDGETS', 'VIEW_SHARED_GOALS'],
+};
+
+/** Status of a household invitation. */
+export type InvitationStatus = 'PENDING' | 'ACCEPTED' | 'EXPIRED' | 'REVOKED';
+
+/** Maps to KMP `com.finance.models.HouseholdInvitation`. */
+export interface HouseholdInvitation extends SyncMetadata {
+  readonly id: SyncId;
+  readonly householdId: SyncId;
+  readonly invitedBy: SyncId;
+  readonly email: string;
+  readonly role: HouseholdRole;
+  readonly status: InvitationStatus;
+  readonly inviteCode: string;
+  readonly expiresAt: Instant;
+}
+
+/**
+ * Account sharing mode for mine/yours/ours finances.
+ * Maps to KMP `com.finance.models.AccountSharingMode`.
+ *
+ * - `PRIVATE` — visible only to the owner ("mine only")
+ * - `SHARED` — visible to all household members ("ours")
+ */
+export type AccountSharingMode = 'PRIVATE' | 'SHARED';
+
+/** Per-account sharing configuration within a household. */
+export interface AccountSharing extends SyncMetadata {
+  readonly id: SyncId;
+  readonly accountId: SyncId;
+  readonly householdId: SyncId;
+  readonly ownerId: SyncId;
+  readonly sharingMode: AccountSharingMode;
+}
+
+/**
+ * Shared budget mode for household budgets.
+ *
+ * - `FLEX` — overall spending limit, spend freely within categories
+ * - `CATEGORY` — per-category limits for the household
+ */
+export type SharedBudgetMode = 'FLEX' | 'CATEGORY';
+
+/** Shared household budget configuration. */
+export interface SharedBudget extends SyncMetadata {
+  readonly id: SyncId;
+  readonly householdId: SyncId;
+  readonly budgetId: SyncId;
+  readonly mode: SharedBudgetMode;
+  readonly isActive: boolean;
+}
+
+/** Per-member contribution tracking for a shared budget. */
+export interface BudgetContribution {
+  readonly memberId: SyncId;
+  readonly memberName: string | null;
+  readonly spentAmount: Cents;
+}
+
+/** Shared household goal with per-member contribution tracking. */
+export interface SharedGoal extends SyncMetadata {
+  readonly id: SyncId;
+  readonly householdId: SyncId;
+  readonly goalId: SyncId;
+  readonly isShared: boolean;
+}
+
+/** Per-member contribution tracking for a shared goal. */
+export interface GoalContribution {
+  readonly memberId: SyncId;
+  readonly memberName: string | null;
+  readonly contributedAmount: Cents;
 }
 
 /** Maps to KMP `com.finance.models.InvestmentType`. */

--- a/apps/web/src/pages/HouseholdPage.css
+++ b/apps/web/src/pages/HouseholdPage.css
@@ -377,14 +377,25 @@
   }
 
   .household-member-item,
-  .household-invitation-item {
+  .household-invitation-item,
+  .household-sharing-item,
+  .household-goal-item {
     flex-direction: column;
     align-items: flex-start;
   }
 
-  .household-member-item__actions {
+  .household-member-item__actions,
+  .household-budget-item__controls {
     width: 100%;
     justify-content: flex-end;
+  }
+
+  .household-permissions-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .household-permissions-table-wrap {
+    overflow-x: auto;
   }
 }
 
@@ -439,4 +450,265 @@
   .household-button {
     border-width: 2px;
   }
+}
+
+/* ---------------------------------------------------------------------------
+ * Member permission count
+ * ------------------------------------------------------------------------- */
+
+.household-member-item__permissions {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+  display: block;
+}
+
+/* ---------------------------------------------------------------------------
+ * Permissions details / accordion
+ * ------------------------------------------------------------------------- */
+
+.household-permissions-details {
+  margin-top: var(--spacing-4);
+  border-top: 1px solid var(--semantic-border-default);
+  padding-top: var(--spacing-3);
+}
+
+.household-permissions-summary {
+  cursor: pointer;
+  font-size: var(--type-scale-body-font-size);
+  font-weight: var(--font-weight-medium);
+  color: var(--semantic-interactive-default);
+  padding: var(--spacing-2) 0;
+}
+
+.household-permissions-summary:hover {
+  text-decoration: underline;
+}
+
+.household-permissions-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: var(--spacing-4);
+  margin-top: var(--spacing-3);
+}
+
+.household-permissions-column__title {
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-primary);
+  margin-bottom: var(--spacing-2);
+}
+
+.household-permissions-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.household-permissions-list__item {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+  padding: var(--spacing-1) 0;
+  text-transform: capitalize;
+}
+
+/* ---------------------------------------------------------------------------
+ * Account sharing items (#1781, #1716)
+ * ------------------------------------------------------------------------- */
+
+.household-sharing-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+}
+
+.household-sharing-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-3);
+  background: var(--semantic-background-secondary);
+  border-radius: var(--border-radius-md);
+  gap: var(--spacing-3);
+}
+
+.household-sharing-item__info {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+}
+
+.household-sharing-item__name {
+  font-weight: var(--font-weight-medium);
+  color: var(--semantic-text-primary);
+}
+
+.household-sharing-item__badge {
+  font-size: var(--type-scale-caption-font-size);
+  padding: var(--spacing-1) var(--spacing-2);
+  border-radius: var(--border-radius-full, 9999px);
+  font-weight: var(--font-weight-medium);
+}
+
+.household-sharing-item__badge--shared {
+  background: var(--color-green-50, #f0fdf4);
+  color: var(--semantic-status-positive);
+}
+
+.household-sharing-item__badge--private {
+  background: var(--color-amber-50, #fffbeb);
+  color: var(--semantic-status-warning);
+}
+
+/* ---------------------------------------------------------------------------
+ * Privacy boundary note
+ * ------------------------------------------------------------------------- */
+
+.household-card__note {
+  margin-top: var(--spacing-4);
+  padding: var(--spacing-3);
+  background: var(--color-blue-50, #eff6ff);
+  border-left: 3px solid var(--semantic-interactive-default);
+  border-radius: var(--border-radius-md);
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+  line-height: var(--line-height-relaxed, 1.5);
+}
+
+/* ---------------------------------------------------------------------------
+ * Shared budget controls (#1784)
+ * ------------------------------------------------------------------------- */
+
+.household-budget-item__info {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.household-budget-item__mode {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+.household-budget-item__controls {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
+/* ---------------------------------------------------------------------------
+ * Shared goal items (#1786)
+ * ------------------------------------------------------------------------- */
+
+.household-goal-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+}
+
+.household-goal-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-3);
+  background: var(--semantic-background-secondary);
+  border-radius: var(--border-radius-md);
+  gap: var(--spacing-3);
+}
+
+.household-goal-item__info {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+}
+
+.household-goal-item__name {
+  font-weight: var(--font-weight-medium);
+  color: var(--semantic-text-primary);
+}
+
+.household-goal-item__badge {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-status-positive);
+}
+
+/* ---------------------------------------------------------------------------
+ * Invitation code display
+ * ------------------------------------------------------------------------- */
+
+.household-invitation-item__code {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+  font-family: monospace;
+}
+
+/* ---------------------------------------------------------------------------
+ * Permission reference table
+ * ------------------------------------------------------------------------- */
+
+.household-permissions-table-wrap {
+  overflow-x: auto;
+}
+
+.household-permissions-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.household-permissions-table th,
+.household-permissions-table td {
+  padding: var(--spacing-2) var(--spacing-3);
+  text-align: left;
+  border-bottom: 1px solid var(--semantic-border-default);
+}
+
+.household-permissions-table th {
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-primary);
+  background: var(--semantic-background-secondary);
+}
+
+.household-permissions-table td {
+  color: var(--semantic-text-secondary);
+  text-transform: capitalize;
+}
+
+.household-permissions-table__cell {
+  text-align: center;
+}
+
+/* ---------------------------------------------------------------------------
+ * Dark mode overrides for new elements
+ * ------------------------------------------------------------------------- */
+
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme='light']) .household-sharing-item__badge--shared {
+    background: rgba(34, 197, 94, 0.1);
+  }
+
+  html:not([data-theme='light']) .household-sharing-item__badge--private {
+    background: rgba(245, 158, 11, 0.1);
+  }
+
+  html:not([data-theme='light']) .household-card__note {
+    background: rgba(59, 130, 246, 0.1);
+  }
+}
+
+[data-theme='dark'] .household-sharing-item__badge--shared {
+  background: rgba(34, 197, 94, 0.1);
+}
+
+[data-theme='dark'] .household-sharing-item__badge--private {
+  background: rgba(245, 158, 11, 0.1);
+}
+
+[data-theme='dark'] .household-card__note {
+  background: rgba(59, 130, 246, 0.1);
 }

--- a/apps/web/src/pages/HouseholdPage.test.tsx
+++ b/apps/web/src/pages/HouseholdPage.test.tsx
@@ -22,16 +22,59 @@ function mockHouseholdResult(overrides: Partial<UseHouseholdResult> = {}): UseHo
     household: null,
     members: [],
     invitations: [],
-    budgetVisibility: [],
+    accountSharings: [],
+    sharedBudgets: [],
+    sharedGoals: [],
     loading: false,
     error: null,
     createHousehold: vi.fn(),
     inviteMember: vi.fn(),
+    acceptInvitation: vi.fn(),
     revokeInvitation: vi.fn(),
     updateMemberRole: vi.fn(),
     removeMember: vi.fn(),
-    toggleBudgetVisibility: vi.fn(),
+    checkPermission: vi.fn().mockReturnValue(false),
+    setAccountSharing: vi.fn(),
+    isAccountVisible: vi.fn().mockReturnValue(false),
+    setSharedBudget: vi.fn(),
+    removeSharedBudget: vi.fn(),
+    setSharedGoal: vi.fn(),
     refresh: vi.fn(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helper — creates a standard household for tests that need one
+// ---------------------------------------------------------------------------
+
+function makeHousehold(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'hh-1',
+    name: 'Smith Family',
+    ownerId: 'user-1',
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-01T00:00:00Z',
+    deletedAt: null,
+    syncVersion: 1,
+    isSynced: true,
+    ...overrides,
+  };
+}
+
+function makeOwnerMember(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'mem-1',
+    householdId: 'hh-1',
+    userId: 'user-1-abcdef',
+    displayName: null,
+    role: 'OWNER' as const,
+    joinedAt: '2025-01-01T00:00:00Z',
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-01T00:00:00Z',
+    deletedAt: null,
+    syncVersion: 1,
+    isSynced: true,
     ...overrides,
   };
 }
@@ -63,33 +106,19 @@ describe('HouseholdPage', () => {
     expect(screen.getByRole('button', { name: /create household/i })).toBeInTheDocument();
   });
 
+  it('mentions privacy-by-default in creation form', () => {
+    mockedUseHousehold.mockReturnValue(mockHouseholdResult());
+
+    render(<HouseholdPage />);
+
+    expect(screen.getByText(/privacy-by-default/i)).toBeInTheDocument();
+  });
+
   it('renders household management when household exists', () => {
     mockedUseHousehold.mockReturnValue(
       mockHouseholdResult({
-        household: {
-          id: 'hh-1',
-          name: 'Smith Family',
-          ownerId: 'user-1',
-          createdAt: '2025-01-01T00:00:00Z',
-          updatedAt: '2025-01-01T00:00:00Z',
-          deletedAt: null,
-          syncVersion: 1,
-          isSynced: true,
-        },
-        members: [
-          {
-            id: 'mem-1',
-            householdId: 'hh-1',
-            userId: 'user-1-abcdef',
-            role: 'OWNER',
-            joinedAt: '2025-01-01T00:00:00Z',
-            createdAt: '2025-01-01T00:00:00Z',
-            updatedAt: '2025-01-01T00:00:00Z',
-            deletedAt: null,
-            syncVersion: 1,
-            isSynced: true,
-          },
-        ],
+        household: makeHousehold(),
+        members: [makeOwnerMember()],
       }),
     );
 
@@ -97,24 +126,18 @@ describe('HouseholdPage', () => {
 
     expect(screen.getByText('Smith Family')).toBeInTheDocument();
     expect(screen.getByText('Family Plan')).toBeInTheDocument();
-    expect(screen.getByText('Members')).toBeInTheDocument();
+    expect(screen.getByText('Members & Roles')).toBeInTheDocument();
     expect(screen.getByText('Invite Member')).toBeInTheDocument();
-    expect(screen.getByText('Budget Sharing')).toBeInTheDocument();
+    expect(screen.getByText('Account Sharing')).toBeInTheDocument();
+    expect(screen.getByText('Shared Budgets')).toBeInTheDocument();
+    expect(screen.getByText('Shared Goals')).toBeInTheDocument();
+    expect(screen.getByText('Permission Reference')).toBeInTheDocument();
   });
 
   it('displays error banner when error exists', () => {
     mockedUseHousehold.mockReturnValue(
       mockHouseholdResult({
-        household: {
-          id: 'hh-1',
-          name: 'Test',
-          ownerId: 'user-1',
-          createdAt: '2025-01-01T00:00:00Z',
-          updatedAt: '2025-01-01T00:00:00Z',
-          deletedAt: null,
-          syncVersion: 1,
-          isSynced: true,
-        },
+        household: makeHousehold({ name: 'Test' }),
         error: 'Something went wrong',
       }),
     );
@@ -127,25 +150,22 @@ describe('HouseholdPage', () => {
   it('shows pending invitations section when invitations exist', () => {
     mockedUseHousehold.mockReturnValue(
       mockHouseholdResult({
-        household: {
-          id: 'hh-1',
-          name: 'Test',
-          ownerId: 'user-1',
-          createdAt: '2025-01-01T00:00:00Z',
-          updatedAt: '2025-01-01T00:00:00Z',
-          deletedAt: null,
-          syncVersion: 1,
-          isSynced: true,
-        },
+        household: makeHousehold({ name: 'Test' }),
         invitations: [
           {
             id: 'inv-1',
             householdId: 'hh-1',
+            invitedBy: 'user-1',
             email: 'partner@example.com',
-            role: 'PARTNER',
-            status: 'pending',
-            createdAt: '2025-01-01T00:00:00Z',
+            role: 'ADMIN',
+            status: 'PENDING',
+            inviteCode: 'abc12345',
             expiresAt: '2025-01-08T00:00:00Z',
+            createdAt: '2025-01-01T00:00:00Z',
+            updatedAt: '2025-01-01T00:00:00Z',
+            deletedAt: null,
+            syncVersion: 1,
+            isSynced: true,
           },
         ],
       }),
@@ -155,30 +175,109 @@ describe('HouseholdPage', () => {
 
     expect(screen.getByText('Pending Invitations')).toBeInTheDocument();
     expect(screen.getByText('partner@example.com')).toBeInTheDocument();
+    expect(screen.getByText('Code: abc12345')).toBeInTheDocument();
   });
 
-  it('renders budget sharing toggles', () => {
+  it('renders account sharing toggles with privacy labels', () => {
     mockedUseHousehold.mockReturnValue(
       mockHouseholdResult({
-        household: {
-          id: 'hh-1',
-          name: 'Test',
-          ownerId: 'user-1',
-          createdAt: '2025-01-01T00:00:00Z',
-          updatedAt: '2025-01-01T00:00:00Z',
-          deletedAt: null,
-          syncVersion: 1,
-          isSynced: true,
-        },
-        budgetVisibility: [{ budgetId: 'budget-1', isShared: true }],
+        household: makeHousehold({ name: 'Test' }),
+        accountSharings: [
+          {
+            id: 'as-1',
+            accountId: 'acct-checking',
+            householdId: 'hh-1',
+            ownerId: 'user-1',
+            sharingMode: 'SHARED',
+            createdAt: '2025-01-01T00:00:00Z',
+            updatedAt: '2025-01-01T00:00:00Z',
+            deletedAt: null,
+            syncVersion: 1,
+            isSynced: true,
+          },
+        ],
       }),
     );
 
     render(<HouseholdPage />);
 
+    // Account sharing section exists
+    expect(screen.getByText('Account Sharing')).toBeInTheDocument();
+    expect(screen.getByText('Checking Account')).toBeInTheDocument();
+
+    // Privacy boundary note exists
+    expect(screen.getByText(/privacy boundary/i)).toBeInTheDocument();
+
+    // Shared account has toggle
     const toggles = screen.getAllByRole('switch');
-    expect(toggles.length).toBe(3);
-    expect(toggles[0]).toHaveAttribute('aria-checked', 'true');
-    expect(toggles[1]).toHaveAttribute('aria-checked', 'false');
+    expect(toggles.length).toBeGreaterThan(0);
+  });
+
+  it('renders shared budget controls with mode selector', () => {
+    mockedUseHousehold.mockReturnValue(
+      mockHouseholdResult({
+        household: makeHousehold({ name: 'Test' }),
+        sharedBudgets: [
+          {
+            id: 'sb-1',
+            householdId: 'hh-1',
+            budgetId: 'budget-groceries',
+            mode: 'FLEX',
+            isActive: true,
+            createdAt: '2025-01-01T00:00:00Z',
+            updatedAt: '2025-01-01T00:00:00Z',
+            deletedAt: null,
+            syncVersion: 1,
+            isSynced: true,
+          },
+        ],
+      }),
+    );
+
+    render(<HouseholdPage />);
+
+    expect(screen.getByText('Shared Budgets')).toBeInTheDocument();
+    expect(screen.getByText('Groceries')).toBeInTheDocument();
+  });
+
+  it('renders shared goals with toggle', () => {
+    mockedUseHousehold.mockReturnValue(
+      mockHouseholdResult({
+        household: makeHousehold({ name: 'Test' }),
+        sharedGoals: [
+          {
+            id: 'sg-1',
+            householdId: 'hh-1',
+            goalId: 'goal-vacation',
+            isShared: true,
+            createdAt: '2025-01-01T00:00:00Z',
+            updatedAt: '2025-01-01T00:00:00Z',
+            deletedAt: null,
+            syncVersion: 1,
+            isSynced: true,
+          },
+        ],
+      }),
+    );
+
+    render(<HouseholdPage />);
+
+    expect(screen.getByText('Shared Goals')).toBeInTheDocument();
+    expect(screen.getByText('Family Vacation')).toBeInTheDocument();
+    expect(screen.getByText('Shared with household')).toBeInTheDocument();
+  });
+
+  it('shows role permission reference table', () => {
+    mockedUseHousehold.mockReturnValue(
+      mockHouseholdResult({
+        household: makeHousehold({ name: 'Test' }),
+        checkPermission: vi.fn().mockReturnValue(true),
+      }),
+    );
+
+    render(<HouseholdPage />);
+
+    expect(screen.getByText('Permission Reference')).toBeInTheDocument();
+    expect(screen.getByLabelText('Role permissions matrix')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/HouseholdPage.tsx
+++ b/apps/web/src/pages/HouseholdPage.tsx
@@ -1,19 +1,21 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /**
- * Family/Household Plan page.
+ * Household management page.
  *
- * Provides household creation, member invitation, role management,
- * and shared vs personal budget toggling.
+ * Provides household creation, member invitation with privacy-by-default,
+ * role management (OWNER, ADMIN, MEMBER, VIEWER), account sharing
+ * (mine/yours/ours), shared budget configuration, and shared goals.
  *
- * References: issue #339
+ * References: issues #1780, #1779, #1781, #1716, #1784, #1786
  */
 
 import { useCallback, useState } from 'react';
 import type { FormEvent } from 'react';
 
 import { useHousehold } from '../hooks/useHousehold';
-import type { HouseholdRole } from '../kmp/bridge';
+import type { HouseholdRole, AccountSharingMode, SharedBudgetMode } from '../kmp/bridge';
+import { ROLE_PERMISSIONS } from '../kmp/bridge';
 
 import './HouseholdPage.css';
 
@@ -21,17 +23,52 @@ import './HouseholdPage.css';
 // Constants
 // ---------------------------------------------------------------------------
 
+/** Role options for assignment (excludes OWNER — assigned only on creation). */
 const ROLE_OPTIONS: readonly { value: HouseholdRole; label: string; description: string }[] = [
-  { value: 'PARTNER', label: 'Partner', description: 'Full access to all shared finances' },
-  { value: 'MEMBER', label: 'Member', description: 'Can view and add transactions' },
+  { value: 'ADMIN', label: 'Admin', description: 'Can manage members and shared finances' },
+  { value: 'MEMBER', label: 'Member', description: 'Can view shared data and add transactions' },
   { value: 'VIEWER', label: 'Viewer', description: 'Read-only access to shared data' },
 ];
 
 const ROLE_LABELS: Record<HouseholdRole, string> = {
   OWNER: 'Owner',
-  PARTNER: 'Partner',
+  ADMIN: 'Admin',
   MEMBER: 'Member',
   VIEWER: 'Viewer',
+};
+
+const SHARING_MODE_LABELS: Record<AccountSharingMode, string> = {
+  PRIVATE: 'Private (Mine Only)',
+  SHARED: 'Shared (Ours)',
+};
+
+const BUDGET_MODE_LABELS: Record<SharedBudgetMode, string> = {
+  FLEX: 'Flex (overall limit)',
+  CATEGORY: 'Category (per-category limits)',
+};
+
+/** Demo account IDs for account sharing toggles. */
+const DEMO_ACCOUNT_IDS = ['acct-checking', 'acct-savings', 'acct-credit'];
+const DEMO_ACCOUNT_NAMES: Record<string, string> = {
+  'acct-checking': 'Checking Account',
+  'acct-savings': 'Savings Account',
+  'acct-credit': 'Credit Card',
+};
+
+/** Demo budget IDs for shared budget configuration. */
+const DEMO_BUDGET_IDS = ['budget-groceries', 'budget-dining', 'budget-entertainment'];
+const DEMO_BUDGET_NAMES: Record<string, string> = {
+  'budget-groceries': 'Groceries',
+  'budget-dining': 'Dining Out',
+  'budget-entertainment': 'Entertainment',
+};
+
+/** Demo goal IDs for shared goals. */
+const DEMO_GOAL_IDS = ['goal-vacation', 'goal-emergency', 'goal-car'];
+const DEMO_GOAL_NAMES: Record<string, string> = {
+  'goal-vacation': 'Family Vacation',
+  'goal-emergency': 'Emergency Fund',
+  'goal-car': 'New Car',
 };
 
 // ---------------------------------------------------------------------------
@@ -43,7 +80,9 @@ export function HouseholdPage() {
     household,
     members,
     invitations,
-    budgetVisibility,
+    accountSharings,
+    sharedBudgets,
+    sharedGoals,
     loading,
     error,
     createHousehold,
@@ -51,7 +90,11 @@ export function HouseholdPage() {
     revokeInvitation,
     updateMemberRole,
     removeMember,
-    toggleBudgetVisibility,
+    setAccountSharing,
+    setSharedBudget,
+    removeSharedBudget,
+    setSharedGoal,
+    checkPermission,
   } = useHousehold();
 
   // -- Create household form state -----------------------------------------
@@ -63,9 +106,6 @@ export function HouseholdPage() {
   const [inviteRole, setInviteRole] = useState<HouseholdRole>('MEMBER');
   const [inviteError, setInviteError] = useState<string | null>(null);
   const [inviteSuccess, setInviteSuccess] = useState(false);
-
-  // -- Budget IDs for demo toggle ------------------------------------------
-  const demoBudgetIds = ['budget-1', 'budget-2', 'budget-3'];
 
   // -- Handlers ------------------------------------------------------------
 
@@ -137,6 +177,7 @@ export function HouseholdPage() {
           </h1>
           <p className="household-card__description">
             Set up a household to share budgets and track finances together with family members.
+            Privacy-by-default: nothing is shared until you explicitly opt in.
           </p>
 
           {createError && (
@@ -173,6 +214,9 @@ export function HouseholdPage() {
     );
   }
 
+  // -- Filter pending invitations for display
+  const pendingInvitations = invitations.filter((inv) => inv.status === 'PENDING');
+
   // -- Household exists — full management UI --------------------------------
 
   return (
@@ -191,11 +235,17 @@ export function HouseholdPage() {
         <span className="household-header__badge">Family Plan</span>
       </header>
 
-      {/* Members Section */}
+      {/* ----------------------------------------------------------------- */}
+      {/* Members & Roles Section (#1780) */}
+      {/* ----------------------------------------------------------------- */}
       <section className="household-card" aria-labelledby="members-title">
         <h2 id="members-title" className="household-card__title">
-          Members
+          Members &amp; Roles
         </h2>
+        <p className="household-card__description">
+          Manage household members and their permission levels. Each role determines what actions a
+          member can perform.
+        </p>
 
         {members.length === 0 ? (
           <p className="household-card__empty">No members yet.</p>
@@ -205,13 +255,16 @@ export function HouseholdPage() {
               <li key={member.id} className="household-member-item">
                 <div className="household-member-item__info">
                   <span className="household-member-item__avatar" aria-hidden="true">
-                    {member.role === 'OWNER' ? '👑' : '👤'}
+                    {member.role === 'OWNER' ? '👑' : member.role === 'ADMIN' ? '🛡️' : '👤'}
                   </span>
                   <div>
                     <span className="household-member-item__name">
-                      {member.userId.slice(0, 8)}…
+                      {member.displayName ?? `${member.userId.slice(0, 8)}…`}
                     </span>
                     <span className="household-member-item__role">{ROLE_LABELS[member.role]}</span>
+                    <span className="household-member-item__permissions">
+                      {ROLE_PERMISSIONS[member.role].length} permissions
+                    </span>
                   </div>
                 </div>
                 {member.role !== 'OWNER' && (
@@ -220,7 +273,7 @@ export function HouseholdPage() {
                       className="household-form-select household-form-select--small"
                       value={member.role}
                       onChange={(e) => updateMemberRole(member.id, e.target.value as HouseholdRole)}
-                      aria-label={`Change role for member ${member.userId.slice(0, 8)}`}
+                      aria-label={`Change role for ${member.displayName ?? member.userId.slice(0, 8)}`}
                     >
                       {ROLE_OPTIONS.map((opt) => (
                         <option key={opt.value} value={opt.value}>
@@ -231,7 +284,7 @@ export function HouseholdPage() {
                     <button
                       className="household-button household-button--danger household-button--small"
                       onClick={() => removeMember(member.id)}
-                      aria-label={`Remove member ${member.userId.slice(0, 8)}`}
+                      aria-label={`Remove ${member.displayName ?? member.userId.slice(0, 8)}`}
                     >
                       Remove
                     </button>
@@ -241,17 +294,42 @@ export function HouseholdPage() {
             ))}
           </ul>
         )}
+
+        {/* Role permissions reference */}
+        <details className="household-permissions-details">
+          <summary className="household-permissions-summary">View role permissions</summary>
+          <div className="household-permissions-grid">
+            {(Object.entries(ROLE_LABELS) as [HouseholdRole, string][]).map(([role, label]) => (
+              <div key={role} className="household-permissions-column">
+                <h4 className="household-permissions-column__title">{label}</h4>
+                <ul className="household-permissions-list" role="list">
+                  {ROLE_PERMISSIONS[role].map((perm) => (
+                    <li key={perm} className="household-permissions-list__item">
+                      {perm.replace(/_/g, ' ').toLowerCase()}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </details>
       </section>
 
-      {/* Invite Section */}
+      {/* ----------------------------------------------------------------- */}
+      {/* Invite Section (#1779) */}
+      {/* ----------------------------------------------------------------- */}
       <section className="household-card" aria-labelledby="invite-title">
         <h2 id="invite-title" className="household-card__title">
           Invite Member
         </h2>
+        <p className="household-card__description">
+          Send an invitation to join your household. New members start with privacy-by-default —
+          nothing is shared until they explicitly choose to share accounts.
+        </p>
 
         {inviteSuccess && (
           <div className="household-banner--success" role="status">
-            Invitation sent successfully!
+            Invitation sent successfully! The invite code has been generated.
           </div>
         )}
 
@@ -306,17 +384,20 @@ export function HouseholdPage() {
       </section>
 
       {/* Pending Invitations */}
-      {invitations.length > 0 && (
+      {pendingInvitations.length > 0 && (
         <section className="household-card" aria-labelledby="invitations-title">
           <h2 id="invitations-title" className="household-card__title">
             Pending Invitations
           </h2>
           <ul className="household-invitation-list" role="list" aria-label="Pending invitations">
-            {invitations.map((inv) => (
+            {pendingInvitations.map((inv) => (
               <li key={inv.id} className="household-invitation-item">
                 <div className="household-invitation-item__info">
                   <span className="household-invitation-item__email">{inv.email}</span>
                   <span className="household-invitation-item__role">{ROLE_LABELS[inv.role]}</span>
+                  <span className="household-invitation-item__code" title="Invite code">
+                    Code: {inv.inviteCode}
+                  </span>
                   <span className="household-invitation-item__status">{inv.status}</span>
                 </div>
                 <button
@@ -332,27 +413,160 @@ export function HouseholdPage() {
         </section>
       )}
 
-      {/* Shared vs Personal Budgets */}
-      <section className="household-card" aria-labelledby="budget-visibility-title">
-        <h2 id="budget-visibility-title" className="household-card__title">
-          Budget Sharing
+      {/* ----------------------------------------------------------------- */}
+      {/* Account Sharing — Mine/Yours/Ours (#1781, #1716) */}
+      {/* ----------------------------------------------------------------- */}
+      <section className="household-card" aria-labelledby="account-sharing-title">
+        <h2 id="account-sharing-title" className="household-card__title">
+          Account Sharing
         </h2>
         <p className="household-card__description">
-          Toggle budgets between shared (visible to all members) and personal (only you).
+          Choose which accounts are shared with the household and which stay private. Private
+          accounts are completely hidden from other household members (mine only). Shared accounts
+          are visible to all members (ours).
         </p>
-        <ul className="household-budget-list" role="list" aria-label="Budget visibility settings">
-          {demoBudgetIds.map((budgetId) => {
-            const vis = budgetVisibility.find((bv) => bv.budgetId === budgetId);
-            const isShared = vis?.isShared ?? false;
+        <ul className="household-sharing-list" role="list" aria-label="Account sharing settings">
+          {DEMO_ACCOUNT_IDS.map((accountId) => {
+            const sharing = accountSharings.find((as) => as.accountId === accountId);
+            const mode: AccountSharingMode = sharing?.sharingMode ?? 'PRIVATE';
+            const isShared = mode === 'SHARED';
             return (
-              <li key={budgetId} className="household-budget-item">
-                <span className="household-budget-item__name">Budget {budgetId.slice(-1)}</span>
+              <li key={accountId} className="household-sharing-item">
+                <div className="household-sharing-item__info">
+                  <span className="household-sharing-item__name">
+                    {DEMO_ACCOUNT_NAMES[accountId]}
+                  </span>
+                  <span
+                    className={`household-sharing-item__badge ${isShared ? 'household-sharing-item__badge--shared' : 'household-sharing-item__badge--private'}`}
+                  >
+                    {isShared ? '🔓 Shared' : '🔒 Private'}
+                  </span>
+                </div>
                 <button
                   className={`household-toggle ${isShared ? 'household-toggle--active' : ''}`}
                   role="switch"
                   aria-checked={isShared}
-                  aria-label={`Toggle sharing for Budget ${budgetId.slice(-1)}`}
-                  onClick={() => toggleBudgetVisibility(budgetId)}
+                  aria-label={`Toggle sharing for ${DEMO_ACCOUNT_NAMES[accountId]}`}
+                  onClick={() =>
+                    setAccountSharing({
+                      accountId,
+                      sharingMode: isShared ? 'PRIVATE' : 'SHARED',
+                    })
+                  }
+                >
+                  <span className="household-toggle__track">
+                    <span className="household-toggle__thumb" />
+                  </span>
+                  <span className="household-toggle__label">{SHARING_MODE_LABELS[mode]}</span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+        <div className="household-card__note" role="note">
+          <strong>Privacy boundary:</strong> Private ("mine only") accounts, transactions, and
+          balances are completely invisible to other household members. This is enforced at the data
+          layer, not just the UI.
+        </div>
+      </section>
+
+      {/* ----------------------------------------------------------------- */}
+      {/* Shared Budgets (#1784) */}
+      {/* ----------------------------------------------------------------- */}
+      <section className="household-card" aria-labelledby="shared-budgets-title">
+        <h2 id="shared-budgets-title" className="household-card__title">
+          Shared Budgets
+        </h2>
+        <p className="household-card__description">
+          Configure budgets that are shared with the household. Choose between flex mode (one
+          overall spending limit) or category mode (per-category limits).
+        </p>
+        <ul className="household-budget-list" role="list" aria-label="Shared budget settings">
+          {DEMO_BUDGET_IDS.map((budgetId) => {
+            const shared = sharedBudgets.find((sb) => sb.budgetId === budgetId);
+            const isActive = shared?.isActive ?? false;
+            const mode: SharedBudgetMode = shared?.mode ?? 'CATEGORY';
+            return (
+              <li key={budgetId} className="household-budget-item">
+                <div className="household-budget-item__info">
+                  <span className="household-budget-item__name">{DEMO_BUDGET_NAMES[budgetId]}</span>
+                  {isActive && (
+                    <span className="household-budget-item__mode">{BUDGET_MODE_LABELS[mode]}</span>
+                  )}
+                </div>
+                <div className="household-budget-item__controls">
+                  {isActive && (
+                    <select
+                      className="household-form-select household-form-select--small"
+                      value={mode}
+                      onChange={(e) =>
+                        setSharedBudget({
+                          budgetId,
+                          mode: e.target.value as SharedBudgetMode,
+                        })
+                      }
+                      aria-label={`Budget mode for ${DEMO_BUDGET_NAMES[budgetId]}`}
+                    >
+                      <option value="FLEX">Flex</option>
+                      <option value="CATEGORY">Category</option>
+                    </select>
+                  )}
+                  <button
+                    className={`household-toggle ${isActive ? 'household-toggle--active' : ''}`}
+                    role="switch"
+                    aria-checked={isActive}
+                    aria-label={`Toggle sharing for ${DEMO_BUDGET_NAMES[budgetId]}`}
+                    onClick={() => {
+                      if (isActive && shared) {
+                        removeSharedBudget(shared.id);
+                      } else {
+                        setSharedBudget({ budgetId, mode });
+                      }
+                    }}
+                  >
+                    <span className="household-toggle__track">
+                      <span className="household-toggle__thumb" />
+                    </span>
+                    <span className="household-toggle__label">
+                      {isActive ? 'Shared' : 'Personal'}
+                    </span>
+                  </button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </section>
+
+      {/* ----------------------------------------------------------------- */}
+      {/* Shared Goals (#1786) */}
+      {/* ----------------------------------------------------------------- */}
+      <section className="household-card" aria-labelledby="shared-goals-title">
+        <h2 id="shared-goals-title" className="household-card__title">
+          Shared Goals
+        </h2>
+        <p className="household-card__description">
+          Share savings goals with the household so everyone can track progress together. Per-member
+          contribution tracking shows who contributed what.
+        </p>
+        <ul className="household-goal-list" role="list" aria-label="Shared goal settings">
+          {DEMO_GOAL_IDS.map((goalId) => {
+            const shared = sharedGoals.find((sg) => sg.goalId === goalId);
+            const isShared = shared?.isShared ?? false;
+            return (
+              <li key={goalId} className="household-goal-item">
+                <div className="household-goal-item__info">
+                  <span className="household-goal-item__name">{DEMO_GOAL_NAMES[goalId]}</span>
+                  {isShared && (
+                    <span className="household-goal-item__badge">Shared with household</span>
+                  )}
+                </div>
+                <button
+                  className={`household-toggle ${isShared ? 'household-toggle--active' : ''}`}
+                  role="switch"
+                  aria-checked={isShared}
+                  aria-label={`Toggle sharing for ${DEMO_GOAL_NAMES[goalId]}`}
+                  onClick={() => setSharedGoal({ goalId, isShared: !isShared })}
                 >
                   <span className="household-toggle__track">
                     <span className="household-toggle__thumb" />
@@ -365,6 +579,65 @@ export function HouseholdPage() {
             );
           })}
         </ul>
+      </section>
+
+      {/* ----------------------------------------------------------------- */}
+      {/* Permission Check Demo (dev reference) */}
+      {/* ----------------------------------------------------------------- */}
+      <section className="household-card" aria-labelledby="permissions-demo-title">
+        <h2 id="permissions-demo-title" className="household-card__title">
+          Permission Reference
+        </h2>
+        <p className="household-card__description">
+          Quick reference for what each role can do in this household.
+        </p>
+        <div className="household-permissions-table-wrap">
+          <table className="household-permissions-table" aria-label="Role permissions matrix">
+            <thead>
+              <tr>
+                <th scope="col">Permission</th>
+                {(Object.keys(ROLE_LABELS) as HouseholdRole[]).map((role) => (
+                  <th key={role} scope="col">
+                    {ROLE_LABELS[role]}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {(
+                [
+                  'MANAGE_MEMBERS',
+                  'INVITE_MEMBERS',
+                  'MANAGE_ROLES',
+                  'VIEW_SHARED_ACCOUNTS',
+                  'EDIT_SHARED_ACCOUNTS',
+                  'CREATE_SHARED_BUDGETS',
+                  'VIEW_SHARED_BUDGETS',
+                  'CREATE_SHARED_GOALS',
+                  'VIEW_SHARED_GOALS',
+                  'ADD_TRANSACTIONS',
+                ] as const
+              ).map((perm) => (
+                <tr key={perm}>
+                  <td>{perm.replace(/_/g, ' ').toLowerCase()}</td>
+                  {(Object.keys(ROLE_LABELS) as HouseholdRole[]).map((role) => (
+                    <td key={role} className="household-permissions-table__cell">
+                      {checkPermission(role, perm) ? (
+                        <span aria-label="Allowed" title="Allowed">
+                          ✅
+                        </span>
+                      ) : (
+                        <span aria-label="Denied" title="Denied">
+                          ❌
+                        </span>
+                      )}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       </section>
     </main>
   );

--- a/apps/web/src/pages/index.ts
+++ b/apps/web/src/pages/index.ts
@@ -25,3 +25,4 @@ export { BillDetailPage } from './BillDetailPage';
 export { CreateBillPage } from './CreateBillPage';
 export { ReportBuilderPage } from './ReportBuilderPage';
 export { PlanningPage } from './PlanningPage';
+export { HouseholdPage } from './HouseholdPage';


### PR DESCRIPTION
## Summary
Household multi-user foundation: roles/permissions, invitation flow, mine/yours/ours account sharing, privacy boundaries, shared budgets, and shared goals.

## Changes
- KMP bridge types: updated roles to OWNER/ADMIN/MEMBER/VIEWER, added permission types, invitation types, account sharing types, shared budget/goal types
- New household repository with SQLite schema (6 tables), CRUD, privacy boundary enforcement
- New HouseholdContext for app-wide household state and permission checks
- Rewritten useHousehold hook with invitation flow, permission checks, account sharing, shared budgets/goals
- Enhanced HouseholdPage with all management sections (members, invitations, account sharing, shared budgets, shared goals, permission reference)
- 22 tests (12 permission logic + 10 page UI states)

## Issues
Closes #1780
Closes #1779
Closes #1781
Closes #1716
Closes #1784
Closes #1786

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>