### PR TITLE
fix(db): use SAVEPOINT for migrations and seed to avoid no-active-txn race (#1975)

### DIFF
--- a/apps/web/src/db/__tests__/sqlite-wasm-savepoint.test.ts
+++ b/apps/web/src/db/__tests__/sqlite-wasm-savepoint.test.ts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { createRequire } from 'node:module';
+import initSqlJs from 'sql.js';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  MIGRATIONS,
+  _runMigrationsForTesting,
+  releaseSavepoint,
+  rollbackToSavepoint,
+  type SqliteDb,
+} from '../sqlite-wasm';
+
+const require = createRequire(import.meta.url);
+const sqlWasmPath = require.resolve('sql.js/dist/sql-wasm.wasm');
+const SQL = await initSqlJs({
+  locateFile: () => sqlWasmPath,
+});
+
+describe('sqlite-wasm savepoint migrations', () => {
+  it('converges schema when migration runner is invoked concurrently', async () => {
+    const db = new SQL.Database();
+
+    try {
+      await expect(
+        Promise.all([
+          _runMigrationsForTesting(SQL, db, 'indexeddb'),
+          _runMigrationsForTesting(SQL, db, 'indexeddb'),
+        ]),
+      ).resolves.toHaveLength(2);
+
+      const appliedMigrations = db.exec(
+        'SELECT version, label FROM _migrations ORDER BY version ASC;',
+      )[0];
+      expect(appliedMigrations?.values).toHaveLength(MIGRATIONS.length);
+      expect(appliedMigrations?.values.map(([version]) => version)).toEqual(
+        MIGRATIONS.map((migration) => migration.version),
+      );
+
+      const schemaTables = db.exec(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('_migrations', 'account', 'transaction') ORDER BY name ASC;",
+      )[0];
+      expect(schemaTables?.values.map(([name]) => name)).toEqual([
+        '_migrations',
+        'account',
+        'transaction',
+      ]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it.each([
+    ['release', releaseSavepoint],
+    ['rollback', rollbackToSavepoint],
+  ] as const)('logs and suppresses no-active-transaction %s failures', (_, helper) => {
+    const db: SqliteDb = {
+      backend: 'opfs',
+      exec: vi.fn(() => {
+        throw new Error('cannot commit - no transaction is active');
+      }),
+      selectAll: vi.fn(),
+      selectOne: vi.fn(),
+      close: vi.fn(),
+    };
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    try {
+      expect(() => helper(db, 'seed_init')).not.toThrow();
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('seed_init'), {
+        backend: 'opfs',
+        savepointName: 'seed_init',
+        error: expect.any(Error),
+      });
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/apps/web/src/db/seed.ts
+++ b/apps/web/src/db/seed.ts
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { Currencies, cents, type LocalDate, type TransactionType } from '../kmp/bridge';
-import { execute, queryOne, type SqliteDb } from './sqlite-wasm';
+import {
+  execute,
+  queryOne,
+  releaseSavepoint,
+  rollbackToSavepoint,
+  type SqliteDb,
+} from './sqlite-wasm';
 import {
   createAccount,
   createBudget,
@@ -58,7 +64,8 @@ export async function seedDatabase(db: SqliteDb): Promise<void> {
   const householdMemberId = crypto.randomUUID();
   const monthStart = firstDayOfCurrentMonth();
 
-  execute(db, 'BEGIN TRANSACTION');
+  const seedSavepoint = 'seed_init';
+  execute(db, `SAVEPOINT ${seedSavepoint}`);
 
   try {
     execute(
@@ -490,12 +497,13 @@ export async function seedDatabase(db: SqliteDb): Promise<void> {
       accountId: checking.id,
     });
 
-    execute(db, 'COMMIT');
+    releaseSavepoint(db, seedSavepoint);
   } catch (error) {
     try {
-      execute(db, 'ROLLBACK');
+      rollbackToSavepoint(db, seedSavepoint);
+      releaseSavepoint(db, seedSavepoint);
     } catch {
-      // ROLLBACK may fail if SQLite already auto-rolled back the transaction.
+      // Preserve the original seed error if SQLite already ended the savepoint.
     }
     throw error;
   }

--- a/apps/web/src/db/sqlite-wasm.ts
+++ b/apps/web/src/db/sqlite-wasm.ts
@@ -98,6 +98,8 @@ export interface QueryResult<T = Row> {
 
 /** Minimal interface exposed by the underlying WASM driver. */
 export interface SqliteDb {
+  /** Storage backend used by this connection, when known. */
+  readonly backend?: StorageBackend;
   exec(sql: string, params?: unknown[]): void;
   selectAll(sql: string, params?: unknown[]): Row[];
   selectOne(sql: string, params?: unknown[]): Row | null;
@@ -870,6 +872,107 @@ function execRaw(
   }
 }
 
+type SavepointOperation = 'release' | 'rollback';
+type SavepointLogBackend = StorageBackend | 'unknown';
+
+const NO_ACTIVE_TRANSACTION_ERROR = 'no transaction is active';
+
+function isNoActiveTransactionError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.toLowerCase().includes(NO_ACTIVE_TRANSACTION_ERROR);
+}
+
+function getSavepointIdentifier(savepointName: string): string {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(savepointName)) {
+    throw new Error(`Invalid SQLite savepoint name: ${savepointName}`);
+  }
+  return savepointName;
+}
+
+function logSuppressedNoActiveTransaction(
+  operation: SavepointOperation,
+  backend: SavepointLogBackend,
+  savepointName: string,
+  error: unknown,
+): void {
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[sqlite-wasm] Suppressed ${operation} failure for savepoint "${savepointName}" on ${backend} backend: ${NO_ACTIVE_TRANSACTION_ERROR}.`,
+    { backend, savepointName, error },
+  );
+}
+
+function execSavepointControl(
+  executor: () => void,
+  operation: SavepointOperation,
+  backend: SavepointLogBackend,
+  savepointName: string,
+): void {
+  try {
+    executor();
+  } catch (error) {
+    if (isNoActiveTransactionError(error)) {
+      logSuppressedNoActiveTransaction(operation, backend, savepointName, error);
+      return;
+    }
+    throw error;
+  }
+}
+
+function releaseSavepointRaw(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  driver: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  db: any,
+  backend: StorageBackend,
+  savepointName: string,
+): void {
+  const savepointIdentifier = getSavepointIdentifier(savepointName);
+  execSavepointControl(
+    () => execRaw(driver, db, `RELEASE SAVEPOINT ${savepointIdentifier};`, backend),
+    'release',
+    backend,
+    savepointName,
+  );
+}
+
+function rollbackToSavepointRaw(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  driver: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  db: any,
+  backend: StorageBackend,
+  savepointName: string,
+): void {
+  const savepointIdentifier = getSavepointIdentifier(savepointName);
+  execSavepointControl(
+    () => execRaw(driver, db, `ROLLBACK TO SAVEPOINT ${savepointIdentifier};`, backend),
+    'rollback',
+    backend,
+    savepointName,
+  );
+}
+
+export function releaseSavepoint(db: SqliteDb, savepointName: string): void {
+  const savepointIdentifier = getSavepointIdentifier(savepointName);
+  execSavepointControl(
+    () => execute(db, `RELEASE SAVEPOINT ${savepointIdentifier};`),
+    'release',
+    db.backend ?? 'unknown',
+    savepointName,
+  );
+}
+
+export function rollbackToSavepoint(db: SqliteDb, savepointName: string): void {
+  const savepointIdentifier = getSavepointIdentifier(savepointName);
+  execSavepointControl(
+    () => execute(db, `ROLLBACK TO SAVEPOINT ${savepointIdentifier};`),
+    'rollback',
+    db.backend ?? 'unknown',
+    savepointName,
+  );
+}
+
 function selectRaw(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   driver: any,
@@ -964,7 +1067,9 @@ async function runMigrations(
       continue;
     }
 
-    execRaw(driver, db, 'BEGIN TRANSACTION;', backend);
+    const savepointName = `migration_${migration.version}`;
+    const savepointIdentifier = getSavepointIdentifier(savepointName);
+    execRaw(driver, db, `SAVEPOINT ${savepointIdentifier};`, backend);
     try {
       for (const stmt of migration.up) {
         if (stmt.includes(MIGRATIONS_TABLE) && stmt.trimStart().startsWith('CREATE TABLE')) {
@@ -981,12 +1086,13 @@ async function runMigrations(
         [migration.version, migration.label, new Date().toISOString()],
       );
 
-      execRaw(driver, db, 'COMMIT;', backend);
+      releaseSavepointRaw(driver, db, backend, savepointName);
     } catch (err) {
       try {
-        execRaw(driver, db, 'ROLLBACK;', backend);
+        rollbackToSavepointRaw(driver, db, backend, savepointName);
+        releaseSavepointRaw(driver, db, backend, savepointName);
       } catch {
-        // ROLLBACK may fail if SQLite already auto-rolled back the transaction.
+        // Preserve the original migration error if SQLite already ended the savepoint.
       }
       throw new Error(
         `Migration v${migration.version} (${migration.label}) failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -994,6 +1100,16 @@ async function runMigrations(
       );
     }
   }
+}
+
+export async function _runMigrationsForTesting(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  driver: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  db: any,
+  backend: StorageBackend = 'indexeddb',
+): Promise<void> {
+  await runMigrations(driver, db, backend);
 }
 
 // ---------------------------------------------------------------------------
@@ -1072,6 +1188,8 @@ function createDbWrapper(
   backend: StorageBackend,
 ): SqliteDb {
   return {
+    backend,
+
     exec(sql: string, params?: unknown[]): void {
       execRaw(driver, db, sql, backend, params);
       if (backend === 'indexeddb') {


### PR DESCRIPTION
Fixes #1975.

## Summary
- Replace migration and seed `BEGIN`/`COMMIT` blocks with named SQLite `SAVEPOINT`/`RELEASE SAVEPOINT` scopes.
- Add safe release/rollback helpers that suppress stale `no transaction is active` failures and warn with backend + savepoint name.
- Add regression coverage for concurrent migration initialization and the defensive suppression path.

## Why SAVEPOINT
SQLite savepoints are nestable and work both inside and outside an existing outer transaction. That makes DB initialization safe when OPFS has stale transaction state or when another component owns an outer transaction on the same connection.

## Validation
- `npm test --workspace=apps/web -- sqlite-wasm`
- `npm test --workspace=apps/web -- src/db/__tests__`
- `npx eslint apps/web/src/db/sqlite-wasm.ts apps/web/src/db/seed.ts apps/web/src/db/__tests__/sqlite-wasm-savepoint.test.ts`
- `npm run type-check --workspace=apps/web`
