### PR TITLE
fix(deploy): tolerate transient compose healthcheck failures

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -197,20 +197,21 @@ jobs:
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null
 
-          # Deploy via SSH: pull latest, rebuild containers, reload Caddy
-          # (Caddy bind-mounts ./Caddyfile so changes need an explicit reload —
-          # `docker compose up -d` only restarts containers whose image/env
-          # changed, not when a mounted config file changed. Without this
-          # reload, CSP / header / route updates silently never take effect.)
+          # Deploy via SSH: pull latest, rebuild containers, reload Caddy.
+          # Note: deliberately NOT `set -e` — historical behaviour tolerates
+          # transient compose healthcheck flakes (e.g. rest container reporting
+          # unhealthy momentarily during startup); failing the deploy on those
+          # would be a regression.
           ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" << DEPLOY
-            set -e
             cd $DEPLOY_PATH
             git pull origin main
             docker compose -f deploy/docker-compose.yml pull
-            docker compose -f deploy/docker-compose.yml up -d --remove-orphans
+            docker compose -f deploy/docker-compose.yml up -d --remove-orphans \
+              || echo "::warning::compose up reported non-zero (deps may be transiently unhealthy)"
 
-            # Hot-reload Caddy with the freshly pulled Caddyfile. Tolerant of
-            # the container name varying across compose project prefixes.
+            # Hot-reload Caddy with the freshly pulled Caddyfile. Bind-mounted
+            # files don't trigger container restart, so without this, CSP /
+            # header / route updates silently never take effect.
             CADDY_CID=\$(docker compose -f deploy/docker-compose.yml ps -q caddy)
             if [ -n "\$CADDY_CID" ]; then
               docker exec "\$CADDY_CID" caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile \


### PR DESCRIPTION
Fix regression introduced in #1972: `set -e` in the SSH heredoc aborted the deploy on a pre-existing transient `rest` container healthcheck flake. Removed `set -e`, added explicit `|| echo warning` on `docker compose up`. Preserves caddy reload step (still tolerant).