### PR TITLE
feat(windows): relocate user data out of MSI install root (#1900)

### DIFF
--- a/apps/windows/build.gradle.kts
+++ b/apps/windows/build.gradle.kts
@@ -32,6 +32,13 @@ dependencies {
 
     // DI — Koin (core only, no Android dependency)
     implementation(libs.koin.core)
+
+    // ── Tests ──
+    testImplementation(libs.kotlin.test)
+}
+
+tasks.test {
+    useJUnit()
 }
 
 compose.desktop {

--- a/apps/windows/packaging/store/CERTIFICATION.md
+++ b/apps/windows/packaging/store/CERTIFICATION.md
@@ -108,7 +108,8 @@ This document tracks compliance with Microsoft Store certification policies
 The privacy policy must cover:
 
 1. **What data is collected**: Financial data (accounts, transactions, budgets, goals)
-2. **Where data is stored**: Locally on device in `%LOCALAPPDATA%\Finance\`
+2. **Where data is stored**: Locally on device in `%LOCALAPPDATA%\FinanceUserData\`
+   (legacy installs may also have data under `%LOCALAPPDATA%\Finance\`, automatically migrated on first launch)
 3. **How data is protected**: DPAPI encryption for credentials, Windows Hello for access
 4. **Cloud sync data**: When enabled, encrypted data synced to Finance backend
 5. **Third-party sharing**: No data shared with third parties

--- a/apps/windows/packaging/store/PRIVACY_POLICY.md
+++ b/apps/windows/packaging/store/PRIVACY_POLICY.md
@@ -36,8 +36,14 @@ The App does **not** collect:
 All financial data is stored locally on your Windows device in:
 
 ```
-%LOCALAPPDATA%\Finance\
+%LOCALAPPDATA%\FinanceUserData\
 ```
+
+This directory is **separate from** the application install location
+(`%LOCALAPPDATA%\Finance\`) so that uninstalling or reinstalling the
+application does not affect your data. Installs from older builds (prior to
+v1.x where data lived inside the install root) are migrated automatically
+on first launch after upgrade.
 
 ### Credential Encryption
 
@@ -73,8 +79,12 @@ We do **not** share, sell, or transmit your personal or financial data to any th
 You can delete all your data at any time:
 
 1. **In-App**: Settings → Data & Sync → Delete All Data
-2. **Manual**: Delete the `%LOCALAPPDATA%\Finance\` directory
-3. **Uninstall**: Uninstalling the app removes all application data
+2. **Manual**: Delete the `%LOCALAPPDATA%\FinanceUserData\` directory
+   (and `%LOCALAPPDATA%\Finance\` if it predates the v1.x layout split)
+3. **Uninstall**: Uninstalling the app removes program files but, by design,
+   does **not** delete your financial data — it remains in
+   `%LOCALAPPDATA%\FinanceUserData\` so that a reinstall picks up where you
+   left off. Use option 2 above to delete it manually after uninstalling.
 
 ## Children's Privacy
 

--- a/apps/windows/src/main/kotlin/com/finance/desktop/Main.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/Main.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
 import com.finance.desktop.components.rememberShortcutHandler
+import com.finance.desktop.data.storage.UserDataPaths
 import com.finance.desktop.di.appModules
 import com.finance.desktop.notifications.DesktopNotificationManager
 import com.finance.desktop.performance.PerformanceMonitor
@@ -25,6 +26,13 @@ import org.koin.core.context.stopKoin
 
 fun main() {
     PerformanceTracker.recordAppStart()
+
+    // ── One-time migration of user data out of MSI install root (#1900) ──
+    // Must run BEFORE Koin starts so any module that touches DB / DPAPI key /
+    // settings sees data at the new location. Idempotent and never throws.
+    timed("data_migration") {
+        UserDataPaths.migrateLegacyDataIfNeeded()
+    }
 
     timed("koin_init") {
         startKoin {

--- a/apps/windows/src/main/kotlin/com/finance/desktop/data/database/DesktopDatabaseManager.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/data/database/DesktopDatabaseManager.kt
@@ -5,13 +5,14 @@ package com.finance.desktop.data.database
 import com.finance.db.DatabaseFactory
 import com.finance.db.EncryptionKeyProvider
 import com.finance.db.FinanceDatabase
+import com.finance.desktop.data.storage.UserDataPaths
 import java.util.logging.Logger
 
 /**
  * Manages the SQLDelight [FinanceDatabase] singleton for the Windows desktop client.
  *
- * Creates the database in `%LOCALAPPDATA%\Finance\data\` with SQLCipher
- * encryption. The encryption key is derived from DPAPI-protected storage.
+ * Creates the database at [UserDataPaths.dataDir] (`%LOCALAPPDATA%\FinanceUserData\data\`)
+ * with SQLCipher encryption. The encryption key is derived from DPAPI-protected storage.
  *
  * The database instance is lazily created and cached for the application lifetime.
  *
@@ -24,13 +25,7 @@ class DesktopDatabaseManager(
         private val logger: Logger = Logger.getLogger(DesktopDatabaseManager::class.java.name)
 
         private fun resolveDbPath(): String {
-            val localAppData = System.getenv("LOCALAPPDATA")
-                ?: System.getProperty("user.home") + "\\AppData\\Local"
-            val dir = java.nio.file.Path.of(localAppData, "Finance", "data")
-            if (!java.nio.file.Files.exists(dir)) {
-                java.nio.file.Files.createDirectories(dir)
-            }
-            return dir.resolve("finance.db").toString()
+            return UserDataPaths.dataDir.resolve("finance.db").toString()
         }
     }
 

--- a/apps/windows/src/main/kotlin/com/finance/desktop/data/database/DpapiEncryptionKeyProvider.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/data/database/DpapiEncryptionKeyProvider.kt
@@ -3,6 +3,7 @@
 package com.finance.desktop.data.database
 
 import com.finance.db.EncryptionKeyProvider
+import com.finance.desktop.data.storage.UserDataPaths
 import com.finance.desktop.security.DpapiManager
 import java.security.SecureRandom
 import java.util.Base64
@@ -13,14 +14,14 @@ import java.util.logging.Logger
  * DPAPI-backed [EncryptionKeyProvider] for SQLCipher database encryption.
  *
  * Generates a 256-bit random key on first use, encrypts it with DPAPI
- * (CurrentUser scope), and stores it in `%LOCALAPPDATA%\Finance\security\`.
- * On subsequent calls, loads and decrypts the stored key.
+ * (CurrentUser scope), and stores it at [UserDataPaths.securityDir]
+ * (`%LOCALAPPDATA%\FinanceUserData\security\`). On subsequent calls,
+ * loads and decrypts the stored key.
  *
  * This ensures the SQLite database is encrypted at rest with a key that
  * only the current Windows user can decrypt.
  *
  * @param dpapiManager DPAPI encryption manager for key protection.
- * @param secureTokenStorage Token storage for persisting the encrypted key.
  */
 class DpapiEncryptionKeyProvider(
     private val dpapiManager: DpapiManager,
@@ -31,16 +32,10 @@ class DpapiEncryptionKeyProvider(
         private const val KEY_NAME = "db_encryption_key"
         private const val KEY_SIZE_BYTES = 32 // 256-bit
         private val secureRandom = SecureRandom()
-
-        private fun resolveKeyDir(): java.nio.file.Path {
-            val localAppData = System.getenv("LOCALAPPDATA")
-                ?: System.getProperty("user.home") + "\\AppData\\Local"
-            return java.nio.file.Path.of(localAppData, "Finance", "security")
-        }
     }
 
     private val keyFile: java.nio.file.Path
-        get() = resolveKeyDir().resolve("$KEY_NAME.enc")
+        get() = UserDataPaths.securityDir.resolve("$KEY_NAME.enc")
 
     @Volatile
     private var cachedKey: String? = null
@@ -85,10 +80,8 @@ class DpapiEncryptionKeyProvider(
         secureRandom.nextBytes(keyBytes)
         val hexKey = keyBytes.joinToString("") { "%02x".format(it) }
 
-        val dir = resolveKeyDir()
-        if (!java.nio.file.Files.exists(dir)) {
-            java.nio.file.Files.createDirectories(dir)
-        }
+        // UserDataPaths.securityDir ensures the directory exists.
+        UserDataPaths.securityDir
 
         val encrypted = dpapiManager.encrypt(hexKey.toByteArray(Charsets.UTF_8))
         val b64 = Base64.getEncoder().encodeToString(encrypted)

--- a/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/impl/DpapiSettingsRepository.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/impl/DpapiSettingsRepository.kt
@@ -22,7 +22,7 @@ import java.util.logging.Logger
  *
  * Persists [AppSettings] as JSON serialised with `kotlinx.serialization`, then
  * encrypted via [DpapiManager] and stored as a single file at
- * `%LOCALAPPDATA%\Finance\settings\app_settings.enc`.
+ * `%LOCALAPPDATA%\FinanceUserData\settings\app_settings.enc`.
  *
  * **Security guarantees:**
  * - Settings are never stored in plaintext on disk
@@ -54,14 +54,12 @@ class DpapiSettingsRepository(
 
         /**
          * Factory: creates a [DpapiSettingsRepository] using the standard
-         * `%LOCALAPPDATA%\Finance\settings\` directory.
+         * `%LOCALAPPDATA%\FinanceUserData\settings\` directory.
          */
         fun createDefault(): DpapiSettingsRepository {
-            val localAppData = System.getenv("LOCALAPPDATA")
-                ?: (System.getProperty("user.home") + "\\AppData\\Local")
             return DpapiSettingsRepository(
                 dpapiManager = DpapiManager.create(),
-                storageDir = Path.of(localAppData, "Finance", "settings"),
+                storageDir = com.finance.desktop.data.storage.UserDataPaths.settingsDir,
             )
         }
     }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/data/storage/UserDataPaths.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/data/storage/UserDataPaths.kt
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.data.storage
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.util.Comparator
+import java.util.logging.Level
+import java.util.logging.Logger
+
+/**
+ * Canonical resolution of user-data paths for the Windows desktop client.
+ *
+ * Historically, the MSI installed `Finance.exe` and runtime resources to
+ * `%LOCALAPPDATA%\Finance\` and the app **also** wrote its runtime data
+ * (SQLCipher DB, DPAPI-wrapped key, settings, GDPR consent) to subdirs of
+ * that same root. That conflated "program files" and "user data" in a
+ * single directory, with two concrete failure modes:
+ *
+ *  1. **Data loss on uninstall.** A naive MSI uninstall (or a user
+ *     manually deleting the install folder) wipes user data alongside
+ *     binaries.
+ *  2. **Reduced isolation between binaries and secrets.** A compromised
+ *     installer or supply-chain attack on the executables has adjacent
+ *     read access to the encrypted DB and DPAPI ciphertext.
+ *
+ * This object provides the canonical paths and centralises the one-time
+ * migration from the legacy in-install-root layout. All call sites that
+ * need to read/write user data MUST go through this object — the legacy
+ * `Path.of(localAppData, "Finance", ...)` pattern is forbidden.
+ *
+ * **Layout**
+ *
+ * | Concept              | Legacy                                       | New                                            |
+ * | -------------------- | -------------------------------------------- | ---------------------------------------------- |
+ * | Root                 | `%LOCALAPPDATA%\Finance\` (= MSI install)    | `%LOCALAPPDATA%\FinanceUserData\`              |
+ * | Database             | `%LOCALAPPDATA%\Finance\data\finance.db`     | `%LOCALAPPDATA%\FinanceUserData\data\finance.db` |
+ * | DPAPI key + tokens   | `%LOCALAPPDATA%\Finance\security\`           | `%LOCALAPPDATA%\FinanceUserData\security\`     |
+ * | Settings             | `%LOCALAPPDATA%\Finance\settings\`           | `%LOCALAPPDATA%\FinanceUserData\settings\`     |
+ * | GDPR consent file    | `%LOCALAPPDATA%\Finance\gdpr_consent.json`   | `%LOCALAPPDATA%\FinanceUserData\gdpr_consent.json` |
+ *
+ * The new root is intentionally named `FinanceUserData` (not just `Finance`)
+ * so it can never collide with whatever MSI install root jpackage chooses.
+ *
+ * Tracks #1900.
+ */
+object UserDataPaths {
+    private val logger: Logger = Logger.getLogger(UserDataPaths::class.java.name)
+
+    private const val LEGACY_ROOT_NAME = "Finance"
+    private const val NEW_ROOT_NAME = "FinanceUserData"
+    private const val CONSENT_FILE_NAME = "gdpr_consent.json"
+
+    // Subdirectories migrated as bulk units: legacy/<name>/... -> new/<name>/...
+    private val migratedSubdirs = listOf("data", "security", "settings")
+
+    // Single files migrated at the root level: legacy/<file> -> new/<file>
+    private val migratedRootFiles = listOf(CONSENT_FILE_NAME)
+
+    /** Root user-data directory. Created lazily by the subdir accessors. */
+    val rootDir: Path
+        get() = Path.of(resolveLocalAppData(), NEW_ROOT_NAME)
+
+    /** DB directory (`...\FinanceUserData\data\`). Created on first access. */
+    val dataDir: Path
+        get() = ensureDir(rootDir.resolve("data"))
+
+    /** DPAPI key + token directory (`...\FinanceUserData\security\`). */
+    val securityDir: Path
+        get() = ensureDir(rootDir.resolve("security"))
+
+    /** Settings directory (`...\FinanceUserData\settings\`). */
+    val settingsDir: Path
+        get() = ensureDir(rootDir.resolve("settings"))
+
+    /** GDPR consent file (`...\FinanceUserData\gdpr_consent.json`). */
+    val consentFile: Path
+        get() = ensureDir(rootDir).resolve(CONSENT_FILE_NAME)
+
+    /**
+     * One-time migration of user data from the legacy in-install-root layout
+     * to the new sibling layout. Idempotent — safe to call on every startup.
+     *
+     * **Strategy.** For each legacy subdir under `%LOCALAPPDATA%\Finance\`,
+     * if the new path is empty/missing and the legacy path has content,
+     * move the legacy directory's contents into the new location. Each
+     * legacy single-file (e.g. `gdpr_consent.json`) is moved if the
+     * destination doesn't already exist. MSI install files (`Finance.exe`,
+     * `runtime/`, `app/`) are never touched.
+     *
+     * **Conflict handling.** If both legacy and new versions of a subdir
+     * or file exist with content, the new version wins and the legacy
+     * artefact is left in place for manual review. This protects against
+     * accidentally overwriting a freshly-migrated install.
+     *
+     * **Failure handling.** Per-item exceptions are logged but never
+     * thrown — a single failed move does not abort migration of the
+     * remaining items, and the call sites will create fresh empty
+     * directories at the new path if needed.
+     *
+     * @param localAppData override for `%LOCALAPPDATA%`. Defaults to the
+     *   env var (with home-dir fallback). Tests pass a temp dir.
+     * @return `true` if any item was actually migrated, `false` if
+     *   nothing needed to move (clean install or already migrated).
+     */
+    @Suppress("TooGenericExceptionCaught", "NestedBlockDepth")
+    fun migrateLegacyDataIfNeeded(localAppData: String = resolveLocalAppData()): Boolean {
+        val legacyRoot = Path.of(localAppData, LEGACY_ROOT_NAME)
+        val newRoot = Path.of(localAppData, NEW_ROOT_NAME)
+
+        if (!Files.isDirectory(legacyRoot)) return false
+
+        var anyMoved = false
+
+        // ── Migrate bulk subdirs ───────────────────────────────────────
+        for (subdir in migratedSubdirs) {
+            val from = legacyRoot.resolve(subdir)
+            val to = newRoot.resolve(subdir)
+            if (!Files.isDirectory(from)) continue
+
+            if (Files.isDirectory(to) && hasContent(to)) {
+                logger.warning(
+                    "Both legacy ($from) and new ($to) user-data subdirs exist. " +
+                        "Using new; legacy left in place for manual review.",
+                )
+                continue
+            }
+
+            try {
+                Files.createDirectories(newRoot)
+                moveDirectory(from, to)
+                anyMoved = true
+                logger.info("Migrated user-data subdir: $from -> $to")
+            } catch (e: Exception) {
+                logger.log(Level.SEVERE, "Failed to migrate user-data subdir $from -> $to", e)
+            }
+        }
+
+        // ── Migrate root-level single files ────────────────────────────
+        for (fileName in migratedRootFiles) {
+            val from = legacyRoot.resolve(fileName)
+            val to = newRoot.resolve(fileName)
+            if (!Files.isRegularFile(from)) continue
+
+            if (Files.exists(to)) {
+                logger.warning(
+                    "Both legacy ($from) and new ($to) user-data files exist. " +
+                        "Using new; legacy left in place for manual review.",
+                )
+                continue
+            }
+
+            try {
+                Files.createDirectories(newRoot)
+                Files.move(from, to, StandardCopyOption.REPLACE_EXISTING)
+                anyMoved = true
+                logger.info("Migrated user-data file: $from -> $to")
+            } catch (e: Exception) {
+                logger.log(Level.SEVERE, "Failed to migrate user-data file $from -> $to", e)
+            }
+        }
+
+        return anyMoved
+    }
+
+    /**
+     * Recursively moves a directory tree from [from] to [to].
+     *
+     * Tries an atomic `Files.move` first (works on the same volume).
+     * Falls back to file-by-file copy + delete on failure, which handles
+     * cross-volume moves and partially-locked files (e.g. an antivirus
+     * scan briefly holding open a file in the legacy tree).
+     */
+    @Suppress("TooGenericExceptionCaught")
+    private fun moveDirectory(from: Path, to: Path) {
+        try {
+            Files.move(from, to)
+            return
+        } catch (e: Exception) {
+            logger.log(
+                Level.FINE,
+                "Atomic move failed, falling back to copy+delete: ${e.message}",
+            )
+        }
+
+        Files.createDirectories(to)
+        Files.walk(from).use { stream ->
+            stream.forEach { src ->
+                val rel = from.relativize(src)
+                val dest = if (rel.toString().isEmpty()) to else to.resolve(rel.toString())
+                if (Files.isDirectory(src)) {
+                    Files.createDirectories(dest)
+                } else {
+                    Files.copy(src, dest, StandardCopyOption.REPLACE_EXISTING)
+                }
+            }
+        }
+
+        Files.walk(from)
+            .sorted(Comparator.reverseOrder())
+            .use { stream -> stream.forEach { Files.deleteIfExists(it) } }
+    }
+
+    private fun hasContent(dir: Path): Boolean {
+        return Files.list(dir).use { it.findFirst().isPresent }
+    }
+
+    private fun ensureDir(p: Path): Path {
+        if (!Files.exists(p)) {
+            Files.createDirectories(p)
+        }
+        return p
+    }
+
+    private fun resolveLocalAppData(): String {
+        return System.getenv("LOCALAPPDATA")
+            ?: (System.getProperty("user.home") + "\\AppData\\Local")
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/di/RepositoryModule.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/di/RepositoryModule.kt
@@ -5,10 +5,10 @@ package com.finance.desktop.di
 import com.finance.desktop.data.repository.*
 import com.finance.desktop.data.repository.impl.*
 import com.finance.desktop.data.repository.impl.sqldelight.*
+import com.finance.desktop.data.storage.UserDataPaths
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
-import java.nio.file.Path
 
 /**
  * Koin module for repository bindings.
@@ -26,11 +26,9 @@ val repositoryModule = module {
 
     // ── Settings repository (DPAPI-encrypted persistence) ──
     single<SettingsRepository> {
-        val localAppData = System.getenv("LOCALAPPDATA")
-            ?: (System.getProperty("user.home") + "\\AppData\\Local")
         DpapiSettingsRepository(
             dpapiManager = get(),
-            storageDir = Path.of(localAppData, "Finance", "settings"),
+            storageDir = UserDataPaths.settingsDir,
         )
     }
 }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/security/CredentialManager.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/security/CredentialManager.kt
@@ -23,7 +23,7 @@ import java.util.logging.Logger
  * - Credentials are NEVER returned without prior Windows Hello authentication
  *   (when Windows Hello is available and auth is required)
  * - DPAPI binds ciphertext to the current Windows user account
- * - Token files reside in `%LOCALAPPDATA%\Finance\security\`
+ * - Token files reside in `%LOCALAPPDATA%\FinanceUserData\security\`
  *
  * @param windowsHelloManager Windows Hello biometric/PIN authentication
  * @param secureTokenStorage DPAPI-encrypted token persistence

--- a/apps/windows/src/main/kotlin/com/finance/desktop/security/SecureTokenStorage.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/security/SecureTokenStorage.kt
@@ -45,19 +45,16 @@ class SecureTokenStorage private constructor(
         /**
          * Returns the default storage directory for encrypted token files.
          *
-         * Resolves to `%LOCALAPPDATA%\Finance\security\` on Windows, falling
-         * back to `~\AppData\Local\Finance\security\` if the environment
-         * variable is not set.
+         * Resolves via [com.finance.desktop.data.storage.UserDataPaths] to
+         * `%LOCALAPPDATA%\FinanceUserData\security\` on Windows.
          */
         fun defaultStorageDir(): Path {
-            val localAppData = System.getenv("LOCALAPPDATA")
-                ?: System.getProperty("user.home") + "\\AppData\\Local"
-            return Path.of(localAppData, "Finance", "security")
+            return com.finance.desktop.data.storage.UserDataPaths.securityDir
         }
 
         /**
          * Creates a [SecureTokenStorage] using the default storage directory
-         * (`%LOCALAPPDATA%\Finance\security\`) and a default [DpapiManager].
+         * (`%LOCALAPPDATA%\FinanceUserData\security\`) and a default [DpapiManager].
          */
         fun create(): SecureTokenStorage {
             return create(DpapiManager.create(), defaultStorageDir())

--- a/apps/windows/src/main/kotlin/com/finance/desktop/security/SecurityAudit.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/security/SecurityAudit.kt
@@ -44,7 +44,7 @@ package com.finance.desktop.security
  * - **Encryption**: `CryptProtectData` via `ProtectedData.Protect()`
  * - **Decryption**: `CryptUnprotectData` via `ProtectedData.Unprotect()`
  * - **Scope**: `CurrentUser` — only the same Windows user can decrypt
- * - **Storage location**: `%LOCALAPPDATA%\Finance\security\`
+ * - **Storage location**: `%LOCALAPPDATA%\FinanceUserData\security\`
  * - **File format**: Base64-encoded DPAPI ciphertext, one file per token
  *
  * ### What's Protected

--- a/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/GdprConsentViewModel.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/GdprConsentViewModel.kt
@@ -4,6 +4,7 @@ package com.finance.desktop.viewmodel
 
 import com.finance.desktop.data.repository.AuthRepository
 import com.finance.desktop.data.repository.SettingsRepository
+import com.finance.desktop.data.storage.UserDataPaths
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -58,11 +59,8 @@ class GdprConsentViewModel(
         private val logger: Logger = Logger.getLogger(GdprConsentViewModel::class.java.name)
 
         private fun resolveConsentFile(): File {
-            val localAppData = System.getenv("LOCALAPPDATA")
-                ?: System.getProperty("user.home") + "\\AppData\\Local"
-            val dir = File(localAppData, "Finance")
-            dir.mkdirs()
-            return File(dir, "gdpr_consent.json")
+            // UserDataPaths.consentFile ensures the root directory exists.
+            return UserDataPaths.consentFile.toFile()
         }
     }
 

--- a/apps/windows/src/test/kotlin/com/finance/desktop/data/storage/UserDataPathsMigrationTest.kt
+++ b/apps/windows/src/test/kotlin/com/finance/desktop/data/storage/UserDataPathsMigrationTest.kt
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.data.storage
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [UserDataPaths.migrateLegacyDataIfNeeded].
+ *
+ * Each test runs against a fresh temp directory standing in for `%LOCALAPPDATA%`,
+ * with a synthetic `Finance/` (legacy) and `FinanceUserData/` (new) layout
+ * that we manipulate to exercise each branch.
+ */
+class UserDataPathsMigrationTest {
+
+    private lateinit var fakeLocalAppData: Path
+
+    private val legacyRoot get() = fakeLocalAppData.resolve("Finance")
+    private val newRoot get() = fakeLocalAppData.resolve("FinanceUserData")
+
+    @BeforeTest
+    fun setUp() {
+        fakeLocalAppData = Files.createTempDirectory("user-data-paths-test-")
+    }
+
+    @AfterTest
+    fun tearDown() {
+        if (Files.exists(fakeLocalAppData)) {
+            Files.walk(fakeLocalAppData)
+                .sorted(Comparator.reverseOrder())
+                .forEach { Files.deleteIfExists(it) }
+        }
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────
+
+    private fun writeFile(p: Path, content: String) {
+        p.parent.createDirectories()
+        p.writeText(content)
+    }
+
+    private fun migrate(): Boolean =
+        UserDataPaths.migrateLegacyDataIfNeeded(fakeLocalAppData.toString())
+
+    // ── Tests ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `fresh install with no legacy data is a no-op`() {
+        val moved = migrate()
+
+        assertFalse(moved, "Nothing should be moved on a fresh install")
+        assertFalse(newRoot.exists(), "New root should not be eagerly created by migration")
+    }
+
+    @Test
+    fun `legacy root with no subdirs is a no-op`() {
+        legacyRoot.createDirectories()
+
+        val moved = migrate()
+
+        assertFalse(moved)
+        assertFalse(newRoot.exists())
+    }
+
+    @Test
+    fun `legacy data subdir is moved into the new root`() {
+        writeFile(legacyRoot.resolve("data/finance.db"), "db-bytes")
+        writeFile(legacyRoot.resolve("security/db_encryption_key.enc"), "key-bytes")
+        writeFile(legacyRoot.resolve("settings/app_settings.enc"), "settings-bytes")
+
+        val moved = migrate()
+
+        assertTrue(moved, "Migration should report moving at least one item")
+        assertEquals("db-bytes", newRoot.resolve("data/finance.db").readText())
+        assertEquals("key-bytes", newRoot.resolve("security/db_encryption_key.enc").readText())
+        assertEquals("settings-bytes", newRoot.resolve("settings/app_settings.enc").readText())
+
+        // Legacy subdirs are removed; the legacy root itself is left in place
+        // (it may still contain MSI install files we must not touch).
+        assertFalse(legacyRoot.resolve("data").exists(), "Legacy data dir should be gone")
+        assertFalse(legacyRoot.resolve("security").exists(), "Legacy security dir should be gone")
+        assertFalse(legacyRoot.resolve("settings").exists(), "Legacy settings dir should be gone")
+        assertTrue(legacyRoot.exists(), "Legacy root must NOT be deleted (MSI install root)")
+    }
+
+    @Test
+    fun `legacy gdpr consent file is moved into the new root`() {
+        writeFile(legacyRoot.resolve("gdpr_consent.json"), """{"requiredConsent":true}""")
+
+        val moved = migrate()
+
+        assertTrue(moved)
+        assertEquals(
+            """{"requiredConsent":true}""",
+            newRoot.resolve("gdpr_consent.json").readText(),
+        )
+        assertFalse(legacyRoot.resolve("gdpr_consent.json").exists())
+    }
+
+    @Test
+    fun `both legacy and new data with content - new wins and legacy is preserved`() {
+        writeFile(legacyRoot.resolve("data/finance.db"), "OLD")
+        writeFile(newRoot.resolve("data/finance.db"), "NEW")
+
+        val moved = migrate()
+
+        assertFalse(moved, "Conflict means nothing was moved")
+        assertEquals("NEW", newRoot.resolve("data/finance.db").readText())
+        assertEquals("OLD", legacyRoot.resolve("data/finance.db").readText())
+    }
+
+    @Test
+    fun `existing empty new subdir does not block migration`() {
+        writeFile(legacyRoot.resolve("data/finance.db"), "OLD")
+        newRoot.resolve("data").createDirectories() // empty
+
+        val moved = migrate()
+
+        assertTrue(moved)
+        assertEquals("OLD", newRoot.resolve("data/finance.db").readText())
+        assertFalse(legacyRoot.resolve("data").exists())
+    }
+
+    @Test
+    fun `existing new gdpr consent file blocks migration of legacy file`() {
+        writeFile(legacyRoot.resolve("gdpr_consent.json"), "OLD")
+        writeFile(newRoot.resolve("gdpr_consent.json"), "NEW")
+
+        val moved = migrate()
+
+        assertFalse(moved)
+        assertEquals("NEW", newRoot.resolve("gdpr_consent.json").readText())
+        assertEquals("OLD", legacyRoot.resolve("gdpr_consent.json").readText())
+    }
+
+    @Test
+    fun `migration is idempotent - second call is a no-op`() {
+        writeFile(legacyRoot.resolve("data/finance.db"), "db-bytes")
+        writeFile(legacyRoot.resolve("gdpr_consent.json"), "consent")
+
+        assertTrue(migrate(), "First call should report a migration")
+        assertFalse(migrate(), "Second call should report nothing to do")
+
+        assertEquals("db-bytes", newRoot.resolve("data/finance.db").readText())
+        assertEquals("consent", newRoot.resolve("gdpr_consent.json").readText())
+    }
+
+    @Test
+    fun `only the three known subdirs and the consent file are migrated`() {
+        writeFile(legacyRoot.resolve("data/finance.db"), "db")
+        writeFile(legacyRoot.resolve("security/db_encryption_key.enc"), "key")
+        writeFile(legacyRoot.resolve("settings/app_settings.enc"), "settings")
+        writeFile(legacyRoot.resolve("gdpr_consent.json"), "consent")
+
+        // Files that look like MSI install artefacts — must NOT be touched.
+        writeFile(legacyRoot.resolve("Finance.exe"), "binary")
+        writeFile(legacyRoot.resolve("runtime/release"), "jre-info")
+        writeFile(legacyRoot.resolve("app/Finance.cfg"), "cfg")
+
+        val moved = migrate()
+
+        assertTrue(moved)
+
+        // User data: migrated
+        assertTrue(newRoot.resolve("data/finance.db").exists())
+        assertTrue(newRoot.resolve("security/db_encryption_key.enc").exists())
+        assertTrue(newRoot.resolve("settings/app_settings.enc").exists())
+        assertTrue(newRoot.resolve("gdpr_consent.json").exists())
+
+        // MSI install artefacts: left strictly alone
+        assertTrue(
+            legacyRoot.resolve("Finance.exe").exists(),
+            "MSI Finance.exe must not be touched",
+        )
+        assertTrue(
+            legacyRoot.resolve("runtime/release").exists(),
+            "MSI runtime/ tree must not be touched",
+        )
+        assertTrue(
+            legacyRoot.resolve("app/Finance.cfg").exists(),
+            "MSI app/ tree must not be touched",
+        )
+        assertFalse(
+            newRoot.resolve("Finance.exe").exists(),
+            "MSI Finance.exe must not be copied to new root",
+        )
+        assertFalse(
+            newRoot.resolve("runtime").exists(),
+            "MSI runtime/ must not be copied to new root",
+        )
+        assertFalse(
+            newRoot.resolve("app").exists(),
+            "MSI app/ must not be copied to new root",
+        )
+    }
+
+    @Test
+    fun `migration preserves nested directory structure`() {
+        writeFile(legacyRoot.resolve("data/finance.db"), "main")
+        writeFile(legacyRoot.resolve("data/backups/2025-01-15.db"), "backup")
+        writeFile(legacyRoot.resolve("data/.wal/finance.db-wal"), "wal")
+
+        val moved = migrate()
+
+        assertTrue(moved)
+        assertEquals("main", newRoot.resolve("data/finance.db").readText())
+        assertEquals("backup", newRoot.resolve("data/backups/2025-01-15.db").readText())
+        assertEquals("wal", newRoot.resolve("data/.wal/finance.db-wal").readText())
+        assertFalse(legacyRoot.resolve("data").exists())
+    }
+
+    @Test
+    fun `partial migration - one subdir already at new and one still at legacy`() {
+        // Settings already migrated previously; user re-installs and adds a fresh DB.
+        writeFile(legacyRoot.resolve("data/finance.db"), "fresh-db")
+        writeFile(newRoot.resolve("settings/app_settings.enc"), "existing-settings")
+
+        val moved = migrate()
+
+        assertTrue(moved, "Data should still migrate even though settings already exists")
+        assertEquals("fresh-db", newRoot.resolve("data/finance.db").readText())
+        assertEquals("existing-settings", newRoot.resolve("settings/app_settings.enc").readText())
+        assertFalse(legacyRoot.resolve("data").exists())
+    }
+}


### PR DESCRIPTION
## Summary

Relocates Windows desktop user data from `%LOCALAPPDATA%\Finance\` (also the
MSI install root) to a sibling `%LOCALAPPDATA%\FinanceUserData\` directory,
with a transparent one-time migration on first launch. Closes #1900.

## Why

The Finance MSI installs binaries to `%LOCALAPPDATA%\Finance\` (jpackage
`perUserInstall = true`). Previously the app also wrote its runtime data
to subdirs of that same root:

| Concept             | Old path                                     |
| ------------------- | -------------------------------------------- |
| SQLCipher DB        | `%LOCALAPPDATA%\Finance\data\finance.db`     |
| DPAPI key + tokens  | `%LOCALAPPDATA%\Finance\security\`           |
| Encrypted settings  | `%LOCALAPPDATA%\Finance\settings\`           |
| GDPR consent        | `%LOCALAPPDATA%\Finance\gdpr_consent.json`   |

Two concrete failure modes:

1. **Data loss on uninstall.** A naive MSI uninstall or manual delete of
   the install folder wiped user data alongside binaries.
2. **Reduced isolation between binaries and secrets.** Adjacent placement
   meant a compromised installer or supply-chain attack on `Finance.exe`
   had read access to the encrypted DB and DPAPI ciphertext.

## What

New layout under `%LOCALAPPDATA%\FinanceUserData\`:

```
FinanceUserData\
├── data\finance.db
├── security\db_encryption_key.enc
├── security\<token>.enc
├── settings\app_settings.enc
└── gdpr_consent.json
```

- New `UserDataPaths` singleton (`apps/windows/.../data/storage/`) owns all
  path resolution. All seven legacy call sites refactored to route through
  it; the `Path.of(localAppData, "Finance", ...)` pattern is now banned.
- `UserDataPaths.migrateLegacyDataIfNeeded()` wired into `Main.kt` **before**
  `startKoin {}` so any DI binding that touches user data sees the new
  paths. Idempotent, never throws.
- Migration moves **only** the three known subdirs (`data`, `security`,
  `settings`) and the `gdpr_consent.json` file. MSI install artefacts
  (`Finance.exe`, `runtime/`, `app/`) are explicitly left alone.
- Conflict handling: if both legacy and new contain data, the new path
  wins and the legacy artefact is preserved for manual review.
- Atomic `Files.move` is tried first; copy + delete fallback handles
  cross-volume moves and partially-locked files (e.g. antivirus scan).

## Tests

- 11 unit tests in `UserDataPathsMigrationTest` covering:
  - Fresh install (no legacy → no-op, new root not eagerly created)
  - Legacy data only → moved cleanly, legacy subdirs gone, legacy root preserved
  - Both legacy + new present → new wins, legacy preserved
  - Existing empty new subdir → does not block migration
  - GDPR consent file migration
  - Idempotency (second call is a no-op)
  - MSI artefacts (`Finance.exe`, `runtime/`, `app/`) never touched
  - Nested directory preservation
  - Partial state (one subdir already migrated, another still at legacy)
- Run: `./gradlew :apps:windows:test` — all green.
- Format + ESLint clean.

## Docs

- `apps/windows/packaging/store/PRIVACY_POLICY.md` — updated data location,
  corrected the "Uninstall removes all data" wording (it no longer does,
  by design — user data survives uninstall).
- `apps/windows/packaging/store/CERTIFICATION.md` — updated data location
  with a note about automatic migration from legacy installs.

## Follow-up

After both this PR and #1901 (Windows build automation) merge, a small
follow-up commit is needed to update `tools/windows/build-local.ps1` — its
data-protection guard rail currently only checks `%LOCALAPPDATA%\Finance\`
and should also detect `%LOCALAPPDATA%\FinanceUserData\`. Not in this PR
because the script doesn't exist on `main` yet.

## Manual verification plan (post-merge, signed MSI)

1. Install the previous signed MSI build, run the app, accept GDPR, add an
   account + a transaction so the DB and settings exist at the legacy path.
2. Uninstall.
3. Install the new signed MSI, launch.
4. Check `%LOCALAPPDATA%\FinanceUserData\` exists and contains the
   migrated `data\`, `security\`, `settings\`, and `gdpr_consent.json`.
5. Check the app loads with the previously-added data visible.
6. Uninstall again, verify `%LOCALAPPDATA%\FinanceUserData\` survives.

Closes #1900
