### PR TITLE
fix(web): bump SW CACHE_VERSION to v2 to evict stale demo-mode bundle

### DIFF
--- a/apps/web/src/__tests__/service-worker-lifecycle.test.ts
+++ b/apps/web/src/__tests__/service-worker-lifecycle.test.ts
@@ -18,7 +18,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 // Service worker caching strategy constants (mirrored from source)
 // ---------------------------------------------------------------------------
 
-const CACHE_VERSION = 'v1';
+const CACHE_VERSION = 'v2';
 const STATIC_CACHE = `finance-static-${CACHE_VERSION}`;
 const API_CACHE = `finance-api-${CACHE_VERSION}`;
 const APP_SHELL: string[] = ['/', '/index.html', '/manifest.json'];
@@ -30,15 +30,15 @@ const STATIC_EXTENSIONS = /\.(js|css|woff2?|ttf|otf|eot|png|jpe?g|gif|svg|ico|we
 
 describe('Cache version naming (#1330)', () => {
   it('static cache includes version prefix', () => {
-    expect(STATIC_CACHE).toBe('finance-static-v1');
+    expect(STATIC_CACHE).toBe('finance-static-v2');
   });
 
   it('API cache includes version prefix', () => {
-    expect(API_CACHE).toBe('finance-api-v1');
+    expect(API_CACHE).toBe('finance-api-v2');
   });
 
   it('changing CACHE_VERSION produces new cache names', () => {
-    const nextVersion = 'v2';
+    const nextVersion = 'v3';
     const nextStatic = `finance-static-${nextVersion}`;
     const nextApi = `finance-api-${nextVersion}`;
 

--- a/apps/web/src/sw/service-worker.ts
+++ b/apps/web/src/sw/service-worker.ts
@@ -29,8 +29,18 @@ import { SYNC_TAG, type ClientToSwMessage, type SwToClientMessage } from '../db/
 // Cache configuration
 // ---------------------------------------------------------------------------
 
-/** Bump this value to invalidate all caches on the next deploy. */
-const CACHE_VERSION = 'v1';
+/**
+ * Bump this value to invalidate all caches on the next deploy.
+ *
+ * v2 (#2021): forces eviction of the v1 precache that pinned the
+ * pre-#2019 web bundle. That bundle was built without
+ * `VITE_SUPABASE_URL`, so `isDemoMode()` evaluated true and the entire
+ * app booted into local-only demo auth. Users with a populated v1
+ * cache continued to see demo mode even after #2019 wired the env vars,
+ * because the SW's `cacheFirst` strategy keeps serving the cached
+ * `/assets/main-*.js` chunks until the cache name changes.
+ */
+const CACHE_VERSION = 'v2';
 
 /** Cache bucket names. */
 const STATIC_CACHE = `finance-static-${CACHE_VERSION}`;


### PR DESCRIPTION
## Problem

After PR #2019 wired `VITE_SUPABASE_URL` into the deploy workflow, the alpha walkthrough still showed demo mode. The build verifier on staging confirms no placeholder strings end up in the bundle:

```
Verified web build env: no Supabase placeholder values found.
```

…yet users still see demo mode. Root cause: the service worker.

## Root cause

`apps/web/src/sw/service-worker.ts:33` set `CACHE_VERSION = 'v1'` and had never been bumped. The fetch handler routes `/assets/main-*.js` through `cacheFirst()` against the `finance-static-v1` cache. The activate handler purges only caches **not matching** the current name (line 89), so renaming the cache is the only way to evict stale precache entries.

Until that cache name changes, the SW keeps serving the **old bundle** built before #2019 — which has `https://placeholder.supabase.co` as `VITE_SUPABASE_URL` fallback, which makes `isDemoMode()` return true (`demo-auth.ts:153-155`), which forces demo auth.

## Fix

Bump `CACHE_VERSION` from `'v1'` to `'v2'`. On the next deploy:

1. Browser detects the changed `sw.js` and installs the new SW.
2. New SW precaches the **new** chunks into `finance-static-v2`.
3. New SW activates → activate handler deletes `finance-static-v1` + `finance-api-v1`.
4. `clients.claim()` (line 95) takes over open tabs.
5. UpdateBanner (#1330) shows; clicking it triggers `window.location.reload()`.
6. Reloaded page is served the new HTML → new chunks → real Supabase URL → demo mode disabled.

Users who don't click the update banner pick up the new bundle on next full reload anyway, because `clients.claim()` means the new SW already controls navigation.

## Tests

Mirror constants in `service-worker-lifecycle.test.ts` updated to `v2`. All 32 lifecycle tests pass.

## Manual verification path (post-merge + deploy)

1. Open the alpha in a fresh incognito window — should NOT show demo banner.
2. Open the alpha in a window that previously showed demo mode — should show an "Update available" banner; clicking it reloads into the real bundle.
3. DevTools → Application → Service Workers shows `finance-static-v2` / `finance-api-v2` and the old v1 caches are gone.

Fixes #2021 (filed alongside)
Resolves persistent demo-mode bug from #2011 walkthrough