### PR TITLE
fix(ci): rebuild apps/web/dist on VM + propagate Vercel deploy failures (#1952)

### DIFF
--- a/.github/workflows/canary-deploy.yml
+++ b/.github/workflows/canary-deploy.yml
@@ -179,14 +179,21 @@ jobs:
           if [ "${{ needs.prepare.outputs.deploy_web }}" = "true" ]; then
             if [ -n "$VERCEL_TOKEN" ]; then
               npm i -g vercel@latest
-              CANARY_URL=$(vercel deploy \
+              set -o pipefail
+              CANARY_LOG=$(mktemp)
+              if ! vercel deploy \
                 --token="$VERCEL_TOKEN" \
                 --scope="$VERCEL_ORG_ID" \
                 --yes \
                 --archive=tgz \
                 --meta canary=true \
                 --meta traffic_pct="$CANARY_PERCENTAGE" \
-                apps/web/dist 2>&1 | tail -1)
+                apps/web/dist >"$CANARY_LOG" 2>&1; then
+                echo "::error::Vercel canary deploy failed:"
+                cat "$CANARY_LOG"
+                exit 1
+              fi
+              CANARY_URL=$(tail -1 "$CANARY_LOG")
               echo "canary_url=$CANARY_URL" >> "$GITHUB_OUTPUT"
               echo "### 🌐 Web Canary Deployed" >> "$GITHUB_STEP_SUMMARY"
               echo "**URL:** $CANARY_URL" >> "$GITHUB_STEP_SUMMARY"
@@ -405,13 +412,20 @@ jobs:
           npm run build -w apps/web
 
           npm i -g vercel@latest
-          DEPLOY_URL=$(vercel deploy \
+          set -o pipefail
+          DEPLOY_LOG=$(mktemp)
+          if ! vercel deploy \
             --token="$VERCEL_TOKEN" \
             --scope="$VERCEL_ORG_ID" \
             --prod \
             --yes \
             --archive=tgz \
-            apps/web/dist 2>&1 | tail -1)
+            apps/web/dist >"$DEPLOY_LOG" 2>&1; then
+            echo "::error::Vercel promotion to production failed:"
+            cat "$DEPLOY_LOG"
+            exit 1
+          fi
+          DEPLOY_URL=$(tail -1 "$DEPLOY_LOG")
 
           echo "### 🌐 Web Promoted to Production" >> "$GITHUB_STEP_SUMMARY"
           echo "**URL:** $DEPLOY_URL" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -211,13 +211,20 @@ jobs:
         run: |
           npm i -g vercel@latest
 
-          DEPLOY_URL=$(vercel deploy \
+          set -o pipefail
+          DEPLOY_LOG=$(mktemp)
+          if ! vercel deploy \
             --token="$VERCEL_TOKEN" \
             --scope="$VERCEL_ORG_ID" \
             --prod \
             --yes \
             --archive=tgz \
-            apps/web/dist 2>&1 | tail -1)
+            apps/web/dist >"$DEPLOY_LOG" 2>&1; then
+            echo "::error::Vercel production deploy failed:"
+            cat "$DEPLOY_LOG"
+            exit 1
+          fi
+          DEPLOY_URL=$(tail -1 "$DEPLOY_LOG")
 
           echo "url=$DEPLOY_URL" >> "$GITHUB_OUTPUT"
           echo "### 🌐 Web Production Deployed" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -113,27 +113,122 @@ jobs:
 
       - name: Deploy to Vercel (staging)
         id: deploy
+        if: ${{ env.VERCEL_TOKEN != '' }}
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
         run: |
+          # Fail loudly on errors and propagate exit codes through pipes so we
+          # don't swallow Vercel failures into the output URL.
+          set -euo pipefail
+
           # Install Vercel CLI
           npm i -g vercel@latest
 
-          # Deploy to staging (preview environment)
-          DEPLOY_URL=$(vercel deploy \
+          # Deploy to staging (preview environment). Use a tempfile for output
+          # so we can inspect failures, but still rely on the command's exit
+          # code rather than capturing stderr into DEPLOY_URL.
+          DEPLOY_LOG=$(mktemp)
+          if ! vercel deploy \
             --token="$VERCEL_TOKEN" \
             --scope="$VERCEL_ORG_ID" \
             --yes \
             --archive=tgz \
-            apps/web/dist 2>&1 | tail -1)
+            apps/web/dist >"$DEPLOY_LOG" 2>&1; then
+            echo "::error::Vercel deploy failed:"
+            cat "$DEPLOY_LOG"
+            exit 1
+          fi
 
+          DEPLOY_URL=$(tail -1 "$DEPLOY_LOG")
           echo "url=$DEPLOY_URL" >> "$GITHUB_OUTPUT"
-          echo "### 🌐 Web Staging Deployed" >> "$GITHUB_STEP_SUMMARY"
+          echo "### 🌐 Web Staging (Vercel) Deployed" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "**URL:** $DEPLOY_URL" >> "$GITHUB_STEP_SUMMARY"
           echo "**Commit:** \`${{ needs.pre-deploy-checks.outputs.sha_short }}\`" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Skip notice — Vercel not configured
+        if: ${{ env.VERCEL_TOKEN == '' }}
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          echo "::warning::VERCEL_TOKEN not set — skipping Vercel deploy. Web is served from the Azure VM via deploy-web-vm."
+          echo "### ⚠️ Vercel Staging Skipped" >> "$GITHUB_STEP_SUMMARY"
+
+  # ---------------------------------------------------------------------------
+  # Web (VM): Build apps/web/dist on the staging VM and let Caddy serve it
+  # ---------------------------------------------------------------------------
+  #
+  # The Azure VM runs Caddy with a bind mount of `apps/web/dist` → /srv/web
+  # (see deploy/docker-compose.yml). For Caddy to serve fresh bits, the VM
+  # filesystem path must be rebuilt — `git pull` alone does NOT do that.
+  # This job SSHes in and runs `npm ci && npm run build -w apps/web` so the
+  # bind-mounted directory is updated. No container restart needed.
+  deploy-web-vm:
+    name: Deploy Web (Azure VM)
+    needs: pre-deploy-checks
+    if: needs.pre-deploy-checks.outputs.web_changed == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment:
+      name: staging
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Rebuild apps/web/dist on staging VM
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PATH: ${{ vars.DEPLOY_PATH || '~/finance' }}
+          SHA_SHORT: ${{ needs.pre-deploy-checks.outputs.sha_short }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$DEPLOY_HOST" ]; then
+            echo "::warning::DEPLOY_HOST not configured — skipping web VM rebuild"
+            echo "### ⚠️ Web Azure VM Skipped" >> "$GITHUB_STEP_SUMMARY"
+            echo "Configure DEPLOY_HOST, DEPLOY_SSH_KEY, and DEPLOY_USER secrets." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # Set up SSH key
+          mkdir -p ~/.ssh
+          echo "$DEPLOY_SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+
+          # SSH in and rebuild. Each line is a separate command so an early
+          # failure aborts the build (set -e inside the heredoc).
+          ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" bash <<'DEPLOY'
+            set -euo pipefail
+            cd ~/finance
+            echo "→ git pull origin main"
+            git pull --ff-only origin main
+            echo "→ npm ci (this can take a few minutes on first run)"
+            npm ci --no-audit --no-fund --silent
+            echo "→ build design tokens"
+            npm run build -w packages/design-tokens --silent
+            echo "→ build apps/web"
+            npm run build -w apps/web --silent
+            echo "→ verify dist"
+            test -f apps/web/dist/index.html
+            ls -la apps/web/dist | head -10
+          DEPLOY
+
+          echo "### 🌐 Web Azure VM Deployed" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Host:** \`$DEPLOY_HOST\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Path:** \`$DEPLOY_PATH/apps/web/dist\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Commit:** \`$SHA_SHORT\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Served at:** https://finance.jrmoulckers.com" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Clean up SSH key
+        if: always()
+        run: rm -f ~/.ssh/deploy_key
 
   # ---------------------------------------------------------------------------
   # Backend: Deploy Docker Compose services to staging
@@ -196,7 +291,7 @@ jobs:
   # ---------------------------------------------------------------------------
   notify:
     name: Deployment Summary
-    needs: [pre-deploy-checks, deploy-web, deploy-backend]
+    needs: [pre-deploy-checks, deploy-web, deploy-web-vm, deploy-backend]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -208,7 +303,8 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "| Component | Status |" >> "$GITHUB_STEP_SUMMARY"
           echo "|-----------|--------|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Web | ${{ needs.deploy-web.result || 'skipped' }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Web (Vercel) | ${{ needs.deploy-web.result || 'skipped' }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Web (Azure VM) | ${{ needs.deploy-web-vm.result || 'skipped' }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Backend | ${{ needs.deploy-backend.result || 'skipped' }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "**Commit:** \`${{ needs.pre-deploy-checks.outputs.sha_short }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -109,8 +109,12 @@ jobs:
           # Install Vercel CLI
           npm i -g vercel@latest
 
-          # Deploy to preview with PR-specific alias
-          DEPLOY_URL=$(vercel deploy \
+          # Deploy to preview with PR-specific alias. Use a tempfile so we
+          # check the exit code separately from the URL parse — piping into
+          # `tail` previously swallowed Vercel failures silently.
+          set -o pipefail
+          DEPLOY_LOG=$(mktemp)
+          if ! vercel deploy \
             --token="$VERCEL_TOKEN" \
             --scope="$VERCEL_ORG_ID" \
             --yes \
@@ -118,7 +122,12 @@ jobs:
             --meta pr="${PR_NUM}" \
             --meta commit="${{ github.sha }}" \
             --meta branch="${{ github.head_ref }}" \
-            apps/web/dist 2>&1 | tail -1)
+            apps/web/dist >"$DEPLOY_LOG" 2>&1; then
+            echo "::error::Vercel preview deploy failed:"
+            cat "$DEPLOY_LOG"
+            exit 1
+          fi
+          DEPLOY_URL=$(tail -1 "$DEPLOY_LOG")
 
           # Set alias for predictable URL
           ALIAS_URL="finance-pr-${PR_NUM}.vercel.app"


### PR DESCRIPTION
Closes #1952.

## What's broken

After all 8 wave-1 alpha PRs (#1943–#1950) merged to main, the alpha at https://finance.jrmoulckers.com is **still 3 weeks stale** — none of the wave-1 fixes (PWA install, account delete, offline pages, restore-refresh, auth resilience, etc.) are actually live.

Root cause is two CI bugs in `deploy-staging.yml`:

### Bug 1 — the VM never rebuilds `apps/web/dist`

`deploy/docker-compose.yml` bind-mounts `${WEB_DIST_PATH:-../apps/web/dist}` from the host into Caddy at `/srv/web`. For Caddy to serve new bits, that host directory must be rebuilt. But:

- `deploy-backend` runs `git pull && docker compose up`, but never `npm ci && npm run build -w apps/web`.
- `deploy-backend` is gated on `backend_changed` (`services/**`, `deploy/**`), so pure-web commits skip it entirely.
- `deploy-web` deploys to Vercel only, never the Azure VM.

Result: every wave-1 commit pushed `apps/web/dist` artifacts that exist in `main`, but never landed on the VM's filesystem.

### Bug 2 — every Vercel deploy job silently swallows failures

All four workflows use the pattern:

```bash
DEPLOY_URL=$(vercel deploy ... 2>&1 | tail -1)
```

Without `pipefail`, the pipeline's exit code is `tail`'s 0, so vercel's actual non-zero exits (e.g. 254 when it autodetects `apps/web/dist` as a tarball and tries to re-run `buildCommand` from `vercel.json`) get swallowed. The error text ends up captured as `DEPLOY_URL`, which then gets aliased as `finance-pr-${PR_NUM}.vercel.app` — and those aliases never resolve. (Probed `finance-pr-{1943..1950}.vercel.app` — all DNS-fail.)

## What this PR does

### New job: `deploy-web-vm` (in `deploy-staging.yml`)

- SSHes to the staging VM and runs `git pull --ff-only`, `npm ci`, builds `packages/design-tokens` and `apps/web`.
- Gated on `web_changed`, so pure-web commits trigger it.
- Caddy's bind mount picks up new files immediately — no container restart needed.
- Includes `set -euo pipefail`, sanity-check on `dist/index.html`, and SSH key cleanup.

### Vercel fixes (all four workflows)

- `deploy-staging.yml`, `preview-deploy.yml`, `deploy-production.yml`, `canary-deploy.yml`: replace the `2>&1 | tail -1` pattern with `set -o pipefail` + tempfile + explicit exit-code check. Failures are now logged via `::error::` and abort the job.
- Staging Vercel step is also gated on `VERCEL_TOKEN` being present, with a clean "skipped" notice if absent — so the VM job can be the sole web deploy path if Vercel is not configured.
- Notify summary now reports both `Web (Vercel)` and `Web (Azure VM)`.

## Verification plan

After merge:

1. CI's `Deploy Web (Azure VM)` job runs. SSH heredoc completes. Step summary shows the host path and commit.
2. `curl -sI https://finance.jrmoulckers.com` shows a fresh `Last-Modified`.
3. `curl -s https://finance.jrmoulckers.com | grep manifest` shows `<link rel="manifest">` (proves #1943 is live).
4. Manual smoke: PWA install indicator appears in browser; account delete actually deletes; etc.

## Manual workaround (run once after merge if CI is still settling)

```bash
ssh user@vm
cd ~/finance \
  && git pull origin main \
  && npm ci \
  && npm run build -w packages/design-tokens \
  && npm run build -w apps/web
```

## Out of scope

- Removing Vercel entirely (canonical alpha host is the Azure VM, so Vercel is somewhat redundant) — deferred. This PR just stops the silent failures.
- Path-filter for `deploy-web-vm` could also check `packages/design-tokens/**` if we want token-only changes to trigger a rebuild; current `web_changed` definition already covers that.
