### PR TITLE
fix(deploy): harden alpha caddy and powersync startup

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -278,6 +278,24 @@ jobs:
             git checkout $SHA
             docker compose -f deploy/docker-compose.yml pull
             docker compose -f deploy/docker-compose.yml up -d --remove-orphans
+
+            # Caddy serves the public site and can safely start before backend
+            # healthchecks settle. If compose left it Created because an
+            # upstream was unhealthy, explicitly start/recreate just Caddy.
+            caddy_started=false
+            for attempt in 1 2 3; do
+              if docker compose -f deploy/docker-compose.yml up -d --no-deps caddy \
+                || docker compose -f deploy/docker-compose.yml start caddy; then
+                caddy_started=true
+                break
+              fi
+              echo "::warning::caddy start attempt ${attempt} failed; retrying"
+              sleep 5
+            done
+            if [ "$caddy_started" != true ]; then
+              echo "::warning::caddy was not confirmed started after retries"
+            fi
+
             docker compose -f deploy/docker-compose.yml ps
             echo "Deployed version: $VERSION ($SHA)"
           DEPLOY

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -209,6 +209,23 @@ jobs:
             docker compose -f deploy/docker-compose.yml up -d --remove-orphans \
               || echo "::warning::compose up reported non-zero (deps may be transiently unhealthy)"
 
+            # Caddy serves the public site and can safely start before backend
+            # healthchecks settle. If compose left it Created because an
+            # upstream was unhealthy, explicitly start/recreate just Caddy.
+            caddy_started=false
+            for attempt in 1 2 3; do
+              if docker compose -f deploy/docker-compose.yml up -d --no-deps caddy \
+                || docker compose -f deploy/docker-compose.yml start caddy; then
+                caddy_started=true
+                break
+              fi
+              echo "::warning::caddy start attempt ${attempt} failed; retrying"
+              sleep 5
+            done
+            if [ "$caddy_started" != true ]; then
+              echo "::warning::caddy was not confirmed started after retries"
+            fi
+
             # Ensure Caddy picks up any bind-mounted Caddyfile changes.
             # Bind-mounted files don't trigger container restart, and
             # `caddy reload` requires a healthy admin API (port 2019) which
@@ -216,7 +233,8 @@ jobs:
             # is fast (<3s, no TLS re-issuance) and guarantees the new
             # Caddyfile is parsed fresh.
             docker compose -f deploy/docker-compose.yml restart caddy \
-              || echo "::warning::caddy restart failed"
+              || docker compose -f deploy/docker-compose.yml start caddy \
+              || echo "::warning::caddy restart/start failed"
 
             docker compose -f deploy/docker-compose.yml ps
           DEPLOY

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -123,16 +123,12 @@ WEB_DIST_PATH=../apps/web/dist
 POWERSYNC_URL=YOUR_POWERSYNC_URL_HERE
 POWERSYNC_PUBLIC_KEY=YOUR_POWERSYNC_PUBLIC_KEY_HERE
 
-# PowerSync replication slot and publication names
-POWERSYNC_SLOT_NAME=powersync
-POWERSYNC_PUBLICATION=powersync
-
 # MongoDB connection URI for PowerSync bucket storage.
 # IMPORTANT: If the password contains special characters (/ + = etc.),
 # they must be URL-encoded (e.g., / → %2F, + → %2B, = → %3D).
 # Use: python3 -c "import urllib.parse; print(urllib.parse.quote('YOUR_PASSWORD'))"
-# Format: mongodb://<user>:<password>@mongo:27017/powersync?authSource=admin
-POWERSYNC_MONGO_URI=mongodb://powersync:YOUR_MONGO_PASSWORD_HERE@mongo:27017/powersync?authSource=admin
+# Format: mongodb://<user>:<password>@mongo:27017/powersync?authSource=admin&replicaSet=rs0
+POWERSYNC_MONGO_URI=mongodb://powersync:YOUR_MONGO_PASSWORD_HERE@mongo:27017/powersync?authSource=admin&replicaSet=rs0
 
 # MongoDB credentials (used by the mongo container)
 MONGO_USER=powersync

--- a/deploy/.env.staging.example
+++ b/deploy/.env.staging.example
@@ -111,14 +111,12 @@ EDGE_FUNCTIONS_PATH=../services/api/supabase/functions
 # ---------------------------------------------------------------------------
 POWERSYNC_URL=https://staging.YOUR_DOMAIN_HERE/sync
 POWERSYNC_PUBLIC_KEY=YOUR_STAGING_POWERSYNC_PUBLIC_KEY_HERE
-POWERSYNC_SLOT_NAME=powersync
-POWERSYNC_PUBLICATION=powersync
 POWERSYNC_SUPABASE_PROJECT_ID=YOUR_STAGING_SUPABASE_PROJECT_ID_HERE
 POWERSYNC_JWKS_URI=
 
 # MongoDB for PowerSync bucket storage
 # Generate password with: openssl rand -base64 24
-POWERSYNC_MONGO_URI=mongodb://powersync:YOUR_STAGING_MONGO_PASSWORD_HERE@mongo:27017/powersync?authSource=admin
+POWERSYNC_MONGO_URI=mongodb://powersync:YOUR_STAGING_MONGO_PASSWORD_HERE@mongo:27017/powersync?authSource=admin&replicaSet=rs0
 MONGO_USER=powersync
 MONGO_PASSWORD=YOUR_STAGING_MONGO_PASSWORD_HERE
 MONGO_PORT=27017

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -103,7 +103,7 @@ chmod 444 volumes/mongo/replica-keyfile
 # URL-encode the Mongo password for the PowerSync connection URI
 MONGO_PASS_ENCODED=$(python3 -c "import urllib.parse; print(urllib.parse.quote('$(grep MONGO_PASSWORD .env | cut -d= -f2)'))")
 # Update POWERSYNC_MONGO_URI in .env with the encoded password:
-#   POWERSYNC_MONGO_URI=mongodb://powersync:${MONGO_PASS_ENCODED}@mongo:27017/powersync?authSource=admin
+#   POWERSYNC_MONGO_URI=mongodb://powersync:${MONGO_PASS_ENCODED}@mongo:27017/powersync?authSource=admin&replicaSet=rs0
 ```
 
 ### Step 4 — Start the stack
@@ -115,7 +115,7 @@ docker compose up -d
 Wait for all services to become healthy:
 
 ```bash
-docker compose ps       # All services should show "healthy"
+docker compose ps       # Long-running services should show "healthy"; mongo-rs-init should exit 0
 docker compose logs -f  # Watch logs for errors (Ctrl+C to exit)
 ```
 
@@ -141,18 +141,13 @@ docker compose exec db psql -U postgres -c "
   ALTER DEFAULT PRIVILEGES IN SCHEMA auth GRANT ALL ON TABLES TO supabase_auth_admin;
 "
 
-# 3. Create PowerSync replication slot and publication
+# 3. Create PowerSync publication (the service manages replication slots)
 docker compose exec db psql -U postgres -c "
-  SELECT pg_create_logical_replication_slot('powersync', 'pgoutput');
   CREATE PUBLICATION powersync FOR ALL TABLES;
 "
 
-# 4. Initialize MongoDB replica set
-docker compose exec mongo mongosh -u powersync -p "$(grep MONGO_PASSWORD .env | cut -d= -f2)" --eval '
-  rs.initiate({_id: "rs0", members: [{_id: 0, host: "mongo:27017"}]})
-'
-
-# 5. Restart auth and powersync to pick up the new configuration
+# 4. Restart auth and powersync to pick up the new configuration
+# MongoDB replica-set initialization is handled by the mongo-rs-init service.
 docker compose restart auth powersync
 ```
 
@@ -309,6 +304,7 @@ docker compose ps
 | `BACKUP_RETENTION_DAYS`   | `30`                                 | Number of daily backups to keep                                                  |
 | `POWERSYNC_URL`           | —                                    | PowerSync instance URL (optional)                                                |
 | `POWERSYNC_PUBLIC_KEY`    | —                                    | PowerSync public key (optional)                                                  |
+| `POWERSYNC_MONGO_URI`     | internal mongo URI                   | Override bucket-storage URI; include `replicaSet=rs0` when using bundled MongoDB |
 
 ---
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -294,13 +294,12 @@ services:
   #
   # Setup (first deployment only):
   #   1. Run on the database:
-  #        SELECT pg_create_logical_replication_slot('powersync', 'pgoutput');
   #        CREATE PUBLICATION powersync FOR ALL TABLES;
-  #   2. Ensure MongoDB is configured as a replica set (see mongo service below).
+  #   2. MongoDB is configured as a single-node replica set by mongo-rs-init.
   #   3. Sync rules are mounted from services/api/powersync/sync-rules.yaml.
   #
-  # Config: v1.20.5+ requires a YAML file at /app/powersync.yaml.
-  # The entrypoint generates it from env vars using the mounted template.
+  # Config: deploy/powersync.yaml follows the current self-hosted service schema
+  # and substitutes PS_* values provided below.
   #
   # Ports: 8080 (API) — internal only, routed through Caddy at /sync/*
   #
@@ -314,54 +313,28 @@ services:
   powersync:
     image: journeyapps/powersync-service:latest
     restart: unless-stopped
+    command: ['start', '-r', 'unified']
     environment:
-      # These env vars are used by the startup script to generate powersync.yaml
+      POWERSYNC_CONFIG_PATH: /config/powersync.yaml
+      NODE_OPTIONS: ${POWERSYNC_NODE_OPTIONS:---max-old-space-size=384}
+      # These PS_* env vars are substituted by deploy/powersync.yaml.
       # TODO(#1306): Replace supabase_admin with a dedicated powersync_replication
       # role once the migration is created (see comment block above).
       PS_PG_URI: postgres://supabase_admin:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-postgres}
-      PS_PG_SLOT: ${POWERSYNC_SLOT_NAME:-powersync}
-      PS_PG_PUBLICATION: ${POWERSYNC_PUBLICATION:-powersync}
-      PS_MONGO_URI: ${POWERSYNC_MONGO_URI}
+      PS_MONGO_URI: ${POWERSYNC_MONGO_URI:-mongodb://powersync:${MONGO_PASSWORD}@mongo:27017/powersync?authSource=admin&replicaSet=rs0}
       PS_JWT_SECRET: ${JWT_SECRET}
-    entrypoint: /usr/bin/sh
-    command:
-      - -c
-      - |
-        node -e "
-          const fs = require('fs');
-          const lines = [
-            'replication:',
-            '  connections:',
-            '    - type: postgresql',
-            '      uri: ' + process.env.PS_PG_URI,
-            '      sslmode: disable',  // Acceptable: traffic stays on Docker bridge network (finance-internal). For production deployments outside Docker, upgrade to sslmode: require or verify-full.
-            '      slot_name: ' + process.env.PS_PG_SLOT,
-            '      publication_name: ' + process.env.PS_PG_PUBLICATION,
-            '',
-            'storage:',
-            '  type: mongodb',
-            '  uri: ' + process.env.PS_MONGO_URI,
-            '',
-            'client_auth:',
-            '  supabase_jwt_secret: ' + process.env.PS_JWT_SECRET,
-            '',
-            'port: 8080',
-            '',
-            'sync_rules:',
-            '  path: /sync-rules/sync-rules.yaml'
-          ].join('\n');
-          fs.writeFileSync('/tmp/powersync.yaml', lines);
-          console.log('Generated /tmp/powersync.yaml');
-        " && exec node service/lib/entry.js start --config-path /tmp/powersync.yaml
+      PS_PORT: '8080'
     volumes:
-      - ${POWERSYNC_SYNC_RULES_PATH:-../services/api/powersync}:/sync-rules:ro
+      - ./powersync.yaml:/config/powersync.yaml:ro
+      - ${POWERSYNC_SYNC_RULES_PATH:-../services/api/powersync}/sync-rules.yaml:/config/sync-config.yaml:ro
     healthcheck:
-      # PowerSync exposes diagnostics on its HTTP port.
-      # Verify HTTP 200 — not just "any status code".
+      # PowerSync exposes official HTTP health probes at /probes/*.
       test:
         [
-          'CMD-SHELL',
-          'node -e "require(\"http\").get(\"http://localhost:8080/\",r=>{process.exit(r.statusCode===200?0:1)}).on(\"error\",()=>process.exit(1))"',
+          'CMD',
+          'node',
+          '-e',
+          "fetch('http://localhost:8080/probes/liveness').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
         ]
       interval: 15s
       timeout: 5s
@@ -370,8 +343,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
-      mongo:
-        condition: service_healthy
+      mongo-rs-init:
+        condition: service_completed_successfully
     deploy:
       resources:
         limits:
@@ -389,10 +362,7 @@ services:
   # PowerSync requires MongoDB for its internal bucket storage.
   # This is NOT used for application data — only sync-engine state.
   # IMPORTANT: Must run as a replica set (PowerSync uses change streams).
-  #
-  # First deployment: After the container starts, run:
-  #   docker exec deploy-mongo-1 mongosh -u <user> -p <pass> --eval \
-  #     'rs.initiate({_id:"rs0",members:[{_id:0,host:"mongo:27017"}]})'
+  # mongo-rs-init performs the idempotent single-node rs.initiate() bootstrap.
   mongo:
     image: mongo:7-jammy
     restart: unless-stopped
@@ -410,7 +380,11 @@ services:
       chown mongodb:mongodb /tmp/mongo-keyfile &&
       exec mongod --replSet rs0 --keyFile /tmp/mongo-keyfile --bind_ip_all"
     healthcheck:
-      test: ['CMD', 'mongosh', '--eval', "db.adminCommand('ping')"]
+      test:
+        [
+          'CMD-SHELL',
+          'mongosh --host localhost:27017 --username "$$MONGO_INITDB_ROOT_USERNAME" --password "$$MONGO_INITDB_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.adminCommand({ ping: 1 })" || exit 1',
+        ]
       interval: 15s
       timeout: 5s
       retries: 5
@@ -423,6 +397,42 @@ services:
         reservations:
           cpus: '0.1'
           memory: 128M
+    networks:
+      - finance-internal
+
+  # ---------------------------------------------------------------------------
+  # MongoDB replica-set bootstrap — required by PowerSync bucket storage
+  # ---------------------------------------------------------------------------
+  mongo-rs-init:
+    image: mongo:7-jammy
+    restart: 'no'
+    environment:
+      MONGO_USER: ${MONGO_USER:-powersync}
+      MONGO_PASSWORD: ${MONGO_PASSWORD}
+    depends_on:
+      mongo:
+        condition: service_healthy
+    entrypoint:
+      - bash
+      - -c
+      - |
+        set -euo pipefail
+        for attempt in {1..30}; do
+          if mongosh --host mongo:27017 --username "$${MONGO_USER}" --password "$${MONGO_PASSWORD}" --authenticationDatabase admin --quiet --eval '
+            try {
+              rs.status();
+              quit(0);
+            } catch (e) {
+              print("Initializing MongoDB replica set: " + (e.codeName || e.message));
+            }
+            rs.initiate({_id:"rs0",members:[{_id:0,host:"mongo:27017"}]});
+          '; then
+            exit 0
+          fi
+          sleep 2
+        done
+        echo "MongoDB replica set initialization failed" >&2
+        exit 1
     networks:
       - finance-internal
 
@@ -458,14 +468,15 @@ services:
       retries: 5
       start_period: 10s
     depends_on:
+      # Caddy can start before upstream services are healthy; reverse_proxy will
+      # connect once each backend is ready. Avoid letting one unhealthy optional
+      # upstream leave the public proxy stuck in Created state during deploy.
       rest:
-        condition: service_healthy
+        condition: service_started
       auth:
-        condition: service_healthy
+        condition: service_started
       edge-functions:
-        condition: service_healthy
-      powersync:
-        condition: service_healthy
+        condition: service_started
     deploy:
       resources:
         limits:

--- a/deploy/powersync.yaml
+++ b/deploy/powersync.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://unpkg.com/@powersync/service-schema@latest/json-schema/powersync-config.json
+# =============================================================================
+# PowerSync Service Configuration
+# =============================================================================
+# Values marked with !env are substituted by the PowerSync service from PS_*
+# environment variables provided by docker-compose.yml.
+
+telemetry:
+  disable_telemetry_sharing: true
+
+replication:
+  connections:
+    - type: postgresql
+      uri: !env PS_PG_URI
+      # Private Docker bridge traffic only. Use verify-full for external DBs.
+      sslmode: disable
+
+storage:
+  type: mongodb
+  uri: !env PS_MONGO_URI
+
+port: !env PS_PORT
+
+# services/api/powersync/sync-rules.yaml is mounted here by docker-compose.yml.
+sync_config:
+  path: /config/sync-config.yaml
+
+client_auth:
+  supabase: true
+  supabase_jwt_secret: !env PS_JWT_SECRET
+
+healthcheck:
+  probes:
+    use_http: true
+
+system:
+  logging:
+    level: info
+    format: text


### PR DESCRIPTION
## Summary
- Addresses session todo `alpha-deploy-caddy-recover` by decoupling Caddy from backend healthcheck readiness and adding a post-`compose up` Caddy start/recreate retry in staging and production deploys.
- Addresses session todo `alpha-vm-powersync-restart` by moving PowerSync to the documented self-hosted config file (`sync_config`), enabling Supabase auth in that config, switching to `/probes/liveness`, adding a MongoDB replica-set bootstrap service, and ensuring the bundled Mongo URI includes `replicaSet=rs0`.
- Updates deploy docs and env examples for the new PowerSync/Mongo startup path.

## Investigation notes
- Latest failed staging deploy logs showed compose aborting on an unhealthy dependency (`deploy-rest-1`), which is enough to leave dependent services like Caddy created but not running.
- PowerSync compose config was generated with deprecated/incorrect keys (`sync_rules`, no `client_auth.supabase`) and the healthcheck targeted `/` instead of the official probe endpoint.
- Official PowerSync self-hosting docs require `sync_config`, `POWERSYNC_CONFIG_PATH`/mounted config, HTTP probes under `/probes/*`, and MongoDB replica-set storage.

## Validation
- `docker compose ... config` could not be run locally because Docker is not installed on this machine.
- Parsed YAML with `npx --yes js-yaml` for compose/workflows; parsed `deploy/powersync.yaml` after normalizing PowerSync's custom `!env` tags.
- `git diff --check` passed.

## Deferred
- No auto-deploy was performed. Runtime verification of the alpha VM containers is deferred until this PR is merged and the user re-deploys.