### PR TITLE
fix(windows): harden auth configuration and lifecycle cleanup

### DIFF
--- a/apps/windows/build.gradle.kts
+++ b/apps/windows/build.gradle.kts
@@ -30,6 +30,9 @@ dependencies {
     // HTTP client — Ktor OkHttp engine for JVM sync networking
     implementation(libs.ktor.client.okhttp)
 
+    // Logging provider for Ktor and sync libraries on JVM/Windows
+    runtimeOnly(libs.slf4j.simple)
+
     // DI — Koin (core only, no Android dependency)
     implementation(libs.koin.core)
 

--- a/apps/windows/src/main/kotlin/com/finance/desktop/Main.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/Main.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
 import com.finance.desktop.components.rememberShortcutHandler
 import com.finance.desktop.data.storage.UserDataPaths
+import com.finance.desktop.di.SupabaseConfig
 import com.finance.desktop.di.appModules
 import com.finance.desktop.notifications.DesktopNotificationManager
 import com.finance.desktop.performance.PerformanceMonitor
@@ -23,8 +24,12 @@ import com.finance.desktop.widgets.WidgetRegistrationManager
 import org.koin.core.context.GlobalContext
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
+import java.awt.GraphicsEnvironment
+import javax.swing.JOptionPane
+import kotlin.system.exitProcess
 
 fun main() {
+    validateStartupConfiguration()
     PerformanceTracker.recordAppStart()
 
     // ── One-time migration of user data out of MSI install root (#1900) ──
@@ -109,5 +114,24 @@ fun main() {
         ) {
             FinanceApp(shortcutHandler, quickAddManager, systemTray)
         }
+    }
+}
+
+private fun validateStartupConfiguration() {
+    try {
+        SupabaseConfig.fromEnvironment()
+    } catch (exception: IllegalStateException) {
+        val message = exception.message ?: "Finance is missing required Supabase configuration."
+        if (!GraphicsEnvironment.isHeadless()) {
+            JOptionPane.showMessageDialog(
+                null,
+                message,
+                "Finance configuration missing",
+                JOptionPane.ERROR_MESSAGE,
+            )
+        } else {
+            System.err.println(message)
+        }
+        exitProcess(1)
     }
 }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/di/AuthModule.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/di/AuthModule.kt
@@ -18,13 +18,17 @@ import org.koin.dsl.module
  * - KMP [TokenStorage] and [TokenManager] for token lifecycle
  * - [DesktopAuthRepository] binding [AuthRepository] interface
  *
- * Supabase configuration is read from environment variables:
+ * Supabase configuration is read from required environment variables:
  * - `SUPABASE_URL` — project URL (e.g., "https://xxx.supabase.co")
  * - `SUPABASE_ANON_KEY` — public/anonymous API key
- *
- * Fallback values are provided for local development.
  */
-val authModule = module {
+val authModule = createAuthModule()
+
+internal fun createAuthModule(
+    configProvider: () -> SupabaseConfig = { SupabaseConfig.fromEnvironment() },
+) = module {
+    single { configProvider() }
+
     // Ktor HTTP client for auth API calls
     single {
         HttpClient(OkHttp) {
@@ -44,10 +48,11 @@ val authModule = module {
 
     // Auth repository
     single<AuthRepository> {
+        val config = get<SupabaseConfig>()
         DesktopAuthRepository(
             httpClient = get(),
-            supabaseUrl = System.getenv("SUPABASE_URL") ?: "https://finance.supabase.co",
-            supabaseAnonKey = System.getenv("SUPABASE_ANON_KEY") ?: "",
+            supabaseUrl = config.url,
+            supabaseAnonKey = config.anonKey,
             secureTokenStorage = get(),
             tokenManager = get(),
         )

--- a/apps/windows/src/main/kotlin/com/finance/desktop/di/SupabaseConfig.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/di/SupabaseConfig.kt
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.di
+
+/** Supabase runtime configuration for the Windows auth client. */
+internal data class SupabaseConfig(
+    val url: String,
+    val anonKey: String,
+) {
+    companion object {
+        const val URL_ENV_VAR = "SUPABASE_URL"
+        const val ANON_KEY_ENV_VAR = "SUPABASE_ANON_KEY"
+
+        fun fromEnvironment(environment: Map<String, String> = System.getenv()): SupabaseConfig {
+            val url = environment[URL_ENV_VAR]?.trim().orEmpty()
+            val anonKey = environment[ANON_KEY_ENV_VAR]?.trim().orEmpty()
+            val missing = buildList {
+                if (url.isBlank()) add(URL_ENV_VAR)
+                if (anonKey.isBlank()) add(ANON_KEY_ENV_VAR)
+            }
+
+            if (missing.isNotEmpty()) {
+                throw IllegalStateException(missingConfigurationMessage(missing))
+            }
+
+            return SupabaseConfig(url = url, anonKey = anonKey)
+        }
+
+        fun missingConfigurationMessage(missing: List<String>): String {
+            return buildString {
+                append("Finance is not configured. Set ")
+                append(URL_ENV_VAR)
+                append(" and ")
+                append(ANON_KEY_ENV_VAR)
+                append(" environment variables and restart Finance.")
+                append(System.lineSeparator())
+                append(System.lineSeparator())
+                append("Missing: ")
+                append(missing.joinToString(", "))
+                append(System.lineSeparator())
+                append(System.lineSeparator())
+                append("On Windows, set them in System Properties → Environment Variables, or run:")
+                append(System.lineSeparator())
+                append("setx ")
+                append(URL_ENV_VAR)
+                append(" \"https://<project>.supabase.co\"")
+                append(System.lineSeparator())
+                append("setx ")
+                append(ANON_KEY_ENV_VAR)
+                append(" \"<anon-key>\"")
+                append(System.lineSeparator())
+                append(System.lineSeparator())
+                append("Restart Finance after updating environment variables.")
+            }
+        }
+    }
+}

--- a/apps/windows/src/main/kotlin/com/finance/desktop/performance/PerformanceInstrumentation.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/performance/PerformanceInstrumentation.kt
@@ -6,6 +6,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -105,15 +108,19 @@ object PerformanceMonitor {
     const val SCREEN_RENDER_WARNING_MS = 500L
 
     private var isRunning = false
+    private var monitorScope: CoroutineScope? = null
+    private var monitorJob: Job? = null
 
     /**
      * Starts the periodic background monitoring.
      */
     fun start() {
-        if (isRunning) return
+        if (monitorJob?.isActive == true) return
         isRunning = true
 
-        CoroutineScope(Dispatchers.Default).launch {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        monitorScope = scope
+        monitorJob = scope.launch {
             logger.info("Performance monitor started")
             while (isActive && isRunning) {
                 PerformanceTracker.captureMemorySnapshot()
@@ -135,6 +142,9 @@ object PerformanceMonitor {
      */
     fun stop() {
         isRunning = false
+        monitorScope?.cancel()
+        monitorScope = null
+        monitorJob = null
         logger.info("Performance monitor stopped")
     }
 }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/sync/DesktopSyncCoordinator.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/sync/DesktopSyncCoordinator.kt
@@ -127,15 +127,10 @@ class DesktopSyncCoordinator(
      * Stop the background sync loop and disconnect.
      */
     fun stop() {
-        syncJob?.cancel()
-        syncJob = null
-        scope.launch {
-            @Suppress("TooGenericExceptionCaught") // Sync disconnect must not crash
-            try {
-                syncEngine.disconnect()
-            } catch (e: Exception) {
-                logger.log(Level.WARNING, "Error during sync disconnect", e)
-            }
+        runBlocking {
+            syncJob?.cancelAndJoin()
+            syncJob = null
+            disconnectSafely()
         }
         logger.info("Sync coordinator stopped")
     }
@@ -146,6 +141,15 @@ class DesktopSyncCoordinator(
     fun dispose() {
         stop()
         scope.cancel()
+    }
+
+    private suspend fun disconnectSafely() {
+        @Suppress("TooGenericExceptionCaught") // Sync disconnect must not crash
+        try {
+            syncEngine.disconnect()
+        } catch (e: Exception) {
+            logger.log(Level.WARNING, "Error during sync disconnect", e)
+        }
     }
 
     private fun formatTrayStatus(status: SyncStatus): String = when (status) {

--- a/apps/windows/src/main/kotlin/com/finance/desktop/widgets/WidgetRegistrationManager.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/widgets/WidgetRegistrationManager.kt
@@ -4,6 +4,9 @@ package com.finance.desktop.widgets
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -100,6 +103,8 @@ class WidgetRegistrationManager(
 
     /** Cached widget content for each widget type. */
     private val widgetContentCache = mutableMapOf<FinanceWidgetType, String>()
+    private var refreshScope: CoroutineScope? = null
+    private var refreshJob: Job? = null
 
     /**
      * Whether the application is running as a packaged MSIX with widget
@@ -128,8 +133,12 @@ class WidgetRegistrationManager(
             return
         }
 
+        if (refreshJob?.isActive == true) return
+
         logger.info("Widget manager initialising for packaged app")
-        CoroutineScope(Dispatchers.IO).launch {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        refreshScope = scope
+        refreshJob = scope.launch {
             refreshAllWidgets()
         }
     }
@@ -184,6 +193,9 @@ class WidgetRegistrationManager(
      * Called on application shutdown to clean up resources.
      */
     fun dispose() {
+        refreshScope?.cancel()
+        refreshScope = null
+        refreshJob = null
         widgetContentCache.clear()
         logger.info("Widget manager disposed")
     }

--- a/apps/windows/src/main/resources/simplelogger.properties
+++ b/apps/windows/src/main/resources/simplelogger.properties
@@ -1,0 +1,5 @@
+org.slf4j.simpleLogger.defaultLogLevel=info
+org.slf4j.simpleLogger.showDateTime=true
+org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss.SSS
+org.slf4j.simpleLogger.showThreadName=true
+org.slf4j.simpleLogger.showShortLogName=true

--- a/apps/windows/src/test/kotlin/com/finance/desktop/di/KoinGraphSmokeTest.kt
+++ b/apps/windows/src/test/kotlin/com/finance/desktop/di/KoinGraphSmokeTest.kt
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.di
+
+import com.finance.core.currency.CurrencyConverter
+import com.finance.core.currency.ExchangeRateProvider
+import com.finance.db.EncryptionKeyProvider
+import com.finance.db.FinanceDatabase
+import com.finance.desktop.data.database.DesktopDatabaseManager
+import com.finance.desktop.data.repository.*
+import com.finance.desktop.notifications.DesktopNotificationManager
+import com.finance.desktop.notifications.EnhancedNotificationManager
+import com.finance.desktop.navigation.DeepLinkHandler
+import com.finance.desktop.security.*
+import com.finance.desktop.sync.DesktopSyncCoordinator
+import com.finance.desktop.tray.FinanceSystemTray
+import com.finance.desktop.tray.QuickAddTransactionManager
+import com.finance.desktop.viewmodel.*
+import com.finance.desktop.voice.VoiceCommandManager
+import com.finance.desktop.voice.VoiceCommandParser
+import com.finance.desktop.widgets.WidgetContentRenderer
+import com.finance.desktop.widgets.WidgetDataProvider
+import com.finance.desktop.widgets.WidgetRegistrationManager
+import com.finance.sync.DefaultSyncEngine
+import com.finance.sync.SyncConfig
+import com.finance.sync.SyncProvider
+import com.finance.sync.auth.TokenManager
+import com.finance.sync.auth.TokenStorage
+import com.finance.sync.delta.DeltaSyncManager
+import com.finance.sync.delta.SequenceTracker
+import com.finance.sync.queue.MutationQueue
+import io.ktor.client.HttpClient
+import org.koin.core.Koin
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.fail
+
+class KoinGraphSmokeTest {
+    @AfterTest
+    fun tearDown() {
+        stopKoin()
+    }
+
+    @Test
+    fun `windows Koin graph resolves registered singletons`() {
+        val testAuthModule = createAuthModule {
+            SupabaseConfig(
+                url = "https://example.supabase.co",
+                anonKey = "anon-key",
+            )
+        }
+        val modules = appModules.map { module ->
+            if (module === authModule) testAuthModule else module
+        }
+        val koin = startKoin { modules(modules) }.koin
+
+        val resolutions = listOf<Pair<String, Koin.() -> Any>>(
+            "EncryptionKeyProvider" to { get<EncryptionKeyProvider>() },
+            "DesktopDatabaseManager" to { get<DesktopDatabaseManager>() },
+            "FinanceDatabase" to { get<FinanceDatabase>() },
+            "AccountRepository" to { get<AccountRepository>() },
+            "TransactionRepository" to { get<TransactionRepository>() },
+            "BudgetRepository" to { get<BudgetRepository>() },
+            "CategoryRepository" to { get<CategoryRepository>() },
+            "GoalRepository" to { get<GoalRepository>() },
+            "SettingsRepository" to { get<SettingsRepository>() },
+            "ExchangeRateProvider" to { get<ExchangeRateProvider>() },
+            "CurrencyConverter" to { get<CurrencyConverter>() },
+            "CurrencyRepository" to { get<CurrencyRepository>() },
+            "HttpClient" to { get<HttpClient>() },
+            "TokenStorage" to { get<TokenStorage>() },
+            "TokenManager" to { get<TokenManager>() },
+            "AuthRepository" to { get<AuthRepository>() },
+            "SyncConfig" to { get<SyncConfig>() },
+            "SyncProvider" to { get<SyncProvider>() },
+            "MutationQueue" to { get<MutationQueue>() },
+            "SequenceTracker" to { get<SequenceTracker>() },
+            "DeltaSyncManager" to { get<DeltaSyncManager>() },
+            "DefaultSyncEngine" to { get<DefaultSyncEngine>() },
+            "DesktopSyncCoordinator" to { get<DesktopSyncCoordinator>() },
+            "WindowsHelloManager" to { get<WindowsHelloManager>() },
+            "DpapiManager" to { get<DpapiManager>() },
+            "SecureTokenStorage" to { get<SecureTokenStorage>() },
+            "CredentialManager" to { get<CredentialManager>() },
+            "AutoLockManager" to { get<AutoLockManager>() },
+            "SessionManager" to { get<SessionManager>() },
+            "CertificatePinningManager" to { get<CertificatePinningManager>() },
+            "DesktopNotificationManager" to { get<DesktopNotificationManager>() },
+            "WidgetDataProvider" to { get<WidgetDataProvider>() },
+            "WidgetContentRenderer" to { get<WidgetContentRenderer>() },
+            "WidgetRegistrationManager" to { get<WidgetRegistrationManager>() },
+            "VoiceCommandManager" to { get<VoiceCommandManager>() },
+            "VoiceCommandParser" to { get<VoiceCommandParser>() },
+            "FinanceSystemTray" to { get<FinanceSystemTray>() },
+            "QuickAddTransactionManager" to { get<QuickAddTransactionManager>() },
+            "EnhancedNotificationManager" to { get<EnhancedNotificationManager>() },
+            "DeepLinkHandler" to { get<DeepLinkHandler>() },
+            "DashboardViewModel" to { get<DashboardViewModel>() },
+            "AccountsViewModel" to { get<AccountsViewModel>() },
+            "TransactionsViewModel" to { get<TransactionsViewModel>() },
+            "BudgetsViewModel" to { get<BudgetsViewModel>() },
+            "GoalsViewModel" to { get<GoalsViewModel>() },
+            "SyncViewModel" to { get<SyncViewModel>() },
+            "SettingsViewModel" to { get<SettingsViewModel>() },
+            "AuthViewModel" to { get<AuthViewModel>() },
+            "LoginViewModel" to { get<LoginViewModel>() },
+            "GdprConsentViewModel" to { get<GdprConsentViewModel>() },
+            "WidgetViewModel" to { get<WidgetViewModel>() },
+            "VoiceTransactionViewModel" to { get<VoiceTransactionViewModel>() },
+            "DiagnosticsViewModel" to { get<DiagnosticsViewModel>() },
+            "WidgetBoardViewModel" to { get<WidgetBoardViewModel>() },
+            "HealthScoreViewModel" to { get<HealthScoreViewModel>() },
+            "ReportBuilderViewModel" to { get<ReportBuilderViewModel>() },
+            "BudgetNegotiationViewModel" to { get<BudgetNegotiationViewModel>() },
+            "EntitlementViewModel" to { get<EntitlementViewModel>() },
+            "TipsViewModel" to { get<TipsViewModel>() },
+            "GamificationViewModel" to { get<GamificationViewModel>() },
+            "CurrencyViewModel" to { get<CurrencyViewModel>() },
+            "NaturalLanguageViewModel" to { get<NaturalLanguageViewModel>() },
+        )
+
+        resolutions.forEach { (name, resolve) ->
+            try {
+                koin.resolve()
+            } catch (exception: Throwable) {
+                fail("Failed to resolve $name", exception)
+            }
+        }
+    }
+}

--- a/apps/windows/src/test/kotlin/com/finance/desktop/di/SupabaseConfigTest.kt
+++ b/apps/windows/src/test/kotlin/com/finance/desktop/di/SupabaseConfigTest.kt
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.desktop.di
+
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+class SupabaseConfigTest {
+    @Test
+    fun `fromEnvironment rejects missing configuration with actionable Windows guidance`() {
+        val exception = try {
+            SupabaseConfig.fromEnvironment(emptyMap())
+            fail("Expected missing Supabase configuration to throw")
+        } catch (exception: IllegalStateException) {
+            exception
+        }
+
+        val message = exception.message.orEmpty()
+        assertContains(message, "Finance is not configured")
+        assertContains(message, SupabaseConfig.URL_ENV_VAR)
+        assertContains(message, SupabaseConfig.ANON_KEY_ENV_VAR)
+        assertContains(message, "System Properties → Environment Variables")
+        assertContains(message, "setx SUPABASE_URL")
+    }
+
+    @Test
+    fun `fromEnvironment returns trimmed Supabase values`() {
+        val config = SupabaseConfig.fromEnvironment(
+            mapOf(
+                SupabaseConfig.URL_ENV_VAR to " https://example.supabase.co ",
+                SupabaseConfig.ANON_KEY_ENV_VAR to " anon-key ",
+            ),
+        )
+
+        assertEquals("https://example.supabase.co", config.url)
+        assertEquals("anon-key", config.anonKey)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ kover = "0.9.1"
 paparazzi = "1.3.5"
 compose-multiplatform = "1.7.3"
 netty = "4.1.133.Final"
+slf4j = "2.0.17"
 
 # Security: forced transitive dependency versions
 commons-lang3 = "3.18.0"
@@ -75,6 +76,7 @@ koin-compose-viewmodel = { module = "io.insert-koin:koin-compose-viewmodel", ver
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
+slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
 
 # Android / Compose
 core-ktx = { module = "androidx.core:core-ktx", version.ref = "core-ktx" }


### PR DESCRIPTION
## Related Issues
Closes #1895
Closes #1896

## Summary
- Adds startup Supabase configuration validation and removes placeholder auth fallbacks so missing `SUPABASE_URL` / `SUPABASE_ANON_KEY` fails fast with Windows setup guidance.
- Hardens Windows shutdown/startup lifecycle by awaiting sync disconnect and owning/cancelling performance and widget coroutine scopes.
- Adds an SLF4J Simple provider/config for JVM logging and introduces Windows unit tests, including Supabase config coverage and a Koin graph smoke test.

## Testing
- `./gradlew.bat :apps:windows:test --stacktrace --console=plain`
- `./gradlew.bat :apps:windows:build --parallel --build-cache --stacktrace --console=plain`
- No ktlint/format task is configured in this repo.

## Risk
Low/Medium. Runtime behavior intentionally changes when Supabase env vars are missing; lifecycle changes are limited to shutdown/background scopes.