### PR TITLE
fix(deploy): allow wasm-unsafe-eval in CSP and hot-reload Caddy

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -197,12 +197,28 @@ jobs:
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null
 
-          # Deploy via SSH: pull latest, rebuild containers
+          # Deploy via SSH: pull latest, rebuild containers, reload Caddy
+          # (Caddy bind-mounts ./Caddyfile so changes need an explicit reload —
+          # `docker compose up -d` only restarts containers whose image/env
+          # changed, not when a mounted config file changed. Without this
+          # reload, CSP / header / route updates silently never take effect.)
           ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" << DEPLOY
+            set -e
             cd $DEPLOY_PATH
             git pull origin main
             docker compose -f deploy/docker-compose.yml pull
             docker compose -f deploy/docker-compose.yml up -d --remove-orphans
+
+            # Hot-reload Caddy with the freshly pulled Caddyfile. Tolerant of
+            # the container name varying across compose project prefixes.
+            CADDY_CID=\$(docker compose -f deploy/docker-compose.yml ps -q caddy)
+            if [ -n "\$CADDY_CID" ]; then
+              docker exec "\$CADDY_CID" caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile \
+                || echo "::warning::caddy reload failed (config may be invalid)"
+            else
+              echo "::warning::caddy container not found; skipped reload"
+            fi
+
             docker compose -f deploy/docker-compose.yml ps
           DEPLOY
 

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -50,8 +50,11 @@
 		# a stricter default policy (#1935).
 		Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(self), web-share=(self)"
 
-		# Content Security Policy — strict, no inline scripts, no eval
-		Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; worker-src 'self'"
+		# Content Security Policy — strict, no JS eval, but allow WASM
+		# instantiation (sqlite-wasm) via the dedicated `wasm-unsafe-eval`
+		# directive. `wasm-unsafe-eval` does NOT enable JS `eval()` — it is
+		# the least-privilege grant for WebAssembly instantiation.
+		Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; worker-src 'self'"
 
 		# Remove server identification
 		-Server

--- a/deploy/Caddyfile.staging
+++ b/deploy/Caddyfile.staging
@@ -25,7 +25,7 @@
 		X-Frame-Options "DENY"
 		X-XSS-Protection "1; mode=block"
 		Referrer-Policy "strict-origin-when-cross-origin"
-		Content-Security-Policy "default-src 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'"
+		Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; connect-src 'self'; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; worker-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
 		-Server
 	}
 


### PR DESCRIPTION
## Critical hotfix — alpha web is unusable without this

**Symptom:** every page load on https://finance.jrmoulckers.com shows:

> Failed to load the database engine. Please check your network connection and reload the page.

**Root cause:** the production CSP shipped with `script-src 'self'` (no `'wasm-unsafe-eval'`), which blocks `WebAssembly.instantiate*` in every browser. The web app's sqlite-wasm storage layer (`apps/web/src/db/sqlite-wasm.ts:778-820`) cannot instantiate the wasm module, throws, and surfaces as `WASM_LOAD_FAILED`. The Vite dev server config grants `'wasm-unsafe-eval'` (see `apps/web/vite.config.ts:199`) which is why this never surfaced locally.

Three weeks of alpha-staleness meant we never exercised the production CSP against the wasm path until tonight's redeploy.

### Changes

1. `deploy/Caddyfile` — add `'wasm-unsafe-eval'` to `script-src`. This grant is WebAssembly-only; it does NOT enable JS `eval()`.
2. `deploy/Caddyfile.staging` — mirror the change and expand the staging CSP to match production shape (was missing `script-src`, `worker-src`, `frame-ancestors`, etc.).
3. `.github/workflows/deploy-staging.yml` — after `docker compose up -d`, invoke `docker exec <caddy-cid> caddy reload --config /etc/caddy/Caddyfile`. Bind-mounted Caddyfile changes don't restart the container, so `up -d` silently skips them. This explains why the `web-share=(self)` Permissions-Policy added in PR #1969 also never showed up in live response headers.

### Verification

After merge → auto-deploy via `deploy/**` path filter → verify:

`\\\powershell
curl -sI https://finance.jrmoulckers.com | grep -iE "(content-security|permissions)"
`\\\

Expected:
- `Content-Security-Policy: ...; script-src 'self' 'wasm-unsafe-eval'; ...`
- `Permissions-Policy: ...; web-share=(self)` (proves Caddy reload now picks up file changes)

Then load the app in a fresh browser session → DB engine loads → dashboard renders.

### Blast radius

CSP/header-only + a deploy-script tweak. No application code changes.