### PR TITLE
fix: prevent modal scrollbar layout shift

### DIFF
--- a/apps/web/src/theme/tokens.css
+++ b/apps/web/src/theme/tokens.css
@@ -182,6 +182,7 @@
 }
 
 html {
+  scrollbar-gutter: stable;
   font-family:
     system-ui,
     -apple-system,


### PR DESCRIPTION
## Summary
- Closes #1921
- Reserves the root scrollbar gutter globally so locking body scroll for dialogs does not widen the viewport.
- Keeps modal open/close from causing responsive background layouts to reflow.

## Changes
- `apps/web/src/theme/tokens.css`: adds `scrollbar-gutter: stable` to the root `html` rule.

## Testing
- `npx vitest run src\components\common\ConfirmDialog.test.tsx --reporter=dot` ✅
- `npx vitest run --reporter=dot` ❌ existing unrelated failure: `src/utils/formatDate.test.ts` expects `24` but received `Dec 23, 2023` in this environment.

## Risk Assessment
Low. CSS-only root scrollbar gutter reservation; no component logic changes.