### PR TITLE
chore(windows): teach build-local.ps1 the new FinanceUserData path

### DIFF
--- a/apps/windows/README.md
+++ b/apps/windows/README.md
@@ -35,9 +35,10 @@ That call will:
    (gitignored).
 2. Run `./gradlew :apps:windows:packageMsi`.
 3. Sign the produced MSI with that cert.
-4. Snapshot any existing user data under `%LOCALAPPDATA%\Finance\data\` and
-   `%LOCALAPPDATA%\Finance\security\` to a timestamped sibling directory
-   (because `-BackupData` was passed), then uninstall the old version.
+4. Snapshot any existing user data under `%LOCALAPPDATA%\Finance\{data,security}\`
+   (legacy layout) and `%LOCALAPPDATA%\FinanceUserData\{data,security,settings}\`
+   (new layout, post-[#1900](../../../../issues/1900)) to a timestamped sibling
+   directory (because `-BackupData` was passed), then uninstall the old version.
 5. Install the freshly-built MSI silently.
 6. Launch `Finance.exe`.
 
@@ -50,9 +51,10 @@ That call will:
    (gitignored).
 2. Run `./gradlew :apps:windows:packageMsi`.
 3. Sign the produced MSI with that cert.
-4. Snapshot any existing user data under `%LOCALAPPDATA%\Finance\data\` and
-   `%LOCALAPPDATA%\Finance\security\` to a timestamped sibling directory,
-   then uninstall the old version.
+4. Snapshot any existing user data under `%LOCALAPPDATA%\Finance\{data,security}\`
+   (legacy layout) and `%LOCALAPPDATA%\FinanceUserData\{data,security,settings}\`
+   (new layout, post-[#1900](../../../../issues/1900)) to a timestamped sibling
+   directory, then uninstall the old version.
 5. Install the freshly-built MSI silently.
 6. Launch `Finance.exe`.
 
@@ -76,16 +78,23 @@ SDK (for `signtool.exe`) and your already-installed JDK 21.
 
 ### Data-safety design
 
-The Windows MSI currently installs to `%LOCALAPPDATA%\Finance\` and the app
-writes its SQLCipher database and DPAPI-wrapped key under that same root
-(`data\finance.db`, `security\db_encryption_key.enc`). A naive MSI uninstall
-will wipe those alongside the binaries. Until [#1900](../../../../issues/1900)
-moves the data outside the install root, the script defends against
-accidental data loss: any uninstall path (`-Uninstall`, or `-Install
--ForceUninstall` when an existing install is present) refuses to proceed if
-user data exists unless you opt in with either `-BackupData` (snapshot to a
-timestamped sibling directory) or `-NoBackup` (proceed and accept the
-loss). If you really want to nuke local data, pass `-NoBackup`.
+The Windows MSI installs `Finance.exe` and runtime resources to
+`%LOCALAPPDATA%\Finance\`. As of [#1900](../../../../issues/1900) the app's
+user data (SQLCipher DB, DPAPI-wrapped key, encrypted settings, GDPR consent)
+lives in a sibling root, `%LOCALAPPDATA%\FinanceUserData\`, so a clean
+uninstall no longer wipes user data. On first launch after upgrading from a
+pre-#1900 build, the app transparently migrates any data still under the
+legacy `%LOCALAPPDATA%\Finance\{data,security,settings}\` paths into the
+new root.
+
+Until that migration has run for every install on the machine the script
+defends against accidental data loss at **both** the legacy and the new
+location: any uninstall path (`-Uninstall`, or `-Install -ForceUninstall`
+when an existing install is present) refuses to proceed if user data exists
+under either root unless you opt in with either `-BackupData` (snapshot to a
+timestamped sibling directory mirroring the on-disk layout) or `-NoBackup`
+(proceed and accept the loss). If you really want to nuke local data, pass
+`-NoBackup`.
 
 ### Why a per-machine self-signed cert?
 

--- a/tools/windows/build-local.ps1
+++ b/tools/windows/build-local.ps1
@@ -14,10 +14,10 @@
 #                                                 # the most recent MSI in build/
 #
 # Data protection: -Install and -Uninstall refuse to touch the existing install
-# if user data is present at %LOCALAPPDATA%\Finance\data\ or \security\ (see #1900
-# for why this lives inside the install root and is being moved out). Pass
-# -BackupData to snapshot to a sibling timestamped folder before proceeding, or
-# -NoBackup to acknowledge the data may be lost.
+# if user data is present at the legacy path (%LOCALAPPDATA%\Finance\{data,security})
+# or the new path shipped in #1900 (%LOCALAPPDATA%\FinanceUserData\{data,security,settings}).
+# Pass -BackupData to snapshot to a sibling timestamped folder before proceeding,
+# or -NoBackup to acknowledge the data may be lost.
 
 [CmdletBinding()]
 param(
@@ -44,6 +44,26 @@ $certDir     = Join-Path $scriptDir 'dev-cert'
 $installRoot = Join-Path $env:LOCALAPPDATA 'Finance'
 $dataDir     = Join-Path $installRoot 'data'
 $keyDir      = Join-Path $installRoot 'security'
+
+# ── User-data root (#1900: data now lives OUTSIDE the install root) ──
+# The app migrates legacy data from $installRoot\{data,security} into
+# $userDataRoot\{data,security,settings} on first launch. Both layouts must
+# be considered "user data" by the data-protection guard until the legacy
+# directories are confirmed empty.
+$userDataRoot     = Join-Path $env:LOCALAPPDATA 'FinanceUserData'
+$newDataDir       = Join-Path $userDataRoot 'data'
+$newKeyDir        = Join-Path $userDataRoot 'security'
+$newSettingsDir   = Join-Path $userDataRoot 'settings'
+
+# Convenience: all directories the data-protection guard inspects,
+# tagged with the layout root they belong to so backups can mirror it.
+$userDataDirs = @(
+    @{ Name = 'legacy data';      Path = $dataDir;        Layout = 'legacy' },
+    @{ Name = 'legacy security';  Path = $keyDir;         Layout = 'legacy' },
+    @{ Name = 'data';             Path = $newDataDir;     Layout = 'new' },
+    @{ Name = 'security';         Path = $newKeyDir;      Layout = 'new' },
+    @{ Name = 'settings';         Path = $newSettingsDir; Layout = 'new' }
+)
 
 function Write-Step([string]$msg)    { Write-Host "`n==> $msg" -ForegroundColor Cyan }
 function Write-Ok([string]$msg)      { Write-Host "    [OK] $msg" -ForegroundColor Green }
@@ -125,24 +145,38 @@ function Get-InstalledFinance {
 }
 
 function Test-UserDataPresent {
-    $hasDb  = (Test-Path $dataDir) -and ((Get-ChildItem $dataDir -File -ErrorAction SilentlyContinue).Count -gt 0)
-    $hasKey = (Test-Path $keyDir)  -and ((Get-ChildItem $keyDir  -File -ErrorAction SilentlyContinue).Count -gt 0)
-    return ($hasDb -or $hasKey)
+    foreach ($entry in $userDataDirs) {
+        $p = $entry.Path
+        if ((Test-Path $p) -and ((Get-ChildItem $p -File -ErrorAction SilentlyContinue).Count -gt 0)) {
+            return $true
+        }
+    }
+    return $false
 }
 
 function Backup-UserData {
     $stamp = Get-Date -Format 'yyyyMMdd-HHmmss'
     $backup = Join-Path $env:LOCALAPPDATA "Finance-backup-$stamp"
     New-Item -ItemType Directory -Path $backup | Out-Null
-    if (Test-Path $dataDir) {
-        Copy-Item -Path $dataDir -Destination (Join-Path $backup 'data') -Recurse -Force
-        Write-Ok "Backed up data\  -> $backup\data"
+
+    # Mirror the on-disk layout under the backup root so a restore is a
+    # straight Copy-Item back to %LOCALAPPDATA%. Legacy and new live in
+    # different sub-roots to keep them distinguishable on restore.
+    $legacyBackup = Join-Path $backup 'Finance'
+    $newBackup    = Join-Path $backup 'FinanceUserData'
+
+    foreach ($entry in $userDataDirs) {
+        $p = $entry.Path
+        if (-not (Test-Path $p)) { continue }
+        $destRoot = if ($entry.Layout -eq 'legacy') { $legacyBackup } else { $newBackup }
+        if (-not (Test-Path $destRoot)) { New-Item -ItemType Directory -Path $destRoot | Out-Null }
+        $leaf = Split-Path $p -Leaf
+        Copy-Item -Path $p -Destination (Join-Path $destRoot $leaf) -Recurse -Force
+        Write-Ok "Backed up $($entry.Name)\  -> $destRoot\$leaf"
     }
-    if (Test-Path $keyDir) {
-        Copy-Item -Path $keyDir -Destination (Join-Path $backup 'security') -Recurse -Force
-        Write-Ok "Backed up security\ -> $backup\security"
-    }
-    Write-Warn2 "Restore manually if needed: Copy-Item $backup\* $installRoot -Recurse -Force"
+
+    Write-Warn2 "Restore (legacy): Copy-Item $legacyBackup\* $installRoot   -Recurse -Force"
+    Write-Warn2 "Restore (new):    Copy-Item $newBackup\*    $userDataRoot  -Recurse -Force"
     return $backup
 }
 
@@ -157,7 +191,7 @@ function Assert-SafeToUninstall {
         Write-Warn2 "User data detected, -NoBackup specified — data may be lost"
         return
     }
-    Write-Fail "Existing user data at $dataDir and/or $keyDir."
+    Write-Fail "Existing user data detected under $installRoot and/or $userDataRoot."
     Write-Fail "Refusing to uninstall to avoid data loss (see #1900)."
     Write-Fail "Re-run with -BackupData (recommended) or -NoBackup to proceed."
     exit 2


### PR DESCRIPTION
## Summary

Updates `tools/windows/build-local.ps1` and `apps/windows/README.md` to
account for the post-#1900 Windows user-data layout. Without this change,
the script's data-protection guard rail still only checks the legacy
`%LOCALAPPDATA%\Finance\{data,security}\` paths — meaning that after
#1900 ships, a developer running `build-local.ps1 -Install -ForceUninstall`
on a machine where migration has already moved data to
`%LOCALAPPDATA%\FinanceUserData\` would silently lose their local DB.

## Why a follow-up PR

This change couldn't ride on #1900 because the script didn't exist on
`main` yet — it shipped in #1899 (PR #1901). Now that both #1899 and
#1900 are merged, this is the small bridge between them.

## Changes

### `tools/windows/build-local.ps1`

- New path vars for the post-#1900 layout: `$userDataRoot`, `$newDataDir`,
  `$newKeyDir`, `$newSettingsDir`. Legacy vars retained.
- `$userDataDirs` lookup table tags each inspected path with
  `Layout = 'legacy' | 'new'`. Used by both presence-check and backup
  to avoid string-prefix ambiguity (see "Bug caught" below).
- `Test-UserDataPresent` iterates the table — returns true if **any** of
  the five tracked locations contains files (was: only two legacy dirs).
- `Backup-UserData` mirrors the on-disk layout under
  `Finance-backup-<timestamp>\{Finance,FinanceUserData}\...` so a restore
  is a straight `Copy-Item` back to the right parent root.
- `Assert-SafeToUninstall` error wording updated to mention both roots.
- Header comment block updated.

### `apps/windows/README.md`

- "Data-safety design" section rewritten to describe the post-#1900
  layout (data outside install root), the legacy migration behaviour,
  and the broader guard rail.
- Two "what `-BackupData` does" bullet blurbs updated.

## Bug caught during smoke-testing

The first draft used `$path.StartsWith($installRoot)` to classify a
discovered user-data dir as legacy vs new. That string-prefix check
silently misclassified the new paths because `FinanceUserData` literally
starts with `Finance` — every new-layout file got backed up into the
legacy backup sub-root. Fixed by tagging each entry in `$userDataDirs`
with an explicit `Layout` field; the smoke tests verify the fix.

## Testing

Manual smoke tests against a synthetic `$env:LOCALAPPDATA` covered:

- Empty world → `Test-UserDataPresent` returns false
- Only legacy data present → true
- Only new data present → true
- Only new settings present → true (verifies the new third subdir is checked)
- Dirs exist but empty → false (empty install state)
- Mixed legacy + new → backup correctly routes each into its own sub-root
- File contents survive the backup round-trip

Parse + format + lint:

- `[System.Management.Automation.Language.Parser]::ParseFile(...)` clean
- `npm run format:check` clean
- `npx eslint . --max-warnings 0` clean

## Issues

Refs #1900
Refs #1899

(No `Closes #N` — both parent issues are already closed by their primary
PRs. This is housekeeping.)
