### PR TITLE
fix(windows): in-app auth UI + non-bypassable gate (#1927)

### DIFF
--- a/apps/windows/src/main/kotlin/com/finance/desktop/FinanceApp.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/FinanceApp.kt
@@ -61,6 +61,7 @@ import com.finance.desktop.data.repository.AuthRepository
 import com.finance.desktop.viewmodel.AuthViewModel
 import com.finance.desktop.viewmodel.AuthUiState
 import com.finance.desktop.viewmodel.GdprConsentViewModel
+import com.finance.desktop.viewmodel.LoginViewModel
 
 /**
  * Root composable for the Finance Windows desktop application.
@@ -236,11 +237,10 @@ private fun AuthGateContent(
             isWindowsHelloAvailable = authState.isWindowsHelloAvailable,
             authError = authState.authError,
             onAuthenticate = { authViewModel.authenticate() },
-            onSkip = { authViewModel.skipAuth() },
         )
     } else {
         LoginScreen(
-            onAuthenticated = { authViewModel.skipAuth() },
+            onAuthenticated = { authViewModel.markAuthenticated() },
         )
     }
 }
@@ -254,8 +254,18 @@ private fun MainAppContent(
     quickAddManager: QuickAddTransactionManager,
     systemTray: FinanceSystemTray,
 ) {
+    val loginViewModel = koinGet<LoginViewModel>()
+    var showSignInScreen by remember { mutableStateOf(false) }
+    val openSignIn = {
+        loginViewModel.resetForSignIn()
+        showSignInScreen = true
+    }
+
     Box(modifier = Modifier.fillMaxSize()) {
-        SidebarNavigation(shortcutHandler = shortcutHandler) { screen ->
+        SidebarNavigation(
+            shortcutHandler = shortcutHandler,
+            onAccountSelected = { /* Settings shows the Account section. */ },
+        ) { screen ->
             when (screen) {
                 Screen.Dashboard -> DashboardScreen()
                 Screen.Accounts -> AccountsScreen()
@@ -276,7 +286,7 @@ private fun MainAppContent(
                 Screen.Referral -> {} // placeholder
                 Screen.Negotiate -> BudgetNegotiationScreen()
                 Screen.Currency -> CurrencyConversionScreen()
-                Screen.Settings -> SettingsScreen()
+                Screen.Settings -> SettingsScreen(onSignInRequested = openSignIn)
             }
         }
 
@@ -288,6 +298,13 @@ private fun MainAppContent(
             quickAddManager = quickAddManager,
             systemTray = systemTray,
         )
+
+        if (showSignInScreen) {
+            LoginScreen(
+                onAuthenticated = { showSignInScreen = false },
+                onCancel = { showSignInScreen = false },
+            )
+        }
     }
 }
 

--- a/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/AuthRepository.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/AuthRepository.kt
@@ -2,7 +2,6 @@
 
 package com.finance.desktop.data.repository
 
-import com.finance.sync.auth.AuthCredentials
 import com.finance.sync.auth.AuthSession
 import kotlinx.coroutines.flow.StateFlow
 
@@ -12,10 +11,19 @@ import kotlinx.coroutines.flow.StateFlow
  * Abstracts the Supabase Auth API for desktop use, coordinating
  * email/password authentication with DPAPI-backed token storage.
  */
+data class AuthAccount(
+    val userId: String,
+    val email: String?,
+    val provider: String?,
+)
+
 interface AuthRepository {
 
     /** Observable authentication session — `null` when signed out. */
     val currentSession: StateFlow<AuthSession?>
+
+    /** Observable signed-in account metadata — `null` when signed out. */
+    val currentAccount: StateFlow<AuthAccount?>
 
     /** Observable authentication state. */
     val isAuthenticated: StateFlow<Boolean>

--- a/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/impl/DesktopAuthRepository.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/data/repository/impl/DesktopAuthRepository.kt
@@ -2,6 +2,7 @@
 
 package com.finance.desktop.data.repository.impl
 
+import com.finance.desktop.data.repository.AuthAccount
 import com.finance.desktop.data.repository.AuthException
 import com.finance.desktop.data.repository.AuthRepository
 import com.finance.desktop.security.SecureTokenStorage
@@ -18,6 +19,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.serialization.json.*
+import java.util.Base64
 import java.util.logging.Level
 import java.util.logging.Logger
 
@@ -47,8 +49,16 @@ class DesktopAuthRepository(
         private val json = Json { ignoreUnknownKeys = true }
     }
 
+    private data class ParsedAuthResponse(
+        val session: AuthSession,
+        val account: AuthAccount,
+    )
+
     private val _currentSession = MutableStateFlow<AuthSession?>(null)
     override val currentSession: StateFlow<AuthSession?> = _currentSession.asStateFlow()
+
+    private val _currentAccount = MutableStateFlow<AuthAccount?>(null)
+    override val currentAccount: StateFlow<AuthAccount?> = _currentAccount.asStateFlow()
 
     private val _isAuthenticated = MutableStateFlow(false)
     override val isAuthenticated: StateFlow<Boolean> = _isAuthenticated.asStateFlow()
@@ -70,9 +80,9 @@ class DesktopAuthRepository(
                 return Result.failure(AuthException("Sign-in failed (${response.status}): $body"))
             }
 
-            val session = parseAuthResponse(response.bodyAsText())
-            storeSession(session)
-            Result.success(session)
+            val parsed = parseAuthResponse(response.bodyAsText())
+            storeSession(parsed.session, parsed.account)
+            Result.success(parsed.session)
         } catch (e: Exception) {
             logger.log(Level.SEVERE, "Sign-in failed", e)
             Result.failure(AuthException("Sign-in failed: ${e.message}", e))
@@ -96,9 +106,9 @@ class DesktopAuthRepository(
                 return Result.failure(AuthException("Sign-up failed (${response.status}): $body"))
             }
 
-            val session = parseAuthResponse(response.bodyAsText())
-            storeSession(session)
-            Result.success(session)
+            val parsed = parseAuthResponse(response.bodyAsText())
+            storeSession(parsed.session, parsed.account)
+            Result.success(parsed.session)
         } catch (e: Exception) {
             logger.log(Level.SEVERE, "Sign-up failed", e)
             Result.failure(AuthException("Sign-up failed: ${e.message}", e))
@@ -143,9 +153,9 @@ class DesktopAuthRepository(
                 return Result.failure(AuthException("Token refresh failed (${response.status})"))
             }
 
-            val session = parseAuthResponse(response.bodyAsText())
-            storeSession(session)
-            Result.success(session)
+            val parsed = parseAuthResponse(response.bodyAsText())
+            storeSession(parsed.session, parsed.account)
+            Result.success(parsed.session)
         } catch (e: Exception) {
             logger.log(Level.SEVERE, "Token refresh failed", e)
             Result.failure(AuthException("Token refresh failed: ${e.message}", e))
@@ -187,23 +197,25 @@ class DesktopAuthRepository(
         }
 
         _currentSession.value = stored
+        _currentAccount.value = accountFromSession(stored)
         _isAuthenticated.value = true
         return Result.success(stored)
     }
 
     @Suppress("ThrowsCount") // Auth operations may throw distinct security exceptions
-    private fun parseAuthResponse(body: String): AuthSession {
+    private fun parseAuthResponse(body: String): ParsedAuthResponse {
         val obj = json.parseToJsonElement(body).jsonObject
         val accessToken = obj["access_token"]?.jsonPrimitive?.content
             ?: throw AuthException("Missing access_token in response")
         val refreshToken = obj["refresh_token"]?.jsonPrimitive?.content
             ?: throw AuthException("Missing refresh_token in response")
         val expiresIn = obj["expires_in"]?.jsonPrimitive?.long ?: 3600L
-        val userId = obj["user"]?.jsonObject?.get("id")?.jsonPrimitive?.content
+        val user = obj["user"]?.jsonObject
+        val userId = user?.get("id")?.jsonPrimitive?.content
             ?: throw AuthException("Missing user.id in response")
 
         val now = Clock.System.now()
-        return AuthSession(
+        val session = AuthSession(
             accessToken = accessToken,
             refreshToken = refreshToken,
             expiresAt = Instant.fromEpochMilliseconds(
@@ -212,9 +224,22 @@ class DesktopAuthRepository(
             userId = userId,
             createdAt = now,
         )
+        return ParsedAuthResponse(
+            session = session,
+            account = AuthAccount(
+                userId = userId,
+                email = user?.get("email")?.jsonPrimitive?.contentOrNull ?: emailFromToken(accessToken),
+                provider = user?.get("app_metadata")
+                    ?.jsonObject
+                    ?.get("provider")
+                    ?.jsonPrimitive
+                    ?.contentOrNull
+                    ?: providerFromToken(accessToken),
+            ),
+        )
     }
 
-    private fun storeSession(session: AuthSession) {
+    private fun storeSession(session: AuthSession, account: AuthAccount = accountFromSession(session)) {
         // Store in DPAPI-encrypted storage
         secureTokenStorage.saveToken(SecureTokenStorage.KEY_ACCESS_TOKEN, session.accessToken)
         secureTokenStorage.saveToken(SecureTokenStorage.KEY_REFRESH_TOKEN, session.refreshToken)
@@ -223,6 +248,7 @@ class DesktopAuthRepository(
         tokenManager.storeTokens(session)
 
         _currentSession.value = session
+        _currentAccount.value = account
         _isAuthenticated.value = true
         logger.info("Session stored for user: ${session.userId}")
     }
@@ -231,7 +257,41 @@ class DesktopAuthRepository(
         secureTokenStorage.clearAllTokens()
         tokenManager.clearTokens()
         _currentSession.value = null
+        _currentAccount.value = null
         _isAuthenticated.value = false
         logger.info("Session cleared")
+    }
+
+    private fun accountFromSession(session: AuthSession): AuthAccount = AuthAccount(
+        userId = session.userId,
+        email = emailFromToken(session.accessToken),
+        provider = providerFromToken(session.accessToken),
+    )
+
+    private fun emailFromToken(accessToken: String): String? = jwtPayload(accessToken)
+        ?.get("email")
+        ?.jsonPrimitive
+        ?.contentOrNull
+
+    private fun providerFromToken(accessToken: String): String? {
+        val payload = jwtPayload(accessToken) ?: return null
+        return payload["app_metadata"]
+            ?.jsonObject
+            ?.get("provider")
+            ?.jsonPrimitive
+            ?.contentOrNull
+    }
+
+    private fun jwtPayload(accessToken: String): JsonObject? {
+        @Suppress("TooGenericExceptionCaught") // Best-effort display metadata only
+        return try {
+            val payload = accessToken.split('.').getOrNull(1) ?: return null
+            val paddedPayload = payload.padEnd(payload.length + ((4 - payload.length % 4) % 4), '=')
+            val decoded = String(Base64.getUrlDecoder().decode(paddedPayload), Charsets.UTF_8)
+            json.parseToJsonElement(decoded).jsonObject
+        } catch (e: Exception) {
+            logger.log(Level.FINE, "Unable to decode auth token metadata", e)
+            null
+        }
     }
 }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/navigation/SidebarNavigation.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/navigation/SidebarNavigation.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ShowChart
@@ -54,6 +55,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -72,8 +74,11 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.finance.desktop.components.KeyboardShortcut
+import com.finance.desktop.data.repository.AuthAccount
+import com.finance.desktop.data.repository.AuthRepository
 import com.finance.desktop.components.KeyboardShortcutEffect
 import com.finance.desktop.components.ShortcutHandler
+import com.finance.desktop.di.koinGet
 import com.finance.desktop.theme.FinanceDesktopTheme
 
 /**
@@ -130,10 +135,14 @@ private val SIDEBAR_COLLAPSED_WIDTH = 64.dp
 @Composable
 fun SidebarNavigation(
     shortcutHandler: ShortcutHandler,
+    onAccountSelected: () -> Unit = {},
     content: @Composable (Screen) -> Unit,
 ) {
     var currentScreen by rememberSaveable { mutableStateOf(Screen.Dashboard) }
     var isExpanded by rememberSaveable { mutableStateOf(true) }
+    val authRepository = koinGet<AuthRepository>()
+    val account by authRepository.currentAccount.collectAsState()
+    val isSignedIn by authRepository.isAuthenticated.collectAsState()
 
     // Register keyboard shortcuts (Ctrl+1 … Ctrl+6)
     KeyboardShortcutEffect(shortcutHandler) {
@@ -149,7 +158,13 @@ fun SidebarNavigation(
         SidebarPanel(
             currentScreen = currentScreen,
             isExpanded = isExpanded,
+            account = account,
+            isSignedIn = isSignedIn,
             onScreenSelected = { currentScreen = it },
+            onAccountSelected = {
+                currentScreen = Screen.Settings
+                onAccountSelected()
+            },
             onToggleExpanded = { isExpanded = !isExpanded },
         )
 
@@ -167,7 +182,10 @@ fun SidebarNavigation(
 private fun SidebarPanel(
     currentScreen: Screen,
     isExpanded: Boolean,
+    account: AuthAccount?,
+    isSignedIn: Boolean,
     onScreenSelected: (Screen) -> Unit,
+    onAccountSelected: () -> Unit,
     onToggleExpanded: () -> Unit,
 ) {
     val sidebarWidth by animateDpAsState(
@@ -235,7 +253,14 @@ private fun SidebarPanel(
 
             Spacer(Modifier.weight(1f))
 
-            // Settings at bottom
+            // Account status and settings at bottom
+            AccountStatusItem(
+                account = account,
+                isSignedIn = isSignedIn,
+                isExpanded = isExpanded,
+                onClick = onAccountSelected,
+            )
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.xs))
             HorizontalDivider(
                 modifier = Modifier.padding(horizontal = FinanceDesktopTheme.spacing.sm),
                 color = MaterialTheme.colorScheme.outlineVariant,
@@ -248,6 +273,87 @@ private fun SidebarPanel(
                 onClick = { onScreenSelected(Screen.Settings) },
             )
             Spacer(Modifier.height(FinanceDesktopTheme.spacing.sm))
+        }
+    }
+}
+
+@Composable
+private fun AccountStatusItem(
+    account: AuthAccount?,
+    isSignedIn: Boolean,
+    isExpanded: Boolean,
+    onClick: () -> Unit,
+) {
+    val title = if (isSignedIn) account?.email ?: account?.userId ?: "Signed in" else "Not signed in"
+    val subtitle = if (isSignedIn) "Account" else "Local-only"
+    val initial = account?.email?.firstOrNull()?.uppercase() ?: "?"
+    val accessibilityLabel = if (isSignedIn) {
+        "Account, $title, signed in. Opens Settings account section"
+    } else {
+        "Not signed in. Opens Settings account section"
+    }
+
+    Row(
+        modifier = Modifier
+            .padding(horizontal = FinanceDesktopTheme.spacing.sm, vertical = 2.dp)
+            .height(48.dp)
+            .then(
+                if (isExpanded) Modifier.width(SIDEBAR_EXPANDED_WIDTH - FinanceDesktopTheme.spacing.lg)
+                else Modifier.width(SIDEBAR_COLLAPSED_WIDTH - FinanceDesktopTheme.spacing.lg),
+            )
+            .background(MaterialTheme.colorScheme.surfaceVariant, RoundedCornerShape(8.dp))
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = ripple(),
+                onClick = onClick,
+            )
+            .semantics {
+                role = Role.Button
+                contentDescription = accessibilityLabel
+            }
+            .padding(horizontal = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(28.dp)
+                .background(
+                    color = if (isSignedIn) {
+                        MaterialTheme.colorScheme.primaryContainer
+                    } else {
+                        MaterialTheme.colorScheme.errorContainer
+                    },
+                    shape = CircleShape,
+                ),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = initial,
+                style = MaterialTheme.typography.labelMedium,
+                color = if (isSignedIn) {
+                    MaterialTheme.colorScheme.onPrimaryContainer
+                } else {
+                    MaterialTheme.colorScheme.onErrorContainer
+                },
+                fontWeight = FontWeight.SemiBold,
+            )
+        }
+        AnimatedVisibility(visible = isExpanded, enter = fadeIn(), exit = fadeOut()) {
+            Column(modifier = Modifier.padding(start = 12.dp)) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                )
+            }
         }
     }
 }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/LockScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/LockScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -48,7 +47,7 @@ import com.finance.desktop.theme.FinanceDesktopTheme
  * - Primary "Unlock with Windows Hello" button (biometric/PIN)
  * - Loading spinner during authentication
  * - Error message on failure with retry
- * - Skip option when Windows Hello is unavailable
+ * - Local-only fallback only when Windows Hello is unavailable
  *
  * ## Accessibility
  *
@@ -61,7 +60,7 @@ import com.finance.desktop.theme.FinanceDesktopTheme
  * @param isWindowsHelloAvailable Whether the device supports Windows Hello.
  * @param authError Error message from the last failed attempt, if any.
  * @param onAuthenticate Callback to initiate Windows Hello authentication.
- * @param onSkip Callback to bypass authentication (fallback).
+ * @param onContinueWithoutAuthentication Optional local-only fallback when Windows Hello is unavailable.
  */
 @Composable
 @Suppress("LongMethod") // Lock screen composable with biometric prompt
@@ -70,7 +69,7 @@ fun LockScreen(
     isWindowsHelloAvailable: Boolean,
     authError: String?,
     onAuthenticate: () -> Unit,
-    onSkip: () -> Unit,
+    onContinueWithoutAuthentication: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     Surface(
@@ -189,22 +188,6 @@ fun LockScreen(
                             fontWeight = FontWeight.SemiBold,
                         )
                     }
-
-                    Spacer(Modifier.height(FinanceDesktopTheme.spacing.lg))
-
-                    // Secondary skip option
-                    TextButton(
-                        onClick = onSkip,
-                        modifier = Modifier.semantics {
-                            contentDescription = "Skip authentication"
-                        },
-                    ) {
-                        Text(
-                            text = "Skip for now",
-                            style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
                 } else {
                     // Windows Hello not available — show enter/skip
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
@@ -215,23 +198,25 @@ fun LockScreen(
                             textAlign = TextAlign.Center,
                         )
                         Spacer(Modifier.height(FinanceDesktopTheme.spacing.lg))
-                        OutlinedButton(
-                            onClick = onSkip,
-                            modifier = Modifier
-                                .width(280.dp)
-                                .height(48.dp)
-                                .semantics {
-                                    contentDescription =
-                                        "Continue without authentication. Windows Hello is not configured."
-                                },
-                        ) {
-                            Text(
-                                text = "Continue without authentication",
-                                style = MaterialTheme.typography.labelLarge,
-                            )
-                        }
+                        if (onContinueWithoutAuthentication != null) {
+                            OutlinedButton(
+                                onClick = onContinueWithoutAuthentication,
+                                modifier = Modifier
+                                    .width(280.dp)
+                                    .height(48.dp)
+                                    .semantics {
+                                        contentDescription =
+                                            "Continue without authentication. Windows Hello is not configured."
+                                    },
+                            ) {
+                                Text(
+                                    text = "Continue without authentication",
+                                    style = MaterialTheme.typography.labelLarge,
+                                )
+                            }
 
-                        Spacer(Modifier.height(FinanceDesktopTheme.spacing.xxl))
+                            Spacer(Modifier.height(FinanceDesktopTheme.spacing.xxl))
+                        }
 
                         Text(
                             text = "Set up Windows Hello in Windows Settings to enable\nbiometric or PIN authentication for Finance.",

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/SettingsScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/SettingsScreen.kt
@@ -20,6 +20,9 @@ import androidx.compose.material.icons.filled.ColorLens
 import androidx.compose.material.icons.filled.CurrencyExchange
 import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.Fingerprint
+import androidx.compose.material.icons.automirrored.filled.Login
+import androidx.compose.material.icons.automirrored.filled.Logout
+import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.Lock
@@ -43,6 +46,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -53,9 +57,13 @@ import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
+import com.finance.desktop.data.repository.AuthAccount
+import com.finance.desktop.data.repository.AuthRepository
 import com.finance.desktop.di.koinGet
 import com.finance.desktop.theme.FinanceDesktopTheme
+import com.finance.desktop.viewmodel.AuthViewModel
 import com.finance.desktop.viewmodel.SettingsViewModel
+import kotlinx.coroutines.launch
 
 // =============================================================================
 // Settings Screen — ViewModel-driven, DPAPI-persisted
@@ -80,9 +88,17 @@ import com.finance.desktop.viewmodel.SettingsViewModel
  */
 @Composable
 @Suppress("LongMethod") // Settings form composable
-fun SettingsScreen(modifier: Modifier = Modifier) {
+fun SettingsScreen(
+    modifier: Modifier = Modifier,
+    onSignInRequested: () -> Unit = {},
+) {
     val viewModel = koinGet<SettingsViewModel>()
     val state by viewModel.uiState.collectAsState()
+    val authRepository = koinGet<AuthRepository>()
+    val authViewModel = koinGet<AuthViewModel>()
+    val account by authRepository.currentAccount.collectAsState()
+    val isSignedIn by authRepository.isAuthenticated.collectAsState()
+    val coroutineScope = rememberCoroutineScope()
 
     if (state.isLoading) {
         Box(
@@ -115,6 +131,23 @@ fun SettingsScreen(modifier: Modifier = Modifier) {
                     contentDescription = "Settings heading"
                 },
             )
+
+            Spacer(Modifier.height(FinanceDesktopTheme.spacing.xxl))
+
+            // ── Account ─────────────────────────────────────────────────
+            SettingsSection("Account") {
+                AccountSetting(
+                    account = account,
+                    isSignedIn = isSignedIn,
+                    onSignIn = onSignInRequested,
+                    onSignOut = {
+                        coroutineScope.launch {
+                            authRepository.signOut()
+                            authViewModel.signOut()
+                        }
+                    },
+                )
+            }
 
             Spacer(Modifier.height(FinanceDesktopTheme.spacing.xxl))
 
@@ -317,6 +350,79 @@ private fun SettingsSection(
 // =============================================================================
 // Setting row types
 // =============================================================================
+
+@Composable
+private fun AccountSetting(
+    account: AuthAccount?,
+    isSignedIn: Boolean,
+    onSignIn: () -> Unit,
+    onSignOut: () -> Unit,
+) {
+    val email = account?.email
+    val provider = formatProvider(account?.provider)
+    val title = if (isSignedIn) email ?: account?.userId ?: "Signed in" else "Not signed in"
+    val description = if (isSignedIn) {
+        "Signed in via $provider"
+    } else {
+        "Your data is local-only. Sign in to enable sync across devices."
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = FinanceDesktopTheme.spacing.sm)
+            .semantics {
+                contentDescription = "Account: $title. $description"
+            },
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = accountIcon(isSignedIn),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(end = FinanceDesktopTheme.spacing.md),
+        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+            )
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        if (isSignedIn) {
+            TextButton(onClick = onSignOut) {
+                Icon(Icons.AutoMirrored.Filled.Logout, contentDescription = null)
+                Text("Sign out")
+            }
+        } else {
+            Button(onClick = onSignIn) {
+                Icon(Icons.AutoMirrored.Filled.Login, contentDescription = null)
+                Text("Sign in")
+            }
+        }
+    }
+    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+}
+
+private fun accountIcon(isSignedIn: Boolean): ImageVector = if (isSignedIn) {
+    Icons.Filled.AccountCircle
+} else {
+    Icons.AutoMirrored.Filled.Login
+}
+
+private fun formatProvider(provider: String?): String = when (provider?.lowercase()) {
+    "email" -> "Email"
+    "github" -> "GitHub"
+    "google" -> "Google"
+    "apple" -> "Apple"
+    null -> "Email"
+    else -> provider
+}
 
 /**
  * Toggle setting row: icon + label + description + switch.

--- a/apps/windows/src/main/kotlin/com/finance/desktop/screens/auth/LoginScreen.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/screens/auth/LoginScreen.kt
@@ -47,6 +47,7 @@ import com.finance.desktop.viewmodel.LoginViewModel
 fun LoginScreen(
     onAuthenticated: () -> Unit,
     modifier: Modifier = Modifier,
+    onCancel: (() -> Unit)? = null,
 ) {
     val viewModel = koinGet<LoginViewModel>()
     val state by viewModel.uiState.collectAsState()
@@ -258,6 +259,18 @@ fun LoginScreen(
                             style = MaterialTheme.typography.labelMedium,
                             color = MaterialTheme.colorScheme.primary,
                         )
+                    }
+
+                    if (onCancel != null) {
+                        TextButton(
+                            onClick = onCancel,
+                            enabled = !state.isLoading,
+                            modifier = Modifier.semantics {
+                                contentDescription = "Cancel sign in"
+                            },
+                        ) {
+                            Text("Cancel")
+                        }
                     }
                 }
             }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/AuthViewModel.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/AuthViewModel.kt
@@ -117,14 +117,23 @@ class AuthViewModel(
     }
 
     /**
-     * Bypasses authentication (for development or when Windows Hello is unavailable).
-     *
-     * In production builds, this should only be called when Windows Hello
-     * is not available on the device.
+     * Marks the app shell as unlocked after a successful non-Windows-Hello auth flow.
      */
-    fun skipAuth() {
+    fun markAuthenticated() {
         _uiState.value = _uiState.value.copy(
             isAuthenticated = true,
+            authError = null,
+        )
+    }
+
+    /**
+     * Enters local-only mode only when no cloud credential is present to protect.
+     */
+    fun continueWithoutCloudAuth() {
+        if (secureTokenStorage.hasToken(SecureTokenStorage.KEY_ACCESS_TOKEN)) return
+        _uiState.value = _uiState.value.copy(
+            isAuthenticated = true,
+            requiresAuth = false,
             authError = null,
         )
     }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/LoginViewModel.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/viewmodel/LoginViewModel.kt
@@ -59,6 +59,10 @@ class LoginViewModel(
         )
     }
 
+    fun resetForSignIn() {
+        _uiState.value = LoginUiState()
+    }
+
     @Suppress("ReturnCount") // Multi-step auth validation
     fun signIn() {
         val state = _uiState.value


### PR DESCRIPTION
## Summary
- Adds a Windows Settings > Account section showing signed-in identity/provider or local-only state.
- Adds a bottom sidebar account/status entry that opens Settings.
- Adds in-app sign-in/sign-out controls using the existing desktop Supabase auth repository.
- Removes the Windows Hello lock-screen skip path so stored-token sessions cannot bypass the auth gate.

## Security note
The previous `Skip for now` action on the Windows Hello lock screen could unlock the app even when DPAPI-protected cloud tokens existed. This PR removes that bypass and keeps local-only mode available only when no cloud credential is being protected.

## Validation
- `./gradlew.bat :apps:windows:test --no-daemon --console=plain`
- `./gradlew.bat :apps:windows:check --no-daemon --console=plain`

Closes #1927