### PR TITLE
fix(auth): handle signup confirmation + offline-safe refresh (#1940 #1942)

### DIFF
--- a/apps/web/src/__tests__/auth-flows.test.tsx
+++ b/apps/web/src/__tests__/auth-flows.test.tsx
@@ -36,6 +36,7 @@ const authState = vi.hoisted(() => ({
   user: null as { id: string; email: string; hasPasskey: boolean } | null,
   webAuthnSupported: true,
   isDemoMode: false,
+  isOffline: false,
 }));
 
 const navigateMock = vi.hoisted(() => vi.fn());
@@ -267,7 +268,7 @@ describe('Signup flow (#1331)', () => {
   });
 
   it('calls signupWithEmail on valid submission', async () => {
-    authState.signupWithEmail.mockResolvedValue(undefined);
+    authState.signupWithEmail.mockResolvedValue({ kind: 'authenticated' });
     renderSignupPage();
 
     fireEvent.change(screen.getByLabelText('Email'), {
@@ -290,7 +291,7 @@ describe('Signup flow (#1331)', () => {
   it('redirects to /dashboard when isAuthenticated becomes true after signup', async () => {
     authState.signupWithEmail.mockImplementation(() => {
       authState.isAuthenticated = true;
-      return Promise.resolve();
+      return Promise.resolve({ kind: 'authenticated' });
     });
     renderSignupPage();
 
@@ -309,6 +310,29 @@ describe('Signup flow (#1331)', () => {
     });
 
     expect(navigateMock).toHaveBeenCalledWith('/dashboard');
+  });
+
+  it('shows confirmation-required UI after signup returns 202 flow', async () => {
+    authState.signupWithEmail.mockResolvedValue({ kind: 'confirmation_required' });
+    renderSignupPage();
+
+    fireEvent.change(screen.getByLabelText('Email'), {
+      target: { value: 'new@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'strongpass1234' },
+    });
+    fireEvent.change(screen.getByLabelText('Confirm Password'), {
+      target: { value: 'strongpass1234' },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Sign up' }));
+    });
+
+    expect(await screen.findByRole('heading', { name: 'Check your email' })).toBeInTheDocument();
+    expect(screen.getByText('new@example.com')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Back to sign in' })).toHaveAttribute('href', '/login');
   });
 
   it('shows error banner when signup fails', async () => {

--- a/apps/web/src/auth/auth-context.test.tsx
+++ b/apps/web/src/auth/auth-context.test.tsx
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AuthProvider, useAuth, type AuthProviderConfig } from './auth-context';
+import { clearTokens } from './token-storage';
+
+const LAST_USER_STORAGE_KEY = 'finance.lastUser';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function base64Url(value: unknown): string {
+  return btoa(JSON.stringify(value)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function makeToken(payload: Record<string, unknown>): string {
+  return `${base64Url({ alg: 'none', typ: 'JWT' })}.${base64Url(payload)}.signature`;
+}
+
+function AuthProbe() {
+  const { isAuthenticated, isLoading, isOffline, user } = useAuth();
+  return (
+    <div>
+      <span data-testid="loading-state">{isLoading ? 'loading' : 'ready'}</span>
+      <span data-testid="auth-state">{isAuthenticated ? 'authenticated' : 'anonymous'}</span>
+      <span data-testid="offline-state">{isOffline ? 'offline' : 'online'}</span>
+      <span data-testid="user-email">{user?.email ?? 'none'}</span>
+    </div>
+  );
+}
+
+describe('AuthProvider refresh restoration', () => {
+  const onUnauthenticated = vi.fn();
+  const config: AuthProviderConfig = {
+    supabaseUrl: 'https://finance-test.supabase.co',
+    supabaseAnonKey: 'anon-key',
+    loginEndpoint: '/api/auth/login',
+    refreshEndpoint: '/api/auth/refresh',
+    logoutEndpoint: '/api/auth/logout',
+    signupEndpoint: '/api/auth/signup',
+    onUnauthenticated,
+  };
+
+  beforeEach(() => {
+    clearTokens();
+    localStorage.clear();
+    onUnauthenticated.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    clearTokens();
+    localStorage.clear();
+  });
+
+  function renderProvider() {
+    return render(
+      <AuthProvider config={config}>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+  }
+
+  it('restores and caches the user on successful refresh', async () => {
+    const token = makeToken({
+      sub: 'user-1',
+      email: 'fresh@example.com',
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(jsonResponse({ access_token: token, expires_in: 3600 })),
+    );
+
+    renderProvider();
+
+    await waitFor(() => expect(screen.getByTestId('loading-state')).toHaveTextContent('ready'));
+    expect(screen.getByTestId('auth-state')).toHaveTextContent('authenticated');
+    expect(screen.getByTestId('offline-state')).toHaveTextContent('online');
+    expect(screen.getByTestId('user-email')).toHaveTextContent('fresh@example.com');
+    expect(JSON.parse(localStorage.getItem(LAST_USER_STORAGE_KEY) ?? '{}')).toMatchObject({
+      id: 'user-1',
+      email: 'fresh@example.com',
+    });
+    expect(onUnauthenticated).not.toHaveBeenCalled();
+  });
+
+  it('clears the cached user and signs out on session_expired refresh', async () => {
+    localStorage.setItem(
+      LAST_USER_STORAGE_KEY,
+      JSON.stringify({ id: 'cached-1', email: 'cached@example.com', hasPasskey: true }),
+    );
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ error: 'expired' }, 401)));
+
+    renderProvider();
+
+    await waitFor(() => expect(screen.getByTestId('loading-state')).toHaveTextContent('ready'));
+    expect(screen.getByTestId('auth-state')).toHaveTextContent('anonymous');
+    expect(screen.getByTestId('user-email')).toHaveTextContent('none');
+    expect(localStorage.getItem(LAST_USER_STORAGE_KEY)).toBeNull();
+    expect(onUnauthenticated).toHaveBeenCalledOnce();
+  });
+
+  it('keeps the cached user offline and retries refresh when the browser comes online', async () => {
+    localStorage.setItem(
+      LAST_USER_STORAGE_KEY,
+      JSON.stringify({ id: 'cached-1', email: 'cached@example.com', hasPasskey: true }),
+    );
+    const retryToken = makeToken({
+      sub: 'cached-1',
+      email: 'cached@example.com',
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    });
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValueOnce(jsonResponse({ access_token: retryToken, expires_in: 3600 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderProvider();
+
+    await waitFor(() => expect(screen.getByTestId('loading-state')).toHaveTextContent('ready'));
+    expect(screen.getByTestId('auth-state')).toHaveTextContent('authenticated');
+    expect(screen.getByTestId('offline-state')).toHaveTextContent('offline');
+    expect(screen.getByTestId('user-email')).toHaveTextContent('cached@example.com');
+    expect(onUnauthenticated).not.toHaveBeenCalled();
+
+    window.dispatchEvent(new Event('online'));
+
+    await waitFor(() => expect(screen.getByTestId('offline-state')).toHaveTextContent('online'));
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(screen.getByTestId('auth-state')).toHaveTextContent('authenticated');
+  });
+});

--- a/apps/web/src/auth/auth-context.test.tsx
+++ b/apps/web/src/auth/auth-context.test.tsx
@@ -137,4 +137,18 @@ describe('AuthProvider refresh restoration', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(screen.getByTestId('auth-state')).toHaveTextContent('authenticated');
   });
+
+  it('redirects to login when network refresh fails and no cached user exists', async () => {
+    expect(localStorage.getItem(LAST_USER_STORAGE_KEY)).toBeNull();
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderProvider();
+
+    await waitFor(() => expect(screen.getByTestId('loading-state')).toHaveTextContent('ready'));
+    expect(screen.getByTestId('auth-state')).toHaveTextContent('anonymous');
+    expect(screen.getByTestId('offline-state')).toHaveTextContent('online');
+    expect(screen.getByTestId('user-email')).toHaveTextContent('none');
+    expect(onUnauthenticated).toHaveBeenCalledOnce();
+  });
 });

--- a/apps/web/src/auth/auth-context.tsx
+++ b/apps/web/src/auth/auth-context.tsx
@@ -24,6 +24,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from 'react';
@@ -76,6 +77,9 @@ export interface AuthUser {
   hasPasskey: boolean;
 }
 
+/** Result of creating a new email/password account. */
+export type SignupResult = { kind: 'authenticated' } | { kind: 'confirmation_required' };
+
 /** Actions available through the auth context. */
 export interface AuthActions {
   /** Sign in with email and password. */
@@ -93,7 +97,7 @@ export interface AuthActions {
   /** Manually trigger a token refresh. */
   refresh: () => Promise<void>;
   /** Create a new account with email and password. */
-  signupWithEmail: (email: string, password: string) => Promise<void>;
+  signupWithEmail: (email: string, password: string) => Promise<SignupResult>;
 }
 
 /** Supported OAuth providers. */
@@ -113,6 +117,8 @@ export interface AuthContextValue extends AuthActions {
   webAuthnSupported: boolean;
   /** Whether the app is running in demo mode (no backend configured). */
   isDemoMode: boolean;
+  /** Whether auth is preserving the last known user while refresh is offline/unreachable. */
+  isOffline: boolean;
   /** Whether the passkey setup prompt should be shown. */
   showPasskeyPrompt: boolean;
   /** Dismiss the passkey setup prompt. */
@@ -142,6 +148,7 @@ export interface AuthProviderConfig {
 // ---------------------------------------------------------------------------
 
 const AuthContext = createContext<AuthContextValue | null>(null);
+const LAST_USER_STORAGE_KEY = 'finance.lastUser';
 
 // ---------------------------------------------------------------------------
 // Provider
@@ -171,14 +178,53 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
   const [error, setError] = useState<string | null>(null);
   const [webAuthnSupported] = useState(() => isWebAuthnSupported());
   const [showPasskeyPrompt, setShowPasskeyPrompt] = useState(false);
+  const [isOffline, setIsOffline] = useState(false);
+  const onlineRetryHandlerRef = useRef<(() => void) | null>(null);
 
   const demoModeActive = isDemoMode(config.supabaseUrl);
-  const isAuthenticated = user !== null && hasValidToken();
+  const isAuthenticated = user !== null && (hasValidToken() || isOffline);
 
   /** Dismiss the passkey prompt (hides it without changing preferences). */
   const dismissPasskeyPrompt = useCallback(() => {
     setShowPasskeyPrompt(false);
   }, []);
+
+  function rememberUser(nextUser: AuthUser): void {
+    setUser(nextUser);
+    cacheLastUser(nextUser);
+  }
+
+  function handleSessionExpired(): void {
+    clearTokens();
+    clearCachedUser();
+    cancelOnlineRestoreRetry();
+    setIsOffline(false);
+    setUser(null);
+    config.onUnauthenticated?.();
+  }
+
+  function scheduleOnlineRestoreRetry(): void {
+    if (onlineRetryHandlerRef.current) {
+      return;
+    }
+
+    const handleOnline = () => {
+      cancelOnlineRestoreRetry();
+      void tryRestoreSession();
+    };
+
+    onlineRetryHandlerRef.current = handleOnline;
+    window.addEventListener('online', handleOnline, { once: true });
+  }
+
+  function cancelOnlineRestoreRetry(): void {
+    if (!onlineRetryHandlerRef.current) {
+      return;
+    }
+
+    window.removeEventListener('online', onlineRetryHandlerRef.current);
+    onlineRetryHandlerRef.current = null;
+  }
 
   // -----------------------------------------------------------------------
   // Initialisation
@@ -227,11 +273,7 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
     // page refresh without storing tokens in localStorage.
     initTokenManager({
       refreshEndpoint: config.refreshEndpoint,
-      onSessionExpired: () => {
-        setUser(null);
-        clearTokens();
-        config.onUnauthenticated?.();
-      },
+      onSessionExpired: handleSessionExpired,
     });
 
     // Initialise WebAuthn
@@ -255,6 +297,7 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
     window.addEventListener('beforeunload', handleBeforeUnload);
     return () => {
       window.removeEventListener('beforeunload', handleBeforeUnload);
+      cancelOnlineRestoreRetry();
     };
   }, []);
 
@@ -263,24 +306,33 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
    * via the HttpOnly refresh cookie.
    */
   async function tryRestoreSession(): Promise<void> {
-    try {
-      const token = await refreshAccessToken();
-      if (token) {
-        // Decode minimal user info from the token
-        const payload = parseTokenPayload(token);
-        if (payload) {
-          setUser({
-            id: payload.sub ?? '',
-            email: payload.email ?? '',
-            hasPasskey: false, // Will be updated on next profile fetch
-          });
+    const result = await refreshAccessToken();
+
+    switch (result.kind) {
+      case 'success': {
+        const restoredUser = userFromToken(result.token) ?? readCachedUser();
+        if (restoredUser) {
+          rememberUser(restoredUser);
         }
+        setIsOffline(false);
+        cancelOnlineRestoreRetry();
+        break;
       }
-    } catch {
-      // No valid session — user needs to log in
-    } finally {
-      setIsLoading(false);
+      case 'session_expired':
+        handleSessionExpired();
+        break;
+      case 'network_error': {
+        const cachedUser = readCachedUser();
+        if (cachedUser) {
+          setUser((current) => current ?? cachedUser);
+        }
+        setIsOffline(true);
+        scheduleOnlineRestoreRetry();
+        break;
+      }
     }
+
+    setIsLoading(false);
   }
 
   // -----------------------------------------------------------------------
@@ -307,11 +359,12 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
         if (demoModeActive) {
           const result = await demoLogin(email, password);
           setAccessToken(result.accessToken);
-          setUser({
+          rememberUser({
             id: result.user.id,
             email: result.user.email,
             hasPasskey: false,
           });
+          setIsOffline(false);
           triggerPasskeyPromptCheck();
           return;
         }
@@ -336,11 +389,12 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
         };
 
         setAccessToken(data.access_token);
-        setUser({
+        rememberUser({
           id: data.user.id,
           email: data.user.email,
           hasPasskey: data.user.has_passkey ?? false,
         });
+        setIsOffline(false);
         triggerPasskeyPromptCheck();
       } catch (err) {
         const message = err instanceof Error ? err.message : 'An unexpected error occurred';
@@ -366,11 +420,12 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
       // CSRF risk of a detached session endpoint (#1310).
       if (result.accessToken) {
         setAccessToken(result.accessToken);
-        setUser({
+        rememberUser({
           id: result.userId,
           email: result.email ?? email ?? '',
           hasPasskey: true,
         });
+        setIsOffline(false);
       } else {
         // Defensive fallback — should not occur with a correctly
         // configured server, but avoids a blank screen if the server
@@ -398,7 +453,13 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
       await registerPasskey(token);
 
       // Update user state and localStorage to reflect passkey registration
-      setUser((prev) => (prev ? { ...prev, hasPasskey: true } : null));
+      setUser((prev) => {
+        const nextUser = prev ? { ...prev, hasPasskey: true } : null;
+        if (nextUser) {
+          cacheLastUser(nextUser);
+        }
+        return nextUser;
+      });
       setHasRegisteredPasskey();
       setShowPasskeyPrompt(false);
     } catch (err) {
@@ -419,6 +480,9 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
       // Best-effort — clear local state regardless
     } finally {
       clearTokens();
+      clearCachedUser();
+      cancelOnlineRestoreRetry();
+      setIsOffline(false);
       setUser(null);
       if (demoModeActive) {
         clearDemoSession();
@@ -449,6 +513,8 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
       clearTokens();
       localStorage.clear();
       sessionStorage.clear();
+      cancelOnlineRestoreRetry();
+      setIsOffline(false);
       setUser(null);
       config.onUnauthenticated?.();
     }
@@ -466,20 +532,34 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
       return;
     }
 
-    try {
-      const token = await refreshAccessToken();
-      if (!token) {
-        setUser(null);
-        config.onUnauthenticated?.();
+    const result = await refreshAccessToken();
+    switch (result.kind) {
+      case 'success': {
+        const refreshedUser = userFromToken(result.token);
+        if (refreshedUser) {
+          rememberUser(refreshedUser);
+        }
+        setIsOffline(false);
+        cancelOnlineRestoreRetry();
+        break;
       }
-    } catch {
-      setUser(null);
-      config.onUnauthenticated?.();
+      case 'session_expired':
+        handleSessionExpired();
+        break;
+      case 'network_error': {
+        const cachedUser = readCachedUser();
+        if (cachedUser) {
+          setUser((current) => current ?? cachedUser);
+        }
+        setIsOffline(true);
+        scheduleOnlineRestoreRetry();
+        break;
+      }
     }
-  }, [config, demoModeActive, user?.email]);
+  }, [demoModeActive, user?.email]);
 
   const signupWithEmail = useCallback(
-    async (email: string, password: string): Promise<void> => {
+    async (email: string, password: string): Promise<SignupResult> => {
       setError(null);
       setIsLoading(true);
 
@@ -489,14 +569,15 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
           // Auto-login after demo signup
           const result = await demoLogin(email, password);
           setAccessToken(result.accessToken);
-          setUser({
+          rememberUser({
             id: result.user.id,
             email: result.user.email,
             hasPasskey: false,
           });
+          setIsOffline(false);
           // demoLogin already calls persistDemoSession
           triggerPasskeyPromptCheck();
-          return;
+          return { kind: 'authenticated' };
         }
 
         const endpoint = config.signupEndpoint ?? '/api/auth/signup';
@@ -505,15 +586,38 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ email, password }),
         });
+        const body = (await response.json().catch(() => ({}))) as {
+          confirmation_required?: boolean;
+          error?: string;
+          access_token?: string;
+          user?: { id: string; email: string; has_passkey?: boolean };
+        };
+
+        if (response.status === 202) {
+          if (body.confirmation_required) {
+            return { kind: 'confirmation_required' };
+          }
+          throw new Error('Signup requires email confirmation, but the response was invalid.');
+        }
 
         if (!response.ok) {
-          const body = (await response.json().catch(() => ({}))) as {
-            error?: string;
-          };
           throw new Error(body.error ?? 'Signup failed');
         }
 
-        // Auto-login: use the same credentials to establish a session
+        if (response.status === 201 && body.access_token && body.user) {
+          setAccessToken(body.access_token);
+          rememberUser({
+            id: body.user.id,
+            email: body.user.email,
+            hasPasskey: body.user.has_passkey ?? false,
+          });
+          setIsOffline(false);
+          triggerPasskeyPromptCheck();
+          return { kind: 'authenticated' };
+        }
+
+        // Auto-login: use the same credentials to establish a session when the
+        // signup endpoint does not return a session directly.
         const loginResponse = await fetch(config.loginEndpoint, {
           method: 'POST',
           credentials: 'include',
@@ -527,15 +631,15 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
             user: { id: string; email: string; has_passkey?: boolean };
           };
           setAccessToken(data.access_token);
-          setUser({
+          rememberUser({
             id: data.user.id,
             email: data.user.email,
             hasPasskey: data.user.has_passkey ?? false,
           });
+          setIsOffline(false);
           triggerPasskeyPromptCheck();
         }
-        // If auto-login fails, the signup still succeeded — caller can
-        // decide to redirect to login or show a message.
+        return { kind: 'authenticated' };
       } catch (err) {
         const message = err instanceof Error ? err.message : 'An unexpected error occurred';
         setError(message);
@@ -590,6 +694,7 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
       error,
       webAuthnSupported,
       isDemoMode: demoModeActive,
+      isOffline,
       showPasskeyPrompt,
       dismissPasskeyPrompt,
       loginWithEmail,
@@ -608,6 +713,7 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
       error,
       webAuthnSupported,
       demoModeActive,
+      isOffline,
       showPasskeyPrompt,
       dismissPasskeyPrompt,
       loginWithEmail,
@@ -715,6 +821,56 @@ export function ProtectedRoute({
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+function cacheLastUser(nextUser: AuthUser): void {
+  try {
+    localStorage.setItem(LAST_USER_STORAGE_KEY, JSON.stringify(nextUser));
+  } catch {
+    // Best-effort only; auth cookies remain the source of truth.
+  }
+}
+
+function readCachedUser(): AuthUser | null {
+  try {
+    const raw = localStorage.getItem(LAST_USER_STORAGE_KEY);
+    if (!raw) return null;
+
+    const parsed = JSON.parse(raw) as Partial<AuthUser>;
+    if (typeof parsed.id !== 'string' || typeof parsed.email !== 'string') {
+      return null;
+    }
+
+    return {
+      id: parsed.id,
+      email: parsed.email,
+      hasPasskey: parsed.hasPasskey === true,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function clearCachedUser(): void {
+  try {
+    localStorage.removeItem(LAST_USER_STORAGE_KEY);
+  } catch {
+    // Best-effort only.
+  }
+}
+
+function userFromToken(token: string): AuthUser | null {
+  const payload = parseTokenPayload(token);
+  if (!payload || (!payload.sub && !payload.email)) {
+    return null;
+  }
+
+  const cachedUser = readCachedUser();
+  return {
+    id: payload.sub ?? cachedUser?.id ?? '',
+    email: payload.email ?? cachedUser?.email ?? '',
+    hasPasskey: cachedUser?.hasPasskey ?? false,
+  };
+}
 
 /**
  * Parse minimal claims from a JWT payload (without verification).

--- a/apps/web/src/auth/auth-context.tsx
+++ b/apps/web/src/auth/auth-context.tsx
@@ -325,9 +325,14 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
         const cachedUser = readCachedUser();
         if (cachedUser) {
           setUser((current) => current ?? cachedUser);
+          setIsOffline(true);
+          scheduleOnlineRestoreRetry();
+        } else {
+          // No cached user — there is no session to keep alive offline.
+          // Treat as session_expired so the app redirects to login instead of
+          // leaving the user stranded on a protected route.
+          handleSessionExpired();
         }
-        setIsOffline(true);
-        scheduleOnlineRestoreRetry();
         break;
       }
     }

--- a/apps/web/src/auth/token-storage.test.ts
+++ b/apps/web/src/auth/token-storage.test.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { clearTokens, initTokenManager, refreshAccessToken } from './token-storage';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('refreshAccessToken', () => {
+  const onSessionExpired = vi.fn();
+
+  beforeEach(() => {
+    clearTokens();
+    onSessionExpired.mockReset();
+    initTokenManager({ refreshEndpoint: '/api/auth/refresh', onSessionExpired });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    clearTokens();
+  });
+
+  it('returns success with the refreshed access token', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse({ access_token: 'header.payload.signature', expires_in: 3600 }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(refreshAccessToken()).resolves.toEqual({
+      kind: 'success',
+      token: 'header.payload.signature',
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/auth/refresh',
+      expect.objectContaining({
+        method: 'POST',
+        credentials: 'include',
+      }),
+    );
+  });
+
+  it('returns session_expired for HTTP 401', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ error: 'expired' }, 401)));
+
+    await expect(refreshAccessToken()).resolves.toEqual({ kind: 'session_expired' });
+    expect(onSessionExpired).not.toHaveBeenCalled();
+  });
+
+  it('returns network_error for fetch failures', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')));
+
+    const result = await refreshAccessToken();
+
+    expect(result.kind).toBe('network_error');
+    if (result.kind === 'network_error') {
+      expect(result.error).toBeInstanceOf(TypeError);
+      expect(result.error.message).toBe('Failed to fetch');
+    }
+    expect(onSessionExpired).not.toHaveBeenCalled();
+  });
+
+  it('returns network_error for server errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ error: 'unavailable' }, 503)));
+
+    const result = await refreshAccessToken();
+
+    expect(result.kind).toBe('network_error');
+    if (result.kind === 'network_error') {
+      expect(result.error.message).toContain('HTTP 503');
+    }
+    expect(onSessionExpired).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/auth/token-storage.ts
+++ b/apps/web/src/auth/token-storage.ts
@@ -45,7 +45,7 @@ export interface TokenManagerConfig {
   refreshEndpoint: string;
 
   /**
-   * Called when a refresh attempt fails (e.g. refresh token expired).
+   * Called when a refresh attempt proves the refresh session expired (HTTP 401).
    * The application should redirect to the login page.
    */
   onSessionExpired: () => void;
@@ -56,6 +56,12 @@ interface RefreshResponse {
   access_token: string;
   expires_in: number;
 }
+
+/** Typed outcome of a cookie-backed access-token refresh attempt. */
+export type RefreshAccessTokenResult =
+  | { kind: 'success'; token: string }
+  | { kind: 'session_expired' }
+  | { kind: 'network_error'; error: Error };
 
 // ---------------------------------------------------------------------------
 // Module State (in-memory only — never persisted)
@@ -74,7 +80,7 @@ let refreshTimerId: ReturnType<typeof setTimeout> | null = null;
 let isRefreshing = false;
 
 /** Queued callers waiting for a refresh to complete. */
-let refreshSubscribers: Array<(token: string | null) => void> = [];
+let refreshSubscribers: Array<(result: RefreshAccessTokenResult) => void> = [];
 
 /** Module configuration. */
 let managerConfig: TokenManagerConfig | null = null;
@@ -128,12 +134,17 @@ function decodeJwtPayload(token: string): JwtPayload {
 /**
  * Notify all queued subscribers after a refresh completes (or fails).
  */
-function notifyRefreshSubscribers(token: string | null): void {
+function notifyRefreshSubscribers(result: RefreshAccessTokenResult): void {
   const subscribers = refreshSubscribers;
   refreshSubscribers = [];
   for (const callback of subscribers) {
-    callback(token);
+    callback(result);
   }
+}
+
+/** Normalise thrown values into Error instances for typed network failures. */
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
 }
 
 /**
@@ -145,9 +156,9 @@ function notifyRefreshSubscribers(token: string | null): void {
  *   3. Set a new HttpOnly refresh cookie.
  *   4. Return `{ access_token, expires_in }` in the response body.
  */
-async function executeRefresh(): Promise<string | null> {
+async function executeRefresh(): Promise<RefreshAccessTokenResult> {
   if (!managerConfig) {
-    return null;
+    return { kind: 'session_expired' };
   }
 
   try {
@@ -159,19 +170,27 @@ async function executeRefresh(): Promise<string | null> {
       },
     });
 
+    if (response.status === 401) {
+      return { kind: 'session_expired' };
+    }
+
     if (!response.ok) {
-      // Refresh failed — session is expired
-      clearTokens();
-      managerConfig.onSessionExpired();
-      return null;
+      return {
+        kind: 'network_error',
+        error: new Error(`Token refresh failed with HTTP ${response.status}`),
+      };
     }
 
     const data = (await response.json()) as RefreshResponse;
+    if (typeof data.access_token !== 'string' || data.access_token.length === 0) {
+      return { kind: 'network_error', error: new Error('Token refresh response was invalid') };
+    }
+
     setAccessToken(data.access_token);
-    return data.access_token;
-  } catch {
-    // Network error — don't clear tokens, retry will happen
-    return null;
+    return { kind: 'success', token: data.access_token };
+  } catch (error) {
+    // Network error — don't clear tokens; callers can retry when connectivity returns.
+    return { kind: 'network_error', error: toError(error) };
   }
 }
 
@@ -193,7 +212,12 @@ function scheduleRefresh(): void {
   const refreshIn = Math.max(timeUntilExpiry - REFRESH_THRESHOLD_MS - REFRESH_SAFETY_MARGIN_MS, 0);
 
   refreshTimerId = setTimeout(() => {
-    void refreshAccessToken();
+    void refreshAccessToken().then((result) => {
+      if (result.kind === 'session_expired') {
+        clearTokens();
+        managerConfig?.onSessionExpired();
+      }
+    });
   }, refreshIn);
 }
 
@@ -256,7 +280,14 @@ export async function getAccessToken(): Promise<string | null> {
   }
 
   // Token is near expiry or expired — refresh
-  return refreshAccessToken();
+  const result = await refreshAccessToken();
+  if (result.kind === 'session_expired') {
+    clearTokens();
+    managerConfig?.onSessionExpired();
+    return null;
+  }
+
+  return result.kind === 'success' ? result.token : null;
 }
 
 /**
@@ -277,12 +308,12 @@ export function getAccessTokenSync(): string | null {
  * Deduplicates concurrent refresh requests — if a refresh is already
  * in-flight, subsequent callers wait for the same result.
  *
- * @returns The new access token, or `null` if refresh failed.
+ * @returns A typed result describing whether refresh succeeded, the session expired, or the network failed.
  */
-export async function refreshAccessToken(): Promise<string | null> {
+export async function refreshAccessToken(): Promise<RefreshAccessTokenResult> {
   // If already refreshing, queue this caller
   if (isRefreshing) {
-    return new Promise<string | null>((resolve) => {
+    return new Promise<RefreshAccessTokenResult>((resolve) => {
       refreshSubscribers.push(resolve);
     });
   }
@@ -290,9 +321,9 @@ export async function refreshAccessToken(): Promise<string | null> {
   isRefreshing = true;
 
   try {
-    const newToken = await executeRefresh();
-    notifyRefreshSubscribers(newToken);
-    return newToken;
+    const result = await executeRefresh();
+    notifyRefreshSubscribers(result);
+    return result;
   } finally {
     isRefreshing = false;
   }

--- a/apps/web/src/pages/SignupPage.test.tsx
+++ b/apps/web/src/pages/SignupPage.test.tsx
@@ -16,6 +16,7 @@ const authState = vi.hoisted(() => ({
   user: null,
   webAuthnSupported: true,
   isDemoMode: false,
+  isOffline: false,
 }));
 
 vi.mock('../auth/auth-context', () => ({
@@ -101,7 +102,7 @@ describe('SignupPage', () => {
   // ── Submission ────────────────────────────────────────────────────────────
 
   it('calls signupWithEmail with trimmed email and password on valid submission', async () => {
-    authState.signupWithEmail.mockResolvedValue(undefined);
+    authState.signupWithEmail.mockResolvedValue({ kind: 'authenticated' });
     renderSignupPage();
     fillValidForm();
 
@@ -116,7 +117,7 @@ describe('SignupPage', () => {
   it('redirects to /dashboard when isAuthenticated becomes true after signup', async () => {
     authState.signupWithEmail.mockImplementation(() => {
       authState.isAuthenticated = true;
-      return Promise.resolve();
+      return Promise.resolve({ kind: 'authenticated' });
     });
     renderSignupPage();
     fillValidForm();
@@ -127,6 +128,28 @@ describe('SignupPage', () => {
 
     // The component re-renders with isAuthenticated = true and navigates.
     expect(navigateMock).toHaveBeenCalledWith('/dashboard');
+  });
+
+  it('shows confirmation-required UI and can resend confirmation email', async () => {
+    authState.signupWithEmail.mockResolvedValue({ kind: 'confirmation_required' });
+    renderSignupPage();
+    fillValidForm();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Sign up' }));
+    });
+
+    expect(await screen.findByRole('heading', { name: 'Check your email' })).toBeInTheDocument();
+    expect(screen.getByText('alex@example.com')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Back to sign in' })).toHaveAttribute('href', '/login');
+    expect(screen.queryByLabelText('Email')).not.toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Resend confirmation email' }));
+    });
+
+    expect(authState.signupWithEmail).toHaveBeenCalledTimes(2);
+    expect(await screen.findByText('Confirmation email sent again.')).toBeInTheDocument();
   });
 
   it('shows error banner when signup fails', async () => {

--- a/apps/web/src/pages/SignupPage.tsx
+++ b/apps/web/src/pages/SignupPage.tsx
@@ -55,6 +55,7 @@ export const SignupPage: React.FC = () => {
   const [confirmPassword, setConfirmPassword] = useState('');
   const [fieldErrors, setFieldErrors] = useState<SignupFieldErrors>({});
   const [submitMessage, setSubmitMessage] = useState<SubmitMessage | null>(null);
+  const [confirmationEmail, setConfirmationEmail] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const uid = useId();
@@ -125,6 +126,7 @@ export const SignupPage: React.FC = () => {
     async (event: React.FormEvent<HTMLFormElement>) => {
       event.preventDefault();
       setSubmitMessage(null);
+      setConfirmationEmail(null);
 
       if (!validate()) {
         return;
@@ -141,7 +143,12 @@ export const SignupPage: React.FC = () => {
       setIsSubmitting(true);
 
       try {
-        await signupWithEmail(email.trim(), password);
+        const signupEmail = email.trim();
+        const result = await signupWithEmail(signupEmail, password);
+        if (result.kind === 'confirmation_required') {
+          setConfirmationEmail(signupEmail);
+          return;
+        }
         // Auto-login is handled by signupWithEmail — the useEffect above
         // will redirect to /dashboard once isAuthenticated becomes true.
       } catch (err) {
@@ -153,8 +160,30 @@ export const SignupPage: React.FC = () => {
         setIsSubmitting(false);
       }
     },
-    [email, navigate, password, signupWithEmail, validate],
+    [email, password, signupWithEmail, validate],
   );
+
+  const handleResendConfirmation = useCallback(async () => {
+    if (!confirmationEmail || !signupWithEmail) {
+      return;
+    }
+
+    setSubmitMessage(null);
+    setIsSubmitting(true);
+    try {
+      const result = await signupWithEmail(confirmationEmail, password);
+      if (result.kind === 'confirmation_required') {
+        setSubmitMessage({ type: 'info', text: 'Confirmation email sent again.' });
+      }
+    } catch (err) {
+      setSubmitMessage({
+        type: 'error',
+        text: err instanceof Error ? err.message : 'Could not resend confirmation email.',
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [confirmationEmail, password, signupWithEmail]);
 
   const isBusy = isSubmitting || isLoading;
 
@@ -182,116 +211,152 @@ export const SignupPage: React.FC = () => {
           </div>
         )}
 
-        <form className="auth-form" onSubmit={handleSubmit} noValidate>
-          <div className="auth-field">
-            <label className="auth-field__label" htmlFor={emailId}>
-              Email
-            </label>
-            <input
-              id={emailId}
-              className="auth-field__input"
-              type="email"
-              autoComplete="email"
-              required
-              value={email}
-              onChange={(event) => {
-                const nextEmail = event.target.value;
-                setEmail(nextEmail);
-                setFieldErrors((current) => ({ ...current, email: undefined }));
-              }}
-              aria-invalid={fieldErrors.email ? 'true' : undefined}
-              aria-describedby={fieldErrors.email ? emailErrorId : undefined}
-            />
-            {fieldErrors.email && (
-              <p id={emailErrorId} className="auth-field__error" role="alert">
-                {fieldErrors.email}
-              </p>
-            )}
-          </div>
-
-          <div className="auth-field">
-            <label className="auth-field__label" htmlFor={passwordId}>
-              Password
-            </label>
-            <input
-              id={passwordId}
-              className="auth-field__input"
-              type="password"
-              autoComplete="new-password"
-              required
-              minLength={MIN_PASSWORD_LENGTH}
-              value={password}
-              onChange={(event) => {
-                const nextPassword = event.target.value;
-                setPassword(nextPassword);
-                setFieldErrors((current) => ({
-                  ...current,
-                  password: undefined,
-                  confirmPassword:
-                    confirmPassword.length > 0 && nextPassword !== confirmPassword
-                      ? 'Passwords do not match.'
-                      : undefined,
-                }));
-              }}
-              aria-invalid={fieldErrors.password ? 'true' : undefined}
-              aria-describedby={[passwordHintId, fieldErrors.password ? passwordErrorId : null]
-                .filter(Boolean)
-                .join(' ')}
-            />
-            <p id={passwordHintId} className="auth-field__hint">
-              Must be at least {MIN_PASSWORD_LENGTH} characters
+        {confirmationEmail ? (
+          <section className="auth-confirmation" aria-live="polite">
+            <h2>Check your email</h2>
+            <p>
+              We sent a confirmation link to <strong>{confirmationEmail}</strong>. Click the link to
+              activate your account, then return here to sign in.
             </p>
-            {password.length > 0 && <PasswordStrengthMeter password={password} />}
-            {fieldErrors.password && (
-              <p id={passwordErrorId} className="auth-field__error" role="alert">
-                {fieldErrors.password}
-              </p>
-            )}
-          </div>
+            <div className="auth-actions">
+              <button
+                type="button"
+                className="auth-submit"
+                onClick={() => {
+                  void handleResendConfirmation();
+                }}
+                disabled={isBusy}
+                aria-busy={isBusy}
+              >
+                {isBusy ? 'Sending...' : 'Resend confirmation email'}
+              </button>
+              <Link to="/login" className="auth-footer__link">
+                Back to sign in
+              </Link>
+              <button
+                type="button"
+                className="auth-footer__link auth-link-button"
+                onClick={() => {
+                  setConfirmationEmail(null);
+                  setSubmitMessage(null);
+                }}
+              >
+                Use a different email
+              </button>
+            </div>
+          </section>
+        ) : (
+          <form className="auth-form" onSubmit={handleSubmit} noValidate>
+            <div className="auth-field">
+              <label className="auth-field__label" htmlFor={emailId}>
+                Email
+              </label>
+              <input
+                id={emailId}
+                className="auth-field__input"
+                type="email"
+                autoComplete="email"
+                required
+                value={email}
+                onChange={(event) => {
+                  const nextEmail = event.target.value;
+                  setEmail(nextEmail);
+                  setFieldErrors((current) => ({ ...current, email: undefined }));
+                }}
+                aria-invalid={fieldErrors.email ? 'true' : undefined}
+                aria-describedby={fieldErrors.email ? emailErrorId : undefined}
+              />
+              {fieldErrors.email && (
+                <p id={emailErrorId} className="auth-field__error" role="alert">
+                  {fieldErrors.email}
+                </p>
+              )}
+            </div>
 
-          <div className="auth-field">
-            <label className="auth-field__label" htmlFor={confirmPasswordId}>
-              Confirm Password
-            </label>
-            <input
-              id={confirmPasswordId}
-              className="auth-field__input"
-              type="password"
-              autoComplete="new-password"
-              required
-              value={confirmPassword}
-              onChange={(event) => {
-                const nextConfirmPassword = event.target.value;
-                setConfirmPassword(nextConfirmPassword);
-                setFieldErrors((current) => ({
-                  ...current,
-                  confirmPassword:
-                    nextConfirmPassword.length > 0 && password !== nextConfirmPassword
-                      ? 'Passwords do not match.'
-                      : undefined,
-                }));
-              }}
-              aria-invalid={confirmPasswordError ? 'true' : undefined}
-              aria-describedby={confirmPasswordError ? confirmPasswordErrorId : undefined}
-            />
-            {confirmPasswordError && (
-              <p id={confirmPasswordErrorId} className="auth-field__error" role="alert">
-                {confirmPasswordError}
+            <div className="auth-field">
+              <label className="auth-field__label" htmlFor={passwordId}>
+                Password
+              </label>
+              <input
+                id={passwordId}
+                className="auth-field__input"
+                type="password"
+                autoComplete="new-password"
+                required
+                minLength={MIN_PASSWORD_LENGTH}
+                value={password}
+                onChange={(event) => {
+                  const nextPassword = event.target.value;
+                  setPassword(nextPassword);
+                  setFieldErrors((current) => ({
+                    ...current,
+                    password: undefined,
+                    confirmPassword:
+                      confirmPassword.length > 0 && nextPassword !== confirmPassword
+                        ? 'Passwords do not match.'
+                        : undefined,
+                  }));
+                }}
+                aria-invalid={fieldErrors.password ? 'true' : undefined}
+                aria-describedby={[passwordHintId, fieldErrors.password ? passwordErrorId : null]
+                  .filter(Boolean)
+                  .join(' ')}
+              />
+              <p id={passwordHintId} className="auth-field__hint">
+                Must be at least {MIN_PASSWORD_LENGTH} characters
               </p>
-            )}
-          </div>
+              {password.length > 0 && <PasswordStrengthMeter password={password} />}
+              {fieldErrors.password && (
+                <p id={passwordErrorId} className="auth-field__error" role="alert">
+                  {fieldErrors.password}
+                </p>
+              )}
+            </div>
 
-          <button type="submit" className="auth-submit" disabled={isBusy} aria-busy={isBusy}>
-            {isBusy ? (
-              <>
-                <LoadingSpinner size={20} label="Creating account" />
-                <span>Creating account...</span>
-              </>
-            ) : (
-              'Sign up'
-            )}
-          </button>
-        </form>
+            <div className="auth-field">
+              <label className="auth-field__label" htmlFor={confirmPasswordId}>
+                Confirm Password
+              </label>
+              <input
+                id={confirmPasswordId}
+                className="auth-field__input"
+                type="password"
+                autoComplete="new-password"
+                required
+                value={confirmPassword}
+                onChange={(event) => {
+                  const nextConfirmPassword = event.target.value;
+                  setConfirmPassword(nextConfirmPassword);
+                  setFieldErrors((current) => ({
+                    ...current,
+                    confirmPassword:
+                      nextConfirmPassword.length > 0 && password !== nextConfirmPassword
+                        ? 'Passwords do not match.'
+                        : undefined,
+                  }));
+                }}
+                aria-invalid={confirmPasswordError ? 'true' : undefined}
+                aria-describedby={confirmPasswordError ? confirmPasswordErrorId : undefined}
+              />
+              {confirmPasswordError && (
+                <p id={confirmPasswordErrorId} className="auth-field__error" role="alert">
+                  {confirmPasswordError}
+                </p>
+              )}
+            </div>
+
+            <button type="submit" className="auth-submit" disabled={isBusy} aria-busy={isBusy}>
+              {isBusy ? (
+                <>
+                  <LoadingSpinner size={20} label="Creating account" />
+                  <span>Creating account...</span>
+                </>
+              ) : (
+                'Sign up'
+              )}
+            </button>
+          </form>
+        )}
 
         <p className="auth-footer">
           Already have an account?{' '}


### PR DESCRIPTION
Auto-generated PR from alpha E2E pass fleet (#1243).

Closes #1940
Closes #1942

See commit message for details. All touched test suites pass and `npm run type-check` is clean as of the dispatch fleet.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>