### PR TITLE
fix(deploy): inject Supabase env vars into web build (#2011)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -128,6 +128,8 @@ jobs:
     if: github.event.inputs.rollback != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    environment:
+      name: production
     steps:
       - name: Checkout at deploy version
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -153,6 +155,13 @@ jobs:
           VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
           VITE_POWERSYNC_URL: ${{ secrets.POWERSYNC_URL }}
         run: npm run build -w apps/web
+
+      - name: Verify web build env
+        if: needs.prepare.outputs.deploy_web == 'true'
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+        run: node tools/verify-build-env.mjs --check-env apps/web/dist
 
       - name: Type check
         run: npm run type-check 2>/dev/null || true
@@ -201,6 +210,12 @@ jobs:
         run: |
           npm run build -w packages/design-tokens
           npm run build -w apps/web
+
+      - name: Verify web build env
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+        run: node tools/verify-build-env.mjs --check-env apps/web/dist
 
       - name: Deploy to Vercel (production)
         id: deploy

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -109,6 +109,9 @@ jobs:
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_PATH: ${{ vars.DEPLOY_PATH || '~/finance' }}
           SHA_SHORT: ${{ needs.pre-deploy-checks.outputs.sha_short }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          POWERSYNC_URL: ${{ secrets.POWERSYNC_URL }}
         run: |
           set -euo pipefail
 
@@ -125,13 +128,26 @@ jobs:
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null
 
+          if [ -z "$SUPABASE_URL" ] || [ -z "$SUPABASE_ANON_KEY" ]; then
+            echo "::error::SUPABASE_URL and SUPABASE_ANON_KEY secrets are required for staging web builds"
+            exit 1
+          fi
+
+          SUPABASE_URL_B64=$(printf '%s' "$SUPABASE_URL" | base64 -w 0)
+          SUPABASE_ANON_KEY_B64=$(printf '%s' "$SUPABASE_ANON_KEY" | base64 -w 0)
+          POWERSYNC_URL_B64=$(printf '%s' "$POWERSYNC_URL" | base64 -w 0)
+
           # SSH in and rebuild. Each line is a separate command so an early
           # failure aborts the build (set -e inside the heredoc). Use
           # `git fetch --force --prune` then `reset --hard` so we recover
           # from any stale refs (e.g. if a prior backend deploy already
           # advanced origin/main before this fetch read its expected value).
-          ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" bash <<'DEPLOY'
+          ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" \
+            "SUPABASE_URL_B64='$SUPABASE_URL_B64' SUPABASE_ANON_KEY_B64='$SUPABASE_ANON_KEY_B64' POWERSYNC_URL_B64='$POWERSYNC_URL_B64' bash -s" <<'DEPLOY'
             set -euo pipefail
+            export VITE_SUPABASE_URL="$(printf '%s' "$SUPABASE_URL_B64" | base64 -d)"
+            export VITE_SUPABASE_ANON_KEY="$(printf '%s' "$SUPABASE_ANON_KEY_B64" | base64 -d)"
+            export VITE_POWERSYNC_URL="$(printf '%s' "$POWERSYNC_URL_B64" | base64 -d)"
             cd ~/finance
             echo "→ git fetch --force --prune origin main"
             git fetch --force --prune origin main
@@ -143,6 +159,8 @@ jobs:
             npm run build -w packages/design-tokens --silent
             echo "→ build apps/web"
             npm run build -w apps/web --silent
+            echo "→ verify Supabase env in build output"
+            node tools/verify-build-env.mjs --check-env apps/web/dist
             echo "→ verify dist"
             test -f apps/web/dist/index.html
             ls -la apps/web/dist | head -10

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -48,6 +48,7 @@ jobs:
     needs: approve
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    environment: ${{ inputs.environment || 'staging' }}
     outputs:
       version: ${{ steps.version.outputs.version }}
       deploy-url: ${{ steps.deploy.outputs.url }}
@@ -83,6 +84,16 @@ jobs:
         env:
           VITE_APP_VERSION: ${{ steps.version.outputs.version }}
           VITE_APP_ENVIRONMENT: ${{ inputs.environment || 'staging' }}
+          VITE_ENVIRONMENT: ${{ inputs.environment || 'staging' }}
+          VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          VITE_POWERSYNC_URL: ${{ secrets.POWERSYNC_URL }}
+
+      - name: Verify web build env
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+        run: node tools/verify-build-env.mjs --check-env apps/web/dist
 
       - name: Run unit tests
         run: npm test -w apps/web

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -50,6 +50,9 @@ jobs:
           npm run build -w apps/web
           echo "duration=$(( SECONDS - BUILD_START ))" >> "$GITHUB_OUTPUT"
 
+      - name: Verify web build env
+        run: node tools/verify-build-env.mjs apps/web/dist
+
       - name: Report bundle size
         run: |
           echo "### 🌐 Web Build Summary" >> "$GITHUB_STEP_SUMMARY"

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -27,10 +27,25 @@ if (!rootElement) {
   throw new Error('Root element not found. Ensure <div id="root"></div> exists in index.html.');
 }
 
-// Auth configuration - in production these would come from environment variables
+function requiredProductionEnv(name: string): never {
+  throw new Error(`${name} is required for production builds`);
+}
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL?.trim()
+  ? import.meta.env.VITE_SUPABASE_URL.trim()
+  : import.meta.env.PROD
+    ? requiredProductionEnv('VITE_SUPABASE_URL')
+    : 'https://placeholder.supabase.co';
+
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY?.trim()
+  ? import.meta.env.VITE_SUPABASE_ANON_KEY.trim()
+  : import.meta.env.PROD
+    ? requiredProductionEnv('VITE_SUPABASE_ANON_KEY')
+    : 'placeholder-anon-key';
+
 const authConfig = {
-  supabaseUrl: import.meta.env.VITE_SUPABASE_URL ?? 'https://placeholder.supabase.co',
-  supabaseAnonKey: import.meta.env.VITE_SUPABASE_ANON_KEY ?? 'placeholder-anon-key',
+  supabaseUrl,
+  supabaseAnonKey,
   loginEndpoint: import.meta.env.VITE_LOGIN_ENDPOINT ?? '/api/auth/login',
   refreshEndpoint: import.meta.env.VITE_REFRESH_ENDPOINT ?? '/api/auth/refresh',
   logoutEndpoint: import.meta.env.VITE_LOGOUT_ENDPOINT ?? '/api/auth/logout',
@@ -55,8 +70,7 @@ const authConfig = {
 // cause issues (e.g. E2E tests under Playwright).
 // NOTE: configureSyncEndpoint is only available on branches with #535 sync wiring.
 // Skip sync configuration when the function doesn't exist.
-const supabaseUrl = authConfig.supabaseUrl;
-if (supabaseUrl && !supabaseUrl.includes('placeholder')) {
+if (authConfig.supabaseUrl && !authConfig.supabaseUrl.includes('placeholder')) {
   void import('./db/sync/replayMutations').then((mod) => {
     if ('configureSyncEndpoint' in mod) {
       (
@@ -68,7 +82,7 @@ if (supabaseUrl && !supabaseUrl.includes('placeholder')) {
           }) => void;
         }
       ).configureSyncEndpoint({
-        baseUrl: `${supabaseUrl}/functions/v1`,
+        baseUrl: `${authConfig.supabaseUrl}/functions/v1`,
         pushEndpoint: '/sync-push',
         apiKey: authConfig.supabaseAnonKey,
       });

--- a/tools/verify-build-env.mjs
+++ b/tools/verify-build-env.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: BUSL-1.1
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { relative, resolve } from 'node:path';
+
+const PLACEHOLDERS = ['https://placeholder.supabase.co', 'placeholder-anon-key'];
+const REQUIRED_ENV = ['VITE_SUPABASE_URL', 'VITE_SUPABASE_ANON_KEY'];
+const TEXT_EXTENSIONS = new Set([
+  '.css',
+  '.html',
+  '.js',
+  '.json',
+  '.map',
+  '.mjs',
+  '.svg',
+  '.txt',
+  '.webmanifest',
+  '.xml',
+]);
+
+const args = process.argv.slice(2);
+const checkEnv = args.includes('--check-env');
+const paths = args.filter((arg) => arg !== '--check-env');
+const distDir = resolve(process.cwd(), paths[0] ?? 'apps/web/dist');
+const errors = [];
+
+if (checkEnv) {
+  for (const name of REQUIRED_ENV) {
+    const value = process.env[name]?.trim();
+    if (!value) {
+      errors.push(`${name} is required for production web builds.`);
+      continue;
+    }
+
+    if (PLACEHOLDERS.some((placeholder) => value.includes(placeholder))) {
+      errors.push(`${name} must not use a placeholder value.`);
+    }
+  }
+}
+
+if (!existsSync(distDir)) {
+  errors.push(`Build output directory does not exist: ${distDir}`);
+} else {
+  for (const file of walk(distDir)) {
+    const content = readFileSync(file, 'utf8');
+    for (const placeholder of PLACEHOLDERS) {
+      if (content.includes(placeholder)) {
+        errors.push(
+          `Built bundle contains placeholder ${JSON.stringify(placeholder)} in ${relative(process.cwd(), file)}`,
+        );
+      }
+    }
+  }
+}
+
+if (errors.length > 0) {
+  for (const error of errors) {
+    console.error(`::error::${error}`);
+  }
+  process.exit(1);
+}
+
+console.log('Verified web build env: no Supabase placeholder values found.');
+
+function* walk(dir) {
+  for (const entry of readdirSync(dir)) {
+    const path = resolve(dir, entry);
+    const stats = statSync(path);
+    if (stats.isDirectory()) {
+      yield* walk(path);
+      continue;
+    }
+
+    if (stats.isFile() && isTextAsset(path)) {
+      yield path;
+    }
+  }
+}
+
+function isTextAsset(path) {
+  const lower = path.toLowerCase();
+  for (const ext of TEXT_EXTENSIONS) {
+    if (lower.endsWith(ext)) {
+      return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
## Root cause
The alpha VM rebuild ran `npm run build -w apps/web` without exporting `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` into the remote build environment, so Vite compiled the placeholder Supabase values and the browser entered demo mode.

## Fix
- Pass the existing `SUPABASE_URL`, `SUPABASE_ANON_KEY`, and `POWERSYNC_URL` environment secrets into staging VM web builds as `VITE_*` variables.
- Verify production/release/web CI bundles with `tools/verify-build-env.mjs` so placeholder Supabase values fail before deploy/upload.
- Make production browser startup throw if required Supabase env vars are missing instead of silently falling back to placeholders.

## Required GitHub secrets
The workflows use these exact secret names:
- `SUPABASE_URL` → Supabase dashboard: Project Settings → API → Project URL.
- `SUPABASE_ANON_KEY` → Supabase dashboard: Project Settings → API → Project API keys → anon/public key.
- `POWERSYNC_URL` → existing PowerSync deployment URL (optional for this issue, still passed through when present).

`gh secret list --repo jrmoulckers/finance` does not show repo-level Supabase secrets. I verified the `staging` and `production` GitHub Environment secrets already include `SUPABASE_URL` and `SUPABASE_ANON_KEY`, and the changed deploy/release jobs now run in those environments where needed.

## Validation
- `npx --no-install tsc --noEmit -p apps\web\tsconfig.json`
- `npm run build -w packages/design-tokens -- --silent`
- `npm run build -w apps/web` with Supabase env set
- `node tools\verify-build-env.mjs --check-env apps\web\dist`
- Targeted auth tests: `npm test -w apps/web -- src/auth/demo-auth.test.ts src/auth/auth-context.test.tsx`

Full `npm test -w apps/web` has one pre-existing/local timezone failure in `src/utils/formatDate.test.ts` (expected date contains `24`, received `Dec 23, 2023`).

Closes #2011