### PR TITLE
feat(export): one-click JSON and CSV downloads for GDPR portability (#1936)

### DIFF
--- a/apps/web/src/components/DataExport.test.tsx
+++ b/apps/web/src/components/DataExport.test.tsx
@@ -2,7 +2,6 @@
 // @vitest-environment jsdom
 
 import React from 'react';
-import '@testing-library/jest-dom/vitest';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';

--- a/apps/web/src/components/DataExport.test.tsx
+++ b/apps/web/src/components/DataExport.test.tsx
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
+// @vitest-environment jsdom
 
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { DataExport } from './DataExport';
@@ -69,6 +71,19 @@ vi.mock('../db/repositories/transactions', () => ({
 
 vi.mock('../db/repositories/budgets', () => ({ getAllBudgets: vi.fn(() => []) }));
 vi.mock('../db/repositories/goals', () => ({ getAllGoals: vi.fn(() => []) }));
+vi.mock('../db/repositories/bills', () => ({ getAllBills: vi.fn(() => []) }));
+vi.mock('../db/repositories/investments', () => ({ getAllInvestments: vi.fn(() => []) }));
+vi.mock('../db/repositories/investment-lots', () => ({ getLotsByInvestment: vi.fn(() => []) }));
+vi.mock('../db/repositories/household', () => ({
+  getHouseholdById: vi.fn(() => ({ id: 'hh-1', name: 'Home', ownerId: 'owner-1' })),
+  getHouseholdMembers: vi.fn(() => []),
+  getHouseholdInvitations: vi.fn(() => []),
+  getAccountSharings: vi.fn(() => []),
+  getSharedBudgets: vi.fn(() => []),
+  getBudgetContributions: vi.fn(() => []),
+  getSharedGoals: vi.fn(() => []),
+  getGoalContributions: vi.fn(() => []),
+}));
 vi.mock('../db/repositories/categories', () => ({
   getAllCategories: vi.fn(() => [
     {
@@ -97,6 +112,7 @@ beforeEach(() => {
     createObjectURL: vi.fn(() => 'blob:mock-url'),
     revokeObjectURL: vi.fn(),
   });
+  vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => undefined);
   Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
   Object.defineProperty(navigator, 'share', { value: undefined, configurable: true });
   Object.defineProperty(navigator, 'canShare', { value: undefined, configurable: true });
@@ -104,6 +120,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  cleanup();
   vi.useRealTimers();
   vi.restoreAllMocks();
 });
@@ -131,8 +148,12 @@ describe('DataExport', () => {
   it('renders the request-my-data entry point and status indicator', () => {
     render(<DataExport />, { wrapper: createTestWrapper(createMockDb()) });
 
+    expect(screen.getByRole('button', { name: /download all data \(json\)/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /download transactions \(csv\)/i }),
+    ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /request my data/i })).toBeInTheDocument();
-    expect(screen.getByText(/local ZIP package/i)).toBeInTheDocument();
+    expect(screen.getByText(/plain JSON dump or transactions CSV/i)).toBeInTheDocument();
     expect(screen.getByRole('status')).toHaveTextContent(/not requested/i);
   });
 
@@ -141,6 +162,41 @@ describe('DataExport', () => {
 
     expect(screen.getByText(/database is not available/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /request my data/i })).toBeDisabled();
+  });
+
+  it('downloads a full JSON export directly from local data', async () => {
+    localStorage.setItem('finance-currency', 'USD');
+    const user = userEvent.setup();
+    render(<DataExport />, { wrapper: createTestWrapper(createMockDb()) });
+
+    await user.click(screen.getByRole('button', { name: /download all data \(json\)/i }));
+
+    const blob = vi.mocked(URL.createObjectURL).mock.calls[0][0] as Blob;
+    const payload = JSON.parse(await blob.text()) as {
+      accounts: unknown[];
+      preferences: unknown[];
+    };
+    expect(blob.type).toBe('application/json;charset=utf-8');
+    expect(payload.accounts).toHaveLength(1);
+    expect(payload.preferences).toEqual([{ key: 'finance-currency', value: 'USD' }]);
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+    expect(screen.getByText(/JSON download started/i)).toBeInTheDocument();
+  });
+
+  it('downloads denormalized transactions CSV directly from local data', async () => {
+    const user = userEvent.setup();
+    render(<DataExport />, { wrapper: createTestWrapper(createMockDb()) });
+
+    await user.click(screen.getByRole('button', { name: /download transactions \(csv\)/i }));
+
+    const blob = vi.mocked(URL.createObjectURL).mock.calls[0][0] as Blob;
+    expect(blob.type).toBe('text/csv;charset=utf-8');
+    await expect(blob.text()).resolves.toContain(
+      'date,account_name,category_name,description,amount,currency\r\n' +
+        '2024-03-06,Checking,Food,Grocery Store,-67.42,USD',
+    );
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+    expect(screen.getByText(/Transactions CSV download started/i)).toBeInTheDocument();
   });
 
   it('shows a confirmation modal with protected-category and mood-tag choices', async () => {

--- a/apps/web/src/components/DataExport.tsx
+++ b/apps/web/src/components/DataExport.tsx
@@ -15,6 +15,12 @@ import {
   type DataAccessManifest,
   type DataAccessPackageResult,
 } from '../lib/data-access-package';
+import {
+  buildDatedExportFileName,
+  buildFullJsonExport,
+  buildTransactionsCsv,
+  serializeFullJsonExport,
+} from '../lib/export/simple-export';
 import './data-export.css';
 
 type ExportStatus =
@@ -107,6 +113,22 @@ function downloadBytes(content: Uint8Array, filename: string, mimeType: string):
   return url;
 }
 
+function triggerBrowserDownload(content: string, filename: string, mimeType: string): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.style.display = 'none';
+  document.body.appendChild(anchor);
+  try {
+    anchor.click();
+  } finally {
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+  }
+}
+
 async function shareOrDownloadPackage(
   packageResult: DataAccessPackageResult,
 ): Promise<string | null> {
@@ -138,6 +160,7 @@ export const DataExport: React.FC<DataExportProps> = ({ className = '' }) => {
   const [packageResult, setPackageResult] = useState<DataAccessPackageResult | null>(null);
   const [objectUrl, setObjectUrl] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState('');
+  const [simpleDownloadMessage, setSimpleDownloadMessage] = useState('');
   const [expirationWarning, setExpirationWarning] = useState(false);
   const cancelledRef = useRef(false);
   const pendingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -180,6 +203,7 @@ export const DataExport: React.FC<DataExportProps> = ({ className = '' }) => {
   const startRequest = useCallback(() => {
     setShowConfirmation(true);
     setErrorMessage('');
+    setSimpleDownloadMessage('');
   }, []);
 
   const cancelRequest = useCallback(() => {
@@ -238,6 +262,53 @@ export const DataExport: React.FC<DataExportProps> = ({ className = '' }) => {
     }, 100);
   }, [db, includeMoodTags, includeProtectedCategories]);
 
+  const downloadFullJson = useCallback(() => {
+    setErrorMessage('');
+    setSimpleDownloadMessage('');
+    try {
+      if (!db)
+        throw new Error('Database is still initializing. Please wait a moment and try again.');
+      const generatedAt = new Date();
+      const exportData = buildFullJsonExport(db, {
+        appVersion: APP_VERSION,
+        generatedAt,
+        preferences: readLocalStorageRecords('finance-'),
+        settings: readLocalStorageRecords('settings-'),
+      });
+      triggerBrowserDownload(
+        serializeFullJsonExport(exportData),
+        buildDatedExportFileName('finance-data', 'json', generatedAt),
+        'application/json;charset=utf-8',
+      );
+      setSimpleDownloadMessage('JSON download started.');
+    } catch (error) {
+      setStatus('error');
+      setErrorMessage(error instanceof Error ? error.message : 'Unable to download JSON export.');
+    }
+  }, [db]);
+
+  const downloadTransactionsCsv = useCallback(() => {
+    setErrorMessage('');
+    setSimpleDownloadMessage('');
+    try {
+      if (!db)
+        throw new Error('Database is still initializing. Please wait a moment and try again.');
+      const generatedAt = new Date();
+      const exportData = buildFullJsonExport(db, { appVersion: APP_VERSION, generatedAt });
+      triggerBrowserDownload(
+        buildTransactionsCsv(exportData),
+        buildDatedExportFileName('finance-transactions', 'csv', generatedAt),
+        'text/csv;charset=utf-8',
+      );
+      setSimpleDownloadMessage('Transactions CSV download started.');
+    } catch (error) {
+      setStatus('error');
+      setErrorMessage(
+        error instanceof Error ? error.message : 'Unable to download transactions CSV.',
+      );
+    }
+  }, [db]);
+
   const deliverPackage = useCallback(async () => {
     if (!packageResult) return;
     try {
@@ -256,7 +327,7 @@ export const DataExport: React.FC<DataExportProps> = ({ className = '' }) => {
       <p id="data-export-description" className="data-export__description">
         {dbUnavailable
           ? 'Database is not available. Please wait for it to initialize.'
-          : 'Generate a local ZIP package with manifest.json, per-domain JSON files, attachments, and a localized README.md. No server roundtrip is used.'}
+          : 'Download a plain JSON dump or transactions CSV immediately, or generate the advanced local ZIP package. No server roundtrip is used.'}
       </p>
 
       <div
@@ -264,6 +335,26 @@ export const DataExport: React.FC<DataExportProps> = ({ className = '' }) => {
         role="group"
         aria-labelledby="data-export-description"
       >
+        <button
+          type="button"
+          className="data-export__button"
+          disabled={dbUnavailable || status === 'pending' || status === 'generating'}
+          onClick={downloadFullJson}
+          aria-describedby="data-export-description"
+        >
+          <DownloadIcon />
+          Download all data (JSON)
+        </button>
+        <button
+          type="button"
+          className="data-export__button"
+          disabled={dbUnavailable || status === 'pending' || status === 'generating'}
+          onClick={downloadTransactionsCsv}
+          aria-describedby="data-export-description"
+        >
+          <DownloadIcon />
+          Download transactions (CSV)
+        </button>
         <button
           type="button"
           className="data-export__button"
@@ -298,6 +389,17 @@ export const DataExport: React.FC<DataExportProps> = ({ className = '' }) => {
           </div>
         )}
       </div>
+
+      {simpleDownloadMessage && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="data-export__feedback data-export__feedback--success"
+        >
+          <CheckIcon />
+          <p className="data-export__feedback-message--success">{simpleDownloadMessage}</p>
+        </div>
+      )}
 
       {showConfirmation && (
         <div

--- a/apps/web/src/lib/export/simple-export.test.ts
+++ b/apps/web/src/lib/export/simple-export.test.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it, vi } from 'vitest';
+import type { SqliteDb } from '../../db/sqlite-wasm';
+import {
+  buildDatedExportFileName,
+  buildFullJsonExport,
+  buildTransactionsCsv,
+  escapeCsvField,
+  serializeFullJsonExport,
+} from './simple-export';
+
+vi.mock('../../db/repositories/accounts', () => ({
+  getAllAccounts: vi.fn(() => [
+    { id: 'acc-1', householdId: 'hh-1', name: 'Checking', currency: { code: 'USD' } },
+  ]),
+}));
+
+vi.mock('../../db/repositories/transactions', () => ({
+  getAllTransactions: vi.fn(() => [
+    {
+      id: 'txn-1',
+      householdId: 'hh-1',
+      accountId: 'acc-1',
+      categoryId: 'cat-1',
+      date: '2024-03-06',
+      payee: 'Grocery Store',
+      note: null,
+      statementDescription: null,
+      amount: { amount: -6742 },
+      currency: { code: 'USD' },
+    },
+  ]),
+}));
+
+vi.mock('../../db/repositories/categories', () => ({
+  getAllCategories: vi.fn(() => [{ id: 'cat-1', householdId: 'hh-1', name: 'Food' }]),
+}));
+
+vi.mock('../../db/repositories/budgets', () => ({
+  getAllBudgets: vi.fn(() => [{ id: 'budget-1', householdId: 'hh-1', categoryId: 'cat-1' }]),
+}));
+
+vi.mock('../../db/repositories/goals', () => ({
+  getAllGoals: vi.fn(() => [{ id: 'goal-1', householdId: 'hh-1', name: 'Emergency fund' }]),
+}));
+
+vi.mock('../../db/repositories/bills', () => ({
+  getAllBills: vi.fn(() => [{ id: 'bill-1', householdId: 'hh-1', name: 'Internet' }]),
+}));
+
+vi.mock('../../db/repositories/investments', () => ({
+  getAllInvestments: vi.fn(() => [{ id: 'inv-1', householdId: 'hh-1', symbol: 'VTI' }]),
+}));
+
+vi.mock('../../db/repositories/investment-lots', () => ({
+  getLotsByInvestment: vi.fn(() => [{ id: 'lot-1', investmentId: 'inv-1', shares: 1 }]),
+}));
+
+vi.mock('../../db/repositories/household', () => ({
+  getHouseholdById: vi.fn(() => ({ id: 'hh-1', name: 'Home', ownerId: 'owner-1' })),
+  getHouseholdMembers: vi.fn(() => [{ id: 'member-1', householdId: 'hh-1', userId: 'owner-1' }]),
+  getHouseholdInvitations: vi.fn(() => []),
+  getAccountSharings: vi.fn(() => [{ id: 'sharing-1', householdId: 'hh-1', accountId: 'acc-1' }]),
+  getSharedBudgets: vi.fn(() => [
+    { id: 'shared-budget-1', householdId: 'hh-1', budgetId: 'budget-1' },
+  ]),
+  getBudgetContributions: vi.fn(() => []),
+  getSharedGoals: vi.fn(() => [{ id: 'shared-goal-1', householdId: 'hh-1', goalId: 'goal-1' }]),
+  getGoalContributions: vi.fn(() => []),
+}));
+
+function createMockDb(): SqliteDb {
+  return { exec: vi.fn(), close: vi.fn() } as unknown as SqliteDb;
+}
+
+describe('simple-export', () => {
+  it('builds a full structured JSON export from local repositories', () => {
+    const generatedAt = new Date('2026-05-26T12:00:00Z');
+    const result = buildFullJsonExport(createMockDb(), {
+      appVersion: '0.1.0',
+      generatedAt,
+      preferences: [{ key: 'finance-currency', value: 'USD' }],
+      settings: [{ key: 'theme', value: 'system' }],
+    });
+
+    expect(result).toMatchObject({
+      schemaVersion: 1,
+      generatedAt: '2026-05-26T12:00:00.000Z',
+      appVersion: '0.1.0',
+      accounts: [{ id: 'acc-1' }],
+      transactions: [{ id: 'txn-1' }],
+      categories: [{ id: 'cat-1' }],
+      budgets: [{ id: 'budget-1' }],
+      goals: [{ id: 'goal-1' }],
+      bills: [{ id: 'bill-1' }],
+      investments: [{ id: 'inv-1' }],
+      investmentLots: [{ id: 'lot-1' }],
+      households: [{ id: 'hh-1' }],
+      householdMembers: [{ id: 'member-1' }],
+      accountSharings: [{ id: 'sharing-1' }],
+      sharedBudgets: [{ id: 'shared-budget-1' }],
+      sharedGoals: [{ id: 'shared-goal-1' }],
+      preferences: [{ key: 'finance-currency', value: 'USD' }],
+      settings: [{ key: 'theme', value: 'system' }],
+    });
+    expect(serializeFullJsonExport(result)).toContain('"transactions"');
+  });
+
+  it('builds denormalized transaction CSV with manual escaping', () => {
+    const csv = buildTransactionsCsv({
+      accounts: [{ id: 'acc-1', name: 'Checking' }],
+      categories: [{ id: 'cat-1', name: 'Food' }],
+      transactions: [
+        {
+          accountId: 'acc-1',
+          categoryId: 'cat-1',
+          date: '2024-03-06',
+          payee: 'Grocery, "Fresh"\nMarket',
+          note: null,
+          statementDescription: null,
+          amount: { amount: -6742 },
+          currency: { code: 'USD' },
+        },
+      ],
+    });
+
+    expect(csv).toBe(
+      'date,account_name,category_name,description,amount,currency\r\n' +
+        '2024-03-06,Checking,Food,"Grocery, ""Fresh""\nMarket",-67.42,USD\r\n',
+    );
+  });
+
+  it('keeps simple CSV fields unquoted and dates filenames', () => {
+    expect(escapeCsvField('plain value')).toBe('plain value');
+    expect(buildDatedExportFileName('finance-data', 'json', new Date('2026-05-26T12:00:00Z'))).toBe(
+      'finance-data-2026-05-26.json',
+    );
+  });
+});

--- a/apps/web/src/lib/export/simple-export.ts
+++ b/apps/web/src/lib/export/simple-export.ts
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import type { SqliteDb } from '../../db/sqlite-wasm';
+import { getAllAccounts } from '../../db/repositories/accounts';
+import { getAllBills } from '../../db/repositories/bills';
+import { getAllBudgets } from '../../db/repositories/budgets';
+import { getAllCategories } from '../../db/repositories/categories';
+import { getAllGoals } from '../../db/repositories/goals';
+import {
+  getAccountSharings,
+  getBudgetContributions,
+  getGoalContributions,
+  getHouseholdById,
+  getHouseholdInvitations,
+  getHouseholdMembers,
+  getSharedBudgets,
+  getSharedGoals,
+} from '../../db/repositories/household';
+import { getAllInvestments } from '../../db/repositories/investments';
+import { getLotsByInvestment } from '../../db/repositories/investment-lots';
+import { getAllTransactions } from '../../db/repositories/transactions';
+
+type HouseholdRecord = NonNullable<ReturnType<typeof getHouseholdById>>;
+
+interface CsvAccountRecord {
+  id: string;
+  name: string;
+}
+
+interface CsvCategoryRecord {
+  id: string;
+  name: string;
+}
+
+interface CsvTransactionRecord {
+  accountId: string;
+  categoryId?: string | null;
+  date: string;
+  payee?: string | null;
+  note?: string | null;
+  statementDescription?: string | null;
+  amount: { amount: number };
+  currency: { code: string };
+}
+
+export type ExportRecord = Record<string, unknown>;
+
+export interface FullJsonExportOptions {
+  appVersion?: string;
+  generatedAt?: Date;
+  preferences?: readonly ExportRecord[];
+  settings?: readonly ExportRecord[];
+}
+
+export interface FullJsonExport {
+  schemaVersion: 1;
+  generatedAt: string;
+  appVersion: string | null;
+  accounts: ReturnType<typeof getAllAccounts>;
+  transactions: ReturnType<typeof getAllTransactions>;
+  categories: ReturnType<typeof getAllCategories>;
+  budgets: ReturnType<typeof getAllBudgets>;
+  goals: ReturnType<typeof getAllGoals>;
+  bills: ReturnType<typeof getAllBills>;
+  investments: ReturnType<typeof getAllInvestments>;
+  investmentLots: ReturnType<typeof getLotsByInvestment>;
+  households: HouseholdRecord[];
+  householdMembers: ReturnType<typeof getHouseholdMembers>;
+  householdInvitations: ReturnType<typeof getHouseholdInvitations>;
+  accountSharings: ReturnType<typeof getAccountSharings>;
+  sharedBudgets: ReturnType<typeof getSharedBudgets>;
+  budgetContributions: ReturnType<typeof getBudgetContributions>;
+  sharedGoals: ReturnType<typeof getSharedGoals>;
+  goalContributions: ReturnType<typeof getGoalContributions>;
+  preferences: ExportRecord[];
+  settings: ExportRecord[];
+}
+
+export interface TransactionsCsvInput {
+  transactions: readonly CsvTransactionRecord[];
+  accounts: readonly CsvAccountRecord[];
+  categories: readonly CsvCategoryRecord[];
+}
+
+export function buildFullJsonExport(
+  db: SqliteDb,
+  options: FullJsonExportOptions = {},
+): FullJsonExport {
+  const accounts = readOptionalTable(() => getAllAccounts(db));
+  const transactions = readOptionalTable(() => getAllTransactions(db));
+  const categories = readOptionalTable(() => getAllCategories(db));
+  const budgets = readOptionalTable(() => getAllBudgets(db));
+  const goals = readOptionalTable(() => getAllGoals(db));
+  const bills = readOptionalTable(() => getAllBills(db));
+  const investments = readOptionalTable(() => getAllInvestments(db));
+  const investmentLots = investments.flatMap((investment) =>
+    readOptionalTable(() => getLotsByInvestment(db, investment.id)),
+  );
+
+  const householdIds = collectHouseholdIds([
+    accounts,
+    transactions,
+    categories,
+    budgets,
+    goals,
+    bills,
+    investments,
+  ]);
+  const households = householdIds
+    .map((householdId) => readOptionalRecord(() => getHouseholdById(db, householdId)))
+    .filter(isPresent);
+  const householdMembers = households.flatMap((household) =>
+    readOptionalTable(() => getHouseholdMembers(db, household.id)),
+  );
+  const householdInvitations = households.flatMap((household) =>
+    readOptionalTable(() => getHouseholdInvitations(db, household.id)),
+  );
+  const accountSharings = households.flatMap((household) =>
+    readOptionalTable(() => getAccountSharings(db, household.id)),
+  );
+  const sharedBudgets = households.flatMap((household) =>
+    readOptionalTable(() => getSharedBudgets(db, household.id)),
+  );
+  const budgetContributions = sharedBudgets.flatMap((sharedBudget) =>
+    readOptionalTable(() => getBudgetContributions(db, sharedBudget.id)),
+  );
+  const sharedGoals = households.flatMap((household) =>
+    readOptionalTable(() => getSharedGoals(db, household.id)),
+  );
+  const goalContributions = sharedGoals.flatMap((sharedGoal) =>
+    readOptionalTable(() => getGoalContributions(db, sharedGoal.id)),
+  );
+
+  return {
+    schemaVersion: 1,
+    generatedAt: (options.generatedAt ?? new Date()).toISOString(),
+    appVersion: options.appVersion ?? null,
+    accounts,
+    transactions,
+    categories,
+    budgets,
+    goals,
+    bills,
+    investments,
+    investmentLots,
+    households,
+    householdMembers,
+    householdInvitations,
+    accountSharings,
+    sharedBudgets,
+    budgetContributions,
+    sharedGoals,
+    goalContributions,
+    preferences: [...(options.preferences ?? [])],
+    settings: [...(options.settings ?? [])],
+  };
+}
+
+export function serializeFullJsonExport(exportData: FullJsonExport): string {
+  return `${JSON.stringify(exportData, null, 2)}\n`;
+}
+
+export function buildTransactionsCsv(input: TransactionsCsvInput): string {
+  const accountsById = new Map(input.accounts.map((account) => [account.id, account]));
+  const categoriesById = new Map(input.categories.map((category) => [category.id, category]));
+  const rows = [
+    ['date', 'account_name', 'category_name', 'description', 'amount', 'currency'],
+    ...input.transactions.map((transaction) => {
+      const account = accountsById.get(transaction.accountId);
+      const category = transaction.categoryId ? categoriesById.get(transaction.categoryId) : null;
+      return [
+        transaction.date,
+        account?.name ?? '',
+        category?.name ?? '',
+        transaction.payee ?? transaction.note ?? transaction.statementDescription ?? '',
+        formatCents(transaction.amount.amount),
+        transaction.currency.code,
+      ];
+    }),
+  ];
+
+  return `${rows.map((row) => row.map(escapeCsvField).join(',')).join('\r\n')}\r\n`;
+}
+
+export function buildTransactionsCsvExport(db: SqliteDb): string {
+  return buildTransactionsCsv(buildFullJsonExport(db));
+}
+
+export function escapeCsvField(value: unknown): string {
+  const text = value == null ? '' : String(value);
+  if (!/[",\r\n]/.test(text)) return text;
+  return `"${text.replaceAll('"', '""')}"`;
+}
+
+export function buildDatedExportFileName(
+  prefix: string,
+  extension: 'csv' | 'json',
+  generatedAt = new Date(),
+): string {
+  return `${prefix}-${generatedAt.toISOString().slice(0, 10)}.${extension}`;
+}
+
+function readOptionalTable<T>(read: () => T[]): T[] {
+  try {
+    return read();
+  } catch (error) {
+    if (isMissingOptionalTable(error)) return [];
+    throw error;
+  }
+}
+
+function readOptionalRecord<T>(read: () => T | null): T | null {
+  try {
+    return read();
+  } catch (error) {
+    if (isMissingOptionalTable(error)) return null;
+    throw error;
+  }
+}
+
+function isMissingOptionalTable(error: unknown): boolean {
+  return error instanceof Error && /no such table/i.test(error.message);
+}
+
+function collectHouseholdIds(
+  recordGroups: readonly (readonly { householdId?: string | null }[])[],
+): string[] {
+  const ids = new Set<string>();
+  for (const records of recordGroups) {
+    for (const record of records) {
+      if (record.householdId) ids.add(record.householdId);
+    }
+  }
+  return [...ids].sort();
+}
+
+function isPresent<T>(value: T | null | undefined): value is T {
+  return value !== null && value !== undefined;
+}
+
+function formatCents(cents: number): string {
+  return (cents / 100).toFixed(2);
+}


### PR DESCRIPTION
Auto-generated PR from alpha E2E pass fleet (#1243).

Closes #1936

See commit message for details. All touched test suites pass and `npm run type-check` is clean as of the dispatch fleet.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>