### PR TITLE
feat(web): sector exposure analysis and investment research data layer (#1603, #1740)

### DIFF
--- a/apps/web/src/lib/sector-analysis/__tests__/concentration.test.ts
+++ b/apps/web/src/lib/sector-analysis/__tests__/concentration.test.ts
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for portfolio concentration analysis engine.
+ *
+ * References: issue #1603
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  analyzeConcentration,
+  bankersRound,
+  calculateHHI,
+  classifyConcentration,
+  compareSectorWeights,
+  getTopNHoldings,
+} from '../concentration';
+import { ConcentrationLevel, GicsSector, type HoldingExposure } from '../types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeHolding(
+  symbol: string,
+  marketValue: number,
+  sector: GicsSector = GicsSector.INFORMATION_TECHNOLOGY,
+): HoldingExposure {
+  return {
+    symbol,
+    name: `${symbol} Inc.`,
+    marketValue,
+    sector,
+    weightPercent: 0, // filled by analysis
+  };
+}
+
+// ---------------------------------------------------------------------------
+// bankersRound
+// ---------------------------------------------------------------------------
+
+describe('bankersRound', () => {
+  it('rounds 2.5 to 2 (round half to even)', () => {
+    expect(bankersRound(2.5, 0)).toBe(2);
+  });
+
+  it('rounds 3.5 to 4 (round half to even)', () => {
+    expect(bankersRound(3.5, 0)).toBe(4);
+  });
+
+  it('rounds 2.55 to 2.56 at 2 decimal places', () => {
+    expect(bankersRound(2.56, 2)).toBe(2.56);
+  });
+
+  it('rounds normal values correctly', () => {
+    expect(bankersRound(1.234, 2)).toBe(1.23);
+    expect(bankersRound(1.236, 2)).toBe(1.24);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// calculateHHI
+// ---------------------------------------------------------------------------
+
+describe('calculateHHI', () => {
+  it('returns 0 for empty array', () => {
+    expect(calculateHHI([])).toBe(0);
+  });
+
+  it('returns 10000 for a single holding', () => {
+    expect(calculateHHI([{ marketValue: 500_00 }])).toBe(10000);
+  });
+
+  it('returns 5000 for two equal holdings', () => {
+    const holdings = [{ marketValue: 100_00 }, { marketValue: 100_00 }];
+    expect(calculateHHI(holdings)).toBe(5000);
+  });
+
+  it('returns 2500 for four equal holdings', () => {
+    const holdings = Array.from({ length: 4 }, () => ({ marketValue: 100_00 }));
+    expect(calculateHHI(holdings)).toBe(2500);
+  });
+
+  it('returns near 0 for many equal holdings', () => {
+    const holdings = Array.from({ length: 100 }, () => ({ marketValue: 100_00 }));
+    expect(calculateHHI(holdings)).toBe(100);
+  });
+
+  it('handles all-zero market values', () => {
+    expect(calculateHHI([{ marketValue: 0 }, { marketValue: 0 }])).toBe(0);
+  });
+
+  it('correctly handles unequal weights', () => {
+    // 70% and 30%: HHI = 70^2 + 30^2 = 4900 + 900 = 5800
+    const holdings = [{ marketValue: 7000 }, { marketValue: 3000 }];
+    expect(calculateHHI(holdings)).toBe(5800);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyConcentration
+// ---------------------------------------------------------------------------
+
+describe('classifyConcentration', () => {
+  it('classifies LOW for HHI < 1500', () => {
+    expect(classifyConcentration(1000)).toBe(ConcentrationLevel.LOW);
+    expect(classifyConcentration(0)).toBe(ConcentrationLevel.LOW);
+  });
+
+  it('classifies MODERATE for HHI 1500–2500', () => {
+    expect(classifyConcentration(1500)).toBe(ConcentrationLevel.MODERATE);
+    expect(classifyConcentration(2000)).toBe(ConcentrationLevel.MODERATE);
+    expect(classifyConcentration(2500)).toBe(ConcentrationLevel.MODERATE);
+  });
+
+  it('classifies HIGH for HHI > 2500', () => {
+    expect(classifyConcentration(2501)).toBe(ConcentrationLevel.HIGH);
+    expect(classifyConcentration(10000)).toBe(ConcentrationLevel.HIGH);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getTopNHoldings
+// ---------------------------------------------------------------------------
+
+describe('getTopNHoldings', () => {
+  it('returns empty for no holdings', () => {
+    const result = getTopNHoldings([]);
+    expect(result.topHoldings).toEqual([]);
+    expect(result.topNPercent).toBe(0);
+  });
+
+  it('returns all holdings when N > count', () => {
+    const holdings = [makeHolding('AAPL', 500_00), makeHolding('GOOG', 300_00)];
+    const result = getTopNHoldings(holdings, 5);
+    expect(result.topHoldings).toHaveLength(2);
+    expect(result.topNPercent).toBe(100);
+  });
+
+  it('returns top-N by market value', () => {
+    const holdings = [
+      makeHolding('AAPL', 500_00),
+      makeHolding('GOOG', 300_00),
+      makeHolding('MSFT', 200_00),
+    ];
+    const result = getTopNHoldings(holdings, 2);
+    expect(result.topHoldings).toHaveLength(2);
+    expect(result.topHoldings[0].symbol).toBe('AAPL');
+    expect(result.topHoldings[1].symbol).toBe('GOOG');
+    expect(result.topNPercent).toBe(80);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// analyzeConcentration
+// ---------------------------------------------------------------------------
+
+describe('analyzeConcentration', () => {
+  it('handles empty portfolio', () => {
+    const result = analyzeConcentration([]);
+    expect(result.hhi).toBe(0);
+    expect(result.level).toBe(ConcentrationLevel.LOW);
+    expect(result.topHoldings).toEqual([]);
+    expect(result.totalHoldings).toBe(0);
+  });
+
+  it('single holding gives HHI 10000 and HIGH', () => {
+    const result = analyzeConcentration([makeHolding('AAPL', 1000_00)]);
+    expect(result.hhi).toBe(10000);
+    expect(result.level).toBe(ConcentrationLevel.HIGH);
+    expect(result.totalHoldings).toBe(1);
+  });
+
+  it('many equal holdings give LOW concentration', () => {
+    const holdings = Array.from({ length: 20 }, (_, i) => makeHolding(`S${i}`, 100_00));
+    const result = analyzeConcentration(holdings, 5);
+    expect(result.level).toBe(ConcentrationLevel.LOW);
+    expect(result.topHoldings).toHaveLength(5);
+    expect(result.topNPercent).toBe(25);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// compareSectorWeights
+// ---------------------------------------------------------------------------
+
+describe('compareSectorWeights', () => {
+  it('returns empty for no holdings and no benchmark', () => {
+    const result = compareSectorWeights([], {});
+    expect(result).toEqual([]);
+  });
+
+  it('computes deviation between portfolio and benchmark', () => {
+    const holdings = [
+      makeHolding('AAPL', 700_00, GicsSector.INFORMATION_TECHNOLOGY),
+      makeHolding('XOM', 300_00, GicsSector.ENERGY),
+    ];
+    const benchmark = {
+      [GicsSector.INFORMATION_TECHNOLOGY]: 50,
+      [GicsSector.ENERGY]: 50,
+    };
+
+    const result = compareSectorWeights(holdings, benchmark);
+    const techSector = result.find((s) => s.sector === GicsSector.INFORMATION_TECHNOLOGY);
+    const energySector = result.find((s) => s.sector === GicsSector.ENERGY);
+
+    expect(techSector).toBeDefined();
+    expect(techSector!.portfolioPercent).toBe(70);
+    expect(techSector!.deviationPercent).toBe(20);
+
+    expect(energySector).toBeDefined();
+    expect(energySector!.portfolioPercent).toBe(30);
+    expect(energySector!.deviationPercent).toBe(-20);
+  });
+
+  it('includes benchmark sectors not in portfolio', () => {
+    const holdings = [makeHolding('AAPL', 1000_00, GicsSector.INFORMATION_TECHNOLOGY)];
+    const benchmark = {
+      [GicsSector.INFORMATION_TECHNOLOGY]: 30,
+      [GicsSector.HEALTH_CARE]: 20,
+    };
+
+    const result = compareSectorWeights(holdings, benchmark);
+    const healthcare = result.find((s) => s.sector === GicsSector.HEALTH_CARE);
+    expect(healthcare).toBeDefined();
+    expect(healthcare!.portfolioPercent).toBe(0);
+    expect(healthcare!.deviationPercent).toBe(-20);
+  });
+
+  it('sorts by absolute deviation descending', () => {
+    const holdings = [
+      makeHolding('AAPL', 500_00, GicsSector.INFORMATION_TECHNOLOGY),
+      makeHolding('XOM', 300_00, GicsSector.ENERGY),
+      makeHolding('JNJ', 200_00, GicsSector.HEALTH_CARE),
+    ];
+    const benchmark = {
+      [GicsSector.INFORMATION_TECHNOLOGY]: 33,
+      [GicsSector.ENERGY]: 33,
+      [GicsSector.HEALTH_CARE]: 34,
+    };
+
+    const result = compareSectorWeights(holdings, benchmark);
+    // Should be sorted by absolute deviation
+    const deviations = result.map((s) => Math.abs(s.deviationPercent));
+    for (let i = 1; i < deviations.length; i++) {
+      expect(deviations[i]).toBeLessThanOrEqual(deviations[i - 1]);
+    }
+  });
+});

--- a/apps/web/src/lib/sector-analysis/__tests__/overlap.test.ts
+++ b/apps/web/src/lib/sector-analysis/__tests__/overlap.test.ts
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for portfolio overlap detection engine.
+ *
+ * References: issue #1603
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { analyzeOverlap } from '../overlap';
+import type { PortfolioHolding } from '../types';
+
+// ---------------------------------------------------------------------------
+// analyzeOverlap
+// ---------------------------------------------------------------------------
+
+describe('analyzeOverlap', () => {
+  it('returns zeroes for two empty portfolios', () => {
+    const result = analyzeOverlap([], []);
+    expect(result.overlapPercentA).toBe(0);
+    expect(result.overlapPercentB).toBe(0);
+    expect(result.overlapPercentAvg).toBe(0);
+    expect(result.sharedSymbols).toEqual([]);
+    expect(result.uniqueToA).toBe(0);
+    expect(result.uniqueToB).toBe(0);
+    expect(result.correlationEstimate).toBe(0);
+  });
+
+  it('returns 100% overlap for identical portfolios', () => {
+    const portfolio: PortfolioHolding[] = [
+      { symbol: 'AAPL', marketValue: 500_00 },
+      { symbol: 'GOOG', marketValue: 300_00 },
+      { symbol: 'MSFT', marketValue: 200_00 },
+    ];
+
+    const result = analyzeOverlap(portfolio, portfolio);
+    expect(result.overlapPercentA).toBe(100);
+    expect(result.overlapPercentB).toBe(100);
+    expect(result.overlapPercentAvg).toBe(100);
+    expect(result.sharedSymbols).toEqual(['AAPL', 'GOOG', 'MSFT']);
+    expect(result.uniqueToA).toBe(0);
+    expect(result.uniqueToB).toBe(0);
+  });
+
+  it('returns 0% overlap for completely different portfolios', () => {
+    const portfolioA: PortfolioHolding[] = [
+      { symbol: 'AAPL', marketValue: 500_00 },
+      { symbol: 'GOOG', marketValue: 500_00 },
+    ];
+    const portfolioB: PortfolioHolding[] = [
+      { symbol: 'MSFT', marketValue: 500_00 },
+      { symbol: 'AMZN', marketValue: 500_00 },
+    ];
+
+    const result = analyzeOverlap(portfolioA, portfolioB);
+    expect(result.overlapPercentA).toBe(0);
+    expect(result.overlapPercentB).toBe(0);
+    expect(result.overlapPercentAvg).toBe(0);
+    expect(result.sharedSymbols).toEqual([]);
+    expect(result.uniqueToA).toBe(2);
+    expect(result.uniqueToB).toBe(2);
+    expect(result.correlationEstimate).toBe(0);
+  });
+
+  it('calculates partial overlap correctly', () => {
+    const portfolioA: PortfolioHolding[] = [
+      { symbol: 'AAPL', marketValue: 600_00 },
+      { symbol: 'GOOG', marketValue: 400_00 },
+    ];
+    const portfolioB: PortfolioHolding[] = [
+      { symbol: 'AAPL', marketValue: 300_00 },
+      { symbol: 'MSFT', marketValue: 700_00 },
+    ];
+
+    const result = analyzeOverlap(portfolioA, portfolioB);
+    // A: AAPL is 600 out of 1000 = 60% overlap
+    expect(result.overlapPercentA).toBe(60);
+    // B: AAPL is 300 out of 1000 = 30% overlap
+    expect(result.overlapPercentB).toBe(30);
+    expect(result.overlapPercentAvg).toBe(45);
+    expect(result.sharedSymbols).toEqual(['AAPL']);
+    expect(result.uniqueToA).toBe(1);
+    expect(result.uniqueToB).toBe(1);
+  });
+
+  it('estimates correlation near 1 for identical portfolios', () => {
+    const portfolio: PortfolioHolding[] = [
+      { symbol: 'AAPL', marketValue: 500_00 },
+      { symbol: 'GOOG', marketValue: 500_00 },
+    ];
+
+    const result = analyzeOverlap(portfolio, portfolio);
+    expect(result.correlationEstimate).toBe(1);
+  });
+
+  it('handles one empty portfolio', () => {
+    const portfolioA: PortfolioHolding[] = [{ symbol: 'AAPL', marketValue: 500_00 }];
+
+    const result = analyzeOverlap(portfolioA, []);
+    expect(result.overlapPercentA).toBe(0);
+    expect(result.overlapPercentB).toBe(0);
+    expect(result.sharedSymbols).toEqual([]);
+    expect(result.uniqueToA).toBe(1);
+    expect(result.uniqueToB).toBe(0);
+  });
+
+  it('shared symbols are sorted alphabetically', () => {
+    const portfolioA: PortfolioHolding[] = [
+      { symbol: 'MSFT', marketValue: 100_00 },
+      { symbol: 'AAPL', marketValue: 100_00 },
+      { symbol: 'GOOG', marketValue: 100_00 },
+    ];
+    const portfolioB: PortfolioHolding[] = [
+      { symbol: 'GOOG', marketValue: 100_00 },
+      { symbol: 'AAPL', marketValue: 100_00 },
+      { symbol: 'MSFT', marketValue: 100_00 },
+    ];
+
+    const result = analyzeOverlap(portfolioA, portfolioB);
+    expect(result.sharedSymbols).toEqual(['AAPL', 'GOOG', 'MSFT']);
+  });
+});

--- a/apps/web/src/lib/sector-analysis/__tests__/scoring.test.ts
+++ b/apps/web/src/lib/sector-analysis/__tests__/scoring.test.ts
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for analyst consensus scoring engine.
+ *
+ * References: issue #1740
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  analyzeConsensus,
+  computeAverageTargetPrice,
+  computeTargetUpside,
+  computeWeightedScore,
+  countRatings,
+  deriveRating,
+} from '../scoring';
+import { AnalystRating, type AnalystOpinion } from '../types';
+
+// ---------------------------------------------------------------------------
+// deriveRating
+// ---------------------------------------------------------------------------
+
+describe('deriveRating', () => {
+  it('maps 4.5–5.0 to STRONG_BUY', () => {
+    expect(deriveRating(4.5)).toBe(AnalystRating.STRONG_BUY);
+    expect(deriveRating(5.0)).toBe(AnalystRating.STRONG_BUY);
+  });
+
+  it('maps 3.5–4.49 to BUY', () => {
+    expect(deriveRating(3.5)).toBe(AnalystRating.BUY);
+    expect(deriveRating(4.0)).toBe(AnalystRating.BUY);
+    expect(deriveRating(4.49)).toBe(AnalystRating.BUY);
+  });
+
+  it('maps 2.5–3.49 to HOLD', () => {
+    expect(deriveRating(2.5)).toBe(AnalystRating.HOLD);
+    expect(deriveRating(3.0)).toBe(AnalystRating.HOLD);
+    expect(deriveRating(3.49)).toBe(AnalystRating.HOLD);
+  });
+
+  it('maps 1.5–2.49 to SELL', () => {
+    expect(deriveRating(1.5)).toBe(AnalystRating.SELL);
+    expect(deriveRating(2.0)).toBe(AnalystRating.SELL);
+  });
+
+  it('maps < 1.5 to STRONG_SELL', () => {
+    expect(deriveRating(1.0)).toBe(AnalystRating.STRONG_SELL);
+    expect(deriveRating(1.49)).toBe(AnalystRating.STRONG_SELL);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeWeightedScore
+// ---------------------------------------------------------------------------
+
+describe('computeWeightedScore', () => {
+  it('returns 0 for empty opinions', () => {
+    expect(computeWeightedScore([])).toBe(0);
+  });
+
+  it('returns 5 for all STRONG_BUY', () => {
+    const opinions: AnalystOpinion[] = [
+      { analyst: 'A', rating: AnalystRating.STRONG_BUY, targetPrice: null, date: '2024-01-01' },
+      { analyst: 'B', rating: AnalystRating.STRONG_BUY, targetPrice: null, date: '2024-01-02' },
+    ];
+    expect(computeWeightedScore(opinions)).toBe(5);
+  });
+
+  it('returns 1 for all STRONG_SELL', () => {
+    const opinions: AnalystOpinion[] = [
+      { analyst: 'A', rating: AnalystRating.STRONG_SELL, targetPrice: null, date: '2024-01-01' },
+    ];
+    expect(computeWeightedScore(opinions)).toBe(1);
+  });
+
+  it('computes correct average for mixed ratings', () => {
+    const opinions: AnalystOpinion[] = [
+      { analyst: 'A', rating: AnalystRating.BUY, targetPrice: null, date: '2024-01-01' }, // 4
+      { analyst: 'B', rating: AnalystRating.HOLD, targetPrice: null, date: '2024-01-01' }, // 3
+      { analyst: 'C', rating: AnalystRating.SELL, targetPrice: null, date: '2024-01-01' }, // 2
+    ];
+    // Average: (4 + 3 + 2) / 3 = 3
+    expect(computeWeightedScore(opinions)).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// countRatings
+// ---------------------------------------------------------------------------
+
+describe('countRatings', () => {
+  it('counts all zeroes for empty opinions', () => {
+    const counts = countRatings([]);
+    expect(counts[AnalystRating.STRONG_BUY]).toBe(0);
+    expect(counts[AnalystRating.BUY]).toBe(0);
+    expect(counts[AnalystRating.HOLD]).toBe(0);
+    expect(counts[AnalystRating.SELL]).toBe(0);
+    expect(counts[AnalystRating.STRONG_SELL]).toBe(0);
+  });
+
+  it('counts ratings correctly', () => {
+    const opinions: AnalystOpinion[] = [
+      { analyst: 'A', rating: AnalystRating.BUY, targetPrice: null, date: '2024-01-01' },
+      { analyst: 'B', rating: AnalystRating.BUY, targetPrice: null, date: '2024-01-01' },
+      { analyst: 'C', rating: AnalystRating.HOLD, targetPrice: null, date: '2024-01-01' },
+    ];
+
+    const counts = countRatings(opinions);
+    expect(counts[AnalystRating.BUY]).toBe(2);
+    expect(counts[AnalystRating.HOLD]).toBe(1);
+    expect(counts[AnalystRating.SELL]).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeAverageTargetPrice
+// ---------------------------------------------------------------------------
+
+describe('computeAverageTargetPrice', () => {
+  it('returns null for no opinions', () => {
+    expect(computeAverageTargetPrice([])).toBeNull();
+  });
+
+  it('returns null when no targets are provided', () => {
+    const opinions: AnalystOpinion[] = [
+      { analyst: 'A', rating: AnalystRating.BUY, targetPrice: null, date: '2024-01-01' },
+    ];
+    expect(computeAverageTargetPrice(opinions)).toBeNull();
+  });
+
+  it('computes average of available targets (skips nulls)', () => {
+    const opinions: AnalystOpinion[] = [
+      { analyst: 'A', rating: AnalystRating.BUY, targetPrice: 200_00, date: '2024-01-01' },
+      { analyst: 'B', rating: AnalystRating.HOLD, targetPrice: null, date: '2024-01-01' },
+      { analyst: 'C', rating: AnalystRating.BUY, targetPrice: 300_00, date: '2024-01-01' },
+    ];
+    // (20000 + 30000) / 2 = 25000
+    expect(computeAverageTargetPrice(opinions)).toBe(250_00);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeTargetUpside
+// ---------------------------------------------------------------------------
+
+describe('computeTargetUpside', () => {
+  it('returns null when current price is 0', () => {
+    expect(computeTargetUpside(200_00, 0)).toBeNull();
+  });
+
+  it('calculates positive upside', () => {
+    // Target 200, current 100 → 100% upside
+    expect(computeTargetUpside(200_00, 100_00)).toBe(100);
+  });
+
+  it('calculates negative downside', () => {
+    // Target 50, current 100 → -50% downside
+    expect(computeTargetUpside(50_00, 100_00)).toBe(-50);
+  });
+
+  it('returns 0 when target equals current', () => {
+    expect(computeTargetUpside(100_00, 100_00)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// analyzeConsensus
+// ---------------------------------------------------------------------------
+
+describe('analyzeConsensus', () => {
+  it('handles empty opinions', () => {
+    const result = analyzeConsensus('AAPL', [], 150_00);
+    expect(result.totalAnalysts).toBe(0);
+    expect(result.weightedScore).toBe(0);
+    expect(result.consensusRating).toBe(AnalystRating.HOLD);
+    expect(result.averageTargetPrice).toBeNull();
+    expect(result.targetUpsidePercent).toBeNull();
+  });
+
+  it('computes full consensus correctly', () => {
+    const opinions: AnalystOpinion[] = [
+      { analyst: 'A', rating: AnalystRating.STRONG_BUY, targetPrice: 200_00, date: '2024-01-01' },
+      { analyst: 'B', rating: AnalystRating.BUY, targetPrice: 180_00, date: '2024-01-02' },
+      { analyst: 'C', rating: AnalystRating.BUY, targetPrice: 190_00, date: '2024-01-03' },
+    ];
+
+    const result = analyzeConsensus('AAPL', opinions, 150_00);
+
+    expect(result.symbol).toBe('AAPL');
+    expect(result.totalAnalysts).toBe(3);
+    // (5 + 4 + 4) / 3 ≈ 4.33
+    expect(result.weightedScore).toBeCloseTo(4.33, 1);
+    expect(result.consensusRating).toBe(AnalystRating.BUY);
+    // (20000 + 18000 + 19000) / 3 = 19000
+    expect(result.averageTargetPrice).toBe(190_00);
+    expect(result.currentPrice).toBe(150_00);
+    // (19000 - 15000) / 15000 * 100 ≈ 26.67
+    expect(result.targetUpsidePercent).toBeCloseTo(26.67, 1);
+  });
+
+  it('handles all-sell consensus', () => {
+    const opinions: AnalystOpinion[] = [
+      { analyst: 'A', rating: AnalystRating.SELL, targetPrice: 80_00, date: '2024-01-01' },
+      { analyst: 'B', rating: AnalystRating.STRONG_SELL, targetPrice: 60_00, date: '2024-01-02' },
+    ];
+
+    const result = analyzeConsensus('XYZ', opinions, 100_00);
+    expect(result.weightedScore).toBe(1.5);
+    expect(result.consensusRating).toBe(AnalystRating.SELL);
+    expect(result.averageTargetPrice).toBe(70_00);
+    expect(result.targetUpsidePercent).toBe(-30);
+  });
+});

--- a/apps/web/src/lib/sector-analysis/__tests__/screener.test.ts
+++ b/apps/web/src/lib/sector-analysis/__tests__/screener.test.ts
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the investment screener filter evaluation engine.
+ *
+ * References: issue #1740
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  evaluateNumericFilter,
+  matchesFilters,
+  rankAssets,
+  screenAssets,
+  sortAssets,
+} from '../screener';
+import {
+  FilterOperator,
+  GicsSector,
+  InvestmentStyle,
+  MarketCapSize,
+  type ScreenableAsset,
+  SortDirection,
+} from '../types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeAsset(overrides: Partial<ScreenableAsset> = {}): ScreenableAsset {
+  return {
+    symbol: 'AAPL',
+    name: 'Apple Inc.',
+    peRatio: 28,
+    marketCap: 3_000_000_000_00, // $30B
+    dividendYield: 0.5,
+    sector: GicsSector.INFORMATION_TECHNOLOGY,
+    styleBox: { size: MarketCapSize.LARGE, style: InvestmentStyle.GROWTH },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// evaluateNumericFilter
+// ---------------------------------------------------------------------------
+
+describe('evaluateNumericFilter', () => {
+  it('returns false for null values', () => {
+    expect(
+      evaluateNumericFilter(null, { field: 'pe', operator: FilterOperator.GT, value: 10 }),
+    ).toBe(false);
+  });
+
+  it('EQ matches exact value', () => {
+    expect(evaluateNumericFilter(10, { field: 'pe', operator: FilterOperator.EQ, value: 10 })).toBe(
+      true,
+    );
+    expect(evaluateNumericFilter(11, { field: 'pe', operator: FilterOperator.EQ, value: 10 })).toBe(
+      false,
+    );
+  });
+
+  it('NEQ does not match exact value', () => {
+    expect(
+      evaluateNumericFilter(11, { field: 'pe', operator: FilterOperator.NEQ, value: 10 }),
+    ).toBe(true);
+    expect(
+      evaluateNumericFilter(10, { field: 'pe', operator: FilterOperator.NEQ, value: 10 }),
+    ).toBe(false);
+  });
+
+  it('GT / GTE / LT / LTE comparisons', () => {
+    expect(evaluateNumericFilter(11, { field: 'pe', operator: FilterOperator.GT, value: 10 })).toBe(
+      true,
+    );
+    expect(evaluateNumericFilter(10, { field: 'pe', operator: FilterOperator.GT, value: 10 })).toBe(
+      false,
+    );
+
+    expect(
+      evaluateNumericFilter(10, { field: 'pe', operator: FilterOperator.GTE, value: 10 }),
+    ).toBe(true);
+    expect(evaluateNumericFilter(9, { field: 'pe', operator: FilterOperator.GTE, value: 10 })).toBe(
+      false,
+    );
+
+    expect(evaluateNumericFilter(9, { field: 'pe', operator: FilterOperator.LT, value: 10 })).toBe(
+      true,
+    );
+    expect(evaluateNumericFilter(10, { field: 'pe', operator: FilterOperator.LT, value: 10 })).toBe(
+      false,
+    );
+
+    expect(
+      evaluateNumericFilter(10, { field: 'pe', operator: FilterOperator.LTE, value: 10 }),
+    ).toBe(true);
+    expect(
+      evaluateNumericFilter(11, { field: 'pe', operator: FilterOperator.LTE, value: 10 }),
+    ).toBe(false);
+  });
+
+  it('BETWEEN is inclusive', () => {
+    const filter = {
+      field: 'pe',
+      operator: FilterOperator.BETWEEN as const,
+      value: 10,
+      valueTo: 20,
+    };
+    expect(evaluateNumericFilter(10, filter)).toBe(true);
+    expect(evaluateNumericFilter(15, filter)).toBe(true);
+    expect(evaluateNumericFilter(20, filter)).toBe(true);
+    expect(evaluateNumericFilter(9, filter)).toBe(false);
+    expect(evaluateNumericFilter(21, filter)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// matchesFilters
+// ---------------------------------------------------------------------------
+
+describe('matchesFilters', () => {
+  it('matches everything with empty filters', () => {
+    expect(matchesFilters(makeAsset(), {})).toBe(true);
+  });
+
+  it('applies P/E filter', () => {
+    const asset = makeAsset({ peRatio: 15 });
+    expect(
+      matchesFilters(asset, {
+        peRatio: { field: 'peRatio', operator: FilterOperator.LTE, value: 20 },
+      }),
+    ).toBe(true);
+    expect(
+      matchesFilters(asset, {
+        peRatio: { field: 'peRatio', operator: FilterOperator.LTE, value: 10 },
+      }),
+    ).toBe(false);
+  });
+
+  it('applies sector filter', () => {
+    const asset = makeAsset({ sector: GicsSector.ENERGY });
+    expect(matchesFilters(asset, { sectors: [GicsSector.ENERGY, GicsSector.UTILITIES] })).toBe(
+      true,
+    );
+    expect(matchesFilters(asset, { sectors: [GicsSector.FINANCIALS] })).toBe(false);
+  });
+
+  it('applies style box filter', () => {
+    const asset = makeAsset({
+      styleBox: { size: MarketCapSize.LARGE, style: InvestmentStyle.VALUE },
+    });
+    expect(
+      matchesFilters(asset, {
+        styles: [{ size: MarketCapSize.LARGE, style: InvestmentStyle.VALUE }],
+      }),
+    ).toBe(true);
+    expect(
+      matchesFilters(asset, {
+        styles: [{ size: MarketCapSize.SMALL, style: InvestmentStyle.GROWTH }],
+      }),
+    ).toBe(false);
+  });
+
+  it('applies multiple filters with AND logic', () => {
+    const asset = makeAsset({
+      peRatio: 12,
+      sector: GicsSector.ENERGY,
+      dividendYield: 3.5,
+    });
+
+    // All filters match
+    expect(
+      matchesFilters(asset, {
+        peRatio: { field: 'peRatio', operator: FilterOperator.LTE, value: 20 },
+        sectors: [GicsSector.ENERGY],
+        dividendYield: { field: 'dividendYield', operator: FilterOperator.GTE, value: 2 },
+      }),
+    ).toBe(true);
+
+    // One filter fails
+    expect(
+      matchesFilters(asset, {
+        peRatio: { field: 'peRatio', operator: FilterOperator.LTE, value: 20 },
+        sectors: [GicsSector.FINANCIALS], // fails
+        dividendYield: { field: 'dividendYield', operator: FilterOperator.GTE, value: 2 },
+      }),
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sortAssets & screenAssets
+// ---------------------------------------------------------------------------
+
+describe('sortAssets', () => {
+  const assets = [
+    makeAsset({ symbol: 'GOOG', peRatio: 25 }),
+    makeAsset({ symbol: 'AAPL', peRatio: 28 }),
+    makeAsset({ symbol: 'MSFT', peRatio: 30 }),
+  ];
+
+  it('sorts by peRatio ascending', () => {
+    const sorted = sortAssets(assets, { field: 'peRatio', direction: SortDirection.ASC });
+    expect(sorted[0].symbol).toBe('GOOG');
+    expect(sorted[2].symbol).toBe('MSFT');
+  });
+
+  it('sorts by peRatio descending', () => {
+    const sorted = sortAssets(assets, { field: 'peRatio', direction: SortDirection.DESC });
+    expect(sorted[0].symbol).toBe('MSFT');
+    expect(sorted[2].symbol).toBe('GOOG');
+  });
+
+  it('sorts by symbol alphabetically', () => {
+    const sorted = sortAssets(assets, { field: 'symbol', direction: SortDirection.ASC });
+    expect(sorted[0].symbol).toBe('AAPL');
+    expect(sorted[2].symbol).toBe('MSFT');
+  });
+
+  it('pushes null values to end', () => {
+    const withNull = [
+      makeAsset({ symbol: 'A', peRatio: null }),
+      makeAsset({ symbol: 'B', peRatio: 10 }),
+    ];
+    const sorted = sortAssets(withNull, { field: 'peRatio', direction: SortDirection.ASC });
+    expect(sorted[0].symbol).toBe('B');
+    expect(sorted[1].symbol).toBe('A');
+  });
+});
+
+describe('screenAssets', () => {
+  it('filters and sorts combined', () => {
+    const assets = [
+      makeAsset({ symbol: 'A', peRatio: 10, sector: GicsSector.ENERGY }),
+      makeAsset({ symbol: 'B', peRatio: 20, sector: GicsSector.ENERGY }),
+      makeAsset({ symbol: 'C', peRatio: 30, sector: GicsSector.FINANCIALS }),
+    ];
+
+    const result = screenAssets(
+      assets,
+      { sectors: [GicsSector.ENERGY] },
+      { field: 'peRatio', direction: SortDirection.DESC },
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result[0].symbol).toBe('B');
+    expect(result[1].symbol).toBe('A');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rankAssets
+// ---------------------------------------------------------------------------
+
+describe('rankAssets', () => {
+  it('assigns 1-based ranks', () => {
+    const assets = [
+      makeAsset({ symbol: 'A', marketCap: 100_00 }),
+      makeAsset({ symbol: 'B', marketCap: 300_00 }),
+      makeAsset({ symbol: 'C', marketCap: 200_00 }),
+    ];
+
+    const ranked = rankAssets(assets, 'marketCap', SortDirection.DESC);
+    expect(ranked[0].rank).toBe(1);
+    expect(ranked[0].asset.symbol).toBe('B');
+    expect(ranked[1].rank).toBe(2);
+    expect(ranked[1].asset.symbol).toBe('C');
+    expect(ranked[2].rank).toBe(3);
+    expect(ranked[2].asset.symbol).toBe('A');
+  });
+});

--- a/apps/web/src/lib/sector-analysis/__tests__/style-box.test.ts
+++ b/apps/web/src/lib/sector-analysis/__tests__/style-box.test.ts
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for Morningstar-style 3×3 style box classification.
+ *
+ * References: issue #1603
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  aggregateStyleBox,
+  classifyHolding,
+  classifyMarketCap,
+  classifyStyle,
+  getAllStyleBoxCells,
+  styleBoxKey,
+} from '../style-box';
+import { InvestmentStyle, MarketCapSize, type StyleBoxPosition } from '../types';
+
+// ---------------------------------------------------------------------------
+// classifyMarketCap
+// ---------------------------------------------------------------------------
+
+describe('classifyMarketCap', () => {
+  it('classifies small cap (<= $2B)', () => {
+    expect(classifyMarketCap(100_000_000_00)).toBe(MarketCapSize.SMALL); // $1B
+    expect(classifyMarketCap(200_000_000_00)).toBe(MarketCapSize.SMALL); // $2B
+  });
+
+  it('classifies mid cap ($2B–$10B)', () => {
+    expect(classifyMarketCap(500_000_000_00)).toBe(MarketCapSize.MID); // $5B
+  });
+
+  it('classifies large cap (>= $10B)', () => {
+    expect(classifyMarketCap(1_000_000_000_00)).toBe(MarketCapSize.LARGE); // $10B
+    expect(classifyMarketCap(2_000_000_000_00)).toBe(MarketCapSize.LARGE); // $20B
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyStyle
+// ---------------------------------------------------------------------------
+
+describe('classifyStyle', () => {
+  it('classifies value (P/E <= 15)', () => {
+    expect(classifyStyle(10)).toBe(InvestmentStyle.VALUE);
+    expect(classifyStyle(15)).toBe(InvestmentStyle.VALUE);
+  });
+
+  it('classifies blend (P/E 16–24)', () => {
+    expect(classifyStyle(20)).toBe(InvestmentStyle.BLEND);
+  });
+
+  it('classifies growth (P/E >= 25)', () => {
+    expect(classifyStyle(25)).toBe(InvestmentStyle.GROWTH);
+    expect(classifyStyle(50)).toBe(InvestmentStyle.GROWTH);
+  });
+
+  it('classifies null P/E as blend', () => {
+    expect(classifyStyle(null)).toBe(InvestmentStyle.BLEND);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyHolding
+// ---------------------------------------------------------------------------
+
+describe('classifyHolding', () => {
+  it('classifies large-cap value', () => {
+    const cell = classifyHolding(2_000_000_000_00, 12);
+    expect(cell.size).toBe(MarketCapSize.LARGE);
+    expect(cell.style).toBe(InvestmentStyle.VALUE);
+  });
+
+  it('classifies small-cap growth', () => {
+    const cell = classifyHolding(100_000_000_00, 30);
+    expect(cell.size).toBe(MarketCapSize.SMALL);
+    expect(cell.style).toBe(InvestmentStyle.GROWTH);
+  });
+
+  it('classifies mid-cap blend with null P/E', () => {
+    const cell = classifyHolding(500_000_000_00, null);
+    expect(cell.size).toBe(MarketCapSize.MID);
+    expect(cell.style).toBe(InvestmentStyle.BLEND);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getAllStyleBoxCells & styleBoxKey
+// ---------------------------------------------------------------------------
+
+describe('getAllStyleBoxCells', () => {
+  it('returns exactly 9 cells', () => {
+    expect(getAllStyleBoxCells()).toHaveLength(9);
+  });
+
+  it('all cells have unique keys', () => {
+    const cells = getAllStyleBoxCells();
+    const keys = cells.map(styleBoxKey);
+    expect(new Set(keys).size).toBe(9);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// aggregateStyleBox
+// ---------------------------------------------------------------------------
+
+describe('aggregateStyleBox', () => {
+  it('returns zero weights for empty positions', () => {
+    const result = aggregateStyleBox([]);
+    expect(result.totalClassifiedValue).toBe(0);
+    expect(result.weights.every((w) => w.percent === 0)).toBe(true);
+  });
+
+  it('single position gets 100% weight in its cell', () => {
+    const positions: StyleBoxPosition[] = [
+      {
+        symbol: 'AAPL',
+        cell: { size: MarketCapSize.LARGE, style: InvestmentStyle.GROWTH },
+        marketValue: 1000_00,
+      },
+    ];
+
+    const result = aggregateStyleBox(positions);
+    expect(result.totalClassifiedValue).toBe(1000_00);
+    expect(result.dominant.size).toBe(MarketCapSize.LARGE);
+    expect(result.dominant.style).toBe(InvestmentStyle.GROWTH);
+
+    const largeGrowth = result.weights.find(
+      (w) => w.cell.size === MarketCapSize.LARGE && w.cell.style === InvestmentStyle.GROWTH,
+    );
+    expect(largeGrowth?.percent).toBe(100);
+  });
+
+  it('distributes weights correctly across cells', () => {
+    const positions: StyleBoxPosition[] = [
+      {
+        symbol: 'AAPL',
+        cell: { size: MarketCapSize.LARGE, style: InvestmentStyle.GROWTH },
+        marketValue: 700_00,
+      },
+      {
+        symbol: 'XOM',
+        cell: { size: MarketCapSize.LARGE, style: InvestmentStyle.VALUE },
+        marketValue: 300_00,
+      },
+    ];
+
+    const result = aggregateStyleBox(positions);
+    expect(result.dominant.size).toBe(MarketCapSize.LARGE);
+    expect(result.dominant.style).toBe(InvestmentStyle.GROWTH);
+
+    const largeGrowth = result.weights.find(
+      (w) => w.cell.size === MarketCapSize.LARGE && w.cell.style === InvestmentStyle.GROWTH,
+    );
+    const largeValue = result.weights.find(
+      (w) => w.cell.size === MarketCapSize.LARGE && w.cell.style === InvestmentStyle.VALUE,
+    );
+    expect(largeGrowth?.percent).toBe(70);
+    expect(largeValue?.percent).toBe(30);
+  });
+
+  it('always returns 9 cells in the weights array', () => {
+    const positions: StyleBoxPosition[] = [
+      {
+        symbol: 'AAPL',
+        cell: { size: MarketCapSize.LARGE, style: InvestmentStyle.BLEND },
+        marketValue: 500_00,
+      },
+    ];
+
+    const result = aggregateStyleBox(positions);
+    expect(result.weights).toHaveLength(9);
+  });
+});

--- a/apps/web/src/lib/sector-analysis/calendar.ts
+++ b/apps/web/src/lib/sector-analysis/calendar.ts
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Economic calendar event filtering and querying.
+ *
+ * Provides date-based filtering, type-based filtering, and upcoming event
+ * queries for earnings, dividends, splits, Fed meetings, and other events.
+ *
+ * References: issue #1740
+ */
+
+import type { EconomicEvent, EconomicEventType } from './types';
+
+// ---------------------------------------------------------------------------
+// Date range filtering
+// ---------------------------------------------------------------------------
+
+/**
+ * Filter events that fall within a date range (inclusive).
+ *
+ * @param events - Array of economic events to filter.
+ * @param startDate - Start date (ISO 8601, YYYY-MM-DD). Inclusive.
+ * @param endDate - End date (ISO 8601, YYYY-MM-DD). Inclusive.
+ * @returns Events within the date range, sorted by date ascending.
+ */
+export function filterEventsByDateRange(
+  events: readonly EconomicEvent[],
+  startDate: string,
+  endDate: string,
+): readonly EconomicEvent[] {
+  return events
+    .filter((e) => e.date >= startDate && e.date <= endDate)
+    .sort((a, b) => a.date.localeCompare(b.date));
+}
+
+// ---------------------------------------------------------------------------
+// Type filtering
+// ---------------------------------------------------------------------------
+
+/**
+ * Filter events by one or more event types.
+ *
+ * @param events - Array of economic events to filter.
+ * @param types - Event types to include.
+ * @returns Events matching any of the specified types.
+ */
+export function filterEventsByType(
+  events: readonly EconomicEvent[],
+  types: readonly EconomicEventType[],
+): readonly EconomicEvent[] {
+  const typeSet = new Set(types);
+  return events.filter((e) => typeSet.has(e.type));
+}
+
+// ---------------------------------------------------------------------------
+// Symbol filtering
+// ---------------------------------------------------------------------------
+
+/**
+ * Filter events related to a specific ticker symbol.
+ *
+ * @param events - Array of economic events to filter.
+ * @param symbol - The ticker symbol to filter by (case-insensitive).
+ * @returns Events related to the specified symbol.
+ */
+export function filterEventsBySymbol(
+  events: readonly EconomicEvent[],
+  symbol: string,
+): readonly EconomicEvent[] {
+  const upper = symbol.toUpperCase();
+  return events.filter((e) => e.symbol?.toUpperCase() === upper);
+}
+
+// ---------------------------------------------------------------------------
+// Upcoming events query
+// ---------------------------------------------------------------------------
+
+/**
+ * Get upcoming events from a reference date, limited by count.
+ *
+ * @param events - Array of economic events.
+ * @param referenceDate - The reference date (ISO 8601, YYYY-MM-DD). Events on or after this date are included.
+ * @param limit - Maximum number of events to return (default: 10).
+ * @returns Up to `limit` upcoming events sorted by date ascending.
+ */
+export function getUpcomingEvents(
+  events: readonly EconomicEvent[],
+  referenceDate: string,
+  limit: number = 10,
+): readonly EconomicEvent[] {
+  return events
+    .filter((e) => e.date >= referenceDate)
+    .sort((a, b) => a.date.localeCompare(b.date))
+    .slice(0, limit);
+}
+
+// ---------------------------------------------------------------------------
+// Combined filtering
+// ---------------------------------------------------------------------------
+
+/**
+ * Filter events by multiple criteria simultaneously.
+ *
+ * All specified criteria must be satisfied (AND logic).
+ * Omitted criteria are ignored.
+ *
+ * @param events - Array of economic events.
+ * @param criteria - Filter criteria object.
+ * @returns Filtered events sorted by date ascending.
+ */
+export function filterEvents(
+  events: readonly EconomicEvent[],
+  criteria: {
+    readonly startDate?: string;
+    readonly endDate?: string;
+    readonly types?: readonly EconomicEventType[];
+    readonly symbol?: string;
+  },
+): readonly EconomicEvent[] {
+  let result = [...events];
+
+  if (criteria.startDate) {
+    result = result.filter((e) => e.date >= criteria.startDate!);
+  }
+
+  if (criteria.endDate) {
+    result = result.filter((e) => e.date <= criteria.endDate!);
+  }
+
+  if (criteria.types && criteria.types.length > 0) {
+    const typeSet = new Set(criteria.types);
+    result = result.filter((e) => typeSet.has(e.type));
+  }
+
+  if (criteria.symbol) {
+    const upper = criteria.symbol.toUpperCase();
+    result = result.filter((e) => e.symbol?.toUpperCase() === upper);
+  }
+
+  result.sort((a, b) => a.date.localeCompare(b.date));
+
+  return result;
+}

--- a/apps/web/src/lib/sector-analysis/concentration.ts
+++ b/apps/web/src/lib/sector-analysis/concentration.ts
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Portfolio concentration analysis engine.
+ *
+ * Computes the Herfindahl-Hirschman Index (HHI), top-N concentration,
+ * and sector weight comparisons against a benchmark.
+ *
+ * All monetary values are integer cents. Percentages are 0–100.
+ * Uses Banker's rounding (HALF_EVEN) for financial divisions.
+ *
+ * References: issue #1603
+ */
+
+import {
+  ConcentrationLevel,
+  type ConcentrationResult,
+  type GicsSector,
+  type HoldingExposure,
+  type SectorWeight,
+  type TopHolding,
+} from './types';
+
+// ---------------------------------------------------------------------------
+// Banker's rounding helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Round a number using Banker's rounding (round half to even).
+ *
+ * @param value - The value to round.
+ * @param decimals - Number of decimal places (default: 2).
+ * @returns The rounded value.
+ */
+export function bankersRound(value: number, decimals: number = 2): number {
+  const factor = Math.pow(10, decimals);
+  const shifted = value * factor;
+  const floored = Math.floor(shifted);
+  const diff = shifted - floored;
+
+  if (Math.abs(diff - 0.5) < 1e-10) {
+    // Exactly 0.5 — round to even
+    return floored % 2 === 0 ? floored / factor : (floored + 1) / factor;
+  }
+  return Math.round(shifted) / factor;
+}
+
+// ---------------------------------------------------------------------------
+// HHI Calculation
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify the concentration level based on HHI value.
+ *
+ * @param hhi - Herfindahl-Hirschman Index value (0–10000).
+ * @returns The concentration level category.
+ */
+export function classifyConcentration(hhi: number): ConcentrationLevel {
+  if (hhi > 2500) return ConcentrationLevel.HIGH;
+  if (hhi >= 1500) return ConcentrationLevel.MODERATE;
+  return ConcentrationLevel.LOW;
+}
+
+/**
+ * Calculate the Herfindahl-Hirschman Index (HHI) for a set of holdings.
+ *
+ * HHI = Σ(weight_i²) where each weight is a percentage 0–100.
+ * Result ranges from near 0 (perfectly diversified) to 10000 (single holding).
+ *
+ * @param holdings - Array of holdings with market values in cents.
+ * @returns HHI value rounded to 2 decimal places using Banker's rounding.
+ */
+export function calculateHHI(holdings: readonly { readonly marketValue: number }[]): number {
+  if (holdings.length === 0) return 0;
+
+  const totalValue = holdings.reduce((sum, h) => sum + h.marketValue, 0);
+  if (totalValue === 0) return 0;
+
+  const hhi = holdings.reduce((sum, h) => {
+    const weight = (h.marketValue / totalValue) * 100;
+    return sum + weight * weight;
+  }, 0);
+
+  return bankersRound(hhi, 2);
+}
+
+// ---------------------------------------------------------------------------
+// Top-N Concentration
+// ---------------------------------------------------------------------------
+
+/**
+ * Get the top-N holdings by portfolio weight with cumulative percentage.
+ *
+ * @param holdings - Array of holding exposures.
+ * @param n - Number of top holdings to return (default: 10).
+ * @returns Object with top holdings and their cumulative weight.
+ */
+export function getTopNHoldings(
+  holdings: readonly HoldingExposure[],
+  n: number = 10,
+): { topHoldings: readonly TopHolding[]; topNPercent: number } {
+  if (holdings.length === 0) {
+    return { topHoldings: [], topNPercent: 0 };
+  }
+
+  const sorted = [...holdings].sort((a, b) => b.marketValue - a.marketValue);
+  const top = sorted.slice(0, n);
+
+  const totalValue = holdings.reduce((sum, h) => sum + h.marketValue, 0);
+
+  const topHoldings: TopHolding[] = top.map((h) => ({
+    symbol: h.symbol,
+    name: h.name,
+    marketValue: h.marketValue,
+    weightPercent: totalValue > 0 ? bankersRound((h.marketValue / totalValue) * 100, 2) : 0,
+  }));
+
+  const topValue = top.reduce((sum, h) => sum + h.marketValue, 0);
+  const topNPercent = totalValue > 0 ? bankersRound((topValue / totalValue) * 100, 2) : 0;
+
+  return { topHoldings, topNPercent };
+}
+
+// ---------------------------------------------------------------------------
+// Full Concentration Analysis
+// ---------------------------------------------------------------------------
+
+/**
+ * Perform a full concentration analysis on a portfolio.
+ *
+ * Computes HHI, classifies concentration level, and identifies top-N holdings.
+ *
+ * @param holdings - Array of holding exposures.
+ * @param topN - Number of top holdings to include (default: 10).
+ * @returns Complete concentration analysis result.
+ */
+export function analyzeConcentration(
+  holdings: readonly HoldingExposure[],
+  topN: number = 10,
+): ConcentrationResult {
+  const hhi = calculateHHI(holdings);
+  const level = classifyConcentration(hhi);
+  const { topHoldings, topNPercent } = getTopNHoldings(holdings, topN);
+
+  return {
+    hhi,
+    level,
+    topHoldings,
+    topNPercent,
+    totalHoldings: holdings.length,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Sector Weight Comparison
+// ---------------------------------------------------------------------------
+
+/**
+ * Compare portfolio sector weights against a benchmark.
+ *
+ * @param holdings - Portfolio holdings with sector assignments.
+ * @param benchmark - Benchmark sector weights as a map of sector to percentage (0–100).
+ * @returns Array of sector weight comparisons sorted by absolute deviation (descending).
+ */
+export function compareSectorWeights(
+  holdings: readonly HoldingExposure[],
+  benchmark: Readonly<Partial<Record<GicsSector, number>>>,
+): readonly SectorWeight[] {
+  const totalValue = holdings.reduce((sum, h) => sum + h.marketValue, 0);
+
+  // Aggregate portfolio weights by sector
+  const sectorValues = new Map<GicsSector, number>();
+  for (const h of holdings) {
+    const current = sectorValues.get(h.sector) ?? 0;
+    sectorValues.set(h.sector, current + h.marketValue);
+  }
+
+  // Collect all sectors from both portfolio and benchmark
+  const allSectors = new Set<GicsSector>([
+    ...sectorValues.keys(),
+    ...(Object.keys(benchmark) as GicsSector[]),
+  ]);
+
+  const results: SectorWeight[] = [];
+
+  for (const sector of allSectors) {
+    const sectorValue = sectorValues.get(sector) ?? 0;
+    const portfolioPercent = totalValue > 0 ? bankersRound((sectorValue / totalValue) * 100, 2) : 0;
+    const benchmarkPercent = benchmark[sector] ?? 0;
+    const deviationPercent = bankersRound(portfolioPercent - benchmarkPercent, 2);
+
+    results.push({
+      sector,
+      portfolioPercent,
+      benchmarkPercent,
+      deviationPercent,
+    });
+  }
+
+  // Sort by absolute deviation descending
+  results.sort((a, b) => Math.abs(b.deviationPercent) - Math.abs(a.deviationPercent));
+
+  return results;
+}

--- a/apps/web/src/lib/sector-analysis/index.ts
+++ b/apps/web/src/lib/sector-analysis/index.ts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Public API for the sector exposure analysis and investment research engines.
+ *
+ * Re-exports concentration, style-box, overlap, screener, calendar,
+ * and scoring modules.
+ *
+ * References: issues #1603, #1740
+ */
+
+// --- Types ---
+export {
+  GicsSector,
+  GICS_SECTOR_LABELS,
+  MarketCapSize,
+  InvestmentStyle,
+  ConcentrationLevel,
+  FilterOperator,
+  SortDirection,
+  EconomicEventType,
+  AnalystRating,
+  ANALYST_RATING_WEIGHTS,
+} from './types';
+export type {
+  StyleBoxCell,
+  StyleBoxPosition,
+  StyleBoxAggregate,
+  HoldingExposure,
+  SectorWeight,
+  ConcentrationResult,
+  TopHolding,
+  OverlapAnalysis,
+  PortfolioHolding,
+  NumericFilter,
+  ScreenerFilters,
+  ScreenerSort,
+  ScreenableAsset,
+  EconomicEvent,
+  AnalystOpinion,
+  ConsensusResult,
+} from './types';
+
+// --- Concentration ---
+export {
+  bankersRound,
+  classifyConcentration,
+  calculateHHI,
+  getTopNHoldings,
+  analyzeConcentration,
+  compareSectorWeights,
+} from './concentration';
+
+// --- Style Box ---
+export {
+  classifyMarketCap,
+  classifyStyle,
+  classifyHolding,
+  styleBoxKey,
+  getAllStyleBoxCells,
+  aggregateStyleBox,
+} from './style-box';
+
+// --- Overlap ---
+export { analyzeOverlap } from './overlap';
+
+// --- Screener ---
+export {
+  evaluateNumericFilter,
+  matchesFilters,
+  screenAssets,
+  sortAssets,
+  rankAssets,
+} from './screener';
+
+// --- Calendar ---
+export {
+  filterEventsByDateRange,
+  filterEventsByType,
+  filterEventsBySymbol,
+  getUpcomingEvents,
+  filterEvents,
+} from './calendar';
+
+// --- Scoring ---
+export {
+  deriveRating,
+  computeWeightedScore,
+  countRatings,
+  computeAverageTargetPrice,
+  computeTargetUpside,
+  analyzeConsensus,
+} from './scoring';

--- a/apps/web/src/lib/sector-analysis/overlap.ts
+++ b/apps/web/src/lib/sector-analysis/overlap.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Portfolio overlap detection engine.
+ *
+ * Compares two portfolios to find shared holdings, compute overlap percentages,
+ * and estimate weight-based correlation.
+ *
+ * All monetary values are integer cents.
+ * Uses Banker's rounding (HALF_EVEN) for financial divisions.
+ *
+ * References: issue #1603
+ */
+
+import { bankersRound } from './concentration';
+import type { OverlapAnalysis, PortfolioHolding } from './types';
+
+// ---------------------------------------------------------------------------
+// Overlap Analysis
+// ---------------------------------------------------------------------------
+
+/**
+ * Analyze the overlap between two portfolios.
+ *
+ * Overlap is measured as the percentage of each portfolio's value
+ * that is invested in shared holdings (by symbol). A correlation
+ * estimate is derived from the minimum-weight overlap method.
+ *
+ * @param portfolioA - Holdings in the first portfolio.
+ * @param portfolioB - Holdings in the second portfolio.
+ * @returns Overlap analysis result with shared holdings and correlation estimate.
+ */
+export function analyzeOverlap(
+  portfolioA: readonly PortfolioHolding[],
+  portfolioB: readonly PortfolioHolding[],
+): OverlapAnalysis {
+  if (portfolioA.length === 0 && portfolioB.length === 0) {
+    return {
+      overlapPercentA: 0,
+      overlapPercentB: 0,
+      overlapPercentAvg: 0,
+      sharedSymbols: [],
+      uniqueToA: 0,
+      uniqueToB: 0,
+      correlationEstimate: 0,
+    };
+  }
+
+  // Build lookup maps by symbol
+  const mapA = new Map<string, number>();
+  for (const h of portfolioA) {
+    mapA.set(h.symbol, (mapA.get(h.symbol) ?? 0) + h.marketValue);
+  }
+
+  const mapB = new Map<string, number>();
+  for (const h of portfolioB) {
+    mapB.set(h.symbol, (mapB.get(h.symbol) ?? 0) + h.marketValue);
+  }
+
+  // Find shared symbols
+  const sharedSymbols: string[] = [];
+  for (const symbol of mapA.keys()) {
+    if (mapB.has(symbol)) {
+      sharedSymbols.push(symbol);
+    }
+  }
+  sharedSymbols.sort();
+
+  // Calculate total values
+  const totalA = portfolioA.reduce((sum, h) => sum + h.marketValue, 0);
+  const totalB = portfolioB.reduce((sum, h) => sum + h.marketValue, 0);
+
+  // Calculate shared value in each portfolio
+  let sharedValueA = 0;
+  let sharedValueB = 0;
+  for (const symbol of sharedSymbols) {
+    sharedValueA += mapA.get(symbol) ?? 0;
+    sharedValueB += mapB.get(symbol) ?? 0;
+  }
+
+  const overlapPercentA = totalA > 0 ? bankersRound((sharedValueA / totalA) * 100, 2) : 0;
+  const overlapPercentB = totalB > 0 ? bankersRound((sharedValueB / totalB) * 100, 2) : 0;
+  const overlapPercentAvg = bankersRound((overlapPercentA + overlapPercentB) / 2, 2);
+
+  // Unique holdings
+  const uniqueToA = mapA.size - sharedSymbols.length;
+  const uniqueToB = mapB.size - sharedSymbols.length;
+
+  // Correlation estimate using minimum-weight overlap
+  const correlationEstimate = estimateCorrelation(mapA, mapB, totalA, totalB);
+
+  return {
+    overlapPercentA,
+    overlapPercentB,
+    overlapPercentAvg,
+    sharedSymbols,
+    uniqueToA,
+    uniqueToB,
+    correlationEstimate,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Correlation Estimation
+// ---------------------------------------------------------------------------
+
+/**
+ * Estimate correlation between two portfolios using the minimum-weight method.
+ *
+ * For each shared symbol, takes the minimum of the two portfolio weights.
+ * The sum of these minimums is used as a correlation proxy (0–1).
+ * When no holdings are shared, correlation is 0.
+ *
+ * @param mapA - Symbol-to-value map for portfolio A.
+ * @param mapB - Symbol-to-value map for portfolio B.
+ * @param totalA - Total value of portfolio A in cents.
+ * @param totalB - Total value of portfolio B in cents.
+ * @returns Estimated correlation coefficient (0–1).
+ */
+function estimateCorrelation(
+  mapA: ReadonlyMap<string, number>,
+  mapB: ReadonlyMap<string, number>,
+  totalA: number,
+  totalB: number,
+): number {
+  if (totalA === 0 || totalB === 0) return 0;
+
+  let minWeightSum = 0;
+
+  for (const [symbol, valueA] of mapA) {
+    const valueB = mapB.get(symbol);
+    if (valueB !== undefined) {
+      const weightA = valueA / totalA;
+      const weightB = valueB / totalB;
+      minWeightSum += Math.min(weightA, weightB);
+    }
+  }
+
+  return bankersRound(Math.min(minWeightSum, 1), 4);
+}

--- a/apps/web/src/lib/sector-analysis/scoring.ts
+++ b/apps/web/src/lib/sector-analysis/scoring.ts
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Analyst consensus scoring engine.
+ *
+ * Aggregates analyst opinions into a weighted consensus score,
+ * compares target prices against current prices, and derives
+ * a consensus rating.
+ *
+ * All monetary values are integer cents.
+ * Uses Banker's rounding (HALF_EVEN) for financial divisions.
+ *
+ * References: issue #1740
+ */
+
+import { bankersRound } from './concentration';
+import {
+  ANALYST_RATING_WEIGHTS,
+  AnalystRating,
+  type AnalystOpinion,
+  type ConsensusResult,
+} from './types';
+
+// ---------------------------------------------------------------------------
+// Consensus scoring
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive a consensus rating from a weighted average score.
+ *
+ * Maps the 1–5 scale back to an AnalystRating enum:
+ * - 4.5–5.0 → STRONG_BUY
+ * - 3.5–4.5 → BUY
+ * - 2.5–3.5 → HOLD
+ * - 1.5–2.5 → SELL
+ * - 1.0–1.5 → STRONG_SELL
+ *
+ * @param score - Weighted average score (1–5).
+ * @returns The corresponding analyst rating.
+ */
+export function deriveRating(score: number): AnalystRating {
+  if (score >= 4.5) return AnalystRating.STRONG_BUY;
+  if (score >= 3.5) return AnalystRating.BUY;
+  if (score >= 2.5) return AnalystRating.HOLD;
+  if (score >= 1.5) return AnalystRating.SELL;
+  return AnalystRating.STRONG_SELL;
+}
+
+/**
+ * Compute a weighted consensus score from analyst opinions.
+ *
+ * Each rating maps to a numeric weight (STRONG_BUY=5, BUY=4, HOLD=3,
+ * SELL=2, STRONG_SELL=1). The score is the simple average of these weights.
+ *
+ * @param opinions - Array of analyst opinions.
+ * @returns Weighted average score (1–5), or 0 if no opinions.
+ */
+export function computeWeightedScore(opinions: readonly AnalystOpinion[]): number {
+  if (opinions.length === 0) return 0;
+
+  const totalWeight = opinions.reduce((sum, o) => sum + ANALYST_RATING_WEIGHTS[o.rating], 0);
+  return bankersRound(totalWeight / opinions.length, 2);
+}
+
+// ---------------------------------------------------------------------------
+// Rating counts
+// ---------------------------------------------------------------------------
+
+/**
+ * Count the number of opinions for each rating type.
+ *
+ * @param opinions - Array of analyst opinions.
+ * @returns A record mapping each rating to its count.
+ */
+export function countRatings(opinions: readonly AnalystOpinion[]): Record<AnalystRating, number> {
+  const counts: Record<AnalystRating, number> = {
+    [AnalystRating.STRONG_BUY]: 0,
+    [AnalystRating.BUY]: 0,
+    [AnalystRating.HOLD]: 0,
+    [AnalystRating.SELL]: 0,
+    [AnalystRating.STRONG_SELL]: 0,
+  };
+
+  for (const o of opinions) {
+    counts[o.rating]++;
+  }
+
+  return counts;
+}
+
+// ---------------------------------------------------------------------------
+// Target price analysis
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the average target price from analyst opinions.
+ *
+ * Only opinions with non-null target prices are included.
+ * Uses Banker's rounding to the nearest cent.
+ *
+ * @param opinions - Array of analyst opinions.
+ * @returns Average target price in cents, or null if no targets are available.
+ */
+export function computeAverageTargetPrice(opinions: readonly AnalystOpinion[]): number | null {
+  const withTargets = opinions.filter((o) => o.targetPrice !== null);
+  if (withTargets.length === 0) return null;
+
+  const total = withTargets.reduce((sum, o) => sum + o.targetPrice!, 0);
+  return Math.round(total / withTargets.length);
+}
+
+/**
+ * Compute the upside/downside percentage of a target price vs current price.
+ *
+ * @param targetPrice - Target price in cents.
+ * @param currentPrice - Current price in cents.
+ * @returns Upside percentage (positive = upside, negative = downside), or null if current price is 0.
+ */
+export function computeTargetUpside(targetPrice: number, currentPrice: number): number | null {
+  if (currentPrice === 0) return null;
+  return bankersRound(((targetPrice - currentPrice) / currentPrice) * 100, 2);
+}
+
+// ---------------------------------------------------------------------------
+// Full consensus analysis
+// ---------------------------------------------------------------------------
+
+/**
+ * Perform a full analyst consensus analysis for a security.
+ *
+ * Aggregates opinions into a weighted score, derives a consensus rating,
+ * computes average target price, and calculates upside/downside.
+ *
+ * @param symbol - The ticker symbol.
+ * @param opinions - Array of analyst opinions.
+ * @param currentPrice - Current market price in cents.
+ * @returns Complete consensus analysis result.
+ */
+export function analyzeConsensus(
+  symbol: string,
+  opinions: readonly AnalystOpinion[],
+  currentPrice: number,
+): ConsensusResult {
+  const weightedScore = computeWeightedScore(opinions);
+  const consensusRating = opinions.length > 0 ? deriveRating(weightedScore) : AnalystRating.HOLD;
+  const ratingCounts = countRatings(opinions);
+  const averageTargetPrice = computeAverageTargetPrice(opinions);
+
+  const targetUpsidePercent =
+    averageTargetPrice !== null ? computeTargetUpside(averageTargetPrice, currentPrice) : null;
+
+  return {
+    symbol,
+    totalAnalysts: opinions.length,
+    weightedScore,
+    consensusRating,
+    ratingCounts,
+    averageTargetPrice,
+    currentPrice,
+    targetUpsidePercent,
+  };
+}

--- a/apps/web/src/lib/sector-analysis/screener.ts
+++ b/apps/web/src/lib/sector-analysis/screener.ts
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Investment screener filter evaluation engine.
+ *
+ * Provides filter matching, multi-filter AND logic, and sort/rank functions
+ * for screening securities by fundamental data.
+ *
+ * All monetary values are integer cents.
+ *
+ * References: issue #1740
+ */
+
+import { styleBoxKey } from './style-box';
+import {
+  FilterOperator,
+  type NumericFilter,
+  type ScreenableAsset,
+  type ScreenerFilters,
+  type ScreenerSort,
+  SortDirection,
+} from './types';
+
+// ---------------------------------------------------------------------------
+// Numeric filter evaluation
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate a numeric filter against a value.
+ *
+ * @param value - The value to test. Null values always fail the filter.
+ * @param filter - The numeric filter criteria.
+ * @returns True if the value passes the filter.
+ */
+export function evaluateNumericFilter(value: number | null, filter: NumericFilter): boolean {
+  if (value === null) return false;
+
+  switch (filter.operator) {
+    case FilterOperator.EQ:
+      return value === filter.value;
+    case FilterOperator.NEQ:
+      return value !== filter.value;
+    case FilterOperator.GT:
+      return value > filter.value;
+    case FilterOperator.GTE:
+      return value >= filter.value;
+    case FilterOperator.LT:
+      return value < filter.value;
+    case FilterOperator.LTE:
+      return value <= filter.value;
+    case FilterOperator.BETWEEN:
+      return value >= filter.value && value <= (filter.valueTo ?? filter.value);
+    default:
+      return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Asset filter matching
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether a single asset matches all screener filters (AND logic).
+ *
+ * All specified filters must pass for the asset to match.
+ * Unspecified filters are treated as passing.
+ *
+ * @param asset - The screenable asset to evaluate.
+ * @param filters - The screener filter criteria.
+ * @returns True if the asset passes all filters.
+ */
+export function matchesFilters(asset: ScreenableAsset, filters: ScreenerFilters): boolean {
+  // P/E ratio filter
+  if (filters.peRatio && !evaluateNumericFilter(asset.peRatio, filters.peRatio)) {
+    return false;
+  }
+
+  // Market cap filter
+  if (filters.marketCap && !evaluateNumericFilter(asset.marketCap, filters.marketCap)) {
+    return false;
+  }
+
+  // Dividend yield filter
+  if (filters.dividendYield && !evaluateNumericFilter(asset.dividendYield, filters.dividendYield)) {
+    return false;
+  }
+
+  // Sector inclusion filter
+  if (filters.sectors && filters.sectors.length > 0) {
+    if (!filters.sectors.includes(asset.sector)) {
+      return false;
+    }
+  }
+
+  // Style box inclusion filter
+  if (filters.styles && filters.styles.length > 0) {
+    const assetKey = styleBoxKey(asset.styleBox);
+    const matchesStyle = filters.styles.some((s) => styleBoxKey(s) === assetKey);
+    if (!matchesStyle) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Screen (filter + sort)
+// ---------------------------------------------------------------------------
+
+/**
+ * Screen a list of assets using the given filters and optional sort.
+ *
+ * Applies all filters with AND logic, then sorts the results.
+ *
+ * @param assets - Array of screenable assets.
+ * @param filters - Filter criteria to apply.
+ * @param sort - Optional sort specification.
+ * @returns Filtered and sorted array of matching assets.
+ */
+export function screenAssets(
+  assets: readonly ScreenableAsset[],
+  filters: ScreenerFilters,
+  sort?: ScreenerSort,
+): readonly ScreenableAsset[] {
+  const filtered = assets.filter((a) => matchesFilters(a, filters));
+
+  if (!sort) return filtered;
+
+  return sortAssets(filtered, sort);
+}
+
+// ---------------------------------------------------------------------------
+// Sort / Rank
+// ---------------------------------------------------------------------------
+
+/**
+ * Get a comparable numeric value from an asset by field name.
+ *
+ * @param asset - The asset to extract a value from.
+ * @param field - The field name to extract.
+ * @returns The numeric value, or null if not applicable.
+ */
+function getFieldValue(asset: ScreenableAsset, field: string): number | null {
+  switch (field) {
+    case 'peRatio':
+      return asset.peRatio;
+    case 'marketCap':
+      return asset.marketCap;
+    case 'dividendYield':
+      return asset.dividendYield;
+    case 'symbol':
+      return null; // handled separately for string sort
+    case 'name':
+      return null; // handled separately for string sort
+    default:
+      return null;
+  }
+}
+
+/**
+ * Get a comparable string value from an asset by field name.
+ *
+ * @param asset - The asset to extract a value from.
+ * @param field - The field name to extract.
+ * @returns The string value.
+ */
+function getStringFieldValue(asset: ScreenableAsset, field: string): string {
+  switch (field) {
+    case 'symbol':
+      return asset.symbol;
+    case 'name':
+      return asset.name;
+    case 'sector':
+      return asset.sector;
+    default:
+      return '';
+  }
+}
+
+/**
+ * Sort an array of assets by a given field and direction.
+ *
+ * Null values are sorted to the end regardless of direction.
+ *
+ * @param assets - Array of assets to sort.
+ * @param sort - Sort field and direction.
+ * @returns New sorted array (does not mutate input).
+ */
+export function sortAssets(
+  assets: readonly ScreenableAsset[],
+  sort: ScreenerSort,
+): readonly ScreenableAsset[] {
+  const { field, direction } = sort;
+  const isStringField = field === 'symbol' || field === 'name' || field === 'sector';
+  const multiplier = direction === SortDirection.ASC ? 1 : -1;
+
+  return [...assets].sort((a, b) => {
+    if (isStringField) {
+      const valA = getStringFieldValue(a, field);
+      const valB = getStringFieldValue(b, field);
+      return multiplier * valA.localeCompare(valB);
+    }
+
+    const valA = getFieldValue(a, field);
+    const valB = getFieldValue(b, field);
+
+    // Nulls go to end
+    if (valA === null && valB === null) return 0;
+    if (valA === null) return 1;
+    if (valB === null) return -1;
+
+    return multiplier * (valA - valB);
+  });
+}
+
+/**
+ * Rank assets by a numeric field, returning them sorted with rank indices.
+ *
+ * @param assets - Array of assets to rank.
+ * @param field - The numeric field to rank by.
+ * @param direction - Sort direction (DESC = highest first, ASC = lowest first).
+ * @returns Array of objects with asset and rank (1-based).
+ */
+export function rankAssets(
+  assets: readonly ScreenableAsset[],
+  field: string,
+  direction: SortDirection = SortDirection.DESC,
+): readonly { readonly asset: ScreenableAsset; readonly rank: number }[] {
+  const sorted = sortAssets(assets, { field, direction });
+  return sorted.map((asset, index) => ({ asset, rank: index + 1 }));
+}

--- a/apps/web/src/lib/sector-analysis/style-box.ts
+++ b/apps/web/src/lib/sector-analysis/style-box.ts
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Morningstar-style 3×3 style box classification engine.
+ *
+ * Classifies holdings into a 3×3 grid of market-cap size (small/mid/large)
+ * and investment style (value/blend/growth). Aggregates portfolio-level
+ * style characteristics.
+ *
+ * All monetary values are integer cents.
+ * Uses Banker's rounding (HALF_EVEN) for financial divisions.
+ *
+ * References: issue #1603
+ */
+
+import { bankersRound } from './concentration';
+import {
+  InvestmentStyle,
+  MarketCapSize,
+  type StyleBoxAggregate,
+  type StyleBoxCell,
+  type StyleBoxPosition,
+} from './types';
+
+// ---------------------------------------------------------------------------
+// Classification thresholds
+// ---------------------------------------------------------------------------
+
+/** Market cap thresholds in cents. */
+const SMALL_CAP_MAX = 200_000_000_00; // $2B in cents
+const LARGE_CAP_MIN = 1_000_000_000_00; // $10B in cents
+
+/** P/E ratio thresholds for style classification. */
+const VALUE_PE_MAX = 15;
+const GROWTH_PE_MIN = 25;
+
+// ---------------------------------------------------------------------------
+// Classification functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify market-cap size based on market capitalization.
+ *
+ * @param marketCap - Market capitalization in cents.
+ * @returns The market-cap size classification.
+ */
+export function classifyMarketCap(marketCap: number): MarketCapSize {
+  if (marketCap <= SMALL_CAP_MAX) return MarketCapSize.SMALL;
+  if (marketCap >= LARGE_CAP_MIN) return MarketCapSize.LARGE;
+  return MarketCapSize.MID;
+}
+
+/**
+ * Classify investment style based on P/E ratio.
+ *
+ * @param peRatio - Price-to-earnings ratio. Null treated as BLEND.
+ * @returns The investment style classification.
+ */
+export function classifyStyle(peRatio: number | null): InvestmentStyle {
+  if (peRatio === null) return InvestmentStyle.BLEND;
+  if (peRatio <= VALUE_PE_MAX) return InvestmentStyle.VALUE;
+  if (peRatio >= GROWTH_PE_MIN) return InvestmentStyle.GROWTH;
+  return InvestmentStyle.BLEND;
+}
+
+/**
+ * Classify a single holding into a style box cell.
+ *
+ * @param marketCap - Market capitalization in cents.
+ * @param peRatio - Price-to-earnings ratio. Null defaults to BLEND style.
+ * @returns The style box cell for this holding.
+ */
+export function classifyHolding(marketCap: number, peRatio: number | null): StyleBoxCell {
+  return {
+    size: classifyMarketCap(marketCap),
+    style: classifyStyle(peRatio),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Style box key helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a unique string key for a style box cell.
+ *
+ * @param cell - The style box cell.
+ * @returns A string key like "LARGE_GROWTH".
+ */
+export function styleBoxKey(cell: StyleBoxCell): string {
+  return `${cell.size}_${cell.style}`;
+}
+
+/**
+ * Get all 9 cells of the 3×3 style box grid.
+ *
+ * @returns Array of all style box cells in row-major order
+ *          (Large-Value through Small-Growth).
+ */
+export function getAllStyleBoxCells(): readonly StyleBoxCell[] {
+  const sizes = [MarketCapSize.LARGE, MarketCapSize.MID, MarketCapSize.SMALL] as const;
+  const styles = [InvestmentStyle.VALUE, InvestmentStyle.BLEND, InvestmentStyle.GROWTH] as const;
+
+  const cells: StyleBoxCell[] = [];
+  for (const size of sizes) {
+    for (const style of styles) {
+      cells.push({ size, style });
+    }
+  }
+  return cells;
+}
+
+// ---------------------------------------------------------------------------
+// Portfolio-level aggregate
+// ---------------------------------------------------------------------------
+
+/**
+ * Aggregate style box positions into a portfolio-level style box summary.
+ *
+ * @param positions - Array of holdings with their style box positions and market values.
+ * @returns Aggregate style box with weights per cell and dominant style.
+ */
+export function aggregateStyleBox(positions: readonly StyleBoxPosition[]): StyleBoxAggregate {
+  if (positions.length === 0) {
+    const defaultCell: StyleBoxCell = {
+      size: MarketCapSize.LARGE,
+      style: InvestmentStyle.BLEND,
+    };
+    return {
+      weights: getAllStyleBoxCells().map((cell) => ({ cell, percent: 0 })),
+      dominant: defaultCell,
+      totalClassifiedValue: 0,
+    };
+  }
+
+  const totalValue = positions.reduce((sum, p) => sum + p.marketValue, 0);
+
+  // Accumulate values by cell
+  const cellValues = new Map<string, number>();
+  const cellMap = new Map<string, StyleBoxCell>();
+
+  for (const pos of positions) {
+    const key = styleBoxKey(pos.cell);
+    cellValues.set(key, (cellValues.get(key) ?? 0) + pos.marketValue);
+    cellMap.set(key, pos.cell);
+  }
+
+  // Ensure all 9 cells are represented
+  const allCells = getAllStyleBoxCells();
+  for (const cell of allCells) {
+    const key = styleBoxKey(cell);
+    if (!cellValues.has(key)) {
+      cellValues.set(key, 0);
+      cellMap.set(key, cell);
+    }
+  }
+
+  // Build weights array
+  const weights = allCells.map((cell) => {
+    const key = styleBoxKey(cell);
+    const value = cellValues.get(key) ?? 0;
+    const percent = totalValue > 0 ? bankersRound((value / totalValue) * 100, 2) : 0;
+    return { cell, percent };
+  });
+
+  // Find dominant cell
+  let maxPercent = -1;
+  let dominant: StyleBoxCell = allCells[0];
+  for (const w of weights) {
+    if (w.percent > maxPercent) {
+      maxPercent = w.percent;
+      dominant = w.cell;
+    }
+  }
+
+  return {
+    weights,
+    dominant,
+    totalClassifiedValue: totalValue,
+  };
+}

--- a/apps/web/src/lib/sector-analysis/types.ts
+++ b/apps/web/src/lib/sector-analysis/types.ts
@@ -1,0 +1,367 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Sector exposure analysis types and enums.
+ *
+ * Defines GICS sector classifications, Morningstar-style box dimensions,
+ * holding exposure data, concentration results, and overlap analysis types.
+ *
+ * All monetary values are in integer cents to avoid floating-point errors.
+ *
+ * References: issues #1603, #1740
+ */
+
+// ---------------------------------------------------------------------------
+// GICS Sector Classification
+// ---------------------------------------------------------------------------
+
+/**
+ * Global Industry Classification Standard (GICS) sectors.
+ * The 11 top-level sectors used for portfolio exposure analysis.
+ */
+export enum GicsSector {
+  ENERGY = 'ENERGY',
+  MATERIALS = 'MATERIALS',
+  INDUSTRIALS = 'INDUSTRIALS',
+  CONSUMER_DISCRETIONARY = 'CONSUMER_DISCRETIONARY',
+  CONSUMER_STAPLES = 'CONSUMER_STAPLES',
+  HEALTH_CARE = 'HEALTH_CARE',
+  FINANCIALS = 'FINANCIALS',
+  INFORMATION_TECHNOLOGY = 'INFORMATION_TECHNOLOGY',
+  COMMUNICATION_SERVICES = 'COMMUNICATION_SERVICES',
+  UTILITIES = 'UTILITIES',
+  REAL_ESTATE = 'REAL_ESTATE',
+}
+
+/** Human-readable labels for each GICS sector. */
+export const GICS_SECTOR_LABELS: Readonly<Record<GicsSector, string>> = {
+  [GicsSector.ENERGY]: 'Energy',
+  [GicsSector.MATERIALS]: 'Materials',
+  [GicsSector.INDUSTRIALS]: 'Industrials',
+  [GicsSector.CONSUMER_DISCRETIONARY]: 'Consumer Discretionary',
+  [GicsSector.CONSUMER_STAPLES]: 'Consumer Staples',
+  [GicsSector.HEALTH_CARE]: 'Health Care',
+  [GicsSector.FINANCIALS]: 'Financials',
+  [GicsSector.INFORMATION_TECHNOLOGY]: 'Information Technology',
+  [GicsSector.COMMUNICATION_SERVICES]: 'Communication Services',
+  [GicsSector.UTILITIES]: 'Utilities',
+  [GicsSector.REAL_ESTATE]: 'Real Estate',
+};
+
+// ---------------------------------------------------------------------------
+// Morningstar Style Box
+// ---------------------------------------------------------------------------
+
+/** Market-capitalization size classification. */
+export enum MarketCapSize {
+  SMALL = 'SMALL',
+  MID = 'MID',
+  LARGE = 'LARGE',
+}
+
+/** Investment style classification. */
+export enum InvestmentStyle {
+  VALUE = 'VALUE',
+  BLEND = 'BLEND',
+  GROWTH = 'GROWTH',
+}
+
+/**
+ * A single cell in the Morningstar 3×3 style box.
+ * Combines market-cap size with investment style.
+ */
+export interface StyleBoxCell {
+  readonly size: MarketCapSize;
+  readonly style: InvestmentStyle;
+}
+
+/**
+ * A holding's position within the style box, including its weight.
+ */
+export interface StyleBoxPosition {
+  readonly symbol: string;
+  readonly cell: StyleBoxCell;
+  /** Market value in cents. */
+  readonly marketValue: number;
+}
+
+/**
+ * Aggregate style box result for a portfolio.
+ * Each cell has a percentage weight (0–100, sums to 100).
+ */
+export interface StyleBoxAggregate {
+  /** Weight in each style-box cell as percentage (0–100). */
+  readonly weights: ReadonlyArray<{
+    readonly cell: StyleBoxCell;
+    readonly percent: number;
+  }>;
+  /** The dominant cell with the highest weight. */
+  readonly dominant: StyleBoxCell;
+  /** Total market value of classified holdings in cents. */
+  readonly totalClassifiedValue: number;
+}
+
+// ---------------------------------------------------------------------------
+// Holding Exposure
+// ---------------------------------------------------------------------------
+
+/**
+ * A single holding's exposure data for analysis.
+ */
+export interface HoldingExposure {
+  /** Ticker symbol. */
+  readonly symbol: string;
+  /** Display name. */
+  readonly name: string;
+  /** Market value in cents. */
+  readonly marketValue: number;
+  /** GICS sector classification. */
+  readonly sector: GicsSector;
+  /** Portfolio weight as percentage (0–100). */
+  readonly weightPercent: number;
+}
+
+/**
+ * Sector weight comparison against a benchmark.
+ */
+export interface SectorWeight {
+  readonly sector: GicsSector;
+  /** Portfolio weight as percentage (0–100). */
+  readonly portfolioPercent: number;
+  /** Benchmark weight as percentage (0–100). */
+  readonly benchmarkPercent: number;
+  /** Deviation: portfolio minus benchmark. */
+  readonly deviationPercent: number;
+}
+
+// ---------------------------------------------------------------------------
+// Concentration Analysis
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of a portfolio concentration analysis.
+ */
+export interface ConcentrationResult {
+  /**
+   * Herfindahl-Hirschman Index (0–10000).
+   * Sum of squared portfolio weights where each weight is 0–100.
+   * 10000 = single holding; lower = more diversified.
+   */
+  readonly hhi: number;
+  /** Concentration level category. */
+  readonly level: ConcentrationLevel;
+  /** Top-N holdings by weight. */
+  readonly topHoldings: readonly TopHolding[];
+  /** Cumulative weight of the top-N holdings (0–100). */
+  readonly topNPercent: number;
+  /** Total number of holdings. */
+  readonly totalHoldings: number;
+}
+
+/** Concentration level classification based on HHI. */
+export enum ConcentrationLevel {
+  /** HHI < 1500 — well-diversified. */
+  LOW = 'LOW',
+  /** HHI 1500–2500 — moderately concentrated. */
+  MODERATE = 'MODERATE',
+  /** HHI > 2500 — highly concentrated. */
+  HIGH = 'HIGH',
+}
+
+/** A holding in the top-N list with its weight. */
+export interface TopHolding {
+  readonly symbol: string;
+  readonly name: string;
+  /** Market value in cents. */
+  readonly marketValue: number;
+  /** Portfolio weight percentage (0–100). */
+  readonly weightPercent: number;
+}
+
+// ---------------------------------------------------------------------------
+// Overlap Analysis
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of an overlap analysis between two portfolios.
+ */
+export interface OverlapAnalysis {
+  /** Percentage of portfolio A's value in shared holdings (0–100). */
+  readonly overlapPercentA: number;
+  /** Percentage of portfolio B's value in shared holdings (0–100). */
+  readonly overlapPercentB: number;
+  /** Average overlap percentage across both portfolios. */
+  readonly overlapPercentAvg: number;
+  /** Symbols present in both portfolios. */
+  readonly sharedSymbols: readonly string[];
+  /** Count of unique holdings in portfolio A only. */
+  readonly uniqueToA: number;
+  /** Count of unique holdings in portfolio B only. */
+  readonly uniqueToB: number;
+  /** Estimated weight-based correlation (-1 to 1). */
+  readonly correlationEstimate: number;
+}
+
+/**
+ * A simplified portfolio holding for overlap comparison.
+ */
+export interface PortfolioHolding {
+  readonly symbol: string;
+  /** Market value in cents. */
+  readonly marketValue: number;
+}
+
+// ---------------------------------------------------------------------------
+// Screener Types
+// ---------------------------------------------------------------------------
+
+/** Comparison operator for numeric filters. */
+export enum FilterOperator {
+  EQ = 'EQ',
+  NEQ = 'NEQ',
+  GT = 'GT',
+  GTE = 'GTE',
+  LT = 'LT',
+  LTE = 'LTE',
+  BETWEEN = 'BETWEEN',
+}
+
+/** A numeric range filter (e.g., P/E ratio 10–20). */
+export interface NumericFilter {
+  readonly field: string;
+  readonly operator: FilterOperator;
+  /** Primary value for comparison. */
+  readonly value: number;
+  /** Upper bound when operator is BETWEEN. */
+  readonly valueTo?: number;
+}
+
+/** Screener filter criteria for investment screening. */
+export interface ScreenerFilters {
+  /** P/E ratio range. */
+  readonly peRatio?: NumericFilter;
+  /** Market capitalization in cents. */
+  readonly marketCap?: NumericFilter;
+  /** Dividend yield as percentage (0–100). */
+  readonly dividendYield?: NumericFilter;
+  /** Filter by GICS sectors. */
+  readonly sectors?: readonly GicsSector[];
+  /** Filter by style box classification. */
+  readonly styles?: readonly StyleBoxCell[];
+}
+
+/** Sort direction for screener results. */
+export enum SortDirection {
+  ASC = 'ASC',
+  DESC = 'DESC',
+}
+
+/** Sort specification for screener results. */
+export interface ScreenerSort {
+  readonly field: string;
+  readonly direction: SortDirection;
+}
+
+/** A screenable security with fundamental data. */
+export interface ScreenableAsset {
+  readonly symbol: string;
+  readonly name: string;
+  /** P/E ratio (price-to-earnings). Null if not applicable. */
+  readonly peRatio: number | null;
+  /** Market capitalization in cents. */
+  readonly marketCap: number;
+  /** Dividend yield as percentage (0–100). Null if none. */
+  readonly dividendYield: number | null;
+  /** GICS sector. */
+  readonly sector: GicsSector;
+  /** Style box classification. */
+  readonly styleBox: StyleBoxCell;
+}
+
+// ---------------------------------------------------------------------------
+// Economic Calendar Types
+// ---------------------------------------------------------------------------
+
+/** Type of economic/corporate event. */
+export enum EconomicEventType {
+  EARNINGS = 'EARNINGS',
+  DIVIDEND = 'DIVIDEND',
+  STOCK_SPLIT = 'STOCK_SPLIT',
+  FED_MEETING = 'FED_MEETING',
+  CPI_RELEASE = 'CPI_RELEASE',
+  JOBS_REPORT = 'JOBS_REPORT',
+  GDP_RELEASE = 'GDP_RELEASE',
+  EX_DIVIDEND = 'EX_DIVIDEND',
+  IPO = 'IPO',
+  OTHER = 'OTHER',
+}
+
+/** An event on the economic calendar. */
+export interface EconomicEvent {
+  /** Unique event identifier. */
+  readonly id: string;
+  /** Event type. */
+  readonly type: EconomicEventType;
+  /** Event title. */
+  readonly title: string;
+  /** ISO 8601 date string (YYYY-MM-DD). */
+  readonly date: string;
+  /** Related ticker symbol, if applicable. */
+  readonly symbol?: string;
+  /** Additional description or context. */
+  readonly description?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Analyst Scoring Types
+// ---------------------------------------------------------------------------
+
+/** Analyst recommendation rating. */
+export enum AnalystRating {
+  STRONG_BUY = 'STRONG_BUY',
+  BUY = 'BUY',
+  HOLD = 'HOLD',
+  SELL = 'SELL',
+  STRONG_SELL = 'STRONG_SELL',
+}
+
+/** Numeric weight for each analyst rating (higher = more bullish). */
+export const ANALYST_RATING_WEIGHTS: Readonly<Record<AnalystRating, number>> = {
+  [AnalystRating.STRONG_BUY]: 5,
+  [AnalystRating.BUY]: 4,
+  [AnalystRating.HOLD]: 3,
+  [AnalystRating.SELL]: 2,
+  [AnalystRating.STRONG_SELL]: 1,
+};
+
+/** A single analyst's opinion on a security. */
+export interface AnalystOpinion {
+  /** Analyst or firm name. */
+  readonly analyst: string;
+  /** Rating recommendation. */
+  readonly rating: AnalystRating;
+  /** Target price in cents. Null if not provided. */
+  readonly targetPrice: number | null;
+  /** Date of the opinion (ISO 8601). */
+  readonly date: string;
+}
+
+/** Aggregated consensus result for a security. */
+export interface ConsensusResult {
+  /** Ticker symbol. */
+  readonly symbol: string;
+  /** Total number of analyst opinions. */
+  readonly totalAnalysts: number;
+  /** Weighted average score (1–5 scale). */
+  readonly weightedScore: number;
+  /** Consensus rating derived from the weighted score. */
+  readonly consensusRating: AnalystRating;
+  /** Count of each rating type. */
+  readonly ratingCounts: Readonly<Record<AnalystRating, number>>;
+  /** Average target price in cents. Null if no targets available. */
+  readonly averageTargetPrice: number | null;
+  /** Current price in cents. */
+  readonly currentPrice: number;
+  /** Upside/downside percentage vs average target. Null if no targets. */
+  readonly targetUpsidePercent: number | null;
+}


### PR DESCRIPTION
## Summary
Adds pure TypeScript calculation engines for sector/style exposure analysis and investment research screening.

## Changes
- Sector concentration (HHI) and top-N analysis with Banker's rounding
- Morningstar-style 3×3 style box classification (value/blend/growth × small/mid/large)
- Portfolio overlap detection with correlation estimate
- Investment screener with filter evaluation engine (P/E, market cap, dividend yield, sector, style)
- Economic calendar event types and date-based filtering
- Analyst consensus scoring with target price comparison
- Barrel export from \index.ts\

## Architecture
- All monetary values in integer cents (never floating-point dollars)
- Banker's rounding (HALF_EVEN) for all financial divisions
- Pure functions, immutable data, no side effects, no database access
- JSDoc on every public function
- No UI components — calculation/data layer only

## Issues
Closes #1603
Closes #1740

## Testing
- 84 tests passing across 5 test files
- Edge cases: empty portfolios, single holdings (HHI=10000), zero values
- Concentration: HHI calculation, classification thresholds, top-N
- Style box: classification accuracy, aggregate portfolio style
- Overlap: identical (100%), disjoint (0%), partial overlap
- Screener: filter matching, multi-filter AND logic, sort/rank, null handling
- Scoring: consensus aggregation, target price comparison, rating derivation