### PR TITLE
feat: wire account deletion end-to-end (#2030)

### DIFF
--- a/apps/web/src/components/settings/AccountDeletionModal.tsx
+++ b/apps/web/src/components/settings/AccountDeletionModal.tsx
@@ -9,8 +9,7 @@ import {
   getHouseholdDeletionImpact,
   type HouseholdDeletionImpact,
 } from '../../lib/account/account-deletion';
-
-const ACCOUNT_DELETED_FLASH_KEY = 'finance:account-deleted-flash';
+import { wipeLocalData } from '../../storage/wipeLocalData';
 
 /**
  * Tolerate missing DatabaseProvider (e.g. in some test harnesses).
@@ -34,7 +33,7 @@ export function useAccountDeletion(): {
   openDeleteModal: () => void;
   deleteModal: React.ReactElement | null;
 } {
-  const { isAuthenticated, user } = useAuth();
+  const { isAuthenticated, logout, user } = useAuth();
   const db = useOptionalDatabase();
   const [isOpen, setIsOpen] = useState(false);
   const [confirmationText, setConfirmationText] = useState('');
@@ -82,8 +81,8 @@ export function useAccountDeletion(): {
     setIsDeleting(true);
 
     try {
-      const response = await fetch('/api/account/delete-account', {
-        method: 'POST',
+      const response = await fetch('/api/account', {
+        method: 'DELETE',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
         body: JSON.stringify({ confirmation: 'DELETE' }),
@@ -98,22 +97,26 @@ export function useAccountDeletion(): {
       // Guard against any future regression of that nature by insisting
       // the response is either 204 (success contract — see the edge
       // function), or a non-HTML payload with a 2xx status.
-      const contentType = response.headers.get('Content-Type') ?? '';
+      const contentType = response.headers?.get('Content-Type') ?? '';
       const looksLikeHtml = contentType.includes('text/html');
       if (!response.ok || looksLikeHtml) {
         throw new Error('Account deletion failed.');
       }
 
       await clearLocalAccountData(db);
-      localStorage.clear();
-      sessionStorage.clear();
-      sessionStorage.setItem(ACCOUNT_DELETED_FLASH_KEY, 'Your account has been deleted.');
-      window.location.assign('/login?accountDeleted=1');
+      await db?.close().catch(() => undefined);
+      await wipeLocalData();
+      try {
+        await logout();
+      } catch {
+        // The account-delete endpoint already revoked the session; continue to login.
+      }
+      window.location.assign('/login');
     } catch {
       setError("Couldn't delete account — please try again or contact support.");
       setIsDeleting(false);
     }
-  }, [db, confirmationText, isAuthenticated, isDeleting]);
+  }, [db, confirmationText, isAuthenticated, isDeleting, logout]);
 
   const deleteModal = isOpen ? (
     <div

--- a/apps/web/src/pages/SettingsPage.test.tsx
+++ b/apps/web/src/pages/SettingsPage.test.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -10,18 +10,23 @@ const offlineStatusMock = {
   isOffline: false,
   isOnline: true,
 };
-const { clearLocalAccountDataMock, householdImpactMock } = vi.hoisted(() => ({
+const { clearLocalAccountDataMock, householdImpactMock, wipeLocalDataMock } = vi.hoisted(() => ({
   clearLocalAccountDataMock: vi.fn<() => Promise<void>>(),
   householdImpactMock: vi.fn(() => ({
     soloOwnedHouseholds: 1,
     memberHouseholds: 2,
     pendingInvites: 3,
   })),
+  wipeLocalDataMock: vi.fn<() => Promise<void>>(),
 }));
 
 vi.mock('../lib/account/account-deletion', () => ({
   clearLocalAccountData: clearLocalAccountDataMock,
   getHouseholdDeletionImpact: householdImpactMock,
+}));
+
+vi.mock('../storage/wipeLocalData', () => ({
+  wipeLocalData: wipeLocalDataMock,
 }));
 
 vi.mock('../auth/auth-context', () => ({
@@ -195,6 +200,8 @@ describe('SettingsPage', () => {
     mockResetSettings.mockReset();
     clearLocalAccountDataMock.mockReset();
     clearLocalAccountDataMock.mockResolvedValue(undefined);
+    wipeLocalDataMock.mockReset();
+    wipeLocalDataMock.mockResolvedValue(undefined);
     householdImpactMock.mockClear();
     householdImpactMock.mockReturnValue({
       soloOwnedHouseholds: 1,
@@ -319,6 +326,39 @@ describe('SettingsPage', () => {
       expect(fetch).not.toHaveBeenCalled();
     });
 
+    it('calls the backend delete endpoint, wipes local data, signs out, and redirects', async () => {
+      const assignSpy = vi.fn();
+      Object.defineProperty(window, 'location', {
+        writable: true,
+        value: { ...window.location, assign: assignSpy },
+      });
+      const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      renderSettingsAt('/settings/account');
+      fireEvent.click(screen.getByRole('button', { name: /^delete account$/i }));
+      await screen.findByRole('dialog', { name: /delete account and all data/i });
+
+      fireEvent.change(screen.getByLabelText(/type delete to confirm/i), {
+        target: { value: 'DELETE' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /yes, delete everything/i }));
+
+      await waitFor(() => {
+        expect(fetch).toHaveBeenCalledWith(
+          '/api/account',
+          expect.objectContaining({ method: 'DELETE', credentials: 'include' }),
+        );
+      });
+      expect(JSON.parse(fetchMock.mock.calls[0][1].body as string)).toEqual({
+        confirmation: 'DELETE',
+      });
+      await waitFor(() => expect(clearLocalAccountDataMock).toHaveBeenCalledTimes(1));
+      expect(wipeLocalDataMock).toHaveBeenCalledTimes(1);
+      expect(logoutMock).toHaveBeenCalledTimes(1);
+      expect(assignSpy).toHaveBeenCalledWith('/login');
+    });
+
     it('treats an HTML 200 response from the delete endpoint as a failure (#1960)', async () => {
       // Production Caddy used to be missing the /api/account/* proxy rule,
       // so this fetch silently returned 200 OK + index.html. The client
@@ -350,6 +390,8 @@ describe('SettingsPage', () => {
       });
 
       expect(clearLocalAccountDataMock).not.toHaveBeenCalled();
+      expect(wipeLocalDataMock).not.toHaveBeenCalled();
+      expect(logoutMock).not.toHaveBeenCalled();
       expect(assignSpy).not.toHaveBeenCalled();
       expect(await screen.findByText(/couldn't delete account/i)).toBeInTheDocument();
     });

--- a/apps/web/src/storage/wipeLocalData.test.ts
+++ b/apps/web/src/storage/wipeLocalData.test.ts
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { wipeLocalData } from './wipeLocalData';
+
+const INDEXED_DB_DATABASES = [
+  'finance-sqlite',
+  'finance-sqlite-encrypted',
+  'finance-encryption',
+  'finance-mutation-queue',
+  'finance-sync-conflicts',
+] as const;
+
+function openDatabase(name: string, storeName: string): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(name, 1);
+    request.onupgradeneeded = () => {
+      request.result.createObjectStore(storeName);
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function hasObjectStore(name: string, storeName: string): Promise<boolean> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(name, 1);
+    request.onsuccess = () => {
+      const db = request.result;
+      const hasStore = db.objectStoreNames.contains(storeName);
+      db.close();
+      resolve(hasStore);
+    };
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function deleteDatabase(name: string): Promise<void> {
+  return new Promise((resolve) => {
+    const request = indexedDB.deleteDatabase(name);
+    request.onsuccess = () => resolve();
+    request.onerror = () => resolve();
+    request.onblocked = () => resolve();
+  });
+}
+
+describe('wipeLocalData', () => {
+  beforeEach(async () => {
+    localStorage.setItem('finance:test', 'local');
+    sessionStorage.setItem('finance:test', 'session');
+
+    await Promise.all(
+      INDEXED_DB_DATABASES.map(async (name) => {
+        const db = await openDatabase(name, `${name}-store`);
+        db.close();
+      }),
+    );
+  });
+
+  afterEach(async () => {
+    vi.unstubAllGlobals();
+    Reflect.deleteProperty(navigator, 'serviceWorker');
+    localStorage.clear();
+    sessionStorage.clear();
+    await Promise.all(INDEXED_DB_DATABASES.map((name) => deleteDatabase(name)));
+  });
+
+  it('clears browser storage, IndexedDB stores, service workers, and caches', async () => {
+    const unregister = vi.fn().mockResolvedValue(true);
+    const getRegistrations = vi.fn().mockResolvedValue([{ unregister }]);
+    Object.defineProperty(navigator, 'serviceWorker', {
+      configurable: true,
+      value: { getRegistrations },
+    });
+
+    const cachesDelete = vi.fn().mockResolvedValue(true);
+    vi.stubGlobal('caches', {
+      keys: vi.fn().mockResolvedValue(['app-cache', 'assets-cache']),
+      delete: cachesDelete,
+    });
+
+    await wipeLocalData();
+
+    expect(localStorage.getItem('finance:test')).toBeNull();
+    expect(sessionStorage.getItem('finance:test')).toBeNull();
+    expect(getRegistrations).toHaveBeenCalledTimes(1);
+    expect(unregister).toHaveBeenCalledTimes(1);
+    expect(cachesDelete).toHaveBeenCalledWith('app-cache');
+    expect(cachesDelete).toHaveBeenCalledWith('assets-cache');
+
+    for (const name of INDEXED_DB_DATABASES) {
+      await expect(hasObjectStore(name, `${name}-store`)).resolves.toBe(false);
+    }
+  });
+});

--- a/apps/web/src/storage/wipeLocalData.ts
+++ b/apps/web/src/storage/wipeLocalData.ts
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+const INDEXED_DB_DATABASES = [
+  'finance-sqlite',
+  'finance-sqlite-encrypted',
+  'finance-encryption',
+  'finance-mutation-queue',
+  'finance-sync-conflicts',
+] as const;
+
+const INDEXED_DB_STORES = [
+  { database: 'finance-sqlite', store: 'finance-sqlite' },
+  { database: 'finance-sqlite-encrypted', store: 'encrypted' },
+  { database: 'finance-encryption', store: 'keys' },
+  { database: 'finance-mutation-queue', store: 'mutations' },
+  { database: 'finance-sync-conflicts', store: 'conflicts' },
+] as const;
+
+const OPFS_DATABASE_FILES = [
+  'finance.db',
+  'finance.db-wal',
+  'finance.db-shm',
+  'finance.db-journal',
+] as const;
+
+interface OpfsDirectoryHandle {
+  removeEntry(name: string, options?: { recursive?: boolean }): Promise<void>;
+}
+
+interface StorageWithDirectory {
+  getDirectory?: () => Promise<OpfsDirectoryHandle>;
+}
+
+/**
+ * Best-effort browser data wipe used after server-confirmed account deletion.
+ */
+export async function wipeLocalData(): Promise<void> {
+  clearStorage(globalThis.localStorage);
+  clearStorage(globalThis.sessionStorage);
+
+  await Promise.allSettled([
+    deleteIndexedDbDatabases(),
+    deleteOpfsDatabaseFiles(),
+    unregisterServiceWorkers(),
+    deleteAllCaches(),
+  ]);
+}
+
+function clearStorage(storage: Storage | undefined): void {
+  try {
+    storage?.clear();
+  } catch {
+    // Best-effort wipe: continue clearing other browser stores.
+  }
+}
+
+async function deleteIndexedDbDatabases(): Promise<void> {
+  if (typeof indexedDB === 'undefined') return;
+
+  await Promise.allSettled(
+    INDEXED_DB_STORES.map(({ database, store }) => clearIndexedDbStore(database, store)),
+  );
+  await Promise.all(INDEXED_DB_DATABASES.map((name) => deleteIndexedDbDatabase(name)));
+}
+
+function clearIndexedDbStore(databaseName: string, storeName: string): Promise<void> {
+  return new Promise((resolve) => {
+    try {
+      const request = indexedDB.open(databaseName);
+      request.onsuccess = () => {
+        const db = request.result;
+        if (!db.objectStoreNames.contains(storeName)) {
+          db.close();
+          resolve();
+          return;
+        }
+
+        const tx = db.transaction(storeName, 'readwrite');
+        tx.objectStore(storeName).clear();
+        tx.oncomplete = () => {
+          db.close();
+          resolve();
+        };
+        tx.onerror = () => {
+          db.close();
+          resolve();
+        };
+        tx.onabort = () => {
+          db.close();
+          resolve();
+        };
+      };
+      request.onerror = () => resolve();
+    } catch {
+      resolve();
+    }
+  });
+}
+
+function deleteIndexedDbDatabase(name: string): Promise<void> {
+  return new Promise((resolve) => {
+    try {
+      const request = indexedDB.deleteDatabase(name);
+      request.onsuccess = () => resolve();
+      request.onerror = () => resolve();
+      request.onblocked = () => resolve();
+    } catch {
+      resolve();
+    }
+  });
+}
+
+async function deleteOpfsDatabaseFiles(): Promise<void> {
+  const storage = globalThis.navigator?.storage as unknown as StorageWithDirectory | undefined;
+  if (typeof storage?.getDirectory !== 'function') return;
+
+  try {
+    const root = await storage.getDirectory();
+    await Promise.allSettled(
+      OPFS_DATABASE_FILES.map((name) => root.removeEntry(name, { recursive: true })),
+    );
+  } catch {
+    // OPFS is optional and unavailable in jsdom/private contexts.
+  }
+}
+
+async function unregisterServiceWorkers(): Promise<void> {
+  const serviceWorker = globalThis.navigator?.serviceWorker;
+  if (typeof serviceWorker?.getRegistrations !== 'function') return;
+
+  try {
+    const registrations = await serviceWorker.getRegistrations();
+    await Promise.allSettled(registrations.map((registration) => registration.unregister()));
+  } catch {
+    // Best-effort wipe: service worker APIs can be blocked by browser policy.
+  }
+}
+
+async function deleteAllCaches(): Promise<void> {
+  if (typeof globalThis.caches?.keys !== 'function') return;
+
+  try {
+    const cacheNames = await globalThis.caches.keys();
+    await Promise.allSettled(cacheNames.map((name) => globalThis.caches.delete(name)));
+  } catch {
+    // Best-effort wipe: cache APIs can be blocked by browser policy.
+  }
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -188,6 +188,7 @@ export default defineConfig({
         changeOrigin: true,
         rewrite: (path) =>
           path
+            .replace(/^\/api\/account$/, '/account-delete')
             .replace(/^\/api\/account\/delete-account$/, '/account-delete')
             .replace(/^\/api\/account\//, '/account-'),
       },

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -124,11 +124,18 @@
 		}
 	}
 
-	# /api/account/delete-account must be rewritten BEFORE the generic
-	# /api/account/ rule because the edge function directory is named
-	# `account-delete` (without the trailing word "account"), not
-	# `account-delete-account`. Order matters here — Caddy evaluates the
-	# `uri replace` directives in the order they appear.
+	# /api/account and /api/account/delete-account must be rewritten BEFORE
+	# the generic /api/account/ rule because the edge function directory is
+	# named `account-delete` (without the trailing word "account"), not
+	# `account-delete-account`.
+	@apiAccountRoot path /api/account
+	handle @apiAccountRoot {
+		uri replace /api/account /functions/v1/account-delete
+		reverse_proxy edge-functions:9000 {
+			header_up X-Real-IP {remote_host}
+		}
+	}
+
 	@apiAccount path /api/account/*
 	handle @apiAccount {
 		uri replace /api/account/delete-account /functions/v1/account-delete

--- a/deploy/Caddyfile.staging
+++ b/deploy/Caddyfile.staging
@@ -79,6 +79,14 @@
 		}
 	}
 
+	@apiAccountRoot path /api/account
+	handle @apiAccountRoot {
+		uri replace /api/account /functions/v1/account-delete
+		reverse_proxy edge-functions:9000 {
+			header_up X-Real-IP {remote_host}
+		}
+	}
+
 	@apiAccount path /api/account/*
 	handle @apiAccount {
 		uri replace /api/account/delete-account /functions/v1/account-delete

--- a/services/api/openapi.yaml
+++ b/services/api/openapi.yaml
@@ -462,17 +462,18 @@ components:
     # -- Account Deletion -----------------------------------------------------
     AccountDeletionRequest:
       type: object
-      required: [confirm]
       properties:
+        confirmation:
+          type: string
+          enum: [DELETE]
+          description: Explicit typed confirmation from the delete-account dialog.
         confirm:
-          oneOf:
-            - type: boolean
-              example: true
-            - type: string
-              example: DELETE_MY_ACCOUNT
-          description: >-
-            Explicit confirmation to prevent accidental deletion.
-            Must be `true` or the string `"DELETE_MY_ACCOUNT"`.
+          type: string
+          enum: [DELETE]
+          description: Backwards-compatible confirmation field.
+      anyOf:
+        - required: [confirmation]
+        - required: [confirm]
 
     DeletionCertificate:
       type: object
@@ -1370,24 +1371,16 @@ paths:
   # =========================================================================
   # Account Deletion
   # =========================================================================
-  /account-deletion:
+  /account-delete:
     delete:
       operationId: deleteAccount
       summary: Delete user account (GDPR Article 17)
       description: >-
-        Permanently deletes the authenticated user's account.  This
-        triggers:
-
-        1. **Audit log** of the deletion request.
-        2. **Crypto-shredding** — encryption keys are destroyed so that
-           encrypted data becomes unrecoverable.
-        3. **Household cleanup** — the user is removed from all
-           households; sole-member households are soft-deleted entirely.
-        4. **Soft-delete** of the user record and passkey credentials.
-        5. **Auth user removal** — the Supabase Auth identity is deleted.
-
-        Returns a **deletion certificate** (per GDPR Article 17) that
-        the client should store locally as proof of erasure.
+        Permanently deletes the authenticated user's account. The web route
+        `/api/account` proxies to this Edge Function. The handler
+        crypto-shreds encryption keys, cascade-deletes user-owned rows,
+        removes sole-owned household data, deletes the Supabase Auth user,
+        clears auth cookies, and returns 204 with no response body.
 
         **This action is irreversible.**
       tags: [Data Management]
@@ -1400,21 +1393,13 @@ paths:
             schema:
               $ref: '#/components/schemas/AccountDeletionRequest'
             examples:
-              confirmBoolean:
-                summary: Confirm with boolean
+              confirmation:
+                summary: Confirm with typed DELETE token
                 value:
-                  confirm: true
-              confirmString:
-                summary: Confirm with string
-                value:
-                  confirm: DELETE_MY_ACCOUNT
+                  confirmation: DELETE
       responses:
-        '200':
-          description: Account deleted — deletion certificate returned.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DeletionCertificate'
+        '204':
+          description: Account and associated user-owned data deleted.
         '400':
           description: Missing or invalid confirmation.
           content:
@@ -1422,9 +1407,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
               example:
-                error: >-
-                  Account deletion requires confirmation. Send
-                  { "confirm": "DELETE_MY_ACCOUNT" } in the request body.
+                error: Type DELETE to confirm account deletion
         '401':
           description: Missing or invalid JWT.
           content:

--- a/services/api/supabase/functions/account-delete/index.ts
+++ b/services/api/supabase/functions/account-delete/index.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /**
- * POST /api/account/delete-account — permanently delete the signed-in account.
+ * DELETE /api/account — permanently delete the signed-in account.
  *
  * Authenticates with either the browser's HttpOnly refresh cookie or a bearer
  * token, deletes user/household data with a service-role client, deletes the
@@ -114,10 +114,10 @@ export function createAccountDeleteHandler(deps: AccountDeleteDeps = {}) {
     const envError = validateEnv('auth-logout', req);
     if (envError) return envError;
 
-    if (req.method !== 'POST') {
+    if (req.method !== 'DELETE' && req.method !== 'POST') {
       return new Response(JSON.stringify({ error: 'Method not allowed' }), {
         status: 405,
-        headers: { ...NO_STORE_JSON_HEADERS, Allow: 'POST' },
+        headers: { ...NO_STORE_JSON_HEADERS, Allow: 'DELETE, POST' },
       });
     }
 

--- a/services/api/supabase/functions/account-delete/index_test.ts
+++ b/services/api/supabase/functions/account-delete/index_test.ts
@@ -6,15 +6,18 @@ import { createAccountDeleteHandler } from './index.ts';
 
 type AdminClient = ReturnType<typeof createAdminClient>;
 
-Deno.test('account-delete returns 405 for non-POST requests', async () => {
+Deno.test('account-delete returns 405 for unsupported requests', async () => {
   withEnv();
   const handler = createAccountDeleteHandler({
     createClient: () => createFakeSupabase().client as unknown as AdminClient,
   });
 
-  const response = await handler(new Request('http://localhost/functions/v1/account-delete'));
+  const response = await handler(
+    new Request('http://localhost/functions/v1/account-delete', { method: 'GET' }),
+  );
 
   assertEquals(response.status, 405);
+  assertEquals(response.headers.get('Allow'), 'DELETE, POST');
 });
 
 Deno.test('account-delete requires authentication before deleting anything', async () => {
@@ -46,7 +49,7 @@ Deno.test('account-delete cascades sole-household data before deleting auth user
 
   const response = await handler(
     new Request('http://localhost/functions/v1/account-delete', {
-      method: 'POST',
+      method: 'DELETE',
       headers: {
         'Content-Type': 'application/json',
         Authorization: 'Bearer access-token',
@@ -100,7 +103,7 @@ Deno.test(
 
     const response = await handler(
       new Request('http://localhost/functions/v1/account-delete', {
-        method: 'POST',
+        method: 'DELETE',
         headers: {
           'Content-Type': 'application/json',
           Authorization: 'Bearer access-token',

--- a/services/api/supabase/functions/account-deletion/index.ts
+++ b/services/api/supabase/functions/account-deletion/index.ts
@@ -15,8 +15,8 @@
  *     audit / invitation rows,
  *   - calls `supabase.auth.admin.deleteUser` LAST so re-sign-in goes
  *     through a fresh signup flow,
- * and is the one exposed at `/api/account/delete-account` via both the
- * Vite dev proxy and the production Caddyfile.
+ * and is the one exposed at `/api/account` via both the Vite dev proxy
+ * and the production Caddyfile.
  *
  * This file is kept for backwards compatibility with the public
  * OpenAPI spec (`services/api/docs/README.md`) and existing audit-log


### PR DESCRIPTION
## Summary
- Wires web delete-account confirmation to DELETE /api/account and redirects to /login after local wipe + sign-out.
- Adds wipeLocalData() to clear web SQLite IndexedDB/OPFS data, storage, service workers, and caches.
- Exposes DELETE /api/account through Vite/Caddy to the existing cascade-delete Edge Function.

## Scope
- Web only. There is no apps/native/ directory in this repo; platform-specific Android/iOS folders were left unchanged.

## Tests
- npm run test -w apps/web -- src/storage/wipeLocalData.test.ts src/pages/SettingsPage.test.tsx
- npm run type-check -w apps/web
- npm run lint -w apps/web
- deno test --no-lock --allow-env services/api/supabase/functions/account-delete/index_test.ts
- npx prettier --check changed files

Closes #2030