### PR TITLE
fix(web): currency negative formats + code/symbol preview wiring + collapsible rates (#2010 items 8,9,10)

### DIFF
--- a/apps/web/src/components/common/CurrencyDisplay.test.tsx
+++ b/apps/web/src/components/common/CurrencyDisplay.test.tsx
@@ -63,6 +63,15 @@ describe('CurrencyDisplay', () => {
     expect(screen.getByText('($12.34)')).toBeInTheDocument();
   });
 
+  it('uses the configured currency display mode', () => {
+    renderWithSettings(createElement(CurrencyDisplay, { amount: 1234 }), {
+      currencyDisplay: 'code',
+    });
+    expect(
+      screen.getByText((content) => content.includes('USD') && content.includes('12.34')),
+    ).toBeInTheDocument();
+  });
+
   it('renders negative amounts without sign in color-only mode', () => {
     renderWithSettings(createElement(CurrencyDisplay, { amount: -1234 }), {
       negativeFormat: 'color-only',

--- a/apps/web/src/components/common/CurrencyDisplay.tsx
+++ b/apps/web/src/components/common/CurrencyDisplay.tsx
@@ -66,6 +66,7 @@ export const CurrencyDisplay: React.FC<CurrencyDisplayProps> = ({
   // Format the visible text using the canonical privacy-aware formatter.
   const baseFormatOptions = {
     currency,
+    currencyDisplay: displaySettings.currencyDisplay,
     minimumFractionDigits: displaySettings.showDecimals ? 2 : 0,
     maximumFractionDigits: displaySettings.showDecimals ? 2 : 0,
   } as const;

--- a/apps/web/src/components/settings/CurrencyRatesSettings.test.tsx
+++ b/apps/web/src/components/settings/CurrencyRatesSettings.test.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { UseExchangeRatesResult } from '../../hooks/useExchangeRates';
@@ -52,6 +52,10 @@ vi.mock('../../hooks/useExchangeRates', () => ({
 // We need to import AFTER mocking
 import { CurrencyRatesSettings } from './CurrencyRatesSettings';
 
+function expandRatesTable(): void {
+  fireEvent.click(screen.getByText('Exchange rates'));
+}
+
 describe('CurrencyRatesSettings', () => {
   beforeEach(() => {
     hookResult = { ...defaultHookResult };
@@ -88,12 +92,14 @@ describe('CurrencyRatesSettings', () => {
 
   it('shows source badges for rates', () => {
     render(<CurrencyRatesSettings />);
+    expandRatesTable();
     const staticBadges = screen.getAllByText('Static');
     expect(staticBadges.length).toBeGreaterThan(0);
   });
 
   it('renders override buttons for each currency', () => {
     render(<CurrencyRatesSettings />);
+    expandRatesTable();
     const overrideButtons = screen.getAllByText('Override');
     expect(overrideButtons.length).toBeGreaterThan(0);
   });
@@ -108,6 +114,7 @@ describe('CurrencyRatesSettings', () => {
       },
     };
     render(<CurrencyRatesSettings />);
+    expandRatesTable();
     expect(screen.getByLabelText('Reset override for EUR')).toBeInTheDocument();
   });
 
@@ -121,8 +128,16 @@ describe('CurrencyRatesSettings', () => {
     expect(screen.getByLabelText('Currency Rates')).toBeInTheDocument();
   });
 
-  it('has proper aria-label on the rates table', () => {
+  it('collapses the rates table by default', () => {
     render(<CurrencyRatesSettings />);
+    const disclosure = screen.getByText('Exchange rates').closest('details');
+    expect(disclosure).toBeInTheDocument();
+    expect(disclosure).not.toHaveAttribute('open');
+  });
+
+  it('has proper aria-label on the rates table after expanding', () => {
+    render(<CurrencyRatesSettings />);
+    expandRatesTable();
     expect(screen.getByRole('table', { name: /Exchange rates from USD/ })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/settings/CurrencyRatesSettings.tsx
+++ b/apps/web/src/components/settings/CurrencyRatesSettings.tsx
@@ -176,107 +176,113 @@ export const CurrencyRatesSettings: React.FC<CurrencyRatesSettingsProps> = ({
         </div>
 
         {/* Rate list */}
-        <div
-          role="table"
-          aria-label={`Exchange rates from ${baseCurrency}`}
-          className="currency-rates-table"
-        >
-          <div role="row" className="currency-rates-table__header">
-            <span role="columnheader" className="currency-rates-table__cell">
-              Currency
-            </span>
-            <span role="columnheader" className="currency-rates-table__cell">
-              Rate
-            </span>
-            <span role="columnheader" className="currency-rates-table__cell">
-              Source
-            </span>
-            <span role="columnheader" className="currency-rates-table__cell">
-              Actions
-            </span>
-          </div>
+        <details className="currency-rates-disclosure">
+          <summary className="currency-rates-disclosure__summary">
+            <span className="currency-rates-disclosure__title">Exchange rates</span>
+            <span className="currency-rates-disclosure__hint">Click to expand</span>
+          </summary>
+          <div
+            role="table"
+            aria-label={`Exchange rates from ${baseCurrency}`}
+            className="currency-rates-table"
+          >
+            <div role="row" className="currency-rates-table__header">
+              <span role="columnheader" className="currency-rates-table__cell">
+                Currency
+              </span>
+              <span role="columnheader" className="currency-rates-table__cell">
+                Rate
+              </span>
+              <span role="columnheader" className="currency-rates-table__cell">
+                Source
+              </span>
+              <span role="columnheader" className="currency-rates-table__cell">
+                Actions
+              </span>
+            </div>
 
-          {displayCurrencies.map((code) => {
-            const rate = rates[code];
-            const isEditing = editingPair === code;
-            const hasOverride = isOverridden(code);
+            {displayCurrencies.map((code) => {
+              const rate = rates[code];
+              const isEditing = editingPair === code;
+              const hasOverride = isOverridden(code);
 
-            return (
-              <div key={code} role="row" className="currency-rates-table__row">
-                <span role="cell" className="currency-rates-table__cell">
-                  {code}
-                </span>
-                <span role="cell" className="currency-rates-table__cell">
-                  {isEditing ? (
-                    <input
-                      type="number"
-                      step="any"
-                      min="0"
-                      className="currency-rates-table__input"
-                      value={editValue}
-                      onChange={(e) => setEditValue(e.target.value)}
-                      onKeyDown={(e) => handleKeyDown(e, code)}
-                      aria-label={`Override rate for ${baseCurrency} to ${code}`}
-                      autoFocus
-                    />
-                  ) : (
-                    <span>{rate ? rate.rate.toFixed(4) : '—'}</span>
-                  )}
-                </span>
-                <span role="cell" className="currency-rates-table__cell">
-                  <span
-                    className={`currency-rates-badge currency-rates-badge--${rate?.source ?? 'static'}`}
-                  >
-                    {getSourceLabel(rate)}
+              return (
+                <div key={code} role="row" className="currency-rates-table__row">
+                  <span role="cell" className="currency-rates-table__cell">
+                    {code}
                   </span>
-                </span>
-                <span role="cell" className="currency-rates-table__cell">
-                  {isEditing ? (
-                    <>
-                      <button
-                        type="button"
-                        className="currency-rates-table__action"
-                        onClick={() => handleSaveEdit(code)}
-                        aria-label={`Save override for ${code}`}
-                      >
-                        Save
-                      </button>
-                      <button
-                        type="button"
-                        className="currency-rates-table__action"
-                        onClick={handleCancelEdit}
-                        aria-label="Cancel editing"
-                      >
-                        Cancel
-                      </button>
-                    </>
-                  ) : (
-                    <>
-                      <button
-                        type="button"
-                        className="currency-rates-table__action"
-                        onClick={() => handleStartEdit(code, rate?.rate ?? 0)}
-                        aria-label={`Override rate for ${code}`}
-                      >
-                        Override
-                      </button>
-                      {hasOverride && (
+                  <span role="cell" className="currency-rates-table__cell">
+                    {isEditing ? (
+                      <input
+                        type="number"
+                        step="any"
+                        min="0"
+                        className="currency-rates-table__input"
+                        value={editValue}
+                        onChange={(e) => setEditValue(e.target.value)}
+                        onKeyDown={(e) => handleKeyDown(e, code)}
+                        aria-label={`Override rate for ${baseCurrency} to ${code}`}
+                        autoFocus
+                      />
+                    ) : (
+                      <span>{rate ? rate.rate.toFixed(4) : '—'}</span>
+                    )}
+                  </span>
+                  <span role="cell" className="currency-rates-table__cell">
+                    <span
+                      className={`currency-rates-badge currency-rates-badge--${rate?.source ?? 'static'}`}
+                    >
+                      {getSourceLabel(rate)}
+                    </span>
+                  </span>
+                  <span role="cell" className="currency-rates-table__cell">
+                    {isEditing ? (
+                      <>
                         <button
                           type="button"
-                          className="currency-rates-table__action currency-rates-table__action--reset"
-                          onClick={() => handleResetOverride(code)}
-                          aria-label={`Reset override for ${code}`}
+                          className="currency-rates-table__action"
+                          onClick={() => handleSaveEdit(code)}
+                          aria-label={`Save override for ${code}`}
                         >
-                          Reset
+                          Save
                         </button>
-                      )}
-                    </>
-                  )}
-                </span>
-              </div>
-            );
-          })}
-        </div>
+                        <button
+                          type="button"
+                          className="currency-rates-table__action"
+                          onClick={handleCancelEdit}
+                          aria-label="Cancel editing"
+                        >
+                          Cancel
+                        </button>
+                      </>
+                    ) : (
+                      <>
+                        <button
+                          type="button"
+                          className="currency-rates-table__action"
+                          onClick={() => handleStartEdit(code, rate?.rate ?? 0)}
+                          aria-label={`Override rate for ${code}`}
+                        >
+                          Override
+                        </button>
+                        {hasOverride && (
+                          <button
+                            type="button"
+                            className="currency-rates-table__action currency-rates-table__action--reset"
+                            onClick={() => handleResetOverride(code)}
+                            aria-label={`Reset override for ${code}`}
+                          >
+                            Reset
+                          </button>
+                        )}
+                      </>
+                    )}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </details>
 
         {/* Disclaimer */}
         <div className="settings-item settings-item--static">

--- a/apps/web/src/components/settings/currency-rates-settings.css
+++ b/apps/web/src/components/settings/currency-rates-settings.css
@@ -7,6 +7,100 @@
  * Uses design tokens for all visual values.
  * ------------------------------------------------------------------- */
 
+.settings-item--stacked {
+  align-items: stretch;
+  flex-direction: column;
+}
+
+.settings-item__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-3, 12px);
+  width: 100%;
+}
+
+.negative-format-preview {
+  display: grid;
+  gap: var(--spacing-2, 8px);
+  width: 100%;
+}
+
+.negative-format-preview__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-3, 12px);
+  color: var(--semantic-text-secondary, #666);
+  font-size: var(--type-scale-caption-font-size, 0.875rem);
+}
+
+.negative-format-preview__amount {
+  color: var(--semantic-text-primary, #111);
+  font-variant-numeric: tabular-nums;
+}
+
+.negative-format-preview__amount--error {
+  color: var(--semantic-error, var(--semantic-amount-negative, #ef4444));
+}
+
+.currency-rates-disclosure {
+  border-bottom: 1px solid var(--semantic-border-default, var(--semantic-border-primary, #e0e0e0));
+}
+
+.currency-rates-disclosure__summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-3, 12px);
+  padding: var(--spacing-3, 12px) var(--card-padding, 16px);
+  cursor: pointer;
+  list-style: none;
+}
+
+.currency-rates-disclosure__summary::-webkit-details-marker {
+  display: none;
+}
+
+.currency-rates-disclosure__summary::after {
+  content: '▾';
+  color: var(--semantic-text-secondary, #666);
+  transition: transform 120ms ease;
+}
+
+.currency-rates-disclosure[open] .currency-rates-disclosure__summary::after {
+  transform: rotate(180deg);
+}
+
+.currency-rates-disclosure__summary:hover {
+  background: var(--semantic-background-secondary, #f5f5f5);
+}
+
+.currency-rates-disclosure__summary:focus-visible {
+  outline: 2px solid var(--semantic-border-focus, #4a90d9);
+  outline-offset: -2px;
+}
+
+.currency-rates-disclosure__title {
+  color: var(--semantic-text-primary, #111);
+}
+
+.currency-rates-disclosure__hint {
+  color: var(--semantic-text-secondary, #666);
+  font-size: var(--type-scale-caption-font-size, 0.75rem);
+  margin-left: auto;
+}
+
+.currency-rates-disclosure[open] .currency-rates-disclosure__summary {
+  border-bottom: 1px solid var(--semantic-border-default, var(--semantic-border-primary, #e0e0e0));
+}
+
+.currency-rates-disclosure .currency-rates-table {
+  border: 0;
+  border-radius: 0;
+  margin: 0;
+}
+
 .currency-rates-table {
   display: flex;
   flex-direction: column;
@@ -125,6 +219,17 @@
 
 /* Responsive: stack on mobile */
 @media (max-width: 480px) {
+  .settings-item__row,
+  .negative-format-preview__row,
+  .currency-rates-disclosure__summary {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .currency-rates-disclosure__hint {
+    margin-left: 0;
+  }
+
   .currency-rates-table__header {
     display: none;
   }

--- a/apps/web/src/pages/SettingsPage.test.tsx
+++ b/apps/web/src/pages/SettingsPage.test.tsx
@@ -116,11 +116,18 @@ vi.mock('../lib/display-settings', () => ({
     updateSettings: mockUpdateSettings,
     resetSettings: mockResetSettings,
   }),
-  formatAmountWithSettings: (amount: number) => {
+  formatAmountWithSettings: (
+    amount: number,
+    settings: { currencyDisplay?: string; negativeFormat?: string } = {},
+  ) => {
     const abs = Math.abs(amount) / 100;
-    const formatted = `$${abs.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ',')}`;
-    if (amount < 0) return `-${formatted}`;
-    return formatted;
+    const formattedNumber = abs.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+    const formatted =
+      settings.currencyDisplay === 'code' ? `USD ${formattedNumber}` : `$${formattedNumber}`;
+    if (amount >= 0) return formatted;
+    if (settings.negativeFormat === 'parentheses') return `(${formatted})`;
+    if (settings.negativeFormat === 'color-only') return formatted;
+    return `-${formatted}`;
   },
   getAmountColor: (amount: number) => {
     if (amount > 0) return '#22c55e';
@@ -372,6 +379,15 @@ describe('SettingsPage', () => {
       renderSettingsAt('/settings/preferences');
 
       expect(screen.getByText('Preview')).toBeInTheDocument();
+    });
+
+    it('renders accurate negative format examples', () => {
+      renderSettingsAt('/settings/preferences');
+
+      const examples = screen.getByLabelText('Negative format examples');
+      expect(examples).toHaveTextContent('Standard-$1,234.56');
+      expect(examples).toHaveTextContent('Accounting($1,234.56)');
+      expect(examples).toHaveTextContent('Color Only$1,234.56');
     });
 
     it('calls updateSettings when show decimals is toggled', () => {

--- a/apps/web/src/pages/settings/SettingsPreferencesPage.test.tsx
+++ b/apps/web/src/pages/settings/SettingsPreferencesPage.test.tsx
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MoneyDisplayProvider } from '../../lib/display-settings';
+import { SettingsPreferencesPage } from './SettingsPreferencesPage';
+
+const setThemeMock = vi.fn();
+
+vi.mock('../../hooks/useTheme', () => ({
+  useTheme: () => ({
+    theme: 'system',
+    setTheme: setThemeMock,
+    themes: ['system', 'light', 'dark', 'dark-oled'],
+  }),
+}));
+
+vi.mock('../../components/settings/CurrencyRatesSettings', () => ({
+  CurrencyRatesSettings: () => <section aria-label="Currency Rates">Currency rates mock</section>,
+}));
+
+function renderPreferences(): void {
+  render(
+    <MoneyDisplayProvider>
+      <SettingsPreferencesPage />
+    </MoneyDisplayProvider>,
+  );
+}
+
+describe('SettingsPreferencesPage currency display polish', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it('renders accurate negative format examples', () => {
+    renderPreferences();
+
+    const examples = screen.getByLabelText('Negative format examples');
+    expect(examples).toHaveTextContent('Standard-$1,234.56');
+    expect(examples).toHaveTextContent('Accounting($1,234.56)');
+
+    const colorOnlyExample = within(examples).getByText('$1,234.56');
+    expect(colorOnlyExample).toHaveClass('negative-format-preview__amount--error');
+  });
+
+  it('updates the live preview when currency display changes to code', () => {
+    renderPreferences();
+
+    fireEvent.change(screen.getByLabelText('Currency display mode'), { target: { value: 'code' } });
+
+    expect(screen.getByRole('group', { name: /live preview/i })).toHaveTextContent('USD');
+  });
+});

--- a/apps/web/src/pages/settings/SettingsPreferencesPage.tsx
+++ b/apps/web/src/pages/settings/SettingsPreferencesPage.tsx
@@ -13,7 +13,7 @@ import {
   saveBnplStackingThresholdCents,
 } from '../../lib/bnpl-liability';
 import type { CurrencyDisplayMode, NegativeFormat } from '../../lib/display-settings';
-import { useMoneyDisplay } from '../../lib/display-settings';
+import { formatAmountWithSettings, useMoneyDisplay } from '../../lib/display-settings';
 
 const CURRENCY_STORAGE_KEY = 'finance-currency';
 const NOTIFICATIONS_STORAGE_KEY = 'finance-notifications';
@@ -52,9 +52,9 @@ function resolveColorForPicker(color: string, fallback: string): string {
 
 /** Labels for negative format options. */
 const NEGATIVE_FORMAT_OPTIONS: Array<{ value: NegativeFormat; label: string }> = [
-  { value: 'minus', label: 'Minus sign (−$1,234.56)' },
-  { value: 'parentheses', label: 'Parentheses (($1,234.56))' },
-  { value: 'color-only', label: 'Color only ($1,234.56)' },
+  { value: 'minus', label: 'Standard' },
+  { value: 'parentheses', label: 'Accounting' },
+  { value: 'color-only', label: 'Color Only' },
 ];
 
 /** Labels for currency display mode options. */
@@ -275,28 +275,61 @@ export const SettingsPreferencesPage: React.FC = () => {
             />
           </div>
 
-          <div className="settings-item settings-item--static">
-            <label className="settings-item__label" htmlFor="settings-negative-format">
-              Negative format
-            </label>
-            <div className="settings-item__control">
-              <select
-                id="settings-negative-format"
-                aria-label="Negative number format"
-                className="settings-item__select"
-                value={displaySettings.negativeFormat}
-                onChange={(e) =>
-                  displaySettings.updateSettings({
-                    negativeFormat: e.target.value as NegativeFormat,
-                  })
-                }
-              >
-                {NEGATIVE_FORMAT_OPTIONS.map((opt) => (
-                  <option key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </option>
-                ))}
-              </select>
+          <div className="settings-item settings-item--static settings-item--stacked">
+            <div className="settings-item__row">
+              <label className="settings-item__label" htmlFor="settings-negative-format">
+                Negative format
+              </label>
+              <div className="settings-item__control">
+                <select
+                  id="settings-negative-format"
+                  aria-label="Negative number format"
+                  className="settings-item__select"
+                  value={displaySettings.negativeFormat}
+                  onChange={(e) =>
+                    displaySettings.updateSettings({
+                      negativeFormat: e.target.value as NegativeFormat,
+                    })
+                  }
+                >
+                  {NEGATIVE_FORMAT_OPTIONS.map((opt) => {
+                    const example = formatAmountWithSettings(
+                      -123456,
+                      { ...displaySettings, negativeFormat: opt.value },
+                      { currency },
+                    );
+                    return (
+                      <option key={opt.value} value={opt.value}>
+                        {opt.label} ({example})
+                      </option>
+                    );
+                  })}
+                </select>
+              </div>
+            </div>
+            <div className="negative-format-preview" aria-label="Negative format examples">
+              {NEGATIVE_FORMAT_OPTIONS.map((opt) => {
+                const example = formatAmountWithSettings(
+                  -123456,
+                  { ...displaySettings, negativeFormat: opt.value },
+                  { currency },
+                );
+                const isColorOnly = opt.value === 'color-only';
+                return (
+                  <div className="negative-format-preview__row" key={opt.value}>
+                    <span className="negative-format-preview__label">{opt.label}</span>
+                    <span
+                      className={
+                        isColorOnly
+                          ? 'negative-format-preview__amount negative-format-preview__amount--error'
+                          : 'negative-format-preview__amount'
+                      }
+                    >
+                      {example}
+                    </span>
+                  </div>
+                );
+              })}
             </div>
           </div>
 
@@ -339,9 +372,9 @@ export const SettingsPreferencesPage: React.FC = () => {
                 flexWrap: 'wrap',
               }}
             >
-              <CurrencyDisplay amount={123456} colorize />
-              <CurrencyDisplay amount={0} colorize />
-              <CurrencyDisplay amount={-123456} colorize />
+              <CurrencyDisplay amount={123456} currency={currency} colorize />
+              <CurrencyDisplay amount={0} currency={currency} colorize />
+              <CurrencyDisplay amount={-123456} currency={currency} colorize />
             </span>
           </div>
 


### PR DESCRIPTION
## Summary
- Fix #2010 item 8: correct negative format examples and render color-only example with semantic error color.
- Fix #2010 item 9: pass currency display mode through CurrencyDisplay and bind previews to selected currency.
- Fix #2010 item 10: make currency rates table default-collapsed via details/summary with styled disclosure row.

## Validation
- npx tsc --noEmit
- npx vitest run src/pages/settings/
- npx vitest run src/pages/SettingsPage.test.tsx src/components/settings/CurrencyRatesSettings.test.tsx src/components/common/CurrencyDisplay.test.tsx

Refs #2010