### PR TITLE
fix(offline): degrade gracefully on per-page loader network failures (#1928)

### DIFF
--- a/apps/web/src/__tests__/dashboard-visualizations.test.tsx
+++ b/apps/web/src/__tests__/dashboard-visualizations.test.tsx
@@ -369,7 +369,7 @@ describe('DashboardPage loading state (#1334)', () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument();
   });
 
   it('does not show summary cards while loading', () => {

--- a/apps/web/src/components/common/RouteErrorBoundary.test.tsx
+++ b/apps/web/src/components/common/RouteErrorBoundary.test.tsx
@@ -94,6 +94,14 @@ describe('RouteErrorBoundary', () => {
       </RouteErrorBoundary>,
     );
 
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'RouteErrorBoundary caught route error',
+      expect.objectContaining({
+        route: 'Budgets',
+        error: expect.objectContaining({ message: 'Budget crash' }),
+        componentStack: expect.any(String),
+      }),
+    );
     expect(captureErrorMock).toHaveBeenCalledTimes(1);
     expect(captureErrorMock).toHaveBeenCalledWith(
       expect.objectContaining({ message: 'Budget crash' }),

--- a/apps/web/src/components/common/RouteErrorBoundary.tsx
+++ b/apps/web/src/components/common/RouteErrorBoundary.tsx
@@ -53,10 +53,19 @@ export class RouteErrorBoundary extends Component<
 
   /** Report the error to monitoring. */
   public override componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    const route = this.props.routeName ?? 'unknown';
+    const componentStack = errorInfo.componentStack?.trim() || 'Unavailable';
+
+    console.error('RouteErrorBoundary caught route error', {
+      route,
+      error,
+      componentStack,
+    });
+
     captureError(error, {
       boundary: 'RouteErrorBoundary',
-      route: this.props.routeName ?? 'unknown',
-      componentStack: errorInfo.componentStack?.trim() || 'Unavailable',
+      route,
+      componentStack,
     });
   }
 

--- a/apps/web/src/components/common/RouteErrorBoundary.tsx
+++ b/apps/web/src/components/common/RouteErrorBoundary.tsx
@@ -56,6 +56,7 @@ export class RouteErrorBoundary extends Component<
     const route = this.props.routeName ?? 'unknown';
     const componentStack = errorInfo.componentStack?.trim() || 'Unavailable';
 
+    // eslint-disable-next-line no-console -- dev visibility; captureError below feeds monitoring
     console.error('RouteErrorBoundary caught route error', {
       route,
       error,

--- a/apps/web/src/components/settings/CurrencyRatesSettings.test.tsx
+++ b/apps/web/src/components/settings/CurrencyRatesSettings.test.tsx
@@ -33,6 +33,7 @@ const defaultHookResult: UseExchangeRatesResult = {
   error: null,
   lastUpdated: '2025-01-15T12:00:00.000Z',
   providerName: 'Static Rates',
+  isOffline: false,
   convert: mockConvert,
   getRate: mockGetRate,
   setOverride: mockSetOverride,

--- a/apps/web/src/hooks/__tests__/useOfflineStatus.test.ts
+++ b/apps/web/src/hooks/__tests__/useOfflineStatus.test.ts
@@ -3,7 +3,11 @@
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { useOfflineStatus } from '../useOfflineStatus';
+import {
+  clearOfflineNetworkFailure,
+  reportOfflineNetworkFailure,
+  useOfflineStatus,
+} from '../useOfflineStatus';
 
 // ---------------------------------------------------------------------------
 // Navigator stubs
@@ -12,6 +16,7 @@ import { useOfflineStatus } from '../useOfflineStatus';
 let onlineState: boolean;
 
 beforeEach(() => {
+  clearOfflineNetworkFailure();
   onlineState = true;
   vi.clearAllMocks();
 
@@ -170,5 +175,37 @@ describe('useOfflineStatus', () => {
       onlineState = true;
       window.dispatchEvent(new Event('online'));
     });
+  });
+
+  it('reports offline when a loader records a network failure while the browser is online', () => {
+    onlineState = true;
+
+    const { result } = renderHook(() => useOfflineStatus());
+
+    act(() => {
+      reportOfflineNetworkFailure();
+    });
+
+    expect(result.current.isOnline).toBe(false);
+    expect(result.current.isOffline).toBe(true);
+    expect(result.current.hasNetworkFailure).toBe(true);
+  });
+
+  it('clears reported network failures when coming back online', () => {
+    onlineState = true;
+    const { result } = renderHook(() => useOfflineStatus());
+
+    act(() => {
+      reportOfflineNetworkFailure();
+    });
+
+    expect(result.current.isOffline).toBe(true);
+
+    act(() => {
+      window.dispatchEvent(new Event('online'));
+    });
+
+    expect(result.current.isOnline).toBe(true);
+    expect(result.current.hasNetworkFailure).toBe(false);
   });
 });

--- a/apps/web/src/hooks/useExchangeRates.ts
+++ b/apps/web/src/hooks/useExchangeRates.ts
@@ -22,6 +22,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ExchangeRate, ExchangeRateProvider } from '../lib/currency/exchange-rate-types';
 import { ExchangeRateService } from '../lib/currency/exchange-rate-service';
 import { getCacheTimestamp } from '../lib/currency/rate-cache';
+import { isNetworkError } from '../lib/network/network-errors';
+import { useOfflineStatus } from './useOfflineStatus';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -39,6 +41,8 @@ export interface UseExchangeRatesResult {
   lastUpdated: string | null;
   /** Name of the active rate provider. */
   providerName: string;
+  /** `true` when exchange-rate requests have degraded due to connectivity. */
+  isOffline: boolean;
   /** Convert an amount (cents) from one currency to another. */
   convert: (amount: number, from: string, to: string) => Promise<number>;
   /** Get the exchange rate for a pair. */
@@ -75,6 +79,7 @@ export function useExchangeRates(
   const [lastUpdated, setLastUpdated] = useState<string | null>(null);
   const [overrides, setOverrides] = useState<Record<string, number>>({});
   const [refreshToken, setRefreshToken] = useState(0);
+  const { isOffline, reportNetworkFailure, clearNetworkFailure } = useOfflineStatus();
 
   // Stable service ref — recreate only when provider changes
   const serviceRef = useRef<ExchangeRateService | null>(null);
@@ -95,13 +100,19 @@ export function useExchangeRates(
       try {
         const allRates = await service.getAllRates(baseCurrency);
         if (!cancelled) {
+          clearNetworkFailure();
           setRates(allRates);
           setLastUpdated(getCacheTimestamp() ?? new Date().toISOString());
           setOverrides(service.getUserOverrides());
         }
       } catch (err) {
         if (!cancelled) {
-          setError(err instanceof Error ? err.message : 'Failed to load exchange rates.');
+          if (isNetworkError(err)) {
+            reportNetworkFailure();
+            setError(null);
+          } else {
+            setError(err instanceof Error ? err.message : 'Failed to load exchange rates.');
+          }
         }
       } finally {
         if (!cancelled) {
@@ -115,7 +126,7 @@ export function useExchangeRates(
     return () => {
       cancelled = true;
     };
-  }, [baseCurrency, refreshToken, service]);
+  }, [baseCurrency, clearNetworkFailure, refreshToken, reportNetworkFailure, service]);
 
   const refresh = useCallback(() => {
     setRefreshToken((t) => t + 1);
@@ -123,17 +134,34 @@ export function useExchangeRates(
 
   const convert = useCallback(
     async (amount: number, from: string, to: string): Promise<number> => {
-      const result = await service.convert(amount, from, to);
-      return result.amount;
+      try {
+        const result = await service.convert(amount, from, to);
+        clearNetworkFailure();
+        return result.amount;
+      } catch (err) {
+        if (isNetworkError(err)) {
+          reportNetworkFailure();
+        }
+        throw err;
+      }
     },
-    [service],
+    [clearNetworkFailure, reportNetworkFailure, service],
   );
 
   const getRate = useCallback(
     async (from: string, to: string): Promise<ExchangeRate> => {
-      return service.getRate(from, to);
+      try {
+        const rate = await service.getRate(from, to);
+        clearNetworkFailure();
+        return rate;
+      } catch (err) {
+        if (isNetworkError(err)) {
+          reportNetworkFailure();
+        }
+        throw err;
+      }
     },
-    [service],
+    [clearNetworkFailure, reportNetworkFailure, service],
   );
 
   const setOverride = useCallback(
@@ -166,6 +194,7 @@ export function useExchangeRates(
     error,
     lastUpdated,
     providerName: service.providerName,
+    isOffline,
     convert,
     getRate,
     setOverride,

--- a/apps/web/src/hooks/useOfflineStatus.ts
+++ b/apps/web/src/hooks/useOfflineStatus.ts
@@ -4,8 +4,11 @@
  * React hook for detecting online / offline network status.
  *
  * Listens for the browser `online` and `offline` events and exposes a
- * boolean `isOffline` flag.  Components that consume this hook will
+ * boolean `isOffline` flag. Components that consume this hook will
  * re-render automatically when connectivity changes.
+ *
+ * Remote loaders can also report a network failure so pages that still have
+ * local SQLite-WASM data can render that data and show an offline banner.
  *
  * Also triggers a Background Sync registration via the service worker
  * whenever the device comes back online, so queued mutations can be
@@ -13,34 +16,74 @@
  *
  * Usage:
  * ```tsx
- * const { isOffline } = useOfflineStatus();
+ * const { isOffline, reportNetworkFailure } = useOfflineStatus();
  * ```
  *
- * References: issues #57, #58
+ * References: issues #57, #58, #1928
  */
 
 import { useCallback, useEffect, useSyncExternalStore } from 'react';
 
 // ---------------------------------------------------------------------------
-// External-store subscription for navigator.onLine
+// External-store subscription for navigator.onLine and network failures
 // ---------------------------------------------------------------------------
 
+const networkFailureListeners = new Set<() => void>();
+let networkFailureVersion = 0;
+let hasReportedNetworkFailure = false;
+
+function emitNetworkFailureChange(): void {
+  networkFailureVersion += 1;
+  for (const listener of networkFailureListeners) {
+    listener();
+  }
+}
+
+export function reportOfflineNetworkFailure(): void {
+  if (hasReportedNetworkFailure) {
+    return;
+  }
+
+  hasReportedNetworkFailure = true;
+  emitNetworkFailureChange();
+}
+
+export function clearOfflineNetworkFailure(): void {
+  if (!hasReportedNetworkFailure) {
+    return;
+  }
+
+  hasReportedNetworkFailure = false;
+  emitNetworkFailureChange();
+}
+
 function subscribe(callback: () => void): () => void {
-  window.addEventListener('online', callback);
+  const handleOnline = () => {
+    if (hasReportedNetworkFailure) {
+      clearOfflineNetworkFailure();
+    } else {
+      callback();
+    }
+  };
+
+  window.addEventListener('online', handleOnline);
   window.addEventListener('offline', callback);
+  networkFailureListeners.add(callback);
+
   return () => {
-    window.removeEventListener('online', callback);
+    window.removeEventListener('online', handleOnline);
     window.removeEventListener('offline', callback);
+    networkFailureListeners.delete(callback);
   };
 }
 
-function getSnapshot(): boolean {
-  return navigator.onLine;
+function getSnapshot(): string {
+  return `${navigator.onLine ? 'online' : 'offline'}:${networkFailureVersion}`;
 }
 
-/** SSR-safe fallback ΓÇö assume online. */
-function getServerSnapshot(): boolean {
-  return true;
+/** SSR-safe fallback — assume online. */
+function getServerSnapshot(): string {
+  return 'online:0';
 }
 
 // ---------------------------------------------------------------------------
@@ -48,14 +91,23 @@ function getServerSnapshot(): boolean {
 // ---------------------------------------------------------------------------
 
 export interface OfflineStatus {
-  /** `true` when the browser reports no network connectivity. */
+  /** `true` when the browser or a remote loader reports no network connectivity. */
   isOffline: boolean;
-  /** `true` when the browser reports network connectivity. */
+  /** `true` when the browser reports network connectivity and no loader has degraded. */
   isOnline: boolean;
+  /** `true` when a remote loader has degraded after a network failure. */
+  hasNetworkFailure: boolean;
+  /** Mark the app as degraded because an optional remote request failed. */
+  reportNetworkFailure: () => void;
+  /** Clear a previously reported remote network failure. */
+  clearNetworkFailure: () => void;
 }
 
 export function useOfflineStatus(): OfflineStatus {
-  const online = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  const browserOnline = navigator.onLine;
+  const isOffline = !browserOnline || hasReportedNetworkFailure;
 
   /**
    * When we transition back to online, tell the service worker to
@@ -75,8 +127,19 @@ export function useOfflineStatus(): OfflineStatus {
     return () => window.removeEventListener('online', handleOnline);
   }, [requestSync]);
 
+  const reportNetworkFailure = useCallback(() => {
+    reportOfflineNetworkFailure();
+  }, []);
+
+  const clearNetworkFailure = useCallback(() => {
+    clearOfflineNetworkFailure();
+  }, []);
+
   return {
-    isOffline: !online,
-    isOnline: online,
+    isOffline,
+    isOnline: !isOffline,
+    hasNetworkFailure: hasReportedNetworkFailure,
+    reportNetworkFailure,
+    clearNetworkFailure,
   };
 }

--- a/apps/web/src/lib/network/network-errors.ts
+++ b/apps/web/src/lib/network/network-errors.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/** Return true when an error represents a recoverable network/offline failure. */
+export function isNetworkError(error: unknown): boolean {
+  if (typeof DOMException !== 'undefined' && error instanceof DOMException) {
+    return (
+      error.name === 'AbortError' || error.name === 'NetworkError' || error.name === 'TimeoutError'
+    );
+  }
+
+  if (error instanceof TypeError) {
+    return true;
+  }
+
+  if (typeof Response !== 'undefined' && error instanceof Response) {
+    return error.status === 0 || error.status >= 500;
+  }
+
+  if (typeof error === 'object' && error !== null && 'status' in error) {
+    const status = Number((error as { status?: unknown }).status);
+    if (status === 0 || status >= 500) {
+      return true;
+    }
+  }
+
+  if (error instanceof Error) {
+    if (
+      error.name === 'AbortError' ||
+      error.name === 'NetworkError' ||
+      error.name === 'TimeoutError'
+    ) {
+      return true;
+    }
+
+    const message = error.message.toLowerCase();
+    return [
+      'failed to fetch',
+      'fetch failed',
+      'networkerror',
+      'network error',
+      'network request failed',
+      'load failed',
+      'err_network',
+      'econnreset',
+      'etimedout',
+      'timeout',
+      '503',
+      '502',
+      '500',
+    ].some((needle) => message.includes(needle));
+  }
+
+  return false;
+}

--- a/apps/web/src/pages/AccountsPage.test.tsx
+++ b/apps/web/src/pages/AccountsPage.test.tsx
@@ -17,6 +17,7 @@ vi.mock('../hooks/useExchangeRates', () => ({
     error: null,
     lastUpdated: null,
     providerName: 'Static Rates',
+    isOffline: false,
     convert: vi.fn().mockResolvedValue(0),
     getRate: vi.fn(),
     setOverride: vi.fn(),

--- a/apps/web/src/pages/AccountsPage.tsx
+++ b/apps/web/src/pages/AccountsPage.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { CurrencyDisplay, EmptyState, ErrorBanner, LoadingSpinner } from '../components/common';
 import { AccountForm } from '../components/forms';
+import { OfflineBanner } from '../components/OfflineBanner';
 import { useAccounts } from '../hooks';
 import { useExchangeRates } from '../hooks/useExchangeRates';
 import type { AccountType } from '../kmp/bridge';
@@ -161,10 +162,12 @@ export const AccountsPage: React.FC = () => {
       }}
     />
   );
+  const offlineBanner = <OfflineBanner />;
 
   if (loading) {
     return (
       <>
+        {offlineBanner}
         <h2 className="page-heading">Accounts</h2>
         <div className="page-loading">
           <LoadingSpinner label="Loading accounts" />
@@ -176,6 +179,7 @@ export const AccountsPage: React.FC = () => {
   if (error) {
     return (
       <>
+        {offlineBanner}
         <h2 className="page-heading">Accounts</h2>
         <ErrorBanner message={error} onRetry={refresh} />
       </>
@@ -185,6 +189,7 @@ export const AccountsPage: React.FC = () => {
   if (accounts.length === 0) {
     return (
       <>
+        {offlineBanner}
         {pageHeader}
         <EmptyState
           title="No accounts yet"
@@ -197,6 +202,7 @@ export const AccountsPage: React.FC = () => {
 
   return (
     <>
+      {offlineBanner}
       {pageHeader}
       <p className="page-summary" aria-live="polite">
         Net worth: <MultiCurrencyTotal accounts={accounts} colorize />

--- a/apps/web/src/pages/BudgetsPage.tsx
+++ b/apps/web/src/pages/BudgetsPage.tsx
@@ -11,6 +11,7 @@ import {
   LoadingSpinner,
 } from '../components/common';
 import { BudgetForm } from '../components/forms';
+import { OfflineBanner } from '../components/OfflineBanner';
 import type { CreateBudgetInput } from '../db/repositories/budgets';
 import { useBudgets, useCategories } from '../hooks';
 import type { Budget } from '../kmp/bridge';
@@ -143,6 +144,7 @@ export const BudgetsPage: React.FC = () => {
 
   return (
     <>
+      <OfflineBanner />
       <div
         style={{
           display: 'flex',

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -10,6 +10,7 @@ import {
   type ViewType,
 } from '../components/charts';
 import { CurrencyDisplay, EmptyState, ErrorBanner, LoadingSpinner } from '../components/common';
+import { OfflineBanner } from '../components/OfflineBanner';
 import { useCategories, useDashboardData, useTransactions } from '../hooks';
 import type { DashboardData } from '../hooks/useDashboardData';
 import type { Transaction } from '../kmp/bridge';
@@ -264,6 +265,7 @@ export const DashboardPage: React.FC = () => {
 
   return (
     <>
+      <OfflineBanner />
       <h2
         style={{
           fontSize: 'var(--type-scale-headline-font-size)',

--- a/apps/web/src/pages/GoalsPage.tsx
+++ b/apps/web/src/pages/GoalsPage.tsx
@@ -10,6 +10,7 @@ import {
   LoadingSpinner,
 } from '../components/common';
 import { GoalForm } from '../components/forms';
+import { OfflineBanner } from '../components/OfflineBanner';
 import type { CreateGoalInput } from '../db/repositories/goals';
 import { useGoals } from '../hooks';
 import type { Goal } from '../kmp/bridge';
@@ -103,6 +104,7 @@ export const GoalsPage: React.FC = () => {
 
   return (
     <>
+      <OfflineBanner />
       <div className="page-section__header" style={{ marginBottom: 'var(--spacing-6)' }}>
         <h2
           style={{

--- a/apps/web/src/pages/TransactionsPage.tsx
+++ b/apps/web/src/pages/TransactionsPage.tsx
@@ -11,6 +11,7 @@ import {
   LoadingSpinner,
 } from '../components/common';
 import { TransactionForm } from '../components/forms';
+import { OfflineBanner } from '../components/OfflineBanner';
 import {
   TransactionFilters,
   TransactionSort,
@@ -438,6 +439,7 @@ export const TransactionsPage: React.FC = () => {
 
   return (
     <>
+      <OfflineBanner />
       <div className="transactions-page-header">
         <h2
           style={{


### PR DESCRIPTION
Auto-generated PR from alpha E2E pass fleet (#1243).

Closes #1928

See commit message for details. All touched test suites pass and `npm run type-check` is clean as of the dispatch fleet.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>