### PR TITLE
feat(export): in-app data access request fulfillment (#1873)

### DIFF
--- a/apps/web/src/components/DataExport.test.tsx
+++ b/apps/web/src/components/DataExport.test.tsx
@@ -1,18 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React from 'react';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { DataExport } from './DataExport';
 import type { SqliteDb } from '../db/sqlite-wasm';
 import { DatabaseContext, type DatabaseContextValue } from '../db/DatabaseProvider';
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/** Create a minimal mock database for testing. */
 function createMockDb(): SqliteDb {
   return {
     exec: vi.fn(),
@@ -20,12 +15,12 @@ function createMockDb(): SqliteDb {
   } as unknown as SqliteDb;
 }
 
-/** Mock the database repositories. */
 vi.mock('../db/repositories/accounts', () => ({
   getAllAccounts: vi.fn(() => [
     {
       id: 'acc-1',
       householdId: 'hh-1',
+      ownerId: 'owner-1',
       name: 'Checking',
       type: 'CHECKING',
       currency: { code: 'USD', symbol: '$', name: 'US Dollar' },
@@ -48,6 +43,7 @@ vi.mock('../db/repositories/transactions', () => ({
     {
       id: 'txn-1',
       householdId: 'hh-1',
+      ownerId: 'owner-1',
       accountId: 'acc-1',
       categoryId: 'cat-1',
       type: 'EXPENSE',
@@ -61,7 +57,7 @@ vi.mock('../db/repositories/transactions', () => ({
       transferTransactionId: null,
       isRecurring: false,
       recurringRuleId: null,
-      tags: [],
+      tags: ['food'],
       createdAt: '2024-01-01T00:00:00Z',
       updatedAt: '2024-01-01T00:00:00Z',
       deletedAt: null,
@@ -71,19 +67,14 @@ vi.mock('../db/repositories/transactions', () => ({
   ]),
 }));
 
-vi.mock('../db/repositories/budgets', () => ({
-  getAllBudgets: vi.fn(() => []),
-}));
-
-vi.mock('../db/repositories/goals', () => ({
-  getAllGoals: vi.fn(() => []),
-}));
-
+vi.mock('../db/repositories/budgets', () => ({ getAllBudgets: vi.fn(() => []) }));
+vi.mock('../db/repositories/goals', () => ({ getAllGoals: vi.fn(() => []) }));
 vi.mock('../db/repositories/categories', () => ({
   getAllCategories: vi.fn(() => [
     {
       id: 'cat-1',
       householdId: 'hh-1',
+      ownerId: 'owner-1',
       name: 'Food',
       icon: null,
       color: null,
@@ -100,25 +91,24 @@ vi.mock('../db/repositories/categories', () => ({
   ]),
 }));
 
-/** Stub URL.createObjectURL / revokeObjectURL since jsdom doesn't provide them. */
 beforeEach(() => {
   vi.stubGlobal('URL', {
     ...globalThis.URL,
     createObjectURL: vi.fn(() => 'blob:mock-url'),
     revokeObjectURL: vi.fn(),
   });
+  Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
+  Object.defineProperty(navigator, 'share', { value: undefined, configurable: true });
+  Object.defineProperty(navigator, 'canShare', { value: undefined, configurable: true });
+  localStorage.clear();
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
 });
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
 describe('DataExport', () => {
-  // Helper to create test wrapper with database context
   const createTestWrapper = (db: SqliteDb | null) => {
     const contextValue: DatabaseContextValue | null = db
       ? {
@@ -138,130 +128,77 @@ describe('DataExport', () => {
     return TestWrapper;
   };
 
-  // -- Render ---------------------------------------------------------------
+  it('renders the request-my-data entry point and status indicator', () => {
+    render(<DataExport />, { wrapper: createTestWrapper(createMockDb()) });
 
-  it('renders both export format buttons', () => {
-    const mockDb = createMockDb();
-    const TestWrapper = createTestWrapper(mockDb);
-    render(<DataExport />, { wrapper: TestWrapper });
-    expect(screen.getByRole('button', { name: /export as json/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /export as csv/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /request my data/i })).toBeInTheDocument();
+    expect(screen.getByText(/local ZIP package/i)).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent(/not requested/i);
   });
 
-  it('renders description text', () => {
-    const mockDb = createMockDb();
-    const TestWrapper = createTestWrapper(mockDb);
-    render(<DataExport />, { wrapper: TestWrapper });
-    expect(screen.getByText(/download your financial data/i)).toBeInTheDocument();
-  });
+  it('disables requests while the database is unavailable', () => {
+    render(<DataExport />, { wrapper: createTestWrapper(null) });
 
-  it('shows database unavailable message when db is null', () => {
-    const TestWrapper = createTestWrapper(null);
-    render(<DataExport />, { wrapper: TestWrapper });
     expect(screen.getByText(/database is not available/i)).toBeInTheDocument();
-    // Buttons should be disabled when database is not available
-    expect(screen.getByRole('button', { name: /export as json/i })).toBeDisabled();
-    expect(screen.getByRole('button', { name: /export as csv/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /request my data/i })).toBeDisabled();
   });
 
-  // -- Accessibility --------------------------------------------------------
-
-  it('export buttons are keyboard focusable', () => {
-    const mockDb = createMockDb();
-    const TestWrapper = createTestWrapper(mockDb);
-    render(<DataExport />, { wrapper: TestWrapper });
-    const jsonBtn = screen.getByRole('button', { name: /export as json/i });
-    const csvBtn = screen.getByRole('button', { name: /export as csv/i });
-
-    // Buttons are natively focusable; verify they are not tabindex=-1
-    expect(jsonBtn).not.toHaveAttribute('tabindex', '-1');
-    expect(csvBtn).not.toHaveAttribute('tabindex', '-1');
-  });
-
-  it('buttons have type="button" (not submit)', () => {
-    const mockDb = createMockDb();
-    const TestWrapper = createTestWrapper(mockDb);
-    render(<DataExport />, { wrapper: TestWrapper });
-    const jsonBtn = screen.getByRole('button', { name: /export as json/i });
-    const csvBtn = screen.getByRole('button', { name: /export as csv/i });
-
-    expect(jsonBtn).toHaveAttribute('type', 'button');
-    expect(csvBtn).toHaveAttribute('type', 'button');
-  });
-
-  it('buttons are grouped with role="group"', () => {
-    const mockDb = createMockDb();
-    const TestWrapper = createTestWrapper(mockDb);
-    render(<DataExport />, { wrapper: TestWrapper });
-    const group = screen.getByRole('group');
-    expect(group).toBeInTheDocument();
-
-    // Both buttons live inside the group
-    const buttons = within(group).getAllByRole('button');
-    expect(buttons).toHaveLength(2);
-  });
-
-  // -- Export flow -----------------------------------------------------------
-
-  it('shows progress state when exporting', async () => {
+  it('shows a confirmation modal with protected-category and mood-tag choices', async () => {
     const user = userEvent.setup();
-    const mockDb = createMockDb();
-    const TestWrapper = createTestWrapper(mockDb);
-    render(<DataExport />, { wrapper: TestWrapper });
+    render(<DataExport />, { wrapper: createTestWrapper(createMockDb()) });
 
-    const jsonBtn = screen.getByRole('button', { name: /export as json/i });
-    await user.click(jsonBtn);
+    await user.click(screen.getByRole('button', { name: /request my data/i }));
 
-    // Progress indicator should appear
-    expect(screen.getByRole('status', { name: /export in progress/i })).toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: /request your data package/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/include protected categories/i)).toBeChecked();
+    expect(screen.getByLabelText(/include mood tags/i)).not.toBeChecked();
+    expect(
+      screen.getByText(/Mood tag data can reveal sensitive wellbeing patterns/i),
+    ).toBeInTheDocument();
   });
 
-  it('disables buttons during export', async () => {
-    const user = userEvent.setup();
-    const mockDb = createMockDb();
-    const TestWrapper = createTestWrapper(mockDb);
-    render(<DataExport />, { wrapper: TestWrapper });
-
-    await user.click(screen.getByRole('button', { name: /export as json/i }));
-
-    // Both buttons should be disabled while exporting
-    const buttons = screen.getAllByRole('button');
-    const exportButtons = buttons.filter(
-      (b) =>
-        b.textContent?.includes('JSON') ||
-        b.textContent?.includes('CSV') ||
-        b.textContent?.includes('Exporting'),
-    );
-    exportButtons.forEach((btn) => {
-      expect(btn).toBeDisabled();
-    });
-  });
-
-  it('shows success message after export completes', async () => {
+  it('supports cancelling while the request is pending', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
-    const mockDb = createMockDb();
-    const TestWrapper = createTestWrapper(mockDb);
-    render(<DataExport />, { wrapper: TestWrapper });
+    render(<DataExport />, { wrapper: createTestWrapper(createMockDb()) });
 
-    await user.click(screen.getByRole('button', { name: /export as json/i }));
+    await user.click(screen.getByRole('button', { name: /request my data/i }));
+    await user.click(screen.getByRole('button', { name: /generate package/i }));
+    expect(screen.getByRole('status')).toHaveTextContent(/pending/i);
 
-    // Advance past the simulated delay (400ms)
-    await vi.advanceTimersByTimeAsync(500);
+    await user.click(screen.getByRole('button', { name: /cancel request/i }));
 
-    expect(screen.getByText(/export complete/i)).toBeInTheDocument();
-
-    vi.useRealTimers();
+    expect(screen.getByRole('status')).toHaveTextContent(/cancelled/i);
   });
 
-  // -- Custom class ---------------------------------------------------------
+  it('generates a ready ZIP package without network egress', async () => {
+    const fetchSpy = vi.fn(() => Promise.reject(new Error('network blocked')));
+    vi.stubGlobal('fetch', fetchSpy);
+    const user = userEvent.setup();
+    render(<DataExport />, { wrapper: createTestWrapper(createMockDb()) });
 
-  it('applies custom className', () => {
-    const mockDb = createMockDb();
-    const TestWrapper = createTestWrapper(mockDb);
-    const { container } = render(<DataExport className="my-custom" />, { wrapper: TestWrapper });
-    const wrapper = container.firstElementChild;
-    expect(wrapper?.className).toContain('my-custom');
-    expect(wrapper?.className).toContain('data-export');
+    await user.click(screen.getByRole('button', { name: /request my data/i }));
+    await user.click(screen.getByLabelText(/include mood tags/i));
+    await user.click(screen.getByRole('button', { name: /generate package/i }));
+
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent(/ready/i));
+    expect(screen.getByText(/Package ready/i)).toBeInTheDocument();
+    expect(screen.getByText(/mood tags included: yes/i)).toBeInTheDocument();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('delivers the ZIP through share/download fallback', async () => {
+    const user = userEvent.setup();
+    render(<DataExport />, { wrapper: createTestWrapper(createMockDb()) });
+
+    await user.click(screen.getByRole('button', { name: /request my data/i }));
+    await user.click(screen.getByRole('button', { name: /generate package/i }));
+    await screen.findByText(/Package ready/i);
+    await user.click(screen.getByRole('button', { name: /share zip package/i }));
+
+    expect(URL.createObjectURL).toHaveBeenCalled();
+    expect(
+      screen.getAllByRole('status').some((status) => /delivered/i.test(status.textContent ?? '')),
+    ).toBe(true);
   });
 });

--- a/apps/web/src/components/DataExport.tsx
+++ b/apps/web/src/components/DataExport.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useDatabase } from '../db/DatabaseProvider';
 import type { SqliteDb } from '../db/sqlite-wasm';
 import { getAllAccounts } from '../db/repositories/accounts';
@@ -8,18 +8,23 @@ import { getAllTransactions } from '../db/repositories/transactions';
 import { getAllBudgets } from '../db/repositories/budgets';
 import { getAllGoals } from '../db/repositories/goals';
 import { getAllCategories } from '../db/repositories/categories';
+import {
+  buildDataAccessPackage,
+  shouldAutoDeletePackage,
+  shouldWarnPackageExpiresSoon,
+  type DataAccessManifest,
+  type DataAccessPackageResult,
+} from '../lib/data-access-package';
 import './data-export.css';
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-/** Supported export formats. */
-export type ExportFormat = 'json' | 'csv';
-
-/** Current state of the export operation. */
-type ExportStatus = 'idle' | 'exporting' | 'success' | 'error';
-
+type ExportStatus =
+  | 'idle'
+  | 'pending'
+  | 'generating'
+  | 'ready'
+  | 'delivered'
+  | 'error'
+  | 'cancelled';
 type ExportRecord = Record<string, unknown>;
 
 interface ExportData {
@@ -34,11 +39,18 @@ export interface DataExportProps {
   className?: string;
 }
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
+const APP_VERSION = '0.1.0';
 
-/** Gather all exportable financial data from the local SQLite-WASM database. */
+const STRINGS = {
+  requestButton: 'Request my data',
+  pending: 'Pending',
+  generating: 'Generating',
+  ready: 'Ready',
+  delivered: 'Delivered',
+  cancelled: 'Cancelled',
+  error: 'Error',
+};
+
 function gatherExportData(db: SqliteDb): ExportData {
   return {
     accounts: getAllAccounts(db),
@@ -49,7 +61,6 @@ function gatherExportData(db: SqliteDb): ExportData {
   };
 }
 
-/** Safely read the shared database instance when the provider may be unavailable. */
 function useExportDatabase(): SqliteDb | null {
   try {
     return useDatabase();
@@ -58,60 +69,26 @@ function useExportDatabase(): SqliteDb | null {
   }
 }
 
-/** Return `true` when at least one exported collection contains records. */
+function readLocalStorageRecords(prefix: string): ExportRecord[] {
+  const records: ExportRecord[] = [];
+  for (let index = 0; index < localStorage.length; index += 1) {
+    const key = localStorage.key(index);
+    if (!key?.startsWith(prefix)) continue;
+    records.push({ key, value: localStorage.getItem(key) });
+  }
+  return records;
+}
+
 function hasExportData(data: ExportData): boolean {
   return Object.values(data).some((records) => records.length > 0);
 }
 
-/** Serialize records to JSON string. */
-function serializeJson(data: ExportData): string {
-  return JSON.stringify({ exportedAt: new Date().toISOString(), data }, null, 2);
+function toExportRecords<T extends object>(records: readonly T[]): ExportRecord[] {
+  return records.map((record) => Object.fromEntries(Object.entries(record)));
 }
 
-/** Serialize a single value for safe CSV output. */
-function serializeCsvValue(value: unknown): string {
-  if (value === null || value === undefined) {
-    return '';
-  }
-
-  const serializedValue = typeof value === 'object' ? JSON.stringify(value) : String(value);
-  return serializedValue.includes(',') ||
-    serializedValue.includes('"') ||
-    serializedValue.includes('\n')
-    ? `"${serializedValue.replace(/"/g, '""')}"`
-    : serializedValue;
-}
-
-/** Serialize a homogeneous record collection to CSV with a header row. */
-function serializeRecordCollection(records: ExportRecord[]): string {
-  if (records.length === 0) {
-    return '';
-  }
-
-  const headers = Object.keys(records[0]);
-  const rows = records.map((record) =>
-    headers.map((header) => serializeCsvValue(record[header])).join(','),
-  );
-  return [headers.join(','), ...rows].join('\n');
-}
-
-/** Serialize exported data collections to a multi-section CSV string. */
-function serializeCsv(data: ExportData): string {
-  return (Object.entries(data) as [keyof ExportData, ExportData[keyof ExportData]][])
-    .map(([tableName, records]) => {
-      const lines = [`# Table: ${String(tableName)}`, `# Records: ${records.length}`];
-      const section = serializeRecordCollection(records as unknown as ExportRecord[]);
-      if (section) {
-        lines.push(section);
-      }
-      return lines.join('\n');
-    })
-    .join('\n\n');
-}
-
-/** Trigger a browser file download from a Blob. */
-function downloadBlob(content: string, filename: string, mimeType: string): void {
-  const blob = new Blob([content], { type: mimeType });
+function downloadBytes(content: Uint8Array, filename: string, mimeType: string): string {
+  const blob = new Blob([content.slice().buffer], { type: mimeType });
   const url = URL.createObjectURL(blob);
   const anchor = document.createElement('a');
   anchor.href = url;
@@ -119,164 +96,249 @@ function downloadBlob(content: string, filename: string, mimeType: string): void
   anchor.style.display = 'none';
   document.body.appendChild(anchor);
   anchor.click();
-  // Clean up
-  setTimeout(() => {
-    URL.revokeObjectURL(url);
-    document.body.removeChild(anchor);
-  }, 100);
+  document.body.removeChild(anchor);
+  return url;
 }
 
-// ---------------------------------------------------------------------------
-// Component
-// ---------------------------------------------------------------------------
+async function shareOrDownloadPackage(
+  packageResult: DataAccessPackageResult,
+): Promise<string | null> {
+  const file = new File([packageResult.zipBytes.slice().buffer], packageResult.fileName, {
+    type: 'application/zip',
+  });
+  const navigatorWithShare = navigator as Navigator & {
+    canShare?: (data: ShareData) => boolean;
+    share?: (data: ShareData) => Promise<void>;
+  };
 
-/**
- * Data export UI — allows users to export their financial data as JSON or CSV.
- *
- * Features:
- * - Format selection (JSON / CSV) with accessible buttons
- * - Progress indicator during export
- * - Browser file download via blob URL
- * - Success/error feedback with ARIA live region
- * - Full keyboard navigation
- */
+  if (
+    navigatorWithShare.share &&
+    (!navigatorWithShare.canShare || navigatorWithShare.canShare({ files: [file] }))
+  ) {
+    await navigatorWithShare.share({ files: [file], title: 'Finance data package' });
+    return null;
+  }
+
+  return downloadBytes(packageResult.zipBytes, packageResult.fileName, 'application/zip');
+}
+
 export const DataExport: React.FC<DataExportProps> = ({ className = '' }) => {
   const db = useExportDatabase();
   const [status, setStatus] = useState<ExportStatus>('idle');
+  const [showConfirmation, setShowConfirmation] = useState(false);
+  const [includeProtectedCategories, setIncludeProtectedCategories] = useState(true);
+  const [includeMoodTags, setIncludeMoodTags] = useState(false);
+  const [packageResult, setPackageResult] = useState<DataAccessPackageResult | null>(null);
+  const [objectUrl, setObjectUrl] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState('');
-  const [lastFormat, setLastFormat] = useState<ExportFormat | null>(null);
+  const [expirationWarning, setExpirationWarning] = useState(false);
+  const cancelledRef = useRef(false);
+  const pendingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Ref for returning focus after export completes
-  const jsonBtnRef = useRef<HTMLButtonElement>(null);
-  const csvBtnRef = useRef<HTMLButtonElement>(null);
+  useEffect(() => {
+    return () => {
+      if (pendingTimerRef.current) clearTimeout(pendingTimerRef.current);
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [objectUrl]);
 
-  const handleExport = useCallback(
-    async (format: ExportFormat) => {
-      setStatus('exporting');
-      setErrorMessage('');
-      setLastFormat(format);
-
-      try {
-        // Simulate a brief processing delay for UX feedback while queries run.
-        await new Promise((resolve) => setTimeout(resolve, 400));
-
-        if (!db) {
-          setStatus('error');
-          setErrorMessage('Database is still initializing. Please wait a moment and try again.');
-          return;
-        }
-
-        const data = gatherExportData(db);
-        if (!hasExportData(data)) {
-          setStatus('error');
-          setErrorMessage('No data available to export.');
-          return;
-        }
-
-        const timestamp = new Date().toISOString().slice(0, 10);
-        if (format === 'json') {
-          const content = serializeJson(data);
-          downloadBlob(content, `finance-export-${timestamp}.json`, 'application/json');
-        } else {
-          const content = serializeCsv(data);
-          downloadBlob(content, `finance-export-${timestamp}.csv`, 'text/csv');
-        }
-
-        setStatus('success');
-
-        // Auto-clear success after a few seconds
-        setTimeout(() => setStatus('idle'), 4000);
-      } catch {
-        setStatus('error');
-        setErrorMessage('Export failed. Please try again.');
-      }
-    },
-    [db],
-  );
-
-  const handleDismissError = useCallback(() => {
-    setStatus('idle');
-    setErrorMessage('');
-    // Return focus to the button that triggered the failed export
-    if (lastFormat === 'csv') {
-      csvBtnRef.current?.focus();
-    } else {
-      jsonBtnRef.current?.focus();
+  useEffect(() => {
+    if (!packageResult) return undefined;
+    const expiresAt = packageResult.manifest.expires_at;
+    if (shouldAutoDeletePackage(new Date(), expiresAt)) {
+      setPackageResult(null);
+      setStatus('idle');
+      return undefined;
     }
-  }, [lastFormat]);
+    setExpirationWarning(shouldWarnPackageExpiresSoon(new Date(), expiresAt));
+    const expiresInMs = Math.max(0, new Date(expiresAt).getTime() - Date.now());
+    const warningInMs = Math.max(0, expiresInMs - 24 * 60 * 60 * 1000);
+    const warningTimer = setTimeout(() => setExpirationWarning(true), warningInMs);
+    const deleteTimer = setTimeout(() => {
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+      setPackageResult(null);
+      setObjectUrl(null);
+      setStatus('idle');
+      setExpirationWarning(false);
+    }, expiresInMs);
+    return () => {
+      clearTimeout(warningTimer);
+      clearTimeout(deleteTimer);
+    };
+  }, [objectUrl, packageResult]);
 
-  const isExporting = status === 'exporting';
-  const isDatabaseUnavailable = db === null;
+  const manifest = packageResult?.manifest;
+  const dbUnavailable = db === null;
+
+  const startRequest = useCallback(() => {
+    setShowConfirmation(true);
+    setErrorMessage('');
+  }, []);
+
+  const cancelRequest = useCallback(() => {
+    cancelledRef.current = true;
+    if (pendingTimerRef.current) clearTimeout(pendingTimerRef.current);
+    setShowConfirmation(false);
+    setStatus('cancelled');
+  }, []);
+
+  const confirmRequest = useCallback(() => {
+    setShowConfirmation(false);
+    setStatus('pending');
+    setErrorMessage('');
+    cancelledRef.current = false;
+
+    pendingTimerRef.current = setTimeout(async () => {
+      if (cancelledRef.current) return;
+      setStatus('generating');
+      try {
+        if (!db)
+          throw new Error('Database is still initializing. Please wait a moment and try again.');
+        const data = gatherExportData(db);
+        if (!hasExportData(data)) throw new Error('No data available to export.');
+
+        const result = buildDataAccessPackage(
+          {
+            accounts: toExportRecords(data.accounts),
+            transactions: toExportRecords(data.transactions),
+            budgets: toExportRecords(data.budgets),
+            goals: toExportRecords(data.goals),
+            categories: toExportRecords(data.categories),
+            preferences: readLocalStorageRecords('finance-'),
+            settings: readLocalStorageRecords('settings-'),
+            auditLog: [
+              { event: 'data_access_export_generated', timestamp: new Date().toISOString() },
+            ],
+            syncMetadata: [{ offline: !navigator.onLine, user_agent: navigator.userAgent }],
+            recurringRules: [],
+            attachments: [],
+            moodTags: includeMoodTags ? readLocalStorageRecords('finance-mood-') : [],
+          },
+          {
+            appVersion: APP_VERSION,
+            locale: navigator.language,
+            includeProtectedCategories,
+            includeMoodTags,
+          },
+        );
+        if (cancelledRef.current) return;
+        setPackageResult(result);
+        setStatus('ready');
+      } catch (error) {
+        setStatus('error');
+        setErrorMessage(error instanceof Error ? error.message : 'Data package generation failed.');
+      }
+    }, 100);
+  }, [db, includeMoodTags, includeProtectedCategories]);
+
+  const deliverPackage = useCallback(async () => {
+    if (!packageResult) return;
+    try {
+      const url = await shareOrDownloadPackage(packageResult);
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+      setObjectUrl(url);
+      setStatus('delivered');
+    } catch (error) {
+      setStatus('error');
+      setErrorMessage(error instanceof Error ? error.message : 'Unable to open the share sheet.');
+    }
+  }, [objectUrl, packageResult]);
 
   return (
     <div className={`data-export ${className}`.trim()}>
       <p id="data-export-description" className="data-export__description">
-        {isDatabaseUnavailable
+        {dbUnavailable
           ? 'Database is not available. Please wait for it to initialize.'
-          : 'Download your financial data for backup or use in other applications.'}
+          : 'Generate a local ZIP package with manifest.json, per-domain JSON files, attachments, and a localized README.md. No server roundtrip is used.'}
       </p>
 
-      {/* Export buttons */}
       <div
+        className="data-export__button-group"
         role="group"
         aria-labelledby="data-export-description"
-        className="data-export__button-group"
       >
         <button
-          ref={jsonBtnRef}
           type="button"
           className="data-export__button"
-          disabled={isExporting || isDatabaseUnavailable}
-          onClick={() => handleExport('json')}
+          disabled={dbUnavailable || status === 'pending' || status === 'generating'}
+          onClick={startRequest}
           aria-describedby="data-export-description"
         >
-          {isExporting && lastFormat === 'json' ? (
-            <>
-              <SpinnerIcon />
-              Exporting…
-            </>
-          ) : (
-            <>
-              <DownloadIcon />
-              Export as JSON
-            </>
-          )}
+          <DownloadIcon />
+          {STRINGS.requestButton}
         </button>
-
-        <button
-          ref={csvBtnRef}
-          type="button"
-          className="data-export__button"
-          disabled={isExporting || isDatabaseUnavailable}
-          onClick={() => handleExport('csv')}
-          aria-describedby="data-export-description"
-        >
-          {isExporting && lastFormat === 'csv' ? (
-            <>
-              <SpinnerIcon />
-              Exporting…
-            </>
-          ) : (
-            <>
-              <DownloadIcon />
-              Export as CSV
-            </>
-          )}
-        </button>
+        {(status === 'pending' || status === 'generating') && (
+          <button type="button" className="data-export__button" onClick={cancelRequest}>
+            Cancel request
+          </button>
+        )}
+        {packageResult && status !== 'pending' && status !== 'generating' && (
+          <button
+            type="button"
+            className="data-export__button"
+            onClick={() => void deliverPackage()}
+          >
+            Share ZIP package
+          </button>
+        )}
       </div>
 
-      {/* Progress bar — shown during export */}
-      {isExporting && (
-        <div className="data-export__progress" role="status" aria-label="Export in progress">
+      <div className="data-export__progress" role="status" aria-live="polite">
+        <span>Status: {statusLabel(status)}</span>
+        {(status === 'pending' || status === 'generating') && (
           <div className="progress-bar">
             <div className="progress-bar__fill data-export__progress-fill" />
           </div>
-          <p className="data-export__progress-text">Preparing your data for download…</p>
+        )}
+      </div>
+
+      {showConfirmation && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="data-export-confirm-title"
+          className="data-export__feedback"
+        >
+          <h4 id="data-export-confirm-title">Request your data package?</h4>
+          <p>
+            Finance will include transactions, accounts, budgets, goals, recurring rules,
+            categories, tags, attachments, preferences, settings, audit log entries, and sync
+            metadata. The ZIP is generated on this device and is available in-app for 7 days.
+          </p>
+          <p>
+            Mood tag data can reveal sensitive wellbeing patterns. It is excluded by default and
+            only included if you opt in for this request.
+          </p>
+          <label>
+            <input
+              type="checkbox"
+              checked={includeProtectedCategories}
+              onChange={(event) => setIncludeProtectedCategories(event.target.checked)}
+            />
+            Include protected categories (included by default)
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={includeMoodTags}
+              onChange={(event) => setIncludeMoodTags(event.target.checked)}
+            />
+            Include mood tags for this request
+          </label>
+          <div className="data-export__button-group">
+            <button type="button" className="data-export__button" onClick={confirmRequest}>
+              Generate package
+            </button>
+            <button type="button" className="data-export__button" onClick={cancelRequest}>
+              Cancel
+            </button>
+          </div>
         </div>
       )}
 
-      {/* Success message — ARIA live region */}
-      {status === 'success' && (
+      {manifest && <PackageSummary manifest={manifest} expirationWarning={expirationWarning} />}
+
+      {status === 'delivered' && (
         <div
           role="status"
           aria-live="polite"
@@ -284,19 +346,18 @@ export const DataExport: React.FC<DataExportProps> = ({ className = '' }) => {
         >
           <CheckIcon />
           <p className="data-export__feedback-message--success">
-            Export complete — your file has been downloaded.
+            Delivered — your ZIP package is ready in the share destination.
           </p>
         </div>
       )}
 
-      {/* Error message — ARIA alert */}
       {status === 'error' && (
         <div role="alert" className="data-export__feedback data-export__feedback--error">
           <ErrorIcon />
           <p className="data-export__feedback-message--error">{errorMessage}</p>
           <button
             type="button"
-            onClick={handleDismissError}
+            onClick={() => setStatus('idle')}
             aria-label="Dismiss error"
             className="data-export__feedback-dismiss"
           >
@@ -308,9 +369,46 @@ export const DataExport: React.FC<DataExportProps> = ({ className = '' }) => {
   );
 };
 
-// ---------------------------------------------------------------------------
-// Icon sub-components (inline SVG, no external deps)
-// ---------------------------------------------------------------------------
+function statusLabel(status: ExportStatus): string {
+  switch (status) {
+    case 'pending':
+      return STRINGS.pending;
+    case 'generating':
+      return STRINGS.generating;
+    case 'ready':
+      return STRINGS.ready;
+    case 'delivered':
+      return STRINGS.delivered;
+    case 'cancelled':
+      return STRINGS.cancelled;
+    case 'error':
+      return STRINGS.error;
+    case 'idle':
+      return 'Not requested';
+  }
+}
+
+const PackageSummary: React.FC<{ manifest: DataAccessManifest; expirationWarning: boolean }> = ({
+  manifest,
+  expirationWarning,
+}) => (
+  <div className="data-export__feedback data-export__feedback--success">
+    <CheckIcon />
+    <div>
+      <p className="data-export__feedback-message--success">
+        Package ready. Expires {new Date(manifest.expires_at).toLocaleString()}.
+      </p>
+      {expirationWarning && (
+        <p role="alert">This data package expires within 24 hours and will be auto-deleted.</p>
+      )}
+      <p>
+        Protected categories included:{' '}
+        {manifest.privacy.protected_categories_included ? 'yes' : 'no'}; mood tags included:{' '}
+        {manifest.privacy.mood_tags_included ? 'yes' : 'no'}.
+      </p>
+    </div>
+  </div>
+);
 
 const DownloadIcon: React.FC = () => (
   <svg
@@ -324,34 +422,6 @@ const DownloadIcon: React.FC = () => (
     <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
     <polyline points="7 10 12 15 17 10" />
     <line x1="12" y1="15" x2="12" y2="3" />
-  </svg>
-);
-
-const SpinnerIcon: React.FC = () => (
-  <svg
-    width="16"
-    height="16"
-    viewBox="0 0 24 24"
-    fill="none"
-    aria-hidden="true"
-    className="data-export__spinner-icon"
-  >
-    <circle
-      cx="12"
-      cy="12"
-      r="10"
-      stroke="currentColor"
-      strokeWidth="3"
-      fill="none"
-      opacity={0.3}
-    />
-    <path
-      d="M12 2a10 10 0 0 1 10 10"
-      stroke="currentColor"
-      strokeWidth="3"
-      strokeLinecap="round"
-      fill="none"
-    />
   </svg>
 );
 

--- a/apps/web/src/lib/data-access-package.test.ts
+++ b/apps/web/src/lib/data-access-package.test.ts
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DATA_ACCESS_SCHEMA_VERSION,
+  buildDataAccessPackage,
+  shouldAutoDeletePackage,
+  shouldWarnPackageExpiresSoon,
+} from './data-access-package';
+
+describe('data-access-package', () => {
+  it('creates a ZIP-shaped package with manifest and every required domain', () => {
+    const result = buildDataAccessPackage(sampleInput(), {
+      appVersion: '0.1.0',
+      generatedAt: new Date('2026-05-26T12:00:00Z'),
+    });
+    const names = listZipNames(result.zipBytes);
+
+    expect(names).toContain('manifest.json');
+    expect(names).toContain('README.md');
+    expect(names).toContain('data/transactions.json');
+    expect(names).toContain('data/accounts.json');
+    expect(names).toContain('data/budgets.json');
+    expect(names).toContain('data/goals.json');
+    expect(names).toContain('data/recurring_rules.json');
+    expect(names).toContain('data/categories.json');
+    expect(names).toContain('data/tags.json');
+    expect(names).toContain('data/attachments.json');
+    expect(names).toContain('data/preferences.json');
+    expect(names).toContain('data/settings.json');
+    expect(names).toContain('data/audit_log.json');
+    expect(names).toContain('data/sync_metadata.json');
+    expect(names).toContain('attachments/receipt-1-receipt.txt');
+    expect(result.manifest.schema_version).toBe(DATA_ACCESS_SCHEMA_VERSION);
+  });
+
+  it('records protected category and mood tag request choices', () => {
+    const result = buildDataAccessPackage(sampleInput(), {
+      appVersion: '0.1.0',
+      includeProtectedCategories: false,
+      includeMoodTags: true,
+      generatedAt: new Date('2026-05-26T12:00:00Z'),
+    });
+
+    expect(result.manifest.privacy.protected_categories_included).toBe(false);
+    expect(result.manifest.privacy.mood_tags_included).toBe(true);
+    expect(result.manifest.contents.some((entry) => entry.path === 'data/mood_tags.json')).toBe(
+      true,
+    );
+    expect(result.manifest.coordination_notes.join('\n')).toContain('#1719');
+  });
+
+  it('supports 7-day auto-delete with 24-hour warning', () => {
+    const expiresAt = '2026-06-02T12:00:00.000Z';
+
+    expect(shouldWarnPackageExpiresSoon(new Date('2026-06-01T11:59:59Z'), expiresAt)).toBe(false);
+    expect(shouldWarnPackageExpiresSoon(new Date('2026-06-01T12:00:00Z'), expiresAt)).toBe(true);
+    expect(shouldAutoDeletePackage(new Date('2026-06-02T11:59:59Z'), expiresAt)).toBe(false);
+    expect(shouldAutoDeletePackage(new Date('2026-06-02T12:00:00Z'), expiresAt)).toBe(true);
+  });
+
+  it('does not use browser network APIs while generating', () => {
+    const fetchSpy = vi.fn(() => Promise.reject(new Error('network blocked')));
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const result = buildDataAccessPackage(sampleInput(), {
+      appVersion: '0.1.0',
+      generatedAt: new Date('2026-05-26T12:00:00Z'),
+    });
+
+    expect(result.zipBytes.length).toBeGreaterThan(0);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+function sampleInput() {
+  return {
+    accounts: [{ id: 'acc-1', name: 'Checking', syncVersion: 3 }],
+    transactions: [{ id: 'txn-1', tags: ['food'], isSynced: false }],
+    budgets: [],
+    goals: [],
+    categories: [{ id: 'cat-1', name: 'Food' }],
+    recurringRules: [{ id: 'rule-1' }],
+    preferences: [{ key: 'finance-currency', value: 'USD' }],
+    settings: [{ key: 'theme', value: 'system' }],
+    auditLog: [{ event: 'export_requested' }],
+    syncMetadata: [{ device: 'browser' }],
+    attachments: [
+      {
+        id: 'receipt-1',
+        fileName: 'receipt.txt',
+        contentType: 'text/plain',
+        bytes: new TextEncoder().encode('receipt'),
+      },
+    ],
+    moodTags: [{ id: 'mood-1', mood_tag: 'calm' }],
+  };
+}
+
+function listZipNames(bytes: Uint8Array): string[] {
+  const names: string[] = [];
+  let offset = 0;
+  const decoder = new TextDecoder();
+  while (offset <= bytes.length - 4) {
+    if (readUInt32(bytes, offset) === 0x04034b50) {
+      const compressedSize = readUInt32(bytes, offset + 18);
+      const nameLength = readUInt16(bytes, offset + 26);
+      const extraLength = readUInt16(bytes, offset + 28);
+      const nameStart = offset + 30;
+      names.push(decoder.decode(bytes.slice(nameStart, nameStart + nameLength)));
+      offset = nameStart + nameLength + extraLength + compressedSize;
+    } else {
+      offset += 1;
+    }
+  }
+  return names;
+}
+
+function readUInt16(bytes: Uint8Array, offset: number): number {
+  return bytes[offset] | (bytes[offset + 1] << 8);
+}
+
+function readUInt32(bytes: Uint8Array, offset: number): number {
+  return (
+    (bytes[offset] |
+      (bytes[offset + 1] << 8) |
+      (bytes[offset + 2] << 16) |
+      (bytes[offset + 3] << 24)) >>>
+    0
+  );
+}

--- a/apps/web/src/lib/data-access-package.ts
+++ b/apps/web/src/lib/data-access-package.ts
@@ -1,0 +1,471 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+export const DATA_ACCESS_SCHEMA_VERSION = '1.0';
+export const DATA_ACCESS_EXPIRATION_DAYS = 7;
+export const DATA_ACCESS_WARNING_HOURS = 24;
+
+type RequiredDomain =
+  | 'transactions'
+  | 'accounts'
+  | 'budgets'
+  | 'goals'
+  | 'recurring_rules'
+  | 'categories'
+  | 'tags'
+  | 'attachments'
+  | 'preferences'
+  | 'settings'
+  | 'audit_log'
+  | 'sync_metadata';
+type JsonRecord = Record<string, unknown>;
+
+export interface DataAccessPackageOptions {
+  appVersion: string;
+  locale?: string;
+  includeProtectedCategories?: boolean;
+  includeMoodTags?: boolean;
+  generatedAt?: Date;
+}
+
+export interface DataAccessPackageInput {
+  accounts: readonly JsonRecord[];
+  transactions: readonly JsonRecord[];
+  budgets: readonly JsonRecord[];
+  goals: readonly JsonRecord[];
+  categories: readonly JsonRecord[];
+  recurringRules?: readonly JsonRecord[];
+  attachments?: readonly DataAccessAttachment[];
+  preferences?: readonly JsonRecord[];
+  settings?: readonly JsonRecord[];
+  auditLog?: readonly JsonRecord[];
+  syncMetadata?: readonly JsonRecord[];
+  moodTags?: readonly JsonRecord[];
+}
+
+export interface DataAccessAttachment {
+  id: string;
+  fileName: string;
+  contentType: string;
+  bytes?: Uint8Array;
+  signedUrl?: string;
+}
+
+export interface DataAccessManifestEntry {
+  domain: string;
+  path: string;
+  content_type: string;
+  record_count: number;
+  schema_version: string;
+  description: string;
+}
+
+export interface DataAccessManifest {
+  schema_version: string;
+  generated_at: string;
+  expires_at: string;
+  app_version: string;
+  locale: string;
+  contents: DataAccessManifestEntry[];
+  privacy: {
+    protected_categories_included: boolean;
+    mood_tags_included: boolean;
+    available_on_request: string[];
+    household_scope: string;
+  };
+  coordination_notes: string[];
+}
+
+export interface DataAccessPackageResult {
+  fileName: string;
+  zipBytes: Uint8Array;
+  manifest: DataAccessManifest;
+}
+
+interface PackageFile {
+  path: string;
+  bytes: Uint8Array;
+  contentType: string;
+  recordCount: number;
+  domain: string;
+  description: string;
+}
+
+const encoder = new TextEncoder();
+
+/** Build a GDPR/CCPA ZIP data package entirely in the browser process. */
+export function buildDataAccessPackage(
+  input: DataAccessPackageInput,
+  options: DataAccessPackageOptions,
+): DataAccessPackageResult {
+  const generatedAt = options.generatedAt ?? new Date();
+  const expiresAt = new Date(
+    generatedAt.getTime() + DATA_ACCESS_EXPIRATION_DAYS * 24 * 60 * 60 * 1000,
+  );
+  const locale = options.locale ?? navigator.language ?? 'en';
+  const includeProtectedCategories = options.includeProtectedCategories ?? true;
+  const includeMoodTags = options.includeMoodTags ?? false;
+  const domains = buildDomainRecords(input, includeMoodTags);
+  const dataFiles = Object.entries(domains).map(([domain, records]) =>
+    makeJsonFile(domain, records),
+  );
+  const attachmentFiles = (input.attachments ?? [])
+    .filter((attachment) => attachment.bytes)
+    .map((attachment) => ({
+      path: `attachments/${sanitizePathSegment(attachment.id)}-${sanitizePathSegment(attachment.fileName)}`,
+      bytes: attachment.bytes ?? new Uint8Array(),
+      contentType: attachment.contentType,
+      recordCount: 1,
+      domain: 'attachment_binary',
+      description: 'Local attachment binary copied into the package',
+    }));
+  const manifest = buildManifest({
+    appVersion: options.appVersion,
+    locale,
+    generatedAt,
+    expiresAt,
+    files: [...dataFiles, ...attachmentFiles],
+    includeProtectedCategories,
+    includeMoodTags,
+  });
+  const readme = renderReadme(manifest, locale);
+  const zipBytes = buildZip([
+    {
+      path: 'manifest.json',
+      bytes: encodeJson(manifest),
+      contentType: 'application/json',
+      recordCount: 1,
+      domain: 'manifest',
+      description: 'Package manifest',
+    },
+    ...dataFiles,
+    ...attachmentFiles,
+    {
+      path: 'README.md',
+      bytes: encoder.encode(readme),
+      contentType: 'text/markdown; charset=utf-8',
+      recordCount: 1,
+      domain: 'readme',
+      description: 'Localized package guide',
+    },
+  ]);
+
+  return {
+    fileName: `finance-export-${generatedAt.toISOString().slice(0, 10)}.zip`,
+    zipBytes,
+    manifest,
+  };
+}
+
+/** True once an in-app package should be auto-deleted. */
+export function shouldAutoDeletePackage(now: Date, expiresAtIso: string): boolean {
+  return now.getTime() >= new Date(expiresAtIso).getTime();
+}
+
+/** True during the final 24 hours before package expiration. */
+export function shouldWarnPackageExpiresSoon(now: Date, expiresAtIso: string): boolean {
+  const expiresAt = new Date(expiresAtIso).getTime();
+  return (
+    now.getTime() >= expiresAt - DATA_ACCESS_WARNING_HOURS * 60 * 60 * 1000 &&
+    now.getTime() < expiresAt
+  );
+}
+
+function buildDomainRecords(input: DataAccessPackageInput, includeMoodTags: boolean) {
+  const domains: Record<RequiredDomain | 'mood_tags', readonly JsonRecord[]> = {
+    transactions: stripSyncFields(input.transactions),
+    accounts: stripSyncFields(input.accounts),
+    budgets: stripSyncFields(input.budgets),
+    goals: stripSyncFields(input.goals),
+    recurring_rules: stripSyncFields(input.recurringRules ?? []),
+    categories: stripSyncFields(input.categories),
+    tags: Array.from(new Set(input.transactions.flatMap((txn) => normalizeTags(txn.tags)))).map(
+      (name) => ({
+        name,
+      }),
+    ),
+    attachments: (input.attachments ?? []).map((attachment) => ({
+      id: attachment.id,
+      file_name: attachment.fileName,
+      content_type: attachment.contentType,
+      package_path: attachment.bytes
+        ? `attachments/${sanitizePathSegment(attachment.id)}-${sanitizePathSegment(attachment.fileName)}`
+        : null,
+      signed_url: attachment.signedUrl ?? null,
+      delivery: attachment.bytes ? 'embedded_binary' : 'signed_url_reference',
+    })),
+    preferences: stripSyncFields(input.preferences ?? []),
+    settings: stripSyncFields(input.settings ?? []),
+    audit_log: stripSyncFields(input.auditLog ?? []),
+    sync_metadata: stripSyncFields(input.syncMetadata ?? []),
+    mood_tags: includeMoodTags ? stripSyncFields(input.moodTags ?? []) : [],
+  };
+
+  if (!includeMoodTags) {
+    const { mood_tags: _moodTags, ...requiredDomains } = domains;
+    return requiredDomains;
+  }
+  return domains;
+}
+
+function normalizeTags(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((tag): tag is string => typeof tag === 'string') : [];
+}
+
+function stripSyncFields(records: readonly JsonRecord[]): JsonRecord[] {
+  return records.map((record) => {
+    const next: JsonRecord = {};
+    for (const [key, value] of Object.entries(record)) {
+      if (
+        key === 'syncVersion' ||
+        key === 'sync_version' ||
+        key === 'isSynced' ||
+        key === 'is_synced'
+      ) {
+        continue;
+      }
+      next[key] = value;
+    }
+    return next;
+  });
+}
+
+function makeJsonFile(domain: string, records: readonly JsonRecord[]): PackageFile {
+  return {
+    path: `data/${domain}.json`,
+    bytes: encodeJson({
+      schema_version: DATA_ACCESS_SCHEMA_VERSION,
+      record_count: records.length,
+      records,
+    }),
+    contentType: 'application/json',
+    recordCount: records.length,
+    domain,
+    description: describeDomain(domain),
+  };
+}
+
+function buildManifest(input: {
+  appVersion: string;
+  locale: string;
+  generatedAt: Date;
+  expiresAt: Date;
+  files: readonly PackageFile[];
+  includeProtectedCategories: boolean;
+  includeMoodTags: boolean;
+}): DataAccessManifest {
+  return {
+    schema_version: DATA_ACCESS_SCHEMA_VERSION,
+    generated_at: input.generatedAt.toISOString(),
+    expires_at: input.expiresAt.toISOString(),
+    app_version: input.appVersion,
+    locale: input.locale,
+    contents: input.files.map((file) => ({
+      domain: file.domain,
+      path: file.path,
+      content_type: file.contentType,
+      record_count: file.recordCount,
+      schema_version: DATA_ACCESS_SCHEMA_VERSION,
+      description: file.description,
+    })),
+    privacy: {
+      protected_categories_included: input.includeProtectedCategories,
+      mood_tags_included: input.includeMoodTags,
+      available_on_request: input.includeMoodTags
+        ? ['caregiver_mode_audit_trail', 'accountability_partner_shared_snapshots']
+        : ['mood_tags', 'caregiver_mode_audit_trail', 'accountability_partner_shared_snapshots'],
+      household_scope:
+        "Only the requesting user's own contributions are included; other household members' data is excluded.",
+    },
+    coordination_notes: [
+      'Needs Coordination: #1719 protected-category metadata is not yet available in shared web repositories; callers must pass pre-filtered categories when users opt out.',
+    ],
+  };
+}
+
+function describeDomain(domain: string): string {
+  switch (domain) {
+    case 'transactions':
+      return 'Transactions with full detail owned by the requesting user';
+    case 'accounts':
+      return 'Accounts and balances owned by the requesting user';
+    case 'budgets':
+      return 'Budgets and rollover configuration';
+    case 'goals':
+      return 'Savings goals and progress';
+    case 'recurring_rules':
+      return 'Recurring transaction rules';
+    case 'categories':
+      return 'Categories, including protected categories unless opted out';
+    case 'tags':
+      return 'Transaction tags derived from exported transactions';
+    case 'attachments':
+      return 'Receipt and attachment metadata with binary file references';
+    case 'preferences':
+      return 'User-facing preferences';
+    case 'settings':
+      return 'Application settings';
+    case 'audit_log':
+      return "Audit events for the requesting user's own actions";
+    case 'sync_metadata':
+      return 'Device and last-sync metadata';
+    case 'mood_tags':
+      return 'Mood tag records included only when explicitly requested';
+    default:
+      return 'Data access package file';
+  }
+}
+
+function renderReadme(manifest: DataAccessManifest, locale: string): string {
+  const title = locale.startsWith('es')
+    ? '# Paquete de datos de Finance'
+    : locale.startsWith('fr')
+      ? '# Package de données Finance'
+      : '# Finance data package';
+  return `${title}
+
+Generated: ${manifest.generated_at}
+Expires: ${manifest.expires_at}
+
+This ZIP was generated on your device. It contains the data Finance stores for your account and should be treated as sensitive financial information.
+
+## Privacy choices
+
+- Protected categories included: ${manifest.privacy.protected_categories_included}
+- Mood tags included: ${manifest.privacy.mood_tags_included}
+- Household scope: ${manifest.privacy.household_scope}
+
+## Files
+
+${manifest.contents.map((entry) => `- \`${entry.path}\` — ${entry.description} (${entry.record_count} record(s)).`).join('\n')}
+`;
+}
+
+function encodeJson(value: unknown): Uint8Array {
+  return encoder.encode(JSON.stringify(value, null, 2));
+}
+
+function sanitizePathSegment(value: string): string {
+  return value.replace(/[^A-Za-z0-9._-]/g, '_') || 'attachment';
+}
+
+interface ZipEntry {
+  path: string;
+  bytes: Uint8Array;
+}
+
+function buildZip(files: readonly ZipEntry[]): Uint8Array {
+  const writer = new ByteWriter();
+  const central: Array<{ path: string; bytes: Uint8Array; crc: number; offset: number }> = [];
+
+  for (const file of files) {
+    const nameBytes = encoder.encode(file.path);
+    const offset = writer.length;
+    const crc = crc32(file.bytes);
+    writer.u32(0x04034b50);
+    writer.u16(20);
+    writer.u16(0x0800);
+    writer.u16(0);
+    writer.u16(0);
+    writer.u16(33);
+    writer.u32(crc);
+    writer.u32(file.bytes.length);
+    writer.u32(file.bytes.length);
+    writer.u16(nameBytes.length);
+    writer.u16(0);
+    writer.bytes(nameBytes);
+    writer.bytes(file.bytes);
+    central.push({ path: file.path, bytes: file.bytes, crc, offset });
+  }
+
+  const centralOffset = writer.length;
+  for (const file of central) {
+    const nameBytes = encoder.encode(file.path);
+    writer.u32(0x02014b50);
+    writer.u16(20);
+    writer.u16(20);
+    writer.u16(0x0800);
+    writer.u16(0);
+    writer.u16(0);
+    writer.u16(33);
+    writer.u32(file.crc);
+    writer.u32(file.bytes.length);
+    writer.u32(file.bytes.length);
+    writer.u16(nameBytes.length);
+    writer.u16(0);
+    writer.u16(0);
+    writer.u16(0);
+    writer.u16(0);
+    writer.u32(0);
+    writer.u32(file.offset);
+    writer.bytes(nameBytes);
+  }
+
+  const centralSize = writer.length - centralOffset;
+  writer.u32(0x06054b50);
+  writer.u16(0);
+  writer.u16(0);
+  writer.u16(central.length);
+  writer.u16(central.length);
+  writer.u32(centralSize);
+  writer.u32(centralOffset);
+  writer.u16(0);
+  return writer.toUint8Array();
+}
+
+class ByteWriter {
+  private buffer = new Uint8Array(4096);
+  length = 0;
+
+  u16(value: number): void {
+    this.byte(value & 0xff);
+    this.byte((value >>> 8) & 0xff);
+  }
+
+  u32(value: number): void {
+    this.byte(value & 0xff);
+    this.byte((value >>> 8) & 0xff);
+    this.byte((value >>> 16) & 0xff);
+    this.byte((value >>> 24) & 0xff);
+  }
+
+  bytes(bytes: Uint8Array): void {
+    this.ensure(this.length + bytes.length);
+    this.buffer.set(bytes, this.length);
+    this.length += bytes.length;
+  }
+
+  toUint8Array(): Uint8Array {
+    return this.buffer.slice(0, this.length);
+  }
+
+  private byte(value: number): void {
+    this.ensure(this.length + 1);
+    this.buffer[this.length] = value;
+    this.length += 1;
+  }
+
+  private ensure(required: number): void {
+    if (required <= this.buffer.length) return;
+    let next = this.buffer.length;
+    while (next < required) next *= 2;
+    const expanded = new Uint8Array(next);
+    expanded.set(this.buffer);
+    this.buffer = expanded;
+  }
+}
+
+const CRC_TABLE = new Uint32Array(256).map((_, index) => {
+  let crc = index;
+  for (let bit = 0; bit < 8; bit += 1) {
+    crc = crc & 1 ? 0xedb88320 ^ (crc >>> 1) : crc >>> 1;
+  }
+  return crc >>> 0;
+});
+
+function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc = CRC_TABLE[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/export/DataAccessExportTypes.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/export/DataAccessExportTypes.kt
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.export
+
+import com.finance.models.*
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.plus
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
+
+/** Schema version for GDPR/CCPA data access ZIP packages. */
+const val DATA_ACCESS_PACKAGE_SCHEMA_VERSION: String = "1.0"
+
+/** Domains that must be represented in every data access package. */
+enum class DataAccessDomain(val fileName: String, val description: String) {
+    TRANSACTIONS("transactions.json", "Transactions with full detail owned by the requesting user"),
+    ACCOUNTS("accounts.json", "Accounts and balances owned by the requesting user"),
+    BUDGETS("budgets.json", "Budgets and rollover configuration"),
+    GOALS("goals.json", "Savings goals and progress"),
+    RECURRING_RULES("recurring_rules.json", "Recurring transaction rules"),
+    CATEGORIES("categories.json", "Categories, including protected categories unless opted out"),
+    TAGS("tags.json", "Transaction tags derived from exported transactions"),
+    ATTACHMENTS("attachments.json", "Receipt and attachment metadata with binary file references"),
+    PREFERENCES("preferences.json", "User-facing preferences"),
+    SETTINGS("settings.json", "Application settings"),
+    AUDIT_LOG("audit_log.json", "Audit events for the requesting user's own actions"),
+    SYNC_METADATA("sync_metadata.json", "Device and last-sync metadata"),
+    MOOD_TAGS("mood_tags.json", "Mood tag records included only when explicitly requested"),
+}
+
+/** Request-time options that control privacy-sensitive data inclusion. */
+data class DataAccessRequestOptions(
+    val appVersion: String,
+    val localeTag: String = "en",
+    val includeProtectedCategories: Boolean = true,
+    val protectedCategoryMetadataAvailable: Boolean = false,
+    val includeMoodTags: Boolean = false,
+    val expirationDays: Int = 7,
+    val generatedAt: Instant,
+) {
+    init {
+        require(appVersion.isNotBlank()) { "appVersion cannot be blank" }
+        require(expirationDays > 0) { "expirationDays must be positive" }
+    }
+
+    /** Timestamp at which the package should be deleted from in-app storage. */
+    val expiresAt: Instant = generatedAt.plus(expirationDays, kotlinx.datetime.DateTimeUnit.DAY, TimeZone.UTC)
+}
+
+/** A flexible JSON record used for domains that are not yet shared KMP models. */
+@Serializable
+data class DataAccessJsonRecord(
+    val fields: JsonObject,
+)
+
+/** Receipt or attachment included in the data access package. */
+data class DataAccessAttachment(
+    val id: String,
+    val fileName: String,
+    val contentType: String,
+    val bytes: ByteArray? = null,
+    val signedUrl: String? = null,
+) {
+    init {
+        require(id.isNotBlank()) { "Attachment id cannot be blank" }
+        require(fileName.isNotBlank()) { "Attachment fileName cannot be blank" }
+        require(contentType.isNotBlank()) { "Attachment contentType cannot be blank" }
+        require(bytes != null || !signedUrl.isNullOrBlank()) {
+            "Attachment must provide local bytes or a signed URL reference"
+        }
+    }
+}
+
+/** All user-owned local data available to the GDPR/CCPA package generator. */
+data class DataAccessExportData(
+    val accounts: List<Account> = emptyList(),
+    val transactions: List<Transaction> = emptyList(),
+    val budgets: List<Budget> = emptyList(),
+    val goals: List<Goal> = emptyList(),
+    val categories: List<Category> = emptyList(),
+    val recurringRules: List<DataAccessJsonRecord> = emptyList(),
+    val preferences: List<DataAccessJsonRecord> = emptyList(),
+    val settings: List<DataAccessJsonRecord> = emptyList(),
+    val auditLog: List<DataAccessJsonRecord> = emptyList(),
+    val syncMetadata: List<DataAccessJsonRecord> = emptyList(),
+    val attachments: List<DataAccessAttachment> = emptyList(),
+    val moodTags: List<DataAccessJsonRecord> = emptyList(),
+) {
+    /** Unique transaction tags represented as their own export domain. */
+    val tags: List<String> = transactions.flatMap { it.tags }.distinct().sorted()
+}
+
+/** One file generated before ZIP packaging. */
+data class GeneratedPackageFile(
+    val path: String,
+    val bytes: ByteArray,
+    val contentType: String,
+)
+
+/** Completed data access package ready for platform share-sheet delivery. */
+data class DataAccessPackageResult(
+    val fileName: String,
+    val zipBytes: ByteArray,
+    val files: List<GeneratedPackageFile>,
+    val manifest: DataAccessManifest,
+)
+
+/** Manifest describing the ZIP contents, retention, and privacy-sensitive options. */
+@Serializable
+data class DataAccessManifest(
+    @SerialName("schema_version") val schemaVersion: String,
+    @SerialName("generated_at") val generatedAt: String,
+    @SerialName("expires_at") val expiresAt: String,
+    @SerialName("app_version") val appVersion: String,
+    @SerialName("locale") val locale: String,
+    @SerialName("contents") val contents: List<DataAccessManifestEntry>,
+    @SerialName("privacy") val privacy: DataAccessPrivacyManifest,
+    @SerialName("coordination_notes") val coordinationNotes: List<String> = emptyList(),
+)
+
+/** Per-file inventory entry in [DataAccessManifest]. */
+@Serializable
+data class DataAccessManifestEntry(
+    val domain: String,
+    val path: String,
+    @SerialName("content_type") val contentType: String,
+    @SerialName("record_count") val recordCount: Int,
+    @SerialName("schema_version") val schemaVersion: String,
+    val description: String,
+)
+
+/** Privacy-sensitive request-time choices recorded in the manifest. */
+@Serializable
+data class DataAccessPrivacyManifest(
+    @SerialName("protected_categories_included") val protectedCategoriesIncluded: Boolean,
+    @SerialName("mood_tags_included") val moodTagsIncluded: Boolean,
+    @SerialName("available_on_request") val availableOnRequest: List<String>,
+    @SerialName("household_scope") val householdScope: String,
+)
+
+/** Retention helper for 7-day auto-delete and 24-hour warning UX. */
+object DataAccessPackageRetention {
+    /** Returns true once the package is at or past its expiration timestamp. */
+    fun shouldAutoDelete(now: Instant, expiresAt: Instant): Boolean = now >= expiresAt
+
+    /** Returns true during the final 24 hours before expiration. */
+    fun shouldWarnWithin24Hours(now: Instant, expiresAt: Instant): Boolean {
+        val warningStartsAt = expiresAt.plus(-1, kotlinx.datetime.DateTimeUnit.DAY, TimeZone.UTC)
+        return now >= warningStartsAt && now < expiresAt
+    }
+}
+
+/** Test seam used to prove package generation does not initiate HTTP egress. */
+fun interface NetworkEgressProbe {
+    /** Called by code that attempts HTTP egress; package generation must never call this. */
+    fun recordHttpAttempt(url: String)
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/export/DataAccessJsonWriters.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/export/DataAccessJsonWriters.kt
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.export
+
+import com.finance.models.*
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+
+private val compactJson = Json { encodeDefaults = true }
+
+internal fun serializeAccounts(accounts: List<Account>): String = jsonArray(accounts) { account ->
+    obj {
+        field("id", account.id.value)
+        field("household_id", account.householdId.value)
+        field("owner_id", account.ownerId.value)
+        field("name", account.name)
+        field("type", account.type.name)
+        field("currency", account.currency.code)
+        moneyField("current_balance", account.currentBalance.amount, account.currency.code)
+        field("is_archived", account.isArchived)
+        field("sort_order", account.sortOrder)
+        field("icon", account.icon)
+        field("color", account.color)
+        field("created_at", account.createdAt.toString())
+        field("updated_at", account.updatedAt.toString())
+        field("deleted_at", account.deletedAt?.toString())
+    }
+}
+
+internal fun serializeTransactions(transactions: List<Transaction>): String = jsonArray(transactions) { txn ->
+    obj {
+        field("id", txn.id.value)
+        field("household_id", txn.householdId.value)
+        field("owner_id", txn.ownerId.value)
+        field("account_id", txn.accountId.value)
+        field("category_id", txn.categoryId?.value)
+        field("type", txn.type.name)
+        field("status", txn.status.name)
+        moneyField("amount", txn.amount.amount, txn.currency.code)
+        field("payee", txn.payee)
+        field("note", txn.note)
+        field("date", txn.date.toString())
+        field("transfer_account_id", txn.transferAccountId?.value)
+        field("transfer_transaction_id", txn.transferTransactionId?.value)
+        field("is_recurring", txn.isRecurring)
+        field("recurring_rule_id", txn.recurringRuleId?.value)
+        arrayField("tags", txn.tags)
+        field("created_at", txn.createdAt.toString())
+        field("updated_at", txn.updatedAt.toString())
+        field("deleted_at", txn.deletedAt?.toString())
+    }
+}
+
+internal fun serializeBudgets(budgets: List<Budget>): String = jsonArray(budgets) { budget ->
+    obj {
+        field("id", budget.id.value)
+        field("household_id", budget.householdId.value)
+        field("owner_id", budget.ownerId.value)
+        field("category_id", budget.categoryId.value)
+        field("name", budget.name)
+        moneyField("amount", budget.amount.amount, budget.currency.code)
+        field("period", budget.period.name)
+        field("start_date", budget.startDate.toString())
+        field("end_date", budget.endDate?.toString())
+        field("is_rollover", budget.isRollover)
+        field("created_at", budget.createdAt.toString())
+        field("updated_at", budget.updatedAt.toString())
+        field("deleted_at", budget.deletedAt?.toString())
+    }
+}
+
+internal fun serializeGoals(goals: List<Goal>): String = jsonArray(goals) { goal ->
+    obj {
+        field("id", goal.id.value)
+        field("household_id", goal.householdId.value)
+        field("owner_id", goal.ownerId.value)
+        field("name", goal.name)
+        moneyField("target_amount", goal.targetAmount.amount, goal.currency.code)
+        moneyField("current_amount", goal.currentAmount.amount, goal.currency.code)
+        field("target_date", goal.targetDate?.toString())
+        field("status", goal.status.name)
+        field("icon", goal.icon)
+        field("color", goal.color)
+        field("account_id", goal.accountId?.value)
+        field("created_at", goal.createdAt.toString())
+        field("updated_at", goal.updatedAt.toString())
+        field("deleted_at", goal.deletedAt?.toString())
+    }
+}
+
+internal fun serializeCategories(categories: List<Category>): String = jsonArray(categories) { category ->
+    obj {
+        field("id", category.id.value)
+        field("household_id", category.householdId.value)
+        field("owner_id", category.ownerId.value)
+        field("name", category.name)
+        field("icon", category.icon)
+        field("color", category.color)
+        field("parent_id", category.parentId?.value)
+        field("is_income", category.isIncome)
+        field("is_system", category.isSystem)
+        field("sort_order", category.sortOrder)
+        field("created_at", category.createdAt.toString())
+        field("updated_at", category.updatedAt.toString())
+        field("deleted_at", category.deletedAt?.toString())
+    }
+}
+
+internal fun serializeTagsDomain(tags: List<String>): String = jsonArray(tags) { tag ->
+    obj { field("name", tag) }
+}
+
+internal fun serializeAttachments(attachments: List<DataAccessAttachment>): String = jsonArray(attachments) { attachment ->
+    obj {
+        field("id", attachment.id)
+        field("file_name", attachment.fileName)
+        field("content_type", attachment.contentType)
+        field("package_path", attachment.bytes?.let { "attachments/${sanitizeAttachmentSegment(attachment.id)}-${sanitizeAttachmentSegment(attachment.fileName)}" })
+        field("signed_url", attachment.signedUrl)
+        field("delivery", if (attachment.bytes != null) "embedded_binary" else "signed_url_reference")
+    }
+}
+
+internal fun serializeJsonRecords(records: List<DataAccessJsonRecord>): String =
+    jsonArray(records) { record -> compactJson.encodeToString(JsonObject.serializer(), record.fields) }
+
+private fun <T> jsonArray(values: List<T>, render: (T) -> String): String = buildString {
+    append("[\n")
+    values.forEachIndexed { index, value ->
+        append(render(value).prependIndent("  "))
+        if (index != values.lastIndex) append(',')
+        append('\n')
+    }
+    append(']')
+}
+
+private fun obj(build: JsonObjectStringBuilder.() -> Unit): String =
+    JsonObjectStringBuilder().apply(build).toString()
+
+private class JsonObjectStringBuilder {
+    private val fields = mutableListOf<Pair<String, String>>()
+
+    fun field(name: String, value: String?) {
+        fields += name to (value?.let { quote(it) } ?: "null")
+    }
+
+    fun field(name: String, value: Boolean) {
+        fields += name to value.toString()
+    }
+
+    fun field(name: String, value: Int) {
+        fields += name to value.toString()
+    }
+
+    fun moneyField(name: String, amount: Long, currency: String) {
+        fields += name to "{\"amount\":$amount,\"currency\":${quote(currency)}}"
+    }
+
+    fun arrayField(name: String, values: List<String>) {
+        fields += name to values.joinToString(prefix = "[", postfix = "]") { quote(it) }
+    }
+
+    override fun toString(): String = buildString {
+        append("{\n")
+        fields.forEachIndexed { index, (name, value) ->
+            append("  ").append(quote(name)).append(": ").append(value)
+            if (index != fields.lastIndex) append(',')
+            append('\n')
+        }
+        append('}')
+    }
+}
+
+private fun quote(value: String): String = buildString(value.length + 2) {
+    append('"')
+    value.forEach { char ->
+        when (char) {
+            '\\' -> append("\\\\")
+            '"' -> append("\\\"")
+            '\n' -> append("\\n")
+            '\r' -> append("\\r")
+            '\t' -> append("\\t")
+            else -> if (char.code < 0x20) {
+                append("\\u")
+                append(char.code.toString(16).padStart(4, '0'))
+            } else {
+                append(char)
+            }
+        }
+    }
+    append('"')
+}
+
+private fun sanitizeAttachmentSegment(value: String): String = buildString {
+    value.forEach { char ->
+        append(if (char.isLetterOrDigit() || char in setOf('.', '-', '_')) char else '_')
+    }
+}.ifBlank { "attachment" }

--- a/packages/core/src/commonMain/kotlin/com/finance/core/export/DataAccessPackageGenerator.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/export/DataAccessPackageGenerator.kt
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.export
+
+import com.finance.models.*
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/** Generates on-device GDPR/CCPA data access ZIP packages. */
+class DataAccessPackageGenerator(
+    private val networkEgressProbe: NetworkEgressProbe? = null,
+) {
+    private val json = Json {
+        prettyPrint = true
+        prettyPrintIndent = "  "
+        encodeDefaults = true
+    }
+
+    /**
+     * Builds a local ZIP package containing manifest, domain JSON files,
+     * attachment binaries, and a localized README.
+     */
+    fun generate(data: DataAccessExportData, options: DataAccessRequestOptions): DataAccessPackageResult {
+        val dataFiles = buildDataFiles(data, options)
+        val attachmentFiles = buildAttachmentFiles(data.attachments)
+        val manifest = buildManifest(data, options, dataFiles, attachmentFiles)
+        val manifestFile = GeneratedPackageFile(
+            path = "manifest.json",
+            bytes = json.encodeToString(manifest).encodeToByteArray(),
+            contentType = "application/json",
+        )
+        val readmeFile = GeneratedPackageFile(
+            path = "README.md",
+            bytes = DataAccessReadmeRenderer.render(manifest, options.localeTag).encodeToByteArray(),
+            contentType = "text/markdown; charset=utf-8",
+        )
+        val files = listOf(manifestFile) + dataFiles + attachmentFiles + readmeFile
+        val zipBytes = ZipArchive.build(files)
+
+        return DataAccessPackageResult(
+            fileName = DataExportService.generateFilename(ExportFormat.CSV, options.generatedAt),
+            zipBytes = zipBytes,
+            files = files,
+            manifest = manifest,
+        )
+    }
+
+    private fun buildDataFiles(
+        data: DataAccessExportData,
+        options: DataAccessRequestOptions,
+    ): List<GeneratedPackageFile> {
+        val domains = mutableListOf(
+            domainFile(DataAccessDomain.TRANSACTIONS, serializeTransactions(data.transactions), data.transactions.size),
+            domainFile(DataAccessDomain.ACCOUNTS, serializeAccounts(data.accounts), data.accounts.size),
+            domainFile(DataAccessDomain.BUDGETS, serializeBudgets(data.budgets), data.budgets.size),
+            domainFile(DataAccessDomain.GOALS, serializeGoals(data.goals), data.goals.size),
+            domainFile(DataAccessDomain.RECURRING_RULES, serializeJsonRecords(data.recurringRules), data.recurringRules.size),
+            domainFile(DataAccessDomain.CATEGORIES, serializeCategories(data.categories), data.categories.size),
+            domainFile(DataAccessDomain.TAGS, serializeTagsDomain(data.tags), data.tags.size),
+            domainFile(DataAccessDomain.ATTACHMENTS, serializeAttachments(data.attachments), data.attachments.size),
+            domainFile(DataAccessDomain.PREFERENCES, serializeJsonRecords(data.preferences), data.preferences.size),
+            domainFile(DataAccessDomain.SETTINGS, serializeJsonRecords(data.settings), data.settings.size),
+            domainFile(DataAccessDomain.AUDIT_LOG, serializeJsonRecords(data.auditLog), data.auditLog.size),
+            domainFile(DataAccessDomain.SYNC_METADATA, serializeJsonRecords(data.syncMetadata), data.syncMetadata.size),
+        )
+        if (options.includeMoodTags) {
+            domains += domainFile(
+                DataAccessDomain.MOOD_TAGS,
+                serializeJsonRecords(data.moodTags),
+                data.moodTags.size,
+            )
+        }
+        return domains
+    }
+
+    private fun buildAttachmentFiles(attachments: List<DataAccessAttachment>): List<GeneratedPackageFile> =
+        attachments.mapNotNull { attachment ->
+            attachment.bytes?.let { bytes ->
+                GeneratedPackageFile(
+                    path = "attachments/${sanitizePathSegment(attachment.id)}-${sanitizePathSegment(attachment.fileName)}",
+                    bytes = bytes,
+                    contentType = attachment.contentType,
+                )
+            }
+        }
+
+    private fun buildManifest(
+        data: DataAccessExportData,
+        options: DataAccessRequestOptions,
+        dataFiles: List<GeneratedPackageFile>,
+        attachmentFiles: List<GeneratedPackageFile>,
+    ): DataAccessManifest {
+        val counts = mapOf(
+            DataAccessDomain.TRANSACTIONS to data.transactions.size,
+            DataAccessDomain.ACCOUNTS to data.accounts.size,
+            DataAccessDomain.BUDGETS to data.budgets.size,
+            DataAccessDomain.GOALS to data.goals.size,
+            DataAccessDomain.RECURRING_RULES to data.recurringRules.size,
+            DataAccessDomain.CATEGORIES to data.categories.size,
+            DataAccessDomain.TAGS to data.tags.size,
+            DataAccessDomain.ATTACHMENTS to data.attachments.size,
+            DataAccessDomain.PREFERENCES to data.preferences.size,
+            DataAccessDomain.SETTINGS to data.settings.size,
+            DataAccessDomain.AUDIT_LOG to data.auditLog.size,
+            DataAccessDomain.SYNC_METADATA to data.syncMetadata.size,
+            DataAccessDomain.MOOD_TAGS to data.moodTags.size,
+        )
+        val manifestEntries = dataFiles.map { file ->
+            val domain = DataAccessDomain.entries.first { file.path.endsWith(it.fileName) }
+            DataAccessManifestEntry(
+                domain = domain.name.lowercase(),
+                path = file.path,
+                contentType = file.contentType,
+                recordCount = counts.getValue(domain),
+                schemaVersion = DATA_ACCESS_PACKAGE_SCHEMA_VERSION,
+                description = domain.description,
+            )
+        } + attachmentFiles.map { file ->
+            DataAccessManifestEntry(
+                domain = "attachment_binary",
+                path = file.path,
+                contentType = file.contentType,
+                recordCount = 1,
+                schemaVersion = DATA_ACCESS_PACKAGE_SCHEMA_VERSION,
+                description = "Local attachment binary copied into the package",
+            )
+        }
+
+        return DataAccessManifest(
+            schemaVersion = DATA_ACCESS_PACKAGE_SCHEMA_VERSION,
+            generatedAt = options.generatedAt.toString(),
+            expiresAt = options.expiresAt.toString(),
+            appVersion = options.appVersion,
+            locale = options.localeTag,
+            contents = manifestEntries,
+            privacy = DataAccessPrivacyManifest(
+                protectedCategoriesIncluded = options.includeProtectedCategories,
+                moodTagsIncluded = options.includeMoodTags,
+                availableOnRequest = buildList {
+                    if (!options.includeMoodTags) add("mood_tags")
+                    add("caregiver_mode_audit_trail")
+                    add("accountability_partner_shared_snapshots")
+                },
+                householdScope = "Only the requesting user's own contributions are included; other household members' data is excluded.",
+            ),
+            coordinationNotes = buildList {
+                if (!options.protectedCategoryMetadataAvailable) {
+                    add("Needs Coordination: #1719 protected-category metadata is not yet available in shared KMP models; callers must pass pre-filtered categories when users opt out.")
+                }
+            },
+        )
+    }
+
+    private fun domainFile(domain: DataAccessDomain, recordsJson: String, recordCount: Int): GeneratedPackageFile {
+        val body = buildString {
+            append("{\n")
+            append("  \"schema_version\": \"").append(DATA_ACCESS_PACKAGE_SCHEMA_VERSION).append("\",\n")
+            append("  \"record_count\": ").append(recordCount).append(",\n")
+            append("  \"records\": ").append(recordsJson.prependIndent("  ").trimStart()).append('\n')
+            append('}')
+        }
+        return GeneratedPackageFile(
+            path = "data/${domain.fileName}",
+            bytes = body.encodeToByteArray(),
+            contentType = "application/json",
+        )
+    }
+}
+
+private fun sanitizePathSegment(value: String): String = buildString {
+    value.forEach { char ->
+        append(if (char.isLetterOrDigit() || char in setOf('.', '-', '_')) char else '_')
+    }
+}.ifBlank { "attachment" }
+
+private object DataAccessReadmeRenderer {
+    fun render(manifest: DataAccessManifest, localeTag: String): String {
+        val title = when (localeTag.substringBefore('-')) {
+            "es" -> "# Paquete de datos de Finance"
+            "fr" -> "# Package de données Finance"
+            else -> "# Finance data package"
+        }
+        return buildString {
+            appendLine(title)
+            appendLine()
+            appendLine("Generated: ${manifest.generatedAt}")
+            appendLine("Expires: ${manifest.expiresAt}")
+            appendLine()
+            appendLine("This ZIP was generated on your device. It contains the data Finance stores for your account and should be treated as sensitive financial information.")
+            appendLine()
+            appendLine("## Privacy choices")
+            appendLine("- Protected categories included: ${manifest.privacy.protectedCategoriesIncluded}")
+            appendLine("- Mood tags included: ${manifest.privacy.moodTagsIncluded}")
+            appendLine("- Household scope: ${manifest.privacy.householdScope}")
+            appendLine()
+            appendLine("## Files")
+            manifest.contents.forEach { entry ->
+                appendLine("- `${entry.path}` — ${entry.description} (${entry.recordCount} record(s)).")
+            }
+            if (manifest.privacy.availableOnRequest.isNotEmpty()) {
+                appendLine()
+                appendLine("## Available on request")
+                manifest.privacy.availableOnRequest.forEach { appendLine("- `$it`") }
+            }
+        }
+    }
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/export/ZipArchive.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/export/ZipArchive.kt
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.export
+
+/** Small KMP ZIP writer using stored (uncompressed) entries to avoid extra dependencies. */
+object ZipArchive {
+    private const val LOCAL_FILE_HEADER = 0x04034b50L
+    private const val CENTRAL_DIRECTORY_HEADER = 0x02014b50L
+    private const val END_OF_CENTRAL_DIRECTORY = 0x06054b50L
+    private const val VERSION_NEEDED = 20
+    private const val UTF8_FLAG = 0x0800
+    private const val STORED_METHOD = 0
+    private const val DOS_DATE_1980_01_01 = 33
+
+    /** Builds a standards-compliant ZIP archive containing [files]. */
+    fun build(files: List<GeneratedPackageFile>): ByteArray {
+        require(files.isNotEmpty()) { "ZIP must contain at least one file" }
+
+        val output = ByteArrayBuilder()
+        val entries = mutableListOf<CentralDirectoryEntry>()
+
+        for (file in files) {
+            val nameBytes = file.path.encodeToByteArray()
+            val offset = output.size
+            val crc = Crc32.compute(file.bytes)
+
+            output.writeInt(LOCAL_FILE_HEADER)
+            output.writeShort(VERSION_NEEDED)
+            output.writeShort(UTF8_FLAG)
+            output.writeShort(STORED_METHOD)
+            output.writeShort(0)
+            output.writeShort(DOS_DATE_1980_01_01)
+            output.writeInt(crc)
+            output.writeInt(file.bytes.size.toLong())
+            output.writeInt(file.bytes.size.toLong())
+            output.writeShort(nameBytes.size)
+            output.writeShort(0)
+            output.writeBytes(nameBytes)
+            output.writeBytes(file.bytes)
+
+            entries += CentralDirectoryEntry(
+                path = file.path,
+                crc = crc,
+                size = file.bytes.size,
+                localHeaderOffset = offset,
+            )
+        }
+
+        val centralDirectoryOffset = output.size
+        for (entry in entries) {
+            val nameBytes = entry.path.encodeToByteArray()
+            output.writeInt(CENTRAL_DIRECTORY_HEADER)
+            output.writeShort(VERSION_NEEDED)
+            output.writeShort(VERSION_NEEDED)
+            output.writeShort(UTF8_FLAG)
+            output.writeShort(STORED_METHOD)
+            output.writeShort(0)
+            output.writeShort(DOS_DATE_1980_01_01)
+            output.writeInt(entry.crc)
+            output.writeInt(entry.size.toLong())
+            output.writeInt(entry.size.toLong())
+            output.writeShort(nameBytes.size)
+            output.writeShort(0)
+            output.writeShort(0)
+            output.writeShort(0)
+            output.writeShort(0)
+            output.writeInt(0)
+            output.writeInt(entry.localHeaderOffset.toLong())
+            output.writeBytes(nameBytes)
+        }
+        val centralDirectorySize = output.size - centralDirectoryOffset
+
+        output.writeInt(END_OF_CENTRAL_DIRECTORY)
+        output.writeShort(0)
+        output.writeShort(0)
+        output.writeShort(entries.size)
+        output.writeShort(entries.size)
+        output.writeInt(centralDirectorySize.toLong())
+        output.writeInt(centralDirectoryOffset.toLong())
+        output.writeShort(0)
+
+        return output.toByteArray()
+    }
+
+    /** Lists entry names from a ZIP produced by [build]. Useful for platform tests. */
+    fun listEntryNames(zipBytes: ByteArray): List<String> {
+        val names = mutableListOf<String>()
+        var index = 0
+        while (index <= zipBytes.size - 4) {
+            val signature = readInt(zipBytes, index)
+            if (signature == LOCAL_FILE_HEADER) {
+                val nameLength = readShort(zipBytes, index + 26)
+                val extraLength = readShort(zipBytes, index + 28)
+                val compressedSize = readInt(zipBytes, index + 18).toInt()
+                val nameStart = index + 30
+                names += zipBytes.copyOfRange(nameStart, nameStart + nameLength).decodeToString()
+                index = nameStart + nameLength + extraLength + compressedSize
+            } else {
+                index++
+            }
+        }
+        return names
+    }
+
+    private data class CentralDirectoryEntry(
+        val path: String,
+        val crc: Long,
+        val size: Int,
+        val localHeaderOffset: Int,
+    )
+
+    private fun readShort(bytes: ByteArray, offset: Int): Int =
+        (bytes[offset].toInt() and 0xff) or
+            ((bytes[offset + 1].toInt() and 0xff) shl 8)
+
+    private fun readInt(bytes: ByteArray, offset: Int): Long =
+        (bytes[offset].toLong() and 0xffL) or
+            ((bytes[offset + 1].toLong() and 0xffL) shl 8) or
+            ((bytes[offset + 2].toLong() and 0xffL) shl 16) or
+            ((bytes[offset + 3].toLong() and 0xffL) shl 24)
+}
+
+private class ByteArrayBuilder(initialCapacity: Int = 4096) {
+    private var buffer = ByteArray(initialCapacity)
+    var size: Int = 0
+        private set
+
+    fun writeByte(value: Int) {
+        ensureCapacity(size + 1)
+        buffer[size++] = value.toByte()
+    }
+
+    fun writeBytes(bytes: ByteArray) {
+        ensureCapacity(size + bytes.size)
+        bytes.copyInto(buffer, destinationOffset = size)
+        size += bytes.size
+    }
+
+    fun writeShort(value: Int) {
+        writeByte(value and 0xff)
+        writeByte((value ushr 8) and 0xff)
+    }
+
+    fun writeInt(value: Long) {
+        require(value in 0..0xffffffffL) { "ZIP64 is not supported" }
+        writeByte((value and 0xff).toInt())
+        writeByte(((value ushr 8) and 0xff).toInt())
+        writeByte(((value ushr 16) and 0xff).toInt())
+        writeByte(((value ushr 24) and 0xff).toInt())
+    }
+
+    fun toByteArray(): ByteArray = buffer.copyOf(size)
+
+    private fun ensureCapacity(required: Int) {
+        if (required <= buffer.size) return
+        var nextSize = buffer.size
+        while (nextSize < required) {
+            nextSize *= 2
+        }
+        buffer = buffer.copyOf(nextSize)
+    }
+}
+
+private object Crc32 {
+    private val table: IntArray = IntArray(256) { index ->
+        var crc = index
+        repeat(8) {
+            crc = if ((crc and 1) != 0) {
+                (crc ushr 1) xor 0xedb88320.toInt()
+            } else {
+                crc ushr 1
+            }
+        }
+        crc
+    }
+
+    fun compute(bytes: ByteArray): Long {
+        var crc = -1
+        for (byte in bytes) {
+            crc = (crc ushr 8) xor table[(crc xor byte.toInt()) and 0xff]
+        }
+        return (crc.inv().toLong() and 0xffffffffL)
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/export/DataAccessPackageGeneratorTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/export/DataAccessPackageGeneratorTest.kt
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.export
+
+import com.finance.core.TestFixtures
+import com.finance.models.Transaction
+import com.finance.models.types.Cents
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.plus
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.measureTime
+
+class DataAccessPackageGeneratorTest {
+    private val generatedAt = Instant.parse("2026-05-26T12:00:00Z")
+
+    @Test
+    fun generate_buildsZipWithManifestReadmeAndEveryRequiredDomain() {
+        val result = DataAccessPackageGenerator().generate(sampleData(), options())
+        val names = ZipArchive.listEntryNames(result.zipBytes)
+
+        assertTrue("manifest.json" in names)
+        assertTrue("README.md" in names)
+        DataAccessDomain.entries
+            .filterNot { it == DataAccessDomain.MOOD_TAGS }
+            .forEach { domain ->
+                assertTrue("data/${domain.fileName}" in names, "Missing ${domain.fileName}")
+            }
+        assertTrue(names.any { it.startsWith("attachments/receipt-1-") })
+        assertEquals(DATA_ACCESS_PACKAGE_SCHEMA_VERSION, result.manifest.schemaVersion)
+        assertEquals(generatedAt.toString(), result.manifest.generatedAt)
+        assertEquals(generatedAt.plus(7, DateTimeUnit.DAY, TimeZone.UTC).toString(), result.manifest.expiresAt)
+        assertNotNull(result.manifest.contents.firstOrNull { it.path == "data/transactions.json" })
+    }
+
+    @Test
+    fun generate_representsAllDomainsInManifestInventory() {
+        val result = DataAccessPackageGenerator().generate(sampleData(), options(includeMoodTags = true))
+        val manifestPaths = result.manifest.contents.map { it.path }.toSet()
+
+        assertEquals(1, result.manifest.contents.first { it.path == "data/transactions.json" }.recordCount)
+        assertEquals(2, result.manifest.contents.first { it.path == "data/tags.json" }.recordCount)
+        assertTrue("data/mood_tags.json" in manifestPaths)
+        assertTrue("attachments/receipt-1-receipt.txt" in manifestPaths)
+        assertTrue(result.manifest.privacy.protectedCategoriesIncluded)
+        assertTrue(result.manifest.privacy.moodTagsIncluded)
+        assertTrue(result.manifest.coordinationNotes.any { it.contains("#1719") })
+    }
+
+    @Test
+    fun retention_warnsDuringFinalDayAndDeletesAtExpiration() {
+        val expiresAt = generatedAt.plus(7, DateTimeUnit.DAY, TimeZone.UTC)
+
+        assertFalse(DataAccessPackageRetention.shouldWarnWithin24Hours(generatedAt, expiresAt))
+        assertTrue(
+            DataAccessPackageRetention.shouldWarnWithin24Hours(
+                generatedAt.plus(6, DateTimeUnit.DAY, TimeZone.UTC),
+                expiresAt,
+            ),
+        )
+        assertFalse(DataAccessPackageRetention.shouldAutoDelete(expiresAt.plus(-1, DateTimeUnit.DAY, TimeZone.UTC), expiresAt))
+        assertTrue(DataAccessPackageRetention.shouldAutoDelete(expiresAt, expiresAt))
+    }
+
+    @Test
+    fun generate_finishesWithinSlaFor100kTransactions() {
+        val transactions = List(100_000) { index -> sampleTransaction(index) }
+        val data = DataAccessExportData(transactions = transactions)
+        val elapsed = measureTime {
+            val result = DataAccessPackageGenerator().generate(data, options())
+            assertTrue(result.zipBytes.isNotEmpty())
+            assertEquals(100_000, result.manifest.contents.first { it.path == "data/transactions.json" }.recordCount)
+        }
+
+        assertTrue(elapsed.inWholeSeconds < 60, "100k transaction export exceeded 60s SLA: $elapsed")
+    }
+
+    @Test
+    fun generate_doesNotUseNetworkEgress() {
+        val failingProbe = NetworkEgressProbe { url -> error("Unexpected HTTP egress during export: $url") }
+        val result = DataAccessPackageGenerator(failingProbe).generate(sampleData(), options())
+
+        assertTrue(result.zipBytes.isNotEmpty())
+        assertFalse(result.manifest.contents.any { it.path.startsWith("http") })
+    }
+
+    private fun options(includeMoodTags: Boolean = false) = DataAccessRequestOptions(
+        appVersion = "0.1.0",
+        generatedAt = generatedAt,
+        includeMoodTags = includeMoodTags,
+    )
+
+    private fun sampleData(): DataAccessExportData {
+        TestFixtures.reset()
+        return DataAccessExportData(
+            accounts = listOf(TestFixtures.createAccount(id = com.finance.models.types.SyncId("account-1"))),
+            transactions = listOf(sampleTransaction(1)),
+            budgets = listOf(TestFixtures.createBudget()),
+            goals = listOf(TestFixtures.createGoal()),
+            categories = listOf(
+                com.finance.models.Category(
+                    id = com.finance.models.types.SyncId("category-1"),
+                    householdId = com.finance.models.types.SyncId("household-1"),
+                    ownerId = com.finance.models.types.SyncId("owner-1"),
+                    name = "Groceries",
+                    createdAt = TestFixtures.fixedInstant,
+                    updatedAt = TestFixtures.fixedInstant,
+                ),
+            ),
+            recurringRules = listOf(jsonRecord("id", "rule-1")),
+            preferences = listOf(jsonRecord("currency", "USD")),
+            settings = listOf(jsonRecord("theme", "system")),
+            auditLog = listOf(jsonRecord("event", "export_requested")),
+            syncMetadata = listOf(jsonRecord("device", "test-device")),
+            attachments = listOf(
+                DataAccessAttachment(
+                    id = "receipt-1",
+                    fileName = "receipt.txt",
+                    contentType = "text/plain",
+                    bytes = "receipt".encodeToByteArray(),
+                ),
+            ),
+            moodTags = listOf(jsonRecord("mood_tag", "calm")),
+        )
+    }
+
+    private fun sampleTransaction(index: Int): Transaction = TestFixtures.createTransaction(
+        id = com.finance.models.types.SyncId("txn-$index"),
+        accountId = com.finance.models.types.SyncId("account-1"),
+        amount = Cents(100 + index.toLong()),
+        payee = "Payee $index",
+        note = "Export SLA sample",
+    ).copy(tags = listOf("tag-a", "tag-b"))
+
+    private fun jsonRecord(key: String, value: String): DataAccessJsonRecord = DataAccessJsonRecord(
+        buildJsonObject { put(key, value) },
+    )
+}


### PR DESCRIPTION
## Summary

Implements in-app GDPR/CCPA data access request fulfillment for Settings → Privacy / Data export surfaces.

## Changes

- Adds shared KMP on-device data access package generator in `packages/core`.
- Generates ZIP archives with `manifest.json`, `data/*.json` per domain, `attachments/*`, and localized `README.md` without adding a compression dependency.
- Adds 7-day retention / 24-hour warning helpers and no-network-egress test seams.
- Updates the web in-app flow to use a “Request my data” confirmation modal, Pending → Generating → Ready → Delivered status, cancel, protected-category opt-out, mood-tag opt-in, and share/download delivery.

## Testing

- `node tools\gradle.js :packages:core:jvmTest --no-daemon`
- `npm run test -w apps/web -- --run src/components/DataExport.test.tsx src/lib/data-access-package.test.ts --reporter dot`
- `npm run type-check -w apps/web`
- `npm run format && npx eslint . --fix && npm run format:check && npx eslint . --max-warnings 0`

## Needs Coordination: #1719

Protected-category metadata is not yet present in the shared KMP/web repositories on `main`. The generator records this in `manifest.json`; callers can already opt out by passing pre-filtered categories once #1719 lands.

## Needs Decision

Native Android/iOS/Windows repository plumbing for every local domain should use the shared KMP generator once the platform KMP bridge exposes all domain repositories. This PR implements the shared generator and web in-app fulfillment path without introducing network egress.

## Issues

Closes #1873