### PR TITLE
chore(ios): add signing and deployment scaffolding (#1239)

### DIFF
--- a/apps/ios/Signing/ExportOptions-adhoc.plist
+++ b/apps/ios/Signing/ExportOptions-adhoc.plist
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<!--
+  ExportOptions-adhoc.plist
+  Export options for Ad Hoc distribution (direct device install).
+
+  Replace YOUR_APPLE_TEAM_ID and YOUR_APP_BUNDLE_ID before use.
+  See apps/ios/Signing/README.md for setup instructions.
+-->
+<dict>
+  <key>method</key>
+  <string>ad-hoc</string>
+
+  <key>teamID</key>
+  <string>YOUR_APPLE_TEAM_ID</string>
+
+  <key>signingStyle</key>
+  <string>manual</string>
+
+  <key>provisioningProfiles</key>
+  <dict>
+    <key>YOUR_APP_BUNDLE_ID</key>
+    <string>match AdHoc YOUR_APP_BUNDLE_ID</string>
+  </dict>
+
+  <key>uploadBitcode</key>
+  <false/>
+
+  <key>compileBitcode</key>
+  <false/>
+
+  <key>thinning</key>
+  <string>&lt;none&gt;</string>
+
+  <key>stripSwiftSymbols</key>
+  <true/>
+</dict>
+</plist>

--- a/apps/ios/Signing/ExportOptions-testflight.plist
+++ b/apps/ios/Signing/ExportOptions-testflight.plist
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<!--
+  ExportOptions-testflight.plist
+  Export options for TestFlight / App Store distribution.
+
+  Replace YOUR_APPLE_TEAM_ID and YOUR_APP_BUNDLE_ID before use.
+  See apps/ios/Signing/README.md for setup instructions.
+-->
+<dict>
+  <key>method</key>
+  <string>app-store</string>
+
+  <key>teamID</key>
+  <string>YOUR_APPLE_TEAM_ID</string>
+
+  <key>signingStyle</key>
+  <string>manual</string>
+
+  <key>provisioningProfiles</key>
+  <dict>
+    <key>YOUR_APP_BUNDLE_ID</key>
+    <string>match AppStore YOUR_APP_BUNDLE_ID</string>
+  </dict>
+
+  <key>uploadBitcode</key>
+  <false/>
+
+  <key>uploadSymbols</key>
+  <true/>
+
+  <key>compileBitcode</key>
+  <false/>
+
+  <key>destination</key>
+  <string>export</string>
+
+  <key>stripSwiftSymbols</key>
+  <true/>
+</dict>
+</plist>

--- a/apps/ios/Signing/README.md
+++ b/apps/ios/Signing/README.md
@@ -1,0 +1,246 @@
+# iOS Code Signing & Deployment Guide
+
+This guide walks through setting up iOS code signing, provisioning profiles, and Fastlane for the Finance app. All steps must be completed by a human with Apple Developer Program access.
+
+## Prerequisites
+
+- macOS with Xcode installed (latest stable)
+- [Fastlane](https://docs.fastlane.tools/) installed (`gem install fastlane` or via Bundler)
+- An Apple Developer Program membership ($99/year)
+
+---
+
+## Step 1: Enroll in the Apple Developer Program
+
+1. Go to <https://developer.apple.com/programs/enroll/>
+2. Sign in with your Apple ID (or create one)
+3. Choose **Individual** or **Organization** enrollment
+   - Individual: instant approval
+   - Organization: requires D-U-N-S number, 24-48 hours for approval
+4. Complete payment ($99 USD/year)
+5. Once approved, note your **Team ID** (10-character alphanumeric string) from [Account → Membership](https://developer.apple.com/account#MembershipDetailsCard)
+
+---
+
+## Step 2: Register an App ID
+
+1. Go to [Certificates, Identifiers & Profiles → Identifiers](https://developer.apple.com/account/resources/identifiers/list)
+2. Click **+** to register a new identifier
+3. Select **App IDs** → **App**
+4. Fill in:
+   - **Description**: `Finance`
+   - **Bundle ID**: Explicit → `com.yourorg.finance` (replace with your actual bundle ID)
+5. Enable these capabilities:
+   - ✅ Sign in with Apple
+   - ✅ Push Notifications
+   - ✅ Associated Domains (for universal links / web credentials)
+6. Click **Continue** → **Register**
+
+---
+
+## Step 3: Create Provisioning Profiles
+
+You need three profiles:
+
+### Development Profile (local testing on physical devices)
+
+1. Go to [Profiles](https://developer.apple.com/account/resources/profiles/list)
+2. Click **+** → **iOS App Development**
+3. Select the App ID from Step 2
+4. Select your development certificate(s)
+5. Select test devices
+6. Name it: `Finance Development`
+7. Download and double-click to install
+
+### Ad Hoc Profile (alpha distribution outside TestFlight)
+
+1. Click **+** → **Ad Hoc**
+2. Select the App ID, distribution certificate, and test devices
+3. Name it: `Finance Ad Hoc`
+4. Download and install
+
+### App Store / TestFlight Profile
+
+1. Click **+** → **App Store Connect**
+2. Select the App ID and distribution certificate
+3. Name it: `Finance App Store`
+4. Download and install
+
+---
+
+## Step 4: Set Up Fastlane Match (Certificate Management)
+
+[Match](https://docs.fastlane.tools/actions/match/) stores signing certificates and provisioning profiles in a private git repository so the whole team (and CI) can share them.
+
+### 4a. Create a Private Certificate Repository
+
+Create a **private** git repository (e.g., `github.com/yourorg/ios-certificates`). This repo will contain encrypted signing certificates — it must be private.
+
+### 4b. Initialize Match
+
+```bash
+cd apps/ios
+fastlane match init
+```
+
+When prompted:
+
+- Storage mode: **git**
+- URL of the git repo: `https://github.com/yourorg/ios-certificates.git`
+
+This updates the `Matchfile` (already scaffolded — just replace placeholder values).
+
+### 4c. Generate Certificates and Profiles
+
+```bash
+# Development certificates + profiles
+fastlane match development
+
+# App Store / TestFlight certificates + profiles
+fastlane match appstore
+```
+
+Match will:
+
+1. Create certificates in the Apple Developer Portal
+2. Create provisioning profiles
+3. Encrypt and store them in your private git repo
+4. Install them on your local machine
+
+**Save the encryption password** — you'll need it for the `MATCH_PASSWORD` secret.
+
+### 4d. Verify Installation
+
+```bash
+fastlane match development --readonly
+fastlane match appstore --readonly
+```
+
+---
+
+## Step 5: Configure App Store Connect API Key
+
+Using an API key avoids interactive Apple ID authentication in CI.
+
+1. Go to [App Store Connect → Users and Access → Integrations → App Store Connect API](https://appstoreconnect.apple.com/access/integrations/api)
+2. Click **+** to generate a new key
+3. Name: `Finance CI`
+4. Access: **App Manager** (minimum required for TestFlight uploads)
+5. Download the `.p8` key file (**you can only download it once**)
+6. Note the **Key ID** and **Issuer ID** from the page
+7. Base64-encode the key:
+   ```bash
+   base64 -i AuthKey_XXXXXXXXXX.p8
+   ```
+
+---
+
+## Step 6: Configure GitHub Actions Secrets
+
+Go to your repo's **Settings → Secrets and variables → Actions** and add:
+
+| Secret Name                       | Value                                        |
+| --------------------------------- | -------------------------------------------- |
+| `APPLE_TEAM_ID`                   | Your 10-character Team ID                    |
+| `MATCH_GIT_URL`                   | URL to your private certificates repo        |
+| `MATCH_PASSWORD`                  | Encryption password from Step 4c             |
+| `APP_STORE_CONNECT_API_KEY_ID`    | Key ID from Step 5                           |
+| `APP_STORE_CONNECT_API_ISSUER_ID` | Issuer ID from Step 5                        |
+| `APP_STORE_CONNECT_API_KEY`       | Base64-encoded `.p8` key content from Step 5 |
+
+### Optional secrets (if using Apple ID auth instead of API key):
+
+| Secret Name                                    | Value                 |
+| ---------------------------------------------- | --------------------- |
+| `FASTLANE_USER`                                | Your Apple ID email   |
+| `FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD` | App-specific password |
+
+Generate an app-specific password at <https://appleid.apple.com/account/manage>.
+
+---
+
+## Step 7: Fill in Scaffolding Placeholders
+
+Replace all placeholder values in the scaffolding code:
+
+| File                    | Placeholder          | Replace With                    |
+| ----------------------- | -------------------- | ------------------------------- |
+| `fastlane/Appfile`      | `YOUR_APP_BUNDLE_ID` | Your registered bundle ID       |
+| `fastlane/Appfile`      | `YOUR_APPLE_TEAM_ID` | Your 10-char Team ID            |
+| `fastlane/Matchfile`    | `YOUR_MATCH_GIT_URL` | Private cert repo URL           |
+| `fastlane/Matchfile`    | `YOUR_APP_BUNDLE_ID` | Your registered bundle ID       |
+| `fastlane/Matchfile`    | `YOUR_APPLE_TEAM_ID` | Your 10-char Team ID            |
+| `fastlane/.env.default` | All `YOUR_*` values  | Actual values (or leave as doc) |
+
+---
+
+## Step 8: Test Locally
+
+```bash
+cd apps/ios
+
+# Verify match can pull certificates
+bundle exec fastlane match development --readonly
+
+# Build a signed alpha
+bundle exec fastlane build_alpha
+
+# Upload to TestFlight (requires API key)
+bundle exec fastlane upload_testflight
+```
+
+---
+
+## Step 9: Test in CI
+
+Push the branch and trigger the release workflow:
+
+```bash
+# Tag an alpha release
+git tag v0.1.0-alpha.1-ios
+git push origin v0.1.0-alpha.1-ios
+```
+
+Or use workflow dispatch in GitHub Actions → Release — iOS → Run workflow.
+
+---
+
+## Export Options
+
+Two export options plist templates are provided:
+
+- **`ExportOptions-testflight.plist`** — For TestFlight / App Store distribution
+- **`ExportOptions-adhoc.plist`** — For Ad Hoc distribution (direct device install)
+
+Replace `YOUR_APPLE_TEAM_ID` and `YOUR_APP_BUNDLE_ID` before use.
+
+---
+
+## Troubleshooting
+
+### "No signing certificate found"
+
+Run `fastlane match appstore` to regenerate. Ensure `MATCH_PASSWORD` is correct.
+
+### "Profile doesn't match bundle identifier"
+
+Verify `APP_BUNDLE_ID` in `Appfile`, `Matchfile`, and `.env.default` all match the App ID registered in the Developer Portal.
+
+### "App Store Connect API authentication failed"
+
+- Verify the API key is base64-encoded correctly: `base64 -i AuthKey_XXX.p8 | tr -d '\n'`
+- Ensure the Key ID, Issuer ID, and key content are all from the same API key
+- Check that the key hasn't been revoked in App Store Connect
+
+### CI keychain errors
+
+The `setup_ci` helper in Fastfile creates a temporary keychain for CI environments. Ensure the workflow calls `before_all` (which is automatic when using Fastlane lanes).
+
+---
+
+## Architecture Notes
+
+- **Match (git-based)** is chosen over manual certificate management for reproducibility and team sharing
+- **App Store Connect API key** is preferred over Apple ID + app-specific password for CI (no 2FA prompts)
+- **`readonly: true` in CI** prevents accidental certificate regeneration — certificates should only be created locally by an authorized team member
+- The existing `release-ios.yml` workflow handles signing via manual keychain setup; after match is configured, consider migrating to match-based signing in CI for consistency

--- a/apps/ios/fastlane/.env.default
+++ b/apps/ios/fastlane/.env.default
@@ -1,0 +1,45 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# .env.default — Fastlane environment variable placeholders
+#
+# ⚠️  DO NOT commit real values here. This file contains PLACEHOLDERS only.
+#     Set actual values via:
+#       - Local:  export the vars in your shell or use a .env.local file (git-ignored)
+#       - CI:     GitHub Actions secrets (see .github/workflows/release-ios.yml)
+#
+# See apps/ios/Signing/README.md for setup instructions.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ── App Identifiers ──────────────────────────────────────────────────────────
+APP_BUNDLE_ID=YOUR_APP_BUNDLE_ID
+# e.g. com.yourorg.finance
+
+# ── Apple Developer Portal ───────────────────────────────────────────────────
+APPLE_TEAM_ID=YOUR_APPLE_TEAM_ID
+# 10-character team ID from https://developer.apple.com/account
+
+# ── Fastlane Match (certificate management) ─────────────────────────────────
+MATCH_GIT_URL=YOUR_MATCH_GIT_URL
+# Private git repo URL, e.g. https://github.com/yourorg/ios-certificates.git
+
+MATCH_PASSWORD=YOUR_MATCH_ENCRYPTION_PASSWORD
+# Passphrase used to encrypt/decrypt certificates in the match repo
+
+# ── App Store Connect API (recommended for CI — no 2FA prompts) ─────────────
+APP_STORE_CONNECT_API_KEY_ID=YOUR_API_KEY_ID
+# Key ID from App Store Connect → Users and Access → Keys
+
+APP_STORE_CONNECT_API_ISSUER_ID=YOUR_API_ISSUER_ID
+# Issuer ID from the same Keys page
+
+APP_STORE_CONNECT_API_KEY=YOUR_BASE64_ENCODED_P8_KEY
+# Base64-encoded contents of the .p8 key file downloaded from App Store Connect
+# Generate with: base64 -i AuthKey_XXXXXXXXXX.p8
+
+# ── Optional: Fastlane Apple ID auth (alternative to API key) ───────────────
+# FASTLANE_USER=YOUR_APPLE_ID_EMAIL
+# FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD=YOUR_APP_SPECIFIC_PASSWORD
+# Generate at https://appleid.apple.com/account/manage → App-Specific Passwords
+
+# ── Optional: Slack notifications ────────────────────────────────────────────
+# SLACK_URL=YOUR_SLACK_WEBHOOK_URL
+# SLACK_CHANNEL=#ios-releases

--- a/apps/ios/fastlane/Appfile
+++ b/apps/ios/fastlane/Appfile
@@ -1,3 +1,31 @@
-app_identifier("com.finance.app")
-# apple_id("") # Your Apple ID
-# team_id("") # Developer Portal Team ID
+# frozen_string_literal: true
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Appfile — Apple Developer & App Store Connect identifiers
+#
+# Replace placeholder values after enrolling in the Apple Developer Program.
+# See apps/ios/Signing/README.md for step-by-step instructions.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Bundle identifier registered in the Apple Developer Portal
+app_identifier("YOUR_APP_BUNDLE_ID") # e.g. "com.yourorg.finance"
+
+# Your Apple ID email (used for App Store Connect authentication)
+# apple_id("YOUR_APPLE_ID_EMAIL") # e.g. "dev@yourorg.com"
+
+# Apple Developer Portal Team ID (10-character alphanumeric)
+team_id("YOUR_APPLE_TEAM_ID") # e.g. "A1B2C3D4E5"
+
+# App Store Connect Team ID (numeric, may differ from Portal Team ID)
+# itc_team_id("YOUR_ITC_TEAM_ID") # e.g. "123456789"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Environment-specific overrides
+# ─────────────────────────────────────────────────────────────────────────────
+# For per-lane overrides, use `for_platform` and `for_lane` blocks:
+#
+# for_platform :ios do
+#   for_lane :build_alpha do
+#     app_identifier("com.yourorg.finance.alpha")
+#   end
+# end

--- a/apps/ios/fastlane/Fastfile
+++ b/apps/ios/fastlane/Fastfile
@@ -1,30 +1,147 @@
+# frozen_string_literal: true
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fastfile — iOS build, sign, and deploy lanes for the Finance app
+#
+# Lanes:
+#   build           — Simulator build for local development
+#   test            — Run unit + UI tests
+#   build_alpha     — Signed alpha build for internal testing (TestFlight)
+#   upload_testflight — Upload a signed IPA to TestFlight
+#   screenshots     — Capture App Store screenshots
+#   deliver_appstore — Submit a release build to App Store review
+#   upload_metadata  — Push metadata only (no binary)
+#
+# Prerequisites:
+#   1. Enroll in Apple Developer Program
+#   2. Configure Matchfile and run `fastlane match`
+#   3. Set required environment variables (see .env.default)
+#   4. See apps/ios/Signing/README.md for full setup guide
+# ─────────────────────────────────────────────────────────────────────────────
+
 default_platform(:ios)
 
+# ── Constants ────────────────────────────────────────────────────────────────
+SCHEME         = "FinanceApp"
+UI_TEST_SCHEME = "FinanceUITests"
+DEVICE         = "iPhone 16"
+MIN_COVERAGE   = 60 # percent — adjust as coverage grows
+
 platform :ios do
-  desc "Build for testing"
+  # ── Setup ────────────────────────────────────────────────────────────────
+
+  before_all do
+    setup_ci if ENV["CI"]
+  end
+
+  # ── Development ──────────────────────────────────────────────────────────
+
+  desc "Build for testing (simulator, no signing)"
   lane :build do
-    build_app(scheme: "Finance", skip_archive: true, destination: "generic/platform=iOS Simulator")
+    build_app(
+      scheme: SCHEME,
+      skip_archive: true,
+      destination: "generic/platform=iOS Simulator",
+      xcargs: "CODE_SIGNING_ALLOWED=NO"
+    )
   end
 
-  desc "Run tests"
+  desc "Run unit and UI tests"
   lane :test do
-    run_tests(scheme: "Finance", device: "iPhone 16")
+    run_tests(
+      scheme: SCHEME,
+      device: DEVICE,
+      code_coverage: true,
+      result_bundle: true,
+      output_directory: ".build/test_output"
+    )
   end
 
-  desc "Capture screenshots for App Store"
+  # ── Alpha / Internal Testing ─────────────────────────────────────────────
+
+  desc "Build a signed alpha for internal distribution via TestFlight"
+  lane :build_alpha do
+    # Sync signing certificates and provisioning profiles via match
+    sync_code_signing(type: "appstore", readonly: is_ci)
+
+    # Increment build number using timestamp for uniqueness
+    increment_build_number(
+      build_number: Time.now.strftime("%Y%m%d%H%M")
+    )
+
+    # Build and archive
+    build_app(
+      scheme: SCHEME,
+      export_method: "app-store",
+      export_options: {
+        provisioningProfiles: {
+          ENV.fetch("APP_BUNDLE_ID", "YOUR_APP_BUNDLE_ID") =>
+            "match AppStore #{ENV.fetch('APP_BUNDLE_ID', 'YOUR_APP_BUNDLE_ID')}"
+        }
+      },
+      output_directory: ".build/alpha",
+      output_name: "Finance-Alpha.ipa",
+      include_bitcode: false,
+      include_symbols: true
+    )
+
+    UI.success("✅ Alpha build complete: .build/alpha/Finance-Alpha.ipa")
+  end
+
+  desc "Upload the latest alpha build to TestFlight"
+  lane :upload_testflight do
+    # Use App Store Connect API key for authentication (no interactive login)
+    api_key = app_store_connect_api_key(
+      key_id: ENV.fetch("APP_STORE_CONNECT_API_KEY_ID", "YOUR_KEY_ID"),
+      issuer_id: ENV.fetch("APP_STORE_CONNECT_API_ISSUER_ID", "YOUR_ISSUER_ID"),
+      key_content: ENV.fetch("APP_STORE_CONNECT_API_KEY", ""),
+      is_key_content_base64: true,
+      in_house: false
+    )
+
+    upload_to_testflight(
+      api_key: api_key,
+      ipa: ".build/alpha/Finance-Alpha.ipa",
+      skip_waiting_for_build_processing: true,
+      distribute_external: false,
+      changelog: changelog_from_git_commits(
+        commits_count: 10,
+        pretty: "- %s"
+      )
+    )
+  end
+
+  # ── Screenshots ──────────────────────────────────────────────────────────
+
+  desc "Capture App Store screenshots"
   lane :screenshots do
-    capture_screenshots(scheme: "FinanceUITests")
+    capture_screenshots(
+      scheme: UI_TEST_SCHEME,
+      devices: [
+        "iPhone 16 Pro Max",
+        "iPhone SE (3rd generation)",
+        "iPad Pro (12.9-inch) (6th generation)"
+      ],
+      languages: ["en-US"],
+      clear_previous_screenshots: true,
+      output_directory: ".build/screenshots"
+    )
   end
 
-  desc "Deploy to TestFlight"
-  lane :deploy_testflight do
-    build_app(scheme: "Finance", export_method: "app-store")
-    upload_to_testflight(skip_waiting_for_build_processing: true)
-  end
+  # ── App Store Release ────────────────────────────────────────────────────
 
-  desc "Submit to App Store for review"
+  desc "Submit to App Store for review (requires human approval gate)"
   lane :deliver_appstore do
-    build_app(scheme: "Finance", export_method: "app-store")
+    sync_code_signing(type: "appstore", readonly: true)
+
+    build_app(
+      scheme: SCHEME,
+      export_method: "app-store",
+      include_bitcode: false,
+      include_symbols: true,
+      output_directory: ".build/release"
+    )
+
     deliver(
       metadata_path: "./fastlane/metadata",
       submit_for_review: false,
@@ -47,5 +164,15 @@ platform :ios do
       skip_screenshots: true,
       force: true
     )
+  end
+
+  # ── Helpers ──────────────────────────────────────────────────────────────
+
+  after_all do |lane|
+    UI.success("✅ Lane :#{lane} completed successfully")
+  end
+
+  error do |lane, exception|
+    UI.error("❌ Lane :#{lane} failed: #{exception.message}")
   end
 end

--- a/apps/ios/fastlane/Matchfile
+++ b/apps/ios/fastlane/Matchfile
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Matchfile — Fastlane Match configuration for certificate management
+#
+# Match stores signing certificates and provisioning profiles in a private
+# git repository, enabling the entire team (and CI) to share them securely.
+#
+# Setup:
+#   1. Create a private git repo for certificates (e.g. github.com/yourorg/ios-certificates)
+#   2. Replace the placeholder values below
+#   3. Run: fastlane match development
+#   4. Run: fastlane match appstore
+#
+# See apps/ios/Signing/README.md for the full setup guide.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# URL of the private git repo that stores certificates and profiles
+git_url("YOUR_MATCH_GIT_URL") # e.g. "https://github.com/yourorg/ios-certificates.git"
+
+# Storage mode — "git" is the default; "google_cloud" and "s3" are also supported
+storage_mode("git")
+
+# Certificate types to manage
+type("appstore") # default type; overridden per-lane in Fastfile
+
+# App identifier(s) — must match Appfile
+app_identifier(["YOUR_APP_BUNDLE_ID"]) # e.g. ["com.yourorg.finance"]
+
+# Apple Developer Portal username (email)
+# username("YOUR_APPLE_ID_EMAIL") # e.g. "dev@yourorg.com"
+
+# Team ID (10-character alphanumeric from Apple Developer Portal)
+team_id("YOUR_APPLE_TEAM_ID") # e.g. "A1B2C3D4E5"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CI Configuration
+# ─────────────────────────────────────────────────────────────────────────────
+
+# In CI, match should NEVER create new certificates — only use existing ones
+# The `readonly` flag is set per-lane in Fastfile based on `is_ci`
+
+# The MATCH_PASSWORD environment variable must be set to decrypt the repo
+# See .env.default for the full list of required env vars


### PR DESCRIPTION
Closes #1239

Adds iOS signing/deployment scaffolding (Fastlane match config templates + docs). Human follow-up required to enroll in Apple Developer Program and provision real certificates; this PR only adds agent-safe scaffolding.