### PR TITLE
feat: add beta access control (#2032)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -112,6 +112,7 @@ jobs:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
           POWERSYNC_URL: ${{ secrets.POWERSYNC_URL }}
+          BETA_ALLOWED_EMAILS: ${{ secrets.BETA_ALLOWED_EMAILS }}
         run: |
           set -euo pipefail
 
@@ -136,6 +137,7 @@ jobs:
           SUPABASE_URL_B64=$(printf '%s' "$SUPABASE_URL" | base64 -w 0)
           SUPABASE_ANON_KEY_B64=$(printf '%s' "$SUPABASE_ANON_KEY" | base64 -w 0)
           POWERSYNC_URL_B64=$(printf '%s' "$POWERSYNC_URL" | base64 -w 0)
+          BETA_ALLOWED_EMAILS_B64=$(printf '%s' "$BETA_ALLOWED_EMAILS" | base64 -w 0)
 
           # SSH in and rebuild. Each line is a separate command so an early
           # failure aborts the build (set -e inside the heredoc). Use
@@ -143,11 +145,12 @@ jobs:
           # from any stale refs (e.g. if a prior backend deploy already
           # advanced origin/main before this fetch read its expected value).
           ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" \
-            "SUPABASE_URL_B64='$SUPABASE_URL_B64' SUPABASE_ANON_KEY_B64='$SUPABASE_ANON_KEY_B64' POWERSYNC_URL_B64='$POWERSYNC_URL_B64' bash -s" <<'DEPLOY'
+            "SUPABASE_URL_B64='$SUPABASE_URL_B64' SUPABASE_ANON_KEY_B64='$SUPABASE_ANON_KEY_B64' POWERSYNC_URL_B64='$POWERSYNC_URL_B64' BETA_ALLOWED_EMAILS_B64='$BETA_ALLOWED_EMAILS_B64' bash -s" <<'DEPLOY'
             set -euo pipefail
             export VITE_SUPABASE_URL="$(printf '%s' "$SUPABASE_URL_B64" | base64 -d)"
             export VITE_SUPABASE_ANON_KEY="$(printf '%s' "$SUPABASE_ANON_KEY_B64" | base64 -d)"
             export VITE_POWERSYNC_URL="$(printf '%s' "$POWERSYNC_URL_B64" | base64 -d)"
+            export VITE_BETA_ALLOWED_EMAILS="$(printf '%s' "$BETA_ALLOWED_EMAILS_B64" | base64 -d)"
             cd ~/finance
             echo "→ git fetch --force --prune origin main"
             git fetch --force --prune origin main

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -85,6 +85,7 @@ jobs:
           NODE_ENV: production
           VITE_APP_VERSION: pr-${{ github.event.pull_request.number || github.event.inputs.pr_number }}-${{ github.sha }}
           VITE_ENVIRONMENT: preview
+          VITE_BETA_ALLOWED_EMAILS: ${{ secrets.BETA_ALLOWED_EMAILS }}
         run: |
           BUILD_START=$SECONDS
           npm run build -w apps/web

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -88,6 +88,7 @@ jobs:
           VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
           VITE_POWERSYNC_URL: ${{ secrets.POWERSYNC_URL }}
+          VITE_BETA_ALLOWED_EMAILS: ${{ secrets.BETA_ALLOWED_EMAILS }}
 
       - name: Verify web build env
         env:

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -13,6 +13,10 @@ VITE_LOGIN_ENDPOINT=/api/auth/login
 VITE_REFRESH_ENDPOINT=/api/auth/refresh
 VITE_LOGOUT_ENDPOINT=/api/auth/logout
 
+# Beta/staging access control (optional)
+# Comma-separated approved account emails. Leave empty/unset to disable the gate.
+VITE_BETA_ALLOWED_EMAILS=
+
 # Local Edge Functions proxy target (Vite dev only)
 VITE_FUNCTIONS_PROXY_TARGET=http://127.0.0.1:54321
 

--- a/apps/web/src/auth/auth-context.test.tsx
+++ b/apps/web/src/auth/auth-context.test.tsx
@@ -3,7 +3,13 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { AuthProvider, useAuth, type AuthProviderConfig } from './auth-context';
+import {
+  AuthProvider,
+  isBetaEmailAllowed,
+  parseBetaAllowedEmails,
+  useAuth,
+  type AuthProviderConfig,
+} from './auth-context';
 import { clearTokens } from './token-storage';
 
 const LAST_USER_STORAGE_KEY = 'finance.lastUser';
@@ -35,6 +41,28 @@ function AuthProbe() {
   );
 }
 
+describe('beta email allowlist', () => {
+  it('allows everyone when the allowlist is empty or unset', () => {
+    expect(isBetaEmailAllowed('anyone@example.com', parseBetaAllowedEmails(undefined))).toBe(true);
+    expect(isBetaEmailAllowed('anyone@example.com', parseBetaAllowedEmails(''))).toBe(true);
+    expect(isBetaEmailAllowed('anyone@example.com', parseBetaAllowedEmails(' ,  '))).toBe(true);
+  });
+
+  it('matches allowlisted emails case-insensitively and trims whitespace', () => {
+    const allowlist = parseBetaAllowedEmails(' beta@example.com, Friend@Example.com ');
+
+    expect(isBetaEmailAllowed('BETA@example.com', allowlist)).toBe(true);
+    expect(isBetaEmailAllowed('friend@example.com ', allowlist)).toBe(true);
+  });
+
+  it('denies emails that are not allowlisted', () => {
+    const allowlist = parseBetaAllowedEmails('beta@example.com');
+
+    expect(isBetaEmailAllowed('outsider@example.com', allowlist)).toBe(false);
+    expect(isBetaEmailAllowed(undefined, allowlist)).toBe(false);
+  });
+});
+
 describe('AuthProvider refresh restoration', () => {
   const onUnauthenticated = vi.fn();
   const config: AuthProviderConfig = {
@@ -59,9 +87,9 @@ describe('AuthProvider refresh restoration', () => {
     localStorage.clear();
   });
 
-  function renderProvider() {
+  function renderProvider(configOverrides: Partial<AuthProviderConfig> = {}) {
     return render(
-      <AuthProvider config={config}>
+      <AuthProvider config={{ ...config, ...configOverrides }}>
         <AuthProbe />
       </AuthProvider>,
     );
@@ -89,6 +117,34 @@ describe('AuthProvider refresh restoration', () => {
       email: 'fresh@example.com',
     });
     expect(onUnauthenticated).not.toHaveBeenCalled();
+  });
+
+  it('shows the beta access required screen when a restored user is not allowlisted', async () => {
+    const token = makeToken({
+      sub: 'user-2',
+      email: 'outsider@example.com',
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ access_token: token, expires_in: 3600 }))
+      .mockResolvedValueOnce(jsonResponse({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderProvider({ betaAllowedEmails: 'beta@example.com' });
+
+    expect(
+      await screen.findByRole('heading', { name: 'Beta access required' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent('outsider@example.com');
+    expect(screen.queryByTestId('auth-state')).not.toBeInTheDocument();
+    expect(localStorage.getItem(LAST_USER_STORAGE_KEY)).toBeNull();
+    expect(onUnauthenticated).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      '/api/auth/logout',
+      expect.objectContaining({ credentials: 'include' }),
+    );
   });
 
   it('clears the cached user and signs out on session_expired refresh', async () => {

--- a/apps/web/src/auth/auth-context.tsx
+++ b/apps/web/src/auth/auth-context.tsx
@@ -57,6 +57,7 @@ import {
   restoreDemoSession,
 } from './demo-auth';
 import { getPasskeyErrorMessage } from './passkey-errors';
+import '../styles/auth.css';
 
 import {
   incrementLoginCount,
@@ -162,6 +163,10 @@ export interface AuthProviderConfig {
   logoutEndpoint: string;
   /** Backend endpoint for account registration. Defaults to '/api/auth/signup'. */
   signupEndpoint?: string;
+  /**
+   * Comma-separated beta/staging allowlist. Empty or unset disables beta access gating.
+   */
+  betaAllowedEmails?: string;
   /** Callback when the user should be redirected to login. */
   onUnauthenticated?: () => void;
 }
@@ -172,6 +177,7 @@ export interface AuthProviderConfig {
 
 const AuthContext = createContext<AuthContextValue | null>(null);
 const LAST_USER_STORAGE_KEY = 'finance.lastUser';
+export const BETA_ACCESS_REQUIRED_MESSAGE = 'Beta access required';
 
 // ---------------------------------------------------------------------------
 // Provider
@@ -204,6 +210,7 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
   const [showPasskeyPrompt, setShowPasskeyPrompt] = useState(false);
   const [isSigningOut, setIsSigningOut] = useState(false);
   const [isOffline, setIsOffline] = useState(false);
+  const [betaAccessDeniedEmail, setBetaAccessDeniedEmail] = useState<string | null>(null);
   const onlineRetryHandlerRef = useRef<(() => void) | null>(null);
   /**
    * Tracks whether the initial session-restore effect has already run for
@@ -220,6 +227,10 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
   const initStartedRef = useRef(false);
 
   const demoModeActive = isDemoMode(config.supabaseUrl);
+  const betaAllowedEmails = useMemo(
+    () => parseBetaAllowedEmails(config.betaAllowedEmails),
+    [config.betaAllowedEmails],
+  );
   const webAuthnConfig = useMemo<WebAuthnConfig>(
     () => ({
       supabaseUrl: config.supabaseUrl,
@@ -227,7 +238,8 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
     }),
     [config.supabaseAnonKey, config.supabaseUrl],
   );
-  const isAuthenticated = user !== null && (hasValidToken() || isOffline);
+  const isAuthenticated =
+    user !== null && (hasValidToken() || isOffline) && betaAccessDeniedEmail === null;
 
   /** Dismiss the passkey prompt (hides it without changing preferences). */
   const dismissPasskeyPrompt = useCallback(() => {
@@ -237,6 +249,35 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
   function rememberUser(nextUser: AuthUser): void {
     setUser(nextUser);
     cacheLastUser(nextUser);
+  }
+
+  async function denyBetaAccess(email: string): Promise<void> {
+    setError(BETA_ACCESS_REQUIRED_MESSAGE);
+    setBetaAccessDeniedEmail(email);
+    setShowPasskeyPrompt(false);
+    clearCachedUser();
+    cancelOnlineRestoreRetry();
+    setIsOffline(false);
+    setUser(null);
+
+    if (demoModeActive) {
+      clearDemoSession();
+      clearTokens();
+      return;
+    }
+
+    await revokeRefreshToken(config.logoutEndpoint);
+  }
+
+  async function rememberAllowedUser(nextUser: AuthUser): Promise<boolean> {
+    if (!isBetaEmailAllowed(nextUser.email, betaAllowedEmails)) {
+      await denyBetaAccess(nextUser.email);
+      return false;
+    }
+
+    setBetaAccessDeniedEmail(null);
+    rememberUser(nextUser);
+    return true;
   }
 
   function handleSessionExpired(): void {
@@ -314,11 +355,12 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
           setAccessToken(token);
           const payload = parseTokenPayload(token);
           if (payload) {
-            setUser({
+            void rememberAllowedUser({
               id: payload.sub ?? '',
               email: payload.email ?? '',
               hasPasskey: false,
-            });
+            }).finally(() => setIsLoading(false));
+            return;
           }
         }
       }
@@ -367,7 +409,7 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
       case 'success': {
         const restoredUser = userFromToken(result.token) ?? readCachedUser();
         if (restoredUser) {
-          rememberUser(restoredUser);
+          await rememberAllowedUser(restoredUser);
         }
         setIsOffline(false);
         cancelOnlineRestoreRetry();
@@ -379,9 +421,10 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
       case 'network_error': {
         const cachedUser = readCachedUser();
         if (cachedUser) {
-          setUser((current) => current ?? cachedUser);
-          setIsOffline(true);
-          scheduleOnlineRestoreRetry();
+          if (await rememberAllowedUser(cachedUser)) {
+            setIsOffline(true);
+            scheduleOnlineRestoreRetry();
+          }
         } else {
           // No cached user — there is no session to keep alive offline.
           // Treat as session_expired so the app redirects to login instead of
@@ -428,11 +471,14 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
         if (demoModeActive) {
           const result = await demoLogin(email, password);
           setAccessToken(result.accessToken);
-          rememberUser({
+          const allowed = await rememberAllowedUser({
             id: result.user.id,
             email: result.user.email,
             hasPasskey: false,
           });
+          if (!allowed) {
+            throw new Error(BETA_ACCESS_REQUIRED_MESSAGE);
+          }
           setIsOffline(false);
           triggerPasskeyPromptCheck();
           return;
@@ -458,11 +504,14 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
         };
 
         setAccessToken(data.access_token);
-        rememberUser({
+        const allowed = await rememberAllowedUser({
           id: data.user.id,
           email: data.user.email,
           hasPasskey: data.user.has_passkey ?? false,
         });
+        if (!allowed) {
+          throw new Error(BETA_ACCESS_REQUIRED_MESSAGE);
+        }
         setIsOffline(false);
         triggerPasskeyPromptCheck();
       } catch (err) {
@@ -500,11 +549,14 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
         // CSRF risk of a detached session endpoint (#1310).
         if (result.accessToken) {
           setAccessToken(result.accessToken);
-          rememberUser({
+          const allowed = await rememberAllowedUser({
             id: result.userId,
             email: result.email ?? email ?? '',
             hasPasskey: true,
           });
+          if (!allowed) {
+            throw new Error(BETA_ACCESS_REQUIRED_MESSAGE);
+          }
           setIsOffline(false);
           // A successful passkey sign-in reaffirms the user's preference
           // (#1983). Idempotent — safe to call on every login.
@@ -629,7 +681,7 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
       case 'success': {
         const refreshedUser = userFromToken(result.token);
         if (refreshedUser) {
-          rememberUser(refreshedUser);
+          await rememberAllowedUser(refreshedUser);
         }
         setIsOffline(false);
         cancelOnlineRestoreRetry();
@@ -641,7 +693,9 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
       case 'network_error': {
         const cachedUser = readCachedUser();
         if (cachedUser) {
-          setUser((current) => current ?? cachedUser);
+          if (!(await rememberAllowedUser(cachedUser))) {
+            break;
+          }
         }
         setIsOffline(true);
         scheduleOnlineRestoreRetry();
@@ -661,11 +715,14 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
           // Auto-login after demo signup
           const result = await demoLogin(email, password);
           setAccessToken(result.accessToken);
-          rememberUser({
+          const allowed = await rememberAllowedUser({
             id: result.user.id,
             email: result.user.email,
             hasPasskey: false,
           });
+          if (!allowed) {
+            throw new Error(BETA_ACCESS_REQUIRED_MESSAGE);
+          }
           setIsOffline(false);
           // demoLogin already calls persistDemoSession
           triggerPasskeyPromptCheck();
@@ -698,11 +755,14 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
 
         if (response.status === 201 && body.access_token && body.user) {
           setAccessToken(body.access_token);
-          rememberUser({
+          const allowed = await rememberAllowedUser({
             id: body.user.id,
             email: body.user.email,
             hasPasskey: body.user.has_passkey ?? false,
           });
+          if (!allowed) {
+            throw new Error(BETA_ACCESS_REQUIRED_MESSAGE);
+          }
           setIsOffline(false);
           triggerPasskeyPromptCheck();
           return { kind: 'authenticated' };
@@ -723,11 +783,14 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
             user: { id: string; email: string; has_passkey?: boolean };
           };
           setAccessToken(data.access_token);
-          rememberUser({
+          const allowed = await rememberAllowedUser({
             id: data.user.id,
             email: data.user.email,
             hasPasskey: data.user.has_passkey ?? false,
           });
+          if (!allowed) {
+            throw new Error(BETA_ACCESS_REQUIRED_MESSAGE);
+          }
           setIsOffline(false);
           triggerPasskeyPromptCheck();
         }
@@ -823,7 +886,58 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
     ],
   );
 
-  return <AuthContext.Provider value={contextValue}>{children}</AuthContext.Provider>;
+  const handleBetaSwitchAccount = useCallback(() => {
+    setBetaAccessDeniedEmail(null);
+    setError(null);
+    clearTokens();
+    clearCachedUser();
+    clearDemoSession();
+    setIsOffline(false);
+    setUser(null);
+    config.onUnauthenticated?.();
+  }, [config]);
+
+  return (
+    <AuthContext.Provider value={contextValue}>
+      {betaAccessDeniedEmail ? (
+        <BetaAccessRequiredScreen
+          email={betaAccessDeniedEmail}
+          onSwitchAccount={handleBetaSwitchAccount}
+        />
+      ) : (
+        children
+      )}
+    </AuthContext.Provider>
+  );
+}
+
+function BetaAccessRequiredScreen({
+  email,
+  onSwitchAccount,
+}: {
+  email: string;
+  onSwitchAccount: () => void;
+}) {
+  return (
+    <main className="auth-page">
+      <section className="auth-card" aria-labelledby="beta-access-required-title">
+        <header className="auth-brand">
+          <h1 id="beta-access-required-title" className="auth-brand__name">
+            Beta access required
+          </h1>
+          <p className="auth-brand__tagline">
+            This deployment is limited to approved beta testers.
+          </p>
+        </header>
+        <div className="auth-error" role="alert">
+          Ask the Finance beta coordinator to add {email} to the beta allowlist, then sign in again.
+        </div>
+        <button type="button" className="auth-submit" onClick={onSwitchAccount}>
+          Sign in with a different account
+        </button>
+      </section>
+    </main>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -917,6 +1031,26 @@ export function ProtectedRoute({
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+export function parseBetaAllowedEmails(value: string | null | undefined): Set<string> {
+  return new Set(
+    (value ?? '')
+      .split(',')
+      .map((email) => email.trim().toLowerCase())
+      .filter((email) => email.length > 0),
+  );
+}
+
+export function isBetaEmailAllowed(
+  email: string | null | undefined,
+  allowedEmails: Set<string>,
+): boolean {
+  if (allowedEmails.size === 0) {
+    return true;
+  }
+
+  return typeof email === 'string' && allowedEmails.has(email.trim().toLowerCase());
+}
 
 function cacheLastUser(nextUser: AuthUser): void {
   try {

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -50,6 +50,7 @@ const authConfig = {
   loginEndpoint: import.meta.env.VITE_LOGIN_ENDPOINT ?? '/api/auth/login',
   refreshEndpoint: import.meta.env.VITE_REFRESH_ENDPOINT ?? '/api/auth/refresh',
   logoutEndpoint: import.meta.env.VITE_LOGOUT_ENDPOINT ?? '/api/auth/logout',
+  betaAllowedEmails: import.meta.env.VITE_BETA_ALLOWED_EMAILS,
   onUnauthenticated: () => {
     // Redirect to login when session expires or user is not authenticated
     const publicAuthPaths = new Set(['/login', '/signup', '/forgot-password', '/reset-password']);

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -66,6 +66,9 @@ SESSION_INACTIVITY_TIMEOUT=1h
 # Auto-confirm email signups (set to true only for testing)
 MAILER_AUTOCONFIRM=false
 
+# Optional web beta/staging account allowlist. Leave empty for production.
+VITE_BETA_ALLOWED_EMAILS=
+
 # ---------------------------------------------------------------------------
 # SMTP (required for email auth, magic links, password reset)
 # ---------------------------------------------------------------------------

--- a/deploy/.env.staging.example
+++ b/deploy/.env.staging.example
@@ -62,6 +62,10 @@ AUTH_RATE_LIMIT_REFRESH=300
 # Auto-confirm signups in staging (set via docker-compose.staging.yml override)
 MAILER_AUTOCONFIRM=true
 
+# Comma-separated account emails allowed through the web beta gate.
+# Leave empty to disable the gate for this environment.
+VITE_BETA_ALLOWED_EMAILS=beta-tester@example.com,friend@example.com
+
 # ---------------------------------------------------------------------------
 # SMTP (required for email auth — can use Mailtrap or similar for staging)
 # ---------------------------------------------------------------------------

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -290,21 +290,26 @@ docker compose ps
 
 ### Optional
 
-| Variable                  | Default                              | Description                                                                      |
-| ------------------------- | ------------------------------------ | -------------------------------------------------------------------------------- |
-| `POSTGRES_DB`             | `postgres`                           | Database name                                                                    |
-| `POSTGRES_USER`           | `supabase_admin`                     | Database superuser name (must be supabase_admin for the supabase/postgres image) |
-| `POSTGRES_PORT`           | `5432`                               | Host port for direct database access                                             |
-| `JWT_EXPIRY`              | `3600`                               | JWT lifetime in seconds                                                          |
-| `AUTH_RATE_LIMIT_EMAIL`   | `30`                                 | Max email sends per hour                                                         |
-| `AUTH_RATE_LIMIT_REFRESH` | `150`                                | Max token refreshes per hour                                                     |
-| `MAILER_AUTOCONFIRM`      | `false`                              | Skip email confirmation (testing)                                                |
-| `AUTH_REDIRECT_URLS`      | —                                    | Allowed OAuth redirect URLs                                                      |
-| `EDGE_FUNCTIONS_PATH`     | `../services/api/supabase/functions` | Path to Edge Functions source                                                    |
-| `BACKUP_RETENTION_DAYS`   | `30`                                 | Number of daily backups to keep                                                  |
-| `POWERSYNC_URL`           | —                                    | PowerSync instance URL (optional)                                                |
-| `POWERSYNC_PUBLIC_KEY`    | —                                    | PowerSync public key (optional)                                                  |
-| `POWERSYNC_MONGO_URI`     | internal mongo URI                   | Override bucket-storage URI; include `replicaSet=rs0` when using bundled MongoDB |
+| Variable                   | Default                              | Description                                                                                                                                          |
+| -------------------------- | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `POSTGRES_DB`              | `postgres`                           | Database name                                                                                                                                        |
+| `POSTGRES_USER`            | `supabase_admin`                     | Database superuser name (must be supabase_admin for the supabase/postgres image)                                                                     |
+| `POSTGRES_PORT`            | `5432`                               | Host port for direct database access                                                                                                                 |
+| `JWT_EXPIRY`               | `3600`                               | JWT lifetime in seconds                                                                                                                              |
+| `AUTH_RATE_LIMIT_EMAIL`    | `30`                                 | Max email sends per hour                                                                                                                             |
+| `AUTH_RATE_LIMIT_REFRESH`  | `150`                                | Max token refreshes per hour                                                                                                                         |
+| `MAILER_AUTOCONFIRM`       | `false`                              | Skip email confirmation (testing)                                                                                                                    |
+| `AUTH_REDIRECT_URLS`       | —                                    | Allowed OAuth redirect URLs                                                                                                                          |
+| `EDGE_FUNCTIONS_PATH`      | `../services/api/supabase/functions` | Path to Edge Functions source                                                                                                                        |
+| `BACKUP_RETENTION_DAYS`    | `30`                                 | Number of daily backups to keep                                                                                                                      |
+| `POWERSYNC_URL`            | —                                    | PowerSync instance URL (optional)                                                                                                                    |
+| `POWERSYNC_PUBLIC_KEY`     | —                                    | PowerSync public key (optional)                                                                                                                      |
+| `POWERSYNC_MONGO_URI`      | internal mongo URI                   | Override bucket-storage URI; include `replicaSet=rs0` when using bundled MongoDB                                                                     |
+| `VITE_BETA_ALLOWED_EMAILS` | empty                                | Comma-separated web beta allowlist; when set, signed-in users whose account email is absent see “Beta access required” before protected routes load. |
+
+#### Granting web beta access
+
+For staging/preview web builds, set `VITE_BETA_ALLOWED_EMAILS` (or the GitHub Environment secret `BETA_ALLOWED_EMAILS`) to a comma-separated list of approved account emails, for example `alice@example.com,bob@example.com`. Users still sign in normally with email/password or passkeys; the app admits only allowlisted account emails after sign-in/session restore. Leave the value empty or unset to disable the gate (the production default).
 
 ---
 

--- a/docs/deployment-pipeline.md
+++ b/docs/deployment-pipeline.md
@@ -74,14 +74,15 @@ Manual re-deploy: **Actions → Deploy — Staging → Run workflow**
 
 Scoped to the `staging` GitHub Environment:
 
-| Secret              | Description                              |
-| ------------------- | ---------------------------------------- |
-| `DEPLOY_HOST`       | Staging server hostname                  |
-| `DEPLOY_SSH_KEY`    | SSH private key for staging              |
-| `DEPLOY_USER`       | SSH username for staging                 |
-| `SUPABASE_URL`      | Supabase URL (e.g. `https://staging...`) |
-| `SUPABASE_ANON_KEY` | Supabase anon key                        |
-| `POWERSYNC_URL`     | PowerSync URL                            |
+| Secret                | Description                                 |
+| --------------------- | ------------------------------------------- |
+| `DEPLOY_HOST`         | Staging server hostname                     |
+| `DEPLOY_SSH_KEY`      | SSH private key for staging                 |
+| `DEPLOY_USER`         | SSH username for staging                    |
+| `SUPABASE_URL`        | Supabase URL (e.g. `https://staging...`)    |
+| `SUPABASE_ANON_KEY`   | Supabase anon key                           |
+| `POWERSYNC_URL`       | PowerSync URL                               |
+| `BETA_ALLOWED_EMAILS` | Optional comma-separated web beta allowlist |
 
 ### Production Server (Backend)
 

--- a/docs/marketing/beta-launch-execution.md
+++ b/docs/marketing/beta-launch-execution.md
@@ -101,20 +101,20 @@
 
 ### Web (Staging PWA)
 
-| Item                     | Detail                                                |
-| ------------------------ | ----------------------------------------------------- |
-| **Distribution method**  | Staging URL with access codes or auth                 |
-| **URL**                  | [staging.finance-app.com or equivalent]               |
-| **Access control**       | Invite codes, basic auth, or Supabase auth-gated      |
-| **Browser targets**      | Chrome 120+, Safari 17+, Firefox 120+, Edge 120+      |
-| **Install instructions** | Provide PWA install instructions (Add to Home Screen) |
+| Item                     | Detail                                                                           |
+| ------------------------ | -------------------------------------------------------------------------------- |
+| **Distribution method**  | Staging URL with auth-gated account allowlist                                    |
+| **URL**                  | [staging.finance-app.com or equivalent]                                          |
+| **Access control**       | Set `VITE_BETA_ALLOWED_EMAILS` / `BETA_ALLOWED_EMAILS` to approved tester emails |
+| **Browser targets**      | Chrome 120+, Safari 17+, Firefox 120+, Edge 120+                                 |
+| **Install instructions** | Provide PWA install instructions (Add to Home Screen)                            |
 
 **Setup steps:**
 
 1. Deploy latest build to staging environment
-2. Configure access control (invite codes or auth)
-3. Test on target browsers
-4. Send staging URL + access code to web testers
+2. Configure `BETA_ALLOWED_EMAILS` in the staging GitHub Environment (comma-separated approved account emails)
+3. Test allowed and denied account sign-in on target browsers
+4. Send staging URL to approved web testers; testers sign in with their allowlisted account email
 
 ### Windows (MSIX Pre-Release)
 


### PR DESCRIPTION
## Related Work Items
Closes #2032

## Summary
Adds app-level beta access control for web staging/preview builds using a comma-separated `VITE_BETA_ALLOWED_EMAILS` allowlist. Users can still sign in with email/password or passkeys; after sign-in or session restore, non-allowlisted account emails are signed out and shown a “Beta access required” screen before protected routes load.

## Approach Chosen
Option B: app-level beta allowlist. This fits the existing auth flow better than Caddy basic auth because it preserves password-less passkey sign-in for approved testers and can be managed through environment-scoped deployment secrets.

## Granting Access
Set the staging/preview GitHub Environment secret `BETA_ALLOWED_EMAILS` to approved account emails, comma-separated (for example `alice@example.com,bob@example.com`). For local/self-hosted builds, set `VITE_BETA_ALLOWED_EMAILS`. Leave it empty or unset to disable the gate, which is the production default.

## Changes
- Added beta allowlist parsing/checking and the denied-access screen in `auth-context.tsx`.
- Wired `VITE_BETA_ALLOWED_EMAILS` into web app config and staging/preview web build workflows.
- Documented the env var/secret in web env examples, deploy docs, deployment pipeline docs, and beta launch docs.
- Added Vitest coverage for allowlist disabled/allowed/denied behavior and denied session restore.

## Testing
- `npm test -w apps/web -- auth-context.test.tsx`
- `npm run type-check -w apps/web`
- `npm run lint -w apps/web`
- `npm run build -w packages/design-tokens && npm run build -w apps/web`

## Risk Assessment
Low. The gate is opt-in: empty/unset allowlist allows existing production behavior. The change is isolated to auth admission after sign-in/session restore and does not alter service-worker registration.