### PR TITLE
feat(transactions): optional mood emoji tagging (alpha tier) (#1874)

### DIFF
--- a/apps/android/src/main/kotlin/com/finance/android/data/repository/TransactionRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/data/repository/TransactionRepository.kt
@@ -57,4 +57,7 @@ interface TransactionRepository : BaseRepository<Transaction> {
         start: LocalDate,
         end: LocalDate,
     ): List<Transaction>
+
+    /** Clears all optional mood tags from local transactions. */
+    suspend fun eraseAllMoodTags(): Int = 0
 }

--- a/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/InMemoryTransactionRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/InMemoryTransactionRepository.kt
@@ -117,4 +117,15 @@ class InMemoryTransactionRepository : TransactionRepository {
         store.value.active()
             .filter { it.householdId == householdId && it.date in start..end }
             .sortedByDescending { it.date }
+
+    override suspend fun eraseAllMoodTags(): Int {
+        val taggedCount = store.value.count { it.moodTag != null }
+        val now = Clock.System.now()
+        store.update { current ->
+            current.map { txn ->
+                if (txn.moodTag != null) txn.copy(moodTag = null, updatedAt = now, isSynced = false) else txn
+            }
+        }
+        return taggedCount
+    }
 }

--- a/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/SqlDelightTransactionRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/data/repository/impl/SqlDelightTransactionRepository.kt
@@ -82,6 +82,7 @@ class SqlDelightTransactionRepository(
                 is_recurring = if (entity.isRecurring) 1L else 0L,
                 recurring_rule_id = entity.recurringRuleId?.value,
                 tags = Json.encodeToString(tagsSerializer, entity.tags),
+                mood_tag = entity.moodTag,
                 created_at = entity.createdAt.toString(),
                 updated_at = entity.updatedAt.toString(),
                 sync_version = entity.syncVersion,
@@ -108,6 +109,7 @@ class SqlDelightTransactionRepository(
                 is_recurring = if (entity.isRecurring) 1L else 0L,
                 recurring_rule_id = entity.recurringRuleId?.value,
                 tags = Json.encodeToString(tagsSerializer, entity.tags),
+                mood_tag = entity.moodTag,
                 updated_at = entity.updatedAt.toString(),
                 sync_version = entity.syncVersion,
                 is_synced = if (entity.isSynced) 1L else 0L,
@@ -190,6 +192,15 @@ class SqlDelightTransactionRepository(
             .map { it.toDomain() }
     }
 
+    /** @inheritDoc */
+    override suspend fun eraseAllMoodTags(): Int = withContext(Dispatchers.IO) {
+        val taggedCount = queries.selectAll().executeAsList().count { it.mood_tag != null }
+        if (taggedCount > 0) {
+            queries.eraseAllMoodTags(Clock.System.now().toString())
+        }
+        taggedCount
+    }
+
     // ── Mapping ─────────────────────────────────────────────────────
 
     /**
@@ -213,6 +224,7 @@ class SqlDelightTransactionRepository(
         isRecurring = is_recurring != 0L,
         recurringRuleId = recurring_rule_id?.let { SyncId(it) },
         tags = Json.decodeFromString(tagsSerializer, tags),
+        moodTag = mood_tag,
         createdAt = Instant.parse(created_at),
         updatedAt = Instant.parse(updated_at),
         deletedAt = deleted_at?.let { Instant.parse(it) },

--- a/apps/android/src/main/kotlin/com/finance/android/data/repository/mock/MockTransactionRepository.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/data/repository/mock/MockTransactionRepository.kt
@@ -95,6 +95,17 @@ class MockTransactionRepository : TransactionRepository {
         }
     }
 
+    override suspend fun eraseAllMoodTags(): Int {
+        val taggedCount = _transactions.value.count { it.moodTag != null }
+        val now = Clock.System.now()
+        _transactions.update { list ->
+            list.map { transaction ->
+                if (transaction.moodTag != null) transaction.copy(moodTag = null, updatedAt = now, isSynced = false) else transaction
+            }
+        }
+        return taggedCount
+    }
+
     override suspend fun getUnsynced(householdId: SyncId): List<Transaction> =
         _transactions.value.filter { it.householdId == householdId && !it.isSynced }
 

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/SettingsScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/SettingsScreen.kt
@@ -118,6 +118,9 @@ fun SettingsScreen(
     onSetSimplifiedView: (Boolean) -> Unit,
     onSetHighContrast: (Boolean) -> Unit,
     onSetHapticFeedback: (Boolean) -> Unit,
+    onSetMoodTagsEnabled: (Boolean) -> Unit,
+    onSetMoodTagsSyncEnabled: (Boolean) -> Unit,
+    onEraseMoodData: () -> Unit,
     onExportClick: () -> Unit,
     onDeleteClick: () -> Unit,
     onExportFormat: (ExportFormat) -> Unit,
@@ -125,6 +128,7 @@ fun SettingsScreen(
     onDeleteTextChanged: (String) -> Unit,
     onConfirmDelete: () -> Unit,
     onDismissDeleteDialog: () -> Unit,
+    showExperimentalSection: Boolean = true,
     onPrivacyPolicyClick: () -> Unit = {},
     onTermsClick: () -> Unit = {},
     onLicensesClick: () -> Unit = {},
@@ -158,6 +162,17 @@ fun SettingsScreen(
             onNotificationsChanged = onSetNotifications,
             onBillRemindersChanged = onSetBillReminders,
         )
+
+        // ── Experimental ────────────────────────────────────────────────
+        if (showExperimentalSection) {
+            ExperimentalSection(
+                moodTagsEnabled = state.moodTagsEnabled,
+                moodTagsSyncEnabled = state.moodTagsSyncEnabled,
+                onMoodTagsEnabledChanged = onSetMoodTagsEnabled,
+                onMoodTagsSyncChanged = onSetMoodTagsSyncEnabled,
+                onEraseMoodData = onEraseMoodData,
+            )
+        }
 
         // ── Security ─────────────────────────────────────────────────────
         SecuritySection(
@@ -472,6 +487,58 @@ private fun CurrencyDropdown(
                 )
             }
         }
+    }
+}
+
+// ── Experimental ─────────────────────────────────────────────────────────────
+
+@Composable
+private fun ExperimentalSection(
+    moodTagsEnabled: Boolean,
+    moodTagsSyncEnabled: Boolean,
+    onMoodTagsEnabledChanged: (Boolean) -> Unit,
+    onMoodTagsSyncChanged: (Boolean) -> Unit,
+    onEraseMoodData: () -> Unit,
+) {
+    var showEraseDialog by remember { mutableStateOf(false) }
+    SectionHeader("Experimental")
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            SettingsToggleRow(
+                label = "Allow mood tags on transactions",
+                description = "Add an optional emoji to saved transactions",
+                checked = moodTagsEnabled,
+                onCheckedChange = onMoodTagsEnabledChanged,
+            )
+            if (moodTagsEnabled) {
+                HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
+                SettingsToggleRow(
+                    label = "Sync mood tags across my devices",
+                    description = "Keep emoji tags local unless this is on",
+                    checked = moodTagsSyncEnabled,
+                    onCheckedChange = onMoodTagsSyncChanged,
+                )
+            }
+            HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
+            OutlinedButton(
+                onClick = { showEraseDialog = true },
+                modifier = Modifier.fillMaxWidth().semantics { contentDescription = "Erase all mood data" },
+            ) { Text("Erase all mood data") }
+        }
+    }
+    if (showEraseDialog) {
+        AlertDialog(
+            onDismissRequest = { showEraseDialog = false },
+            title = { Text("Erase all mood data?") },
+            text = { Text("This removes mood tags from your transactions on this device.") },
+            confirmButton = {
+                Button(onClick = { showEraseDialog = false; onEraseMoodData() }) { Text("Erase mood data") }
+            },
+            dismissButton = { TextButton(onClick = { showEraseDialog = false }) { Text("Cancel") } },
+        )
     }
 }
 
@@ -1035,6 +1102,9 @@ fun SettingsScreen(
         onSetSimplifiedView = viewModel::setSimplifiedViewEnabled,
         onSetHighContrast = themePreferenceManager::setHighContrastEnabled,
         onSetHapticFeedback = viewModel::setHapticFeedbackEnabled,
+        onSetMoodTagsEnabled = viewModel::setMoodTagsEnabled,
+        onSetMoodTagsSyncEnabled = viewModel::setMoodTagsSyncEnabled,
+        onEraseMoodData = viewModel::eraseAllMoodData,
         onExportClick = viewModel::showExportDialog,
         onDeleteClick = viewModel::showDeleteDialog,
         onExportFormat = viewModel::exportData,
@@ -1113,6 +1183,9 @@ private fun SettingsScreenPreviewLight() {
                 onSetSimplifiedView = {},
                 onSetHighContrast = {},
                 onSetHapticFeedback = {},
+                onSetMoodTagsEnabled = {},
+                onSetMoodTagsSyncEnabled = {},
+                onEraseMoodData = {},
                 onExportClick = {},
                 onDeleteClick = {},
                 onExportFormat = {},
@@ -1151,6 +1224,9 @@ private fun SettingsScreenPreviewDark() {
                 onSetSimplifiedView = {},
                 onSetHighContrast = {},
                 onSetHapticFeedback = {},
+                onSetMoodTagsEnabled = {},
+                onSetMoodTagsSyncEnabled = {},
+                onEraseMoodData = {},
                 onExportClick = {},
                 onDeleteClick = {},
                 onExportFormat = {},

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/SettingsViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/SettingsViewModel.kt
@@ -107,6 +107,10 @@ data class SettingsUiState(
     val hapticFeedbackEnabled: Boolean = false,
     val hapticFeedbackAvailable: Boolean = false,
 
+    // Experimental
+    val moodTagsEnabled: Boolean = false,
+    val moodTagsSyncEnabled: Boolean = false,
+
     // About
     val appVersion: String = "1.0.0",
 
@@ -144,6 +148,8 @@ private object PrefKeys {
     const val SIMPLIFIED_VIEW = "simplified_view"
     const val HIGH_CONTRAST = "high_contrast"
     const val HAPTIC_FEEDBACK = HAPTIC_FEEDBACK_PREF_KEY
+    const val MOOD_TAGS_ENABLED = "experimental.moodTags.enabled"
+    const val MOOD_TAGS_SYNC_ENABLED = "experimental.moodTags.syncEnabled"
     const val USER_NAME = "user_name"
     const val USER_EMAIL = "user_email"
 }
@@ -221,6 +227,8 @@ class SettingsViewModel(
                 highContrastEnabled = prefs.getBoolean(PrefKeys.HIGH_CONTRAST, false),
                 hapticFeedbackAvailable = hapticsAvailable,
                 hapticFeedbackEnabled = prefs.getBoolean(PrefKeys.HAPTIC_FEEDBACK, hapticsAvailable),
+                moodTagsEnabled = prefs.getBoolean(PrefKeys.MOOD_TAGS_ENABLED, false),
+                moodTagsSyncEnabled = prefs.getBoolean(PrefKeys.MOOD_TAGS_SYNC_ENABLED, false),
             )
         }
     }
@@ -294,6 +302,36 @@ class SettingsViewModel(
         }
         updatePref { putBoolean(PrefKeys.HAPTIC_FEEDBACK, enabled) }
         _uiState.update { it.copy(hapticFeedbackEnabled = enabled) }
+    }
+
+    fun setMoodTagsEnabled(enabled: Boolean) {
+        updatePref {
+            putBoolean(PrefKeys.MOOD_TAGS_ENABLED, enabled)
+            if (!enabled) putBoolean(PrefKeys.MOOD_TAGS_SYNC_ENABLED, false)
+        }
+        _uiState.update {
+            it.copy(
+                moodTagsEnabled = enabled,
+                moodTagsSyncEnabled = if (enabled) it.moodTagsSyncEnabled else false,
+            )
+        }
+    }
+
+    fun setMoodTagsSyncEnabled(enabled: Boolean) {
+        updatePref { putBoolean(PrefKeys.MOOD_TAGS_SYNC_ENABLED, enabled) }
+        _uiState.update { it.copy(moodTagsSyncEnabled = enabled) }
+    }
+
+    fun eraseAllMoodData() {
+        viewModelScope.launch {
+            val rows = withContext(Dispatchers.IO) { transactionRepository.eraseAllMoodTags() }
+            updatePref {
+                putBoolean(PrefKeys.MOOD_TAGS_ENABLED, false)
+                putBoolean(PrefKeys.MOOD_TAGS_SYNC_ENABLED, false)
+            }
+            _uiState.update { it.copy(moodTagsEnabled = false, moodTagsSyncEnabled = false) }
+            _events.emit(SettingsEvent.ShowToast("Mood data erased from $rows transactions"))
+        }
     }
 
     // -- Sign out --------------------------------------------------------------

--- a/apps/android/src/main/kotlin/com/finance/android/ui/screens/TransactionCreateScreen.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/screens/TransactionCreateScreen.kt
@@ -162,6 +162,13 @@ fun TransactionCreateScreen(
                     CreateStep.CONFIRM -> ConfirmStep(state)
                 }
             }
+            if (state.currentStep == CreateStep.CONFIRM && state.moodTagsEnabled) {
+                MoodTagPicker(
+                    selectedMoodTag = state.selectedMoodTag,
+                    onMoodTagSelected = viewModel::selectMoodTag,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                )
+            }
             ActionBar(state.currentStep, state.isSaving, state.isEditing, viewModel::nextStep, viewModel::save, Modifier.padding(16.dp))
         }
     }
@@ -332,6 +339,7 @@ private fun ConfirmStep(state: TransactionCreateUiState) {
                     CRow("Category", state.selectedCategoryName); HorizontalDivider()
                     CRow("Account", state.selectedAccountName)
                     if (state.isBnplLiability) { HorizontalDivider(); CRow("BNPL installments", state.bnplInstallmentCountText) }
+                    if (state.selectedMoodTag != null) { HorizontalDivider(); CRow("Mood tag", state.selectedMoodTag) }
                     if (state.transactionType == TransactionType.TRANSFER) { HorizontalDivider(); CRow("To Account", state.selectedTransferAccountName) }
                     HorizontalDivider(); CRow("Date", state.date.toString())
                     if (state.note.isNotBlank()) { HorizontalDivider(); CRow("Note", state.note) }
@@ -346,6 +354,30 @@ private fun CRow(label: String, value: String) {
     Row(Modifier.fillMaxWidth().semantics { contentDescription = "$label: $value" }, horizontalArrangement = Arrangement.SpaceBetween) {
         Text(label, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
         Text(value, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium)
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun MoodTagPicker(selectedMoodTag: String?, onMoodTagSelected: (String?) -> Unit, modifier: Modifier = Modifier) {
+    val tags = listOf("😊", "😐", "😟", "😡", "🤩", "😴")
+    FlowRow(modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        tags.forEach { tag ->
+            FilterChip(
+                selected = selectedMoodTag == tag,
+                onClick = { onMoodTagSelected(tag) },
+                label = { Text(tag) },
+                modifier = Modifier.semantics { contentDescription = "Mood tag $tag" },
+            )
+        }
+        if (selectedMoodTag != null) {
+            FilterChip(
+                selected = false,
+                onClick = { onMoodTagSelected(null) },
+                label = { Text("Remove") },
+                modifier = Modifier.semantics { contentDescription = "Remove mood tag" },
+            )
+        }
     }
 }
 

--- a/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/TransactionCreateViewModel.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/TransactionCreateViewModel.kt
@@ -2,6 +2,7 @@
 
 package com.finance.android.ui.viewmodel
 
+import android.content.SharedPreferences
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -62,6 +63,8 @@ data class TransactionCreateUiState(
     val selectedTransferAccountName: String = "",
     val isBnplLiability: Boolean = false,
     val bnplInstallmentCountText: String = "4",
+    val moodTagsEnabled: Boolean = false,
+    val selectedMoodTag: String? = null,
 )
 
 /**
@@ -85,6 +88,7 @@ class TransactionCreateViewModel(
     private val transactionRepository: TransactionRepository,
     private val accountRepository: AccountRepository,
     private val categoryRepository: CategoryRepository,
+    private val prefs: SharedPreferences? = null,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(TransactionCreateUiState())
     val uiState: StateFlow<TransactionCreateUiState> = _uiState.asStateFlow()
@@ -108,6 +112,8 @@ class TransactionCreateViewModel(
     /** Navigation argument key used to distinguish edit mode from create mode. */
     private val editTransactionId: String? = savedStateHandle["id"]
 
+    private val moodTagsEnabledKey = "experimental.moodTags.enabled"
+
     init {
         viewModelScope.launch {
             val householdId = householdIdProvider.householdId.value ?: run {
@@ -124,6 +130,7 @@ class TransactionCreateViewModel(
             _uiState.update {
                 it.copy(
                     categories = cats, accounts = accts,
+                    moodTagsEnabled = prefs?.getBoolean(moodTagsEnabledKey, false) ?: false,
                     selectedAccountId = accts.firstOrNull()?.id,
                     selectedAccountName = accts.firstOrNull()?.name ?: "",
                 )
@@ -157,6 +164,7 @@ class TransactionCreateViewModel(
                             isBnplLiability = txn.tags.contains(BNPL_TAG),
                             bnplInstallmentCountText = txn.tags.firstOrNull { tag -> tag.startsWith(BNPL_INSTALLMENTS_PREFIX) }
                                 ?.removePrefix(BNPL_INSTALLMENTS_PREFIX) ?: "4",
+                            selectedMoodTag = txn.moodTag,
                         )
                     }
                 }
@@ -238,6 +246,11 @@ class TransactionCreateViewModel(
     fun updateBnplInstallmentCount(value: String) {
         _uiState.update { it.copy(bnplInstallmentCountText = value.filter(Char::isDigit).take(2), errors = emptyList()) }
     }
+    fun selectMoodTag(tag: String?) {
+        _uiState.update { current ->
+            current.copy(selectedMoodTag = if (current.selectedMoodTag == tag) null else tag, errors = emptyList())
+        }
+    }
 
     fun save() {
         val errs = validateAll(_uiState.value)
@@ -267,6 +280,7 @@ class TransactionCreateViewModel(
                 date = s.date,
                 transferAccountId = s.selectedTransferAccountId,
                 tags = transactionTags,
+                moodTag = s.selectedMoodTag.takeIf { s.moodTagsEnabled },
                 updatedAt = now,
                 isSynced = false,
             ) ?: Transaction(
@@ -284,6 +298,7 @@ class TransactionCreateViewModel(
                 date = s.date,
                 transferAccountId = s.selectedTransferAccountId,
                 tags = transactionTags,
+                moodTag = s.selectedMoodTag.takeIf { s.moodTagsEnabled },
                 createdAt = now,
                 updatedAt = now,
             )

--- a/apps/android/src/test/kotlin/com/finance/android/ui/snapshot/SettingsSnapshotTest.kt
+++ b/apps/android/src/test/kotlin/com/finance/android/ui/snapshot/SettingsSnapshotTest.kt
@@ -57,6 +57,9 @@ class SettingsSnapshotTest {
                     onSetSimplifiedView = {},
                     onSetHighContrast = {},
                     onSetHapticFeedback = {},
+                    onSetMoodTagsEnabled = {},
+                    onSetMoodTagsSyncEnabled = {},
+                    onEraseMoodData = {},
                     onExportClick = {},
                     onDeleteClick = {},
                     onExportFormat = {},
@@ -64,6 +67,7 @@ class SettingsSnapshotTest {
                     onDeleteTextChanged = {},
                     onConfirmDelete = {},
                     onDismissDeleteDialog = {},
+                    showExperimentalSection = false,
                 )
             }
         }

--- a/apps/ios/Finance/KMP/SwiftExportBridgeProvider.swift
+++ b/apps/ios/Finance/KMP/SwiftExportBridgeProvider.swift
@@ -126,6 +126,7 @@ struct BridgedTransactionRepository: TransactionRepository {
     func updateTransaction(_ transaction: TransactionItem) async throws { try await module.updateTransaction(transaction) }
     func deleteTransaction(id: String) async throws { try await module.deleteTransaction(id: id) }
     func deleteAllTransactions() async throws { try await module.deleteAllTransactions() }
+    func eraseAllMoodTags() async throws {}
 }
 
 /// Adapts `SwiftExportBudgetModule` to the existing `BudgetRepository` protocol.

--- a/apps/ios/Finance/Models/TransactionItem.swift
+++ b/apps/ios/Finance/Models/TransactionItem.swift
@@ -72,7 +72,8 @@ struct TransactionItem: Identifiable, Hashable, Sendable {
     let type: TransactionTypeUI
     let status: TransactionStatusUI
     let notes: String
-    let tags: [String]
+    let tagNames: [String]
+    let moodTag: String?
     let isRecurring: Bool
     let receiptData: Data?
     let tags: [Tag]
@@ -91,7 +92,8 @@ struct TransactionItem: Identifiable, Hashable, Sendable {
         type: TransactionTypeUI = .expense,
         status: TransactionStatusUI = .cleared,
         notes: String = "",
-        tags: [String] = [],
+        tagNames: [String] = [],
+        moodTag: String? = nil,
         isRecurring: Bool = false,
         receiptData: Data? = nil,
         tags: [Tag] = []
@@ -106,7 +108,8 @@ struct TransactionItem: Identifiable, Hashable, Sendable {
         self.type = type
         self.status = status
         self.notes = notes
-        self.tags = tags
+        self.tagNames = tagNames
+        self.moodTag = moodTag
         self.isRecurring = isRecurring
         self.receiptData = receiptData
         self.tags = tags

--- a/apps/ios/Finance/Repositories/KMP/KMPTransactionRepository.swift
+++ b/apps/ios/Finance/Repositories/KMP/KMPTransactionRepository.swift
@@ -59,4 +59,9 @@ struct KMPTransactionRepository: TransactionRepository {
         Self.logger.info("Deleting all transactions via KMP bridge")
         await store.deleteAllTransactions()
     }
+
+    func eraseAllMoodTags() async throws {
+        Self.logger.info("Erasing mood tags via KMP bridge")
+        await store.eraseAllMoodTags()
+    }
 }

--- a/apps/ios/Finance/Repositories/KMP/LocalDataStore.swift
+++ b/apps/ios/Finance/Repositories/KMP/LocalDataStore.swift
@@ -158,6 +158,29 @@ actor LocalDataStore {
         Self.logger.info("All transactions deleted")
     }
 
+    func eraseAllMoodTags() {
+        transactions = transactions.mapValues { transaction in
+            TransactionItem(
+                id: transaction.id,
+                payee: transaction.payee,
+                category: transaction.category,
+                accountName: transaction.accountName,
+                amountMinorUnits: transaction.amountMinorUnits,
+                currencyCode: transaction.currencyCode,
+                date: transaction.date,
+                type: transaction.type,
+                status: transaction.status,
+                notes: transaction.notes,
+                tagNames: transaction.tagNames,
+                moodTag: nil,
+                isRecurring: transaction.isRecurring,
+                receiptData: transaction.receiptData,
+                tags: transaction.tags
+            )
+        }
+        Self.logger.info("Mood tags erased")
+    }
+
     // MARK: - Budgets
 
     func getBudgets() -> [BudgetItem] {

--- a/apps/ios/Finance/Repositories/KMP/PersistentDataStore.swift
+++ b/apps/ios/Finance/Repositories/KMP/PersistentDataStore.swift
@@ -290,6 +290,32 @@ actor PersistentDataStore {
         Self.logger.info("All transactions deleted")
     }
 
+    func eraseAllMoodTags() async throws {
+        await initialise()
+        let updated = transactions.mapValues { transaction in
+            TransactionItem(
+                id: transaction.id,
+                payee: transaction.payee,
+                category: transaction.category,
+                accountName: transaction.accountName,
+                amountMinorUnits: transaction.amountMinorUnits,
+                currencyCode: transaction.currencyCode,
+                date: transaction.date,
+                type: transaction.type,
+                status: transaction.status,
+                notes: transaction.notes,
+                tagNames: transaction.tagNames,
+                moodTag: nil,
+                isRecurring: transaction.isRecurring,
+                receiptData: transaction.receiptData,
+                tags: transaction.tags
+            )
+        }
+        transactions = updated
+        for transaction in updated.values { try? diskStore?.saveTransaction(transaction) }
+        Self.logger.info("Mood tags erased")
+    }
+
     // MARK: - Budgets
 
     func getBudgets() async throws -> [BudgetItem] {

--- a/apps/ios/Finance/Repositories/Mocks/MockTransactionRepository.swift
+++ b/apps/ios/Finance/Repositories/Mocks/MockTransactionRepository.swift
@@ -106,4 +106,8 @@ struct MockTransactionRepository: TransactionRepository {
     func deleteAllTransactions() async throws {
         // No-op for mock — mock data is stateless and returns hardcoded values.
     }
+
+    func eraseAllMoodTags() async throws {
+        // No-op for mock — mock data is stateless and returns hardcoded values.
+    }
 }

--- a/apps/ios/Finance/Repositories/TransactionRepository.swift
+++ b/apps/ios/Finance/Repositories/TransactionRepository.swift
@@ -38,4 +38,11 @@ protocol TransactionRepository: Sendable {
 
     /// Permanently deletes every transaction. Used for GDPR "Delete Everything".
     func deleteAllTransactions() async throws
+
+    /// Clears mood tags from all transactions on this device.
+    func eraseAllMoodTags() async throws
+}
+
+extension TransactionRepository {
+    func eraseAllMoodTags() async throws {}
 }

--- a/apps/ios/Finance/Screens/SettingsView.swift
+++ b/apps/ios/Finance/Screens/SettingsView.swift
@@ -30,6 +30,7 @@ struct SettingsView: View {
                 notificationsSection
                 accessibilitySection
                 securitySection
+                experimentalSection
                 syncSection
                 dataSection
                 aboutSection
@@ -239,6 +240,43 @@ struct SettingsView: View {
             }
             .accessibilityLabel(String(localized: "Privacy Policy"))
             .accessibilityHint(String(localized: "Opens the privacy policy"))
+        }
+    }
+
+    // MARK: - Experimental
+
+    private var experimentalSection: some View {
+        Section(String(localized: "Experimental")) {
+            Toggle(isOn: $viewModel.moodTagsEnabled) {
+                Label(String(localized: "Allow mood tags on transactions"), systemImage: "face.smiling")
+            }
+            .accessibilityLabel(String(localized: "Allow mood tags on transactions"))
+
+            if viewModel.moodTagsEnabled {
+                Toggle(isOn: $viewModel.moodTagsSyncEnabled) {
+                    Label(String(localized: "Sync mood tags across my devices"), systemImage: "arrow.triangle.2.circlepath")
+                }
+                .accessibilityLabel(String(localized: "Sync mood tags across my devices"))
+            }
+
+            Button(role: .destructive) {
+                viewModel.showingMoodEraseConfirmation = true
+            } label: {
+                Label(String(localized: "Erase all mood data"), systemImage: "trash")
+            }
+            .accessibilityLabel(String(localized: "Erase all mood data"))
+            .confirmationDialog(
+                String(localized: "Erase all mood data?"),
+                isPresented: $viewModel.showingMoodEraseConfirmation,
+                titleVisibility: .visible
+            ) {
+                Button(String(localized: "Erase mood data"), role: .destructive) {
+                    Task { await viewModel.eraseAllMoodData() }
+                }
+                Button(String(localized: "Cancel"), role: .cancel) {}
+            } message: {
+                Text(String(localized: "This removes mood tags from your transactions on this device."))
+            }
         }
     }
 

--- a/apps/ios/Finance/Screens/TransactionCreateView.swift
+++ b/apps/ios/Finance/Screens/TransactionCreateView.swift
@@ -232,6 +232,25 @@ struct TransactionCreateView: View {
                     .accessibilityHint(String(localized: "Adds the entered text as a tag"))
                 }
             }
+            if viewModel.moodTagsEnabled {
+                Section(String(localized: "Mood tag")) {
+                    HStack {
+                        ForEach(viewModel.moodTagOptions, id: .self) { emoji in
+                            Button {
+                                viewModel.selectMoodTag(emoji)
+                            } label: {
+                                Text(emoji).font(.title2)
+                            }
+                            .buttonStyle(.bordered)
+                            .accessibilityLabel(String(localized: "Mood tag (emoji)"))
+                        }
+                        if viewModel.moodTag != nil {
+                            Button(String(localized: "Remove")) { viewModel.clearMoodTag() }
+                                .accessibilityLabel(String(localized: "Remove mood tag"))
+                        }
+                    }
+                }
+            }
             Section(String(localized: "Date")) {
                 DatePicker(String(localized: "Date"), selection: $viewModel.date, displayedComponents: .date)
                     .accessibilityLabel(String(localized: "Transaction date"))
@@ -269,6 +288,9 @@ struct TransactionCreateView: View {
                     LabeledContent(String(localized: "BNPL installments")) { Text(viewModel.bnplInstallmentCount) }
                 }
                 LabeledContent(String(localized: "Date")) { Text(viewModel.date, style: .date) }
+                if let moodTag = viewModel.moodTag {
+                    LabeledContent(String(localized: "Mood tag")) { Text(moodTag) }
+                }
                 if !viewModel.tags.isEmpty {
                     LabeledContent(String(localized: "Tags")) {
                         Text(viewModel.tags.joined(separator: ", ")).foregroundStyle(.secondary)

--- a/apps/ios/Finance/Screens/TransactionDetailView.swift
+++ b/apps/ios/Finance/Screens/TransactionDetailView.swift
@@ -25,7 +25,7 @@ struct TransactionDetailView: View {
     private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.finance", category: "TransactionDetailView")
 
     init(transaction: TransactionItem, repository: TransactionRepository = RepositoryProvider.shared.transactions) {
-        _transaction = State(initialValue: transaction); _editedNotes = State(initialValue: transaction.notes); _receiptImageData = State(initialValue: transaction.receiptData); _isBnplInstallmentPaid = State(initialValue: transaction.tags.contains("bnpl-installment-paid")); self.repository = repository
+        _transaction = State(initialValue: transaction); _editedNotes = State(initialValue: transaction.notes); _receiptImageData = State(initialValue: transaction.receiptData); _isBnplInstallmentPaid = State(initialValue: transaction.tagNames.contains("bnpl-installment-paid")); self.repository = repository
     }
 
     var body: some View {
@@ -116,7 +116,7 @@ struct TransactionDetailView: View {
 
     @ViewBuilder
     private var bnplSection: some View {
-        if transaction.tags.contains("bnpl") {
+        if transaction.tagNames.contains("bnpl") {
             Section(String(localized: "BNPL Liability")) {
                 Text(isBnplInstallmentPaid ? String(localized: "Installment paid") : String(localized: "Installment due"))
                 if !isBnplInstallmentPaid {
@@ -316,6 +316,8 @@ struct TransactionDetailView: View {
             type: transaction.type,
             status: transaction.status,
             notes: editedNotes,
+            tagNames: transaction.tagNames,
+            moodTag: transaction.moodTag,
             isRecurring: transaction.isRecurring,
             receiptData: transaction.receiptData,
             tags: transaction.tags

--- a/apps/ios/Finance/ViewModels/SettingsViewModel.swift
+++ b/apps/ios/Finance/ViewModels/SettingsViewModel.swift
@@ -26,6 +26,8 @@ private enum SettingsKeys {
     static let lastSyncDate = "finance_last_sync_date"
     static let pendingChangesCount = "finance_pending_changes_count"
     static let bnplStackingThreshold = "finance_bnpl_stacking_threshold"
+    static let moodTagsEnabled = "experimental.moodTags.enabled"
+    static let moodTagsSyncEnabled = "experimental.moodTags.syncEnabled"
 }
 
 enum DeletionConfirmationStep: Sendable {
@@ -72,6 +74,17 @@ final class SettingsViewModel {
         didSet { defaults.set(bnplStackingThreshold, forKey: SettingsKeys.bnplStackingThreshold) }
     }
 
+    var moodTagsEnabled: Bool {
+        didSet {
+            defaults.set(moodTagsEnabled, forKey: SettingsKeys.moodTagsEnabled)
+            if !moodTagsEnabled { moodTagsSyncEnabled = false }
+        }
+    }
+
+    var moodTagsSyncEnabled: Bool {
+        didSet { defaults.set(moodTagsSyncEnabled, forKey: SettingsKeys.moodTagsSyncEnabled) }
+    }
+
     // MARK: - Biometric State
 
     /// Whether the biometric app-lock is currently enabled.
@@ -111,6 +124,7 @@ final class SettingsViewModel {
     // MARK: - Delete Confirmation
 
     var showingDeleteConfirmation = false
+    var showingMoodEraseConfirmation = false
     var deletionConfirmationStep: DeletionConfirmationStep = .none
     var isDeletingData = false
     var currentDeletionStep: DeletionStep?
@@ -221,6 +235,12 @@ final class SettingsViewModel {
         self.hapticFeedbackAvailable = HapticFeedbackPreferences.deviceSupportsHaptics
         self.hapticFeedbackEnabled = HapticFeedbackPreferences.isEnabled(defaults: defaults)
         self.bnplStackingThreshold = defaults.string(forKey: SettingsKeys.bnplStackingThreshold) ?? "500"
+        self.moodTagsEnabled = Self.bool(
+            forKey: SettingsKeys.moodTagsEnabled, default: false, in: defaults
+        )
+        self.moodTagsSyncEnabled = Self.bool(
+            forKey: SettingsKeys.moodTagsSyncEnabled, default: false, in: defaults
+        )
         self.lastSyncDate = defaults.object(forKey: SettingsKeys.lastSyncDate) as? Date
         self.pendingChangesCount = defaults.integer(forKey: SettingsKeys.pendingChangesCount)
 
@@ -390,6 +410,16 @@ final class SettingsViewModel {
         }
     }
 
+    func eraseAllMoodData() async {
+        do {
+            try await transactionRepository.eraseAllMoodTags()
+            moodTagsEnabled = false
+            moodTagsSyncEnabled = false
+        } catch {
+            errorMessage = String(localized: "Failed to erase mood data. Please try again.")
+        }
+    }
+
     func cancelDeletion() {
         deletionConfirmationStep = .none; deleteConfirmationText = ""
         isDeletingData = false; currentDeletionStep = nil; deletionError = nil
@@ -474,6 +504,7 @@ final class SettingsViewModel {
                 SettingsKeys.budgetAlerts, SettingsKeys.goalMilestones,
                 HapticFeedbackPreferences.key,
                 SettingsKeys.lastSyncDate, SettingsKeys.pendingChangesCount,
+                SettingsKeys.moodTagsEnabled, SettingsKeys.moodTagsSyncEnabled,
             ] {
                 defaults.removeObject(forKey: key)
             }

--- a/apps/ios/Finance/ViewModels/TransactionCreateViewModel.swift
+++ b/apps/ios/Finance/ViewModels/TransactionCreateViewModel.swift
@@ -50,6 +50,9 @@ final class TransactionCreateViewModel {
     var validationMessage = ""
     var selectedStatus: TransactionStatusUI = .pending
     var tags: [String] = []
+    var moodTag: String?
+    var moodTagsEnabled = UserDefaults.standard.bool(forKey: "experimental.moodTags.enabled")
+    let moodTagOptions = ["😊", "😐", "😟", "😡", "🤩", "😴"]
     var currentTagText = ""
     var isBnplLiability = false
     var bnplInstallmentCount = "4"
@@ -115,6 +118,12 @@ final class TransactionCreateViewModel {
     }
 
     /// Removes a tag at the specified index.
+    func selectMoodTag(_ tag: String) {
+        moodTag = moodTag == tag ? nil : tag
+    }
+
+    func clearMoodTag() { moodTag = nil }
+
     func removeTag(at index: Int) {
         guard tags.indices.contains(index) else { return }
         tags.remove(at: index)
@@ -152,10 +161,11 @@ final class TransactionCreateViewModel {
             date = transaction.date
             currencyCode = transaction.currencyCode
             selectedStatus = transaction.status
-            tags = transaction.tags
-            isBnplLiability = transaction.tags.contains(Self.bnplTag)
-            bnplInstallmentCount = transaction.tags.first(where: { $0.hasPrefix(Self.bnplInstallmentsPrefix) })?
+            tags = transaction.tagNames
+            isBnplLiability = transaction.tagNames.contains(Self.bnplTag)
+            bnplInstallmentCount = transaction.tagNames.first(where: { $0.hasPrefix(Self.bnplInstallmentsPrefix) })?
                 .replacingOccurrences(of: Self.bnplInstallmentsPrefix, with: "") ?? "4"
+            moodTag = transaction.moodTag
             // Category and account IDs are resolved after loadData()
         } else if let quickEntryAction {
             applyQuickEntry(action: quickEntryAction)
@@ -244,7 +254,8 @@ final class TransactionCreateViewModel {
             date: date,
             type: transactionType,
             status: selectedStatus,
-            tags: persistedTags
+            tagNames: persistedTags,
+            moodTag: moodTagsEnabled ? moodTag : nil
         )
 
         do {

--- a/apps/ios/Finance/ViewModels/TransactionsViewModel.swift
+++ b/apps/ios/Finance/ViewModels/TransactionsViewModel.swift
@@ -217,7 +217,7 @@ final class TransactionsViewModel {
         if t.status.displayName.localizedCaseInsensitiveContains(query) { return true }
         if t.type.displayName.localizedCaseInsensitiveContains(query) { return true }
         // Match tags
-        if t.tags.contains(where: { $0.localizedCaseInsensitiveContains(query) }) { return true }
+        if t.tagNames.contains(where: { $0.localizedCaseInsensitiveContains(query) }) { return true }
         // Match formatted amount (e.g. "12.50")
         let amountStr = String(format: "%.2f", Double(abs(t.amountMinorUnits)) / 100.0)
         if amountStr.contains(query) { return true }

--- a/apps/web/src/components/DataExport.tsx
+++ b/apps/web/src/components/DataExport.tsx
@@ -51,10 +51,17 @@ const STRINGS = {
   error: 'Error',
 };
 
-function gatherExportData(db: SqliteDb): ExportData {
+/** Gather all exportable financial data from the local SQLite-WASM database. */
+function gatherExportData(db: SqliteDb, includeMoodTags: boolean): ExportData {
+  const transactions = getAllTransactions(db).map((transaction) => {
+    if (includeMoodTags) return transaction;
+    const { moodTag: _moodTag, ...exportableTransaction } = transaction;
+    return exportableTransaction as typeof transaction;
+  });
+
   return {
     accounts: getAllAccounts(db),
-    transactions: getAllTransactions(db),
+    transactions,
     budgets: getAllBudgets(db),
     goals: getAllGoals(db),
     categories: getAllCategories(db),
@@ -194,7 +201,7 @@ export const DataExport: React.FC<DataExportProps> = ({ className = '' }) => {
       try {
         if (!db)
           throw new Error('Database is still initializing. Please wait a moment and try again.');
-        const data = gatherExportData(db);
+        const data = gatherExportData(db, includeMoodTags);
         if (!hasExportData(data)) throw new Error('No data available to export.');
 
         const result = buildDataAccessPackage(

--- a/apps/web/src/components/forms/TransactionForm.tsx
+++ b/apps/web/src/components/forms/TransactionForm.tsx
@@ -45,6 +45,12 @@ import type {
 import { BNPL_CUSTOM_FIELD_KEYS } from '../../lib/bnpl-liability';
 import type { CategorySuggestion } from '../../lib/categorization';
 import type { MerchantMatchResult } from '../../lib/merchants';
+import {
+  MOOD_TAGS,
+  MOOD_TAGS_CHANGED_EVENT,
+  isMoodTagsEnabled,
+  normalizeMoodTag,
+} from '../../lib/mood-tags';
 import { transactionSchema } from '../../lib/validation';
 import { CounterpartyInput } from '../transactions/CounterpartyInput';
 
@@ -197,6 +203,8 @@ export function TransactionForm({
   const [date, setDate] = useState(todayISO);
   const [notes, setNotes] = useState('');
   const [tagsInput, setTagsInput] = useState('');
+  const [moodTag, setMoodTag] = useState<string | null>(null);
+  const [moodTagsEnabled, setMoodTagsEnabled] = useState(() => isMoodTagsEnabled());
   const [errors, setErrors] = useState<FormErrors>({});
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -238,6 +246,16 @@ export function TransactionForm({
     }
   }, [isOpen]);
 
+  useEffect(() => {
+    const refreshMoodPreference = () => setMoodTagsEnabled(isMoodTagsEnabled());
+    window.addEventListener(MOOD_TAGS_CHANGED_EVENT, refreshMoodPreference);
+    window.addEventListener('storage', refreshMoodPreference);
+    return () => {
+      window.removeEventListener(MOOD_TAGS_CHANGED_EVENT, refreshMoodPreference);
+      window.removeEventListener('storage', refreshMoodPreference);
+    };
+  }, []);
+
   // -- initialize on open --------------------------------------------------
   useEffect(() => {
     if (!isOpen) {
@@ -257,6 +275,7 @@ export function TransactionForm({
     setDate(initialData?.date ?? todayISO());
     setNotes(initialData?.note ?? '');
     setTagsInput(initialData ? tagsToString(initialData.tags) : '');
+    setMoodTag(normalizeMoodTag(initialData?.moodTag));
     setCounterpartyName(initialData?.counterpartyName ?? '');
     setMerchantMatch(null);
     setIsBnplLiability(
@@ -414,6 +433,7 @@ export function TransactionForm({
         categoryId: categoryId || null,
         note: notes.trim() || null,
         tags: parseTags(tagsInput),
+        ...(moodTagsEnabled ? { moodTag } : {}),
         merchantCity: merchantCity.trim() || null,
         merchantState: merchantState.trim() || null,
         merchantZip: merchantZip.trim() || null,
@@ -450,6 +470,7 @@ export function TransactionForm({
         setDate(todayISO());
         setNotes('');
         setTagsInput('');
+        setMoodTag(null);
         setCounterpartyName('');
         setMerchantMatch(null);
         setIsBnplLiability(false);
@@ -482,6 +503,8 @@ export function TransactionForm({
       categoryId,
       notes,
       tagsInput,
+      moodTag,
+      moodTagsEnabled,
       merchantCity,
       merchantState,
       merchantZip,
@@ -792,6 +815,38 @@ export function TransactionForm({
                 </div>
               )}
             </div>
+
+            {moodTagsEnabled && (
+              <fieldset className="form-radio-group" aria-label="Mood tag">
+                <legend className="form-radio-group__legend">Mood tag</legend>
+                <div
+                  className="form-radio-group__options"
+                  role="group"
+                  aria-label="Optional mood tag"
+                >
+                  {MOOD_TAGS.map((emoji) => (
+                    <button
+                      key={emoji}
+                      type="button"
+                      className="form-button form-button--secondary"
+                      aria-pressed={moodTag === emoji}
+                      onClick={() => setMoodTag(moodTag === emoji ? null : emoji)}
+                    >
+                      {emoji}
+                    </button>
+                  ))}
+                  {moodTag && (
+                    <button
+                      type="button"
+                      className="form-button form-button--secondary"
+                      onClick={() => setMoodTag(null)}
+                    >
+                      Remove
+                    </button>
+                  )}
+                </div>
+              </fieldset>
+            )}
 
             {/* Additional Details — expandable section */}
             <fieldset className="form-group" style={{ border: 'none', padding: 0, margin: 0 }}>

--- a/apps/web/src/db/repositories/transactions.ts
+++ b/apps/web/src/db/repositories/transactions.ts
@@ -42,6 +42,7 @@ const TRANSACTION_COLUMNS = [
   'is_recurring',
   'recurring_rule_id',
   'tags',
+  'mood_tag',
   'merchant_address',
   'merchant_city',
   'merchant_state',
@@ -86,6 +87,7 @@ export interface CreateTransactionInput {
   isRecurring?: boolean;
   recurringRuleId?: SyncId | null;
   tags?: readonly string[];
+  moodTag?: string | null;
   merchantAddress?: string | null;
   merchantCity?: string | null;
   merchantState?: string | null;
@@ -116,6 +118,7 @@ export interface UpdateTransactionInput {
   isRecurring?: boolean;
   recurringRuleId?: SyncId | null;
   tags?: readonly string[];
+  moodTag?: string | null;
   merchantAddress?: string | null;
   merchantCity?: string | null;
   merchantState?: string | null;
@@ -147,6 +150,7 @@ function mapTransaction(row: Row): Transaction {
     isRecurring: toBoolean(row.is_recurring),
     recurringRuleId: optionalString(row.recurring_rule_id),
     tags: parseTags(row.tags),
+    moodTag: optionalString(row.mood_tag),
     merchantAddress: optionalString(row.merchant_address),
     merchantCity: optionalString(row.merchant_city),
     merchantState: optionalString(row.merchant_state),
@@ -253,6 +257,7 @@ export function createTransaction(db: SqliteDb, input: CreateTransactionInput): 
       is_recurring,
       recurring_rule_id,
       tags,
+      mood_tag,
       merchant_address,
       merchant_city,
       merchant_state,
@@ -270,7 +275,7 @@ export function createTransaction(db: SqliteDb, input: CreateTransactionInput): 
       sync_version,
       is_synced
     ) VALUES (
-      ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+      ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
       ${SQLITE_NOW_EXPRESSION},
       ${SQLITE_NOW_EXPRESSION},
       NULL,
@@ -294,6 +299,7 @@ export function createTransaction(db: SqliteDb, input: CreateTransactionInput): 
       input.isRecurring ? 1 : 0,
       input.recurringRuleId ?? null,
       serializeTags(input.tags ?? []),
+      input.moodTag ?? null,
       input.merchantAddress ?? null,
       input.merchantCity ?? null,
       input.merchantState ?? null,
@@ -353,6 +359,7 @@ export function updateTransaction(
         ? updates.recurringRuleId
         : existingTransaction.recurringRuleId,
     tags: updates.tags ?? existingTransaction.tags,
+    moodTag: updates.moodTag !== undefined ? updates.moodTag : existingTransaction.moodTag,
     merchantAddress:
       updates.merchantAddress !== undefined
         ? updates.merchantAddress
@@ -409,6 +416,7 @@ export function updateTransaction(
             is_recurring = ?,
             recurring_rule_id = ?,
             tags = ?,
+            mood_tag = ?,
             merchant_address = ?,
             merchant_city = ?,
             merchant_state = ?,
@@ -441,6 +449,7 @@ export function updateTransaction(
       mergedTransaction.isRecurring ? 1 : 0,
       mergedTransaction.recurringRuleId,
       serializeTags(mergedTransaction.tags),
+      mergedTransaction.moodTag,
       mergedTransaction.merchantAddress,
       mergedTransaction.merchantCity,
       mergedTransaction.merchantState,
@@ -479,6 +488,14 @@ export function deleteTransaction(db: SqliteDb, transactionId: SyncId): boolean 
   );
 
   return true;
+}
+
+/** Erase all mood tags from local transactions. */
+export function eraseAllMoodTags(db: SqliteDb): void {
+  execute(
+    db,
+    `UPDATE "transaction" SET mood_tag = NULL, updated_at = ${SQLITE_NOW_EXPRESSION}, sync_version = 1, is_synced = 0 WHERE mood_tag IS NOT NULL`,
+  );
 }
 
 /** Return transactions for a single account with optional filters applied. */

--- a/apps/web/src/db/sqlite-wasm.ts
+++ b/apps/web/src/db/sqlite-wasm.ts
@@ -281,6 +281,7 @@ export const MIGRATIONS: Migration[] = [
         is_recurring            INTEGER NOT NULL DEFAULT 0,
         recurring_rule_id       TEXT,
         tags                    TEXT    NOT NULL DEFAULT '[]',
+        mood_tag                TEXT,
         created_at              TEXT    NOT NULL,
         updated_at              TEXT    NOT NULL,
         deleted_at              TEXT,
@@ -367,6 +368,11 @@ export const MIGRATIONS: Migration[] = [
         updated_at   TEXT NOT NULL
       );`,
     ],
+  },
+  {
+    version: 2,
+    label: 'add-mood-tag-to-transactions',
+    up: ['ALTER TABLE "transaction" ADD COLUMN mood_tag TEXT;'],
   },
 ];
 // ---------------------------------------------------------------------------

--- a/apps/web/src/kmp/bridge.ts
+++ b/apps/web/src/kmp/bridge.ts
@@ -119,6 +119,7 @@ export interface Transaction extends SyncMetadata {
   readonly isRecurring: boolean;
   readonly recurringRuleId: SyncId | null;
   readonly tags: readonly string[];
+  readonly moodTag?: string | null;
 
   // Merchant location (all optional)
   readonly merchantAddress: string | null;

--- a/apps/web/src/lib/mood-tags.ts
+++ b/apps/web/src/lib/mood-tags.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+export const MOOD_TAGS = ['😊', '😐', '😟', '😡', '🤩', '😴'] as const;
+export type MoodTag = (typeof MOOD_TAGS)[number];
+
+export const MOOD_TAGS_ENABLED_KEY = 'experimental.moodTags.enabled';
+export const MOOD_TAGS_SYNC_ENABLED_KEY = 'experimental.moodTags.syncEnabled';
+export const MOOD_TAGS_CHANGED_EVENT = 'finance:mood-tags-preferences-changed';
+
+export function isMoodTagsEnabled(): boolean {
+  return localStorage.getItem(MOOD_TAGS_ENABLED_KEY) === 'true';
+}
+
+export function isMoodTagSyncEnabled(): boolean {
+  return isMoodTagsEnabled() && localStorage.getItem(MOOD_TAGS_SYNC_ENABLED_KEY) === 'true';
+}
+
+export function setMoodTagPreference(key: string, enabled: boolean): void {
+  localStorage.setItem(key, String(enabled));
+  window.dispatchEvent(new Event(MOOD_TAGS_CHANGED_EVENT));
+}
+
+export function normalizeMoodTag(value: string | null | undefined): MoodTag | null {
+  return MOOD_TAGS.includes(value as MoodTag) ? (value as MoodTag) : null;
+}

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -5,6 +5,8 @@ import React, { useCallback, useState } from 'react';
 import { useAuth } from '../auth/auth-context';
 import { CurrencyDisplay } from '../components/common/CurrencyDisplay';
 import { DataExport } from '../components/DataExport';
+import { useDatabase } from '../db/DatabaseProvider';
+import { eraseAllMoodTags } from '../db/repositories/transactions';
 import { CrashReportingSettings, PrivacySettings } from '../components/gdpr';
 import { SettingInfoWidget } from '../components/settings';
 import { CurrencyRatesSettings } from '../components/settings/CurrencyRatesSettings';
@@ -20,6 +22,12 @@ import {
 import type { CurrencyDisplayMode, NegativeFormat } from '../lib/display-settings';
 import { useMoneyDisplay } from '../lib/display-settings';
 import { initMonitoring } from '../lib/monitoring';
+import {
+  MOOD_TAGS_CHANGED_EVENT,
+  MOOD_TAGS_ENABLED_KEY,
+  MOOD_TAGS_SYNC_ENABLED_KEY,
+  setMoodTagPreference,
+} from '../lib/mood-tags';
 
 const APP_VERSION = '0.1.0';
 const CURRENCY_STORAGE_KEY = 'finance-currency';
@@ -72,6 +80,14 @@ const CURRENCY_DISPLAY_OPTIONS: Array<{ value: CurrencyDisplayMode; label: strin
   { value: 'name', label: 'Name (US Dollar)' },
 ];
 
+function useSettingsDatabase() {
+  try {
+    return useDatabase();
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Settings page for managing local web-app preferences and account actions.
  */
@@ -91,6 +107,12 @@ export const SettingsPage: React.FC = () => {
   const [bnplStackingThreshold, setBnplStackingThreshold] = useState(() =>
     String(loadBnplStackingThresholdCents() / 100),
   );
+  const [moodTagsEnabled, setMoodTagsEnabled] = useState(
+    () => localStorage.getItem(MOOD_TAGS_ENABLED_KEY) === 'true',
+  );
+  const [moodTagsSyncEnabled, setMoodTagsSyncEnabled] = useState(
+    () => localStorage.getItem(MOOD_TAGS_SYNC_ENABLED_KEY) === 'true',
+  );
 
   const {
     isAuthenticated,
@@ -104,6 +126,7 @@ export const SettingsPage: React.FC = () => {
   } = useAuth();
   const { isOffline } = useOfflineStatus();
   const displaySettings = useMoneyDisplay();
+  const db = useSettingsDatabase();
   const [isPasskeyLoading, setIsPasskeyLoading] = useState(false);
   const [passkeyMessage, setPasskeyMessage] = useState<string | null>(null);
 
@@ -142,6 +165,32 @@ export const SettingsPage: React.FC = () => {
       initMonitoring();
     }
   }, []);
+
+  const handleMoodTagsEnabledChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    const enabled = event.target.checked;
+    setMoodTagPreference(MOOD_TAGS_ENABLED_KEY, enabled);
+    setMoodTagsEnabled(enabled);
+    if (!enabled) {
+      setMoodTagPreference(MOOD_TAGS_SYNC_ENABLED_KEY, false);
+      setMoodTagsSyncEnabled(false);
+    }
+  }, []);
+
+  const handleMoodTagsSyncChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    const enabled = event.target.checked;
+    setMoodTagPreference(MOOD_TAGS_SYNC_ENABLED_KEY, enabled);
+    setMoodTagsSyncEnabled(enabled);
+  }, []);
+
+  const handleEraseMoodData = useCallback(() => {
+    if (!window.confirm('Erase all mood data?')) return;
+    if (db) eraseAllMoodTags(db);
+    setMoodTagPreference(MOOD_TAGS_ENABLED_KEY, false);
+    setMoodTagPreference(MOOD_TAGS_SYNC_ENABLED_KEY, false);
+    setMoodTagsEnabled(false);
+    setMoodTagsSyncEnabled(false);
+    window.dispatchEvent(new Event(MOOD_TAGS_CHANGED_EVENT));
+  }, [db]);
 
   const handleMonitoringToggle = useCallback((enabled: boolean) => {
     localStorage.setItem(MONITORING_CONSENT_STORAGE_KEY, String(enabled));
@@ -318,6 +367,48 @@ export const SettingsPage: React.FC = () => {
               />
             </div>
           </SettingInfoWidget>
+        </div>
+      </section>
+      <section aria-label="Experimental" className="page-section">
+        <div className="settings-group">
+          <h3 className="settings-group__title">Experimental</h3>
+          <div className="settings-item settings-item--static">
+            <label className="settings-item__label" htmlFor="settings-mood-tags">
+              Allow mood tags on transactions
+            </label>
+            <input
+              type="checkbox"
+              id="settings-mood-tags"
+              checked={moodTagsEnabled}
+              onChange={handleMoodTagsEnabledChange}
+              aria-label="Allow mood tags on transactions"
+              className="settings-item__checkbox"
+            />
+          </div>
+          {moodTagsEnabled && (
+            <div className="settings-item settings-item--static">
+              <label className="settings-item__label" htmlFor="settings-mood-tags-sync">
+                Sync mood tags across my devices
+              </label>
+              <input
+                type="checkbox"
+                id="settings-mood-tags-sync"
+                checked={moodTagsSyncEnabled}
+                onChange={handleMoodTagsSyncChange}
+                aria-label="Sync mood tags across my devices"
+                className="settings-item__checkbox"
+              />
+            </div>
+          )}
+          <button
+            type="button"
+            className="settings-item settings-item--button"
+            onClick={handleEraseMoodData}
+            aria-label="Erase all mood data"
+          >
+            <span className="settings-item__label">Erase all mood data</span>
+            <span className="settings-item__value">⌫</span>
+          </button>
         </div>
       </section>
       <section aria-label="Display" className="page-section">

--- a/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/SettingsRepository.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/SettingsRepository.kt
@@ -33,6 +33,8 @@ data class AppSettings(
     // ── Data & Sync ──
     val defaultCurrency: String = "USD",
     val cloudSyncEnabled: Boolean = true,
+    val moodTagsEnabled: Boolean = false,
+    val moodTagsSyncEnabled: Boolean = false,
 )
 
 /**

--- a/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/TransactionRepository.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/TransactionRepository.kt
@@ -14,4 +14,5 @@ interface TransactionRepository {
     fun observeByDateRange(householdId: SyncId, start: LocalDate, end: LocalDate): Flow<List<Transaction>>
     suspend fun insert(entity: Transaction)
     suspend fun delete(id: SyncId)
+    suspend fun eraseAllMoodTags(): Int
 }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/impl/InMemoryTransactionRepository.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/impl/InMemoryTransactionRepository.kt
@@ -15,6 +15,12 @@ class InMemoryTransactionRepository : TransactionRepository {
     override fun observeByAccount(accountId: SyncId) = store.map { it.filter { t -> t.accountId == accountId && t.deletedAt == null } }
     override fun observeByDateRange(householdId: SyncId, start: LocalDate, end: LocalDate) = store.map { it.filter { t -> t.date >= start && t.date <= end && t.deletedAt == null } }
     override suspend fun insert(entity: Transaction) { store.update { it + entity } }
+    override suspend fun eraseAllMoodTags(): Int {
+        val taggedCount = store.value.count { it.moodTag != null }
+        store.update { current -> current.map { txn -> if (txn.moodTag != null) txn.copy(moodTag = null) else txn } }
+        return taggedCount
+    }
+
     override suspend fun delete(id: SyncId) { val now = Clock.System.now(); store.update { l -> l.map { if (it.id == id) it.copy(deletedAt = now) else it } } }
 }
 

--- a/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/impl/sqldelight/SqlDelightTransactionRepository.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/impl/sqldelight/SqlDelightTransactionRepository.kt
@@ -78,12 +78,20 @@ class SqlDelightTransactionRepository(
             is_recurring = if (entity.isRecurring) 1L else 0L,
             recurring_rule_id = entity.recurringRuleId?.value,
             tags = entity.tags.joinToString(","),
+            mood_tag = entity.moodTag,
             created_at = entity.createdAt.toString(),
             updated_at = entity.updatedAt.toString(),
             sync_version = entity.syncVersion,
             is_synced = if (entity.isSynced) 1L else 0L,
         )
         refreshCache()
+    }
+
+    override suspend fun eraseAllMoodTags(): Int = withContext(Dispatchers.IO) {
+        val taggedCount = queries.selectAll().executeAsList().count { it.mood_tag != null }
+        if (taggedCount > 0) queries.eraseAllMoodTags(Clock.System.now().toString())
+        refreshCache()
+        taggedCount
     }
 
     override suspend fun delete(id: SyncId) = withContext(Dispatchers.IO) {
@@ -125,6 +133,7 @@ internal fun com.finance.db.Transaction.toTransaction(): Transaction = Transacti
     isRecurring = is_recurring != 0L,
     recurringRuleId = recurring_rule_id?.let { SyncId(it) },
     tags = tags.split(",").filter { it.isNotBlank() },
+    moodTag = mood_tag,
     createdAt = Instant.parse(created_at),
     updatedAt = Instant.parse(updated_at),
     deletedAt = deleted_at?.let { Instant.parse(it) },

--- a/apps/windows/src/main/kotlin/com/finance/desktop/di/ViewModelModule.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/di/ViewModelModule.kt
@@ -24,7 +24,7 @@ val viewModelModule = module {
     single { BudgetsViewModel(get(), get()) }
     single { GoalsViewModel(get()) }
     single { SyncViewModel(get()) }
-    single { SettingsViewModel(get(), get()) }
+    single { SettingsViewModel(get(), get(), get()) }
     single { AuthViewModel(get(), get()) }
     single { LoginViewModel(get()) }
     single { GdprConsentViewModel(get(), get()) }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/SettingsScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/SettingsScreen.kt
@@ -35,6 +35,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Snackbar
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -179,6 +181,45 @@ fun SettingsScreen(modifier: Modifier = Modifier) {
                     checked = state.goalNotificationsEnabled,
                     onCheckedChange = viewModel::setGoalNotifications,
                 )
+            }
+
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.xxl))
+
+            // ── Experimental ────────────────────────────────────────────
+            SettingsSection("Experimental") {
+                var showEraseDialog by remember { mutableStateOf(false) }
+                ToggleSetting(
+                    icon = Icons.Filled.Info,
+                    label = "Allow mood tags on transactions",
+                    description = "Add an optional emoji to saved transactions",
+                    checked = state.moodTagsEnabled,
+                    onCheckedChange = viewModel::setMoodTagsEnabled,
+                )
+                if (state.moodTagsEnabled) {
+                    ToggleSetting(
+                        icon = Icons.Filled.Sync,
+                        label = "Sync mood tags across my devices",
+                        description = "Keep emoji tags local unless this is on",
+                        checked = state.moodTagsSyncEnabled,
+                        onCheckedChange = viewModel::setMoodTagsSyncEnabled,
+                    )
+                }
+                TextButton(onClick = { showEraseDialog = true }) {
+                    Text("Erase all mood data")
+                }
+                if (showEraseDialog) {
+                    AlertDialog(
+                        onDismissRequest = { showEraseDialog = false },
+                        title = { Text("Erase all mood data?") },
+                        text = { Text("This removes mood tags from your transactions on this device.") },
+                        confirmButton = {
+                            Button(onClick = { showEraseDialog = false; viewModel.eraseAllMoodData() }) {
+                                Text("Erase mood data")
+                            }
+                        },
+                        dismissButton = { TextButton(onClick = { showEraseDialog = false }) { Text("Cancel") } },
+                    )
+                }
             }
 
             Spacer(Modifier.height(FinanceDesktopTheme.spacing.xxl))

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/TransactionFormDialog.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/TransactionFormDialog.kt
@@ -73,6 +73,7 @@ data class TransactionFormState(
     val type: TransactionType = TransactionType.EXPENSE,
     val status: TransactionStatus = TransactionStatus.PENDING,
     val tags: List<String> = emptyList(),
+    val moodTag: String? = null,
     val note: String = "",
     val isBnplLiability: Boolean = tags.contains(BNPL_TAG),
     val bnplInstallmentCount: String = tags.firstOrNull { it.startsWith(BNPL_INSTALLMENTS_PREFIX) }
@@ -100,6 +101,7 @@ fun TransactionFormDialog(
     initialState: TransactionFormState = TransactionFormState(),
     isEdit: Boolean = false,
     onDismiss: () -> Unit,
+    moodTagsEnabled: Boolean = false,
     onSave: (TransactionFormState) -> Unit,
 ) {
     var formState by remember { mutableStateOf(initialState) }
@@ -203,6 +205,16 @@ fun TransactionFormDialog(
                 )
 
                 Spacer(Modifier.height(FinanceDesktopTheme.spacing.md))
+
+                if (moodTagsEnabled) {
+                    MoodTagPicker(
+                        selectedMoodTag = formState.moodTag,
+                        onMoodTagSelected = { tag ->
+                            formState = formState.copy(moodTag = if (formState.moodTag == tag) null else tag)
+                        },
+                    )
+                    Spacer(Modifier.height(FinanceDesktopTheme.spacing.md))
+                }
 
                 // ── Note field ──
                 OutlinedTextField(
@@ -313,6 +325,30 @@ private fun TransactionTypeToggle(
                     if (selectedType == TransactionType.TRANSFER) ", selected" else ""
             },
         )
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun MoodTagPicker(selectedMoodTag: String?, onMoodTagSelected: (String?) -> Unit) {
+    val tags = listOf("😊", "😐", "😟", "😡", "🤩", "😴")
+    FlowRow(horizontalArrangement = Arrangement.spacedBy(FinanceDesktopTheme.spacing.xs)) {
+        tags.forEach { tag ->
+            FilterChip(
+                selected = selectedMoodTag == tag,
+                onClick = { onMoodTagSelected(tag) },
+                label = { Text(tag) },
+                modifier = Modifier.semantics { contentDescription = "Mood tag $tag" },
+            )
+        }
+        if (selectedMoodTag != null) {
+            FilterChip(
+                selected = false,
+                onClick = { onMoodTagSelected(null) },
+                label = { Text("Remove") },
+                modifier = Modifier.semantics { contentDescription = "Remove mood tag" },
+            )
+        }
     }
 }
 

--- a/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/SettingsViewModel.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/SettingsViewModel.kt
@@ -4,6 +4,7 @@ package com.finance.desktop.viewmodel
 
 import com.finance.desktop.data.repository.AppSettings
 import com.finance.desktop.data.repository.SettingsRepository
+import com.finance.desktop.data.repository.TransactionRepository
 import com.finance.desktop.security.WindowsHelloManager
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -38,6 +39,8 @@ data class SettingsUiState(
     // ── Data & Sync ──
     val defaultCurrency: String = "USD",
     val cloudSyncEnabled: Boolean = true,
+    val moodTagsEnabled: Boolean = false,
+    val moodTagsSyncEnabled: Boolean = false,
 
     // ── Transient UI state ──
     val requiresAuth: Boolean = false,
@@ -63,6 +66,7 @@ data class SettingsUiState(
 class SettingsViewModel(
     private val settingsRepository: SettingsRepository,
     private val windowsHelloManager: WindowsHelloManager,
+    private val transactionRepository: TransactionRepository,
 ) : DesktopViewModel() {
 
     companion object {
@@ -128,6 +132,29 @@ class SettingsViewModel(
 
     fun setCloudSyncEnabled(enabled: Boolean) =
         updateAndSave { it.copy(cloudSyncEnabled = enabled) }
+
+    fun setMoodTagsEnabled(enabled: Boolean) = updateAndSave {
+        it.copy(
+            moodTagsEnabled = enabled,
+            moodTagsSyncEnabled = if (enabled) it.moodTagsSyncEnabled else false,
+        )
+    }
+
+    fun setMoodTagsSyncEnabled(enabled: Boolean) =
+        updateAndSave { it.copy(moodTagsSyncEnabled = enabled) }
+
+    fun eraseAllMoodData() {
+        viewModelScope.launch {
+            @Suppress("TooGenericExceptionCaught")
+            try {
+                transactionRepository.eraseAllMoodTags()
+                updateAndSave { it.copy(moodTagsEnabled = false, moodTagsSyncEnabled = false) }
+            } catch (e: Exception) {
+                logger.log(Level.SEVERE, "Failed to erase mood data", e)
+                _uiState.value = _uiState.value.copy(errorMessage = "Failed to erase mood data: ${e.message}")
+            }
+        }
+    }
 
     // ── Reset ───────────────────────────────────────────────────────────────
 
@@ -241,6 +268,8 @@ private fun AppSettings.toUiState(): SettingsUiState = SettingsUiState(
     goalNotificationsEnabled = goalNotificationsEnabled,
     defaultCurrency = defaultCurrency,
     cloudSyncEnabled = cloudSyncEnabled,
+    moodTagsEnabled = moodTagsEnabled,
+    moodTagsSyncEnabled = moodTagsSyncEnabled,
 )
 
 private fun SettingsUiState.toAppSettings(): AppSettings = AppSettings(
@@ -254,4 +283,6 @@ private fun SettingsUiState.toAppSettings(): AppSettings = AppSettings(
     goalNotificationsEnabled = goalNotificationsEnabled,
     defaultCurrency = defaultCurrency,
     cloudSyncEnabled = cloudSyncEnabled,
+    moodTagsEnabled = moodTagsEnabled,
+    moodTagsSyncEnabled = moodTagsSyncEnabled,
 )

--- a/packages/core/src/commonMain/kotlin/com/finance/core/export/CsvExportSerializer.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/export/CsvExportSerializer.kt
@@ -35,6 +35,8 @@ class CsvExportSerializer : ExportSerializer {
 
     override val format: ExportFormat = ExportFormat.CSV
 
+    private var includeMoodTagsForCurrentExport: Boolean = false
+
     override fun serialize(data: ExportData, metadata: ExportMetadata): String {
         val sb = StringBuilder()
 
@@ -43,7 +45,9 @@ class CsvExportSerializer : ExportSerializer {
 
         // ── Entity sections ──────────────────────────────────────────
         appendAccountsSection(sb, data.accounts)
+        includeMoodTagsForCurrentExport = data.includeMoodTags
         appendTransactionsSection(sb, data.transactions)
+        includeMoodTagsForCurrentExport = false
         appendCategoriesSection(sb, data.categories)
         appendBudgetsSection(sb, data.budgets)
         appendGoalsSection(sb, data.goals)
@@ -101,40 +105,50 @@ class CsvExportSerializer : ExportSerializer {
     }
 
     private fun appendTransactionsSection(sb: StringBuilder, transactions: List<Transaction>) {
+        val includeMoodTags = transactions.any { it.moodTag != null } && includeMoodTagsForCurrentExport
+
         sb.appendLine("# TRANSACTIONS")
-        val headers = listOf(
-            "id", "household_id", "owner_id", "account_id", "category_id",
-            "type", "status", "amount", "currency",
-            "payee", "note", "date",
-            "transfer_account_id", "transfer_transaction_id",
-            "is_recurring", "recurring_rule_id", "tags",
-            "created_at", "updated_at", "deleted_at",
-        )
+        val headers = buildList {
+            addAll(
+                listOf(
+                    "id", "household_id", "owner_id", "account_id", "category_id",
+                    "type", "status", "amount", "currency",
+                    "payee", "note", "date",
+                    "transfer_account_id", "transfer_transaction_id",
+                    "is_recurring", "recurring_rule_id", "tags",
+                ),
+            )
+            if (includeMoodTags) add("mood_tag")
+            addAll(listOf("created_at", "updated_at", "deleted_at"))
+        }
         @Suppress("SpreadOperator")
         sb.appendRow(*headers.toTypedArray())
         for (txn in transactions) {
-            sb.appendRow(
-                txn.id.value,
-                txn.householdId.value,
-                txn.ownerId.value,
-                txn.accountId.value,
-                txn.categoryId?.value ?: "",
-                txn.type.name,
-                txn.status.name,
-                formatCentsDisplay(txn.amount, txn.currency),
-                txn.currency.code,
-                txn.payee ?: "",
-                txn.note ?: "",
-                txn.date.toString(),
-                txn.transferAccountId?.value ?: "",
-                txn.transferTransactionId?.value ?: "",
-                txn.isRecurring.toString(),
-                txn.recurringRuleId?.value ?: "",
-                txn.tags.joinToString(";"),
-                txn.createdAt.toString(),
-                txn.updatedAt.toString(),
-                txn.deletedAt?.toString() ?: "",
-            )
+            val row = buildList {
+                add(txn.id.value)
+                add(txn.householdId.value)
+                add(txn.ownerId.value)
+                add(txn.accountId.value)
+                add(txn.categoryId?.value ?: "")
+                add(txn.type.name)
+                add(txn.status.name)
+                add(formatCentsDisplay(txn.amount, txn.currency))
+                add(txn.currency.code)
+                add(txn.payee ?: "")
+                add(txn.note ?: "")
+                add(txn.date.toString())
+                add(txn.transferAccountId?.value ?: "")
+                add(txn.transferTransactionId?.value ?: "")
+                add(txn.isRecurring.toString())
+                add(txn.recurringRuleId?.value ?: "")
+                add(txn.tags.joinToString(";"))
+                if (includeMoodTags) add(txn.moodTag ?: "")
+                add(txn.createdAt.toString())
+                add(txn.updatedAt.toString())
+                add(txn.deletedAt?.toString() ?: "")
+            }
+            @Suppress("SpreadOperator")
+            sb.appendRow(*row.toTypedArray())
         }
         sb.appendCrlf()
     }

--- a/packages/core/src/commonMain/kotlin/com/finance/core/export/ExportData.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/export/ExportData.kt
@@ -37,6 +37,8 @@ data class ExportData(
     val budgets: List<Budget>,
     /** Active (non-deleted) goals to include in the export. */
     val goals: List<Goal>,
+    /** Include optional mood tags in transaction export output. Defaults to private. */
+    val includeMoodTags: Boolean = false,
 ) {
     /** `true` when every entity list is empty — nothing to export. */
     val isEmpty: Boolean

--- a/packages/core/src/commonMain/kotlin/com/finance/core/export/JsonExportSerializer.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/export/JsonExportSerializer.kt
@@ -8,6 +8,8 @@ import com.finance.models.types.Currency
 import com.finance.models.types.SyncId
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
@@ -45,6 +47,7 @@ import kotlinx.serialization.json.Json
  * @see ExportSerializer
  * @see DataExportService
  */
+@OptIn(ExperimentalSerializationApi::class)
 class JsonExportSerializer : ExportSerializer {
 
     override val format: ExportFormat = ExportFormat.JSON
@@ -137,7 +140,7 @@ class JsonExportSerializer : ExportSerializer {
         companion object {
             fun from(data: ExportData): ExportDataDto = ExportDataDto(
                 accounts = data.accounts.map { AccountDto.from(it) },
-                transactions = data.transactions.map { TransactionDto.from(it) },
+                transactions = data.transactions.map { TransactionDto.from(it, data.includeMoodTags) },
                 categories = data.categories.map { CategoryDto.from(it) },
                 budgets = data.budgets.map { BudgetDto.from(it) },
                 goals = data.goals.map { GoalDto.from(it) },
@@ -224,12 +227,14 @@ class JsonExportSerializer : ExportSerializer {
         @SerialName("is_recurring") val isRecurring: Boolean,
         @SerialName("recurring_rule_id") val recurringRuleId: String?,
         val tags: List<String>,
+        @EncodeDefault(EncodeDefault.Mode.NEVER)
+        @SerialName("mood_tag") val moodTag: String? = null,
         @SerialName("created_at") val createdAt: String,
         @SerialName("updated_at") val updatedAt: String,
         @SerialName("deleted_at") val deletedAt: String?,
     ) {
         companion object {
-            fun from(transaction: Transaction): TransactionDto = TransactionDto(
+            fun from(transaction: Transaction, includeMoodTag: Boolean): TransactionDto = TransactionDto(
                 id = transaction.id.value,
                 householdId = transaction.householdId.value,
                 ownerId = transaction.ownerId.value,
@@ -246,6 +251,7 @@ class JsonExportSerializer : ExportSerializer {
                 isRecurring = transaction.isRecurring,
                 recurringRuleId = transaction.recurringRuleId?.value,
                 tags = transaction.tags,
+                moodTag = transaction.moodTag.takeIf { includeMoodTag },
                 createdAt = transaction.createdAt.toString(),
                 updatedAt = transaction.updatedAt.toString(),
                 deletedAt = transaction.deletedAt?.toString(),

--- a/packages/core/src/commonMain/kotlin/com/finance/core/mood/MoodTagPrivacyFilters.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/mood/MoodTagPrivacyFilters.kt
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.mood
+
+/** Privacy filters that keep mood tags out of shared visibility surfaces. */
+object MoodTagPrivacyFilters {
+    /** Removes mood_tag unless the user explicitly opts into device sync. */
+    fun filterForSync(rowData: Map<String, String?>, syncEnabled: Boolean): Map<String, String?> =
+        if (syncEnabled) rowData else rowData - MoodTags.COLUMN_NAME
+
+    /** Mood tags are never included in household-sharing payloads. */
+    fun filterForHouseholdSharing(rowData: Map<String, String?>): Map<String, String?> =
+        rowData - MoodTags.COLUMN_NAME
+
+    /** Mood tags are never included in accountability-partner payloads. */
+    fun filterForAccountabilityPartner(rowData: Map<String, String?>): Map<String, String?> =
+        rowData - MoodTags.COLUMN_NAME
+
+    /** Mood tags are never included in caregiver payloads. */
+    fun filterForCaregiver(rowData: Map<String, String?>): Map<String, String?> =
+        rowData - MoodTags.COLUMN_NAME
+}
+
+/** Store abstraction for erasing all persisted mood tags. */
+fun interface MoodTagStore {
+    suspend fun eraseAllMoodTags(): Int
+}
+
+/** Coordinates local erasure and resetting mood preferences. */
+class MoodTagEraseService(
+    private val store: MoodTagStore,
+    private val savePreferences: suspend (MoodTagPreferences) -> Unit,
+) {
+    suspend fun eraseAll(): Int {
+        val rows = store.eraseAllMoodTags()
+        savePreferences(MoodTagPreferences())
+        return rows
+    }
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/mood/MoodTags.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/mood/MoodTags.kt
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.mood
+
+/** Shared alpha-tier mood tag constants and preference keys. */
+object MoodTags {
+    const val ENABLED_PREF_KEY = "experimental.moodTags.enabled"
+    const val SYNC_ENABLED_PREF_KEY = "experimental.moodTags.syncEnabled"
+    const val COLUMN_NAME = "mood_tag"
+
+    val allowed: Set<String> = setOf("😊", "😐", "😟", "😡", "🤩", "😴")
+
+    /** Returns true when [tag] is null or one of the six allowed emoji tags. */
+    fun isAllowed(tag: String?): Boolean = tag == null || tag in allowed
+
+    /** Returns [tag] when allowed, otherwise null. */
+    fun normalize(tag: String?): String? = tag?.takeIf { it in allowed }
+}
+
+/** Persisted mood tagging preferences. Both toggles are off by default. */
+data class MoodTagPreferences(
+    val enabled: Boolean = false,
+    val syncEnabled: Boolean = false,
+) {
+    val effectiveSyncEnabled: Boolean get() = enabled && syncEnabled
+}
+
+/** Neutral user-facing strings used by mood tag surfaces. */
+object MoodTagCopy {
+    const val SETTINGS_SECTION = "Experimental"
+    const val ALLOW_LABEL = "Allow mood tags on transactions"
+    const val ALLOW_DESCRIPTION = "Add an optional emoji to saved transactions."
+    const val SYNC_LABEL = "Sync mood tags across my devices"
+    const val SYNC_DESCRIPTION = "Keep emoji tags local unless you turn this on."
+    const val ERASE_LABEL = "Erase all mood data"
+    const val ERASE_CONFIRM_TITLE = "Erase all mood data?"
+    const val ERASE_CONFIRM_MESSAGE = "This removes mood tags from your transactions on this device."
+    const val ERASE_CONFIRM_ACTION = "Erase mood data"
+    const val PICKER_LABEL = "Mood tag"
+    const val PICKER_HINT = "Optional mood or energy emoji"
+    const val CLEAR_LABEL = "Remove mood tag"
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/export/CsvExportSerializerTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/export/CsvExportSerializerTest.kt
@@ -189,6 +189,29 @@ class CsvExportSerializerTest {
     }
 
     @Test
+    fun serialize_excludesMoodTagByDefault() {
+        TestFixtures.reset()
+        val data = sampleData().copy(
+            transactions = listOf(TestFixtures.createExpense().copy(moodTag = "😊")),
+        )
+        val content = serializer.serialize(data, sampleMetadata())
+        assertFalse(content.lines().first { it.contains("recurring_rule_id") }.contains("mood_tag"))
+        assertFalse(content.contains("😊"))
+    }
+
+    @Test
+    fun serialize_includesMoodTagWhenExportOptsIn() {
+        TestFixtures.reset()
+        val data = sampleData().copy(
+            transactions = listOf(TestFixtures.createExpense().copy(moodTag = "😊")),
+            includeMoodTags = true,
+        )
+        val content = serializer.serialize(data, sampleMetadata())
+        assertTrue(content.lines().first { it.contains("recurring_rule_id") }.contains("mood_tag"))
+        assertTrue(content.contains("😊"))
+    }
+
+    @Test
     fun serialize_jpyCurrency_noDecimalPlaces() {
         TestFixtures.reset()
         val data = ExportData(

--- a/packages/core/src/commonTest/kotlin/com/finance/core/export/JsonExportSerializerTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/export/JsonExportSerializerTest.kt
@@ -196,6 +196,27 @@ class JsonExportSerializerTest {
     }
 
     @Test
+    fun serialize_excludesMoodTagByDefault() {
+        val data = sampleData().copy(
+            transactions = listOf(TestFixtures.createExpense().copy(moodTag = "😊")),
+        )
+        val root = serializeAndParse(data = data)
+        val txn = root["data"]!!.jsonObject["transactions"]!!.jsonArray[0].jsonObject
+        assertFalse("mood_tag" in txn)
+    }
+
+    @Test
+    fun serialize_includesMoodTagWhenExportOptsIn() {
+        val data = sampleData().copy(
+            transactions = listOf(TestFixtures.createExpense().copy(moodTag = "😊")),
+            includeMoodTags = true,
+        )
+        val root = serializeAndParse(data = data)
+        val txn = root["data"]!!.jsonObject["transactions"]!!.jsonArray[0].jsonObject
+        assertEquals("😊", txn["mood_tag"]?.jsonPrimitive?.content)
+    }
+
+    @Test
     fun serialize_categoriesHaveCorrectFields() {
         val root = serializeAndParse()
         val category = root["data"]!!.jsonObject["categories"]!!.jsonArray[0].jsonObject

--- a/packages/core/src/commonTest/kotlin/com/finance/core/mood/MoodTagEraseBenchmarkTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/mood/MoodTagEraseBenchmarkTest.kt
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.mood
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.measureTime
+
+class MoodTagEraseBenchmarkTest {
+    @Test fun eraseAllMoodData_10kRowsCompletesUnderOneSecond() = runTest {
+        val rows = MutableList(10_000) { "😊" as String? }
+        val service = MoodTagEraseService(
+            store = MoodTagStore {
+                var changed = 0
+                for (index in rows.indices) {
+                    if (rows[index] != null) {
+                        rows[index] = null
+                        changed++
+                    }
+                }
+                changed
+            },
+            savePreferences = { assertEquals(MoodTagPreferences(), it) },
+        )
+
+        val elapsed = measureTime {
+            assertEquals(10_000, service.eraseAll())
+        }
+
+        assertTrue(rows.all { it == null })
+        assertTrue(elapsed.inWholeMilliseconds < 1_000, "Erase took ${elapsed.inWholeMilliseconds}ms")
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/mood/MoodTagPrivacyFiltersTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/mood/MoodTagPrivacyFiltersTest.kt
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.mood
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class MoodTagPrivacyFiltersTest {
+    private val row = mapOf("id" to "txn-1", "mood_tag" to "😊", "amount" to "1200")
+
+    @Test fun syncFilter_removesMoodTagWhenSyncOff() {
+        val filtered = MoodTagPrivacyFilters.filterForSync(row, syncEnabled = false)
+        assertFalse("mood_tag" in filtered)
+    }
+
+    @Test fun syncFilter_keepsMoodTagWhenSyncOn() {
+        val filtered = MoodTagPrivacyFilters.filterForSync(row, syncEnabled = true)
+        assertEquals("😊", filtered["mood_tag"])
+    }
+
+    @Test fun householdAndVisibilityFiltersAlwaysRemoveMoodTag() {
+        assertFalse("mood_tag" in MoodTagPrivacyFilters.filterForHouseholdSharing(row))
+        assertFalse("mood_tag" in MoodTagPrivacyFilters.filterForAccountabilityPartner(row))
+        assertFalse("mood_tag" in MoodTagPrivacyFilters.filterForCaregiver(row))
+    }
+
+    @Test fun preferencesDefaultOff() {
+        val prefs = MoodTagPreferences()
+        assertFalse(prefs.enabled)
+        assertFalse(prefs.syncEnabled)
+        assertFalse(prefs.effectiveSyncEnabled)
+    }
+
+    @Test fun allowedTagsAreSixEmoji() {
+        assertEquals(6, MoodTags.allowed.size)
+        assertTrue(MoodTags.isAllowed("😴"))
+        assertFalse(MoodTags.isAllowed("x"))
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/mood/MoodTagStringLintTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/mood/MoodTagStringLintTest.kt
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.mood
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+
+class MoodTagStringLintTest {
+    @Test fun moodTagCopyHasNoClinicalWords() {
+        val forbidden = listOf("depression", "anxiety", "stress", "mental health", "disorder", "diagnosis", "therapy", "treatment")
+        val copy = listOf(
+            MoodTagCopy.SETTINGS_SECTION,
+            MoodTagCopy.ALLOW_LABEL,
+            MoodTagCopy.ALLOW_DESCRIPTION,
+            MoodTagCopy.SYNC_LABEL,
+            MoodTagCopy.SYNC_DESCRIPTION,
+            MoodTagCopy.ERASE_LABEL,
+            MoodTagCopy.ERASE_CONFIRM_TITLE,
+            MoodTagCopy.ERASE_CONFIRM_MESSAGE,
+            MoodTagCopy.ERASE_CONFIRM_ACTION,
+            MoodTagCopy.PICKER_LABEL,
+            MoodTagCopy.PICKER_HINT,
+            MoodTagCopy.CLEAR_LABEL,
+        ).joinToString(" ").lowercase()
+
+        forbidden.forEach { word ->
+            assertFalse(copy.contains(word), "Forbidden word in mood tag copy: $word")
+        }
+    }
+}

--- a/packages/models/src/commonMain/kotlin/com/finance/db/migration/migrations/MigrationInitializer.kt
+++ b/packages/models/src/commonMain/kotlin/com/finance/db/migration/migrations/MigrationInitializer.kt
@@ -12,5 +12,6 @@ object MigrationInitializer {
         registerV002()
         registerV003()
         registerV005()
+        registerV006()
     }
 }

--- a/packages/models/src/commonMain/kotlin/com/finance/db/migration/migrations/V001_InitialSchema.kt
+++ b/packages/models/src/commonMain/kotlin/com/finance/db/migration/migrations/V001_InitialSchema.kt
@@ -122,6 +122,7 @@ val V001_InitialSchema = Migration(
             is_recurring INTEGER NOT NULL DEFAULT 0,
             recurring_rule_id TEXT,
             tags TEXT NOT NULL DEFAULT '[]',
+            mood_tag TEXT,
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL,
             deleted_at TEXT,

--- a/packages/models/src/commonMain/kotlin/com/finance/db/migration/migrations/V006_MoodTagMigration.kt
+++ b/packages/models/src/commonMain/kotlin/com/finance/db/migration/migrations/V006_MoodTagMigration.kt
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.db.migration.migrations
+
+import com.finance.db.migration.Migration
+import com.finance.db.migration.MigrationRegistry
+
+val V006_MoodTagMigration = Migration(
+    version = 6,
+    description = "Add optional mood tag column to transactions",
+    up = listOf(
+        """ALTER TABLE "transaction" ADD COLUMN mood_tag TEXT""",
+    ),
+    down = listOf(
+        """ALTER TABLE "transaction" DROP COLUMN mood_tag""",
+    ),
+)
+
+internal fun registerV006() {
+    MigrationRegistry.register(V006_MoodTagMigration)
+}

--- a/packages/models/src/commonMain/kotlin/com/finance/db/repository/impl/EntityMappers.kt
+++ b/packages/models/src/commonMain/kotlin/com/finance/db/repository/impl/EntityMappers.kt
@@ -41,7 +41,7 @@ object EntityMappers {
         transferAccountId: String?, transferTransactionId: String?,
         isRecurring: Long, recurringRuleId: String?, tags: String,
         createdAt: String, updatedAt: String, deletedAt: String?,
-        syncVersion: Long, isSynced: Long,
+        syncVersion: Long, isSynced: Long, moodTag: String? = null,
     ): Transaction = Transaction(
         id = SyncId(id), householdId = SyncId(householdId), ownerId = SyncId(ownerId),
         accountId = SyncId(accountId), categoryId = categoryId?.let { SyncId(it) },
@@ -51,7 +51,8 @@ object EntityMappers {
         transferAccountId = transferAccountId?.let { SyncId(it) },
         transferTransactionId = transferTransactionId?.let { SyncId(it) },
         isRecurring = isRecurring != 0L, recurringRuleId = recurringRuleId?.let { SyncId(it) },
-        tags = parseTags(tags), createdAt = Instant.parse(createdAt),
+        tags = parseTags(tags), moodTag = moodTag,
+        createdAt = Instant.parse(createdAt),
         updatedAt = Instant.parse(updatedAt), deletedAt = deletedAt?.let { Instant.parse(it) },
         syncVersion = syncVersion, isSynced = isSynced != 0L,
     )

--- a/packages/models/src/commonMain/kotlin/com/finance/db/repository/impl/SqlDelightTransactionRepository.kt
+++ b/packages/models/src/commonMain/kotlin/com/finance/db/repository/impl/SqlDelightTransactionRepository.kt
@@ -72,7 +72,7 @@ class SqlDelightTransactionRepository(
             entity.payee, entity.note, entity.date.toString(),
             entity.transferAccountId?.value, entity.transferTransactionId?.value,
             if (entity.isRecurring) 1L else 0L, entity.recurringRuleId?.value,
-            EntityMappers.serializeTags(entity.tags),
+            EntityMappers.serializeTags(entity.tags), entity.moodTag,
             entity.createdAt.toString(), entity.updatedAt.toString(),
             entity.syncVersion, 0L,
         )
@@ -86,7 +86,7 @@ class SqlDelightTransactionRepository(
             entity.payee, entity.note, entity.date.toString(),
             entity.transferAccountId?.value, entity.transferTransactionId?.value,
             if (entity.isRecurring) 1L else 0L, entity.recurringRuleId?.value,
-            EntityMappers.serializeTags(entity.tags),
+            EntityMappers.serializeTags(entity.tags), entity.moodTag,
             now, entity.syncVersion + 1, 0L, entity.id.value,
         )
     }
@@ -110,13 +110,13 @@ class SqlDelightTransactionRepository(
         categoryId: String?, type: String, status: String, amount: Long,
         currency: String, payee: String?, note: String?, date: String,
         transferAccountId: String?, transferTransactionId: String?,
-        isRecurring: Long, recurringRuleId: String?, tags: String,
+        isRecurring: Long, recurringRuleId: String?, tags: String, moodTag: String?,
         createdAt: String, updatedAt: String, deletedAt: String?,
         syncVersion: Long, isSynced: Long,
     ): Transaction = EntityMappers.mapTransaction(
         id, householdId, ownerId, accountId, categoryId, type, status,
         amount, currency, payee, note, date, transferAccountId,
         transferTransactionId, isRecurring, recurringRuleId, tags,
-        createdAt, updatedAt, deletedAt, syncVersion, isSynced,
+        createdAt, updatedAt, deletedAt, syncVersion, isSynced, moodTag,
     )
 }

--- a/packages/models/src/commonMain/kotlin/com/finance/models/Transaction.kt
+++ b/packages/models/src/commonMain/kotlin/com/finance/models/Transaction.kt
@@ -39,9 +39,13 @@ data class Transaction(
     val deletedAt: Instant? = null,
     val syncVersion: Long = 0,
     val isSynced: Boolean = false,
+    val moodTag: String? = null,
 ) {
     init {
         require(amount.amount != 0L) { "Transaction amount cannot be zero" }
+        require(moodTag == null || moodTag in setOf("😊", "😐", "😟", "😡", "🤩", "😴")) {
+            "Mood tag must be one of the supported emoji tags"
+        }
         if (type == TransactionType.TRANSFER) {
             require(transferAccountId != null) { "Transfer must have a destination account" }
         }

--- a/packages/models/src/commonMain/sqldelight/com/finance/db/Transaction.sq
+++ b/packages/models/src/commonMain/sqldelight/com/finance/db/Transaction.sq
@@ -19,6 +19,7 @@ CREATE TABLE IF NOT EXISTS "transaction" (
     is_recurring INTEGER NOT NULL DEFAULT 0,
     recurring_rule_id TEXT,
     tags TEXT NOT NULL DEFAULT '[]',
+    mood_tag TEXT,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL,
     deleted_at TEXT,
@@ -88,8 +89,8 @@ WHERE household_id = ? AND date >= ? AND date <= ? AND deleted_at IS NULL
 GROUP BY account_id;
 
 insert:
-INSERT INTO "transaction" (id, household_id, owner_id, account_id, category_id, type, status, amount, currency, payee, note, date, transfer_account_id, transfer_transaction_id, is_recurring, recurring_rule_id, tags, created_at, updated_at, sync_version, is_synced)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+INSERT INTO "transaction" (id, household_id, owner_id, account_id, category_id, type, status, amount, currency, payee, note, date, transfer_account_id, transfer_transaction_id, is_recurring, recurring_rule_id, tags, mood_tag, created_at, updated_at, sync_version, is_synced)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 update:
 UPDATE "transaction" SET
@@ -107,6 +108,7 @@ UPDATE "transaction" SET
     is_recurring = ?,
     recurring_rule_id = ?,
     tags = ?,
+    mood_tag = ?,
     updated_at = ?,
     sync_version = ?,
     is_synced = ?
@@ -126,3 +128,6 @@ SELECT * FROM "transaction" WHERE household_id = ? AND is_synced = 0;
 
 markSyncedById:
 UPDATE "transaction" SET is_synced = 1 WHERE id = ?;
+
+eraseAllMoodTags:
+UPDATE "transaction" SET mood_tag = NULL, updated_at = ?, sync_version = sync_version + 1, is_synced = 0 WHERE mood_tag IS NOT NULL;

--- a/packages/models/src/commonMain/sqldelight/migrations/5.sqm
+++ b/packages/models/src/commonMain/sqldelight/migrations/5.sqm
@@ -1,0 +1,3 @@
+-- Migration v5 → v6: Add optional mood tag to transactions
+
+ALTER TABLE "transaction" ADD COLUMN mood_tag TEXT;

--- a/packages/models/src/commonTest/kotlin/com/finance/db/repository/MigrationSystemTest.kt
+++ b/packages/models/src/commonTest/kotlin/com/finance/db/repository/MigrationSystemTest.kt
@@ -6,6 +6,7 @@ import com.finance.db.migration.migrations.V001_InitialSchema
 import com.finance.db.migration.migrations.V002_OwnerIdMigration
 import com.finance.db.migration.migrations.V003_PerformanceIndexes
 import com.finance.db.migration.migrations.V005_Liabilities
+import com.finance.db.migration.migrations.V006_MoodTagMigration
 import com.finance.db.migration.migrations.MigrationInitializer
 import com.finance.db.migration.MigrationRegistry
 import kotlin.test.Test
@@ -54,10 +55,19 @@ class MigrationSystemTest {
         assertTrue(sql.contains("idx_liability_installment_due_date"))
     }
 
+    @Test fun v006_hasCorrectVersion() = assertEquals(6, V006_MoodTagMigration.version)
+
+    @Test fun v006_addsMoodTagColumn() {
+        val sql = V006_MoodTagMigration.up.joinToString("\n")
+        assertTrue(sql.contains("mood_tag"))
+        assertTrue(sql.contains("ALTER TABLE ") && sql.contains("mood_tag TEXT"))
+    }
+
     @Test fun migrationsAreInOrder() {
         assertTrue(V001_InitialSchema.version < V002_OwnerIdMigration.version)
         assertTrue(V002_OwnerIdMigration.version < V003_PerformanceIndexes.version)
         assertTrue(V003_PerformanceIndexes.version < V005_Liabilities.version)
+        assertTrue(V005_Liabilities.version < V006_MoodTagMigration.version)
     }
 
     @Test fun migrationInitializer_canBeCalledTwice() {
@@ -72,7 +82,7 @@ class MigrationSystemTest {
 
     @Test fun migrationRegistry_latestVersion() {
         MigrationInitializer.initialize()
-        assertTrue(MigrationRegistry.latestVersion() >= 5)
+        assertTrue(MigrationRegistry.latestVersion() >= 6)
     }
 
     @Test fun migrationRegistry_getByVersion() {

--- a/packages/models/src/commonTest/kotlin/com/finance/models/TransactionTest.kt
+++ b/packages/models/src/commonTest/kotlin/com/finance/models/TransactionTest.kt
@@ -183,6 +183,18 @@ class TransactionTest {
     }
 
     @Test
+    fun defaultMoodTagIsNull() {
+        val txn = expense()
+        assertNull(txn.moodTag)
+    }
+
+    @Test
+    fun moodTagCanBeSet() {
+        val txn = expense().copy(moodTag = "😊")
+        assertEquals("😊", txn.moodTag)
+    }
+
+    @Test
     fun defaultIsRecurringIsFalse() {
         val txn = expense()
         assertFalse(txn.isRecurring)

--- a/packages/sync/src/commonMain/kotlin/com/finance/sync/repository/RepositorySyncBridge.kt
+++ b/packages/sync/src/commonMain/kotlin/com/finance/sync/repository/RepositorySyncBridge.kt
@@ -2,6 +2,7 @@
 
 package com.finance.sync.repository
 
+import com.finance.core.mood.MoodTagPrivacyFilters
 import com.finance.sync.ChangeOperation
 import com.finance.sync.MutationOperation
 import com.finance.sync.SyncChange
@@ -24,6 +25,7 @@ class RepositorySyncBridge(
     private val repositories: Map<String, SyncableRepository<*>>,
     private val mutationQueue: MutationQueue,
     private val clock: Clock = Clock.System,
+    private val moodTagSyncEnabled: () -> Boolean = { false },
 ) {
 
     @Suppress("UNCHECKED_CAST")
@@ -32,7 +34,7 @@ class RepositorySyncBridge(
         for ((tableName, repo) in repositories) {
             val unsynced = (repo as SyncableRepository<Any>).getUnsynced()
             for (entity in unsynced) {
-                val rowData = repo.toRowData(entity)
+                val rowData = filterOutboundRow(tableName, repo.toRowData(entity))
                 val id = rowData["id"] ?: continue
                 val mutation = SyncMutation(
                     id = "${tableName}_${id}_${clock.now().toEpochMilliseconds()}",
@@ -49,6 +51,13 @@ class RepositorySyncBridge(
         }
         return count
     }
+
+    private fun filterOutboundRow(tableName: String, rowData: Map<String, String?>): Map<String, String?> =
+        if (tableName == "transactions" || tableName == "transaction") {
+            MoodTagPrivacyFilters.filterForSync(rowData, moodTagSyncEnabled())
+        } else {
+            rowData
+        }
 
     suspend fun applyIncomingChanges(changes: List<SyncChange>): Int {
         var applied = 0

--- a/packages/sync/src/commonTest/kotlin/com/finance/sync/repository/RepositorySyncBridgeTest.kt
+++ b/packages/sync/src/commonTest/kotlin/com/finance/sync/repository/RepositorySyncBridgeTest.kt
@@ -13,12 +13,13 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class RepositorySyncBridgeTest {
 
     data class TestEntity(val id: String, val name: String, val householdId: String = "hh-001",
-        val isSynced: Boolean = false, val syncVersion: Long = 0)
+        val isSynced: Boolean = false, val syncVersion: Long = 0, val moodTag: String? = null)
 
     class FakeSyncableRepository(override val tableName: String = "test_entity") : SyncableRepository<TestEntity> {
         val entities = mutableMapOf<String, TestEntity>()
@@ -41,9 +42,13 @@ class RepositorySyncBridgeTest {
             if (isDelete) entities.remove(id)
             else entities[id] = TestEntity(id, rowData["name"] ?: "", isSynced = true, syncVersion = syncVersion)
         }
-        override suspend fun toRowData(entity: TestEntity): Map<String, String?> = mapOf(
-            "id" to entity.id, "name" to entity.name, "household_id" to entity.householdId,
-            "sync_version" to entity.syncVersion.toString())
+        override suspend fun toRowData(entity: TestEntity): Map<String, String?> = buildMap {
+            put("id", entity.id)
+            put("name", entity.name)
+            put("household_id", entity.householdId)
+            put("sync_version", entity.syncVersion.toString())
+            if (entity.moodTag != null) put("mood_tag", entity.moodTag)
+        }
         override fun observeUnsyncedCount(): Flow<Int> = flowOf(entities.values.count { !it.isSynced })
     }
 
@@ -119,6 +124,23 @@ class RepositorySyncBridgeTest {
             Clock.System.now(), recordId = "e1")))
         assertTrue("e1" in repo.syncedIds)
         assertEquals(5L, repo.entities["e1"]?.syncVersion)
+    }
+
+    @Test fun collectUnsyncedMutations_stripsMoodTagByDefault() = runTest {
+        val repo = FakeSyncableRepository(tableName = "transactions")
+        repo.entities["t1"] = TestEntity("t1", "Txn", isSynced = false, moodTag = "😊")
+        val queue = FakeMutationQueue()
+        RepositorySyncBridge(mapOf("transactions" to repo), queue).collectUnsyncedMutations()
+        assertFalse("mood_tag" in queue.mutations.single().rowData)
+    }
+
+    @Test fun collectUnsyncedMutations_keepsMoodTagWhenSyncEnabled() = runTest {
+        val repo = FakeSyncableRepository(tableName = "transactions")
+        repo.entities["t1"] = TestEntity("t1", "Txn", isSynced = false, moodTag = "😊")
+        val queue = FakeMutationQueue()
+        RepositorySyncBridge(mapOf("transactions" to repo), queue, moodTagSyncEnabled = { true })
+            .collectUnsyncedMutations()
+        assertEquals("😊", queue.mutations.single().rowData["mood_tag"])
     }
 
     @Test fun multipleRepositories_collectionSpansAll() = runTest {

--- a/services/api/supabase/migrations/20260306000001_initial_schema.sql
+++ b/services/api/supabase/migrations/20260306000001_initial_schema.sql
@@ -161,6 +161,7 @@ CREATE TABLE transactions (
     recurring_rule          TEXT,
     transfer_account_id     UUID        REFERENCES accounts(id),
     status                  TEXT        NOT NULL DEFAULT 'CLEARED',
+    mood_tag                TEXT,
     created_at              TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at              TIMESTAMPTZ NOT NULL DEFAULT now(),
     deleted_at              TIMESTAMPTZ,

--- a/services/api/supabase/migrations/20260331000002_add_mood_tag_to_transactions.sql
+++ b/services/api/supabase/migrations/20260331000002_add_mood_tag_to_transactions.sql
@@ -1,0 +1,11 @@
+-- SPDX-License-Identifier: BUSL-1.1
+
+-- Migration: 20260331000002_add_mood_tag_to_transactions
+-- Description: Add optional local-first mood tag to transactions
+-- Issues: #1874
+
+ALTER TABLE transactions
+    ADD COLUMN mood_tag TEXT NULL;
+
+COMMENT ON COLUMN transactions.mood_tag IS
+    'Optional single emoji mood tag for user-owned transaction entry; excluded from household and visibility sharing surfaces.';

--- a/services/api/supabase/migrations/down/20260331000002_add_mood_tag_to_transactions.down.sql
+++ b/services/api/supabase/migrations/down/20260331000002_add_mood_tag_to_transactions.down.sql
@@ -1,0 +1,7 @@
+-- SPDX-License-Identifier: BUSL-1.1
+
+-- DOWN Migration: 20260331000002_add_mood_tag_to_transactions
+-- Description: Remove optional mood tag from transactions
+-- Issues: #1874
+
+ALTER TABLE transactions DROP COLUMN IF EXISTS mood_tag;


### PR DESCRIPTION
Closes #1874
Refs #1773

## Summary
- Adds optional transaction mood emoji tagging alpha scope (6 emoji picker, single tag, off by default).
- Adds `mood_tag` to local SQLDelight/web schema and Supabase migrations.
- Adds private-by-default sync/export/shared visibility filtering plus erase-all controls.
- Adds Settings → Experimental controls across Android, iOS, Web, and Windows.

## Not in this PR
- Correlation view is intentionally NOT in this PR — that is beta-cycle work.

## Test plan
- `npm run format:check`
- `npx eslint . --max-warnings 0`
- `npm run type-check -w apps/web`
- `npm test -w apps/web -- src/components/forms/TransactionForm.test.tsx`
- `./gradlew.bat :packages:models:jvmTest :packages:core:jvmTest :packages:sync:jvmTest --no-daemon --console=plain --rerun-tasks`
- `./gradlew.bat :apps:windows:compileKotlin --no-daemon --console=plain --rerun-tasks`

## Notes
- Android local compile was not available in this worktree because the Android SDK is not configured locally; CI should run Android validation.
- Full local web test suite has one existing timezone-sensitive failure in `src/utils/formatDate.test.ts`; the touched TransactionForm test passes.