### PR TITLE
fix(windows): replace xerial sqlite-jdbc with SQLCipher-enabled Willena fork (#1894)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ kotlinx-datetime = "0.6.1"
 sqldelight = "2.0.2"
 detekt = "1.23.7"
 sqlcipher-android = "4.6.1"
+sqlite-jdbc-crypt = "3.51.2.0"
 ktor = "3.0.3"
 koin = "4.0.1"
 timber = "5.0.1"
@@ -57,6 +58,10 @@ sqldelight-native-driver = { module = "app.cash.sqldelight:native-driver", versi
 sqldelight-jvm-driver = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqldelight" }
 sqldelight-js-driver = { module = "app.cash.sqldelight:web-worker-driver", version.ref = "sqldelight" }
 sqlcipher-android = { module = "net.zetetic:sqlcipher-android", version.ref = "sqlcipher-android" }
+# SQLCipher-enabled drop-in replacement for org.xerial:sqlite-jdbc.
+# Stock xerial silently ignores `cipher`/`key` JDBC properties, leaving the
+# on-disk database plaintext. The Willena fork honors them. See #1894.
+sqlite-jdbc-crypt = { module = "io.github.willena:sqlite-jdbc", version.ref = "sqlite-jdbc-crypt" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-client-auth = { module = "io.ktor:ktor-client-auth", version.ref = "ktor" }

--- a/packages/models/build.gradle.kts
+++ b/packages/models/build.gradle.kts
@@ -23,6 +23,7 @@ kotlin {
         val jvmMain by getting {
             dependencies {
                 implementation(libs.sqldelight.jvm.driver)
+                implementation(libs.sqlite.jdbc.crypt)
             }
         }
         if (project.extra["androidSdkAvailable"] as Boolean) {
@@ -58,4 +59,15 @@ sqldelight {
             generateAsync.set(true)
         }
     }
+}
+
+// SQLDelight's sqlite-driver pulls in xerial's `org.xerial:sqlite-jdbc`, which
+// SILENTLY drops the `cipher`/`key` JDBC properties — leaving the on-disk DB
+// plaintext (see #1894). The Willena fork `io.github.willena:sqlite-jdbc` is a
+// drop-in replacement that honors SQLCipher properties; we add it above and
+// strip xerial from every JVM-side configuration here. Excluding from all JVM
+// configurations (not just runtimeClasspath) ensures the kapt/test/etc. paths
+// can't accidentally pull xerial back in via another transitive route.
+configurations.matching { it.name.startsWith("jvm") }.configureEach {
+    exclude(group = "org.xerial", module = "sqlite-jdbc")
 }


### PR DESCRIPTION
## Summary

Closes the critical security gap where the Windows desktop app's local database was being written to disk in **plaintext** despite the code paths and log lines claiming SQLCipher encryption.

`DesktopDatabaseManager` constructs a `DpapiEncryptionKeyProvider`, generates a 256-bit key, encrypts it with DPAPI, and passes it to `DatabaseFactory.jvm.kt` which sets `cipher=sqlcipher` and `key=<hex>` JDBC properties on `JdbcSqliteDriver`. The problem: SQLDelight's `sqlite-driver` brings in `org.xerial:sqlite-jdbc` transitively, and stock xerial has **no SQLCipher support** — the `cipher`/`key` properties are silently ignored.

Result on alpha installs: a plain SQLite database with no encryption at rest, despite log lines claiming otherwise and DPAPI dutifully generating + protecting an unused key.

## What changed

```diff
# gradle/libs.versions.toml
+sqlite-jdbc-crypt = "3.51.2.0"
+sqlite-jdbc-crypt = { module = "io.github.willena:sqlite-jdbc", version.ref = "sqlite-jdbc-crypt" }

# packages/models/build.gradle.kts
 val jvmMain by getting {
     dependencies {
         implementation(libs.sqldelight.jvm.driver)
+        implementation(libs.sqlite.jdbc.crypt)
     }
 }

+configurations.matching { it.name.startsWith("jvm") }.configureEach {
+    exclude(group = "org.xerial", module = "sqlite-jdbc")
+}
```

`io.github.willena:sqlite-jdbc` is the actively-maintained SQLCipher-enabled fork of xerial. It is a drop-in replacement that honors the `cipher` and `key` JDBC properties out of the box, so **no application code changes are required**. The xerial JAR is stripped from every JVM-side configuration so a future transitive route can't accidentally re-introduce it.

## Verification (manual smoke test)

Built `:apps:windows:createDistributable`, deleted `%LOCALAPPDATA%\Finance\data\finance.db` AND `%LOCALAPPDATA%\Finance\security\db_encryption_key.enc`, launched the new Finance.exe, then inspected the database file header.

|                        | Before fix             | After fix                                 |
| ---------------------- | ---------------------- | ----------------------------------------- |
| First 16 bytes (ASCII) | `SQLite format 3\0...` | random bytes                              |
| First 16 bytes (hex)   | `53 51 4C 69 74 65 ...`| `7A F4 E5 50 F1 BD 3F 20 2D A4 C1 B5 ...` |
| Reads with no key      | ✅ trivially            | ❌ "file is not a database"                |
| Size                   | 286,720 bytes          | 286,720 bytes (schema still bootstraps)   |
| DPAPI key file         | written, unused        | written + actually used                   |

The header transition from "SQLite format 3" to random bytes is the diagnostic SQLCipher specifies for confirming a database is encrypted — only the cipher key holder can produce a readable B-tree page out of those bytes.

Also confirmed:
- App reaches the same point in startup it did before (tray + notification manager init complete, no early exit)
- `:packages:models:jvmTest` green
- `:packages:models:dependencies --configuration jvmRuntimeClasspath` shows `io.github.willena:sqlite-jdbc:3.51.2.0` and **no** `org.xerial:sqlite-jdbc` line

## Migration impact

Anyone with an existing **plaintext** `finance.db` from the broken build will hit "file is not a database" on next launch because the cipher mismatch is irrecoverable without manual export. Since the only person who has installed the broken MSI is the alpha tester (this repo owner), the documented fix is: delete `%LOCALAPPDATA%\Finance\data\finance.db` before first launch with this build. A future PR could add a graceful "this database appears unencrypted — rebuild it?" check; not in scope for the alpha cutover.

## Not covered here

- **#1895** AuthModule placeholder fail-fast — separate PR
- **#1896** Windows hardening grab-bag — separate PR

## Risk / non-risk

- Willena fork tracks upstream xerial closely (3.51.2.0 vs xerial's 3.45.2.0 — newer SQLite, same `org.sqlite.*` package, drop-in API). JdbcSqliteDriver compiles against `org.sqlite.SQLiteConfig` / `JDBC`, all preserved by the fork.
- iOS and Android encryption paths are untouched (co.touchlab native driver + `PRAGMA key` on iOS; `net.zetetic:sqlcipher-android` on Android).
- This PR has zero application-code diff. The only changes are dependency management.

## Verification checklist

- [x] Local build green (`:apps:windows:createDistributable`)
- [x] Tests green (`:packages:models:jvmTest`)
- [x] Format + lint clean (`npm run format:check && npx eslint . --max-warnings 0`)
- [x] DB header confirmed encrypted on freshly-launched Finance.exe
- [x] DPAPI key generated, persisted, decryptable, and CONSUMED by the driver

Closes #1894
Related: #1892, #1897
