### PR TITLE
fix(deps): sync package-lock.json with package.json after #1918

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1203,11 +1203,11 @@
       }
     },
     "node_modules/@bundled-es-modules/deepmerge": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@bundled-es-modules/deepmerge/-/deepmerge-4.3.1.tgz",
-      "integrity": "sha512-Rk453EklPUPC3NRWc3VUNI/SSUjdBaFoaQvFRmNBNtMHVtOFD5AntiWg5kEE1hqcPqedYFDzxE3ZcMYPcA195w==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/deepmerge/-/deepmerge-4.3.2.tgz",
+      "integrity": "sha512-q8doe7ndrY2IolUOFIn0A0++JBX38pMhN7kFhTF4cnjIcILf6X6H2yWczInyv8ZFdR0lrE8088X8XS5efxXz8A==",
       "dev": true,
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "deepmerge": "^4.3.1"
       }
@@ -12411,6 +12411,34 @@
       ],
       "license": "MIT"
     },
+    "node_modules/style-dictionary": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-5.4.3.tgz",
+      "integrity": "sha512-VpIXPFqIJXR5bLzWhV9PjB7NBteyAVHq9THk5Hyw6zRqAjgfJkH9zalC9szLthkQlS+S8szmmq6tlnLWFksmTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bundled-es-modules/deepmerge": "^4.3.2",
+        "@bundled-es-modules/glob": "^13.0.6",
+        "@bundled-es-modules/memfs": "^4.17.0",
+        "@zip.js/zip.js": "^2.7.44",
+        "chalk": "^5.3.0",
+        "change-case": "^5.3.0",
+        "colorjs.io": "^0.5.2",
+        "commander": "^12.1.0",
+        "is-plain-obj": "^4.1.0",
+        "json5": "^2.2.2",
+        "path-unified": "^0.2.0",
+        "prettier": "^3.3.3",
+        "tinycolor2": "^1.6.0"
+      },
+      "bin": {
+        "style-dictionary": "bin/style-dictionary.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
     "node_modules/styled-components": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.4.1.tgz",
@@ -13513,34 +13541,6 @@
       "version": "0.1.0",
       "devDependencies": {
         "style-dictionary": "^5.4.2"
-      }
-    },
-    "packages/design-tokens/node_modules/style-dictionary": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-5.4.1.tgz",
-      "integrity": "sha512-x8sqaLZCYDP+wzPkrUPPlnBuQ9ndwtzzrQE9AchXARGmC7KFnjVwDufDokiGsgDuUR9V94Iw5D0K8Oyxj7vrlQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@bundled-es-modules/deepmerge": "^4.3.1",
-        "@bundled-es-modules/glob": "^13.0.6",
-        "@bundled-es-modules/memfs": "^4.17.0",
-        "@zip.js/zip.js": "^2.7.44",
-        "chalk": "^5.3.0",
-        "change-case": "^5.3.0",
-        "colorjs.io": "^0.5.2",
-        "commander": "^12.1.0",
-        "is-plain-obj": "^4.1.0",
-        "json5": "^2.2.2",
-        "path-unified": "^0.2.0",
-        "prettier": "^3.3.3",
-        "tinycolor2": "^1.6.0"
-      },
-      "bin": {
-        "style-dictionary": "bin/style-dictionary.js"
-      },
-      "engines": {
-        "node": ">=22.0.0"
       }
     },
     "services/api": {


### PR DESCRIPTION
Auto-detected during alpha E2E fleet PR opening (#1943-#1950 all failing 'npm ci').

The npm-dev group bump #1918 brought in a transitive sub-dep that requires @bundled-es-modules/deepmerge@4.3.2, but the lockfile still pins 4.3.1, causing CI to fail with 'lock file's @bundled-es-modules/deepmerge@4.3.1 does not satisfy @bundled-es-modules/deepmerge@4.3.2'.

This PR regenerates the lockfile via 
pm install. No package.json changes.

**Merge this first** to unblock #1943, #1944, #1945, #1946, #1947, #1948, #1949 (then #1950 once #1943 merges).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>