### PR TITLE
fix(web): export + share polish (#1934, #1935, #1963, #1964)

### DIFF
--- a/apps/web/src/components/DataExport.test.tsx
+++ b/apps/web/src/components/DataExport.test.tsx
@@ -151,8 +151,11 @@ describe('DataExport', () => {
     expect(
       screen.getByRole('button', { name: /download transactions \(csv\)/i }),
     ).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /request my data/i })).toBeInTheDocument();
-    expect(screen.getByText(/plain JSON dump or transactions CSV/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /download all data \(csv zip\)/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /request my data package/i })).toBeInTheDocument();
+    expect(screen.getByText(/Download your data directly/i)).toBeInTheDocument();
     expect(screen.getByRole('status')).toHaveTextContent(/not requested/i);
   });
 
@@ -160,7 +163,7 @@ describe('DataExport', () => {
     render(<DataExport />, { wrapper: createTestWrapper(null) });
 
     expect(screen.getByText(/database is not available/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /request my data/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /request my data package/i })).toBeDisabled();
   });
 
   it('downloads a full JSON export directly from local data', async () => {
@@ -202,7 +205,7 @@ describe('DataExport', () => {
     const user = userEvent.setup();
     render(<DataExport />, { wrapper: createTestWrapper(createMockDb()) });
 
-    await user.click(screen.getByRole('button', { name: /request my data/i }));
+    await user.click(screen.getByRole('button', { name: /request my data package/i }));
 
     expect(screen.getByRole('dialog', { name: /request your data package/i })).toBeInTheDocument();
     expect(screen.getByLabelText(/include protected categories/i)).toBeChecked();
@@ -217,7 +220,7 @@ describe('DataExport', () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
     render(<DataExport />, { wrapper: createTestWrapper(createMockDb()) });
 
-    await user.click(screen.getByRole('button', { name: /request my data/i }));
+    await user.click(screen.getByRole('button', { name: /request my data package/i }));
     await user.click(screen.getByRole('button', { name: /generate package/i }));
     expect(screen.getByRole('status')).toHaveTextContent(/pending/i);
 
@@ -232,7 +235,7 @@ describe('DataExport', () => {
     const user = userEvent.setup();
     render(<DataExport />, { wrapper: createTestWrapper(createMockDb()) });
 
-    await user.click(screen.getByRole('button', { name: /request my data/i }));
+    await user.click(screen.getByRole('button', { name: /request my data package/i }));
     await user.click(screen.getByLabelText(/include mood tags/i));
     await user.click(screen.getByRole('button', { name: /generate package/i }));
 
@@ -242,18 +245,86 @@ describe('DataExport', () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it('delivers the ZIP through share/download fallback', async () => {
+  it('downloads the ZIP via the always-available download button', async () => {
     const user = userEvent.setup();
     render(<DataExport />, { wrapper: createTestWrapper(createMockDb()) });
 
-    await user.click(screen.getByRole('button', { name: /request my data/i }));
+    await user.click(screen.getByRole('button', { name: /request my data package/i }));
     await user.click(screen.getByRole('button', { name: /generate package/i }));
     await screen.findByText(/Package ready/i);
-    await user.click(screen.getByRole('button', { name: /share zip package/i }));
+    await user.click(screen.getByRole('button', { name: /^download zip$/i }));
 
     expect(URL.createObjectURL).toHaveBeenCalled();
     expect(
       screen.getAllByRole('status').some((status) => /delivered/i.test(status.textContent ?? '')),
     ).toBe(true);
+  });
+
+  it('hides Share button when navigator.share is not supported', async () => {
+    // Default beforeEach sets navigator.share = undefined.
+    const user = userEvent.setup();
+    render(<DataExport />, { wrapper: createTestWrapper(createMockDb()) });
+
+    await user.click(screen.getByRole('button', { name: /request my data package/i }));
+    await user.click(screen.getByRole('button', { name: /generate package/i }));
+    await screen.findByText(/Package ready/i);
+
+    expect(screen.queryByRole('button', { name: /share my exported package/i })).toBeNull();
+  });
+
+  it('disables Share button when no package has been generated yet', () => {
+    Object.defineProperty(navigator, 'share', { value: vi.fn(), configurable: true });
+    Object.defineProperty(navigator, 'canShare', {
+      value: vi.fn(() => true),
+      configurable: true,
+    });
+    render(<DataExport />, { wrapper: createTestWrapper(createMockDb()) });
+
+    const shareBtn = screen.getByRole('button', { name: /share my exported package/i });
+    expect(shareBtn).toBeDisabled();
+    expect(shareBtn).toHaveAttribute('title', expect.stringMatching(/generate a package first/i));
+    expect(screen.getByText(/opens your device's share sheet/i)).toBeInTheDocument();
+  });
+
+  it('silently dismisses share when the user cancels (AbortError)', async () => {
+    const shareSpy = vi.fn(() => Promise.reject(new DOMException('cancelled', 'AbortError')));
+    Object.defineProperty(navigator, 'share', { value: shareSpy, configurable: true });
+    Object.defineProperty(navigator, 'canShare', {
+      value: vi.fn(() => true),
+      configurable: true,
+    });
+    const user = userEvent.setup();
+    render(<DataExport />, { wrapper: createTestWrapper(createMockDb()) });
+
+    await user.click(screen.getByRole('button', { name: /request my data package/i }));
+    await user.click(screen.getByRole('button', { name: /generate package/i }));
+    await screen.findByText(/Package ready/i);
+    await user.click(screen.getByRole('button', { name: /share my exported package/i }));
+
+    await waitFor(() => expect(shareSpy).toHaveBeenCalled());
+    // No error banner.
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('renders an "unsupported" message when share rejects with NotAllowedError', async () => {
+    const shareSpy = vi.fn(() =>
+      Promise.reject(new DOMException('Permission denied', 'NotAllowedError')),
+    );
+    Object.defineProperty(navigator, 'share', { value: shareSpy, configurable: true });
+    Object.defineProperty(navigator, 'canShare', {
+      value: vi.fn(() => true),
+      configurable: true,
+    });
+    const user = userEvent.setup();
+    render(<DataExport />, { wrapper: createTestWrapper(createMockDb()) });
+
+    await user.click(screen.getByRole('button', { name: /request my data package/i }));
+    await user.click(screen.getByRole('button', { name: /generate package/i }));
+    await screen.findByText(/Package ready/i);
+    await user.click(screen.getByRole('button', { name: /share my exported package/i }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/sharing isn't available/i);
+    expect(alert).not.toHaveTextContent(/permission denied/i);
   });
 });

--- a/apps/web/src/components/DataExport.tsx
+++ b/apps/web/src/components/DataExport.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useDatabase } from '../db/DatabaseProvider';
 import type { SqliteDb } from '../db/sqlite-wasm';
 import { getAllAccounts } from '../db/repositories/accounts';
@@ -16,6 +16,7 @@ import {
   type DataAccessPackageResult,
 } from '../lib/data-access-package';
 import {
+  buildAllCsvZip,
   buildDatedExportFileName,
   buildFullJsonExport,
   buildTransactionsCsv,
@@ -48,7 +49,7 @@ export interface DataExportProps {
 const APP_VERSION = '0.1.0';
 
 const STRINGS = {
-  requestButton: 'Request my data',
+  requestButton: 'Request my data package',
   pending: 'Pending',
   generating: 'Generating',
   ready: 'Ready',
@@ -83,17 +84,17 @@ function useExportDatabase(): SqliteDb | null {
 }
 
 function readLocalStorageRecords(prefix: string): ExportRecord[] {
-  const records: ExportRecord[] = [];
-  for (let index = 0; index < localStorage.length; index += 1) {
-    const key = localStorage.key(index);
-    if (!key?.startsWith(prefix)) continue;
-    records.push({ key, value: localStorage.getItem(key) });
+  try {
+    const records: ExportRecord[] = [];
+    for (let index = 0; index < localStorage.length; index += 1) {
+      const key = localStorage.key(index);
+      if (!key?.startsWith(prefix)) continue;
+      records.push({ key, value: localStorage.getItem(key) });
+    }
+    return records;
+  } catch {
+    return [];
   }
-  return records;
-}
-
-function hasExportData(data: ExportData): boolean {
-  return Object.values(data).some((records) => records.length > 0);
 }
 
 function toExportRecords<T extends object>(records: readonly T[]): ExportRecord[] {
@@ -129,26 +130,99 @@ function triggerBrowserDownload(content: string, filename: string, mimeType: str
   }
 }
 
-async function shareOrDownloadPackage(
+function triggerBytesDownload(bytes: Uint8Array, filename: string, mimeType: string): void {
+  const blob = new Blob([bytes.slice().buffer], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.style.display = 'none';
+  document.body.appendChild(anchor);
+  try {
+    anchor.click();
+  } finally {
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+  }
+}
+
+type NavigatorWithShare = Navigator & {
+  canShare?: (data: ShareData) => boolean;
+  share?: (data: ShareData) => Promise<void>;
+};
+
+/**
+ * Probe whether the current browser actually supports sharing a file via the
+ * Web Share API Level 2.
+ *
+ * Desktop Edge/Chrome on Windows expose `navigator.share` but reject file
+ * payloads; calling `canShare({ files: [file] })` is the only reliable way to
+ * distinguish "share sheet available" from "share sheet only handles text".
+ */
+export function canShareFiles(file: File): boolean {
+  if (typeof navigator === 'undefined') return false;
+  const nav = navigator as NavigatorWithShare;
+  if (typeof nav.share !== 'function') return false;
+  if (typeof nav.canShare !== 'function') return false;
+  try {
+    return nav.canShare({ files: [file] });
+  } catch {
+    return false;
+  }
+}
+
+type ShareOutcome =
+  | { kind: 'shared' }
+  | { kind: 'cancelled' }
+  | { kind: 'unsupported' }
+  | { kind: 'error'; message: string };
+
+/**
+ * Attempt to open the system share sheet for a generated ZIP package.
+ *
+ * Distinguishes:
+ * - `AbortError` (user dismissed the sheet) → silent.
+ * - `NotAllowedError` (Permissions-Policy blocks share, browser doesn't allow
+ *   file share, or activation gesture was consumed) → clear "unsupported"
+ *   message.
+ * - Anything else → generic error with the underlying message.
+ */
+export async function shareZipPackage(
   packageResult: DataAccessPackageResult,
-): Promise<string | null> {
+): Promise<ShareOutcome> {
+  if (
+    typeof navigator === 'undefined' ||
+    typeof (navigator as NavigatorWithShare).share !== 'function'
+  ) {
+    return { kind: 'unsupported' };
+  }
+
   const file = new File([packageResult.zipBytes.slice().buffer], packageResult.fileName, {
     type: 'application/zip',
   });
-  const navigatorWithShare = navigator as Navigator & {
-    canShare?: (data: ShareData) => boolean;
-    share?: (data: ShareData) => Promise<void>;
-  };
 
-  if (
-    navigatorWithShare.share &&
-    (!navigatorWithShare.canShare || navigatorWithShare.canShare({ files: [file] }))
-  ) {
-    await navigatorWithShare.share({ files: [file], title: 'Finance data package' });
-    return null;
+  if (!canShareFiles(file)) {
+    return { kind: 'unsupported' };
   }
 
-  return downloadBytes(packageResult.zipBytes, packageResult.fileName, 'application/zip');
+  try {
+    await (navigator as NavigatorWithShare).share!({
+      files: [file],
+      title: 'Finance data package',
+    });
+    return { kind: 'shared' };
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      return { kind: 'cancelled' };
+    }
+    if (error instanceof DOMException && error.name === 'NotAllowedError') {
+      // Browser refused — typically a Permissions-Policy block or the
+      // user-activation requirement. Fall back gracefully.
+      return { kind: 'unsupported' };
+    }
+    const message = error instanceof Error ? error.message : 'Unable to open the share sheet.';
+    return { kind: 'error', message };
+  }
 }
 
 export const DataExport: React.FC<DataExportProps> = ({ className = '' }) => {
@@ -164,6 +238,23 @@ export const DataExport: React.FC<DataExportProps> = ({ className = '' }) => {
   const [expirationWarning, setExpirationWarning] = useState(false);
   const cancelledRef = useRef(false);
   const pendingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Feature-detect Web Share with file support. We can't run the check until
+  // a package exists (canShare wants a sample file), but `navigator.share`
+  // existing is a necessary precondition we can probe up front.
+  const shareApiPresent = useMemo(
+    () =>
+      typeof navigator !== 'undefined' &&
+      typeof (navigator as NavigatorWithShare).share === 'function',
+    [],
+  );
+  const shareSupported = useMemo(() => {
+    if (!shareApiPresent || !packageResult) return false;
+    const probe = new File([new Uint8Array(0)], packageResult.fileName, {
+      type: 'application/zip',
+    });
+    return canShareFiles(probe);
+  }, [shareApiPresent, packageResult]);
 
   useEffect(() => {
     return () => {
@@ -226,7 +317,6 @@ export const DataExport: React.FC<DataExportProps> = ({ className = '' }) => {
         if (!db)
           throw new Error('Database is still initializing. Please wait a moment and try again.');
         const data = gatherExportData(db, includeMoodTags);
-        if (!hasExportData(data)) throw new Error('No data available to export.');
 
         const result = buildDataAccessPackage(
           {
@@ -309,75 +399,194 @@ export const DataExport: React.FC<DataExportProps> = ({ className = '' }) => {
     }
   }, [db]);
 
-  const deliverPackage = useCallback(async () => {
-    if (!packageResult) return;
+  const downloadAllCsvZip = useCallback(() => {
+    setErrorMessage('');
+    setSimpleDownloadMessage('');
     try {
-      const url = await shareOrDownloadPackage(packageResult);
+      if (!db)
+        throw new Error('Database is still initializing. Please wait a moment and try again.');
+      const generatedAt = new Date();
+      const exportData = buildFullJsonExport(db, {
+        appVersion: APP_VERSION,
+        generatedAt,
+        preferences: readLocalStorageRecords('finance-'),
+        settings: readLocalStorageRecords('settings-'),
+      });
+      const zipBytes = buildAllCsvZip(exportData);
+      triggerBytesDownload(
+        zipBytes,
+        buildDatedExportFileName('finance-data-csv', 'zip', generatedAt),
+        'application/zip',
+      );
+      setSimpleDownloadMessage('All-data CSV (ZIP) download started.');
+    } catch (error) {
+      setStatus('error');
+      setErrorMessage(error instanceof Error ? error.message : 'Unable to download CSV ZIP.');
+    }
+  }, [db]);
+
+  const downloadPackage = useCallback(() => {
+    if (!packageResult) return;
+    setErrorMessage('');
+    try {
+      const url = downloadBytes(packageResult.zipBytes, packageResult.fileName, 'application/zip');
       if (objectUrl) URL.revokeObjectURL(objectUrl);
       setObjectUrl(url);
       setStatus('delivered');
+      setSimpleDownloadMessage('ZIP download started.');
     } catch (error) {
       setStatus('error');
-      setErrorMessage(error instanceof Error ? error.message : 'Unable to open the share sheet.');
+      setErrorMessage(error instanceof Error ? error.message : 'Unable to download the package.');
     }
   }, [objectUrl, packageResult]);
+
+  const sharePackage = useCallback(async () => {
+    if (!packageResult) return;
+    setErrorMessage('');
+    const outcome = await shareZipPackage(packageResult);
+    switch (outcome.kind) {
+      case 'shared':
+        setStatus('delivered');
+        return;
+      case 'cancelled':
+        // Per platform UX guidance: a user-cancelled share is not an error.
+        return;
+      case 'unsupported':
+        setStatus('error');
+        setErrorMessage("Sharing isn't available in this browser. Use Download ZIP instead.");
+        return;
+      case 'error':
+        setStatus('error');
+        setErrorMessage(
+          `Couldn't open the share sheet — ${outcome.message}. Try downloading instead.`,
+        );
+        return;
+    }
+  }, [packageResult]);
+
+  const requestDisabled = dbUnavailable || status === 'pending' || status === 'generating';
 
   return (
     <div className={`data-export ${className}`.trim()}>
       <p id="data-export-description" className="data-export__description">
         {dbUnavailable
           ? 'Database is not available. Please wait for it to initialize.'
-          : 'Download a plain JSON dump or transactions CSV immediately, or generate the advanced local ZIP package. No server roundtrip is used.'}
+          : 'Download your data directly, or generate a signed ZIP package for sharing. Everything happens on this device — no server roundtrip.'}
       </p>
 
-      <div
-        className="data-export__button-group"
-        role="group"
-        aria-labelledby="data-export-description"
-      >
-        <button
-          type="button"
-          className="data-export__button"
-          disabled={dbUnavailable || status === 'pending' || status === 'generating'}
-          onClick={downloadFullJson}
-          aria-describedby="data-export-description"
-        >
-          <DownloadIcon />
-          Download all data (JSON)
-        </button>
-        <button
-          type="button"
-          className="data-export__button"
-          disabled={dbUnavailable || status === 'pending' || status === 'generating'}
-          onClick={downloadTransactionsCsv}
-          aria-describedby="data-export-description"
-        >
-          <DownloadIcon />
-          Download transactions (CSV)
-        </button>
-        <button
-          type="button"
-          className="data-export__button"
-          disabled={dbUnavailable || status === 'pending' || status === 'generating'}
-          onClick={startRequest}
-          aria-describedby="data-export-description"
-        >
-          <DownloadIcon />
-          {STRINGS.requestButton}
-        </button>
-        {(status === 'pending' || status === 'generating') && (
-          <button type="button" className="data-export__button" onClick={cancelRequest}>
-            Cancel request
-          </button>
-        )}
-        {packageResult && status !== 'pending' && status !== 'generating' && (
+      <div className="data-export__group" role="group" aria-labelledby="data-export-direct-heading">
+        <h4 id="data-export-direct-heading" className="data-export__group-title">
+          Direct download
+        </h4>
+        <p className="data-export__group-help">
+          One-click downloads that work for both fresh and populated accounts.
+        </p>
+        <div className="data-export__button-row">
           <button
             type="button"
             className="data-export__button"
-            onClick={() => void deliverPackage()}
+            disabled={requestDisabled}
+            onClick={downloadFullJson}
+            aria-describedby="data-export-description"
           >
-            Share ZIP package
+            <DownloadIcon />
+            Download all data (JSON)
           </button>
+          <button
+            type="button"
+            className="data-export__button"
+            disabled={requestDisabled}
+            onClick={downloadAllCsvZip}
+            aria-describedby="data-export-description"
+          >
+            <DownloadIcon />
+            Download all data (CSV ZIP)
+          </button>
+          <button
+            type="button"
+            className="data-export__button"
+            disabled={requestDisabled}
+            onClick={downloadTransactionsCsv}
+            aria-describedby="data-export-description"
+          >
+            <DownloadIcon />
+            Download transactions (CSV)
+          </button>
+        </div>
+      </div>
+
+      <div
+        className="data-export__group"
+        role="group"
+        aria-labelledby="data-export-package-heading"
+      >
+        <h4 id="data-export-package-heading" className="data-export__group-title">
+          Signed data package
+        </h4>
+        <p className="data-export__group-help">
+          A signed ZIP with a manifest, README, and per-entity JSON files. Kept on-device for 7
+          days.
+        </p>
+        <div className="data-export__button-row">
+          <button
+            type="button"
+            className="data-export__button"
+            disabled={requestDisabled}
+            onClick={startRequest}
+          >
+            <DownloadIcon />
+            {STRINGS.requestButton}
+          </button>
+          {(status === 'pending' || status === 'generating') && (
+            <button type="button" className="data-export__button" onClick={cancelRequest}>
+              Cancel request
+            </button>
+          )}
+          {packageResult && status !== 'pending' && status !== 'generating' && (
+            <>
+              <button
+                type="button"
+                className="data-export__button data-export__button--primary"
+                onClick={downloadPackage}
+              >
+                <DownloadIcon />
+                Download ZIP
+              </button>
+              {shareApiPresent && (
+                <button
+                  type="button"
+                  className="data-export__button"
+                  onClick={() => void sharePackage()}
+                  disabled={!shareSupported}
+                  aria-describedby="data-export-share-help"
+                  title={
+                    shareSupported
+                      ? undefined
+                      : "Sharing isn't available in this browser — use Download ZIP."
+                  }
+                >
+                  Share my exported package
+                </button>
+              )}
+            </>
+          )}
+          {!packageResult && shareApiPresent && (
+            <button
+              type="button"
+              className="data-export__button"
+              disabled
+              aria-describedby="data-export-share-help"
+              title="Generate a package first, then share."
+            >
+              Share my exported package
+            </button>
+          )}
+        </div>
+        {shareApiPresent && (
+          <p id="data-export-share-help" className="data-export__group-help">
+            Opens your device's share sheet (Files, AirDrop, Messages, etc.).
+            {!packageResult && ' Generate a package first.'}
+          </p>
         )}
       </div>
 
@@ -406,36 +615,58 @@ export const DataExport: React.FC<DataExportProps> = ({ className = '' }) => {
           role="dialog"
           aria-modal="true"
           aria-labelledby="data-export-confirm-title"
-          className="data-export__feedback"
+          aria-describedby="data-export-confirm-body"
+          className="data-export__dialog"
         >
-          <h4 id="data-export-confirm-title">Request your data package?</h4>
-          <p>
+          <h4 id="data-export-confirm-title" className="data-export__dialog-title">
+            Request your data package
+          </h4>
+          <p id="data-export-confirm-body" className="data-export__dialog-body">
             Finance will include transactions, accounts, budgets, goals, recurring rules,
             categories, tags, attachments, preferences, settings, audit log entries, and sync
             metadata. The ZIP is generated on this device and is available in-app for 7 days.
           </p>
-          <p>
-            Mood tag data can reveal sensitive wellbeing patterns. It is excluded by default and
-            only included if you opt in for this request.
-          </p>
-          <label>
-            <input
-              type="checkbox"
-              checked={includeProtectedCategories}
-              onChange={(event) => setIncludeProtectedCategories(event.target.checked)}
-            />
-            Include protected categories (included by default)
-          </label>
-          <label>
-            <input
-              type="checkbox"
-              checked={includeMoodTags}
-              onChange={(event) => setIncludeMoodTags(event.target.checked)}
-            />
-            Include mood tags for this request
-          </label>
-          <div className="data-export__button-group">
-            <button type="button" className="data-export__button" onClick={confirmRequest}>
+
+          <fieldset className="data-export__fieldset">
+            <legend className="data-export__legend">Privacy options</legend>
+
+            <label className="data-export__option">
+              <input
+                type="checkbox"
+                className="data-export__checkbox"
+                checked={includeProtectedCategories}
+                onChange={(event) => setIncludeProtectedCategories(event.target.checked)}
+              />
+              <span className="data-export__option-text">
+                <span className="data-export__option-label">Include protected categories</span>
+                <span className="data-export__option-help">
+                  Sensitive categories like medical or debt. Included by default.
+                </span>
+              </span>
+            </label>
+
+            <label className="data-export__option">
+              <input
+                type="checkbox"
+                className="data-export__checkbox"
+                checked={includeMoodTags}
+                onChange={(event) => setIncludeMoodTags(event.target.checked)}
+              />
+              <span className="data-export__option-text">
+                <span className="data-export__option-label">Include mood tags</span>
+                <span className="data-export__option-help">
+                  Mood tag data can reveal sensitive wellbeing patterns. Off by default.
+                </span>
+              </span>
+            </label>
+          </fieldset>
+
+          <div className="data-export__dialog-actions">
+            <button
+              type="button"
+              className="data-export__button data-export__button--primary"
+              onClick={confirmRequest}
+            >
               Generate package
             </button>
             <button type="button" className="data-export__button" onClick={cancelRequest}>
@@ -541,8 +772,7 @@ const CheckIcon: React.FC = () => (
     viewBox="0 0 24 24"
     fill="none"
     aria-hidden="true"
-    className="data-export__icon data-export__icon--shrink"
-    style={{ stroke: 'var(--semantic-status-positive)' }}
+    className="data-export__icon data-export__icon--shrink data-export__icon--positive"
   >
     <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
     <polyline points="22 4 12 14.01 9 11.01" />
@@ -556,8 +786,7 @@ const ErrorIcon: React.FC = () => (
     viewBox="0 0 24 24"
     fill="none"
     aria-hidden="true"
-    className="data-export__icon data-export__icon--shrink"
-    style={{ stroke: 'var(--semantic-status-negative)' }}
+    className="data-export__icon data-export__icon--shrink data-export__icon--negative"
   >
     <circle cx="12" cy="12" r="10" />
     <line x1="12" y1="8" x2="12" y2="12" />

--- a/apps/web/src/components/data-export.css
+++ b/apps/web/src/components/data-export.css
@@ -7,12 +7,49 @@
  * Uses design-token CSS custom properties throughout.
  * ------------------------------------------------------------------- */
 
+.data-export {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
 .data-export__description {
   font-size: var(--type-scale-body-font-size);
   color: var(--semantic-text-secondary);
-  margin-bottom: var(--spacing-4);
+  margin: 0;
 }
 
+/* Action groups (Direct download / Signed data package) */
+.data-export__group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  padding: var(--spacing-3) var(--spacing-4);
+  border: 1px solid var(--semantic-border-default, var(--semantic-interactive-default));
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-surface-secondary, transparent);
+}
+
+.data-export__group-title {
+  margin: 0;
+  font-size: var(--type-scale-body-font-size);
+  font-weight: var(--font-weight-medium);
+  color: var(--semantic-text-primary);
+}
+
+.data-export__group-help {
+  margin: 0;
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+.data-export__button-row {
+  display: flex;
+  gap: var(--spacing-3);
+  flex-wrap: wrap;
+}
+
+/* Legacy class kept for any external selectors still pointing at it. */
 .data-export__button-group {
   display: flex;
   gap: var(--spacing-3);
@@ -31,6 +68,12 @@
   cursor: pointer;
   font-size: var(--type-scale-body-font-size);
   font-weight: var(--font-weight-medium);
+  white-space: nowrap;
+}
+
+.data-export__button--primary {
+  background: var(--semantic-interactive-default);
+  color: var(--semantic-text-on-interactive, #fff);
 }
 
 .data-export__button:disabled {
@@ -43,9 +86,107 @@
   outline-offset: 2px;
 }
 
+/* -------------------------------------------------------------------
+ * Confirmation dialog — single-column vertical form
+ * ------------------------------------------------------------------- */
+
+.data-export__dialog {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+  padding: var(--spacing-4);
+  border-radius: var(--border-radius-md);
+  border: 1px solid var(--semantic-border-default, var(--semantic-interactive-default));
+  background: var(--semantic-surface-primary, transparent);
+}
+
+.data-export__dialog-title {
+  margin: 0;
+  font-size: var(--type-scale-heading-3-font-size, 1.125rem);
+  font-weight: var(--font-weight-semibold, 600);
+  color: var(--semantic-text-primary);
+}
+
+.data-export__dialog-body {
+  margin: 0;
+  font-size: var(--type-scale-body-font-size);
+  color: var(--semantic-text-secondary);
+  line-height: 1.5;
+}
+
+.data-export__fieldset {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+  margin: 0;
+  padding: var(--spacing-3) var(--spacing-4);
+  border: 1px solid var(--semantic-border-default, var(--semantic-interactive-default));
+  border-radius: var(--border-radius-md);
+  min-width: 0;
+}
+
+.data-export__legend {
+  padding: 0 var(--spacing-2);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-medium);
+  color: var(--semantic-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.data-export__option {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  column-gap: var(--spacing-3);
+  align-items: start;
+  cursor: pointer;
+  min-width: 0;
+}
+
+.data-export__checkbox {
+  margin-top: 0.2rem;
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
+}
+
+.data-export__option-text {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+  min-width: 0;
+}
+
+.data-export__option-label {
+  font-size: var(--type-scale-body-font-size);
+  font-weight: var(--font-weight-medium);
+  color: var(--semantic-text-primary);
+  /* Critical: keep label on one line where possible, otherwise wrap at word
+   * boundaries — never break to one syllable per line (#1934). */
+  white-space: normal;
+  word-break: normal;
+  overflow-wrap: break-word;
+  line-height: 1.4;
+}
+
+.data-export__option-help {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+  white-space: normal;
+  word-break: normal;
+  overflow-wrap: break-word;
+  line-height: 1.4;
+}
+
+.data-export__dialog-actions {
+  display: flex;
+  gap: var(--spacing-3);
+  flex-wrap: wrap;
+}
+
 /* Progress section */
 .data-export__progress {
-  margin-top: var(--spacing-4);
+  margin-top: 0;
 }
 
 .data-export__progress-text {
@@ -56,7 +197,7 @@
 
 /* Success / error feedback */
 .data-export__feedback {
-  margin-top: var(--spacing-4);
+  margin-top: 0;
   display: flex;
   align-items: center;
   gap: var(--spacing-2);
@@ -113,6 +254,14 @@
   flex-shrink: 0;
 }
 
+.data-export__icon--positive {
+  stroke: var(--semantic-status-positive);
+}
+
+.data-export__icon--negative {
+  stroke: var(--semantic-status-negative);
+}
+
 .data-export__spinner-icon {
   animation: spinner-rotate 1s linear infinite;
 }
@@ -120,6 +269,23 @@
 .data-export__progress-fill {
   width: 100%;
   animation: export-progress 0.8s ease-in-out infinite alternate;
+}
+
+/* -------------------------------------------------------------------
+ * Responsive: keep dialog single-column on mobile; on wider viewports allow
+ * the two privacy-options checkboxes to sit side by side.
+ * ------------------------------------------------------------------- */
+
+@media (min-width: 720px) {
+  .data-export__fieldset {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    column-gap: var(--spacing-6, 1.5rem);
+    row-gap: var(--spacing-3);
+  }
+  .data-export__legend {
+    grid-column: 1 / -1;
+  }
 }
 
 /* -------------------------------------------------------------------
@@ -191,7 +357,10 @@
   }
 
   .data-export__feedback--success,
-  .data-export__feedback--error {
+  .data-export__feedback--error,
+  .data-export__group,
+  .data-export__dialog,
+  .data-export__fieldset {
     border-width: 2px;
   }
 }

--- a/apps/web/src/lib/data-access-package.ts
+++ b/apps/web/src/lib/data-access-package.ts
@@ -348,9 +348,24 @@ function sanitizePathSegment(value: string): string {
   return value.replace(/[^A-Za-z0-9._-]/g, '_') || 'attachment';
 }
 
-interface ZipEntry {
+/**
+ * Entry in a ZIP archive built by {@link buildZipArchive}.
+ *
+ * @public
+ */
+export interface ZipEntry {
   path: string;
   bytes: Uint8Array;
+}
+
+/**
+ * Build a minimal, store-only (uncompressed) ZIP archive. Shared zip utility
+ * used by both the data-access package and the per-entity CSV export.
+ *
+ * @public
+ */
+export function buildZipArchive(files: readonly ZipEntry[]): Uint8Array {
+  return buildZip(files);
 }
 
 function buildZip(files: readonly ZipEntry[]): Uint8Array {

--- a/apps/web/src/lib/export/simple-export.test.ts
+++ b/apps/web/src/lib/export/simple-export.test.ts
@@ -3,8 +3,11 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { SqliteDb } from '../../db/sqlite-wasm';
 import {
+  buildAllCsvZip,
   buildDatedExportFileName,
+  buildEntityCsvFiles,
   buildFullJsonExport,
+  buildGenericCsv,
   buildTransactionsCsv,
   escapeCsvField,
   serializeFullJsonExport,
@@ -107,6 +110,35 @@ describe('simple-export', () => {
     expect(serializeFullJsonExport(result)).toContain('"transactions"');
   });
 
+  it('degrades to an empty list when a repository throws (not just no-such-table)', async () => {
+    const accounts = await import('../../db/repositories/accounts');
+    const transactions = await import('../../db/repositories/transactions');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    // A populated row that fails strict mapping (e.g. missing required
+    // household_id on a pre-migration legacy row) used to abort the whole
+    // export with an unhandled exception. The export now logs + skips so
+    // every other entity is still serialized. (Regression: #1963.)
+    const original = vi.mocked(accounts.getAllAccounts).getMockImplementation();
+    vi.mocked(accounts.getAllAccounts).mockImplementationOnce(() => {
+      throw new Error('Missing required field: account.household_id');
+    });
+    try {
+      const result = buildFullJsonExport(createMockDb(), {
+        appVersion: '0.1.0',
+        generatedAt: new Date('2026-05-26T12:00:00Z'),
+      });
+      expect(result.accounts).toEqual([]);
+      // Other repos still resolve normally.
+      expect(result.transactions.length).toBeGreaterThan(0);
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      if (original) vi.mocked(accounts.getAllAccounts).mockImplementation(original);
+      warnSpy.mockRestore();
+      // Ensure transactions mock is untouched.
+      expect(vi.mocked(transactions.getAllTransactions)).toBeDefined();
+    }
+  });
+
   it('builds denormalized transaction CSV with manual escaping', () => {
     const csv = buildTransactionsCsv({
       accounts: [{ id: 'acc-1', name: 'Checking' }],
@@ -136,5 +168,90 @@ describe('simple-export', () => {
     expect(buildDatedExportFileName('finance-data', 'json', new Date('2026-05-26T12:00:00Z'))).toBe(
       'finance-data-2026-05-26.json',
     );
+    expect(
+      buildDatedExportFileName('finance-data-csv', 'zip', new Date('2026-05-26T12:00:00Z')),
+    ).toBe('finance-data-csv-2026-05-26.zip');
+  });
+
+  it('builds per-entity CSV files with stable filenames and header-only output for empty entities', () => {
+    const exportData = buildFullJsonExport(createMockDb(), {
+      appVersion: '0.1.0',
+      generatedAt: new Date('2026-05-26T12:00:00Z'),
+    });
+    const files = buildEntityCsvFiles(exportData);
+    const names = files.map((f) => f.name);
+    expect(names).toEqual(
+      expect.arrayContaining([
+        'accounts.csv',
+        'transactions.csv',
+        'categories.csv',
+        'budgets.csv',
+        'goals.csv',
+        'bills.csv',
+        'investments.csv',
+        'investment_lots.csv',
+        'households.csv',
+        'household_members.csv',
+        'household_invitations.csv',
+        'account_sharings.csv',
+        'shared_budgets.csv',
+        'budget_contributions.csv',
+        'shared_goals.csv',
+        'goal_contributions.csv',
+        'preferences.csv',
+        'settings.csv',
+      ]),
+    );
+
+    // Every file is non-empty (at minimum a header row), even when there are
+    // no records — fresh-account users can still open the file.
+    for (const file of files) {
+      expect(file.contents.length).toBeGreaterThan(0);
+      expect(file.contents.endsWith('\r\n')).toBe(true);
+    }
+
+    const accountsCsv = files.find((file) => file.name === 'accounts.csv');
+    expect(accountsCsv?.contents).toMatch(/^currency,householdId,id,name\r\n/);
+
+    const empty = files.find((file) => file.name === 'household_invitations.csv');
+    expect(empty?.contents).toBe('(empty)\r\n');
+  });
+
+  it('produces a ZIP archive containing manifest.json and per-entity CSVs', () => {
+    const exportData = buildFullJsonExport(createMockDb(), {
+      appVersion: '0.1.0',
+      generatedAt: new Date('2026-05-26T12:00:00Z'),
+    });
+    const zipBytes = buildAllCsvZip(exportData);
+
+    // ZIP files always start with the "PK\003\004" local-file-header signature.
+    expect(zipBytes[0]).toBe(0x50);
+    expect(zipBytes[1]).toBe(0x4b);
+    expect(zipBytes[2]).toBe(0x03);
+    expect(zipBytes[3]).toBe(0x04);
+
+    // The filenames are stored in the central directory verbatim; assert a few
+    // expected paths appear in the byte stream.
+    const text = new TextDecoder().decode(zipBytes);
+    expect(text).toContain('manifest.json');
+    expect(text).toContain('accounts.csv');
+    expect(text).toContain('transactions.csv');
+    expect(text).toContain('preferences.csv');
+  });
+
+  it('flattens nested objects in generic CSV by JSON-stringifying values', () => {
+    const csv = buildGenericCsv([
+      { id: 'a-1', amount: { value: 100, currency: 'USD' }, tags: ['food', 'cash'] },
+      { id: 'a-2', amount: { value: 200, currency: 'EUR' }, tags: [] },
+    ]);
+    const [header, row1, row2] = csv.trim().split('\r\n');
+    expect(header).toBe('amount,id,tags');
+    expect(row1).toContain('"{""value"":100,""currency"":""USD""}"');
+    expect(row1).toContain('a-1');
+    expect(row2).toContain('a-2');
+  });
+
+  it('returns an empty-marker CSV when the collection is empty', () => {
+    expect(buildGenericCsv([])).toBe('(empty)\r\n');
   });
 });

--- a/apps/web/src/lib/export/simple-export.ts
+++ b/apps/web/src/lib/export/simple-export.ts
@@ -19,6 +19,7 @@ import {
 import { getAllInvestments } from '../../db/repositories/investments';
 import { getLotsByInvestment } from '../../db/repositories/investment-lots';
 import { getAllTransactions } from '../../db/repositories/transactions';
+import { buildZipArchive, type ZipEntry } from '../data-access-package';
 
 type HouseholdRecord = NonNullable<ReturnType<typeof getHouseholdById>>;
 
@@ -186,6 +187,153 @@ export function buildTransactionsCsvExport(db: SqliteDb): string {
   return buildTransactionsCsv(buildFullJsonExport(db));
 }
 
+/** A single CSV file produced by {@link buildEntityCsvFiles}. */
+export interface EntityCsvFile {
+  /** Filename (no path) — e.g. `transactions.csv`. */
+  name: string;
+  /** UTF-8 encoded CSV body, header row + data rows. */
+  contents: string;
+}
+
+const FULL_EXPORT_ENTITY_KEYS = [
+  'accounts',
+  'transactions',
+  'categories',
+  'budgets',
+  'goals',
+  'bills',
+  'investments',
+  'investmentLots',
+  'households',
+  'householdMembers',
+  'householdInvitations',
+  'accountSharings',
+  'sharedBudgets',
+  'budgetContributions',
+  'sharedGoals',
+  'goalContributions',
+  'preferences',
+  'settings',
+] as const satisfies readonly (keyof FullJsonExport)[];
+
+/** Map camelCase JSON keys to snake_case CSV filenames for the per-entity zip. */
+const CSV_FILENAMES: Record<(typeof FULL_EXPORT_ENTITY_KEYS)[number], string> = {
+  accounts: 'accounts.csv',
+  transactions: 'transactions.csv',
+  categories: 'categories.csv',
+  budgets: 'budgets.csv',
+  goals: 'goals.csv',
+  bills: 'bills.csv',
+  investments: 'investments.csv',
+  investmentLots: 'investment_lots.csv',
+  households: 'households.csv',
+  householdMembers: 'household_members.csv',
+  householdInvitations: 'household_invitations.csv',
+  accountSharings: 'account_sharings.csv',
+  sharedBudgets: 'shared_budgets.csv',
+  budgetContributions: 'budget_contributions.csv',
+  sharedGoals: 'shared_goals.csv',
+  goalContributions: 'goal_contributions.csv',
+  preferences: 'preferences.csv',
+  settings: 'settings.csv',
+};
+
+/**
+ * Build one CSV per entity from a full JSON export. Each file always emits a
+ * header row — even when the entity has no records — so the output is
+ * consistent for fresh-account users.
+ */
+export function buildEntityCsvFiles(exportData: FullJsonExport): EntityCsvFile[] {
+  return FULL_EXPORT_ENTITY_KEYS.map((key) => {
+    const records = (exportData[key] as readonly unknown[] | undefined) ?? [];
+    return {
+      name: CSV_FILENAMES[key],
+      contents: buildGenericCsv(records),
+    };
+  });
+}
+
+/**
+ * Build a ZIP containing one CSV per entity plus a small manifest.
+ * Used by the "Download all data (CSV)" action.
+ */
+export function buildAllCsvZip(exportData: FullJsonExport): Uint8Array {
+  const encoder = new TextEncoder();
+  const csvFiles = buildEntityCsvFiles(exportData);
+  const manifest = {
+    schemaVersion: exportData.schemaVersion,
+    generatedAt: exportData.generatedAt,
+    appVersion: exportData.appVersion,
+    files: csvFiles.map((file) => ({ name: file.name })),
+  };
+  const entries: ZipEntry[] = [
+    { path: 'manifest.json', bytes: encoder.encode(`${JSON.stringify(manifest, null, 2)}\n`) },
+    ...csvFiles.map((file) => ({ path: file.name, bytes: encoder.encode(file.contents) })),
+  ];
+  return buildZipArchive(entries);
+}
+
+/**
+ * Build a CSV body for an arbitrary collection of plain objects.
+ *
+ * - Headers are the union of all top-level keys across rows, sorted for
+ *   determinism.
+ * - Nested objects and arrays are JSON-stringified into a single cell.
+ * - When the collection is empty, returns the header `(empty)` so the file
+ *   is still a valid CSV that downstream tools can open.
+ */
+export function buildGenericCsv(records: readonly unknown[]): string {
+  if (records.length === 0) {
+    return '(empty)\r\n';
+  }
+
+  const headers = collectHeaders(records);
+  const lines: string[] = [headers.map(escapeCsvField).join(',')];
+  for (const record of records) {
+    const flat = isPlainRecord(record) ? flattenForCsv(record) : { value: stringify(record) };
+    lines.push(headers.map((header) => escapeCsvField(flat[header] ?? '')).join(','));
+  }
+  return `${lines.join('\r\n')}\r\n`;
+}
+
+function collectHeaders(records: readonly unknown[]): string[] {
+  const headerSet = new Set<string>();
+  for (const record of records) {
+    if (!isPlainRecord(record)) {
+      headerSet.add('value');
+      continue;
+    }
+    for (const key of Object.keys(flattenForCsv(record))) {
+      headerSet.add(key);
+    }
+  }
+  return [...headerSet].sort();
+}
+
+function flattenForCsv(record: Record<string, unknown>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(record)) {
+    out[key] = stringify(value);
+  }
+  return out;
+}
+
+function stringify(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (typeof value === 'bigint') return value.toString();
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 export function escapeCsvField(value: unknown): string {
   const text = value == null ? '' : String(value);
   if (!/[",\r\n]/.test(text)) return text;
@@ -194,7 +342,7 @@ export function escapeCsvField(value: unknown): string {
 
 export function buildDatedExportFileName(
   prefix: string,
-  extension: 'csv' | 'json',
+  extension: 'csv' | 'json' | 'zip',
   generatedAt = new Date(),
 ): string {
   return `${prefix}-${generatedAt.toISOString().slice(0, 10)}.${extension}`;
@@ -204,8 +352,12 @@ function readOptionalTable<T>(read: () => T[]): T[] {
   try {
     return read();
   } catch (error) {
-    if (isMissingOptionalTable(error)) return [];
-    throw error;
+    // Always degrade gracefully: an export must not abort because a single
+    // optional table or row is missing / partially populated. Missing tables
+    // and stricter row-validation errors (missing required fields on
+    // pre-migration rows) both surface as `Error` instances.
+    logExportReadFailure(error);
+    return [];
   }
 }
 
@@ -213,14 +365,20 @@ function readOptionalRecord<T>(read: () => T | null): T | null {
   try {
     return read();
   } catch (error) {
-    if (isMissingOptionalTable(error)) return null;
-    throw error;
+    logExportReadFailure(error);
+    return null;
   }
 }
 
-function isMissingOptionalTable(error: unknown): boolean {
-  return error instanceof Error && /no such table/i.test(error.message);
+/* eslint-disable no-console -- intentional diagnostic for export read failures */
+function logExportReadFailure(error: unknown): void {
+  // Surface in dev so we can diagnose; never throw — the export is best-effort
+  // and must always produce a downloadable artifact.
+  if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+    console.warn('[export] skipping unreadable table:', error);
+  }
 }
+/* eslint-enable no-console */
 
 function collectHouseholdIds(
   recordGroups: readonly (readonly { householdId?: string | null }[])[],

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -44,8 +44,11 @@
 		# Referrer policy
 		Referrer-Policy "strict-origin-when-cross-origin"
 
-		# Permissions-Policy — restrict sensitive browser APIs
-		Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(self)"
+		# Permissions-Policy — restrict sensitive browser APIs.
+		# `web-share=(self)` explicitly grants the Web Share API to the app
+		# origin so navigator.share() / canShare({ files }) is not blocked by
+		# a stricter default policy (#1935).
+		Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(self), web-share=(self)"
 
 		# Content Security Policy — strict, no inline scripts, no eval
 		Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; worker-src 'self'"


### PR DESCRIPTION
## Summary

Polish bundle for the Data Export + Share flow surfaced in the alpha walkthrough.

Fixes #1934
Fixes #1935
Fixes #1963
Fixes #1964

## Changes

### Layout — `#1934`
- Replaced the 5-column cramped grid with two grouped cards: **Direct download** and **Signed data package**.
- Confirmation modal is now a single-column form with a `<fieldset>`, proper checkbox + helper text rows, and `overflow-wrap: break-word` so labels never break to one syllable per line.
- Responsive privacy options: 2 columns ≥ 720px, single column on mobile.
- Renamed primary CTA "Request my data" → "Request my data package".

### Share fix — `#1935`
- Two-phase feature detection: `navigator.share` at module load + `navigator.canShare({ files: [probe] })` once a package exists. Share button is hidden when the API isn't present.
- New `shareZipPackage()` helper categorises outcomes:
  - `AbortError` → silent (user dismissed)
  - `NotAllowedError` → "Sharing isn't available in this browser"
  - other errors → "Couldn't open the share sheet — `<reason>`. Try downloading instead."
- Added always-available **Download ZIP** primary action so users have a guaranteed path.
- Added `Permissions-Policy: web-share=(self)` to production `Caddyfile` so stricter defaults can't block share at the HTTP-header layer.

### Full export resilience — `#1963`
- Hardened `readOptionalTable`/`readOptionalRecord` in `simple-export.ts` to catch **all** repository errors (previously only `no such table`). A legacy row missing a required field (e.g. pre-migration `household_id`) used to abort the whole export — now the offending table degrades to `[]` while everything else still serializes. Logs `console.warn` for dev diagnostics.
- New `buildAllCsvZip()` produces a ZIP of one CSV per entity + `manifest.json`. Each CSV has a header row (or `(empty)` marker) so fresh-account users still get a valid artifact.
- New **Download all data (CSV ZIP)** button alongside JSON and transactions-CSV.

### Wording — `#1964`
- "Share ZIP package" → **"Share my exported package"**.
- Helper text under the button: "Opens your device's share sheet (Files, AirDrop, Messages, etc.)."
- Button is disabled with a tooltip ("Generate a package first, then share.") until a package exists.

## Tests

- Updated `DataExport.test.tsx` for renamed labels.
- Added share-fallback tests: hidden when Web Share API absent, disabled when no package, silent on `AbortError`, "unsupported" message on `NotAllowedError`.
- Added `simple-export.test.ts` coverage for `buildEntityCsvFiles`, `buildAllCsvZip` (ZIP header signature + filenames in bytes), `buildGenericCsv` (nested-object flattening, empty marker), and the resilient repo-read path.

All targeted Vitest suites pass (20/20). Full suite: 6381/6382 pass (single pre-existing timezone failure in `formatDate.test.ts`, unrelated). `npm run -w apps/web lint` and `npm run -w apps/web build` both clean.

## Files

- `apps/web/src/components/DataExport.tsx` — redesigned card, share fallback, CSV-ZIP button
- `apps/web/src/components/DataExport.test.tsx` — new + updated tests
- `apps/web/src/components/data-export.css` — group cards, single-column form, no syllable wrapping
- `apps/web/src/lib/data-access-package.ts` — export `buildZipArchive` for reuse
- `apps/web/src/lib/export/simple-export.ts` — resilient repo reads + `buildAllCsvZip`/`buildEntityCsvFiles`/`buildGenericCsv`
- `apps/web/src/lib/export/simple-export.test.ts` — new tests
- `deploy/Caddyfile` — `web-share=(self)` in Permissions-Policy
