### PR TITLE
fix(web): SettingInfoWidget — drop 'Info:' prefix + muted outlined icon (#2010 items 4,5)

### DIFF
--- a/apps/web/src/components/settings/SettingInfoWidget.test.tsx
+++ b/apps/web/src/components/settings/SettingInfoWidget.test.tsx
@@ -32,7 +32,9 @@ describe('SettingInfoWidget', () => {
     );
 
     expect(screen.getByText('Currency Setting')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /more info/i })).toBeInTheDocument();
+    const button = screen.getByRole('button', { name: 'Sets the default display currency.' });
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute('title', 'Sets the default display currency.');
   });
 
   it('renders only children when setting has no description', () => {
@@ -43,7 +45,9 @@ describe('SettingInfoWidget', () => {
     );
 
     expect(screen.getByText('Unknown Setting')).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /more info/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Sets the default display currency.' }),
+    ).not.toBeInTheDocument();
   });
 
   it('expands description on button click', () => {
@@ -53,7 +57,7 @@ describe('SettingInfoWidget', () => {
       </SettingInfoWidget>,
     );
 
-    const button = screen.getByRole('button', { name: /more info/i });
+    const button = screen.getByRole('button', { name: 'Sets the default display currency.' });
     expect(button).toHaveAttribute('aria-expanded', 'false');
 
     fireEvent.click(button);
@@ -71,7 +75,7 @@ describe('SettingInfoWidget', () => {
       </SettingInfoWidget>,
     );
 
-    const button = screen.getByRole('button', { name: /more info/i });
+    const button = screen.getByRole('button', { name: 'Sets the default display currency.' });
     fireEvent.click(button); // expand
     fireEvent.click(button); // collapse
 
@@ -85,7 +89,7 @@ describe('SettingInfoWidget', () => {
       </SettingInfoWidget>,
     );
 
-    const button = screen.getByRole('button', { name: /more info/i });
+    const button = screen.getByRole('button', { name: 'Sets the default display currency.' });
     const controlsId = button.getAttribute('aria-controls');
     expect(controlsId).toBeTruthy();
 
@@ -102,7 +106,7 @@ describe('SettingInfoWidget', () => {
       </SettingInfoWidget>,
     );
 
-    const button = screen.getByRole('button', { name: /more info/i });
+    const button = screen.getByRole('button', { name: 'Sets the default display currency.' });
     fireEvent.keyDown(button, { key: 'Enter' });
     expect(button).toHaveAttribute('aria-expanded', 'true');
   });

--- a/apps/web/src/components/settings/SettingInfoWidget.tsx
+++ b/apps/web/src/components/settings/SettingInfoWidget.tsx
@@ -2,6 +2,8 @@
 
 import { useCallback, useId, useRef, useState, type KeyboardEvent } from 'react';
 
+import { AppIcon } from '../icons';
+
 import { SETTING_DESCRIPTIONS, type SettingDescription } from './setting-descriptions';
 
 import './setting-info-widget.css';
@@ -17,7 +19,7 @@ export interface SettingInfoWidgetProps {
 /**
  * Wraps a setting item with an expandable info description.
  *
- * Shows a small info button (ℹ️) inline with the setting.
+ * Shows a small info button inline with the setting.
  * Clicking it expands an accessible description panel below.
  */
 export function SettingInfoWidget({ settingKey, children }: SettingInfoWidgetProps) {
@@ -58,12 +60,10 @@ export function SettingInfoWidget({ settingKey, children }: SettingInfoWidgetPro
           onKeyDown={handleKeyDown}
           aria-expanded={isExpanded}
           aria-controls={contentId}
-          aria-label={`More info about ${settingKey} setting`}
-          title={`Info: ${description.summary}`}
+          aria-label={description.summary}
+          title={description.summary}
         >
-          <span aria-hidden="true" className="setting-info-widget__icon">
-            ℹ️
-          </span>
+          <AppIcon className="setting-info-widget__icon" name="info" size={24} />
         </button>
       </div>
 

--- a/apps/web/src/components/settings/setting-info-widget.css
+++ b/apps/web/src/components/settings/setting-info-widget.css
@@ -29,11 +29,15 @@
   background: transparent;
   cursor: pointer;
   flex-shrink: 0;
-  transition: background-color 0.15s ease;
+  color: var(--semantic-text-secondary);
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease;
 }
 
 .setting-info-widget__trigger:hover {
   background-color: var(--semantic-background-secondary);
+  color: var(--semantic-text-primary);
 }
 
 .setting-info-widget__trigger:focus-visible {
@@ -42,8 +46,7 @@
 }
 
 .setting-info-widget__icon {
-  font-size: 16px;
-  line-height: 1;
+  display: block;
 }
 
 .setting-info-widget__content {


### PR DESCRIPTION
References #2010 (tracker; does not close).

Settings polish wave-2 checkboxes addressed:
- [x] Item 4: Info button hover text drops the `Info: ` prefix and shows only the setting description.
- [x] Item 5: Info button visual styling uses the muted outlined AppIcon `info` glyph at 24×24 instead of the filled/emoji treatment.

Validation:
- `npx tsc --noEmit` equivalent: `./node_modules/.bin/tsc.cmd --noEmit`
- `npx vitest run src/components/settings/` equivalent: `./node_modules/.bin/vitest.cmd run src/components/settings/`
