### PR TITLE
feat(web): add investment tracking - account taxonomy, cost-basis, asset allocation, fee analyzer (#1585, #1588, #1595, #1625)

### DIFF
--- a/apps/web/src/db/repositories/index.ts
+++ b/apps/web/src/db/repositories/index.ts
@@ -6,4 +6,5 @@ export * from './budgets';
 export * from './goals';
 export * from './categories';
 export * from './investments';
+export * from './investment-lots';
 export * from './bills';

--- a/apps/web/src/db/repositories/investment-lots.ts
+++ b/apps/web/src/db/repositories/investment-lots.ts
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * SQLite-WASM repository for investment lots (tax-lot level tracking).
+ *
+ * Handles CRUD operations for the `investment_lot` table, enabling
+ * lot-level cost-basis tracking with FIFO, LIFO, specific ID, and
+ * average cost methods.
+ *
+ * References: issue #1588
+ */
+
+import type { InvestmentLot, SyncId } from '../../kmp/bridge';
+import { execute, query, queryOne, type Row, type SqliteDb } from '../sqlite-wasm';
+import {
+  SQLITE_NOW_EXPRESSION,
+  mapCents,
+  mapSyncMetadata,
+  requireNumber,
+  requireString,
+} from './helpers';
+
+const LOT_COLUMNS = [
+  'id',
+  'investment_id',
+  'purchase_date',
+  'shares',
+  'cost_per_share',
+  'total_cost',
+  'created_at',
+  'updated_at',
+  'deleted_at',
+  'sync_version',
+  'is_synced',
+].join(', ');
+
+const LOT_BASE_QUERY = `SELECT ${LOT_COLUMNS} FROM investment_lot WHERE deleted_at IS NULL`;
+
+/** Input used when creating a new lot record. */
+export interface CreateLotInput {
+  investmentId: SyncId;
+  purchaseDate: string;
+  shares: number;
+  costPerShare: { amount: number };
+}
+
+/** Input used when updating an existing lot record. */
+export interface UpdateLotInput {
+  purchaseDate?: string;
+  shares?: number;
+  costPerShare?: { amount: number };
+}
+
+/** Map a raw database row to an InvestmentLot domain object. */
+function mapLot(row: Row): InvestmentLot {
+  const shares = requireNumber(row.shares, 'investment_lot.shares');
+  const costPerShare = mapCents(row.cost_per_share, 'investment_lot.cost_per_share');
+
+  return {
+    id: requireString(row.id, 'investment_lot.id'),
+    investmentId: requireString(row.investment_id, 'investment_lot.investment_id'),
+    purchaseDate: requireString(row.purchase_date, 'investment_lot.purchase_date'),
+    shares,
+    costPerShare,
+    totalCost: mapCents(row.total_cost, 'investment_lot.total_cost'),
+    ...mapSyncMetadata(row),
+  };
+}
+
+/** Return all non-deleted lots for a specific investment, ordered by purchase date. */
+export function getLotsByInvestment(db: SqliteDb, investmentId: SyncId): InvestmentLot[] {
+  return query<Row>(db, `${LOT_BASE_QUERY} AND investment_id = ? ORDER BY purchase_date ASC`, [
+    investmentId,
+  ]).rows.map(mapLot);
+}
+
+/** Find a single non-deleted lot by its identifier. */
+export function getLotById(db: SqliteDb, lotId: SyncId): InvestmentLot | null {
+  const row = queryOne<Row>(db, `${LOT_BASE_QUERY} AND id = ?`, [lotId]);
+  return row ? mapLot(row) : null;
+}
+
+/** Insert a new lot row and return the created lot. */
+export function createLot(db: SqliteDb, input: CreateLotInput): InvestmentLot {
+  const id = crypto.randomUUID();
+  const totalCost = Math.round(input.shares * input.costPerShare.amount);
+
+  execute(
+    db,
+    `INSERT INTO investment_lot (
+      id,
+      investment_id,
+      purchase_date,
+      shares,
+      cost_per_share,
+      total_cost,
+      created_at,
+      updated_at,
+      deleted_at,
+      sync_version,
+      is_synced
+    ) VALUES (
+      ?, ?, ?, ?, ?, ?,
+      ${SQLITE_NOW_EXPRESSION},
+      ${SQLITE_NOW_EXPRESSION},
+      NULL,
+      1,
+      0
+    )`,
+    [
+      id,
+      input.investmentId,
+      input.purchaseDate,
+      input.shares,
+      input.costPerShare.amount,
+      totalCost,
+    ],
+  );
+
+  const created = getLotById(db, id);
+  if (!created) {
+    throw new Error('Failed to create investment lot.');
+  }
+
+  return created;
+}
+
+/** Update a lot row and return the refreshed lot. */
+export function updateLot(
+  db: SqliteDb,
+  lotId: SyncId,
+  updates: UpdateLotInput,
+): InvestmentLot | null {
+  const existing = getLotById(db, lotId);
+  if (!existing) {
+    return null;
+  }
+
+  const merged = {
+    purchaseDate: updates.purchaseDate ?? existing.purchaseDate,
+    shares: updates.shares ?? existing.shares,
+    costPerShare: updates.costPerShare ?? existing.costPerShare,
+  };
+
+  const totalCost = Math.round(merged.shares * merged.costPerShare.amount);
+
+  execute(
+    db,
+    `UPDATE investment_lot
+        SET purchase_date = ?,
+            shares = ?,
+            cost_per_share = ?,
+            total_cost = ?,
+            updated_at = ${SQLITE_NOW_EXPRESSION},
+            sync_version = 1,
+            is_synced = 0
+      WHERE id = ?
+        AND deleted_at IS NULL`,
+    [merged.purchaseDate, merged.shares, merged.costPerShare.amount, totalCost, lotId],
+  );
+
+  return getLotById(db, lotId);
+}
+
+/** Soft-delete a lot row by marking its deleted timestamp. */
+export function deleteLot(db: SqliteDb, lotId: SyncId): boolean {
+  const existing = getLotById(db, lotId);
+  if (!existing) {
+    return false;
+  }
+
+  execute(
+    db,
+    `UPDATE investment_lot
+        SET deleted_at = ${SQLITE_NOW_EXPRESSION},
+            updated_at = ${SQLITE_NOW_EXPRESSION},
+            sync_version = 1,
+            is_synced = 0
+      WHERE id = ?
+        AND deleted_at IS NULL`,
+    [lotId],
+  );
+
+  return true;
+}

--- a/apps/web/src/hooks/useInvestments.ts
+++ b/apps/web/src/hooks/useInvestments.ts
@@ -7,15 +7,18 @@
  * All operations are synchronous against the local DB; errors are captured
  * in state rather than thrown so callers can render gracefully.
  *
+ * Extended to support lot-level cost-basis tracking (#1588),
+ * target-vs-actual allocation (#1595), and fee analysis (#1625).
+ *
  * Usage:
  * ```tsx
  * const { investments, loading, error, createInvestment, refresh } = useInvestments();
  * ```
  *
- * References: issue #1105
+ * References: issues #1105, #1585, #1588, #1595, #1625
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDatabase } from '../db/DatabaseProvider';
 import {
   createInvestment as repoCreateInvestment,
@@ -25,7 +28,18 @@ import {
   type CreateInvestmentInput,
   type UpdateInvestmentInput,
 } from '../db/repositories/investments';
-import type { Investment, SyncId } from '../kmp/bridge';
+import {
+  createLot as repoCreateLot,
+  deleteLot as repoDeleteLot,
+  getLotsByInvestment,
+  updateLot as repoUpdateLot,
+  type CreateLotInput,
+  type UpdateLotInput,
+} from '../db/repositories/investment-lots';
+import type { Investment, InvestmentLot, SyncId } from '../kmp/bridge';
+import { computeAllocation, analyzeFees, DEFAULT_ASSET_CLASS_MAP } from '../lib/investment';
+import type { HoldingWithClass, FeeHoldingInput } from '../lib/investment';
+import type { AllocationAnalysis, AllocationTarget, FeeAnalysis } from '../types/investment';
 
 // ---------------------------------------------------------------------------
 // Public interface
@@ -70,6 +84,51 @@ export interface UseInvestmentsResult {
    * @returns `true` if deletion succeeded, `false` otherwise.
    */
   deleteInvestment: (investmentId: SyncId) => boolean;
+
+  // --- Lot operations (#1588) ---
+
+  /**
+   * Get all lots for a specific investment.
+   * @returns Array of lots, or empty array on error.
+   */
+  getLots: (investmentId: SyncId) => InvestmentLot[];
+  /**
+   * Create a new lot for an investment.
+   * @returns The created lot, or `null` if creation failed.
+   */
+  createLot: (input: CreateLotInput) => InvestmentLot | null;
+  /**
+   * Update an existing lot.
+   * @returns The updated lot, or `null` if not found or update failed.
+   */
+  updateLot: (lotId: SyncId, updates: UpdateLotInput) => InvestmentLot | null;
+  /**
+   * Soft-delete a lot.
+   * @returns `true` if deletion succeeded, `false` otherwise.
+   */
+  deleteLot: (lotId: SyncId) => boolean;
+
+  // --- Allocation analysis (#1595) ---
+
+  /**
+   * Compute target-vs-actual allocation analysis.
+   * @param targets - User-defined target allocation percentages.
+   * @returns Allocation analysis with deviations and rebalancing suggestions.
+   */
+  computeAllocationAnalysis: (targets: readonly AllocationTarget[]) => AllocationAnalysis;
+
+  // --- Fee analysis (#1625) ---
+
+  /**
+   * Run fee analysis for the portfolio.
+   * @param expenseRatios - Map of investmentId → expense ratio in basis points.
+   * @param annualReturnPercent - Expected annual return (default: 7%).
+   * @returns Complete fee analysis with projections and comparisons.
+   */
+  computeFeeAnalysis: (
+    expenseRatios: ReadonlyMap<string, number>,
+    annualReturnPercent?: number,
+  ) => FeeAnalysis;
 }
 
 // ---------------------------------------------------------------------------
@@ -188,6 +247,110 @@ export function useInvestments(): UseInvestmentsResult {
     [db, refresh],
   );
 
+  // --- Lot operations (#1588) ---
+
+  const getLots = useCallback(
+    (investmentId: SyncId): InvestmentLot[] => {
+      try {
+        return getLotsByInvestment(db, investmentId);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : '';
+        if (!message.includes('no such table')) {
+          setError(err instanceof Error ? err.message : 'Failed to load lots.');
+        }
+        return [];
+      }
+    },
+    [db],
+  );
+
+  const createLot = useCallback(
+    (input: CreateLotInput): InvestmentLot | null => {
+      try {
+        const created = repoCreateLot(db, input);
+        refresh();
+        return created;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to create lot.');
+        setLoading(false);
+        return null;
+      }
+    },
+    [db, refresh],
+  );
+
+  const updateLotFn = useCallback(
+    (lotId: SyncId, updates: UpdateLotInput): InvestmentLot | null => {
+      try {
+        const updated = repoUpdateLot(db, lotId, updates);
+        if (updated !== null) {
+          refresh();
+        }
+        return updated;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to update lot.');
+        setLoading(false);
+        return null;
+      }
+    },
+    [db, refresh],
+  );
+
+  const deleteLotFn = useCallback(
+    (lotId: SyncId): boolean => {
+      try {
+        const deleted = repoDeleteLot(db, lotId);
+        if (deleted) {
+          refresh();
+        }
+        return deleted;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to delete lot.');
+        setLoading(false);
+        return false;
+      }
+    },
+    [db, refresh],
+  );
+
+  // --- Allocation analysis (#1595) ---
+
+  const holdingsWithClass: HoldingWithClass[] = useMemo(
+    () =>
+      investments.map((inv) => ({
+        symbol: inv.symbol,
+        marketValue: Math.round(inv.shares * inv.currentPricePerShare.amount),
+        assetClass: DEFAULT_ASSET_CLASS_MAP[inv.type],
+      })),
+    [investments],
+  );
+
+  const computeAllocationAnalysis = useCallback(
+    (targets: readonly AllocationTarget[]): AllocationAnalysis => {
+      return computeAllocation(holdingsWithClass, targets);
+    },
+    [holdingsWithClass],
+  );
+
+  // --- Fee analysis (#1625) ---
+
+  const computeFeeAnalysis = useCallback(
+    (expenseRatios: ReadonlyMap<string, number>, annualReturnPercent: number = 7): FeeAnalysis => {
+      const feeHoldings: FeeHoldingInput[] = investments
+        .filter((inv) => expenseRatios.has(inv.id))
+        .map((inv) => ({
+          investmentId: inv.id,
+          symbol: inv.symbol,
+          name: inv.name,
+          expenseRatioBps: expenseRatios.get(inv.id) ?? 0,
+          marketValue: Math.round(inv.shares * inv.currentPricePerShare.amount),
+        }));
+
+      return analyzeFees(feeHoldings, annualReturnPercent);
+    },
+    [investments],
+  );
+
   return {
     investments,
     summary,
@@ -197,5 +360,11 @@ export function useInvestments(): UseInvestmentsResult {
     createInvestment,
     updateInvestment,
     deleteInvestment,
+    getLots,
+    createLot,
+    updateLot: updateLotFn,
+    deleteLot: deleteLotFn,
+    computeAllocationAnalysis,
+    computeFeeAnalysis,
   };
 }

--- a/apps/web/src/kmp/bridge.ts
+++ b/apps/web/src/kmp/bridge.ts
@@ -243,6 +243,37 @@ export interface Investment extends SyncMetadata {
   readonly lastPriceUpdate: Instant | null;
 }
 
+/** Maps to KMP `com.finance.models.TaxTreatment`. */
+export type TaxTreatment = 'TAXABLE' | 'TAX_DEFERRED' | 'TAX_FREE';
+
+/** Maps to KMP `com.finance.models.InvestmentAccountSubtype`. */
+export type InvestmentAccountSubtype =
+  | 'BROKERAGE'
+  | 'TRADITIONAL_IRA'
+  | 'ROTH_IRA'
+  | 'SEP_IRA'
+  | 'SIMPLE_IRA'
+  | '401K'
+  | '403B'
+  | '457B'
+  | 'HSA'
+  | '529'
+  | 'TRUST'
+  | 'OTHER';
+
+/** Maps to KMP `com.finance.models.CostBasisMethod`. */
+export type CostBasisMethod = 'FIFO' | 'LIFO' | 'SPECIFIC_ID' | 'AVERAGE_COST';
+
+/** Maps to KMP `com.finance.models.InvestmentLot`. */
+export interface InvestmentLot extends SyncMetadata {
+  readonly id: SyncId;
+  readonly investmentId: SyncId;
+  readonly purchaseDate: LocalDate;
+  readonly shares: number;
+  readonly costPerShare: Cents;
+  readonly totalCost: Cents;
+}
+
 /** Maps to KMP `com.finance.models.BillFrequency`. */
 export type BillFrequency = 'ONE_TIME' | 'WEEKLY' | 'BIWEEKLY' | 'MONTHLY' | 'QUARTERLY' | 'YEARLY';
 

--- a/apps/web/src/lib/investment/allocation.test.ts
+++ b/apps/web/src/lib/investment/allocation.test.ts
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the asset allocation engine.
+ *
+ * Covers target validation, allocation computation, deviation calculation,
+ * and rebalancing suggestions.
+ *
+ * References: issue #1595
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { AllocationTarget } from '../../types/investment';
+import {
+  ALLOCATION_PRESETS,
+  computeAllocation,
+  getRebalancingSuggestions,
+  validateTargets,
+} from './allocation';
+import type { HoldingWithClass } from './allocation';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const standardTargets: readonly AllocationTarget[] = [
+  { assetClass: 'US_STOCKS', targetPercent: 60 },
+  { assetClass: 'BONDS', targetPercent: 30 },
+  { assetClass: 'CASH', targetPercent: 10 },
+];
+
+const balancedHoldings: readonly HoldingWithClass[] = [
+  { symbol: 'VTI', marketValue: 60000_00, assetClass: 'US_STOCKS' },
+  { symbol: 'BND', marketValue: 30000_00, assetClass: 'BONDS' },
+  { symbol: 'CASH', marketValue: 10000_00, assetClass: 'CASH' },
+];
+
+const driftedHoldings: readonly HoldingWithClass[] = [
+  { symbol: 'VTI', marketValue: 70000_00, assetClass: 'US_STOCKS' },
+  { symbol: 'AAPL', marketValue: 10000_00, assetClass: 'US_STOCKS' },
+  { symbol: 'BND', marketValue: 15000_00, assetClass: 'BONDS' },
+  { symbol: 'CASH', marketValue: 5000_00, assetClass: 'CASH' },
+];
+
+// ---------------------------------------------------------------------------
+// validateTargets
+// ---------------------------------------------------------------------------
+
+describe('validateTargets', () => {
+  it('returns true when targets sum to 100', () => {
+    expect(validateTargets(standardTargets)).toBe(true);
+  });
+
+  it('returns false when targets sum to less than 100', () => {
+    const under: AllocationTarget[] = [
+      { assetClass: 'US_STOCKS', targetPercent: 50 },
+      { assetClass: 'BONDS', targetPercent: 30 },
+    ];
+    expect(validateTargets(under)).toBe(false);
+  });
+
+  it('returns false when targets sum to more than 100', () => {
+    const over: AllocationTarget[] = [
+      { assetClass: 'US_STOCKS', targetPercent: 60 },
+      { assetClass: 'BONDS', targetPercent: 50 },
+    ];
+    expect(validateTargets(over)).toBe(false);
+  });
+
+  it('returns true for empty targets (0 = not 100, so false)', () => {
+    expect(validateTargets([])).toBe(false);
+  });
+
+  it('handles floating-point precision', () => {
+    const precise: AllocationTarget[] = [
+      { assetClass: 'US_STOCKS', targetPercent: 33.33 },
+      { assetClass: 'BONDS', targetPercent: 33.34 },
+      { assetClass: 'CASH', targetPercent: 33.33 },
+    ];
+    expect(validateTargets(precise)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Presets validation
+// ---------------------------------------------------------------------------
+
+describe('ALLOCATION_PRESETS', () => {
+  it('all presets sum to 100%', () => {
+    for (const preset of ALLOCATION_PRESETS) {
+      expect(validateTargets(preset.targets)).toBe(true);
+    }
+  });
+
+  it('includes at least 3 presets', () => {
+    expect(ALLOCATION_PRESETS.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeAllocation
+// ---------------------------------------------------------------------------
+
+describe('computeAllocation', () => {
+  it('computes perfectly balanced allocation with zero deviations', () => {
+    const analysis = computeAllocation(balancedHoldings, standardTargets);
+
+    expect(analysis.totalPortfolioValue).toBe(100000_00);
+    expect(analysis.isTargetValid).toBe(true);
+
+    const stocks = analysis.comparisons.find((c) => c.assetClass === 'US_STOCKS');
+    expect(stocks?.actualPercent).toBe(60);
+    expect(stocks?.deviationPercent).toBe(0);
+    expect(stocks?.rebalanceAmount).toBe(0);
+  });
+
+  it('detects drift from target allocation', () => {
+    const analysis = computeAllocation(driftedHoldings, standardTargets);
+
+    // Total: 70000 + 10000 + 15000 + 5000 = 100000 (dollars)
+    expect(analysis.totalPortfolioValue).toBe(100000_00);
+
+    const stocks = analysis.comparisons.find((c) => c.assetClass === 'US_STOCKS');
+    expect(stocks?.actualPercent).toBe(80);
+    expect(stocks?.deviationPercent).toBe(20);
+    // Target 60% of 10000000 = 6000000, actual 8000000 → rebalance = -2000000
+    expect(stocks?.rebalanceAmount).toBe(-20000_00);
+
+    const bonds = analysis.comparisons.find((c) => c.assetClass === 'BONDS');
+    expect(bonds?.actualPercent).toBe(15);
+    expect(bonds?.deviationPercent).toBe(-15);
+    expect(bonds?.rebalanceAmount).toBe(15000_00);
+  });
+
+  it('handles empty portfolio', () => {
+    const analysis = computeAllocation([], standardTargets);
+
+    expect(analysis.totalPortfolioValue).toBe(0);
+    expect(analysis.isTargetValid).toBe(true);
+  });
+
+  it('includes asset classes present in holdings but not in targets', () => {
+    const holdingsWithCrypto: HoldingWithClass[] = [
+      { symbol: 'VTI', marketValue: 50000_00, assetClass: 'US_STOCKS' },
+      { symbol: 'BTC', marketValue: 10000_00, assetClass: 'CRYPTO' },
+    ];
+
+    const targets: AllocationTarget[] = [{ assetClass: 'US_STOCKS', targetPercent: 100 }];
+
+    const analysis = computeAllocation(holdingsWithCrypto, targets);
+
+    const crypto = analysis.comparisons.find((c) => c.assetClass === 'CRYPTO');
+    expect(crypto).toBeDefined();
+    expect(crypto?.targetPercent).toBe(0);
+    expect(crypto?.actualPercent).toBeGreaterThan(0);
+  });
+
+  it('flags invalid targets when they do not sum to 100', () => {
+    const badTargets: AllocationTarget[] = [{ assetClass: 'US_STOCKS', targetPercent: 50 }];
+
+    const analysis = computeAllocation(balancedHoldings, badTargets);
+    expect(analysis.isTargetValid).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getRebalancingSuggestions
+// ---------------------------------------------------------------------------
+
+describe('getRebalancingSuggestions', () => {
+  it('returns asset classes with deviation exceeding threshold', () => {
+    const analysis = computeAllocation(driftedHoldings, standardTargets);
+    const suggestions = getRebalancingSuggestions(analysis, 5);
+
+    expect(suggestions.length).toBeGreaterThan(0);
+    for (const s of suggestions) {
+      expect(Math.abs(s.deviationPercent)).toBeGreaterThanOrEqual(5);
+    }
+  });
+
+  it('returns empty when all deviations are within threshold', () => {
+    const analysis = computeAllocation(balancedHoldings, standardTargets);
+    const suggestions = getRebalancingSuggestions(analysis, 1);
+
+    expect(suggestions).toHaveLength(0);
+  });
+
+  it('returns empty when targets are invalid', () => {
+    const badTargets: AllocationTarget[] = [{ assetClass: 'US_STOCKS', targetPercent: 50 }];
+    const analysis = computeAllocation(driftedHoldings, badTargets);
+    const suggestions = getRebalancingSuggestions(analysis);
+
+    expect(suggestions).toHaveLength(0);
+  });
+
+  it('uses default 1% threshold', () => {
+    // Slightly drifted portfolio
+    const slightDrift: HoldingWithClass[] = [
+      { symbol: 'VTI', marketValue: 61000_00, assetClass: 'US_STOCKS' },
+      { symbol: 'BND', marketValue: 29500_00, assetClass: 'BONDS' },
+      { symbol: 'CASH', marketValue: 9500_00, assetClass: 'CASH' },
+    ];
+
+    const analysis = computeAllocation(slightDrift, standardTargets);
+    const suggestions = getRebalancingSuggestions(analysis);
+
+    // 1% deviation in stocks → should appear
+    expect(suggestions.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/apps/web/src/lib/investment/allocation.ts
+++ b/apps/web/src/lib/investment/allocation.ts
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Target-vs-actual asset allocation engine.
+ *
+ * Computes current portfolio allocation by asset class, compares against
+ * user-defined targets, and generates rebalancing suggestions.
+ *
+ * All monetary values are integer cents. Percentages are 0–100.
+ *
+ * References: issue #1595
+ */
+
+import type { InvestmentType } from '../../kmp/bridge';
+import { ASSET_CLASS_LABELS } from '../../types/investment';
+import type {
+  AllocationAnalysis,
+  AllocationComparison,
+  AllocationTarget,
+  AssetClass,
+} from '../../types/investment';
+
+// ---------------------------------------------------------------------------
+// Asset class mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Default mapping from InvestmentType to AssetClass.
+ *
+ * Users can override per-holding, but this provides sensible defaults.
+ */
+export const DEFAULT_ASSET_CLASS_MAP: Record<InvestmentType, AssetClass> = {
+  STOCK: 'US_STOCKS',
+  BOND: 'BONDS',
+  ETF: 'US_STOCKS',
+  MUTUAL_FUND: 'US_STOCKS',
+  CRYPTO: 'CRYPTO',
+  REAL_ESTATE: 'REAL_ESTATE',
+  COMMODITY: 'COMMODITIES',
+  OTHER: 'OTHER',
+};
+
+// ---------------------------------------------------------------------------
+// Preset allocation templates
+// ---------------------------------------------------------------------------
+
+/** Common allocation preset strategies. */
+export interface AllocationPreset {
+  readonly name: string;
+  readonly description: string;
+  readonly targets: readonly AllocationTarget[];
+}
+
+/** Pre-built allocation templates for common investment strategies. */
+export const ALLOCATION_PRESETS: readonly AllocationPreset[] = [
+  {
+    name: 'Aggressive Growth',
+    description: '90% stocks, 10% bonds — suited for long time horizons.',
+    targets: [
+      { assetClass: 'US_STOCKS', targetPercent: 60 },
+      { assetClass: 'INTERNATIONAL_STOCKS', targetPercent: 30 },
+      { assetClass: 'BONDS', targetPercent: 10 },
+    ],
+  },
+  {
+    name: 'Balanced',
+    description: '60% stocks, 30% bonds, 10% alternatives.',
+    targets: [
+      { assetClass: 'US_STOCKS', targetPercent: 40 },
+      { assetClass: 'INTERNATIONAL_STOCKS', targetPercent: 20 },
+      { assetClass: 'BONDS', targetPercent: 30 },
+      { assetClass: 'CASH', targetPercent: 10 },
+    ],
+  },
+  {
+    name: 'Conservative',
+    description: '30% stocks, 50% bonds, 20% cash — lower volatility.',
+    targets: [
+      { assetClass: 'US_STOCKS', targetPercent: 20 },
+      { assetClass: 'INTERNATIONAL_STOCKS', targetPercent: 10 },
+      { assetClass: 'BONDS', targetPercent: 50 },
+      { assetClass: 'CASH', targetPercent: 20 },
+    ],
+  },
+  {
+    name: 'Three-Fund Portfolio',
+    description: 'Classic Bogleheads approach: US stocks, international stocks, bonds.',
+    targets: [
+      { assetClass: 'US_STOCKS', targetPercent: 50 },
+      { assetClass: 'INTERNATIONAL_STOCKS', targetPercent: 30 },
+      { assetClass: 'BONDS', targetPercent: 20 },
+    ],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Allocation computation
+// ---------------------------------------------------------------------------
+
+/** Holding with market value and asset class assignment. */
+export interface HoldingWithClass {
+  readonly symbol: string;
+  readonly marketValue: number; // cents
+  readonly assetClass: AssetClass;
+}
+
+/**
+ * Validate that target allocations sum to 100%.
+ *
+ * @param targets - Array of allocation targets.
+ * @returns True if percentages sum to exactly 100.
+ */
+export function validateTargets(targets: readonly AllocationTarget[]): boolean {
+  const sum = targets.reduce((acc, t) => acc + t.targetPercent, 0);
+  return Math.abs(sum - 100) < 0.01;
+}
+
+/**
+ * Compute target-vs-actual asset allocation analysis.
+ *
+ * @param holdings - Portfolio holdings with assigned asset classes.
+ * @param targets - User-defined target allocation percentages.
+ * @returns Full allocation analysis with deviations and rebalancing suggestions.
+ */
+export function computeAllocation(
+  holdings: readonly HoldingWithClass[],
+  targets: readonly AllocationTarget[],
+): AllocationAnalysis {
+  const isTargetValid = validateTargets(targets);
+
+  // Compute total portfolio value
+  const totalPortfolioValue = holdings.reduce((sum, h) => sum + h.marketValue, 0);
+
+  // Aggregate actual allocation by asset class
+  const actualByClass = new Map<AssetClass, number>();
+  for (const holding of holdings) {
+    const current = actualByClass.get(holding.assetClass) ?? 0;
+    actualByClass.set(holding.assetClass, current + holding.marketValue);
+  }
+
+  // Build comparison for each target asset class
+  const targetClasses = new Set(targets.map((t) => t.assetClass));
+  // Also include asset classes that have actual holdings but no target
+  for (const ac of actualByClass.keys()) {
+    targetClasses.add(ac);
+  }
+
+  const comparisons: AllocationComparison[] = [];
+
+  for (const assetClass of targetClasses) {
+    const target = targets.find((t) => t.assetClass === assetClass);
+    const targetPercent = target?.targetPercent ?? 0;
+    const currentValue = actualByClass.get(assetClass) ?? 0;
+    const actualPercent =
+      totalPortfolioValue > 0 ? Math.round((currentValue / totalPortfolioValue) * 10000) / 100 : 0;
+    const deviationPercent = Math.round((actualPercent - targetPercent) * 100) / 100;
+    const targetValue = Math.round((targetPercent / 100) * totalPortfolioValue);
+    const rebalanceAmount = targetValue - currentValue;
+
+    comparisons.push({
+      assetClass,
+      label: ASSET_CLASS_LABELS[assetClass],
+      targetPercent,
+      actualPercent,
+      deviationPercent,
+      currentValue,
+      targetValue,
+      rebalanceAmount,
+    });
+  }
+
+  // Sort: largest deviation first for actionable display
+  comparisons.sort((a, b) => Math.abs(b.deviationPercent) - Math.abs(a.deviationPercent));
+
+  return {
+    totalPortfolioValue,
+    comparisons,
+    isTargetValid,
+  };
+}
+
+/**
+ * Generate rebalancing trade suggestions.
+ *
+ * Returns a list of asset classes with the dollar amount to buy or sell
+ * to bring the portfolio back to target allocation.
+ *
+ * @param analysis - The allocation analysis result.
+ * @param threshold - Minimum deviation percentage to suggest a trade (default: 1%).
+ * @returns Filtered comparisons that exceed the threshold.
+ */
+export function getRebalancingSuggestions(
+  analysis: AllocationAnalysis,
+  threshold: number = 1,
+): readonly AllocationComparison[] {
+  if (!analysis.isTargetValid) {
+    return [];
+  }
+
+  return analysis.comparisons.filter((c) => Math.abs(c.deviationPercent) >= threshold);
+}

--- a/apps/web/src/lib/investment/cost-basis.test.ts
+++ b/apps/web/src/lib/investment/cost-basis.test.ts
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the cost-basis calculation engine.
+ *
+ * Covers lot-level gain/loss, FIFO/LIFO/specific ID/average cost
+ * selection, average cost basis computation, and wash sale detection.
+ *
+ * References: issue #1588
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { Lot } from '../../types/investment';
+import {
+  computeAllLotGainLoss,
+  computeAverageCostBasis,
+  computeLotGainLoss,
+  detectWashSales,
+  selectLotsForSale,
+} from './cost-basis';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function makeLot(overrides: Partial<Lot> & { id: string; shares: number }): Lot {
+  const costPerShare = overrides.costPerShare ?? { amount: 10000 };
+  return {
+    investmentId: 'inv-1',
+    purchaseDate: '2024-01-15',
+    totalCost: { amount: Math.round(overrides.shares * costPerShare.amount) },
+    costPerShare,
+    createdAt: '2024-01-15T00:00:00Z',
+    updatedAt: '2024-01-15T00:00:00Z',
+    ...overrides,
+  };
+}
+
+const lot1 = makeLot({
+  id: 'lot-1',
+  shares: 10,
+  purchaseDate: '2023-01-15',
+  costPerShare: { amount: 10000 },
+});
+
+const lot2 = makeLot({
+  id: 'lot-2',
+  shares: 5,
+  purchaseDate: '2023-06-15',
+  costPerShare: { amount: 12000 },
+});
+
+const lot3 = makeLot({
+  id: 'lot-3',
+  shares: 8,
+  purchaseDate: '2024-03-01',
+  costPerShare: { amount: 11000 },
+});
+
+// ---------------------------------------------------------------------------
+// computeLotGainLoss
+// ---------------------------------------------------------------------------
+
+describe('computeLotGainLoss', () => {
+  it('computes unrealized gain correctly', () => {
+    const result = computeLotGainLoss(lot1, 15000, '2025-01-20');
+
+    expect(result.marketValue).toBe(150000); // 10 shares × $150
+    expect(result.unrealizedGainLoss).toBe(50000); // 150000 - 100000
+    expect(result.unrealizedGainLossPercent).toBe(50);
+    expect(result.isLongTerm).toBe(true);
+    expect(result.daysHeld).toBeGreaterThan(365);
+  });
+
+  it('computes unrealized loss correctly', () => {
+    const result = computeLotGainLoss(lot2, 10000, '2025-01-20');
+
+    expect(result.marketValue).toBe(50000); // 5 shares × $100
+    expect(result.unrealizedGainLoss).toBe(-10000); // 50000 - 60000
+    expect(result.unrealizedGainLossPercent).toBeCloseTo(-16.67, 1);
+  });
+
+  it('handles zero cost basis', () => {
+    const freeLot = makeLot({
+      id: 'free',
+      shares: 10,
+      costPerShare: { amount: 0 },
+    });
+
+    const result = computeLotGainLoss(freeLot, 5000, '2025-01-20');
+    expect(result.unrealizedGainLossPercent).toBe(0);
+  });
+
+  it('identifies short-term lots correctly', () => {
+    const result = computeLotGainLoss(lot3, 15000, '2024-06-01');
+
+    expect(result.isLongTerm).toBe(false);
+    expect(result.daysHeld).toBeLessThanOrEqual(365);
+  });
+
+  it('returns lot reference in result', () => {
+    const result = computeLotGainLoss(lot1, 15000, '2025-01-20');
+    expect(result.lot).toBe(lot1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeAllLotGainLoss
+// ---------------------------------------------------------------------------
+
+describe('computeAllLotGainLoss', () => {
+  it('computes gain/loss for all lots', () => {
+    const results = computeAllLotGainLoss([lot1, lot2, lot3], 13000, '2025-01-20');
+
+    expect(results).toHaveLength(3);
+    expect(results[0].lot.id).toBe('lot-1');
+    expect(results[1].lot.id).toBe('lot-2');
+    expect(results[2].lot.id).toBe('lot-3');
+  });
+
+  it('returns empty array for no lots', () => {
+    const results = computeAllLotGainLoss([], 13000);
+    expect(results).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectLotsForSale — FIFO
+// ---------------------------------------------------------------------------
+
+describe('selectLotsForSale — FIFO', () => {
+  it('selects oldest lots first', () => {
+    const { selectedLots, totalCostBasis } = selectLotsForSale([lot3, lot1, lot2], 12, 'FIFO');
+
+    // lot1 (10 shares, $100/share) should be first, then lot2 (2 of 5 shares, $120/share)
+    expect(selectedLots).toHaveLength(2);
+    expect(selectedLots[0].lot.id).toBe('lot-1');
+    expect(selectedLots[0].sharesToSell).toBe(10);
+    expect(selectedLots[1].lot.id).toBe('lot-2');
+    expect(selectedLots[1].sharesToSell).toBe(2);
+    expect(totalCostBasis).toBe(124000); // 10×10000 + 2×12000
+  });
+
+  it('handles selling fewer shares than one lot', () => {
+    const { selectedLots } = selectLotsForSale([lot1, lot2], 3, 'FIFO');
+
+    expect(selectedLots).toHaveLength(1);
+    expect(selectedLots[0].lot.id).toBe('lot-1');
+    expect(selectedLots[0].sharesToSell).toBe(3);
+  });
+
+  it('returns empty for zero shares', () => {
+    const { selectedLots, totalCostBasis } = selectLotsForSale([lot1], 0, 'FIFO');
+    expect(selectedLots).toHaveLength(0);
+    expect(totalCostBasis).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectLotsForSale — LIFO
+// ---------------------------------------------------------------------------
+
+describe('selectLotsForSale — LIFO', () => {
+  it('selects newest lots first', () => {
+    const { selectedLots } = selectLotsForSale([lot1, lot2, lot3], 10, 'LIFO');
+
+    // lot3 (2024-03-01, 8 shares) first, then lot2 (2023-06-15, 2 shares)
+    expect(selectedLots[0].lot.id).toBe('lot-3');
+    expect(selectedLots[0].sharesToSell).toBe(8);
+    expect(selectedLots[1].lot.id).toBe('lot-2');
+    expect(selectedLots[1].sharesToSell).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectLotsForSale — Specific ID
+// ---------------------------------------------------------------------------
+
+describe('selectLotsForSale — SPECIFIC_ID', () => {
+  it('selects specified lots in order', () => {
+    const { selectedLots } = selectLotsForSale([lot1, lot2, lot3], 13, 'SPECIFIC_ID', [
+      'lot-2',
+      'lot-3',
+    ]);
+
+    expect(selectedLots[0].lot.id).toBe('lot-2');
+    expect(selectedLots[0].sharesToSell).toBe(5);
+    expect(selectedLots[1].lot.id).toBe('lot-3');
+    expect(selectedLots[1].sharesToSell).toBe(8);
+  });
+
+  it('returns empty when no lot IDs provided', () => {
+    const { selectedLots } = selectLotsForSale([lot1], 5, 'SPECIFIC_ID');
+    expect(selectedLots).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectLotsForSale — Average Cost
+// ---------------------------------------------------------------------------
+
+describe('selectLotsForSale — AVERAGE_COST', () => {
+  it('uses weighted average cost basis', () => {
+    const { totalCostBasis } = selectLotsForSale([lot1, lot2, lot3], 10, 'AVERAGE_COST');
+
+    // Total cost: 100000 + 60000 + 88000 = 248000
+    // Total shares: 10 + 5 + 8 = 23
+    // Avg cost/share: 248000/23 ≈ 10782.6
+    // 10 shares × 10782.6 ≈ 107826
+    expect(totalCostBasis).toBeCloseTo(107826, -1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeAverageCostBasis
+// ---------------------------------------------------------------------------
+
+describe('computeAverageCostBasis', () => {
+  it('computes weighted average cost', () => {
+    const result = computeAverageCostBasis([lot1, lot2, lot3]);
+
+    // Total cost: 100000 + 60000 + 88000 = 248000
+    // Total shares: 10 + 5 + 8 = 23
+    // Avg: 248000/23 ≈ 10783
+    expect(result.amount).toBe(10783);
+  });
+
+  it('returns 0 for empty lots', () => {
+    const result = computeAverageCostBasis([]);
+    expect(result.amount).toBe(0);
+  });
+
+  it('handles single lot', () => {
+    const result = computeAverageCostBasis([lot1]);
+    expect(result.amount).toBe(10000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectWashSales
+// ---------------------------------------------------------------------------
+
+describe('detectWashSales', () => {
+  it('detects a wash sale within 30-day window', () => {
+    const soldLots = [{ lotId: 'lot-sold', soldDate: '2024-03-10' as const, realizedLoss: -5000 }];
+
+    const replacementLot = makeLot({
+      id: 'lot-replacement',
+      shares: 5,
+      purchaseDate: '2024-03-15',
+    });
+
+    const alerts = detectWashSales(soldLots, [replacementLot], 'AAPL');
+
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].lotId).toBe('lot-sold');
+    expect(alerts[0].symbol).toBe('AAPL');
+    expect(alerts[0].disallowedLoss).toBe(5000);
+  });
+
+  it('does not flag sales with gains', () => {
+    const soldLots = [{ lotId: 'lot-sold', soldDate: '2024-03-10' as const, realizedLoss: 5000 }];
+
+    const replacementLot = makeLot({
+      id: 'lot-replacement',
+      shares: 5,
+      purchaseDate: '2024-03-15',
+    });
+
+    const alerts = detectWashSales(soldLots, [replacementLot], 'AAPL');
+    expect(alerts).toHaveLength(0);
+  });
+
+  it('does not flag purchases outside the 30-day window', () => {
+    const soldLots = [{ lotId: 'lot-sold', soldDate: '2024-01-10' as const, realizedLoss: -5000 }];
+
+    const distantLot = makeLot({
+      id: 'lot-distant',
+      shares: 5,
+      purchaseDate: '2024-06-15',
+    });
+
+    const alerts = detectWashSales(soldLots, [distantLot], 'AAPL');
+    expect(alerts).toHaveLength(0);
+  });
+
+  it('does not flag the same lot as both sold and replacement', () => {
+    const soldLots = [{ lotId: 'lot-1', soldDate: '2024-03-10' as const, realizedLoss: -5000 }];
+
+    // Only lot in the all-lots list is the one that was sold
+    const alerts = detectWashSales(soldLots, [lot1], 'AAPL');
+    // lot1 has purchaseDate 2023-01-15, far from 2024-03-10
+    expect(alerts).toHaveLength(0);
+  });
+
+  it('detects wash sale from purchase before the sale', () => {
+    const soldLots = [{ lotId: 'lot-sold', soldDate: '2024-03-20' as const, realizedLoss: -3000 }];
+
+    const preSaleLot = makeLot({
+      id: 'lot-pre',
+      shares: 3,
+      purchaseDate: '2024-03-05',
+    });
+
+    const alerts = detectWashSales(soldLots, [preSaleLot], 'VTI');
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].replacementDate).toBe('2024-03-05');
+  });
+});

--- a/apps/web/src/lib/investment/cost-basis.ts
+++ b/apps/web/src/lib/investment/cost-basis.ts
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Cost-basis calculation engine for lot-level investment tracking.
+ *
+ * Supports FIFO, LIFO, specific identification, and average cost methods.
+ * All monetary values are integer cents. Wash sale detection uses the
+ * IRS 30-day rule (no replacement purchase within 30 days of a loss sale).
+ *
+ * References: issue #1588
+ */
+
+import type { Cents, LocalDate } from '../../kmp/bridge';
+import type { CostBasisMethod, Lot, LotGainLoss, WashSaleAlert } from '../../types/investment';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Parse an ISO-8601 date string to a Date object. */
+function parseDate(dateStr: LocalDate): Date {
+  return new Date(dateStr + 'T00:00:00Z');
+}
+
+/** Calculate the number of days between two ISO date strings. */
+function daysBetween(startDate: LocalDate, endDate: LocalDate): number {
+  const start = parseDate(startDate);
+  const end = parseDate(endDate);
+  const diffMs = end.getTime() - start.getTime();
+  return Math.floor(diffMs / (1000 * 60 * 60 * 24));
+}
+
+/** Get today as an ISO-8601 date string. */
+function todayISO(): LocalDate {
+  return new Date().toISOString().slice(0, 10);
+}
+
+// ---------------------------------------------------------------------------
+// Lot-level gain/loss
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute unrealized gain/loss for a single lot.
+ *
+ * @param lot - The purchase lot.
+ * @param currentPricePerShareCents - Current market price per share in cents.
+ * @param asOfDate - Date to compute against (defaults to today).
+ * @returns Computed gain/loss details.
+ */
+export function computeLotGainLoss(
+  lot: Lot,
+  currentPricePerShareCents: number,
+  asOfDate?: LocalDate,
+): LotGainLoss {
+  const evalDate = asOfDate ?? todayISO();
+  const marketValue = Math.round(lot.shares * currentPricePerShareCents);
+  const costBasis = lot.totalCost.amount;
+  const unrealizedGainLoss = marketValue - costBasis;
+  const unrealizedGainLossPercent =
+    costBasis !== 0 ? Math.round((unrealizedGainLoss / costBasis) * 10000) / 100 : 0;
+  const daysHeld = daysBetween(lot.purchaseDate, evalDate);
+  const isLongTerm = daysHeld > 365;
+
+  return {
+    lot,
+    marketValue,
+    unrealizedGainLoss,
+    unrealizedGainLossPercent,
+    isLongTerm,
+    daysHeld,
+  };
+}
+
+/**
+ * Compute gain/loss for all lots of a position.
+ *
+ * @param lots - All lots for a single symbol/investment.
+ * @param currentPricePerShareCents - Current price per share in cents.
+ * @param asOfDate - Date to compute against (defaults to today).
+ * @returns Array of lot gain/loss computations.
+ */
+export function computeAllLotGainLoss(
+  lots: readonly Lot[],
+  currentPricePerShareCents: number,
+  asOfDate?: LocalDate,
+): LotGainLoss[] {
+  return lots.map((lot) => computeLotGainLoss(lot, currentPricePerShareCents, asOfDate));
+}
+
+// ---------------------------------------------------------------------------
+// Cost-basis methods — select lots to sell
+// ---------------------------------------------------------------------------
+
+/**
+ * Select lots to sell using the specified cost-basis method.
+ *
+ * Returns lots in the order they should be sold, along with the total
+ * cost basis for the shares being sold.
+ *
+ * @param lots - Available lots for the position.
+ * @param sharesToSell - Number of shares to sell.
+ * @param method - Cost-basis selection method.
+ * @param specificLotIds - Lot IDs for specific identification method.
+ * @returns Selected lots with adjusted shares, and total cost basis in cents.
+ */
+export function selectLotsForSale(
+  lots: readonly Lot[],
+  sharesToSell: number,
+  method: CostBasisMethod,
+  specificLotIds?: readonly string[],
+): { selectedLots: Array<{ lot: Lot; sharesToSell: number }>; totalCostBasis: number } {
+  if (sharesToSell <= 0) {
+    return { selectedLots: [], totalCostBasis: 0 };
+  }
+
+  let orderedLots: readonly Lot[];
+
+  switch (method) {
+    case 'FIFO':
+      orderedLots = [...lots].sort(
+        (a, b) => parseDate(a.purchaseDate).getTime() - parseDate(b.purchaseDate).getTime(),
+      );
+      break;
+    case 'LIFO':
+      orderedLots = [...lots].sort(
+        (a, b) => parseDate(b.purchaseDate).getTime() - parseDate(a.purchaseDate).getTime(),
+      );
+      break;
+    case 'SPECIFIC_ID':
+      if (!specificLotIds || specificLotIds.length === 0) {
+        return { selectedLots: [], totalCostBasis: 0 };
+      }
+      orderedLots = specificLotIds
+        .map((id) => lots.find((l) => l.id === id))
+        .filter((l): l is Lot => l !== undefined);
+      break;
+    case 'AVERAGE_COST':
+      // Average cost treats all lots equally; order doesn't matter
+      orderedLots = lots;
+      break;
+    default:
+      orderedLots = lots;
+  }
+
+  if (method === 'AVERAGE_COST') {
+    const totalShares = lots.reduce((sum, l) => sum + l.shares, 0);
+    const totalCost = lots.reduce((sum, l) => sum + l.totalCost.amount, 0);
+    const avgCostPerShare = totalShares > 0 ? totalCost / totalShares : 0;
+    const effectiveShares = Math.min(sharesToSell, totalShares);
+    const totalCostBasis = Math.round(effectiveShares * avgCostPerShare);
+
+    return {
+      selectedLots: lots.map((lot) => ({
+        lot,
+        sharesToSell: Math.min(lot.shares, (lot.shares / totalShares) * effectiveShares),
+      })),
+      totalCostBasis,
+    };
+  }
+
+  const selectedLots: Array<{ lot: Lot; sharesToSell: number }> = [];
+  let remaining = sharesToSell;
+  let totalCostBasis = 0;
+
+  for (const lot of orderedLots) {
+    if (remaining <= 0) break;
+
+    const sellFromLot = Math.min(remaining, lot.shares);
+    selectedLots.push({ lot, sharesToSell: sellFromLot });
+    totalCostBasis += Math.round(sellFromLot * lot.costPerShare.amount);
+    remaining -= sellFromLot;
+  }
+
+  return { selectedLots, totalCostBasis };
+}
+
+// ---------------------------------------------------------------------------
+// Average cost basis
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the average cost per share across all lots.
+ *
+ * @param lots - All lots for a single position.
+ * @returns Average cost per share in cents, or 0 if no lots.
+ */
+export function computeAverageCostBasis(lots: readonly Lot[]): Cents {
+  const totalShares = lots.reduce((sum, l) => sum + l.shares, 0);
+  const totalCost = lots.reduce((sum, l) => sum + l.totalCost.amount, 0);
+
+  if (totalShares === 0) {
+    return { amount: 0 };
+  }
+
+  return { amount: Math.round(totalCost / totalShares) };
+}
+
+// ---------------------------------------------------------------------------
+// Wash sale detection
+// ---------------------------------------------------------------------------
+
+/** The IRS wash sale window in days. */
+const WASH_SALE_WINDOW_DAYS = 30;
+
+/**
+ * Detect potential wash sales for a symbol.
+ *
+ * A wash sale occurs when a security is sold at a loss and a substantially
+ * identical security is purchased within 30 days before or after the sale.
+ *
+ * This is a simplified detection that checks lot purchase dates against
+ * sale dates. It does NOT handle all IRS edge cases (e.g., options, related
+ * securities, partial wash sales).
+ *
+ * @param soldLots - Lots that were sold (with sale date and realized loss).
+ * @param allLots - All lots (including new purchases) for the same symbol.
+ * @param symbol - The ticker symbol.
+ * @returns Array of wash sale alerts.
+ */
+export function detectWashSales(
+  soldLots: ReadonlyArray<{
+    lotId: string;
+    soldDate: LocalDate;
+    realizedLoss: number;
+  }>,
+  allLots: readonly Lot[],
+  symbol: string,
+): WashSaleAlert[] {
+  const alerts: WashSaleAlert[] = [];
+
+  for (const sold of soldLots) {
+    // Only check sales that resulted in a loss
+    if (sold.realizedLoss >= 0) continue;
+
+    const soldDate = parseDate(sold.soldDate);
+
+    for (const lot of allLots) {
+      if (lot.id === sold.lotId) continue;
+
+      const purchaseDate = parseDate(lot.purchaseDate);
+      const daysDiff = Math.abs(
+        (purchaseDate.getTime() - soldDate.getTime()) / (1000 * 60 * 60 * 24),
+      );
+
+      if (daysDiff <= WASH_SALE_WINDOW_DAYS) {
+        alerts.push({
+          lotId: sold.lotId,
+          symbol,
+          soldDate: sold.soldDate,
+          replacementDate: lot.purchaseDate,
+          disallowedLoss: Math.abs(sold.realizedLoss),
+        });
+        break; // One alert per sold lot
+      }
+    }
+  }
+
+  return alerts;
+}

--- a/apps/web/src/lib/investment/fee-analysis.test.ts
+++ b/apps/web/src/lib/investment/fee-analysis.test.ts
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the fee analysis and fee-drag calculator.
+ *
+ * Covers fee summary computation, fee drag projections, comparison
+ * scenarios, and the full analysis pipeline.
+ *
+ * References: issue #1625
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { FeeHoldingInput } from './fee-analysis';
+import {
+  analyzeFees,
+  computeFeeSummary,
+  formatExpenseRatio,
+  generateFeeComparisons,
+  projectFeeDrag,
+  projectFeeDragMultiYear,
+} from './fee-analysis';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const holdings: readonly FeeHoldingInput[] = [
+  {
+    investmentId: 'inv-1',
+    symbol: 'VTI',
+    name: 'Vanguard Total Stock Market',
+    expenseRatioBps: 3, // 0.03%
+    marketValue: 500000_00,
+  },
+  {
+    investmentId: 'inv-2',
+    symbol: 'VXUS',
+    name: 'Vanguard Total International',
+    expenseRatioBps: 7, // 0.07%
+    marketValue: 300000_00,
+  },
+  {
+    investmentId: 'inv-3',
+    symbol: 'BND',
+    name: 'Vanguard Total Bond Market',
+    expenseRatioBps: 3, // 0.03%
+    marketValue: 200000_00,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// computeFeeSummary
+// ---------------------------------------------------------------------------
+
+describe('computeFeeSummary', () => {
+  it('computes total portfolio value', () => {
+    const summary = computeFeeSummary(holdings);
+    expect(summary.totalValue).toBe(1000000_00); // $10,000
+  });
+
+  it('computes per-fund annual fees', () => {
+    const summary = computeFeeSummary(holdings);
+
+    const vtiFee = summary.fundFees.find((f) => f.symbol === 'VTI');
+    // 50000000 × 3 / 10000 = 15000
+    expect(vtiFee?.annualFee).toBe(15000);
+
+    const vxusFee = summary.fundFees.find((f) => f.symbol === 'VXUS');
+    // 30000000 × 7 / 10000 = 21000
+    expect(vxusFee?.annualFee).toBe(21000);
+  });
+
+  it('computes total annual fees', () => {
+    const summary = computeFeeSummary(holdings);
+    // 15000 + 21000 + 6000 = 42000
+    expect(summary.totalAnnualFees).toBe(42000);
+  });
+
+  it('computes weighted average expense ratio', () => {
+    const summary = computeFeeSummary(holdings);
+    // Weighted: (5000000×3 + 3000000×7 + 2000000×3) / 10000000
+    // = (15000000 + 21000000 + 6000000) / 10000000 = 4.2 → rounds to 4
+    expect(summary.weightedExpenseRatioBps).toBe(4);
+  });
+
+  it('handles empty holdings', () => {
+    const summary = computeFeeSummary([]);
+    expect(summary.totalValue).toBe(0);
+    expect(summary.totalAnnualFees).toBe(0);
+    expect(summary.weightedExpenseRatioBps).toBe(0);
+    expect(summary.fundFees).toHaveLength(0);
+  });
+
+  it('sorts fund fees by annual fee descending', () => {
+    const summary = computeFeeSummary(holdings);
+    for (let i = 1; i < summary.fundFees.length; i++) {
+      expect(summary.fundFees[i - 1].annualFee).toBeGreaterThanOrEqual(
+        summary.fundFees[i].annualFee,
+      );
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// projectFeeDrag
+// ---------------------------------------------------------------------------
+
+describe('projectFeeDrag', () => {
+  it('projects value without fees using compound growth', () => {
+    // $10,000 at 7% for 10 years: 10000 × 1.07^10 ≈ $19,671.51
+    const result = projectFeeDrag(1000000, 7, 0, 10);
+    expect(result.valueWithoutFees).toBe(1967151);
+    expect(result.valueWithFees).toBe(1967151);
+    expect(result.totalFeesPaid).toBe(0);
+  });
+
+  it('computes fee drag with a non-zero expense ratio', () => {
+    // $10,000 at 7% with 100bps (1%) fee for 10 years
+    // Without fees: 10000 × 1.07^10
+    // With fees: 10000 × 1.06^10
+    const result = projectFeeDrag(1000000, 7, 100, 10);
+
+    expect(result.valueWithoutFees).toBe(1967151);
+    expect(result.valueWithFees).toBe(1790848);
+    expect(result.totalFeesPaid).toBe(176303);
+    expect(result.feeDragPercent).toBeGreaterThan(0);
+  });
+
+  it('handles zero initial value', () => {
+    const result = projectFeeDrag(0, 7, 50, 10);
+    expect(result.valueWithoutFees).toBe(0);
+    expect(result.valueWithFees).toBe(0);
+    expect(result.totalFeesPaid).toBe(0);
+  });
+
+  it('handles zero return rate', () => {
+    const result = projectFeeDrag(1000000, 0, 50, 10);
+    expect(result.valueWithoutFees).toBe(1000000);
+    // With fees of 0.5%: 10000 × (1 - 0.005)^10 ≈ 9511
+    expect(result.valueWithFees).toBeLessThan(1000000);
+  });
+
+  it('fee drag increases over longer time horizons', () => {
+    const r10 = projectFeeDrag(1000000, 7, 50, 10);
+    const r20 = projectFeeDrag(1000000, 7, 50, 20);
+    const r30 = projectFeeDrag(1000000, 7, 50, 30);
+
+    expect(r20.totalFeesPaid).toBeGreaterThan(r10.totalFeesPaid);
+    expect(r30.totalFeesPaid).toBeGreaterThan(r20.totalFeesPaid);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// projectFeeDragMultiYear
+// ---------------------------------------------------------------------------
+
+describe('projectFeeDragMultiYear', () => {
+  it('generates projections for 10, 20, and 30 years', () => {
+    const projections = projectFeeDragMultiYear(1000000, 7, 50);
+
+    expect(projections).toHaveLength(3);
+    expect(projections[0].years).toBe(10);
+    expect(projections[1].years).toBe(20);
+    expect(projections[2].years).toBe(30);
+  });
+
+  it('shows increasing fee drag over time', () => {
+    const projections = projectFeeDragMultiYear(1000000, 7, 100);
+
+    expect(projections[2].feeDragPercent).toBeGreaterThan(projections[0].feeDragPercent);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateFeeComparisons
+// ---------------------------------------------------------------------------
+
+describe('generateFeeComparisons', () => {
+  it('generates comparison scenarios', () => {
+    const scenarios = [
+      { label: 'Low Cost', expenseRatioBps: 3 },
+      { label: 'Medium Cost', expenseRatioBps: 50 },
+    ];
+
+    const comparisons = generateFeeComparisons(1000000, 7, scenarios);
+
+    expect(comparisons).toHaveLength(2);
+    expect(comparisons[0].label).toBe('Low Cost');
+    expect(comparisons[0].expenseRatioBps).toBe(3);
+    expect(comparisons[0].projections).toHaveLength(3);
+  });
+
+  it('lower fees result in higher ending values', () => {
+    const scenarios = [
+      { label: 'Low', expenseRatioBps: 3 },
+      { label: 'High', expenseRatioBps: 100 },
+    ];
+
+    const comparisons = generateFeeComparisons(1000000, 7, scenarios);
+
+    // At 30 years, low-fee should have higher value
+    const low30 = comparisons[0].projections[2];
+    const high30 = comparisons[1].projections[2];
+    expect(low30.valueWithFees).toBeGreaterThan(high30.valueWithFees);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// analyzeFees (full pipeline)
+// ---------------------------------------------------------------------------
+
+describe('analyzeFees', () => {
+  it('produces complete analysis with summary, projections, and comparisons', () => {
+    const analysis = analyzeFees(holdings);
+
+    expect(analysis.summary.totalValue).toBe(1000000_00);
+    expect(analysis.projections).toHaveLength(3);
+    expect(analysis.comparisons.length).toBeGreaterThan(0);
+  });
+
+  it('uses custom annual return rate', () => {
+    const analysis10 = analyzeFees(holdings, 10);
+    const analysis5 = analyzeFees(holdings, 5);
+
+    // Higher return → higher ending values
+    expect(analysis10.projections[2].valueWithoutFees).toBeGreaterThan(
+      analysis5.projections[2].valueWithoutFees,
+    );
+  });
+
+  it('uses custom comparison scenarios', () => {
+    const custom = [{ label: 'Free', expenseRatioBps: 0 }];
+    const analysis = analyzeFees(holdings, 7, custom);
+
+    expect(analysis.comparisons).toHaveLength(1);
+    expect(analysis.comparisons[0].label).toBe('Free');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatExpenseRatio
+// ---------------------------------------------------------------------------
+
+describe('formatExpenseRatio', () => {
+  it('formats basis points as percentage', () => {
+    expect(formatExpenseRatio(3)).toBe('0.03%');
+    expect(formatExpenseRatio(10)).toBe('0.10%');
+    expect(formatExpenseRatio(100)).toBe('1.00%');
+    expect(formatExpenseRatio(75)).toBe('0.75%');
+  });
+
+  it('handles zero', () => {
+    expect(formatExpenseRatio(0)).toBe('0.00%');
+  });
+});

--- a/apps/web/src/lib/investment/fee-analysis.ts
+++ b/apps/web/src/lib/investment/fee-analysis.ts
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Investment fee analyzer and long-term fee-drag calculator.
+ *
+ * Calculates weighted expense ratios, total annual fees, and projects
+ * the long-term impact of fees on portfolio growth. Supports "what if
+ * lower fees" comparison scenarios.
+ *
+ * All monetary values are integer cents. Expense ratios are in basis
+ * points (1 bp = 0.01%).
+ *
+ * References: issue #1625
+ */
+
+import type {
+  FeeAnalysis,
+  FeeComparisonScenario,
+  FeeDragProjection,
+  FundFeeInfo,
+  PortfolioFeeSummary,
+} from '../../types/investment';
+
+// ---------------------------------------------------------------------------
+// Fee summary computation
+// ---------------------------------------------------------------------------
+
+/** Input holding for fee analysis. */
+export interface FeeHoldingInput {
+  readonly investmentId: string;
+  readonly symbol: string;
+  readonly name: string;
+  /** Expense ratio in basis points (e.g., 3 for 0.03%). */
+  readonly expenseRatioBps: number;
+  /** Current market value in cents. */
+  readonly marketValue: number;
+}
+
+/**
+ * Compute portfolio-level fee summary from individual holdings.
+ *
+ * @param holdings - Holdings with expense ratios and market values.
+ * @returns Portfolio fee summary with per-fund breakdown.
+ */
+export function computeFeeSummary(holdings: readonly FeeHoldingInput[]): PortfolioFeeSummary {
+  const totalValue = holdings.reduce((sum, h) => sum + h.marketValue, 0);
+
+  const fundFees: FundFeeInfo[] = holdings.map((h) => {
+    const annualFee = Math.round((h.marketValue * h.expenseRatioBps) / 10000);
+    return {
+      investmentId: h.investmentId,
+      symbol: h.symbol,
+      name: h.name,
+      expenseRatioBps: h.expenseRatioBps,
+      marketValue: h.marketValue,
+      annualFee,
+    };
+  });
+
+  const totalAnnualFees = fundFees.reduce((sum, f) => sum + f.annualFee, 0);
+
+  // Weighted average expense ratio: Σ(value_i × er_i) / Σ(value_i)
+  const weightedExpenseRatioBps =
+    totalValue > 0
+      ? Math.round(
+          holdings.reduce((sum, h) => sum + h.marketValue * h.expenseRatioBps, 0) / totalValue,
+        )
+      : 0;
+
+  // Sort by annual fee descending for display
+  fundFees.sort((a, b) => b.annualFee - a.annualFee);
+
+  return {
+    totalValue,
+    weightedExpenseRatioBps,
+    totalAnnualFees,
+    fundFees,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fee drag projection
+// ---------------------------------------------------------------------------
+
+/**
+ * Project portfolio growth with and without fees over a given number of years.
+ *
+ * Uses compound growth formula:
+ *   - Without fees: V = P × (1 + r)^t
+ *   - With fees: V = P × (1 + r - f)^t
+ *
+ * @param initialValueCents - Starting portfolio value in cents.
+ * @param annualReturnPercent - Expected annual return as a percentage (e.g., 7 for 7%).
+ * @param expenseRatioBps - Annual expense ratio in basis points.
+ * @param years - Number of years to project.
+ * @returns Fee drag projection for the given time horizon.
+ */
+export function projectFeeDrag(
+  initialValueCents: number,
+  annualReturnPercent: number,
+  expenseRatioBps: number,
+  years: number,
+): FeeDragProjection {
+  const annualReturn = annualReturnPercent / 100;
+  const expenseRatio = expenseRatioBps / 10000;
+
+  const valueWithoutFees = Math.round(initialValueCents * Math.pow(1 + annualReturn, years));
+  const valueWithFees = Math.round(
+    initialValueCents * Math.pow(1 + annualReturn - expenseRatio, years),
+  );
+  const totalFeesPaid = valueWithoutFees - valueWithFees;
+
+  const growthWithoutFees = valueWithoutFees - initialValueCents;
+  const feeDragPercent =
+    growthWithoutFees > 0 ? Math.round((totalFeesPaid / growthWithoutFees) * 10000) / 100 : 0;
+
+  return {
+    years,
+    valueWithoutFees,
+    valueWithFees,
+    totalFeesPaid,
+    feeDragPercent,
+  };
+}
+
+/**
+ * Generate fee drag projections for standard time horizons (10, 20, 30 years).
+ *
+ * @param initialValueCents - Starting portfolio value in cents.
+ * @param annualReturnPercent - Expected annual return percentage.
+ * @param expenseRatioBps - Expense ratio in basis points.
+ * @returns Projections at 10, 20, and 30 years.
+ */
+export function projectFeeDragMultiYear(
+  initialValueCents: number,
+  annualReturnPercent: number,
+  expenseRatioBps: number,
+): FeeDragProjection[] {
+  return [10, 20, 30].map((years) =>
+    projectFeeDrag(initialValueCents, annualReturnPercent, expenseRatioBps, years),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Fee comparison ("what if lower fees")
+// ---------------------------------------------------------------------------
+
+/** Default comparison scenarios for common low-cost alternatives. */
+export const DEFAULT_FEE_COMPARISON_SCENARIOS: ReadonlyArray<{
+  label: string;
+  expenseRatioBps: number;
+}> = [
+  { label: 'Ultra Low Cost (0.03%)', expenseRatioBps: 3 },
+  { label: 'Low Cost Index (0.10%)', expenseRatioBps: 10 },
+  { label: 'Average Index Fund (0.20%)', expenseRatioBps: 20 },
+];
+
+/**
+ * Generate comparison scenarios showing the impact of switching to lower-fee alternatives.
+ *
+ * @param initialValueCents - Starting portfolio value in cents.
+ * @param annualReturnPercent - Expected annual return percentage.
+ * @param scenarios - Array of alternative fee scenarios.
+ * @returns Comparison scenarios with projections.
+ */
+export function generateFeeComparisons(
+  initialValueCents: number,
+  annualReturnPercent: number,
+  scenarios: ReadonlyArray<{ label: string; expenseRatioBps: number }>,
+): FeeComparisonScenario[] {
+  return scenarios.map((scenario) => ({
+    label: scenario.label,
+    expenseRatioBps: scenario.expenseRatioBps,
+    projections: projectFeeDragMultiYear(
+      initialValueCents,
+      annualReturnPercent,
+      scenario.expenseRatioBps,
+    ),
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Full analysis
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a comprehensive fee analysis for the portfolio.
+ *
+ * Combines fee summary, fee drag projections, and comparison scenarios.
+ *
+ * @param holdings - Holdings with expense ratios.
+ * @param annualReturnPercent - Expected annual return (default: 7%).
+ * @param comparisonScenarios - Alternative fee scenarios (defaults provided).
+ * @returns Complete fee analysis result.
+ */
+export function analyzeFees(
+  holdings: readonly FeeHoldingInput[],
+  annualReturnPercent: number = 7,
+  comparisonScenarios: ReadonlyArray<{
+    label: string;
+    expenseRatioBps: number;
+  }> = DEFAULT_FEE_COMPARISON_SCENARIOS,
+): FeeAnalysis {
+  const summary = computeFeeSummary(holdings);
+
+  const projections = projectFeeDragMultiYear(
+    summary.totalValue,
+    annualReturnPercent,
+    summary.weightedExpenseRatioBps,
+  );
+
+  const comparisons = generateFeeComparisons(
+    summary.totalValue,
+    annualReturnPercent,
+    comparisonScenarios,
+  );
+
+  return {
+    summary,
+    projections,
+    comparisons,
+  };
+}
+
+/**
+ * Format basis points as a human-readable percentage string.
+ *
+ * @param bps - Expense ratio in basis points.
+ * @returns Formatted string like "0.03%".
+ */
+export function formatExpenseRatio(bps: number): string {
+  return `${(bps / 100).toFixed(2)}%`;
+}

--- a/apps/web/src/lib/investment/index.ts
+++ b/apps/web/src/lib/investment/index.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Public API for the investment calculation engines.
+ *
+ * Re-exports cost-basis, allocation, and fee analysis modules.
+ *
+ * References: issues #1585, #1588, #1595, #1625
+ */
+
+export {
+  computeLotGainLoss,
+  computeAllLotGainLoss,
+  selectLotsForSale,
+  computeAverageCostBasis,
+  detectWashSales,
+} from './cost-basis';
+
+export {
+  DEFAULT_ASSET_CLASS_MAP,
+  ALLOCATION_PRESETS,
+  validateTargets,
+  computeAllocation,
+  getRebalancingSuggestions,
+} from './allocation';
+export type { HoldingWithClass, AllocationPreset } from './allocation';
+
+export {
+  computeFeeSummary,
+  projectFeeDrag,
+  projectFeeDragMultiYear,
+  generateFeeComparisons,
+  analyzeFees,
+  formatExpenseRatio,
+  DEFAULT_FEE_COMPARISON_SCENARIOS,
+} from './fee-analysis';
+export type { FeeHoldingInput } from './fee-analysis';

--- a/apps/web/src/pages/InvestmentDetailPage.test.tsx
+++ b/apps/web/src/pages/InvestmentDetailPage.test.tsx
@@ -46,22 +46,38 @@ function renderWithRoute(investmentId: string) {
 }
 
 describe('InvestmentDetailPage', () => {
+  const baseMockReturn = {
+    investments: [mockInvestment],
+    summary: {
+      totalValue: 195000,
+      totalCostBasis: 150000,
+      totalGainLoss: 45000,
+      totalGainLossPercent: 30,
+    },
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    createInvestment: vi.fn(),
+    updateInvestment: vi.fn(),
+    deleteInvestment: vi.fn(),
+    getLots: vi.fn().mockReturnValue([]),
+    createLot: vi.fn(),
+    updateLot: vi.fn(),
+    deleteLot: vi.fn(),
+    computeAllocationAnalysis: vi.fn().mockReturnValue({
+      totalPortfolioValue: 195000,
+      comparisons: [],
+      isTargetValid: true,
+    }),
+    computeFeeAnalysis: vi.fn().mockReturnValue({
+      summary: { totalValue: 0, weightedExpenseRatioBps: 0, totalAnnualFees: 0, fundFees: [] },
+      projections: [],
+      comparisons: [],
+    }),
+  };
+
   beforeEach(() => {
-    mockedUseInvestments.mockReturnValue({
-      investments: [mockInvestment],
-      summary: {
-        totalValue: 195000,
-        totalCostBasis: 150000,
-        totalGainLoss: 45000,
-        totalGainLossPercent: 30,
-      },
-      loading: false,
-      error: null,
-      refresh: vi.fn(),
-      createInvestment: vi.fn(),
-      updateInvestment: vi.fn(),
-      deleteInvestment: vi.fn(),
-    });
+    mockedUseInvestments.mockReturnValue(baseMockReturn);
   });
 
   it('renders investment details with symbol and name', () => {
@@ -88,14 +104,11 @@ describe('InvestmentDetailPage', () => {
 
   it('renders loading state', () => {
     mockedUseInvestments.mockReturnValue({
+      ...baseMockReturn,
       investments: [],
       summary: { totalValue: 0, totalCostBasis: 0, totalGainLoss: 0, totalGainLossPercent: 0 },
       loading: true,
       error: null,
-      refresh: vi.fn(),
-      createInvestment: vi.fn(),
-      updateInvestment: vi.fn(),
-      deleteInvestment: vi.fn(),
     });
 
     renderWithRoute('inv-1');
@@ -105,14 +118,11 @@ describe('InvestmentDetailPage', () => {
 
   it('renders error state', () => {
     mockedUseInvestments.mockReturnValue({
+      ...baseMockReturn,
       investments: [],
       summary: { totalValue: 0, totalCostBasis: 0, totalGainLoss: 0, totalGainLossPercent: 0 },
       loading: false,
       error: 'Database error',
-      refresh: vi.fn(),
-      createInvestment: vi.fn(),
-      updateInvestment: vi.fn(),
-      deleteInvestment: vi.fn(),
     });
 
     renderWithRoute('inv-1');

--- a/apps/web/src/pages/InvestmentsPage.test.tsx
+++ b/apps/web/src/pages/InvestmentsPage.test.tsx
@@ -62,22 +62,38 @@ const mockInvestments = [
 ];
 
 describe('InvestmentsPage', () => {
+  const baseMockReturn = {
+    investments: mockInvestments,
+    summary: {
+      totalValue: 807500,
+      totalCostBasis: 700000,
+      totalGainLoss: 107500,
+      totalGainLossPercent: 15.36,
+    },
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    createInvestment: vi.fn(),
+    updateInvestment: vi.fn(),
+    deleteInvestment: vi.fn(),
+    getLots: vi.fn().mockReturnValue([]),
+    createLot: vi.fn(),
+    updateLot: vi.fn(),
+    deleteLot: vi.fn(),
+    computeAllocationAnalysis: vi.fn().mockReturnValue({
+      totalPortfolioValue: 807500,
+      comparisons: [],
+      isTargetValid: true,
+    }),
+    computeFeeAnalysis: vi.fn().mockReturnValue({
+      summary: { totalValue: 0, weightedExpenseRatioBps: 0, totalAnnualFees: 0, fundFees: [] },
+      projections: [],
+      comparisons: [],
+    }),
+  };
+
   beforeEach(() => {
-    mockedUseInvestments.mockReturnValue({
-      investments: mockInvestments,
-      summary: {
-        totalValue: 807500,
-        totalCostBasis: 700000,
-        totalGainLoss: 107500,
-        totalGainLossPercent: 15.36,
-      },
-      loading: false,
-      error: null,
-      refresh: vi.fn(),
-      createInvestment: vi.fn(),
-      updateInvestment: vi.fn(),
-      deleteInvestment: vi.fn(),
-    });
+    mockedUseInvestments.mockReturnValue(baseMockReturn);
   });
 
   it('renders portfolio summary with total value', () => {
@@ -118,14 +134,11 @@ describe('InvestmentsPage', () => {
 
   it('renders loading state', () => {
     mockedUseInvestments.mockReturnValue({
+      ...baseMockReturn,
       investments: [],
       summary: { totalValue: 0, totalCostBasis: 0, totalGainLoss: 0, totalGainLossPercent: 0 },
       loading: true,
       error: null,
-      refresh: vi.fn(),
-      createInvestment: vi.fn(),
-      updateInvestment: vi.fn(),
-      deleteInvestment: vi.fn(),
     });
 
     render(
@@ -140,14 +153,12 @@ describe('InvestmentsPage', () => {
   it('renders error state with retry', () => {
     const refresh = vi.fn();
     mockedUseInvestments.mockReturnValue({
+      ...baseMockReturn,
       investments: [],
       summary: { totalValue: 0, totalCostBasis: 0, totalGainLoss: 0, totalGainLossPercent: 0 },
       loading: false,
       error: 'Failed to load investments.',
       refresh,
-      createInvestment: vi.fn(),
-      updateInvestment: vi.fn(),
-      deleteInvestment: vi.fn(),
     });
 
     render(
@@ -161,14 +172,11 @@ describe('InvestmentsPage', () => {
 
   it('renders empty state when no investments exist', () => {
     mockedUseInvestments.mockReturnValue({
+      ...baseMockReturn,
       investments: [],
       summary: { totalValue: 0, totalCostBasis: 0, totalGainLoss: 0, totalGainLossPercent: 0 },
       loading: false,
       error: null,
-      refresh: vi.fn(),
-      createInvestment: vi.fn(),
-      updateInvestment: vi.fn(),
-      deleteInvestment: vi.fn(),
     });
 
     render(

--- a/apps/web/src/types/investment.ts
+++ b/apps/web/src/types/investment.ts
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Investment domain types for account taxonomy, lot-level cost-basis tracking,
+ * target-vs-actual asset allocation, and fee analysis.
+ *
+ * All monetary values are integer cents. Shares use floating-point to support
+ * fractional shares (e.g., 0.5 shares of BRK.A).
+ *
+ * References: issues #1585, #1588, #1595, #1625
+ */
+
+import type { Cents, Instant, LocalDate, SyncId } from '../kmp/bridge';
+
+// ---------------------------------------------------------------------------
+// #1585 — Account taxonomy and tax-treatment metadata
+// ---------------------------------------------------------------------------
+
+/** Tax treatment classification for investment accounts. */
+export type TaxTreatment = 'TAXABLE' | 'TAX_DEFERRED' | 'TAX_FREE';
+
+/** Specific investment account sub-types within each tax treatment. */
+export type InvestmentAccountSubtype =
+  | 'BROKERAGE'
+  | 'TRADITIONAL_IRA'
+  | 'ROTH_IRA'
+  | 'SEP_IRA'
+  | 'SIMPLE_IRA'
+  | '401K'
+  | '403B'
+  | '457B'
+  | 'HSA'
+  | '529'
+  | 'TRUST'
+  | 'OTHER';
+
+/** Map from account subtype to its tax treatment. */
+export const ACCOUNT_SUBTYPE_TAX_TREATMENT: Record<InvestmentAccountSubtype, TaxTreatment> = {
+  BROKERAGE: 'TAXABLE',
+  TRADITIONAL_IRA: 'TAX_DEFERRED',
+  SEP_IRA: 'TAX_DEFERRED',
+  SIMPLE_IRA: 'TAX_DEFERRED',
+  '401K': 'TAX_DEFERRED',
+  '403B': 'TAX_DEFERRED',
+  '457B': 'TAX_DEFERRED',
+  ROTH_IRA: 'TAX_FREE',
+  HSA: 'TAX_FREE',
+  '529': 'TAX_FREE',
+  TRUST: 'TAXABLE',
+  OTHER: 'TAXABLE',
+};
+
+/** Human-readable labels for investment account subtypes. */
+export const ACCOUNT_SUBTYPE_LABELS: Record<InvestmentAccountSubtype, string> = {
+  BROKERAGE: 'Taxable Brokerage',
+  TRADITIONAL_IRA: 'Traditional IRA',
+  ROTH_IRA: 'Roth IRA',
+  SEP_IRA: 'SEP IRA',
+  SIMPLE_IRA: 'SIMPLE IRA',
+  '401K': '401(k)',
+  '403B': '403(b)',
+  '457B': '457(b)',
+  HSA: 'HSA',
+  '529': '529 Plan',
+  TRUST: 'Trust',
+  OTHER: 'Other',
+};
+
+/** Human-readable labels for tax treatments. */
+export const TAX_TREATMENT_LABELS: Record<TaxTreatment, string> = {
+  TAXABLE: 'Taxable',
+  TAX_DEFERRED: 'Tax-Deferred',
+  TAX_FREE: 'Tax-Free',
+};
+
+/** Extended account metadata for investment accounts. */
+export interface InvestmentAccountMetadata {
+  readonly subtype: InvestmentAccountSubtype;
+  readonly taxTreatment: TaxTreatment;
+  readonly institutionName: string | null;
+  readonly accountNumber: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// #1588 — Lot-level position detail and cost-basis tracking
+// ---------------------------------------------------------------------------
+
+/** Cost-basis calculation method. */
+export type CostBasisMethod = 'FIFO' | 'LIFO' | 'SPECIFIC_ID' | 'AVERAGE_COST';
+
+/** Human-readable labels for cost-basis methods. */
+export const COST_BASIS_METHOD_LABELS: Record<CostBasisMethod, string> = {
+  FIFO: 'First In, First Out (FIFO)',
+  LIFO: 'Last In, First Out (LIFO)',
+  SPECIFIC_ID: 'Specific Identification',
+  AVERAGE_COST: 'Average Cost',
+};
+
+/** A single purchase lot for a position. */
+export interface Lot {
+  readonly id: SyncId;
+  readonly investmentId: SyncId;
+  readonly purchaseDate: LocalDate;
+  /** Number of shares in this lot. */
+  readonly shares: number;
+  /** Cost per share in cents at time of purchase. */
+  readonly costPerShare: Cents;
+  /** Total cost basis in cents (shares × costPerShare). */
+  readonly totalCost: Cents;
+  readonly createdAt: Instant;
+  readonly updatedAt: Instant;
+}
+
+/** Computed gain/loss details for a single lot. */
+export interface LotGainLoss {
+  readonly lot: Lot;
+  /** Current market value of this lot in cents. */
+  readonly marketValue: number;
+  /** Unrealized gain/loss in cents. */
+  readonly unrealizedGainLoss: number;
+  /** Unrealized gain/loss as a percentage of cost basis. */
+  readonly unrealizedGainLossPercent: number;
+  /** Whether this lot qualifies as a long-term holding (> 1 year). */
+  readonly isLongTerm: boolean;
+  /** Number of days held. */
+  readonly daysHeld: number;
+}
+
+/** Wash sale detection result for a lot. */
+export interface WashSaleAlert {
+  readonly lotId: SyncId;
+  readonly symbol: string;
+  /** The lot that was sold at a loss. */
+  readonly soldDate: LocalDate;
+  /** The replacement purchase that triggered the wash sale. */
+  readonly replacementDate: LocalDate;
+  /** The disallowed loss amount in cents. */
+  readonly disallowedLoss: number;
+}
+
+// ---------------------------------------------------------------------------
+// #1595 — Target-vs-actual asset allocation
+// ---------------------------------------------------------------------------
+
+/** Asset class for allocation purposes. */
+export type AssetClass =
+  | 'US_STOCKS'
+  | 'INTERNATIONAL_STOCKS'
+  | 'BONDS'
+  | 'REAL_ESTATE'
+  | 'COMMODITIES'
+  | 'CRYPTO'
+  | 'CASH'
+  | 'OTHER';
+
+/** Human-readable labels for asset classes. */
+export const ASSET_CLASS_LABELS: Record<AssetClass, string> = {
+  US_STOCKS: 'US Stocks',
+  INTERNATIONAL_STOCKS: 'International Stocks',
+  BONDS: 'Bonds',
+  REAL_ESTATE: 'Real Estate',
+  COMMODITIES: 'Commodities',
+  CRYPTO: 'Crypto',
+  CASH: 'Cash',
+  OTHER: 'Other',
+};
+
+/** Target allocation for a single asset class (percentage 0–100). */
+export interface AllocationTarget {
+  readonly assetClass: AssetClass;
+  /** Target percentage (0–100). */
+  readonly targetPercent: number;
+}
+
+/** Actual allocation computed from current holdings. */
+export interface AllocationActual {
+  readonly assetClass: AssetClass;
+  /** Current value in cents. */
+  readonly currentValue: number;
+  /** Actual percentage (0–100). */
+  readonly actualPercent: number;
+}
+
+/** Combined target vs actual for one asset class. */
+export interface AllocationComparison {
+  readonly assetClass: AssetClass;
+  readonly label: string;
+  readonly targetPercent: number;
+  readonly actualPercent: number;
+  /** Deviation: actual - target. Positive = overweight, negative = underweight. */
+  readonly deviationPercent: number;
+  readonly currentValue: number;
+  /** Target value in cents based on total portfolio value. */
+  readonly targetValue: number;
+  /** Amount to buy (positive) or sell (negative) in cents to rebalance. */
+  readonly rebalanceAmount: number;
+}
+
+/** Full allocation analysis result. */
+export interface AllocationAnalysis {
+  readonly totalPortfolioValue: number;
+  readonly comparisons: readonly AllocationComparison[];
+  /** True if all target percentages sum to 100%. */
+  readonly isTargetValid: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// #1625 — Fee analysis and fee-drag calculation
+// ---------------------------------------------------------------------------
+
+/** Fee metadata for a fund or ETF holding. */
+export interface FundFeeInfo {
+  readonly investmentId: SyncId;
+  readonly symbol: string;
+  readonly name: string;
+  /** Expense ratio as basis points (e.g., 3 = 0.03%). */
+  readonly expenseRatioBps: number;
+  /** Current market value in cents. */
+  readonly marketValue: number;
+  /** Annual fee in cents (marketValue × expenseRatio). */
+  readonly annualFee: number;
+}
+
+/** Portfolio-level fee summary. */
+export interface PortfolioFeeSummary {
+  /** Total portfolio value in cents. */
+  readonly totalValue: number;
+  /** Weighted average expense ratio in basis points. */
+  readonly weightedExpenseRatioBps: number;
+  /** Total annual fees in cents. */
+  readonly totalAnnualFees: number;
+  /** Per-fund fee breakdown. */
+  readonly fundFees: readonly FundFeeInfo[];
+}
+
+/** Fee drag projection for a single time horizon. */
+export interface FeeDragProjection {
+  /** Number of years projected. */
+  readonly years: number;
+  /** Portfolio value without fees in cents. */
+  readonly valueWithoutFees: number;
+  /** Portfolio value with current fees in cents. */
+  readonly valueWithFees: number;
+  /** Total fees paid over the period in cents. */
+  readonly totalFeesPaid: number;
+  /** Percentage of returns lost to fees. */
+  readonly feeDragPercent: number;
+}
+
+/** Comparison scenario for "what if lower fees". */
+export interface FeeComparisonScenario {
+  readonly label: string;
+  /** Alternative expense ratio in basis points. */
+  readonly expenseRatioBps: number;
+  readonly projections: readonly FeeDragProjection[];
+}
+
+/** Full fee analysis result. */
+export interface FeeAnalysis {
+  readonly summary: PortfolioFeeSummary;
+  /** Fee drag projections at 10, 20, 30 year horizons. */
+  readonly projections: readonly FeeDragProjection[];
+  /** Comparison with lower-fee alternatives. */
+  readonly comparisons: readonly FeeComparisonScenario[];
+}


### PR DESCRIPTION
## Summary

Investment tracking features: account taxonomy with tax treatment, lot-level cost-basis tracking, target vs actual asset allocation, and fee drag analysis.

## Changes

- New investment types (TaxTreatment, CostBasisMethod, AssetClass, Lot, FeeAnalysis models)
- Cost-basis engine: FIFO, LIFO, specific ID, average cost with wash sale detection
- Allocation engine: target-vs-actual analysis, preset strategies, rebalancing suggestions
- Fee analyzer: expense ratio tracking, fee drag projections (10/20/30yr), lower-fee comparisons
- InvestmentLot bridge type and investment-lots repository with CRUD
- Extended useInvestments hook with lot ops, allocation, and fee analysis
- 69 tests across all calculation engines and page components

Closes #1585
Closes #1588
Closes #1595
Closes #1625

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>