### PR TITLE
fix(web): household member name + invite code label + click-to-copy (#1931, #1932, #1933)

### DIFF
--- a/apps/web/src/auth/auth-context.tsx
+++ b/apps/web/src/auth/auth-context.tsx
@@ -76,6 +76,14 @@ export interface AuthUser {
   email: string;
   /** Whether the user has a registered passkey. */
   hasPasskey: boolean;
+  /**
+   * Best-effort display name derived from OAuth claims
+   * (`name`, `full_name`, `given_name`, or `user_metadata.full_name`).
+   * Empty when no name was supplied (e.g. email/password signup).
+   *
+   * Issue #1931: never render a raw UUID for a logged-in user.
+   */
+  name?: string;
 }
 
 /** Result of creating a new email/password account. */
@@ -844,11 +852,15 @@ function readCachedUser(): AuthUser | null {
       return null;
     }
 
-    return {
+    const user: AuthUser = {
       id: parsed.id,
       email: parsed.email,
       hasPasskey: parsed.hasPasskey === true,
     };
+    if (typeof parsed.name === 'string' && parsed.name.trim().length > 0) {
+      user.name = parsed.name.trim();
+    }
+    return user;
   } catch {
     return null;
   }
@@ -869,10 +881,68 @@ function userFromToken(token: string): AuthUser | null {
   }
 
   const cachedUser = readCachedUser();
-  return {
+  const name = pickDisplayName(payload);
+  const user: AuthUser = {
     id: payload.sub ?? cachedUser?.id ?? '',
     email: payload.email ?? cachedUser?.email ?? '',
     hasPasskey: cachedUser?.hasPasskey ?? false,
+  };
+  if (name) {
+    user.name = name;
+  } else if (cachedUser?.name) {
+    user.name = cachedUser.name;
+  }
+  return user;
+}
+
+/**
+ * Pick the best human-readable display name from JWT claims.
+ *
+ * Supabase / OAuth providers expose the name under any of:
+ *   - `name`              (Google OIDC standard)
+ *   - `full_name`         (Supabase user_metadata projection)
+ *   - `user_metadata.full_name` / `user_metadata.name`
+ *   - first + last combined
+ *
+ * We return `undefined` if none is available so callers can fall back
+ * to email.
+ *
+ * Issue #1931.
+ */
+function pickDisplayName(payload: TokenPayload): string | undefined {
+  const candidates: Array<string | undefined> = [
+    payload.name,
+    payload.full_name,
+    payload.user_metadata?.full_name,
+    payload.user_metadata?.name,
+  ];
+
+  const first = payload.given_name ?? payload.user_metadata?.given_name;
+  const last = payload.family_name ?? payload.user_metadata?.family_name;
+  if (first || last) {
+    candidates.push([first, last].filter(Boolean).join(' '));
+  }
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim().length > 0) {
+      return candidate.trim();
+    }
+  }
+  return undefined;
+}
+
+interface TokenPayload {
+  sub?: string;
+  email?: string;
+  name?: string;
+  full_name?: string;
+  given_name?: string;
+  family_name?: string;
+  user_metadata?: {
+    full_name?: string;
+    name?: string;
+    given_name?: string;
+    family_name?: string;
   };
 }
 
@@ -881,7 +951,7 @@ function userFromToken(token: string): AuthUser | null {
  * Only used to extract user info for the UI — all real validation
  * happens server-side.
  */
-function parseTokenPayload(token: string): { sub?: string; email?: string } | null {
+function parseTokenPayload(token: string): TokenPayload | null {
   try {
     const parts = token.split('.');
     if (parts.length !== 3) return null;
@@ -889,7 +959,7 @@ function parseTokenPayload(token: string): { sub?: string; email?: string } | nu
     const base64 = parts[1]!.replace(/-/g, '+').replace(/_/g, '/');
     const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), '=');
     const json = atob(padded);
-    return JSON.parse(json) as { sub?: string; email?: string };
+    return JSON.parse(json) as TokenPayload;
   } catch {
     return null;
   }

--- a/apps/web/src/hooks/useHousehold.ts
+++ b/apps/web/src/hooks/useHousehold.ts
@@ -27,6 +27,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 
+import { useAuth } from '../auth/auth-context';
 import type {
   AccountSharing,
   AccountSharingMode,
@@ -183,6 +184,13 @@ function generateInviteCode(): string {
  * - #1786: Shared savings goals
  */
 export function useHousehold(): UseHouseholdResult {
+  // Issue #1931: capture the current authenticated user so we can stamp
+  // the owner member's displayName at creation time (and avoid showing
+  // the raw user UUID).  `useAuth` may throw if a provider is absent
+  // (e.g. some isolated unit tests that don't mount AuthProvider), so we
+  // guard with a try/catch and degrade gracefully to anonymous behaviour.
+  const authUser = useOptionalAuthUser();
+
   const [household, setHousehold] = useState<Household | null>(null);
   const [members, setMembers] = useState<HouseholdMember[]>([]);
   const [invitations, setInvitations] = useState<HouseholdInvitation[]>([]);
@@ -218,46 +226,57 @@ export function useHousehold(): UseHouseholdResult {
   }, [refreshToken]);
 
   // -- Household creation --
-  const createHousehold = useCallback((input: CreateHouseholdInput): Household | null => {
-    try {
-      const now = new Date().toISOString();
-      const ownerId = crypto.randomUUID();
-      const newHousehold: Household = {
-        id: crypto.randomUUID(),
-        name: input.name.trim(),
-        ownerId,
-        createdAt: now,
-        updatedAt: now,
-        deletedAt: null,
-        syncVersion: 1,
-        isSynced: false,
-      };
+  const createHousehold = useCallback(
+    (input: CreateHouseholdInput): Household | null => {
+      try {
+        const now = new Date().toISOString();
+        // Issue #1931: when an auth user is available, use *their* id so the
+        // owner member maps back to the signed-in account.  Otherwise fall
+        // back to a random UUID for demo/unauth flows.
+        const ownerId = authUser?.id?.trim() ? authUser.id : crypto.randomUUID();
+        // Prefer the OAuth name, then email — never expose a raw UUID.
+        const ownerDisplayName =
+          (authUser?.name && authUser.name.trim().length > 0 ? authUser.name.trim() : null) ??
+          (authUser?.email && authUser.email.trim().length > 0 ? authUser.email.trim() : null);
 
-      const ownerMember: HouseholdMember = {
-        id: crypto.randomUUID(),
-        householdId: newHousehold.id,
-        userId: ownerId,
-        displayName: null,
-        role: 'OWNER',
-        joinedAt: now,
-        createdAt: now,
-        updatedAt: now,
-        deletedAt: null,
-        syncVersion: 1,
-        isSynced: false,
-      };
+        const newHousehold: Household = {
+          id: crypto.randomUUID(),
+          name: input.name.trim(),
+          ownerId,
+          createdAt: now,
+          updatedAt: now,
+          deletedAt: null,
+          syncVersion: 1,
+          isSynced: false,
+        };
 
-      saveToStorage(STORAGE_KEY_HOUSEHOLD, newHousehold);
-      saveToStorage(STORAGE_KEY_MEMBERS, [ownerMember]);
+        const ownerMember: HouseholdMember = {
+          id: crypto.randomUUID(),
+          householdId: newHousehold.id,
+          userId: ownerId,
+          displayName: ownerDisplayName,
+          role: 'OWNER',
+          joinedAt: now,
+          createdAt: now,
+          updatedAt: now,
+          deletedAt: null,
+          syncVersion: 1,
+          isSynced: false,
+        };
 
-      setHousehold(newHousehold);
-      setMembers([ownerMember]);
-      return newHousehold;
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to create household.');
-      return null;
-    }
-  }, []);
+        saveToStorage(STORAGE_KEY_HOUSEHOLD, newHousehold);
+        saveToStorage(STORAGE_KEY_MEMBERS, [ownerMember]);
+
+        setHousehold(newHousehold);
+        setMembers([ownerMember]);
+        return newHousehold;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to create household.');
+        return null;
+      }
+    },
+    [authUser?.id, authUser?.name, authUser?.email],
+  );
 
   // -- Invitation flow (#1779) --
   const inviteMember = useCallback(
@@ -623,4 +642,22 @@ export function useHousehold(): UseHouseholdResult {
     setSharedGoal: setSharedGoalFn,
     refresh,
   };
+}
+
+/**
+ * Read the current auth user without throwing when no AuthProvider is mounted.
+ *
+ * The auth context throws by design (so misuse is caught early), but the
+ * household hook is also exercised in unit tests that intentionally mount
+ * components in isolation.  We swallow that error and return `null` rather
+ * than forcing every test to wrap children in `<AuthProvider>`.
+ *
+ * Issue #1931.
+ */
+function useOptionalAuthUser(): { id: string; email: string; name?: string } | null {
+  try {
+    return useAuth().user;
+  } catch {
+    return null;
+  }
 }

--- a/apps/web/src/lib/household/display-name.test.ts
+++ b/apps/web/src/lib/household/display-name.test.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import { buildInviteUrl, getMemberDisplayName, truncateUserId } from './display-name';
+
+describe('getMemberDisplayName', () => {
+  it('prefers the member-stored displayName', () => {
+    expect(
+      getMemberDisplayName(
+        { displayName: 'Jordan Smith', userId: 'c4580b09-aaaa-bbbb-cccc-dddddddddddd' },
+        { name: 'Other Name', email: 'other@example.com' },
+      ),
+    ).toBe('Jordan Smith');
+  });
+
+  it('falls back to the profile name when displayName is missing', () => {
+    expect(
+      getMemberDisplayName(
+        { displayName: null, userId: 'c4580b09-aaaa-bbbb-cccc-dddddddddddd' },
+        { name: 'Jordan from Google', email: 'jordan@example.com' },
+      ),
+    ).toBe('Jordan from Google');
+  });
+
+  it('falls back to email when no displayName or profile name is available', () => {
+    expect(
+      getMemberDisplayName(
+        { displayName: '   ', userId: 'c4580b09-aaaa-bbbb-cccc-dddddddddddd' },
+        { name: null, email: 'jordan@example.com' },
+      ),
+    ).toBe('jordan@example.com');
+  });
+
+  it('falls back to a truncated user id when nothing else is available', () => {
+    expect(
+      getMemberDisplayName(
+        { displayName: null, userId: 'c4580b09-aaaa-bbbb-cccc-dddddddddddd' },
+        null,
+      ),
+    ).toBe('c4580b09…');
+  });
+
+  it('returns the friendly placeholder when no identifier exists at all', () => {
+    expect(getMemberDisplayName({ displayName: null, userId: null })).toBe('Unknown member');
+  });
+
+  it('treats whitespace-only fields as missing', () => {
+    expect(
+      getMemberDisplayName({ displayName: '   ', userId: '   ' }, { name: '   ', email: '   ' }),
+    ).toBe('Unknown member');
+  });
+
+  it('respects a custom placeholder', () => {
+    expect(getMemberDisplayName({ displayName: null, userId: null }, null, 'Pending')).toBe(
+      'Pending',
+    );
+  });
+});
+
+describe('truncateUserId', () => {
+  it('truncates long UUIDs to the first 8 characters with an ellipsis', () => {
+    expect(truncateUserId('c4580b09-aaaa-bbbb-cccc-dddddddddddd')).toBe('c4580b09…');
+  });
+
+  it('returns the value unchanged when shorter than the truncate length', () => {
+    expect(truncateUserId('short')).toBe('short');
+  });
+
+  it('returns null for empty or whitespace input', () => {
+    expect(truncateUserId('')).toBeNull();
+    expect(truncateUserId('   ')).toBeNull();
+    expect(truncateUserId(null)).toBeNull();
+    expect(truncateUserId(undefined)).toBeNull();
+  });
+
+  it('respects a custom truncate length', () => {
+    expect(truncateUserId('abcdef-1234', 4)).toBe('abcd…');
+  });
+});
+
+describe('buildInviteUrl', () => {
+  it('builds an invite URL from an explicit origin', () => {
+    expect(buildInviteUrl('abc12345', 'https://finance.example.com')).toBe(
+      'https://finance.example.com/invite/abc12345',
+    );
+  });
+
+  it('strips a trailing slash from the origin', () => {
+    expect(buildInviteUrl('abc12345', 'https://finance.example.com/')).toBe(
+      'https://finance.example.com/invite/abc12345',
+    );
+  });
+
+  it('uses window.location.origin when no explicit origin is given', () => {
+    // jsdom defaults window.location.origin to http://localhost:3000 / similar.
+    const expectedOrigin = window.location.origin.replace(/\/+$/, '');
+    expect(buildInviteUrl('abc12345')).toBe(`${expectedOrigin}/invite/abc12345`);
+  });
+
+  it('still produces a usable URL with an empty code', () => {
+    expect(buildInviteUrl('', 'https://finance.example.com')).toBe(
+      'https://finance.example.com/invite/',
+    );
+  });
+});

--- a/apps/web/src/lib/household/display-name.ts
+++ b/apps/web/src/lib/household/display-name.ts
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Display-name and invite-URL helpers for the Household feature.
+ *
+ * Resolves a household member to a human-readable label using the
+ * fallback chain agreed on in issue #1931:
+ *
+ *   member.displayName  →  fallback profile name  →  fallback email
+ *                       →  truncated user id  →  generic placeholder
+ *
+ * The raw UUID should *never* be shown to the user; it is a fail-safe
+ * only used when we have literally no other identifier.
+ *
+ * References: issues #1931, #1932, #1933
+ */
+
+/** Minimal shape of an identifiable household participant. */
+export interface MemberLike {
+  /** Stored display name, if previously captured (e.g. from OAuth). */
+  readonly displayName?: string | null;
+  /** Raw user id (UUID). Last-resort identifier. */
+  readonly userId?: string | null;
+}
+
+/** Optional auth-derived profile used as a secondary fallback. */
+export interface ProfileFallback {
+  /** OAuth name (Google `name`, etc.) or user-set full name. */
+  readonly name?: string | null;
+  /** Email address — always preferred over a raw UUID. */
+  readonly email?: string | null;
+}
+
+/** A trimmed-and-normalised string, or `null` if not usable. */
+function clean(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Truncate a UUID for last-resort display.
+ *
+ * Returns the first `length` characters followed by an ellipsis.
+ * Returns `null` if the input is empty.
+ */
+export function truncateUserId(userId: string | null | undefined, length = 8): string | null {
+  const cleaned = clean(userId);
+  if (!cleaned) return null;
+  if (cleaned.length <= length) return cleaned;
+  return `${cleaned.slice(0, length)}…`;
+}
+
+/**
+ * Resolve the best human-readable label for a household member.
+ *
+ * Priority order (issue #1931):
+ *   1. `member.displayName` (already stored)
+ *   2. `profile.name`       (OAuth full name)
+ *   3. `profile.email`      (always-available identifier)
+ *   4. truncated `userId`   (fail-safe, should rarely appear)
+ *   5. `placeholder`        (final fallback, default "Unknown member")
+ *
+ * Whitespace-only values are treated as missing so we never render
+ * an empty span.
+ */
+export function getMemberDisplayName(
+  member: MemberLike,
+  profile?: ProfileFallback | null,
+  placeholder = 'Unknown member',
+): string {
+  return (
+    clean(member.displayName) ??
+    clean(profile?.name) ??
+    clean(profile?.email) ??
+    truncateUserId(member.userId) ??
+    placeholder
+  );
+}
+
+/**
+ * Build the full shareable invite URL for an invitation code.
+ *
+ * The visible UI continues to render the bare code; this URL is what
+ * gets copied to the clipboard so the recipient can click straight
+ * through to the accept-invite page (issue #1933).
+ *
+ * @param code   Invitation code (bare token).
+ * @param origin Origin to use (defaults to `window.location.origin`
+ *               when available, else an empty string).
+ */
+export function buildInviteUrl(code: string, origin?: string): string {
+  const safeCode = clean(code) ?? '';
+  const safeOrigin =
+    clean(origin) ??
+    (typeof window !== 'undefined' && typeof window.location?.origin === 'string'
+      ? window.location.origin
+      : '');
+  // Strip trailing slash from the origin so we don't end up with `//invite/...`.
+  const normalisedOrigin = safeOrigin.replace(/\/+$/, '');
+  return `${normalisedOrigin}/invite/${safeCode}`;
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -6,7 +6,7 @@ import { createRoot } from 'react-dom/client';
 import { BrowserRouter, useLocation } from 'react-router-dom';
 import { App } from './App';
 import { AuthProvider } from './auth/auth-context';
-import { ErrorBoundary } from './components/common';
+import { ErrorBoundary, ToastProvider } from './components/common';
 import { ScrollToTop } from './components/navigation/ScrollToTop';
 import { DatabaseProvider } from './db/DatabaseProvider';
 import { MoneyDisplayProvider } from './lib/display-settings';
@@ -116,16 +116,18 @@ const DatabaseGate: FC<{ children: ReactNode }> = ({ children }) => {
 createRoot(rootElement).render(
   <StrictMode>
     <ErrorBoundary>
-      <AuthProvider config={authConfig}>
-        <MoneyDisplayProvider>
-          <BrowserRouter>
-            <ScrollToTop />
-            <DatabaseGate>
-              <App />
-            </DatabaseGate>
-          </BrowserRouter>
-        </MoneyDisplayProvider>
-      </AuthProvider>
+      <ToastProvider>
+        <AuthProvider config={authConfig}>
+          <MoneyDisplayProvider>
+            <BrowserRouter>
+              <ScrollToTop />
+              <DatabaseGate>
+                <App />
+              </DatabaseGate>
+            </BrowserRouter>
+          </MoneyDisplayProvider>
+        </AuthProvider>
+      </ToastProvider>
     </ErrorBoundary>
   </StrictMode>,
 );

--- a/apps/web/src/pages/HouseholdPage.css
+++ b/apps/web/src/pages/HouseholdPage.css
@@ -641,10 +641,59 @@
  * Invitation code display
  * ------------------------------------------------------------------------- */
 
-.household-invitation-item__code {
+.household-invitation-item__code-group {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
+.household-invitation-item__code-label {
   font-size: var(--type-scale-caption-font-size);
   color: var(--semantic-text-secondary);
-  font-family: monospace;
+  font-weight: var(--font-weight-medium);
+  text-transform: none;
+}
+
+.household-invitation-item__code {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-1) var(--spacing-2);
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-primary);
+  background: var(--semantic-surface-subtle, var(--semantic-surface-secondary));
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--radius-sm, 4px);
+  cursor: pointer;
+  font-family: inherit;
+  line-height: 1.2;
+  transition:
+    background 120ms ease-in-out,
+    border-color 120ms ease-in-out;
+}
+
+.household-invitation-item__code:hover,
+.household-invitation-item__code:focus-visible {
+  background: var(--semantic-surface-hover, var(--semantic-surface-tertiary));
+  border-color: var(--semantic-border-emphasis, var(--semantic-border-default));
+}
+
+.household-invitation-item__code:focus-visible {
+  outline: 2px solid var(--semantic-focus-ring, var(--semantic-action-primary));
+  outline-offset: 2px;
+}
+
+.household-invitation-item__code-text {
+  font-family:
+    ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
+  font-weight: var(--font-weight-medium);
+}
+
+.household-invitation-item__code-hint {
+  font-size: calc(var(--type-scale-caption-font-size) * 0.85);
+  color: var(--semantic-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 /* ---------------------------------------------------------------------------

--- a/apps/web/src/pages/HouseholdPage.test.tsx
+++ b/apps/web/src/pages/HouseholdPage.test.tsx
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import { render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { useAuth } from '../auth/auth-context';
+import { useToast } from '../components/common/Toast';
 import { useHousehold } from '../hooks/useHousehold';
 import type { UseHouseholdResult } from '../hooks/useHousehold';
 import { HouseholdPage } from './HouseholdPage';
@@ -15,7 +17,17 @@ vi.mock('../hooks/useHousehold', () => ({
   useHousehold: vi.fn(),
 }));
 
+vi.mock('../auth/auth-context', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('../components/common/Toast', () => ({
+  useToast: vi.fn(),
+}));
+
 const mockedUseHousehold = vi.mocked(useHousehold);
+const mockedUseAuth = vi.mocked(useAuth);
+const mockedUseToast = vi.mocked(useToast);
 
 function mockHouseholdResult(overrides: Partial<UseHouseholdResult> = {}): UseHouseholdResult {
   return {
@@ -86,6 +98,36 @@ function makeOwnerMember(overrides: Record<string, unknown> = {}) {
 describe('HouseholdPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: no signed-in user.  Tests that exercise the OAuth-fallback
+    // path override this with a more specific value.
+    mockedUseAuth.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+      isLoading: false,
+      error: null,
+      webAuthnSupported: false,
+      isDemoMode: false,
+      isOffline: false,
+      showPasskeyPrompt: false,
+      dismissPasskeyPrompt: vi.fn(),
+      loginWithEmail: vi.fn(),
+      loginWithPasskey: vi.fn(),
+      loginWithOAuth: vi.fn(),
+      registerNewPasskey: vi.fn(),
+      logout: vi.fn(),
+      deleteAccount: vi.fn(),
+      refresh: vi.fn(),
+      signupWithEmail: vi.fn(),
+    } as unknown as ReturnType<typeof useAuth>);
+
+    mockedUseToast.mockReturnValue({
+      showToast: vi.fn(),
+      dismissToast: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
   });
 
   it('shows loading state', () => {
@@ -147,7 +189,7 @@ describe('HouseholdPage', () => {
     expect(screen.getByRole('alert')).toHaveTextContent('Something went wrong');
   });
 
-  it('shows pending invitations section when invitations exist', () => {
+  it('shows pending invitations section with invite code label and bare code value', () => {
     mockedUseHousehold.mockReturnValue(
       mockHouseholdResult({
         household: makeHousehold({ name: 'Test' }),
@@ -175,7 +217,147 @@ describe('HouseholdPage', () => {
 
     expect(screen.getByText('Pending Invitations')).toBeInTheDocument();
     expect(screen.getByText('partner@example.com')).toBeInTheDocument();
-    expect(screen.getByText('Code: abc12345')).toBeInTheDocument();
+    // #1932: explicit label is shown
+    expect(screen.getByText('Invite code:')).toBeInTheDocument();
+    // #1932: bare code is the visible text (no "Code: " prefix)
+    expect(screen.getByText('abc12345')).toBeInTheDocument();
+    // #1933: code is a button (focusable, click-to-copy)
+    expect(
+      screen.getByRole('button', { name: /copy invite link for partner@example\.com/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('copies the full invite URL to the clipboard and shows a toast when the code is clicked', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    const showToast = vi.fn();
+    mockedUseToast.mockReturnValue({
+      showToast,
+      dismissToast: vi.fn(),
+    });
+
+    mockedUseHousehold.mockReturnValue(
+      mockHouseholdResult({
+        household: makeHousehold({ name: 'Test' }),
+        invitations: [
+          {
+            id: 'inv-1',
+            householdId: 'hh-1',
+            invitedBy: 'user-1',
+            email: 'partner@example.com',
+            role: 'ADMIN',
+            status: 'PENDING',
+            inviteCode: 'abc12345',
+            expiresAt: '2025-01-08T00:00:00Z',
+            createdAt: '2025-01-01T00:00:00Z',
+            updatedAt: '2025-01-01T00:00:00Z',
+            deletedAt: null,
+            syncVersion: 1,
+            isSynced: true,
+          },
+        ],
+      }),
+    );
+
+    render(<HouseholdPage />);
+
+    const copyButton = screen.getByRole('button', {
+      name: /copy invite link for partner@example\.com/i,
+    });
+
+    fireEvent.click(copyButton);
+
+    // Wait a microtask for the awaited writeText to resolve.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    const copied = writeText.mock.calls[0]?.[0] as string;
+    expect(copied).toMatch(/\/invite\/abc12345$/);
+    expect(showToast).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'success', message: 'Invite link copied' }),
+    );
+  });
+
+  it('renders the OAuth name for the owner instead of the raw user UUID', () => {
+    mockedUseAuth.mockReturnValue({
+      user: {
+        id: 'user-1-abcdef',
+        email: 'jordan@example.com',
+        name: 'Jordan Smith',
+        hasPasskey: false,
+      },
+      isAuthenticated: true,
+      isLoading: false,
+      error: null,
+      webAuthnSupported: false,
+      isDemoMode: false,
+      isOffline: false,
+      showPasskeyPrompt: false,
+      dismissPasskeyPrompt: vi.fn(),
+      loginWithEmail: vi.fn(),
+      loginWithPasskey: vi.fn(),
+      loginWithOAuth: vi.fn(),
+      registerNewPasskey: vi.fn(),
+      logout: vi.fn(),
+      deleteAccount: vi.fn(),
+      refresh: vi.fn(),
+      signupWithEmail: vi.fn(),
+    } as unknown as ReturnType<typeof useAuth>);
+
+    mockedUseHousehold.mockReturnValue(
+      mockHouseholdResult({
+        household: makeHousehold(),
+        members: [makeOwnerMember({ displayName: null, userId: 'user-1-abcdef' })],
+      }),
+    );
+
+    render(<HouseholdPage />);
+
+    expect(screen.getByText('Jordan Smith')).toBeInTheDocument();
+    // The raw UUID must not appear.
+    expect(screen.queryByText(/user-1-a/)).not.toBeInTheDocument();
+  });
+
+  it('falls back to the email address when no OAuth name is available', () => {
+    mockedUseAuth.mockReturnValue({
+      user: {
+        id: 'user-1-abcdef',
+        email: 'jordan@example.com',
+        hasPasskey: false,
+      },
+      isAuthenticated: true,
+      isLoading: false,
+      error: null,
+      webAuthnSupported: false,
+      isDemoMode: false,
+      isOffline: false,
+      showPasskeyPrompt: false,
+      dismissPasskeyPrompt: vi.fn(),
+      loginWithEmail: vi.fn(),
+      loginWithPasskey: vi.fn(),
+      loginWithOAuth: vi.fn(),
+      registerNewPasskey: vi.fn(),
+      logout: vi.fn(),
+      deleteAccount: vi.fn(),
+      refresh: vi.fn(),
+      signupWithEmail: vi.fn(),
+    } as unknown as ReturnType<typeof useAuth>);
+
+    mockedUseHousehold.mockReturnValue(
+      mockHouseholdResult({
+        household: makeHousehold(),
+        members: [makeOwnerMember({ displayName: null, userId: 'user-1-abcdef' })],
+      }),
+    );
+
+    render(<HouseholdPage />);
+
+    expect(screen.getByText('jordan@example.com')).toBeInTheDocument();
   });
 
   it('renders account sharing toggles with privacy labels', () => {

--- a/apps/web/src/pages/HouseholdPage.tsx
+++ b/apps/web/src/pages/HouseholdPage.tsx
@@ -13,9 +13,12 @@
 import { useCallback, useState } from 'react';
 import type { FormEvent } from 'react';
 
+import { useAuth } from '../auth/auth-context';
+import { useToast } from '../components/common/Toast';
 import { useHousehold } from '../hooks/useHousehold';
 import type { HouseholdRole, AccountSharingMode, SharedBudgetMode } from '../kmp/bridge';
 import { ROLE_PERMISSIONS } from '../kmp/bridge';
+import { buildInviteUrl, getMemberDisplayName } from '../lib/household/display-name';
 
 import './HouseholdPage.css';
 
@@ -97,6 +100,13 @@ export function HouseholdPage() {
     checkPermission,
   } = useHousehold();
 
+  // Issue #1931: pull the auth user as a fallback for the owner's display name
+  // (so the user's own entry never shows a raw UUID).
+  const authUser = useOptionalAuthUser();
+
+  // Issue #1933: copy the full invite URL on click and confirm via toast.
+  const toast = useOptionalToast();
+
   // -- Create household form state -----------------------------------------
   const [householdName, setHouseholdName] = useState('');
   const [createError, setCreateError] = useState<string | null>(null);
@@ -154,6 +164,54 @@ export function HouseholdPage() {
       }
     },
     [inviteEmail, inviteRole, inviteMember],
+  );
+
+  /**
+   * Resolve a member to a human-readable label.
+   *
+   * For the OWNER specifically we also fall back to the current
+   * signed-in user's OAuth name / email so the user's *own* row
+   * never displays a raw UUID (issue #1931).
+   */
+  const resolveMemberName = useCallback(
+    (member: { displayName?: string | null; userId?: string | null; role: HouseholdRole }) => {
+      const isCurrentUser =
+        member.role === 'OWNER' || (authUser?.id && member.userId === authUser.id);
+      const profile = isCurrentUser
+        ? { name: authUser?.name ?? null, email: authUser?.email ?? null }
+        : null;
+      return getMemberDisplayName(member, profile);
+    },
+    [authUser?.id, authUser?.name, authUser?.email],
+  );
+
+  /**
+   * Click handler for the invite-code chip.
+   *
+   * Issue #1933: copies the full invite URL (not just the bare code) to
+   * the clipboard and shows a brief "Invite link copied" toast.  Falls
+   * back to `document.execCommand('copy')` on browsers that don't expose
+   * `navigator.clipboard.writeText` (older Safari, file://, http://, etc.).
+   */
+  const handleCopyInvite = useCallback(
+    async (code: string) => {
+      const url = buildInviteUrl(code);
+      const success = await copyToClipboard(url);
+      if (success) {
+        toast?.showToast({
+          type: 'success',
+          message: 'Invite link copied',
+          duration: 2000,
+        });
+      } else {
+        toast?.showToast({
+          type: 'error',
+          message: `Couldn't copy automatically. Copy this link manually: ${url}`,
+          duration: 6000,
+        });
+      }
+    },
+    [toast],
   );
 
   // -- Loading state -------------------------------------------------------
@@ -251,47 +309,52 @@ export function HouseholdPage() {
           <p className="household-card__empty">No members yet.</p>
         ) : (
           <ul className="household-member-list" role="list" aria-label="Household members">
-            {members.map((member) => (
-              <li key={member.id} className="household-member-item">
-                <div className="household-member-item__info">
-                  <span className="household-member-item__avatar" aria-hidden="true">
-                    {member.role === 'OWNER' ? '👑' : member.role === 'ADMIN' ? '🛡️' : '👤'}
-                  </span>
-                  <div>
-                    <span className="household-member-item__name">
-                      {member.displayName ?? `${member.userId.slice(0, 8)}…`}
+            {members.map((member) => {
+              const name = resolveMemberName(member);
+              return (
+                <li key={member.id} className="household-member-item">
+                  <div className="household-member-item__info">
+                    <span className="household-member-item__avatar" aria-hidden="true">
+                      {member.role === 'OWNER' ? '👑' : member.role === 'ADMIN' ? '🛡️' : '👤'}
                     </span>
-                    <span className="household-member-item__role">{ROLE_LABELS[member.role]}</span>
-                    <span className="household-member-item__permissions">
-                      {ROLE_PERMISSIONS[member.role].length} permissions
-                    </span>
+                    <div>
+                      <span className="household-member-item__name">{name}</span>
+                      <span className="household-member-item__role">
+                        {ROLE_LABELS[member.role]}
+                      </span>
+                      <span className="household-member-item__permissions">
+                        {ROLE_PERMISSIONS[member.role].length} permissions
+                      </span>
+                    </div>
                   </div>
-                </div>
-                {member.role !== 'OWNER' && (
-                  <div className="household-member-item__actions">
-                    <select
-                      className="household-form-select household-form-select--small"
-                      value={member.role}
-                      onChange={(e) => updateMemberRole(member.id, e.target.value as HouseholdRole)}
-                      aria-label={`Change role for ${member.displayName ?? member.userId.slice(0, 8)}`}
-                    >
-                      {ROLE_OPTIONS.map((opt) => (
-                        <option key={opt.value} value={opt.value}>
-                          {opt.label}
-                        </option>
-                      ))}
-                    </select>
-                    <button
-                      className="household-button household-button--danger household-button--small"
-                      onClick={() => removeMember(member.id)}
-                      aria-label={`Remove ${member.displayName ?? member.userId.slice(0, 8)}`}
-                    >
-                      Remove
-                    </button>
-                  </div>
-                )}
-              </li>
-            ))}
+                  {member.role !== 'OWNER' && (
+                    <div className="household-member-item__actions">
+                      <select
+                        className="household-form-select household-form-select--small"
+                        value={member.role}
+                        onChange={(e) =>
+                          updateMemberRole(member.id, e.target.value as HouseholdRole)
+                        }
+                        aria-label={`Change role for ${name}`}
+                      >
+                        {ROLE_OPTIONS.map((opt) => (
+                          <option key={opt.value} value={opt.value}>
+                            {opt.label}
+                          </option>
+                        ))}
+                      </select>
+                      <button
+                        className="household-button household-button--danger household-button--small"
+                        onClick={() => removeMember(member.id)}
+                        aria-label={`Remove ${name}`}
+                      >
+                        Remove
+                      </button>
+                    </div>
+                  )}
+                </li>
+              );
+            })}
           </ul>
         )}
 
@@ -389,14 +452,46 @@ export function HouseholdPage() {
           <h2 id="invitations-title" className="household-card__title">
             Pending Invitations
           </h2>
-          <ul className="household-invitation-list" role="list" aria-label="Pending invitations">
+          <p className="household-card__description" id="invitations-helper">
+            Send the invite code (or click the code to copy the full invite link) to the person you
+            want to share with. They can paste it at <code>/invite</code> or click the link from
+            their email.
+          </p>
+          <ul
+            className="household-invitation-list"
+            role="list"
+            aria-label="Pending invitations"
+            aria-describedby="invitations-helper"
+          >
             {pendingInvitations.map((inv) => (
               <li key={inv.id} className="household-invitation-item">
                 <div className="household-invitation-item__info">
                   <span className="household-invitation-item__email">{inv.email}</span>
                   <span className="household-invitation-item__role">{ROLE_LABELS[inv.role]}</span>
-                  <span className="household-invitation-item__code" title="Invite code">
-                    Code: {inv.inviteCode}
+                  <span className="household-invitation-item__code-group">
+                    <span
+                      className="household-invitation-item__code-label"
+                      id={`invite-code-label-${inv.id}`}
+                    >
+                      Invite code:
+                    </span>
+                    <button
+                      type="button"
+                      className="household-invitation-item__code"
+                      onClick={() => void handleCopyInvite(inv.inviteCode)}
+                      aria-label={`Copy invite link for ${inv.email}`}
+                      title="Click to copy the full invite link"
+                    >
+                      {/*
+                        Issue #1932: keep the bare code as the visible label so
+                        users still recognise the value being copied.  Issue
+                        #1933: clicking copies the full URL, not the bare code.
+                      */}
+                      <code className="household-invitation-item__code-text">{inv.inviteCode}</code>
+                      <span aria-hidden="true" className="household-invitation-item__code-hint">
+                        Copy link
+                      </span>
+                    </button>
                   </span>
                   <span className="household-invitation-item__status">{inv.status}</span>
                 </div>
@@ -644,3 +739,81 @@ export function HouseholdPage() {
 }
 
 export default HouseholdPage;
+
+// ---------------------------------------------------------------------------
+// Local helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the auth user without throwing if no AuthProvider is mounted.
+ *
+ * `useAuth()` is intentionally strict (throws on misuse) so production
+ * callers fail loudly, but a handful of unit tests render the page
+ * without wrapping it in `<AuthProvider>`.  We swallow that error and
+ * fall back to `null`; the display-name resolver handles a missing
+ * profile gracefully by falling back to `member.displayName` /
+ * truncated UUID.
+ *
+ * Issue #1931.
+ */
+function useOptionalAuthUser(): { id: string; email: string; name?: string } | null {
+  try {
+    return useAuth().user;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the toast API without throwing if no ToastProvider is mounted.
+ *
+ * Same rationale as {@link useOptionalAuthUser}: we don't want to force
+ * every test render to wrap children in `<ToastProvider>`, and a missing
+ * toast is a soft degradation (clipboard write still succeeds; the user
+ * just doesn't see the confirmation).
+ *
+ * Issue #1933.
+ */
+function useOptionalToast(): ReturnType<typeof useToast> | null {
+  try {
+    return useToast();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Copy `text` to the clipboard.
+ *
+ * Uses `navigator.clipboard.writeText` when available (modern browsers,
+ * secure contexts) and falls back to the legacy `document.execCommand`
+ * shim otherwise.  Returns `true` on success.
+ *
+ * Issue #1933.
+ */
+async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // Fall through to the legacy shim below.
+  }
+
+  try {
+    if (typeof document === 'undefined') return false;
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'absolute';
+    textarea.style.left = '-9999px';
+    document.body.appendChild(textarea);
+    textarea.select();
+    const ok = document.execCommand('copy');
+    document.body.removeChild(textarea);
+    return ok;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Three small, related Household polish fixes — all isolated to `apps/web/src/`.

### #1931 — Household member shows raw UUID instead of profile name / email

* Added `apps/web/src/lib/household/display-name.ts` with a `getMemberDisplayName(member, profile?)` resolver implementing the agreed fallback chain:
  1. `member.displayName`
  2. OAuth/profile `name` (Google `name`, Supabase `user_metadata.full_name`, `given_name`/`family_name`, etc.)
  3. `email`
  4. Truncated UUID (8 chars + `…`)
  5. Friendly placeholder (`"Unknown member"`)
* Extended `AuthUser` with an optional `name` parsed from the JWT (`name`, `full_name`, `user_metadata.{full_name,name,given_name,family_name}`).
* `useHousehold.createHousehold` now stamps the owner member's `displayName` from the signed-in user, so the user's own row is **never** a raw UUID.
* `HouseholdPage` resolves the OAuth name/email for the OWNER row at render time as well, so existing households created before this fix also recover.

### #1932 — Pending-invite code is unlabeled

* Added an explicit "**Invite code:**" label next to each code.
* Added one-line helper text under the section heading explaining what to do with the code.
* The code itself is now visually a chip (monospace, subtle background and border) so it reads as code at a glance, with a small "Copy link" hint.

### #1933 — Clicking the invite code copies the full invite URL

* The chip is now a `<button>` (keyboard-focusable, Enter/Space trigger, visible focus ring).
* Click handler builds `${origin}/invite/${code}` via `buildInviteUrl(...)` and copies it with `navigator.clipboard.writeText`, falling back to a `document.execCommand('copy')` shim where the modern API is unavailable.
* Confirms via a 2-second `"Invite link copied"` toast using the existing `useToast()` API. Failures surface a longer error toast with the manual-copy URL so the user is never silently stranded.
* Wired `ToastProvider` into `main.tsx` (was previously exported but not mounted).

## Tests added

* `apps/web/src/lib/household/display-name.test.ts` (15 tests) — full fallback chain for `getMemberDisplayName`, `truncateUserId`, and `buildInviteUrl` (with/without origin, trailing slash, empty code).
* `apps/web/src/pages/HouseholdPage.test.tsx` — new cases for:
  * "Invite code:" label is rendered and the bare code is the visible text.
  * Clicking the code calls `navigator.clipboard.writeText` with `…/invite/<code>` **and** triggers a `success` toast with the message `"Invite link copied"`.
  * OAuth name renders for the owner instead of the UUID.
  * Email is used when no OAuth name is available.

## Verification

* `npm run -w apps/web lint` — ✅ clean
* `npm run -w apps/web test` — ✅ **6390** passing; the one pre-existing failure is `formatDate.test.ts > formats an ISO date string`, a timezone-dependent test untouched by this PR.
* `npm run -w apps/web build` — ✅ succeeds (after a first-run `packages/design-tokens` build, unrelated to this change).

## Accessibility

* Invite code button: keyboard-accessible, visible focus ring, descriptive `aria-label` (e.g. `"Copy invite link for partner@example.com"`), `title` tooltip.
* Toast: existing component already uses `role="status"` for non-errors and `role="alert"` for errors (polite SR announcement, dismissible).
* Members list: no UUIDs leak into rendered text or aria-labels — the resolver is reused for both display text and the role-change/remove button labels.

Fixes #1931
Fixes #1932
Fixes #1933
