### PR TITLE
feat(web): banking connection abstraction layer (#1853)

### DIFF
--- a/apps/web/src/lib/banking/__tests__/connection-manager.test.ts
+++ b/apps/web/src/lib/banking/__tests__/connection-manager.test.ts
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ConnectionManager, categorizeError } from '../connection-manager';
+import { ProviderRegistry } from '../provider-registry';
+import type { BankConnectionProvider, ProviderFeatures, RefreshResult } from '../types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const noopFeatures: ProviderFeatures = {
+  realTimeBalance: false,
+  transactionWebhooks: false,
+  investmentAccounts: false,
+  creditCards: false,
+  loans: false,
+  bnpl: false,
+  crypto: false,
+  internationalBanks: false,
+};
+
+function stubProvider(
+  overrides: Partial<BankConnectionProvider> & { id: string },
+): BankConnectionProvider {
+  return {
+    name: overrides.id,
+    supportedCountries: [],
+    features: noopFeatures,
+    initializeConnection: vi.fn().mockResolvedValue({ sessionId: 'sess-1' }),
+    completeConnection: vi.fn().mockResolvedValue({
+      id: 'conn-1',
+      providerId: overrides.id,
+      providerConnectionId: 'pc-1',
+      institutionName: 'Test Bank',
+      status: 'active',
+      createdAt: new Date().toISOString(),
+    }),
+    refreshConnection: vi.fn().mockResolvedValue({ connectionId: 'conn-1', success: true }),
+    removeConnection: vi.fn().mockResolvedValue(undefined),
+    getAccounts: vi.fn().mockResolvedValue([]),
+    getTransactions: vi.fn().mockResolvedValue([]),
+    getBalances: vi.fn().mockResolvedValue([]),
+    getConnectionStatus: vi.fn().mockResolvedValue({ status: 'active' }),
+    getProviderHealth: vi.fn().mockResolvedValue({
+      isHealthy: true,
+      checkedAt: new Date().toISOString(),
+    }),
+    ...overrides,
+  } as BankConnectionProvider;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ConnectionManager', () => {
+  let registry: ProviderRegistry;
+  let manager: ConnectionManager;
+
+  beforeEach(() => {
+    registry = new ProviderRegistry();
+    // Use zero delays to keep tests fast
+    manager = new ConnectionManager(registry, {
+      maxRetries: 2,
+      baseDelayMs: 0,
+    });
+  });
+
+  // -- createConnection -----------------------------------------------------
+
+  it('creates a connection through the correct provider', async () => {
+    const provider = stubProvider({ id: 'test' });
+    registry.registerProvider(provider);
+
+    const session = await manager.createConnection('test', {});
+    expect(session.sessionId).toBe('sess-1');
+    expect(provider.initializeConnection).toHaveBeenCalledOnce();
+  });
+
+  it('throws when creating a connection with an unknown provider', async () => {
+    await expect(manager.createConnection('nope', {})).rejects.toThrow('not registered');
+  });
+
+  // -- completeConnection ---------------------------------------------------
+
+  it('completes and stores a connection', async () => {
+    const provider = stubProvider({ id: 'test' });
+    registry.registerProvider(provider);
+
+    const conn = await manager.completeConnection('test', 'sess-1');
+    expect(conn.id).toBe('conn-1');
+
+    const stored = manager.getConnectionsByProvider('test');
+    expect(stored).toHaveLength(1);
+    expect(stored[0].id).toBe('conn-1');
+  });
+
+  // -- refreshAllConnections ------------------------------------------------
+
+  it('refreshes all connections and returns results', async () => {
+    const provider = stubProvider({ id: 'p1' });
+    registry.registerProvider(provider);
+
+    // Manually add two connections
+    manager.addConnection({
+      id: 'c1',
+      providerId: 'p1',
+      providerConnectionId: 'pc1',
+      institutionName: 'Bank A',
+      status: 'active',
+      createdAt: new Date().toISOString(),
+    });
+    manager.addConnection({
+      id: 'c2',
+      providerId: 'p1',
+      providerConnectionId: 'pc2',
+      institutionName: 'Bank B',
+      status: 'active',
+      createdAt: new Date().toISOString(),
+    });
+
+    vi.mocked(provider.refreshConnection).mockImplementation(
+      async (id: string): Promise<RefreshResult> => ({
+        connectionId: id,
+        success: true,
+        newTransactions: 5,
+      }),
+    );
+
+    const results = await manager.refreshAllConnections();
+    expect(results).toHaveLength(2);
+    expect(results.every((r) => r.success)).toBe(true);
+  });
+
+  it('isolates errors — one failure does not block others', async () => {
+    const provider = stubProvider({ id: 'p1' });
+    registry.registerProvider(provider);
+
+    manager.addConnection({
+      id: 'good',
+      providerId: 'p1',
+      providerConnectionId: 'pc1',
+      institutionName: 'Good Bank',
+      status: 'active',
+      createdAt: new Date().toISOString(),
+    });
+    manager.addConnection({
+      id: 'bad',
+      providerId: 'p1',
+      providerConnectionId: 'pc2',
+      institutionName: 'Bad Bank',
+      status: 'active',
+      createdAt: new Date().toISOString(),
+    });
+
+    vi.mocked(provider.refreshConnection).mockImplementation(
+      async (id: string): Promise<RefreshResult> => {
+        if (id === 'bad') throw new Error('Authentication expired');
+        return { connectionId: id, success: true };
+      },
+    );
+
+    const results = await manager.refreshAllConnections();
+    const good = results.find((r) => r.connectionId === 'good');
+    const bad = results.find((r) => r.connectionId === 'bad');
+
+    expect(good?.success).toBe(true);
+    expect(bad?.success).toBe(false);
+    expect(bad?.error?.code).toBe('AUTHENTICATION_EXPIRED');
+  });
+
+  // -- retry logic ----------------------------------------------------------
+
+  it('retries retryable errors up to maxRetries', async () => {
+    const provider = stubProvider({ id: 'p1' });
+    registry.registerProvider(provider);
+
+    manager.addConnection({
+      id: 'retry-conn',
+      providerId: 'p1',
+      providerConnectionId: 'pc1',
+      institutionName: 'Slow Bank',
+      status: 'active',
+      createdAt: new Date().toISOString(),
+    });
+
+    vi.mocked(provider.refreshConnection).mockRejectedValue(
+      new Error('Provider unavailable — 503'),
+    );
+
+    const results = await manager.refreshAllConnections();
+    expect(results).toHaveLength(1);
+    expect(results[0].success).toBe(false);
+    expect(results[0].error?.code).toBe('PROVIDER_DOWN');
+
+    // initial + 2 retries = 3 calls total
+    expect(provider.refreshConnection).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry non-retryable errors', async () => {
+    const provider = stubProvider({ id: 'p1' });
+    registry.registerProvider(provider);
+
+    manager.addConnection({
+      id: 'auth-conn',
+      providerId: 'p1',
+      providerConnectionId: 'pc1',
+      institutionName: 'Auth Bank',
+      status: 'active',
+      createdAt: new Date().toISOString(),
+    });
+
+    vi.mocked(provider.refreshConnection).mockRejectedValue(new Error('Authentication expired'));
+
+    await manager.refreshAllConnections();
+    // Only 1 call — no retry for auth errors
+    expect(provider.refreshConnection).toHaveBeenCalledTimes(1);
+  });
+
+  // -- removeConnection -----------------------------------------------------
+
+  it('removes a connection from the manager and provider', async () => {
+    const provider = stubProvider({ id: 'p1' });
+    registry.registerProvider(provider);
+
+    manager.addConnection({
+      id: 'rm-conn',
+      providerId: 'p1',
+      providerConnectionId: 'pc1',
+      institutionName: 'Remove Bank',
+      status: 'active',
+      createdAt: new Date().toISOString(),
+    });
+
+    await manager.removeConnection('rm-conn');
+    expect(manager.getAllConnections()).toHaveLength(0);
+    expect(provider.removeConnection).toHaveBeenCalledWith('rm-conn');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// categorizeError
+// ---------------------------------------------------------------------------
+
+describe('categorizeError', () => {
+  it.each([
+    ['Authentication expired', 'AUTHENTICATION_EXPIRED', false],
+    ['Auth token invalid', 'AUTHENTICATION_EXPIRED', false],
+    ['Rate limit exceeded', 'RATE_LIMITED', true],
+    ['Too many requests', 'RATE_LIMITED', true],
+    ['Provider unavailable 503', 'PROVIDER_DOWN', true],
+    ['Request timeout', 'PROVIDER_DOWN', true],
+    ['Invalid credentials', 'INVALID_CREDENTIALS', false],
+    ['Institution not supported', 'INSTITUTION_NOT_SUPPORTED', false],
+    ['Something unknown happened', 'UNKNOWN', false],
+  ])('categorizes "%s" as %s (retryable=%s)', (message, expectedCode, expectedRetryable) => {
+    const result = categorizeError(new Error(message));
+    expect(result.code).toBe(expectedCode);
+    expect(result.retryable).toBe(expectedRetryable);
+  });
+
+  it('handles non-Error values', () => {
+    const result = categorizeError('simple string error');
+    expect(result.message).toBe('simple string error');
+  });
+
+  it('handles null/undefined', () => {
+    const result = categorizeError(null);
+    expect(result.code).toBe('UNKNOWN');
+  });
+});

--- a/apps/web/src/lib/banking/__tests__/manual-provider.test.ts
+++ b/apps/web/src/lib/banking/__tests__/manual-provider.test.ts
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect } from 'vitest';
+import { ManualImportProvider } from '../manual-provider';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const CSV_CONTENT = `Date,Amount,Description
+01/15/2024,42.99,Whole Foods
+01/16/2024,-100.00,ATM Withdrawal
+01/17/2024,1500.00,Payroll Deposit`;
+
+const OFX_CONTENT = `
+<OFX>
+<BANKMSGSRSV1>
+<STMTTRNRS>
+<STMTRS>
+<BANKTRANLIST>
+<STMTTRN>
+<DTPOSTED>20240115
+<TRNAMT>-42.99
+<NAME>Whole Foods
+<FITID>WF-001
+</STMTTRN>
+<STMTTRN>
+<DTPOSTED>20240116
+<TRNAMT>1500.00
+<NAME>Payroll
+<FITID>PAY-001
+</STMTTRN>
+</BANKTRANLIST>
+</STMTRS>
+</STMTTRNRS>
+</BANKMSGSRSV1>
+</OFX>`;
+
+const QIF_CONTENT = `!Type:Bank
+D01/15/2024
+T-42.99
+PWhole Foods
+^
+D01/16/2024
+T1500.00
+PPayroll
+^`;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ManualImportProvider', () => {
+  // -- Feature flags --------------------------------------------------------
+
+  it('has all features set to false', () => {
+    const provider = new ManualImportProvider();
+    const features = provider.features;
+
+    expect(features.realTimeBalance).toBe(false);
+    expect(features.transactionWebhooks).toBe(false);
+    expect(features.investmentAccounts).toBe(false);
+    expect(features.creditCards).toBe(false);
+    expect(features.loans).toBe(false);
+    expect(features.bnpl).toBe(false);
+    expect(features.crypto).toBe(false);
+    expect(features.internationalBanks).toBe(false);
+  });
+
+  it('has correct provider identity', () => {
+    const provider = new ManualImportProvider();
+    expect(provider.id).toBe('manual');
+    expect(provider.name).toBe('Manual Import');
+    expect(provider.supportedCountries).toEqual([]);
+  });
+
+  // -- CSV import -----------------------------------------------------------
+
+  it('imports CSV transactions through the provider interface', async () => {
+    const provider = new ManualImportProvider();
+
+    const session = await provider.initializeConnection({
+      metadata: { content: CSV_CONTENT, format: 'csv', institutionName: 'Test Bank' },
+    });
+    expect(session.sessionId).toBeTruthy();
+
+    const connection = await provider.completeConnection(session.sessionId);
+    expect(connection.status).toBe('active');
+    expect(connection.institutionName).toBe('Test Bank');
+
+    const accounts = await provider.getAccounts(connection.id);
+    expect(accounts).toHaveLength(1);
+    expect(accounts[0].institution).toBe('Test Bank');
+
+    const txs = await provider.getTransactions(connection.id, {
+      from: '2024-01-01',
+      to: '2024-12-31',
+    });
+    expect(txs).toHaveLength(3);
+    // Verify amounts are in cents
+    expect(txs.some((t) => t.amountCents === 4299)).toBe(true);
+  });
+
+  // -- OFX import -----------------------------------------------------------
+
+  it('imports OFX transactions through the provider interface', async () => {
+    const provider = new ManualImportProvider();
+
+    const session = await provider.initializeConnection({
+      metadata: { content: OFX_CONTENT, format: 'ofx' },
+    });
+    const connection = await provider.completeConnection(session.sessionId);
+
+    const txs = await provider.getTransactions(connection.id, {
+      from: '2024-01-01',
+      to: '2024-12-31',
+    });
+    expect(txs).toHaveLength(2);
+    // OFX amount -42.99 → -4299 cents
+    expect(txs.some((t) => t.amountCents === -4299)).toBe(true);
+    // OFX amount 1500.00 → 150000 cents
+    expect(txs.some((t) => t.amountCents === 150000)).toBe(true);
+  });
+
+  // -- QIF import -----------------------------------------------------------
+
+  it('imports QIF transactions through the provider interface', async () => {
+    const provider = new ManualImportProvider();
+
+    const session = await provider.initializeConnection({
+      metadata: { content: QIF_CONTENT, format: 'qif' },
+    });
+    const connection = await provider.completeConnection(session.sessionId);
+
+    const txs = await provider.getTransactions(connection.id, {
+      from: '2024-01-01',
+      to: '2024-12-31',
+    });
+    expect(txs).toHaveLength(2);
+    expect(txs.some((t) => t.amountCents === -4299)).toBe(true);
+    expect(txs.some((t) => t.amountCents === 150000)).toBe(true);
+  });
+
+  // -- Error handling -------------------------------------------------------
+
+  it('throws when content is missing', async () => {
+    const provider = new ManualImportProvider();
+    await expect(provider.initializeConnection({ metadata: { format: 'csv' } })).rejects.toThrow(
+      'content',
+    );
+  });
+
+  it('throws on invalid session ID', async () => {
+    const provider = new ManualImportProvider();
+    await expect(provider.completeConnection('bad-id')).rejects.toThrow('No manual import session');
+  });
+
+  // -- Date filtering -------------------------------------------------------
+
+  it('filters transactions by date range', async () => {
+    const provider = new ManualImportProvider();
+    const session = await provider.initializeConnection({
+      metadata: { content: CSV_CONTENT, format: 'csv' },
+    });
+    const conn = await provider.completeConnection(session.sessionId);
+
+    const narrow = await provider.getTransactions(conn.id, {
+      from: '2024-01-15',
+      to: '2024-01-15',
+    });
+    expect(narrow).toHaveLength(1);
+  });
+
+  // -- Provider health & status ---------------------------------------------
+
+  it('reports healthy status', async () => {
+    const provider = new ManualImportProvider();
+    const health = await provider.getProviderHealth();
+    expect(health.isHealthy).toBe(true);
+
+    const status = await provider.getConnectionStatus('any');
+    expect(status.status).toBe('active');
+  });
+
+  // -- Remove connection ----------------------------------------------------
+
+  it('removes imported data', async () => {
+    const provider = new ManualImportProvider();
+    const session = await provider.initializeConnection({
+      metadata: { content: CSV_CONTENT, format: 'csv' },
+    });
+    const conn = await provider.completeConnection(session.sessionId);
+
+    await provider.removeConnection(conn.id);
+    const accounts = await provider.getAccounts(conn.id);
+    expect(accounts).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/banking/__tests__/mock-provider.test.ts
+++ b/apps/web/src/lib/banking/__tests__/mock-provider.test.ts
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect } from 'vitest';
+import { MockProvider } from '../mock-provider';
+
+describe('MockProvider', () => {
+  // -- Identity & features --------------------------------------------------
+
+  it('has correct provider identity', () => {
+    const mock = new MockProvider();
+    expect(mock.id).toBe('mock');
+    expect(mock.name).toBe('Mock Provider');
+    expect(mock.supportedCountries).toContain('US');
+    expect(mock.supportedCountries).toContain('GB');
+  });
+
+  it('reports expected feature flags', () => {
+    const mock = new MockProvider();
+    expect(mock.features.realTimeBalance).toBe(true);
+    expect(mock.features.creditCards).toBe(true);
+    expect(mock.features.bnpl).toBe(false);
+    expect(mock.features.crypto).toBe(false);
+  });
+
+  // -- Data generation ------------------------------------------------------
+
+  it('generates the configured number of accounts', async () => {
+    const mock = new MockProvider({ accountCount: 5 });
+    const session = await mock.initializeConnection({});
+    const conn = await mock.completeConnection(session.sessionId);
+    const accounts = await mock.getAccounts(conn.id);
+    expect(accounts).toHaveLength(5);
+  });
+
+  it('generates transactions for each account', async () => {
+    const mock = new MockProvider({
+      accountCount: 2,
+      transactionsPerAccount: 10,
+    });
+    const session = await mock.initializeConnection({});
+    const conn = await mock.completeConnection(session.sessionId);
+    const txs = await mock.getTransactions(conn.id, {
+      from: '2000-01-01',
+      to: '2099-12-31',
+    });
+    expect(txs).toHaveLength(20);
+  });
+
+  it('generates transactions with integer cent amounts', async () => {
+    const mock = new MockProvider({ transactionsPerAccount: 5 });
+    const session = await mock.initializeConnection({});
+    const conn = await mock.completeConnection(session.sessionId);
+    const txs = await mock.getTransactions(conn.id, {
+      from: '2000-01-01',
+      to: '2099-12-31',
+    });
+
+    for (const tx of txs) {
+      expect(Number.isInteger(tx.amountCents)).toBe(true);
+    }
+  });
+
+  // -- Deterministic output -------------------------------------------------
+
+  it('produces deterministic data with the same seed', async () => {
+    const run = async (seed: number) => {
+      const mock = new MockProvider({ seed, accountCount: 2, transactionsPerAccount: 3 });
+      const session = await mock.initializeConnection({});
+      const conn = await mock.completeConnection(session.sessionId);
+      const accounts = await mock.getAccounts(conn.id);
+      const txs = await mock.getTransactions(conn.id, {
+        from: '2000-01-01',
+        to: '2099-12-31',
+      });
+      return { accounts, txs };
+    };
+
+    const first = await run(99);
+    const second = await run(99);
+
+    // Account IDs and names should match
+    expect(first.accounts.map((a) => a.id)).toEqual(second.accounts.map((a) => a.id));
+
+    // Transaction amounts and dates should match
+    expect(first.txs.map((t) => t.amountCents)).toEqual(second.txs.map((t) => t.amountCents));
+    expect(first.txs.map((t) => t.date)).toEqual(second.txs.map((t) => t.date));
+  });
+
+  it('produces different data with different seeds', async () => {
+    const run = async (seed: number) => {
+      const mock = new MockProvider({ seed, accountCount: 1, transactionsPerAccount: 5 });
+      const session = await mock.initializeConnection({});
+      const conn = await mock.completeConnection(session.sessionId);
+      return mock.getTransactions(conn.id, {
+        from: '2000-01-01',
+        to: '2099-12-31',
+      });
+    };
+
+    const txsA = await run(1);
+    const txsB = await run(2);
+
+    // Very unlikely to be identical with different seeds
+    const amountsA = txsA.map((t) => t.amountCents);
+    const amountsB = txsB.map((t) => t.amountCents);
+    expect(amountsA).not.toEqual(amountsB);
+  });
+
+  // -- Date range filtering -------------------------------------------------
+
+  it('filters transactions by date range', async () => {
+    const mock = new MockProvider({ transactionsPerAccount: 50 });
+    const session = await mock.initializeConnection({});
+    const conn = await mock.completeConnection(session.sessionId);
+
+    const all = await mock.getTransactions(conn.id, {
+      from: '2000-01-01',
+      to: '2099-12-31',
+    });
+
+    const narrow = await mock.getTransactions(conn.id, {
+      from: '2024-03-01',
+      to: '2024-03-31',
+    });
+
+    expect(narrow.length).toBeLessThanOrEqual(all.length);
+    for (const tx of narrow) {
+      expect(tx.date >= '2024-03-01').toBe(true);
+      expect(tx.date <= '2024-03-31').toBe(true);
+    }
+  });
+
+  // -- Error simulation -----------------------------------------------------
+
+  it('simulates errors when configured', async () => {
+    const mock = new MockProvider({ simulateError: 'Provider unavailable' });
+    await expect(mock.initializeConnection({})).rejects.toThrow('Provider unavailable');
+
+    // Error resets after first throw
+    const session = await mock.initializeConnection({});
+    expect(session.sessionId).toBeTruthy();
+  });
+
+  // -- Balance & status -----------------------------------------------------
+
+  it('returns balances for all accounts', async () => {
+    const mock = new MockProvider({ accountCount: 3 });
+    const session = await mock.initializeConnection({});
+    const conn = await mock.completeConnection(session.sessionId);
+    const balances = await mock.getBalances(conn.id);
+    expect(balances).toHaveLength(3);
+    for (const b of balances) {
+      expect(Number.isInteger(b.currentCents)).toBe(true);
+    }
+  });
+
+  it('reports healthy status', async () => {
+    const mock = new MockProvider();
+    const health = await mock.getProviderHealth();
+    expect(health.isHealthy).toBe(true);
+
+    const status = await mock.getConnectionStatus('any');
+    expect(status.status).toBe('active');
+  });
+
+  // -- Remove ---------------------------------------------------------------
+
+  it('removes connection data', async () => {
+    const mock = new MockProvider();
+    const session = await mock.initializeConnection({});
+    const conn = await mock.completeConnection(session.sessionId);
+    await mock.removeConnection(conn.id);
+    const accounts = await mock.getAccounts(conn.id);
+    expect(accounts).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/banking/__tests__/provider-registry.test.ts
+++ b/apps/web/src/lib/banking/__tests__/provider-registry.test.ts
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { BankConnectionProvider, ProviderFeatures } from '../types';
+import { ProviderRegistry } from '../provider-registry';
+
+// ---------------------------------------------------------------------------
+// Helpers — minimal stub provider
+// ---------------------------------------------------------------------------
+
+function stubProvider(
+  overrides: Partial<BankConnectionProvider> & { id: string },
+): BankConnectionProvider {
+  const noopFeatures: ProviderFeatures = {
+    realTimeBalance: false,
+    transactionWebhooks: false,
+    investmentAccounts: false,
+    creditCards: false,
+    loans: false,
+    bnpl: false,
+    crypto: false,
+    internationalBanks: false,
+  };
+
+  return {
+    name: overrides.id,
+    supportedCountries: [],
+    features: noopFeatures,
+    initializeConnection: vi.fn(),
+    completeConnection: vi.fn(),
+    refreshConnection: vi.fn(),
+    removeConnection: vi.fn(),
+    getAccounts: vi.fn(),
+    getTransactions: vi.fn(),
+    getBalances: vi.fn(),
+    getConnectionStatus: vi.fn(),
+    getProviderHealth: vi.fn(),
+    ...overrides,
+  } as BankConnectionProvider;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ProviderRegistry', () => {
+  let registry: ProviderRegistry;
+
+  beforeEach(() => {
+    registry = new ProviderRegistry();
+  });
+
+  // -- registerProvider / getProvider ----------------------------------------
+
+  it('registers and retrieves a provider by ID', () => {
+    const p = stubProvider({ id: 'plaid' });
+    registry.registerProvider(p);
+    expect(registry.getProvider('plaid')).toBe(p);
+  });
+
+  it('returns undefined for an unregistered ID', () => {
+    expect(registry.getProvider('nonexistent')).toBeUndefined();
+  });
+
+  it('throws when registering a duplicate ID', () => {
+    registry.registerProvider(stubProvider({ id: 'plaid' }));
+    expect(() => registry.registerProvider(stubProvider({ id: 'plaid' }))).toThrow(
+      'already registered',
+    );
+  });
+
+  // -- getAllProviders -------------------------------------------------------
+
+  it('returns all registered providers', () => {
+    registry.registerProvider(stubProvider({ id: 'a' }));
+    registry.registerProvider(stubProvider({ id: 'b' }));
+    registry.registerProvider(stubProvider({ id: 'c' }));
+    expect(registry.getAllProviders()).toHaveLength(3);
+  });
+
+  it('returns an empty array when no providers are registered', () => {
+    expect(registry.getAllProviders()).toEqual([]);
+  });
+
+  // -- getProvidersForCountry -----------------------------------------------
+
+  it('filters providers by supported country (case-insensitive)', () => {
+    registry.registerProvider(stubProvider({ id: 'us-only', supportedCountries: ['US'] }));
+    registry.registerProvider(stubProvider({ id: 'gb-only', supportedCountries: ['GB'] }));
+    registry.registerProvider(stubProvider({ id: 'both', supportedCountries: ['US', 'GB'] }));
+
+    const us = registry.getProvidersForCountry('us');
+    expect(us.map((p) => p.id)).toEqual(['us-only', 'both']);
+
+    const gb = registry.getProvidersForCountry('GB');
+    expect(gb.map((p) => p.id)).toEqual(['gb-only', 'both']);
+  });
+
+  it('returns empty array when no provider matches the country', () => {
+    registry.registerProvider(stubProvider({ id: 'us-only', supportedCountries: ['US'] }));
+    expect(registry.getProvidersForCountry('JP')).toEqual([]);
+  });
+
+  // -- getProvidersWithFeature ----------------------------------------------
+
+  it('filters providers by feature flag', () => {
+    registry.registerProvider(
+      stubProvider({
+        id: 'realtime',
+        features: {
+          realTimeBalance: true,
+          transactionWebhooks: false,
+          investmentAccounts: false,
+          creditCards: false,
+          loans: false,
+          bnpl: false,
+          crypto: false,
+          internationalBanks: false,
+        },
+      }),
+    );
+    registry.registerProvider(
+      stubProvider({
+        id: 'basic',
+        features: {
+          realTimeBalance: false,
+          transactionWebhooks: false,
+          investmentAccounts: false,
+          creditCards: false,
+          loans: false,
+          bnpl: false,
+          crypto: false,
+          internationalBanks: false,
+        },
+      }),
+    );
+
+    const realtime = registry.getProvidersWithFeature('realTimeBalance');
+    expect(realtime).toHaveLength(1);
+    expect(realtime[0].id).toBe('realtime');
+  });
+
+  it('returns empty array when no provider has the feature', () => {
+    registry.registerProvider(stubProvider({ id: 'basic' }));
+    expect(registry.getProvidersWithFeature('crypto')).toEqual([]);
+  });
+
+  // -- clear ----------------------------------------------------------------
+
+  it('clears all providers', () => {
+    registry.registerProvider(stubProvider({ id: 'a' }));
+    registry.registerProvider(stubProvider({ id: 'b' }));
+    registry.clear();
+    expect(registry.getAllProviders()).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/banking/__tests__/transaction-normalizer.test.ts
+++ b/apps/web/src/lib/banking/__tests__/transaction-normalizer.test.ts
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect } from 'vitest';
+import {
+  dollarsToCents,
+  bankersRound,
+  normalizeDate,
+  mapCategory,
+  mapAccountType,
+  normalizeTransaction,
+  normalizeAccount,
+  deduplicateTransactions,
+} from '../transaction-normalizer';
+import type { BankTransaction } from '../types';
+
+// ---------------------------------------------------------------------------
+// dollarsToCents
+// ---------------------------------------------------------------------------
+
+describe('dollarsToCents', () => {
+  it('converts whole dollars', () => {
+    expect(dollarsToCents(1)).toBe(100);
+    expect(dollarsToCents(0)).toBe(0);
+    expect(dollarsToCents(100)).toBe(10000);
+  });
+
+  it('converts fractional dollars', () => {
+    expect(dollarsToCents(1.5)).toBe(150);
+    expect(dollarsToCents(19.99)).toBe(1999);
+    expect(dollarsToCents(0.01)).toBe(1);
+  });
+
+  it('handles negative amounts', () => {
+    expect(dollarsToCents(-42.5)).toBe(-4250);
+    expect(dollarsToCents(-0.01)).toBe(-1);
+  });
+
+  it('handles sub-cent values with Bankers rounding', () => {
+    // 12.345 * 100 = 1234.5 → round to even → 1234
+    expect(dollarsToCents(12.345)).toBe(1234);
+    // 12.355 * 100 = 1235.5 → round to even → 1236
+    expect(dollarsToCents(12.355)).toBe(1236);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bankersRound
+// ---------------------------------------------------------------------------
+
+describe('bankersRound', () => {
+  it('rounds down when below halfway', () => {
+    expect(bankersRound(2.3)).toBe(2);
+  });
+
+  it('rounds up when above halfway', () => {
+    expect(bankersRound(2.7)).toBe(3);
+  });
+
+  it('rounds half to even (down for even floor)', () => {
+    expect(bankersRound(2.5)).toBe(2);
+    expect(bankersRound(4.5)).toBe(4);
+  });
+
+  it('rounds half to even (up for odd floor)', () => {
+    expect(bankersRound(3.5)).toBe(4);
+    expect(bankersRound(5.5)).toBe(6);
+  });
+
+  it('handles negative values', () => {
+    // -2.5: floor = -3, diff = 0.5, floor(-3) is odd → round to -2
+    // Actually for negative: Math.floor(-2.5) = -3, diff = -2.5 - (-3) = 0.5
+    // -3 % 2 = -1 (odd) → -3 + 1 = -2
+    expect(bankersRound(-2.5)).toBe(-2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeDate
+// ---------------------------------------------------------------------------
+
+describe('normalizeDate', () => {
+  it('normalizes ISO date strings', () => {
+    expect(normalizeDate('2024-03-15')).toBe('2024-03-15');
+  });
+
+  it('normalizes ISO datetime strings', () => {
+    expect(normalizeDate('2024-03-15T12:30:00Z')).toBe('2024-03-15');
+  });
+
+  it('normalizes US-format dates (M/D/Y)', () => {
+    expect(normalizeDate('3/15/2024')).toBe('2024-03-15');
+    expect(normalizeDate('12/1/2024')).toBe('2024-12-01');
+  });
+
+  it('normalizes Date objects', () => {
+    const d = new Date('2024-06-01T00:00:00Z');
+    expect(normalizeDate(d)).toBe('2024-06-01');
+  });
+
+  it('normalizes Unix timestamps', () => {
+    const ts = new Date('2024-01-01').getTime();
+    expect(normalizeDate(ts)).toBe('2024-01-01');
+  });
+
+  it('returns today for undefined/invalid input', () => {
+    const today = new Date().toISOString().slice(0, 10);
+    expect(normalizeDate(undefined)).toBe(today);
+    expect(normalizeDate('not-a-date')).toBe(today);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mapCategory
+// ---------------------------------------------------------------------------
+
+describe('mapCategory', () => {
+  it('maps known categories', () => {
+    expect(mapCategory('Groceries')).toBe('groceries');
+    expect(mapCategory('Food and Drink')).toBe('food_and_drink');
+    expect(mapCategory('TRANSPORTATION')).toBe('transportation');
+    expect(mapCategory('income')).toBe('income');
+  });
+
+  it('returns uncategorized for unknown categories', () => {
+    expect(mapCategory('Intergalactic Travel')).toBe('uncategorized');
+  });
+
+  it('returns uncategorized for undefined/empty', () => {
+    expect(mapCategory(undefined)).toBe('uncategorized');
+    expect(mapCategory('')).toBe('uncategorized');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mapAccountType
+// ---------------------------------------------------------------------------
+
+describe('mapAccountType', () => {
+  it('maps known account types', () => {
+    expect(mapAccountType('checking')).toBe('checking');
+    expect(mapAccountType('Savings')).toBe('savings');
+    expect(mapAccountType('credit card')).toBe('credit_card');
+    expect(mapAccountType('Investment')).toBe('investment');
+    expect(mapAccountType('loan')).toBe('loan');
+  });
+
+  it('returns other for unknown types', () => {
+    expect(mapAccountType('prepaid')).toBe('other');
+    expect(mapAccountType(undefined)).toBe('other');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeTransaction
+// ---------------------------------------------------------------------------
+
+describe('normalizeTransaction', () => {
+  it('converts dollar amounts to cents', () => {
+    const tx = normalizeTransaction(
+      { id: 'tx-1', amount: 42.99, date: '2024-01-15', description: 'Test' },
+      'plaid',
+    );
+    expect(tx.amountCents).toBe(4299);
+  });
+
+  it('preserves amountCents when provided', () => {
+    const tx = normalizeTransaction({ id: 'tx-1', amountCents: 1234, date: '2024-01-15' }, 'plaid');
+    expect(tx.amountCents).toBe(1234);
+  });
+
+  it('maps categories', () => {
+    const tx = normalizeTransaction({ id: 'tx-1', category: 'Groceries' }, 'plaid');
+    expect(tx.category).toBe('groceries');
+  });
+
+  it('handles missing fields gracefully', () => {
+    const tx = normalizeTransaction({}, 'plaid');
+    expect(tx.amountCents).toBe(0);
+    expect(tx.description).toBe('Unknown');
+    expect(tx.pending).toBe(false);
+    expect(tx.providerTransactionId).toContain('plaid');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeAccount
+// ---------------------------------------------------------------------------
+
+describe('normalizeAccount', () => {
+  it('normalizes a complete account', () => {
+    const acct = normalizeAccount(
+      {
+        id: 'acct-1',
+        name: 'My Checking',
+        type: 'depository',
+        currency: 'usd',
+        institution: 'Chase',
+        mask: '4521',
+      },
+      'plaid',
+    );
+    expect(acct.name).toBe('My Checking');
+    expect(acct.type).toBe('checking'); // depository → checking
+    expect(acct.currency).toBe('USD'); // uppercased
+    expect(acct.mask).toBe('4521');
+  });
+
+  it('handles missing fields with defaults', () => {
+    const acct = normalizeAccount({}, 'manual');
+    expect(acct.name).toBe('Unnamed Account');
+    expect(acct.type).toBe('other');
+    expect(acct.currency).toBe('USD');
+    expect(acct.institution).toBe('Unknown');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deduplicateTransactions
+// ---------------------------------------------------------------------------
+
+describe('deduplicateTransactions', () => {
+  it('removes duplicates by provider transaction ID', () => {
+    const txs: BankTransaction[] = [
+      {
+        id: '1',
+        providerTransactionId: 'ptx-a',
+        accountId: 'a1',
+        date: '2024-01-01',
+        amountCents: 100,
+        description: 'First',
+        pending: false,
+      },
+      {
+        id: '2',
+        providerTransactionId: 'ptx-a',
+        accountId: 'a1',
+        date: '2024-01-01',
+        amountCents: 100,
+        description: 'Duplicate',
+        pending: false,
+      },
+      {
+        id: '3',
+        providerTransactionId: 'ptx-b',
+        accountId: 'a1',
+        date: '2024-01-02',
+        amountCents: 200,
+        description: 'Unique',
+        pending: false,
+      },
+    ];
+
+    const deduped = deduplicateTransactions(txs);
+    expect(deduped).toHaveLength(2);
+    expect(deduped[0].description).toBe('First'); // First occurrence wins
+    expect(deduped[1].providerTransactionId).toBe('ptx-b');
+  });
+
+  it('returns empty for empty input', () => {
+    expect(deduplicateTransactions([])).toEqual([]);
+  });
+
+  it('returns all when no duplicates', () => {
+    const txs: BankTransaction[] = [
+      {
+        id: '1',
+        providerTransactionId: 'a',
+        accountId: 'a1',
+        date: '2024-01-01',
+        amountCents: 100,
+        description: 'A',
+        pending: false,
+      },
+      {
+        id: '2',
+        providerTransactionId: 'b',
+        accountId: 'a1',
+        date: '2024-01-02',
+        amountCents: 200,
+        description: 'B',
+        pending: false,
+      },
+    ];
+    expect(deduplicateTransactions(txs)).toHaveLength(2);
+  });
+});

--- a/apps/web/src/lib/banking/connection-manager.ts
+++ b/apps/web/src/lib/banking/connection-manager.ts
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Connection manager — orchestrates the banking connection lifecycle.
+ *
+ * Sits between the UI layer (hooks/components) and individual
+ * {@link BankConnectionProvider} implementations. Provides:
+ *
+ * - Connection creation routing to the correct provider
+ * - Batch refresh with error isolation (one failure doesn't block others)
+ * - Retry logic with configurable exponential backoff
+ * - Structured error categorization
+ *
+ * @module banking/connection-manager
+ */
+
+import type { ProviderRegistry } from './provider-registry';
+import type {
+  BankConnection,
+  ConnectionConfig,
+  ConnectionError,
+  ConnectionErrorCode,
+  ConnectionSession,
+  RefreshResult,
+} from './types';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/**
+ * Configuration for the {@link ConnectionManager}'s retry behavior.
+ */
+export interface RetryConfig {
+  /** Maximum number of retry attempts before giving up. @default 3 */
+  maxRetries: number;
+  /** Base delay in milliseconds (doubled each attempt). @default 1000 */
+  baseDelayMs: number;
+}
+
+const DEFAULT_RETRY_CONFIG: RetryConfig = {
+  maxRetries: 3,
+  baseDelayMs: 1000,
+};
+
+// ---------------------------------------------------------------------------
+// Error helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Categorize an unknown error into a {@link ConnectionErrorCode}.
+ *
+ * The heuristic inspects error messages for well-known keywords. Real
+ * provider implementations should throw pre-categorized errors, but this
+ * acts as a safety net.
+ *
+ * @param error - The caught error value.
+ * @returns A categorized {@link ConnectionError}.
+ */
+export function categorizeError(error: unknown): ConnectionError {
+  const message = error instanceof Error ? error.message : String(error ?? 'Unknown error');
+  const lower = message.toLowerCase();
+
+  let code: ConnectionErrorCode = 'UNKNOWN';
+  let retryable = false;
+
+  if (
+    lower.includes('authentication') ||
+    lower.includes('auth') ||
+    lower.includes('expired') ||
+    lower.includes('token')
+  ) {
+    code = 'AUTHENTICATION_EXPIRED';
+    retryable = false;
+  } else if (
+    lower.includes('rate limit') ||
+    lower.includes('rate_limit') ||
+    lower.includes('throttle') ||
+    lower.includes('too many requests')
+  ) {
+    code = 'RATE_LIMITED';
+    retryable = true;
+  } else if (
+    lower.includes('provider') ||
+    lower.includes('unavailable') ||
+    lower.includes('503') ||
+    lower.includes('502') ||
+    lower.includes('timeout')
+  ) {
+    code = 'PROVIDER_DOWN';
+    retryable = true;
+  } else if (
+    lower.includes('credential') ||
+    lower.includes('password') ||
+    lower.includes('invalid')
+  ) {
+    code = 'INVALID_CREDENTIALS';
+    retryable = false;
+  } else if (
+    lower.includes('institution') ||
+    lower.includes('not supported') ||
+    lower.includes('unsupported')
+  ) {
+    code = 'INSTITUTION_NOT_SUPPORTED';
+    retryable = false;
+  }
+
+  return { code, message, retryable, providerError: error };
+}
+
+// ---------------------------------------------------------------------------
+// Sleep helper
+// ---------------------------------------------------------------------------
+
+/** @internal Pause execution for `ms` milliseconds. */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ---------------------------------------------------------------------------
+// ConnectionManager
+// ---------------------------------------------------------------------------
+
+/**
+ * Orchestrates creation, refresh, and error handling for banking connections.
+ */
+export class ConnectionManager {
+  /** @internal in-memory connection store (keyed by connection ID). */
+  private readonly connections = new Map<string, BankConnection>();
+  private readonly registry: ProviderRegistry;
+  private readonly retryConfig: RetryConfig;
+
+  /**
+   * @param registry - The provider registry to resolve providers from.
+   * @param retryConfig - Optional retry configuration overrides.
+   */
+  constructor(registry: ProviderRegistry, retryConfig?: Partial<RetryConfig>) {
+    this.registry = registry;
+    this.retryConfig = { ...DEFAULT_RETRY_CONFIG, ...retryConfig };
+  }
+
+  /**
+   * Begin a new connection through the specified provider.
+   *
+   * @param providerId - ID of the registered provider.
+   * @param config - Connection configuration.
+   * @returns A {@link ConnectionSession} to continue the handshake.
+   * @throws {Error} If the provider ID is not registered.
+   */
+  async createConnection(providerId: string, config: ConnectionConfig): Promise<ConnectionSession> {
+    const provider = this.registry.getProvider(providerId);
+    if (!provider) {
+      throw new Error(`Provider "${providerId}" is not registered.`);
+    }
+    return provider.initializeConnection(config);
+  }
+
+  /**
+   * Complete a connection handshake and store the resulting connection.
+   *
+   * @param providerId - ID of the provider that started the session.
+   * @param sessionId - The session ID returned from {@link createConnection}.
+   * @param metadata - Provider-specific completion data.
+   * @returns The established {@link BankConnection}.
+   */
+  async completeConnection(
+    providerId: string,
+    sessionId: string,
+    metadata?: Record<string, unknown>,
+  ): Promise<BankConnection> {
+    const provider = this.registry.getProvider(providerId);
+    if (!provider) {
+      throw new Error(`Provider "${providerId}" is not registered.`);
+    }
+    const connection = await provider.completeConnection(sessionId, metadata);
+    this.connections.set(connection.id, connection);
+    return connection;
+  }
+
+  /**
+   * Refresh **all** stored connections, isolating individual failures.
+   *
+   * Each connection is refreshed through its provider. If one connection
+   * fails, the error is captured in the result and the remaining connections
+   * continue to refresh.
+   *
+   * @returns An array of {@link RefreshResult} — one per connection.
+   */
+  async refreshAllConnections(): Promise<RefreshResult[]> {
+    const results: RefreshResult[] = [];
+
+    const entries = Array.from(this.connections.values());
+
+    await Promise.all(
+      entries.map(async (conn) => {
+        const result = await this.refreshWithRetry(conn);
+        results.push(result);
+      }),
+    );
+
+    return results;
+  }
+
+  /**
+   * Return all stored connections for a given provider.
+   *
+   * @param providerId - The provider ID to filter by.
+   * @returns Connections managed by that provider.
+   */
+  getConnectionsByProvider(providerId: string): BankConnection[] {
+    return Array.from(this.connections.values()).filter((c) => c.providerId === providerId);
+  }
+
+  /**
+   * Return all stored connections.
+   *
+   * @returns Every tracked connection.
+   */
+  getAllConnections(): BankConnection[] {
+    return Array.from(this.connections.values());
+  }
+
+  /**
+   * Store an externally-created connection (e.g., from manual import).
+   *
+   * @param connection - The connection to track.
+   */
+  addConnection(connection: BankConnection): void {
+    this.connections.set(connection.id, connection);
+  }
+
+  /**
+   * Remove a connection from the manager and provider.
+   *
+   * @param connectionId - The connection to remove.
+   */
+  async removeConnection(connectionId: string): Promise<void> {
+    const conn = this.connections.get(connectionId);
+    if (!conn) return;
+
+    const provider = this.registry.getProvider(conn.providerId);
+    if (provider) {
+      await provider.removeConnection(connectionId);
+    }
+    this.connections.delete(connectionId);
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal helpers
+  // -------------------------------------------------------------------------
+
+  /**
+   * Refresh a single connection with exponential backoff retry.
+   *
+   * @internal
+   */
+  private async refreshWithRetry(conn: BankConnection): Promise<RefreshResult> {
+    const provider = this.registry.getProvider(conn.providerId);
+    if (!provider) {
+      return {
+        connectionId: conn.id,
+        success: false,
+        error: {
+          code: 'UNKNOWN',
+          message: `Provider "${conn.providerId}" not found in registry.`,
+          retryable: false,
+        },
+      };
+    }
+
+    let lastError: ConnectionError | undefined;
+
+    for (let attempt = 0; attempt <= this.retryConfig.maxRetries; attempt++) {
+      try {
+        const result = await provider.refreshConnection(conn.id);
+        // Update stored connection status on success
+        if (result.success) {
+          this.connections.set(conn.id, {
+            ...conn,
+            status: 'active',
+            lastRefreshedAt: new Date().toISOString(),
+          });
+        }
+        return result;
+      } catch (err) {
+        lastError = categorizeError(err);
+
+        // Don't retry non-retryable errors
+        if (!lastError.retryable) break;
+
+        // Don't sleep after the last attempt
+        if (attempt < this.retryConfig.maxRetries) {
+          const delay = this.retryConfig.baseDelayMs * Math.pow(2, attempt);
+          await sleep(delay);
+        }
+      }
+    }
+
+    return {
+      connectionId: conn.id,
+      success: false,
+      error: lastError ?? {
+        code: 'UNKNOWN',
+        message: 'Refresh failed with no error details.',
+        retryable: false,
+      },
+    };
+  }
+}

--- a/apps/web/src/lib/banking/index.ts
+++ b/apps/web/src/lib/banking/index.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Banking connection abstraction layer — barrel export.
+ *
+ * Re-exports all public types, classes, and utilities from the banking
+ * module. Consumers should import from `lib/banking` rather than reaching
+ * into individual files.
+ *
+ * @module banking
+ */
+
+// Types
+export type {
+  AccountBalance,
+  BankAccount,
+  BankAccountType,
+  BankConnection,
+  BankConnectionProvider,
+  BankTransaction,
+  ConnectionConfig,
+  ConnectionError,
+  ConnectionErrorCode,
+  ConnectionSession,
+  ConnectionStatus,
+  ConnectionStatusType,
+  DateRange,
+  ProviderFeatures,
+  ProviderHealth,
+  RefreshResult,
+} from './types';
+
+// Provider registry
+export { ProviderRegistry, defaultRegistry } from './provider-registry';
+
+// Connection manager
+export { ConnectionManager, categorizeError } from './connection-manager';
+export type { RetryConfig } from './connection-manager';
+
+// Transaction normalizer
+export {
+  normalizeTransaction,
+  normalizeAccount,
+  deduplicateTransactions,
+  dollarsToCents,
+  bankersRound,
+  mapCategory,
+  mapAccountType,
+  normalizeDate,
+} from './transaction-normalizer';
+export type { RawProviderTransaction, RawProviderAccount } from './transaction-normalizer';
+
+// Manual provider
+export { ManualImportProvider } from './manual-provider';
+export type { ImportFormat } from './manual-provider';
+
+// Mock provider
+export { MockProvider } from './mock-provider';
+export type { MockProviderConfig } from './mock-provider';

--- a/apps/web/src/lib/banking/manual-provider.ts
+++ b/apps/web/src/lib/banking/manual-provider.ts
@@ -1,0 +1,362 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Manual import provider — implements {@link BankConnectionProvider} for
+ * file-based imports (CSV, OFX, QIF).
+ *
+ * This provider wraps the existing `lib/csv-parser` to allow CSV data
+ * to flow through the same provider abstraction as automated aggregators.
+ * It also includes lightweight inline parsers for OFX and QIF so the
+ * provider works standalone without external dependencies.
+ *
+ * **No network calls** — all data originates from user-supplied file content.
+ *
+ * @module banking/manual-provider
+ */
+
+import type {
+  AccountBalance,
+  BankAccount,
+  BankConnection,
+  BankConnectionProvider,
+  BankTransaction,
+  ConnectionConfig,
+  ConnectionSession,
+  ConnectionStatus,
+  DateRange,
+  ProviderFeatures,
+  ProviderHealth,
+  RefreshResult,
+} from './types';
+import { dollarsToCents, mapCategory, normalizeDate } from './transaction-normalizer';
+
+// ---------------------------------------------------------------------------
+// Internal storage (in-memory, per-instance)
+// ---------------------------------------------------------------------------
+
+interface ImportedData {
+  accounts: BankAccount[];
+  transactions: BankTransaction[];
+}
+
+/** Supported file formats. */
+export type ImportFormat = 'csv' | 'ofx' | 'qif';
+
+// ---------------------------------------------------------------------------
+// Lightweight inline parsers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse CSV content into raw transaction-like rows.
+ *
+ * This is a simplified parser for the provider interface. For full RFC 4180
+ * compliance, use `lib/csv-parser`.
+ *
+ * @internal
+ */
+function parseCsv(content: string): Array<{ date: string; amount: string; description: string }> {
+  const lines = content
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter(Boolean);
+  if (lines.length < 2) return [];
+
+  // Assume first line is header
+  const headerLine = lines[0].toLowerCase();
+  const delimiter = headerLine.includes('\t') ? '\t' : ',';
+  const headers = headerLine.split(delimiter).map((h) => h.trim());
+
+  const dateIdx = headers.findIndex((h) => ['date', 'transaction date', 'posted date'].includes(h));
+  const amountIdx = headers.findIndex((h) => ['amount', 'value', 'transaction amount'].includes(h));
+  const descIdx = headers.findIndex((h) =>
+    ['description', 'memo', 'payee', 'name', 'transaction description'].includes(h),
+  );
+
+  return lines.slice(1).map((line) => {
+    const cols = line.split(delimiter).map((c) => c.trim().replace(/^"|"$/g, ''));
+    return {
+      date: cols[dateIdx] ?? '',
+      amount: cols[amountIdx] ?? '0',
+      description: cols[descIdx] ?? '',
+    };
+  });
+}
+
+/**
+ * Parse OFX/QFX content into raw transaction-like rows.
+ *
+ * This parser handles the SGML-ish subset of OFX 1.x used by most banks.
+ *
+ * @internal
+ */
+function parseOfx(
+  content: string,
+): Array<{ date: string; amount: string; description: string; id?: string }> {
+  const results: Array<{
+    date: string;
+    amount: string;
+    description: string;
+    id?: string;
+  }> = [];
+
+  // Split on STMTTRN blocks
+  const txBlocks = content.split(/<STMTTRN>/i).slice(1);
+
+  for (const block of txBlocks) {
+    const endIdx = block.search(/<\/STMTTRN>/i);
+    const txContent = endIdx >= 0 ? block.slice(0, endIdx) : block;
+
+    const getTag = (tag: string): string => {
+      const re = new RegExp(`<${tag}>([^<\\r\\n]+)`, 'i');
+      const m = txContent.match(re);
+      return m?.[1]?.trim() ?? '';
+    };
+
+    const rawDate = getTag('DTPOSTED');
+    // OFX dates are YYYYMMDD or YYYYMMDDHHMMSS
+    const date =
+      rawDate.length >= 8
+        ? `${rawDate.slice(0, 4)}-${rawDate.slice(4, 6)}-${rawDate.slice(6, 8)}`
+        : rawDate;
+
+    results.push({
+      date,
+      amount: getTag('TRNAMT'),
+      description: getTag('NAME') || getTag('MEMO'),
+      id: getTag('FITID') || undefined,
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Parse QIF content into raw transaction-like rows.
+ *
+ * QIF records are delimited by `^` lines.
+ *
+ * @internal
+ */
+function parseQif(content: string): Array<{ date: string; amount: string; description: string }> {
+  const results: Array<{
+    date: string;
+    amount: string;
+    description: string;
+  }> = [];
+
+  const records = content.split('^').filter((r) => r.trim());
+
+  for (const record of records) {
+    const lines = record
+      .split(/\r?\n/)
+      .map((l) => l.trim())
+      .filter(Boolean);
+
+    let date = '';
+    let amount = '0';
+    let description = '';
+
+    for (const line of lines) {
+      const code = line[0];
+      const value = line.slice(1).trim();
+      switch (code) {
+        case 'D':
+          date = value;
+          break;
+        case 'T':
+        case '$':
+          amount = value.replace(/,/g, '');
+          break;
+        case 'P':
+        case 'M':
+          if (!description) description = value;
+          break;
+      }
+    }
+
+    if (date || amount !== '0') {
+      results.push({ date, amount, description });
+    }
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// ManualImportProvider
+// ---------------------------------------------------------------------------
+
+/**
+ * Banking provider that imports transactions from user-uploaded files.
+ *
+ * Usage:
+ * ```ts
+ * const provider = new ManualImportProvider();
+ * const session = await provider.initializeConnection({
+ *   metadata: { content: csvString, format: 'csv', institutionName: 'My Bank' },
+ * });
+ * const connection = await provider.completeConnection(session.sessionId);
+ * const txs = await provider.getTransactions(connection.id, { from: '2024-01-01', to: '2024-12-31' });
+ * ```
+ */
+export class ManualImportProvider implements BankConnectionProvider {
+  readonly id = 'manual';
+  readonly name = 'Manual Import';
+  readonly supportedCountries: readonly string[] = []; // Format-agnostic
+  readonly features: ProviderFeatures = {
+    realTimeBalance: false,
+    transactionWebhooks: false,
+    investmentAccounts: false,
+    creditCards: false,
+    loans: false,
+    bnpl: false,
+    crypto: false,
+    internationalBanks: false,
+  };
+
+  /** @internal session staging area */
+  private readonly sessions = new Map<
+    string,
+    { content: string; format: ImportFormat; institutionName: string }
+  >();
+
+  /** @internal imported data per connection */
+  private readonly data = new Map<string, ImportedData>();
+
+  /**
+   * Initialize a manual import "connection".
+   *
+   * Expects `config.metadata` to contain:
+   * - `content` — raw file content as a string
+   * - `format` — `"csv"`, `"ofx"`, or `"qif"`
+   * - `institutionName` (optional) — display name for the institution
+   */
+  async initializeConnection(config: ConnectionConfig): Promise<ConnectionSession> {
+    const meta = config.metadata ?? {};
+    const content = meta.content as string | undefined;
+    const format = (meta.format as ImportFormat | undefined) ?? 'csv';
+    const institutionName = (meta.institutionName as string | undefined) ?? 'Manual Import';
+
+    if (!content || typeof content !== 'string') {
+      throw new Error('Manual import requires "content" in metadata.');
+    }
+
+    const sessionId = crypto.randomUUID();
+    this.sessions.set(sessionId, { content, format, institutionName });
+
+    return { sessionId };
+  }
+
+  /**
+   * Complete the import by parsing the staged file content.
+   */
+  async completeConnection(sessionId: string): Promise<BankConnection> {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      throw new Error(`No manual import session found for "${sessionId}".`);
+    }
+
+    const connectionId = crypto.randomUUID();
+    const accountId = crypto.randomUUID();
+
+    // Parse based on format
+    let rawTxs: Array<{
+      date: string;
+      amount: string;
+      description: string;
+      id?: string;
+    }>;
+
+    switch (session.format) {
+      case 'ofx':
+        rawTxs = parseOfx(session.content);
+        break;
+      case 'qif':
+        rawTxs = parseQif(session.content);
+        break;
+      case 'csv':
+      default:
+        rawTxs = parseCsv(session.content);
+        break;
+    }
+
+    const transactions: BankTransaction[] = rawTxs.map((raw, idx) => ({
+      id: crypto.randomUUID(),
+      providerTransactionId: raw.id ?? `manual-${sessionId}-${idx}`,
+      accountId,
+      date: normalizeDate(raw.date),
+      amountCents: dollarsToCents(parseFloat(raw.amount) || 0),
+      description: raw.description || 'Imported Transaction',
+      category: mapCategory(undefined),
+      pending: false,
+    }));
+
+    const account: BankAccount = {
+      id: accountId,
+      providerAccountId: `manual-${accountId}`,
+      name: `${session.institutionName} Account`,
+      type: 'checking',
+      currency: 'USD',
+      institution: session.institutionName,
+    };
+
+    this.data.set(connectionId, { accounts: [account], transactions });
+    this.sessions.delete(sessionId);
+
+    return {
+      id: connectionId,
+      providerId: this.id,
+      providerConnectionId: `manual-${connectionId}`,
+      institutionName: session.institutionName,
+      status: 'active',
+      createdAt: new Date().toISOString(),
+    };
+  }
+
+  /** Manual connections cannot be refreshed. */
+  async refreshConnection(connectionId: string): Promise<RefreshResult> {
+    return { connectionId, success: true, newTransactions: 0 };
+  }
+
+  /** Remove stored import data. */
+  async removeConnection(connectionId: string): Promise<void> {
+    this.data.delete(connectionId);
+  }
+
+  /** Return accounts for the imported connection. */
+  async getAccounts(connectionId: string): Promise<BankAccount[]> {
+    return this.data.get(connectionId)?.accounts ?? [];
+  }
+
+  /** Return transactions within the specified date range. */
+  async getTransactions(connectionId: string, dateRange: DateRange): Promise<BankTransaction[]> {
+    const all = this.data.get(connectionId)?.transactions ?? [];
+    return all.filter((tx) => tx.date >= dateRange.from && tx.date <= dateRange.to);
+  }
+
+  /** Manual imports do not track balances. */
+  async getBalances(connectionId: string): Promise<AccountBalance[]> {
+    const accounts = this.data.get(connectionId)?.accounts ?? [];
+    return accounts.map((a) => ({
+      accountId: a.id,
+      currentCents: 0,
+      availableCents: 0,
+      currency: a.currency,
+      asOf: new Date().toISOString(),
+    }));
+  }
+
+  /** Manual connections are always "active" once imported. */
+  async getConnectionStatus(_connectionId: string): Promise<ConnectionStatus> {
+    return { status: 'active', message: 'Manual import — always active.' };
+  }
+
+  /** Manual provider is always healthy (no external dependency). */
+  async getProviderHealth(): Promise<ProviderHealth> {
+    return {
+      isHealthy: true,
+      message: 'Manual import provider — no external dependency.',
+      checkedAt: new Date().toISOString(),
+    };
+  }
+}

--- a/apps/web/src/lib/banking/mock-provider.ts
+++ b/apps/web/src/lib/banking/mock-provider.ts
@@ -1,0 +1,376 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Mock banking provider for testing and development.
+ *
+ * Generates realistic-looking financial data (accounts, transactions,
+ * balances) without any network calls. Output is **deterministic** when
+ * a seed is provided, making it suitable for snapshot tests.
+ *
+ * Supports configurable:
+ * - Number of accounts
+ * - Transaction volume per account
+ * - Error simulation (force specific error types)
+ *
+ * @module banking/mock-provider
+ */
+
+import type {
+  AccountBalance,
+  BankAccount,
+  BankAccountType,
+  BankConnection,
+  BankConnectionProvider,
+  BankTransaction,
+  ConnectionConfig,
+  ConnectionSession,
+  ConnectionStatus,
+  DateRange,
+  ProviderFeatures,
+  ProviderHealth,
+  RefreshResult,
+} from './types';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/**
+ * Options to customize mock data generation.
+ */
+export interface MockProviderConfig {
+  /** Seed for deterministic random number generation. @default 42 */
+  seed?: number;
+  /** Number of accounts to generate per connection. @default 3 */
+  accountCount?: number;
+  /** Number of transactions to generate per account. @default 25 */
+  transactionsPerAccount?: number;
+  /** Force an error on the next operation (then resets). */
+  simulateError?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Seeded PRNG (Mulberry32)
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a seeded pseudo-random number generator (Mulberry32).
+ *
+ * @param seed - Integer seed.
+ * @returns A function that returns the next pseudo-random float in [0, 1).
+ * @internal
+ */
+function createRng(seed: number): () => number {
+  let s = seed | 0;
+  return () => {
+    s = (s + 0x6d2b79f5) | 0;
+    let t = Math.imul(s ^ (s >>> 15), 1 | s);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Data pools
+// ---------------------------------------------------------------------------
+
+const ACCOUNT_TEMPLATES: Array<{
+  name: string;
+  type: BankAccountType;
+  institution: string;
+  mask: string;
+}> = [
+  {
+    name: 'Chase Checking',
+    type: 'checking',
+    institution: 'JPMorgan Chase',
+    mask: '4521',
+  },
+  {
+    name: 'Chase Savings',
+    type: 'savings',
+    institution: 'JPMorgan Chase',
+    mask: '7833',
+  },
+  {
+    name: 'Amex Platinum',
+    type: 'credit_card',
+    institution: 'American Express',
+    mask: '1008',
+  },
+  {
+    name: 'Ally Savings',
+    type: 'savings',
+    institution: 'Ally Bank',
+    mask: '9214',
+  },
+  {
+    name: 'Capital One Venture',
+    type: 'credit_card',
+    institution: 'Capital One',
+    mask: '3347',
+  },
+  {
+    name: 'Vanguard Brokerage',
+    type: 'investment',
+    institution: 'Vanguard',
+    mask: '6671',
+  },
+  {
+    name: 'SoFi Checking',
+    type: 'checking',
+    institution: 'SoFi',
+    mask: '2290',
+  },
+  {
+    name: 'Auto Loan',
+    type: 'loan',
+    institution: 'Capital One Auto',
+    mask: '5512',
+  },
+];
+
+const MERCHANTS = [
+  'Whole Foods Market',
+  'Amazon.com',
+  'Starbucks',
+  'Shell Gas Station',
+  'Netflix',
+  'Spotify',
+  'Target',
+  'Walmart',
+  "Trader Joe's",
+  'Uber',
+  'Lyft',
+  'DoorDash',
+  'Costco',
+  'Home Depot',
+  'CVS Pharmacy',
+  'Chipotle',
+  'Apple',
+  'Google Cloud',
+  'Electric Company',
+  'Water Utility',
+];
+
+const CATEGORIES = [
+  'groceries',
+  'food_and_drink',
+  'transportation',
+  'shopping',
+  'entertainment',
+  'utilities',
+  'healthcare',
+  'subscriptions',
+  'housing',
+  'income',
+  'transfer',
+];
+
+// ---------------------------------------------------------------------------
+// MockProvider
+// ---------------------------------------------------------------------------
+
+/**
+ * A mock banking provider that generates realistic fake data.
+ *
+ * Use this for development, demos, and automated testing.
+ *
+ * ```ts
+ * const mock = new MockProvider({ seed: 123, accountCount: 2 });
+ * const session = await mock.initializeConnection({});
+ * const conn = await mock.completeConnection(session.sessionId);
+ * const accounts = await mock.getAccounts(conn.id);
+ * ```
+ */
+export class MockProvider implements BankConnectionProvider {
+  readonly id = 'mock';
+  readonly name = 'Mock Provider';
+  readonly supportedCountries: readonly string[] = ['US', 'GB', 'CA', 'AU'];
+  readonly features: ProviderFeatures = {
+    realTimeBalance: true,
+    transactionWebhooks: true,
+    investmentAccounts: true,
+    creditCards: true,
+    loans: true,
+    bnpl: false,
+    crypto: false,
+    internationalBanks: true,
+  };
+
+  private readonly config: Required<
+    Pick<MockProviderConfig, 'seed' | 'accountCount' | 'transactionsPerAccount'>
+  >;
+  private simulateError: string | undefined;
+  private readonly connections = new Map<
+    string,
+    {
+      connection: BankConnection;
+      accounts: BankAccount[];
+      transactions: BankTransaction[];
+    }
+  >();
+
+  constructor(config?: MockProviderConfig) {
+    this.config = {
+      seed: config?.seed ?? 42,
+      accountCount: config?.accountCount ?? 3,
+      transactionsPerAccount: config?.transactionsPerAccount ?? 25,
+    };
+    this.simulateError = config?.simulateError;
+  }
+
+  /** Initialize a mock connection session. */
+  async initializeConnection(_config: ConnectionConfig): Promise<ConnectionSession> {
+    this.maybeThrow();
+    const sessionId = this.deterministicId('session');
+    return { sessionId, expiresInSeconds: 3600 };
+  }
+
+  /** Complete the mock connection and generate fake data. */
+  async completeConnection(sessionId: string): Promise<BankConnection> {
+    this.maybeThrow();
+
+    const rng = createRng(this.config.seed);
+    const connectionId = this.deterministicId('conn');
+
+    // Generate accounts
+    const accounts: BankAccount[] = [];
+    for (let i = 0; i < this.config.accountCount; i++) {
+      const template = ACCOUNT_TEMPLATES[i % ACCOUNT_TEMPLATES.length];
+      accounts.push({
+        id: this.deterministicId(`acct-${i}`),
+        providerAccountId: `mock-acct-${i}`,
+        name: template.name,
+        type: template.type,
+        currency: 'USD',
+        institution: template.institution,
+        mask: template.mask,
+      });
+    }
+
+    // Generate transactions
+    const transactions: BankTransaction[] = [];
+    const baseDate = new Date('2024-01-15');
+
+    for (const account of accounts) {
+      for (let t = 0; t < this.config.transactionsPerAccount; t++) {
+        const dayOffset = Math.floor(rng() * 365);
+        const date = new Date(baseDate);
+        date.setDate(date.getDate() + dayOffset);
+
+        const isIncome = rng() < 0.15;
+        const amountDollars = isIncome ? 500 + rng() * 4500 : -(1 + rng() * 200);
+        const amountCents = Math.round(amountDollars * 100);
+
+        const merchantIdx = Math.floor(rng() * MERCHANTS.length);
+        const categoryIdx = isIncome
+          ? CATEGORIES.indexOf('income')
+          : Math.floor(rng() * (CATEGORIES.length - 2)); // Exclude income/transfer mostly
+
+        transactions.push({
+          id: this.deterministicId(`tx-${account.id}-${t}`),
+          providerTransactionId: `mock-tx-${account.id}-${t}`,
+          accountId: account.id,
+          date: date.toISOString().slice(0, 10),
+          amountCents,
+          description: MERCHANTS[merchantIdx],
+          category: CATEGORIES[categoryIdx >= 0 ? categoryIdx : 0],
+          merchant: MERCHANTS[merchantIdx],
+          pending: rng() < 0.05,
+        });
+      }
+    }
+
+    const connection: BankConnection = {
+      id: connectionId,
+      providerId: this.id,
+      providerConnectionId: `mock-provider-conn-${sessionId}`,
+      institutionName: 'Mock Bank',
+      status: 'active',
+      lastRefreshedAt: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+    };
+
+    this.connections.set(connectionId, { connection, accounts, transactions });
+    return connection;
+  }
+
+  /** Simulate a refresh. */
+  async refreshConnection(connectionId: string): Promise<RefreshResult> {
+    this.maybeThrow();
+    return { connectionId, success: true, newTransactions: 0 };
+  }
+
+  /** Remove mock connection data. */
+  async removeConnection(connectionId: string): Promise<void> {
+    this.connections.delete(connectionId);
+  }
+
+  /** Return mock accounts. */
+  async getAccounts(connectionId: string): Promise<BankAccount[]> {
+    return this.connections.get(connectionId)?.accounts ?? [];
+  }
+
+  /** Return mock transactions filtered by date range. */
+  async getTransactions(connectionId: string, dateRange: DateRange): Promise<BankTransaction[]> {
+    const all = this.connections.get(connectionId)?.transactions ?? [];
+    return all
+      .filter((tx) => tx.date >= dateRange.from && tx.date <= dateRange.to)
+      .sort((a, b) => b.date.localeCompare(a.date));
+  }
+
+  /** Return mock balances. */
+  async getBalances(connectionId: string): Promise<AccountBalance[]> {
+    const rng = createRng(this.config.seed + 999);
+    const accounts = this.connections.get(connectionId)?.accounts ?? [];
+    return accounts.map((a) => ({
+      accountId: a.id,
+      currentCents: Math.round(rng() * 1000000),
+      availableCents: Math.round(rng() * 1000000),
+      currency: a.currency,
+      asOf: new Date().toISOString(),
+    }));
+  }
+
+  /** Return mock connection status. */
+  async getConnectionStatus(_connectionId: string): Promise<ConnectionStatus> {
+    return { status: 'active', message: 'Mock connection is healthy.' };
+  }
+
+  /** Return mock provider health. */
+  async getProviderHealth(): Promise<ProviderHealth> {
+    return {
+      isHealthy: true,
+      latencyMs: 12,
+      message: 'Mock provider — always healthy.',
+      checkedAt: new Date().toISOString(),
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  /**
+   * Generate a deterministic ID from a label and the configured seed.
+   * @internal
+   */
+  private deterministicId(label: string): string {
+    // Simple deterministic string — good enough for tests
+    const hash = `${this.config.seed}-${label}`;
+    return `mock-${hash}`;
+  }
+
+  /**
+   * Throw if error simulation is configured (then reset).
+   * @internal
+   */
+  private maybeThrow(): void {
+    if (this.simulateError) {
+      const msg = this.simulateError;
+      this.simulateError = undefined;
+      throw new Error(msg);
+    }
+  }
+}

--- a/apps/web/src/lib/banking/provider-registry.ts
+++ b/apps/web/src/lib/banking/provider-registry.ts
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Provider registry — discover, register, and query banking providers.
+ *
+ * The registry is the single source of truth for which
+ * {@link BankConnectionProvider} implementations are available at runtime.
+ * Consumers filter providers by country or capability before presenting
+ * choices to the user.
+ *
+ * A default singleton ({@link defaultRegistry}) is exported for convenience;
+ * tests and alternative configurations can create their own instances.
+ *
+ * @module banking/provider-registry
+ */
+
+import type { BankConnectionProvider, ProviderFeatures } from './types';
+
+/**
+ * Registry that holds and queries {@link BankConnectionProvider} instances.
+ */
+export class ProviderRegistry {
+  /** @internal provider map keyed by provider ID */
+  private readonly providers = new Map<string, BankConnectionProvider>();
+
+  /**
+   * Register a banking provider.
+   *
+   * @param provider - The provider implementation to register.
+   * @throws {Error} If a provider with the same `id` is already registered.
+   */
+  registerProvider(provider: BankConnectionProvider): void {
+    if (this.providers.has(provider.id)) {
+      throw new Error(`Provider with id "${provider.id}" is already registered.`);
+    }
+    this.providers.set(provider.id, provider);
+  }
+
+  /**
+   * Retrieve a provider by its unique identifier.
+   *
+   * @param id - The provider ID (e.g., `"plaid"`, `"manual"`).
+   * @returns The provider, or `undefined` if not found.
+   */
+  getProvider(id: string): BankConnectionProvider | undefined {
+    return this.providers.get(id);
+  }
+
+  /**
+   * Return every registered provider.
+   *
+   * @returns An array of all providers (order is insertion order).
+   */
+  getAllProviders(): BankConnectionProvider[] {
+    return Array.from(this.providers.values());
+  }
+
+  /**
+   * Return providers that list the given country in their
+   * {@link BankConnectionProvider.supportedCountries}.
+   *
+   * @param countryCode - ISO 3166-1 alpha-2 code (case-insensitive).
+   * @returns Providers supporting that country.
+   */
+  getProvidersForCountry(countryCode: string): BankConnectionProvider[] {
+    const upper = countryCode.toUpperCase();
+    return this.getAllProviders().filter((p) =>
+      p.supportedCountries.some((c) => c.toUpperCase() === upper),
+    );
+  }
+
+  /**
+   * Return providers whose {@link ProviderFeatures} include a truthy value
+   * for the requested feature key.
+   *
+   * @param feature - A key of {@link ProviderFeatures}.
+   * @returns Providers that support the feature.
+   */
+  getProvidersWithFeature(feature: keyof ProviderFeatures): BankConnectionProvider[] {
+    return this.getAllProviders().filter((p) => p.features[feature]);
+  }
+
+  /**
+   * Remove all registered providers (useful in tests).
+   */
+  clear(): void {
+    this.providers.clear();
+  }
+}
+
+/**
+ * Default singleton registry.
+ *
+ * Application bootstrap code registers providers here; hooks and managers
+ * consume from this instance unless overridden.
+ */
+export const defaultRegistry = new ProviderRegistry();

--- a/apps/web/src/lib/banking/transaction-normalizer.ts
+++ b/apps/web/src/lib/banking/transaction-normalizer.ts
@@ -1,0 +1,341 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Normalizes provider-specific financial data into the app's standard models.
+ *
+ * Different banking aggregators return transactions and accounts in wildly
+ * different shapes. This module converts them all to the canonical
+ * {@link BankTransaction} and {@link BankAccount} types used throughout
+ * the application.
+ *
+ * Key responsibilities:
+ * - Dollar → integer-cent conversion with Banker's rounding (HALF_EVEN)
+ * - Date normalization to ISO-8601 (YYYY-MM-DD)
+ * - Category mapping from provider taxonomies to the app's category set
+ * - Deduplication by provider transaction ID
+ *
+ * @module banking/transaction-normalizer
+ */
+
+import type { BankAccount, BankAccountType, BankTransaction } from './types';
+
+// ---------------------------------------------------------------------------
+// Raw provider data shapes (intentionally loose)
+// ---------------------------------------------------------------------------
+
+/**
+ * A transaction record as returned by any provider before normalization.
+ *
+ * All fields are optional because different providers supply different subsets.
+ */
+export interface RawProviderTransaction {
+  /** Provider's unique transaction identifier. */
+  id?: string;
+  /** Transaction date in any reasonable string format. */
+  date?: string;
+  /** Amount as a number (dollars, euros, etc. — NOT cents). */
+  amount?: number;
+  /** Amount already expressed in integer cents (some providers do this). */
+  amountCents?: number;
+  /** Primary description or payee line. */
+  description?: string;
+  /** Provider-specific category label. */
+  category?: string;
+  /** Merchant name. */
+  merchant?: string;
+  /** Whether the transaction is pending. */
+  pending?: boolean;
+  /** Account this transaction belongs to (provider-specific ID). */
+  accountId?: string;
+}
+
+/**
+ * An account record as returned by any provider before normalization.
+ */
+export interface RawProviderAccount {
+  /** Provider's unique account identifier. */
+  id?: string;
+  /** Display name. */
+  name?: string;
+  /** Account type in the provider's own taxonomy. */
+  type?: string;
+  /** ISO 4217 currency code. */
+  currency?: string;
+  /** Institution name. */
+  institution?: string;
+  /** Last four digits or mask. */
+  mask?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Category mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps common provider category labels (lowercased) to the app's category
+ * set. Unknown categories fall through to `"uncategorized"`.
+ */
+const CATEGORY_MAP: Record<string, string> = {
+  // Food & drink
+  food: 'food_and_drink',
+  'food and drink': 'food_and_drink',
+  restaurants: 'food_and_drink',
+  groceries: 'groceries',
+  grocery: 'groceries',
+
+  // Transportation
+  transportation: 'transportation',
+  transport: 'transportation',
+  travel: 'travel',
+  'gas stations': 'transportation',
+  gas: 'transportation',
+
+  // Housing
+  rent: 'housing',
+  mortgage: 'housing',
+  housing: 'housing',
+
+  // Utilities
+  utilities: 'utilities',
+  'phone bill': 'utilities',
+  internet: 'utilities',
+
+  // Shopping
+  shopping: 'shopping',
+  merchandise: 'shopping',
+  clothing: 'shopping',
+
+  // Entertainment
+  entertainment: 'entertainment',
+  recreation: 'entertainment',
+
+  // Health
+  healthcare: 'healthcare',
+  'health care': 'healthcare',
+  medical: 'healthcare',
+  pharmacy: 'healthcare',
+
+  // Income
+  income: 'income',
+  payroll: 'income',
+  salary: 'income',
+  'direct deposit': 'income',
+
+  // Transfer
+  transfer: 'transfer',
+  'bank transfer': 'transfer',
+  payment: 'transfer',
+
+  // Education
+  education: 'education',
+  tuition: 'education',
+
+  // Personal care
+  'personal care': 'personal_care',
+
+  // Subscriptions
+  subscription: 'subscriptions',
+  subscriptions: 'subscriptions',
+
+  // Insurance
+  insurance: 'insurance',
+
+  // Taxes
+  tax: 'taxes',
+  taxes: 'taxes',
+};
+
+/**
+ * Map a provider-specific category label to the app's standard category.
+ *
+ * @param providerCategory - Raw category string from the provider.
+ * @returns App-standard category, or `"uncategorized"` if no mapping exists.
+ */
+export function mapCategory(providerCategory: string | undefined): string {
+  if (!providerCategory) return 'uncategorized';
+  return CATEGORY_MAP[providerCategory.toLowerCase().trim()] ?? 'uncategorized';
+}
+
+// ---------------------------------------------------------------------------
+// Amount helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a floating-point dollar amount to integer cents using
+ * Banker's rounding (round half to even).
+ *
+ * @param dollars - Amount in dollars (e.g., 12.345).
+ * @returns Amount in integer cents (e.g., 1234 for $12.345 → rounds to 1234).
+ */
+export function dollarsToCents(dollars: number): number {
+  // Multiply first, then apply Banker's rounding
+  const raw = dollars * 100;
+  return bankersRound(raw);
+}
+
+/**
+ * Banker's rounding (HALF_EVEN): when the value is exactly halfway between
+ * two integers, round to the nearest **even** integer.
+ *
+ * @param value - A numeric value.
+ * @returns The rounded integer.
+ */
+export function bankersRound(value: number): number {
+  const floored = Math.floor(value);
+  const diff = value - floored;
+
+  // Tolerance for "exactly halfway" due to floating-point imprecision
+  const EPSILON = 1e-9;
+
+  if (Math.abs(diff - 0.5) < EPSILON) {
+    // Exactly halfway — round to even
+    return floored % 2 === 0 ? floored : floored + 1;
+  }
+  return Math.round(value);
+}
+
+// ---------------------------------------------------------------------------
+// Date helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a date value to ISO-8601 date string (YYYY-MM-DD).
+ *
+ * Accepts ISO strings, `Date` objects, Unix timestamps (milliseconds),
+ * and several common date formats.
+ *
+ * @param raw - Date in any reasonable format.
+ * @returns Normalized YYYY-MM-DD string, or today's date if parsing fails.
+ */
+export function normalizeDate(raw: string | number | Date | undefined): string {
+  if (!raw) return todayISO();
+
+  let d: Date;
+  if (raw instanceof Date) {
+    d = raw;
+  } else if (typeof raw === 'number') {
+    d = new Date(raw);
+  } else {
+    // Try parsing common formats; Date.parse handles ISO and RFC 2822.
+    // For MM/DD/YYYY or DD/MM/YYYY ambiguity we assume M/D/Y (US convention).
+    const cleaned = raw.trim();
+    const slashParts = cleaned.split('/');
+    if (slashParts.length === 3) {
+      const [m, day, y] = slashParts;
+      d = new Date(`${y}-${m.padStart(2, '0')}-${day.padStart(2, '0')}`);
+    } else {
+      d = new Date(cleaned);
+    }
+  }
+
+  if (isNaN(d.getTime())) return todayISO();
+
+  return d.toISOString().slice(0, 10);
+}
+
+/** Today's date as YYYY-MM-DD. */
+function todayISO(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+// ---------------------------------------------------------------------------
+// Account type mapping
+// ---------------------------------------------------------------------------
+
+const ACCOUNT_TYPE_MAP: Record<string, BankAccountType> = {
+  checking: 'checking',
+  depository: 'checking',
+  savings: 'savings',
+  credit: 'credit_card',
+  'credit card': 'credit_card',
+  credit_card: 'credit_card',
+  loan: 'loan',
+  mortgage: 'loan',
+  investment: 'investment',
+  brokerage: 'investment',
+  retirement: 'investment',
+  '401k': 'investment',
+  ira: 'investment',
+};
+
+/**
+ * Map a provider account type string to the app's {@link BankAccountType}.
+ *
+ * @param providerType - Raw type string from the provider.
+ * @returns Normalized account type, defaulting to `"other"`.
+ */
+export function mapAccountType(providerType: string | undefined): BankAccountType {
+  if (!providerType) return 'other';
+  return ACCOUNT_TYPE_MAP[providerType.toLowerCase().trim()] ?? 'other';
+}
+
+// ---------------------------------------------------------------------------
+// Public normalization functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a provider-specific transaction into the app's standard
+ * {@link BankTransaction} model.
+ *
+ * @param raw - Raw transaction data from the provider.
+ * @param providerId - Identifier of the originating provider.
+ * @returns Normalized transaction with amount in integer cents.
+ */
+export function normalizeTransaction(
+  raw: RawProviderTransaction,
+  providerId: string,
+): BankTransaction {
+  const providerTxId = raw.id ?? `${providerId}-${Date.now()}`;
+  const amountCents =
+    raw.amountCents !== undefined ? Math.round(raw.amountCents) : dollarsToCents(raw.amount ?? 0);
+
+  return {
+    id: crypto.randomUUID(),
+    providerTransactionId: providerTxId,
+    accountId: raw.accountId ?? '',
+    date: normalizeDate(raw.date),
+    amountCents,
+    description: (raw.description ?? '').trim() || 'Unknown',
+    category: mapCategory(raw.category),
+    merchant: raw.merchant?.trim() || undefined,
+    pending: raw.pending ?? false,
+  };
+}
+
+/**
+ * Normalize a provider-specific account into the app's standard
+ * {@link BankAccount} model.
+ *
+ * @param raw - Raw account data from the provider.
+ * @param providerId - Identifier of the originating provider.
+ * @returns Normalized account record.
+ */
+export function normalizeAccount(raw: RawProviderAccount, providerId: string): BankAccount {
+  return {
+    id: crypto.randomUUID(),
+    providerAccountId: raw.id ?? `${providerId}-${Date.now()}`,
+    name: (raw.name ?? '').trim() || 'Unnamed Account',
+    type: mapAccountType(raw.type),
+    currency: (raw.currency ?? 'USD').toUpperCase(),
+    institution: (raw.institution ?? '').trim() || 'Unknown',
+    mask: raw.mask?.trim() || undefined,
+  };
+}
+
+/**
+ * Deduplicate an array of transactions by their provider transaction ID.
+ *
+ * When duplicates are found the **first** occurrence wins (preserving
+ * insertion order).
+ *
+ * @param transactions - Array of normalized transactions.
+ * @returns Deduplicated array.
+ */
+export function deduplicateTransactions(transactions: BankTransaction[]): BankTransaction[] {
+  const seen = new Set<string>();
+  return transactions.filter((tx) => {
+    if (seen.has(tx.providerTransactionId)) return false;
+    seen.add(tx.providerTransactionId);
+    return true;
+  });
+}

--- a/apps/web/src/lib/banking/types.ts
+++ b/apps/web/src/lib/banking/types.ts
@@ -1,0 +1,366 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Core types for the provider-agnostic banking connection abstraction layer.
+ *
+ * Every banking aggregator (Plaid, MX, TrueLayer, manual import, etc.) implements
+ * the {@link BankConnectionProvider} interface. The rest of the app interacts
+ * with banking data exclusively through these normalized types — never through
+ * provider-specific models.
+ *
+ * Monetary values are always expressed as **integer cents** to avoid
+ * floating-point rounding errors in financial calculations.
+ *
+ * @module banking/types
+ */
+
+// ---------------------------------------------------------------------------
+// Provider capability flags
+// ---------------------------------------------------------------------------
+
+/**
+ * Feature flags describing what a specific banking provider supports.
+ *
+ * Consumers can query these flags to conditionally render UI or skip
+ * unsupported operations without try/catch guessing.
+ */
+export interface ProviderFeatures {
+  /** Provider can return up-to-the-second balance data. */
+  realTimeBalance: boolean;
+  /** Provider pushes transaction updates via webhooks. */
+  transactionWebhooks: boolean;
+  /** Provider surfaces brokerage / investment account data. */
+  investmentAccounts: boolean;
+  /** Provider surfaces credit card accounts. */
+  creditCards: boolean;
+  /** Provider surfaces loan accounts (mortgage, auto, personal). */
+  loans: boolean;
+  /** Provider surfaces Buy-Now-Pay-Later installment plans. */
+  bnpl: boolean;
+  /** Provider surfaces cryptocurrency wallet data. */
+  crypto: boolean;
+  /** Provider supports institutions outside the home country. */
+  internationalBanks: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Connection lifecycle types
+// ---------------------------------------------------------------------------
+
+/**
+ * Configuration supplied when initiating a new banking connection.
+ *
+ * Different providers interpret these fields according to their own API —
+ * the `metadata` bag allows provider-specific extras without polluting the
+ * shared interface.
+ */
+export interface ConnectionConfig {
+  /** Target financial institution identifier (provider-specific). */
+  institutionId?: string;
+  /** ISO 3166-1 alpha-2 country code for the institution. */
+  countryCode?: string;
+  /** Opaque provider-specific configuration. */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Represents an in-progress connection handshake.
+ *
+ * Providers that require multi-step authentication (OAuth redirect, MFA, etc.)
+ * return a session that the UI must complete before data is available.
+ */
+export interface ConnectionSession {
+  /** Unique identifier for this connection attempt. */
+  sessionId: string;
+  /** Provider-specific URL or token the UI needs to continue the flow. */
+  redirectUrl?: string;
+  /** Seconds until this session expires. */
+  expiresInSeconds?: number;
+  /** Opaque provider-specific session data. */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * A fully established connection to a financial institution.
+ */
+export interface BankConnection {
+  /** Stable identifier for this connection (app-generated UUID). */
+  id: string;
+  /** Identifier of the provider that manages this connection. */
+  providerId: string;
+  /** Provider-specific connection/item identifier. */
+  providerConnectionId: string;
+  /** Human-readable institution name. */
+  institutionName: string;
+  /** Current connection health status. */
+  status: ConnectionStatusType;
+  /** ISO-8601 timestamp of the last successful data refresh. */
+  lastRefreshedAt?: string;
+  /** ISO-8601 timestamp when the connection was created. */
+  createdAt: string;
+  /** Opaque provider-specific connection data. */
+  metadata?: Record<string, unknown>;
+}
+
+/** Possible states for a banking connection. */
+export type ConnectionStatusType = 'active' | 'degraded' | 'disconnected' | 'pending' | 'error';
+
+/**
+ * Detailed status information for a connection.
+ */
+export interface ConnectionStatus {
+  /** Overall connection health. */
+  status: ConnectionStatusType;
+  /** Human-readable status message. */
+  message?: string;
+  /** ISO-8601 timestamp of the last successful sync. */
+  lastSuccessfulSync?: string;
+  /** If status is `error`, the categorized error code. */
+  errorCode?: ConnectionErrorCode;
+}
+
+/**
+ * Health / availability information for a banking provider.
+ */
+export interface ProviderHealth {
+  /** Whether the provider's API is reachable and responding. */
+  isHealthy: boolean;
+  /** Provider-reported latency in milliseconds. */
+  latencyMs?: number;
+  /** Human-readable health summary. */
+  message?: string;
+  /** ISO-8601 timestamp of this health check. */
+  checkedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Normalized financial data types
+// ---------------------------------------------------------------------------
+
+/**
+ * A normalized bank account, independent of the originating provider.
+ */
+export interface BankAccount {
+  /** Stable identifier for this account (app-generated UUID). */
+  id: string;
+  /** Provider-specific account identifier. */
+  providerAccountId: string;
+  /** Human-readable account name (e.g., "Chase Checking ••1234"). */
+  name: string;
+  /** Account type in the app's taxonomy. */
+  type: BankAccountType;
+  /** ISO 4217 currency code (e.g., "USD"). */
+  currency: string;
+  /** Financial institution name. */
+  institution: string;
+  /** Last four digits or mask of the account number. */
+  mask?: string;
+}
+
+/** Supported account types. */
+export type BankAccountType =
+  | 'checking'
+  | 'savings'
+  | 'credit_card'
+  | 'loan'
+  | 'investment'
+  | 'other';
+
+/**
+ * A normalized financial transaction in integer cents.
+ */
+export interface BankTransaction {
+  /** Stable identifier for this transaction (app-generated UUID). */
+  id: string;
+  /** Provider-specific transaction identifier (used for deduplication). */
+  providerTransactionId: string;
+  /** Provider-specific account identifier this transaction belongs to. */
+  accountId: string;
+  /** ISO-8601 date string (YYYY-MM-DD). */
+  date: string;
+  /** Transaction amount in **integer cents**. Negative = outflow. */
+  amountCents: number;
+  /** Primary transaction description / payee. */
+  description: string;
+  /** App-level category (normalized from provider categories). */
+  category?: string;
+  /** Merchant name, if available. */
+  merchant?: string;
+  /** Whether this transaction is still pending settlement. */
+  pending: boolean;
+}
+
+/**
+ * Balance snapshot for a single account, in integer cents.
+ */
+export interface AccountBalance {
+  /** Provider-specific account identifier. */
+  accountId: string;
+  /** Current (ledger) balance in **integer cents**. */
+  currentCents: number;
+  /** Available balance in **integer cents** (may differ due to holds). */
+  availableCents?: number;
+  /** ISO 4217 currency code. */
+  currency: string;
+  /** ISO-8601 timestamp when this balance was captured. */
+  asOf: string;
+}
+
+// ---------------------------------------------------------------------------
+// Date range helper
+// ---------------------------------------------------------------------------
+
+/**
+ * An inclusive date range for querying transactions.
+ */
+export interface DateRange {
+  /** Start date in ISO-8601 format (YYYY-MM-DD). */
+  from: string;
+  /** End date in ISO-8601 format (YYYY-MM-DD). */
+  to: string;
+}
+
+// ---------------------------------------------------------------------------
+// Refresh & error types
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of refreshing one or more banking connections.
+ */
+export interface RefreshResult {
+  /** The connection that was refreshed. */
+  connectionId: string;
+  /** Whether the refresh completed successfully. */
+  success: boolean;
+  /** Number of new transactions discovered during refresh. */
+  newTransactions?: number;
+  /** Error details if the refresh failed. */
+  error?: ConnectionError;
+}
+
+/** Categorized error codes for banking connection failures. */
+export type ConnectionErrorCode =
+  | 'AUTHENTICATION_EXPIRED'
+  | 'PROVIDER_DOWN'
+  | 'RATE_LIMITED'
+  | 'INVALID_CREDENTIALS'
+  | 'INSTITUTION_NOT_SUPPORTED'
+  | 'UNKNOWN';
+
+/**
+ * A structured error from a banking connection operation.
+ */
+export interface ConnectionError {
+  /** Categorized error code for programmatic handling. */
+  code: ConnectionErrorCode;
+  /** Human-readable error message. */
+  message: string;
+  /** Whether the operation can be retried. */
+  retryable: boolean;
+  /** Provider-specific error details. */
+  providerError?: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Provider interface
+// ---------------------------------------------------------------------------
+
+/**
+ * The main abstraction for banking data providers.
+ *
+ * Any banking aggregator (Plaid, MX, TrueLayer, manual CSV import, etc.)
+ * implements this interface. The rest of the application uses
+ * {@link ProviderRegistry} and {@link ConnectionManager} to interact with
+ * providers without knowing their implementation details.
+ */
+export interface BankConnectionProvider {
+  /** Unique identifier for this provider (e.g., "plaid", "mx", "manual"). */
+  readonly id: string;
+  /** Human-readable display name. */
+  readonly name: string;
+  /** ISO 3166-1 alpha-2 country codes this provider supports. */
+  readonly supportedCountries: readonly string[];
+  /** Capability flags for this provider. */
+  readonly features: ProviderFeatures;
+
+  // -- Connection lifecycle --------------------------------------------------
+
+  /**
+   * Begin a new connection flow with a financial institution.
+   *
+   * @param config - Connection parameters (institution, country, extras).
+   * @returns A session object the UI uses to complete the handshake.
+   */
+  initializeConnection(config: ConnectionConfig): Promise<ConnectionSession>;
+
+  /**
+   * Finalize a connection after the user completes authentication.
+   *
+   * @param sessionId - The session ID from {@link initializeConnection}.
+   * @param metadata - Provider-specific completion data (e.g., public token).
+   * @returns The established connection record.
+   */
+  completeConnection(
+    sessionId: string,
+    metadata?: Record<string, unknown>,
+  ): Promise<BankConnection>;
+
+  /**
+   * Refresh data for an existing connection.
+   *
+   * @param connectionId - The app-level connection ID.
+   * @returns Refresh result with success/failure and new transaction count.
+   */
+  refreshConnection(connectionId: string): Promise<RefreshResult>;
+
+  /**
+   * Permanently remove a connection and revoke provider-side access.
+   *
+   * @param connectionId - The app-level connection ID to remove.
+   */
+  removeConnection(connectionId: string): Promise<void>;
+
+  // -- Data access -----------------------------------------------------------
+
+  /**
+   * Retrieve all accounts for a given connection.
+   *
+   * @param connectionId - The app-level connection ID.
+   * @returns Normalized bank accounts.
+   */
+  getAccounts(connectionId: string): Promise<BankAccount[]>;
+
+  /**
+   * Retrieve transactions for a connection within a date range.
+   *
+   * @param connectionId - The app-level connection ID.
+   * @param dateRange - Inclusive date range filter.
+   * @returns Normalized transactions sorted by date descending.
+   */
+  getTransactions(connectionId: string, dateRange: DateRange): Promise<BankTransaction[]>;
+
+  /**
+   * Retrieve current balances for all accounts in a connection.
+   *
+   * @param connectionId - The app-level connection ID.
+   * @returns Balance snapshots for each account.
+   */
+  getBalances(connectionId: string): Promise<AccountBalance[]>;
+
+  // -- Status ----------------------------------------------------------------
+
+  /**
+   * Check the health/status of a specific connection.
+   *
+   * @param connectionId - The app-level connection ID.
+   * @returns Detailed connection status.
+   */
+  getConnectionStatus(connectionId: string): Promise<ConnectionStatus>;
+
+  /**
+   * Check the overall health of this provider's API.
+   *
+   * @returns Provider health information.
+   */
+  getProviderHealth(): Promise<ProviderHealth>;
+}


### PR DESCRIPTION
## Summary
Adds a provider-agnostic banking connection abstraction layer. Any banking aggregator (Plaid, MX, TrueLayer) or self-hosted solution can be integrated by implementing the BankConnectionProvider interface.

## Changes
- \BankConnectionProvider\ interface with full lifecycle and data methods
- \ProviderRegistry\ for multi-provider discovery and filtering by country/feature
- \ConnectionManager\ with exponential backoff retry logic and error isolation
- \TransactionNormalizer\ for provider-to-app format conversion (dollar→cents, date normalization, category mapping, deduplication)
- \ManualImportProvider\ with inline CSV/OFX/QIF parsers for file-based imports
- \MockProvider\ for testing with deterministic seed-based data generation
- All monetary values in integer cents with Banker's rounding (HALF_EVEN)
- JSDoc on every public function and interface
- No UI components — pure data/infrastructure layer

## Architecture
\\\
Provider (Plaid/MX/Manual/Mock)
    ↕
ProviderRegistry (discovery & filtering)
    ↕
ConnectionManager (lifecycle, retry, error isolation)
    ↕
TransactionNormalizer (raw → normalized BankTransaction/BankAccount)
\\\

## New Dependencies
None — zero new dependencies added.

## Testing
- 80 tests across 5 test files, all passing
- Provider registry: register, get, filter by country/feature, duplicate ID handling
- Connection manager: create connection, refresh all, retry logic, error isolation, error categorization
- Transaction normalizer: dollar→cents conversion, Banker's rounding, date normalization, deduplication, category mapping
- Manual provider: CSV/OFX/QIF import through provider interface, feature flags, date filtering
- Mock provider: deterministic seed-based generation, error simulation, balance/status reporting

## Issues
Closes #1853