### PR TITLE
fix(web): render UpdateBanner at root + auto-activate waiting SW

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -15,6 +15,54 @@
   </head>
   <body>
     <div id="root"></div>
+    <script>
+      // Auto-apply waiting service-worker updates (#2023).
+      //
+      // When a new build is deployed, the browser detects the changed
+      // /sw.js and installs a new SW which enters the "waiting" state
+      // until the old SW's clients close. Without manual intervention
+      // (clicking an "Update available" banner), users can stay pinned
+      // to the old bundle indefinitely — see the demo-mode-stuck bug
+      // from #2021 where the banner only rendered inside the
+      // authenticated layout, so users stuck on /login could never
+      // trigger the update.
+      //
+      // This inline script runs on every page load (Caddy serves
+      // /index.html with no-cache, so this is always the latest copy)
+      // and immediately tells any waiting SW to skipWaiting. It also
+      // listens for `updatefound` so newly-installed waiting SWs are
+      // activated as soon as they're ready (handles the race where the
+      // browser is still fetching /sw.js when this script runs).
+      //
+      // The reload guard prevents an infinite loop if controllerchange
+      // fires for an unrelated reason.
+      if ('serviceWorker' in navigator) {
+        var reloaded = false;
+        navigator.serviceWorker.addEventListener('controllerchange', function () {
+          if (reloaded) return;
+          reloaded = true;
+          window.location.reload();
+        });
+        var activateWaiting = function (reg) {
+          if (reg && reg.waiting && navigator.serviceWorker.controller) {
+            reg.waiting.postMessage({ type: 'SKIP_WAITING' });
+          }
+        };
+        navigator.serviceWorker.getRegistration().then(function (reg) {
+          if (!reg) return;
+          activateWaiting(reg);
+          reg.addEventListener('updatefound', function () {
+            var installing = reg.installing;
+            if (!installing) return;
+            installing.addEventListener('statechange', function () {
+              if (installing.state === 'installed') {
+                activateWaiting(reg);
+              }
+            });
+          });
+        });
+      }
+    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/apps/web/src/components/layout/AppLayout.test.tsx
+++ b/apps/web/src/components/layout/AppLayout.test.tsx
@@ -40,7 +40,6 @@ vi.mock('../common/ConflictResolutionDialog', () => ({
 vi.mock('../common', () => ({
   KeyboardShortcutsModal: ({ isOpen }: { isOpen: boolean; onClose: () => void }) =>
     isOpen ? <div data-testid="keyboard-shortcuts-modal">Shortcuts Modal</div> : null,
-  UpdateBanner: () => <div data-testid="update-banner">Update Banner</div>,
   SyncStatusBar: () => <div data-testid="sync-status-bar">Sync Status</div>,
 }));
 
@@ -159,12 +158,6 @@ describe('AppLayout', () => {
     render(<AppLayout {...defaultProps} />);
 
     expect(screen.getByRole('banner', { name: 'App header' })).toBeInTheDocument();
-  });
-
-  it('renders the UpdateBanner', () => {
-    render(<AppLayout {...defaultProps} />);
-
-    expect(screen.getByTestId('update-banner')).toBeInTheDocument();
   });
 
   it('renders without the removed OfflineBanner (offline state handled by SyncStatusBar)', () => {

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback, useState } from 'react';
 
-import { KeyboardShortcutsModal, UpdateBanner, SyncStatusBar } from '../common';
+import { KeyboardShortcutsModal, SyncStatusBar } from '../common';
 import { ConflictResolutionDialog } from '../common/ConflictResolutionDialog';
 import { useKeyboardShortcuts } from '../../hooks';
 import { usePrivacyMode } from '../../contexts/PrivacyModeContext';
@@ -66,7 +66,6 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
         onOpenShortcuts={openKeyboardShortcuts}
       />
       <div className="app-shell">
-        <UpdateBanner />
         <SyncStatusBar />
         <header className="app-header" aria-label="App header">
           <h1 className="app-header__title">{pageTitle}</h1>

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -6,7 +6,7 @@ import { createRoot } from 'react-dom/client';
 import { BrowserRouter, useLocation } from 'react-router-dom';
 import { App } from './App';
 import { AuthProvider } from './auth/auth-context';
-import { ErrorBoundary, ToastProvider } from './components/common';
+import { ErrorBoundary, ToastProvider, UpdateBanner } from './components/common';
 import { ScrollToTop } from './components/navigation/ScrollToTop';
 import { DatabaseProvider } from './db/DatabaseProvider';
 import { MoneyDisplayProvider } from './lib/display-settings';
@@ -157,6 +157,7 @@ createRoot(rootElement).render(
           <MoneyDisplayProvider>
             <BrowserRouter>
               <ScrollToTop />
+              <UpdateBanner />
               <DatabaseGate>
                 <App />
               </DatabaseGate>


### PR DESCRIPTION
## Problem (compounding #2021)

After #2021 bumped `CACHE_VERSION` to evict stale SW caches, users still couldn't exit demo mode. Two layered bugs prevented the SW update from ever firing on stuck users:

1. `UpdateBanner` is the only UI that can trigger the new SW. It was rendered **only inside `AppLayout`** (`AppLayout.tsx:69`) — i.e. only after sign-in. In demo mode users are pinned to `/login`, which doesn't mount AppLayout, so the banner could never appear.
2. Even with the banner visible there's no auto-update path. A reload alone doesn't `skipWaiting` — the new SW just sits in the waiting state forever.

## Fix

**(a) Move UpdateBanner to the app root** (`main.tsx`) so it renders on every route. The component already short-circuits to `null` when `updateAvailable` is false, so it's a no-op on most loads.

**(b) Add an inline auto-update script to `index.html`** that:
- Listens for any SW `controllerchange` and reloads once (with guard against infinite loops).
- On script-run and on `updatefound`, posts `SKIP_WAITING` to any waiting registration so newly-installed SWs activate immediately.

Caddy serves `/index.html` with `Cache-Control: no-cache, must-revalidate` (`deploy/Caddyfile:199`), so the inline script is always the latest copy. The SW message handler at `service-worker.ts:201` already supports `SKIP_WAITING`.

After this lands and deploys, the user flow becomes:
1. Load alpha → fresh index.html (always) → inline script runs.
2. Browser fetches /sw.js (no-cache from Caddy) → sees v2 content → installs.
3. New SW reaches `installed` state → inline script's `updatefound` handler posts SKIP_WAITING.
4. New SW activates → claims clients → `controllerchange` → inline script reloads once.
5. Reloaded page serves new bundle from v2 cache → real Supabase URL → demo mode off.

No manual interaction required — just one reload (or just open the tab if it was already closed).

## Tests

- `AppLayout.test.tsx`: removed the now-irrelevant `renders the UpdateBanner` test + its mock entry; ownership moved out of this component.
- Local: AppLayout (13), UpdateBanner (5), useServiceWorkerUpdate (8), service-worker-lifecycle (32), SW unit (7) — **65 tests pass**.
- `vite build` succeeds. `prettier --check` and `eslint` on the changed files: clean.

## Manual verification path (post-merge + deploy)

1. Open the alpha — should show "Update available" banner immediately on the login page (because UpdateBanner is at root now), OR auto-reload silently into the new bundle (because the inline script auto-activates the waiting SW).
2. After auto-reload, no demo-mode banner; real passkey signin works; Settings → Sync section is visible.

Fixes #2021 (root cause behind alpha walkthrough demo-mode-stuck symptom)