### PR TITLE
fix(account): actually delete user data + safe confirmation flow (#1937 #1938)

### DIFF
--- a/apps/web/src/lib/account/account-deletion.ts
+++ b/apps/web/src/lib/account/account-deletion.ts
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { clearEncryptedData } from '../../db/encryption';
+import { clearQueue } from '../../db/mutation-queue';
+import {
+  getHouseholdById,
+  getHouseholdInvitations,
+  getHouseholdMembers,
+} from '../../db/repositories/household';
+import type { SqliteDb } from '../../db/sqlite-wasm';
+import type { SyncId } from '../../kmp/bridge';
+
+export interface HouseholdDeletionImpact {
+  soloOwnedHouseholds: number;
+  memberHouseholds: number;
+  pendingInvites: number;
+}
+
+const LOCAL_TABLE_DELETE_ORDER = [
+  'shared_goal',
+  'shared_budget',
+  'account_sharing',
+  'household_invitation',
+  '"transaction"',
+  'budget',
+  'goal',
+  'category',
+  'account',
+  'household_member',
+  'household',
+  'user',
+  'widget_privacy_config',
+] as const;
+
+export function getHouseholdDeletionImpact(
+  db: SqliteDb | null,
+  userId: SyncId | null | undefined,
+): HouseholdDeletionImpact {
+  if (!db || !userId) {
+    return { soloOwnedHouseholds: 0, memberHouseholds: 0, pendingInvites: 0 };
+  }
+
+  const membershipRows = db.selectAll(
+    `SELECT DISTINCT household_id FROM household_member WHERE user_id = ? AND deleted_at IS NULL`,
+    [userId],
+  );
+  const ownedRows = db.selectAll(
+    `SELECT id FROM household WHERE owner_id = ? AND deleted_at IS NULL`,
+    [userId],
+  );
+
+  const householdIds = new Set<string>();
+  for (const row of membershipRows) {
+    if (typeof row.household_id === 'string') householdIds.add(row.household_id);
+  }
+  for (const row of ownedRows) {
+    if (typeof row.id === 'string') householdIds.add(row.id);
+  }
+
+  let soloOwnedHouseholds = 0;
+  let memberHouseholds = 0;
+  let pendingInvites = 0;
+
+  for (const householdId of householdIds) {
+    const household = getHouseholdById(db, householdId);
+    if (!household) continue;
+
+    const members = getHouseholdMembers(db, householdId);
+    const otherMembers = members.filter((member) => member.userId !== userId);
+    const isOwner = household.ownerId === userId;
+
+    if (isOwner && otherMembers.length === 0) {
+      soloOwnedHouseholds += 1;
+    } else {
+      memberHouseholds += 1;
+    }
+
+    pendingInvites += getHouseholdInvitations(db, householdId).filter(
+      (invite) =>
+        invite.status === 'PENDING' &&
+        (invite.invitedBy === userId || household.ownerId === userId),
+    ).length;
+  }
+
+  return { soloOwnedHouseholds, memberHouseholds, pendingInvites };
+}
+
+export async function clearLocalAccountData(db: SqliteDb | null): Promise<void> {
+  if (db) {
+    for (const table of LOCAL_TABLE_DELETE_ORDER) {
+      try {
+        db.exec(`DELETE FROM ${table}`);
+      } catch {
+        // Older local schemas may not have every optional feature table.
+      }
+    }
+  }
+
+  await Promise.all([
+    clearQueue().catch(() => undefined),
+    clearEncryptedData().catch(() => undefined),
+  ]);
+}

--- a/apps/web/src/pages/SettingsPage.test.tsx
+++ b/apps/web/src/pages/SettingsPage.test.tsx
@@ -9,6 +9,19 @@ const offlineStatusMock = {
   isOffline: false,
   isOnline: true,
 };
+const { clearLocalAccountDataMock, householdImpactMock } = vi.hoisted(() => ({
+  clearLocalAccountDataMock: vi.fn<() => Promise<void>>(),
+  householdImpactMock: vi.fn(() => ({
+    soloOwnedHouseholds: 1,
+    memberHouseholds: 2,
+    pendingInvites: 3,
+  })),
+}));
+
+vi.mock('../lib/account/account-deletion', () => ({
+  clearLocalAccountData: clearLocalAccountDataMock,
+  getHouseholdDeletionImpact: householdImpactMock,
+}));
 
 vi.mock('../auth/auth-context', () => ({
   useAuth: () => ({
@@ -49,9 +62,12 @@ vi.mock('../hooks/useTheme', () => ({
 
 // Mock the GDPR components to avoid pulling in full consent logic
 vi.mock('../components/gdpr', () => ({
-  PrivacySettings: () => (
+  PrivacySettings: ({ onDeleteAccount }: { onDeleteAccount?: () => void }) => (
     <section aria-label="Privacy & Data">
       <div>Privacy Settings Mock</div>
+      <button type="button" onClick={onDeleteAccount}>
+        Delete My Account & Data
+      </button>
     </section>
   ),
   CrashReportingSettings: () => <div>Crash Reporting Settings Mock</div>,
@@ -141,6 +157,15 @@ describe('SettingsPage', () => {
     setThemeMock.mockReset();
     mockUpdateSettings.mockReset();
     mockResetSettings.mockReset();
+    clearLocalAccountDataMock.mockReset();
+    clearLocalAccountDataMock.mockResolvedValue(undefined);
+    householdImpactMock.mockClear();
+    householdImpactMock.mockReturnValue({
+      soloOwnedHouseholds: 1,
+      memberHouseholds: 2,
+      pendingInvites: 3,
+    });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
     logoutMock.mockResolvedValue(undefined);
     deleteAccountMock.mockResolvedValue(undefined);
     offlineStatusMock.isOffline = false;
@@ -228,6 +253,31 @@ describe('SettingsPage', () => {
     // "Data" and "Privacy & Data" sections both exist
     const dataRegions = screen.getAllByRole('region', { name: /data/i });
     expect(dataRegions.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('gates account deletion behind typed confirmation and shows household impact', async () => {
+    render(<SettingsPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: /delete my account & data/i }));
+
+    const dialog = await screen.findByRole('dialog', { name: /delete account and all data/i });
+    expect(dialog).toHaveTextContent('1 solo-owned household will be permanently deleted.');
+    expect(dialog).toHaveTextContent('2 households will keep existing; you will be removed');
+    expect(dialog).toHaveTextContent('3 pending invites will be revoked.');
+
+    const destructiveButton = screen.getByRole('button', { name: /yes, delete everything/i });
+    const cancelButton = screen.getByRole('button', { name: /cancel/i });
+
+    expect(destructiveButton).toBeDisabled();
+    expect(destructiveButton).toHaveClass('settings-account-delete__confirm-button--danger');
+    expect(cancelButton).toHaveClass('settings-account-delete__cancel-button--secondary');
+
+    fireEvent.change(screen.getByLabelText(/type delete to confirm/i), {
+      target: { value: 'DELETE' },
+    });
+
+    expect(destructiveButton).toBeEnabled();
+    expect(fetch).not.toHaveBeenCalled();
   });
 
   describe('Display settings section', () => {

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import { useAuth } from '../auth/auth-context';
 import { CurrencyDisplay } from '../components/common/CurrencyDisplay';
@@ -28,11 +28,17 @@ import {
   MOOD_TAGS_SYNC_ENABLED_KEY,
   setMoodTagPreference,
 } from '../lib/mood-tags';
+import {
+  clearLocalAccountData,
+  getHouseholdDeletionImpact,
+  type HouseholdDeletionImpact,
+} from '../lib/account/account-deletion';
 
 const APP_VERSION = '0.1.0';
 const CURRENCY_STORAGE_KEY = 'finance-currency';
 const NOTIFICATIONS_STORAGE_KEY = 'finance-notifications';
 const MONITORING_CONSENT_STORAGE_KEY = 'finance-monitoring-consent';
+const ACCOUNT_DELETED_FLASH_KEY = 'finance:account-deleted-flash';
 
 type CurrencyPreference = 'USD' | 'EUR' | 'GBP' | 'CAD' | 'AUD' | 'JPY';
 
@@ -118,7 +124,6 @@ export const SettingsPage: React.FC = () => {
     isAuthenticated,
     isLoading,
     logout,
-    deleteAccount,
     user,
     registerNewPasskey,
     webAuthnSupported,
@@ -129,6 +134,15 @@ export const SettingsPage: React.FC = () => {
   const db = useSettingsDatabase();
   const [isPasskeyLoading, setIsPasskeyLoading] = useState(false);
   const [passkeyMessage, setPasskeyMessage] = useState<string | null>(null);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [deleteConfirmationText, setDeleteConfirmationText] = useState('');
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [isDeletingAccount, setIsDeletingAccount] = useState(false);
+  const [householdImpact, setHouseholdImpact] = useState<HouseholdDeletionImpact>({
+    soloOwnedHouseholds: 0,
+    memberHouseholds: 0,
+    pendingInvites: 0,
+  });
 
   const handleThemeChange = useCallback(
     (event: React.ChangeEvent<HTMLSelectElement>) => {
@@ -256,6 +270,59 @@ export const SettingsPage: React.FC = () => {
 
     await logout();
   }, [isAuthenticated, isLoading, logout]);
+
+  const openDeleteModal = useCallback(() => {
+    setDeleteConfirmationText('');
+    setDeleteError(null);
+    setIsDeleteModalOpen(true);
+  }, []);
+
+  const closeDeleteModal = useCallback(() => {
+    if (isDeletingAccount) return;
+    setIsDeleteModalOpen(false);
+    setDeleteConfirmationText('');
+    setDeleteError(null);
+  }, [isDeletingAccount]);
+
+  useEffect(() => {
+    if (!isDeleteModalOpen) return;
+    try {
+      setHouseholdImpact(getHouseholdDeletionImpact(db, user?.id));
+    } catch {
+      setHouseholdImpact({ soloOwnedHouseholds: 0, memberHouseholds: 0, pendingInvites: 0 });
+    }
+  }, [db, isDeleteModalOpen, user?.id]);
+
+  const handleAccountDelete = useCallback(async () => {
+    if (!isAuthenticated || deleteConfirmationText !== 'DELETE' || isDeletingAccount) {
+      return;
+    }
+
+    setDeleteError(null);
+    setIsDeletingAccount(true);
+
+    try {
+      const response = await fetch('/api/account/delete-account', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ confirmation: 'DELETE' }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Account deletion failed.');
+      }
+
+      await clearLocalAccountData(db);
+      localStorage.clear();
+      sessionStorage.clear();
+      sessionStorage.setItem(ACCOUNT_DELETED_FLASH_KEY, 'Your account has been deleted.');
+      window.location.assign('/login?accountDeleted=1');
+    } catch {
+      setDeleteError("Couldn't delete account — please try again or contact support.");
+      setIsDeletingAccount(false);
+    }
+  }, [db, deleteConfirmationText, isAuthenticated, isDeletingAccount]);
 
   return (
     <>
@@ -705,11 +772,120 @@ export const SettingsPage: React.FC = () => {
           ) as HTMLButtonElement | null;
           exportBtn?.click();
         }}
-        onDeleteAccount={async () => {
+        onDeleteAccount={() => {
           if (!isAuthenticated) return;
-          await deleteAccount();
+          openDeleteModal();
         }}
       />
+      {isDeleteModalOpen && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="delete-account-title"
+          aria-describedby="delete-account-description"
+          style={{
+            position: 'fixed',
+            inset: 0,
+            zIndex: 1000,
+            display: 'grid',
+            placeItems: 'center',
+            padding: 'var(--spacing-4, 1rem)',
+            background: 'rgba(15, 23, 42, 0.72)',
+          }}
+        >
+          <div
+            style={{
+              width: 'min(100%, 36rem)',
+              borderRadius: 'var(--radius-lg, 1rem)',
+              padding: 'var(--spacing-6, 1.5rem)',
+              background: 'var(--semantic-surface-primary, var(--color-surface))',
+              boxShadow: 'var(--shadow-xl, 0 24px 64px rgba(0, 0, 0, 0.28))',
+            }}
+          >
+            <h3 id="delete-account-title" className="settings-group__title">
+              Delete account and all data
+            </h3>
+            <p id="delete-account-description" className="settings-item__description">
+              This permanently deletes your account, personal finance data, passkeys, connected bank
+              links, audit entries, and authentication record. This cannot be undone.
+            </p>
+            <ul aria-label="Household deletion impact" className="settings-item__description">
+              <li>
+                {householdImpact.soloOwnedHouseholds} solo-owned household
+                {householdImpact.soloOwnedHouseholds === 1 ? '' : 's'} will be permanently deleted.
+              </li>
+              <li>
+                {householdImpact.memberHouseholds} household
+                {householdImpact.memberHouseholds === 1 ? '' : 's'} will keep existing; you will be
+                removed and ownership transfers if needed.
+              </li>
+              <li>
+                {householdImpact.pendingInvites} pending invite
+                {householdImpact.pendingInvites === 1 ? '' : 's'} will be revoked.
+              </li>
+            </ul>
+            <label className="settings-item__label" htmlFor="delete-account-confirmation">
+              Type DELETE to confirm
+            </label>
+            <input
+              id="delete-account-confirmation"
+              className="settings-item__input"
+              value={deleteConfirmationText}
+              onChange={(event) => setDeleteConfirmationText(event.target.value)}
+              disabled={isDeletingAccount}
+              autoComplete="off"
+            />
+            {deleteError && (
+              <p role="alert" style={{ color: 'var(--semantic-danger, #dc2626)' }}>
+                {deleteError}
+              </p>
+            )}
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'flex-end',
+                gap: 'var(--spacing-3, 0.75rem)',
+                marginTop: 'var(--spacing-5, 1.25rem)',
+              }}
+            >
+              <button
+                type="button"
+                className="settings-account-delete__cancel-button settings-account-delete__cancel-button--secondary"
+                onClick={closeDeleteModal}
+                disabled={isDeletingAccount}
+                style={{
+                  border: '1px solid var(--semantic-border-primary, #d1d5db)',
+                  background: 'transparent',
+                  color: 'var(--semantic-text-secondary, #475569)',
+                  padding: '0.625rem 1rem',
+                  borderRadius: 'var(--radius-md, 0.5rem)',
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="settings-account-delete__confirm-button settings-account-delete__confirm-button--danger"
+                onClick={() => {
+                  void handleAccountDelete();
+                }}
+                disabled={deleteConfirmationText !== 'DELETE' || isDeletingAccount}
+                style={{
+                  border: '1px solid var(--semantic-danger, #dc2626)',
+                  background: 'var(--semantic-danger, #dc2626)',
+                  color: '#fff',
+                  fontWeight: 700,
+                  padding: '0.625rem 1rem',
+                  borderRadius: 'var(--radius-md, 0.5rem)',
+                  opacity: deleteConfirmationText !== 'DELETE' || isDeletingAccount ? 0.55 : 1,
+                }}
+              >
+                {isDeletingAccount ? 'Deleting…' : 'Yes, Delete Everything'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
       <CrashReportingSettings enabled={monitoringEnabled} onToggle={handleMonitoringToggle} />
     </>
   );

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -163,6 +163,14 @@ export default defineConfig({
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api\/auth\//, '/auth-'),
       },
+      '/api/account': {
+        target: process.env.VITE_AUTH_PROXY_TARGET ?? 'http://localhost:54321/functions/v1',
+        changeOrigin: true,
+        rewrite: (path) =>
+          path
+            .replace(/^\/api\/account\/delete-account$/, '/account-delete')
+            .replace(/^\/api\/account\//, '/account-'),
+      },
     },
     headers: {
       // Strict CSP - no inline scripts, no eval

--- a/services/api/scripts/serve-functions.ts
+++ b/services/api/scripts/serve-functions.ts
@@ -38,6 +38,7 @@ import { handler as authRefresh } from '../supabase/functions/auth-refresh/index
 import { handler as authLogout } from '../supabase/functions/auth-logout/index.ts';
 import { handler as authOAuthStart } from '../supabase/functions/auth-oauth-start/index.ts';
 import { handler as authOAuthCallback } from '../supabase/functions/auth-oauth-callback/index.ts';
+import { handler as accountDeleteHandler } from '../supabase/functions/account-delete/index.ts';
 
 type Handler = (req: Request) => Promise<Response>;
 
@@ -50,6 +51,7 @@ const routes: Record<string, Handler> = {
   'auth-logout': authLogout,
   'auth-oauth-start': authOAuthStart,
   'auth-oauth-callback': authOAuthCallback,
+  'account-delete': accountDeleteHandler,
 };
 
 async function dispatch(req: Request): Promise<Response> {

--- a/services/api/supabase/functions/account-delete/index.ts
+++ b/services/api/supabase/functions/account-delete/index.ts
@@ -1,0 +1,408 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * POST /api/account/delete-account — permanently delete the signed-in account.
+ *
+ * Authenticates with either the browser's HttpOnly refresh cookie or a bearer
+ * token, deletes user/household data with a service-role client, deletes the
+ * Supabase Auth user last, and clears the refresh cookie on success.
+ */
+
+import { validateEnv } from '../_shared/env.ts';
+import {
+  buildClearCookie,
+  COOKIE_PKCE,
+  COOKIE_POST_LOGIN,
+  COOKIE_REFRESH,
+  parseCookies,
+} from '../_shared/cookie.ts';
+import { refreshGrant } from '../_shared/supabase-auth.ts';
+import { type AuthenticatedUser, createAdminClient } from '../_shared/auth.ts';
+
+const NO_STORE_JSON_HEADERS = {
+  'Content-Type': 'application/json',
+  'Cache-Control': 'no-store',
+  Pragma: 'no-cache',
+};
+
+interface AccountDeleteBody {
+  confirmation?: unknown;
+  confirm?: unknown;
+}
+
+interface HouseholdPlan {
+  householdId: string;
+  otherMemberUserIds: string[];
+  createdBy: string | null;
+}
+
+interface AccountDeleteDeps {
+  createClient?: typeof createAdminClient;
+  refreshGrantFn?: typeof refreshGrant;
+}
+
+type SupabaseAdminClient = ReturnType<typeof createAdminClient>;
+
+const HOUSEHOLD_CHILD_TABLES = [
+  'connector_access_log',
+  'open_banking_connections',
+  'connector_permissions',
+  'bank_connection_health',
+  'bank_sync_log',
+  'bank_connection_accounts',
+  'bank_connections',
+  'webhook_deliveries',
+  'webhook_endpoints',
+  'scheduled_reports',
+  'report_configs',
+  'report_templates',
+  'anomaly_alerts',
+  'anomaly_rules',
+  'bill_reminders',
+  'detected_bills',
+  'import_jobs',
+  'investment_holdings',
+  'investment_portfolios',
+  'family_plan_subscriptions',
+  'notifications',
+  'audit_log',
+  'household_invitations',
+  'recurring_transaction_templates',
+  'transactions',
+  'budgets',
+  'goals',
+  'categories',
+  'accounts',
+  'household_members',
+] as const;
+
+const USER_OWNED_TABLES: ReadonlyArray<readonly [table: string, column: string]> = [
+  ['connector_permissions', 'owner_id'],
+  ['open_banking_connections', 'owner_id'],
+  ['bank_connections', 'owner_id'],
+  ['webhook_endpoints', 'created_by'],
+  ['scheduled_reports', 'owner_id'],
+  ['report_configs', 'owner_id'],
+  ['report_templates', 'owner_id'],
+  ['bill_reminders', 'owner_id'],
+  ['detected_bills', 'owner_id'],
+  ['import_jobs', 'owner_id'],
+  ['investment_holdings', 'owner_id'],
+  ['investment_portfolios', 'owner_id'],
+  ['family_plan_subscriptions', 'billing_owner_id'],
+  ['family_plan_subscriptions', 'owner_id'],
+  ['notifications', 'owner_id'],
+  ['notifications', 'user_id'],
+  ['notification_log', 'user_id'],
+  ['notification_preferences', 'user_id'],
+  ['data_export_audit_log', 'user_id'],
+  ['sync_health_logs', 'user_id'],
+  ['user_consents', 'user_id'],
+  ['webauthn_challenges', 'user_id'],
+  ['passkey_credentials', 'user_id'],
+  ['recurring_transaction_templates', 'owner_id'],
+  ['transactions', 'owner_id'],
+  ['budgets', 'owner_id'],
+  ['goals', 'owner_id'],
+  ['categories', 'owner_id'],
+  ['accounts', 'owner_id'],
+  ['audit_log', 'user_id'],
+] as const;
+
+export function createAccountDeleteHandler(deps: AccountDeleteDeps = {}) {
+  return async (req: Request): Promise<Response> => {
+    const envError = validateEnv('auth-logout', req);
+    if (envError) return envError;
+
+    if (req.method !== 'POST') {
+      return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+        status: 405,
+        headers: { ...NO_STORE_JSON_HEADERS, Allow: 'POST' },
+      });
+    }
+
+    let body: AccountDeleteBody = {};
+    try {
+      body = (await req.json()) as AccountDeleteBody;
+    } catch {
+      // Empty body is handled by the confirmation check below.
+    }
+
+    if (body.confirmation !== 'DELETE' && body.confirm !== 'DELETE') {
+      return new Response(JSON.stringify({ error: 'Type DELETE to confirm account deletion' }), {
+        status: 400,
+        headers: NO_STORE_JSON_HEADERS,
+      });
+    }
+
+    const supabase = (deps.createClient ?? createAdminClient)();
+    const user = await getAuthenticatedUser(req, supabase, deps.refreshGrantFn ?? refreshGrant);
+    if (!user) return unauthorized(req);
+
+    try {
+      await deleteAccountData(supabase, user);
+      const { error: authDeleteError } = await supabase.auth.admin.deleteUser(user.id);
+      if (authDeleteError) throw authDeleteError;
+
+      const headers = new Headers({
+        'Cache-Control': 'no-store',
+        Pragma: 'no-cache',
+      });
+      headers.append('Set-Cookie', buildClearCookie(req, COOKIE_REFRESH));
+      headers.append('Set-Cookie', buildClearCookie(req, COOKIE_PKCE));
+      headers.append('Set-Cookie', buildClearCookie(req, COOKIE_POST_LOGIN));
+      return new Response(null, { status: 204, headers });
+    } catch (err) {
+      console.error(
+        JSON.stringify({
+          timestamp: new Date().toISOString(),
+          level: 'error',
+          function: 'account-delete',
+          user_id: user.id,
+          message: err instanceof Error ? err.message : String(err),
+        }),
+      );
+      return new Response(JSON.stringify({ error: 'Could not delete account' }), {
+        status: 500,
+        headers: NO_STORE_JSON_HEADERS,
+      });
+    }
+  };
+}
+
+export const handler = createAccountDeleteHandler();
+
+if (import.meta.main) Deno.serve(handler);
+
+async function getAuthenticatedUser(
+  req: Request,
+  supabase: SupabaseAdminClient,
+  refreshGrantFn: typeof refreshGrant,
+): Promise<AuthenticatedUser | null> {
+  const accessToken = await getAccessToken(req, refreshGrantFn);
+  if (!accessToken) return null;
+
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser(accessToken);
+  if (error || !user) return null;
+  return { id: user.id, email: user.email ?? '' };
+}
+
+async function getAccessToken(
+  req: Request,
+  refreshGrantFn: typeof refreshGrant,
+): Promise<string | null> {
+  const authHeader = req.headers.get('Authorization');
+  if (authHeader?.startsWith('Bearer ')) {
+    return authHeader.slice('Bearer '.length);
+  }
+
+  const refreshToken = parseCookies(req)[COOKIE_REFRESH];
+  if (!refreshToken) return null;
+  const tokens = await refreshGrantFn(refreshToken);
+  return tokens?.access_token ?? null;
+}
+
+async function deleteAccountData(
+  supabase: SupabaseAdminClient,
+  user: AuthenticatedUser,
+): Promise<void> {
+  const plans = await loadHouseholdPlans(supabase, user.id);
+  const soleHouseholdIds = plans
+    .filter((plan) => plan.otherMemberUserIds.length === 0)
+    .map((plan) => plan.householdId);
+  const sharedHouseholds = plans.filter((plan) => plan.otherMemberUserIds.length > 0);
+
+  for (const plan of sharedHouseholds) {
+    if (plan.createdBy === user.id) {
+      await updateRows(
+        supabase,
+        'households',
+        { created_by: plan.otherMemberUserIds[0] },
+        'id',
+        plan.householdId,
+      );
+    }
+  }
+
+  await bestEffortRpc(supabase, 'destroy_user_encryption_keys', {
+    p_user_id: user.id,
+    p_destroyed_by: user.id,
+    p_reason: 'account_deletion',
+  });
+
+  for (const householdId of soleHouseholdIds) {
+    await bestEffortRpc(supabase, 'destroy_household_encryption_keys', {
+      p_household_id: householdId,
+      p_destroyed_by: user.id,
+      p_reason: 'account_deletion_sole_owner',
+    });
+  }
+
+  if (soleHouseholdIds.length > 0) {
+    await deleteByIn(supabase, 'encryption_keys', 'household_id', soleHouseholdIds);
+    for (const table of HOUSEHOLD_CHILD_TABLES) {
+      await deleteByIn(supabase, table, 'household_id', soleHouseholdIds);
+    }
+    await deleteByIn(supabase, 'households', 'id', soleHouseholdIds);
+  }
+
+  await updateRows(
+    supabase,
+    'household_invitations',
+    { accepted_by: null },
+    'accepted_by',
+    user.id,
+  );
+  await deleteByEq(supabase, 'household_invitations', 'invited_by', user.id);
+  await updateRows(supabase, 'anomaly_alerts', { reviewed_by: null }, 'reviewed_by', user.id);
+  await deleteAnomalyRulesOwnedByUser(supabase, user.id);
+  await deleteReferralRows(supabase, user.id);
+
+  for (const [table, column] of USER_OWNED_TABLES) {
+    await deleteByEq(supabase, table, column, user.id);
+  }
+
+  await deleteByEq(supabase, 'encryption_keys', 'destroyed_by', user.id);
+  await deleteByEq(supabase, 'encryption_keys', 'user_id', user.id);
+  await deleteByEq(supabase, 'household_members', 'user_id', user.id);
+  await deleteByEq(supabase, 'users', 'id', user.id);
+}
+
+async function loadHouseholdPlans(
+  supabase: SupabaseAdminClient,
+  userId: string,
+): Promise<HouseholdPlan[]> {
+  const { data: memberships, error: membershipError } = await supabase
+    .from('household_members')
+    .select('household_id')
+    .eq('user_id', userId)
+    .is('deleted_at', null);
+  if (membershipError) throw membershipError;
+
+  const householdIds = [
+    ...new Set(
+      ((memberships ?? []) as Array<{ household_id: string | null }>)
+        .map((membership) => membership.household_id)
+        .filter((id): id is string => typeof id === 'string' && id.length > 0),
+    ),
+  ];
+  if (householdIds.length === 0) return [];
+
+  const { data: households, error: householdError } = await supabase
+    .from('households')
+    .select('id, created_by')
+    .in('id', householdIds);
+  if (householdError) throw householdError;
+
+  const createdByByHousehold = new Map(
+    ((households ?? []) as Array<{ id: string; created_by: string | null }>).map((household) => [
+      household.id,
+      household.created_by,
+    ]),
+  );
+
+  const plans: HouseholdPlan[] = [];
+  for (const householdId of householdIds) {
+    const { data: others, error: othersError } = await supabase
+      .from('household_members')
+      .select('user_id')
+      .eq('household_id', householdId)
+      .neq('user_id', userId)
+      .is('deleted_at', null);
+    if (othersError) throw othersError;
+
+    plans.push({
+      householdId,
+      createdBy: createdByByHousehold.get(householdId) ?? null,
+      otherMemberUserIds: ((others ?? []) as Array<{ user_id: string | null }>)
+        .map((member) => member.user_id)
+        .filter((id): id is string => typeof id === 'string' && id.length > 0),
+    });
+  }
+  return plans;
+}
+
+async function bestEffortRpc(
+  supabase: SupabaseAdminClient,
+  functionName: string,
+  args: Record<string, unknown>,
+): Promise<void> {
+  const { error } = await supabase.rpc(functionName, args);
+  if (error) {
+    console.warn(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        level: 'warn',
+        function: 'account-delete',
+        rpc: functionName,
+        message: error.message,
+      }),
+    );
+  }
+}
+
+async function deleteAnomalyRulesOwnedByUser(
+  supabase: SupabaseAdminClient,
+  userId: string,
+): Promise<void> {
+  const { data, error } = await supabase.from('anomaly_rules').select('id').eq('owner_id', userId);
+  if (error) throw error;
+
+  const ruleIds = ((data ?? []) as Array<{ id: string | null }>)
+    .map((rule) => rule.id)
+    .filter((id): id is string => typeof id === 'string' && id.length > 0);
+  await deleteByIn(supabase, 'anomaly_alerts', 'rule_id', ruleIds);
+  await deleteByEq(supabase, 'anomaly_rules', 'owner_id', userId);
+}
+
+async function deleteReferralRows(supabase: SupabaseAdminClient, userId: string): Promise<void> {
+  const { error } = await supabase
+    .from('referrals')
+    .delete()
+    .or(`referrer_id.eq.${userId},referee_id.eq.${userId}`);
+  if (error) throw error;
+}
+
+async function deleteByEq(
+  supabase: SupabaseAdminClient,
+  table: string,
+  column: string,
+  value: string,
+): Promise<void> {
+  const { error } = await supabase.from(table).delete().eq(column, value);
+  if (error) throw error;
+}
+
+async function deleteByIn(
+  supabase: SupabaseAdminClient,
+  table: string,
+  column: string,
+  values: string[],
+): Promise<void> {
+  if (values.length === 0) return;
+  const { error } = await supabase.from(table).delete().in(column, values);
+  if (error) throw error;
+}
+
+async function updateRows(
+  supabase: SupabaseAdminClient,
+  table: string,
+  values: Record<string, unknown>,
+  column: string,
+  value: string,
+): Promise<void> {
+  const { error } = await supabase.from(table).update(values).eq(column, value);
+  if (error) throw error;
+}
+
+function unauthorized(req: Request): Response {
+  const headers = new Headers(NO_STORE_JSON_HEADERS);
+  headers.append('Set-Cookie', buildClearCookie(req, COOKIE_REFRESH));
+  return new Response(JSON.stringify({ error: 'Authentication required' }), {
+    status: 401,
+    headers,
+  });
+}

--- a/services/api/supabase/functions/account-delete/index_test.ts
+++ b/services/api/supabase/functions/account-delete/index_test.ts
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { assert, assertEquals } from 'https://deno.land/std@0.208.0/assert/mod.ts';
+import { createAdminClient } from '../_shared/auth.ts';
+import { createAccountDeleteHandler } from './index.ts';
+
+type AdminClient = ReturnType<typeof createAdminClient>;
+
+Deno.test('account-delete returns 405 for non-POST requests', async () => {
+  withEnv();
+  const handler = createAccountDeleteHandler({
+    createClient: () => createFakeSupabase().client as unknown as AdminClient,
+  });
+
+  const response = await handler(new Request('http://localhost/functions/v1/account-delete'));
+
+  assertEquals(response.status, 405);
+});
+
+Deno.test('account-delete requires authentication before deleting anything', async () => {
+  withEnv();
+  const fake = createFakeSupabase();
+  const handler = createAccountDeleteHandler({
+    createClient: () => fake.client as unknown as AdminClient,
+  });
+
+  const response = await handler(
+    new Request('http://localhost/functions/v1/account-delete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ confirmation: 'DELETE' }),
+    }),
+  );
+
+  assertEquals(response.status, 401);
+  assertEquals(fake.operations.length, 0);
+  assertEquals(fake.deletedAuthUser, null);
+});
+
+Deno.test('account-delete cascades sole-household data before deleting auth user', async () => {
+  withEnv();
+  const fake = createFakeSupabase();
+  const handler = createAccountDeleteHandler({
+    createClient: () => fake.client as unknown as AdminClient,
+  });
+
+  const response = await handler(
+    new Request('http://localhost/functions/v1/account-delete', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer access-token',
+      },
+      body: JSON.stringify({ confirmation: 'DELETE' }),
+    }),
+  );
+
+  assertEquals(response.status, 204);
+  assert(fake.operations.some((op) => op === 'rpc:destroy_user_encryption_keys'));
+  assert(fake.operations.some((op) => op === 'rpc:destroy_household_encryption_keys'));
+  assert(fake.operations.indexOf('delete:transactions') < fake.operations.indexOf('delete:users'));
+  assert(
+    fake.operations.indexOf('delete:users') < fake.operations.indexOf('auth.deleteUser:user-1'),
+  );
+  assertEquals(fake.deletedAuthUser, 'user-1');
+  assert(response.headers.get('Set-Cookie')?.includes('finance_refresh='));
+});
+
+function withEnv(): void {
+  Deno.env.set('SUPABASE_URL', 'http://localhost:54321');
+  Deno.env.set('SUPABASE_SERVICE_ROLE_KEY', 'service-role');
+  Deno.env.set('SUPABASE_ANON_KEY', 'anon');
+}
+
+interface FakeState {
+  operations: string[];
+  deletedAuthUser: string | null;
+}
+
+interface FakeClient {
+  auth: {
+    getUser: (
+      token: string,
+    ) => Promise<{ data: { user: { id: string; email: string } }; error: null }>;
+    admin: { deleteUser: (userId: string) => Promise<{ error: null }> };
+  };
+  rpc: (name: string, args: Record<string, unknown>) => Promise<{ data: unknown[]; error: null }>;
+  from: (table: string) => FakeQuery;
+}
+
+function createFakeSupabase(): FakeState & { client: FakeClient } {
+  const state: FakeState = { operations: [], deletedAuthUser: null };
+  const client = {
+    auth: {
+      getUser: (_token: string) =>
+        Promise.resolve({
+          data: { user: { id: 'user-1', email: 'alex@example.com' } },
+          error: null,
+        }),
+      admin: {
+        deleteUser: (userId: string) => {
+          state.deletedAuthUser = userId;
+          state.operations.push(`auth.deleteUser:${userId}`);
+          return Promise.resolve({ error: null });
+        },
+      },
+    },
+    rpc: (name: string, _args: Record<string, unknown>) => {
+      state.operations.push(`rpc:${name}`);
+      return Promise.resolve({ data: [], error: null });
+    },
+    from: (table: string) => new FakeQuery(table, state),
+  };
+  return {
+    operations: state.operations,
+    get deletedAuthUser() {
+      return state.deletedAuthUser;
+    },
+    client,
+  };
+}
+
+class FakeQuery {
+  private op: 'select' | 'delete' | 'update' | null = null;
+  private filters = new Map<string, unknown>();
+
+  constructor(
+    private readonly table: string,
+    private readonly state: FakeState,
+  ) {}
+
+  select(_columns?: string): this {
+    this.op = 'select';
+    return this;
+  }
+
+  delete(): this {
+    this.op = 'delete';
+    this.state.operations.push(`delete:${this.table}`);
+    return this;
+  }
+
+  update(_values: Record<string, unknown>): this {
+    this.op = 'update';
+    this.state.operations.push(`update:${this.table}`);
+    return this;
+  }
+
+  eq(column: string, value: unknown): this {
+    this.filters.set(column, value);
+    return this;
+  }
+
+  neq(column: string, value: unknown): this {
+    this.filters.set(`neq:${column}`, value);
+    return this;
+  }
+
+  is(column: string, value: unknown): this {
+    this.filters.set(`is:${column}`, value);
+    return this;
+  }
+
+  in(column: string, value: unknown): this {
+    this.filters.set(`in:${column}`, value);
+    return this;
+  }
+
+  or(_filter: string): this {
+    return this;
+  }
+
+  then(resolve: (value: { data: unknown[]; error: null }) => void): void {
+    resolve({ data: this.resolveData(), error: null });
+  }
+
+  private resolveData(): unknown[] {
+    if (this.op !== 'select') return [];
+    if (this.table === 'household_members' && this.filters.get('user_id') === 'user-1') {
+      return [{ household_id: 'household-1' }];
+    }
+    if (this.table === 'household_members' && this.filters.get('household_id') === 'household-1') {
+      return [];
+    }
+    if (this.table === 'households') {
+      return [{ id: 'household-1', created_by: 'user-1' }];
+    }
+    return [];
+  }
+}


### PR DESCRIPTION
Auto-generated PR from alpha E2E pass fleet (#1243).

Closes #1937
Closes #1938

See commit message for details. All touched test suites pass and `npm run type-check` is clean as of the dispatch fleet.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>