### PR TITLE
test(cdn): allow 'wasm-unsafe-eval' in CSP validator

### DIFF
--- a/apps/web/src/lib/cdn/caddy-config-validator.test.ts
+++ b/apps/web/src/lib/cdn/caddy-config-validator.test.ts
@@ -150,13 +150,16 @@ describe('Security headers in Caddyfile', () => {
     expect(caddyfileContent).toContain('-Server');
   });
 
-  it('CSP disallows eval', () => {
-    // The CSP should not contain unsafe-eval
+  it('CSP disallows generic eval (allows wasm-unsafe-eval for WebAssembly)', () => {
+    // CSP must not enable arbitrary `eval()`. The Caddyfile is allowed to use
+    // the narrower `'wasm-unsafe-eval'` directive which only permits
+    // WebAssembly instantiation (required by sqlite-wasm) — see #1972.
     const cspLine = caddyfileContent
       .split('\n')
       .find((line) => line.includes('Content-Security-Policy'));
     expect(cspLine).toBeDefined();
-    expect(cspLine).not.toContain('unsafe-eval');
+    // Match a quoted `'unsafe-eval'` that is NOT preceded by `wasm-`.
+    expect(cspLine).not.toMatch(/(?<!wasm-)'unsafe-eval'/);
   });
 
   it('CSP allows worker-src self for service worker', () => {


### PR DESCRIPTION
Trivial test fix. `'unsafe-eval'` and `'wasm-unsafe-eval'` are different CSP directives — the latter only enables WebAssembly instantiation (required by sqlite-wasm and added in #1972). The old assertion `not.toContain('unsafe-eval')` was a substring check and failed against `'wasm-unsafe-eval'`. Switched to a negative-lookbehind regex.`n`nUnblocks PRs #1984, #1985, #1986, #1987.