### PR TITLE
chore(ci): drop broken Vercel staging step; VM is canonical alpha host

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -3,12 +3,13 @@
 # =============================================================================
 #
 # Deploys the latest main branch to the staging environment:
-#   - Web: Deploy to Vercel preview / staging URL
-#   - Backend: Update Docker Compose services on staging server
+#   - Web (Azure VM): Rebuild apps/web/dist on the staging VM; Caddy serves it
+#     from a bind mount at https://finance.jrmoulckers.com.
+#   - Backend: Update Docker Compose services on the same staging VM.
 #
 # This workflow creates GitHub Deployment records for tracking.
 #
-# Issue: #886
+# Issues: #886 (original), #1952 (canonical alpha host moved to Azure VM)
 # =============================================================================
 
 name: Deploy — Staging
@@ -71,90 +72,6 @@ jobs:
         id: meta
         run: |
           echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
-
-  # ---------------------------------------------------------------------------
-  # Web: Deploy to Vercel staging
-  # ---------------------------------------------------------------------------
-  deploy-web:
-    name: Deploy Web (Staging)
-    needs: pre-deploy-checks
-    if: needs.pre-deploy-checks.outputs.web_changed == 'true' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    environment:
-      name: staging
-      url: ${{ steps.deploy.outputs.url }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build design tokens
-        run: npm run build -w packages/design-tokens
-
-      - name: Build web (staging)
-        env:
-          NODE_ENV: production
-          VITE_APP_VERSION: ${{ needs.pre-deploy-checks.outputs.sha_short }}
-          VITE_ENVIRONMENT: staging
-          VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
-          VITE_POWERSYNC_URL: ${{ secrets.POWERSYNC_URL }}
-        run: npm run build -w apps/web
-
-      - name: Deploy to Vercel (staging)
-        id: deploy
-        if: ${{ env.VERCEL_TOKEN != '' }}
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-        run: |
-          # Fail loudly on errors and propagate exit codes through pipes so we
-          # don't swallow Vercel failures into the output URL.
-          set -euo pipefail
-
-          # Install Vercel CLI
-          npm i -g vercel@latest
-
-          # Deploy to staging (preview environment). Use a tempfile for output
-          # so we can inspect failures, but still rely on the command's exit
-          # code rather than capturing stderr into DEPLOY_URL.
-          DEPLOY_LOG=$(mktemp)
-          if ! vercel deploy \
-            --token="$VERCEL_TOKEN" \
-            --scope="$VERCEL_ORG_ID" \
-            --yes \
-            --archive=tgz \
-            apps/web/dist >"$DEPLOY_LOG" 2>&1; then
-            echo "::error::Vercel deploy failed:"
-            cat "$DEPLOY_LOG"
-            exit 1
-          fi
-
-          DEPLOY_URL=$(tail -1 "$DEPLOY_LOG")
-          echo "url=$DEPLOY_URL" >> "$GITHUB_OUTPUT"
-          echo "### 🌐 Web Staging (Vercel) Deployed" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "**URL:** $DEPLOY_URL" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Commit:** \`${{ needs.pre-deploy-checks.outputs.sha_short }}\`" >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Skip notice — Vercel not configured
-        if: ${{ env.VERCEL_TOKEN == '' }}
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-        run: |
-          echo "::warning::VERCEL_TOKEN not set — skipping Vercel deploy. Web is served from the Azure VM via deploy-web-vm."
-          echo "### ⚠️ Vercel Staging Skipped" >> "$GITHUB_STEP_SUMMARY"
 
   # ---------------------------------------------------------------------------
   # Web (VM): Build apps/web/dist on the staging VM and let Caddy serve it
@@ -303,7 +220,7 @@ jobs:
   # ---------------------------------------------------------------------------
   notify:
     name: Deployment Summary
-    needs: [pre-deploy-checks, deploy-web, deploy-web-vm, deploy-backend]
+    needs: [pre-deploy-checks, deploy-web-vm, deploy-backend]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -315,7 +232,6 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "| Component | Status |" >> "$GITHUB_STEP_SUMMARY"
           echo "|-----------|--------|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Web (Vercel) | ${{ needs.deploy-web.result || 'skipped' }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Web (Azure VM) | ${{ needs.deploy-web-vm.result || 'skipped' }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Backend | ${{ needs.deploy-backend.result || 'skipped' }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Drops the Vercel staging step from `deploy-staging.yml`. It has been broken since project inception — uploads `apps/web/dist` tarball, then Vercel re-runs the stored `buildCommand` (`npm run build -w apps/web`) which fails inside the tarball with no workspace context (exit 254).

Per #1952, the canonical alpha host is the Azure VM at `finance.jrmoulckers.com`, which is now rebuilt + served correctly by `deploy-web-vm` (#1953) and serialized in #1955.

## Changes

- Remove the `deploy-web` job from `.github/workflows/deploy-staging.yml`.
- Drop `deploy-web` from `notify.needs` and the summary table.
- Update header comment to reflect VM-as-canonical-host.

## Verification

- `node -e "yaml.load(...)"` — YAML parses.
- Grep confirms no remaining `deploy-web` references (only `deploy-web-vm`).
- Job set is now: `pre-deploy-checks → deploy-backend → deploy-web-vm → notify`.

Other workflows unchanged:
- `preview-deploy.yml` — Vercel preview per PR (still works).
- `deploy-production.yml` — production Vercel deploy (unchanged).
- `canary-deploy.yml` — canary Vercel deploys (unchanged).

This will turn the persistently-red `Deploy Web (Staging)` check into a clean green run.

Follow-up to #1952.
