### PR TITLE
fix(web): replace NetWorth milestone emoji literals with AppIcon (#2008)

### DIFF
--- a/apps/web/src/components/icons/AppIcon.tsx
+++ b/apps/web/src/components/icons/AppIcon.tsx
@@ -13,6 +13,8 @@ export type IconName =
   | 'car'
   | 'chart-bar'
   | 'check'
+  | 'check-circle'
+  | 'circle'
   | 'clipboard'
   | 'cloud'
   | 'database'
@@ -90,6 +92,8 @@ const paths: Record<IconName, string[]> = {
   ],
   'chart-bar': ['M4 19V9', 'M12 19V5', 'M20 19v-7', 'M3 21h18'],
   check: ['m5 12 4 4L19 6'],
+  'check-circle': ['M9 12l2 2 4-4', 'M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z'],
+  circle: ['M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z'],
   clipboard: ['M9 4h6l1 2h3v16H5V6h3l1-2Z', 'M9 10h6', 'M9 14h6'],
   cloud: ['M17.5 19H7a5 5 0 1 1 1.5-9.8A6 6 0 0 1 20 12a3.5 3.5 0 0 1-2.5 7Z'],
   database: [

--- a/apps/web/src/pages/NetWorthPage.tsx
+++ b/apps/web/src/pages/NetWorthPage.tsx
@@ -15,6 +15,7 @@
 
 import React from 'react';
 import { CurrencyDisplay, EmptyState, ErrorBanner, LoadingSpinner } from '../components/common';
+import { AppIcon } from '../components/icons';
 import { useNetWorth } from '../hooks/useNetWorth';
 import type { AssetClassBreakdown, NetWorthMilestone } from '../lib/analytics/net-worth';
 import { CHART_COLORS } from '../components/charts/chart-palette';
@@ -78,7 +79,7 @@ const MilestoneList: React.FC<MilestoneListProps> = ({ milestones }) => (
         aria-label={`${ms.label}: ${ms.reached ? 'reached' : 'not yet reached'}`}
       >
         <span className="analytics-milestone__icon" aria-hidden="true">
-          {ms.reached ? '✅' : '⬜'}
+          <AppIcon name={ms.reached ? 'check-circle' : 'circle'} />
         </span>
         <span className="analytics-milestone__label">{ms.label}</span>
       </div>


### PR DESCRIPTION
Closes #2008

## Summary
- Replace NetWorth milestone emoji literals with AppIcon SVGs.
- Add check-circle and circle icon names for reached and pending milestone states.

## Validation
- npx tsc --noEmit
- npx vitest run src/pages/NetWorthPage.test.tsx