### PR TITLE
fix(web): replace inline emoji iconography

### DIFF
--- a/apps/web/src/components/auth/PasskeySetupPrompt.tsx
+++ b/apps/web/src/components/auth/PasskeySetupPrompt.tsx
@@ -14,6 +14,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { AppIcon } from '../icons';
 
 import { useAuth } from '../../auth/auth-context';
 import {
@@ -232,7 +233,7 @@ export function PasskeySetupPrompt({ isOpen, onClose }: PasskeySetupPromptProps)
       >
         {/* Icon */}
         <div className="passkey-prompt__icon" aria-hidden="true">
-          🔐
+          <AppIcon name="shield" />
         </div>
 
         {/* Title */}

--- a/apps/web/src/components/bank/ConnectionHealthCard.tsx
+++ b/apps/web/src/components/bank/ConnectionHealthCard.tsx
@@ -11,6 +11,7 @@
  */
 
 import React from 'react';
+import { AppIcon } from '../icons';
 
 import type { BankConnectionHealth } from '../../hooks/useBankConnections';
 
@@ -133,9 +134,13 @@ export const ConnectionHealthCard: React.FC<ConnectionHealthCardProps> = ({
         <div className="connection-health-card__detail">
           <span className="connection-health-card__label">Access</span>
           <span className="connection-health-card__value">
-            {connection.permissionLevel === 'read_only'
-              ? '🔒 Read-only'
-              : connection.permissionLevel}
+            {connection.permissionLevel === 'read_only' ? (
+              <>
+                <AppIcon name="lock" /> Read-only
+              </>
+            ) : (
+              connection.permissionLevel
+            )}
           </span>
         </div>
 

--- a/apps/web/src/components/bank/SafetyCenter.tsx
+++ b/apps/web/src/components/bank/SafetyCenter.tsx
@@ -12,6 +12,7 @@
  */
 
 import React, { useCallback, useEffect, useState } from 'react';
+import { AppIcon, type IconName } from '../icons';
 
 import type {
   ConnectorPermission,
@@ -40,11 +41,11 @@ export interface SafetyCenterProps {
 // ---------------------------------------------------------------------------
 
 /** Human-readable permission level labels. */
-const PERMISSION_LABELS: Record<string, string> = {
-  read_only: '🔒 Read-only',
-  read_write: '🔓 Read & Write',
-  read_balance: '👁️ Balance only',
-  read_transactions: '📋 Transactions only',
+const PERMISSION_LABELS: Record<string, { icon: IconName; label: string }> = {
+  read_only: { icon: 'lock', label: 'Read-only' },
+  read_write: { icon: 'unlock', label: 'Read & Write' },
+  read_balance: { icon: 'eye', label: 'Balance only' },
+  read_transactions: { icon: 'clipboard', label: 'Transactions only' },
 };
 
 /** Human-readable access type labels. */
@@ -158,7 +159,14 @@ export const SafetyCenter: React.FC<SafetyCenterProps> = ({
 
                 <div className="safety-center__item-details">
                   <span className="safety-center__permission-badge">
-                    {PERMISSION_LABELS[perm.permissionLevel] ?? perm.permissionLevel}
+                    {PERMISSION_LABELS[perm.permissionLevel] ? (
+                      <>
+                        <AppIcon name={PERMISSION_LABELS[perm.permissionLevel].icon} />{' '}
+                        {PERMISSION_LABELS[perm.permissionLevel].label}
+                      </>
+                    ) : (
+                      perm.permissionLevel
+                    )}
                   </span>
 
                   <span

--- a/apps/web/src/components/budgets/BudgetAnalytics.tsx
+++ b/apps/web/src/components/budgets/BudgetAnalytics.tsx
@@ -26,6 +26,7 @@ import {
   type ChangeDirection,
 } from '../../lib/budget-analytics';
 import './budget-analytics.css';
+import { AppIcon, type IconName } from '../icons';
 
 // ---------------------------------------------------------------------------
 // Props
@@ -63,10 +64,10 @@ const HEALTH_LABELS: Record<BudgetHealthStatus, string> = {
   'over-budget': 'Over Budget',
 };
 
-const HEALTH_ICONS: Record<BudgetHealthStatus, string> = {
-  'on-track': '✓',
-  'at-risk': '⚠',
-  'over-budget': '✗',
+const HEALTH_ICONS: Record<BudgetHealthStatus, IconName> = {
+  'on-track': 'check',
+  'at-risk': 'alert-triangle',
+  'over-budget': 'x',
 };
 
 /** Renders the traffic-light budget health indicator with text + icon. */
@@ -79,8 +80,7 @@ function HealthIndicator({ status }: { status: BudgetHealthStatus }) {
     >
       <span className="health-indicator__icon" aria-hidden="true" />
       <span className="health-indicator__label">
-        <span aria-hidden="true">{HEALTH_ICONS[status]} </span>
-        {HEALTH_LABELS[status]}
+        <AppIcon name={HEALTH_ICONS[status]} /> {HEALTH_LABELS[status]}
       </span>
     </span>
   );

--- a/apps/web/src/components/celebrations/MilestoneCelebration.test.tsx
+++ b/apps/web/src/components/celebrations/MilestoneCelebration.test.tsx
@@ -24,7 +24,7 @@ const baseMilestone: Milestone = {
   type: 'first-transaction',
   title: 'First Transaction!',
   description: 'You logged your first transaction. Great start!',
-  icon: '🎉',
+  icon: 'sparkles',
 };
 
 function renderCelebration(overrides: Partial<MilestoneCelebrationProps> = {}) {
@@ -62,7 +62,7 @@ describe('MilestoneCelebration', () => {
   it('renders the milestone icon', () => {
     renderCelebration();
 
-    expect(screen.getByText('🎉')).toBeInTheDocument();
+    expect(document.querySelector('.milestone-celebration__icon svg')).toBeInTheDocument();
   });
 
   it('renders each milestone type correctly', () => {
@@ -71,19 +71,19 @@ describe('MilestoneCelebration', () => {
         type: 'goal-50',
         title: 'Halfway!',
         description: "You're at 50% of your savings goal!",
-        icon: '⭐',
+        icon: 'sparkles',
       },
       {
         type: 'streak-7',
         title: '7-Day Streak!',
         description: 'A whole week of consistent logging!',
-        icon: '📅',
+        icon: 'calendar',
       },
       {
         type: 'goal-100',
         title: 'Goal Achieved!',
         description: 'Congratulations! You reached your savings goal!',
-        icon: '🏆',
+        icon: 'trophy',
       },
     ];
 

--- a/apps/web/src/components/celebrations/MilestoneCelebration.tsx
+++ b/apps/web/src/components/celebrations/MilestoneCelebration.tsx
@@ -11,6 +11,7 @@
  */
 
 import { useCallback, useEffect, useRef } from 'react';
+import { AppIcon } from '../icons';
 
 import type { Milestone, MilestoneType } from '../../hooks/useMilestones';
 import { useReducedMotion } from '../../hooks/useReducedMotion';
@@ -95,7 +96,7 @@ export const MilestoneCelebration: React.FC<MilestoneCelebrationProps> = ({
 
       {/* Icon */}
       <span className="milestone-celebration__icon" aria-hidden="true">
-        {milestone.icon}
+        <AppIcon name={milestone.icon} />
       </span>
 
       {/* Text */}

--- a/apps/web/src/components/dashboard/PredictiveBalanceCard.tsx
+++ b/apps/web/src/components/dashboard/PredictiveBalanceCard.tsx
@@ -22,6 +22,7 @@
 import React, { useCallback, useState } from 'react';
 import { CurrencyDisplay } from '../common';
 import type { PredictionSummary, AccountPrediction } from '../../lib/predictiveBalance';
+import { AppIcon, type IconName } from '../icons';
 
 import '../../styles/predictive-balance.css';
 
@@ -38,14 +39,14 @@ export interface PredictiveBalanceCardProps {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function getTrendIcon(trend: AccountPrediction['trend']): string {
+function getTrendIcon(trend: AccountPrediction['trend']): IconName {
   switch (trend) {
     case 'positive':
-      return '📈';
+      return 'trending-up';
     case 'negative':
-      return '📉';
+      return 'trending-down';
     case 'flat':
-      return '➡️';
+      return 'arrow-right';
   }
 }
 
@@ -104,7 +105,7 @@ export const PredictiveBalanceCard: React.FC<PredictiveBalanceCardProps> = ({ pr
             className={`predictive-card__trend predictive-card__trend--${overallTrend}`}
             aria-label={getTrendLabel(overallTrend)}
           >
-            <span aria-hidden="true">{getTrendIcon(overallTrend)}</span>
+            <AppIcon name={getTrendIcon(overallTrend)} />
             <CurrencyDisplay amount={prediction.predictedChangeCents} colorize showSign />
           </span>
         </div>
@@ -140,7 +141,7 @@ export const PredictiveBalanceCard: React.FC<PredictiveBalanceCardProps> = ({ pr
                       className={`predictive-card__account-trend predictive-card__trend--${account.trend}`}
                       aria-label={getTrendLabel(account.trend)}
                     >
-                      <span aria-hidden="true">{getTrendIcon(account.trend)}</span>
+                      <AppIcon name={getTrendIcon(account.trend)} />
                     </span>
                   </div>
                   <div className="predictive-card__account-amounts">

--- a/apps/web/src/components/forms/BulkEditToolbar.tsx
+++ b/apps/web/src/components/forms/BulkEditToolbar.tsx
@@ -20,6 +20,7 @@
 import React, { useCallback, useState } from 'react';
 import type { Category, SyncId } from '../../kmp/bridge';
 import type { BulkUpdateFields, BulkOperationResult } from '../../hooks/useBulkTransactions';
+import { AppIcon } from '../icons';
 
 import '../../styles/bulk-edit.css';
 
@@ -112,7 +113,7 @@ export const BulkEditToolbar: React.FC<BulkEditToolbarProps> = ({
             aria-expanded={showCategoryPicker}
             aria-label="Change category for selected transactions"
           >
-            <span aria-hidden="true">📁</span> Category
+            <AppIcon name="folder" /> Category
           </button>
           {showCategoryPicker && (
             <div
@@ -153,7 +154,7 @@ export const BulkEditToolbar: React.FC<BulkEditToolbarProps> = ({
             onClick={() => setShowDeleteConfirm(true)}
             aria-label={`Delete ${selectionCount} selected transactions`}
           >
-            <span aria-hidden="true">🗑️</span> Delete
+            <AppIcon name="trash" /> Delete
           </button>
         ) : (
           <div

--- a/apps/web/src/components/forms/NaturalLanguageInput.tsx
+++ b/apps/web/src/components/forms/NaturalLanguageInput.tsx
@@ -17,6 +17,7 @@
 
 import { useCallback, useRef, useState } from 'react';
 import type { FormEvent, KeyboardEvent } from 'react';
+import { AppIcon, type IconName } from '../icons';
 
 import { useNaturalLanguageInput } from '../../hooks/useNaturalLanguageInput';
 import type { EditableField } from '../../hooks/useNaturalLanguageInput';
@@ -191,7 +192,7 @@ export function NaturalLanguageInput({
                 aria-expanded={showLocaleMenu}
                 aria-haspopup="listbox"
               >
-                🌐 {locale}
+                <AppIcon name="globe" /> {locale}
               </button>
               {showLocaleMenu && (
                 <ul className="nl-locale-menu" role="listbox" aria-label="Select input locale">
@@ -284,7 +285,7 @@ export function NaturalLanguageInput({
                   <span className="nl-suggestion-text">{suggestion.text}</span>
                   {suggestion.source === 'history' && (
                     <span className="nl-suggestion-badge" aria-label="From history">
-                      🕐
+                      <AppIcon name="calendar" />
                     </span>
                   )}
                 </li>
@@ -370,7 +371,7 @@ export function NaturalLanguageInput({
             {parsedTransaction.payee && (
               <ParsedTag
                 field="payee"
-                icon="📍"
+                icon="map-pin"
                 label={parsedTransaction.payee}
                 confidence={parsedTransaction.fieldConfidences.payee}
                 editingField={editingField}
@@ -383,7 +384,7 @@ export function NaturalLanguageInput({
             {parsedTransaction.amountCents != null && (
               <ParsedTag
                 field="amount"
-                icon="💰"
+                icon="wallet"
                 label={formatCents(parsedTransaction.amountCents)}
                 confidence={parsedTransaction.fieldConfidences.amount}
                 editingField={editingField}
@@ -396,7 +397,7 @@ export function NaturalLanguageInput({
             {parsedTransaction.category && (
               <ParsedTag
                 field="category"
-                icon="🏷️"
+                icon="tag"
                 label={parsedTransaction.category}
                 confidence={parsedTransaction.fieldConfidences.category}
                 editingField={editingField}
@@ -409,7 +410,7 @@ export function NaturalLanguageInput({
             {parsedTransaction.date && (
               <ParsedTag
                 field="date"
-                icon="📅"
+                icon="calendar"
                 label={parsedTransaction.date}
                 confidence={parsedTransaction.fieldConfidences.date}
                 editingField={editingField}
@@ -423,10 +424,10 @@ export function NaturalLanguageInput({
               field="type"
               icon={
                 parsedTransaction.type === 'INCOME'
-                  ? '📈'
+                  ? 'trending-up'
                   : parsedTransaction.type === 'TRANSFER'
-                    ? '🔄'
-                    : '📉'
+                    ? 'refresh'
+                    : 'trending-down'
               }
               label={parsedTransaction.type}
               confidence={parsedTransaction.fieldConfidences.type}
@@ -478,7 +479,7 @@ export function NaturalLanguageInput({
 
 interface ParsedTagProps {
   field: EditableField;
-  icon: string;
+  icon: IconName;
   label: string;
   confidence: { value: number; label: string };
   editingField: EditableField | null;
@@ -515,7 +516,7 @@ function ParsedTag({
   if (isEditing) {
     return (
       <span className={`nl-parsed-tag nl-parsed-tag--${field} nl-parsed-tag--editing`}>
-        <span aria-hidden="true">{icon}</span>
+        <AppIcon name={icon} />
         <input
           ref={quickFixRef}
           className="nl-quickfix-input"
@@ -543,7 +544,7 @@ function ParsedTag({
       aria-label={`${field}: ${label} (${confidence.label} confidence, ${Math.round(confidence.value * 100)}%). Click to edit.`}
       title={`Click to correct ${field}`}
     >
-      <span aria-hidden="true">{icon}</span>
+      <AppIcon name={icon} />
       <span>{label}</span>
       <span
         className={`nl-field-confidence nl-field-confidence--${confidence.label}`}

--- a/apps/web/src/components/gamification/achievements-engine.ts
+++ b/apps/web/src/components/gamification/achievements-engine.ts
@@ -9,6 +9,8 @@
  * All monetary values are in cents (integers).
  */
 
+import type { IconName } from '../icons';
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -27,8 +29,8 @@ export interface Achievement {
   readonly name: string;
   /** Description of how to earn this achievement. */
   readonly description: string;
-  /** Emoji icon for the badge. */
-  readonly icon: string;
+  /** Icon name for the badge. */
+  readonly icon: IconName;
   /** Category grouping. */
   readonly category: AchievementCategory;
   /** Current status. */
@@ -119,7 +121,7 @@ interface AchievementDefinition {
   id: string;
   name: string;
   description: string;
-  icon: string;
+  icon: IconName;
   category: AchievementCategory;
   check: (input: GamificationInput) => { unlocked: boolean; progress: number };
   points: number;
@@ -131,7 +133,7 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
     id: 'first-transaction',
     name: 'First Step',
     description: 'Log your first transaction',
-    icon: '👣',
+    icon: 'account',
     category: 'tracking',
     check: (input) => ({
       unlocked: input.transactionCount >= 1,
@@ -143,7 +145,7 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
     id: 'transaction-10',
     name: 'Getting Started',
     description: 'Log 10 transactions',
-    icon: '📝',
+    icon: 'edit',
     category: 'tracking',
     check: (input) => ({
       unlocked: input.transactionCount >= 10,
@@ -155,7 +157,7 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
     id: 'transaction-100',
     name: 'Dedicated Tracker',
     description: 'Log 100 transactions',
-    icon: '📊',
+    icon: 'chart-bar',
     category: 'tracking',
     check: (input) => ({
       unlocked: input.transactionCount >= 100,
@@ -167,7 +169,7 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
     id: 'transaction-500',
     name: 'Finance Master',
     description: 'Log 500 transactions',
-    icon: '🏆',
+    icon: 'trophy',
     category: 'tracking',
     check: (input) => ({
       unlocked: input.transactionCount >= 500,
@@ -179,7 +181,7 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
     id: 'daily-streak-7',
     name: 'Week Warrior',
     description: 'Log transactions for 7 consecutive days',
-    icon: '🔥',
+    icon: 'flame',
     category: 'tracking',
     check: (input) => ({
       unlocked: input.longestDailyLoggingStreak >= 7,
@@ -191,7 +193,7 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
     id: 'daily-streak-30',
     name: 'Monthly Champion',
     description: 'Log transactions for 30 consecutive days',
-    icon: '💪',
+    icon: 'trophy',
     category: 'tracking',
     check: (input) => ({
       unlocked: input.longestDailyLoggingStreak >= 30,
@@ -205,7 +207,7 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
     id: 'first-budget',
     name: 'Budget Beginner',
     description: 'Create your first budget',
-    icon: '📋',
+    icon: 'clipboard',
     category: 'budgeting',
     check: (input) => ({
       unlocked: input.budgetCount >= 1,
@@ -217,7 +219,7 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
     id: 'budget-under',
     name: 'Under Budget',
     description: 'Stay under budget for a month',
-    icon: '✨',
+    icon: 'sparkles',
     category: 'budgeting',
     check: (input) => ({
       unlocked: input.budgetAdherenceMonths >= 1,
@@ -229,7 +231,7 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
     id: 'budget-streak-3',
     name: 'Budget Streak',
     description: 'Stay under budget for 3 consecutive months',
-    icon: '🎯',
+    icon: 'target',
     category: 'budgeting',
     check: (input) => ({
       unlocked: input.budgetAdherenceMonths >= 3,
@@ -243,7 +245,7 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
     id: 'first-goal',
     name: 'Goal Setter',
     description: 'Create your first savings goal',
-    icon: '🎯',
+    icon: 'target',
     category: 'saving',
     check: (input) => ({
       unlocked: input.goalCount >= 1,
@@ -255,7 +257,7 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
     id: 'goal-completed',
     name: 'Goal Crusher',
     description: 'Complete a savings goal',
-    icon: '🏅',
+    icon: 'medal',
     category: 'saving',
     check: (input) => ({
       unlocked: input.goalsCompleted >= 1,
@@ -267,7 +269,7 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
     id: 'saved-1000',
     name: 'First Thousand',
     description: 'Save $1,000 across all goals',
-    icon: '💰',
+    icon: 'wallet',
     category: 'saving',
     check: (input) => ({
       unlocked: input.totalSaved >= 100000,
@@ -279,7 +281,7 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
     id: 'saved-10000',
     name: 'Serious Saver',
     description: 'Save $10,000 across all goals',
-    icon: '💎',
+    icon: 'sparkles',
     category: 'saving',
     check: (input) => ({
       unlocked: input.totalSaved >= 1000000,
@@ -293,7 +295,7 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
     id: 'first-account',
     name: 'Account Opener',
     description: 'Add your first account',
-    icon: '🏦',
+    icon: 'bank',
     category: 'milestone',
     check: (input) => ({
       unlocked: input.accountCount >= 1,
@@ -305,7 +307,7 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
     id: 'multi-account',
     name: 'Diversified',
     description: 'Track 3 or more accounts',
-    icon: '🗂️',
+    icon: 'folder',
     category: 'milestone',
     check: (input) => ({
       unlocked: input.accountCount >= 3,
@@ -317,7 +319,7 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
     id: 'category-organizer',
     name: 'Well Organized',
     description: 'Use 5 or more spending categories',
-    icon: '🏷️',
+    icon: 'tag',
     category: 'milestone',
     check: (input) => ({
       unlocked: input.categoriesUsed >= 5,
@@ -329,7 +331,7 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
     id: 'positive-net-worth',
     name: 'In the Green',
     description: 'Achieve positive net worth',
-    icon: '🌿',
+    icon: 'leaf',
     category: 'milestone',
     check: (input) => ({
       unlocked: input.netWorth > 0 && input.accountCount > 0,

--- a/apps/web/src/components/gdpr/PrivacyGate.tsx
+++ b/apps/web/src/components/gdpr/PrivacyGate.tsx
@@ -35,6 +35,7 @@ import {
   type ConsentCategory,
 } from '../../lib/consent-storage';
 import './privacy-gate.css';
+import { AppIcon } from '../icons';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -91,7 +92,7 @@ export const PrivacyGate: React.FC<PrivacyGateProps> = ({
     <section className="privacy-gate" aria-label={`${featureName} requires consent`}>
       <div className="privacy-gate__card">
         <div className="privacy-gate__icon" aria-hidden="true">
-          🔒
+          <AppIcon name="lock" />
         </div>
 
         <h3 className="privacy-gate__title">{featureName}</h3>

--- a/apps/web/src/components/icons/AppIcon.tsx
+++ b/apps/web/src/components/icons/AppIcon.tsx
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import type { CSSProperties, SVGProps } from 'react';
+
+export type IconName =
+  | 'account'
+  | 'alert-circle'
+  | 'alert-triangle'
+  | 'arrow-right'
+  | 'bank'
+  | 'bell'
+  | 'calendar'
+  | 'car'
+  | 'chart-bar'
+  | 'check'
+  | 'clipboard'
+  | 'cloud'
+  | 'database'
+  | 'download'
+  | 'edit'
+  | 'eye'
+  | 'file-text'
+  | 'film'
+  | 'flame'
+  | 'folder'
+  | 'gift'
+  | 'globe'
+  | 'heart-pulse'
+  | 'home'
+  | 'info'
+  | 'laptop'
+  | 'leaf'
+  | 'lightning'
+  | 'lock'
+  | 'mail'
+  | 'map-pin'
+  | 'medal'
+  | 'package'
+  | 'plane'
+  | 'refresh'
+  | 'search'
+  | 'settings'
+  | 'shield'
+  | 'shopping-cart'
+  | 'sparkles'
+  | 'tag'
+  | 'target'
+  | 'trash'
+  | 'trending-down'
+  | 'trending-up'
+  | 'trophy'
+  | 'unlock'
+  | 'upload'
+  | 'wallet'
+  | 'x';
+
+export interface AppIconProps extends Omit<SVGProps<SVGSVGElement>, 'aria-hidden' | 'focusable'> {
+  name: IconName;
+  size?: number | string;
+  label?: string;
+}
+
+const paths: Record<IconName, string[]> = {
+  account: ['M20 21a8 8 0 0 0-16 0', 'M12 13a4 4 0 1 0 0-8 4 4 0 0 0 0 8Z'],
+  'alert-circle': ['M12 8v5', 'M12 16h.01', 'M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z'],
+  'alert-triangle': ['m12 3 10 18H2L12 3Z', 'M12 10v4', 'M12 17h.01'],
+  'arrow-right': ['M5 12h14', 'm13 6 6 6-6 6'],
+  bank: [
+    'M3 21h18',
+    'M5 10h14',
+    'M6 10v8',
+    'M10 10v8',
+    'M14 10v8',
+    'M18 10v8',
+    'M12 3 4 7h16l-8-4Z',
+  ],
+  bell: ['M18 8a6 6 0 1 0-12 0c0 7-3 7-3 9h18c0-2-3-2-3-9Z', 'M14 21a2 2 0 0 1-4 0'],
+  calendar: [
+    'M8 2v4',
+    'M16 2v4',
+    'M3 10h18',
+    'M5 4h14a2 2 0 0 1 2 2v13a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2Z',
+  ],
+  car: [
+    'M5 17h14',
+    'M7 17v2',
+    'M17 17v2',
+    'M5 13l2-6h10l2 6',
+    'M6 13h12a2 2 0 0 1 2 2v2H4v-2a2 2 0 0 1 2-2Z',
+  ],
+  'chart-bar': ['M4 19V9', 'M12 19V5', 'M20 19v-7', 'M3 21h18'],
+  check: ['m5 12 4 4L19 6'],
+  clipboard: ['M9 4h6l1 2h3v16H5V6h3l1-2Z', 'M9 10h6', 'M9 14h6'],
+  cloud: ['M17.5 19H7a5 5 0 1 1 1.5-9.8A6 6 0 0 1 20 12a3.5 3.5 0 0 1-2.5 7Z'],
+  database: [
+    'M21 6c0 2.2-4 4-9 4S3 8.2 3 6s4-4 9-4 9 1.8 9 4Z',
+    'M21 6v6c0 2.2-4 4-9 4s-9-1.8-9-4V6',
+    'M21 12v6c0 2.2-4 4-9 4s-9-1.8-9-4v-6',
+  ],
+  download: ['M12 3v12', 'm7 10 5 5 5-5', 'M5 21h14'],
+  edit: ['M12 20h9', 'M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5Z'],
+  eye: ['M2 12s4-7 10-7 10 7 10 7-4 7-10 7S2 12 2 12Z', 'M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z'],
+  'file-text': [
+    'M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6Z',
+    'M14 2v6h6',
+    'M8 13h8',
+    'M8 17h8',
+  ],
+  film: ['M4 4h16v16H4V4Z', 'M8 4v16', 'M16 4v16', 'M4 8h4', 'M16 8h4'],
+  flame: ['M12 22c4 0 7-3 7-7 0-3-2-6-6-10 .5 3-1 4.5-3 6-1.5 1.1-3 2.4-3 5a5 5 0 0 0 5 6Z'],
+  folder: ['M3 6h7l2 2h9v10a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V6Z'],
+  gift: ['M20 12v8H4v-8', 'M4 8h16v4H4z', 'M12 8v12', 'M12 8c-2-4-6-4-6-1 0 2 3 1 6 1Z'],
+  globe: [
+    'M12 21a9 9 0 1 0 0-18 9 9 0 0 0 0 18Z',
+    'M12 3c2.5 2.5 4 5.5 4 9s-1.5 6.5-4 9',
+    'M3 12h18',
+  ],
+  'heart-pulse': [
+    'M20.8 4.6a5.5 5.5 0 0 0-7.8 0L12 5.6l-1-1a5.5 5.5 0 1 0-7.8 7.8L12 21l3-3',
+    'M8 14h2l1.5-3 3 6 1.5-3h2',
+  ],
+  home: ['M3 11 12 3l9 8v10h-6v-6H9v6H3V11Z'],
+  info: ['M12 16v-4', 'M12 8h.01', 'M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z'],
+  laptop: ['M4 5h16v11H4V5Z', 'M2 19h20'],
+  leaf: ['M20 4c-7 0-12 4-12 10 0 3 2 6 5 6 6 0 9-6 7-16Z', 'M4 20c3-5 7-8 12-10'],
+  lightning: ['m13 2-9 12h7l-1 8 10-13h-7V2Z'],
+  lock: ['M7 10V7a5 5 0 0 1 10 0v3', 'M5 10h14v11H5V10Z'],
+  mail: ['M4 4h16v16H4V4Z', 'm4 7 8 6 8-6'],
+  'map-pin': [
+    'M12 21s7-5 7-12a7 7 0 1 0-14 0c0 7 7 12 7 12Z',
+    'M12 12a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z',
+  ],
+  medal: ['M12 22a6 6 0 1 0 0-12 6 6 0 0 0 0 12Z', 'm8 2 4 6 4-6'],
+  package: ['m3 7 9 5 9-5', 'M3 7l9-5 9 5v10l-9 5-9-5V7Z', 'M12 12v10'],
+  plane: ['M22 2 11 13', 'm22 2-7 20-4-9-9-4 20-7Z'],
+  refresh: [
+    'M21 12a9 9 0 0 1-15 6.7L3 16',
+    'M3 16v5h5',
+    'M3 12a9 9 0 0 1 15-6.7L21 8',
+    'M21 8V3h-5',
+  ],
+  search: ['m21 21-4.3-4.3', 'M19 11a8 8 0 1 1-16 0 8 8 0 0 1 16 0Z'],
+  settings: ['M12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z', 'M19 12h3M2 12h3M12 2v3M12 19v3'],
+  shield: ['M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10Z'],
+  'shopping-cart': ['M6 6h15l-2 8H8L6 3H3', 'M9 21h.01', 'M18 21h.01'],
+  sparkles: ['m12 3 1.8 5.2L19 10l-5.2 1.8L12 17l-1.8-5.2L5 10l5.2-1.8L12 3Z'],
+  tag: ['M20 10 14 4H5v9l6 6a3 3 0 0 0 4 0l5-5a3 3 0 0 0 0-4Z', 'M8 8h.01'],
+  target: [
+    'M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20Z',
+    'M12 18a6 6 0 1 0 0-12 6 6 0 0 0 0 12Z',
+    'M12 14a2 2 0 1 0 0-4 2 2 0 0 0 0 4Z',
+  ],
+  trash: ['M3 6h18', 'm19 6-1 16H6L5 6', 'M9 6V3h6v3', 'M9 10v8', 'M15 10v8'],
+  'trending-down': ['M22 17 13.5 8.5l-5 5L2 7', 'M17 17h5v-5'],
+  'trending-up': ['m22 7-8.5 8.5-5-5L2 17', 'M17 7h5v5'],
+  trophy: ['M8 21h8', 'M12 17v4', 'M7 4h10v5a5 5 0 0 1-10 0V4Z', 'M7 6H4a3 3 0 0 0 3 3'],
+  unlock: ['M7 10V7a5 5 0 0 1 9.5-2', 'M5 10h14v11H5V10Z'],
+  upload: ['M12 21V9', 'm7 14 5-5 5 5', 'M5 3h14'],
+  wallet: ['M3 7h17a1 1 0 0 1 1 1v10a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7Z', 'M3 7a3 3 0 0 1 3-3h12v3'],
+  x: ['M6 6l12 12', 'M18 6 6 18'],
+};
+
+export function AppIcon({ name, size = 16, label, style, ...svgProps }: AppIconProps) {
+  const iconStyle: CSSProperties = {
+    display: 'inline-block',
+    verticalAlign: '-0.125em',
+    flexShrink: 0,
+    ...style,
+  };
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      aria-hidden={label ? undefined : true}
+      aria-label={label}
+      role={label ? 'img' : undefined}
+      focusable="false"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      style={iconStyle}
+      {...svgProps}
+    >
+      {paths[name].map((d) => (
+        <path key={d} d={d} />
+      ))}
+    </svg>
+  );
+}

--- a/apps/web/src/components/icons/index.ts
+++ b/apps/web/src/components/icons/index.ts
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+export { AppIcon } from './AppIcon';
+export type { AppIconProps, IconName } from './AppIcon';

--- a/apps/web/src/components/import/CsvImportWizard.tsx
+++ b/apps/web/src/components/import/CsvImportWizard.tsx
@@ -16,6 +16,7 @@
  */
 
 import React, { useCallback, useRef, useState } from 'react';
+import { AppIcon } from '../icons';
 
 import { parseCsv, autoDetectColumns, type CsvParseResult } from '../../utils/csvParser';
 
@@ -220,7 +221,7 @@ export const CsvImportWizard: React.FC<CsvImportWizardProps> = ({
       tabIndex={0}
       aria-label="Upload CSV file. Click or drag and drop."
     >
-      <span aria-hidden="true">📁</span>
+      <AppIcon name="folder" />
       <p className="csv-import-wizard__dropzone-text">
         Drag and drop a CSV file here, or click to browse
       </p>
@@ -323,7 +324,7 @@ export const CsvImportWizard: React.FC<CsvImportWizardProps> = ({
 
         {duplicateCount > 0 && (
           <div className="csv-import-wizard__warning" role="alert">
-            ⚠ {duplicateCount} potential duplicate
+            <AppIcon name="alert-triangle" /> {duplicateCount} potential duplicate
             {duplicateCount === 1 ? ' transaction' : ' transactions'} detected. These will be
             skipped during import.
           </div>

--- a/apps/web/src/components/import/ImportComplete.tsx
+++ b/apps/web/src/components/import/ImportComplete.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { AppIcon } from '../icons';
 
 import type { ImportSummary } from '../../hooks/useImport';
 
@@ -13,7 +14,7 @@ export interface ImportCompleteProps {
 export const ImportComplete: React.FC<ImportCompleteProps> = ({ summary, onReset }) => (
   <section aria-labelledby="complete-heading" className="import-complete">
     <span className="import-complete__icon" aria-hidden="true">
-      ✅
+      <AppIcon name="check" />
     </span>
     <h3 id="complete-heading" className="import-complete__title">
       Import Complete

--- a/apps/web/src/components/tips/ContextualTips.tsx
+++ b/apps/web/src/components/tips/ContextualTips.tsx
@@ -19,6 +19,7 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { FinancialTip, TipSeverity } from './tips-engine';
 import './tips.css';
+import { AppIcon, type IconName } from '../icons';
 
 // ---------------------------------------------------------------------------
 // Props
@@ -37,17 +38,17 @@ export interface ContextualTipsProps {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function getSeverityIcon(severity: TipSeverity): string {
+function getSeverityIcon(severity: TipSeverity): IconName {
   switch (severity) {
     case 'critical':
-      return '🚨';
+      return 'alert-triangle';
     case 'warning':
-      return '⚠️';
+      return 'alert-circle';
     case 'success':
-      return '✅';
+      return 'check';
     case 'info':
     default:
-      return '💡';
+      return 'info';
   }
 }
 
@@ -91,7 +92,7 @@ export const ContextualTips: React.FC<ContextualTipsProps> = ({
             aria-label={`${getSeverityLabel(tip.severity)}: ${tip.title}`}
           >
             <div className="contextual-tip__icon" aria-hidden="true">
-              {getSeverityIcon(tip.severity)}
+              <AppIcon name={getSeverityIcon(tip.severity)} />
             </div>
             <div className="contextual-tip__content">
               <h3 className="contextual-tip__title">{tip.title}</h3>

--- a/apps/web/src/hooks/useMilestones.ts
+++ b/apps/web/src/hooks/useMilestones.ts
@@ -22,6 +22,7 @@
  */
 
 import { useCallback, useMemo, useState } from 'react';
+import type { IconName } from '../components/icons';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -48,8 +49,8 @@ export interface Milestone {
   title: string;
   /** Description text. */
   description: string;
-  /** Emoji icon for the celebration. */
-  icon: string;
+  /** Icon name for the celebration. */
+  icon: IconName;
 }
 
 /** Progress data supplied to the hook. */
@@ -106,59 +107,61 @@ function saveDismissed(dismissed: Set<MilestoneType>): void {
 // Milestone definitions
 // ---------------------------------------------------------------------------
 
-const MILESTONE_DEFS: Record<MilestoneType, { title: string; description: string; icon: string }> =
-  {
-    'first-transaction': {
-      title: 'First Transaction!',
-      description: 'You logged your first transaction. Great start!',
-      icon: '🎉',
-    },
-    'first-budget': {
-      title: 'Budget Created!',
-      description: 'Your first budget is set up. Stay on track!',
-      icon: '📊',
-    },
-    'first-goal': {
-      title: 'Goal Set!',
-      description: 'You created your first savings goal. Keep going!',
-      icon: '🎯',
-    },
-    'goal-25': {
-      title: '25% There!',
-      description: "You've reached a quarter of your goal!",
-      icon: '🌱',
-    },
-    'goal-50': {
-      title: 'Halfway!',
-      description: "You're at 50% of your savings goal!",
-      icon: '⭐',
-    },
-    'goal-75': {
-      title: 'Almost There!',
-      description: '75% complete — the finish line is in sight!',
-      icon: '🔥',
-    },
-    'goal-100': {
-      title: 'Goal Achieved!',
-      description: 'Congratulations! You reached your savings goal!',
-      icon: '🏆',
-    },
-    'streak-7': {
-      title: '7-Day Streak!',
-      description: 'A whole week of consistent logging!',
-      icon: '📅',
-    },
-    'streak-30': {
-      title: '30-Day Streak!',
-      description: "A full month — you're building a habit!",
-      icon: '💪',
-    },
-    'streak-90': {
-      title: '90-Day Streak!',
-      description: 'Three months strong! Incredible dedication!',
-      icon: '👑',
-    },
-  };
+const MILESTONE_DEFS: Record<
+  MilestoneType,
+  { title: string; description: string; icon: IconName }
+> = {
+  'first-transaction': {
+    title: 'First Transaction!',
+    description: 'You logged your first transaction. Great start!',
+    icon: 'sparkles',
+  },
+  'first-budget': {
+    title: 'Budget Created!',
+    description: 'Your first budget is set up. Stay on track!',
+    icon: 'chart-bar',
+  },
+  'first-goal': {
+    title: 'Goal Set!',
+    description: 'You created your first savings goal. Keep going!',
+    icon: 'target',
+  },
+  'goal-25': {
+    title: '25% There!',
+    description: "You've reached a quarter of your goal!",
+    icon: 'leaf',
+  },
+  'goal-50': {
+    title: 'Halfway!',
+    description: "You're at 50% of your savings goal!",
+    icon: 'sparkles',
+  },
+  'goal-75': {
+    title: 'Almost There!',
+    description: '75% complete — the finish line is in sight!',
+    icon: 'flame',
+  },
+  'goal-100': {
+    title: 'Goal Achieved!',
+    description: 'Congratulations! You reached your savings goal!',
+    icon: 'trophy',
+  },
+  'streak-7': {
+    title: '7-Day Streak!',
+    description: 'A whole week of consistent logging!',
+    icon: 'calendar',
+  },
+  'streak-30': {
+    title: '30-Day Streak!',
+    description: "A full month — you're building a habit!",
+    icon: 'trophy',
+  },
+  'streak-90': {
+    title: '90-Day Streak!',
+    description: 'Three months strong! Incredible dedication!',
+    icon: 'medal',
+  },
+};
 
 // ---------------------------------------------------------------------------
 // Hook

--- a/apps/web/src/hooks/usePrivacyDashboard.ts
+++ b/apps/web/src/hooks/usePrivacyDashboard.ts
@@ -16,6 +16,7 @@
  */
 
 import { useCallback, useEffect, useState } from 'react';
+import type { IconName } from '../components/icons';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -38,7 +39,7 @@ export interface DataCategory {
   /** Estimated storage in bytes (0 if not calculable). */
   readonly estimatedBytes: number;
   /** Icon name for the category. */
-  readonly icon: string;
+  readonly icon: IconName;
 }
 
 /** Shape returned by {@link usePrivacyDashboard}. */
@@ -81,7 +82,7 @@ const DATA_CATEGORY_DEFS: Omit<DataCategory, 'estimatedBytes'>[] = [
     storageLocation: 'SQLite (OPFS)',
     leavesDevice: false,
     leavesDeviceCondition: 'Only if Cloud Sync is enabled',
-    icon: '🏦',
+    icon: 'bank',
   },
   {
     id: 'transactions',
@@ -91,7 +92,7 @@ const DATA_CATEGORY_DEFS: Omit<DataCategory, 'estimatedBytes'>[] = [
     storageLocation: 'SQLite (OPFS)',
     leavesDevice: false,
     leavesDeviceCondition: 'Only if Cloud Sync is enabled',
-    icon: '💳',
+    icon: 'wallet',
   },
   {
     id: 'budgets',
@@ -101,7 +102,7 @@ const DATA_CATEGORY_DEFS: Omit<DataCategory, 'estimatedBytes'>[] = [
     storageLocation: 'SQLite (OPFS)',
     leavesDevice: false,
     leavesDeviceCondition: 'Only if Cloud Sync is enabled',
-    icon: '📊',
+    icon: 'chart-bar',
   },
   {
     id: 'goals',
@@ -111,7 +112,7 @@ const DATA_CATEGORY_DEFS: Omit<DataCategory, 'estimatedBytes'>[] = [
     storageLocation: 'SQLite (OPFS)',
     leavesDevice: false,
     leavesDeviceCondition: 'Only if Cloud Sync is enabled',
-    icon: '🎯',
+    icon: 'target',
   },
   {
     id: 'categories',
@@ -120,7 +121,7 @@ const DATA_CATEGORY_DEFS: Omit<DataCategory, 'estimatedBytes'>[] = [
       'Custom spending categories and tags for organizing transactions. Includes auto-categorization rules.',
     storageLocation: 'SQLite (OPFS)',
     leavesDevice: false,
-    icon: '🏷️',
+    icon: 'tag',
   },
   {
     id: 'settings',
@@ -129,7 +130,7 @@ const DATA_CATEGORY_DEFS: Omit<DataCategory, 'estimatedBytes'>[] = [
       'Your preferences: theme, currency, notification settings, privacy mode, and display options.',
     storageLocation: 'localStorage',
     leavesDevice: false,
-    icon: '⚙️',
+    icon: 'settings',
   },
   {
     id: 'consent',
@@ -138,7 +139,7 @@ const DATA_CATEGORY_DEFS: Omit<DataCategory, 'estimatedBytes'>[] = [
       'Timestamped records of your privacy consent choices. Required for GDPR compliance and your own audit trail.',
     storageLocation: 'localStorage',
     leavesDevice: false,
-    icon: '📋',
+    icon: 'clipboard',
   },
   {
     id: 'investments',
@@ -147,7 +148,7 @@ const DATA_CATEGORY_DEFS: Omit<DataCategory, 'estimatedBytes'>[] = [
     storageLocation: 'SQLite (OPFS)',
     leavesDevice: false,
     leavesDeviceCondition: 'Only if Cloud Sync is enabled',
-    icon: '📈',
+    icon: 'trending-up',
   },
 ];
 

--- a/apps/web/src/lib/a11y.ts
+++ b/apps/web/src/lib/a11y.ts
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
+import type { IconName } from '../components/icons';
+
 /**
  * Accessibility utility functions for the Finance web app.
  *
@@ -123,26 +125,26 @@ export function getStatusIndicator(amount: number): {
  *
  * @example
  * ```ts
- * getGoalStatusIndicator(100); // { icon: '✓', label: 'Goal reached', tone: 'positive' }
- * getGoalStatusIndicator(60);  // { icon: '◐', label: 'In progress', tone: 'positive' }
- * getGoalStatusIndicator(20);  // { icon: '○', label: 'Getting started', tone: 'warning' }
+ * getGoalStatusIndicator(100); // { icon: 'check', label: 'Goal reached', tone: 'positive' }
+ * getGoalStatusIndicator(60);  // { icon: 'target', label: 'In progress', tone: 'positive' }
+ * getGoalStatusIndicator(20);  // { icon: 'target', label: 'Getting started', tone: 'warning' }
  * ```
  */
 export function getGoalStatusIndicator(percentComplete: number): {
-  icon: string;
+  icon: IconName;
   label: string;
   tone: 'positive' | 'warning' | 'negative';
 } {
   if (percentComplete >= 100) {
-    return { icon: '✓', label: 'Goal reached', tone: 'positive' };
+    return { icon: 'check', label: 'Goal reached', tone: 'positive' };
   }
   if (percentComplete >= 50) {
-    return { icon: '◐', label: 'In progress', tone: 'positive' };
+    return { icon: 'target', label: 'In progress', tone: 'positive' };
   }
   if (percentComplete >= 25) {
-    return { icon: '◔', label: 'Getting started', tone: 'warning' };
+    return { icon: 'target', label: 'Getting started', tone: 'warning' };
   }
-  return { icon: '○', label: 'Just started', tone: 'negative' };
+  return { icon: 'target', label: 'Just started', tone: 'negative' };
 }
 
 /**
@@ -152,23 +154,23 @@ export function getGoalStatusIndicator(percentComplete: number): {
  *
  * @example
  * ```ts
- * getBudgetStatusIndicator(95);  // { icon: '⚠', label: 'Over limit', tone: 'negative' }
- * getBudgetStatusIndicator(80);  // { icon: '◐', label: 'Near limit', tone: 'warning' }
- * getBudgetStatusIndicator(50);  // { icon: '●', label: 'On track', tone: 'positive' }
+ * getBudgetStatusIndicator(95);  // { icon: 'alert-triangle', label: 'Over limit', tone: 'negative' }
+ * getBudgetStatusIndicator(80);  // { icon: 'target', label: 'Near limit', tone: 'warning' }
+ * getBudgetStatusIndicator(50);  // { icon: 'check', label: 'On track', tone: 'positive' }
  * ```
  */
 export function getBudgetStatusIndicator(percentUsed: number): {
-  icon: string;
+  icon: IconName;
   label: string;
   tone: 'positive' | 'warning' | 'negative';
 } {
   if (percentUsed > 90) {
-    return { icon: '⚠', label: 'Over limit', tone: 'negative' };
+    return { icon: 'alert-triangle', label: 'Over limit', tone: 'negative' };
   }
   if (percentUsed > 75) {
-    return { icon: '◐', label: 'Near limit', tone: 'warning' };
+    return { icon: 'target', label: 'Near limit', tone: 'warning' };
   }
-  return { icon: '●', label: 'On track', tone: 'positive' };
+  return { icon: 'check', label: 'On track', tone: 'positive' };
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/pages/AccountDetailPage.tsx
+++ b/apps/web/src/pages/AccountDetailPage.tsx
@@ -2,6 +2,7 @@
 
 import React, { useCallback, useMemo, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
+import { AppIcon } from '../components/icons';
 
 import { CurrencyDisplay, ErrorBanner, LoadingSpinner } from '../components/common';
 import { AccountDeleteDialog } from '../components/accounts';
@@ -87,7 +88,7 @@ export const AccountDetailPage: React.FC = () => {
             onClick={() => setIsFormOpen(true)}
             aria-label={`Edit ${account.name}`}
           >
-            ✏️ Edit
+            <AppIcon name="edit" /> Edit
           </button>
           <button
             type="button"
@@ -95,7 +96,7 @@ export const AccountDetailPage: React.FC = () => {
             onClick={() => setDeletingAccount(account)}
             aria-label={`Delete ${account.name}`}
           >
-            🗑️ Delete
+            <AppIcon name="trash" /> Delete
           </button>
         </div>
       </div>

--- a/apps/web/src/pages/AchievementsPage.test.tsx
+++ b/apps/web/src/pages/AchievementsPage.test.tsx
@@ -4,6 +4,7 @@ import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import { AchievementsPage } from './AchievementsPage';
+import type { GamificationState } from '../components/gamification/achievements-engine';
 
 vi.mock('../hooks/useGamification', () => ({
   useGamification: vi.fn(),
@@ -12,13 +13,13 @@ vi.mock('../hooks/useGamification', () => ({
 import { useGamification } from '../hooks/useGamification';
 const mockedUseGamification = vi.mocked(useGamification);
 
-const makeState = () => ({
+const makeState = (): GamificationState => ({
   achievements: [
     {
       id: 'first-transaction',
       name: 'First Step',
       description: 'Log your first transaction',
-      icon: '👣',
+      icon: 'account',
       category: 'tracking' as const,
       status: 'unlocked' as const,
       progress: 100,
@@ -27,7 +28,7 @@ const makeState = () => ({
       id: 'transaction-10',
       name: 'Getting Started',
       description: 'Log 10 transactions',
-      icon: '📝',
+      icon: 'edit',
       category: 'tracking' as const,
       status: 'locked' as const,
       progress: 50,
@@ -36,7 +37,7 @@ const makeState = () => ({
       id: 'first-budget',
       name: 'Budget Beginner',
       description: 'Create your first budget',
-      icon: '📋',
+      icon: 'clipboard',
       category: 'budgeting' as const,
       status: 'unlocked' as const,
       progress: 100,
@@ -45,7 +46,7 @@ const makeState = () => ({
       id: 'first-goal',
       name: 'Goal Setter',
       description: 'Create your first savings goal',
-      icon: '🎯',
+      icon: 'target',
       category: 'saving' as const,
       status: 'locked' as const,
       progress: 0,
@@ -54,7 +55,7 @@ const makeState = () => ({
       id: 'first-account',
       name: 'Account Opener',
       description: 'Add your first account',
-      icon: '🏦',
+      icon: 'bank',
       category: 'milestone' as const,
       status: 'unlocked' as const,
       progress: 100,

--- a/apps/web/src/pages/AchievementsPage.tsx
+++ b/apps/web/src/pages/AchievementsPage.tsx
@@ -22,6 +22,7 @@ import type {
 } from '../components/gamification/achievements-engine';
 import { getAchievementsByCategory } from '../components/gamification/achievements-engine';
 import './AchievementsPage.css';
+import { AppIcon } from '../components/icons';
 
 // ---------------------------------------------------------------------------
 // Sub-components
@@ -44,7 +45,7 @@ const AchievementBadge: React.FC<AchievementBadgeProps> = ({ achievement }) => {
         aria-hidden="true"
         style={{ opacity: isUnlocked ? 1 : 0.4 }}
       >
-        {achievement.icon}
+        <AppIcon name={achievement.icon} />
       </div>
       <div className="achievement-badge__info">
         <h4 className="achievement-badge__name">{achievement.name}</h4>
@@ -67,7 +68,7 @@ const AchievementBadge: React.FC<AchievementBadgeProps> = ({ achievement }) => {
       </div>
       {isUnlocked && (
         <span className="achievement-badge__check" aria-hidden="true">
-          ✓
+          <AppIcon name="check" />
         </span>
       )}
     </article>
@@ -81,7 +82,7 @@ interface StreakCardProps {
 const StreakCard: React.FC<StreakCardProps> = ({ streak }) => (
   <article className="streak-card" aria-label={`${streak.label} streak`}>
     <div className="streak-card__flame" aria-hidden="true">
-      🔥
+      <AppIcon name="flame" />
     </div>
     <div className="streak-card__info">
       <h4 className="streak-card__label">{streak.label}</h4>
@@ -128,7 +129,7 @@ const MilestoneCard: React.FC<MilestoneCardProps> = ({ milestone }) => (
     {milestone.nextMilestone !== null ? (
       <p className="milestone-card__next">Next milestone: {milestone.nextMilestone}%</p>
     ) : (
-      <p className="milestone-card__next milestone-card__next--completed">Goal complete! 🎉</p>
+      <p className="milestone-card__next milestone-card__next--completed">Goal complete!</p>
     )}
   </article>
 );

--- a/apps/web/src/pages/BillsPage.tsx
+++ b/apps/web/src/pages/BillsPage.tsx
@@ -18,6 +18,7 @@ import {
 } from '../components/common';
 import { useBills } from '../hooks';
 import type { Bill, BillFrequency, BillStatus } from '../kmp/bridge';
+import { AppIcon, type IconName } from '../components/icons';
 
 /** Human-readable labels for bill frequency. */
 const FREQUENCY_LABELS: Record<BillFrequency, string> = {
@@ -63,17 +64,17 @@ function getStatusStyle(status: BillStatus): React.CSSProperties {
   }
 }
 
-/** Emoji icons for bill status. */
-function getStatusIcon(status: BillStatus): string {
+/** Icons for bill status. */
+function getStatusIcon(status: BillStatus): IconName {
   switch (status) {
     case 'UPCOMING':
-      return '📅';
+      return 'calendar';
     case 'PAID':
-      return '✅';
+      return 'check';
     case 'OVERDUE':
-      return '⚠️';
+      return 'alert-triangle';
     case 'CANCELLED':
-      return '❌';
+      return 'x';
   }
 }
 
@@ -196,7 +197,7 @@ export const BillsPage: React.FC = () => {
               }}
             >
               <p style={{ margin: 0, fontSize: 'var(--type-scale-body-font-size)' }}>
-                🔔 Enable notifications to get reminded before bills are due.
+                <AppIcon name="bell" /> Enable notifications to get reminded before bills are due.
               </p>
               <button
                 type="button"
@@ -320,8 +321,7 @@ export const BillsPage: React.FC = () => {
                         style={{ textDecoration: 'none', color: 'inherit' }}
                         aria-label={`View details for ${bill.name}`}
                       >
-                        <span aria-hidden="true">{getStatusIcon(bill.status)} </span>
-                        {bill.name}
+                        <AppIcon name={getStatusIcon(bill.status)} /> {bill.name}
                       </Link>
                     </h3>
                     <span
@@ -377,7 +377,7 @@ export const BillsPage: React.FC = () => {
                         marginBottom: 'var(--spacing-2)',
                       }}
                     >
-                      ⚡ Auto-pay enabled
+                      <AppIcon name="lightning" /> Auto-pay enabled
                     </p>
                   )}
 

--- a/apps/web/src/pages/BudgetDetailPage.tsx
+++ b/apps/web/src/pages/BudgetDetailPage.tsx
@@ -2,6 +2,7 @@
 
 import React, { useCallback, useMemo, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
+import { AppIcon, type IconName } from '../components/icons';
 
 import { ConfirmDialog, CurrencyDisplay, ErrorBanner, LoadingSpinner } from '../components/common';
 import { BudgetForm } from '../components/forms';
@@ -19,20 +20,20 @@ const PERIOD_LABELS: Record<string, string> = {
   YEARLY: 'Yearly',
 };
 
-function getBudgetIcon(iconName: string | null | undefined): string {
+function getBudgetIcon(iconName: string | null | undefined): IconName {
   switch (iconName) {
     case 'utensils':
-      return '🛒';
+      return 'shopping-cart';
     case 'home':
-      return '🏠';
+      return 'home';
     case 'car':
-      return '🚗';
+      return 'car';
     case 'film':
-      return '🎬';
+      return 'film';
     case 'wallet':
-      return '💰';
+      return 'wallet';
     default:
-      return '📊';
+      return 'chart-bar';
   }
 }
 
@@ -148,7 +149,7 @@ export const BudgetDetailPage: React.FC = () => {
 
       <div className="page-header">
         <h2 className="page-heading">
-          <span aria-hidden="true">{getBudgetIcon(category?.icon)}</span> {budget.name}
+          <AppIcon name={getBudgetIcon(category?.icon)} /> {budget.name}
         </h2>
         <div className="page-actions">
           <button
@@ -157,7 +158,7 @@ export const BudgetDetailPage: React.FC = () => {
             onClick={() => setIsFormOpen(true)}
             aria-label={`Edit ${budget.name}`}
           >
-            ✏️ Edit
+            <AppIcon name="edit" /> Edit
           </button>
           <button
             type="button"
@@ -165,7 +166,7 @@ export const BudgetDetailPage: React.FC = () => {
             onClick={() => setDeletingBudget(budget)}
             aria-label={`Delete ${budget.name}`}
           >
-            🗑️ Delete
+            <AppIcon name="trash" /> Delete
           </button>
         </div>
       </div>
@@ -291,7 +292,7 @@ export const BudgetDetailPage: React.FC = () => {
                     : 'var(--semantic-status-negative)',
               }}
             >
-              <span aria-hidden="true">{budgetStatus.icon} </span>
+              <AppIcon name={budgetStatus.icon} />{' '}
               {budget.remainingAmount.amount >= 0 ? (
                 <>
                   <CurrencyDisplay

--- a/apps/web/src/pages/BudgetsPage.tsx
+++ b/apps/web/src/pages/BudgetsPage.tsx
@@ -16,21 +16,22 @@ import type { CreateBudgetInput } from '../db/repositories/budgets';
 import { useBudgets, useCategories } from '../hooks';
 import type { Budget } from '../kmp/bridge';
 import { getBudgetStatusIndicator } from '../lib/a11y';
+import { AppIcon, type IconName } from '../components/icons';
 
-function getBudgetIcon(iconName: string | null | undefined): string {
+function getBudgetIcon(iconName: string | null | undefined): IconName {
   switch (iconName) {
     case 'utensils':
-      return '🛒';
+      return 'shopping-cart';
     case 'home':
-      return '🏠';
+      return 'home';
     case 'car':
-      return '🚗';
+      return 'car';
     case 'film':
-      return '🎬';
+      return 'film';
     case 'wallet':
-      return '💰';
+      return 'wallet';
     default:
-      return '📊';
+      return 'chart-bar';
   }
 }
 
@@ -321,8 +322,7 @@ export const BudgetsPage: React.FC = () => {
                               style={{ textDecoration: 'none', color: 'inherit' }}
                               aria-label={`View details for ${budget.name}`}
                             >
-                              <span aria-hidden="true">{getBudgetIcon(category?.icon)}</span>{' '}
-                              {budget.name}
+                              <AppIcon name={getBudgetIcon(category?.icon)} /> {budget.name}
                             </Link>
                           </p>
                           <p
@@ -350,7 +350,7 @@ export const BudgetsPage: React.FC = () => {
                             aria-label={`Edit ${budget.name}`}
                             title="Edit budget"
                           >
-                            <span aria-hidden="true">✏️</span>
+                            <AppIcon name="edit" />
                           </button>
                           <button
                             type="button"
@@ -359,7 +359,7 @@ export const BudgetsPage: React.FC = () => {
                             aria-label={`Delete ${budget.name}`}
                             title="Delete budget"
                           >
-                            <span aria-hidden="true">🗑️</span>
+                            <AppIcon name="trash" />
                           </button>
                         </div>
                       </div>
@@ -372,7 +372,7 @@ export const BudgetsPage: React.FC = () => {
                               : 'var(--semantic-status-negative)',
                         }}
                       >
-                        <span aria-hidden="true">{budgetStatus.icon} </span>
+                        <AppIcon name={budgetStatus.icon} />{' '}
                         {remainingAmount >= 0 ? (
                           <>
                             <CurrencyDisplay

--- a/apps/web/src/pages/CategoriesPage.tsx
+++ b/apps/web/src/pages/CategoriesPage.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { useCallback, useMemo, useState } from 'react';
+import { AppIcon, type IconName } from '../components/icons';
 
 import { ConfirmDialog, EmptyState, ErrorBanner, LoadingSpinner } from '../components/common';
 import { CategoryForm } from '../components/forms';
@@ -9,35 +10,35 @@ import { useCategories, useTransactions } from '../hooks';
 import type { Category } from '../kmp/bridge';
 import '../styles/pages.css';
 
-function getCategoryIcon(iconName: string | null | undefined): string {
-  if (iconName && iconName.length <= 4) {
-    return iconName;
-  }
+function isCustomCategoryIcon(iconName: string | null | undefined): iconName is string {
+  return Boolean(iconName && iconName.length <= 4);
+}
 
+function getCategoryIcon(iconName: string | null | undefined): IconName {
   switch (iconName) {
     case 'utensils':
     case 'food':
     case 'groceries':
-      return '🛒';
+      return 'shopping-cart';
     case 'home':
-      return '🏠';
+      return 'home';
     case 'car':
     case 'transport':
-      return '🚗';
+      return 'car';
     case 'film':
     case 'entertainment':
-      return '🎬';
+      return 'film';
     case 'wallet':
     case 'income':
-      return '💰';
+      return 'wallet';
     case 'bolt':
     case 'utilities':
-      return '⚡';
+      return 'lightning';
     case 'heart':
     case 'health':
-      return '💊';
+      return 'heart-pulse';
     default:
-      return '🏷️';
+      return 'tag';
   }
 }
 
@@ -252,7 +253,11 @@ export const CategoriesPage: React.FC = () => {
                             background: category.color ?? 'var(--semantic-background-secondary)',
                           }}
                         >
-                          {getCategoryIcon(category.icon)}
+                          {isCustomCategoryIcon(category.icon) ? (
+                            category.icon
+                          ) : (
+                            <AppIcon name={getCategoryIcon(category.icon)} />
+                          )}
                         </span>
                         <h3 className="category-card__name">{category.name}</h3>
                       </div>

--- a/apps/web/src/pages/DataImportWizardPage.tsx
+++ b/apps/web/src/pages/DataImportWizardPage.tsx
@@ -13,6 +13,7 @@
 
 import { useCallback, useRef, useState } from 'react';
 import type { DragEvent, ChangeEvent } from 'react';
+import { AppIcon } from '../components/icons';
 
 import { useDataImportWizard } from '../hooks/useDataImportWizard';
 import type {
@@ -120,7 +121,7 @@ function InlineEditField({
     >
       {hasError && (
         <span className="import-inline-error-icon" aria-hidden="true">
-          ⚠
+          <AppIcon name="alert-triangle" />
         </span>
       )}
       {value || '—'}
@@ -149,7 +150,7 @@ function DuplicateComparisonCard({ comparison, action, onAction }: DuplicateComp
     >
       <div className="import-duplicate-card__header">
         <span className="import-duplicate-card__badge" aria-hidden="true">
-          ⚠ Potential Duplicate
+          <AppIcon name="alert-triangle" /> Potential Duplicate
         </span>
         <span className="import-duplicate-card__row">Row {rowIndex + 1}</span>
       </div>
@@ -432,7 +433,7 @@ export function DataImportWizardPage() {
               aria-current={i === currentStepIndex ? 'step' : undefined}
             >
               <span className="import-step__number" aria-hidden="true">
-                {i < currentStepIndex ? '✓' : i + 1}
+                {i < currentStepIndex ? <AppIcon name="check" /> : i + 1}
               </span>
               <span className="import-step__label">{STEP_LABELS[s]}</span>
             </li>
@@ -475,7 +476,7 @@ export function DataImportWizardPage() {
             }}
           >
             <span className="import-dropzone__icon" aria-hidden="true">
-              📁
+              <AppIcon name="folder" />
             </span>
             <span className="import-dropzone__text">
               {dragActive ? 'Drop your file here' : 'Click or drag CSV file here'}
@@ -604,9 +605,15 @@ export function DataImportWizardPage() {
           </h2>
 
           <div className="import-preview-stats" role="status">
-            <span className="import-stat import-stat--success">✓ {validCount} valid</span>
-            <span className="import-stat import-stat--warning">⚠ {duplicateCount} duplicates</span>
-            <span className="import-stat import-stat--error">✗ {errorCount} errors</span>
+            <span className="import-stat import-stat--success">
+              <AppIcon name="check" /> {validCount} valid
+            </span>
+            <span className="import-stat import-stat--warning">
+              <AppIcon name="alert-triangle" /> {duplicateCount} duplicates
+            </span>
+            <span className="import-stat import-stat--error">
+              <AppIcon name="x" /> {errorCount} errors
+            </span>
           </div>
 
           {errorCount > 0 && (
@@ -695,7 +702,7 @@ export function DataImportWizardPage() {
       {step === 'complete' && result && (
         <section className="import-card import-card--complete" aria-labelledby="complete-title">
           <span className="import-complete-icon" aria-hidden="true">
-            🎉
+            <AppIcon name="sparkles" />
           </span>
           <h2 id="complete-title" className="import-card__title">
             Import Complete!

--- a/apps/web/src/pages/GoalDetailPage.tsx
+++ b/apps/web/src/pages/GoalDetailPage.tsx
@@ -2,6 +2,7 @@
 
 import React, { useCallback, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
+import { AppIcon, type IconName } from '../components/icons';
 
 import { ConfirmDialog, CurrencyDisplay, ErrorBanner, LoadingSpinner } from '../components/common';
 import { GoalForm } from '../components/forms';
@@ -11,18 +12,18 @@ import type { Goal } from '../kmp/bridge';
 import { getGoalStatusIndicator } from '../lib/a11y';
 import '../styles/pages.css';
 
-function getGoalIcon(iconName: string | null | undefined): string {
+function getGoalIcon(iconName: string | null | undefined): IconName {
   switch (iconName) {
     case 'shield':
-      return '🛡️';
+      return 'shield';
     case 'plane':
-      return '✈️';
+      return 'plane';
     case 'home':
-      return '🏡';
+      return 'home';
     case 'laptop':
-      return '💻';
+      return 'laptop';
     default:
-      return '🎯';
+      return 'target';
   }
 }
 
@@ -155,7 +156,7 @@ export const GoalDetailPage: React.FC = () => {
 
       <div className="page-header">
         <h2 className="page-heading">
-          <span aria-hidden="true">{getGoalIcon(goal.icon)}</span> {goal.name}
+          <AppIcon name={getGoalIcon(goal.icon)} /> {goal.name}
         </h2>
         <div className="page-actions">
           <button
@@ -164,7 +165,7 @@ export const GoalDetailPage: React.FC = () => {
             onClick={() => setIsFormOpen(true)}
             aria-label={`Edit ${goal.name}`}
           >
-            ✏️ Edit
+            <AppIcon name="edit" /> Edit
           </button>
           <button
             type="button"
@@ -172,7 +173,7 @@ export const GoalDetailPage: React.FC = () => {
             onClick={() => setDeletingGoal(goal)}
             aria-label={`Delete ${goal.name}`}
           >
-            🗑️ Delete
+            <AppIcon name="trash" /> Delete
           </button>
         </div>
       </div>
@@ -274,9 +275,9 @@ export const GoalDetailPage: React.FC = () => {
             }}
           >
             <span>
-              <span aria-hidden="true">{goalStatus.icon} </span>
+              <AppIcon name={goalStatus.icon} />{' '}
               {percentComplete >= 100 ? (
-                'Goal reached! 🎉'
+                'Goal reached!'
               ) : (
                 <>
                   <CurrencyDisplay

--- a/apps/web/src/pages/GoalsPage.tsx
+++ b/apps/web/src/pages/GoalsPage.tsx
@@ -15,19 +15,20 @@ import type { CreateGoalInput } from '../db/repositories/goals';
 import { useGoals } from '../hooks';
 import type { Goal } from '../kmp/bridge';
 import { getGoalStatusIndicator } from '../lib/a11y';
+import { AppIcon, type IconName } from '../components/icons';
 
-function getGoalIcon(iconName: string | null | undefined): string {
+function getGoalIcon(iconName: string | null | undefined): IconName {
   switch (iconName) {
     case 'shield':
-      return '🛡️';
+      return 'shield';
     case 'plane':
-      return '✈️';
+      return 'plane';
     case 'home':
-      return '🏡';
+      return 'home';
     case 'laptop':
-      return '💻';
+      return 'laptop';
     default:
-      return '🎯';
+      return 'target';
   }
 }
 
@@ -213,7 +214,7 @@ export const GoalsPage: React.FC = () => {
                           style={{ textDecoration: 'none', color: 'inherit' }}
                           aria-label={`View details for ${goal.name}`}
                         >
-                          <span aria-hidden="true">{getGoalIcon(goal.icon)}</span> {goal.name}
+                          <AppIcon name={getGoalIcon(goal.icon)} /> {goal.name}
                         </Link>
                       </h3>
                       <div
@@ -306,7 +307,7 @@ export const GoalsPage: React.FC = () => {
                       }}
                     >
                       <span>
-                        <span aria-hidden="true">{goalStatus.icon} </span>
+                        <AppIcon name={goalStatus.icon} />{' '}
                         {percentComplete >= 100 ? (
                           'Goal reached!'
                         ) : (

--- a/apps/web/src/pages/HouseholdPage.tsx
+++ b/apps/web/src/pages/HouseholdPage.tsx
@@ -12,6 +12,7 @@
 
 import { useCallback, useState } from 'react';
 import type { FormEvent } from 'react';
+import { AppIcon } from '../components/icons';
 
 import { useAuth } from '../auth/auth-context';
 import { useToast } from '../components/common/Toast';
@@ -315,7 +316,13 @@ export function HouseholdPage() {
                 <li key={member.id} className="household-member-item">
                   <div className="household-member-item__info">
                     <span className="household-member-item__avatar" aria-hidden="true">
-                      {member.role === 'OWNER' ? '👑' : member.role === 'ADMIN' ? '🛡️' : '👤'}
+                      {member.role === 'OWNER' ? (
+                        <AppIcon name="medal" />
+                      ) : member.role === 'ADMIN' ? (
+                        <AppIcon name="shield" />
+                      ) : (
+                        <AppIcon name="account" />
+                      )}
                     </span>
                     <div>
                       <span className="household-member-item__name">{name}</span>
@@ -534,7 +541,15 @@ export function HouseholdPage() {
                   <span
                     className={`household-sharing-item__badge ${isShared ? 'household-sharing-item__badge--shared' : 'household-sharing-item__badge--private'}`}
                   >
-                    {isShared ? '🔓 Shared' : '🔒 Private'}
+                    {isShared ? (
+                      <>
+                        <AppIcon name="unlock" /> Shared
+                      </>
+                    ) : (
+                      <>
+                        <AppIcon name="lock" /> Private
+                      </>
+                    )}
                   </span>
                 </div>
                 <button
@@ -719,11 +734,11 @@ export function HouseholdPage() {
                     <td key={role} className="household-permissions-table__cell">
                       {checkPermission(role, perm) ? (
                         <span aria-label="Allowed" title="Allowed">
-                          ✅
+                          <AppIcon name="check" />
                         </span>
                       ) : (
                         <span aria-label="Denied" title="Denied">
-                          ❌
+                          <AppIcon name="x" />
                         </span>
                       )}
                     </td>

--- a/apps/web/src/pages/ImportPage.tsx
+++ b/apps/web/src/pages/ImportPage.tsx
@@ -25,6 +25,7 @@
 
 import React, { useId } from 'react';
 import { Link } from 'react-router-dom';
+import { AppIcon } from '../components/icons';
 
 import {
   ColumnMapper,
@@ -100,7 +101,7 @@ const UploadStep: React.FC<UploadStepProps> = ({
 
       {uploadError !== null && (
         <div className="import-error-banner" role="alert">
-          <span aria-hidden="true">⚠️</span>
+          <AppIcon name="alert-triangle" />
           {uploadError}
         </div>
       )}

--- a/apps/web/src/pages/InsightsPage.tsx
+++ b/apps/web/src/pages/InsightsPage.tsx
@@ -17,6 +17,7 @@ import { useInsights } from '../hooks/useInsights';
 import { formatCurrency } from '../lib/currency';
 import type { InsightsData, MonthComparison, Recommendation } from '../hooks/useInsights';
 import './InsightsPage.css';
+import { AppIcon, type IconName } from '../components/icons';
 
 // ---------------------------------------------------------------------------
 // Sub-components
@@ -94,12 +95,12 @@ interface RecommendationCardProps {
 }
 
 const RecommendationCard: React.FC<RecommendationCardProps> = ({ recommendation }) => {
-  const icon =
+  const icon: IconName =
     recommendation.severity === 'success'
-      ? '✅'
+      ? 'check'
       : recommendation.severity === 'warning'
-        ? '⚠️'
-        : '💡';
+        ? 'alert-triangle'
+        : 'info';
 
   return (
     <article
@@ -108,7 +109,7 @@ const RecommendationCard: React.FC<RecommendationCardProps> = ({ recommendation 
       role="listitem"
     >
       <span className="insights-recommendation__icon" aria-hidden="true">
-        {icon}
+        <AppIcon name={icon} />
       </span>
       <div className="insights-recommendation__content">
         <h3 className="insights-recommendation__title">{recommendation.title}</h3>

--- a/apps/web/src/pages/InvestmentsPage.tsx
+++ b/apps/web/src/pages/InvestmentsPage.tsx
@@ -14,6 +14,7 @@ import { CurrencyDisplay, EmptyState, ErrorBanner, LoadingSpinner } from '../com
 import { useInvestments } from '../hooks';
 import { formatCurrency, formatGainLoss } from '../lib/currency';
 import type { Investment, InvestmentType } from '../kmp/bridge';
+import { AppIcon, type IconName } from '../components/icons';
 
 /** Color palette for the allocation pie chart. */
 const CHART_COLORS = [
@@ -39,25 +40,25 @@ const TYPE_LABELS: Record<InvestmentType, string> = {
   OTHER: 'Other',
 };
 
-/** Emoji icons for investment types. */
-function getInvestmentIcon(type: InvestmentType): string {
+/** Icons for investment types. */
+function getInvestmentIcon(type: InvestmentType): IconName {
   switch (type) {
     case 'STOCK':
-      return '📈';
+      return 'trending-up';
     case 'BOND':
-      return '🏛️';
+      return 'bank';
     case 'ETF':
-      return '📊';
+      return 'chart-bar';
     case 'MUTUAL_FUND':
-      return '💼';
+      return 'folder';
     case 'CRYPTO':
-      return '₿';
+      return 'wallet';
     case 'REAL_ESTATE':
-      return '🏠';
+      return 'home';
     case 'COMMODITY':
-      return '🥇';
+      return 'medal';
     default:
-      return '💰';
+      return 'wallet';
   }
 }
 
@@ -428,7 +429,7 @@ export const InvestmentsPage: React.FC = () => {
                               style={{ textDecoration: 'none', color: 'inherit' }}
                               aria-label={`View details for ${inv.name} (${inv.symbol})`}
                             >
-                              <span aria-hidden="true">{getInvestmentIcon(inv.type)} </span>
+                              <AppIcon name={getInvestmentIcon(inv.type)} />{' '}
                               <strong>{inv.symbol}</strong>
                               <br />
                               <span

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -255,7 +255,7 @@ export const LoginPage: React.FC = () => {
                   <span>Signing in...</span>
                 </>
               ) : (
-                '🔐 Sign in with biometrics'
+                'Sign in with biometrics'
               )}
             </button>
 

--- a/apps/web/src/pages/OnboardingPage.tsx
+++ b/apps/web/src/pages/OnboardingPage.tsx
@@ -20,6 +20,7 @@ import { useConsent } from '../hooks/useConsent';
 import { useConsentHistory } from '../hooks/useConsentHistory';
 import type { FeatureAvailability } from '../lib/local-only-mode';
 import './OnboardingPage.css';
+import { AppIcon } from '../components/icons';
 
 // ---------------------------------------------------------------------------
 // Sub-components
@@ -42,7 +43,7 @@ const FeatureRow: React.FC<{
     >
       {feature.availableLocalOnly ? (
         <span className="onboarding__check" aria-hidden="true">
-          ✓
+          <AppIcon name="check" />
         </span>
       ) : (
         <span className="onboarding__cross" aria-hidden="true">
@@ -52,7 +53,7 @@ const FeatureRow: React.FC<{
     </td>
     <td className="onboarding__feature-cell" aria-label="Available with Account">
       <span className="onboarding__check" aria-hidden="true">
-        ✓
+        <AppIcon name="check" />
       </span>
     </td>
   </tr>
@@ -131,17 +132,25 @@ const OnboardingPage: React.FC = () => {
             {/* Local Only */}
             <article className="onboarding__path-card onboarding__path-card--local">
               <div className="onboarding__path-icon" aria-hidden="true">
-                🔒
+                <AppIcon name="lock" />
               </div>
               <h2 className="onboarding__path-title">Local Only</h2>
               <p className="onboarding__path-description">
                 Keep everything on this device. No account needed. No data ever leaves your browser.
               </p>
               <ul className="onboarding__path-features" role="list">
-                <li role="listitem">✓ Full budgeting & tracking</li>
-                <li role="listitem">✓ All data stays on device</li>
-                <li role="listitem">✓ No email required</li>
-                <li role="listitem">✓ Works completely offline</li>
+                <li role="listitem">
+                  <AppIcon name="check" /> Full budgeting & tracking
+                </li>
+                <li role="listitem">
+                  <AppIcon name="check" /> All data stays on device
+                </li>
+                <li role="listitem">
+                  <AppIcon name="check" /> No email required
+                </li>
+                <li role="listitem">
+                  <AppIcon name="check" /> Works completely offline
+                </li>
               </ul>
               <button
                 type="button"
@@ -158,17 +167,25 @@ const OnboardingPage: React.FC = () => {
             {/* Account */}
             <article className="onboarding__path-card onboarding__path-card--account">
               <div className="onboarding__path-icon" aria-hidden="true">
-                ☁️
+                <AppIcon name="cloud" />
               </div>
               <h2 className="onboarding__path-title">Create Account</h2>
               <p className="onboarding__path-description">
                 Sign up to sync across devices and share with household members.
               </p>
               <ul className="onboarding__path-features" role="list">
-                <li role="listitem">✓ Everything in Local Only</li>
-                <li role="listitem">✓ Sync across devices</li>
-                <li role="listitem">✓ Household sharing</li>
-                <li role="listitem">✓ Automatic cloud backups</li>
+                <li role="listitem">
+                  <AppIcon name="check" /> Everything in Local Only
+                </li>
+                <li role="listitem">
+                  <AppIcon name="check" /> Sync across devices
+                </li>
+                <li role="listitem">
+                  <AppIcon name="check" /> Household sharing
+                </li>
+                <li role="listitem">
+                  <AppIcon name="check" /> Automatic cloud backups
+                </li>
               </ul>
               <button
                 type="button"
@@ -257,7 +274,7 @@ const OnboardingPage: React.FC = () => {
       <div className="onboarding__container onboarding__container--narrow">
         <div className="onboarding__complete">
           <div className="onboarding__complete-icon" aria-hidden="true">
-            🎉
+            <AppIcon name="sparkles" />
           </div>
           <h1 className="onboarding__title">You&apos;re All Set!</h1>
           <p className="onboarding__subtitle">
@@ -265,13 +282,15 @@ const OnboardingPage: React.FC = () => {
           </p>
           <div className="onboarding__complete-details">
             <p className="onboarding__complete-item">
-              🔒 <strong>Local-only mode</strong> — no data leaves your browser
+              <AppIcon name="lock" /> <strong>Local-only mode</strong> — no data leaves your browser
             </p>
             <p className="onboarding__complete-item">
-              💾 <strong>SQLite storage</strong> — fast, reliable, offline-first
+              <AppIcon name="database" /> <strong>SQLite storage</strong> — fast, reliable,
+              offline-first
             </p>
             <p className="onboarding__complete-item">
-              🔄 <strong>Upgrade anytime</strong> — create an account later to enable sync
+              <AppIcon name="refresh" /> <strong>Upgrade anytime</strong> — create an account later
+              to enable sync
             </p>
           </div>
           <button

--- a/apps/web/src/pages/PlanningPage.tsx
+++ b/apps/web/src/pages/PlanningPage.tsx
@@ -33,6 +33,7 @@ import type {
   SweepLogEntry,
 } from '../lib/planning';
 import './PlanningPage.css';
+import { AppIcon, type IconName } from '../components/icons';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -40,11 +41,11 @@ import './PlanningPage.css';
 
 type PlanningTab = 'scenarios' | 'retirement' | 'goals' | 'sweep';
 
-const TAB_CONFIG: { id: PlanningTab; label: string; icon: string }[] = [
-  { id: 'scenarios', label: 'What-If Modeler', icon: '🔮' },
-  { id: 'retirement', label: 'Retirement', icon: '🏖️' },
-  { id: 'goals', label: 'Savings Goals', icon: '🎯' },
-  { id: 'sweep', label: 'Automations', icon: '⚡' },
+const TAB_CONFIG: { id: PlanningTab; label: string; icon: IconName }[] = [
+  { id: 'scenarios', label: 'What-If Modeler', icon: 'sparkles' },
+  { id: 'retirement', label: 'Retirement', icon: 'leaf' },
+  { id: 'goals', label: 'Savings Goals', icon: 'target' },
+  { id: 'sweep', label: 'Automations', icon: 'lightning' },
 ];
 
 // ---------------------------------------------------------------------------
@@ -95,11 +96,16 @@ const ReadinessScoreCircle: React.FC<{
 
 /** Single retirement factor display. */
 const FactorItem: React.FC<{ factor: RetirementFactor }> = ({ factor }) => {
-  const icon = factor.impact === 'positive' ? '✅' : factor.impact === 'negative' ? '⚠️' : 'ℹ️';
+  const icon: IconName =
+    factor.impact === 'positive'
+      ? 'check'
+      : factor.impact === 'negative'
+        ? 'alert-triangle'
+        : 'info';
   return (
     <li className="factor-item" role="listitem">
       <span className="factor-icon" aria-hidden="true">
-        {icon}
+        <AppIcon name={icon} />
       </span>
       <div>
         <span className="factor-item__label">{factor.label}</span>
@@ -289,7 +295,7 @@ const GoalProgressCard: React.FC<{ goal: LinkedGoal }> = ({ goal }) => (
             className={`milestone__icon ${m.reached ? 'milestone__icon--reached' : ''}`}
             aria-hidden="true"
           >
-            {m.reached ? '✓' : m.percent}
+            {m.reached ? <AppIcon name="check" /> : m.percent}
           </span>
           <span className="milestone__label">{m.percent}%</span>
         </div>
@@ -406,7 +412,7 @@ const ScenariosPanel: React.FC = () => {
       {scenarios.length === 0 ? (
         <div className="planning-empty">
           <div className="planning-empty__icon" aria-hidden="true">
-            🔮
+            <AppIcon name="sparkles" />
           </div>
           <p className="planning-empty__text">
             Create a &quot;what if&quot; scenario to see how financial decisions impact your future.
@@ -697,7 +703,7 @@ const GoalsPanel: React.FC = () => {
     return (
       <div className="planning-empty">
         <div className="planning-empty__icon" aria-hidden="true">
-          🎯
+          <AppIcon name="target" />
         </div>
         <p className="planning-empty__text">
           No savings goals yet. Create a goal from the Goals page to track progress here.
@@ -762,14 +768,14 @@ const SweepPanel: React.FC = () => {
           disabled={rules.length === 0}
           aria-label="Simulate all sweep rules"
         >
-          🔄 Simulate All Rules
+          <AppIcon name="refresh" /> Simulate All Rules
         </button>
       </div>
 
       {rules.length === 0 ? (
         <div className="planning-empty">
           <div className="planning-empty__icon" aria-hidden="true">
-            ⚡
+            <AppIcon name="lightning" />
           </div>
           <p className="planning-empty__text">
             No sweep rules configured. Rules automate savings transfers like round-ups,
@@ -881,7 +887,7 @@ export const PlanningPage: React.FC = () => {
             aria-controls={`panel-${tab.id}`}
             onClick={() => setActiveTab(tab.id)}
           >
-            <span aria-hidden="true">{tab.icon}</span> {tab.label}
+            <AppIcon name={tab.icon} /> {tab.label}
           </button>
         ))}
       </div>

--- a/apps/web/src/pages/PrivacyDashboardPage.test.tsx
+++ b/apps/web/src/pages/PrivacyDashboardPage.test.tsx
@@ -15,6 +15,7 @@ import PrivacyDashboardPage from './PrivacyDashboardPage';
 import { useConsent } from '../hooks/useConsent';
 import { useConsentHistory } from '../hooks/useConsentHistory';
 import { usePrivacyDashboard } from '../hooks/usePrivacyDashboard';
+import type { DataCategory } from '../hooks/usePrivacyDashboard';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -58,14 +59,14 @@ const mockConsent = {
   hasCompletedFirstRun: true,
 };
 
-const mockCategories = [
+const mockCategories: DataCategory[] = [
   {
     id: 'accounts',
     name: 'Financial Accounts',
     description: 'Bank accounts and credit cards.',
     storageLocation: 'SQLite (OPFS)' as const,
     leavesDevice: false,
-    icon: '🏦',
+    icon: 'bank',
     estimatedBytes: 0,
   },
   {
@@ -74,7 +75,7 @@ const mockCategories = [
     description: 'Your preferences.',
     storageLocation: 'localStorage' as const,
     leavesDevice: false,
-    icon: '⚙️',
+    icon: 'settings',
     estimatedBytes: 512,
   },
 ];

--- a/apps/web/src/pages/PrivacyDashboardPage.tsx
+++ b/apps/web/src/pages/PrivacyDashboardPage.tsx
@@ -28,6 +28,7 @@ import {
   type ConsentCategory,
 } from '../lib/consent-storage';
 import './PrivacyDashboardPage.css';
+import { AppIcon } from '../components/icons';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -156,21 +157,23 @@ const PrivacyDashboardPage: React.FC = () => {
                 aria-label={category.name}
               >
                 <div className="privacy-dashboard__category-icon" aria-hidden="true">
-                  {category.icon}
+                  <AppIcon name={category.icon} />
                 </div>
                 <div className="privacy-dashboard__category-content">
                   <h3 className="privacy-dashboard__category-name">{category.name}</h3>
                   <p className="privacy-dashboard__category-description">{category.description}</p>
                   <div className="privacy-dashboard__category-meta">
                     <span className="privacy-dashboard__category-storage">
-                      📦 {category.storageLocation}
+                      <AppIcon name="package" /> {category.storageLocation}
                     </span>
                     {category.leavesDevice ? (
                       <span className="privacy-dashboard__category-leaves">
-                        ☁️ {category.leavesDeviceCondition ?? 'May sync'}
+                        <AppIcon name="cloud" /> {category.leavesDeviceCondition ?? 'May sync'}
                       </span>
                     ) : (
-                      <span className="privacy-dashboard__category-local">🔒 Stays on device</span>
+                      <span className="privacy-dashboard__category-local">
+                        <AppIcon name="lock" /> Stays on device
+                      </span>
                     )}
                     {category.estimatedBytes > 0 && (
                       <span className="privacy-dashboard__category-size">
@@ -269,7 +272,9 @@ const PrivacyDashboardPage: React.FC = () => {
         <h2 className="privacy-dashboard__section-title">Your Data Rights</h2>
         <div className="privacy-dashboard__rights">
           <article className="privacy-dashboard__right-card">
-            <h3 className="privacy-dashboard__right-title">📥 Export Your Data</h3>
+            <h3 className="privacy-dashboard__right-title">
+              <AppIcon name="download" /> Export Your Data
+            </h3>
             <p className="privacy-dashboard__right-description">
               Download all your financial data in JSON or CSV format. This is your data — you can
               take it with you at any time.
@@ -279,7 +284,9 @@ const PrivacyDashboardPage: React.FC = () => {
             </a>
           </article>
           <article className="privacy-dashboard__right-card">
-            <h3 className="privacy-dashboard__right-title">🗑️ Delete Your Data</h3>
+            <h3 className="privacy-dashboard__right-title">
+              <AppIcon name="trash" /> Delete Your Data
+            </h3>
             <p className="privacy-dashboard__right-description">
               Permanently delete all your data from this device. If you have an account, you can
               also request server-side deletion.

--- a/apps/web/src/pages/ReceiptOcrPage.tsx
+++ b/apps/web/src/pages/ReceiptOcrPage.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { useId, useMemo, useState } from 'react';
+import { AppIcon } from '../components/icons';
 
 import { useAccounts } from '../hooks/useAccounts';
 import { useTransactions } from '../hooks/useTransactions';
@@ -144,7 +145,7 @@ export const ReceiptOcrPage: React.FC = () => {
 
       {error !== null && (
         <div className="import-error-banner" role="alert">
-          <span aria-hidden="true">⚠️</span>
+          <AppIcon name="alert-triangle" />
           {error}
         </div>
       )}

--- a/apps/web/src/pages/ReferralPage.tsx
+++ b/apps/web/src/pages/ReferralPage.tsx
@@ -10,6 +10,7 @@
  */
 
 import { useCallback, useState } from 'react';
+import { AppIcon, type IconName } from '../components/icons';
 
 import { useReferral } from '../hooks/useReferral';
 import type { ReferralStatus } from '../hooks/useReferral';
@@ -27,11 +28,11 @@ const STATUS_LABELS: Record<ReferralStatus, string> = {
   rewarded: 'Rewarded',
 };
 
-const STATUS_ICONS: Record<ReferralStatus, string> = {
-  pending: '⏳',
-  signed_up: '✉️',
-  activated: '✅',
-  rewarded: '🎁',
+const STATUS_ICONS: Record<ReferralStatus, IconName> = {
+  pending: 'calendar',
+  signed_up: 'mail',
+  activated: 'check',
+  rewarded: 'gift',
 };
 
 // ---------------------------------------------------------------------------
@@ -142,7 +143,13 @@ export function ReferralPage() {
               onClick={handleCopy}
               aria-label={copied ? 'Link copied!' : 'Copy referral link'}
             >
-              {copied ? '✓ Copied!' : 'Copy Link'}
+              {copied ? (
+                <>
+                  <AppIcon name="check" /> Copied!
+                </>
+              ) : (
+                'Copy Link'
+              )}
             </button>
             <button
               className="referral-button referral-button--primary"
@@ -170,7 +177,7 @@ export function ReferralPage() {
             {referrals.map((referral) => (
               <li key={referral.id} className="referral-list__item">
                 <span className="referral-list__icon" aria-hidden="true">
-                  {STATUS_ICONS[referral.status]}
+                  <AppIcon name={STATUS_ICONS[referral.status]} />
                 </span>
                 <div className="referral-list__info">
                   <span className="referral-list__email">{referral.referredEmail}</span>

--- a/apps/web/src/pages/TransactionDetailPage.tsx
+++ b/apps/web/src/pages/TransactionDetailPage.tsx
@@ -2,6 +2,7 @@
 
 import React, { useCallback, useMemo, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
+import { AppIcon } from '../components/icons';
 
 import { ConfirmDialog, CurrencyDisplay, ErrorBanner, LoadingSpinner } from '../components/common';
 import { TransactionForm } from '../components/forms';
@@ -238,7 +239,7 @@ export const TransactionDetailPage: React.FC = () => {
             onClick={() => setIsFormOpen(true)}
             aria-label={`Edit ${label}`}
           >
-            <span aria-hidden="true">✏️</span>
+            <AppIcon name="edit" />
           </button>
           <button
             type="button"
@@ -246,7 +247,7 @@ export const TransactionDetailPage: React.FC = () => {
             onClick={() => setDeletingTransaction(transaction)}
             aria-label={`Delete ${label}`}
           >
-            <span aria-hidden="true">🗑️</span>
+            <AppIcon name="trash" />
           </button>
         </div>
       </div>
@@ -413,7 +414,7 @@ export const TransactionDetailPage: React.FC = () => {
                       className="icon-button"
                       style={{ fontSize: '0.875rem', padding: 'var(--spacing-1)' }}
                     >
-                      {copiedRefId ? '✓' : '📋'}
+                      {copiedRefId ? <AppIcon name="check" /> : <AppIcon name="clipboard" />}
                     </button>
                   </dd>
                 </div>

--- a/apps/web/src/pages/TransactionsPage.tsx
+++ b/apps/web/src/pages/TransactionsPage.tsx
@@ -2,6 +2,7 @@
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { AppIcon } from '../components/icons';
 
 import {
   ConfirmDialog,
@@ -156,44 +157,6 @@ function ChevronDownIcon() {
         fill="none"
         stroke="currentColor"
         strokeWidth="1.75"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-function PencilIcon() {
-  return (
-    <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false">
-      <path
-        d="M3.25 11.75 3 13l1.25-.25 7.35-7.35-1-1-7.35 7.35Z"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <path
-        d="m9.9 3.7.7-.7a1.1 1.1 0 0 1 1.55 0l.85.85a1.1 1.1 0 0 1 0 1.55l-.7.7"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-function ImportIcon() {
-  return (
-    <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false">
-      <path
-        d="M8 2.75v6.5m0 0L5.5 6.75M8 9.25l2.5-2.5M3.25 10.5v1.75c0 .55.45 1 1 1h7.5c.55 0 1-.45 1-1V10.5"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.5"
         strokeLinecap="round"
         strokeLinejoin="round"
       />
@@ -524,7 +487,7 @@ export const TransactionsPage: React.FC = () => {
           disabled={transactions.length === 0}
           style={{ marginRight: 'var(--spacing-2)' }}
         >
-          <span aria-hidden="true">📤</span> Export CSV
+          <AppIcon name="upload" /> Export CSV
         </button>
         <div className="add-transaction-menu" ref={addMenuRef}>
           <div className="add-transaction-split-button">
@@ -559,8 +522,7 @@ export const TransactionsPage: React.FC = () => {
                 role="menuitem"
                 onClick={handleOpenCreateForm}
               >
-                <PencilIcon />
-                Manual Entry
+                <AppIcon name="edit" /> Manual Entry
               </button>
               <button
                 type="button"
@@ -568,8 +530,7 @@ export const TransactionsPage: React.FC = () => {
                 role="menuitem"
                 onClick={handleImportFromFile}
               >
-                <ImportIcon />
-                Import from File
+                <AppIcon name="download" /> Import from File
               </button>
             </div>
           )}
@@ -666,7 +627,7 @@ export const TransactionsPage: React.FC = () => {
                               onClick={() => handleEditTransaction(transaction)}
                               aria-label={`Edit ${transactionLabel}`}
                             >
-                              <span aria-hidden="true">✏️</span>
+                              <AppIcon name="edit" />
                             </button>
                             <button
                               type="button"
@@ -674,7 +635,7 @@ export const TransactionsPage: React.FC = () => {
                               onClick={() => setDeletingTransaction(transaction)}
                               aria-label={`Delete ${transactionLabel}`}
                             >
-                              <span aria-hidden="true">🗑️</span>
+                              <AppIcon name="trash" />
                             </button>
                           </div>
                         </div>

--- a/apps/web/src/pages/WatchlistsPage.tsx
+++ b/apps/web/src/pages/WatchlistsPage.tsx
@@ -34,6 +34,7 @@ import {
 } from '../hooks/useSpendingWatchlists';
 
 import '../styles/watchlists.css';
+import { AppIcon } from '../components/icons';
 
 // ---------------------------------------------------------------------------
 // Subcomponents
@@ -58,7 +59,15 @@ const AlertCard: React.FC<AlertCardProps> = ({ alert, onDismiss }) => (
   >
     <div className="watchlist-alert__content">
       <span className="watchlist-alert__icon" aria-hidden="true">
-        {alert.level === 'critical' ? '🚨' : alert.level === 'warning' ? '⚠️' : 'ℹ️'}
+        <AppIcon
+          name={
+            alert.level === 'critical'
+              ? 'alert-triangle'
+              : alert.level === 'warning'
+                ? 'alert-circle'
+                : 'info'
+          }
+        />
       </span>
       <div className="watchlist-alert__text">
         <p className="watchlist-alert__message">{alert.message}</p>
@@ -136,7 +145,13 @@ const WatchlistItem: React.FC<WatchlistItemProps> = ({
           aria-label={`${watchlist.alertsEnabled ? 'Disable' : 'Enable'} alerts for ${watchlist.categoryName}`}
           aria-pressed={watchlist.alertsEnabled}
         >
-          {watchlist.alertsEnabled ? '🔔 Alerts on' : '🔕 Alerts off'}
+          {watchlist.alertsEnabled ? (
+            <>
+              <AppIcon name="bell" /> Alerts on
+            </>
+          ) : (
+            'Alerts off'
+          )}
         </button>
         <button
           type="button"


### PR DESCRIPTION
Closes #1979

## Summary
- Added a reusable inline SVG `AppIcon` component following the existing currentColor SVG pattern.
- Replaced 205 inline emoji glyph/icon occurrences across 43 web source files with inline SVG icons.
- Updated tests/fixtures that asserted or typed icon literals.

## Deliberately kept
- Emoji in notification/celebration copy that users read (milestone notifications, goal completion messages, child goal labels).
- User-generated/picker content such as category icon placeholders and mood tags.
- Non-emoji control symbols still used as close/star glyphs where outside this issue's emoji iconography scope.

## Validation
- `npm run type-check -w apps/web` ✅
- `cd apps/web; npx vitest run --reporter=dot` runs, with the existing unrelated `src/utils/formatDate.test.ts` locale/date expectation failure (`Dec 23, 2023` vs expected `24`).