### PR TITLE
fix(web): sidebar navigation expand/collapse toggle

### DIFF
--- a/apps/web/src/components/layout/Navigation.tsx
+++ b/apps/web/src/components/layout/Navigation.tsx
@@ -211,9 +211,10 @@ const SidebarGroup: React.FC<SidebarGroupProps> = ({
       </h2>
       <ul
         id={sectionId}
-        className="sidebar-nav__list sidebar-nav__list--nested"
+        className={`sidebar-nav__list sidebar-nav__list--nested${expanded ? '' : ' sidebar-nav__list--collapsed'}`}
         role="list"
         hidden={!expanded}
+        aria-hidden={!expanded}
       >
         {items.map((item) => {
           const active = isActive(activePath, item.href);

--- a/apps/web/src/components/layout/Navigation/__tests__/SidebarNavigation.expand-collapse.test.tsx
+++ b/apps/web/src/components/layout/Navigation/__tests__/SidebarNavigation.expand-collapse.test.tsx
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../../auth/auth-context', () => ({
+  useAuth: () => ({
+    isAuthenticated: true,
+    isLoading: false,
+    user: { id: 'test-user', email: 'test@example.com', hasPasskey: false },
+    error: null,
+    logout: vi.fn(),
+  }),
+}));
+
+import { SidebarNavigation } from '../../Navigation';
+
+describe('SidebarNavigation expand/collapse regression', () => {
+  it('collapses and re-expands a group even when that group contains the active route', () => {
+    render(<SidebarNavigation activePath="/subscriptions" onNavigate={vi.fn()} />);
+
+    const moneyToggle = screen.getByRole('button', { name: 'Money section' });
+    const moneyList = document.getElementById('sidebar-group-money');
+
+    expect(moneyToggle).toHaveAttribute('aria-expanded', 'true');
+    expect(moneyList).not.toHaveClass('sidebar-nav__list--collapsed');
+
+    fireEvent.click(moneyToggle);
+
+    expect(moneyToggle).toHaveAttribute('aria-expanded', 'false');
+    expect(moneyList).toHaveAttribute('hidden');
+    expect(moneyList).toHaveAttribute('aria-hidden', 'true');
+    expect(moneyList).toHaveClass('sidebar-nav__list--collapsed');
+
+    fireEvent.click(moneyToggle);
+
+    expect(moneyToggle).toHaveAttribute('aria-expanded', 'true');
+    expect(moneyList).not.toHaveAttribute('hidden');
+    expect(moneyList).toHaveAttribute('aria-hidden', 'false');
+    expect(moneyList).not.toHaveClass('sidebar-nav__list--collapsed');
+  });
+});

--- a/apps/web/src/styles/navigation-chrome.css
+++ b/apps/web/src/styles/navigation-chrome.css
@@ -102,12 +102,13 @@
   padding-bottom: var(--spacing-1);
 }
 
-/* Honour the `hidden` HTML attribute on collapsed group lists.
- * Needed because `.sidebar-nav__list { display: flex }` in responsive.css is
- * author-origin and otherwise overrides the browser's `[hidden]` UA default
- * (#2005). */
+/* Honour the collapsed state on group lists. The explicit class mirrors the
+ * React state, while the `[hidden]` selector preserves native semantics. Use
+ * `!important` so base list display rules cannot leave a collapsed menu visible
+ * when stylesheet order changes (#2005). */
+.sidebar-nav__list--collapsed,
 .sidebar-nav__list[hidden] {
-  display: none;
+  display: none !important;
 }
 
 /* ── Enhanced active state for sidebar items ──────────────────────────── */


### PR DESCRIPTION
## Summary
- Mirror sidebar group expansion state into an explicit collapsed class and aria-hidden attribute.
- Force collapsed nav lists to display:none so base flex list styles cannot leave menus visible.
- Add a regression test for collapsing/re-expanding an active sidebar group.

## Tests
- npm run test -w apps/web -- Navigation.test.tsx SidebarNavigation.expand-collapse.test.tsx
- npm run type-check -w apps/web

No matching recent GitHub bug issue was found to reference (latest bug issue was #2022, unrelated).