### PR TITLE
chore(android): add signing and deployment scaffolding (#1242)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,12 @@ obj/
 *.keystore
 secrets/
 .secrets/
+keystore.properties
+fastlane/play-store-service-account.json
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/
+fastlane/test_output/
 
 # === Build artifacts ===
 coverage/

--- a/apps/android/Gemfile
+++ b/apps/android/Gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "fastlane", "~> 2.225"
+
+# Fastlane plugins (add as needed)
+# gem "fastlane-plugin-firebase_app_distribution"

--- a/apps/android/build.gradle.kts
+++ b/apps/android/build.gradle.kts
@@ -1,10 +1,23 @@
 // SPDX-License-Identifier: BUSL-1.1
 
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.paparazzi)
+}
+
+// ── Keystore properties ──────────────────────────────────────────
+// Load signing credentials from keystore.properties (local dev) or fall
+// back to gradle.properties / environment variables (CI).
+// Copy keystore.properties.template → keystore.properties and fill in values.
+val keystorePropertiesFile = rootProject.file("apps/android/keystore.properties")
+val keystoreProperties = Properties().apply {
+    if (keystorePropertiesFile.exists()) {
+        keystorePropertiesFile.inputStream().use { load(it) }
+    }
 }
 
 android {
@@ -38,16 +51,21 @@ android {
     }
 
     // ── Release signing ─────────────────────────────────────────────
-    // Credentials are read from gradle.properties or environment variables.
-    // See docs/android/play-store-submission.md for setup instructions.
+    // Credentials are read from keystore.properties (local), gradle.properties,
+    // or environment variables (CI). See keystore.properties.template for setup.
     signingConfigs {
         create("release") {
-            val keystoreFile = project.findProperty("FINANCE_KEYSTORE_FILE") as String?
-            if (keystoreFile != null) {
-                storeFile = file(keystoreFile)
-                storePassword = project.findProperty("FINANCE_KEYSTORE_PASSWORD") as String?
-                keyAlias = project.findProperty("FINANCE_KEY_ALIAS") as String?
-                keyPassword = project.findProperty("FINANCE_KEY_PASSWORD") as String?
+            // Prefer keystore.properties, fall back to gradle.properties / env vars
+            val ksFile = keystoreProperties.getProperty("STORE_FILE")
+                ?: project.findProperty("FINANCE_KEYSTORE_FILE") as String?
+            if (ksFile != null) {
+                storeFile = file(ksFile)
+                storePassword = keystoreProperties.getProperty("STORE_PASSWORD")
+                    ?: project.findProperty("FINANCE_KEYSTORE_PASSWORD") as String?
+                keyAlias = keystoreProperties.getProperty("KEY_ALIAS")
+                    ?: project.findProperty("FINANCE_KEY_ALIAS") as String?
+                keyPassword = keystoreProperties.getProperty("KEY_PASSWORD")
+                    ?: project.findProperty("FINANCE_KEY_PASSWORD") as String?
             }
         }
     }
@@ -64,8 +82,9 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",
             )
-            val keystoreFile = project.findProperty("FINANCE_KEYSTORE_FILE") as String?
-            if (keystoreFile != null) {
+            val ksFile = keystoreProperties.getProperty("STORE_FILE")
+                ?: project.findProperty("FINANCE_KEYSTORE_FILE") as String?
+            if (ksFile != null) {
                 signingConfig = signingConfigs.getByName("release")
             }
         }

--- a/apps/android/fastlane/Appfile
+++ b/apps/android/fastlane/Appfile
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: BUSL-1.1
+#
+# Fastlane Appfile — Android
+# See: https://docs.fastlane.tools/advanced/Appfile/
+#
+# TODO(human): Replace YOUR_PACKAGE_NAME with the real application ID
+# (e.g., "com.finance.android") once the Play Console listing is created.
+
+package_name("YOUR_PACKAGE_NAME")
+
+# Path to the Google Play service-account JSON key.
+# In CI this is written from the GOOGLE_PLAY_SERVICE_ACCOUNT_JSON secret.
+# Locally, place the file at this path or override via SUPPLY_JSON_KEY env var.
+json_key_file("fastlane/play-store-service-account.json")

--- a/apps/android/fastlane/Fastfile
+++ b/apps/android/fastlane/Fastfile
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: BUSL-1.1
+#
+# Fastlane Fastfile — Android
+# See: https://docs.fastlane.tools/actions/
+#
+# Usage:
+#   bundle exec fastlane build_alpha          # Build signed release APK/AAB
+#   bundle exec fastlane upload_internal      # Upload AAB to Play Store internal track
+#
+# Prerequisites:
+#   - keystore.properties filled in (or CI env vars set)
+#   - Google Play service account JSON at fastlane/play-store-service-account.json
+#   - App listing created in Google Play Console
+
+default_platform(:android)
+
+platform :android do
+  # ── Build Alpha ──────────────────────────────────────────────────
+  # Assembles a signed release build (APK + AAB) using Gradle.
+  # Signing credentials come from:
+  #   - keystore.properties (local dev)
+  #   - Environment variables / gradle.properties (CI)
+  desc "Build signed release APK and AAB for alpha distribution"
+  lane :build_alpha do
+    gradle(
+      task: "clean",
+      project_dir: "."
+    )
+
+    # Build AAB for Play Store upload
+    gradle(
+      task: "bundle",
+      build_type: "Release",
+      project_dir: ".",
+      print_command: true,
+      flags: "--parallel --build-cache --stacktrace"
+    )
+
+    # Build APK for direct testing / sideloading
+    gradle(
+      task: "assemble",
+      build_type: "Release",
+      project_dir: ".",
+      print_command: true,
+      flags: "--parallel --build-cache --stacktrace"
+    )
+
+    UI.success("✅ Release APK and AAB built successfully")
+
+    # Print artifact locations
+    aab_path = lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH]
+    apk_path = lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH]
+    UI.message("AAB: #{aab_path}") if aab_path
+    UI.message("APK: #{apk_path}") if apk_path
+  end
+
+  # ── Upload to Internal Testing ──────────────────────────────────
+  # Uploads the AAB to Google Play's internal testing track.
+  # Requires a service account JSON with release-manager permissions.
+  desc "Upload AAB to Google Play internal testing track"
+  lane :upload_internal do
+    # Build first if no AAB exists
+    aab_path = Dir.glob("build/outputs/bundle/release/*.aab").first
+    build_alpha unless aab_path
+
+    aab_path = Dir.glob("build/outputs/bundle/release/*.aab").first
+    UI.user_error!("No AAB found — build failed?") unless aab_path
+
+    upload_to_play_store(
+      track: "internal",
+      aab: aab_path,
+      skip_upload_metadata: true,
+      skip_upload_changelogs: false,
+      skip_upload_images: true,
+      skip_upload_screenshots: true,
+      release_status: "draft"
+    )
+
+    UI.success("✅ AAB uploaded to internal testing track (draft)")
+  end
+
+  # ── Upload to Alpha Track ──────────────────────────────────────
+  # Promotes a build to the alpha (closed testing) track.
+  desc "Upload AAB to Google Play alpha (closed testing) track"
+  lane :upload_alpha do
+    aab_path = Dir.glob("build/outputs/bundle/release/*.aab").first
+    build_alpha unless aab_path
+
+    aab_path = Dir.glob("build/outputs/bundle/release/*.aab").first
+    UI.user_error!("No AAB found — build failed?") unless aab_path
+
+    upload_to_play_store(
+      track: "alpha",
+      aab: aab_path,
+      skip_upload_metadata: true,
+      skip_upload_changelogs: false,
+      skip_upload_images: true,
+      skip_upload_screenshots: true,
+      release_status: "draft"
+    )
+
+    UI.success("✅ AAB uploaded to alpha track (draft)")
+  end
+end

--- a/apps/android/fastlane/README.md
+++ b/apps/android/fastlane/README.md
@@ -1,0 +1,64 @@
+# Fastlane — Android
+
+This directory contains [Fastlane](https://fastlane.tools/) configuration for
+building, signing, and deploying the Finance Android app.
+
+## Setup
+
+### Prerequisites
+
+1. Ruby 3.x with Bundler (`gem install bundler`)
+2. A filled-in `keystore.properties` file (copy from `keystore.properties.template`)
+3. Google Play service account JSON at `fastlane/play-store-service-account.json`
+
+### Install Fastlane
+
+```bash
+cd apps/android
+bundle install
+```
+
+## Lanes
+
+| Lane              | Description                                       |
+| ----------------- | ------------------------------------------------- |
+| `build_alpha`     | Build signed release APK + AAB                    |
+| `upload_internal` | Upload AAB to Play Store internal testing (draft) |
+| `upload_alpha`    | Upload AAB to Play Store alpha track (draft)      |
+
+### Usage
+
+```bash
+cd apps/android
+bundle exec fastlane build_alpha
+bundle exec fastlane upload_internal
+```
+
+## CI Integration
+
+In CI (GitHub Actions), signing credentials are injected via environment
+variables and GitHub Secrets. The `release-android.yml` workflow handles
+keystore decoding and Gradle property injection automatically.
+
+### Required GitHub Secrets
+
+| Secret                             | Description                             |
+| ---------------------------------- | --------------------------------------- |
+| `ANDROID_KEYSTORE_BASE64`          | Base64-encoded release keystore file    |
+| `ANDROID_KEYSTORE_PASSWORD`        | Keystore password                       |
+| `ANDROID_KEY_ALIAS`                | Key alias (e.g., `finance`)             |
+| `ANDROID_KEY_PASSWORD`             | Key password                            |
+| `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` | Service account JSON for Play Store API |
+
+## Metadata Management
+
+The `metadata/android/` directory (managed by `supply`) holds Play Store
+listing metadata (title, description, changelogs, screenshots). To pull
+existing metadata from the Play Store:
+
+```bash
+bundle exec fastlane supply init
+```
+
+See [Fastlane supply docs](https://docs.fastlane.tools/actions/supply/) for
+more details on metadata management.

--- a/apps/android/fastlane/metadata/android/en-US/changelogs/1.txt
+++ b/apps/android/fastlane/metadata/android/en-US/changelogs/1.txt
@@ -1,0 +1,1 @@
+Initial alpha release.

--- a/apps/android/fastlane/metadata/android/en-US/full_description.txt
+++ b/apps/android/fastlane/metadata/android/en-US/full_description.txt
@@ -1,0 +1,13 @@
+Finance is a privacy-first financial tracking app for personal, family, and partnered finances. Track spending, manage budgets, set savings goals, and stay on top of your financial health — all while keeping your data private and secure.
+
+Features:
+• Multi-account tracking with real-time balances
+• Budget management with category breakdowns
+• Savings goals with progress tracking
+• Recurring transaction support
+• Offline-first — works without internet
+• End-to-end encryption for your financial data
+• Cross-platform sync (iOS, Android, Web, Windows)
+• Accessibility built-in (TalkBack, dynamic type, high contrast)
+
+Your financial data stays on your device by default. Sync is optional and fully encrypted.

--- a/apps/android/fastlane/metadata/android/en-US/short_description.txt
+++ b/apps/android/fastlane/metadata/android/en-US/short_description.txt
@@ -1,0 +1,1 @@
+Privacy-first personal finance tracking for individuals and families.

--- a/apps/android/fastlane/metadata/android/en-US/title.txt
+++ b/apps/android/fastlane/metadata/android/en-US/title.txt
@@ -1,0 +1,1 @@
+Finance

--- a/apps/android/keystore.properties.template
+++ b/apps/android/keystore.properties.template
@@ -1,0 +1,17 @@
+# Android Release Keystore Configuration
+# Copy this file to keystore.properties and fill in real values.
+# NEVER commit keystore.properties to version control.
+#
+# See docs/android/play-store-submission.md for setup instructions.
+
+# Path to the release keystore file (absolute or relative to project root)
+STORE_FILE=finance-release.keystore
+
+# Keystore password
+STORE_PASSWORD=YOUR_KEYSTORE_PASSWORD_HERE
+
+# Key alias within the keystore
+KEY_ALIAS=finance
+
+# Key password (often the same as STORE_PASSWORD)
+KEY_PASSWORD=YOUR_KEY_PASSWORD_HERE


### PR DESCRIPTION
Closes #1242

Adds Android signing/deployment scaffolding (Gradle config + docs). Human follow-up required to register Play Console and generate the keystore; this PR only adds the agent-safe scaffolding pieces.