### PR TITLE
chore(windows): substitute MSIX publisher and widget CLSID placeholders (#1244)

### DIFF
--- a/apps/windows/packaging/AppxManifest.xml
+++ b/apps/windows/packaging/AppxManifest.xml
@@ -25,14 +25,14 @@
   IgnorableNamespaces="uap uap3 rescap desktop com">
 
   <Identity
-    Name="${MSIX_PACKAGE_IDENTITY}"
-    Publisher="${MSIX_PUBLISHER_IDENTITY}"
+    Name="Finance.Alpha"
+    Publisher="CN=Finance Dev, O=Finance, L=Local, S=Dev, C=US"
     Version="${MSIX_PACKAGE_VERSION}"
     ProcessorArchitecture="x64" />
 
   <Properties>
     <DisplayName>Finance</DisplayName>
-    <PublisherDisplayName>${MSIX_PUBLISHER_DISPLAY_NAME}</PublisherDisplayName>
+    <PublisherDisplayName>Finance Dev</PublisherDisplayName>
     <Logo>assets\StoreLogo.png</Logo>
     <Description>Personal finance tracker — budgets, accounts, and investments in one place.</Description>
   </Properties>
@@ -108,7 +108,7 @@
         <com:Extension Category="windows.comServer">
           <com:ComServer>
             <com:ExeServer Executable="Finance.exe" DisplayName="Finance Widget Provider">
-              <com:Class Id="${WIDGET_PROVIDER_CLSID}" DisplayName="Finance Widget Provider" />
+              <com:Class Id="2b1d9145-edf5-4f48-923c-bf03c8d715c5" DisplayName="Finance Widget Provider" />
             </com:ExeServer>
           </com:ComServer>
         </com:Extension>
@@ -125,7 +125,7 @@
                   <Icon Path="assets\Square44x44Logo.png" />
                 </ProviderIcons>
                 <Activation>
-                  <CreateInstance ClassId="${WIDGET_PROVIDER_CLSID}" />
+                  <CreateInstance ClassId="2b1d9145-edf5-4f48-923c-bf03c8d715c5" />
                 </Activation>
                 <Definitions>
                   <Definition


### PR DESCRIPTION
## Summary

Substitutes the four `` placeholders in `apps/windows/packaging/AppxManifest.xml` with concrete values for the alpha sideload signing path, so MSIX builds can produce a valid, signable manifest without requiring CI-time substitution for these fields.

## Changes

- `MSIX_PACKAGE_IDENTITY` -> `Finance.Alpha` (sideload-only package name, no Store conflict)
- `MSIX_PUBLISHER_IDENTITY` -> `CN=Finance Dev, O=Finance, L=Local, S=Dev, C=US` (must match the self-signed cert Subject byte-for-byte; that's the cert generated locally per docs/windows/code-signing-setup.md Option C)
- `MSIX_PUBLISHER_DISPLAY_NAME` -> `Finance Dev`
- `WIDGET_PROVIDER_CLSID` -> `2b1d9145-edf5-4f48-923c-bf03c8d715c5` (stable GUID, replaces both occurrences: `com:Class Id` and `CreateInstance ClassId`)

`MSIX_PACKAGE_VERSION` remains templated (substituted by CI from the git tag at build time).

## Why

The merged scaffolding in #1866 left these placeholders for human substitution. They were intentionally deferred. Filling them is part of the human-action follow-up that unblocks the Windows leg of #1243 alpha E2E verification. Apple/Android prerequisites have been separately deferred to beta; Windows is moving forward with self-signed sideload for alpha.

## Issues

Refs #1244
Refs #1243

## Testing

- `npm run format:check` - pass
- `npx eslint . --max-warnings 0` - pass
- XML manifest structure unchanged; only placeholder values substituted
- Publisher value verified to match the locally generated self-signed cert Subject

## Follow-ups (not in this PR)

- Set `WINDOWS_SIGNING_CERT_BASE64` and `WINDOWS_CERT_PASSWORD` GitHub Actions secrets (human action)
- Run local sign-msix.ps1 dry run with the cert thumbprint `9A143AED071F96CB9B19F72BF89954A34C37ACC2`