### PR TITLE
fix(web): polish transaction form and transactions actions

### DIFF
--- a/apps/web/e2e/responsive.spec.ts
+++ b/apps/web/e2e/responsive.spec.ts
@@ -157,9 +157,8 @@ test.describe('Mobile viewport (375px)', () => {
     await page.goto('/transactions');
     await waitForPageLoad(page);
 
-    // Open the "Add Transaction" dropdown, then click Manual Entry.
-    await page.getByRole('button', { name: /add.*transaction/i }).click();
-    await page.getByRole('menuitem', { name: /manual entry/i }).click();
+    // Open the default Add Transaction action.
+    await page.getByRole('button', { name: 'Add Transaction', exact: true }).click();
 
     const dialog = page.getByRole('dialog');
     await expect(dialog).toBeVisible();
@@ -341,8 +340,7 @@ test.describe('Desktop viewport (1280px)', () => {
     await page.goto('/transactions');
     await waitForPageLoad(page);
 
-    await page.getByRole('button', { name: /add.*transaction/i }).click();
-    await page.getByRole('menuitem', { name: /manual entry/i }).click();
+    await page.getByRole('button', { name: 'Add Transaction', exact: true }).click();
 
     const dialog = page.getByRole('dialog');
     await expect(dialog).toBeVisible();

--- a/apps/web/e2e/transactions.spec.ts
+++ b/apps/web/e2e/transactions.spec.ts
@@ -51,15 +51,17 @@ test.describe('Transactions page', () => {
   test('shows the Add Transaction button', async ({ authenticatedPage: page }) => {
     await page.goto('/transactions');
 
-    const addButton = page.getByRole('button', { name: /add.*transaction/i });
+    const addButton = page.getByRole('button', { name: 'Add Transaction', exact: true });
     await expect(addButton).toBeVisible();
   });
 
-  test('clicking Add Transaction opens dropdown menu', async ({ authenticatedPage: page }) => {
+  test('clicking transaction options opens split-button menu', async ({
+    authenticatedPage: page,
+  }) => {
     await page.goto('/transactions');
 
-    const addButton = page.getByRole('button', { name: /add.*transaction/i });
-    await addButton.click();
+    const menuButton = page.getByRole('button', { name: /open transaction options/i });
+    await menuButton.click();
 
     // Dropdown menu should appear with Manual Entry and Import options
     const manualEntry = page.getByRole('menuitem', { name: /manual entry/i });
@@ -71,7 +73,7 @@ test.describe('Transactions page', () => {
   test('clicking Manual Entry opens form dialog', async ({ authenticatedPage: page }) => {
     await page.goto('/transactions');
 
-    await page.getByRole('button', { name: /add.*transaction/i }).click();
+    await page.getByRole('button', { name: /open transaction options/i }).click();
     await page.getByRole('menuitem', { name: /manual entry/i }).click();
 
     const dialog = page.getByRole('dialog');
@@ -85,8 +87,7 @@ test.describe('Transactions page', () => {
     authenticatedPage: page,
   }) => {
     await page.goto('/transactions');
-    await page.getByRole('button', { name: /add.*transaction/i }).click();
-    await page.getByRole('menuitem', { name: /manual entry/i }).click();
+    await page.getByRole('button', { name: 'Add Transaction', exact: true }).click();
 
     const dialog = page.getByRole('dialog');
     await expect(dialog).toBeVisible();

--- a/apps/web/src/components/forms/TransactionForm.test.tsx
+++ b/apps/web/src/components/forms/TransactionForm.test.tsx
@@ -108,6 +108,8 @@ describe('TransactionForm', () => {
     expect(screen.getByRole('dialog', { name: 'New Transaction' })).toBeInTheDocument();
     expect(screen.getByLabelText('Amount')).toBeInTheDocument();
     expect(screen.getByLabelText('Payee')).toBeInTheDocument();
+    expect(screen.getByText(/What appears on your statement/i)).toBeInTheDocument();
+    expect(screen.getByText(/The actual merchant or person/i)).toBeInTheDocument();
     expect(screen.getByLabelText('Category')).toBeInTheDocument();
     expect(screen.getByLabelText('Account')).toBeInTheDocument();
     expect(screen.getByLabelText('Date')).toHaveValue('2025-06-15');
@@ -131,6 +133,10 @@ describe('TransactionForm', () => {
 
     expect(screen.getByText('Amount must be greater than zero.')).toBeInTheDocument();
     expect(screen.getByText('Please select an account.')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'Some fields need attention — see highlighted errors above.',
+    );
+    expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'polite');
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
@@ -187,6 +193,35 @@ describe('TransactionForm', () => {
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
 
+  it('locks body scrolling while the modal is open and restores it on close', () => {
+    document.body.style.overflow = 'auto';
+
+    const { rerender } = render(
+      <TransactionForm
+        isOpen={true}
+        onSubmit={vi.fn().mockResolvedValue(undefined)}
+        onCancel={vi.fn()}
+        accounts={accounts}
+        categories={categories}
+      />,
+    );
+
+    expect(document.body.style.overflow).toBe('hidden');
+
+    rerender(
+      <TransactionForm
+        isOpen={false}
+        onSubmit={vi.fn().mockResolvedValue(undefined)}
+        onCancel={vi.fn()}
+        accounts={accounts}
+        categories={categories}
+      />,
+    );
+
+    expect(document.body.style.overflow).toBe('auto');
+    document.body.style.overflow = '';
+  });
+
   // ---------------------------------------------------------------------------
   // Additional details
   // ---------------------------------------------------------------------------
@@ -200,13 +235,13 @@ describe('TransactionForm', () => {
     // Expand it
     fireEvent.click(screen.getByRole('button', { name: /additional details/i }));
 
-    expect(screen.getByLabelText('Merchant City')).toBeInTheDocument();
-    expect(screen.getByLabelText('Merchant State')).toBeInTheDocument();
+    expect(screen.getByLabelText('Merchant City')).toHaveAttribute('placeholder', 'Seattle');
+    expect(screen.getByLabelText('Merchant State')).toHaveAttribute('placeholder', 'WA');
     expect(screen.getByLabelText('Merchant ZIP')).toBeInTheDocument();
     expect(screen.getByLabelText('Merchant Country')).toBeInTheDocument();
     expect(screen.getByLabelText('Statement Description')).toBeInTheDocument();
     expect(screen.getByLabelText('External Reference ID')).toBeInTheDocument();
-    expect(screen.getByLabelText('Extra Notes')).toBeInTheDocument();
+    expect(screen.getByLabelText('Extra Notes')).not.toHaveAttribute('placeholder');
     expect(screen.getByText('+ Add Field')).toBeInTheDocument();
   });
 

--- a/apps/web/src/components/forms/TransactionForm.tsx
+++ b/apps/web/src/components/forms/TransactionForm.tsx
@@ -247,6 +247,19 @@ export function TransactionForm({
   }, [isOpen]);
 
   useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
     const refreshMoodPreference = () => setMoodTagsEnabled(isMoodTagsEnabled());
     window.addEventListener(MOOD_TAGS_CHANGED_EVENT, refreshMoodPreference);
     window.addEventListener('storage', refreshMoodPreference);
@@ -534,6 +547,7 @@ export function TransactionForm({
   const hasAmountError = Boolean(errors.amount);
   const hasDescriptionError = Boolean(errors.description);
   const hasAccountError = Boolean(errors.accountId);
+  const hasValidationErrors = Object.keys(errors).length > 0;
 
   return (
     <div className="form-dialog" role="presentation" onKeyDown={handleKeyDown}>
@@ -596,6 +610,9 @@ export function TransactionForm({
               >
                 Payee
               </label>
+              <p id="txn-description-help" className="form-group__help">
+                What appears on your statement (e.g. “AMZN MKTPL*XYZ”).
+              </p>
               <input
                 id="txn-description"
                 className={`form-input${hasDescriptionError ? ' form-input--error' : ''}`}
@@ -603,7 +620,9 @@ export function TransactionForm({
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
                 aria-invalid={hasDescriptionError}
-                aria-describedby={hasDescriptionError ? 'txn-description-error' : undefined}
+                aria-describedby={`txn-description-help${
+                  hasDescriptionError ? ' txn-description-error' : ''
+                }`}
                 aria-required="true"
                 autoComplete="off"
               />
@@ -657,6 +676,9 @@ export function TransactionForm({
               <label htmlFor="txn-counterparty" className="form-group__label">
                 Counterparty
               </label>
+              <p id="txn-counterparty-help" className="form-group__help">
+                The actual merchant or person (e.g. “Amazon”, “Sarah Lee”).
+              </p>
               <CounterpartyInput
                 id="txn-counterparty"
                 value={counterpartyName}
@@ -665,10 +687,11 @@ export function TransactionForm({
                 matchResult={merchantMatch}
                 onMerchantMatch={handleMerchantMatch}
                 placeholder="e.g. Walgreens, Amazon"
+                ariaDescribedBy="txn-counterparty-help"
               />
             </div>
 
-            <fieldset className="form-group">
+            <fieldset className="form-group form-fieldset">
               <legend className="form-group__label">Buy-now-pay-later liability</legend>
               <label className="form-checkbox-row">
                 <input
@@ -913,6 +936,7 @@ export function TransactionForm({
                         type="text"
                         value={merchantCity}
                         onChange={(e) => setMerchantCity(e.target.value)}
+                        placeholder="Seattle"
                         autoComplete="off"
                       />
                     </div>
@@ -926,6 +950,7 @@ export function TransactionForm({
                         type="text"
                         value={merchantState}
                         onChange={(e) => setMerchantState(e.target.value)}
+                        placeholder="WA"
                         autoComplete="off"
                       />
                     </div>
@@ -1071,13 +1096,18 @@ export function TransactionForm({
                       value={extraNotes}
                       onChange={(e) => setExtraNotes(e.target.value)}
                       rows={3}
-                      placeholder="Free-form text — bank memos, import leftovers, etc."
                     />
                   </div>
                 </div>
               )}
             </fieldset>
           </div>
+
+          {hasValidationErrors && (
+            <div className="form-submit-summary" role="status" aria-live="polite">
+              Some fields need attention — see highlighted errors above.
+            </div>
+          )}
 
           {/* Actions */}
           <div className="form-actions">

--- a/apps/web/src/components/forms/forms.css
+++ b/apps/web/src/components/forms/forms.css
@@ -36,6 +36,7 @@
   max-width: 520px;
   max-height: calc(100dvh - var(--spacing-8));
   overflow-y: auto;
+  overscroll-behavior: contain;
   background: var(--semantic-background-primary);
   border: 1px solid var(--semantic-border-default);
   border-radius: var(--border-radius-lg, var(--border-radius-md));
@@ -91,6 +92,38 @@
 .form-group__label--required::after {
   content: ' *';
   color: var(--semantic-status-negative);
+}
+
+.form-group__help {
+  margin: 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+  line-height: var(--line-height-normal);
+}
+
+.form-fieldset {
+  min-inline-size: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.form-checkbox-row {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-2);
+  color: var(--semantic-text-primary);
+  font-size: var(--type-scale-body-font-size);
+  line-height: var(--line-height-normal);
+  cursor: pointer;
+}
+
+.form-checkbox-row input[type='checkbox'] {
+  width: 1rem;
+  height: 1rem;
+  flex: 0 0 auto;
+  margin: 0.125rem 0 0;
+  accent-color: var(--semantic-interactive-default);
 }
 
 /* ---------------------------------------------------------------------------
@@ -446,7 +479,8 @@
  * Form-level error banner
  * ------------------------------------------------------------------------- */
 
-.form-banner-error {
+.form-banner-error,
+.form-submit-summary {
   display: flex;
   align-items: center;
   gap: var(--spacing-2);
@@ -457,6 +491,10 @@
   color: var(--semantic-status-negative);
   font-size: var(--type-scale-caption-font-size);
   font-weight: var(--font-weight-medium);
+}
+
+.form-submit-summary {
+  margin-top: var(--spacing-4);
 }
 
 /* ---------------------------------------------------------------------------
@@ -513,7 +551,8 @@
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath d='M3 5l3 3 3-3' fill='none' stroke='%23aaa' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
   }
 
-  html:not([data-theme='light']) .form-banner-error {
+  html:not([data-theme='light']) .form-banner-error,
+  html:not([data-theme='light']) .form-submit-summary {
     background: rgba(239, 68, 68, 0.1);
   }
 
@@ -530,7 +569,8 @@
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath d='M3 5l3 3 3-3' fill='none' stroke='%23aaa' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
 }
 
-[data-theme='dark'] .form-banner-error {
+[data-theme='dark'] .form-banner-error,
+[data-theme='dark'] .form-submit-summary {
   background: rgba(239, 68, 68, 0.1);
 }
 

--- a/apps/web/src/components/navigation/Breadcrumb.tsx
+++ b/apps/web/src/components/navigation/Breadcrumb.tsx
@@ -57,7 +57,7 @@ export const Breadcrumb: FC<BreadcrumbProps> = ({ segments, ariaLabel = 'Breadcr
               <span>{segment.label}</span>
             )}
             <span className="breadcrumb__separator" aria-hidden="true">
-              /
+              ›
             </span>
           </li>
         ))}

--- a/apps/web/src/components/navigation/breadcrumb.css
+++ b/apps/web/src/components/navigation/breadcrumb.css
@@ -21,7 +21,7 @@
   list-style: none;
   margin: 0;
   padding: 0;
-  font-size: var(--font-size-sm, 0.875rem);
+  font-size: var(--type-scale-caption-font-size, var(--font-size-sm, 0.875rem));
   color: var(--semantic-text-secondary, #666);
 }
 
@@ -32,12 +32,14 @@
 }
 
 .breadcrumb__link {
-  color: var(--semantic-text-link, #2563eb);
+  color: var(--semantic-text-secondary, #666);
+  font-weight: var(--font-weight-medium, 500);
   text-decoration: none;
 }
 
 .breadcrumb__link:hover {
-  text-decoration: underline;
+  color: var(--semantic-text-primary, #111);
+  text-decoration: none;
 }
 
 .breadcrumb__link:focus-visible {
@@ -53,7 +55,7 @@
 
 .breadcrumb__current {
   color: var(--semantic-text-primary, #111);
-  font-weight: 500;
+  font-weight: var(--font-weight-medium, 500);
 }
 
 /* On narrow screens, hide the current page segment to avoid duplication

--- a/apps/web/src/components/transactions/CounterpartyInput.test.tsx
+++ b/apps/web/src/components/transactions/CounterpartyInput.test.tsx
@@ -6,7 +6,7 @@
  * References: issue #1514
  */
 
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, createEvent, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { KnownMerchant } from '../../lib/merchants';
@@ -197,6 +197,40 @@ describe('CounterpartyInput', () => {
 
     fireEvent.keyDown(input, { key: 'Escape' });
     expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('dismisses dropdown and prevents form submission on Enter with free text', () => {
+    render(
+      <CounterpartyInput
+        value="wal"
+        onChange={vi.fn()}
+        merchants={MOCK_MERCHANTS}
+        recentCounterparties={MOCK_RECENT}
+      />,
+    );
+
+    const input = screen.getByRole('combobox');
+    fireEvent.focus(input);
+    expect(screen.queryByRole('listbox')).not.toBeNull();
+
+    const enterEvent = createEvent.keyDown(input, { key: 'Enter' });
+    fireEvent(input, enterEvent);
+
+    expect(enterEvent.defaultPrevented).toBe(true);
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('selects the highlighted suggestion on Enter', async () => {
+    const onChange = vi.fn();
+    render(<CounterpartyInput value="ama" onChange={onChange} merchants={MOCK_MERCHANTS} />);
+
+    const input = screen.getByRole('combobox');
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onChange).toHaveBeenCalledWith('Amazon');
+    await waitFor(() => expect(screen.queryByRole('listbox')).toBeNull());
   });
 
   it('is disabled when disabled prop is true', () => {

--- a/apps/web/src/components/transactions/CounterpartyInput.tsx
+++ b/apps/web/src/components/transactions/CounterpartyInput.tsx
@@ -51,6 +51,8 @@ export interface CounterpartyInputProps {
   disabled?: boolean;
   /** Placeholder text. */
   placeholder?: string;
+  /** IDs of helper or error text that describe the input. */
+  ariaDescribedBy?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -129,6 +131,7 @@ export function CounterpartyInput({
   id: externalId,
   disabled = false,
   placeholder = 'Enter counterparty name',
+  ariaDescribedBy,
 }: CounterpartyInputProps) {
   const autoId = useId();
   const inputId = externalId ?? `counterparty-${autoId}`;
@@ -176,8 +179,6 @@ export function CounterpartyInput({
           confidence: 1,
         });
       }
-
-      inputRef.current?.focus();
     },
     [onChange, onMerchantMatch],
   );
@@ -194,6 +195,17 @@ export function CounterpartyInput({
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        if (showDropdown && focusedIndex >= 0 && focusedIndex < suggestions.length) {
+          handleSelect(suggestions[focusedIndex]);
+          return;
+        }
+        setIsOpen(false);
+        setFocusedIndex(-1);
+        return;
+      }
+
       if (!showDropdown) {
         if (e.key === 'ArrowDown' && suggestions.length > 0) {
           e.preventDefault();
@@ -211,12 +223,6 @@ export function CounterpartyInput({
         case 'ArrowUp':
           e.preventDefault();
           setFocusedIndex((prev) => (prev > 0 ? prev - 1 : suggestions.length - 1));
-          break;
-        case 'Enter':
-          e.preventDefault();
-          if (focusedIndex >= 0 && focusedIndex < suggestions.length) {
-            handleSelect(suggestions[focusedIndex]);
-          }
           break;
         case 'Escape':
           e.preventDefault();
@@ -255,6 +261,7 @@ export function CounterpartyInput({
           aria-controls={listboxId}
           aria-activedescendant={activeDescendantId}
           aria-autocomplete="list"
+          aria-describedby={ariaDescribedBy}
           autoComplete="off"
         />
       </div>

--- a/apps/web/src/pages/TransactionsPage.test.tsx
+++ b/apps/web/src/pages/TransactionsPage.test.tsx
@@ -254,20 +254,32 @@ describe('TransactionsPage', () => {
     expect(screen.getByText('Transactions')).toBeInTheDocument();
   });
 
-  it('displays Add Transaction dropdown with Manual Entry and Import options', () => {
+  it('opens the default add transaction action from the split button primary action', () => {
     render(
       <MemoryRouter>
         <TransactionsPage />
       </MemoryRouter>,
     );
 
-    const addButton = screen.getByRole('button', { name: /add transaction/i });
-    expect(addButton).toBeInTheDocument();
-    expect(addButton).toHaveAttribute('aria-haspopup', 'true');
-    expect(addButton).toHaveAttribute('aria-expanded', 'false');
+    fireEvent.click(screen.getByRole('button', { name: 'Add Transaction' }));
 
-    fireEvent.click(addButton);
-    expect(addButton).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('dialog', { name: 'Transaction form' })).toBeInTheDocument();
+  });
+
+  it('displays Add Transaction split-button menu with Manual Entry and Import options', () => {
+    render(
+      <MemoryRouter>
+        <TransactionsPage />
+      </MemoryRouter>,
+    );
+
+    const menuButton = screen.getByRole('button', { name: /open transaction options/i });
+    expect(menuButton).toBeInTheDocument();
+    expect(menuButton).toHaveAttribute('aria-haspopup', 'menu');
+    expect(menuButton).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(menuButton);
+    expect(menuButton).toHaveAttribute('aria-expanded', 'true');
     expect(screen.getByRole('menuitem', { name: /manual entry/i })).toBeInTheDocument();
     expect(screen.getByRole('menuitem', { name: /import from file/i })).toBeInTheDocument();
   });

--- a/apps/web/src/pages/TransactionsPage.tsx
+++ b/apps/web/src/pages/TransactionsPage.tsx
@@ -134,6 +134,73 @@ function getTransactionLabel(transaction: Transaction): string {
   );
 }
 
+function PlusIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+      <path
+        d="M8 3.25v9.5M3.25 8h9.5"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+function ChevronDownIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+      <path
+        d="M4.5 6.25 8 9.75l3.5-3.5"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function PencilIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+      <path
+        d="M3.25 11.75 3 13l1.25-.25 7.35-7.35-1-1-7.35 7.35Z"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="m9.9 3.7.7-.7a1.1 1.1 0 0 1 1.55 0l.85.85a1.1 1.1 0 0 1 0 1.55l-.7.7"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function ImportIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+      <path
+        d="M8 2.75v6.5m0 0L5.5 6.75M8 9.25l2.5-2.5M3.25 10.5v1.75c0 .55.45 1 1 1h7.5c.55 0 1-.45 1-1V10.5"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Sort logic
 // ---------------------------------------------------------------------------
@@ -460,16 +527,26 @@ export const TransactionsPage: React.FC = () => {
           <span aria-hidden="true">📤</span> Export CSV
         </button>
         <div className="add-transaction-menu" ref={addMenuRef}>
-          <button
-            type="button"
-            className="add-button"
-            onClick={() => setAddMenuOpen((prev) => !prev)}
-            aria-label="Add transaction"
-            aria-expanded={addMenuOpen}
-            aria-haspopup="true"
-          >
-            <span aria-hidden="true">+</span> Add Transaction
-          </button>
+          <div className="add-transaction-split-button">
+            <button
+              type="button"
+              className="add-button add-transaction-split-button__primary"
+              onClick={handleOpenCreateForm}
+            >
+              <PlusIcon />
+              Add Transaction
+            </button>
+            <button
+              type="button"
+              className="add-button add-transaction-split-button__toggle"
+              onClick={() => setAddMenuOpen((prev) => !prev)}
+              aria-label="Open transaction options"
+              aria-expanded={addMenuOpen}
+              aria-haspopup="menu"
+            >
+              <ChevronDownIcon />
+            </button>
+          </div>
           {addMenuOpen && (
             <div
               className="add-transaction-dropdown"
@@ -482,7 +559,8 @@ export const TransactionsPage: React.FC = () => {
                 role="menuitem"
                 onClick={handleOpenCreateForm}
               >
-                <span aria-hidden="true">✏️</span> Manual Entry
+                <PencilIcon />
+                Manual Entry
               </button>
               <button
                 type="button"
@@ -490,7 +568,8 @@ export const TransactionsPage: React.FC = () => {
                 role="menuitem"
                 onClick={handleImportFromFile}
               >
-                <span aria-hidden="true">📥</span> Import from File
+                <ImportIcon />
+                Import from File
               </button>
             </div>
           )}

--- a/apps/web/src/styles/responsive.css
+++ b/apps/web/src/styles/responsive.css
@@ -331,6 +331,70 @@
   outline: 2px solid var(--semantic-border-focus);
   outline-offset: 2px;
 }
+.add-button svg {
+  width: 1rem;
+  height: 1rem;
+  flex: 0 0 auto;
+}
+.add-transaction-menu {
+  position: relative;
+  display: inline-flex;
+}
+.add-transaction-split-button {
+  display: inline-flex;
+  align-items: stretch;
+  filter: drop-shadow(0 1px 2px rgba(15, 23, 42, 0.08));
+}
+.add-transaction-split-button__primary {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+.add-transaction-split-button__toggle {
+  min-width: 40px;
+  padding-inline: var(--spacing-2);
+  border-left-color: rgba(255, 255, 255, 0.35);
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+.add-transaction-dropdown {
+  position: absolute;
+  top: calc(100% + var(--spacing-1));
+  right: 0;
+  z-index: 100;
+  min-width: 220px;
+  padding: var(--spacing-1);
+  background: var(--semantic-background-primary);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-lg, var(--border-radius-md));
+  box-shadow: var(--shadow-lg, 0 10px 25px rgba(0, 0, 0, 0.15));
+}
+.add-transaction-dropdown__item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  width: 100%;
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 0;
+  border-radius: var(--border-radius-md);
+  background: transparent;
+  color: var(--semantic-text-primary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.add-transaction-dropdown__item:hover,
+.add-transaction-dropdown__item:focus-visible {
+  background: var(--semantic-background-secondary);
+}
+.add-transaction-dropdown__item:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: -2px;
+}
+.add-transaction-dropdown__item svg {
+  width: 1rem;
+  height: 1rem;
+  color: var(--semantic-text-secondary);
+}
 .list-group {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
Closes #1913.
Closes #1915.

### #1913 — Transaction form polish
- Added helper text distinguishing Payee (statement text) from Counterparty (actual merchant/person).
- Enter in Counterparty now prevents accidental form submit, closes suggestions, and applies the highlighted suggestion when present.
- Restyled the BNPL liability fieldset to use form-row styling instead of browser fieldset chrome.
- Added Merchant City/State placeholders and removed the Extra Notes placeholder.
- Locked body scrolling while the transaction modal is open and contained modal overscroll.

### #1915 — Transactions page polish
- Added an aria-live inline submit summary near the actions when validation blocks save.
- Reworked Add Transaction into a minimal styled split-button: primary opens Manual Entry; chevron opens a popover menu for Manual Entry/Import from File. This uses local BEM styling rather than introducing a new shared menu component.
- Updated shared breadcrumbs to use muted parent link styling, a chevron separator, and token-based current-page text.

## Tests
- `cd apps/web; npx vitest run --reporter=dot TransactionForm TransactionsPage`
- `cd apps/web; npx vitest run --reporter=dot CounterpartyInput`

## Notes
- Work was done in an isolated worktree because the main checkout had unrelated active changes on another branch.