### PR TITLE
fix(web): sidebar nav group toggle now collapses reliably (#2005)

### DIFF
--- a/apps/web/src/components/layout/Navigation.test.tsx
+++ b/apps/web/src/components/layout/Navigation.test.tsx
@@ -278,4 +278,55 @@ describe('SidebarNavigation', () => {
     expect(moneyList?.hasAttribute('hidden')).toBe(true);
     expect(moneyToggle).toHaveAttribute('aria-expanded', 'false');
   });
+
+  it('can collapse a group that contains the currently active route (#2005)', () => {
+    // Regression: previously `expanded = userExpanded || containsActive`
+    // made the section permanently expanded as long as the active route was
+    // inside it. Users could click the chevron and watch nothing happen.
+    render(<SidebarNavigation {...defaultProps} activePath="/subscriptions" />);
+
+    const moneyToggle = screen.getByRole('button', { name: 'Money section' });
+    // Group opens on mount because it contains the active route.
+    expect(moneyToggle).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.click(moneyToggle);
+
+    expect(moneyToggle).toHaveAttribute('aria-expanded', 'false');
+    const moneyList = document.getElementById('sidebar-group-money');
+    expect(moneyList?.hasAttribute('hidden')).toBe(true);
+  });
+
+  it('auto-expands a group on cross-group navigation (#2005)', () => {
+    // After the user collapses Money on /dashboard, navigating into a Money
+    // route should re-open the group so the active item is visible.
+    const { rerender } = render(<SidebarNavigation {...defaultProps} activePath="/dashboard" />);
+
+    const moneyToggle = screen.getByRole('button', { name: 'Money section' });
+    // Default-expanded; collapse it.
+    fireEvent.click(moneyToggle);
+    expect(moneyToggle).toHaveAttribute('aria-expanded', 'false');
+
+    // Simulate cross-group navigation into /accounts.
+    rerender(<SidebarNavigation {...defaultProps} activePath="/accounts" />);
+
+    expect(moneyToggle).toHaveAttribute('aria-expanded', 'true');
+    const moneyList = document.getElementById('sidebar-group-money');
+    expect(moneyList?.hasAttribute('hidden')).toBe(false);
+  });
+
+  it('does not re-expand a group on same-group navigation after user collapsed it (#2005)', () => {
+    // If the user collapses Money while on /transactions and then navigates
+    // to /accounts (still in Money), the section should stay collapsed
+    // because containsActive did not flip from false to true.
+    const { rerender } = render(<SidebarNavigation {...defaultProps} activePath="/transactions" />);
+
+    const moneyToggle = screen.getByRole('button', { name: 'Money section' });
+    fireEvent.click(moneyToggle);
+    expect(moneyToggle).toHaveAttribute('aria-expanded', 'false');
+
+    rerender(<SidebarNavigation {...defaultProps} activePath="/accounts" />);
+
+    // Money still contains the active route; no rising edge → stays collapsed.
+    expect(moneyToggle).toHaveAttribute('aria-expanded', 'false');
+  });
 });

--- a/apps/web/src/components/layout/Navigation.tsx
+++ b/apps/web/src/components/layout/Navigation.tsx
@@ -15,7 +15,7 @@
  * two layouts can never drift.
  */
 
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useAuth } from '../../auth/auth-context';
 
@@ -166,11 +166,24 @@ const SidebarGroup: React.FC<SidebarGroupProps> = ({
   defaultExpanded,
 }) => {
   const containsActive = items.some((item) => isActive(activePath, item.href));
-  const [userExpanded, setUserExpanded] = useState(defaultExpanded);
-  // The section is always visible when one of its routes is active so the
-  // user can see where they are in the IA. Otherwise the user controls
-  // expand/collapse via the toggle.
-  const expanded = userExpanded || containsActive;
+  // Initialise from the static default, OR force-open if the active route is
+  // already inside this group at mount (so the user always lands on a visible
+  // active item even when the group would otherwise start collapsed, #2005).
+  const [userExpanded, setUserExpanded] = useState(defaultExpanded || containsActive);
+
+  // Auto-expand only on the *rising edge* of containsActive — i.e. when the
+  // user navigates INTO this group from another. This keeps the helpful
+  // "show me where I am" behaviour without sticking the section open and
+  // making the toggle non-functional (#2005).
+  const prevContainsActive = useRef(containsActive);
+  useEffect(() => {
+    if (containsActive && !prevContainsActive.current) {
+      setUserExpanded(true);
+    }
+    prevContainsActive.current = containsActive;
+  }, [containsActive]);
+
+  const expanded = userExpanded;
 
   const sectionId = `sidebar-group-${group}`;
   const headingId = `sidebar-group-${group}-heading`;

--- a/apps/web/src/styles/navigation-chrome.css
+++ b/apps/web/src/styles/navigation-chrome.css
@@ -102,6 +102,14 @@
   padding-bottom: var(--spacing-1);
 }
 
+/* Honour the `hidden` HTML attribute on collapsed group lists.
+ * Needed because `.sidebar-nav__list { display: flex }` in responsive.css is
+ * author-origin and otherwise overrides the browser's `[hidden]` UA default
+ * (#2005). */
+.sidebar-nav__list[hidden] {
+  display: none;
+}
+
 /* ── Enhanced active state for sidebar items ──────────────────────────── */
 
 .sidebar-nav__item {


### PR DESCRIPTION
Closes #2005.

## Symptom
Clicking a sidebar section header chevron (Money / Plan / Insights / Connect) didn't collapse the items underneath. Chevron flipped visually but children stayed rendered.

## Root causes (two compounding bugs)
1. **CSS override.** `.sidebar-nav__list { display: flex }` (responsive.css) is author-origin and beats the browser's UA default `[hidden] { display: none }`. So the `hidden` attribute set by `Navigation.tsx` was visually ignored.
2. **Logic lock.** `expanded = userExpanded || containsActive` forced the group containing the active route to stay open forever (e.g. Money locked open on /subscriptions).

## Fix
1. Added `.sidebar-nav__list[hidden] { display: none }` to navigation-chrome.css.
2. Replaced the OR with a `useRef`/`useEffect` that auto-expands only on the **rising edge** of containsActive — i.e. cross-group navigation. The user otherwise has full control. The active item's left-rail accent still indicates "where am I" without locking the section open.

## Tests
30 tests in `Navigation.test.tsx` pass, including 3 new regressions:
- collapsing a group that contains the active route works
- cross-group navigation auto-expands the destination group
- same-group navigation does not re-expand after manual collapse

Surfaced during alpha walkthrough re-verification (sub-issue of #1977's nav-shell fix).