### PR TITLE
fix(web): implement password reset (#1925)

### DIFF
--- a/apps/web/e2e/auth.spec.ts
+++ b/apps/web/e2e/auth.spec.ts
@@ -20,8 +20,23 @@ test('unauthenticated redirect to login', async ({ page }) => {
   await expect(page).toHaveURL(/login/);
 });
 
-test('login page links to signup', async ({ page }) => {
+test('login page links to signup and forgot password', async ({ page }) => {
   await page.goto('/login');
   const signupLink = page.getByRole('link', { name: /sign up/i });
   await expect(signupLink).toBeVisible();
+  await expect(page.getByRole('link', { name: /forgot password/i })).toBeVisible();
+});
+
+test('forgot password page renders', async ({ page }) => {
+  await page.goto('/forgot-password');
+  await expect(page.getByRole('heading', { name: /finance/i })).toBeVisible();
+  await expect(page.getByText('Reset your password', { exact: true })).toBeVisible();
+  await expect(page.getByLabel(/email/i)).toBeVisible();
+});
+
+test('reset password page renders invalid-link state', async ({ page }) => {
+  await page.goto('/reset-password');
+  await expect(page.getByRole('heading', { name: /finance/i })).toBeVisible();
+  await expect(page.getByText(/choose a new password/i)).toBeVisible();
+  await expect(page.getByRole('button', { name: /update password/i })).toBeDisabled();
 });

--- a/apps/web/src/lib/auth/password-reset.ts
+++ b/apps/web/src/lib/auth/password-reset.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/** Client helpers for the password-reset auth flow. */
+
+const PASSWORD_RESET_REQUEST_ENDPOINT = '/api/auth/request-password-reset';
+const PASSWORD_RESET_ENDPOINT = '/api/auth/reset-password';
+
+interface ErrorBody {
+  error?: string;
+}
+
+/** Request a password reset email without revealing whether the account exists. */
+export async function requestPasswordResetEmail(email: string, redirectTo: string): Promise<void> {
+  const response = await fetch(PASSWORD_RESET_REQUEST_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, redirectTo }),
+  });
+
+  if (!response.ok) {
+    throw new Error(await readErrorMessage(response, 'Could not send reset email.'));
+  }
+}
+
+/** Update the current recovery session's password. */
+export async function resetPassword(accessToken: string, password: string): Promise<void> {
+  const response = await fetch(PASSWORD_RESET_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ accessToken, password }),
+  });
+
+  if (!response.ok) {
+    throw new Error(await readErrorMessage(response, 'Could not update password.'));
+  }
+}
+
+async function readErrorMessage(response: Response, fallback: string): Promise<string> {
+  const body = (await response.json().catch(() => ({}))) as ErrorBody;
+  return body.error ?? fallback;
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -34,7 +34,8 @@ const authConfig = {
   logoutEndpoint: import.meta.env.VITE_LOGOUT_ENDPOINT ?? '/api/auth/logout',
   onUnauthenticated: () => {
     // Redirect to login when session expires or user is not authenticated
-    if (window.location.pathname !== '/login' && window.location.pathname !== '/signup') {
+    const publicAuthPaths = new Set(['/login', '/signup', '/forgot-password', '/reset-password']);
+    if (!publicAuthPaths.has(window.location.pathname)) {
       window.location.href = '/login';
     }
   },
@@ -82,13 +83,13 @@ initMonitoring();
 /**
  * Routes that render without waiting for SQLite-WASM initialisation.
  *
- * Pre-auth pages (login, signup) never access the database, so gating them
+ * Pre-auth pages (login, signup, password reset) never access the database, so gating them
  * behind DatabaseProvider unnecessarily blocks rendering.  On CI especially
  * (headless Chromium + OPFS + WASM fetch), initialisation can exceed 60 s
  * and cause the E2E authenticatedPage fixture to time out before the login
  * form ever appears.
  */
-const PRE_AUTH_ROUTES = new Set(['/login', '/signup']);
+const PRE_AUTH_ROUTES = new Set(['/login', '/signup', '/forgot-password', '/reset-password']);
 
 /**
  * Conditionally wraps children in DatabaseProvider.

--- a/apps/web/src/pages/ForgotPasswordPage.test.tsx
+++ b/apps/web/src/pages/ForgotPasswordPage.test.tsx
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ForgotPasswordPage } from './ForgotPasswordPage';
+
+function renderForgotPasswordPage() {
+  return render(
+    <MemoryRouter>
+      <ForgotPasswordPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('ForgotPasswordPage', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  it('renders the email form and sign-in link', () => {
+    renderForgotPasswordPage();
+
+    expect(screen.getByRole('heading', { name: 'Finance' })).toBeInTheDocument();
+    expect(screen.getByText('Reset your password')).toBeInTheDocument();
+    expect(screen.getByLabelText('Email')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Sign in' })).toHaveAttribute('href', '/login');
+  });
+
+  it('requests a reset email with an absolute reset redirect URL', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({ accepted: true }), { status: 202 }));
+    renderForgotPasswordPage();
+
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: ' alex@example.com ' } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Send reset link' }));
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/auth/request-password-reset',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: 'alex@example.com',
+          redirectTo: `${window.location.origin}/reset-password`,
+        }),
+      }),
+    );
+    expect(
+      await screen.findByText(
+        "If an account exists for that email, you'll receive a reset link shortly.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('does not call the backend for an invalid email', async () => {
+    renderForgotPasswordPage();
+
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'not-an-email' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Send reset link' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Enter a valid email address.');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('shows a non-account-specific error when the request fails', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'Could not send reset email.' }), { status: 502 }),
+    );
+    renderForgotPasswordPage();
+
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'alex@example.com' } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Send reset link' }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Could not send reset email.');
+    });
+  });
+});

--- a/apps/web/src/pages/ForgotPasswordPage.tsx
+++ b/apps/web/src/pages/ForgotPasswordPage.tsx
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import React, { useId, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { z } from 'zod';
+
+import { LoadingSpinner } from '../components/common/LoadingSpinner';
+import { requestPasswordResetEmail } from '../lib/auth/password-reset';
+
+import '../styles/auth.css';
+
+const emailSchema = z.string().trim().email();
+const GENERIC_SUCCESS_MESSAGE =
+  "If an account exists for that email, you'll receive a reset link shortly.";
+
+/** Starts the email-based password reset flow. */
+export const ForgotPasswordPage: React.FC = () => {
+  const uid = useId();
+  const emailId = `${uid}-email`;
+  const emailErrorId = `${uid}-email-error`;
+
+  const [email, setEmail] = useState('');
+  const [emailError, setEmailError] = useState<string | null>(null);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const redirectTo = useMemo(() => `${window.location.origin}/reset-password`, []);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setStatusMessage(null);
+    setSubmitError(null);
+
+    const parsedEmail = emailSchema.safeParse(email);
+    if (!parsedEmail.success) {
+      setEmailError('Enter a valid email address.');
+      return;
+    }
+
+    setEmailError(null);
+    setIsSubmitting(true);
+
+    try {
+      await requestPasswordResetEmail(parsedEmail.data, redirectTo);
+      setStatusMessage(GENERIC_SUCCESS_MESSAGE);
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : 'Could not send reset email.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <main className="auth-page">
+      <section className="auth-card" aria-labelledby={`${uid}-title`}>
+        <header className="auth-brand">
+          <h1 id={`${uid}-title`} className="auth-brand__name">
+            Finance
+          </h1>
+          <p className="auth-brand__tagline">Reset your password</p>
+        </header>
+
+        {statusMessage && (
+          <div className="auth-info" role="status" aria-live="polite">
+            {statusMessage}
+          </div>
+        )}
+
+        {submitError && (
+          <div className="auth-error" role="alert" aria-live="polite">
+            {submitError}
+          </div>
+        )}
+
+        <form className="auth-form" onSubmit={handleSubmit} noValidate>
+          <p className="auth-instructions">
+            Enter your email address and we&apos;ll send a link to reset your password.
+          </p>
+
+          <div className="auth-field">
+            <label className="auth-field__label" htmlFor={emailId}>
+              Email
+            </label>
+            <input
+              id={emailId}
+              className="auth-field__input"
+              type="email"
+              autoComplete="email"
+              required
+              value={email}
+              onChange={(event) => {
+                setEmail(event.target.value);
+                setEmailError(null);
+              }}
+              disabled={isSubmitting}
+              aria-invalid={emailError ? 'true' : undefined}
+              aria-describedby={emailError ? emailErrorId : undefined}
+            />
+            {emailError && (
+              <p id={emailErrorId} className="auth-field__error" role="alert">
+                {emailError}
+              </p>
+            )}
+          </div>
+
+          <button
+            type="submit"
+            className="auth-submit"
+            disabled={isSubmitting}
+            aria-busy={isSubmitting}
+          >
+            {isSubmitting ? (
+              <>
+                <LoadingSpinner size={20} label="Sending reset link" />
+                <span>Sending...</span>
+              </>
+            ) : (
+              'Send reset link'
+            )}
+          </button>
+        </form>
+
+        <p className="auth-footer">
+          Remember your password?{' '}
+          <Link to="/login" className="auth-footer__link">
+            Sign in
+          </Link>
+        </p>
+      </section>
+    </main>
+  );
+};
+
+export default ForgotPasswordPage;

--- a/apps/web/src/pages/LoginPage.test.tsx
+++ b/apps/web/src/pages/LoginPage.test.tsx
@@ -49,6 +49,7 @@ describe('LoginPage', () => {
   beforeEach(() => {
     authState.loginWithEmail.mockReset();
     authState.loginWithPasskey.mockReset();
+    authState.loginWithOAuth.mockReset();
     authState.isAuthenticated = false;
     authState.isLoading = false;
     authState.error = null;
@@ -76,6 +77,27 @@ describe('LoginPage', () => {
     renderLoginPage();
 
     expect(screen.getByRole('link', { name: 'Sign up' })).toHaveAttribute('href', '/signup');
+  });
+
+  it('shows forgot password link without requiring a login error', () => {
+    renderLoginPage();
+
+    expect(screen.getByRole('link', { name: 'Forgot password?' })).toHaveAttribute(
+      'href',
+      '/forgot-password',
+    );
+  });
+
+  it('shows password-updated banner from route state', () => {
+    render(
+      <MemoryRouter
+        initialEntries={[{ pathname: '/login', state: { message: 'Password updated.' } }]}
+      >
+        <LoginPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('status')).toHaveTextContent('Password updated.');
   });
 
   it('shows passkey button when webAuthn supported', () => {

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { useEffect, useId, useRef, useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 
 import { useAuth } from '../auth/auth-context';
 import { PasskeySetupPrompt } from '../components/auth/PasskeySetupPrompt';
@@ -22,6 +22,7 @@ interface LoginFieldErrors {
  */
 export const LoginPage: React.FC = () => {
   const navigate = useNavigate();
+  const location = useLocation();
   const {
     loginWithEmail,
     loginWithPasskey,
@@ -121,6 +122,8 @@ export const LoginPage: React.FC = () => {
   };
 
   const isBusy = isSubmitting || isLoading;
+  const locationState = location.state as { message?: unknown } | null;
+  const infoMessage = typeof locationState?.message === 'string' ? locationState.message : null;
 
   return (
     <main className="auth-page">
@@ -140,6 +143,12 @@ export const LoginPage: React.FC = () => {
           </div>
         )}
 
+        {infoMessage && (
+          <div className="auth-info" role="status" aria-live="polite">
+            {infoMessage}
+          </div>
+        )}
+
         {error && (
           <div
             ref={errorRef}
@@ -149,13 +158,6 @@ export const LoginPage: React.FC = () => {
             tabIndex={-1}
           >
             {error}
-            {!isDemoMode && (
-              <p className="auth-error__forgot">
-                <Link to="/forgot-password" className="auth-footer__link">
-                  Forgot password?
-                </Link>
-              </p>
-            )}
           </div>
         )}
 
@@ -247,6 +249,13 @@ export const LoginPage: React.FC = () => {
               <p id={passwordErrorId} className="form-error">
                 {fieldErrors.password ?? ' '}
               </p>
+              {!isDemoMode && (
+                <p className="auth-forgot-password">
+                  <Link to="/forgot-password" className="auth-footer__link">
+                    Forgot password?
+                  </Link>
+                </p>
+              )}
             </div>
           </div>
 

--- a/apps/web/src/pages/ResetPasswordPage.test.tsx
+++ b/apps/web/src/pages/ResetPasswordPage.test.tsx
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ResetPasswordPage } from './ResetPasswordPage';
+
+const navigateMock = vi.hoisted(() => vi.fn());
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
+function renderResetPasswordPage(
+  initialEntry = '/reset-password#access_token=recovery-token&type=recovery',
+) {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <ResetPasswordPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('ResetPasswordPage', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+    navigateMock.mockReset();
+  });
+
+  it('renders password fields and recovery link', () => {
+    renderResetPasswordPage();
+
+    expect(screen.getByText('Choose a new password')).toBeInTheDocument();
+    expect(screen.getByLabelText('New password')).toBeInTheDocument();
+    expect(screen.getByLabelText('Confirm new password')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Request password reset' })).toHaveAttribute(
+      'href',
+      '/forgot-password',
+    );
+  });
+
+  it('updates the password using the recovery access token and redirects to login', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    renderResetPasswordPage('/reset-password#type=recovery&access_token=recovery-token');
+
+    fireEvent.change(screen.getByLabelText('New password'), {
+      target: { value: 'newStrongPass123' },
+    });
+    fireEvent.change(screen.getByLabelText('Confirm new password'), {
+      target: { value: 'newStrongPass123' },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Update password' }));
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/auth/reset-password',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ accessToken: 'recovery-token', password: 'newStrongPass123' }),
+      }),
+    );
+    expect(navigateMock).toHaveBeenCalledWith('/login', {
+      replace: true,
+      state: { message: 'Password updated. Sign in with your new password.' },
+    });
+  });
+
+  it('validates matching passwords before calling the backend', async () => {
+    renderResetPasswordPage();
+
+    fireEvent.change(screen.getByLabelText('New password'), {
+      target: { value: 'newStrongPass123' },
+    });
+    fireEvent.change(screen.getByLabelText('Confirm new password'), {
+      target: { value: 'differentPass123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Update password' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Passwords do not match.');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('shows an error when the recovery token is missing', async () => {
+    renderResetPasswordPage('/reset-password');
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Reset link is invalid or expired. Request a new password reset link.',
+    );
+    expect(screen.getByRole('button', { name: 'Update password' })).toBeDisabled();
+  });
+
+  it('shows backend reset errors', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'Reset link is invalid or expired.' }), { status: 400 }),
+    );
+    renderResetPasswordPage();
+
+    fireEvent.change(screen.getByLabelText('New password'), {
+      target: { value: 'newStrongPass123' },
+    });
+    fireEvent.change(screen.getByLabelText('Confirm new password'), {
+      target: { value: 'newStrongPass123' },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Update password' }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Reset link is invalid or expired.');
+    });
+  });
+});

--- a/apps/web/src/pages/ResetPasswordPage.tsx
+++ b/apps/web/src/pages/ResetPasswordPage.tsx
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import React, { useId, useMemo, useState } from 'react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+
+import { LoadingSpinner } from '../components/common/LoadingSpinner';
+import { resetPassword } from '../lib/auth/password-reset';
+import { passwordSchema } from '../lib/validation';
+
+import '../styles/auth.css';
+
+interface ResetFieldErrors {
+  password?: string;
+  confirmPassword?: string;
+}
+
+/** Completes Supabase's recovery-token password reset flow. */
+export const ResetPasswordPage: React.FC = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const uid = useId();
+
+  const passwordId = `${uid}-password`;
+  const confirmPasswordId = `${uid}-confirm-password`;
+  const passwordErrorId = `${uid}-password-error`;
+  const confirmPasswordErrorId = `${uid}-confirm-password-error`;
+
+  const recoveryParams = useMemo(
+    () => readRecoveryParams(location.search, location.hash),
+    [location.hash, location.search],
+  );
+  const accessToken = recoveryParams.get('access_token');
+  const recoveryError = recoveryParams.get('error_description') ?? recoveryParams.get('error');
+
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [fieldErrors, setFieldErrors] = useState<ResetFieldErrors>({});
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const validate = (): boolean => {
+    const errors: ResetFieldErrors = {};
+    const passwordResult = passwordSchema.safeParse(password);
+
+    if (!passwordResult.success) {
+      errors.password = 'Password must be at least 12 characters.';
+    }
+
+    if (password !== confirmPassword) {
+      errors.confirmPassword = 'Passwords do not match.';
+    }
+
+    setFieldErrors(errors);
+    return Object.keys(errors).length === 0;
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSubmitError(null);
+
+    if (!accessToken) {
+      setSubmitError('Reset link is invalid or expired. Request a new password reset link.');
+      return;
+    }
+
+    if (!validate()) {
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      await resetPassword(accessToken, password);
+      navigate('/login', {
+        replace: true,
+        state: { message: 'Password updated. Sign in with your new password.' },
+      });
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : 'Could not update password.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const linkError = recoveryError
+    ? recoveryError
+    : !accessToken
+      ? 'Reset link is invalid or expired. Request a new password reset link.'
+      : null;
+
+  return (
+    <main className="auth-page">
+      <section className="auth-card" aria-labelledby={`${uid}-title`}>
+        <header className="auth-brand">
+          <h1 id={`${uid}-title`} className="auth-brand__name">
+            Finance
+          </h1>
+          <p className="auth-brand__tagline">Choose a new password</p>
+        </header>
+
+        {linkError && (
+          <div className="auth-error" role="alert" aria-live="polite">
+            {linkError}
+          </div>
+        )}
+
+        {submitError && !linkError && (
+          <div className="auth-error" role="alert" aria-live="polite">
+            {submitError}
+          </div>
+        )}
+
+        <form className="auth-form" onSubmit={handleSubmit} noValidate>
+          <div className="auth-field">
+            <label className="auth-field__label" htmlFor={passwordId}>
+              New password
+            </label>
+            <input
+              id={passwordId}
+              className="auth-field__input"
+              type="password"
+              autoComplete="new-password"
+              required
+              minLength={12}
+              value={password}
+              onChange={(event) => {
+                setPassword(event.target.value);
+                setFieldErrors((current) => ({ ...current, password: undefined }));
+              }}
+              disabled={isSubmitting || Boolean(linkError)}
+              aria-invalid={fieldErrors.password ? 'true' : undefined}
+              aria-describedby={fieldErrors.password ? passwordErrorId : undefined}
+            />
+            <p className="auth-field__hint">Must be at least 12 characters</p>
+            {fieldErrors.password && (
+              <p id={passwordErrorId} className="auth-field__error" role="alert">
+                {fieldErrors.password}
+              </p>
+            )}
+          </div>
+
+          <div className="auth-field">
+            <label className="auth-field__label" htmlFor={confirmPasswordId}>
+              Confirm new password
+            </label>
+            <input
+              id={confirmPasswordId}
+              className="auth-field__input"
+              type="password"
+              autoComplete="new-password"
+              required
+              value={confirmPassword}
+              onChange={(event) => {
+                setConfirmPassword(event.target.value);
+                setFieldErrors((current) => ({ ...current, confirmPassword: undefined }));
+              }}
+              disabled={isSubmitting || Boolean(linkError)}
+              aria-invalid={fieldErrors.confirmPassword ? 'true' : undefined}
+              aria-describedby={fieldErrors.confirmPassword ? confirmPasswordErrorId : undefined}
+            />
+            {fieldErrors.confirmPassword && (
+              <p id={confirmPasswordErrorId} className="auth-field__error" role="alert">
+                {fieldErrors.confirmPassword}
+              </p>
+            )}
+          </div>
+
+          <button
+            type="submit"
+            className="auth-submit"
+            disabled={isSubmitting || Boolean(linkError)}
+            aria-busy={isSubmitting}
+          >
+            {isSubmitting ? (
+              <>
+                <LoadingSpinner size={20} label="Updating password" />
+                <span>Updating...</span>
+              </>
+            ) : (
+              'Update password'
+            )}
+          </button>
+        </form>
+
+        <p className="auth-footer">
+          Need a new link?{' '}
+          <Link to="/forgot-password" className="auth-footer__link">
+            Request password reset
+          </Link>
+        </p>
+      </section>
+    </main>
+  );
+};
+
+function readRecoveryParams(search: string, hash: string): URLSearchParams {
+  const params = new URLSearchParams(search);
+  const hashParams = new URLSearchParams(hash.startsWith('#') ? hash.slice(1) : hash);
+
+  for (const [key, value] of hashParams.entries()) {
+    params.set(key, value);
+  }
+
+  return params;
+}
+
+export default ResetPasswordPage;

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -30,6 +30,8 @@ const DataImportWizard = lazy(() => import('./pages/DataImportWizardPage'));
 const ReceiptOcr = lazy(() => import('./pages/ReceiptOcrPage'));
 const Login = lazy(() => import('./pages/LoginPage'));
 const Signup = lazy(() => import('./pages/SignupPage'));
+const ForgotPassword = lazy(() => import('./pages/ForgotPasswordPage'));
+const ResetPassword = lazy(() => import('./pages/ResetPasswordPage'));
 const NotFound = lazy(() => import('./pages/NotFoundPage'));
 const Watchlists = lazy(() => import('./pages/WatchlistsPage'));
 const Household = lazy(() => import('./pages/HouseholdPage'));
@@ -159,6 +161,24 @@ export const AppRoutes: FC = () => (
             <Signup />
           </RouteBoundary>
         </RedirectIfAuthenticated>
+      }
+    />
+    <Route
+      path="/forgot-password"
+      element={
+        <RedirectIfAuthenticated>
+          <RouteBoundary name="Forgot Password">
+            <ForgotPassword />
+          </RouteBoundary>
+        </RedirectIfAuthenticated>
+      }
+    />
+    <Route
+      path="/reset-password"
+      element={
+        <RouteBoundary name="Reset Password">
+          <ResetPassword />
+        </RouteBoundary>
       }
     />
 

--- a/apps/web/src/styles/auth.css
+++ b/apps/web/src/styles/auth.css
@@ -278,10 +278,18 @@
   }
 }
 
-/* ─── Forgot password link in error banner ───────────────────────────────── */
+/* ─── Auth helper text and links ─────────────────────────────────────────── */
 
-.auth-error__forgot {
-  margin-top: var(--spacing-2);
+.auth-instructions {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-body-font-size, 1rem);
+  margin: 0;
+  text-align: center;
+}
+
+.auth-forgot-password {
+  margin: 0;
+  text-align: right;
   font-size: var(--type-scale-caption-font-size);
 }
 

--- a/services/api/scripts/serve-functions.ts
+++ b/services/api/scripts/serve-functions.ts
@@ -28,6 +28,8 @@
  *   - POST /auth-signup
  *   - POST /auth-refresh
  *   - POST /auth-logout
+ *   - POST /auth-request-password-reset
+ *   - POST /auth-reset-password
  *   - GET  /auth-oauth-start
  *   - GET  /auth-oauth-callback
  */
@@ -36,6 +38,8 @@ import { handler as authLogin } from '../supabase/functions/auth-login/index.ts'
 import { handler as authSignup } from '../supabase/functions/auth-signup/index.ts';
 import { handler as authRefresh } from '../supabase/functions/auth-refresh/index.ts';
 import { handler as authLogout } from '../supabase/functions/auth-logout/index.ts';
+import { handler as authRequestPasswordReset } from '../supabase/functions/auth-request-password-reset/index.ts';
+import { handler as authResetPassword } from '../supabase/functions/auth-reset-password/index.ts';
 import { handler as authOAuthStart } from '../supabase/functions/auth-oauth-start/index.ts';
 import { handler as authOAuthCallback } from '../supabase/functions/auth-oauth-callback/index.ts';
 import { handler as accountDeleteHandler } from '../supabase/functions/account-delete/index.ts';
@@ -49,6 +53,8 @@ const routes: Record<string, Handler> = {
   'auth-signup': authSignup,
   'auth-refresh': authRefresh,
   'auth-logout': authLogout,
+  'auth-request-password-reset': authRequestPasswordReset,
+  'auth-reset-password': authResetPassword,
   'auth-oauth-start': authOAuthStart,
   'auth-oauth-callback': authOAuthCallback,
   'account-delete': accountDeleteHandler,

--- a/services/api/supabase/functions/_shared/env.ts
+++ b/services/api/supabase/functions/_shared/env.ts
@@ -41,6 +41,8 @@ const FUNCTION_ENV_VARS: Record<string, readonly EnvVarSpec[]> = {
   'auth-webhook': [{ name: 'AUTH_WEBHOOK_SECRET', type: 'string' }],
   'auth-login': [{ name: 'SUPABASE_ANON_KEY', type: 'string' }],
   'auth-signup': [{ name: 'SUPABASE_ANON_KEY', type: 'string' }],
+  'auth-request-password-reset': [{ name: 'SUPABASE_ANON_KEY', type: 'string' }],
+  'auth-reset-password': [{ name: 'SUPABASE_ANON_KEY', type: 'string' }],
   'auth-refresh': [{ name: 'SUPABASE_ANON_KEY', type: 'string' }],
   'auth-logout': [{ name: 'SUPABASE_ANON_KEY', type: 'string' }],
   'auth-oauth-start': [

--- a/services/api/supabase/functions/_shared/supabase-auth.ts
+++ b/services/api/supabase/functions/_shared/supabase-auth.ts
@@ -156,6 +156,42 @@ export function buildAuthorizeUrl(
   return `${authUrl()}/authorize?${params.toString()}`;
 }
 
+/**
+ * Ask Supabase Auth to send a password recovery email.
+ *
+ * Returns the upstream status code so callers can keep account-existence
+ * responses generic while still surfacing service outages.
+ */
+export async function requestPasswordRecovery(email: string, redirectTo: string): Promise<number> {
+  const url = `${authUrl()}/recover?${new URLSearchParams({ redirect_to: redirectTo }).toString()}`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      apikey: requireEnv('SUPABASE_ANON_KEY'),
+    },
+    body: JSON.stringify({ email }),
+  });
+  return response.status;
+}
+
+/** Update a user's password using the recovery access token from Supabase. */
+export async function updatePasswordWithAccessToken(
+  accessToken: string,
+  password: string,
+): Promise<boolean> {
+  const response = await fetch(`${authUrl()}/user`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+      apikey: requireEnv('SUPABASE_ANON_KEY'),
+    },
+    body: JSON.stringify({ password }),
+  });
+  return response.ok;
+}
+
 // ---------------------------------------------------------------------------
 // PKCE / state generation
 // ---------------------------------------------------------------------------

--- a/services/api/supabase/functions/auth-request-password-reset/index.ts
+++ b/services/api/supabase/functions/auth-request-password-reset/index.ts
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * POST /api/auth/request-password-reset — request a Supabase recovery email.
+ *
+ * Always returns the same accepted response for valid email-shaped input so the
+ * endpoint does not reveal whether an account exists for the submitted address.
+ */
+
+import { validateEnv } from '../_shared/env.ts';
+import { requestPasswordRecovery } from '../_shared/supabase-auth.ts';
+
+const NO_STORE_HEADERS = {
+  'Content-Type': 'application/json',
+  'Cache-Control': 'no-store',
+  Pragma: 'no-cache',
+};
+
+interface RequestPasswordResetBody {
+  email?: unknown;
+  redirectTo?: unknown;
+}
+
+export const handler = async (req: Request): Promise<Response> => {
+  const envError = validateEnv('auth-request-password-reset', req);
+  if (envError) return envError;
+
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+      headers: { ...NO_STORE_HEADERS, Allow: 'POST' },
+    });
+  }
+
+  let body: RequestPasswordResetBody;
+  try {
+    body = (await req.json()) as RequestPasswordResetBody;
+  } catch {
+    return badRequest('Invalid JSON body');
+  }
+
+  if (typeof body.email !== 'string') {
+    return badRequest('email is required');
+  }
+
+  const email = body.email.trim();
+  if (email.length === 0 || email.length > 320 || !email.includes('@')) {
+    return badRequest('Enter a valid email address.');
+  }
+
+  let redirectTo: string;
+  try {
+    redirectTo = normalizeRedirectTo(req, body.redirectTo);
+  } catch {
+    return badRequest('redirectTo must be an http(s) URL for this origin');
+  }
+
+  const upstreamStatus = await requestPasswordRecovery(email, redirectTo).catch(() => 503);
+  if (upstreamStatus >= 500) {
+    return new Response(JSON.stringify({ error: 'Could not send reset email.' }), {
+      status: 502,
+      headers: NO_STORE_HEADERS,
+    });
+  }
+
+  return new Response(JSON.stringify({ accepted: true }), {
+    status: 202,
+    headers: NO_STORE_HEADERS,
+  });
+};
+
+if (import.meta.main) Deno.serve(handler);
+
+function normalizeRedirectTo(req: Request, value: unknown): string {
+  const origin = req.headers.get('Origin') ?? new URL(req.url).origin;
+  const fallback = new URL('/reset-password', origin).toString();
+
+  if (value === undefined || value === null || value === '') {
+    return fallback;
+  }
+
+  if (typeof value !== 'string') {
+    throw new Error('invalid redirectTo');
+  }
+
+  const redirectUrl = new URL(value);
+  if (!['http:', 'https:'].includes(redirectUrl.protocol) || redirectUrl.origin !== origin) {
+    throw new Error('invalid redirectTo');
+  }
+
+  return redirectUrl.toString();
+}
+
+function badRequest(message: string): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status: 400,
+    headers: NO_STORE_HEADERS,
+  });
+}

--- a/services/api/supabase/functions/auth-reset-password/index.ts
+++ b/services/api/supabase/functions/auth-reset-password/index.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/** POST /api/auth/reset-password — update the password for a recovery token. */
+
+import { validateEnv } from '../_shared/env.ts';
+import { updatePasswordWithAccessToken } from '../_shared/supabase-auth.ts';
+
+const NO_STORE_HEADERS = {
+  'Content-Type': 'application/json',
+  'Cache-Control': 'no-store',
+  Pragma: 'no-cache',
+};
+
+interface ResetPasswordBody {
+  accessToken?: unknown;
+  password?: unknown;
+}
+
+export const handler = async (req: Request): Promise<Response> => {
+  const envError = validateEnv('auth-reset-password', req);
+  if (envError) return envError;
+
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+      headers: { ...NO_STORE_HEADERS, Allow: 'POST' },
+    });
+  }
+
+  let body: ResetPasswordBody;
+  try {
+    body = (await req.json()) as ResetPasswordBody;
+  } catch {
+    return badRequest('Invalid JSON body');
+  }
+
+  if (typeof body.accessToken !== 'string' || body.accessToken.length === 0) {
+    return badRequest('Reset link is invalid or expired.');
+  }
+
+  if (typeof body.password !== 'string') {
+    return badRequest('password is required');
+  }
+
+  if (body.password.length < 12 || body.password.length > 128) {
+    return badRequest('Password must be between 12 and 128 characters.');
+  }
+
+  const updated = await updatePasswordWithAccessToken(body.accessToken, body.password).catch(
+    () => false,
+  );
+  if (!updated) {
+    return new Response(JSON.stringify({ error: 'Reset link is invalid or expired.' }), {
+      status: 400,
+      headers: NO_STORE_HEADERS,
+    });
+  }
+
+  return new Response(JSON.stringify({ ok: true }), {
+    status: 200,
+    headers: NO_STORE_HEADERS,
+  });
+};
+
+if (import.meta.main) Deno.serve(handler);
+
+function badRequest(message: string): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status: 400,
+    headers: NO_STORE_HEADERS,
+  });
+}


### PR DESCRIPTION
## Summary
- Adds visible forgot-password entry point and standalone `/forgot-password` + `/reset-password` auth pages.
- Wires password reset through same-origin auth endpoints backed by Supabase recovery/update APIs.
- Adds unit coverage for login link visibility and both password reset pages, plus auth route smoke coverage.

## Validation
- `npm install --no-audit --no-fund`
- `npm run lint -w apps/web`
- `npm exec -w apps/web -- vitest run src\pages\LoginPage.test.tsx src\pages\ForgotPasswordPage.test.tsx src\pages\ResetPasswordPage.test.tsx`
- `npm run build -w packages/design-tokens && npm run build -w apps/web`
- `deno check supabase\functions\auth-request-password-reset\index.ts supabase\functions\auth-reset-password\index.ts supabase\functions\_shared\supabase-auth.ts` (from `services/api`)

Note: the full `npm run test -w apps/web` command was attempted twice and stalled before completing any full-suite results in this worktree; the focused touched tests above pass.

## Operational follow-up
- Confirm Supabase Auth redirect URL allowlist includes `/reset-password` for local, alpha, and production.

Closes #1925