### PR TITLE
fix(web): pin sidebar footer + suppress passkey UI in demo mode

### DIFF
--- a/apps/web/src/auth/auth-context.tsx
+++ b/apps/web/src/auth/auth-context.tsx
@@ -470,6 +470,19 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
 
   const loginWithPasskey = useCallback(async (email?: string): Promise<void> => {
     setError(null);
+
+    // Hard guard for demo mode (#2011). The initialisation `useEffect`
+    // returns early in demo mode and never calls `initWebAuthn()`, so a
+    // call into `authenticateWithPasskey` here would throw the cryptic
+    // developer-facing "WebAuthn not initialised. Call initWebAuthn()
+    // first." error. The UI is supposed to hide passkey controls in demo
+    // mode, but defence-in-depth in case some surface forgets.
+    if (demoModeActive) {
+      const message = 'Passkey sign-in is not available in demo mode.';
+      setError(message);
+      throw new Error(message);
+    }
+
     setIsLoading(true);
 
     try {
@@ -502,7 +515,7 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [demoModeActive]);
 
   const registerNewPasskey = useCallback(async (): Promise<void> => {
     setError(null);

--- a/apps/web/src/auth/auth-context.tsx
+++ b/apps/web/src/auth/auth-context.tsx
@@ -468,54 +468,57 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
     [config.loginEndpoint, demoModeActive],
   );
 
-  const loginWithPasskey = useCallback(async (email?: string): Promise<void> => {
-    setError(null);
+  const loginWithPasskey = useCallback(
+    async (email?: string): Promise<void> => {
+      setError(null);
 
-    // Hard guard for demo mode (#2011). The initialisation `useEffect`
-    // returns early in demo mode and never calls `initWebAuthn()`, so a
-    // call into `authenticateWithPasskey` here would throw the cryptic
-    // developer-facing "WebAuthn not initialised. Call initWebAuthn()
-    // first." error. The UI is supposed to hide passkey controls in demo
-    // mode, but defence-in-depth in case some surface forgets.
-    if (demoModeActive) {
-      const message = 'Passkey sign-in is not available in demo mode.';
-      setError(message);
-      throw new Error(message);
-    }
-
-    setIsLoading(true);
-
-    try {
-      const result = await authenticateWithPasskey(email);
-
-      // The verify step returns a full Supabase session (access_token,
-      // refresh_token, user). No separate session-minting call is needed —
-      // binding session issuance to the WebAuthn ceremony eliminates the
-      // CSRF risk of a detached session endpoint (#1310).
-      if (result.accessToken) {
-        setAccessToken(result.accessToken);
-        rememberUser({
-          id: result.userId,
-          email: result.email ?? email ?? '',
-          hasPasskey: true,
-        });
-        setIsOffline(false);
-        // A successful passkey sign-in reaffirms the user's preference
-        // (#1983). Idempotent — safe to call on every login.
-        setPreferredAuthMethod('passkey');
-      } else {
-        // Defensive fallback — should not occur with a correctly
-        // configured server, but avoids a blank screen if the server
-        // response shape changes.
-        throw new Error('Passkey verification succeeded but no session token was returned.');
+      // Hard guard for demo mode (#2011). The initialisation `useEffect`
+      // returns early in demo mode and never calls `initWebAuthn()`, so a
+      // call into `authenticateWithPasskey` here would throw the cryptic
+      // developer-facing "WebAuthn not initialised. Call initWebAuthn()
+      // first." error. The UI is supposed to hide passkey controls in demo
+      // mode, but defence-in-depth in case some surface forgets.
+      if (demoModeActive) {
+        const message = 'Passkey sign-in is not available in demo mode.';
+        setError(message);
+        throw new Error(message);
       }
-    } catch (err) {
-      setError(getPasskeyErrorMessage(err, 'authentication'));
-      throw err;
-    } finally {
-      setIsLoading(false);
-    }
-  }, [demoModeActive]);
+
+      setIsLoading(true);
+
+      try {
+        const result = await authenticateWithPasskey(email);
+
+        // The verify step returns a full Supabase session (access_token,
+        // refresh_token, user). No separate session-minting call is needed —
+        // binding session issuance to the WebAuthn ceremony eliminates the
+        // CSRF risk of a detached session endpoint (#1310).
+        if (result.accessToken) {
+          setAccessToken(result.accessToken);
+          rememberUser({
+            id: result.userId,
+            email: result.email ?? email ?? '',
+            hasPasskey: true,
+          });
+          setIsOffline(false);
+          // A successful passkey sign-in reaffirms the user's preference
+          // (#1983). Idempotent — safe to call on every login.
+          setPreferredAuthMethod('passkey');
+        } else {
+          // Defensive fallback — should not occur with a correctly
+          // configured server, but avoids a blank screen if the server
+          // response shape changes.
+          throw new Error('Passkey verification succeeded but no session token was returned.');
+        }
+      } catch (err) {
+        setError(getPasskeyErrorMessage(err, 'authentication'));
+        throw err;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [demoModeActive],
+  );
 
   const registerNewPasskey = useCallback(async (): Promise<void> => {
     setError(null);

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -240,7 +240,12 @@ export const LoginPage: React.FC = () => {
         )}
 
         {/* ── Passkey-first layout: biometric primary when preferred (#1983) ── */}
-        {passkeyPrimary && (
+        {/* Passkey UI is suppressed in demo mode (#2011) — the demo build
+            ships with a placeholder Supabase URL, so `initWebAuthn()` is
+            skipped in `auth-context.tsx`. Showing the button would call
+            into an uninitialised WebAuthn module and surface the cryptic
+            "WebAuthn not initialised" developer error to end users. */}
+        {passkeyPrimary && !isDemoMode && (
           <div className="auth-actions" style={{ marginBottom: 'var(--spacing-4)' }}>
             <button
               type="button"
@@ -371,8 +376,10 @@ export const LoginPage: React.FC = () => {
               )}
             </button>
 
-            {/* Show passkey as secondary when no passkey registered yet */}
-            {webAuthnSupported && !passkeyPrimary ? (
+            {/* Show passkey as secondary when no passkey registered yet
+                — but never in demo mode (#2011), where WebAuthn is not
+                initialised. */}
+            {webAuthnSupported && !passkeyPrimary && !isDemoMode ? (
               <>
                 <div className="auth-divider" aria-hidden="true">
                   <span className="auth-divider__text">or</span>

--- a/apps/web/src/pages/settings/SettingsSyncPage.tsx
+++ b/apps/web/src/pages/settings/SettingsSyncPage.tsx
@@ -146,14 +146,15 @@ export const SettingsSyncPage: React.FC = () => {
               <select
                 id="settings-preferred-auth-method"
                 className="settings-item__value"
-                value={preferredAuth ?? ''}
+                value={preferredAuth ?? 'password'}
                 onChange={handlePreferredAuthChange}
                 aria-describedby="settings-preferred-auth-method-help"
               >
-                <option value="" disabled>
-                  Not set
+                <option value="password">Password (default)</option>
+                <option value="passkey" disabled={!webAuthnSupported}>
+                  Passkey (biometrics)
+                  {!webAuthnSupported ? ' — not supported in this browser' : ''}
                 </option>
-                <option value="passkey">Passkey (biometrics)</option>
               </select>
               <p id="settings-preferred-auth-method-help" className="settings-item__help">
                 Controls which option is shown first on the sign-in page.

--- a/apps/web/src/styles/responsive.css
+++ b/apps/web/src/styles/responsive.css
@@ -767,10 +767,18 @@
     display: none;
   }
   .app-sidebar {
+    /*
+     * Pin the entire sidebar to the viewport (#2011). Using `height: 100dvh`
+     * (not `min-height`) constrains the flex column to exactly viewport
+     * height; the inner `.app-sidebar__nav` (flex: 1; overflow-y: auto)
+     * absorbs overflow, which keeps `.app-sidebar__footer` (Shortcuts /
+     * Settings / Sign Out) visible at the bottom of the screen at all
+     * times instead of scrolling off below the page fold.
+     */
     display: flex;
     flex-direction: column;
     width: var(--layout-sidebar-width);
-    min-height: 100dvh;
+    height: 100dvh;
     position: sticky;
     top: 0;
     background: var(--navigation-background);


### PR DESCRIPTION
Cluster of small fixes from alpha walkthrough re-verification of #1983 (passkey + sign-out).

## Changes

### 1. Sidebar footer pinned to viewport
The Shortcuts / Settings / Sign Out footer scrolled off-screen on tall pages. Desktop `.app-sidebar` (responsive.css) used `min-height: 100dvh` + `position: sticky`, so the sidebar grew with its content and the footer flowed below the fold. Switched to `height: 100dvh` so the sidebar is exactly viewport-tall; the already-scrollable inner `.app-sidebar__nav` absorbs overflow.

### 2. Passkey UI suppressed in demo mode
Alpha currently ships with the placeholder Supabase URL (see #2011), so `isDemoMode` is true and `initWebAuthn()` is never called. Clicking "Sign in with passkey" surfaced the cryptic "WebAuthn not initialised. Call initWebAuthn() first." developer error to end users. Three layers of defence:

- `LoginPage`: hide both passkey buttons (primary biometric CTA and secondary "Sign in with passkey") when `isDemoMode`.
- `auth-context.loginWithPasskey`: throw a friendly "Passkey sign-in is not available in demo mode." early.

(This is cosmetic for the demo-mode case; once #2011 is fixed and the real Supabase URL is shipped, `isDemoMode` flips to false and the existing UI returns.)

### 3. Preferred sign-in method dropdown gains a real "Password" option
Settings → Sync → "Preferred sign-in method" used to show `[Not set, Passkey (biometrics)]`, which looked like the dropdown was broken. `'password'` is already a valid `PreferredAuthMethod` value, so add it explicitly. Defaults to "Password (default)" when no preference is stored. Disables the passkey option (with explanatory suffix) when `webAuthnSupported` is false.

## Closes
- (UX fix for) #2011 (placeholder Supabase URL is the root cause; this PR makes the symptom less hostile)

## Test plan
- `npx vitest run src/auth/auth-context.test.tsx src/pages/LoginPage.test.tsx` → 18 tests pass
- `npx tsc --noEmit` → clean

## Verification on live alpha (after merge + redeploy)
1. Open https://finance.jrmoulckers.com in a narrow + tall viewport. Sidebar footer (Shortcuts / Settings / Sign Out) stays pinned to the bottom of the screen regardless of scroll position.
2. Log out, return to `/login`. No "Sign in with passkey" button visible (because alpha is in demo mode per #2011).
3. Settings → Sync → "Preferred sign-in method" shows `[Password (default), Passkey (biometrics)]` instead of `[Not set, Passkey]` (note: section is currently hidden under demo mode; verify after #2011 lands).
