### PR TITLE
ci(windows): locate signtool from Windows SDK (#1904)

### DIFF
--- a/.github/workflows/build-windows-main.yml
+++ b/.github/workflows/build-windows-main.yml
@@ -96,13 +96,29 @@ jobs:
         if: env.HAS_SIGNING_SECRETS == 'true'
         shell: pwsh
         run: |
+          # Locate signtool from the Windows SDK — GitHub-hosted windows-latest
+          # runners do NOT have signtool.exe on PATH, even though the SDK is
+          # installed. Mirrors tools/windows/build-local.ps1's Find-SignTool.
+          $sdkRoot = 'C:\Program Files (x86)\Windows Kits\10\bin'
+          $signtool = $null
+          if (Test-Path $sdkRoot) {
+              $signtool = Get-ChildItem -Path $sdkRoot -Directory |
+                  Where-Object { $_.Name -match '^\d+\.\d+\.\d+\.\d+$' } |
+                  Sort-Object -Property { [version]$_.Name } -Descending |
+                  ForEach-Object { Join-Path $_.FullName 'x64\signtool.exe' } |
+                  Where-Object { Test-Path $_ } |
+                  Select-Object -First 1
+          }
+          if (-not $signtool) { throw "signtool.exe not found under $sdkRoot" }
+          Write-Host "Using signtool: $signtool"
+
           $certBytes = [System.Convert]::FromBase64String("${{ secrets.WINDOWS_SIGNING_CERT_BASE64 }}")
           $certPath = Join-Path $env:RUNNER_TEMP "signing-cert.pfx"
           [System.IO.File]::WriteAllBytes($certPath, $certBytes)
           try {
               # Sign both the versioned and stable copies (they're separate files on disk).
               foreach ($target in @("${{ steps.msi.outputs.versioned }}", "${{ steps.msi.outputs.stable }}")) {
-                  & signtool sign /f $certPath /p "${{ secrets.WINDOWS_CERT_PASSWORD }}" `
+                  & $signtool sign /f $certPath /p "${{ secrets.WINDOWS_CERT_PASSWORD }}" `
                       /fd sha256 /tr http://timestamp.digicert.com /td sha256 $target
                   if ($LASTEXITCODE -ne 0) { throw "signtool exit $LASTEXITCODE on $target" }
                   Write-Host "Signed: $target"

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -114,6 +114,22 @@ jobs:
         if: env.HAS_SIGNING_SECRETS == 'true'
         shell: pwsh
         run: |
+          # Locate signtool from the Windows SDK — GitHub-hosted windows-latest
+          # runners do NOT have signtool.exe on PATH, even though the SDK is
+          # installed. Mirrors tools/windows/build-local.ps1's Find-SignTool.
+          $sdkRoot = 'C:\Program Files (x86)\Windows Kits\10\bin'
+          $signtool = $null
+          if (Test-Path $sdkRoot) {
+              $signtool = Get-ChildItem -Path $sdkRoot -Directory |
+                  Where-Object { $_.Name -match '^\d+\.\d+\.\d+\.\d+$' } |
+                  Sort-Object -Property { [version]$_.Name } -Descending |
+                  ForEach-Object { Join-Path $_.FullName 'x64\signtool.exe' } |
+                  Where-Object { Test-Path $_ } |
+                  Select-Object -First 1
+          }
+          if (-not $signtool) { throw "signtool.exe not found under $sdkRoot" }
+          Write-Host "Using signtool: $signtool"
+
           # Decode signing certificate from secret
           $certBytes = [System.Convert]::FromBase64String("${{ secrets.WINDOWS_SIGNING_CERT_BASE64 }}")
           $certPath = Join-Path $env:RUNNER_TEMP "signing-cert.pfx"
@@ -126,7 +142,7 @@ jobs:
               if (-not $msiFiles) { throw "No MSI found in expected output dir." }
               foreach ($file in $msiFiles) {
                   Write-Host "Signing: $($file.FullName)"
-                  & signtool sign /f $certPath /p "${{ secrets.WINDOWS_CERT_PASSWORD }}" `
+                  & $signtool sign /f $certPath /p "${{ secrets.WINDOWS_CERT_PASSWORD }}" `
                       /fd sha256 /tr http://timestamp.digicert.com /td sha256 $file.FullName
                   if ($LASTEXITCODE -ne 0) { throw "signtool exit $LASTEXITCODE on $($file.FullName)" }
               }


### PR DESCRIPTION
## Summary

Fix both Windows MSI signing workflows so they can find `signtool.exe` on GitHub-hosted `windows-latest` runners. Mirrors the SDK-discovery logic from `tools/windows/build-local.ps1`.

## Root cause

`windows-latest` ships the Windows SDK but does **not** add `signtool.exe` to PATH. The bare `& signtool sign ...` invocation in:
- `.github/workflows/build-windows-main.yml` (Sign MSI step)
- `.github/workflows/release-windows.yml` (Sign MSI step)

fails on every run with `The term 'signtool' is not recognized...`. Failing runs include 26593752086 (#1901), 26594704264 (#1902), 26599379054 (#1903).

## Fix

In each workflow, enumerate `C:\Program Files (x86)\Windows Kits\10\bin\<ver>\x64\signtool.exe`, pick the highest SDK version, and invoke by full path:

```pwsh
$sdkRoot = 'C:\Program Files (x86)\Windows Kits\10\bin'
$signtool = Get-ChildItem -Path $sdkRoot -Directory |
    Where-Object { $_.Name -match '^\d+\.\d+\.\d+\.\d+$' } |
    Sort-Object -Property { [version]$_.Name } -Descending |
    ForEach-Object { Join-Path $_.FullName 'x64\signtool.exe' } |
    Where-Object { Test-Path $_ } |
    Select-Object -First 1
```

Then `& $signtool sign ...` instead of `& signtool sign ...`. No new dependencies, no new actions.

## Why mirror build-local.ps1?

`tools/windows/build-local.ps1` already implements this exact pattern (`Find-SignTool`) and signs successfully on local Windows. Lifting the same approach into CI keeps one mental model.

## Validation

- Confirmed signtool.exe location on a Microsoft-hosted `windows-latest` runner matches this layout (Windows SDK in `C:\Program Files (x86)\Windows Kits\10\bin\<ver>\x64\`).
- The discovery loop fails fast with a clear error if signtool is ever missing.

## Issues

Closes #1904