### PR TITLE
chore(e2e): expand Playwright matrix across browsers (#2034)

### DIFF
--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -180,7 +180,7 @@ jobs:
             report += `- ✅ Read-only Gradle cache on feature branches\n`;
             report += `- ✅ Concurrency groups with cancel-in-progress\n`;
             report += `- ✅ Path-filtered triggers (affected-only builds)\n`;
-            report += `- ✅ E2E test sharding (4 parallel runners)\n`;
+            report += `- ✅ E2E browser matrix with mobile smoke coverage\n`;
 
             core.summary.addRaw(report);
             await core.summary.write();

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -109,7 +109,7 @@ jobs:
         run: npx -w apps/web playwright install --with-deps chromium
 
       - name: Run E2E tests
-        run: npx -w apps/web playwright test
+        run: npx -w apps/web playwright test --project=chromium
 
       - name: Lighthouse audit
         uses: treosh/lighthouse-ci-action@3e7e23fb74242897f95c0ba9cabad3d0227b9b18 # v12.6.2

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches: [main]
     paths: ['apps/web/**', 'packages/design-tokens/**']
+  schedule:
+    - cron: '0 6 * * *'
 
 concurrency:
   group: web-${{ github.ref }}
@@ -102,14 +104,14 @@ jobs:
       - run: npm test -w apps/web
 
   e2e-tests:
-    name: E2E Tests (shard ${{ matrix.shard }})
+    name: E2E Tests (${{ matrix.browser }})
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
-        shard: [1/4, 2/4, 3/4, 4/4]
+        browser: ${{ fromJSON(github.event_name == 'pull_request' && '["chromium","webkit","firefox","chromium-edge","mobile-chrome"]' || '["chromium","webkit","firefox","chromium-edge","mobile-chrome","mobile-safari"]') }}
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -133,22 +135,41 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ hashFiles('apps/web/package.json') }}
           restore-keys: ${{ runner.os }}-playwright-
 
-      - name: Install Playwright browsers
-        run: npx -w apps/web playwright install --with-deps chromium
+      - name: Install Playwright browser
+        run: |
+          case "${{ matrix.browser }}" in
+            chromium|mobile-chrome)
+              npx -w apps/web playwright install --with-deps chromium
+              ;;
+            webkit|mobile-safari)
+              npx -w apps/web playwright install --with-deps webkit
+              ;;
+            firefox)
+              npx -w apps/web playwright install --with-deps firefox
+              ;;
+            chromium-edge)
+              npx -w apps/web playwright install --with-deps msedge
+              ;;
+          esac
 
-      - name: Run E2E tests (shard ${{ matrix.shard }})
-        run: npx -w apps/web playwright test --shard=${{ matrix.shard }}
+      - name: Run E2E tests (${{ matrix.browser }})
+        run: |
+          if [[ "${{ matrix.browser }}" == mobile-* ]]; then
+            npx -w apps/web playwright test e2e/auth.spec.ts -g "login page renders" --project=${{ matrix.browser }}
+          else
+            npx -w apps/web playwright test --project=${{ matrix.browser }}
+          fi
 
       - name: Upload blob report
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: e2e-blob-report-${{ strategy.job-index }}
+          name: e2e-blob-report-${{ matrix.browser }}
           path: apps/web/blob-report/
           retention-days: 7
           if-no-files-found: ignore
 
-  # Merge all shard reports into a single HTML report
+  # Merge all browser reports into a single HTML report
   e2e-report:
     name: Merge E2E Reports
     needs: e2e-tests
@@ -193,15 +214,15 @@ jobs:
         run: |
           echo "### 🎭 E2E Test Report" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "Sharded across 4 parallel runners with 2 retries for flaky tests." >> "$GITHUB_STEP_SUMMARY"
+          echo "Browser matrix: chromium, webkit, firefox, chromium-edge, mobile-chrome; mobile-safari on main/nightly only. Mobile projects run a startup smoke test. CI retries flaky tests twice." >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "📊 **Download the full HTML report** from the \`e2e-html-report\` artifact above." >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          # Check if any shards failed
+          # Check if any browser jobs failed
           if [ "${{ needs.e2e-tests.result }}" = "failure" ]; then
-            echo "⚠️ Some E2E shards failed — check individual shard logs for details." >> "$GITHUB_STEP_SUMMARY"
+            echo "⚠️ Some E2E browser jobs failed — check individual logs for details." >> "$GITHUB_STEP_SUMMARY"
           elif [ "${{ needs.e2e-tests.result }}" = "success" ]; then
-            echo "✅ All E2E shards passed." >> "$GITHUB_STEP_SUMMARY"
+            echo "✅ All E2E browser jobs passed." >> "$GITHUB_STEP_SUMMARY"
           fi
 
   lighthouse:

--- a/apps/web/e2e/cross-browser.spec.ts
+++ b/apps/web/e2e/cross-browser.spec.ts
@@ -8,8 +8,8 @@
  * and offline indicators. These tests run within the existing Playwright
  * setup using the `authenticatedPage` fixture.
  *
- * The Playwright config defines browser projects (chromium, firefox, webkit)
- * so these tests automatically run across all configured browsers.
+ * The Playwright config defines desktop browser projects (chromium, firefox,
+ * webkit, and Edge); CI runs mobile projects as startup smoke coverage.
  *
  * References: issue #1343
  */

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from '@playwright/test';
+import { defineConfig, devices } from '@playwright/test';
 
 const isCI = !!process.env.CI;
 
@@ -12,10 +12,22 @@ export default defineConfig({
   // Retry flaky tests in CI (0 retries locally for fast feedback)
   retries: isCI ? 2 : 0,
 
-  // Use blob reporter in CI for shard merging, HTML locally for debugging
+  // Use blob reporter in CI for browser report merging, HTML locally for debugging
   reporter: isCI
     ? [['blob', { outputDir: 'blob-report' }], ['github']]
     : [['html', { open: 'never' }]],
+
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+    { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+    {
+      name: 'chromium-edge',
+      use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    },
+    { name: 'mobile-chrome', use: { ...devices['Pixel 5'] } },
+    { name: 'mobile-safari', use: { ...devices['iPhone 12'] } },
+  ],
 
   use: {
     baseURL: 'http://localhost:5173',


### PR DESCRIPTION
## Summary
- Added Playwright projects for WebKit/Safari, Firefox, Edge, Pixel 5 Chrome, and iPhone 12 Safari while keeping Chromium baseline.
- Converted Web CI E2E to a browser matrix: PRs run chromium, webkit, firefox, chromium-edge, and mobile-chrome; main/nightly also run mobile-safari.
- Mobile browser jobs run a startup smoke test to cover mobile targets without running desktop-only suites on phone viewports.
- Kept release-web E2E scoped to chromium so release runtime does not expand unexpectedly.

## Validation
- npm ci
- npx -w apps/web playwright install --with-deps webkit firefox chromium msedge
- npm run build -w packages/design-tokens
- npx -w apps/web playwright test e2e/auth.spec.ts -g "login page renders" --project=webkit --project=firefox --project=chromium-edge --project=mobile-chrome --project=mobile-safari --reporter=line
- npx prettier --check apps/web/playwright.config.ts apps/web/e2e/cross-browser.spec.ts .github/workflows/web-ci.yml .github/workflows/release-web.yml .github/workflows/build-perf.yml

Closes #2034