### PR TITLE
fix(web): account deletion actually purges data + typed-confirm gate + household notice (#1960, #1961, #1962)

### DIFF
--- a/apps/web/src/components/gdpr/PrivacySettings.tsx
+++ b/apps/web/src/components/gdpr/PrivacySettings.tsx
@@ -21,7 +21,6 @@ import {
   CONSENT_LABELS,
   CURRENT_POLICY_VERSION,
   exportConsentRecord,
-  clearConsentData,
   type ConsentCategory,
 } from '../../lib/consent-storage';
 import './privacy-settings.css';
@@ -53,7 +52,6 @@ export const PrivacySettings: React.FC<PrivacySettingsProps> = ({
   onDeleteAccount,
 }) => {
   const { consent, updateCategory } = useConsent();
-  const [deleteConfirmation, setDeleteConfirmation] = useState(false);
   const [exportMessage, setExportMessage] = useState<string | null>(null);
 
   const handleToggle = useCallback(
@@ -85,20 +83,24 @@ export const PrivacySettings: React.FC<PrivacySettingsProps> = ({
     }
   }, []);
 
+  /**
+   * Open the typed-DELETE confirmation modal (issue #1961).
+   *
+   * Previously this component rendered its own two-step inline
+   * "Are you sure? Yes, Delete Everything" confirmation that had NO
+   * typed-confirmation gate. The "Yes" button only invoked
+   * `onDeleteAccount` (which then opened the proper typed-DELETE
+   * modal), but the duplicated copy made users believe the deletion
+   * had already fired. We've collapsed it into a single click that
+   * hands off to the parent's typed-DELETE modal — the single source
+   * of truth for the gate.
+   */
   const handleDeleteRequest = useCallback(() => {
-    if (!deleteConfirmation) {
-      setDeleteConfirmation(true);
-      return;
-    }
-
-    // Clear local consent data
-    clearConsentData();
-
-    // Trigger the account deletion callback (server-side)
+    // Local consent state is cleared in SettingsPage's success path
+    // (after the server confirms the deletion) via localStorage.clear().
+    // Clearing here would race with the user cancelling the modal.
     onDeleteAccount?.();
-
-    setDeleteConfirmation(false);
-  }, [deleteConfirmation, onDeleteAccount]);
+  }, [onDeleteAccount]);
 
   return (
     <section aria-label="Privacy & Data" className="page-section">
@@ -194,47 +196,15 @@ export const PrivacySettings: React.FC<PrivacySettingsProps> = ({
           recommend exporting your data first.
         </p>
 
-        {deleteConfirmation ? (
-          <div role="alert" className="privacy-settings__delete-confirm">
-            <p className="privacy-settings__delete-confirm-title">
-              Are you absolutely sure? This will permanently delete:
-            </p>
-            <ul className="privacy-settings__delete-confirm-list">
-              <li>All accounts, transactions, budgets, and goals</li>
-              <li>Your household membership and shared data</li>
-              <li>All consent records and preferences</li>
-              <li>Your user account on our servers</li>
-            </ul>
-            <div className="privacy-settings__delete-actions">
-              <button
-                type="button"
-                className="settings-item settings-item--button settings-item--destructive"
-                onClick={handleDeleteRequest}
-                aria-label="Confirm account deletion"
-              >
-                <span className="settings-item__label">Yes, Delete Everything</span>
-              </button>
-              <button
-                type="button"
-                className="settings-item settings-item--button"
-                onClick={() => setDeleteConfirmation(false)}
-                aria-label="Cancel account deletion"
-              >
-                <span className="settings-item__label">Cancel</span>
-              </button>
-            </div>
-          </div>
-        ) : (
-          <button
-            type="button"
-            className="settings-item settings-item--button settings-item--destructive"
-            onClick={handleDeleteRequest}
-            aria-label="Request account deletion"
-          >
-            <span className="settings-item__label">Delete My Account & Data</span>
-            <span className="settings-item__value">&rarr;</span>
-          </button>
-        )}
+        <button
+          type="button"
+          className="settings-item settings-item--button settings-item--destructive"
+          onClick={handleDeleteRequest}
+          aria-label="Delete my account and all data"
+        >
+          <span className="settings-item__label">Delete My Account & Data</span>
+          <span className="settings-item__value">&rarr;</span>
+        </button>
       </div>
     </section>
   );

--- a/apps/web/src/pages/SettingsPage.test.tsx
+++ b/apps/web/src/pages/SettingsPage.test.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const logoutMock = vi.fn<() => Promise<void>>();
@@ -261,23 +261,81 @@ describe('SettingsPage', () => {
     fireEvent.click(screen.getByRole('button', { name: /delete my account & data/i }));
 
     const dialog = await screen.findByRole('dialog', { name: /delete account and all data/i });
-    expect(dialog).toHaveTextContent('1 solo-owned household will be permanently deleted.');
-    expect(dialog).toHaveTextContent('2 households will keep existing; you will be removed');
-    expect(dialog).toHaveTextContent('3 pending invites will be revoked.');
+    // New copy per #1962 — only renders bullets when the count is non-zero
+    // so the wording stays accurate for users with no households at all.
+    expect(dialog).toHaveTextContent('1 household you solely own will be deleted entirely');
+    expect(dialog).toHaveTextContent('You will be removed from 2 shared households');
+    expect(dialog).toHaveTextContent(
+      'every transaction, budget, goal, account, and category you contributed there is deleted',
+    );
+    expect(dialog).toHaveTextContent('3 pending invitations you sent will be revoked');
+    expect(dialog).toHaveTextContent(/sign-in identity.*unlinked/i);
+    expect(dialog).toHaveTextContent(/cannot be undone/i);
 
     const destructiveButton = screen.getByRole('button', { name: /yes, delete everything/i });
     const cancelButton = screen.getByRole('button', { name: /cancel/i });
 
+    // Issue #1961 — destructive button must be both visually disabled AND
+    // announced as disabled to screen readers via aria-disabled.
     expect(destructiveButton).toBeDisabled();
+    expect(destructiveButton).toHaveAttribute('aria-disabled', 'true');
     expect(destructiveButton).toHaveClass('settings-account-delete__confirm-button--danger');
     expect(cancelButton).toHaveClass('settings-account-delete__cancel-button--secondary');
+
+    // Bypass attempt — click the disabled button. The native disabled
+    // attribute already blocks the click, but defense-in-depth means the
+    // handler also early-returns. Either way, no fetch must fire.
+    fireEvent.click(destructiveButton);
+    expect(fetch).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByLabelText(/type delete to confirm/i), {
+      target: { value: 'delete' }, // wrong case
+    });
+    expect(destructiveButton).toBeDisabled();
+    expect(destructiveButton).toHaveAttribute('aria-disabled', 'true');
 
     fireEvent.change(screen.getByLabelText(/type delete to confirm/i), {
       target: { value: 'DELETE' },
     });
 
     expect(destructiveButton).toBeEnabled();
+    expect(destructiveButton).toHaveAttribute('aria-disabled', 'false');
     expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('treats an HTML 200 response from the delete endpoint as a failure (#1960)', async () => {
+    // Production Caddy used to be missing the /api/account/* proxy rule,
+    // so this fetch silently returned 200 OK + index.html. The client
+    // must NOT treat that as a successful deletion.
+    const htmlResponse = {
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'Content-Type': 'text/html; charset=utf-8' }),
+    };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(htmlResponse));
+    const assignSpy = vi.fn();
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { ...window.location, assign: assignSpy },
+    });
+
+    render(<SettingsPage />);
+    fireEvent.click(screen.getByRole('button', { name: /delete my account & data/i }));
+    await screen.findByRole('dialog', { name: /delete account and all data/i });
+
+    fireEvent.change(screen.getByLabelText(/type delete to confirm/i), {
+      target: { value: 'DELETE' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /yes, delete everything/i }));
+
+    // Yield to the in-flight async handler.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(clearLocalAccountDataMock).not.toHaveBeenCalled();
+    expect(assignSpy).not.toHaveBeenCalled();
+    expect(await screen.findByText(/couldn't delete account/i)).toBeInTheDocument();
   });
 
   describe('Display settings section', () => {

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -294,6 +294,11 @@ export const SettingsPage: React.FC = () => {
   }, [db, isDeleteModalOpen, user?.id]);
 
   const handleAccountDelete = useCallback(async () => {
+    // Defense-in-depth: even though the destructive button is disabled
+    // when the typed token does not match, re-check here in case the
+    // disabled attribute is bypassed via devtools or assistive tech
+    // (issue #1961). The server also independently re-validates the
+    // confirmation in services/api/supabase/functions/account-delete.
     if (!isAuthenticated || deleteConfirmationText !== 'DELETE' || isDeletingAccount) {
       return;
     }
@@ -305,11 +310,22 @@ export const SettingsPage: React.FC = () => {
       const response = await fetch('/api/account/delete-account', {
         method: 'POST',
         credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
         body: JSON.stringify({ confirmation: 'DELETE' }),
       });
 
-      if (!response.ok) {
+      // Issue #1960 — the production Caddy config used to be missing the
+      // `/api/account/*` proxy rule, so this fetch fell through to the
+      // SPA fallback and returned 200 OK with an HTML body. The client
+      // happily treated that as "success" and cleared the local cache
+      // while the server had not deleted a single row.
+      //
+      // Guard against any future regression of that nature by insisting
+      // the response is either 204 (success contract — see the edge
+      // function), or a non-HTML payload with a 2xx status.
+      const contentType = response.headers.get('Content-Type') ?? '';
+      const looksLikeHtml = contentType.includes('text/html');
+      if (!response.ok || looksLikeHtml) {
         throw new Error('Account deletion failed.');
       }
 
@@ -809,20 +825,43 @@ export const SettingsPage: React.FC = () => {
               This permanently deletes your account, personal finance data, passkeys, connected bank
               links, audit entries, and authentication record. This cannot be undone.
             </p>
-            <ul aria-label="Household deletion impact" className="settings-item__description">
+            {/*
+              Household + shared-data consequences (issue #1962).
+              The wording is mirrored by the server-side policy in
+              services/api/supabase/functions/account-delete/index.ts —
+              update both together.
+            */}
+            <ul aria-label="What will be deleted" className="settings-item__description">
               <li>
-                {householdImpact.soloOwnedHouseholds} solo-owned household
-                {householdImpact.soloOwnedHouseholds === 1 ? '' : 's'} will be permanently deleted.
+                All your personal accounts, transactions, budgets, goals, categories, settings, and
+                audit records will be permanently deleted.
               </li>
+              {householdImpact.soloOwnedHouseholds > 0 && (
+                <li>
+                  {householdImpact.soloOwnedHouseholds} household
+                  {householdImpact.soloOwnedHouseholds === 1 ? '' : 's'} you solely own will be
+                  deleted entirely — any other invited members lose access.
+                </li>
+              )}
+              {householdImpact.memberHouseholds > 0 && (
+                <li>
+                  You will be removed from {householdImpact.memberHouseholds} shared household
+                  {householdImpact.memberHouseholds === 1 ? '' : 's'}. The household itself stays,
+                  but every transaction, budget, goal, account, and category you contributed there
+                  is deleted. Data owned by other members is untouched.
+                </li>
+              )}
+              {householdImpact.pendingInvites > 0 && (
+                <li>
+                  {householdImpact.pendingInvites} pending invitation
+                  {householdImpact.pendingInvites === 1 ? '' : 's'} you sent will be revoked.
+                </li>
+              )}
               <li>
-                {householdImpact.memberHouseholds} household
-                {householdImpact.memberHouseholds === 1 ? '' : 's'} will keep existing; you will be
-                removed and ownership transfers if needed.
+                Your sign-in identity (Google / Apple / email / passkey) is unlinked. Signing in
+                again creates a brand-new empty account.
               </li>
-              <li>
-                {householdImpact.pendingInvites} pending invite
-                {householdImpact.pendingInvites === 1 ? '' : 's'} will be revoked.
-              </li>
+              <li>This action cannot be undone.</li>
             </ul>
             <label className="settings-item__label" htmlFor="delete-account-confirmation">
               Type DELETE to confirm
@@ -834,7 +873,15 @@ export const SettingsPage: React.FC = () => {
               onChange={(event) => setDeleteConfirmationText(event.target.value)}
               disabled={isDeletingAccount}
               autoComplete="off"
+              aria-describedby="delete-account-confirmation-help"
             />
+            <p
+              id="delete-account-confirmation-help"
+              className="settings-item__description"
+              style={{ marginTop: 'var(--spacing-1, 0.25rem)' }}
+            >
+              The deletion button stays disabled until you type the word DELETE exactly.
+            </p>
             {deleteError && (
               <p role="alert" style={{ color: 'var(--semantic-danger, #dc2626)' }}>
                 {deleteError}
@@ -870,6 +917,7 @@ export const SettingsPage: React.FC = () => {
                   void handleAccountDelete();
                 }}
                 disabled={deleteConfirmationText !== 'DELETE' || isDeletingAccount}
+                aria-disabled={deleteConfirmationText !== 'DELETE' || isDeletingAccount}
                 style={{
                   border: '1px solid var(--semantic-danger, #dc2626)',
                   background: 'var(--semantic-danger, #dc2626)',
@@ -878,6 +926,10 @@ export const SettingsPage: React.FC = () => {
                   padding: '0.625rem 1rem',
                   borderRadius: 'var(--radius-md, 0.5rem)',
                   opacity: deleteConfirmationText !== 'DELETE' || isDeletingAccount ? 0.55 : 1,
+                  cursor:
+                    deleteConfirmationText !== 'DELETE' || isDeletingAccount
+                      ? 'not-allowed'
+                      : 'pointer',
                 }}
               >
                 {isDeletingAccount ? 'Deleting…' : 'Yes, Delete Everything'}

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -94,6 +94,45 @@
 	}
 
 	# -------------------------------------------------------------------------
+	# /api/auth/* and /api/account/* — same-origin façade for Edge Functions.
+	#
+	# The Vite dev server proxies these to /functions/v1/auth-* and
+	# /functions/v1/account-* (apps/web/vite.config.ts). In production we
+	# need the exact same rewrite or every `/api/auth/*` and
+	# `/api/account/*` call falls through to the SPA `handle {}` block at
+	# the bottom of this file, returns 200 OK with the index.html body,
+	# and the client reads `response.ok === true`. That is what caused
+	# #1960 — "Delete account" reported success while the server never
+	# ran the edge function and zero rows were deleted.
+	#
+	# We use `uri replace` (not `handle_path`) because the edge function
+	# routing matches on the path *after* the `/functions/v1/` prefix has
+	# been stripped server-side; rewriting in-place preserves cookies and
+	# the Host header.
+	# -------------------------------------------------------------------------
+	@apiAuth path /api/auth/*
+	handle @apiAuth {
+		uri replace /api/auth/ /functions/v1/auth-
+		reverse_proxy edge-functions:9000 {
+			header_up X-Real-IP {remote_host}
+		}
+	}
+
+	# /api/account/delete-account must be rewritten BEFORE the generic
+	# /api/account/ rule because the edge function directory is named
+	# `account-delete` (without the trailing word "account"), not
+	# `account-delete-account`. Order matters here — Caddy evaluates the
+	# `uri replace` directives in the order they appear.
+	@apiAccount path /api/account/*
+	handle @apiAccount {
+		uri replace /api/account/delete-account /functions/v1/account-delete
+		uri replace /api/account/ /functions/v1/account-
+		reverse_proxy edge-functions:9000 {
+			header_up X-Real-IP {remote_host}
+		}
+	}
+
+	# -------------------------------------------------------------------------
 	# Health check endpoint (no auth required)
 	# -------------------------------------------------------------------------
 	handle /health {

--- a/deploy/Caddyfile.staging
+++ b/deploy/Caddyfile.staging
@@ -66,6 +66,29 @@
 	}
 
 	# -------------------------------------------------------------------------
+	# /api/auth/* and /api/account/* — same-origin façade for Edge Functions.
+	# Mirrors the Vite dev proxy (apps/web/vite.config.ts). Without these
+	# rewrites the client fetches fall through to the SPA fallback and
+	# silently "succeed" with an HTML body — see #1960.
+	# -------------------------------------------------------------------------
+	@apiAuth path /api/auth/*
+	handle @apiAuth {
+		uri replace /api/auth/ /functions/v1/auth-
+		reverse_proxy edge-functions:9000 {
+			header_up X-Real-IP {remote_host}
+		}
+	}
+
+	@apiAccount path /api/account/*
+	handle @apiAccount {
+		uri replace /api/account/delete-account /functions/v1/account-delete
+		uri replace /api/account/ /functions/v1/account-
+		reverse_proxy edge-functions:9000 {
+			header_up X-Real-IP {remote_host}
+		}
+	}
+
+	# -------------------------------------------------------------------------
 	# Health check endpoint (no auth required)
 	# -------------------------------------------------------------------------
 	handle /health {

--- a/services/api/supabase/functions/account-delete/index.ts
+++ b/services/api/supabase/functions/account-delete/index.ts
@@ -209,30 +209,51 @@ async function deleteAccountData(
   supabase: SupabaseAdminClient,
   user: AuthenticatedUser,
 ): Promise<void> {
+  // ---------------------------------------------------------------------
+  // Household deletion policy (issue #1962):
+  //
+  //   - Solely-owned households (no other members): DELETED entirely.
+  //     All child data rows and the household record itself are removed.
+  //
+  //   - Shared households (>=1 other member): the user's MEMBERSHIP is
+  //     removed and any data they personally owned (transactions,
+  //     budgets, goals, categories, accounts, etc.) is DELETED via the
+  //     USER_OWNED_TABLES loop below. The household entity and the
+  //     other members' data stay intact.
+  //
+  //     We intentionally do NOT silently transfer household ownership
+  //     ("created_by") to another member — that surprised collaborators
+  //     in alpha. If the deleting user was the recorded creator, the
+  //     historical `created_by` reference is cleared (best-effort —
+  //     ignored if the column is NOT NULL). The household continues to
+  //     exist for the remaining members.
+  //
+  // Delete order (must not change without testing — see #1960):
+  //   1. Resolve household memberships & ownership.
+  //   2. Crypto-shred user encryption keys (defense in depth — even if
+  //      a later step fails, encrypted data is unrecoverable).
+  //   3. Crypto-shred sole-household keys + delete sole-household rows.
+  //   4. Detach shared-household ownership references for this user.
+  //   5. Delete invitation + audit references that point at this user.
+  //   6. Delete every user-owned row across USER_OWNED_TABLES.
+  //   7. Delete the user's `household_members` rows and `users` row.
+  //   8. (Caller) Delete the Supabase Auth user LAST — keeps re-sign-in
+  //      flowing through a fresh signup so no data resurrects.
+  // ---------------------------------------------------------------------
   const plans = await loadHouseholdPlans(supabase, user.id);
   const soleHouseholdIds = plans
     .filter((plan) => plan.otherMemberUserIds.length === 0)
     .map((plan) => plan.householdId);
   const sharedHouseholds = plans.filter((plan) => plan.otherMemberUserIds.length > 0);
 
-  for (const plan of sharedHouseholds) {
-    if (plan.createdBy === user.id) {
-      await updateRows(
-        supabase,
-        'households',
-        { created_by: plan.otherMemberUserIds[0] },
-        'id',
-        plan.householdId,
-      );
-    }
-  }
-
+  // Step 2: crypto-shred user encryption keys (best-effort).
   await bestEffortRpc(supabase, 'destroy_user_encryption_keys', {
     p_user_id: user.id,
     p_destroyed_by: user.id,
     p_reason: 'account_deletion',
   });
 
+  // Step 3: crypto-shred + purge sole-owned households.
   for (const householdId of soleHouseholdIds) {
     await bestEffortRpc(supabase, 'destroy_household_encryption_keys', {
       p_household_id: householdId,
@@ -249,6 +270,22 @@ async function deleteAccountData(
     await deleteByIn(supabase, 'households', 'id', soleHouseholdIds);
   }
 
+  // Step 4: detach this user from shared-household ownership without
+  // silently re-assigning to another member. Best-effort — if `created_by`
+  // is NOT NULL the column update fails harmlessly and the household
+  // simply keeps its historical creator pointer (the user row itself is
+  // deleted below, so any FK from `households.created_by → users.id`
+  // would have prevented account deletion long before we got here; in
+  // practice the column is nullable, see #1962 discussion).
+  for (const plan of sharedHouseholds) {
+    if (plan.createdBy === user.id) {
+      await bestEffortUpdate(supabase, 'households', { created_by: null }, 'id', plan.householdId);
+    }
+  }
+
+  // Step 5: clear references that point AT this user from other people's
+  // invitations / audit rows. Without this, FK constraints can block the
+  // delete and the user's `users` row would survive.
   await updateRows(
     supabase,
     'household_invitations',
@@ -261,14 +298,21 @@ async function deleteAccountData(
   await deleteAnomalyRulesOwnedByUser(supabase, user.id);
   await deleteReferralRows(supabase, user.id);
 
+  // Step 6: delete every user-owned row. For shared households this is
+  // how the user's contributed data (transactions, budgets, etc.) is
+  // removed — they all carry `owner_id = user.id`.
   for (const [table, column] of USER_OWNED_TABLES) {
     await deleteByEq(supabase, table, column, user.id);
   }
 
+  // Step 7: remove key material and membership rows, then the user row.
   await deleteByEq(supabase, 'encryption_keys', 'destroyed_by', user.id);
   await deleteByEq(supabase, 'encryption_keys', 'user_id', user.id);
   await deleteByEq(supabase, 'household_members', 'user_id', user.id);
   await deleteByEq(supabase, 'users', 'id', user.id);
+  // Step 8 (`supabase.auth.admin.deleteUser`) is invoked by the caller —
+  // ALWAYS LAST so a partial failure leaves the auth row in place and
+  // the user can retry from a known state.
 }
 
 async function loadHouseholdPlans(
@@ -396,6 +440,33 @@ async function updateRows(
 ): Promise<void> {
   const { error } = await supabase.from(table).update(values).eq(column, value);
   if (error) throw error;
+}
+
+/**
+ * Like updateRows but never throws — used for "nice to clear" pointers
+ * such as `households.created_by` where a NOT NULL constraint or RLS
+ * failure must NOT block the rest of the deletion. Logged for review.
+ */
+async function bestEffortUpdate(
+  supabase: SupabaseAdminClient,
+  table: string,
+  values: Record<string, unknown>,
+  column: string,
+  value: string,
+): Promise<void> {
+  const { error } = await supabase.from(table).update(values).eq(column, value);
+  if (error) {
+    console.warn(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        level: 'warn',
+        function: 'account-delete',
+        table,
+        column,
+        message: error.message,
+      }),
+    );
+  }
 }
 
 function unauthorized(req: Request): Response {

--- a/services/api/supabase/functions/account-delete/index_test.ts
+++ b/services/api/supabase/functions/account-delete/index_test.ts
@@ -66,6 +66,72 @@ Deno.test('account-delete cascades sole-household data before deleting auth user
   assert(response.headers.get('Set-Cookie')?.includes('finance_refresh='));
 });
 
+Deno.test('account-delete rejects when confirmation token is missing', async () => {
+  withEnv();
+  const fake = createFakeSupabase();
+  const handler = createAccountDeleteHandler({
+    createClient: () => fake.client as unknown as AdminClient,
+  });
+
+  const response = await handler(
+    new Request('http://localhost/functions/v1/account-delete', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer access-token',
+      },
+      body: JSON.stringify({}),
+    }),
+  );
+
+  assertEquals(response.status, 400);
+  assertEquals(fake.operations.length, 0);
+  assertEquals(fake.deletedAuthUser, null);
+});
+
+Deno.test(
+  'account-delete does NOT silently transfer shared-household ownership (#1962)',
+  async () => {
+    withEnv();
+    const fake = createFakeSupabase({ sharedHousehold: true });
+    const handler = createAccountDeleteHandler({
+      createClient: () => fake.client as unknown as AdminClient,
+    });
+
+    const response = await handler(
+      new Request('http://localhost/functions/v1/account-delete', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer access-token',
+        },
+        body: JSON.stringify({ confirmation: 'DELETE' }),
+      }),
+    );
+
+    assertEquals(response.status, 204);
+    // The household entity itself must NOT be deleted (others still use it).
+    assert(!fake.operations.includes('delete:households'));
+    // The user's contributed rows in the shared household ARE deleted via
+    // owner_id (USER_OWNED_TABLES loop).
+    assert(fake.operations.includes('delete:transactions'));
+    assert(fake.operations.includes('delete:budgets'));
+    assert(fake.operations.includes('delete:goals'));
+    // created_by is cleared, NOT reassigned to another member.
+    const householdUpdates = fake.updates.filter((u) => u.table === 'households');
+    assert(householdUpdates.length > 0, 'expected an update to households');
+    for (const update of householdUpdates) {
+      assertEquals(
+        update.values.created_by,
+        null,
+        'created_by must be null, never another user_id',
+      );
+    }
+    // Auth user is still deleted last.
+    assertEquals(fake.deletedAuthUser, 'user-1');
+  },
+);
+
 function withEnv(): void {
   Deno.env.set('SUPABASE_URL', 'http://localhost:54321');
   Deno.env.set('SUPABASE_SERVICE_ROLE_KEY', 'service-role');
@@ -74,7 +140,9 @@ function withEnv(): void {
 
 interface FakeState {
   operations: string[];
+  updates: Array<{ table: string; values: Record<string, unknown> }>;
   deletedAuthUser: string | null;
+  sharedHousehold: boolean;
 }
 
 interface FakeClient {
@@ -88,8 +156,17 @@ interface FakeClient {
   from: (table: string) => FakeQuery;
 }
 
-function createFakeSupabase(): FakeState & { client: FakeClient } {
-  const state: FakeState = { operations: [], deletedAuthUser: null };
+interface FakeSupabaseOptions {
+  sharedHousehold?: boolean;
+}
+
+function createFakeSupabase(opts: FakeSupabaseOptions = {}): FakeState & { client: FakeClient } {
+  const state: FakeState = {
+    operations: [],
+    updates: [],
+    deletedAuthUser: null,
+    sharedHousehold: opts.sharedHousehold === true,
+  };
   const client = {
     auth: {
       getUser: (_token: string) =>
@@ -113,8 +190,12 @@ function createFakeSupabase(): FakeState & { client: FakeClient } {
   };
   return {
     operations: state.operations,
+    updates: state.updates,
     get deletedAuthUser() {
       return state.deletedAuthUser;
+    },
+    get sharedHousehold() {
+      return state.sharedHousehold;
     },
     client,
   };
@@ -123,6 +204,7 @@ function createFakeSupabase(): FakeState & { client: FakeClient } {
 class FakeQuery {
   private op: 'select' | 'delete' | 'update' | null = null;
   private filters = new Map<string, unknown>();
+  private updateValues: Record<string, unknown> | null = null;
 
   constructor(
     private readonly table: string,
@@ -140,9 +222,11 @@ class FakeQuery {
     return this;
   }
 
-  update(_values: Record<string, unknown>): this {
+  update(values: Record<string, unknown>): this {
     this.op = 'update';
+    this.updateValues = values;
     this.state.operations.push(`update:${this.table}`);
+    this.state.updates.push({ table: this.table, values });
     return this;
   }
 
@@ -180,7 +264,8 @@ class FakeQuery {
       return [{ household_id: 'household-1' }];
     }
     if (this.table === 'household_members' && this.filters.get('household_id') === 'household-1') {
-      return [];
+      // When shared, return another member; when sole, return empty.
+      return this.state.sharedHousehold ? [{ user_id: 'user-2' }] : [];
     }
     if (this.table === 'households') {
       return [{ id: 'household-1', created_by: 'user-1' }];

--- a/services/api/supabase/functions/account-deletion/index.ts
+++ b/services/api/supabase/functions/account-deletion/index.ts
@@ -1,6 +1,31 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /**
+ * @deprecated Use `account-delete/index.ts` instead (#1949, #1960).
+ *
+ * This handler implemented a SOFT-DELETE (setting `deleted_at` columns
+ * and shredding encryption keys) which left the underlying rows in
+ * place. The same OAuth identity could sign back in and PowerSync
+ * would re-hydrate every row because none of them were actually
+ * removed — the alpha-blocker reported in #1960.
+ *
+ * The active production handler is `account-delete/index.ts`, which
+ *   - deletes (not soft-deletes) every user-owned row,
+ *   - clears references that point at the user from other peoples'
+ *     audit / invitation rows,
+ *   - calls `supabase.auth.admin.deleteUser` LAST so re-sign-in goes
+ *     through a fresh signup flow,
+ * and is the one exposed at `/api/account/delete-account` via both the
+ * Vite dev proxy and the production Caddyfile.
+ *
+ * This file is kept for backwards compatibility with the public
+ * OpenAPI spec (`services/api/docs/README.md`) and existing audit-log
+ * references, but it is NOT mounted in `serve-functions.ts` and MUST
+ * NOT be re-wired without first replacing its soft-delete behaviour
+ * with a real cascade.
+ */
+
+/**
  * Account Deletion Edge Function (#98)
  *
  * GDPR Article 17 — Right to Erasure.


### PR DESCRIPTION
# Fix the account-deletion stack (alpha-blocker)

Three related bugs surfaced during the alpha E2E walkthrough. They form a
single failure mode end-to-end, so they are fixed together.

| Issue | Severity | Summary |
| --- | --- | --- |
| #1960 | CRITICAL | `Delete account` reported success but never deleted server-side data |
| #1961 | High | Typed-confirmation gate not enforced on the destructive button |
| #1962 | Medium | Confirmation dialog did not enumerate household / shared-data consequences |

## Root cause of #1960 (the data-integrity bug)

The web client correctly POSTs `/api/account/delete-account`, and the
Edge Function `services/api/supabase/functions/account-delete` is fully
implemented (it cascade-deletes user data and then calls
`supabase.auth.admin.deleteUser`).

In dev, `apps/web/vite.config.ts` rewrites `/api/account/delete-account`
to `/functions/v1/account-delete` and everything works.

**In production, the Caddyfile had no `/api/*` proxy rule.** The
`/api/account/delete-account` request fell through to the SPA fallback
(`handle { ... try_files {path} /index.html }`), which returned
`200 OK` with the index.html body. The client code only checked
`response.ok`, treated the HTML as success, cleared the local cache,
and signed out. On next sign-in PowerSync re-hydrated every row from
Postgres — because the server had never received a delete request.

## What changed

### `deploy/Caddyfile` + `deploy/Caddyfile.staging` (#1960)

Added two same-origin rewrites that mirror the Vite dev proxy:

```caddyfile
@apiAuth path /api/auth/*
handle @apiAuth {
    uri replace /api/auth/ /functions/v1/auth-
    reverse_proxy edge-functions:9000 { header_up X-Real-IP {remote_host} }
}

@apiAccount path /api/account/*
handle @apiAccount {
    uri replace /api/account/delete-account /functions/v1/account-delete
    uri replace /api/account/ /functions/v1/account-
    reverse_proxy edge-functions:9000 { header_up X-Real-IP {remote_host} }
}
```

Order matters in the `/api/account` block: the function directory is
named `account-delete`, not `account-delete-account`, so the specific
rewrite is declared first.

### `apps/web/src/pages/SettingsPage.tsx` (#1960, #1961, #1962)

- Destructive button now carries **`aria-disabled`** in addition to the
  native `disabled` attribute, with a `cursor: not-allowed` style.
- Handler retains the early-return on `deleteConfirmationText !== 'DELETE'`
  as defense in depth.
- **Defense-in-depth content-type check**: an `text/html` response (the
  exact failure mode behind #1960) is now treated as a failure and the
  client refuses to clear local data or redirect.
- Dialog bullets rewritten per #1962:
  - personal-data deletion
  - solely-owned households deleted entirely (count, only if `> 0`)
  - shared households: user removed, **user-contributed data deleted**,
    other members' data unaffected — no silent ownership transfer
  - pending invitations revoked (only if `> 0`)
  - OAuth / passkey identity unlinked → fresh-signup on re-sign-in
  - irreversibility
- Confirmation input gains `aria-describedby` pointing at a help line:
  "The deletion button stays disabled until you type the word DELETE
  exactly."

### `apps/web/src/components/gdpr/PrivacySettings.tsx` (#1961)

Removed the misleading two-step inline "Are you sure? **Yes, Delete
Everything**" confirmation. That UI had no typed-DELETE gate and used
the same button copy as the real modal — testers reasonably believed
the destructive action had fired. The button now hands off directly to
the parent's typed-DELETE modal, which is the single source of truth
for the gate. Dropped the now-unused `clearConsentData` import (consent
is cleared via `localStorage.clear()` after the server confirms the
deletion).

### `services/api/supabase/functions/account-delete/index.ts` (#1962)

- Removed the **silent ownership transfer** for shared households. The
  household's `created_by` pointer is best-effort set to `null` instead
  of being reassigned to a surprised collaborator.
- Added a large header comment on `deleteAccountData` documenting the
  household policy and the **exact delete order** (data first, auth user
  last — partial failures leave a recoverable state).

### `services/api/supabase/functions/account-deletion/index.ts`

Added a `@deprecated` banner at the top of the **old soft-delete**
handler so a future operator does not re-wire it by mistake. The
soft-delete behaviour was a contributing factor to #1960 conceptually
(it would have masked the same bug differently). The file is kept
because the OpenAPI spec and audit-log docs still reference it; it is
not mounted in `serve-functions.ts`.

## Tests

- `apps/web/src/pages/SettingsPage.test.tsx`
  - Verifies `aria-disabled` toggles with the typed token (incl. wrong
    case).
  - Verifies clicking the disabled destructive button does **not** call
    `fetch`.
  - New regression test for #1960: an HTML `200 OK` response surfaces
    an error and does **not** clear local data or redirect.
- `services/api/supabase/functions/account-delete/index_test.ts`
  - Rejects when the confirmation token is missing.
  - **Asserts no silent ownership transfer**: in the shared-household
    case the `households` row is updated with `created_by: null` (never
    another user_id) and the household itself is preserved.

## Local verification

- `npx vitest run` — 6373/6374 tests pass. The one failing test
  (`apps/web/src/utils/formatDate.test.ts`) is a pre-existing
  timezone-sensitive test that fails on `main` too (last touched in
  #1533); unrelated to this PR.
- `deno test --allow-all services/api/supabase/functions/account-delete/index_test.ts`
  — 5 / 5 pass.
- `npx tsc --noEmit` — clean.
- `npx eslint` on changed files — clean.

Fixes #1960
Fixes #1961
Fixes #1962
