### PR TITLE
chore(deps): ignore @vitejs/plugin-react 6.x in dependabot (follow-up to closing #2000)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,13 @@ updates:
       npm-major:
         update-types:
           - 'major'
+    ignore:
+      # @vitejs/plugin-react@6.x is incompatible with Vite 8 — the Fast Refresh
+      # preamble is never injected and every dev page crashes with
+      # "$RefreshSig$ is not defined". Pinned to 5.x in #1995 (#1908). Revisit
+      # when upstream ships a Vite 8-compatible 6.x.
+      - dependency-name: '@vitejs/plugin-react'
+        versions: ['6.x']
     commit-message:
       prefix: 'chore(deps)'
     open-pull-requests-limit: 15


### PR DESCRIPTION
Closing #2000 isn't enough — dependabot will re-propose the same 6.x bump every Monday until the upstream incompatibility is resolved.

This adds an `ignore` rule for `@vitejs/plugin-react` versions `6.x` so dependabot stops trying.

When upstream ships a Vite 8-compatible @vitejs/plugin-react 6.x (or 7.x), drop the ignore rule and bump.

### References
- #1908 — original bug report
- #1995 — pinned to 5.2.0
- #2000 — closed dependabot PR that this prevents from recurring