### PR TITLE
fix(db): recompute account balance on transaction CRUD (#1914)

### DIFF
--- a/apps/web/src/db/repositories/accounts.ts
+++ b/apps/web/src/db/repositories/accounts.ts
@@ -227,3 +227,23 @@ export function getAccountsByType(db: SqliteDb, type: AccountType): Account[] {
     type,
   ]).rows.map(mapAccount);
 }
+
+/** Recompute an account balance from its non-deleted transactions. */
+export function recomputeAccountBalance(db: SqliteDb, accountId: SyncId): void {
+  execute(
+    db,
+    `UPDATE account
+        SET current_balance = (
+              SELECT COALESCE(SUM(amount), 0)
+              FROM "transaction"
+              WHERE account_id = ?
+                AND deleted_at IS NULL
+            ),
+            updated_at = ${SQLITE_NOW_EXPRESSION},
+            sync_version = 1,
+            is_synced = 0
+      WHERE id = ?
+        AND deleted_at IS NULL`,
+    [accountId, accountId],
+  );
+}

--- a/apps/web/src/db/repositories/transactions.test.ts
+++ b/apps/web/src/db/repositories/transactions.test.ts
@@ -10,6 +10,7 @@ import {
   getAllTransactions,
   getTransactionById,
   getTransactionsByDateRange,
+  updateTransaction,
   type CreateTransactionInput,
   type TransactionFilters,
 } from './transactions';
@@ -577,6 +578,86 @@ describe('transactions repository', () => {
       expect(sql).not.toContain('LIKE');
       const params = mockQuery.mock.calls[0][2] as unknown[];
       expect(params).toEqual([]);
+    });
+  });
+
+  describe('balance recomputation', () => {
+    const transactionRow = (overrides: Partial<Row> = {}): Row => ({
+      id: 'txn-1',
+      household_id: 'hh-1',
+      account_id: 'acc-1',
+      category_id: null,
+      type: 'EXPENSE',
+      status: 'CLEARED',
+      amount: -5000,
+      currency: 'USD',
+      payee: null,
+      note: null,
+      date: '2024-01-15',
+      transfer_account_id: null,
+      transfer_transaction_id: null,
+      is_recurring: 0,
+      recurring_rule_id: null,
+      tags: '[]',
+      created_at: '2024-01-15T10:00:00Z',
+      updated_at: '2024-01-15T10:00:00Z',
+      deleted_at: null,
+      sync_version: 1,
+      is_synced: 0,
+      ...overrides,
+    });
+
+    const expectBalanceRecomputeFor = (callIndex: number, accountId: string) => {
+      expect(mockExecute).toHaveBeenNthCalledWith(
+        callIndex,
+        mockDb,
+        expect.stringContaining('UPDATE account'),
+        [accountId, accountId],
+      );
+      const sql = mockExecute.mock.calls[callIndex - 1][1];
+      expect(sql).toContain('SELECT COALESCE(SUM(amount), 0)');
+      expect(sql).toContain('deleted_at IS NULL');
+    };
+
+    it('recomputes the account balance after insert', () => {
+      mockQueryOne.mockReturnValue(transactionRow());
+
+      createTransaction(mockDb, {
+        householdId: 'hh-1',
+        accountId: 'acc-1',
+        type: 'EXPENSE' as TransactionType,
+        amount: { amount: -5000 },
+        date: '2024-01-15',
+      });
+
+      expectBalanceRecomputeFor(2, 'acc-1');
+    });
+
+    it('recomputes the account balance after an amount update', () => {
+      mockQueryOne.mockReturnValue(transactionRow());
+
+      updateTransaction(mockDb, 'txn-1', { amount: { amount: -7500 } });
+
+      expectBalanceRecomputeFor(2, 'acc-1');
+    });
+
+    it('recomputes both accounts when a transaction moves accounts', () => {
+      mockQueryOne
+        .mockReturnValueOnce(transactionRow({ account_id: 'acc-1' }))
+        .mockReturnValueOnce(transactionRow({ account_id: 'acc-2' }));
+
+      updateTransaction(mockDb, 'txn-1', { accountId: 'acc-2' });
+
+      expectBalanceRecomputeFor(2, 'acc-1');
+      expectBalanceRecomputeFor(3, 'acc-2');
+    });
+
+    it('recomputes the account balance after delete', () => {
+      mockQueryOne.mockReturnValue(transactionRow());
+
+      deleteTransaction(mockDb, 'txn-1');
+
+      expectBalanceRecomputeFor(2, 'acc-1');
     });
   });
 });

--- a/apps/web/src/db/repositories/transactions.ts
+++ b/apps/web/src/db/repositories/transactions.ts
@@ -10,6 +10,7 @@ import type {
 } from '../../kmp/bridge';
 import { Currencies } from '../../kmp/bridge';
 import { execute, query, queryOne, type Row, type SqliteDb } from '../sqlite-wasm';
+import { recomputeAccountBalance } from './accounts';
 import {
   SQLITE_NOW_EXPRESSION,
   createLikePattern,
@@ -319,6 +320,8 @@ export function createTransaction(db: SqliteDb, input: CreateTransactionInput): 
     throw new Error('Failed to create transaction.');
   }
 
+  recomputeAccountBalance(db, input.accountId);
+
   return createdTransaction;
 }
 
@@ -465,6 +468,11 @@ export function updateTransaction(
     ],
   );
 
+  if (existingTransaction.accountId !== mergedTransaction.accountId) {
+    recomputeAccountBalance(db, existingTransaction.accountId);
+  }
+  recomputeAccountBalance(db, mergedTransaction.accountId);
+
   return getTransactionById(db, transactionId);
 }
 
@@ -486,6 +494,8 @@ export function deleteTransaction(db: SqliteDb, transactionId: SyncId): boolean 
         AND deleted_at IS NULL`,
     [transactionId],
   );
+
+  recomputeAccountBalance(db, existingTransaction.accountId);
 
   return true;
 }

--- a/apps/web/src/db/sqlite-wasm.ts
+++ b/apps/web/src/db/sqlite-wasm.ts
@@ -390,6 +390,77 @@ export const MIGRATIONS: Migration[] = [
       `ALTER TABLE "transaction" ADD COLUMN counterparty_account_id TEXT;`,
     ],
   },
+  {
+    version: 5,
+    label: 'account-balance-recompute-triggers',
+    up: [
+      `CREATE TRIGGER IF NOT EXISTS trg_transaction_balance_insert
+        AFTER INSERT ON "transaction"
+        FOR EACH ROW
+        BEGIN
+          UPDATE account
+          SET current_balance = (
+            SELECT COALESCE(SUM(amount), 0)
+            FROM "transaction"
+            WHERE account_id = NEW.account_id
+              AND deleted_at IS NULL
+          )
+          WHERE id = NEW.account_id
+            AND deleted_at IS NULL;
+        END;`,
+      `CREATE TRIGGER IF NOT EXISTS trg_transaction_balance_update_new
+        AFTER UPDATE ON "transaction"
+        FOR EACH ROW
+        BEGIN
+          UPDATE account
+          SET current_balance = (
+            SELECT COALESCE(SUM(amount), 0)
+            FROM "transaction"
+            WHERE account_id = NEW.account_id
+              AND deleted_at IS NULL
+          )
+          WHERE id = NEW.account_id
+            AND deleted_at IS NULL;
+        END;`,
+      `CREATE TRIGGER IF NOT EXISTS trg_transaction_balance_update_old
+        AFTER UPDATE OF account_id ON "transaction"
+        FOR EACH ROW
+        WHEN OLD.account_id IS NOT NEW.account_id
+        BEGIN
+          UPDATE account
+          SET current_balance = (
+            SELECT COALESCE(SUM(amount), 0)
+            FROM "transaction"
+            WHERE account_id = OLD.account_id
+              AND deleted_at IS NULL
+          )
+          WHERE id = OLD.account_id
+            AND deleted_at IS NULL;
+        END;`,
+      `CREATE TRIGGER IF NOT EXISTS trg_transaction_balance_delete
+        AFTER DELETE ON "transaction"
+        FOR EACH ROW
+        BEGIN
+          UPDATE account
+          SET current_balance = (
+            SELECT COALESCE(SUM(amount), 0)
+            FROM "transaction"
+            WHERE account_id = OLD.account_id
+              AND deleted_at IS NULL
+          )
+          WHERE id = OLD.account_id
+            AND deleted_at IS NULL;
+        END;`,
+      `UPDATE account
+        SET current_balance = (
+          SELECT COALESCE(SUM(amount), 0)
+          FROM "transaction"
+          WHERE account_id = account.id
+            AND deleted_at IS NULL
+        )
+        WHERE deleted_at IS NULL;`,
+    ],
+  },
 ];
 // ---------------------------------------------------------------------------
 // OPFS / IndexedDB feature detection

--- a/services/api/supabase/migrations/20260331000003_recompute_account_balance_trigger.sql
+++ b/services/api/supabase/migrations/20260331000003_recompute_account_balance_trigger.sql
@@ -1,0 +1,62 @@
+-- SPDX-License-Identifier: BUSL-1.1
+
+-- Keep account balances derived from non-deleted transactions.
+-- The cloud schema stores this as accounts.balance_cents (the web/local name is current_balance).
+-- Transaction amounts are signed cents in the shared model/seed data, so balances are SUM(amount_cents).
+
+CREATE OR REPLACE FUNCTION public.recompute_account_balance_cents(target_account_id UUID)
+RETURNS void
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  UPDATE accounts
+  SET balance_cents = (
+        SELECT COALESCE(SUM(amount_cents), 0)::BIGINT
+        FROM transactions
+        WHERE account_id = target_account_id
+          AND deleted_at IS NULL
+      ),
+      updated_at = now()
+  WHERE id = target_account_id
+    AND deleted_at IS NULL;
+$$;
+
+CREATE OR REPLACE FUNCTION public.recalculate_account_balance()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    PERFORM public.recompute_account_balance_cents(OLD.account_id);
+    RETURN OLD;
+  END IF;
+
+  IF TG_OP = 'UPDATE' AND OLD.account_id IS DISTINCT FROM NEW.account_id THEN
+    PERFORM public.recompute_account_balance_cents(OLD.account_id);
+  END IF;
+
+  PERFORM public.recompute_account_balance_cents(NEW.account_id);
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_recalculate_balance ON public.transactions;
+
+CREATE TRIGGER trg_recalculate_balance
+  AFTER INSERT OR UPDATE OR DELETE ON public.transactions
+  FOR EACH ROW
+  EXECUTE FUNCTION public.recalculate_account_balance();
+
+-- Backfill existing accounts once so stale balances are corrected immediately.
+UPDATE public.accounts AS account
+SET balance_cents = (
+      SELECT COALESCE(SUM(t.amount_cents), 0)::BIGINT
+      FROM public.transactions AS t
+      WHERE t.account_id = account.id
+        AND t.deleted_at IS NULL
+    ),
+    updated_at = now()
+WHERE account.deleted_at IS NULL;


### PR DESCRIPTION
Auto-generated PR from alpha E2E pass fleet (#1243).

Closes #1914

See commit message for details. All touched test suites pass and `npm run type-check` is clean as of the dispatch fleet.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>