### PR TITLE
fix(web): standardize Planning page text inputs (#2007)

### DIFF
--- a/apps/web/src/pages/PlanningPage.tsx
+++ b/apps/web/src/pages/PlanningPage.tsx
@@ -381,6 +381,7 @@ const ScenariosPanel: React.FC = () => {
     <div>
       <div className="planning-actions">
         <input
+          className="form-input"
           type="text"
           value={newName}
           onChange={(e) => setNewName(e.target.value)}


### PR DESCRIPTION
## Summary
- Added the standard `form-input` class to the Planning page new scenario text input.
- Audited Planning page inputs; the range slider and sweep-rule checkbox already use component-specific classes.

## Validation
- `npx tsc --noEmit`
- `npx vitest run src/pages/PlanningPage.test.tsx`

Closes #2007
