### PR TITLE
fix(web): passkey routing + error UI (#1926)

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -13,5 +13,8 @@ VITE_LOGIN_ENDPOINT=/api/auth/login
 VITE_REFRESH_ENDPOINT=/api/auth/refresh
 VITE_LOGOUT_ENDPOINT=/api/auth/logout
 
+# Local Edge Functions proxy target (Vite dev only)
+VITE_FUNCTIONS_PROXY_TARGET=http://127.0.0.1:54321
+
 # Sync Configuration (optional — defaults to Supabase Edge Function path)
 # VITE_SYNC_PUSH_ENDPOINT=/api/sync/push

--- a/apps/web/src/auth/auth-context.tsx
+++ b/apps/web/src/auth/auth-context.tsx
@@ -56,6 +56,7 @@ import {
   isDemoMode,
   restoreDemoSession,
 } from './demo-auth';
+import { getPasskeyErrorMessage } from './passkey-errors';
 
 import {
   incrementLoginCount,
@@ -438,8 +439,7 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
         throw new Error('Passkey verification succeeded but no session token was returned.');
       }
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Passkey authentication failed';
-      setError(message);
+      setError(getPasskeyErrorMessage(err, 'authentication'));
       throw err;
     } finally {
       setIsLoading(false);
@@ -468,8 +468,7 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
       setHasRegisteredPasskey();
       setShowPasskeyPrompt(false);
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Passkey registration failed';
-      setError(message);
+      setError(getPasskeyErrorMessage(err, 'registration'));
       throw err;
     }
   }, []);

--- a/apps/web/src/auth/passkey-errors.test.ts
+++ b/apps/web/src/auth/passkey-errors.test.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import { getPasskeyErrorMessage } from './passkey-errors';
+
+describe('getPasskeyErrorMessage', () => {
+  it('maps fetch failures to a passkey service message', () => {
+    expect(getPasskeyErrorMessage(new TypeError('Failed to fetch'))).toBe(
+      "Your browser couldn't reach the passkey service. Check your connection and try again.",
+    );
+  });
+
+  it('maps unsupported browsers to an actionable fallback', () => {
+    expect(getPasskeyErrorMessage(new Error('WebAuthn is not supported in this browser.'))).toBe(
+      "Your browser or device doesn't support passkeys. Sign in with email and password instead.",
+    );
+  });
+
+  it('maps missing credentials to a no-passkey message', () => {
+    expect(getPasskeyErrorMessage(new Error('Credential not found'))).toBe(
+      'No passkey was found for this account or device. Sign in with email and password, then add a passkey from Settings.',
+    );
+  });
+
+  it('maps browser cancellation differently for registration', () => {
+    const error = new DOMException('The operation was aborted', 'AbortError');
+
+    expect(getPasskeyErrorMessage(error, 'registration')).toBe(
+      'Passkey setup was cancelled or blocked by your browser. Try again when you are ready.',
+    );
+  });
+
+  it('keeps specific server messages when no friendly mapping applies', () => {
+    expect(getPasskeyErrorMessage(new Error('Rate limit exceeded'))).toBe('Rate limit exceeded');
+  });
+});

--- a/apps/web/src/auth/passkey-errors.ts
+++ b/apps/web/src/auth/passkey-errors.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+export type PasskeyErrorContext = 'authentication' | 'registration';
+
+const PASSKEY_SERVICE_UNREACHABLE =
+  "Your browser couldn't reach the passkey service. Check your connection and try again.";
+
+const PASSKEY_NOT_FOUND =
+  'No passkey was found for this account or device. Sign in with email and password, then add a passkey from Settings.';
+
+const PASSKEY_NOT_SUPPORTED =
+  "Your browser or device doesn't support passkeys. Sign in with email and password instead.";
+
+const PASSKEY_ORIGIN_UNAVAILABLE =
+  'Passkeys are not available from this browser origin. Use localhost or HTTPS, then try again.';
+
+const PASSKEY_REGISTRATION_CANCELLED =
+  'Passkey setup was cancelled or blocked by your browser. Try again when you are ready.';
+
+const PASSKEY_AUTHENTICATION_CANCELLED =
+  'The passkey request was cancelled, timed out, or blocked by your browser. Try again or sign in with email and password.';
+
+const PASSKEY_REGISTRATION_FAILED =
+  'Passkey setup failed. Try again, or continue using email and password.';
+
+const PASSKEY_AUTHENTICATION_FAILED =
+  'Passkey sign-in failed. Try again, or sign in with email and password.';
+
+export function getPasskeyErrorMessage(
+  error: unknown,
+  context: PasskeyErrorContext = 'authentication',
+): string {
+  const message = getErrorMessage(error);
+  const normalizedMessage = message.toLowerCase();
+  const errorName = getErrorName(error);
+
+  if (isNetworkError(error, normalizedMessage)) {
+    return PASSKEY_SERVICE_UNREACHABLE;
+  }
+
+  if (
+    errorName === 'NotSupportedError' ||
+    normalizedMessage.includes('webauthn is not supported') ||
+    normalizedMessage.includes('not supported in this browser')
+  ) {
+    return PASSKEY_NOT_SUPPORTED;
+  }
+
+  if (
+    errorName === 'SecurityError' ||
+    normalizedMessage.includes('relying party') ||
+    normalizedMessage.includes('origin')
+  ) {
+    return PASSKEY_ORIGIN_UNAVAILABLE;
+  }
+
+  if (isNoPasskeyError(normalizedMessage)) {
+    return PASSKEY_NOT_FOUND;
+  }
+
+  if (
+    errorName === 'NotAllowedError' ||
+    errorName === 'AbortError' ||
+    normalizedMessage.includes('cancelled') ||
+    normalizedMessage.includes('canceled') ||
+    normalizedMessage.includes('denied') ||
+    normalizedMessage.includes('timed out')
+  ) {
+    return context === 'registration'
+      ? PASSKEY_REGISTRATION_CANCELLED
+      : PASSKEY_AUTHENTICATION_CANCELLED;
+  }
+
+  if (normalizedMessage.includes('unauthorized') && context === 'registration') {
+    return 'Sign in again before setting up a passkey.';
+  }
+
+  if (
+    normalizedMessage.includes('internal server error') ||
+    normalizedMessage.includes('edge function error') ||
+    normalizedMessage.includes('function not found')
+  ) {
+    return 'The passkey service is unavailable. Try again in a few minutes or sign in with email and password.';
+  }
+
+  return (
+    message ||
+    (context === 'registration' ? PASSKEY_REGISTRATION_FAILED : PASSKEY_AUTHENTICATION_FAILED)
+  );
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  return '';
+}
+
+function getErrorName(error: unknown): string {
+  if (error && typeof error === 'object' && 'name' in error) {
+    const name = (error as { name?: unknown }).name;
+    return typeof name === 'string' ? name : '';
+  }
+  return '';
+}
+
+function isNetworkError(error: unknown, normalizedMessage: string): boolean {
+  return (
+    (error instanceof TypeError && normalizedMessage.includes('failed to fetch')) ||
+    normalizedMessage.includes('networkerror') ||
+    normalizedMessage.includes('network request failed')
+  );
+}
+
+function isNoPasskeyError(normalizedMessage: string): boolean {
+  return (
+    normalizedMessage.includes('credential not found') ||
+    normalizedMessage.includes('no credential') ||
+    normalizedMessage.includes('no passkey') ||
+    normalizedMessage.includes('not registered')
+  );
+}

--- a/apps/web/src/auth/webauthn.test.ts
+++ b/apps/web/src/auth/webauthn.test.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import { getWebAuthnFunctionUrl } from './webauthn';
+
+describe('getWebAuthnFunctionUrl', () => {
+  it('uses the same-origin Edge Functions route so Vite can proxy local dev traffic', () => {
+    expect(getWebAuthnFunctionUrl('passkey-authenticate', 'options')).toBe(
+      '/functions/v1/passkey-authenticate?step=options',
+    );
+  });
+
+  it('encodes the step query parameter', () => {
+    expect(getWebAuthnFunctionUrl('passkey-register', 'verify next')).toBe(
+      '/functions/v1/passkey-register?step=verify%20next',
+    );
+  });
+});

--- a/apps/web/src/auth/webauthn.ts
+++ b/apps/web/src/auth/webauthn.ts
@@ -22,7 +22,7 @@
 
 /** Configuration for the WebAuthn client. */
 export interface WebAuthnConfig {
-  /** Supabase project URL (e.g. "https://<project>.supabase.co"). */
+  /** Supabase project URL. Retained for compatibility with auth configuration. */
   supabaseUrl: string;
   /** Supabase anon/public API key. */
   supabaseAnonKey: string;
@@ -156,6 +156,12 @@ export async function isConditionalMediationAvailable(): Promise<boolean> {
 
 let config: WebAuthnConfig | null = null;
 
+const EDGE_FUNCTIONS_BASE_PATH = '/functions/v1';
+
+export function getWebAuthnFunctionUrl(functionName: string, step: string): string {
+  return `${EDGE_FUNCTIONS_BASE_PATH}/${functionName}?step=${encodeURIComponent(step)}`;
+}
+
 /**
  * Initialize the WebAuthn module with Supabase connection details.
  * Must be called before `registerPasskey` or `authenticateWithPasskey`.
@@ -182,7 +188,7 @@ async function callEdgeFunction<T>(
     throw new Error('WebAuthn not initialised. Call initWebAuthn() first.');
   }
 
-  const url = `${config.supabaseUrl}/functions/v1/${functionName}?step=${step}`;
+  const url = getWebAuthnFunctionUrl(functionName, step);
 
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -98,6 +98,10 @@ function allowServiceWorkerRootScope(): Plugin {
   };
 }
 
+const functionsProxyTarget = process.env.VITE_FUNCTIONS_PROXY_TARGET ?? 'http://127.0.0.1:54321';
+const authProxyTarget =
+  process.env.VITE_AUTH_PROXY_TARGET ?? `${functionsProxyTarget}/functions/v1`;
+
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react(), copySqlJsWasm(), swPrecacheManifest(), allowServiceWorkerRootScope()],
@@ -166,20 +170,21 @@ export default defineConfig({
   server: {
     port: 5173,
     strictPort: false,
-    // Proxy `/api/auth/*` to the local Supabase Edge Functions runtime
-    // (#1886). Same-origin proxying preserves HttpOnly cookie path
-    // matching (cookies use Path=/api/auth) and avoids CORS preflight
-    // entirely. In production these endpoints will be served from the
-    // same origin as the web app via Azure Front Door / nginx, so the
-    // client-side URL stays the same and no proxy is needed there.
+    // Proxy auth and Edge Function calls to the local Supabase runtime.
+    // Same-origin proxying preserves cookie path matching and avoids CORS
+    // preflights in dev. Production routes `/functions/v1/*` through Caddy.
     proxy: {
+      '/functions/v1': {
+        target: functionsProxyTarget,
+        changeOrigin: true,
+      },
       '/api/auth': {
-        target: process.env.VITE_AUTH_PROXY_TARGET ?? 'http://localhost:54321/functions/v1',
+        target: authProxyTarget,
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api\/auth\//, '/auth-'),
       },
       '/api/account': {
-        target: process.env.VITE_AUTH_PROXY_TARGET ?? 'http://localhost:54321/functions/v1',
+        target: authProxyTarget,
         changeOrigin: true,
         rewrite: (path) =>
           path

--- a/services/api/.env.example
+++ b/services/api/.env.example
@@ -46,7 +46,7 @@ OAUTH_REDIRECT_BASE=http://localhost:5173
 # ---------------------------------------------------------------------------
 WEBAUTHN_RP_NAME=Finance App (Local)
 WEBAUTHN_RP_ID=localhost
-WEBAUTHN_ORIGIN=http://localhost:3000
+WEBAUTHN_ORIGIN=http://localhost:5173
 
 # ---------------------------------------------------------------------------
 # CORS — comma-separated list of allowed origins

--- a/services/api/scripts/serve-functions.ts
+++ b/services/api/scripts/serve-functions.ts
@@ -30,6 +30,8 @@
  *   - POST /auth-logout
  *   - GET  /auth-oauth-start
  *   - GET  /auth-oauth-callback
+ *   - POST /passkey-register
+ *   - POST /passkey-authenticate
  */
 
 import { handler as authLogin } from '../supabase/functions/auth-login/index.ts';
@@ -39,6 +41,8 @@ import { handler as authLogout } from '../supabase/functions/auth-logout/index.t
 import { handler as authOAuthStart } from '../supabase/functions/auth-oauth-start/index.ts';
 import { handler as authOAuthCallback } from '../supabase/functions/auth-oauth-callback/index.ts';
 import { handler as accountDeleteHandler } from '../supabase/functions/account-delete/index.ts';
+import { handler as passkeyRegister } from '../supabase/functions/passkey-register/index.ts';
+import { handler as passkeyAuthenticate } from '../supabase/functions/passkey-authenticate/index.ts';
 
 type Handler = (req: Request) => Promise<Response>;
 
@@ -52,6 +56,8 @@ const routes: Record<string, Handler> = {
   'auth-oauth-start': authOAuthStart,
   'auth-oauth-callback': authOAuthCallback,
   'account-delete': accountDeleteHandler,
+  'passkey-register': passkeyRegister,
+  'passkey-authenticate': passkeyAuthenticate,
 };
 
 async function dispatch(req: Request): Promise<Response> {

--- a/services/api/supabase/functions/passkey-authenticate/index.ts
+++ b/services/api/supabase/functions/passkey-authenticate/index.ts
@@ -21,7 +21,6 @@
  *   WEBAUTHN_ORIGIN           — Expected origin
  */
 
-import { serve } from 'https://deno.land/std@0.208.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.0';
 import {
   generateAuthenticationOptions,
@@ -69,7 +68,7 @@ function base64urlToBytes(base64url: string): Uint8Array {
   return Uint8Array.from(binary, (c) => c.charCodeAt(0));
 }
 
-serve(async (req: Request): Promise<Response> => {
+export const handler = async (req: Request): Promise<Response> => {
   // Handle CORS preflight
   if (req.method === 'OPTIONS') {
     return handleCorsPreflightRequest(req);
@@ -395,4 +394,6 @@ serve(async (req: Request): Promise<Response> => {
       headers: { ...getCorsHeaders(req), 'Content-Type': 'application/json' },
     });
   }
-});
+};
+
+if (import.meta.main) Deno.serve(handler);

--- a/services/api/supabase/functions/passkey-register/index.ts
+++ b/services/api/supabase/functions/passkey-register/index.ts
@@ -17,7 +17,6 @@
  *   WEBAUTHN_ORIGIN           — Expected origin (e.g. "https://app.finance.example.com")
  */
 
-import { serve } from 'https://deno.land/std@0.208.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.0';
 import {
   generateRegistrationOptions,
@@ -56,7 +55,7 @@ async function getAuthenticatedUser(req: Request): Promise<{ id: string; email: 
   return { id: user.id, email: user.email ?? '' };
 }
 
-serve(async (req: Request): Promise<Response> => {
+export const handler = async (req: Request): Promise<Response> => {
   // Handle CORS preflight
   if (req.method === 'OPTIONS') {
     return handleCorsPreflightRequest(req);
@@ -298,4 +297,6 @@ serve(async (req: Request): Promise<Response> => {
       headers: { ...getCorsHeaders(req), 'Content-Type': 'application/json' },
     });
   }
-});
+};
+
+if (import.meta.main) Deno.serve(handler);


### PR DESCRIPTION
## Summary
- route passkey WebAuthn calls through same-origin `/functions/v1` so Vite can proxy local dev traffic
- mount `passkey-register` and `passkey-authenticate` in the local Edge Function runner
- map passkey failures to actionable UI messages and cover the mapper/route helper with tests

Closes #1926

## Testing
- `npm run lint -w apps/web`
- `npm exec -w apps/web -- vitest run src/auth/passkey-errors.test.ts src/auth/webauthn.test.ts --reporter verbose`
- `$env:TZ='UTC'; npm exec -w apps/web -- vitest run --reporter=json --outputFile ..\..\vitest-results.json`
- `npm run build -w packages/design-tokens && npm run build -w apps/web`

Note: plain local `npm run test -w apps/web` fails in this Windows timezone on pre-existing `formatDate.test.ts` date-only expectation; the full suite passes with `TZ=UTC`.