### PR TITLE
fix(web): inputs + card alignment + swatches + sync copy + About + Advanced polish (#2010)

### DIFF
--- a/apps/web/src/components/settings/AccountDeletionModal.tsx
+++ b/apps/web/src/components/settings/AccountDeletionModal.tsx
@@ -190,7 +190,7 @@ export function useAccountDeletion(): {
         </label>
         <input
           id="delete-account-confirmation"
-          className="settings-item__input"
+          className="form-input settings-item__input"
           value={confirmationText}
           onChange={(event) => setConfirmationText(event.target.value)}
           disabled={isDeleting}

--- a/apps/web/src/components/settings/setting-descriptions.ts
+++ b/apps/web/src/components/settings/setting-descriptions.ts
@@ -41,7 +41,8 @@ export const SETTING_DESCRIPTIONS: Record<string, SettingDescription> = {
     summary: 'Sets the unpaid BNPL installment total that triggers a stacking alert.',
     impact:
       'The threshold is stored locally and only changes when the app warns about overlapping installment obligations.',
-    recommendation: 'Use a number that reflects the point where multiple BNPL payments become risky.',
+    recommendation:
+      'Use a number that reflects the point where multiple BNPL payments become risky.',
   },
   monitoring: {
     summary: 'Sends anonymous error reports to help improve app stability.',

--- a/apps/web/src/components/settings/setting-descriptions.ts
+++ b/apps/web/src/components/settings/setting-descriptions.ts
@@ -37,6 +37,12 @@ export const SETTING_DESCRIPTIONS: Record<string, SettingDescription> = {
       'When enabled, the app may request notification permission from your browser. No data is sent to external servers.',
     recommendation: 'Enable for timely bill reminders and budget warnings.',
   },
+  'bnpl-stacking-threshold': {
+    summary: 'Sets the unpaid BNPL installment total that triggers a stacking alert.',
+    impact:
+      'The threshold is stored locally and only changes when the app warns about overlapping installment obligations.',
+    recommendation: 'Use a number that reflects the point where multiple BNPL payments become risky.',
+  },
   monitoring: {
     summary: 'Sends anonymous error reports to help improve app stability.',
     impact:
@@ -66,5 +72,25 @@ export const SETTING_DESCRIPTIONS: Record<string, SettingDescription> = {
     impact:
       'Exported files contain all your transactions, accounts, and budgets. Store exports securely.',
     recommendation: 'Export periodically as a backup, especially before major changes.',
+  },
+  accountDeletion: {
+    summary: 'Permanently deletes your account, synced data, and household access.',
+    impact: 'This is irreversible after confirmation and also unlinks your sign-in identity.',
+    recommendation: 'Export your data before deleting your account.',
+  },
+  moodTags: {
+    summary: 'Allows optional mood tags to be attached to transactions.',
+    impact: 'When disabled, mood tag controls are hidden and mood tag sync is turned off.',
+    recommendation: 'Enable only if you want to track emotional context alongside spending.',
+  },
+  moodTagsSync: {
+    summary: 'Syncs transaction mood tags across your signed-in devices.',
+    impact: 'Mood tag metadata follows the same sync path as other transaction data.',
+    recommendation: 'Keep disabled if you only want mood tags on this device.',
+  },
+  eraseMoodData: {
+    summary: 'Removes all saved mood tags and disables mood-tag preferences.',
+    impact: 'This destructive action cannot restore erased mood tags later.',
+    recommendation: 'Use only when you are sure you no longer need mood history.',
   },
 };

--- a/apps/web/src/pages/SettingsPage.test.tsx
+++ b/apps/web/src/pages/SettingsPage.test.tsx
@@ -442,7 +442,7 @@ describe('SettingsPage', () => {
     it('shows online sync status and passkey registration state', () => {
       renderSettingsAt('/settings/sync');
 
-      expect(screen.getByText('Online — synced')).toBeInTheDocument();
+      expect(screen.getByText('All synced')).toBeInTheDocument();
       expect(screen.getByText('✓ Registered')).toBeInTheDocument();
     });
 

--- a/apps/web/src/pages/SettingsPage.test.tsx
+++ b/apps/web/src/pages/SettingsPage.test.tsx
@@ -156,6 +156,7 @@ vi.mock('../components/settings/CurrencyRatesSettings', () => ({
 
 import { SettingsPage } from './SettingsPage';
 import { SettingsAccountPage } from './settings/SettingsAccountPage';
+import { SettingsAboutPage } from './settings/SettingsAboutPage';
 import { SettingsAdvancedPage } from './settings/SettingsAdvancedPage';
 import { SettingsPreferencesPage } from './settings/SettingsPreferencesPage';
 import { SettingsPrivacyPage } from './settings/SettingsPrivacyPage';
@@ -176,6 +177,7 @@ function renderSettingsAt(path: string) {
           <Route path="privacy" element={<SettingsPrivacyPage />} />
           <Route path="sync" element={<SettingsSyncPage />} />
           <Route path="advanced" element={<SettingsAdvancedPage />} />
+          <Route path="about" element={<SettingsAboutPage />} />
         </Route>
       </Routes>
     </MemoryRouter>,
@@ -227,7 +229,7 @@ describe('SettingsPage', () => {
       const nav = screen.getByRole('navigation', { name: /settings sections/i });
       expect(nav).toBeInTheDocument();
       // Each section is a real <a> link inside <nav> for keyboard nav.
-      ['Account', 'Preferences', 'Privacy & Data', 'Sync & Devices', 'Advanced'].forEach(
+      ['Account', 'Preferences', 'Privacy & Data', 'Sync & Devices', 'Advanced', 'About'].forEach(
         (label) => {
           expect(nav.querySelector(`a[href$='${label.toLowerCase().split(' ')[0]}']`)).toBeTruthy();
         },
@@ -469,13 +471,28 @@ describe('SettingsPage', () => {
   });
 
   describe('Advanced sub-page', () => {
-    it('renders the version and experimental mood-tags controls', () => {
+    it('renders experimental mood-tags controls', () => {
       renderSettingsAt('/settings/advanced');
 
-      expect(screen.getByText('0.1.0')).toBeInTheDocument();
       expect(
         screen.getByRole('checkbox', { name: 'Allow mood tags on transactions' }),
       ).toBeInTheDocument();
+      expect(screen.queryByRole('heading', { name: 'About' })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('About sub-page', () => {
+    it('renders app metadata, license, and credits', () => {
+      renderSettingsAt('/settings/about');
+
+      expect(screen.getByRole('heading', { name: 'About', level: 2 })).toBeInTheDocument();
+      expect(screen.getByText('0.1.0')).toBeInTheDocument();
+      expect(screen.getByText('Not available in this build')).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: /open business source license/i })).toHaveAttribute(
+        'href',
+        'https://github.com/jrmoulckers/finance/blob/main/LICENSE',
+      );
+      expect(screen.getByText(/Built with React, Vite, TypeScript/i)).toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/pages/SettingsPage.test.tsx
+++ b/apps/web/src/pages/SettingsPage.test.tsx
@@ -482,10 +482,14 @@ describe('SettingsPage', () => {
         screen.getByRole('checkbox', { name: 'Sync mood tags across my devices' }),
       ).toBeInTheDocument();
       expect(
-        screen.getByRole('button', { name: /more info about moodTags setting/i }),
+        screen.getByRole('button', {
+          name: /allows optional mood tags to be attached to transactions/i,
+        }),
       ).toBeInTheDocument();
       expect(
-        screen.getByRole('button', { name: /more info about moodTagsSync setting/i }),
+        screen.getByRole('button', {
+          name: /syncs transaction mood tags across your signed-in devices/i,
+        }),
       ).toBeInTheDocument();
       expect(screen.queryByRole('heading', { name: 'About' })).not.toBeInTheDocument();
     });
@@ -499,7 +503,9 @@ describe('SettingsPage', () => {
         'danger-zone-card__action',
       );
       expect(
-        screen.getByRole('button', { name: /more info about eraseMoodData setting/i }),
+        screen.getByRole('button', {
+          name: /removes all saved mood tags and disables mood-tag preferences/i,
+        }),
       ).toBeInTheDocument();
     });
   });

--- a/apps/web/src/pages/SettingsPage.test.tsx
+++ b/apps/web/src/pages/SettingsPage.test.tsx
@@ -481,7 +481,9 @@ describe('SettingsPage', () => {
       expect(
         screen.getByRole('checkbox', { name: 'Sync mood tags across my devices' }),
       ).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: /more info about moodTags setting/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /more info about moodTags setting/i }),
+      ).toBeInTheDocument();
       expect(
         screen.getByRole('button', { name: /more info about moodTagsSync setting/i }),
       ).toBeInTheDocument();

--- a/apps/web/src/pages/SettingsPage.test.tsx
+++ b/apps/web/src/pages/SettingsPage.test.tsx
@@ -471,13 +471,34 @@ describe('SettingsPage', () => {
   });
 
   describe('Advanced sub-page', () => {
-    it('renders experimental mood-tags controls', () => {
+    it('renders experimental mood-tags controls with info buttons', () => {
+      localStorage.setItem('experimental.moodTags.enabled', 'true');
       renderSettingsAt('/settings/advanced');
 
       expect(
         screen.getByRole('checkbox', { name: 'Allow mood tags on transactions' }),
       ).toBeInTheDocument();
+      expect(
+        screen.getByRole('checkbox', { name: 'Sync mood tags across my devices' }),
+      ).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /more info about moodTags setting/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /more info about moodTagsSync setting/i }),
+      ).toBeInTheDocument();
       expect(screen.queryByRole('heading', { name: 'About' })).not.toBeInTheDocument();
+    });
+
+    it('treats erase mood data as a danger-zone action with info', () => {
+      renderSettingsAt('/settings/advanced');
+
+      expect(screen.getByRole('region', { name: /danger zone/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: 'Danger Zone' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /^erase all mood data$/i })).toHaveClass(
+        'danger-zone-card__action',
+      );
+      expect(
+        screen.getByRole('button', { name: /more info about eraseMoodData setting/i }),
+      ).toBeInTheDocument();
     });
   });
 

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -24,7 +24,8 @@ const SETTINGS_SECTIONS: ReadonlyArray<{ to: string; label: string; description:
     description: 'Privacy mode, consent, export, deletion',
   },
   { to: 'sync', label: 'Sync & Devices', description: 'Sync status, passkeys, biometric lock' },
-  { to: 'advanced', label: 'Advanced', description: 'Experimental features, about' },
+  { to: 'advanced', label: 'Advanced', description: 'Experimental features' },
+  { to: 'about', label: 'About', description: 'Version, build, license, credits' },
 ];
 
 /**

--- a/apps/web/src/pages/settings/SettingsAboutPage.tsx
+++ b/apps/web/src/pages/settings/SettingsAboutPage.tsx
@@ -55,8 +55,7 @@ export const SettingsAboutPage: React.FC = () => (
         <div className="settings-item settings-item--static">
           <span className="settings-item__label">Acknowledgements</span>
           <span className="settings-item__value">
-            Built with React, Vite, TypeScript, sql.js, wa-sqlite, Recharts, D3, and
-            Tesseract.js.
+            Built with React, Vite, TypeScript, sql.js, wa-sqlite, Recharts, D3, and Tesseract.js.
           </span>
         </div>
       </div>

--- a/apps/web/src/pages/settings/SettingsAboutPage.tsx
+++ b/apps/web/src/pages/settings/SettingsAboutPage.tsx
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import React from 'react';
+
+import packageJson from '../../../package.json';
+
+const BUILD_SHA =
+  import.meta.env.VITE_BUILD_SHA ??
+  import.meta.env.VITE_GIT_SHA ??
+  import.meta.env.VITE_COMMIT_SHA ??
+  '';
+
+const SHORT_BUILD_SHA = BUILD_SHA ? BUILD_SHA.slice(0, 12) : 'Not available in this build';
+
+/**
+ * About sub-page — app metadata, license, and acknowledgements.
+ */
+export const SettingsAboutPage: React.FC = () => (
+  <>
+    <h2 className="settings-subpage__title">About</h2>
+
+    <section aria-label="About" className="page-section">
+      <div className="settings-group">
+        <h3 className="settings-group__title">App</h3>
+        <div className="settings-item settings-item--static">
+          <span className="settings-item__label">Version</span>
+          <span className="settings-item__value">{packageJson.version}</span>
+        </div>
+        <div className="settings-item settings-item--static">
+          <span className="settings-item__label">Build SHA</span>
+          <span className="settings-item__value">{SHORT_BUILD_SHA}</span>
+        </div>
+      </div>
+    </section>
+
+    <section aria-label="Legal" className="page-section">
+      <div className="settings-group">
+        <h3 className="settings-group__title">Legal</h3>
+        <a
+          className="settings-item settings-item--button"
+          href="https://github.com/jrmoulckers/finance/blob/main/LICENSE"
+          target="_blank"
+          rel="noreferrer"
+          aria-label="Open Business Source License"
+        >
+          <span className="settings-item__label">License</span>
+          <span className="settings-item__value">BUSL-1.1</span>
+        </a>
+      </div>
+    </section>
+
+    <section aria-label="Credits and acknowledgements" className="page-section">
+      <div className="settings-group">
+        <h3 className="settings-group__title">Credits</h3>
+        <div className="settings-item settings-item--static">
+          <span className="settings-item__label">Acknowledgements</span>
+          <span className="settings-item__value">
+            Built with React, Vite, TypeScript, sql.js, wa-sqlite, Recharts, D3, and
+            Tesseract.js.
+          </span>
+        </div>
+      </div>
+    </section>
+  </>
+);
+
+export default SettingsAboutPage;

--- a/apps/web/src/pages/settings/SettingsAdvancedPage.tsx
+++ b/apps/web/src/pages/settings/SettingsAdvancedPage.tsx
@@ -2,6 +2,7 @@
 
 import React, { useCallback, useState } from 'react';
 
+import { SettingInfoWidget } from '../../components/settings';
 import { useDatabase } from '../../db/DatabaseProvider';
 import { eraseAllMoodTags } from '../../db/repositories/transactions';
 import {
@@ -64,43 +65,64 @@ export const SettingsAdvancedPage: React.FC = () => {
       <section aria-label="Experimental" className="page-section">
         <div className="settings-group">
           <h3 className="settings-group__title">Experimental</h3>
-          <div className="settings-item settings-item--static">
-            <label className="settings-item__label" htmlFor="settings-mood-tags">
-              Allow mood tags on transactions
-            </label>
-            <input
-              type="checkbox"
-              id="settings-mood-tags"
-              checked={moodTagsEnabled}
-              onChange={handleMoodTagsEnabledChange}
-              aria-label="Allow mood tags on transactions"
-              className="settings-item__checkbox"
-            />
-          </div>
-          {moodTagsEnabled && (
+          <SettingInfoWidget settingKey="moodTags">
             <div className="settings-item settings-item--static">
-              <label className="settings-item__label" htmlFor="settings-mood-tags-sync">
-                Sync mood tags across my devices
+              <label className="settings-item__label" htmlFor="settings-mood-tags">
+                Allow mood tags on transactions
               </label>
               <input
                 type="checkbox"
-                id="settings-mood-tags-sync"
-                checked={moodTagsSyncEnabled}
-                onChange={handleMoodTagsSyncChange}
-                aria-label="Sync mood tags across my devices"
+                id="settings-mood-tags"
+                checked={moodTagsEnabled}
+                onChange={handleMoodTagsEnabledChange}
+                aria-label="Allow mood tags on transactions"
                 className="settings-item__checkbox"
               />
             </div>
+          </SettingInfoWidget>
+          {moodTagsEnabled && (
+            <SettingInfoWidget settingKey="moodTagsSync">
+              <div className="settings-item settings-item--static">
+                <label className="settings-item__label" htmlFor="settings-mood-tags-sync">
+                  Sync mood tags across my devices
+                </label>
+                <input
+                  type="checkbox"
+                  id="settings-mood-tags-sync"
+                  checked={moodTagsSyncEnabled}
+                  onChange={handleMoodTagsSyncChange}
+                  aria-label="Sync mood tags across my devices"
+                  className="settings-item__checkbox"
+                />
+              </div>
+            </SettingInfoWidget>
           )}
-          <button
-            type="button"
-            className="settings-item settings-item--button"
-            onClick={handleEraseMoodData}
-            aria-label="Erase all mood data"
-          >
-            <span className="settings-item__label">Erase all mood data</span>
-            <span className="settings-item__value">⌫</span>
-          </button>
+        </div>
+      </section>
+
+      <section aria-label="Danger Zone" className="page-section">
+        {/* TODO(#2010): Replace this inline card with the shared <DangerZone> once fix/settings-arrows-danger-zone-2010 is merged. */}
+        <div className="danger-zone-card">
+          <div className="danger-zone-card__header">
+            <h3 className="danger-zone-card__title">Danger Zone</h3>
+            <p className="danger-zone-card__description">
+              Destructive Advanced actions live here so they are visually separated from safe
+              preferences.
+            </p>
+          </div>
+          <div className="danger-zone-card__content">
+            <SettingInfoWidget settingKey="eraseMoodData">
+              <button
+                type="button"
+                className="danger-zone-card__action"
+                onClick={handleEraseMoodData}
+                aria-label="Erase all mood data"
+              >
+                <span>Erase all mood data</span>
+                <span aria-hidden="true">⌫</span>
+              </button>
+            </SettingInfoWidget>
+          </div>
         </div>
       </section>
     </>

--- a/apps/web/src/pages/settings/SettingsAdvancedPage.tsx
+++ b/apps/web/src/pages/settings/SettingsAdvancedPage.tsx
@@ -11,8 +11,6 @@ import {
   setMoodTagPreference,
 } from '../../lib/mood-tags';
 
-const APP_VERSION = '0.1.0';
-
 function useOptionalDatabase() {
   try {
     return useDatabase();
@@ -22,8 +20,7 @@ function useOptionalDatabase() {
 }
 
 /**
- * Advanced sub-page — experimental feature flags, developer-leaning
- * preferences, and metadata such as the app version.
+ * Advanced sub-page — experimental feature flags and developer-leaning preferences.
  */
 export const SettingsAdvancedPage: React.FC = () => {
   const db = useOptionalDatabase();
@@ -104,16 +101,6 @@ export const SettingsAdvancedPage: React.FC = () => {
             <span className="settings-item__label">Erase all mood data</span>
             <span className="settings-item__value">⌫</span>
           </button>
-        </div>
-      </section>
-
-      <section aria-label="About" className="page-section">
-        <div className="settings-group">
-          <h3 className="settings-group__title">About</h3>
-          <div className="settings-item settings-item--static">
-            <span className="settings-item__label">Version</span>
-            <span className="settings-item__value">{APP_VERSION}</span>
-          </div>
         </div>
       </section>
     </>

--- a/apps/web/src/pages/settings/SettingsPreferencesPage.tsx
+++ b/apps/web/src/pages/settings/SettingsPreferencesPage.tsx
@@ -145,7 +145,7 @@ export const SettingsPreferencesPage: React.FC = () => {
               <div className="settings-item__control">
                 <input
                   id="settings-bnpl-threshold"
-                  className="settings-item__input"
+                  className="form-input settings-item__input"
                   type="number"
                   min="1"
                   step="1"

--- a/apps/web/src/pages/settings/SettingsPreferencesPage.tsx
+++ b/apps/web/src/pages/settings/SettingsPreferencesPage.tsx
@@ -202,14 +202,7 @@ export const SettingsPreferencesPage: React.FC = () => {
       <section aria-label="Display" className="page-section">
         <div className="settings-group">
           <h3 className="settings-group__title">Display</h3>
-          <p
-            className="settings-group__description"
-            style={{
-              fontSize: 'var(--font-size-sm, 0.875rem)',
-              color: 'var(--semantic-text-secondary)',
-              marginBottom: 'var(--spacing-4, 1rem)',
-            }}
-          >
+          <p className="settings-group__description">
             Customize how monetary amounts appear throughout the app.
           </p>
 

--- a/apps/web/src/pages/settings/SettingsSyncPage.tsx
+++ b/apps/web/src/pages/settings/SettingsSyncPage.tsx
@@ -90,7 +90,7 @@ export const SettingsSyncPage: React.FC = () => {
                   className={`settings-item__status-dot ${isOffline ? 'settings-item__status-dot--offline' : 'settings-item__status-dot--online'}`}
                 />
                 <span className="settings-item__value">
-                  {isOffline ? 'Offline — changes saved locally' : 'Online — synced'}
+                  {isOffline ? 'Offline — changes saved locally' : 'All synced'}
                 </span>
               </span>
             </div>

--- a/apps/web/src/pages/settings/SettingsSyncPage.tsx
+++ b/apps/web/src/pages/settings/SettingsSyncPage.tsx
@@ -145,7 +145,7 @@ export const SettingsSyncPage: React.FC = () => {
               </label>
               <select
                 id="settings-preferred-auth-method"
-                className="settings-item__value"
+                className="settings-item__select"
                 value={preferredAuth ?? 'password'}
                 onChange={handlePreferredAuthChange}
                 aria-describedby="settings-preferred-auth-method-help"

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -31,6 +31,7 @@ const SettingsPreferences = lazy(() => import('./pages/settings/SettingsPreferen
 const SettingsPrivacy = lazy(() => import('./pages/settings/SettingsPrivacyPage'));
 const SettingsSync = lazy(() => import('./pages/settings/SettingsSyncPage'));
 const SettingsAdvanced = lazy(() => import('./pages/settings/SettingsAdvancedPage'));
+const SettingsAbout = lazy(() => import('./pages/settings/SettingsAboutPage'));
 const DataImportWizard = lazy(() => import('./pages/DataImportWizardPage'));
 const ReceiptOcr = lazy(() => import('./pages/ReceiptOcrPage'));
 const Login = lazy(() => import('./pages/LoginPage'));
@@ -393,6 +394,14 @@ export const AppRoutes: FC = () => (
         element={
           <RouteBoundary name="Settings · Advanced">
             <SettingsAdvanced />
+          </RouteBoundary>
+        }
+      />
+      <Route
+        path="about"
+        element={
+          <RouteBoundary name="Settings · About">
+            <SettingsAbout />
           </RouteBoundary>
         }
       />

--- a/apps/web/src/styles/responsive.css
+++ b/apps/web/src/styles/responsive.css
@@ -792,6 +792,74 @@
 .settings-item--destructive .settings-item__value {
   color: var(--semantic-status-negative);
 }
+.danger-zone-card {
+  --danger-border: var(--semantic-border-error, var(--semantic-status-negative));
+  --danger-fg: var(--semantic-status-negative);
+
+  overflow: hidden;
+  margin-bottom: var(--spacing-4);
+  border: 1px solid var(--danger-border);
+  border-radius: var(--card-border-radius);
+  background: rgba(239, 68, 68, 0.06);
+}
+.danger-zone-card__header {
+  padding: var(--spacing-4) var(--card-padding);
+  border-bottom: 1px solid var(--danger-border);
+}
+.danger-zone-card__title {
+  margin: 0 0 var(--spacing-2);
+  color: var(--danger-fg);
+  font-size: var(--type-scale-label-font-size);
+  font-weight: var(--font-weight-bold, 700);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.danger-zone-card__description {
+  margin: 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+  line-height: 1.5;
+}
+.danger-zone-card__content {
+  padding: var(--spacing-4) var(--card-padding);
+}
+.danger-zone-card .setting-info-widget__row {
+  align-items: stretch;
+}
+.danger-zone-card__action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+  width: 100%;
+  min-height: 44px;
+  padding: var(--spacing-3) var(--spacing-4);
+  border: 1px solid var(--danger-border);
+  border-radius: var(--border-radius-md, 0.5rem);
+  background: var(--danger-fg);
+  color: var(--semantic-text-inverse, #fff);
+  font: inherit;
+  font-weight: var(--font-weight-bold, 700);
+  text-align: left;
+  cursor: pointer;
+}
+.danger-zone-card__action:hover:not(:disabled) {
+  filter: brightness(0.95);
+}
+.danger-zone-card__action:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+}
+@media (prefers-contrast: more) {
+  .danger-zone-card {
+    background: var(--semantic-background-primary);
+    border-width: 2px;
+  }
+
+  .danger-zone-card__action {
+    border-width: 2px;
+  }
+}
 @media (max-width: 640px) {
   .settings-item {
     grid-template-columns: minmax(0, 1fr);

--- a/apps/web/src/styles/responsive.css
+++ b/apps/web/src/styles/responsive.css
@@ -614,25 +614,44 @@
   color: var(--semantic-amount-negative);
 }
 .settings-group {
+  --settings-card-gutter: var(--card-padding);
+  --settings-row-min-height: 3.5rem;
+  --settings-label-column: minmax(10rem, 0.42fr);
+  --settings-value-column: minmax(0, 0.58fr);
+
   background: var(--card-background);
   border: 1px solid var(--card-border);
   border-radius: var(--card-border-radius);
   overflow: hidden;
   margin-bottom: var(--spacing-4);
 }
+.settings-group__title,
+.settings-group__description {
+  padding-right: var(--settings-card-gutter);
+  padding-left: var(--settings-card-gutter);
+}
 .settings-group__title {
+  margin: 0;
+  padding-top: var(--spacing-3);
+  padding-bottom: var(--spacing-3);
   font-size: var(--type-scale-label-font-size);
   color: var(--semantic-text-secondary);
   text-transform: uppercase;
-  padding: var(--spacing-3) var(--card-padding);
+}
+.settings-group__description {
+  margin: 0 0 var(--spacing-4);
+  font-size: var(--font-size-sm, 0.875rem);
+  color: var(--semantic-text-secondary);
 }
 .settings-item {
-  display: flex;
+  display: grid;
+  grid-template-columns: var(--settings-label-column) var(--settings-value-column);
   align-items: center;
-  justify-content: space-between;
-  gap: var(--spacing-3);
+  column-gap: var(--spacing-4);
+  row-gap: var(--spacing-1);
   width: 100%;
-  padding: var(--spacing-3) var(--card-padding);
+  min-height: var(--settings-row-min-height);
+  padding: var(--spacing-3) var(--settings-card-gutter);
   border: none;
   border-bottom: 1px solid var(--semantic-border-default);
   background: transparent;
@@ -640,7 +659,9 @@
   font: inherit;
   text-align: left;
 }
-.settings-item:last-child {
+.settings-item:last-child,
+.setting-info-widget:last-child > .setting-info-widget__row > .settings-item:last-child,
+.setting-info-widget:last-child > .settings-item:last-child {
   border-bottom: none;
 }
 .settings-item--button {
@@ -661,10 +682,15 @@
   outline-offset: -2px;
 }
 .settings-item__label {
+  min-width: 0;
   color: var(--semantic-text-primary);
+  font-weight: var(--font-weight-medium, 500);
 }
 .settings-item__value {
+  min-width: 0;
   color: var(--semantic-text-secondary);
+  justify-self: end;
+  text-align: right;
 }
 .settings-item__value--muted {
   opacity: 0.5;
@@ -676,9 +702,15 @@
   align-items: center;
   justify-content: flex-end;
   gap: var(--spacing-2);
+  min-width: 0;
+  justify-self: stretch;
 }
-.settings-item__select {
+.settings-item__select,
+.settings-item__input {
+  width: 100%;
+  max-width: 16rem;
   min-width: 8rem;
+  justify-self: end;
   padding: var(--spacing-2) var(--spacing-3);
   border: 1px solid var(--semantic-border-default);
   border-radius: var(--border-radius-md);
@@ -687,14 +719,62 @@
   font: inherit;
 }
 .settings-item__select:focus-visible,
-.settings-item__checkbox:focus-visible {
+.settings-item__input:focus-visible,
+.settings-item__checkbox:focus-visible,
+.settings-item__color-input:focus-visible {
   outline: 2px solid var(--semantic-border-focus);
   outline-offset: 2px;
 }
 .settings-item__checkbox {
   width: 20px;
   height: 20px;
+  justify-self: end;
   accent-color: var(--semantic-interactive-default);
+}
+.settings-item__description,
+.settings-item__help {
+  grid-column: 2;
+  margin: 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size, 0.875rem);
+  line-height: 1.45;
+}
+.settings-item > :only-child {
+  grid-column: 1 / -1;
+  justify-self: start;
+  text-align: left;
+}
+.settings-item__color-input {
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 3px;
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-primary);
+  cursor: pointer;
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 1px var(--semantic-background-primary);
+  transition:
+    border-color 120ms ease,
+    box-shadow 120ms ease,
+    transform 120ms ease;
+}
+.settings-item__color-input:hover {
+  border-color: var(--semantic-interactive-default);
+  box-shadow: 0 0 0 3px var(--semantic-surface-selected, rgba(37, 99, 235, 0.12));
+  transform: translateY(-1px);
+}
+.settings-item__color-input::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+.settings-item__color-input::-webkit-color-swatch {
+  border: none;
+  border-radius: calc(var(--border-radius-md) - 3px);
+}
+.settings-item__color-input::-moz-color-swatch {
+  border: none;
+  border-radius: calc(var(--border-radius-md) - 3px);
 }
 .settings-item__status-dot {
   width: 10px;
@@ -711,6 +791,32 @@
 .settings-item--destructive .settings-item__label,
 .settings-item--destructive .settings-item__value {
   color: var(--semantic-status-negative);
+}
+@media (max-width: 640px) {
+  .settings-item {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .settings-item__value,
+  .settings-item__control,
+  .settings-item__status,
+  .settings-item__select,
+  .settings-item__input,
+  .settings-item__checkbox {
+    grid-column: 1;
+    justify-self: stretch;
+    text-align: left;
+  }
+
+  .settings-item__checkbox,
+  .settings-item__color-input {
+    justify-self: start;
+  }
+
+  .settings-item__description,
+  .settings-item__help {
+    grid-column: 1;
+  }
 }
 .dashboard-charts {
   display: grid;


### PR DESCRIPTION
## Summary
Fixes six sub-items from #2010:

- [x] Item 3: Added `form-input` to Settings text/number inputs and audited Settings inputs for class drift.
- [x] Item 6: Standardized Settings card gutters, row height, and label/value column ratio.
- [x] Item 7: Normalized color swatch sizing with a 2px selected ring, focus ring, and hover affordance.
- [x] Item 11: Aligned Settings sync copy with canonical sync status wording (`All synced`, `Offline — changes saved locally`).
- [x] Item 12: Added Advanced setting info widgets and gave erase mood data Danger Zone treatment.
- [x] Item 13: Promoted About to its own Settings rail section with version, build SHA, license, and credits.

## Notes
- Item 12 used an inline `.danger-zone-card` fallback because `fix/settings-arrows-danger-zone-2010` was not merged into this branch yet. A TODO points to replacing it with the shared `<DangerZone>` component after that branch lands.

## Validation
- `npx --no-install tsc --noEmit`
- `npx --no-install vitest run src/pages/settings/ --passWithNoTests` (no tests matched that folder)
- `npx --no-install vitest run src/pages/SettingsPage.test.tsx`

Fixes #2010