### PR TITLE
fix(web): restore injectReactRefreshPreamble workaround (#1908)

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -83,6 +83,40 @@ function swPrecacheManifest(): Plugin {
   };
 }
 
+/**
+ * Workaround for an interaction between `@vitejs/plugin-react@6.x` and
+ * `vite@8.x` where the React Fast Refresh preamble is never injected into
+ * `index.html` in dev. The oxc-based JSX transform still emits calls to
+ * `$RefreshSig$()` and `$RefreshReg$()` at the top of every module, so the
+ * browser throws `ReferenceError: $RefreshSig$ is not defined` and the app
+ * never mounts. Inject the preamble ourselves before any other transform.
+ *
+ * Mirrors the code at https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/src/index.ts
+ */
+function injectReactRefreshPreamble(): Plugin {
+  return {
+    name: 'inject-react-refresh-preamble',
+    apply: 'serve',
+    transformIndexHtml: {
+      order: 'pre',
+      handler() {
+        return [
+          {
+            tag: 'script',
+            attrs: { type: 'module' },
+            children: [
+              'import { injectIntoGlobalHook } from "/@react-refresh";',
+              'injectIntoGlobalHook(window);',
+              'window.$RefreshReg$ = () => {};',
+              'window.$RefreshSig$ = () => (type) => type;',
+            ].join('\n'),
+          },
+        ];
+      },
+    },
+  };
+}
+
 function allowServiceWorkerRootScope(): Plugin {
   return {
     name: 'allow-service-worker-root-scope',
@@ -100,7 +134,13 @@ function allowServiceWorkerRootScope(): Plugin {
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), copySqlJsWasm(), swPrecacheManifest(), allowServiceWorkerRootScope()],
+  plugins: [
+    react(),
+    injectReactRefreshPreamble(),
+    copySqlJsWasm(),
+    swPrecacheManifest(),
+    allowServiceWorkerRootScope(),
+  ],
 
   resolve: {
     alias: {

--- a/deno.lock
+++ b/deno.lock
@@ -1,0 +1,117 @@
+{
+  "version": "5",
+  "remote": {
+    "https://deno.land/std@0.208.0/assert/_constants.ts": "8a9da298c26750b28b326b297316cdde860bc237533b07e1337c021379e6b2a9",
+    "https://deno.land/std@0.208.0/assert/_diff.ts": "58e1461cc61d8eb1eacbf2a010932bf6a05b79344b02ca38095f9b805795dc48",
+    "https://deno.land/std@0.208.0/assert/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
+    "https://deno.land/std@0.208.0/assert/assert.ts": "9a97dad6d98c238938e7540736b826440ad8c1c1e54430ca4c4e623e585607ee",
+    "https://deno.land/std@0.208.0/assert/assert_almost_equals.ts": "e15ca1f34d0d5e0afae63b3f5d975cbd18335a132e42b0c747d282f62ad2cd6c",
+    "https://deno.land/std@0.208.0/assert/assert_array_includes.ts": "6856d7f2c3544bc6e62fb4646dfefa3d1df5ff14744d1bca19f0cbaf3b0d66c9",
+    "https://deno.land/std@0.208.0/assert/assert_equals.ts": "d8ec8a22447fbaf2fc9d7c3ed2e66790fdb74beae3e482855d75782218d68227",
+    "https://deno.land/std@0.208.0/assert/assert_exists.ts": "407cb6b9fb23a835cd8d5ad804e2e2edbbbf3870e322d53f79e1c7a512e2efd7",
+    "https://deno.land/std@0.208.0/assert/assert_false.ts": "0ccbcaae910f52c857192ff16ea08bda40fdc79de80846c206bfc061e8c851c6",
+    "https://deno.land/std@0.208.0/assert/assert_greater.ts": "ae2158a2d19313bf675bf7251d31c6dc52973edb12ac64ac8fc7064152af3e63",
+    "https://deno.land/std@0.208.0/assert/assert_greater_or_equal.ts": "1439da5ebbe20855446cac50097ac78b9742abe8e9a43e7de1ce1426d556e89c",
+    "https://deno.land/std@0.208.0/assert/assert_instance_of.ts": "3aedb3d8186e120812d2b3a5dea66a6e42bf8c57a8bd927645770bd21eea554c",
+    "https://deno.land/std@0.208.0/assert/assert_is_error.ts": "c21113094a51a296ffaf036767d616a78a2ae5f9f7bbd464cd0197476498b94b",
+    "https://deno.land/std@0.208.0/assert/assert_less.ts": "aec695db57db42ec3e2b62e97e1e93db0063f5a6ec133326cc290ff4b71b47e4",
+    "https://deno.land/std@0.208.0/assert/assert_less_or_equal.ts": "5fa8b6a3ffa20fd0a05032fe7257bf985d207b85685fdbcd23651b70f928c848",
+    "https://deno.land/std@0.208.0/assert/assert_match.ts": "c4083f80600bc190309903c95e397a7c9257ff8b5ae5c7ef91e834704e672e9b",
+    "https://deno.land/std@0.208.0/assert/assert_not_equals.ts": "9f1acab95bd1f5fc9a1b17b8027d894509a745d91bac1718fdab51dc76831754",
+    "https://deno.land/std@0.208.0/assert/assert_not_instance_of.ts": "0c14d3dfd9ab7a5276ed8ed0b18c703d79a3d106102077ec437bfe7ed912bd22",
+    "https://deno.land/std@0.208.0/assert/assert_not_match.ts": "3796a5b0c57a1ce6c1c57883dd4286be13a26f715ea662318ab43a8491a13ab0",
+    "https://deno.land/std@0.208.0/assert/assert_not_strict_equals.ts": "4cdef83df17488df555c8aac1f7f5ec2b84ad161b6d0645ccdbcc17654e80c99",
+    "https://deno.land/std@0.208.0/assert/assert_object_match.ts": "d8fc2867cfd92eeacf9cea621e10336b666de1874a6767b5ec48988838370b54",
+    "https://deno.land/std@0.208.0/assert/assert_rejects.ts": "45c59724de2701e3b1f67c391d6c71c392363635aad3f68a1b3408f9efca0057",
+    "https://deno.land/std@0.208.0/assert/assert_strict_equals.ts": "b1f538a7ea5f8348aeca261d4f9ca603127c665e0f2bbfeb91fa272787c87265",
+    "https://deno.land/std@0.208.0/assert/assert_string_includes.ts": "b821d39ebf5cb0200a348863c86d8c4c4b398e02012ce74ad15666fc4b631b0c",
+    "https://deno.land/std@0.208.0/assert/assert_throws.ts": "63784e951475cb7bdfd59878cd25a0931e18f6dc32a6077c454b2cd94f4f4bcd",
+    "https://deno.land/std@0.208.0/assert/assertion_error.ts": "4d0bde9b374dfbcbe8ac23f54f567b77024fb67dbb1906a852d67fe050d42f56",
+    "https://deno.land/std@0.208.0/assert/equal.ts": "9f1a46d5993966d2596c44e5858eec821859b45f783a5ee2f7a695dfc12d8ece",
+    "https://deno.land/std@0.208.0/assert/fail.ts": "c36353d7ae6e1f7933d45f8ea51e358c8c4b67d7e7502028598fe1fea062e278",
+    "https://deno.land/std@0.208.0/assert/mod.ts": "37c49a26aae2b254bbe25723434dc28cd7532e444cf0b481a97c045d110ec085",
+    "https://deno.land/std@0.208.0/assert/unimplemented.ts": "d56fbeecb1f108331a380f72e3e010a1f161baa6956fd0f7cf3e095ae1a4c75a",
+    "https://deno.land/std@0.208.0/assert/unreachable.ts": "4600dc0baf7d9c15a7f7d234f00c23bca8f3eba8b140286aaca7aa998cf9a536",
+    "https://deno.land/std@0.208.0/fmt/colors.ts": "34b3f77432925eb72cf0bfb351616949746768620b8e5ead66da532f93d10ba2",
+    "https://deno.land/std@0.208.0/testing/asserts.ts": "605bbd2ef0695e2a4324d810c4ad22e56041d51afb9584fc0b4e81084b14b1d6"
+  },
+  "workspace": {
+    "packageJson": {
+      "dependencies": [
+        "npm:@changesets/changelog-github@0.7",
+        "npm:@changesets/cli@^2.31.0",
+        "npm:@commitlint/cli@^21.0.1",
+        "npm:@commitlint/config-conventional@^21.0.1",
+        "npm:@eslint/js@^10.0.1",
+        "npm:eslint@^10.4.0",
+        "npm:husky@^9.1.7",
+        "npm:lint-staged@^17.0.5",
+        "npm:prettier@^3.8.3",
+        "npm:turbo@^2.9.14",
+        "npm:typescript-eslint@^8.59.4"
+      ],
+      "overrides": {
+        "dompurify": ">=3.4.1",
+        "fast-xml-parser": ">=5.7.0",
+        "protobufjs": ">=7.5.5",
+        "brace-expansion": ">=5.0.6||<5.0.0",
+        "postcss": ">=8.5.10",
+        "styled-components": ">=6.4.1",
+        "react": "19.2.6",
+        "react-dom": "19.2.6"
+      }
+    },
+    "members": {
+      "apps/web": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@playwright/test@^1.60.0",
+            "npm:@storybook/addon-a11y@^10.4.1",
+            "npm:@storybook/react-vite@^10.4.1",
+            "npm:@storybook/react@^10.4.1",
+            "npm:@testing-library/dom@^10.4.1",
+            "npm:@testing-library/jest-dom@^6.9.1",
+            "npm:@testing-library/react@^16.3.2",
+            "npm:@types/d3@^7.4.3",
+            "npm:@types/react-dom@^19.1.5",
+            "npm:@types/react@^19.2.15",
+            "npm:@types/sql.js@^1.4.11",
+            "npm:@vitejs/plugin-react@^6.0.2",
+            "npm:d3@^7.9.0",
+            "npm:fake-indexeddb@^6.2.5",
+            "npm:jsdom@^29.1.1",
+            "npm:nanoid@^5.1.11",
+            "npm:react-dom@^19.2.6",
+            "npm:react-router-dom@^7.15.1",
+            "npm:react@^19.2.6",
+            "npm:recharts@^3.8.1",
+            "npm:source-map-js@^1.2.1",
+            "npm:sql.js@^1.14.1",
+            "npm:storybook@^10.4.1",
+            "npm:tesseract.js@7",
+            "npm:typescript@^6.0.3",
+            "npm:vite@^8.0.14",
+            "npm:vitest@^4.1.7",
+            "npm:wa-sqlite@1",
+            "npm:zod@^4.4.3"
+          ]
+        }
+      },
+      "packages/design-tokens": {
+        "packageJson": {
+          "dependencies": [
+            "npm:style-dictionary@^5.4.1"
+          ]
+        }
+      },
+      "services/api": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@redocly/cli@^2.31.4",
+            "npm:yaml@^2.9.0"
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Auto-generated PR from alpha E2E pass fleet (#1243).

Closes #1908

**Stacked on #1943 (PWA fix)** — depends on the `allowServiceWorkerRootScope` plugin landing first. After #1943 merges, GitHub will auto-retarget this to `main`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>