### PR TITLE
chore(agents): allow agents to edit non-gating labels (#1876)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@ The following operations require EXPLICIT human approval. NEVER perform these au
 
 - **Git remote operations** — **MUST push own feature branches** (`git push origin <feature-branch>`) — this is mandatory and auto-approved, never ask for permission; **MUST** `git fetch origin main` and `git rebase origin/main` on own feature branch as pre-push hygiene; no pushing to `main`/`master`/release branches; no `git push --force`; `git push --force-with-lease` on feature branches requires human approval; no `pull`/`remote`/`merge` from remote
 - **PR/review operations** — **MUST create PRs** with linked issues and detailed descriptions — this is mandatory and auto-approved, never ask for permission; no merging, closing, or approving PRs or reviews
-- **Remote platform mutations** — No GitHub API writes (issue close, label changes, repo settings, releases, deployments)
+- **Remote platform mutations** — No issue close/reopen/delete; no repo settings/releases/deployments. Label edits ARE allowed for routine triage, EXCEPT gating/lifecycle labels (`blocked`, `breaking-change`, `security`, `stale`, and any `wontfix`/`duplicate`/`invalid`/`do-not-merge` style label) which remain human-only. See `AGENTS.md` §"Category 3" for the full rule.
 - **Outside project boundary** — No file access outside the repository root; no system config changes; no global package installs
 - **Destructive file operations** — See detailed rules below
 - **Package publishing** — See detailed rules below

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,15 +194,25 @@ AI agents MUST NOT:
 
 ### Category 3: Remote Platform Operations
 
+AI agents MAY:
+
+- **Edit labels on issues and PRs** with `gh issue edit --add-label` / `--remove-label` and `gh pr edit --add-label` / `--remove-label` — as part of routine triage, sprint grooming, and platform-parity tracking (see "Business Sprint Integration" below).
+
 AI agents MUST NOT execute:
 
-- GitHub API writes (closing issues, changing labels, modifying repo settings)
+- **Close, reopen, or delete issues** — humans only. `gh issue close`, `gh issue reopen`, `gh issue delete` are forbidden. Leave a comment requesting closure if needed.
+- **Add, remove, or modify the following gating/lifecycle labels** — these gate PR merge or mark issue completion/removal and are reserved for humans:
+  - **PR-gating labels:** `blocked`, `breaking-change`, `security`
+  - **Completion/removal labels:** `stale`, plus any future `wontfix` / `duplicate` / `invalid` / `do-not-merge` style labels (treat any label whose semantic effect is "this work should not proceed / should be discarded / should be merged with caution" as gating, even if not listed above)
+- Modify repo settings, branch protection, secrets, or webhooks
 - Deployment triggers or release publishing
 - Hosting/infrastructure configuration changes
 - Cloud service API calls (AWS, GCP, Azure, etc.)
-- Any `gh repo`, `gh issue close/delete`, or `gh release` command
+- Any `gh repo`, `gh release`, or `gh api` write that touches repo configuration
 
-**Why:** Remote platform changes can affect production systems, billing, and user data.
+**Why:** Issue closure and gating-label changes are decisions about whether work proceeds or ships — those stay with humans. Routine labeling (priority, platform, component, effort, phase, sprint, feature-area) is mechanical triage work that agents should be able to do as part of grooming and platform-parity tracking. Remote platform changes (settings, deployments, releases) can affect production systems, billing, and user data.
+
+**When in doubt about a label:** if removing or adding the label would change _whether or when a PR can merge_, or _whether an issue is considered done/wontfix/duplicate_, treat it as restricted and leave a comment requesting the human do it. Otherwise it's fair game.
 
 ### Category 4: Operations Outside Project Boundary
 


### PR DESCRIPTION
## Summary

Loosens `AGENTS.md` Category 3 and the parallel one-liner in `.github/copilot-instructions.md` to allow AI agents to do routine label triage on issues and PRs, while keeping a small set of gating/lifecycle labels reserved for humans.

Closes #1876.

## What changed

### Before

Category 3 forbade *all* label changes outright:

```
GitHub API writes (closing issues, changing labels, modifying repo settings)
```

This blocked agents from doing the routine triage / sprint grooming the same doc explicitly expects under "Business Sprint Integration → Product Management → Groom backlog (label, prioritize, decompose large issues)".

### After

Agents MAY:

- Add/remove labels via `gh issue edit` / `gh pr edit` for routine triage (priority, platform, component, effort, phase, sprint, feature-area, etc.)

Agents MUST NOT:

- **Close, reopen, or delete issues** — humans only (unchanged).
- **Add/remove/modify the following gating/lifecycle labels:**
  - PR-gating: `blocked`, `breaking-change`, `security`
  - Completion/removal: `stale`, plus any future `wontfix` / `duplicate` / `invalid` / `do-not-merge` style label (rule of thumb: if removing/adding the label changes *whether/when work proceeds or merges*, it's gating).
- Modify repo settings, releases, deployments, or any other Category 3 item (unchanged).

## Why

- Unblocks agents on routine labeling work the docs already expect from them.
- Keeps the high-leverage gating + completion decisions firmly with humans.
- The "rule of thumb" language scales to new labels without doc updates every time the label set evolves.

## Test plan

Docs-only PR.

- [x] `npm run ci:check:quick` — Prettier passes
- No code or behavior changes — no tests to add/modify

## Out of scope

- Closing/reopening issues remains forbidden.
- No changes to other Category 3 items (repo settings, deployments, etc.).
- No automation triggered by this change — it just unblocks agents from being able to do label work when invoked.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
