### PR TITLE
fix(windows): bootstrap SQLite schema via SQLDelight Schema (#1893)

### DIFF
--- a/packages/models/src/jvmMain/kotlin/com/finance/db/DatabaseFactory.jvm.kt
+++ b/packages/models/src/jvmMain/kotlin/com/finance/db/DatabaseFactory.jvm.kt
@@ -4,6 +4,7 @@
 
 package com.finance.db
 
+import app.cash.sqldelight.async.coroutines.synchronous
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import java.util.Properties
 
@@ -22,11 +23,16 @@ actual class DatabaseFactory(
             put("cipher", "sqlcipher")
             put("key", key)
         }
+        // Passing the synchronous schema causes JdbcSqliteDriver to call
+        // Schema.create() on a fresh DB (PRAGMA user_version = 0) or
+        // Schema.migrate() on an out-of-date DB. Without this, the local
+        // DB file is created with no tables and every repository's
+        // refreshCache() fails with "no such table: account" (see #1893).
         val driver = JdbcSqliteDriver(
             url = "jdbc:sqlite:$dbPath",
             properties = properties,
+            schema = FinanceDatabase.Schema.synchronous(),
         )
-        // Schema creation handled by MigrationExecutor
         return FinanceDatabase(driver)
     }
 }


### PR DESCRIPTION
## Summary
The JVM `DatabaseFactory` constructed `JdbcSqliteDriver` without a schema parameter, so on every first launch the Windows app created an empty 0-byte database file and every repository's `refreshCache()` failed with `[SQLITE_ERROR] no such table: account`. The UI stalled before the GDPR onboarding screen could complete.

The previous code comment claimed _"Schema creation handled by MigrationExecutor"_, but the hand-rolled `MigrationExecutor` is never wired into any JVM entry point. The simplest correct fix is to use SQLDelight's built-in version tracking by passing the schema to the driver constructor.

## What changed
```diff
+import app.cash.sqldelight.async.coroutines.synchronous
 ...
 val driver = JdbcSqliteDriver(
     url = "jdbc:sqlite:$dbPath",
     properties = properties,
+    schema = FinanceDatabase.Schema.synchronous(),
 )
-// Schema creation handled by MigrationExecutor
```

Mirrors the iOS factory pattern. On a fresh DB (`PRAGMA user_version = 0`) the driver calls `Schema.create()`. On upgrades it runs the `.sqm` migrations under `packages/models/src/commonMain/sqldelight/migrations/{1..5}.sqm`. The unused `MigrationExecutor` and `MigrationRegistry` code is left in place — it can be removed separately if/when no tests reference it.

## Verification
Locally rebuilt with `:apps:windows:createDistributable`, deleted the stale `%LOCALAPPDATA%\Finance\data\finance.db` (was 0 bytes), launched `Finance.exe`:

- DB file grew to **286,720 bytes**
- All 7 expected tables present: `account`, `transaction`, `category`, `budget`, `goal`, `household`, `household_member`
- No more `no such table` warnings in stderr
- Process stayed alive and reached the system tray + notification manager initialization

`:packages:models:jvmTest` ✅ green.

## Not covered here
- **#1894** (SQLCipher silently disabled): xerial sqlite-jdbc ignores the `cipher`/`key` properties. The DB above is plain-text SQLite despite the log line claiming encryption. Tracked separately.
- **#1895** (AuthModule placeholder Supabase URL fallback). Tracked separately.
- **#1896** (Windows hardening grab-bag). Tracked separately.

## End-to-end alpha unblock chain
1. #1892 (java.sql modules + tray icon) — open, CI green, awaiting merge
2. **#1893 (this PR) — schema bootstrap**
3. Once both merge, the Windows MSI smoke step of the #1243 alpha pass becomes testable.

Closes #1893
Related: #1890, #1892
