### PR TITLE
fix(web): clarify UpdateBanner copy as app-update prompt (#2012)

### DIFF
--- a/apps/web/src/components/common/UpdateBanner.test.tsx
+++ b/apps/web/src/components/common/UpdateBanner.test.tsx
@@ -31,23 +31,23 @@ describe('UpdateBanner', () => {
 
     render(<UpdateBanner />);
 
-    expect(screen.getByText('Update available')).toBeInTheDocument();
+    expect(screen.getByText('A new version of the app is available')).toBeInTheDocument();
     expect(
       screen.getByRole('button', {
-        name: 'Update the app now and reload to the latest version',
+        name: 'Reload the page to install the new app version',
       }),
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Dismiss update notification' })).toBeInTheDocument();
   });
 
-  it('calls applyUpdate when the Update now button is clicked', () => {
+  it('calls applyUpdate when the reload-to-update button is clicked', () => {
     swUpdateMock.updateAvailable = true;
 
     render(<UpdateBanner />);
 
     fireEvent.click(
       screen.getByRole('button', {
-        name: 'Update the app now and reload to the latest version',
+        name: 'Reload the page to install the new app version',
       }),
     );
 
@@ -59,11 +59,11 @@ describe('UpdateBanner', () => {
 
     render(<UpdateBanner />);
 
-    expect(screen.getByText('Update available')).toBeInTheDocument();
+    expect(screen.getByText('A new version of the app is available')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Dismiss update notification' }));
 
-    expect(screen.queryByText('Update available')).not.toBeInTheDocument();
+    expect(screen.queryByText('A new version of the app is available')).not.toBeInTheDocument();
   });
 
   it('has a polite live region for screen reader announcements', () => {

--- a/apps/web/src/components/common/UpdateBanner.tsx
+++ b/apps/web/src/components/common/UpdateBanner.tsx
@@ -21,15 +21,15 @@ export const UpdateBanner: React.FC = () => {
 
   return (
     <div className="update-banner" role="status" aria-live="polite" aria-atomic="true">
-      <span className="update-banner__text">Update available</span>
+      <span className="update-banner__text">A new version of the app is available</span>
       <div className="update-banner__actions">
         <button
           type="button"
           className="update-banner__action"
-          aria-label="Update the app now and reload to the latest version"
+          aria-label="Reload the page to install the new app version"
           onClick={applyUpdate}
         >
-          Update now
+          Reload to update
         </button>
         <button
           type="button"


### PR DESCRIPTION
## Summary
- Clarifies UpdateBanner as a new app version prompt
- Changes primary action copy to reload-focused wording
- Updates UpdateBanner tests for the new text and aria-label

Closes #2012

## Tests
- npx vitest run src/components/common/UpdateBanner.test.tsx
- npx prettier --check apps/web/src/components/common/UpdateBanner.tsx apps/web/src/components/common/UpdateBanner.test.tsx