### PR TITLE
ci(windows): automate local + CI MSI builds (#1899)

### DIFF
--- a/.github/workflows/build-windows-main.yml
+++ b/.github/workflows/build-windows-main.yml
@@ -1,0 +1,184 @@
+name: Build — Windows (main)
+
+# Auto-builds, signs (when secrets present), and publishes a rolling
+# pre-release MSI on every push to main that touches Windows-relevant code.
+# The rolling release is tagged `latest-main` and force-overwritten each run,
+# so testers always have a stable URL pointing at the current build.
+#
+# Stable, tagged releases continue to flow through .github/workflows/release-windows.yml.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/windows/**'
+      - 'packages/**'
+      - 'build-logic/**'
+      - 'gradle/**'
+      - '*.gradle.kts'
+      - 'gradle.properties'
+      - 'config/detekt/**'
+      - '.github/workflows/build-windows-main.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: build-windows-main-${{ github.ref }}
+  cancel-in-progress: true # Newer main commits supersede older in-flight runs.
+
+permissions:
+  contents: write # Required to create / update the rolling pre-release.
+  actions: read
+
+env:
+  HAS_SIGNING_SECRETS: ${{ secrets.WINDOWS_SIGNING_CERT_BASE64 != '' && secrets.WINDOWS_CERT_PASSWORD != '' }}
+  ROLLING_TAG: latest-main
+
+jobs:
+  build:
+    name: Build, Sign & Publish (rolling-main)
+    runs-on: windows-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Compute version
+        id: version
+        shell: bash
+        run: |
+          SHA="${GITHUB_SHA::7}"
+          VERSION="main-${SHA}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+          echo "📦 Rolling main build: ${VERSION}"
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          cache-read-only: true
+
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+
+      - name: Build & package MSI
+        run: ./gradlew :apps:windows:packageMsi --parallel --build-cache --stacktrace
+
+      - name: Run tests
+        run: ./gradlew :apps:windows:test --parallel --build-cache --stacktrace
+
+      - name: Locate MSI
+        id: msi
+        shell: pwsh
+        run: |
+          $msi = Get-ChildItem -Path "apps/windows/build/compose/binaries/main/msi" -Filter "*.msi" |
+              Sort-Object LastWriteTime -Descending | Select-Object -First 1
+          if (-not $msi) { Write-Error "No MSI produced." ; exit 1 }
+          $versioned = Join-Path $msi.DirectoryName "Finance-${{ steps.version.outputs.version }}.msi"
+          $stable    = Join-Path $msi.DirectoryName "Finance-main.msi"
+          if ($msi.FullName -ne $versioned) { Copy-Item $msi.FullName $versioned -Force }
+          Copy-Item $versioned $stable -Force
+          echo "versioned=$versioned" >> $env:GITHUB_OUTPUT
+          echo "stable=$stable" >> $env:GITHUB_OUTPUT
+          echo "name=$(Split-Path $versioned -Leaf)" >> $env:GITHUB_OUTPUT
+          Write-Host "MSI: $versioned ($([math]::Round((Get-Item $versioned).Length / 1MB, 1)) MB)"
+          Write-Host "Stable alias: $stable"
+
+      - name: Sign MSI
+        if: env.HAS_SIGNING_SECRETS == 'true'
+        shell: pwsh
+        run: |
+          $certBytes = [System.Convert]::FromBase64String("${{ secrets.WINDOWS_SIGNING_CERT_BASE64 }}")
+          $certPath = Join-Path $env:RUNNER_TEMP "signing-cert.pfx"
+          [System.IO.File]::WriteAllBytes($certPath, $certBytes)
+          try {
+              # Sign both the versioned and stable copies (they're separate files on disk).
+              foreach ($target in @("${{ steps.msi.outputs.versioned }}", "${{ steps.msi.outputs.stable }}")) {
+                  & signtool sign /f $certPath /p "${{ secrets.WINDOWS_CERT_PASSWORD }}" `
+                      /fd sha256 /tr http://timestamp.digicert.com /td sha256 $target
+                  if ($LASTEXITCODE -ne 0) { throw "signtool exit $LASTEXITCODE on $target" }
+                  Write-Host "Signed: $target"
+              }
+          } finally {
+              Remove-Item $certPath -Force -ErrorAction SilentlyContinue
+          }
+
+      - name: Warn if signing skipped
+        if: env.HAS_SIGNING_SECRETS != 'true'
+        run: |
+          echo "::warning::WINDOWS_SIGNING_CERT_BASE64 or WINDOWS_CERT_PASSWORD secret is empty — MSI published unsigned."
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: windows-main-msi
+          path: |
+            ${{ steps.msi.outputs.versioned }}
+            ${{ steps.msi.outputs.stable }}
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Publish rolling pre-release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $tag = "${{ env.ROLLING_TAG }}"
+          $version = "${{ steps.version.outputs.version }}"
+          $versioned = "${{ steps.msi.outputs.versioned }}"
+          $stable    = "${{ steps.msi.outputs.stable }}"
+          $stableName = Split-Path $stable -Leaf
+
+          # Force-move the tag to the current commit so the release always points here.
+          git tag -f $tag
+          git push -f origin $tag
+
+          # Delete any existing release on the rolling tag, then recreate. This is
+          # simpler and more deterministic than `gh release edit --clobber` for
+          # asset cycling — assets get a fresh release each push.
+          gh release delete $tag --yes --cleanup-tag=false 2>$null
+
+          $notes = @"
+          **Rolling pre-release** built automatically from ``main``. The ``$tag``
+          tag always points at the latest signed-or-unsigned MSI from ``main``.
+
+          - Stable download URL (always current): ``$stableName``
+          - SHA-versioned asset (for archaeology): ``$(Split-Path $versioned -Leaf)``
+
+          Commit: ${{ github.sha }}
+          Workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          "@
+          $notesFile = Join-Path $env:RUNNER_TEMP "release-notes.md"
+          $notes | Out-File -FilePath $notesFile -Encoding utf8
+
+          gh release create $tag $versioned $stable `
+              --title "Windows main rolling build ($version)" `
+              --notes-file $notesFile `
+              --prerelease `
+              --target ${{ github.sha }}
+
+          $stableUrl = "${{ github.server_url }}/${{ github.repository }}/releases/download/$tag/$stableName"
+          echo "::notice::Rolling release published: $stableUrl"
+
+      - name: Job summary
+        if: always()
+        shell: pwsh
+        run: |
+          $stableUrl = "${{ github.server_url }}/${{ github.repository }}/releases/download/${{ env.ROLLING_TAG }}/Finance-main.msi"
+          $body = @"
+          ## 🪟 Windows main build — ${{ steps.version.outputs.version }}
+
+          - **Stable download URL:** $stableUrl
+          - **Versioned asset:** ``${{ steps.msi.outputs.name }}``
+          - **Signed:** ${{ env.HAS_SIGNING_SECRETS == 'true' }}
+          - **Rolling release page:** ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ env.ROLLING_TAG }}
+          "@
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $body

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -31,11 +31,14 @@ on:
 
 concurrency:
   group: release-windows-${{ github.ref }}
-  cancel-in-progress: false # Never cancel release builds
+  cancel-in-progress: false # Never cancel release builds — every tag is a distinct artifact.
 
 permissions:
   contents: write
   actions: read
+
+env:
+  HAS_SIGNING_SECRETS: ${{ secrets.WINDOWS_SIGNING_CERT_BASE64 != '' && secrets.WINDOWS_CERT_PASSWORD != '' }}
 
 jobs:
   # ── Gate: require approval for store releases ───────────────────
@@ -79,8 +82,17 @@ jobs:
         id: version
         shell: bash
         run: |
-          TAG="${GITHUB_REF#refs/tags/}"
-          VERSION=$(echo "$TAG" | sed -E 's/^v//;s/-windows$//')
+          # Tag pushes -> strip refs/tags/ and any -windows suffix.
+          # workflow_dispatch from a branch -> fall back to branch-name + short SHA so
+          # downstream steps never see "refs/heads/main" as the version string.
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+            VERSION=$(echo "$TAG" | sed -E 's/^v//;s/-windows$//')
+          else
+            BRANCH="${GITHUB_REF#refs/heads/}"
+            SHA="${GITHUB_SHA::7}"
+            VERSION="${BRANCH}-${SHA}"
+          fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "📦 Version: ${VERSION}"
 
@@ -89,42 +101,50 @@ jobs:
 
       - name: Run tests
         run: ./gradlew :apps:windows:test --parallel --build-cache --stacktrace
-        continue-on-error: true
+        # Tests now gate the release. Previously continue-on-error swallowed failures.
 
-      - name: Package MSIX
+      - name: Package MSI
         run: ./gradlew :apps:windows:packageMsi --parallel --build-cache --stacktrace
 
       - name: Package distributable
         run: ./gradlew :apps:windows:createDistributable --parallel --build-cache --stacktrace
         continue-on-error: true
 
-      - name: Sign MSIX package
-        if: inputs.channel == 'store'
+      - name: Sign MSI
+        if: env.HAS_SIGNING_SECRETS == 'true'
         shell: pwsh
         run: |
           # Decode signing certificate from secret
           $certBytes = [System.Convert]::FromBase64String("${{ secrets.WINDOWS_SIGNING_CERT_BASE64 }}")
           $certPath = Join-Path $env:RUNNER_TEMP "signing-cert.pfx"
           [System.IO.File]::WriteAllBytes($certPath, $certBytes)
-
-          # Find MSIX files and sign them
-          $msixFiles = Get-ChildItem -Path "apps/windows/build" -Filter "*.msi" -Recurse
-          foreach ($file in $msixFiles) {
-            Write-Host "Signing: $($file.FullName)"
-            & signtool sign /f $certPath /p "${{ secrets.WINDOWS_CERT_PASSWORD }}" /fd sha256 /tr http://timestamp.digicert.com /td sha256 $file.FullName
+          try {
+              # Sign exactly the MSI(s) jpackage produced — narrowed from the prior
+              # recursive search over apps/windows/build to avoid catching stale or
+              # incidental MSI files left behind by earlier builds.
+              $msiFiles = Get-ChildItem -Path "apps/windows/build/compose/binaries/main/msi" -Filter "*.msi"
+              if (-not $msiFiles) { throw "No MSI found in expected output dir." }
+              foreach ($file in $msiFiles) {
+                  Write-Host "Signing: $($file.FullName)"
+                  & signtool sign /f $certPath /p "${{ secrets.WINDOWS_CERT_PASSWORD }}" `
+                      /fd sha256 /tr http://timestamp.digicert.com /td sha256 $file.FullName
+                  if ($LASTEXITCODE -ne 0) { throw "signtool exit $LASTEXITCODE on $($file.FullName)" }
+              }
+          } finally {
+              Remove-Item $certPath -Force -ErrorAction SilentlyContinue
           }
 
-          # Clean up certificate
-          Remove-Item $certPath -Force
+      - name: Warn if signing skipped
+        if: env.HAS_SIGNING_SECRETS != 'true'
+        run: |
+          echo "::warning::WINDOWS_SIGNING_CERT_BASE64 or WINDOWS_CERT_PASSWORD secret is empty — release MSI published unsigned."
 
-      - name: Upload MSIX artifact
+      - name: Upload MSI artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: windows-release-msix
-          path: |
-            apps/windows/build/compose/binaries/**/*.msi
-            apps/windows/build/compose/binaries/**/*.msix
-          if-no-files-found: warn
+          name: windows-release-msi
+          path: apps/windows/build/compose/binaries/main/msi/*.msi
+          if-no-files-found: error
           retention-days: 30
 
       - name: Upload distributable
@@ -186,7 +206,7 @@ jobs:
 
           echo "" >> release-notes.md
           echo "### Artifacts" >> release-notes.md
-          echo "- MSIX installer (for Microsoft Store / sideloading)" >> release-notes.md
+          echo "- MSI installer (signed when secrets are configured)" >> release-notes.md
           echo "- Standalone distributable" >> release-notes.md
 
       - name: Create GitHub Release

--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,10 @@ obj/
 *.pfx
 *.jks
 *.keystore
+
+# Local Windows dev signing cert exports (auto-generated per-machine)
+tools/windows/dev-cert/*
+!tools/windows/dev-cert/.gitkeep
 secrets/
 .secrets/
 keystore.properties

--- a/apps/windows/README.md
+++ b/apps/windows/README.md
@@ -1,0 +1,215 @@
+# Finance — Windows app
+
+The Windows build of Finance is a Compose Desktop app packaged as an MSI via
+jpackage. There are three supported ways to produce an installable binary:
+
+| Flow                                                     | When to use                                                         | Trigger                                                               |
+| -------------------------------------------------------- | ------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| **Local build script** (`tools/windows/build-local.ps1`) | Day-to-day dev. Iterate on Windows-only bugs without waiting on CI. | `pwsh tools/windows/build-local.ps1 [flags]`                          |
+| **Rolling main build** (`build-windows-main.yml`)        | "I want the latest signed MSI from `main` right now."               | Auto-runs on every push to `main` that touches Windows-relevant code. |
+| **Tagged release** (`release-windows.yml`)               | Cutting a versioned release for testers / stores.                   | `git tag v1.2.3-windows && git push --tags` (or `workflow_dispatch`). |
+
+The two CI flows are intentionally split: the rolling-main build is
+always-on with no approval gate, the tagged release goes through the
+`staging`/`production` GitHub Environment approval before publishing.
+
+---
+
+## 1. Local build script — `tools/windows/build-local.ps1`
+
+The script wraps the full edit → build → sign → install → run loop into a
+single command so you don't need to memorize Gradle task names, msiexec
+flags, or signtool incantations.
+
+### Quickstart
+
+```pwsh
+# From repo root, in PowerShell 7+:
+pwsh tools/windows/build-local.ps1 -Install -ForceUninstall -BackupData -Run
+```
+
+That call will:
+
+1. Generate (or reuse) a per-machine self-signed code-signing certificate in
+   `Cert:\CurrentUser\My` and export it to `tools/windows/dev-cert/<COMPUTERNAME>.pfx`
+   (gitignored).
+2. Run `./gradlew :apps:windows:packageMsi`.
+3. Sign the produced MSI with that cert.
+4. Snapshot any existing user data under `%LOCALAPPDATA%\Finance\data\` and
+   `%LOCALAPPDATA%\Finance\security\` to a timestamped sibling directory
+   (because `-BackupData` was passed), then uninstall the old version.
+5. Install the freshly-built MSI silently.
+6. Launch `Finance.exe`.
+
+> 💡 If you skip both `-BackupData` and `-NoBackup` and any user data is
+> present, the script will **refuse** to uninstall and exit with code 2.
+> That's the data-protection guard rail — see below.
+
+1. Generate (or reuse) a per-machine self-signed code-signing certificate in
+   `Cert:\CurrentUser\My` and export it to `tools/windows/dev-cert/<COMPUTERNAME>.pfx`
+   (gitignored).
+2. Run `./gradlew :apps:windows:packageMsi`.
+3. Sign the produced MSI with that cert.
+4. Snapshot any existing user data under `%LOCALAPPDATA%\Finance\data\` and
+   `%LOCALAPPDATA%\Finance\security\` to a timestamped sibling directory,
+   then uninstall the old version.
+5. Install the freshly-built MSI silently.
+6. Launch `Finance.exe`.
+
+### Flags
+
+| Flag              | Effect                                                                                                      |
+| ----------------- | ----------------------------------------------------------------------------------------------------------- |
+| `-Install`        | Run msiexec install after build (default: just build).                                                      |
+| `-Run`            | Launch `Finance.exe` after install.                                                                         |
+| `-Uninstall`      | Uninstall the currently-installed Finance MSI and exit.                                                     |
+| `-InstallOnly`    | Skip the Gradle build; install whatever MSI is already on disk.                                             |
+| `-ForceUninstall` | If an install exists at the target version, uninstall it first.                                             |
+| `-NoSign`         | Skip signing. Fast local-only iteration. SmartScreen will object.                                           |
+| `-BackupData`     | Snapshot user data to a timestamped sibling dir before uninstall.                                           |
+| `-NoBackup`       | Acknowledge that uninstalling may destroy user data. Required (or `-BackupData`) when user data is present. |
+| `-Clean`          | `./gradlew :apps:windows:clean` before building.                                                            |
+
+The script lives at [`tools/windows/build-local.ps1`](../../tools/windows/build-local.ps1)
+and is fully self-contained — no external dependencies beyond the Windows
+SDK (for `signtool.exe`) and your already-installed JDK 21.
+
+### Data-safety design
+
+The Windows MSI currently installs to `%LOCALAPPDATA%\Finance\` and the app
+writes its SQLCipher database and DPAPI-wrapped key under that same root
+(`data\finance.db`, `security\db_encryption_key.enc`). A naive MSI uninstall
+will wipe those alongside the binaries. Until [#1900](../../../../issues/1900)
+moves the data outside the install root, the script defends against
+accidental data loss: any uninstall path (`-Uninstall`, or `-Install
+-ForceUninstall` when an existing install is present) refuses to proceed if
+user data exists unless you opt in with either `-BackupData` (snapshot to a
+timestamped sibling directory) or `-NoBackup` (proceed and accept the
+loss). If you really want to nuke local data, pass `-NoBackup`.
+
+### Why a per-machine self-signed cert?
+
+- SmartScreen reputation does **not** transfer between dev certs across
+  machines, so there's no value in sharing one.
+- The cert lives in `Cert:\CurrentUser\My` and is exported encrypted with a
+  password derived from `$env:COMPUTERNAME` — the PFX is useless on any
+  other machine.
+- The PFX export pattern `tools/windows/dev-cert/*.pfx` is gitignored
+  (`.gitignore` explicit entry + global `*.pfx` rule).
+
+---
+
+## 2. Rolling-main CI build — `build-windows-main.yml`
+
+[`.github/workflows/build-windows-main.yml`](../../.github/workflows/build-windows-main.yml)
+auto-runs on every push to `main` that touches anything Windows could care
+about (`apps/windows/**`, `packages/**`, `build-logic/**`, `gradle/**`,
+top-level Gradle files, detekt config, or the workflow itself).
+
+On every run it:
+
+1. Builds the MSI via `./gradlew :apps:windows:packageMsi`.
+2. Runs the Windows test suite. **Test failures fail the build.**
+3. Signs the MSI when `WINDOWS_SIGNING_CERT_BASE64` and
+   `WINDOWS_CERT_PASSWORD` repo secrets are present. Otherwise emits a
+   `::warning::` and uploads unsigned.
+4. Publishes (or force-overwrites) a pre-release tagged **`latest-main`**
+   with two asset names:
+   - `Finance-main.msi` — **stable URL** that always points at the most
+     recent build. Use this for testers ("just grab the latest").
+   - `Finance-main-<sha7>.msi` — versioned alias for forensic / bisect use.
+
+The stable download URL is therefore:
+
+```
+https://github.com/jrmoulckers/finance/releases/download/latest-main/Finance-main.msi
+```
+
+`concurrency: cancel-in-progress: true` means a newer push supersedes an
+in-flight build — only the latest `main` commit ever wins the rolling
+release.
+
+---
+
+## 3. Tagged release — `release-windows.yml`
+
+[`.github/workflows/release-windows.yml`](../../.github/workflows/release-windows.yml)
+is reserved for cutting versioned releases. It triggers on `v*-windows` or
+`v*` tag pushes and on manual `workflow_dispatch`. Each tag produces its
+own permanent GitHub Release with auto-generated notes from the git log
+since the previous tag.
+
+Key differences from the rolling-main build:
+
+- `cancel-in-progress: false` — every tag is a distinct artifact, never
+  cancelled by a follow-up tag.
+- Gated by a GitHub Environment approval (`staging` or `production`
+  depending on `inputs.channel`).
+- Always-sign when secrets are present (same env-mapped boolean as
+  build-windows-main); the legacy `channel == 'store'` gate is gone.
+
+### Cutting a Windows release
+
+```bash
+git fetch origin main
+git checkout main && git pull
+git tag v1.2.3-windows
+git push origin v1.2.3-windows
+```
+
+Then approve the workflow in the GitHub UI when prompted.
+
+---
+
+## Signing secret setup
+
+Both CI workflows look for two repo secrets:
+
+- `WINDOWS_SIGNING_CERT_BASE64` — base64-encoded PFX file
+- `WINDOWS_CERT_PASSWORD` — password for the PFX
+
+To encode a PFX:
+
+```pwsh
+[Convert]::ToBase64String([IO.File]::ReadAllBytes("cert.pfx")) | Set-Clipboard
+```
+
+Paste that into `Repo Settings → Secrets and variables → Actions → New
+repository secret` as `WINDOWS_SIGNING_CERT_BASE64`. Both workflows
+gracefully skip signing if either secret is missing, emit a `::warning::`,
+and publish unsigned binaries.
+
+The local script does **not** read these secrets — it uses its own
+per-machine self-signed cert exclusively. That keeps real signing keys off
+developer machines.
+
+---
+
+## SmartScreen on local / unsigned builds
+
+Self-signed MSIs trip SmartScreen's "Windows protected your PC" dialog.
+That's expected — click **More info → Run anyway**. Signed CI builds will
+trip it too until our publisher reputation builds up over time.
+
+---
+
+## Troubleshooting
+
+| Symptom                                           | Likely cause                                                                                                                   | Fix                                                                                                                                        |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `MSI exit 1638` from the local script             | Another version is already installed.                                                                                          | Re-run with `-ForceUninstall`.                                                                                                             |
+| `signtool: command not found`                     | Windows SDK not installed, or signtool not on PATH.                                                                            | The script searches `C:\Program Files (x86)\Windows Kits\10\bin\*\x64\` automatically; install the Windows 10/11 SDK if it can't find one. |
+| App launches then dies immediately                | Likely a regression of [#1890](../../../../issues/1890) (JRE modules) — DB driver or DPAPI native libs missing.                | Check `%LOCALAPPDATA%\Finance\app\Finance.cfg` and the Windows event log.                                                                  |
+| `no such table: <name>` warning on launch         | Regression of [#1893](../../../../issues/1893). The schema bootstrap isn't running.                                            | Confirm `Schema.synchronous()` is still wired in `DatabaseFactory.jvm.kt`.                                                                 |
+| DB file starts with `SQLite format 3\0`           | Regression of [#1894](../../../../issues/1894) — running plain `org.xerial:sqlite-jdbc` instead of the Willena SQLCipher fork. | Confirm the top-level `configurations.matching` exclude in `packages/models/build.gradle.kts` is intact.                                   |
+| Want to nuke local data and re-test fresh install | —                                                                                                                              | `pwsh tools/windows/build-local.ps1 -Uninstall -NoBackup` then re-run with `-Install -Run`.                                                |
+
+---
+
+## Related issues
+
+- [#1899](../../../../issues/1899) — this PR: Windows build & release automation
+- [#1900](../../../../issues/1900) — move Windows app data out of the MSI install root
+- [#1890](../../../../issues/1890), [#1893](../../../../issues/1893),
+  [#1894](../../../../issues/1894) — the original alpha-blocker bugs that
+  motivated this tooling

--- a/tools/windows/README.md
+++ b/tools/windows/README.md
@@ -1,0 +1,34 @@
+# Windows dev tooling
+
+## Local build & test
+
+```powershell
+# Build, sign with auto-generated per-machine dev cert
+tools\windows\build-local.ps1
+
+# Build + sign + install + launch
+tools\windows\build-local.ps1 -Install -Run
+
+# Replace an existing install (data-protected)
+tools\windows\build-local.ps1 -Install -ForceUninstall -BackupData -Run
+
+# Uninstall only (data-protected)
+tools\windows\build-local.ps1 -Uninstall -BackupData
+
+# Skip Gradle rebuild — just resign + install the most recent MSI
+tools\windows\build-local.ps1 -InstallOnly -Install -Run
+
+# Skip signing entirely (Windows will warn about an unknown publisher)
+tools\windows\build-local.ps1 -NoSign
+```
+
+See `apps/windows/README.md` for the full developer guide, including
+how local builds relate to CI signed builds and the GitHub Releases
+rolling-main channel.
+
+## What's in this folder
+
+- `build-local.ps1` — the local build script. See file header for full flag docs.
+- `dev-cert/` — auto-generated per-machine self-signed PFX exports. **Gitignored.**
+  Each machine gets its own cert in `Cert:\CurrentUser\My`; the PFX in this folder
+  is just a file-system round-trip for `signtool`.

--- a/tools/windows/build-local.ps1
+++ b/tools/windows/build-local.ps1
@@ -1,0 +1,278 @@
+# Finance Windows — Local Build & Test Script
+#
+# One-command build + sign + install + run for the Windows Compose Desktop app.
+# Intended for developer use only. CI uses .github/workflows/build-windows-main.yml
+# and release-windows.yml which sign with the real WINDOWS_SIGNING_CERT_BASE64.
+#
+# Usage examples (run from the repo root or any worktree):
+#   tools\windows\build-local.ps1                 # build + sign (no install)
+#   tools\windows\build-local.ps1 -Install        # build + sign + install
+#   tools\windows\build-local.ps1 -Install -Run   # build + sign + install + launch
+#   tools\windows\build-local.ps1 -Uninstall      # uninstall only (data-protected)
+#   tools\windows\build-local.ps1 -NoSign         # skip signing (SmartScreen warns)
+#   tools\windows\build-local.ps1 -InstallOnly    # skip Gradle, just sign+install
+#                                                 # the most recent MSI in build/
+#
+# Data protection: -Install and -Uninstall refuse to touch the existing install
+# if user data is present at %LOCALAPPDATA%\Finance\data\ or \security\ (see #1900
+# for why this lives inside the install root and is being moved out). Pass
+# -BackupData to snapshot to a sibling timestamped folder before proceeding, or
+# -NoBackup to acknowledge the data may be lost.
+
+[CmdletBinding()]
+param(
+    [switch]$Install,
+    [switch]$Run,
+    [switch]$Uninstall,
+    [switch]$NoSign,
+    [switch]$InstallOnly,
+    [switch]$ForceUninstall,
+    [switch]$BackupData,
+    [switch]$NoBackup,
+    [switch]$Clean
+)
+
+$ErrorActionPreference = 'Stop'
+$PSStyle.OutputRendering = 'Host'
+
+# ── Paths ───────────────────────────────────────────────────────────
+$scriptDir   = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot    = Resolve-Path (Join-Path $scriptDir '..\..')
+$gradlew     = Join-Path $repoRoot 'gradlew.bat'
+$msiOutDir   = Join-Path $repoRoot 'apps\windows\build\compose\binaries\main\msi'
+$certDir     = Join-Path $scriptDir 'dev-cert'
+$installRoot = Join-Path $env:LOCALAPPDATA 'Finance'
+$dataDir     = Join-Path $installRoot 'data'
+$keyDir      = Join-Path $installRoot 'security'
+
+function Write-Step([string]$msg)    { Write-Host "`n==> $msg" -ForegroundColor Cyan }
+function Write-Ok([string]$msg)      { Write-Host "    [OK] $msg" -ForegroundColor Green }
+function Write-Warn2([string]$msg)   { Write-Host "    [!]  $msg" -ForegroundColor Yellow }
+function Write-Fail([string]$msg)    { Write-Host "    [X]  $msg" -ForegroundColor Red }
+
+# ── Discover signtool from Windows SDK ──────────────────────────────
+function Find-SignTool {
+    $sdkRoot = 'C:\Program Files (x86)\Windows Kits\10\bin'
+    if (-not (Test-Path $sdkRoot)) { return $null }
+    $candidate = Get-ChildItem -Path $sdkRoot -Directory |
+        Where-Object { $_.Name -match '^\d+\.\d+\.\d+\.\d+$' } |
+        Sort-Object -Property { [version]$_.Name } -Descending |
+        ForEach-Object { Join-Path $_.FullName 'x64\signtool.exe' } |
+        Where-Object { Test-Path $_ } |
+        Select-Object -First 1
+    return $candidate
+}
+
+# ── Per-machine dev cert (in user store, optionally exported to PFX) ──
+function Get-DevCert {
+    $subject = "CN=Finance Dev ($env:COMPUTERNAME)"
+    $existing = Get-ChildItem Cert:\CurrentUser\My |
+        Where-Object { $_.Subject -eq $subject -and $_.NotAfter -gt (Get-Date) } |
+        Sort-Object NotAfter -Descending |
+        Select-Object -First 1
+    if ($existing) {
+        Write-Ok "Reusing dev cert thumbprint $($existing.Thumbprint)"
+        return $existing
+    }
+    Write-Step "Generating per-machine dev code-signing cert ($subject)"
+    $cert = New-SelfSignedCertificate `
+        -Type CodeSigningCert `
+        -Subject $subject `
+        -CertStoreLocation 'Cert:\CurrentUser\My' `
+        -KeyAlgorithm RSA `
+        -KeyLength 2048 `
+        -NotAfter (Get-Date).AddYears(2)
+    Write-Ok "Created cert thumbprint $($cert.Thumbprint)"
+    return $cert
+}
+
+function Get-DevPfxPath {
+    if (-not (Test-Path $certDir)) { New-Item -ItemType Directory -Path $certDir | Out-Null }
+    return (Join-Path $certDir "$env:COMPUTERNAME.pfx")
+}
+
+function Get-DevPfxPassword {
+    # Per-machine password derived from machine name + a fixed dev string.
+    # Never committed, never crosses machines, only used to round-trip the cert
+    # into a file signtool can read.
+    return (ConvertTo-SecureString "finance-dev-$env:COMPUTERNAME" -AsPlainText -Force)
+}
+
+function Export-DevPfx([System.Security.Cryptography.X509Certificates.X509Certificate2]$cert) {
+    $pfxPath = Get-DevPfxPath
+    $pw = Get-DevPfxPassword
+    Export-PfxCertificate -Cert $cert -FilePath $pfxPath -Password $pw -Force | Out-Null
+    Write-Ok "Exported PFX to $pfxPath"
+    return $pfxPath
+}
+
+# ── MSI install bookkeeping ─────────────────────────────────────────
+function Get-InstalledFinance {
+    $uninstallRoots = @(
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall',
+        'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall',
+        'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall'
+    )
+    foreach ($root in $uninstallRoots) {
+        if (-not (Test-Path $root)) { continue }
+        $hit = Get-ChildItem $root -ErrorAction SilentlyContinue |
+            Get-ItemProperty -ErrorAction SilentlyContinue |
+            Where-Object { $_.DisplayName -eq 'Finance' } |
+            Select-Object -First 1 DisplayName, DisplayVersion, InstallLocation, PSChildName
+        if ($hit) { return $hit }
+    }
+    return $null
+}
+
+function Test-UserDataPresent {
+    $hasDb  = (Test-Path $dataDir) -and ((Get-ChildItem $dataDir -File -ErrorAction SilentlyContinue).Count -gt 0)
+    $hasKey = (Test-Path $keyDir)  -and ((Get-ChildItem $keyDir  -File -ErrorAction SilentlyContinue).Count -gt 0)
+    return ($hasDb -or $hasKey)
+}
+
+function Backup-UserData {
+    $stamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+    $backup = Join-Path $env:LOCALAPPDATA "Finance-backup-$stamp"
+    New-Item -ItemType Directory -Path $backup | Out-Null
+    if (Test-Path $dataDir) {
+        Copy-Item -Path $dataDir -Destination (Join-Path $backup 'data') -Recurse -Force
+        Write-Ok "Backed up data\  -> $backup\data"
+    }
+    if (Test-Path $keyDir) {
+        Copy-Item -Path $keyDir -Destination (Join-Path $backup 'security') -Recurse -Force
+        Write-Ok "Backed up security\ -> $backup\security"
+    }
+    Write-Warn2 "Restore manually if needed: Copy-Item $backup\* $installRoot -Recurse -Force"
+    return $backup
+}
+
+function Assert-SafeToUninstall {
+    if (-not (Test-UserDataPresent)) { return }
+    if ($BackupData) {
+        Write-Step "User data detected — backing up before uninstall"
+        Backup-UserData | Out-Null
+        return
+    }
+    if ($NoBackup) {
+        Write-Warn2 "User data detected, -NoBackup specified — data may be lost"
+        return
+    }
+    Write-Fail "Existing user data at $dataDir and/or $keyDir."
+    Write-Fail "Refusing to uninstall to avoid data loss (see #1900)."
+    Write-Fail "Re-run with -BackupData (recommended) or -NoBackup to proceed."
+    exit 2
+}
+
+function Invoke-Uninstall {
+    Assert-SafeToUninstall
+    $finance = Get-InstalledFinance
+    if (-not $finance) {
+        Write-Warn2 'Finance is not installed.'
+        return
+    }
+    $productCode = $finance.PSChildName
+    Write-Step "Uninstalling Finance $($finance.DisplayVersion) ($productCode)"
+    $msiArgs = @('/x', $productCode, '/quiet', '/norestart', '/L*v', (Join-Path $env:TEMP 'finance-uninstall.log'))
+    $p = Start-Process -FilePath 'msiexec.exe' -ArgumentList $msiArgs -Wait -PassThru -NoNewWindow
+    if ($p.ExitCode -ne 0) {
+        Write-Fail "msiexec exit code $($p.ExitCode). Log: $env:TEMP\finance-uninstall.log"
+        exit $p.ExitCode
+    }
+    Write-Ok 'Uninstall complete.'
+}
+
+function Invoke-Install([string]$msiPath) {
+    Write-Step "Installing $msiPath"
+    $msiArgs = @('/i', $msiPath, '/quiet', '/norestart', '/L*v', (Join-Path $env:TEMP 'finance-install.log'))
+    $p = Start-Process -FilePath 'msiexec.exe' -ArgumentList $msiArgs -Wait -PassThru -NoNewWindow
+    if ($p.ExitCode -eq 1638) {
+        Write-Warn2 'msiexec 1638: another version installed. Uninstalling first.'
+        if (-not $ForceUninstall) {
+            Write-Fail 'Pass -ForceUninstall to remove the existing install first.'
+            Write-Fail '(Data protection: also pass -BackupData or -NoBackup.)'
+            exit 1638
+        }
+        Invoke-Uninstall
+        $p = Start-Process -FilePath 'msiexec.exe' -ArgumentList $msiArgs -Wait -PassThru -NoNewWindow
+    }
+    if ($p.ExitCode -ne 0) {
+        Write-Fail "msiexec exit code $($p.ExitCode). Log: $env:TEMP\finance-install.log"
+        exit $p.ExitCode
+    }
+    Write-Ok 'Install complete.'
+}
+
+# ── Main flow ───────────────────────────────────────────────────────
+Push-Location $repoRoot
+try {
+    if ($Uninstall) {
+        Invoke-Uninstall
+        exit 0
+    }
+
+    if (-not $InstallOnly) {
+        if ($Clean) {
+            Write-Step 'Cleaning previous Windows build outputs'
+            & $gradlew ':apps:windows:clean' '--no-daemon'
+            if ($LASTEXITCODE -ne 0) { Write-Fail 'Clean failed.'; exit $LASTEXITCODE }
+        }
+        Write-Step 'Building MSI (this may take several minutes on a cold cache)'
+        & $gradlew ':apps:windows:packageMsi' '--no-daemon'
+        if ($LASTEXITCODE -ne 0) { Write-Fail 'Gradle build failed.'; exit $LASTEXITCODE }
+    }
+
+    $msi = Get-ChildItem $msiOutDir -Filter '*.msi' -ErrorAction SilentlyContinue |
+        Sort-Object LastWriteTime -Descending | Select-Object -First 1
+    if (-not $msi) {
+        Write-Fail "No MSI produced at $msiOutDir"
+        exit 1
+    }
+    Write-Ok "MSI: $($msi.FullName) ($([math]::Round($msi.Length / 1MB, 1)) MB)"
+
+    if (-not $NoSign) {
+        Write-Step 'Signing MSI with per-machine dev cert'
+        $signtool = Find-SignTool
+        if (-not $signtool) {
+            Write-Fail 'signtool.exe not found. Install Windows 10/11 SDK (kits 10\bin\<ver>\x64\).'
+            Write-Fail 'Or re-run with -NoSign to skip signing.'
+            exit 1
+        }
+        Write-Ok "signtool: $signtool"
+        $cert = Get-DevCert
+        $pfx  = Export-DevPfx $cert
+        $pw   = Get-DevPfxPassword
+        $pwPlain = [System.Net.NetworkCredential]::new('', $pw).Password
+        & $signtool sign /f $pfx /p $pwPlain /fd sha256 /td sha256 /tr http://timestamp.digicert.com $msi.FullName
+        if ($LASTEXITCODE -ne 0) {
+            Write-Fail 'signtool failed.'
+            exit $LASTEXITCODE
+        }
+        Write-Ok 'MSI signed.'
+        $sig = Get-AuthenticodeSignature $msi.FullName
+        Write-Ok "Signature: $($sig.Status), Signer: $($sig.SignerCertificate.Subject)"
+        Write-Warn2 'Dev cert is self-signed — SmartScreen will still warn on first run for non-trusted users.'
+    } else {
+        Write-Warn2 'Skipping sign (-NoSign).'
+    }
+
+    if ($Install) {
+        Invoke-Install $msi.FullName
+        if ($Run) {
+            $exe = Join-Path $installRoot 'Finance.exe'
+            if (Test-Path $exe) {
+                Write-Step "Launching $exe"
+                Start-Process -FilePath $exe
+                Write-Ok 'Launched.'
+            } else {
+                Write-Fail "Installed but $exe not found."
+            }
+        }
+    } else {
+        Write-Host ""
+        Write-Host "To install:   tools\windows\build-local.ps1 -InstallOnly -Install [-ForceUninstall -BackupData] [-Run]" -ForegroundColor Cyan
+        Write-Host "Or manually:  msiexec /i `"$($msi.FullName)`"" -ForegroundColor Cyan
+    }
+}
+finally {
+    Pop-Location
+}

--- a/tools/windows/dev-cert/.gitkeep
+++ b/tools/windows/dev-cert/.gitkeep
@@ -1,0 +1,2 @@
+# Auto-generated per-machine dev certs land here.
+# This whole folder's contents are gitignored — see ../../.gitignore.


### PR DESCRIPTION
# Windows: automate local + CI MSI builds

Adds three reproducible flows so Windows MSIs are always easy to produce — locally for iteration, and remotely on every push to `main` for testers.

Closes #1899

## What changed

### 1. New: `tools/windows/build-local.ps1`

One-command edit → build → sign → install → run loop.

```pwsh
pwsh tools/windows/build-local.ps1 -Install -ForceUninstall -BackupData -Run
```

- Generates (or reuses) a **per-machine** self-signed code-signing cert in `Cert:\CurrentUser\My`, exported to `tools/windows/dev-cert/<COMPUTERNAME>.pfx` (gitignored).
- Discovers `signtool.exe` from any Windows 10/11 SDK install.
- **Data-protection guard rail:** refuses to uninstall when user data (`%LOCALAPPDATA%\Finance\data\` or `\security\`) is present unless `-BackupData` (snapshot to timestamped sibling dir) or `-NoBackup` (acknowledge loss) is passed. Until #1900 moves data out of the install root, this is the defensive interim.
- Flags: `-Install`, `-Run`, `-Uninstall`, `-InstallOnly`, `-ForceUninstall`, `-NoSign`, `-BackupData`, `-NoBackup`, `-Clean`.

### 2. New: `.github/workflows/build-windows-main.yml`

Auto-runs on every push to `main` that touches Windows-relevant code (matches the `paths:` filter in `windows-ci.yml`).

- Always signs when `WINDOWS_SIGNING_CERT_BASE64` + `WINDOWS_CERT_PASSWORD` secrets are present; emits a `::warning::` and publishes unsigned otherwise.
- **Tests gate the build** — no `continue-on-error`.
- Publishes/force-overwrites a pre-release tagged **`latest-main`** with two asset names:
  - `Finance-main.msi` — **stable URL** that always points at the most recent main build (`/releases/download/latest-main/Finance-main.msi`).
  - `Finance-main-<sha7>.msi` — versioned alias for bisect / archaeology.
- `concurrency: cancel-in-progress: true` — newer pushes supersede in-flight builds.

### 3. Modified: `.github/workflows/release-windows.yml`

Hardening pass from rubber-duck review:

- **Defensive version extraction:** workflow_dispatch from a non-tag ref now produces `<branch>-<sha7>`, not `refs/heads/main`.
- **Drop `inputs.channel == 'store'` gate** on signing; sign whenever secrets are present via env-mapped `HAS_SIGNING_SECRETS` boolean.
- **Tight MSI target:** replace recursive `Get-ChildItem ... -Recurse` glob with the specific jpackage output dir to avoid catching stale MSIs.
- **Tests gate the release:** remove `continue-on-error: true` from the test step.
- Rename **"Sign MSIX package"** → **"Sign MSI"** (jpackage produces MSI, not MSIX).
- Tighten the artifact upload path + name to match.
- Concurrency note added: `cancel-in-progress: false` is correct here — every tag is a distinct artifact.

### 4. New: `apps/windows/README.md`

Developer-facing entry point covering all three flows, signing-secret setup (base64-encode + paste), SmartScreen handling, and a troubleshooting table keyed to the three regression bugs we just shipped fixes for (#1890, #1893, #1894).

### 5. `.gitignore`

Explicit entry for `tools/windows/dev-cert/*` (with `!.gitkeep` exception). Already covered by the global `*.pfx` rule, but explicit beats implicit.

## Why three flows?

| Flow                | Use case                                                              | Trigger                          |
| ------------------- | --------------------------------------------------------------------- | -------------------------------- |
| Local script        | Day-to-day dev, iterate on Windows-only bugs without waiting on CI    | `pwsh tools/windows/build-local.ps1 [flags]` |
| Rolling main build  | "Give me the latest signed MSI from main, right now"                  | Push to main, paths filter       |
| Tagged release      | Cutting a versioned release for testers/stores, with approval gate    | `git tag v1.2.3-windows && git push --tags` |

The rolling-main flow is the one we were missing: signed MSIs on every commit, stable download URL, no human in the loop. This is what unblocks alpha testers from "I need a working installer now."

## Rubber-duck critique items adopted

- Defensive data-dir protection in the local script (refuse to nuke without explicit opt-in)
- Split workflows (don't shoehorn rolling-main into the tag-driven release workflow)
- Version extraction defensiveness
- `paths:` filter parity with `windows-ci.yml`
- Env-mapped secret-presence check (`HAS_SIGNING_SECRETS`) instead of inline secret comparison in `if:` (avoids the historical bug where missing secrets cause the workflow to silently skip)
- Per-machine cert in `Cert:\CurrentUser\My`, NOT shared (SmartScreen reputation never transferred between dev certs anyway)
- Tight MSI target path (no recursive glob)

## Testing

- [x] Both new/modified workflow YAML files parse cleanly via `yaml.parse()`.
- [x] `tools/windows/build-local.ps1` parses cleanly via `[System.Management.Automation.Language.Parser]::ParseFile()`.
- [x] `npm run format:check && npx eslint . --max-warnings 0` clean.
- [x] No changes to existing tag-driven release behavior beyond the rubber-duck fixes (the tag-trigger and release-notes job are untouched in shape).

## Follow-ups

- **#1900** — the real fix for data colocated with binaries (move out of install root). The script's `-BackupData`/`-NoBackup` flags are the interim defense.
- Once this is merged, the rolling `latest-main` Release will be live after the next main push that touches a Windows-relevant path. Testers can bookmark the stable URL.
