### PR TITLE
fix(web): chunky chevrons + DangerZone component (#2010 items 1,2)

### DIFF
--- a/apps/web/src/components/icons/AppIcon.tsx
+++ b/apps/web/src/components/icons/AppIcon.tsx
@@ -14,6 +14,7 @@ export type IconName =
   | 'chart-bar'
   | 'check'
   | 'check-circle'
+  | 'chevron-right'
   | 'circle'
   | 'clipboard'
   | 'cloud'
@@ -93,6 +94,7 @@ const paths: Record<IconName, string[]> = {
   'chart-bar': ['M4 19V9', 'M12 19V5', 'M20 19v-7', 'M3 21h18'],
   check: ['m5 12 4 4L19 6'],
   'check-circle': ['M9 12l2 2 4-4', 'M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z'],
+  'chevron-right': ['m9 18 6-6-6-6'],
   circle: ['M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z'],
   clipboard: ['M9 4h6l1 2h3v16H5V6h3l1-2Z', 'M9 10h6', 'M9 14h6'],
   cloud: ['M17.5 19H7a5 5 0 1 1 1.5-9.8A6 6 0 0 1 20 12a3.5 3.5 0 0 1-2.5 7Z'],

--- a/apps/web/src/components/settings/DangerZone.tsx
+++ b/apps/web/src/components/settings/DangerZone.tsx
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { useId, type ReactNode } from 'react';
+
+export interface DangerZoneProps {
+  title?: ReactNode;
+  description: ReactNode;
+  children: ReactNode;
+  className?: string;
+}
+
+export function DangerZone({ title = 'Danger Zone', description, children, className }: DangerZoneProps) {
+  const headingId = useId();
+  const sectionClassName = ['page-section', 'danger-zone-section', className]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <section aria-labelledby={headingId} className={sectionClassName}>
+      <div className="danger-zone">
+        <div className="danger-zone__header">
+          <h3 id={headingId} className="danger-zone__title">
+            {title}
+          </h3>
+          <p className="danger-zone__description">{description}</p>
+        </div>
+        <div className="danger-zone__content">{children}</div>
+      </div>
+    </section>
+  );
+}
+
+export default DangerZone;

--- a/apps/web/src/components/settings/DangerZone.tsx
+++ b/apps/web/src/components/settings/DangerZone.tsx
@@ -9,7 +9,12 @@ export interface DangerZoneProps {
   className?: string;
 }
 
-export function DangerZone({ title = 'Danger Zone', description, children, className }: DangerZoneProps) {
+export function DangerZone({
+  title = 'Danger Zone',
+  description,
+  children,
+  className,
+}: DangerZoneProps) {
   const headingId = useId();
   const sectionClassName = ['page-section', 'danger-zone-section', className]
     .filter(Boolean)

--- a/apps/web/src/components/settings/index.ts
+++ b/apps/web/src/components/settings/index.ts
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
+export { DangerZone } from './DangerZone';
+export type { DangerZoneProps } from './DangerZone';
 export { SettingInfoWidget } from './SettingInfoWidget';
 export type { SettingInfoWidgetProps } from './SettingInfoWidget';
 export { SETTING_DESCRIPTIONS } from './setting-descriptions';

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -16,6 +16,7 @@ import './theme/tokens.css';
 import './styles/responsive.css';
 import './styles/responsive-layout.css';
 import './styles/navigation-chrome.css';
+import './styles/danger-zone.css';
 import './styles/accessibility.css';
 import './styles/reduced-motion.css';
 import './styles/font-scaling.css';

--- a/apps/web/src/pages/settings/SettingsAccountPage.tsx
+++ b/apps/web/src/pages/settings/SettingsAccountPage.tsx
@@ -3,7 +3,8 @@
 import React, { useCallback, useState } from 'react';
 
 import { useAuth } from '../../auth/auth-context';
-import { SettingInfoWidget } from '../../components/settings';
+import { AppIcon } from '../../components/icons';
+import { DangerZone, SettingInfoWidget } from '../../components/settings';
 import { useAccountDeletion } from '../../components/settings/AccountDeletionModal';
 
 /**
@@ -55,7 +56,9 @@ export const SettingsAccountPage: React.FC = () => {
             aria-label="Sign out"
           >
             <span className="settings-item__label">Sign Out</span>
-            <span className="settings-item__value">&rarr;</span>
+            <span className="settings-item__value settings-item__chevron">
+              <AppIcon name="chevron-right" size={20} strokeWidth={2.75} />
+            </span>
           </button>
           {signOutError && (
             <div className="settings-item settings-item--static" role="alert">
@@ -65,23 +68,25 @@ export const SettingsAccountPage: React.FC = () => {
         </div>
       </section>
 
-      <section aria-label="Danger Zone" className="page-section">
-        <div className="settings-group">
-          <h3 className="settings-group__title">Danger Zone</h3>
-          <SettingInfoWidget settingKey="accountDeletion">
-            <button
-              type="button"
-              className="settings-item settings-item--button settings-item--destructive"
-              onClick={openDeleteModal}
-              disabled={!isAuthenticated}
-              aria-label="Delete account"
-            >
-              <span className="settings-item__label">Delete account</span>
-              <span className="settings-item__value">&rarr;</span>
-            </button>
-          </SettingInfoWidget>
-        </div>
-      </section>
+      <DangerZone description="Permanently delete your account, synced data, and household access. This action cannot be undone.">
+        <SettingInfoWidget settingKey="accountDeletion">
+          <button
+            type="button"
+            className="danger-zone__action"
+            onClick={openDeleteModal}
+            disabled={!isAuthenticated}
+            aria-label="Delete account"
+          >
+            <span className="danger-zone__action-label">Delete account</span>
+            <AppIcon
+              name="chevron-right"
+              size={20}
+              strokeWidth={2.75}
+              className="danger-zone__action-icon"
+            />
+          </button>
+        </SettingInfoWidget>
+      </DangerZone>
 
       {deleteModal}
     </>

--- a/apps/web/src/styles/danger-zone.css
+++ b/apps/web/src/styles/danger-zone.css
@@ -1,0 +1,98 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+.danger-zone {
+  --danger-border: var(--semantic-border-error, var(--semantic-status-negative));
+  --danger-fg: var(--semantic-status-negative);
+
+  overflow: hidden;
+  border: 1px solid var(--danger-border);
+  border-radius: var(--card-border-radius);
+  background: rgba(239, 68, 68, 0.06);
+}
+
+.danger-zone__header {
+  padding: var(--spacing-4) var(--card-padding);
+  border-bottom: 1px solid var(--danger-border);
+}
+
+.danger-zone__title {
+  margin: 0 0 var(--spacing-2);
+  color: var(--danger-fg);
+  font-size: var(--type-scale-label-font-size);
+  font-weight: var(--font-weight-bold, 700);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.danger-zone__description {
+  margin: 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+  line-height: 1.5;
+}
+
+.danger-zone__content {
+  padding: var(--spacing-4) var(--card-padding);
+}
+
+.danger-zone .setting-info-widget__row {
+  align-items: stretch;
+}
+
+.danger-zone__action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+  width: 100%;
+  min-height: 44px;
+  padding: var(--spacing-3) var(--spacing-4);
+  border: 1px solid var(--danger-border);
+  border-radius: var(--border-radius-md, 0.5rem);
+  background: var(--danger-fg);
+  color: var(--semantic-text-inverse, #fff);
+  font: inherit;
+  font-weight: var(--font-weight-bold, 700);
+  text-align: left;
+  cursor: pointer;
+}
+
+.danger-zone__action:hover:not(:disabled) {
+  filter: brightness(0.95);
+}
+
+.danger-zone__action:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+.danger-zone__action:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+}
+
+.danger-zone__action-icon,
+.settings-item__chevron {
+  flex-shrink: 0;
+}
+
+.settings-item__chevron {
+  display: inline-flex;
+  align-items: center;
+  color: var(--semantic-text-secondary);
+}
+
+.settings-item--button:hover:not(:disabled) .settings-item__chevron {
+  color: var(--semantic-text-primary);
+}
+
+@media (prefers-contrast: more) {
+  .danger-zone {
+    background: var(--semantic-background-primary);
+    border-width: 2px;
+  }
+
+  .danger-zone__action {
+    border-width: 2px;
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes #2010 tracker items 1 and 2.
- [x] Item 1: Settings Account Sign Out/Delete account rows now use AppIcon chevron-right instead of skinny text arrows.
- [x] Item 2: Account Danger Zone now uses a bordered red card, explanatory subtext, and a stronger danger action button.

## Notes
- Exports a reusable `<DangerZone>` component from `apps/web/src/components/settings/DangerZone.tsx` for the Advanced section's item 12 treatment (`Erase all mood data`).

## Validation
- `npx tsc --noEmit`
- `npx vitest run src/pages/settings/ src/components/settings/`