### PR TITLE
fix(web): session resilience + PWA install eligibility (#1909, #1965, #1966)

### DIFF
--- a/apps/web/e2e/session-persistence.spec.ts
+++ b/apps/web/e2e/session-persistence.spec.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * E2E regression test for #1966 — "Page reload signs the user out".
+ *
+ * Uses the existing `authenticatedPage` fixture which mocks the
+ * `/api/auth/refresh` endpoint to always return a valid session (the
+ * production cookie-based flow is equivalent: an HttpOnly refresh cookie
+ * persists across reloads and the backend rotates it on each call).
+ *
+ * Asserts that:
+ *   1. After landing on `/dashboard` the user is authenticated (the
+ *      fixture proves this).
+ *   2. After F5 / `page.reload()` the user STAYS on `/dashboard` rather
+ *      than being redirected to `/login`.
+ *   3. Deep links survive reload — `/accounts` reloaded stays on
+ *      `/accounts`.
+ */
+
+import { expect, test } from './fixtures';
+
+test('session persists across page reload (#1966)', async ({ authenticatedPage }) => {
+  // Sanity-check: the fixture landed us on /dashboard.
+  await expect(authenticatedPage).toHaveURL(/\/dashboard$/);
+
+  // Reload — the AuthProvider must restore the session via the (mocked)
+  // refresh endpoint and the route guard must NOT redirect to /login.
+  await authenticatedPage.reload();
+
+  await expect(authenticatedPage).toHaveURL(/\/dashboard$/);
+  // Login form should not be present anywhere after restore.
+  await expect(authenticatedPage.getByRole('button', { name: /sign in/i })).toHaveCount(0);
+});
+
+test('session persists across deep-link reload (#1966)', async ({ authenticatedPage }) => {
+  await authenticatedPage.goto('/accounts');
+  await expect(authenticatedPage).toHaveURL(/\/accounts$/);
+
+  await authenticatedPage.reload();
+
+  await expect(authenticatedPage).toHaveURL(/\/accounts$/);
+});

--- a/apps/web/public/manifest.json
+++ b/apps/web/public/manifest.json
@@ -1,9 +1,14 @@
 {
+  "id": "/?source=pwa",
   "name": "Finance",
   "short_name": "Finance",
   "description": "Multi-platform financial tracking application",
-  "start_url": "/",
+  "lang": "en-US",
+  "dir": "ltr",
+  "scope": "/",
+  "start_url": "/?source=pwa",
   "display": "standalone",
+  "display_override": ["standalone", "minimal-ui", "browser"],
   "orientation": "any",
   "theme_color": "#1565C0",
   "background_color": "#FFFFFF",
@@ -12,12 +17,14 @@
     {
       "src": "/icons/icon-192.png",
       "sizes": "192x192",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "any"
     },
     {
       "src": "/icons/icon-512.png",
       "sizes": "512x512",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "any"
     },
     {
       "src": "/icons/icon-512-maskable.png",

--- a/apps/web/src/__tests__/pwa-install.test.ts
+++ b/apps/web/src/__tests__/pwa-install.test.ts
@@ -37,8 +37,22 @@ describe('PWA manifest.json (#1329)', () => {
     expect(typeof manifest.short_name).toBe('string');
   });
 
-  it('has start_url set to "/"', () => {
-    expect(manifest.start_url).toBe('/');
+  it('has start_url rooted at "/"', () => {
+    // start_url may include a tracking query (e.g. ?source=pwa) but must
+    // resolve to the app root so installed sessions land on the home page.
+    expect(typeof manifest.start_url).toBe('string');
+    const startUrl = new URL(manifest.start_url as string, 'https://example.com');
+    expect(startUrl.pathname).toBe('/');
+  });
+
+  it('has explicit id rooted at "/" so Chromium treats updates as the same app (#1965)', () => {
+    expect(typeof manifest.id).toBe('string');
+    const id = new URL(manifest.id as string, 'https://example.com');
+    expect(id.pathname).toBe('/');
+  });
+
+  it('declares scope "/" so the SW controls the entire origin (#1965)', () => {
+    expect(manifest.scope).toBe('/');
   });
 
   it('has display set to "standalone"', () => {

--- a/apps/web/src/auth/auth-context.test.tsx
+++ b/apps/web/src/auth/auth-context.test.tsx
@@ -151,4 +151,45 @@ describe('AuthProvider refresh restoration', () => {
     expect(screen.getByTestId('user-email')).toHaveTextContent('none');
     expect(onUnauthenticated).toHaveBeenCalledOnce();
   });
+
+  it('runs session restore exactly once under React StrictMode (#1966 regression)', async () => {
+    // StrictMode mounts the provider twice in development.  Before
+    // #1966 hardening this fired `tryRestoreSession()` twice (and
+    // `handleSessionExpired()` twice when the refresh failed), which
+    // could race the redirect-to-login flow against a still-pending
+    // refresh.  The useRef guard now ensures the bootstrap runs once.
+    const token = makeToken({
+      sub: 'user-strict',
+      email: 'strict@example.com',
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ access_token: token, expires_in: 3600 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { StrictMode } = await import('react');
+
+    render(
+      <StrictMode>
+        <AuthProvider config={config}>
+          <AuthProbe />
+        </AuthProvider>
+      </StrictMode>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('loading-state')).toHaveTextContent('ready'));
+    expect(screen.getByTestId('auth-state')).toHaveTextContent('authenticated');
+    expect(screen.getByTestId('user-email')).toHaveTextContent('strict@example.com');
+
+    // Exactly one /api/auth/refresh call even though StrictMode mounted
+    // the provider twice.  Multiple calls would indicate the useRef guard
+    // is broken.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/auth/refresh',
+      expect.objectContaining({ credentials: 'include' }),
+    );
+    expect(onUnauthenticated).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/auth/auth-context.tsx
+++ b/apps/web/src/auth/auth-context.tsx
@@ -181,6 +181,19 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
   const [showPasskeyPrompt, setShowPasskeyPrompt] = useState(false);
   const [isOffline, setIsOffline] = useState(false);
   const onlineRetryHandlerRef = useRef<(() => void) | null>(null);
+  /**
+   * Tracks whether the initial session-restore effect has already run for
+   * this provider instance (#1966).  React 19 StrictMode mounts the
+   * provider twice in development, which previously fired
+   * `tryRestoreSession()` twice and could redirect the user to /login
+   * mid-restore via duplicate `handleSessionExpired` calls.
+   *
+   * `useRef` survives StrictMode's mount → unmount → re-mount cycle
+   * because React keeps the underlying fiber's ref object alive across
+   * the simulated remount.  Gating the effect body on this ref ensures
+   * the auth bootstrap runs exactly once per page load.
+   */
+  const initStartedRef = useRef(false);
 
   const demoModeActive = isDemoMode(config.supabaseUrl);
   const isAuthenticated = user !== null && (hasValidToken() || isOffline);
@@ -232,6 +245,18 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
   // -----------------------------------------------------------------------
 
   useEffect(() => {
+    // StrictMode mounts this effect twice in dev.  The second invocation
+    // would re-fire `tryRestoreSession()` and any side-effecting
+    // `handleSessionExpired()` calls — including the hard
+    // `window.location.href = '/login'` navigation registered by
+    // `config.onUnauthenticated`.  Gating on the module-/instance-scoped
+    // ref ensures the auth bootstrap runs exactly once per page load
+    // (#1966).
+    if (initStartedRef.current) {
+      return;
+    }
+    initStartedRef.current = true;
+
     if (demoModeActive) {
       // In demo mode, skip WebAuthn and use localStorage-based session
       // persistence instead of the HttpOnly cookie refresh flow.

--- a/apps/web/src/db/DatabaseProvider.tsx
+++ b/apps/web/src/db/DatabaseProvider.tsx
@@ -7,6 +7,7 @@ import {
   initDatabaseWithDiagnostics,
   getUserFriendlyStorageMessage,
   StorageError,
+  _resetInitSingletonForTesting,
   type SqliteDb,
   type StorageDiagnostics,
   type StorageErrorCode,
@@ -106,6 +107,10 @@ export function DatabaseProvider({ children }: DatabaseProviderProps) {
   const [reloadToken, setReloadToken] = useState(0);
 
   const retryInitialization = useCallback(() => {
+    // Clear the cached singleton so the next init call actually retries
+    // (the singleton clears itself on rejection, but explicit reset is
+    // safer if the retry button is somehow pressed during a success).
+    _resetInitSingletonForTesting();
     setReloadToken((currentValue) => currentValue + 1);
   }, []);
 
@@ -113,8 +118,17 @@ export function DatabaseProvider({ children }: DatabaseProviderProps) {
     // In E2E mode the stub DB is already set — skip real WASM init.
     if (isE2E) return;
 
+    // React 19 StrictMode double-mounts the provider in dev.  We rely on
+    // the module-level singleton in `initDatabaseWithDiagnostics()` so
+    // both mounts converge on the SAME init promise — running the
+    // migration sequence exactly once (#1909).
+    //
+    // We intentionally DO NOT call `db.close()` in the cleanup function.
+    // The database is a process-wide singleton that lives for the page
+    // lifetime.  Closing it during StrictMode's synthetic unmount would
+    // hand the second mount a dead instance and cause "Cannot commit:
+    // no transaction is active" or "database is closed" errors.
     let isDisposed = false;
-    let initializedDb: SqliteDb | null = null;
 
     const initializeDatabase = async () => {
       setIsLoading(true);
@@ -123,27 +137,18 @@ export function DatabaseProvider({ children }: DatabaseProviderProps) {
 
       try {
         const result = await initDatabaseWithDiagnostics();
-        initializedDb = result.db;
 
-        await seedDatabase(initializedDb);
+        await seedDatabase(result.db);
 
         if (isDisposed) {
-          await initializedDb.close();
-          initializedDb = null;
+          // Provider truly unmounted (not just StrictMode replay) — leave
+          // the cached DB in place; the next provider mount will pick it
+          // up via the singleton promise.
           return;
         }
 
-        setCtxValue({ db: initializedDb, diagnostics: result.diagnostics });
+        setCtxValue({ db: result.db, diagnostics: result.diagnostics });
       } catch (initializationError) {
-        if (initializedDb) {
-          try {
-            await initializedDb.close();
-          } catch {
-            // Ignore cleanup failures after an init error.
-          }
-          initializedDb = null;
-        }
-
         if (!isDisposed) {
           setInitError(toInitError(initializationError));
         }
@@ -158,10 +163,6 @@ export function DatabaseProvider({ children }: DatabaseProviderProps) {
 
     return () => {
       isDisposed = true;
-      if (initializedDb) {
-        void initializedDb.close();
-        initializedDb = null;
-      }
     };
   }, [isE2E, reloadToken]);
 

--- a/apps/web/src/db/__tests__/DatabaseProvider.test.tsx
+++ b/apps/web/src/db/__tests__/DatabaseProvider.test.tsx
@@ -4,7 +4,12 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { DatabaseProvider, useDatabase, useStorageDiagnostics } from '../DatabaseProvider';
-import { StorageError, type StorageDiagnostics, type SqliteDb } from '../sqlite-wasm';
+import {
+  StorageError,
+  _resetInitSingletonForTesting,
+  type StorageDiagnostics,
+  type SqliteDb,
+} from '../sqlite-wasm';
 
 // Mock the sqlite-wasm module — we test provider behavior, not real WASM
 vi.mock('../sqlite-wasm', async (importOriginal) => {
@@ -53,6 +58,10 @@ function DiagnosticsConsumer() {
 describe('DatabaseProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset the module-level init singleton so each test starts fresh
+    // (the singleton dedupes across StrictMode mounts in production — for
+    // tests we must explicitly clear it).
+    _resetInitSingletonForTesting();
     // Reset E2E flag
     if (typeof window !== 'undefined') {
       delete window.__PLAYWRIGHT_E2E__;
@@ -218,6 +227,45 @@ describe('DatabaseProvider', () => {
     });
 
     expect(screen.getByText(/storage space is full/i)).toBeInTheDocument();
+  });
+
+  it('StrictMode double-mount converges on a ready DB without errors (#1909 regression)', async () => {
+    // StrictMode intentionally mounts then unmounts then re-mounts the
+    // provider in dev to surface side-effect bugs.  Before #1909 this
+    // launched two concurrent OPFS init paths and crashed the migration
+    // runner with "Cannot commit: no transaction is active".  The fix
+    // wraps init in a module-level singleton (covered in
+    // sqlite-wasm-singleton.test.ts) AND removes `db.close()` from the
+    // provider cleanup so the second mount inherits a live DB.
+    //
+    // This test asserts the React-layer contract: even after StrictMode's
+    // mount → unmount → re-mount cycle, the consumer renders against a
+    // valid database instance with no error banner.
+    (initDatabaseWithDiagnostics as Mock).mockResolvedValue({
+      db: mockDb,
+      diagnostics: mockDiagnostics,
+    });
+
+    const { StrictMode } = await import('react');
+
+    render(
+      <StrictMode>
+        <DatabaseProvider>
+          <DbConsumer />
+        </DatabaseProvider>
+      </StrictMode>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('db-ready')).toHaveTextContent('Database ready');
+    });
+
+    // No error banner — the migration race condition would surface here.
+    expect(screen.queryByRole('alert')).toBeNull();
+
+    // db.close() must NOT be called during the StrictMode cleanup —
+    // doing so would hand the second mount a dead connection.
+    expect(mockDb.close).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/db/sqlite-wasm.ts
+++ b/apps/web/src/db/sqlite-wasm.ts
@@ -582,6 +582,40 @@ function classifyError(err: unknown): StorageErrorCode {
 // ---------------------------------------------------------------------------
 
 /**
+ * Module-level singleton promise (#1909).
+ *
+ * Under React 19 StrictMode (dev), the {@link DatabaseProvider} effect
+ * mounts twice — back-to-back — which previously launched two concurrent
+ * `initDatabaseInternal()` calls against the same OPFS file.  The second
+ * call's `BEGIN TRANSACTION` would auto-commit/rollback the first call's
+ * still-open transaction, and the first call's subsequent `COMMIT;` would
+ * throw "Cannot commit: no transaction is active".
+ *
+ * We dedupe by caching the in-flight promise.  Both StrictMode mounts now
+ * share the same database instance and the same migration sequence runs
+ * exactly once.
+ *
+ * On rejection we clear the cache so that {@link retryInitialization} from
+ * the provider UI can recover from transient failures (e.g. flaky OPFS
+ * handle, quota exhausted then freed).
+ */
+let _initPromise: Promise<StorageInitResult> | null = null;
+
+/**
+ * Reset the cached init promise.
+ *
+ * Intended ONLY for the Vitest test suite where module-level state from
+ * one test can otherwise leak into the next.  Production code should
+ * never need to call this — the singleton is designed to last for the
+ * lifetime of the page.
+ *
+ * @internal
+ */
+export function _resetInitSingletonForTesting(): void {
+  _initPromise = null;
+}
+
+/**
  * Initialises (or opens) the Finance SQLite database.
  *
  * 1. Detects the best storage backend (OPFS preferred, IndexedDB fallback).
@@ -595,12 +629,28 @@ function classifyError(err: unknown): StorageErrorCode {
  *
  * Throws {@link StorageError} with a machine-readable `code` on failure.
  *
+ * Concurrent callers (e.g. React 19 StrictMode's double-mounted effect)
+ * receive the same in-flight promise — the database is opened and
+ * migrations are executed exactly once per page load (#1909).
+ *
  * Usage:
  * ```ts
  * const { db, diagnostics } = await initDatabaseWithDiagnostics();
  * ```
  */
-export async function initDatabaseWithDiagnostics(): Promise<StorageInitResult> {
+export function initDatabaseWithDiagnostics(): Promise<StorageInitResult> {
+  if (!_initPromise) {
+    _initPromise = initDatabaseInternal().catch((error) => {
+      // Allow the caller to retry after a failure (e.g. via the
+      // ErrorBanner retry button in DatabaseProvider).
+      _initPromise = null;
+      throw error;
+    });
+  }
+  return _initPromise;
+}
+
+async function initDatabaseInternal(): Promise<StorageInitResult> {
   const detectedBackend = await detectBackend();
   const opfsAvailable = detectedBackend === 'opfs';
   let didFallback = false;

--- a/apps/web/src/hooks/__tests__/useServiceWorkerUpdate.test.ts
+++ b/apps/web/src/hooks/__tests__/useServiceWorkerUpdate.test.ts
@@ -4,15 +4,7 @@ import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useServiceWorkerUpdate } from '../useServiceWorkerUpdate';
-
-// ---------------------------------------------------------------------------
-// Mocks
-// ---------------------------------------------------------------------------
-
-// Mock the service worker URL import so the module can load
-vi.mock('../../sw/service-worker.ts?worker&url', () => ({
-  default: '/sw.js',
-}));
+import { _resetServiceWorkerRegistrationForTesting } from '../../sw/register';
 
 // ---------------------------------------------------------------------------
 // Setup
@@ -28,6 +20,11 @@ let registerPromiseResolve: (reg: unknown) => void;
 
 beforeEach(() => {
   vi.clearAllMocks();
+
+  // Reset the registerAppServiceWorker singleton so each test triggers
+  // a fresh navigator.serviceWorker.register() call.  Otherwise the
+  // first test's resolved promise leaks into subsequent tests (#1965).
+  _resetServiceWorkerRegistrationForTesting();
 
   mockRegistration = {
     waiting: null,
@@ -58,6 +55,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  _resetServiceWorkerRegistrationForTesting();
   vi.restoreAllMocks();
 });
 

--- a/apps/web/src/hooks/useServiceWorkerUpdate.ts
+++ b/apps/web/src/hooks/useServiceWorkerUpdate.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import serviceWorkerUrl from '../sw/service-worker.ts?worker&url';
+import { registerAppServiceWorker } from '../sw/register';
 
 import type { ClientToSwMessage } from '../db/sync/types';
 
@@ -10,7 +10,15 @@ export interface UseServiceWorkerUpdateResult {
   applyUpdate: () => void;
 }
 
-/** Listen for waiting service workers and expose a way to activate them immediately. */
+/**
+ * Listen for waiting service workers and expose a way to activate them
+ * immediately.
+ *
+ * The actual SW registration happens at app boot in `main.tsx` via
+ * {@link registerAppServiceWorker} (#1965) — this hook reuses the
+ * resulting Registration rather than registering its own, so the SW is
+ * installed even on anonymous routes where this hook never mounts.
+ */
 export function useServiceWorkerUpdate(): UseServiceWorkerUpdateResult {
   const [updateAvailable, setUpdateAvailable] = useState(false);
   const registrationRef = useRef<ServiceWorkerRegistration | null>(null);
@@ -56,14 +64,13 @@ export function useServiceWorkerUpdate(): UseServiceWorkerUpdateResult {
       });
     };
 
-    navigator.serviceWorker
-      .register(serviceWorkerUrl, { scope: '/', type: 'module' })
+    registerAppServiceWorker()
       .then((registration) => {
-        if (mounted) {
+        if (mounted && registration) {
           monitorRegistration(registration);
         }
       })
-      .catch((err) => {
+      .catch((err: unknown) => {
         // eslint-disable-next-line no-console -- dev visibility; SW errors are non-fatal
         console.error('[sw] registration failed', err);
         registrationRef.current = null;

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -11,6 +11,7 @@ import { ScrollToTop } from './components/navigation/ScrollToTop';
 import { DatabaseProvider } from './db/DatabaseProvider';
 import { MoneyDisplayProvider } from './lib/display-settings';
 import { initMonitoring } from './lib/monitoring';
+import { registerAppServiceWorker } from './sw/register';
 import './theme/tokens.css';
 import './styles/responsive.css';
 import './styles/responsive-layout.css';
@@ -75,6 +76,25 @@ if (supabaseUrl && !supabaseUrl.includes('placeholder')) {
 }
 
 initMonitoring();
+
+// ---------------------------------------------------------------------------
+// Service worker registration
+// ---------------------------------------------------------------------------
+//
+// Registered at boot (NOT inside the authenticated layout) so the SW is
+// active on ALL pages, including the anonymous `/login` and `/signup`
+// routes.  Chromium's PWA installability heuristic only credits the
+// install icon when the page that hosts the manifest link is controlled
+// by a SW with a `fetch` handler (#1965).
+if (typeof window !== 'undefined') {
+  // Wait for the load event so the SW install doesn't compete with
+  // critical app-shell rendering.  No await — registration is best-effort.
+  if (document.readyState === 'complete') {
+    void registerAppServiceWorker();
+  } else {
+    window.addEventListener('load', () => void registerAppServiceWorker(), { once: true });
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Route-aware database gate

--- a/apps/web/src/sw/__tests__/register.test.ts
+++ b/apps/web/src/sw/__tests__/register.test.ts
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the app-boot service-worker registration (#1965).
+ *
+ * The registration must:
+ *   - Call `navigator.serviceWorker.register()` at the root scope using
+ *     the canonical `/sw.js` URL emitted by Vite's `input.sw` entry.
+ *   - Return the same Promise to all callers (singleton).
+ *   - Resolve to `null` (not throw) when `serviceWorker` is unavailable.
+ *   - Clear the cache on failure so retries are possible after fixing
+ *     the underlying issue (e.g. flaky network for the SW script).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { _resetServiceWorkerRegistrationForTesting, registerAppServiceWorker } from '../register';
+
+describe('registerAppServiceWorker (#1965)', () => {
+  beforeEach(() => {
+    _resetServiceWorkerRegistrationForTesting();
+  });
+
+  afterEach(() => {
+    _resetServiceWorkerRegistrationForTesting();
+    vi.restoreAllMocks();
+  });
+
+  it('registers the SW at the root scope using a root-served URL', async () => {
+    const fakeReg = { scope: '/' } as ServiceWorkerRegistration;
+    const register = vi.fn().mockResolvedValue(fakeReg);
+
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: { register },
+      configurable: true,
+      writable: true,
+    });
+
+    const result = await registerAppServiceWorker();
+    expect(register).toHaveBeenCalledTimes(1);
+
+    // The URL must be a root-served path (either `/sw.js` for the
+    // production bundle or `/src/sw/service-worker.ts` for dev) so the
+    // browser permits `scope: '/'` without a Service-Worker-Allowed
+    // header on a non-root path.
+    const [url, options] = register.mock.calls[0] ?? [];
+    expect(typeof url).toBe('string');
+    expect((url as string).startsWith('/')).toBe(true);
+    expect((url as string).startsWith('/assets/')).toBe(false);
+    expect(options).toMatchObject({ scope: '/', type: 'module' });
+    expect(result).toBe(fakeReg);
+  });
+
+  it('returns the same promise for concurrent callers (singleton)', async () => {
+    const fakeReg = { scope: '/' } as ServiceWorkerRegistration;
+    const register = vi.fn().mockResolvedValue(fakeReg);
+
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: { register },
+      configurable: true,
+      writable: true,
+    });
+
+    const a = registerAppServiceWorker();
+    const b = registerAppServiceWorker();
+    const c = registerAppServiceWorker();
+
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+
+    await Promise.all([a, b, c]);
+
+    // Only one underlying register() call, even with three callers.
+    expect(register).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves to null when serviceWorker is unavailable', async () => {
+    // Strip serviceWorker from navigator
+    const original = Object.getOwnPropertyDescriptor(navigator, 'serviceWorker');
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+
+    const result = await registerAppServiceWorker();
+    expect(result).toBeNull();
+
+    // Restore so it doesn't leak into other tests
+    if (original) Object.defineProperty(navigator, 'serviceWorker', original);
+  });
+
+  it('clears the singleton on failure so callers can retry', async () => {
+    const register = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce({ scope: '/' } as ServiceWorkerRegistration);
+
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: { register },
+      configurable: true,
+      writable: true,
+    });
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const first = await registerAppServiceWorker();
+    expect(first).toBeNull();
+    expect(consoleError).toHaveBeenCalled();
+
+    const second = await registerAppServiceWorker();
+    expect(second).toEqual({ scope: '/' });
+    expect(register).toHaveBeenCalledTimes(2);
+
+    consoleError.mockRestore();
+  });
+});

--- a/apps/web/src/sw/register.ts
+++ b/apps/web/src/sw/register.ts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Service worker registration (#1965).
+ *
+ * Chromium's PWA installability heuristic requires a service worker with
+ * a `fetch` handler to be REGISTERED AND ACTIVE on the page that hosts
+ * the manifest link.  Previously we registered the SW lazily from
+ * `useServiceWorkerUpdate`, which is mounted inside `AppLayout` — only
+ * AFTER the user signs in and navigates to an authenticated route.  As a
+ * result, anonymous visits to `/`, `/login`, etc. never installed the SW,
+ * so the install icon never appeared in Chrome's address bar.
+ *
+ * The previous registration also imported the SW via `?worker&url`, which
+ * caused Vite to emit a hashed bundle under `/assets/src-<hash>.js`.
+ * Browsers reject `scope: '/'` for a SW that lives at `/assets/...` unless
+ * Caddy serves `Service-Worker-Allowed: /` on that path (we don't).
+ * The Vite config's `rollupOptions.input.sw` already emits the canonical
+ * `/sw.js` at the site root, and the dev middleware
+ * (`allowServiceWorkerRootScope` plugin) attaches the right header to the
+ * TS source URL.  We therefore pick the URL explicitly based on
+ * `import.meta.env.DEV`.
+ *
+ * Registering at app boot (and pointing at the root-scoped URL) fixes
+ * both issues:
+ *
+ *   - The SW is installed on the first page load (any route).
+ *   - On reload, the existing SW controls the navigation and Chromium
+ *     credits the page with the installability flag.
+ *   - The Update Banner (#1330) still uses `useServiceWorkerUpdate()` to
+ *     surface new-worker prompts; it now looks up the already-registered
+ *     worker instead of registering one.
+ *
+ * The registration is a no-op in jsdom (test) environments and on
+ * browsers without `serviceWorker` support.
+ */
+
+/**
+ * The URL of the bundled service worker.
+ *
+ * - In production: `/sw.js` is emitted by Vite's `rollupOptions.input.sw`
+ *   entry at the site root.  Same path as the page, so the default scope
+ *   already matches `/` without any extra `Service-Worker-Allowed`
+ *   header.
+ * - In development: Vite serves the TS source directly; the
+ *   `allowServiceWorkerRootScope` middleware in `vite.config.ts` sets
+ *   `Service-Worker-Allowed: /` on that response so the dev SW can also
+ *   claim the root scope.
+ */
+const SERVICE_WORKER_URL: string = import.meta.env.DEV ? '/src/sw/service-worker.ts' : '/sw.js';
+
+/**
+ * Track the registration so subscribers can wait for it without
+ * triggering a second `navigator.serviceWorker.register()` call (which
+ * would otherwise be safely deduped by the browser, but consumers need
+ * the same Registration instance to attach `updatefound` listeners).
+ */
+let registrationPromise: Promise<ServiceWorkerRegistration | null> | null = null;
+
+/**
+ * Register the application service worker at the root scope.
+ *
+ * Idempotent — subsequent calls return the same in-flight promise.
+ * Returns `null` (not undefined / throws) when the environment cannot
+ * register a worker, so callers can write
+ * `const reg = await registerAppServiceWorker(); if (!reg) ...`.
+ */
+export function registerAppServiceWorker(): Promise<ServiceWorkerRegistration | null> {
+  if (registrationPromise) {
+    return registrationPromise;
+  }
+
+  if (
+    typeof navigator === 'undefined' ||
+    !('serviceWorker' in navigator) ||
+    !navigator.serviceWorker
+  ) {
+    registrationPromise = Promise.resolve(null);
+    return registrationPromise;
+  }
+
+  registrationPromise = navigator.serviceWorker
+    .register(SERVICE_WORKER_URL, { scope: '/', type: 'module' })
+    .then((registration) => registration)
+    .catch((error: unknown) => {
+      // SW registration is non-fatal — the app still works without it,
+      // it just loses offline / installability capabilities.
+      // eslint-disable-next-line no-console -- dev visibility; production users get unaffected app
+      console.error('[sw] registration failed', error);
+      registrationPromise = null;
+      return null;
+    });
+
+  return registrationPromise;
+}
+
+/**
+ * Reset registration state.  Test-only helper.
+ *
+ * @internal
+ */
+export function _resetServiceWorkerRegistrationForTesting(): void {
+  registrationPromise = null;
+}


### PR DESCRIPTION
# fix(web): session resilience + PWA install eligibility

Closes three alpha-blocking client bugs in the boot / auth / service-worker layer. Bundled into one PR because they share the boot path and the React 19 StrictMode dev surface.

| # | Title | Root cause | Fix |
|---|---|---|---|
| #1909 | SQLite-WASM "Cannot commit: no transaction is active" on first login | React 19 StrictMode double-mounts `DatabaseProvider`'s effect; two concurrent `initDatabaseWithDiagnostics()` calls open OPFS in parallel and race on `BEGIN`/`COMMIT` inside the migration runner. The second call's `BEGIN` auto-commits the first call's tx, so the first call's `COMMIT` throws. | Module-level `_initPromise` singleton in `sqlite-wasm.ts` so concurrent callers share one in-flight init. Drop `db.close()` from `DatabaseProvider`'s effect cleanup (StrictMode would kill the DB before the second mount could use it). |
| #1965 | PWA install indicator missing in Chromium | (a) SW was registered inside `useServiceWorkerUpdate`, which only mounted in `AppLayout` — anonymous routes (`/login`, `/signup`, `/`) never had a SW. Chromium installability requires SW active on the page hosting the manifest. (b) Even after moving registration to boot, the `?worker&url` import produced a hashed `/assets/src-<hash>.js` path; browsers reject `scope: '/'` for SWs served outside the root unless `Service-Worker-Allowed: /` is set, which our Caddy config does not set for hashed assets. | New `sw/register.ts` singleton; called from `main.tsx` on `window.load` so it runs for ALL routes. URL is the canonical root-served `/sw.js` in production (Vite emits this via `rollupOptions.input.sw`) and `/src/sw/service-worker.ts` in dev (where the existing middleware sets the allow header). Manifest gains `id`, `scope`, `lang`, `dir`, `display_override`, and `purpose: any` on PNG icons; `start_url` becomes `/?source=pwa`. |
| #1966 | Page reload signs the user out | Client side, the refresh-cookie flow was already correct, but `AuthProvider`'s bootstrap effect could fire twice under StrictMode and race the refresh call. | Add `initStartedRef` `useRef` guard so the bootstrap runs exactly once across StrictMode's double-mount. Vitest + Playwright e2e regression added. |

## Verification

- `npm run -w apps/web lint` ✅
- `npm run -w apps/web type-check` ✅
- `npm run -w apps/web build` ✅ — `dist/sw.js` is the canonical SW the registration now points at
- `npx vitest run src/sw src/db/__tests__/DatabaseProvider.test.tsx src/auth/auth-context.test.tsx src/hooks/__tests__/useServiceWorkerUpdate.test.ts src/__tests__/pwa-install.test.ts` — all green
- Full repo `vitest run` matches `main`: 393/394 test files pass (the only failure is the pre-existing `formatDate.test.ts > formats an ISO date string` which fails on any TZ west of UTC because `new Date('2023-12-24')` parses as UTC midnight = Dec 23 in PST; fails on `main` too, not in this PR's scope)

## Files

**New**
- `apps/web/src/sw/register.ts` — boot-time SW registration singleton with env-aware URL.
- `apps/web/src/sw/__tests__/register.test.ts` — singleton + root-scope assertion.
- `apps/web/e2e/session-persistence.spec.ts` — Playwright: sign in → reload → still authenticated; deep-link reload survives.

**Modified**
- `apps/web/src/db/sqlite-wasm.ts` — `_initPromise` singleton + `_resetInitSingletonForTesting` test hook.
- `apps/web/src/db/DatabaseProvider.tsx` — drop `db.close()` from cleanup; reset singleton on retry.
- `apps/web/src/db/__tests__/DatabaseProvider.test.tsx` — StrictMode regression test.
- `apps/web/src/auth/auth-context.tsx` — `initStartedRef` guard on the bootstrap effect.
- `apps/web/src/auth/auth-context.test.tsx` — StrictMode regression test.
- `apps/web/src/main.tsx` — call `registerAppServiceWorker()` on `window.load`.
- `apps/web/src/hooks/useServiceWorkerUpdate.ts` — reuse the boot singleton.
- `apps/web/src/hooks/__tests__/useServiceWorkerUpdate.test.ts` — reset singleton between tests.
- `apps/web/public/manifest.json` — Chromium installability fields.
- `apps/web/src/__tests__/pwa-install.test.ts` — assert new manifest fields.

## Boundaries / follow-ups

- **Backend follow-up for #1966** (@backend-engineer): The most likely real-world cause of the reload-signs-out behavior in production is `services/api/supabase/functions/auth-refresh/index.ts` calling `buildClearCookie` on every `401`. Any transient backend hiccup then permanently invalidates the session. The client-side guard in this PR is necessary but not sufficient without that backend fix.
- No changes outside `apps/web/` (no `packages/`, no `services/`, no other apps, no `.github/workflows/`).
- No new dependencies. Bundle size unchanged (`/sw.js` already existed; we just point at it).

Fixes #1909
Fixes #1965
Fixes #1966
