### PR TITLE
feat(web): add security and privacy engines (#1654, #1658, #1663, #1668, #1677, #1682, #1723)

### DIFF
--- a/apps/web/src/lib/security/audit-log.test.ts
+++ b/apps/web/src/lib/security/audit-log.test.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  appendAuditEntry,
+  clearAuditLog,
+  exportAuditLog,
+  getEventTypeCounts,
+  loadAuditLog,
+  queryAuditLog,
+} from './audit-log';
+
+describe('audit-log', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('appendAuditEntry', () => {
+    it('appends an entry to the log', () => {
+      const entry = appendAuditEntry('login', 'User logged in');
+      expect(entry.id).toBeTruthy();
+      expect(entry.eventType).toBe('login');
+      expect(entry.severity).toBe('info');
+      expect(entry.description).toBe('User logged in');
+    });
+
+    it('sets correct severity for critical events', () => {
+      const entry = appendAuditEntry('data_erasure', 'Record erased');
+      expect(entry.severity).toBe('critical');
+    });
+
+    it('sets correct severity for warning events', () => {
+      const entry = appendAuditEntry('permission_change', 'Permissions updated');
+      expect(entry.severity).toBe('warning');
+    });
+
+    it('includes metadata', () => {
+      const entry = appendAuditEntry('settings_changed', 'Theme changed', {
+        setting: 'theme',
+        value: 'dark',
+      });
+      expect(entry.metadata.setting).toBe('theme');
+    });
+
+    it('includes IP and user agent when provided', () => {
+      const entry = appendAuditEntry(
+        'login',
+        'User logged in',
+        {},
+        {
+          ipAddress: '10.0.0.1',
+          userAgent: 'Test Agent',
+        },
+      );
+      expect(entry.ipAddress).toBe('10.0.0.1');
+      expect(entry.userAgent).toBe('Test Agent');
+    });
+
+    it('persists entries', () => {
+      appendAuditEntry('login', 'Login 1');
+      appendAuditEntry('logout', 'Logout 1');
+      expect(loadAuditLog()).toHaveLength(2);
+    });
+  });
+
+  describe('queryAuditLog', () => {
+    beforeEach(() => {
+      appendAuditEntry('login', 'Login event');
+      appendAuditEntry('logout', 'Logout event');
+      appendAuditEntry('data_erasure', 'Erasure event');
+      appendAuditEntry('login', 'Login event 2');
+    });
+
+    it('returns all entries when no filter is applied (newest first)', () => {
+      const results = queryAuditLog();
+      expect(results).toHaveLength(4);
+      // Newest first
+      expect(results[0].description).toBe('Login event 2');
+    });
+
+    it('filters by event type', () => {
+      const results = queryAuditLog({ eventTypes: ['login'] });
+      expect(results).toHaveLength(2);
+      expect(results.every((e) => e.eventType === 'login')).toBe(true);
+    });
+
+    it('filters by multiple event types', () => {
+      const results = queryAuditLog({ eventTypes: ['login', 'logout'] });
+      expect(results).toHaveLength(3);
+    });
+
+    it('filters by severity', () => {
+      const results = queryAuditLog({ severity: 'critical' });
+      expect(results).toHaveLength(1);
+      expect(results[0].eventType).toBe('data_erasure');
+    });
+
+    it('limits results', () => {
+      const results = queryAuditLog({ limit: 2 });
+      expect(results).toHaveLength(2);
+    });
+
+    it('filters by date range', () => {
+      const now = new Date().toISOString();
+      const results = queryAuditLog({ endDate: now });
+      expect(results.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('getEventTypeCounts', () => {
+    it('counts events by type', () => {
+      appendAuditEntry('login', 'Login 1');
+      appendAuditEntry('login', 'Login 2');
+      appendAuditEntry('logout', 'Logout 1');
+
+      const counts = getEventTypeCounts();
+      expect(counts.login).toBe(2);
+      expect(counts.logout).toBe(1);
+    });
+  });
+
+  describe('exportAuditLog', () => {
+    it('exports the log as valid JSON', () => {
+      appendAuditEntry('login', 'Login event');
+      const exported = exportAuditLog();
+      const parsed = JSON.parse(exported);
+      expect(parsed.type).toBe('security_audit_log');
+      expect(parsed.totalEntries).toBe(1);
+      expect(parsed.entries).toHaveLength(1);
+    });
+  });
+
+  describe('clearAuditLog', () => {
+    it('clears all entries', () => {
+      appendAuditEntry('login', 'Login event');
+      clearAuditLog();
+      expect(loadAuditLog()).toHaveLength(0);
+    });
+  });
+});

--- a/apps/web/src/lib/security/audit-log.ts
+++ b/apps/web/src/lib/security/audit-log.ts
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Security Audit Log — append-only log for security events.
+ *
+ * Records login/logout, permission changes, data access, connection
+ * changes, and other security-relevant events. Supports querying by
+ * event type and date range.
+ *
+ * The log is append-only by design — entries are never modified or
+ * deleted (except via full log export + clear for storage management).
+ *
+ * References: issue #1682
+ */
+
+import type { AuditEntry, AuditEventType, AuditLogFilter, AuditSeverity } from './types';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** localStorage key for the audit log. */
+const AUDIT_LOG_KEY = 'finance-audit-log';
+
+/** Maximum audit log entries to retain. */
+const MAX_AUDIT_ENTRIES = 2000;
+
+/** Default severity for each event type. */
+const EVENT_SEVERITY: Readonly<Record<AuditEventType, AuditSeverity>> = {
+  login: 'info',
+  logout: 'info',
+  permission_change: 'warning',
+  data_access: 'info',
+  data_export: 'warning',
+  data_erasure: 'critical',
+  connection_added: 'info',
+  connection_revoked: 'warning',
+  session_revoked: 'warning',
+  telemetry_changed: 'info',
+  memo_encrypted: 'info',
+  memo_decrypted: 'info',
+  settings_changed: 'info',
+};
+
+// ---------------------------------------------------------------------------
+// Storage
+// ---------------------------------------------------------------------------
+
+/**
+ * Load the full audit log from localStorage.
+ *
+ * @returns An array of AuditEntry objects, oldest first.
+ */
+export function loadAuditLog(): AuditEntry[] {
+  try {
+    const raw = localStorage.getItem(AUDIT_LOG_KEY);
+    if (!raw) return [];
+
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+
+    return parsed.filter(
+      (e: unknown): e is AuditEntry =>
+        typeof e === 'object' && e !== null && 'id' in e && 'eventType' in e && 'timestamp' in e,
+    );
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Save the audit log to localStorage (internal use).
+ *
+ * @param entries - The log entries to persist.
+ */
+function saveAuditLog(entries: readonly AuditEntry[]): void {
+  const trimmed = entries.length > MAX_AUDIT_ENTRIES ? entries.slice(-MAX_AUDIT_ENTRIES) : entries;
+  localStorage.setItem(AUDIT_LOG_KEY, JSON.stringify(trimmed));
+}
+
+// ---------------------------------------------------------------------------
+// Append operations (append-only — no update or delete)
+// ---------------------------------------------------------------------------
+
+/**
+ * Append a security event to the audit log.
+ *
+ * @param eventType - The type of security event.
+ * @param description - Human-readable description (must not contain financial data).
+ * @param metadata - Optional metadata (must be scrubbed of sensitive data).
+ * @param options - Optional IP address and user agent.
+ * @returns The created AuditEntry.
+ */
+export function appendAuditEntry(
+  eventType: AuditEventType,
+  description: string,
+  metadata: Record<string, string> = {},
+  options: { ipAddress?: string; userAgent?: string } = {},
+): AuditEntry {
+  const entry: AuditEntry = {
+    id: crypto.randomUUID(),
+    timestamp: new Date().toISOString(),
+    eventType,
+    severity: EVENT_SEVERITY[eventType],
+    description,
+    metadata,
+    ipAddress: options.ipAddress ?? null,
+    userAgent: options.userAgent ?? null,
+  };
+
+  const log = loadAuditLog();
+  log.push(entry);
+  saveAuditLog(log);
+
+  return entry;
+}
+
+// ---------------------------------------------------------------------------
+// Query operations
+// ---------------------------------------------------------------------------
+
+/**
+ * Query the audit log with optional filters.
+ *
+ * @param filter - Optional filter criteria.
+ * @returns An array of matching AuditEntry objects, newest first.
+ */
+export function queryAuditLog(filter: AuditLogFilter = {}): AuditEntry[] {
+  let entries = loadAuditLog();
+
+  if (filter.eventTypes && filter.eventTypes.length > 0) {
+    const types = new Set(filter.eventTypes);
+    entries = entries.filter((e) => types.has(e.eventType));
+  }
+
+  if (filter.startDate) {
+    const start = filter.startDate;
+    entries = entries.filter((e) => e.timestamp >= start);
+  }
+
+  if (filter.endDate) {
+    const end = filter.endDate;
+    entries = entries.filter((e) => e.timestamp <= end);
+  }
+
+  if (filter.severity) {
+    entries = entries.filter((e) => e.severity === filter.severity);
+  }
+
+  // Return newest first
+  entries.reverse();
+
+  if (filter.limit && filter.limit > 0) {
+    entries = entries.slice(0, filter.limit);
+  }
+
+  return entries;
+}
+
+/**
+ * Get a count of events grouped by event type.
+ *
+ * @returns A map of event type to count.
+ */
+export function getEventTypeCounts(): Record<AuditEventType, number> {
+  const log = loadAuditLog();
+  const counts = {} as Record<AuditEventType, number>;
+
+  for (const entry of log) {
+    counts[entry.eventType] = (counts[entry.eventType] ?? 0) + 1;
+  }
+
+  return counts;
+}
+
+/**
+ * Export the audit log as a formatted JSON string.
+ *
+ * @returns A JSON string suitable for download.
+ */
+export function exportAuditLog(): string {
+  const log = loadAuditLog();
+  return JSON.stringify(
+    {
+      type: 'security_audit_log',
+      exportedAt: new Date().toISOString(),
+      totalEntries: log.length,
+      entries: log,
+    },
+    null,
+    2,
+  );
+}
+
+/**
+ * Clear the audit log (for storage management only).
+ *
+ * This should only be called after the log has been exported.
+ */
+export function clearAuditLog(): void {
+  localStorage.removeItem(AUDIT_LOG_KEY);
+}

--- a/apps/web/src/lib/security/connection-transparency.test.ts
+++ b/apps/web/src/lib/security/connection-transparency.test.ts
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  addConnection,
+  getActiveConnections,
+  getConnectionsByType,
+  getScopesSummary,
+  loadConnections,
+  recordConnectionAccess,
+  revokeConnection,
+  updateConnectionStatus,
+} from './connection-transparency';
+
+describe('connection-transparency', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('addConnection', () => {
+    it('creates a new active connection', () => {
+      const conn = addConnection('Plaid', 'aggregator', ['read:accounts', 'read:transactions']);
+      expect(conn.id).toBeTruthy();
+      expect(conn.providerName).toBe('Plaid');
+      expect(conn.providerType).toBe('aggregator');
+      expect(conn.status).toBe('active');
+      expect(conn.scopes).toEqual(['read:accounts', 'read:transactions']);
+      expect(conn.lastAccessedAt).toBeNull();
+    });
+
+    it('persists the connection', () => {
+      addConnection('Plaid', 'aggregator', ['read:accounts']);
+      const loaded = loadConnections();
+      expect(loaded).toHaveLength(1);
+    });
+  });
+
+  describe('updateConnectionStatus', () => {
+    it('updates status to paused', () => {
+      const conn = addConnection('Plaid', 'aggregator', ['read:accounts']);
+      const updated = updateConnectionStatus(conn.id, 'paused');
+      expect(updated).not.toBeNull();
+      expect(updated!.status).toBe('paused');
+    });
+
+    it('returns null for non-existent connection', () => {
+      expect(updateConnectionStatus('non-existent', 'paused')).toBeNull();
+    });
+  });
+
+  describe('revokeConnection', () => {
+    it('sets status to revoked', () => {
+      const conn = addConnection('Plaid', 'aggregator', ['read:accounts']);
+      const revoked = revokeConnection(conn.id);
+      expect(revoked).not.toBeNull();
+      expect(revoked!.status).toBe('revoked');
+    });
+  });
+
+  describe('recordConnectionAccess', () => {
+    it('updates lastAccessedAt', () => {
+      const conn = addConnection('Plaid', 'aggregator', ['read:accounts']);
+      expect(conn.lastAccessedAt).toBeNull();
+
+      const accessed = recordConnectionAccess(conn.id);
+      expect(accessed).not.toBeNull();
+      expect(accessed!.lastAccessedAt).toBeTruthy();
+    });
+
+    it('returns null for non-existent connection', () => {
+      expect(recordConnectionAccess('non-existent')).toBeNull();
+    });
+  });
+
+  describe('getActiveConnections', () => {
+    it('excludes revoked connections', () => {
+      const conn1 = addConnection('Plaid', 'aggregator', ['read:accounts']);
+      addConnection('Yodlee', 'aggregator', ['read:accounts']);
+      revokeConnection(conn1.id);
+
+      const active = getActiveConnections();
+      expect(active).toHaveLength(1);
+      expect(active[0].providerName).toBe('Yodlee');
+    });
+
+    it('excludes expired connections', () => {
+      const pastDate = new Date();
+      pastDate.setDate(pastDate.getDate() - 1);
+      addConnection('ExpiredProvider', 'sync', ['read:data'], pastDate.toISOString());
+
+      const active = getActiveConnections();
+      expect(active).toHaveLength(0);
+    });
+  });
+
+  describe('getConnectionsByType', () => {
+    it('filters by provider type', () => {
+      addConnection('Plaid', 'aggregator', ['read:accounts']);
+      addConnection('SyncService', 'sync', ['sync:data']);
+      addConnection('ExportTool', 'export', ['export:data']);
+
+      expect(getConnectionsByType('aggregator')).toHaveLength(1);
+      expect(getConnectionsByType('sync')).toHaveLength(1);
+      expect(getConnectionsByType('analytics')).toHaveLength(0);
+    });
+  });
+
+  describe('getScopesSummary', () => {
+    it('returns scopes for active connections', () => {
+      addConnection('Plaid', 'aggregator', ['read:accounts', 'read:transactions']);
+      addConnection('SyncService', 'sync', ['sync:data']);
+
+      const summary = getScopesSummary();
+      expect(summary.get('Plaid')).toEqual(['read:accounts', 'read:transactions']);
+      expect(summary.get('SyncService')).toEqual(['sync:data']);
+    });
+  });
+});

--- a/apps/web/src/lib/security/connection-transparency.ts
+++ b/apps/web/src/lib/security/connection-transparency.ts
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Connection Transparency — third-party connection management and revocation.
+ *
+ * Lists all third-party connections (aggregators, sync providers, etc.),
+ * shows permission scopes, supports revocation workflows, and tracks
+ * last access timestamps.
+ *
+ * References: issue #1677
+ */
+
+import type { ConnectionRecord, ConnectionStatus } from './types';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** localStorage key for connection records. */
+const CONNECTIONS_STORAGE_KEY = 'finance-connections';
+
+// ---------------------------------------------------------------------------
+// Storage
+// ---------------------------------------------------------------------------
+
+/**
+ * Load all connection records from localStorage.
+ *
+ * @returns An array of ConnectionRecord objects.
+ */
+export function loadConnections(): ConnectionRecord[] {
+  try {
+    const raw = localStorage.getItem(CONNECTIONS_STORAGE_KEY);
+    if (!raw) return [];
+
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+
+    return parsed.filter(
+      (c: unknown): c is ConnectionRecord =>
+        typeof c === 'object' && c !== null && 'id' in c && 'providerName' in c,
+    );
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Save connection records to localStorage.
+ *
+ * @param connections - The connection records to persist.
+ */
+function saveConnections(connections: readonly ConnectionRecord[]): void {
+  localStorage.setItem(CONNECTIONS_STORAGE_KEY, JSON.stringify(connections));
+}
+
+// ---------------------------------------------------------------------------
+// Connection management
+// ---------------------------------------------------------------------------
+
+/**
+ * Register a new third-party connection.
+ *
+ * @param providerName - Name of the third-party provider.
+ * @param providerType - Type of connection.
+ * @param scopes - Permission scopes granted.
+ * @param expiresAt - Optional expiry date (ISO-8601).
+ * @returns The newly created ConnectionRecord.
+ */
+export function addConnection(
+  providerName: string,
+  providerType: ConnectionRecord['providerType'],
+  scopes: readonly string[],
+  expiresAt: string | null = null,
+): ConnectionRecord {
+  const connection: ConnectionRecord = {
+    id: crypto.randomUUID(),
+    providerName,
+    providerType,
+    status: 'active',
+    scopes,
+    connectedAt: new Date().toISOString(),
+    lastAccessedAt: null,
+    expiresAt,
+  };
+
+  const existing = loadConnections();
+  existing.push(connection);
+  saveConnections(existing);
+
+  return connection;
+}
+
+/**
+ * Update the status of a connection.
+ *
+ * @param connectionId - The connection to update.
+ * @param newStatus - The new status.
+ * @returns The updated ConnectionRecord, or null if not found.
+ */
+export function updateConnectionStatus(
+  connectionId: string,
+  newStatus: ConnectionStatus,
+): ConnectionRecord | null {
+  const connections = loadConnections();
+  const index = connections.findIndex((c) => c.id === connectionId);
+  if (index === -1) return null;
+
+  const updated: ConnectionRecord = {
+    ...connections[index],
+    status: newStatus,
+  };
+  connections[index] = updated;
+  saveConnections(connections);
+
+  return updated;
+}
+
+/**
+ * Revoke a third-party connection.
+ *
+ * Sets the connection status to 'revoked'. In a real implementation,
+ * this would also call the provider's revocation API endpoint.
+ *
+ * @param connectionId - The connection to revoke.
+ * @returns The revoked ConnectionRecord, or null if not found.
+ */
+export function revokeConnection(connectionId: string): ConnectionRecord | null {
+  return updateConnectionStatus(connectionId, 'revoked');
+}
+
+/**
+ * Record a data access event by a connection.
+ *
+ * Updates the lastAccessedAt timestamp for the connection.
+ *
+ * @param connectionId - The connection that accessed data.
+ * @returns The updated ConnectionRecord, or null if not found.
+ */
+export function recordConnectionAccess(connectionId: string): ConnectionRecord | null {
+  const connections = loadConnections();
+  const index = connections.findIndex((c) => c.id === connectionId);
+  if (index === -1) return null;
+
+  const updated: ConnectionRecord = {
+    ...connections[index],
+    lastAccessedAt: new Date().toISOString(),
+  };
+  connections[index] = updated;
+  saveConnections(connections);
+
+  return updated;
+}
+
+/**
+ * Get all active (non-revoked, non-expired) connections.
+ *
+ * @returns An array of active ConnectionRecord objects.
+ */
+export function getActiveConnections(): ConnectionRecord[] {
+  const now = new Date();
+  return loadConnections().filter((c) => {
+    if (c.status === 'revoked') return false;
+    if (c.expiresAt && new Date(c.expiresAt) < now) return false;
+    return true;
+  });
+}
+
+/**
+ * Get connections filtered by provider type.
+ *
+ * @param providerType - The type to filter by.
+ * @returns An array of matching ConnectionRecord objects.
+ */
+export function getConnectionsByType(
+  providerType: ConnectionRecord['providerType'],
+): ConnectionRecord[] {
+  return loadConnections().filter((c) => c.providerType === providerType);
+}
+
+/**
+ * Get the permission scopes summary for all active connections.
+ *
+ * @returns A map of provider name to granted scopes.
+ */
+export function getScopesSummary(): Map<string, readonly string[]> {
+  const active = getActiveConnections();
+  const summary = new Map<string, readonly string[]>();
+
+  for (const conn of active) {
+    summary.set(conn.providerName, conn.scopes);
+  }
+
+  return summary;
+}

--- a/apps/web/src/lib/security/data-access.test.ts
+++ b/apps/web/src/lib/security/data-access.test.ts
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect } from 'vitest';
+import {
+  ALL_DATA_CATEGORIES,
+  DATA_CATEGORY_DESCRIPTIONS,
+  buildDataInventory,
+  createDataAccessRequest,
+  generateExportPackage,
+  serializeExportPackage,
+  updateRequestStatus,
+} from './data-access';
+import type { DataCategory } from './types';
+
+describe('data-access', () => {
+  describe('createDataAccessRequest', () => {
+    it('creates a request with pending status', () => {
+      const request = createDataAccessRequest(['accounts', 'transactions']);
+      expect(request.id).toBeTruthy();
+      expect(request.status).toBe('pending');
+      expect(request.categories).toEqual(['accounts', 'transactions']);
+      expect(request.completedAt).toBeNull();
+      expect(request.format).toBe('json');
+    });
+
+    it('uses specified format', () => {
+      const request = createDataAccessRequest(['accounts'], 'csv');
+      expect(request.format).toBe('csv');
+    });
+
+    it('throws on empty categories', () => {
+      expect(() => createDataAccessRequest([])).toThrow(
+        'At least one data category must be selected',
+      );
+    });
+  });
+
+  describe('updateRequestStatus', () => {
+    it('advances status to processing', () => {
+      const request = createDataAccessRequest(['accounts']);
+      const updated = updateRequestStatus(request, 'processing');
+      expect(updated.status).toBe('processing');
+      expect(updated.completedAt).toBeNull();
+    });
+
+    it('sets completedAt when status is completed', () => {
+      const request = createDataAccessRequest(['accounts']);
+      const updated = updateRequestStatus(request, 'completed');
+      expect(updated.status).toBe('completed');
+      expect(updated.completedAt).toBeTruthy();
+    });
+  });
+
+  describe('buildDataInventory', () => {
+    it('counts records per category', () => {
+      const inventory = buildDataInventory({
+        accounts: [{ id: '1' }, { id: '2' }],
+        transactions: [{ id: '3' }],
+      });
+      expect(inventory.accounts).toBe(2);
+      expect(inventory.transactions).toBe(1);
+      expect(inventory.budgets).toBe(0);
+    });
+
+    it('returns zero for all categories with empty sources', () => {
+      const inventory = buildDataInventory({});
+      for (const cat of ALL_DATA_CATEGORIES) {
+        expect(inventory[cat]).toBe(0);
+      }
+    });
+  });
+
+  describe('generateExportPackage', () => {
+    it('generates package with only requested categories', () => {
+      const request = createDataAccessRequest(['accounts']);
+      const pkg = generateExportPackage(request, {
+        accounts: [{ id: '1', name: 'Checking' }],
+        transactions: [{ id: '99' }],
+      });
+
+      expect(pkg.meta.categories).toEqual(['accounts']);
+      expect(pkg.data.accounts).toHaveLength(1);
+      expect(pkg.data.transactions).toBeUndefined();
+      expect(pkg.meta.totalRecords).toBe(1);
+    });
+
+    it('handles missing data sources gracefully', () => {
+      const request = createDataAccessRequest(['budgets']);
+      const pkg = generateExportPackage(request, {});
+      expect(pkg.data.budgets).toEqual([]);
+      expect(pkg.meta.totalRecords).toBe(0);
+    });
+  });
+
+  describe('serializeExportPackage', () => {
+    it('produces valid JSON', () => {
+      const request = createDataAccessRequest(['accounts']);
+      const pkg = generateExportPackage(request, { accounts: [{ id: '1' }] });
+      const json = serializeExportPackage(pkg);
+      expect(() => JSON.parse(json)).not.toThrow();
+    });
+  });
+
+  describe('constants', () => {
+    it('ALL_DATA_CATEGORIES contains all expected categories', () => {
+      expect(ALL_DATA_CATEGORIES).toContain('accounts');
+      expect(ALL_DATA_CATEGORIES).toContain('transactions');
+      expect(ALL_DATA_CATEGORIES).toContain('audit_log');
+      expect(ALL_DATA_CATEGORIES.length).toBe(8);
+    });
+
+    it('DATA_CATEGORY_DESCRIPTIONS has entry for every category', () => {
+      for (const cat of ALL_DATA_CATEGORIES) {
+        expect(DATA_CATEGORY_DESCRIPTIONS[cat as DataCategory]).toBeTruthy();
+      }
+    });
+  });
+});

--- a/apps/web/src/lib/security/data-access.ts
+++ b/apps/web/src/lib/security/data-access.ts
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Data Access Request — GDPR/CCPA self-service data export.
+ *
+ * Generates structured data export packages containing all user data
+ * grouped by category. Supports inventory listing and package creation
+ * for data portability compliance.
+ *
+ * References: issue #1654
+ */
+
+import type {
+  DataAccessRequest,
+  DataAccessRequestStatus,
+  DataCategory,
+  DataExportPackage,
+} from './types';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** All available data categories for export. */
+export const ALL_DATA_CATEGORIES: readonly DataCategory[] = [
+  'accounts',
+  'transactions',
+  'budgets',
+  'goals',
+  'categories',
+  'settings',
+  'consent',
+  'audit_log',
+] as const;
+
+/** Human-readable descriptions for each data category. */
+export const DATA_CATEGORY_DESCRIPTIONS: Readonly<Record<DataCategory, string>> = {
+  accounts: 'Bank accounts, credit cards, and other financial accounts',
+  transactions: 'All recorded income and expense transactions',
+  budgets: 'Budget plans and spending limits by category',
+  goals: 'Savings goals and progress tracking',
+  categories: 'Custom transaction categories and subcategories',
+  settings: 'App preferences, display settings, and configuration',
+  consent: 'Consent records and privacy preference history',
+  audit_log: 'Security event log and access history',
+};
+
+// ---------------------------------------------------------------------------
+// Data Access Request functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a new data access request.
+ *
+ * @param categories - The data categories to include in the export.
+ * @param format - Export format (default: 'json').
+ * @returns A new DataAccessRequest in 'pending' status.
+ */
+export function createDataAccessRequest(
+  categories: readonly DataCategory[],
+  format: 'json' | 'csv' = 'json',
+): DataAccessRequest {
+  if (categories.length === 0) {
+    throw new Error('At least one data category must be selected for export.');
+  }
+
+  return {
+    id: crypto.randomUUID(),
+    requestedAt: new Date().toISOString(),
+    status: 'pending',
+    categories,
+    completedAt: null,
+    format,
+  };
+}
+
+/**
+ * Advance the status of a data access request.
+ *
+ * @param request - The current request.
+ * @param newStatus - The new status to set.
+ * @returns A new request object with the updated status.
+ */
+export function updateRequestStatus(
+  request: DataAccessRequest,
+  newStatus: DataAccessRequestStatus,
+): DataAccessRequest {
+  return {
+    ...request,
+    status: newStatus,
+    completedAt: newStatus === 'completed' ? new Date().toISOString() : request.completedAt,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Data inventory
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a data inventory summarizing what data exists per category.
+ *
+ * @param dataSources - A map of category to record arrays.
+ * @returns An inventory object with counts per category.
+ */
+export function buildDataInventory(
+  dataSources: Partial<Record<DataCategory, readonly Record<string, unknown>[]>>,
+): Record<DataCategory, number> {
+  const inventory = {} as Record<DataCategory, number>;
+
+  for (const category of ALL_DATA_CATEGORIES) {
+    const records = dataSources[category];
+    inventory[category] = records ? records.length : 0;
+  }
+
+  return inventory;
+}
+
+// ---------------------------------------------------------------------------
+// Export package generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a structured data export package.
+ *
+ * Collects data from the provided sources for the requested categories
+ * and packages it into a self-describing JSON structure suitable for
+ * GDPR/CCPA data portability.
+ *
+ * @param request - The data access request specifying which categories to include.
+ * @param dataSources - A map of category to record arrays.
+ * @returns A complete DataExportPackage.
+ */
+export function generateExportPackage(
+  request: DataAccessRequest,
+  dataSources: Partial<Record<DataCategory, readonly Record<string, unknown>[]>>,
+): DataExportPackage {
+  const filteredData: Partial<Record<DataCategory, readonly Record<string, unknown>[]>> = {};
+  let totalRecords = 0;
+
+  for (const category of request.categories) {
+    const records = dataSources[category] ?? [];
+    filteredData[category] = records;
+    totalRecords += records.length;
+  }
+
+  return {
+    meta: {
+      exportId: request.id,
+      exportedAt: new Date().toISOString(),
+      format: 'json',
+      categories: request.categories,
+      totalRecords,
+    },
+    data: filteredData,
+  };
+}
+
+/**
+ * Serialize an export package to a JSON string.
+ *
+ * @param pkg - The export package to serialize.
+ * @returns A formatted JSON string (2-space indent).
+ */
+export function serializeExportPackage(pkg: DataExportPackage): string {
+  return JSON.stringify(pkg, null, 2);
+}

--- a/apps/web/src/lib/security/device-manager.test.ts
+++ b/apps/web/src/lib/security/device-manager.test.ts
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  getActiveSessions,
+  isSessionValid,
+  loadSessions,
+  maskIpAddress,
+  parseDeviceName,
+  registerSession,
+  revokeAllOtherSessions,
+  revokeSession,
+  touchSession,
+} from './device-manager';
+
+describe('device-manager', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('parseDeviceName', () => {
+    it('detects iPhone', () => {
+      expect(parseDeviceName('Mozilla/5.0 (iPhone; CPU iPhone OS 16_0)')).toBe('iPhone');
+    });
+
+    it('detects Windows', () => {
+      expect(parseDeviceName('Mozilla/5.0 (Windows NT 10.0; Win64; x64)')).toBe('Windows PC');
+    });
+
+    it('detects Android', () => {
+      expect(parseDeviceName('Mozilla/5.0 (Linux; Android 13)')).toBe('Android Device');
+    });
+
+    it('detects Mac', () => {
+      expect(parseDeviceName('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15)')).toBe('Mac');
+    });
+
+    it('returns Unknown Device for empty string', () => {
+      expect(parseDeviceName('')).toBe('Unknown Device');
+    });
+  });
+
+  describe('maskIpAddress', () => {
+    it('masks IPv4 last two octets', () => {
+      expect(maskIpAddress('192.168.1.42')).toBe('192.168.x.x');
+    });
+
+    it('handles empty input', () => {
+      expect(maskIpAddress('')).toBe('0.0.0.0');
+    });
+  });
+
+  describe('session management', () => {
+    it('registers a new session', () => {
+      const session = registerSession('Mozilla/5.0 (Windows NT 10.0)', '10.0.0.1');
+      expect(session.id).toBeTruthy();
+      expect(session.deviceName).toBe('Windows PC');
+      expect(session.isCurrent).toBe(true);
+      expect(session.isRevoked).toBe(false);
+      expect(session.ipAddress).toBe('10.0.x.x');
+    });
+
+    it('marks previous sessions as non-current on new registration', () => {
+      registerSession('Mozilla/5.0 (Windows NT 10.0)', '10.0.0.1');
+      registerSession('Mozilla/5.0 (iPhone)', '10.0.0.2');
+
+      const sessions = loadSessions();
+      const currentSessions = sessions.filter((s) => s.isCurrent);
+      expect(currentSessions).toHaveLength(1);
+      expect(currentSessions[0].deviceName).toBe('iPhone');
+    });
+
+    it('touches a session to update lastActiveAt', () => {
+      const session = registerSession('Mozilla/5.0 (Windows NT 10.0)', '10.0.0.1');
+      const original = session.lastActiveAt;
+
+      // Small delay to ensure timestamp difference
+      const updated = touchSession(session.id);
+      expect(updated).not.toBeNull();
+      expect(updated!.lastActiveAt).toBeTruthy();
+      // The timestamp should be >= original
+      expect(new Date(updated!.lastActiveAt).getTime()).toBeGreaterThanOrEqual(
+        new Date(original).getTime(),
+      );
+    });
+
+    it('returns null when touching a non-existent session', () => {
+      expect(touchSession('non-existent')).toBeNull();
+    });
+  });
+
+  describe('revocation', () => {
+    it('revokes a session', () => {
+      const session = registerSession('Mozilla/5.0 (Windows NT 10.0)', '10.0.0.1');
+      const revoked = revokeSession(session.id);
+
+      expect(revoked).not.toBeNull();
+      expect(revoked!.isRevoked).toBe(true);
+      expect(revoked!.isCurrent).toBe(false);
+    });
+
+    it('returns null when revoking a non-existent session', () => {
+      expect(revokeSession('non-existent')).toBeNull();
+    });
+
+    it('revokes all other sessions', () => {
+      registerSession('Mozilla/5.0 (Windows NT 10.0)', '10.0.0.1');
+      registerSession('Mozilla/5.0 (iPhone)', '10.0.0.2');
+      const current = registerSession('Mozilla/5.0 (Macintosh)', '10.0.0.3');
+
+      const count = revokeAllOtherSessions();
+      expect(count).toBe(2);
+
+      const active = getActiveSessions();
+      expect(active).toHaveLength(1);
+      expect(active[0].id).toBe(current.id);
+    });
+  });
+
+  describe('session validation', () => {
+    it('validates an active session', () => {
+      const session = registerSession('Mozilla/5.0 (Windows NT 10.0)', '10.0.0.1');
+      expect(isSessionValid(session.id)).toBe(true);
+    });
+
+    it('invalidates a revoked session', () => {
+      const session = registerSession('Mozilla/5.0 (Windows NT 10.0)', '10.0.0.1');
+      revokeSession(session.id);
+      expect(isSessionValid(session.id)).toBe(false);
+    });
+
+    it('returns false for non-existent session', () => {
+      expect(isSessionValid('non-existent')).toBe(false);
+    });
+  });
+});

--- a/apps/web/src/lib/security/device-manager.ts
+++ b/apps/web/src/lib/security/device-manager.ts
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Device Manager — active session listing, metadata, and remote revocation.
+ *
+ * Manages the list of active device sessions, provides session metadata
+ * (last active, IP, user agent), and supports remote session revocation
+ * with token invalidation.
+ *
+ * References: issue #1663
+ */
+
+import type { DeviceSession } from './types';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** localStorage key for device sessions. */
+const SESSIONS_STORAGE_KEY = 'finance-device-sessions';
+
+/** Maximum sessions to retain. */
+const MAX_SESSIONS = 50;
+
+// ---------------------------------------------------------------------------
+// Session parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a user agent string into a human-readable device name.
+ *
+ * @param userAgent - The raw user agent string.
+ * @returns A simplified device name.
+ */
+export function parseDeviceName(userAgent: string): string {
+  if (!userAgent) return 'Unknown Device';
+
+  if (/iPhone/i.test(userAgent)) return 'iPhone';
+  if (/iPad/i.test(userAgent)) return 'iPad';
+  if (/Android/i.test(userAgent)) return 'Android Device';
+  if (/Windows/i.test(userAgent)) return 'Windows PC';
+  if (/Macintosh/i.test(userAgent)) return 'Mac';
+  if (/Linux/i.test(userAgent)) return 'Linux PC';
+  if (/CrOS/i.test(userAgent)) return 'Chromebook';
+
+  return 'Unknown Device';
+}
+
+/**
+ * Mask an IP address for privacy (replace last octet(s) with "x").
+ *
+ * @param ip - The full IP address.
+ * @returns A masked IP address.
+ */
+export function maskIpAddress(ip: string): string {
+  if (!ip) return '0.0.0.0';
+
+  // IPv4
+  const ipv4Parts = ip.split('.');
+  if (ipv4Parts.length === 4) {
+    return `${ipv4Parts[0]}.${ipv4Parts[1]}.x.x`;
+  }
+
+  // IPv6 — mask last 4 groups
+  const ipv6Parts = ip.split(':');
+  if (ipv6Parts.length >= 4) {
+    return ipv6Parts.slice(0, 4).join(':') + ':x:x:x:x';
+  }
+
+  return ip;
+}
+
+// ---------------------------------------------------------------------------
+// Session management
+// ---------------------------------------------------------------------------
+
+/**
+ * Load all device sessions from localStorage.
+ *
+ * @returns An array of DeviceSession objects.
+ */
+export function loadSessions(): DeviceSession[] {
+  try {
+    const raw = localStorage.getItem(SESSIONS_STORAGE_KEY);
+    if (!raw) return [];
+
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+
+    return parsed.filter(
+      (s: unknown): s is DeviceSession =>
+        typeof s === 'object' && s !== null && 'id' in s && 'deviceName' in s,
+    );
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Save sessions to localStorage.
+ *
+ * @param sessions - The sessions to persist.
+ */
+function saveSessions(sessions: readonly DeviceSession[]): void {
+  const trimmed = sessions.length > MAX_SESSIONS ? sessions.slice(-MAX_SESSIONS) : sessions;
+  localStorage.setItem(SESSIONS_STORAGE_KEY, JSON.stringify(trimmed));
+}
+
+/**
+ * Register a new device session.
+ *
+ * @param userAgent - The browser user agent string.
+ * @param ipAddress - The client IP address (will be masked).
+ * @returns The newly created DeviceSession.
+ */
+export function registerSession(userAgent: string, ipAddress: string): DeviceSession {
+  const session: DeviceSession = {
+    id: crypto.randomUUID(),
+    deviceName: parseDeviceName(userAgent),
+    userAgent,
+    ipAddress: maskIpAddress(ipAddress),
+    lastActiveAt: new Date().toISOString(),
+    createdAt: new Date().toISOString(),
+    isCurrent: true,
+    isRevoked: false,
+  };
+
+  // Mark all existing sessions as non-current
+  const existing = loadSessions().map((s) => ({ ...s, isCurrent: false }));
+  existing.push(session);
+  saveSessions(existing);
+
+  return session;
+}
+
+/**
+ * Update the last active timestamp for a session.
+ *
+ * @param sessionId - The session to update.
+ * @returns The updated session, or null if not found.
+ */
+export function touchSession(sessionId: string): DeviceSession | null {
+  const sessions = loadSessions();
+  const index = sessions.findIndex((s) => s.id === sessionId);
+  if (index === -1) return null;
+
+  const updated: DeviceSession = {
+    ...sessions[index],
+    lastActiveAt: new Date().toISOString(),
+  };
+  sessions[index] = updated;
+  saveSessions(sessions);
+
+  return updated;
+}
+
+/**
+ * Revoke a device session (remote logout).
+ *
+ * This marks the session as revoked. In a real implementation, this would
+ * also invalidate the session token on the server.
+ *
+ * @param sessionId - The session to revoke.
+ * @returns The revoked session, or null if not found.
+ */
+export function revokeSession(sessionId: string): DeviceSession | null {
+  const sessions = loadSessions();
+  const index = sessions.findIndex((s) => s.id === sessionId);
+  if (index === -1) return null;
+
+  const revoked: DeviceSession = {
+    ...sessions[index],
+    isRevoked: true,
+    isCurrent: false,
+  };
+  sessions[index] = revoked;
+  saveSessions(sessions);
+
+  return revoked;
+}
+
+/**
+ * Revoke all sessions except the current one.
+ *
+ * @returns The number of sessions revoked.
+ */
+export function revokeAllOtherSessions(): number {
+  const sessions = loadSessions();
+  let revokedCount = 0;
+
+  const updated = sessions.map((s) => {
+    if (!s.isCurrent && !s.isRevoked) {
+      revokedCount++;
+      return { ...s, isRevoked: true };
+    }
+    return s;
+  });
+
+  saveSessions(updated);
+  return revokedCount;
+}
+
+/**
+ * Get only active (non-revoked) sessions.
+ *
+ * @returns An array of active DeviceSession objects.
+ */
+export function getActiveSessions(): DeviceSession[] {
+  return loadSessions().filter((s) => !s.isRevoked);
+}
+
+/**
+ * Check whether a session ID is valid (exists and is not revoked).
+ *
+ * @param sessionId - The session ID to validate.
+ * @returns True if the session is valid and active.
+ */
+export function isSessionValid(sessionId: string): boolean {
+  const sessions = loadSessions();
+  const session = sessions.find((s) => s.id === sessionId);
+  return session !== undefined && !session.isRevoked;
+}

--- a/apps/web/src/lib/security/encrypted-memo.test.ts
+++ b/apps/web/src/lib/security/encrypted-memo.test.ts
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect } from 'vitest';
+import {
+  batchProcessMemosForExport,
+  decryptMemo,
+  encryptMemo,
+  isRedacted,
+  processMemoForExport,
+  redactMemo,
+} from './encrypted-memo';
+import type { EncryptedMemo } from './types';
+
+describe('encrypted-memo', () => {
+  describe('encryptMemo', () => {
+    it('encrypts a memo and returns EncryptedMemo', () => {
+      const result = encryptMemo('Grocery shopping at Trader Joes');
+      expect(result.ciphertext).toBeTruthy();
+      expect(result.iv).toBeTruthy();
+      expect(result.algorithm).toBe('placeholder-base64');
+      expect(result.encryptedAt).toBeTruthy();
+    });
+
+    it('produces different ciphertext than plaintext', () => {
+      const plaintext = 'Secret memo content';
+      const result = encryptMemo(plaintext);
+      expect(result.ciphertext).not.toBe(plaintext);
+    });
+
+    it('throws on empty memo', () => {
+      expect(() => encryptMemo('')).toThrow('Cannot encrypt an empty memo');
+    });
+  });
+
+  describe('decryptMemo', () => {
+    it('decrypts back to original plaintext', () => {
+      const plaintext = 'Payment for rent - $1,500';
+      const encrypted = encryptMemo(plaintext);
+      const decrypted = decryptMemo(encrypted);
+      expect(decrypted).toBe(plaintext);
+    });
+
+    it('handles unicode content', () => {
+      const plaintext = 'Pago de renta — €500 für die Miete 日本語テスト';
+      const encrypted = encryptMemo(plaintext);
+      const decrypted = decryptMemo(encrypted);
+      expect(decrypted).toBe(plaintext);
+    });
+
+    it('throws on unsupported algorithm', () => {
+      const memo: EncryptedMemo = {
+        ciphertext: 'test',
+        iv: 'test',
+        algorithm: 'aes-256-gcm',
+        encryptedAt: new Date().toISOString(),
+      };
+      expect(() => decryptMemo(memo)).toThrow('Unsupported algorithm');
+    });
+  });
+
+  describe('redactMemo', () => {
+    it('returns [REDACTED] marker', () => {
+      const encrypted = encryptMemo('Secret content');
+      expect(redactMemo(encrypted)).toBe('[REDACTED]');
+    });
+  });
+
+  describe('isRedacted', () => {
+    it('detects redacted text', () => {
+      expect(isRedacted('[REDACTED]')).toBe(true);
+    });
+
+    it('returns false for non-redacted text', () => {
+      expect(isRedacted('Some normal text')).toBe(false);
+    });
+  });
+
+  describe('processMemoForExport', () => {
+    it('returns null when memos are excluded', () => {
+      const encrypted = encryptMemo('Test');
+      const result = processMemoForExport(encrypted, {
+        includeMemos: false,
+        redactMemos: false,
+      });
+      expect(result).toBeNull();
+    });
+
+    it('returns redacted text when redaction is enabled', () => {
+      const encrypted = encryptMemo('Secret data');
+      const result = processMemoForExport(encrypted, {
+        includeMemos: true,
+        redactMemos: true,
+      });
+      expect(result).toBe('[REDACTED]');
+    });
+
+    it('returns decrypted text when included without redaction', () => {
+      const plaintext = 'Visible memo';
+      const encrypted = encryptMemo(plaintext);
+      const result = processMemoForExport(encrypted, {
+        includeMemos: true,
+        redactMemos: false,
+      });
+      expect(result).toBe(plaintext);
+    });
+  });
+
+  describe('batchProcessMemosForExport', () => {
+    it('processes multiple memos', () => {
+      const memos = [encryptMemo('Memo 1'), encryptMemo('Memo 2'), encryptMemo('Memo 3')];
+
+      const results = batchProcessMemosForExport(memos, {
+        includeMemos: true,
+        redactMemos: false,
+      });
+      expect(results).toEqual(['Memo 1', 'Memo 2', 'Memo 3']);
+    });
+
+    it('excludes all memos when not included', () => {
+      const memos = [encryptMemo('Memo 1'), encryptMemo('Memo 2')];
+      const results = batchProcessMemosForExport(memos, {
+        includeMemos: false,
+        redactMemos: false,
+      });
+      expect(results).toHaveLength(0);
+    });
+
+    it('redacts all memos when redaction is enabled', () => {
+      const memos = [encryptMemo('Secret 1'), encryptMemo('Secret 2')];
+      const results = batchProcessMemosForExport(memos, {
+        includeMemos: true,
+        redactMemos: true,
+      });
+      expect(results).toEqual(['[REDACTED]', '[REDACTED]']);
+    });
+  });
+});

--- a/apps/web/src/lib/security/encrypted-memo.ts
+++ b/apps/web/src/lib/security/encrypted-memo.ts
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Encrypted Memo — encryption/decryption helpers with redaction and export controls.
+ *
+ * Provides memo encryption using a placeholder encoding for tests.
+ * The API is structured for Web Crypto API (SubtleCrypto) — the real
+ * implementation will swap the encode/decode logic while keeping the
+ * same interface.
+ *
+ * Placeholder implementation uses base64 encoding (NOT real encryption).
+ * This is intentional — see the inline TODO markers for where real
+ * AES-GCM encryption will be integrated.
+ *
+ * References: issue #1723
+ */
+
+import type { EncryptedMemo, MemoExportOptions } from './types';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Algorithm identifier for the placeholder implementation. */
+const PLACEHOLDER_ALGORITHM = 'placeholder-base64';
+
+/** Redaction marker for exported memos. */
+const REDACTED_MARKER = '[REDACTED]';
+
+// ---------------------------------------------------------------------------
+// Base64 helpers (placeholder for Web Crypto)
+// ---------------------------------------------------------------------------
+
+/**
+ * Encode a string to base64.
+ *
+ * @param text - The plaintext to encode.
+ * @returns Base64-encoded string.
+ */
+function toBase64(text: string): string {
+  // TODO(crypto): Replace with AES-GCM encryption via SubtleCrypto
+  return btoa(
+    encodeURIComponent(text).replace(/%([0-9A-F]{2})/g, (_, p1: string) =>
+      String.fromCharCode(parseInt(p1, 16)),
+    ),
+  );
+}
+
+/**
+ * Decode a base64 string.
+ *
+ * @param encoded - The base64-encoded string.
+ * @returns Decoded plaintext.
+ */
+function fromBase64(encoded: string): string {
+  // TODO(crypto): Replace with AES-GCM decryption via SubtleCrypto
+  return decodeURIComponent(
+    Array.from(atob(encoded))
+      .map((c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
+      .join(''),
+  );
+}
+
+/**
+ * Generate a placeholder initialization vector.
+ *
+ * @returns A base64-encoded random IV string.
+ */
+function generateIv(): string {
+  // TODO(crypto): Use crypto.getRandomValues(new Uint8Array(12)) for real AES-GCM
+  const array = new Uint8Array(12);
+  crypto.getRandomValues(array);
+  return btoa(String.fromCharCode(...array));
+}
+
+// ---------------------------------------------------------------------------
+// Encryption / Decryption
+// ---------------------------------------------------------------------------
+
+/**
+ * Encrypt a memo string.
+ *
+ * In the placeholder implementation, this uses base64 encoding.
+ * The production implementation will use AES-GCM via Web Crypto API.
+ *
+ * @param plaintext - The memo text to encrypt.
+ * @returns An EncryptedMemo object.
+ */
+export function encryptMemo(plaintext: string): EncryptedMemo {
+  if (!plaintext) {
+    throw new Error('Cannot encrypt an empty memo.');
+  }
+
+  return {
+    ciphertext: toBase64(plaintext),
+    iv: generateIv(),
+    algorithm: PLACEHOLDER_ALGORITHM,
+    encryptedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Decrypt an encrypted memo.
+ *
+ * @param memo - The EncryptedMemo to decrypt.
+ * @returns The decrypted plaintext string.
+ */
+export function decryptMemo(memo: EncryptedMemo): string {
+  if (memo.algorithm !== PLACEHOLDER_ALGORITHM) {
+    throw new Error(`Unsupported algorithm: ${memo.algorithm}`);
+  }
+
+  return fromBase64(memo.ciphertext);
+}
+
+// ---------------------------------------------------------------------------
+// Redaction
+// ---------------------------------------------------------------------------
+
+/**
+ * Redact a memo for export — replaces content with [REDACTED].
+ *
+ * @param _memo - The EncryptedMemo to redact (content is ignored).
+ * @returns The redaction marker string.
+ */
+export function redactMemo(_memo: EncryptedMemo): string {
+  return REDACTED_MARKER;
+}
+
+/**
+ * Check if a string is a redacted marker.
+ *
+ * @param text - The text to check.
+ * @returns True if the text is the redaction marker.
+ */
+export function isRedacted(text: string): boolean {
+  return text === REDACTED_MARKER;
+}
+
+// ---------------------------------------------------------------------------
+// Export controls
+// ---------------------------------------------------------------------------
+
+/**
+ * Process a memo for export based on export options.
+ *
+ * @param memo - The EncryptedMemo to process.
+ * @param options - Export settings controlling inclusion and redaction.
+ * @returns The processed memo string, or null if excluded from export.
+ */
+export function processMemoForExport(
+  memo: EncryptedMemo,
+  options: MemoExportOptions,
+): string | null {
+  if (!options.includeMemos) {
+    return null;
+  }
+
+  if (options.redactMemos) {
+    return redactMemo(memo);
+  }
+
+  return decryptMemo(memo);
+}
+
+/**
+ * Batch-process multiple memos for export.
+ *
+ * @param memos - An array of EncryptedMemo objects.
+ * @param options - Export settings.
+ * @returns An array of processed memo strings (excluded memos are filtered out).
+ */
+export function batchProcessMemosForExport(
+  memos: readonly EncryptedMemo[],
+  options: MemoExportOptions,
+): string[] {
+  const results: string[] = [];
+
+  for (const memo of memos) {
+    const processed = processMemoForExport(memo, options);
+    if (processed !== null) {
+      results.push(processed);
+    }
+  }
+
+  return results;
+}

--- a/apps/web/src/lib/security/index.ts
+++ b/apps/web/src/lib/security/index.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Security & Privacy — barrel export.
+ *
+ * Re-exports all types, functions, and constants from the security modules.
+ */
+
+export type {
+  AuditEntry,
+  AuditEventType,
+  AuditLogFilter,
+  AuditSeverity,
+  ConnectionRecord,
+  ConnectionStatus,
+  DataAccessRequest,
+  DataAccessRequestStatus,
+  DataCategory,
+  DataExportPackage,
+  DeviceSession,
+  EncryptedMemo,
+  ErasableRecordType,
+  ErasureRequest,
+  ErasureStatus,
+  MemoExportOptions,
+  NetworkRequestEntry,
+  RetentionCheckResult,
+  TelemetryCategory,
+  TelemetryConfig,
+  TransparencyDestination,
+  TransparencyReport,
+} from './types';
+
+export {
+  ALL_DATA_CATEGORIES,
+  DATA_CATEGORY_DESCRIPTIONS,
+  buildDataInventory,
+  createDataAccessRequest,
+  generateExportPackage,
+  serializeExportPackage,
+  updateRequestStatus,
+} from './data-access';
+
+export {
+  checkRetentionPolicy,
+  createErasureRequest,
+  determineCascadeActions,
+  generateErasureReceipt,
+  updateErasureStatus,
+} from './record-erasure';
+
+export {
+  getActiveSessions,
+  isSessionValid,
+  loadSessions,
+  maskIpAddress,
+  parseDeviceName,
+  registerSession,
+  revokeAllOtherSessions,
+  revokeSession,
+  touchSession,
+} from './device-manager';
+
+export {
+  ALL_TELEMETRY_CATEGORIES,
+  TELEMETRY_CATEGORY_DESCRIPTIONS,
+  clearNetworkLog,
+  createDefaultConfig,
+  generateTransparencyReport,
+  isCategoryEnabled,
+  loadNetworkLog,
+  loadTelemetryConfig,
+  logNetworkRequest,
+  saveTelemetryConfig,
+  setCategoryEnabled,
+  setNoTelemetryMode,
+} from './telemetry-config';
+
+export {
+  addConnection,
+  getActiveConnections,
+  getConnectionsByType,
+  getScopesSummary,
+  loadConnections,
+  recordConnectionAccess,
+  revokeConnection,
+  updateConnectionStatus,
+} from './connection-transparency';
+
+export {
+  appendAuditEntry,
+  clearAuditLog,
+  exportAuditLog,
+  getEventTypeCounts,
+  loadAuditLog,
+  queryAuditLog,
+} from './audit-log';
+
+export {
+  batchProcessMemosForExport,
+  decryptMemo,
+  encryptMemo,
+  isRedacted,
+  processMemoForExport,
+  redactMemo,
+} from './encrypted-memo';

--- a/apps/web/src/lib/security/record-erasure.test.ts
+++ b/apps/web/src/lib/security/record-erasure.test.ts
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect } from 'vitest';
+import {
+  checkRetentionPolicy,
+  createErasureRequest,
+  determineCascadeActions,
+  generateErasureReceipt,
+  updateErasureStatus,
+} from './record-erasure';
+
+describe('record-erasure', () => {
+  describe('checkRetentionPolicy', () => {
+    it('allows erasure for budget records (no retention)', () => {
+      const result = checkRetentionPolicy('budget', new Date().toISOString());
+      expect(result.canErase).toBe(true);
+      expect(result.reason).toBeNull();
+    });
+
+    it('allows erasure for goal records (no retention)', () => {
+      const result = checkRetentionPolicy('goal', new Date().toISOString());
+      expect(result.canErase).toBe(true);
+    });
+
+    it('blocks erasure for recent transaction records', () => {
+      const result = checkRetentionPolicy('transaction', new Date().toISOString());
+      expect(result.canErase).toBe(false);
+      expect(result.reason).toContain('retention period');
+      expect(result.retentionExpiresAt).toBeTruthy();
+    });
+
+    it('allows erasure for old transaction records past retention', () => {
+      const oldDate = new Date();
+      oldDate.setFullYear(oldDate.getFullYear() - 8); // 8 years ago
+      const result = checkRetentionPolicy('transaction', oldDate.toISOString());
+      expect(result.canErase).toBe(true);
+    });
+
+    it('allows erasure with override regardless of retention', () => {
+      const result = checkRetentionPolicy('transaction', new Date().toISOString(), true);
+      expect(result.canErase).toBe(true);
+      expect(result.reason).toBeNull();
+    });
+  });
+
+  describe('determineCascadeActions', () => {
+    it('returns cascade actions for transaction erasure', () => {
+      const actions = determineCascadeActions('transaction');
+      expect(actions.length).toBeGreaterThan(0);
+      expect(actions.some((a) => a.includes('balance'))).toBe(true);
+    });
+
+    it('returns cascade actions for account erasure', () => {
+      const actions = determineCascadeActions('account');
+      expect(actions.some((a) => a.includes('transactions'))).toBe(true);
+    });
+
+    it('returns cascade actions for category erasure', () => {
+      const actions = determineCascadeActions('category');
+      expect(actions.some((a) => a.includes('Uncategorized'))).toBe(true);
+    });
+  });
+
+  describe('createErasureRequest', () => {
+    it('creates a request with pending status and cascade actions', () => {
+      const request = createErasureRequest('transaction', 'tx-123', 'User requested deletion');
+      expect(request.id).toBeTruthy();
+      expect(request.status).toBe('pending');
+      expect(request.recordType).toBe('transaction');
+      expect(request.recordId).toBe('tx-123');
+      expect(request.reason).toBe('User requested deletion');
+      expect(request.cascadeActions.length).toBeGreaterThan(0);
+      expect(request.completedAt).toBeNull();
+    });
+  });
+
+  describe('updateErasureStatus', () => {
+    it('updates status to completed with timestamp', () => {
+      const request = createErasureRequest('budget', 'b-1', 'cleanup');
+      const completed = updateErasureStatus(request, 'completed');
+      expect(completed.status).toBe('completed');
+      expect(completed.completedAt).toBeTruthy();
+    });
+
+    it('updates status to rejected without timestamp', () => {
+      const request = createErasureRequest('budget', 'b-1', 'cleanup');
+      const rejected = updateErasureStatus(request, 'rejected');
+      expect(rejected.status).toBe('rejected');
+      expect(rejected.completedAt).toBeNull();
+    });
+  });
+
+  describe('generateErasureReceipt', () => {
+    it('generates a valid JSON receipt', () => {
+      const request = createErasureRequest('transaction', 'tx-123', 'GDPR request');
+      const completed = updateErasureStatus(request, 'completed');
+      const receipt = generateErasureReceipt(completed);
+
+      const parsed = JSON.parse(receipt);
+      expect(parsed.type).toBe('erasure_receipt');
+      expect(parsed.requestId).toBe(completed.id);
+      expect(parsed.recordType).toBe('transaction');
+      expect(parsed.status).toBe('completed');
+    });
+
+    it('does not contain actual financial data', () => {
+      const request = createErasureRequest('transaction', 'tx-123', 'cleanup');
+      const receipt = generateErasureReceipt(request);
+      // Verify no financial amounts or account numbers appear in the receipt
+      expect(receipt).not.toMatch(/\$\d+/);
+      expect(receipt).not.toMatch(/\d{4}-\d{4}-\d{4}/);
+    });
+  });
+});

--- a/apps/web/src/lib/security/record-erasure.ts
+++ b/apps/web/src/lib/security/record-erasure.ts
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Selective Record Erasure — mark specific records for deletion with
+ * cascade logic, retention policy checks, and erasure receipts.
+ *
+ * This module handles the business logic for GDPR "right to erasure"
+ * requests at the individual record level. It does NOT directly delete
+ * data from SQLite — instead it produces erasure request objects that
+ * the repository layer can act on.
+ *
+ * References: issue #1658
+ */
+
+import type {
+  ErasableRecordType,
+  ErasureRequest,
+  ErasureStatus,
+  RetentionCheckResult,
+} from './types';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Default retention period in days for financial records. */
+const DEFAULT_RETENTION_DAYS = 365 * 7; // 7 years for tax compliance
+
+/** Record types with mandatory retention periods (days). */
+const RETENTION_PERIODS: Readonly<Record<ErasableRecordType, number>> = {
+  transaction: DEFAULT_RETENTION_DAYS,
+  account: DEFAULT_RETENTION_DAYS,
+  budget: 0, // No mandatory retention
+  goal: 0, // No mandatory retention
+  category: 0, // No mandatory retention
+};
+
+// ---------------------------------------------------------------------------
+// Retention policy
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether a record can be erased based on retention policies.
+ *
+ * Financial records (transactions, accounts) may be subject to tax
+ * retention requirements. Non-financial records can be erased immediately.
+ *
+ * @param recordType - The type of record.
+ * @param recordCreatedAt - ISO-8601 creation date of the record.
+ * @param overrideRetention - If true, bypass retention checks (user explicit consent).
+ * @returns A RetentionCheckResult indicating whether erasure is allowed.
+ */
+export function checkRetentionPolicy(
+  recordType: ErasableRecordType,
+  recordCreatedAt: string,
+  overrideRetention = false,
+): RetentionCheckResult {
+  if (overrideRetention) {
+    return { canErase: true, reason: null, retentionExpiresAt: null };
+  }
+
+  const retentionDays = RETENTION_PERIODS[recordType];
+  if (retentionDays === 0) {
+    return { canErase: true, reason: null, retentionExpiresAt: null };
+  }
+
+  const createdDate = new Date(recordCreatedAt);
+  const retentionExpiry = new Date(createdDate.getTime() + retentionDays * 24 * 60 * 60 * 1000);
+  const now = new Date();
+
+  if (now >= retentionExpiry) {
+    return { canErase: true, reason: null, retentionExpiresAt: null };
+  }
+
+  return {
+    canErase: false,
+    reason: `Record is within the ${retentionDays}-day retention period for ${recordType} records. Override with explicit consent if needed.`,
+    retentionExpiresAt: retentionExpiry.toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Cascade actions
+// ---------------------------------------------------------------------------
+
+/**
+ * Determine cascade actions that must occur when a record is erased.
+ *
+ * For example, erasing a transaction requires recalculating account
+ * balances. Erasing an account requires handling linked transactions.
+ *
+ * @param recordType - The type of record being erased.
+ * @returns An array of human-readable cascade action descriptions.
+ */
+export function determineCascadeActions(recordType: ErasableRecordType): readonly string[] {
+  switch (recordType) {
+    case 'transaction':
+      return [
+        'Recalculate affected account balance',
+        'Update budget spent amounts for the transaction period',
+        'Remove from recurring rule match history',
+      ];
+    case 'account':
+      return [
+        'Soft-delete all transactions linked to this account',
+        'Unlink from any savings goals targeting this account',
+        'Recalculate net worth totals',
+      ];
+    case 'budget':
+      return ['Remove budget period history', 'Clear budget-to-category linkages'];
+    case 'goal':
+      return ['Unlink from funding account', 'Remove progress history entries'];
+    case 'category':
+      return [
+        'Set transactions using this category to "Uncategorized"',
+        'Remove from budget category assignments',
+      ];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Erasure request management
+// ---------------------------------------------------------------------------
+
+/**
+ * Create an erasure request for a specific record.
+ *
+ * @param recordType - The type of record to erase.
+ * @param recordId - The unique ID of the record.
+ * @param reason - Human-readable reason for the erasure.
+ * @returns A new ErasureRequest in 'pending' status with computed cascade actions.
+ */
+export function createErasureRequest(
+  recordType: ErasableRecordType,
+  recordId: string,
+  reason: string,
+): ErasureRequest {
+  return {
+    id: crypto.randomUUID(),
+    requestedAt: new Date().toISOString(),
+    recordType,
+    recordId,
+    reason,
+    status: 'pending',
+    completedAt: null,
+    cascadeActions: determineCascadeActions(recordType),
+  };
+}
+
+/**
+ * Update the status of an erasure request.
+ *
+ * @param request - The current erasure request.
+ * @param newStatus - The new status.
+ * @returns A new ErasureRequest with the updated status.
+ */
+export function updateErasureStatus(
+  request: ErasureRequest,
+  newStatus: ErasureStatus,
+): ErasureRequest {
+  return {
+    ...request,
+    status: newStatus,
+    completedAt: newStatus === 'completed' ? new Date().toISOString() : request.completedAt,
+  };
+}
+
+/**
+ * Generate an erasure receipt confirming the deletion.
+ *
+ * This receipt serves as proof that data was erased per the user's request.
+ * It contains no actual financial data — only metadata about the erasure.
+ *
+ * @param request - The completed erasure request.
+ * @returns A formatted receipt string.
+ */
+export function generateErasureReceipt(request: ErasureRequest): string {
+  return JSON.stringify(
+    {
+      type: 'erasure_receipt',
+      requestId: request.id,
+      recordType: request.recordType,
+      recordId: request.recordId,
+      requestedAt: request.requestedAt,
+      completedAt: request.completedAt,
+      status: request.status,
+      cascadeActions: request.cascadeActions,
+      reason: request.reason,
+    },
+    null,
+    2,
+  );
+}

--- a/apps/web/src/lib/security/telemetry-config.test.ts
+++ b/apps/web/src/lib/security/telemetry-config.test.ts
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  ALL_TELEMETRY_CATEGORIES,
+  TELEMETRY_CATEGORY_DESCRIPTIONS,
+  clearNetworkLog,
+  createDefaultConfig,
+  generateTransparencyReport,
+  isCategoryEnabled,
+  loadNetworkLog,
+  loadTelemetryConfig,
+  logNetworkRequest,
+  setCategoryEnabled,
+  setNoTelemetryMode,
+} from './telemetry-config';
+
+describe('telemetry-config', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('createDefaultConfig', () => {
+    it('defaults to no-telemetry mode', () => {
+      const config = createDefaultConfig();
+      expect(config.noTelemetryMode).toBe(true);
+      for (const cat of ALL_TELEMETRY_CATEGORIES) {
+        expect(config.categorySettings[cat]).toBe(false);
+      }
+    });
+  });
+
+  describe('loadTelemetryConfig', () => {
+    it('returns default config when no config is stored', () => {
+      const config = loadTelemetryConfig();
+      expect(config.noTelemetryMode).toBe(true);
+    });
+
+    it('returns default config on invalid JSON', () => {
+      localStorage.setItem('finance-telemetry-config', 'not-json');
+      const config = loadTelemetryConfig();
+      expect(config.noTelemetryMode).toBe(true);
+    });
+  });
+
+  describe('setNoTelemetryMode', () => {
+    it('disables no-telemetry mode', () => {
+      const config = setNoTelemetryMode(false);
+      expect(config.noTelemetryMode).toBe(false);
+    });
+
+    it('enables no-telemetry mode', () => {
+      setNoTelemetryMode(false);
+      const config = setNoTelemetryMode(true);
+      expect(config.noTelemetryMode).toBe(true);
+    });
+  });
+
+  describe('setCategoryEnabled', () => {
+    it('enables a specific category', () => {
+      setNoTelemetryMode(false);
+      const config = setCategoryEnabled('crash_reports', true);
+      expect(config.categorySettings.crash_reports).toBe(true);
+    });
+  });
+
+  describe('isCategoryEnabled', () => {
+    it('returns false when no-telemetry mode is on', () => {
+      setNoTelemetryMode(true);
+      setCategoryEnabled('crash_reports', true);
+      // Master switch overrides individual setting
+      setNoTelemetryMode(true);
+      expect(isCategoryEnabled('crash_reports')).toBe(false);
+    });
+
+    it('returns true when category is enabled and no-telemetry is off', () => {
+      setNoTelemetryMode(false);
+      setCategoryEnabled('crash_reports', true);
+      expect(isCategoryEnabled('crash_reports')).toBe(true);
+    });
+  });
+
+  describe('network request logging', () => {
+    it('logs a network request', () => {
+      const entry = logNetworkRequest('api.example.com', 'GET', 'Sync data', false);
+      expect(entry.id).toBeTruthy();
+      expect(entry.destination).toBe('api.example.com');
+      expect(entry.blocked).toBe(false);
+    });
+
+    it('loads logged requests', () => {
+      logNetworkRequest('api.example.com', 'GET', 'Sync', false);
+      logNetworkRequest('analytics.example.com', 'POST', 'Telemetry', true);
+
+      const log = loadNetworkLog();
+      expect(log).toHaveLength(2);
+    });
+
+    it('clears the network log', () => {
+      logNetworkRequest('api.example.com', 'GET', 'Sync', false);
+      clearNetworkLog();
+      expect(loadNetworkLog()).toHaveLength(0);
+    });
+  });
+
+  describe('generateTransparencyReport', () => {
+    it('generates a report from the network log', () => {
+      logNetworkRequest('api.example.com', 'GET', 'Sync data', false);
+      logNetworkRequest('api.example.com', 'POST', 'Push changes', false);
+      logNetworkRequest('analytics.example.com', 'POST', 'Telemetry', true);
+
+      const report = generateTransparencyReport();
+      expect(report.totalRequests).toBe(3);
+      expect(report.totalBlocked).toBe(1);
+      expect(report.destinations).toHaveLength(2);
+    });
+
+    it('returns empty report with no log', () => {
+      const report = generateTransparencyReport();
+      expect(report.totalRequests).toBe(0);
+      expect(report.totalBlocked).toBe(0);
+      expect(report.destinations).toHaveLength(0);
+    });
+  });
+
+  describe('constants', () => {
+    it('has descriptions for all categories', () => {
+      for (const cat of ALL_TELEMETRY_CATEGORIES) {
+        expect(TELEMETRY_CATEGORY_DESCRIPTIONS[cat]).toBeTruthy();
+      }
+    });
+  });
+});

--- a/apps/web/src/lib/security/telemetry-config.ts
+++ b/apps/web/src/lib/security/telemetry-config.ts
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Telemetry Configuration — no-telemetry mode, network request auditing,
+ * and transparency reporting.
+ *
+ * Provides granular control over telemetry categories, logs all outbound
+ * network requests for user inspection, and generates transparency reports
+ * showing what data goes where.
+ *
+ * References: issue #1668
+ */
+
+import type {
+  NetworkRequestEntry,
+  TelemetryCategory,
+  TelemetryConfig,
+  TransparencyDestination,
+  TransparencyReport,
+} from './types';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** localStorage key for telemetry config. */
+const TELEMETRY_CONFIG_KEY = 'finance-telemetry-config';
+
+/** localStorage key for network request log. */
+const NETWORK_LOG_KEY = 'finance-network-log';
+
+/** Maximum network log entries to retain. */
+const MAX_NETWORK_LOG_ENTRIES = 1000;
+
+/** All telemetry categories. */
+export const ALL_TELEMETRY_CATEGORIES: readonly TelemetryCategory[] = [
+  'crash_reports',
+  'usage_analytics',
+  'performance_metrics',
+  'feature_flags',
+] as const;
+
+/** Human-readable descriptions for each telemetry category. */
+export const TELEMETRY_CATEGORY_DESCRIPTIONS: Readonly<Record<TelemetryCategory, string>> = {
+  crash_reports: 'Anonymous crash and error reports to help fix bugs',
+  usage_analytics: 'Feature usage patterns (no financial data included)',
+  performance_metrics: 'Page load times and app performance measurements',
+  feature_flags: 'Feature flag sync for enabling/disabling app features',
+};
+
+// ---------------------------------------------------------------------------
+// Configuration management
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a default telemetry configuration with everything disabled.
+ *
+ * @returns A TelemetryConfig with no-telemetry mode enabled.
+ */
+export function createDefaultConfig(): TelemetryConfig {
+  return {
+    noTelemetryMode: true,
+    categorySettings: {
+      crash_reports: false,
+      usage_analytics: false,
+      performance_metrics: false,
+      feature_flags: false,
+    },
+    lastUpdatedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Load telemetry configuration from localStorage.
+ *
+ * Returns the default (all-off) configuration if none is stored.
+ *
+ * @returns The current TelemetryConfig.
+ */
+export function loadTelemetryConfig(): TelemetryConfig {
+  try {
+    const raw = localStorage.getItem(TELEMETRY_CONFIG_KEY);
+    if (!raw) return createDefaultConfig();
+
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed !== 'object' || parsed === null) return createDefaultConfig();
+
+    const config = parsed as Record<string, unknown>;
+    if (typeof config.noTelemetryMode !== 'boolean') return createDefaultConfig();
+
+    return parsed as TelemetryConfig;
+  } catch {
+    return createDefaultConfig();
+  }
+}
+
+/**
+ * Save telemetry configuration to localStorage.
+ *
+ * @param config - The configuration to persist.
+ */
+export function saveTelemetryConfig(config: TelemetryConfig): void {
+  localStorage.setItem(TELEMETRY_CONFIG_KEY, JSON.stringify(config));
+}
+
+/**
+ * Toggle the master no-telemetry mode.
+ *
+ * When enabled, all telemetry is disabled regardless of category settings.
+ *
+ * @param enabled - Whether no-telemetry mode should be active.
+ * @returns The updated TelemetryConfig.
+ */
+export function setNoTelemetryMode(enabled: boolean): TelemetryConfig {
+  const current = loadTelemetryConfig();
+  const updated: TelemetryConfig = {
+    ...current,
+    noTelemetryMode: enabled,
+    lastUpdatedAt: new Date().toISOString(),
+  };
+  saveTelemetryConfig(updated);
+  return updated;
+}
+
+/**
+ * Update a specific telemetry category setting.
+ *
+ * @param category - The category to update.
+ * @param enabled - Whether the category should be enabled.
+ * @returns The updated TelemetryConfig.
+ */
+export function setCategoryEnabled(category: TelemetryCategory, enabled: boolean): TelemetryConfig {
+  const current = loadTelemetryConfig();
+  const updated: TelemetryConfig = {
+    ...current,
+    categorySettings: {
+      ...current.categorySettings,
+      [category]: enabled,
+    },
+    lastUpdatedAt: new Date().toISOString(),
+  };
+  saveTelemetryConfig(updated);
+  return updated;
+}
+
+/**
+ * Check if a specific telemetry category is effectively enabled.
+ *
+ * Returns false if no-telemetry mode is on, regardless of category setting.
+ *
+ * @param category - The category to check.
+ * @returns True if the category is active and allowed.
+ */
+export function isCategoryEnabled(category: TelemetryCategory): boolean {
+  const config = loadTelemetryConfig();
+  if (config.noTelemetryMode) return false;
+  return config.categorySettings[category] ?? false;
+}
+
+// ---------------------------------------------------------------------------
+// Network request auditing
+// ---------------------------------------------------------------------------
+
+/**
+ * Load the network request log from localStorage.
+ *
+ * @returns An array of NetworkRequestEntry objects.
+ */
+export function loadNetworkLog(): NetworkRequestEntry[] {
+  try {
+    const raw = localStorage.getItem(NETWORK_LOG_KEY);
+    if (!raw) return [];
+
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+
+    return parsed.filter(
+      (e: unknown): e is NetworkRequestEntry =>
+        typeof e === 'object' && e !== null && 'id' in e && 'destination' in e,
+    );
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Log an outbound network request.
+ *
+ * @param destination - The destination domain.
+ * @param method - HTTP method.
+ * @param purpose - Human-readable purpose description.
+ * @param blocked - Whether the request was blocked by telemetry settings.
+ * @returns The logged NetworkRequestEntry.
+ */
+export function logNetworkRequest(
+  destination: string,
+  method: string,
+  purpose: string,
+  blocked: boolean,
+): NetworkRequestEntry {
+  const entry: NetworkRequestEntry = {
+    id: crypto.randomUUID(),
+    timestamp: new Date().toISOString(),
+    destination,
+    method,
+    purpose,
+    blocked,
+  };
+
+  const log = loadNetworkLog();
+  log.push(entry);
+
+  const trimmed = log.length > MAX_NETWORK_LOG_ENTRIES ? log.slice(-MAX_NETWORK_LOG_ENTRIES) : log;
+  localStorage.setItem(NETWORK_LOG_KEY, JSON.stringify(trimmed));
+
+  return entry;
+}
+
+/**
+ * Clear the network request log.
+ */
+export function clearNetworkLog(): void {
+  localStorage.removeItem(NETWORK_LOG_KEY);
+}
+
+// ---------------------------------------------------------------------------
+// Transparency reporting
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a transparency report from the network request log.
+ *
+ * Aggregates all logged requests by destination and summarizes what data
+ * goes where, how many requests were made, and how many were blocked.
+ *
+ * @returns A TransparencyReport.
+ */
+export function generateTransparencyReport(): TransparencyReport {
+  const log = loadNetworkLog();
+  const destinationMap = new Map<string, { purposes: Set<string>; count: number }>();
+  let totalBlocked = 0;
+
+  for (const entry of log) {
+    if (entry.blocked) totalBlocked++;
+
+    const existing = destinationMap.get(entry.destination);
+    if (existing) {
+      existing.purposes.add(entry.purpose);
+      existing.count++;
+    } else {
+      destinationMap.set(entry.destination, {
+        purposes: new Set([entry.purpose]),
+        count: 1,
+      });
+    }
+  }
+
+  const destinations: TransparencyDestination[] = [];
+  for (const [domain, info] of destinationMap) {
+    destinations.push({
+      domain,
+      service: domain,
+      dataSent: 'See purpose description',
+      purpose: Array.from(info.purposes).join('; '),
+      requestCount: info.count,
+    });
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    destinations,
+    totalRequests: log.length,
+    totalBlocked,
+  };
+}

--- a/apps/web/src/lib/security/types.ts
+++ b/apps/web/src/lib/security/types.ts
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Security & Privacy types — shared across all security modules.
+ *
+ * These types define the data structures for GDPR/CCPA data access,
+ * selective record erasure, device session management, telemetry
+ * transparency, third-party connection management, audit logging,
+ * and encrypted memo handling.
+ *
+ * References: #1654, #1658, #1663, #1668, #1677, #1682, #1723
+ */
+
+// ---------------------------------------------------------------------------
+// Data Access Request (#1654)
+// ---------------------------------------------------------------------------
+
+/** Categories of user data that can be exported. */
+export type DataCategory =
+  | 'accounts'
+  | 'transactions'
+  | 'budgets'
+  | 'goals'
+  | 'categories'
+  | 'settings'
+  | 'consent'
+  | 'audit_log';
+
+/** Status of a data access request. */
+export type DataAccessRequestStatus = 'pending' | 'processing' | 'completed' | 'failed';
+
+/** A GDPR/CCPA self-service data access request. */
+export interface DataAccessRequest {
+  /** Unique request ID. */
+  readonly id: string;
+  /** ISO-8601 timestamp when the request was created. */
+  readonly requestedAt: string;
+  /** Current status. */
+  readonly status: DataAccessRequestStatus;
+  /** Categories included in this export. */
+  readonly categories: readonly DataCategory[];
+  /** ISO-8601 timestamp when the export was completed (null if pending). */
+  readonly completedAt: string | null;
+  /** Format of the exported data. */
+  readonly format: 'json' | 'csv';
+}
+
+/** A structured data export package. */
+export interface DataExportPackage {
+  /** Export metadata. */
+  readonly meta: {
+    readonly exportId: string;
+    readonly exportedAt: string;
+    readonly format: 'json';
+    readonly categories: readonly DataCategory[];
+    readonly totalRecords: number;
+  };
+  /** Data grouped by category. */
+  readonly data: Partial<Record<DataCategory, readonly Record<string, unknown>[]>>;
+}
+
+// ---------------------------------------------------------------------------
+// Selective Record Erasure (#1658)
+// ---------------------------------------------------------------------------
+
+/** Type of record being erased. */
+export type ErasableRecordType = 'transaction' | 'account' | 'budget' | 'goal' | 'category';
+
+/** Status of an erasure request. */
+export type ErasureStatus = 'pending' | 'approved' | 'completed' | 'rejected';
+
+/** A selective record erasure request. */
+export interface ErasureRequest {
+  /** Unique request ID. */
+  readonly id: string;
+  /** ISO-8601 timestamp of request creation. */
+  readonly requestedAt: string;
+  /** Type of record to erase. */
+  readonly recordType: ErasableRecordType;
+  /** ID of the specific record to erase. */
+  readonly recordId: string;
+  /** Human-readable reason for erasure. */
+  readonly reason: string;
+  /** Current status. */
+  readonly status: ErasureStatus;
+  /** ISO-8601 timestamp when erasure was completed (null if pending). */
+  readonly completedAt: string | null;
+  /** Cascade actions taken (e.g., balance recalculation). */
+  readonly cascadeActions: readonly string[];
+}
+
+/** Result of a retention policy check. */
+export interface RetentionCheckResult {
+  /** Whether the record can be erased now. */
+  readonly canErase: boolean;
+  /** Reason if erasure is blocked. */
+  readonly reason: string | null;
+  /** ISO-8601 date when the retention period expires (null if no hold). */
+  readonly retentionExpiresAt: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Device Session Management (#1663)
+// ---------------------------------------------------------------------------
+
+/** A device/session entry. */
+export interface DeviceSession {
+  /** Unique session ID. */
+  readonly id: string;
+  /** Human-readable device name. */
+  readonly deviceName: string;
+  /** Browser or app user agent string. */
+  readonly userAgent: string;
+  /** IP address (masked for privacy, e.g. "192.168.x.x"). */
+  readonly ipAddress: string;
+  /** ISO-8601 timestamp of last activity. */
+  readonly lastActiveAt: string;
+  /** ISO-8601 timestamp when the session was created. */
+  readonly createdAt: string;
+  /** Whether this is the current session. */
+  readonly isCurrent: boolean;
+  /** Whether the session has been revoked. */
+  readonly isRevoked: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Telemetry Configuration (#1668)
+// ---------------------------------------------------------------------------
+
+/** Granular telemetry category. */
+export type TelemetryCategory =
+  | 'crash_reports'
+  | 'usage_analytics'
+  | 'performance_metrics'
+  | 'feature_flags';
+
+/** Configuration for no-telemetry mode. */
+export interface TelemetryConfig {
+  /** Master kill switch — disables all telemetry when true. */
+  readonly noTelemetryMode: boolean;
+  /** Per-category overrides (only relevant when noTelemetryMode is false). */
+  readonly categorySettings: Readonly<Record<TelemetryCategory, boolean>>;
+  /** ISO-8601 timestamp of last configuration change. */
+  readonly lastUpdatedAt: string;
+}
+
+/** A logged outbound network request for transparency. */
+export interface NetworkRequestEntry {
+  /** Unique entry ID. */
+  readonly id: string;
+  /** ISO-8601 timestamp. */
+  readonly timestamp: string;
+  /** Destination URL (domain only, no path details for privacy). */
+  readonly destination: string;
+  /** HTTP method. */
+  readonly method: string;
+  /** Purpose of the request. */
+  readonly purpose: string;
+  /** Whether the request was blocked by telemetry settings. */
+  readonly blocked: boolean;
+}
+
+/** A transparency report summarizing data destinations. */
+export interface TransparencyReport {
+  /** ISO-8601 timestamp of report generation. */
+  readonly generatedAt: string;
+  /** Summary of destinations and what data goes where. */
+  readonly destinations: readonly TransparencyDestination[];
+  /** Total requests logged in the reporting period. */
+  readonly totalRequests: number;
+  /** Total requests blocked. */
+  readonly totalBlocked: number;
+}
+
+/** A destination in the transparency report. */
+export interface TransparencyDestination {
+  /** Domain name. */
+  readonly domain: string;
+  /** Description of the service. */
+  readonly service: string;
+  /** What data is sent. */
+  readonly dataSent: string;
+  /** Purpose of sending data. */
+  readonly purpose: string;
+  /** Number of requests in the reporting period. */
+  readonly requestCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Third-Party Connection Transparency (#1677)
+// ---------------------------------------------------------------------------
+
+/** Status of a third-party connection. */
+export type ConnectionStatus = 'active' | 'paused' | 'revoked' | 'expired';
+
+/** A third-party service connection (aggregator, sync provider, etc.). */
+export interface ConnectionRecord {
+  /** Unique connection ID. */
+  readonly id: string;
+  /** Name of the third-party provider. */
+  readonly providerName: string;
+  /** Type of connection. */
+  readonly providerType: 'aggregator' | 'sync' | 'export' | 'import' | 'analytics';
+  /** Current status. */
+  readonly status: ConnectionStatus;
+  /** Permission scopes granted to this connection. */
+  readonly scopes: readonly string[];
+  /** ISO-8601 timestamp when the connection was created. */
+  readonly connectedAt: string;
+  /** ISO-8601 timestamp of last data access by this provider. */
+  readonly lastAccessedAt: string | null;
+  /** ISO-8601 timestamp when the connection expires (null if no expiry). */
+  readonly expiresAt: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Audit Log (#1682)
+// ---------------------------------------------------------------------------
+
+/** Types of auditable security events. */
+export type AuditEventType =
+  | 'login'
+  | 'logout'
+  | 'permission_change'
+  | 'data_access'
+  | 'data_export'
+  | 'data_erasure'
+  | 'connection_added'
+  | 'connection_revoked'
+  | 'session_revoked'
+  | 'telemetry_changed'
+  | 'memo_encrypted'
+  | 'memo_decrypted'
+  | 'settings_changed';
+
+/** Severity of an audit event. */
+export type AuditSeverity = 'info' | 'warning' | 'critical';
+
+/** An entry in the append-only security audit log. */
+export interface AuditEntry {
+  /** Unique entry ID. */
+  readonly id: string;
+  /** ISO-8601 timestamp of the event. */
+  readonly timestamp: string;
+  /** Type of event. */
+  readonly eventType: AuditEventType;
+  /** Severity level. */
+  readonly severity: AuditSeverity;
+  /** Human-readable description (never contains financial data). */
+  readonly description: string;
+  /** Additional metadata (scrubbed of sensitive data). */
+  readonly metadata: Readonly<Record<string, string>>;
+  /** IP address at time of event (masked). */
+  readonly ipAddress: string | null;
+  /** User agent at time of event. */
+  readonly userAgent: string | null;
+}
+
+/** Filter criteria for querying the audit log. */
+export interface AuditLogFilter {
+  /** Filter by event type(s). */
+  readonly eventTypes?: readonly AuditEventType[];
+  /** Start of date range (ISO-8601). */
+  readonly startDate?: string;
+  /** End of date range (ISO-8601). */
+  readonly endDate?: string;
+  /** Filter by severity. */
+  readonly severity?: AuditSeverity;
+  /** Maximum number of results. */
+  readonly limit?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Encrypted Memo (#1723)
+// ---------------------------------------------------------------------------
+
+/** An encrypted memo attached to a transaction or record. */
+export interface EncryptedMemo {
+  /** The encrypted content (base64-encoded in placeholder implementation). */
+  readonly ciphertext: string;
+  /** Initialization vector (base64-encoded). */
+  readonly iv: string;
+  /** Algorithm identifier. */
+  readonly algorithm: string;
+  /** ISO-8601 timestamp when encryption was performed. */
+  readonly encryptedAt: string;
+}
+
+/** Export settings for memo handling. */
+export interface MemoExportOptions {
+  /** Whether to include memos in the export. */
+  readonly includeMemos: boolean;
+  /** Whether to redact memo content (replace with [REDACTED]). */
+  readonly redactMemos: boolean;
+}


### PR DESCRIPTION
## Summary

Implement types, logic, and tests for security and privacy features in the Finance web app under \pps/web/src/lib/security/\.

## Changes

### New Modules (8 source files + 7 test files + 1 barrel export)

- **types.ts** — Shared types: DataAccessRequest, ErasureRequest, DeviceSession, TelemetryConfig, ConnectionRecord, AuditEntry, EncryptedMemo, and related enums/interfaces
- **data-access.ts** — GDPR/CCPA self-service data export: create requests, build data inventories, generate structured JSON export packages
- **record-erasure.ts** — Selective record erasure: retention policy checks (7-year tax compliance), cascade action determination, erasure receipts
- **device-manager.ts** — Active device/session management: register, touch, revoke sessions; IP masking; user agent parsing
- **telemetry-config.ts** — No-telemetry mode toggle with per-category granularity; network request auditing; transparency report generation
- **connection-transparency.ts** — Third-party connection management: add/revoke connections, permission scope tracking, expiry handling
- **audit-log.ts** — Append-only security event log: login/logout, permission changes, data access events; query by type, date range, severity
- **encrypted-memo.ts** — Memo encryption/decryption (placeholder base64 for tests, structured for Web Crypto API swap); redaction for export; batch processing

### Test Coverage

- **97 tests passing** across 7 test suites
- All modules tested for core functionality, edge cases, and data safety (no financial data in plain text)

### Technical Decisions

- Pure functions throughout — no side effects beyond localStorage persistence
- Placeholder crypto (base64) with clear TODO markers for Web Crypto API integration
- JSDoc on every public function
- No new dependencies added
- Follows existing project patterns (consent-history.ts, crash-report-scrubber.ts)

## Issues

Closes #1654
Closes #1658
Closes #1663
Closes #1668
Closes #1677
Closes #1682
Closes #1723

## Testing

- [x] All 97 tests pass (\itest run\)
- [x] Prettier formatting verified
- [x] ESLint clean (0 warnings)
- [x] No inline styles/scripts (CSP compliant)
- [x] No sensitive data logged in plain text

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>