### PR TITLE
feat(ui): haptic confirmation on transaction save (#1756)

### DIFF
--- a/apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt
@@ -37,6 +37,8 @@ import com.finance.android.ui.streak.StreakRepository
 import com.finance.android.ui.streak.StreakViewModel
 import com.finance.android.ui.streak.TransactionBackedStreakRepository
 import com.finance.android.ui.accessibility.CognitiveAccessibilityManager
+import com.finance.android.ui.feedback.DefaultHapticAvailabilityChecker
+import com.finance.android.ui.feedback.HapticAvailabilityChecker
 import com.finance.android.ui.theme.ThemeManager
 import com.finance.android.ui.theme.ThemePreferenceManager
 import com.finance.android.ui.tips.TipsViewModel
@@ -122,6 +124,11 @@ val appModule = module {
     /** Biometric availability check — delegates to [androidx.biometric.BiometricManager]. */
     single<BiometricAvailabilityChecker> {
         DefaultBiometricAvailabilityChecker(androidContext())
+    }
+
+    /** Haptic availability check — controls the default Accessibility haptic toggle. */
+    single<HapticAvailabilityChecker> {
+        DefaultHapticAvailabilityChecker(androidContext())
     }
 
     /** Theme preference manager — provides reactive theme state for the whole app. */

--- a/apps/android/src/main/kotlin/com/finance/android/ui/feedback/FinancialEvent.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/feedback/FinancialEvent.kt
@@ -5,7 +5,8 @@ package com.finance.android.ui.feedback
 /**
  * Sealed hierarchy of financial events that trigger haptic feedback.
  *
- * Each event maps to a specific vibration pattern via [HapticFeedbackManager].
+ * Legacy event names retained for existing callers; transaction-save surfaces use
+ * the shared core haptic effects directly.
  */
 sealed class FinancialEvent {
 

--- a/apps/android/src/main/kotlin/com/finance/android/ui/feedback/HapticFeedbackManager.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/feedback/HapticFeedbackManager.kt
@@ -3,138 +3,97 @@
 package com.finance.android.ui.feedback
 
 import android.content.Context
-import android.os.VibrationEffect
+import android.os.Build
 import android.os.Vibrator
+import android.os.VibratorManager
+import android.provider.Settings
+import android.view.HapticFeedbackConstants
+import android.view.View
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
-import androidx.core.content.getSystemService
+import androidx.compose.ui.platform.LocalView
+import com.finance.core.haptics.HapticFeedback
+import com.finance.core.haptics.HapticFeedbackDispatcher
+import com.finance.core.haptics.HapticFeedbackEffect
+import com.finance.core.haptics.HapticFeedbackSettings
 
-/**
- * Maps [FinancialEvent]s to distinct haptic-feedback patterns.
- *
- * Pattern catalogue:
- * | Event              | Pattern                        |
- * |--------------------|--------------------------------|
- * | TransactionSaved   | Confirm (single tick)          |
- * | BudgetThreshold    | Warning (two short ticks)      |
- * | GoalMilestone      | Heavy click + confirm          |
- * | SyncComplete       | Light tick                     |
- * | Error              | Reject (three sharp pulses)    |
- *
- * The manager respects the user preference [hapticsEnabled]. When haptics
- * are disabled no vibration is emitted.
- *
- * @param context        Application context for accessing the [Vibrator] service.
- * @param hapticsEnabled Whether haptic feedback is currently enabled by the user.
- */
-class HapticFeedbackManager(
-    private val context: Context,
-    var hapticsEnabled: Boolean = true,
-) {
-    private val vibrator: Vibrator? by lazy {
-        context.getSystemService<Vibrator>()
-    }
+/** Checks whether the current Android device exposes a haptic actuator. */
+fun interface HapticAvailabilityChecker {
+    /** Returns true when haptic hardware is available. */
+    fun isHapticFeedbackAvailable(): Boolean
+}
 
-    /**
-     * Triggers the haptic pattern associated with [event].
-     *
-     * No-ops silently when [hapticsEnabled] is `false` or the device
-     * lacks a vibrator.
-     */
-    @Suppress("ReturnCount") // Multiple early returns improve readability
-    fun triggerEvent(event: FinancialEvent) {
-        if (!hapticsEnabled) return
-        val vib = vibrator ?: return
-        if (!vib.hasVibrator()) return
-
-        when (event) {
-            is FinancialEvent.TransactionSaved -> vibrateConfirm(vib)
-            is FinancialEvent.BudgetThreshold -> vibrateWarning(vib)
-            is FinancialEvent.GoalMilestone -> vibrateGoalMilestone(vib)
-            is FinancialEvent.SyncComplete -> vibrateLightTick(vib)
-            is FinancialEvent.Error -> vibrateReject(vib)
+/** Android implementation of [HapticAvailabilityChecker]. */
+class DefaultHapticAvailabilityChecker(private val context: Context) : HapticAvailabilityChecker {
+    override fun isHapticFeedbackAvailable(): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val manager = context.getSystemService(VibratorManager::class.java)
+            manager?.defaultVibrator?.hasVibrator() == true
+        } else {
+            @Suppress("DEPRECATION")
+            val vibrator = context.getSystemService(Context.VIBRATOR_SERVICE) as? Vibrator
+            @Suppress("DEPRECATION")
+            vibrator?.hasVibrator() == true
         }
-    }
-
-    // ── Patterns ────────────────────────────────────────────────────────
-
-    /** Single confirm tick. */
-    private fun vibrateConfirm(vib: Vibrator) {
-        vib.vibrate(VibrationEffect.createOneShot(DURATION_CLICK_MS, AMPLITUDE_CONFIRM))
-    }
-
-    /** Two short ticks — budget warning. */
-    private fun vibrateWarning(vib: Vibrator) {
-        vib.vibrate(
-            VibrationEffect.createWaveform(
-                longArrayOf(0, DURATION_TICK_MS, GAP_SHORT_MS, DURATION_TICK_MS),
-                intArrayOf(0, AMPLITUDE_WARNING, 0, AMPLITUDE_WARNING),
-                -1,
-            ),
-        )
-    }
-
-    /** Heavy click followed by a confirm tick — goal milestone. */
-    private fun vibrateGoalMilestone(vib: Vibrator) {
-        vib.vibrate(
-            VibrationEffect.createWaveform(
-                longArrayOf(0, DURATION_HEAVY_MS, GAP_SHORT_MS, DURATION_CLICK_MS),
-                intArrayOf(0, AMPLITUDE_HEAVY, 0, AMPLITUDE_CONFIRM),
-                -1,
-            ),
-        )
-    }
-
-    /** Single light tick — sync complete. */
-    private fun vibrateLightTick(vib: Vibrator) {
-        vib.vibrate(VibrationEffect.createOneShot(DURATION_TICK_MS, AMPLITUDE_LIGHT))
-    }
-
-    /** Three sharp pulses — error / rejection. */
-    private fun vibrateReject(vib: Vibrator) {
-        vib.vibrate(
-            VibrationEffect.createWaveform(
-                longArrayOf(
-                    0, DURATION_REJECT_MS, GAP_SHORT_MS,
-                    DURATION_REJECT_MS, GAP_SHORT_MS,
-                    DURATION_REJECT_MS,
-                ),
-                intArrayOf(
-                    0, AMPLITUDE_REJECT, 0,
-                    AMPLITUDE_REJECT, 0,
-                    AMPLITUDE_REJECT,
-                ),
-                -1,
-            ),
-        )
-    }
-
-    companion object {
-        private const val DURATION_CLICK_MS = 50L
-        private const val DURATION_TICK_MS = 30L
-        private const val DURATION_HEAVY_MS = 80L
-        private const val DURATION_REJECT_MS = 40L
-        private const val GAP_SHORT_MS = 60L
-
-        private const val AMPLITUDE_LIGHT = 80
-        private const val AMPLITUDE_CONFIRM = 140
-        private const val AMPLITUDE_WARNING = 170
-        private const val AMPLITUDE_HEAVY = 255
-        private const val AMPLITUDE_REJECT = 220
     }
 }
 
-/**
- * Remembers a [HapticFeedbackManager] scoped to the current Compose context.
- *
- * @param hapticsEnabled Whether haptics are enabled (e.g. from user preferences).
- */
-@Composable
-fun rememberHapticFeedbackManager(hapticsEnabled: Boolean = true): HapticFeedbackManager {
-    val context = LocalContext.current
-    return remember(context, hapticsEnabled) {
-        HapticFeedbackManager(context = context, hapticsEnabled = hapticsEnabled)
+/** Android [HapticFeedback] bridge backed by [View.performHapticFeedback]. */
+class AndroidHapticFeedback(private val view: View) : HapticFeedback {
+    override fun perform(effect: HapticFeedbackEffect) {
+        if (isReduceMotionEnabled()) return
+        val constant = when (effect) {
+            HapticFeedbackEffect.TRANSACTION_SAVE_SUCCESS -> confirmConstant()
+            HapticFeedbackEffect.TRANSACTION_VALIDATION_WARNING -> warningConstant()
+        }
+        view.performHapticFeedback(constant)
     }
+
+    private fun confirmConstant(): Int = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        HapticFeedbackConstants.CONFIRM
+    } else {
+        HapticFeedbackConstants.KEYBOARD_TAP
+    }
+
+    private fun warningConstant(): Int = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        HapticFeedbackConstants.REJECT
+    } else {
+        HapticFeedbackConstants.KEYBOARD_TAP
+    }
+
+    private fun isReduceMotionEnabled(): Boolean {
+        return Settings.Global.getFloat(
+            view.context.contentResolver,
+            Settings.Global.ANIMATOR_DURATION_SCALE,
+            1f,
+        ) == 0f
+    }
+}
+
+/** Remembers a transaction-save haptic dispatcher for Compose screens. */
+@Composable
+fun rememberTransactionHapticFeedback(
+    appHapticsEnabled: Boolean,
+    deviceSupportsHaptics: Boolean,
+): HapticFeedbackDispatcher {
+    val view = LocalView.current
+    return remember(view, appHapticsEnabled, deviceSupportsHaptics) {
+        HapticFeedbackDispatcher(
+            feedback = AndroidHapticFeedback(view),
+            settingsProvider = {
+                HapticFeedbackSettings(
+                    deviceSupportsHaptics = deviceSupportsHaptics,
+                    appHapticsEnabled = appHapticsEnabled,
+                )
+            },
+        )
+    }
+}
+
+/** Returns whether the current device supports haptics. */
+@Composable
+fun rememberHapticFeedbackAvailable(): Boolean {
+    val context = LocalContext.current
+    return remember(context) { DefaultHapticAvailabilityChecker(context).isHapticFeedbackAvailable() }
 }

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/SettingsScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/SettingsScreen.kt
@@ -91,6 +91,7 @@ import java.io.File
  * @param onSetAppLockTimeout      Callback when app-lock timeout changes.
  * @param onSetSimplifiedView      Callback when simplified-view toggle changes.
  * @param onSetHighContrast        Callback when high-contrast toggle changes.
+ * @param onSetHapticFeedback      Callback when haptic feedback toggle changes.
  * @param onExportClick            Callback when "Export data" is tapped.
  * @param onDeleteClick            Callback when "Delete account" is tapped.
  * @param onExportFormat           Callback when a format is picked in the export dialog.
@@ -116,6 +117,7 @@ fun SettingsScreen(
     onSetAppLockTimeout: (AppLockTimeout) -> Unit,
     onSetSimplifiedView: (Boolean) -> Unit,
     onSetHighContrast: (Boolean) -> Unit,
+    onSetHapticFeedback: (Boolean) -> Unit,
     onExportClick: () -> Unit,
     onDeleteClick: () -> Unit,
     onExportFormat: (ExportFormat) -> Unit,
@@ -170,9 +172,12 @@ fun SettingsScreen(
         AccessibilitySection(
             simplifiedViewEnabled = state.simplifiedViewEnabled,
             highContrastEnabled = state.highContrastEnabled,
+            hapticFeedbackEnabled = state.hapticFeedbackEnabled,
+            hapticFeedbackAvailable = state.hapticFeedbackAvailable,
             themePreference = state.themePreference,
             onSimplifiedViewChanged = onSetSimplifiedView,
             onHighContrastChanged = onSetHighContrast,
+            onHapticFeedbackChanged = onSetHapticFeedback,
             onThemePreferenceChanged = onSetThemePreference,
         )
 
@@ -561,9 +566,12 @@ private fun AppLockTimeoutSelector(
 private fun AccessibilitySection(
     simplifiedViewEnabled: Boolean,
     highContrastEnabled: Boolean,
+    hapticFeedbackEnabled: Boolean,
+    hapticFeedbackAvailable: Boolean,
     themePreference: ThemePreference,
     onSimplifiedViewChanged: (Boolean) -> Unit,
     onHighContrastChanged: (Boolean) -> Unit,
+    onHapticFeedbackChanged: (Boolean) -> Unit,
     onThemePreferenceChanged: (ThemePreference) -> Unit,
 ) {
     SectionHeader("Accessibility")
@@ -636,6 +644,20 @@ private fun AccessibilitySection(
                 description = "Increase contrast for better visibility",
                 checked = highContrastEnabled,
                 onCheckedChange = onHighContrastChanged,
+            )
+
+            HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
+
+            SettingsToggleRow(
+                label = "Haptic feedback",
+                description = if (hapticFeedbackAvailable) {
+                    "Play subtle confirmations and warnings when saving transactions"
+                } else {
+                    "Haptic feedback is not available on this device"
+                },
+                checked = hapticFeedbackEnabled,
+                onCheckedChange = onHapticFeedbackChanged,
+                enabled = hapticFeedbackAvailable,
             )
         }
     }
@@ -1012,6 +1034,7 @@ fun SettingsScreen(
         onSetAppLockTimeout = viewModel::setAppLockTimeout,
         onSetSimplifiedView = viewModel::setSimplifiedViewEnabled,
         onSetHighContrast = themePreferenceManager::setHighContrastEnabled,
+        onSetHapticFeedback = viewModel::setHapticFeedbackEnabled,
         onExportClick = viewModel::showExportDialog,
         onDeleteClick = viewModel::showDeleteDialog,
         onExportFormat = viewModel::exportData,
@@ -1089,6 +1112,7 @@ private fun SettingsScreenPreviewLight() {
                 onSetAppLockTimeout = {},
                 onSetSimplifiedView = {},
                 onSetHighContrast = {},
+                onSetHapticFeedback = {},
                 onExportClick = {},
                 onDeleteClick = {},
                 onExportFormat = {},
@@ -1126,6 +1150,7 @@ private fun SettingsScreenPreviewDark() {
                 onSetAppLockTimeout = {},
                 onSetSimplifiedView = {},
                 onSetHighContrast = {},
+                onSetHapticFeedback = {},
                 onExportClick = {},
                 onDeleteClick = {},
                 onExportFormat = {},
@@ -1178,5 +1203,7 @@ private fun previewState() = SettingsUiState(
     appLockTimeout = AppLockTimeout.ONE_MINUTE,
     simplifiedViewEnabled = false,
     highContrastEnabled = false,
+    hapticFeedbackEnabled = true,
+    hapticFeedbackAvailable = true,
     appVersion = "1.0.0",
 )

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/SettingsViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/SettingsViewModel.kt
@@ -18,6 +18,7 @@ import com.finance.core.export.ExportData
 import com.finance.core.export.ExportFormat
 import com.finance.core.export.ExportOutcome
 import com.finance.core.export.JsonExportSerializer
+import com.finance.android.ui.feedback.HapticAvailabilityChecker
 import com.finance.android.ui.theme.ThemePreference
 import com.finance.android.ui.theme.ThemePreferenceManager
 import com.finance.sync.auth.AuthManager
@@ -102,6 +103,8 @@ data class SettingsUiState(
     // Accessibility
     val simplifiedViewEnabled: Boolean = false,
     val highContrastEnabled: Boolean = false,
+    val hapticFeedbackEnabled: Boolean = false,
+    val hapticFeedbackAvailable: Boolean = false,
 
     // About
     val appVersion: String = "1.0.0",
@@ -127,6 +130,8 @@ data class SettingsUiState(
  * stores the actual data in `"finance_settings_encrypted"` and handles
  * migration from the legacy plain-text file (#1314).
  */
+internal const val HAPTIC_FEEDBACK_PREF_KEY = "haptic_feedback"
+
 private object PrefKeys {
     const val FILE_NAME = "finance_settings"
     const val DEFAULT_CURRENCY = "default_currency"
@@ -136,6 +141,7 @@ private object PrefKeys {
     const val APP_LOCK_TIMEOUT = "app_lock_timeout"
     const val SIMPLIFIED_VIEW = "simplified_view"
     const val HIGH_CONTRAST = "high_contrast"
+    const val HAPTIC_FEEDBACK = HAPTIC_FEEDBACK_PREF_KEY
     const val USER_NAME = "user_name"
     const val USER_EMAIL = "user_email"
 }
@@ -154,6 +160,7 @@ private object PrefKeys {
  *
  * @param prefs Local preferences store for settings persistence.
  * @param biometricChecker Abstraction to query biometric hardware availability.
+ * @param hapticChecker Abstraction to query haptic hardware availability.
  * @param householdIdProvider Provides the authenticated user's household ID.
  * @param transactionRepository Source for transaction data used in data export.
  * @param categoryRepository Source for category data used in data export.
@@ -167,6 +174,7 @@ private object PrefKeys {
 class SettingsViewModel(
     private val prefs: SharedPreferences,
     private val biometricChecker: BiometricAvailabilityChecker,
+    private val hapticChecker: HapticAvailabilityChecker,
     private val householdIdProvider: HouseholdIdProvider,
     private val transactionRepository: TransactionRepository,
     private val categoryRepository: CategoryRepository,
@@ -190,6 +198,7 @@ class SettingsViewModel(
     // -- Preference persistence -----------------------------------------------
 
     private fun loadPreferences() {
+        val hapticsAvailable = hapticChecker.isHapticFeedbackAvailable()
         _uiState.update { current ->
             current.copy(
                 userName = prefs.getString(PrefKeys.USER_NAME, "") ?: "",
@@ -207,6 +216,8 @@ class SettingsViewModel(
                     ?: AppLockTimeout.ONE_MINUTE,
                 simplifiedViewEnabled = prefs.getBoolean(PrefKeys.SIMPLIFIED_VIEW, false),
                 highContrastEnabled = prefs.getBoolean(PrefKeys.HIGH_CONTRAST, false),
+                hapticFeedbackAvailable = hapticsAvailable,
+                hapticFeedbackEnabled = prefs.getBoolean(PrefKeys.HAPTIC_FEEDBACK, hapticsAvailable),
             )
         }
     }
@@ -263,6 +274,17 @@ class SettingsViewModel(
     fun setHighContrastEnabled(enabled: Boolean) {
         updatePref { putBoolean(PrefKeys.HIGH_CONTRAST, enabled) }
         _uiState.update { it.copy(highContrastEnabled = enabled) }
+    }
+
+    fun setHapticFeedbackEnabled(enabled: Boolean) {
+        if (enabled && !_uiState.value.hapticFeedbackAvailable) {
+            viewModelScope.launch {
+                _events.emit(SettingsEvent.ShowToast("Haptic feedback is not available on this device"))
+            }
+            return
+        }
+        updatePref { putBoolean(PrefKeys.HAPTIC_FEEDBACK, enabled) }
+        _uiState.update { it.copy(hapticFeedbackEnabled = enabled) }
     }
 
     // -- Sign out --------------------------------------------------------------

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/TransactionCreateScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/TransactionCreateScreen.kt
@@ -2,6 +2,7 @@
 
 package com.finance.android.ui.screens
 
+import android.content.SharedPreferences
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
@@ -66,6 +67,7 @@ import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -82,8 +84,11 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.finance.android.ui.theme.FinanceTheme
 import com.finance.android.ui.data.SampleData
+import com.finance.android.ui.feedback.rememberHapticFeedbackAvailable
+import com.finance.android.ui.feedback.rememberTransactionHapticFeedback
+import com.finance.android.ui.theme.FinanceTheme
+import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import com.finance.android.ui.viewmodel.CreateStep
 import com.finance.android.ui.viewmodel.TransactionCreateUiState
@@ -106,7 +111,28 @@ fun TransactionCreateScreen(
     viewModel: TransactionCreateViewModel = koinViewModel(),
 ) {
     val state by viewModel.uiState.collectAsState()
-    if (state.isSaved) { onSaved(); return }
+    val prefs: SharedPreferences = koinInject()
+    val hapticsAvailable = rememberHapticFeedbackAvailable()
+    val hapticFeedbackEnabled = prefs.getBoolean(HAPTIC_FEEDBACK_PREF_KEY, hapticsAvailable)
+    val hapticFeedback = rememberTransactionHapticFeedback(
+        appHapticsEnabled = hapticFeedbackEnabled,
+        deviceSupportsHaptics = hapticsAvailable,
+    )
+
+    LaunchedEffect(state.errors) {
+        if (state.errors.isNotEmpty()) {
+            hapticFeedback.validationFailed()
+        }
+    }
+
+    LaunchedEffect(state.isSaved) {
+        if (state.isSaved) {
+            hapticFeedback.transactionSaved()
+            onSaved()
+        }
+    }
+
+    if (state.isSaved) return
 
     Scaffold(topBar = {
         TopAppBar(title = { Text(if (state.isEditing) "Edit Transaction" else "New Transaction",

--- a/apps/android/src/test/kotlin/com/finance/android/ui/snapshot/SettingsSnapshotTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/ui/snapshot/SettingsSnapshotTest.kt
@@ -34,6 +34,8 @@ class SettingsSnapshotTest {
         appLockTimeout = AppLockTimeout.ONE_MINUTE,
         simplifiedViewEnabled = false,
         highContrastEnabled = false,
+        hapticFeedbackEnabled = true,
+        hapticFeedbackAvailable = true,
         appVersion = "1.0.0",
     )
 
@@ -54,6 +56,7 @@ class SettingsSnapshotTest {
                     onSetAppLockTimeout = {},
                     onSetSimplifiedView = {},
                     onSetHighContrast = {},
+                    onSetHapticFeedback = {},
                     onExportClick = {},
                     onDeleteClick = {},
                     onExportFormat = {},

--- a/apps/ios/Finance/Accessibility/HapticFeedbackPreferences.swift
+++ b/apps/ios/Finance/Accessibility/HapticFeedbackPreferences.swift
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import CoreHaptics
+import Foundation
+
+/// Persists the app-level haptic feedback setting.
+enum HapticFeedbackPreferences {
+    static let key = "finance_haptic_feedback_enabled"
+
+    /// Returns true when this device supports haptics.
+    static var deviceSupportsHaptics: Bool {
+        CHHapticEngine.capabilitiesForHardware().supportsHaptics
+    }
+
+    /// Reads the user preference, defaulting on only when haptics are supported.
+    static func isEnabled(defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: key) == nil
+            ? deviceSupportsHaptics
+            : defaults.bool(forKey: key)
+    }
+
+    /// Stores the user preference.
+    static func setEnabled(_ enabled: Bool, defaults: UserDefaults = .standard) {
+        defaults.set(enabled, forKey: key)
+    }
+}

--- a/apps/ios/Finance/Accessibility/HapticManager.swift
+++ b/apps/ios/Finance/Accessibility/HapticManager.swift
@@ -71,6 +71,11 @@ final class HapticManager {
         playNotification(type: .success)
     }
 
+    /// Soft warning tap — played when transaction validation fails.
+    func validationWarning() {
+        playNotification(type: .warning)
+    }
+
     /// Warning pattern — played when spending crosses a budget threshold.
     ///
     /// Uses a custom Core Haptics pattern:
@@ -160,7 +165,7 @@ final class HapticManager {
     /// Prepares the engine so the first haptic plays without latency.
     /// Call this from the app's `onAppear` or scene-phase handler.
     func prepare() {
-        guard supportsHaptics else { return }
+        guard supportsHaptics, hapticsAllowed else { return }
         startEngine()
     }
 
@@ -171,6 +176,10 @@ final class HapticManager {
     }
 
     // MARK: - Private Helpers
+
+    private var hapticsAllowed: Bool {
+        HapticFeedbackPreferences.isEnabled() && !UIAccessibility.isReduceMotionEnabled
+    }
 
     /// Configures auto-restart handlers on the engine.
     private func configureEngine(_ engine: CHHapticEngine) {
@@ -206,6 +215,7 @@ final class HapticManager {
     /// respects the system-wide "System Haptics" toggle in
     /// Settings → Sounds & Haptics.
     private func playNotification(type: UINotificationFeedbackGenerator.FeedbackType) {
+        guard supportsHaptics, hapticsAllowed else { return }
         let generator = UINotificationFeedbackGenerator()
         generator.prepare()
         generator.notificationOccurred(type)
@@ -213,7 +223,7 @@ final class HapticManager {
 
     /// Plays an arbitrary `CHHapticEvent` pattern through the engine.
     private func playPattern(events: [CHHapticEvent]) {
-        guard let engine else { return }
+        guard hapticsAllowed, let engine else { return }
 
         do {
             let pattern = try CHHapticPattern(events: events, parameters: [])

--- a/apps/ios/Finance/Screens/SettingsView.swift
+++ b/apps/ios/Finance/Screens/SettingsView.swift
@@ -28,6 +28,7 @@ struct SettingsView: View {
                 accountSection
                 generalSection
                 notificationsSection
+                accessibilitySection
                 securitySection
                 syncSection
                 dataSection
@@ -161,6 +162,31 @@ struct SettingsView: View {
                 }
                 .accessibilityLabel(String(localized: "Goal milestones"))
                 .accessibilityHint(String(localized: "Receive notifications for goal progress milestones"))
+            }
+        }
+    }
+
+    // MARK: - Accessibility
+
+    private var accessibilitySection: some View {
+        Section(String(localized: "Accessibility")) {
+            Toggle(isOn: $viewModel.hapticFeedbackEnabled) {
+                Label(String(localized: "Haptic feedback"), systemImage: "waveform")
+            }
+            .disabled(!viewModel.hapticFeedbackAvailable)
+            .accessibilityIdentifier("haptic_feedback_toggle")
+            .accessibilityLabel(String(localized: "Haptic feedback"))
+            .accessibilityHint(
+                viewModel.hapticFeedbackAvailable
+                    ? String(localized: "Play subtle confirmations and warnings when saving transactions")
+                    : String(localized: "Haptic feedback is not available on this device")
+            )
+
+            if !viewModel.hapticFeedbackAvailable {
+                Text(String(localized: "Haptic feedback is not available on this device."))
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .accessibilityLabel(String(localized: "Haptic feedback is not available on this device."))
             }
         }
     }

--- a/apps/ios/Finance/Screens/TransactionCreateView.swift
+++ b/apps/ios/Finance/Screens/TransactionCreateView.swift
@@ -284,7 +284,14 @@ struct TransactionCreateView: View {
             }
             if viewModel.currentStep == .review {
                 Button {
-                    Task { if await viewModel.save() { dismiss() } }
+                    Task {
+                        if await viewModel.save() {
+                            HapticManager.shared.transactionSaved()
+                            dismiss()
+                        } else {
+                            HapticManager.shared.validationWarning()
+                        }
+                    }
                 } label: {
                     if viewModel.isSaving { ProgressView().frame(maxWidth: .infinity) }
                     else { Text(viewModel.saveButtonTitle).frame(maxWidth: .infinity) }

--- a/apps/ios/Finance/Screens/TransactionEditView.swift
+++ b/apps/ios/Finance/Screens/TransactionEditView.swift
@@ -169,7 +169,7 @@ struct TransactionEditView: View {
             HapticManager.shared.transactionSaved()
             onComplete?()
             dismiss()
-        } else { HapticManager.shared.error() }
+        } else { HapticManager.shared.validationWarning() }
     }
 
     private func performDelete() async {

--- a/apps/ios/Finance/ViewModels/SettingsViewModel.swift
+++ b/apps/ios/Finance/ViewModels/SettingsViewModel.swift
@@ -58,6 +58,14 @@ final class SettingsViewModel {
         didSet { defaults.set(goalMilestonesEnabled, forKey: SettingsKeys.goalMilestones) }
     }
 
+    /// Whether subtle haptic confirmations and warnings are enabled.
+    var hapticFeedbackEnabled: Bool {
+        didSet { HapticFeedbackPreferences.setEnabled(hapticFeedbackEnabled, defaults: defaults) }
+    }
+
+    /// Whether this device supports haptic feedback.
+    let hapticFeedbackAvailable: Bool
+
     // MARK: - Biometric State
 
     /// Whether the biometric app-lock is currently enabled.
@@ -204,6 +212,8 @@ final class SettingsViewModel {
         self.goalMilestonesEnabled = Self.bool(
             forKey: SettingsKeys.goalMilestones, default: true, in: defaults
         )
+        self.hapticFeedbackAvailable = HapticFeedbackPreferences.deviceSupportsHaptics
+        self.hapticFeedbackEnabled = HapticFeedbackPreferences.isEnabled(defaults: defaults)
         self.lastSyncDate = defaults.object(forKey: SettingsKeys.lastSyncDate) as? Date
         self.pendingChangesCount = defaults.integer(forKey: SettingsKeys.pendingChangesCount)
 
@@ -455,6 +465,7 @@ final class SettingsViewModel {
             for key in [
                 SettingsKeys.currency, SettingsKeys.notifications,
                 SettingsKeys.budgetAlerts, SettingsKeys.goalMilestones,
+                HapticFeedbackPreferences.key,
                 SettingsKeys.lastSyncDate, SettingsKeys.pendingChangesCount,
             ] {
                 defaults.removeObject(forKey: key)

--- a/apps/ios/FinanceWatch/Haptics/WatchHapticFeedback.swift
+++ b/apps/ios/FinanceWatch/Haptics/WatchHapticFeedback.swift
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import Foundation
+import WatchKit
+
+/// watchOS haptic bridge for transaction-save feedback.
+enum WatchHapticFeedback {
+    static let preferenceKey = "finance_haptic_feedback_enabled"
+
+    /// Plays a transaction-save success confirmation when enabled.
+    static func transactionSaved(defaults: UserDefaults = .standard) {
+        guard isEnabled(defaults: defaults) else { return }
+        WKInterfaceDevice.current().play(.success)
+    }
+
+    /// Plays a soft validation warning when enabled.
+    static func validationWarning(defaults: UserDefaults = .standard) {
+        guard isEnabled(defaults: defaults) else { return }
+        WKInterfaceDevice.current().play(.failure)
+    }
+
+    private static func isEnabled(defaults: UserDefaults) -> Bool {
+        defaults.object(forKey: preferenceKey) == nil
+            ? true
+            : defaults.bool(forKey: preferenceKey)
+    }
+}

--- a/apps/ios/Package.swift
+++ b/apps/ios/Package.swift
@@ -74,6 +74,7 @@ let package = Package(
                 "BalanceView.swift",
                 "RecentTransactionsView.swift",
                 "BudgetStatusView.swift",
+                "Haptics/WatchHapticFeedback.swift",
                 "ComplicationProvider.swift",
                 "BudgetComplicationProvider.swift",
                 "SpendingComplicationProvider.swift",

--- a/apps/ios/Tests/SettingsViewModelTests.swift
+++ b/apps/ios/Tests/SettingsViewModelTests.swift
@@ -37,6 +37,11 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertTrue(vm.notificationsEnabled, "Notifications should default to enabled")
         XCTAssertTrue(vm.budgetAlertsEnabled, "Budget alerts should default to enabled")
         XCTAssertTrue(vm.goalMilestonesEnabled, "Goal milestones should default to enabled")
+        XCTAssertEqual(
+            vm.hapticFeedbackEnabled,
+            HapticFeedbackPreferences.deviceSupportsHaptics,
+            "Haptic feedback should default on only when the device supports it"
+        )
     }
 
     // MARK: - Persistence: Currency
@@ -133,6 +138,30 @@ final class SettingsViewModelTests: XCTestCase {
 
         XCTAssertFalse(vm.goalMilestonesEnabled,
                        "Goal milestones state should be restored from UserDefaults")
+    }
+
+    // MARK: - Persistence: Haptic Feedback
+
+    @MainActor
+    func testHapticFeedbackTogglePersists() {
+        let vm = makeViewModel()
+
+        vm.hapticFeedbackEnabled = false
+
+        XCTAssertFalse(
+            testDefaults.bool(forKey: HapticFeedbackPreferences.key),
+            "Haptic feedback toggle should be written to UserDefaults"
+        )
+    }
+
+    @MainActor
+    func testHapticFeedbackRestoredFromUserDefaults() {
+        testDefaults.set(false, forKey: HapticFeedbackPreferences.key)
+
+        let vm = makeViewModel()
+
+        XCTAssertFalse(vm.hapticFeedbackEnabled,
+                       "Haptic feedback state should be restored from UserDefaults")
     }
 
     // MARK: - Export: JSON

--- a/packages/core/src/commonMain/kotlin/com/finance/core/haptics/HapticFeedback.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/haptics/HapticFeedback.kt
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.haptics
+
+/** Semantic haptic patterns shared by transaction-save UI surfaces. */
+enum class HapticFeedbackEffect {
+    /** Confirmation after a transaction is saved successfully. */
+    TRANSACTION_SAVE_SUCCESS,
+
+    /** Soft warning when transaction validation fails. */
+    TRANSACTION_VALIDATION_WARNING,
+}
+
+/** Platform haptic feedback bridge. Implementations must honor OS-level haptic settings. */
+fun interface HapticFeedback {
+    /** Performs the platform mapping for [effect], or no-ops when unavailable. */
+    fun perform(effect: HapticFeedbackEffect)
+}
+
+/** No-op feedback for visual-only surfaces such as Web and Windows. */
+object NoOpHapticFeedback : HapticFeedback {
+    override fun perform(effect: HapticFeedbackEffect) = Unit
+}
+
+/** App/device haptic preference snapshot used by [HapticFeedbackDispatcher]. */
+data class HapticFeedbackSettings(
+    val deviceSupportsHaptics: Boolean,
+    val appHapticsEnabled: Boolean = deviceSupportsHaptics,
+) {
+    /** True when haptic feedback is both supported and enabled in app settings. */
+    val canPerformHaptics: Boolean = deviceSupportsHaptics && appHapticsEnabled
+}
+
+/** Dispatches semantic haptic events only when the user's settings allow it. */
+class HapticFeedbackDispatcher(
+    private val feedback: HapticFeedback,
+    private val settingsProvider: () -> HapticFeedbackSettings,
+) {
+    /** Emits the success haptic for a completed transaction save. */
+    fun transactionSaved() {
+        perform(HapticFeedbackEffect.TRANSACTION_SAVE_SUCCESS)
+    }
+
+    /** Emits the soft warning haptic for a transaction validation failure. */
+    fun validationFailed() {
+        perform(HapticFeedbackEffect.TRANSACTION_VALIDATION_WARNING)
+    }
+
+    private fun perform(effect: HapticFeedbackEffect) {
+        if (settingsProvider().canPerformHaptics) {
+            feedback.perform(effect)
+        }
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/haptics/HapticFeedbackDispatcherTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/haptics/HapticFeedbackDispatcherTest.kt
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.haptics
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class HapticFeedbackDispatcherTest {
+    @Test
+    fun `transaction save dispatches success effect when enabled`() {
+        val recorder = RecordingHapticFeedback()
+        val dispatcher = HapticFeedbackDispatcher(
+            feedback = recorder,
+            settingsProvider = { HapticFeedbackSettings(deviceSupportsHaptics = true) },
+        )
+
+        dispatcher.transactionSaved()
+
+        assertEquals(listOf(HapticFeedbackEffect.TRANSACTION_SAVE_SUCCESS), recorder.effects)
+    }
+
+    @Test
+    fun `validation failure dispatches warning effect when enabled`() {
+        val recorder = RecordingHapticFeedback()
+        val dispatcher = HapticFeedbackDispatcher(
+            feedback = recorder,
+            settingsProvider = { HapticFeedbackSettings(deviceSupportsHaptics = true) },
+        )
+
+        dispatcher.validationFailed()
+
+        assertEquals(listOf(HapticFeedbackEffect.TRANSACTION_VALIDATION_WARNING), recorder.effects)
+    }
+
+    @Test
+    fun `dispatcher no-ops when app toggle is disabled`() {
+        val recorder = RecordingHapticFeedback()
+        val dispatcher = HapticFeedbackDispatcher(
+            feedback = recorder,
+            settingsProvider = {
+                HapticFeedbackSettings(
+                    deviceSupportsHaptics = true,
+                    appHapticsEnabled = false,
+                )
+            },
+        )
+
+        dispatcher.transactionSaved()
+        dispatcher.validationFailed()
+
+        assertEquals(emptyList(), recorder.effects)
+    }
+
+    @Test
+    fun `dispatcher no-ops when device has no haptic support`() {
+        val recorder = RecordingHapticFeedback()
+        val dispatcher = HapticFeedbackDispatcher(
+            feedback = recorder,
+            settingsProvider = { HapticFeedbackSettings(deviceSupportsHaptics = false) },
+        )
+
+        dispatcher.transactionSaved()
+
+        assertEquals(emptyList(), recorder.effects)
+    }
+
+    private class RecordingHapticFeedback : HapticFeedback {
+        val effects = mutableListOf<HapticFeedbackEffect>()
+
+        override fun perform(effect: HapticFeedbackEffect) {
+            effects += effect
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds subtle transaction-save haptic feedback for mobile surfaces while preserving visual-only Web and Windows behavior.

## Changes

- Adds a shared `packages/core` haptic feedback interface/dispatcher with success and validation-warning effects.
- Maps Android transaction-save feedback to `HapticFeedbackConstants.CONFIRM` / `REJECT` on API 30+, with `KEYBOARD_TAP` fallback.
- Adds Android Settings → Accessibility haptic toggle, defaulting on when haptic hardware is available.
- Adds iOS haptic preference storage, Settings → Accessibility toggle, and `.success` / `.warning` transaction-save feedback.
- Adds a watchOS haptic bridge using `WKInterfaceDevice.play(.success/.failure)` for any watch transaction-save surface.
- Leaves Web and Windows visual-only behavior unchanged via no-op shared feedback semantics.

## Testing

- `node tools\\gradle.js :packages:core:jvmTest`
- `npm run format`
- `npx eslint . --fix`
- `npm run format:check`
- `npx eslint . --max-warnings 0`

## Notes

- Swift tests could not be run locally because `swift` is not installed in this Windows environment.
- Android app compilation could not be run locally because the Android SDK is not configured in this worktree; CI remains the source of truth.

Closes #1756