### PR TITLE
feat(web): add contribute-to-goal UI (#1924)

### DIFF
--- a/apps/web/src/components/goals/GoalContributionDialog.test.tsx
+++ b/apps/web/src/components/goals/GoalContributionDialog.test.tsx
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Goal } from '../../kmp/bridge';
+import { MoneyDisplayProvider } from '../../lib/display-settings';
+import { GoalContributionDialog } from './GoalContributionDialog';
+
+const syncMetadata = {
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-01T00:00:00Z',
+  deletedAt: null,
+  syncVersion: 1,
+  isSynced: true,
+};
+
+function makeGoal(overrides: Partial<Goal> = {}): Goal {
+  return {
+    id: 'goal-1',
+    householdId: 'household-1',
+    name: 'Emergency Fund',
+    description: 'Keep three months saved.',
+    targetAmount: { amount: 100000 },
+    currentAmount: { amount: 25000 },
+    currency: { code: 'USD', decimalPlaces: 2 },
+    targetDate: '2025-12-31',
+    status: 'ACTIVE',
+    icon: 'shield',
+    color: '#059669',
+    accountId: null,
+    ...syncMetadata,
+    ...overrides,
+  };
+}
+
+function renderDialog(
+  props: Partial<ComponentProps<typeof GoalContributionDialog>> = {},
+  goal = makeGoal(),
+) {
+  const onSubmit = vi.fn<NonNullable<ComponentProps<typeof GoalContributionDialog>['onSubmit']>>();
+  const onCancel = vi.fn();
+
+  render(
+    <MoneyDisplayProvider>
+      <GoalContributionDialog
+        isOpen
+        goal={goal}
+        onSubmit={onSubmit}
+        onCancel={onCancel}
+        {...props}
+      />
+    </MoneyDisplayProvider>,
+  );
+
+  return { onSubmit, onCancel };
+}
+
+describe('GoalContributionDialog', () => {
+  it('submits a positive contribution with an optional note', async () => {
+    const { onSubmit, onCancel } = renderDialog();
+
+    fireEvent.change(screen.getByLabelText('Amount'), { target: { value: '125.50' } });
+    fireEvent.change(screen.getByLabelText('Note'), { target: { value: 'Paycheck transfer' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({
+        goalId: 'goal-1',
+        amount: { amount: 12550 },
+        note: 'Paycheck transfer',
+      });
+    });
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it('shows a validation error when the amount is not positive', async () => {
+    const { onSubmit } = renderDialog();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Enter a positive contribution amount.',
+    );
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('asks for confirmation before contributing past the goal target', async () => {
+    const goal = makeGoal({ currentAmount: { amount: 95000 } });
+    const { onSubmit } = renderDialog({}, goal);
+
+    fireEvent.change(screen.getByLabelText('Amount'), { target: { value: '100.00' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    expect(
+      screen.getByRole('alertdialog', { name: 'Contribution exceeds goal' }),
+    ).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Still Contribute' }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({
+        goalId: 'goal-1',
+        amount: { amount: 10000 },
+        note: null,
+      });
+    });
+  });
+});

--- a/apps/web/src/components/goals/GoalContributionDialog.tsx
+++ b/apps/web/src/components/goals/GoalContributionDialog.tsx
@@ -1,0 +1,363 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type FormEvent,
+  type KeyboardEvent,
+} from 'react';
+
+import { useFocusTrap } from '../../accessibility/aria';
+import type { Goal } from '../../kmp/bridge';
+import type { GoalContributionInput } from '../../db/repositories/goals';
+import { useMoneyDisplay } from '../../lib/display-settings';
+import { ConfirmDialog, CurrencyDisplay } from '../common';
+import '../forms/forms.css';
+
+export interface GoalContributionDialogProps {
+  isOpen: boolean;
+  goal: Goal | null;
+  onSubmit: (input: GoalContributionInput) => Promise<void> | void;
+  onCancel: () => void;
+}
+
+function parseContributionAmount(value: string, decimalPlaces = 2): number | null {
+  const normalized = value
+    .replace(/,/g, '')
+    .replace(/[^0-9.-]/g, '')
+    .trim();
+  const parsed = Number.parseFloat(normalized);
+
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return null;
+  }
+
+  return Math.round(parsed * Math.pow(10, decimalPlaces));
+}
+
+function formatInputAmount(
+  amountInMinorUnits: number,
+  currency: string,
+  decimalPlaces: number,
+  currencyDisplay: Intl.NumberFormatOptions['currencyDisplay'],
+): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+    currencyDisplay,
+    minimumFractionDigits: decimalPlaces,
+    maximumFractionDigits: decimalPlaces,
+  }).format(amountInMinorUnits / Math.pow(10, decimalPlaces));
+}
+
+export function GoalContributionDialog({
+  isOpen,
+  goal,
+  onSubmit,
+  onCancel,
+}: GoalContributionDialogProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const amountInputRef = useRef<HTMLInputElement>(null);
+  const amountErrorId = useId();
+  const titleId = useId();
+  const displaySettings = useMoneyDisplay();
+
+  const [amount, setAmount] = useState('');
+  const [note, setNote] = useState('');
+  const [amountError, setAmountError] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [pendingInput, setPendingInput] = useState<GoalContributionInput | null>(null);
+
+  useFocusTrap(panelRef, { active: isOpen, restoreFocus: true });
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    setAmount('');
+    setNote('');
+    setAmountError(null);
+    setSubmitError(null);
+    setSubmitting(false);
+    setPendingInput(null);
+
+    const id = requestAnimationFrame(() => {
+      amountInputRef.current?.focus();
+    });
+
+    return () => cancelAnimationFrame(id);
+  }, [goal?.id, isOpen]);
+
+  const handleCancel = useCallback(() => {
+    if (submitting) {
+      return;
+    }
+
+    onCancel();
+  }, [onCancel, submitting]);
+
+  const submitContribution = useCallback(
+    async (input: GoalContributionInput) => {
+      setSubmitting(true);
+      setSubmitError(null);
+
+      try {
+        await onSubmit(input);
+        setAmount('');
+        setNote('');
+        setPendingInput(null);
+        onCancel();
+      } catch (err) {
+        setSubmitError(err instanceof Error ? err.message : 'Failed to contribute to goal.');
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [onCancel, onSubmit],
+  );
+
+  const buildContributionInput = useCallback((): GoalContributionInput | null => {
+    if (!goal) {
+      return null;
+    }
+
+    const amountInMinorUnits = parseContributionAmount(amount, goal.currency.decimalPlaces);
+    if (amountInMinorUnits === null) {
+      setAmountError('Enter a positive contribution amount.');
+      return null;
+    }
+
+    setAmountError(null);
+    return {
+      goalId: goal.id,
+      amount: { amount: amountInMinorUnits },
+      note: note.trim() || null,
+    };
+  }, [amount, goal, note]);
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent) => {
+      event.preventDefault();
+
+      const input = buildContributionInput();
+      if (!goal || input === null) {
+        return;
+      }
+
+      if (goal.currentAmount.amount + input.amount.amount > goal.targetAmount.amount) {
+        setPendingInput(input);
+        return;
+      }
+
+      await submitContribution(input);
+    },
+    [buildContributionInput, goal, submitContribution],
+  );
+
+  const handleConfirmOverGoal = useCallback(async () => {
+    if (pendingInput === null) {
+      return;
+    }
+
+    await submitContribution(pendingInput);
+  }, [pendingInput, submitContribution]);
+
+  const handleCancelOverGoal = useCallback(() => {
+    setPendingInput(null);
+  }, []);
+
+  const handleAmountBlur = useCallback(() => {
+    if (!goal) {
+      return;
+    }
+
+    const amountInMinorUnits = parseContributionAmount(amount, goal.currency.decimalPlaces);
+    if (amountInMinorUnits === null) {
+      return;
+    }
+
+    setAmount(
+      formatInputAmount(
+        amountInMinorUnits,
+        goal.currency.code,
+        goal.currency.decimalPlaces,
+        displaySettings.currencyDisplay,
+      ),
+    );
+  }, [amount, displaySettings.currencyDisplay, goal]);
+
+  const handleAmountFocus = useCallback(() => {
+    if (!goal) {
+      return;
+    }
+
+    const amountInMinorUnits = parseContributionAmount(amount, goal.currency.decimalPlaces);
+    if (amountInMinorUnits === null) {
+      return;
+    }
+
+    setAmount(
+      (amountInMinorUnits / Math.pow(10, goal.currency.decimalPlaces)).toFixed(
+        goal.currency.decimalPlaces,
+      ),
+    );
+  }, [amount, goal]);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        handleCancel();
+      }
+    },
+    [handleCancel],
+  );
+
+  if (!isOpen || goal === null) {
+    return null;
+  }
+
+  const hasAmountError = amountError !== null;
+  const projectedAmount = (() => {
+    const parsed = parseContributionAmount(amount, goal.currency.decimalPlaces);
+    return parsed === null ? goal.currentAmount.amount : goal.currentAmount.amount + parsed;
+  })();
+
+  return (
+    <>
+      <div className="form-dialog" role="presentation" onKeyDown={handleKeyDown}>
+        <div className="form-dialog__backdrop" aria-hidden="true" onClick={handleCancel} />
+        <div
+          ref={panelRef}
+          className="form-dialog__panel"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={titleId}
+        >
+          <h2 id={titleId} className="form-dialog__title">
+            Contribute to {goal.name}
+          </h2>
+
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: '1fr 1fr',
+              gap: 'var(--spacing-3)',
+              marginBottom: 'var(--spacing-4)',
+            }}
+          >
+            <div>
+              <p className="card__title">Current</p>
+              <p className="card__value">
+                <CurrencyDisplay amount={goal.currentAmount.amount} currency={goal.currency.code} />
+              </p>
+            </div>
+            <div>
+              <p className="card__title">After contribution</p>
+              <p className="card__value">
+                <CurrencyDisplay amount={projectedAmount} currency={goal.currency.code} />
+              </p>
+            </div>
+          </div>
+
+          {submitError && (
+            <div className="form-banner-error" role="alert">
+              {submitError}
+            </div>
+          )}
+
+          <form onSubmit={handleSubmit} noValidate>
+            <div className="form-fields">
+              <div className="form-group">
+                <label
+                  htmlFor="goal-contribution-amount"
+                  className="form-group__label form-group__label--required"
+                >
+                  Amount
+                </label>
+                <input
+                  ref={amountInputRef}
+                  id="goal-contribution-amount"
+                  className={`form-input${hasAmountError ? ' form-input--error' : ''}`}
+                  type="text"
+                  inputMode="decimal"
+                  value={amount}
+                  onChange={(event) => setAmount(event.target.value)}
+                  onBlur={handleAmountBlur}
+                  onFocus={handleAmountFocus}
+                  placeholder={formatInputAmount(
+                    0,
+                    goal.currency.code,
+                    goal.currency.decimalPlaces,
+                    displaySettings.currencyDisplay,
+                  )}
+                  aria-invalid={hasAmountError}
+                  aria-describedby={hasAmountError ? amountErrorId : undefined}
+                  aria-required="true"
+                  autoComplete="off"
+                />
+                {hasAmountError && (
+                  <span id={amountErrorId} className="form-error" role="alert">
+                    {amountError}
+                  </span>
+                )}
+              </div>
+
+              <div className="form-group">
+                <label htmlFor="goal-contribution-note" className="form-group__label">
+                  Note
+                </label>
+                <textarea
+                  id="goal-contribution-note"
+                  className="form-textarea"
+                  value={note}
+                  onChange={(event) => setNote(event.target.value)}
+                  rows={3}
+                  placeholder="Optional note about this contribution"
+                />
+              </div>
+            </div>
+
+            <div className="form-actions">
+              <button
+                type="button"
+                className="form-button form-button--secondary"
+                onClick={handleCancel}
+                disabled={submitting}
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className="form-button form-button--primary"
+                disabled={submitting}
+                aria-busy={submitting}
+              >
+                {submitting ? 'Contributing…' : 'Submit'}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+
+      <ConfirmDialog
+        isOpen={pendingInput !== null}
+        title="Contribution exceeds goal"
+        message="This would exceed your goal — still contribute?"
+        confirmLabel="Still Contribute"
+        cancelLabel="Go Back"
+        variant="warning"
+        onConfirm={handleConfirmOverGoal}
+        onCancel={handleCancelOverGoal}
+        isLoading={submitting}
+      />
+    </>
+  );
+}
+
+export default GoalContributionDialog;

--- a/apps/web/src/db/repositories/goals.test.ts
+++ b/apps/web/src/db/repositories/goals.test.ts
@@ -5,6 +5,7 @@ import type { GoalStatus } from '../../kmp/bridge';
 import { Currencies } from '../../kmp/bridge';
 import type { Row, SqliteDb } from '../sqlite-wasm';
 import {
+  contributeToGoal,
   createGoal,
   deleteGoal,
   getActiveGoals,
@@ -428,6 +429,151 @@ describe('goals repository', () => {
 
       expect(params[2]).toBe('For the new roof');
       expect(goal?.description).toBe('For the new roof');
+    });
+  });
+
+  describe('contributeToGoal', () => {
+    it('adds the contribution to current amount', () => {
+      mockQueryOne
+        .mockReturnValueOnce({
+          id: 'goal-1',
+          household_id: 'hh-1',
+          name: 'Goal',
+          description: null,
+          target_amount: 100000,
+          current_amount: 25000,
+          currency: 'USD',
+          target_date: null,
+          status: 'ACTIVE',
+          icon: null,
+          color: null,
+          account_id: null,
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T00:00:00Z',
+          deleted_at: null,
+          sync_version: 1,
+          is_synced: 0,
+        })
+        .mockReturnValueOnce({
+          id: 'goal-1',
+          household_id: 'hh-1',
+          name: 'Goal',
+          description: null,
+          target_amount: 100000,
+          current_amount: 40000,
+          currency: 'USD',
+          target_date: null,
+          status: 'ACTIVE',
+          icon: null,
+          color: null,
+          account_id: null,
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-02T00:00:00Z',
+          deleted_at: null,
+          sync_version: 1,
+          is_synced: 0,
+        });
+
+      const goal = contributeToGoal(mockDb, 'goal-1', {
+        goalId: 'goal-1',
+        amount: { amount: 15000 },
+        note: 'Paycheck transfer',
+      });
+
+      expect(mockExecute).toHaveBeenCalledWith(mockDb, expect.stringContaining('UPDATE goal'), [
+        40000,
+        'ACTIVE',
+        'goal-1',
+      ]);
+      expect(mockExecute).toHaveBeenCalledWith(
+        mockDb,
+        expect.stringContaining('INSERT INTO goal_progress_contribution'),
+        expect.arrayContaining([
+          expect.any(String),
+          'goal-1',
+          'hh-1',
+          15000,
+          'USD',
+          'Paycheck transfer',
+        ]),
+      );
+      expect(goal?.currentAmount.amount).toBe(40000);
+    });
+
+    it('marks the goal completed when the contribution reaches the target', () => {
+      mockQueryOne
+        .mockReturnValueOnce({
+          id: 'goal-1',
+          household_id: 'hh-1',
+          name: 'Goal',
+          description: null,
+          target_amount: 100000,
+          current_amount: 95000,
+          currency: 'USD',
+          target_date: null,
+          status: 'ACTIVE',
+          icon: null,
+          color: null,
+          account_id: null,
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T00:00:00Z',
+          deleted_at: null,
+          sync_version: 1,
+          is_synced: 0,
+        })
+        .mockReturnValueOnce({
+          id: 'goal-1',
+          household_id: 'hh-1',
+          name: 'Goal',
+          description: null,
+          target_amount: 100000,
+          current_amount: 105000,
+          currency: 'USD',
+          target_date: null,
+          status: 'COMPLETED',
+          icon: null,
+          color: null,
+          account_id: null,
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-02T00:00:00Z',
+          deleted_at: null,
+          sync_version: 1,
+          is_synced: 0,
+        });
+
+      const goal = contributeToGoal(mockDb, 'goal-1', {
+        goalId: 'goal-1',
+        amount: { amount: 10000 },
+      });
+
+      expect((mockExecute.mock.calls[0][2] as unknown[])[1]).toBe('COMPLETED');
+      expect(goal?.status).toBe('COMPLETED');
+    });
+
+    it('rejects non-positive contribution amounts', () => {
+      mockQueryOne.mockReturnValue({
+        id: 'goal-1',
+        household_id: 'hh-1',
+        name: 'Goal',
+        target_amount: 100000,
+        current_amount: 25000,
+        currency: 'USD',
+        target_date: null,
+        status: 'ACTIVE',
+        icon: null,
+        color: null,
+        account_id: null,
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z',
+        deleted_at: null,
+        sync_version: 1,
+        is_synced: 0,
+      });
+
+      expect(() =>
+        contributeToGoal(mockDb, 'goal-1', { goalId: 'goal-1', amount: { amount: 0 } }),
+      ).toThrow('Contribution amount must be greater than zero.');
+      expect(mockExecute).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/db/repositories/goals.ts
+++ b/apps/web/src/db/repositories/goals.ts
@@ -64,6 +64,13 @@ export interface UpdateGoalInput {
   accountId?: SyncId | null;
 }
 
+/** Input used when adding progress to an existing goal. */
+export interface GoalContributionInput {
+  goalId: SyncId;
+  amount: { amount: number };
+  note?: string | null;
+}
+
 function mapGoal(row: Row): Goal {
   return {
     id: requireString(row.id, 'goal.id'),
@@ -206,6 +213,77 @@ export function updateGoal(db: SqliteDb, goalId: SyncId, updates: UpdateGoalInpu
       mergedGoal.color,
       mergedGoal.accountId,
       goalId,
+    ],
+  );
+
+  return getGoalById(db, goalId);
+}
+
+/** Add a positive contribution amount to a goal's current progress. */
+export function contributeToGoal(
+  db: SqliteDb,
+  goalId: SyncId,
+  input: GoalContributionInput,
+): Goal | null {
+  const existingGoal = getGoalById(db, goalId);
+  if (!existingGoal) {
+    return null;
+  }
+
+  if (!Number.isFinite(input.amount.amount) || input.amount.amount <= 0) {
+    throw new Error('Contribution amount must be greater than zero.');
+  }
+
+  const nextCurrentAmount = existingGoal.currentAmount.amount + input.amount.amount;
+  const nextStatus =
+    nextCurrentAmount >= existingGoal.targetAmount.amount ? 'COMPLETED' : existingGoal.status;
+
+  const contributionId = crypto.randomUUID();
+
+  execute(
+    db,
+    `UPDATE goal
+        SET current_amount = ?,
+            status = ?,
+            updated_at = ${SQLITE_NOW_EXPRESSION},
+            sync_version = 1,
+            is_synced = 0
+      WHERE id = ?
+        AND deleted_at IS NULL`,
+    [nextCurrentAmount, nextStatus, goalId],
+  );
+
+  execute(
+    db,
+    `INSERT INTO goal_progress_contribution (
+      id,
+      goal_id,
+      household_id,
+      amount,
+      currency,
+      note,
+      contributed_at,
+      created_at,
+      updated_at,
+      deleted_at,
+      sync_version,
+      is_synced
+    ) VALUES (
+      ?, ?, ?, ?, ?, ?,
+      ${SQLITE_NOW_EXPRESSION},
+      ${SQLITE_NOW_EXPRESSION},
+      ${SQLITE_NOW_EXPRESSION},
+      NULL,
+      1,
+      0
+    )`,
+    [
+      contributionId,
+      goalId,
+      existingGoal.householdId,
+      input.amount.amount,
+      existingGoal.currency.code,
+      input.note?.trim() || null,
     ],
   );
 

--- a/apps/web/src/db/sqlite-wasm.ts
+++ b/apps/web/src/db/sqlite-wasm.ts
@@ -468,6 +468,31 @@ export const MIGRATIONS: Migration[] = [
     label: 'add-description-to-goals',
     up: [`ALTER TABLE goal ADD COLUMN description TEXT;`],
   },
+  {
+    version: 7,
+    label: 'add-goal-progress-contributions',
+    up: [
+      `CREATE TABLE IF NOT EXISTS goal_progress_contribution (
+        id             TEXT    NOT NULL PRIMARY KEY,
+        goal_id        TEXT    NOT NULL,
+        household_id   TEXT    NOT NULL,
+        amount         INTEGER NOT NULL,
+        currency       TEXT    NOT NULL DEFAULT 'USD',
+        note           TEXT,
+        contributed_at TEXT    NOT NULL,
+        created_at     TEXT    NOT NULL,
+        updated_at     TEXT    NOT NULL,
+        deleted_at     TEXT,
+        sync_version   INTEGER NOT NULL DEFAULT 0,
+        is_synced      INTEGER NOT NULL DEFAULT 0,
+        FOREIGN KEY (goal_id)      REFERENCES goal(id),
+        FOREIGN KEY (household_id) REFERENCES household(id)
+      );`,
+      `CREATE INDEX IF NOT EXISTS idx_goal_progress_contribution_goal ON goal_progress_contribution (goal_id);`,
+      `CREATE INDEX IF NOT EXISTS idx_goal_progress_contribution_household ON goal_progress_contribution (household_id);`,
+      `CREATE INDEX IF NOT EXISTS idx_goal_progress_contribution_sync ON goal_progress_contribution (is_synced);`,
+    ],
+  },
 ];
 // ---------------------------------------------------------------------------
 // OPFS / IndexedDB feature detection

--- a/apps/web/src/hooks/__tests__/useGoals.test.ts
+++ b/apps/web/src/hooks/__tests__/useGoals.test.ts
@@ -19,12 +19,14 @@ vi.mock('../../db/DatabaseProvider', () => ({
 const mockGetAllGoals = vi.fn<(...args: unknown[]) => Goal[]>();
 const mockCreateGoal = vi.fn<(...args: unknown[]) => Goal>();
 const mockUpdateGoal = vi.fn<(...args: unknown[]) => Goal | null>();
+const mockContributeToGoal = vi.fn<(...args: unknown[]) => Goal | null>();
 const mockDeleteGoal = vi.fn<(...args: unknown[]) => boolean>();
 
 vi.mock('../../db/repositories/goals', () => ({
   getAllGoals: (...args: unknown[]) => mockGetAllGoals(...args),
   createGoal: (...args: unknown[]) => mockCreateGoal(...args),
   updateGoal: (...args: unknown[]) => mockUpdateGoal(...args),
+  contributeToGoal: (...args: unknown[]) => mockContributeToGoal(...args),
   deleteGoal: (...args: unknown[]) => mockDeleteGoal(...args),
 }));
 
@@ -215,6 +217,54 @@ describe('useGoals', () => {
 
     expect(returned).toBeNull();
     expect(result.current.error).toBe('Update failed');
+  });
+
+  // -----------------------------------------------------------------------
+  // CRUD — contributeToGoal
+  // -----------------------------------------------------------------------
+
+  it('contributes to a goal and triggers refresh', () => {
+    mockGetAllGoals.mockReturnValue([makeGoal()]);
+    const updated = makeGoal({ currentAmount: { amount: 300000 } });
+    mockContributeToGoal.mockReturnValue(updated);
+
+    const { result } = renderHook(() => useGoals());
+
+    let returned: Goal | null = null;
+    act(() => {
+      returned = result.current.contributeToGoal('goal-1', {
+        goalId: 'goal-1',
+        amount: { amount: 50000 },
+        note: 'Paycheck transfer',
+      });
+    });
+
+    expect(returned).toEqual(updated);
+    expect(mockContributeToGoal).toHaveBeenCalledWith(mockDb, 'goal-1', {
+      goalId: 'goal-1',
+      amount: { amount: 50000 },
+      note: 'Paycheck transfer',
+    });
+  });
+
+  it('returns null and sets error when contributeToGoal throws', () => {
+    mockGetAllGoals.mockReturnValue([makeGoal()]);
+    mockContributeToGoal.mockImplementation(() => {
+      throw new Error('Contribution failed');
+    });
+
+    const { result } = renderHook(() => useGoals());
+
+    let returned: Goal | null = null;
+    act(() => {
+      returned = result.current.contributeToGoal('goal-1', {
+        goalId: 'goal-1',
+        amount: { amount: 50000 },
+      });
+    });
+
+    expect(returned).toBeNull();
+    expect(result.current.error).toBe('Contribution failed');
   });
 
   // -----------------------------------------------------------------------

--- a/apps/web/src/hooks/useGoals.ts
+++ b/apps/web/src/hooks/useGoals.ts
@@ -18,11 +18,13 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useDatabase } from '../db/DatabaseProvider';
 import {
+  contributeToGoal as repoContributeToGoal,
   createGoal as repoCreateGoal,
   deleteGoal as repoDeleteGoal,
   getAllGoals,
   updateGoal as repoUpdateGoal,
   type CreateGoalInput,
+  type GoalContributionInput,
   type UpdateGoalInput,
 } from '../db/repositories/goals';
 import type { Goal, SyncId } from '../kmp/bridge';
@@ -54,6 +56,11 @@ export interface UseGoalsResult {
    * @returns The updated goal, or `null` if the goal was not found or update failed.
    */
   updateGoal: (goalId: SyncId, updates: UpdateGoalInput) => Goal | null;
+  /**
+   * Add progress to a goal and automatically refresh the list.
+   * @returns The updated goal, or `null` if the goal was not found or contribution failed.
+   */
+  contributeToGoal: (goalId: SyncId, input: GoalContributionInput) => Goal | null;
   /**
    * Soft-delete a goal and automatically refresh the list.
    * @returns `true` if deletion succeeded, `false` otherwise.
@@ -127,6 +134,23 @@ export function useGoals(): UseGoalsResult {
     [db, refresh],
   );
 
+  const contributeToGoal = useCallback(
+    (goalId: SyncId, input: GoalContributionInput): Goal | null => {
+      try {
+        const updated = repoContributeToGoal(db, goalId, input);
+        if (updated !== null) {
+          refresh();
+        }
+        return updated;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to contribute to goal.');
+        setLoading(false);
+        return null;
+      }
+    },
+    [db, refresh],
+  );
+
   const deleteGoal = useCallback(
     (goalId: SyncId): boolean => {
       try {
@@ -151,6 +175,7 @@ export function useGoals(): UseGoalsResult {
     refresh,
     createGoal,
     updateGoal,
+    contributeToGoal,
     deleteGoal,
   };
 }

--- a/apps/web/src/pages/GoalDetailPage.test.tsx
+++ b/apps/web/src/pages/GoalDetailPage.test.tsx
@@ -65,6 +65,7 @@ describe('GoalDetailPage', () => {
       refresh: refreshMock,
       createGoal: vi.fn(),
       updateGoal: vi.fn(),
+      contributeToGoal: vi.fn(),
       deleteGoal: vi.fn(),
     });
   });
@@ -81,6 +82,7 @@ describe('GoalDetailPage', () => {
       refresh: refreshMock,
       createGoal: vi.fn(),
       updateGoal: vi.fn(),
+      contributeToGoal: vi.fn(),
       deleteGoal: vi.fn(),
     });
 
@@ -101,6 +103,7 @@ describe('GoalDetailPage', () => {
       refresh: refreshMock,
       createGoal: vi.fn(),
       updateGoal: vi.fn(),
+      contributeToGoal: vi.fn(),
       deleteGoal: vi.fn(),
     });
 
@@ -118,6 +121,7 @@ describe('GoalDetailPage', () => {
       refresh: refreshMock,
       createGoal: vi.fn(),
       updateGoal: vi.fn(),
+      contributeToGoal: vi.fn(),
       deleteGoal: vi.fn(),
     });
 
@@ -236,6 +240,7 @@ describe('GoalDetailPage', () => {
       refresh: refreshMock,
       createGoal: vi.fn(),
       updateGoal: vi.fn(),
+      contributeToGoal: vi.fn(),
       deleteGoal: vi.fn(),
     });
 
@@ -268,6 +273,7 @@ describe('GoalDetailPage', () => {
       refresh: refreshMock,
       createGoal: vi.fn(),
       updateGoal: vi.fn(),
+      contributeToGoal: vi.fn(),
       deleteGoal: vi.fn(),
     });
 

--- a/apps/web/src/pages/GoalsPage.test.tsx
+++ b/apps/web/src/pages/GoalsPage.test.tsx
@@ -95,6 +95,7 @@ describe('GoalsPage', () => {
       refresh: vi.fn(),
       createGoal: vi.fn(),
       updateGoal: vi.fn(),
+      contributeToGoal: vi.fn(),
       deleteGoal: vi.fn(),
     });
   });
@@ -138,5 +139,15 @@ describe('GoalsPage', () => {
     );
     const progressBars = screen.getAllByRole('progressbar');
     expect(progressBars.length).toBe(4);
+  });
+
+  it('displays a contribute action for each goal', () => {
+    render(
+      <MemoryRouter>
+        <GoalsPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getAllByRole('button', { name: /contribute to/i })).toHaveLength(4);
   });
 });

--- a/apps/web/src/pages/GoalsPage.tsx
+++ b/apps/web/src/pages/GoalsPage.tsx
@@ -8,10 +8,12 @@ import {
   EmptyState,
   ErrorBanner,
   LoadingSpinner,
+  useToast,
 } from '../components/common';
+import { GoalContributionDialog } from '../components/goals/GoalContributionDialog';
 import { GoalForm } from '../components/forms';
 import { OfflineBanner } from '../components/OfflineBanner';
-import type { CreateGoalInput } from '../db/repositories/goals';
+import type { CreateGoalInput, GoalContributionInput } from '../db/repositories/goals';
 import { useGoals } from '../hooks';
 import type { Goal } from '../kmp/bridge';
 import { getGoalStatusIndicator } from '../lib/a11y';
@@ -32,12 +34,23 @@ function getGoalIcon(iconName: string | null | undefined): IconName {
   }
 }
 
+function useOptionalToast(): ReturnType<typeof useToast> | null {
+  try {
+    return useToast();
+  } catch {
+    return null;
+  }
+}
+
 export const GoalsPage: React.FC = () => {
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [editingGoal, setEditingGoal] = useState<Goal | null>(null);
   const [deletingGoal, setDeletingGoal] = useState<Goal | null>(null);
+  const [contributingGoal, setContributingGoal] = useState<Goal | null>(null);
   const [isDeletingGoal, setIsDeletingGoal] = useState(false);
-  const { goals, loading, error, refresh, createGoal, updateGoal, deleteGoal } = useGoals();
+  const { goals, loading, error, refresh, createGoal, updateGoal, contributeToGoal, deleteGoal } =
+    useGoals();
+  const toast = useOptionalToast();
   const totalTarget = goals.reduce((sum, goal) => sum + goal.targetAmount.amount, 0);
   const totalSaved = goals.reduce((sum, goal) => sum + goal.currentAmount.amount, 0);
 
@@ -58,6 +71,14 @@ export const GoalsPage: React.FC = () => {
 
   const handleRequestDelete = useCallback((goal: Goal) => {
     setDeletingGoal(goal);
+  }, []);
+
+  const handleContributeGoal = useCallback((goal: Goal) => {
+    setContributingGoal(goal);
+  }, []);
+
+  const handleCloseContribution = useCallback(() => {
+    setContributingGoal(null);
   }, []);
 
   const handleCancelDelete = useCallback(() => {
@@ -82,6 +103,22 @@ export const GoalsPage: React.FC = () => {
       setIsFormOpen(false);
     },
     [createGoal, editingGoal, updateGoal],
+  );
+
+  const handleSubmitContribution = useCallback(
+    async (input: GoalContributionInput) => {
+      const updatedGoal = contributeToGoal(input.goalId, input);
+      if (updatedGoal === null) {
+        throw new Error('Failed to contribute to goal.');
+      }
+
+      toast?.showToast({
+        type: 'success',
+        message: `Contribution added to ${updatedGoal.name}`,
+        duration: 3000,
+      });
+    },
+    [contributeToGoal, toast],
   );
 
   const handleConfirmDelete = useCallback(async () => {
@@ -329,6 +366,22 @@ export const GoalsPage: React.FC = () => {
                             : 'Past due'}
                       </span>
                     </div>
+                    <div
+                      style={{
+                        display: 'flex',
+                        justifyContent: 'flex-end',
+                        marginTop: 'var(--spacing-4)',
+                      }}
+                    >
+                      <button
+                        type="button"
+                        className="form-button form-button--secondary"
+                        onClick={() => handleContributeGoal(goal)}
+                        aria-label={`Contribute to ${goal.name}`}
+                      >
+                        Contribute
+                      </button>
+                    </div>
                   </article>
                 );
               })}
@@ -336,6 +389,12 @@ export const GoalsPage: React.FC = () => {
           </section>
         </>
       )}
+      <GoalContributionDialog
+        isOpen={contributingGoal !== null}
+        goal={contributingGoal}
+        onCancel={handleCloseContribution}
+        onSubmit={handleSubmitContribution}
+      />
       <GoalForm
         isOpen={isFormOpen}
         onCancel={handleCloseForm}


### PR DESCRIPTION
## Summary
- Added a Contribute button on each goal card that opens a modal contribution form.
- Wired contributions through `useGoals`/repository logic to update `current_amount`, complete reached goals, and store contribution notes locally.
- Added a goal progress contribution table migration.

## Tests
- PASS: `npx vitest run src\components\goals\GoalContributionDialog.test.tsx src\db\repositories\goals.test.ts src\hooks\__tests__\useGoals.test.ts src\pages\GoalsPage.test.tsx src\pages\GoalDetailPage.test.tsx src\db\__tests__\sqlite-wasm.test.ts`
- PASS: `npm run type-check`
- PASS: `npx prettier --check` on changed files
- NOTE: full `npx vitest run` currently has 1 unrelated failure in `src/utils/formatDate.test.ts` (`expected 'Dec 23, 2023' to contain '24'`).

Fixes #1924