### PR TITLE
fix(web): redesign primary navigation — grouped IA, mobile-complete reachability (#1930)

### DIFF
--- a/apps/web/e2e/accounts.spec.ts
+++ b/apps/web/e2e/accounts.spec.ts
@@ -78,9 +78,11 @@ test.describe('Accounts page', () => {
   test('shows account cards or empty state', async ({ authenticatedPage: page }) => {
     await page.goto('/accounts');
 
-    // Wait for loading to complete — either account data appears or empty state
-    const accountList = page.getByRole('list');
-    const emptyState = page.getByText(/no accounts yet/i);
+    // Wait for loading to complete — either account data appears or empty state.
+    // Scope to <main> so the sidebar/section nav lists don't match.
+    const mainRegion = page.getByRole('main');
+    const accountList = mainRegion.getByRole('list').first();
+    const emptyState = mainRegion.getByText(/no accounts yet/i);
 
     // One of these should be visible after loading
     await expect(accountList.or(emptyState)).toBeVisible();
@@ -94,8 +96,10 @@ test.describe('Accounts page', () => {
     // Wait for the page to finish loading (either data or empty state).
     // Avoid `networkidle` — the Vite dev server keeps connections open for
     // HMR, which prevents networkidle from resolving on CI runners.
-    const accountList = page.getByRole('list');
-    const emptyState = page.getByText(/no accounts yet/i);
+    // Scope to <main> so the sidebar/section nav lists don't match.
+    const mainRegion = page.getByRole('main');
+    const accountList = mainRegion.getByRole('list').first();
+    const emptyState = mainRegion.getByText(/no accounts yet/i);
     await expect(accountList.or(emptyState)).toBeVisible();
 
     // Check if there are account links (seed data present)
@@ -130,7 +134,12 @@ test.describe('Account detail page', () => {
     await page.goto('/accounts');
 
     // Wait for the page to finish loading (data or empty state).
-    const listOrEmpty = page.getByRole('list').or(page.getByText(/no accounts yet/i));
+    // Scope to <main> so the sidebar/section nav lists don't match.
+    const mainRegion = page.getByRole('main');
+    const listOrEmpty = mainRegion
+      .getByRole('list')
+      .first()
+      .or(mainRegion.getByText(/no accounts yet/i));
     await expect(listOrEmpty).toBeVisible();
 
     const accountLinks = page.getByRole('link').filter({

--- a/apps/web/e2e/nav-reachability.spec.ts
+++ b/apps/web/e2e/nav-reachability.spec.ts
@@ -19,6 +19,19 @@ import { type Page } from '@playwright/test';
 import { test, expect } from './fixtures';
 
 // ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Escape a string for use inside a RegExp. We can't rely on the input
+ * being free of regex metacharacters (CodeQL js/incomplete-sanitization
+ * specifically flags partial escapes like `.replace(/\//g, '\\/')`).
+ */
+const escapeRegex = (input: string): string => input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const hrefRegex = (href: string): RegExp => new RegExp(escapeRegex(href));
+
+// ---------------------------------------------------------------------------
 // Destinations under test
 // ---------------------------------------------------------------------------
 
@@ -126,7 +139,7 @@ test.describe('Desktop navigation reachability (#1930)', () => {
       await link.click();
 
       // The SPA navigates client-side; the URL must reflect the destination.
-      await expect(page).toHaveURL(new RegExp(dest.href.replace(/\//g, '\\/')));
+      await expect(page).toHaveURL(hrefRegex(dest.href));
     });
   }
 });
@@ -153,7 +166,7 @@ test.describe('Mobile navigation reachability (#1930)', () => {
       await expect(tab).toBeVisible();
       await tab.click();
 
-      await expect(page).toHaveURL(new RegExp(dest.href.replace(/\//g, '\\/')));
+      await expect(page).toHaveURL(hrefRegex(dest.href));
     });
   }
 
@@ -177,7 +190,7 @@ test.describe('Mobile navigation reachability (#1930)', () => {
 
       // Sheet closes and the SPA navigates.
       await expect(sheet).toBeHidden();
-      await expect(page).toHaveURL(new RegExp(dest.href.replace(/\//g, '\\/')));
+      await expect(page).toHaveURL(hrefRegex(dest.href));
     });
   }
 

--- a/apps/web/e2e/nav-reachability.spec.ts
+++ b/apps/web/e2e/nav-reachability.spec.ts
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Navigation reachability — verifies every destination in the primary
+ * nav config (`apps/web/src/components/layout/navConfig.tsx`) is
+ * reachable at both 375px (mobile) and 1280px (desktop) viewports.
+ *
+ * This is the regression guard for #1930: on narrow viewports the old
+ * bottom tab bar dropped most destinations and there was no overflow
+ * affordance, leaving 10+ routes unreachable.
+ *
+ * The test does not assert that pages load correctly (other suites do
+ * that); it only asserts that the navigation chrome links to each route
+ * and that activating each link navigates the SPA there.
+ */
+
+import { test, expect, type Page } from './fixtures';
+
+// ---------------------------------------------------------------------------
+// Destinations under test
+// ---------------------------------------------------------------------------
+
+/**
+ * Mirror of `NAV_CONFIG` from `apps/web/src/components/layout/navConfig.tsx`.
+ *
+ * We keep a shadow list here (rather than importing from the source) so
+ * the test breaks loudly when a new destination is added to the nav but
+ * the e2e coverage is forgotten — and so the test does not depend on
+ * the app's TypeScript build.
+ */
+const NAV_DESTINATIONS = [
+  // pinned
+  { label: 'Dashboard', href: '/dashboard', priority: 0 },
+  // Money
+  { label: 'Accounts', href: '/accounts', priority: 1 },
+  { label: 'Transactions', href: '/transactions', priority: 2 },
+  { label: 'Bills', href: '/bills', priority: 10 },
+  { label: 'Investments', href: '/investments', priority: 11 },
+  { label: 'Subscriptions', href: '/subscriptions', priority: 12 },
+  // Plan
+  { label: 'Budgets', href: '/budgets', priority: 3 },
+  { label: 'Goals', href: '/goals', priority: 13 },
+  { label: 'Planning', href: '/planning', priority: 14 },
+  { label: 'Categories', href: '/categories', priority: 15 },
+  // Insights
+  { label: 'Insights', href: '/insights', priority: 20 },
+  { label: 'Cash Flow', href: '/cash-flow', priority: 21 },
+  { label: 'Net Worth', href: '/net-worth', priority: 22 },
+  { label: 'Reports', href: '/report-builder', priority: 23 },
+  { label: 'Achievements', href: '/achievements', priority: 24 },
+  { label: 'Watchlists', href: '/watchlists', priority: 25 },
+  // Connect
+  { label: 'Household', href: '/household', priority: 30 },
+  { label: 'Bank Connections', href: '/bank-connections', priority: 31 },
+  { label: 'Import Data', href: '/import', priority: 32 },
+  { label: 'Privacy', href: '/privacy-dashboard', priority: 33 },
+] as const;
+
+/** How many priority items fit on the mobile bottom-nav (rest = "More"). */
+const BOTTOM_NAV_SLOTS = 4;
+
+const MOBILE = { width: 375, height: 812 };
+const DESKTOP = { width: 1280, height: 800 };
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function waitForAppShell(page: Page): Promise<void> {
+  await page
+    .getByRole('status', { name: /loading/i })
+    .waitFor({ state: 'hidden', timeout: 15_000 })
+    .catch(() => {
+      // Loading indicator may have already disappeared — fine.
+    });
+}
+
+/**
+ * Sorted by mobilePriority, the first 4 are the bottom-nav priority
+ * destinations; the rest must be reachable via the "More" sheet.
+ */
+function priorityDestinations(): readonly { label: string; href: string }[] {
+  return [...NAV_DESTINATIONS].sort((a, b) => a.priority - b.priority).slice(0, BOTTOM_NAV_SLOTS);
+}
+
+function moreSheetDestinations(): readonly { label: string; href: string }[] {
+  const priority = new Set(priorityDestinations().map((d) => d.href));
+  return NAV_DESTINATIONS.filter((d) => !priority.has(d.href));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Desktop reachability (1280 × 800)
+// ═══════════════════════════════════════════════════════════════════════════
+
+test.describe('Desktop navigation reachability (#1930)', () => {
+  test.beforeEach(async ({ authenticatedPage: page }) => {
+    await page.setViewportSize(DESKTOP);
+  });
+
+  for (const dest of NAV_DESTINATIONS) {
+    test(`sidebar can navigate to ${dest.label} (${dest.href})`, async ({
+      authenticatedPage: page,
+    }) => {
+      await page.goto('/dashboard');
+      await waitForAppShell(page);
+
+      const sidebar = page.locator('aside[aria-label="Main navigation"]');
+      await expect(sidebar).toBeVisible();
+
+      // Expand all collapsible group sections so every destination is queryable.
+      // Section toggles have accessible names like "Money section".
+      for (const groupLabel of ['Money', 'Plan', 'Insights', 'Connect']) {
+        const toggle = sidebar.getByRole('button', { name: `${groupLabel} section` });
+        if (await toggle.count()) {
+          const expanded = await toggle.getAttribute('aria-expanded');
+          if (expanded === 'false') {
+            await toggle.click();
+          }
+        }
+      }
+
+      const link = sidebar.getByRole('button', { name: dest.label, exact: true });
+      await expect(link).toBeVisible();
+      await link.click();
+
+      // The SPA navigates client-side; the URL must reflect the destination.
+      await expect(page).toHaveURL(new RegExp(dest.href.replace(/\//g, '\\/')));
+    });
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Mobile reachability (375 × 812)
+// ═══════════════════════════════════════════════════════════════════════════
+
+test.describe('Mobile navigation reachability (#1930)', () => {
+  test.beforeEach(async ({ authenticatedPage: page }) => {
+    await page.setViewportSize(MOBILE);
+  });
+
+  // Each top-priority destination is on the bottom tab bar directly.
+  for (const dest of priorityDestinations()) {
+    test(`bottom-nav can navigate to ${dest.label}`, async ({ authenticatedPage: page }) => {
+      await page.goto('/dashboard');
+      await waitForAppShell(page);
+
+      const bottomNav = page.locator('nav.bottom-nav');
+      await expect(bottomNav).toBeVisible();
+
+      const tab = bottomNav.getByRole('button', { name: dest.label, exact: true });
+      await expect(tab).toBeVisible();
+      await tab.click();
+
+      await expect(page).toHaveURL(new RegExp(dest.href.replace(/\//g, '\\/')));
+    });
+  }
+
+  // Every non-priority destination must be reachable via the More sheet.
+  for (const dest of moreSheetDestinations()) {
+    test(`More sheet can navigate to ${dest.label}`, async ({ authenticatedPage: page }) => {
+      await page.goto('/dashboard');
+      await waitForAppShell(page);
+
+      const bottomNav = page.locator('nav.bottom-nav');
+      const moreButton = bottomNav.getByRole('button', { name: 'More destinations' });
+      await expect(moreButton).toBeVisible();
+      await moreButton.click();
+
+      const sheet = page.getByRole('dialog');
+      await expect(sheet).toBeVisible();
+
+      const link = sheet.getByRole('button', { name: dest.label, exact: true });
+      await expect(link).toBeVisible();
+      await link.click();
+
+      // Sheet closes and the SPA navigates.
+      await expect(sheet).toBeHidden();
+      await expect(page).toHaveURL(new RegExp(dest.href.replace(/\//g, '\\/')));
+    });
+  }
+
+  test('More sheet closes when Escape is pressed', async ({ authenticatedPage: page }) => {
+    await page.goto('/dashboard');
+    await waitForAppShell(page);
+
+    await page.locator('nav.bottom-nav').getByRole('button', { name: 'More destinations' }).click();
+
+    await expect(page.getByRole('dialog')).toBeVisible();
+
+    await page.keyboard.press('Escape');
+
+    await expect(page.getByRole('dialog')).toBeHidden();
+  });
+
+  test('Settings is reachable from the More sheet', async ({ authenticatedPage: page }) => {
+    await page.goto('/dashboard');
+    await waitForAppShell(page);
+
+    await page.locator('nav.bottom-nav').getByRole('button', { name: 'More destinations' }).click();
+
+    const sheet = page.getByRole('dialog');
+    await sheet.getByRole('button', { name: 'Settings', exact: true }).click();
+
+    await expect(page).toHaveURL(/\/settings/);
+  });
+});

--- a/apps/web/e2e/nav-reachability.spec.ts
+++ b/apps/web/e2e/nav-reachability.spec.ts
@@ -14,7 +14,9 @@
  * and that activating each link navigates the SPA there.
  */
 
-import { test, expect, type Page } from './fixtures';
+import { type Page } from '@playwright/test';
+
+import { test, expect } from './fixtures';
 
 // ---------------------------------------------------------------------------
 // Destinations under test

--- a/apps/web/e2e/responsive.spec.ts
+++ b/apps/web/e2e/responsive.spec.ts
@@ -143,8 +143,12 @@ test.describe('Mobile viewport (375px)', () => {
     const bottomNav = page.locator('nav.bottom-nav');
     const navButtons = bottomNav.getByRole('button');
 
-    // Expect the 5 primary nav items for mobile: Dashboard, Accounts, Transactions, Budgets, Goals
+    // Expect 5 buttons on the bottom nav: the 4 highest-priority
+    // destinations (Dashboard, Accounts, Transactions, Budgets) plus a
+    // "More" button that opens the sheet listing the remaining routes
+    // (#1930).
     await expect(navButtons).toHaveCount(5);
+    await expect(bottomNav.getByRole('button', { name: 'More destinations' })).toBeVisible();
   });
 
   test('form dialog is full-screen on small mobile', async ({ authenticatedPage: page }) => {

--- a/apps/web/src/components/layout/MoreNavSheet.tsx
+++ b/apps/web/src/components/layout/MoreNavSheet.tsx
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * MoreNavSheet — full-height drawer that surfaces every navigation
+ * destination not already on the bottom-nav tab bar. Opened from the
+ * "More" tab on narrow viewports so nothing in the app is unreachable
+ * via the navigation chrome (#1930).
+ *
+ * Accessibility:
+ *   - Renders as `role="dialog"` with `aria-modal="true"`.
+ *   - Focus is moved into the sheet on open and restored to the trigger
+ *     on close.
+ *   - Escape closes the sheet.
+ *   - The active route is marked with `aria-current="page"`.
+ */
+
+import React, { useCallback, useEffect, useRef } from 'react';
+
+import {
+  MORE_SHEET_ITEMS,
+  NAV_GROUP_LABELS,
+  NAV_GROUP_ORDER,
+  type NavConfigItem,
+  type NavGroup,
+} from './navConfig';
+import { CloseIcon, KeyboardIcon, SettingsIcon, SignOutIcon } from './navIcons';
+
+export interface MoreNavSheetProps {
+  /** Whether the sheet is open. */
+  open: boolean;
+  /** Close the sheet (Escape, overlay click, item click). */
+  onClose: () => void;
+  /** The current route path, used to mark the active item. */
+  activePath: string;
+  /** Navigate to a route. */
+  onNavigate: (path: string) => void;
+  /** Optional: open the keyboard-shortcuts modal. */
+  onOpenShortcuts?: () => void;
+  /** Optional: sign-out handler. */
+  onSignOut?: () => void | Promise<void>;
+}
+
+/** Bucket items into their groups, preserving config order. */
+function bucketByGroup(items: readonly NavConfigItem[]): Map<NavGroup, NavConfigItem[]> {
+  const buckets = new Map<NavGroup, NavConfigItem[]>();
+  for (const group of NAV_GROUP_ORDER) {
+    buckets.set(group, []);
+  }
+  for (const item of items) {
+    if (!item.group) continue;
+    buckets.get(item.group)?.push(item);
+  }
+  return buckets;
+}
+
+export const MoreNavSheet: React.FC<MoreNavSheetProps> = ({
+  open,
+  onClose,
+  activePath,
+  onNavigate,
+  onOpenShortcuts,
+  onSignOut,
+}) => {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+
+  // Focus management: remember the trigger, focus into the sheet on open,
+  // restore focus on close.
+  useEffect(() => {
+    if (!open) return;
+    previouslyFocusedRef.current = document.activeElement as HTMLElement | null;
+    // Defer to next frame so the dialog has rendered.
+    const id = window.requestAnimationFrame(() => {
+      closeButtonRef.current?.focus();
+    });
+    return () => {
+      window.cancelAnimationFrame(id);
+      previouslyFocusedRef.current?.focus();
+    };
+  }, [open]);
+
+  // Escape to close.
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [open, onClose]);
+
+  // Lock body scroll while the sheet is open.
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  const handleNavigate = useCallback(
+    (path: string) => {
+      onClose();
+      onNavigate(path);
+    },
+    [onClose, onNavigate],
+  );
+
+  const handleSignOut = useCallback(async () => {
+    onClose();
+    if (onSignOut) {
+      await onSignOut();
+    }
+  }, [onClose, onSignOut]);
+
+  if (!open) return null;
+
+  const buckets = bucketByGroup(MORE_SHEET_ITEMS);
+
+  return (
+    <div className="more-sheet" role="dialog" aria-modal="true" aria-labelledby="more-sheet-title">
+      <button
+        type="button"
+        className="more-sheet__scrim"
+        aria-label="Close menu"
+        onClick={onClose}
+      />
+      <div className="more-sheet__panel" ref={dialogRef}>
+        <header className="more-sheet__header">
+          <h2 id="more-sheet-title" className="more-sheet__title">
+            All destinations
+          </h2>
+          <button
+            ref={closeButtonRef}
+            type="button"
+            className="more-sheet__close"
+            aria-label="Close menu"
+            onClick={onClose}
+          >
+            <CloseIcon />
+          </button>
+        </header>
+
+        <div className="more-sheet__body">
+          {NAV_GROUP_ORDER.map((group) => {
+            const items = buckets.get(group) ?? [];
+            if (items.length === 0) return null;
+            return (
+              <section
+                key={group}
+                className="more-sheet__group"
+                aria-labelledby={`more-sheet-group-${group}`}
+              >
+                <h3 id={`more-sheet-group-${group}`} className="more-sheet__group-heading">
+                  {NAV_GROUP_LABELS[group]}
+                </h3>
+                <ul className="more-sheet__list" role="list">
+                  {items.map((item) => {
+                    const isActive = activePath === item.href;
+                    return (
+                      <li key={item.id}>
+                        <button
+                          type="button"
+                          className={`more-sheet__item${isActive ? ' more-sheet__item--active' : ''}`}
+                          aria-current={isActive ? 'page' : undefined}
+                          aria-label={item.label}
+                          onClick={() => handleNavigate(item.href)}
+                        >
+                          <span className="more-sheet__item-icon" aria-hidden="true">
+                            {item.icon}
+                          </span>
+                          <span className="more-sheet__item-text">
+                            <span className="more-sheet__item-label">{item.label}</span>
+                            {item.description ? (
+                              <span className="more-sheet__item-description">
+                                {item.description}
+                              </span>
+                            ) : null}
+                          </span>
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </section>
+            );
+          })}
+
+          <section className="more-sheet__group" aria-label="Account">
+            <h3 className="more-sheet__group-heading">Account</h3>
+            <ul className="more-sheet__list" role="list">
+              <li>
+                <button
+                  type="button"
+                  className={`more-sheet__item${activePath === '/settings' ? ' more-sheet__item--active' : ''}`}
+                  aria-current={activePath === '/settings' ? 'page' : undefined}
+                  aria-label="Settings"
+                  onClick={() => handleNavigate('/settings')}
+                >
+                  <span className="more-sheet__item-icon" aria-hidden="true">
+                    <SettingsIcon />
+                  </span>
+                  <span className="more-sheet__item-text">
+                    <span className="more-sheet__item-label">Settings</span>
+                    <span className="more-sheet__item-description">
+                      Profile, security, appearance and notifications.
+                    </span>
+                  </span>
+                </button>
+              </li>
+              {onOpenShortcuts ? (
+                <li>
+                  <button
+                    type="button"
+                    className="more-sheet__item"
+                    aria-keyshortcuts="Shift+/"
+                    aria-label="Keyboard shortcuts"
+                    onClick={() => {
+                      onClose();
+                      onOpenShortcuts();
+                    }}
+                  >
+                    <span className="more-sheet__item-icon" aria-hidden="true">
+                      <KeyboardIcon />
+                    </span>
+                    <span className="more-sheet__item-text">
+                      <span className="more-sheet__item-label">Keyboard shortcuts</span>
+                      <span className="more-sheet__item-description">
+                        Speed up navigation and common actions.
+                      </span>
+                    </span>
+                  </button>
+                </li>
+              ) : null}
+              {onSignOut ? (
+                <li>
+                  <button
+                    type="button"
+                    className="more-sheet__item more-sheet__item--danger"
+                    aria-label="Sign out"
+                    onClick={handleSignOut}
+                  >
+                    <span className="more-sheet__item-icon" aria-hidden="true">
+                      <SignOutIcon />
+                    </span>
+                    <span className="more-sheet__item-text">
+                      <span className="more-sheet__item-label">Sign out</span>
+                    </span>
+                  </button>
+                </li>
+              ) : null}
+            </ul>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MoreNavSheet;

--- a/apps/web/src/components/layout/Navigation.test.tsx
+++ b/apps/web/src/components/layout/Navigation.test.tsx
@@ -21,7 +21,13 @@ vi.mock('../../auth/auth-context', () => ({
   }),
 }));
 
-import { BottomNavigation, SidebarNavigation, NAV_ITEMS } from './Navigation';
+import { BottomNavigation, SidebarNavigation } from './Navigation';
+import {
+  BOTTOM_NAV_PRIORITY_ITEMS,
+  NAV_CONFIG,
+  NAV_GROUP_LABELS,
+  PINNED_NAV_ITEMS,
+} from './navConfig';
 
 describe('BottomNavigation', () => {
   const defaultProps = {
@@ -29,25 +35,45 @@ describe('BottomNavigation', () => {
     onNavigate: vi.fn(),
   };
 
-  it('renders 5 navigation items for mobile', () => {
+  it('renders the priority destinations plus a More button', () => {
     render(<BottomNavigation {...defaultProps} />);
 
-    const buttons = screen.getAllByRole('button');
-    expect(buttons).toHaveLength(5);
+    // 4 priority items + 1 "More" button = 5 buttons on the bottom nav.
+    const nav = screen.getByRole('navigation', { name: 'Main navigation' });
+    const buttons = within(nav).getAllByRole('button');
+    expect(buttons).toHaveLength(BOTTOM_NAV_PRIORITY_ITEMS.length + 1);
   });
 
-  it('renders the first 5 expected nav item labels', () => {
+  it('renders the four priority nav item labels', () => {
     render(<BottomNavigation {...defaultProps} />);
 
-    for (const item of NAV_ITEMS.slice(0, 5)) {
+    for (const item of BOTTOM_NAV_PRIORITY_ITEMS) {
       expect(screen.getByRole('button', { name: item.label })).toBeInTheDocument();
     }
+  });
+
+  it('renders the More button with the right ARIA attributes', () => {
+    render(<BottomNavigation {...defaultProps} />);
+
+    const moreButton = screen.getByRole('button', { name: 'More destinations' });
+    expect(moreButton).toBeInTheDocument();
+    expect(moreButton).toHaveAttribute('aria-haspopup', 'dialog');
+    expect(moreButton).toHaveAttribute('aria-expanded', 'false');
   });
 
   it('marks the active item with aria-current="page"', () => {
     render(<BottomNavigation {...defaultProps} activePath="/accounts" />);
 
     expect(screen.getByRole('button', { name: 'Accounts' })).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+  });
+
+  it('marks the More button active when the current route is reachable only via the sheet', () => {
+    render(<BottomNavigation {...defaultProps} activePath="/insights" />);
+
+    expect(screen.getByRole('button', { name: 'More destinations' })).toHaveAttribute(
       'aria-current',
       'page',
     );
@@ -62,7 +88,7 @@ describe('BottomNavigation', () => {
     );
   });
 
-  it('calls onNavigate with the correct path when a nav item is clicked', () => {
+  it('calls onNavigate with the correct path when a priority item is clicked', () => {
     const onNavigate = vi.fn();
     render(<BottomNavigation {...defaultProps} onNavigate={onNavigate} />);
 
@@ -70,6 +96,28 @@ describe('BottomNavigation', () => {
 
     expect(onNavigate).toHaveBeenCalledTimes(1);
     expect(onNavigate).toHaveBeenCalledWith('/transactions');
+  });
+
+  it('opens the More sheet when the More button is clicked', () => {
+    render(<BottomNavigation {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'More destinations' }));
+
+    // The sheet is a dialog with the title "All destinations".
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('All destinations')).toBeInTheDocument();
+  });
+
+  it('every destination not on the bottom-nav is reachable from the More sheet', () => {
+    render(<BottomNavigation {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'More destinations' }));
+
+    const dialog = screen.getByRole('dialog');
+    for (const item of NAV_CONFIG) {
+      if (BOTTOM_NAV_PRIORITY_ITEMS.some((p) => p.id === item.id)) continue;
+      expect(within(dialog).getByRole('button', { name: item.label })).toBeInTheDocument();
+    }
   });
 
   it('has an accessible nav label', () => {
@@ -85,15 +133,29 @@ describe('SidebarNavigation', () => {
     onNavigate: vi.fn(),
   };
 
-  it('renders all primary nav items', () => {
+  it('renders the pinned destinations at the top', () => {
     render(<SidebarNavigation {...defaultProps} />);
 
-    for (const item of NAV_ITEMS) {
+    for (const item of PINNED_NAV_ITEMS) {
       expect(screen.getByRole('button', { name: item.label })).toBeInTheDocument();
     }
   });
 
-  it('renders the Settings button', () => {
+  it('renders every navigation destination somewhere in the sidebar (groups expand on demand)', () => {
+    render(<SidebarNavigation {...defaultProps} activePath="/insights" />);
+
+    // Expand the Connect group so its items are queryable; the other
+    // groups (Money, Plan) are expanded by default and Insights is forced
+    // open because /insights is the active route.
+    const expandConnect = screen.getByRole('button', { name: 'Connect section' });
+    fireEvent.click(expandConnect);
+
+    for (const item of NAV_CONFIG) {
+      expect(screen.getByRole('button', { name: item.label })).toBeInTheDocument();
+    }
+  });
+
+  it('renders the Settings button in the footer', () => {
     render(<SidebarNavigation {...defaultProps} />);
 
     expect(screen.getByRole('button', { name: 'Settings' })).toBeInTheDocument();
@@ -119,6 +181,16 @@ describe('SidebarNavigation', () => {
 
     expect(screen.getByRole('button', { name: 'Dashboard' })).not.toHaveAttribute('aria-current');
     expect(screen.getByRole('button', { name: 'Settings' })).not.toHaveAttribute('aria-current');
+  });
+
+  it('forces the section open when one of its routes is active', () => {
+    render(<SidebarNavigation {...defaultProps} activePath="/cash-flow" />);
+
+    // /cash-flow is in the "Insights" group, which is collapsed by default.
+    // Because the active route is inside it, the group must auto-expand and
+    // the Cash Flow button must be visible.
+    const cashFlow = screen.getByRole('button', { name: 'Cash Flow' });
+    expect(cashFlow).toHaveAttribute('aria-current', 'page');
   });
 
   it('calls onNavigate with the correct path when a nav item is clicked', () => {
@@ -170,18 +242,10 @@ describe('SidebarNavigation', () => {
     expect(screen.queryByRole('button', { name: 'Shortcuts' })).not.toBeInTheDocument();
   });
 
-  it('has a nav region with accessible label', () => {
+  it('has a Primary nav region with accessible label', () => {
     render(<SidebarNavigation {...defaultProps} />);
 
     expect(screen.getByRole('navigation', { name: 'Primary' })).toBeInTheDocument();
-  });
-
-  it('renders nav items in a list', () => {
-    render(<SidebarNavigation {...defaultProps} />);
-
-    const lists = screen.getAllByRole('list');
-    const listItems = within(lists[0]).getAllByRole('listitem');
-    expect(listItems).toHaveLength(NAV_ITEMS.length);
   });
 
   it('renders a Sign Out button', () => {
@@ -190,9 +254,28 @@ describe('SidebarNavigation', () => {
     expect(screen.getByRole('button', { name: 'Sign out' })).toBeInTheDocument();
   });
 
-  it('renders a More toggle button', () => {
+  it('renders a section header for each nav group', () => {
     render(<SidebarNavigation {...defaultProps} />);
 
-    expect(screen.getByRole('button', { name: /More/ })).toBeInTheDocument();
+    for (const label of Object.values(NAV_GROUP_LABELS)) {
+      expect(screen.getByRole('button', { name: `${label} section` })).toBeInTheDocument();
+    }
+  });
+
+  it('toggling a group header collapses the items underneath', () => {
+    render(<SidebarNavigation {...defaultProps} />);
+
+    // Money is expanded by default and contains Accounts.
+    expect(screen.getByRole('button', { name: 'Accounts' })).toBeVisible();
+
+    const moneyToggle = screen.getByRole('button', { name: 'Money section' });
+    fireEvent.click(moneyToggle);
+
+    // After collapsing, the parent list has `hidden` so the items are
+    // still in the DOM but not accessible.
+    const moneyList = document.getElementById('sidebar-group-money');
+    expect(moneyList).not.toBeNull();
+    expect(moneyList?.hasAttribute('hidden')).toBe(true);
+    expect(moneyToggle).toHaveAttribute('aria-expanded', 'false');
   });
 });

--- a/apps/web/src/components/layout/Navigation.tsx
+++ b/apps/web/src/components/layout/Navigation.tsx
@@ -1,142 +1,64 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import React, { useState } from 'react';
+/**
+ * Primary navigation chrome.
+ *
+ * - `SidebarNavigation` is the wide-screen layout: a pinned Dashboard at
+ *   the top, four collapsible grouped sections (Money, Plan, Insights,
+ *   Connect), and a pinned footer for Shortcuts / Settings / Sign Out.
+ * - `BottomNavigation` is the narrow-screen tab bar. It surfaces the
+ *   four most-used destinations plus a "More" button that opens a sheet
+ *   listing every remaining destination — every route in the app is
+ *   reachable on every viewport (#1930).
+ *
+ * Both components read from the same `NAV_CONFIG` source-of-truth so the
+ * two layouts can never drift.
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+
 import { useAuth } from '../../auth/auth-context';
 
+import { MoreNavSheet } from './MoreNavSheet';
+import {
+  BOTTOM_NAV_PRIORITY_ITEMS,
+  NAV_CONFIG,
+  NAV_GROUP_LABELS,
+  NAV_GROUP_ORDER,
+  PINNED_NAV_ITEMS,
+  getItemsByGroup,
+  type NavConfigItem,
+  type NavGroup,
+} from './navConfig';
+import { ChevronDownIcon, KeyboardIcon, MoreIcon, SettingsIcon, SignOutIcon } from './navIcons';
+
+// ---------------------------------------------------------------------------
+// Back-compat shims for existing consumers / tests.
+// ---------------------------------------------------------------------------
+
+/**
+ * @deprecated Prefer `NAV_CONFIG` from `./navConfig`. Kept so existing
+ * tests and external imports continue to compile during the migration.
+ */
 export interface NavItem {
   path: string;
   label: string;
   icon: React.ReactNode;
 }
 
-/** Primary navigation items shown in the main nav section. */
-export const NAV_ITEMS: NavItem[] = [
-  {
-    path: '/dashboard',
-    label: 'Dashboard',
-    icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-        <path d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-4 0a1 1 0 01-1-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 01-1 1h-2z" />
-      </svg>
-    ),
-  },
-  {
-    path: '/accounts',
-    label: 'Accounts',
-    icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-        <path d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" />
-      </svg>
-    ),
-  },
-  {
-    path: '/transactions',
-    label: 'Transactions',
-    icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-        <path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
-      </svg>
-    ),
-  },
-  {
-    path: '/budgets',
-    label: 'Budgets',
-    icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-        <path d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17" />
-      </svg>
-    ),
-  },
-  {
-    path: '/goals',
-    label: 'Goals',
-    icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-        <path d="M13 10V3L4 14h7v7l9-11h-7z" />
-      </svg>
-    ),
-  },
-  {
-    path: '/investments',
-    label: 'Investments',
-    icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-        <path d="M3 17l6-6 4 4 8-8" />
-        <path d="M17 7h4v4" />
-      </svg>
-    ),
-  },
-  {
-    path: '/bills',
-    label: 'Bills',
-    icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-        <path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2" />
-        <path d="M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
-        <path d="M9 14l2 2 4-4" />
-      </svg>
-    ),
-  },
-  {
-    path: '/insights',
-    label: 'Insights',
-    icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-        <path d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-      </svg>
-    ),
-  },
-  {
-    path: '/household',
-    label: 'Household',
-    icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-        <path d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
-      </svg>
-    ),
-  },
-  {
-    path: '/categories',
-    label: 'Categories',
-    icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-        <path d="M7 7h.01M3 11.172V5a2 2 0 012-2h6.172a2 2 0 011.414.586l7.828 7.828a2 2 0 010 2.828l-6.172 6.172a2 2 0 01-2.828 0l-7.828-7.828A2 2 0 013 11.172z" />
-      </svg>
-    ),
-  },
-];
+/**
+ * @deprecated Use `NAV_CONFIG` directly. Provided for backwards
+ * compatibility with code that imported the old flat array.
+ */
+export const NAV_ITEMS: NavItem[] = NAV_CONFIG.map((item) => ({
+  path: item.href,
+  label: item.label,
+  icon: item.icon,
+}));
 
-/** Secondary navigation items shown in a collapsible "More" section. */
-export const MORE_NAV_ITEMS: NavItem[] = [
-  {
-    path: '/report-builder',
-    label: 'Report Builder',
-    icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-        <path d="M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-      </svg>
-    ),
-  },
-  {
-    path: '/achievements',
-    label: 'Achievements',
-    icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-        <path d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
-      </svg>
-    ),
-  },
-  {
-    path: '/watchlists',
-    label: 'Watchlists',
-    icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-        <path d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-        <path d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-      </svg>
-    ),
-  },
-];
+// ---------------------------------------------------------------------------
+// Shared types
+// ---------------------------------------------------------------------------
 
 export interface NavigationProps {
   activePath: string;
@@ -145,29 +67,165 @@ export interface NavigationProps {
   onOpenFeedback?: () => void;
 }
 
-/** Bottom navigation for mobile viewports. */
-export const BottomNavigation: React.FC<NavigationProps> = ({ activePath, onNavigate }) => (
-  <nav className="bottom-nav" aria-label="Main navigation">
-    {NAV_ITEMS.slice(0, 5).map((item) => {
-      const isActive = activePath === item.path;
-      return (
-        <button
-          key={item.path}
-          type="button"
-          className={`nav-item${isActive ? ' nav-item--active' : ''}`}
-          aria-current={isActive ? 'page' : undefined}
-          aria-label={item.label}
-          onClick={() => onNavigate(item.path)}
-        >
-          <span className="nav-item__icon">{item.icon}</span>
-          <span className="nav-item__label">{item.label}</span>
-        </button>
-      );
-    })}
-  </nav>
-);
+function isActive(activePath: string, href: string): boolean {
+  return activePath === href || activePath.startsWith(href + '/');
+}
 
-/** Sidebar navigation for desktop viewports with pinned footer. */
+// ---------------------------------------------------------------------------
+// Bottom navigation (mobile)
+// ---------------------------------------------------------------------------
+
+/**
+ * Bottom tab bar for narrow viewports. Renders the four highest-priority
+ * destinations plus a "More" tab that opens {@link MoreNavSheet}.
+ */
+export const BottomNavigation: React.FC<NavigationProps> = ({
+  activePath,
+  onNavigate,
+  onOpenShortcuts,
+}) => {
+  const { logout } = useAuth();
+  const [moreOpen, setMoreOpen] = useState(false);
+
+  const isMoreActive = useMemo(() => {
+    // The "More" tab should appear active when the user is on any route
+    // that is reachable only via the sheet (i.e. not a priority item).
+    if (BOTTOM_NAV_PRIORITY_ITEMS.some((item) => isActive(activePath, item.href))) {
+      return false;
+    }
+    return NAV_CONFIG.some((item) => isActive(activePath, item.href));
+  }, [activePath]);
+
+  const handleSignOut = useCallback(async () => {
+    await logout();
+  }, [logout]);
+
+  return (
+    <>
+      <nav className="bottom-nav" aria-label="Main navigation">
+        {BOTTOM_NAV_PRIORITY_ITEMS.map((item) => {
+          const active = isActive(activePath, item.href);
+          return (
+            <button
+              key={item.id}
+              type="button"
+              className={`nav-item${active ? ' nav-item--active' : ''}`}
+              aria-current={active ? 'page' : undefined}
+              aria-label={item.label}
+              onClick={() => onNavigate(item.href)}
+            >
+              <span className="nav-item__icon">{item.icon}</span>
+              <span className="nav-item__label">{item.label}</span>
+            </button>
+          );
+        })}
+        <button
+          type="button"
+          className={`nav-item nav-item--more${isMoreActive ? ' nav-item--active' : ''}`}
+          aria-label="More destinations"
+          aria-haspopup="dialog"
+          aria-expanded={moreOpen}
+          aria-current={isMoreActive ? 'page' : undefined}
+          onClick={() => setMoreOpen(true)}
+        >
+          <span className="nav-item__icon">
+            <MoreIcon />
+          </span>
+          <span className="nav-item__label">More</span>
+        </button>
+      </nav>
+      <MoreNavSheet
+        open={moreOpen}
+        onClose={() => setMoreOpen(false)}
+        activePath={activePath}
+        onNavigate={onNavigate}
+        onOpenShortcuts={onOpenShortcuts}
+        onSignOut={handleSignOut}
+      />
+    </>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Sidebar navigation (desktop)
+// ---------------------------------------------------------------------------
+
+interface SidebarGroupProps {
+  group: NavGroup;
+  items: readonly NavConfigItem[];
+  activePath: string;
+  onNavigate: (path: string) => void;
+  defaultExpanded: boolean;
+}
+
+const SidebarGroup: React.FC<SidebarGroupProps> = ({
+  group,
+  items,
+  activePath,
+  onNavigate,
+  defaultExpanded,
+}) => {
+  const containsActive = items.some((item) => isActive(activePath, item.href));
+  const [userExpanded, setUserExpanded] = useState(defaultExpanded);
+  // The section is always visible when one of its routes is active so the
+  // user can see where they are in the IA. Otherwise the user controls
+  // expand/collapse via the toggle.
+  const expanded = userExpanded || containsActive;
+
+  const sectionId = `sidebar-group-${group}`;
+  const headingId = `sidebar-group-${group}-heading`;
+  const label = NAV_GROUP_LABELS[group];
+
+  return (
+    <section className="app-sidebar__group" aria-labelledby={headingId} data-expanded={expanded}>
+      <h2 id={headingId} className="app-sidebar__group-heading">
+        <button
+          type="button"
+          className="app-sidebar__group-toggle"
+          aria-expanded={expanded}
+          aria-controls={sectionId}
+          aria-label={`${label} section`}
+          onClick={() => setUserExpanded((prev) => !prev)}
+        >
+          <span className="app-sidebar__group-label">{label}</span>
+          <span
+            className={`app-sidebar__group-chevron${expanded ? ' app-sidebar__group-chevron--expanded' : ''}`}
+            aria-hidden="true"
+          >
+            <ChevronDownIcon />
+          </span>
+        </button>
+      </h2>
+      <ul
+        id={sectionId}
+        className="sidebar-nav__list sidebar-nav__list--nested"
+        role="list"
+        hidden={!expanded}
+      >
+        {items.map((item) => {
+          const active = isActive(activePath, item.href);
+          return (
+            <li key={item.id} role="listitem">
+              <button
+                type="button"
+                className={`sidebar-nav__item${active ? ' sidebar-nav__item--active' : ''}`}
+                aria-current={active ? 'page' : undefined}
+                onClick={() => onNavigate(item.href)}
+              >
+                <span className="sidebar-nav__item-icon" aria-hidden="true">
+                  {item.icon}
+                </span>
+                <span>{item.label}</span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+};
+
+/** Sidebar navigation for wide viewports. */
 export const SidebarNavigation: React.FC<NavigationProps> = ({
   activePath,
   onNavigate,
@@ -175,12 +233,11 @@ export const SidebarNavigation: React.FC<NavigationProps> = ({
   onOpenFeedback,
 }) => {
   const { logout } = useAuth();
-  const [moreExpanded, setMoreExpanded] = useState(false);
-  const isSettingsActive = activePath === '/settings';
+  const isSettingsActive = isActive(activePath, '/settings');
 
-  const handleSignOut = async () => {
+  const handleSignOut = useCallback(async () => {
     await logout();
-  };
+  }, [logout]);
 
   return (
     <aside className="app-sidebar" aria-label="Main navigation">
@@ -188,81 +245,45 @@ export const SidebarNavigation: React.FC<NavigationProps> = ({
         <span className="app-sidebar__logo">Finance</span>
       </div>
 
-      {/* Scrollable navigation section */}
-      <div className="app-sidebar__scrollable">
-        <nav className="app-sidebar__nav" aria-label="Primary">
-          <ul className="sidebar-nav__list" role="list">
-            {NAV_ITEMS.map((item) => {
-              const isActive = activePath === item.path;
-              return (
-                <li key={item.path} role="listitem">
-                  <button
-                    type="button"
-                    className={`sidebar-nav__item${isActive ? ' sidebar-nav__item--active' : ''}`}
-                    aria-current={isActive ? 'page' : undefined}
-                    onClick={() => onNavigate(item.path)}
-                  >
-                    <span className="sidebar-nav__item-icon">{item.icon}</span>
-                    <span>{item.label}</span>
-                  </button>
-                </li>
-              );
-            })}
-          </ul>
-        </nav>
+      <nav className="app-sidebar__nav" aria-label="Primary">
+        {/* Pinned destinations (Dashboard) */}
+        <ul className="sidebar-nav__list" role="list">
+          {PINNED_NAV_ITEMS.map((item) => {
+            const active = isActive(activePath, item.href);
+            return (
+              <li key={item.id} role="listitem">
+                <button
+                  type="button"
+                  className={`sidebar-nav__item${active ? ' sidebar-nav__item--active' : ''}`}
+                  aria-current={active ? 'page' : undefined}
+                  onClick={() => onNavigate(item.href)}
+                >
+                  <span className="sidebar-nav__item-icon" aria-hidden="true">
+                    {item.icon}
+                  </span>
+                  <span>{item.label}</span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
 
-        {/* Collapsible "More" section */}
-        <div className="app-sidebar__more">
-          <button
-            type="button"
-            className="sidebar-nav__item sidebar-nav__item--more-toggle"
-            aria-expanded={moreExpanded}
-            aria-controls="sidebar-more-section"
-            onClick={() => setMoreExpanded((prev) => !prev)}
-          >
-            <span className="sidebar-nav__item-icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                <path d="M5 12h.01M12 12h.01M19 12h.01M6 12a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0z" />
-              </svg>
-            </span>
-            <span>More</span>
-            <span
-              className={`sidebar-nav__item-chevron${moreExpanded ? ' sidebar-nav__item-chevron--expanded' : ''}`}
-              aria-hidden="true"
-            >
-              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                <path d="M19 9l-7 7-7-7" />
-              </svg>
-            </span>
-          </button>
-          {moreExpanded && (
-            <ul
-              id="sidebar-more-section"
-              className="sidebar-nav__list sidebar-nav__list--nested"
-              role="list"
-            >
-              {MORE_NAV_ITEMS.map((item) => {
-                const isActive = activePath === item.path;
-                return (
-                  <li key={item.path} role="listitem">
-                    <button
-                      type="button"
-                      className={`sidebar-nav__item${isActive ? ' sidebar-nav__item--active' : ''}`}
-                      aria-current={isActive ? 'page' : undefined}
-                      onClick={() => onNavigate(item.path)}
-                    >
-                      <span className="sidebar-nav__item-icon">{item.icon}</span>
-                      <span>{item.label}</span>
-                    </button>
-                  </li>
-                );
-              })}
-            </ul>
-          )}
-        </div>
-      </div>
+        {/* Grouped destinations. Money + Plan are expanded by default
+            because they hold the most-used routes; Insights + Connect
+            start collapsed to reduce cognitive load. */}
+        {NAV_GROUP_ORDER.map((group) => (
+          <SidebarGroup
+            key={group}
+            group={group}
+            items={getItemsByGroup(group)}
+            activePath={activePath}
+            onNavigate={onNavigate}
+            defaultExpanded={group === 'money' || group === 'plan'}
+          />
+        ))}
+      </nav>
 
-      {/* Pinned footer — always visible without scrolling */}
+      {/* Pinned footer — always visible without scrolling. */}
       <div className="app-sidebar__footer">
         {onOpenShortcuts ? (
           <button
@@ -272,100 +293,7 @@ export const SidebarNavigation: React.FC<NavigationProps> = ({
             onClick={onOpenShortcuts}
           >
             <span className="sidebar-nav__item-icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                <rect
-                  x="2"
-                  y="4"
-                  width="20"
-                  height="16"
-                  rx="2"
-                  ry="2"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                />
-                <line
-                  x1="6"
-                  y1="8"
-                  x2="6"
-                  y2="8"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                />
-                <line
-                  x1="10"
-                  y1="8"
-                  x2="10"
-                  y2="8"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                />
-                <line
-                  x1="14"
-                  y1="8"
-                  x2="14"
-                  y2="8"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                />
-                <line
-                  x1="18"
-                  y1="8"
-                  x2="18"
-                  y2="8"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                />
-                <line
-                  x1="6"
-                  y1="12"
-                  x2="6"
-                  y2="12"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                />
-                <line
-                  x1="10"
-                  y1="12"
-                  x2="10"
-                  y2="12"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                />
-                <line
-                  x1="14"
-                  y1="12"
-                  x2="14"
-                  y2="12"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                />
-                <line
-                  x1="18"
-                  y1="12"
-                  x2="18"
-                  y2="12"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                />
-                <line
-                  x1="8"
-                  y1="16"
-                  x2="16"
-                  y2="16"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                />
-              </svg>
+              <KeyboardIcon />
             </span>
             <span>Shortcuts</span>
           </button>
@@ -378,16 +306,7 @@ export const SidebarNavigation: React.FC<NavigationProps> = ({
             onClick={onOpenFeedback}
           >
             <span className="sidebar-nav__item-icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                <path
-                  d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinejoin="round"
-                  strokeLinecap="round"
-                />
-              </svg>
+              <KeyboardIcon />
             </span>
             <span>Feedback</span>
           </button>
@@ -399,10 +318,7 @@ export const SidebarNavigation: React.FC<NavigationProps> = ({
           onClick={() => onNavigate('/settings')}
         >
           <span className="sidebar-nav__item-icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-              <path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.573-1.066z" />
-              <path d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-            </svg>
+            <SettingsIcon />
           </span>
           <span>Settings</span>
         </button>
@@ -413,9 +329,7 @@ export const SidebarNavigation: React.FC<NavigationProps> = ({
           aria-label="Sign out"
         >
           <span className="sidebar-nav__item-icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-              <path d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
-            </svg>
+            <SignOutIcon />
           </span>
           <span>Sign Out</span>
         </button>

--- a/apps/web/src/components/layout/index.ts
+++ b/apps/web/src/components/layout/index.ts
@@ -5,6 +5,18 @@ export type { AppLayoutProps } from './AppLayout';
 export { BottomNavigation, SidebarNavigation, NAV_ITEMS } from './Navigation';
 export type { NavigationProps, NavItem } from './Navigation';
 export {
+  NAV_CONFIG,
+  NAV_GROUP_LABELS,
+  NAV_GROUP_ORDER,
+  BOTTOM_NAV_PRIORITY_ITEMS,
+  PINNED_NAV_ITEMS,
+  MORE_SHEET_ITEMS,
+  getItemsByGroup,
+} from './navConfig';
+export type { NavConfigItem, NavGroup } from './navConfig';
+export { MoreNavSheet } from './MoreNavSheet';
+export type { MoreNavSheetProps } from './MoreNavSheet';
+export {
   ResponsiveContainer,
   ResponsiveGrid,
   ResponsiveStack,

--- a/apps/web/src/components/layout/navConfig.tsx
+++ b/apps/web/src/components/layout/navConfig.tsx
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Single source of truth for primary navigation destinations.
+ *
+ * Both the desktop sidebar and the mobile bottom-nav / "More" sheet render
+ * from this config so every route is reachable on every viewport (#1930).
+ *
+ * Conventions:
+ *   - `mobilePriority` < 99 surfaces the item on the bottom-nav tab bar
+ *     (lower = higher priority). The bottom-nav reserves 4 slots for the
+ *     top-priority items and 1 slot for the "More" button.
+ *   - `group` clusters items in the sidebar and the "More" sheet. Items
+ *     without a group are pinned at the top of the sidebar.
+ *   - `description` is shown beneath the label in the "More" sheet to help
+ *     new users disambiguate destinations.
+ */
+
+import type React from 'react';
+
+import {
+  DashboardIcon,
+  AccountsIcon,
+  TransactionsIcon,
+  BillsIcon,
+  InvestmentsIcon,
+  SubscriptionsIcon,
+  BudgetsIcon,
+  GoalsIcon,
+  PlanningIcon,
+  CategoriesIcon,
+  InsightsIcon,
+  CashFlowIcon,
+  NetWorthIcon,
+  ReportsIcon,
+  AchievementsIcon,
+  WatchlistsIcon,
+  HouseholdIcon,
+  BankIcon,
+  ImportIcon,
+  PrivacyIcon,
+} from './navIcons';
+
+/** Named navigation groups, displayed in this order in the sidebar. */
+export type NavGroup = 'money' | 'plan' | 'insights' | 'connect';
+
+/** Display label for each group header. */
+export const NAV_GROUP_LABELS: Record<NavGroup, string> = {
+  money: 'Money',
+  plan: 'Plan',
+  insights: 'Insights',
+  connect: 'Connect',
+};
+
+/** Sidebar render order for groups. */
+export const NAV_GROUP_ORDER: NavGroup[] = ['money', 'plan', 'insights', 'connect'];
+
+/** A single destination in the primary navigation. */
+export interface NavConfigItem {
+  /** Stable identifier. */
+  id: string;
+  /** Visible label. */
+  label: string;
+  /** Target route path. */
+  href: string;
+  /** Icon element (24×24 stroke SVG). */
+  icon: React.ReactNode;
+  /** Group bucket; omit for pinned/top-level destinations. */
+  group?: NavGroup;
+  /**
+   * Position on the mobile bottom-nav (lower = higher priority).
+   * Items with priority >= 99 only appear in the "More" sheet.
+   */
+  mobilePriority: number;
+  /** One-line helper text shown in the "More" sheet. */
+  description?: string;
+}
+
+/**
+ * Every destination reachable from the primary navigation.
+ * Order within each group controls render order in the sidebar.
+ */
+export const NAV_CONFIG: readonly NavConfigItem[] = [
+  // ── pinned (no group) ────────────────────────────────────────────────
+  {
+    id: 'dashboard',
+    label: 'Dashboard',
+    href: '/dashboard',
+    icon: <DashboardIcon />,
+    mobilePriority: 0,
+    description: 'Overview of balances, spending and insights.',
+  },
+
+  // ── Money ────────────────────────────────────────────────────────────
+  {
+    id: 'accounts',
+    label: 'Accounts',
+    href: '/accounts',
+    icon: <AccountsIcon />,
+    group: 'money',
+    mobilePriority: 1,
+    description: 'Bank, credit, cash and investment accounts.',
+  },
+  {
+    id: 'transactions',
+    label: 'Transactions',
+    href: '/transactions',
+    icon: <TransactionsIcon />,
+    group: 'money',
+    mobilePriority: 2,
+    description: 'Every debit and credit, across all accounts.',
+  },
+  {
+    id: 'bills',
+    label: 'Bills',
+    href: '/bills',
+    icon: <BillsIcon />,
+    group: 'money',
+    mobilePriority: 10,
+    description: 'Upcoming and recurring bill reminders.',
+  },
+  {
+    id: 'investments',
+    label: 'Investments',
+    href: '/investments',
+    icon: <InvestmentsIcon />,
+    group: 'money',
+    mobilePriority: 11,
+    description: 'Holdings, performance and watchlists.',
+  },
+  {
+    id: 'subscriptions',
+    label: 'Subscriptions',
+    href: '/subscriptions',
+    icon: <SubscriptionsIcon />,
+    group: 'money',
+    mobilePriority: 12,
+    description: 'Recurring memberships and renewals.',
+  },
+
+  // ── Plan ─────────────────────────────────────────────────────────────
+  {
+    id: 'budgets',
+    label: 'Budgets',
+    href: '/budgets',
+    icon: <BudgetsIcon />,
+    group: 'plan',
+    mobilePriority: 3,
+    description: 'Track spending against monthly limits.',
+  },
+  {
+    id: 'goals',
+    label: 'Goals',
+    href: '/goals',
+    icon: <GoalsIcon />,
+    group: 'plan',
+    mobilePriority: 13,
+    description: 'Savings targets and progress.',
+  },
+  {
+    id: 'planning',
+    label: 'Planning',
+    href: '/planning',
+    icon: <PlanningIcon />,
+    group: 'plan',
+    mobilePriority: 14,
+    description: 'Long-range projections and what-ifs.',
+  },
+  {
+    id: 'categories',
+    label: 'Categories',
+    href: '/categories',
+    icon: <CategoriesIcon />,
+    group: 'plan',
+    mobilePriority: 15,
+    description: 'Customise how transactions are classified.',
+  },
+
+  // ── Insights ─────────────────────────────────────────────────────────
+  {
+    id: 'insights',
+    label: 'Insights',
+    href: '/insights',
+    icon: <InsightsIcon />,
+    group: 'insights',
+    mobilePriority: 20,
+    description: 'Trends, anomalies and personalised tips.',
+  },
+  {
+    id: 'cash-flow',
+    label: 'Cash Flow',
+    href: '/cash-flow',
+    icon: <CashFlowIcon />,
+    group: 'insights',
+    mobilePriority: 21,
+    description: 'Money in vs. money out over time.',
+  },
+  {
+    id: 'net-worth',
+    label: 'Net Worth',
+    href: '/net-worth',
+    icon: <NetWorthIcon />,
+    group: 'insights',
+    mobilePriority: 22,
+    description: 'Assets minus liabilities, tracked monthly.',
+  },
+  {
+    id: 'reports',
+    label: 'Reports',
+    href: '/report-builder',
+    icon: <ReportsIcon />,
+    group: 'insights',
+    mobilePriority: 23,
+    description: 'Build and export custom reports.',
+  },
+  {
+    id: 'achievements',
+    label: 'Achievements',
+    href: '/achievements',
+    icon: <AchievementsIcon />,
+    group: 'insights',
+    mobilePriority: 24,
+    description: 'Milestones and streaks you have earned.',
+  },
+  {
+    id: 'watchlists',
+    label: 'Watchlists',
+    href: '/watchlists',
+    icon: <WatchlistsIcon />,
+    group: 'insights',
+    mobilePriority: 25,
+    description: 'Symbols and markets you follow.',
+  },
+
+  // ── Connect ──────────────────────────────────────────────────────────
+  {
+    id: 'household',
+    label: 'Household',
+    href: '/household',
+    icon: <HouseholdIcon />,
+    group: 'connect',
+    mobilePriority: 30,
+    description: 'Shared budgets, goals and members.',
+  },
+  {
+    id: 'bank-connections',
+    label: 'Bank Connections',
+    href: '/bank-connections',
+    icon: <BankIcon />,
+    group: 'connect',
+    mobilePriority: 31,
+    description: 'Linked institutions and sync status.',
+  },
+  {
+    id: 'import',
+    label: 'Import Data',
+    href: '/import',
+    icon: <ImportIcon />,
+    group: 'connect',
+    mobilePriority: 32,
+    description: 'Bring in CSVs, OFX files and receipts.',
+  },
+  {
+    id: 'privacy',
+    label: 'Privacy',
+    href: '/privacy-dashboard',
+    icon: <PrivacyIcon />,
+    group: 'connect',
+    mobilePriority: 33,
+    description: 'Consent, data export and deletion.',
+  },
+];
+
+/** How many priority items show on the mobile bottom-nav (the 5th slot is "More"). */
+export const BOTTOM_NAV_PRIORITY_COUNT = 4;
+
+/**
+ * Bottom-nav priority items, sorted by `mobilePriority`. The bottom-nav
+ * appends a "More" button so all remaining items are still reachable.
+ */
+export const BOTTOM_NAV_PRIORITY_ITEMS: readonly NavConfigItem[] = [...NAV_CONFIG]
+  .sort((a, b) => a.mobilePriority - b.mobilePriority)
+  .slice(0, BOTTOM_NAV_PRIORITY_COUNT);
+
+/** Destinations pinned above the grouped sections in the sidebar. */
+export const PINNED_NAV_ITEMS: readonly NavConfigItem[] = NAV_CONFIG.filter(
+  (item) => item.group === undefined,
+);
+
+/** Destinations bucketed by group, preserving config order within each. */
+export function getItemsByGroup(group: NavGroup): readonly NavConfigItem[] {
+  return NAV_CONFIG.filter((item) => item.group === group);
+}
+
+/**
+ * Items shown inside the mobile "More" sheet — everything that is not a
+ * bottom-nav priority item, grouped for scanning.
+ */
+export const MORE_SHEET_ITEMS: readonly NavConfigItem[] = NAV_CONFIG.filter(
+  (item) => !BOTTOM_NAV_PRIORITY_ITEMS.some((p) => p.id === item.id),
+);

--- a/apps/web/src/components/layout/navIcons.tsx
+++ b/apps/web/src/components/layout/navIcons.tsx
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Inline SVG icons used by the primary navigation.
+ *
+ * Each icon is a 24×24 viewBox stroke icon — the consuming component
+ * controls size and colour via CSS. Icons inherit `currentColor` so they
+ * pick up the active / hover / muted nav states automatically.
+ */
+
+import type { FC } from 'react';
+
+interface IconProps {
+  className?: string;
+}
+
+const Svg: FC<{ children: React.ReactNode; className?: string }> = ({ children, className }) => (
+  <svg
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+    focusable="false"
+    className={className}
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    {children}
+  </svg>
+);
+
+export const DashboardIcon: FC<IconProps> = ({ className }) => (
+  <Svg className={className}>
+    <rect x="3" y="3" width="7" height="9" rx="1" />
+    <rect x="14" y="3" width="7" height="5" rx="1" />
+    <rect x="14" y="12" width="7" height="9" rx="1" />
+    <rect x="3" y="16" width="7" height="5" rx="1" />
+  </Svg>
+);
+
+export const AccountsIcon: FC<IconProps> = ({ className }) => (
+  <Svg className={className}>
+    <rect x="3" y="6" width="18" height="13" rx="2" />
+    <path d="M3 10h18" />
+    <path d="M7 15h2" />
+  </Svg>
+);
+
+export const TransactionsIcon: FC<IconProps> = ({ className }) => (
+  <Svg className={className}>
+    <path d="M4 7h12" />
+    <path d="M13 4l3 3-3 3" />
+    <path d="M20 17H8" />
+    <path d="M11 20l-3-3 3-3" />
+  </Svg>
+);
+
+export const BillsIcon: FC<IconProps> = ({ className }) => (
+  <Svg className={className}>
+    <path d="M6 3h12v18l-3-2-3 2-3-2-3 2z" />
+    <path d="M9 8h6" />
+    <path d="M9 12h6" />
+    <path d="M9 16h4" />
+  </Svg>
+);
+
+export const InvestmentsIcon: FC<IconProps> = ({ className }) => (
+  <Svg className={className}>
+    <path d="M3 17l6-6 4 4 8-8" />
+    <path d="M14 7h7v7" />
+  </Svg>
+);
+
+export const SubscriptionsIcon: FC<IconProps> = ({ className }) => (
+  <Svg className={className}>
+    <path d="M3 12a9 9 0 0 1 15-6.7L21 8" />
+    <path d="M21 3v5h-5" />
+    <path d="M21 12a9 9 0 0 1-15 6.7L3 16" />
+    <path d="M3 21v-5h5" />
+  </Svg>
+);
+
+export const BudgetsIcon: FC<IconProps> = ({ className }) => (
+  <Svg className={className}>
+    <path d="M21 12a9 9 0 1 1-9-9" />
+    <path d="M21 12h-9V3" />
+  </Svg>
+);
+
+export const GoalsIcon: FC<IconProps> = ({ className }) => (
+  <Svg className={className}>
+    <circle cx="12" cy="12" r="9" />
+    <circle cx="12" cy="12" r="5" />
+    <circle cx="12" cy="12" r="1.5" />
+  </Svg>
+);
+
+export const PlanningIcon: FC<IconProps> = ({ className }) => (
+  <Svg className={className}>
+    <rect x="3" y="5" width="18" height="16" rx="2" />
+    <path d="M3 9h18" />
+    <path d="M8 3v4" />
+    <path d="M16 3v4" />
+    <path d="M8 14h2" />
+    <path d="M14 14h2" />
+    <path d="M8 18h2" />
+    <path d="M14 18h2" />
+  </Svg>
+);
+
+export const CategoriesIcon: FC<IconProps> = ({ className }) => (
+  <Svg className={className}>
+    <rect x="3" y="3" width="8" height="8" rx="1" />
+    <rect x="13" y="3" width="8" height="8" rx="1" />
+    <rect x="3" y="13" width="8" height="8" rx="1" />
+    <rect x="13" y="13" width="8" height="8" rx="1" />
+  </Svg>
+);
+
+export const InsightsIcon: FC<IconProps> = ({ className }) => (
+  <Svg className={className}>
+    <path d="M9 21h6" />
+    <path d="M10 17h4" />
+    <path d="M12 3a6 6 0 0 0-4 10.5c.8.8 1.5 1.7 1.7 2.5h4.6c.2-.8.9-1.7 1.7-2.5A6 6 0 0 0 12 3z" />
+  </Svg>
+);
+
+export const CashFlowIcon: FC<IconProps> = ({ className }) => (
+  <Svg className={className}>
+    <path d="M3 17l5-5 4 4 4-6 5 5" />
+    <path d="M3 21h18" />
+  </Svg>
+);
+
+export const NetWorthIcon: FC<IconProps> = ({ className }) => (
+  <Svg className={className}>
+    <path d="M12 3v18" />
+    <path d="M18 7c-1.5-1.5-3.5-2-6-2-3 0-5 1.5-5 3.5S9 12 12 12s5 1 5 3.5-2 3.5-5 3.5c-2.5 0-4.5-.5-6-2" />
+  </Svg>
+);
+
+export const ReportsIcon: FC<IconProps> = ({ className }) => (
+  <Svg className={className}>
+    <path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z" />
+    <path d="M14 3v6h6" />
+    <path d="M9 17v-3" />
+    <path d="M12 17v-5" />
+    <path d="M15 17v-2" />
+  </Svg>
+);
+
+export const AchievementsIcon: FC<IconProps> = ({ className }) => (
+  <Svg className={className}>
+    <circle cx="12" cy="9" r="6" />
+    <path d="M9 14l-2 7 5-3 5 3-2-7" />
+  </Svg>
+);
+
+export const WatchlistsIcon: FC<IconProps> = ({ className }) => (
+  <Svg className={className}>
+    <circle cx="12" cy="12" r="3" />
+    <path d="M2 12s4-7 10-7 10 7 10 7-4 7-10 7-10-7-10-7z" />
+  </Svg>
+);
+
+export const HouseholdIcon: FC<IconProps> = ({ className }) => (
+  <Svg className={className}>
+    <circle cx="9" cy="8" r="3" />
+    <path d="M3 20c0-3 2.5-5 6-5s6 2 6 5" />
+    <circle cx="17" cy="9" r="2.5" />
+    <path d="M21 19c0-2.2-1.7-4-4-4" />
+  </Svg>
+);
+
+export const BankIcon: FC<IconProps> = ({ className }) => (
+  <Svg className={className}>
+    <path d="M3 10l9-6 9 6" />
+    <path d="M5 10v8" />
+    <path d="M9 10v8" />
+    <path d="M15 10v8" />
+    <path d="M19 10v8" />
+    <path d="M3 21h18" />
+  </Svg>
+);
+
+export const ImportIcon: FC<IconProps> = ({ className }) => (
+  <Svg className={className}>
+    <path d="M12 3v12" />
+    <path d="M7 10l5 5 5-5" />
+    <path d="M5 21h14" />
+  </Svg>
+);
+
+export const PrivacyIcon: FC<IconProps> = ({ className }) => (
+  <Svg className={className}>
+    <path d="M12 3l8 3v5c0 5-3.5 8.5-8 10-4.5-1.5-8-5-8-10V6z" />
+    <path d="M9 12l2 2 4-4" />
+  </Svg>
+);
+
+export const MoreIcon: FC<IconProps> = ({ className }) => (
+  <Svg className={className}>
+    <circle cx="5" cy="12" r="1.5" />
+    <circle cx="12" cy="12" r="1.5" />
+    <circle cx="19" cy="12" r="1.5" />
+  </Svg>
+);
+
+export const ChevronDownIcon: FC<IconProps> = ({ className }) => (
+  <Svg className={className}>
+    <path d="M6 9l6 6 6-6" />
+  </Svg>
+);
+
+export const CloseIcon: FC<IconProps> = ({ className }) => (
+  <Svg className={className}>
+    <path d="M6 6l12 12" />
+    <path d="M18 6L6 18" />
+  </Svg>
+);
+
+export const SettingsIcon: FC<IconProps> = ({ className }) => (
+  <Svg className={className}>
+    <circle cx="12" cy="12" r="3" />
+    <path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1a1.7 1.7 0 0 0-1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1a1.7 1.7 0 0 0 1.5-1 1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3h.1a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5h.1a1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8v.1a1.7 1.7 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1z" />
+  </Svg>
+);
+
+export const KeyboardIcon: FC<IconProps> = ({ className }) => (
+  <Svg className={className}>
+    <rect x="2" y="5" width="20" height="14" rx="2" />
+    <path d="M6 9h.01" />
+    <path d="M10 9h.01" />
+    <path d="M14 9h.01" />
+    <path d="M18 9h.01" />
+    <path d="M6 13h.01" />
+    <path d="M10 13h.01" />
+    <path d="M14 13h.01" />
+    <path d="M18 13h.01" />
+    <path d="M8 17h8" />
+  </Svg>
+);
+
+export const SignOutIcon: FC<IconProps> = ({ className }) => (
+  <Svg className={className}>
+    <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+    <path d="M16 17l5-5-5-5" />
+    <path d="M21 12H9" />
+  </Svg>
+);

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -14,6 +14,7 @@ import { initMonitoring } from './lib/monitoring';
 import './theme/tokens.css';
 import './styles/responsive.css';
 import './styles/responsive-layout.css';
+import './styles/navigation-chrome.css';
 import './styles/accessibility.css';
 import './styles/reduced-motion.css';
 import './styles/font-scaling.css';

--- a/apps/web/src/styles/navigation-chrome.css
+++ b/apps/web/src/styles/navigation-chrome.css
@@ -1,0 +1,407 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/*
+ * Primary navigation styles.
+ *
+ * Layers on top of the shell styles defined in responsive.css. Adds:
+ *   - Grouped, collapsible sections in the desktop sidebar.
+ *   - A clearer active-state indicator (left rail + colour + weight).
+ *   - The mobile "More" sheet drawer.
+ *   - The "More" tab in the bottom nav.
+ */
+
+/* ── Sidebar groups (desktop) ─────────────────────────────────────────── */
+
+.app-sidebar__group {
+  display: flex;
+  flex-direction: column;
+  border-top: 1px solid var(--semantic-border-default, var(--navigation-border));
+  padding: var(--spacing-2) var(--spacing-1) 0;
+  margin-top: var(--spacing-2);
+}
+
+.app-sidebar__group:first-of-type {
+  border-top: none;
+  margin-top: 0;
+}
+
+.app-sidebar__group-heading {
+  margin: 0;
+  padding: 0;
+  font-size: 11px;
+  font-weight: var(--font-weight-semibold, 600);
+}
+
+.app-sidebar__group-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: var(--spacing-2) var(--spacing-3);
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--semantic-text-secondary, var(--navigation-text));
+  font: inherit;
+  font-size: 11px;
+  font-weight: var(--font-weight-semibold, 600);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border-radius: var(--border-radius-sm, 4px);
+}
+
+.app-sidebar__group-toggle:hover,
+.app-sidebar__group-toggle:focus-visible {
+  color: var(--semantic-text-primary, var(--navigation-text-active));
+}
+
+.app-sidebar__group-toggle:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+}
+
+.app-sidebar__group-label {
+  flex: 1;
+  text-align: left;
+}
+
+.app-sidebar__group-chevron {
+  display: inline-flex;
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  transition: transform 150ms ease;
+}
+
+.app-sidebar__group-chevron svg {
+  width: 14px;
+  height: 14px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.app-sidebar__group-chevron--expanded {
+  transform: rotate(0deg);
+}
+
+.app-sidebar__group:not([data-expanded='true']) .app-sidebar__group-chevron {
+  transform: rotate(-90deg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .app-sidebar__group-chevron {
+    transition: none;
+  }
+}
+
+.sidebar-nav__list--nested {
+  padding-top: 0;
+  padding-bottom: var(--spacing-1);
+}
+
+/* ── Enhanced active state for sidebar items ──────────────────────────── */
+
+.sidebar-nav__item {
+  position: relative;
+  font-weight: var(--font-weight-medium, 500);
+}
+
+/* Left rail accent on the active row — readable in any theme because it
+ * uses the same accent token as the bottom-nav indicator. */
+.sidebar-nav__item[aria-current='page']::before,
+.sidebar-nav__item--active::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 6px;
+  bottom: 6px;
+  width: 3px;
+  border-radius: 2px;
+  background: var(
+    --navigation-indicator,
+    var(--semantic-interactive-default, var(--color-blue-700, currentColor))
+  );
+}
+
+.sidebar-nav__item[aria-current='page'],
+.sidebar-nav__item--active {
+  font-weight: var(--font-weight-semibold, 600);
+}
+
+.sidebar-nav__item--sign-out {
+  color: var(--semantic-text-secondary, var(--navigation-text));
+}
+
+.sidebar-nav__item--sign-out:hover,
+.sidebar-nav__item--sign-out:focus-visible {
+  color: var(--semantic-status-negative, var(--color-red-700));
+}
+
+/* ── Bottom-nav "More" tab ────────────────────────────────────────────── */
+
+.nav-item--more .nav-item__icon svg {
+  width: 24px;
+  height: 24px;
+}
+
+/* ── More sheet (mobile drawer) ───────────────────────────────────────── */
+
+.more-sheet {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  display: flex;
+  flex-direction: column;
+}
+
+.more-sheet__scrim {
+  position: absolute;
+  inset: 0;
+  border: none;
+  padding: 0;
+  margin: 0;
+  background: rgba(15, 23, 42, 0.55);
+  cursor: pointer;
+  /* Don't show a focus ring on the scrim — the close button is the
+   * focusable affordance. */
+  outline: none;
+}
+
+.more-sheet__panel {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  max-height: 92dvh;
+  display: flex;
+  flex-direction: column;
+  background: var(--semantic-background-primary, var(--navigation-background, #fff));
+  color: var(--semantic-text-primary);
+  border-top-left-radius: var(--border-radius-lg, 16px);
+  border-top-right-radius: var(--border-radius-lg, 16px);
+  box-shadow: 0 -8px 32px rgba(0, 0, 0, 0.18);
+  overflow: hidden;
+  /* Honour the device safe-area on iOS so the bottom edge isn't cut off. */
+  padding-bottom: env(safe-area-inset-bottom, 0);
+  animation: more-sheet-slide-up 180ms ease-out;
+}
+
+@keyframes more-sheet-slide-up {
+  from {
+    transform: translateY(8%);
+    opacity: 0.6;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .more-sheet__panel {
+    animation: none;
+  }
+}
+
+.more-sheet__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-4);
+  border-bottom: 1px solid var(--semantic-border-default, var(--navigation-border));
+  flex-shrink: 0;
+}
+
+.more-sheet__title {
+  margin: 0;
+  font-size: var(--type-scale-title-font-size, 1.125rem);
+  font-weight: var(--font-weight-semibold, 600);
+  color: var(--semantic-text-primary);
+}
+
+.more-sheet__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: var(--border-radius-md, 8px);
+  color: var(--semantic-text-secondary);
+  cursor: pointer;
+}
+
+.more-sheet__close:hover,
+.more-sheet__close:focus-visible {
+  background: var(--semantic-background-secondary);
+  color: var(--semantic-text-primary);
+}
+
+.more-sheet__close:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+}
+
+.more-sheet__close svg {
+  width: 20px;
+  height: 20px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.more-sheet__body {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--spacing-2) var(--spacing-3) var(--spacing-4);
+  -webkit-overflow-scrolling: touch;
+}
+
+.more-sheet__group {
+  margin-top: var(--spacing-4);
+}
+
+.more-sheet__group:first-child {
+  margin-top: var(--spacing-2);
+}
+
+.more-sheet__group-heading {
+  margin: 0 0 var(--spacing-2);
+  padding: 0 var(--spacing-2);
+  font-size: 11px;
+  font-weight: var(--font-weight-semibold, 600);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--semantic-text-secondary);
+}
+
+.more-sheet__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.more-sheet__item {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-3);
+  width: 100%;
+  padding: var(--spacing-3);
+  background: none;
+  border: 1px solid transparent;
+  border-radius: var(--border-radius-md, 8px);
+  color: var(--semantic-text-primary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  min-height: 56px;
+}
+
+.more-sheet__item:hover,
+.more-sheet__item:focus-visible {
+  background: var(--semantic-background-secondary);
+}
+
+.more-sheet__item:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: -2px;
+}
+
+.more-sheet__item--active {
+  background: var(--color-blue-50, rgba(59, 130, 246, 0.08));
+  color: var(--semantic-text-primary);
+  font-weight: var(--font-weight-semibold, 600);
+  position: relative;
+}
+
+.more-sheet__item--active::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 8px;
+  bottom: 8px;
+  width: 3px;
+  border-radius: 2px;
+  background: var(
+    --navigation-indicator,
+    var(--semantic-interactive-default, var(--color-blue-700))
+  );
+}
+
+[data-theme='dark'] .more-sheet__item--active {
+  background: rgba(96, 165, 250, 0.16);
+}
+
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme='light']) .more-sheet__item--active {
+    background: rgba(96, 165, 250, 0.16);
+  }
+}
+
+.more-sheet__item--danger {
+  color: var(--semantic-status-negative, var(--color-red-700));
+}
+
+.more-sheet__item-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
+  color: var(--semantic-text-secondary);
+}
+
+.more-sheet__item--active .more-sheet__item-icon,
+.more-sheet__item--danger .more-sheet__item-icon {
+  color: inherit;
+}
+
+.more-sheet__item-icon svg {
+  width: 22px;
+  height: 22px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.more-sheet__item-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
+}
+
+.more-sheet__item-label {
+  font-size: var(--type-scale-body-font-size, 1rem);
+  line-height: 1.25;
+}
+
+.more-sheet__item-description {
+  font-size: var(--type-scale-caption-font-size, 0.8125rem);
+  color: var(--semantic-text-secondary);
+  line-height: 1.3;
+  font-weight: var(--font-weight-regular, 400);
+}
+
+/* Hide the More sheet on viewports where the sidebar is the primary nav.
+ * It's only triggered from the bottom-nav and the bottom-nav itself is
+ * hidden ≥ 768px, but a defensive guard keeps the DOM tidy. */
+@media (min-width: 768px) {
+  .more-sheet {
+    display: none;
+  }
+}


### PR DESCRIPTION
Fixes #1930

## New information architecture

`apps/web/src/components/layout/navConfig.tsx` is now the single source of
truth for every navigation destination. Both the wide-screen sidebar and the
narrow-screen bottom-nav-plus-sheet render from the same `NAV_CONFIG`
array, so the two layouts can never drift again.

**Groups (sidebar + "More" sheet):**

| Group    | Destinations                                                                |
|----------|-----------------------------------------------------------------------------|
| _pinned_ | Dashboard                                                                   |
| Money    | Accounts, Transactions, Bills, Investments, Subscriptions                   |
| Plan     | Budgets, Goals, Planning, Categories                                        |
| Insights | Insights, Cash Flow, Net Worth, Reports, Achievements, Watchlists           |
| Connect  | Household, Bank Connections, Import Data, Privacy                           |
| _footer_ | Shortcuts, Settings, Sign Out                                               |

**Mobile bottom-nav priority slots:** Dashboard · Accounts · Transactions · Budgets · **More**

The "More" tab opens a full-height sheet that lists every other
destination grouped under the same headings, each with a one-line
description for new users. Settings, Shortcuts and Sign Out are also
surfaced there so the mobile user gets to every flow that desktop users
do — the #1 acceptance criterion from the issue.

## Acceptance checklist

- [x] On narrow viewports, **every** sidebar destination is reachable
  (via the "More" sheet).
- [x] On wide viewports the sidebar has 1 pinned destination + 4 group
  section headers + 3 footer items = 8 top-level items (≤ 8).
- [x] No destination is duplicated. (Old `MORE_NAV_ITEMS` list folded
  into the grouped config; Achievements and Watchlists now live under
  Insights.)
- [x] Keyboard navigation hits every destination — sidebar items are
  ordinary `<button>` elements in document order; group toggles use
  proper `aria-expanded` / `aria-controls`.
- [x] Active route marked with `aria-current="page"` everywhere
  (sidebar item, bottom-nav tab, More-sheet item, and the "More" tab
  itself when the current route is reachable only via the sheet).
- [x] Sheet is a real `role="dialog" aria-modal="true"` with focus
  trapping behaviour (focus moves to the close button on open,
  restored to the trigger on close, Escape closes, body scroll
  locked).

## Files

```
new   apps/web/src/components/layout/navConfig.tsx       — single source of truth
new   apps/web/src/components/layout/navIcons.tsx        — 20+ shared stroke icons
new   apps/web/src/components/layout/MoreNavSheet.tsx    — mobile drawer
new   apps/web/src/styles/navigation-chrome.css          — grouped sidebar + sheet
edit  apps/web/src/components/layout/Navigation.tsx      — config-driven sidebar + bottom-nav
edit  apps/web/src/components/layout/Navigation.test.tsx — 27 unit tests for the new structure
edit  apps/web/src/components/layout/index.ts            — re-exports
edit  apps/web/src/main.tsx                              — wire new CSS
edit  apps/web/e2e/responsive.spec.ts                    — assert 4+More bottom-nav layout
new   apps/web/e2e/nav-reachability.spec.ts              — every route reachable at 375 & 1280
```

Scope is intentionally limited to the navigation chrome — no page
internals were touched. The existing `NavItem` / `NAV_ITEMS` shape is
preserved as a deprecated back-compat shim so other agents working in
`apps/web/src/` in parallel will not see merge surprises.

## Validation

| Command                                    | Result                                                                 |
|--------------------------------------------|------------------------------------------------------------------------|
| `npm run -w packages/design-tokens build`  | ✅                                                                     |
| `npm run -w apps/web type-check`           | ✅                                                                     |
| `npm run -w apps/web lint`                 | ✅                                                                     |
| `npm run -w apps/web build`                | ✅                                                                     |
| `npm run -w apps/web test`                 | 6378 / 6379 pass ¹                                                     |
| `nav-reachability.spec.ts` (Playwright)    | new — parametrised over every destination at 375 px and 1280 px        |

¹ The single failure is the pre-existing `src/utils/formatDate.test.ts`
flake on Windows timezones — reproduces on `main` and is unrelated to
this change.

## Screenshots

Local sandboxed screenshot capture against the dev server was flaky in
this environment (the dashboard hydration races the screenshot helper).
The new Playwright `nav-reachability.spec.ts` is the authoritative
regression guard — it walks each destination via the visible
navigation chrome at both viewports, which is the original acceptance
test from the issue.
