### PR TITLE
feat: route in-app feedback to GitHub triage (#2031)

### DIFF
--- a/apps/web/src/components/FeedbackDialog.tsx
+++ b/apps/web/src/components/FeedbackDialog.tsx
@@ -3,29 +3,23 @@
 /**
  * FeedbackDialog — Modal form for users to report bugs, give feedback, or suggest features.
  *
- * For alpha: stores submissions in localStorage. Backend integration planned.
+ * Submits feedback to the backend `/api/feedback` facade, which creates a
+ * GitHub issue for beta triage using a server-side token.
  *
  * @module components/FeedbackDialog
- * References: issue #1476
+ * References: issues #1476, #2031
  */
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
+import packageJson from '../../package.json';
+import { buildFeedbackDiagnostics, submitFeedback } from '../lib/feedback';
 
-/** Feedback submission type. */
-export type FeedbackType = 'bug' | 'feedback' | 'suggestion';
-
-/** A stored feedback entry. */
-export interface FeedbackEntry {
-  id: string;
-  type: FeedbackType;
-  description: string;
-  email: string;
-  timestamp: string;
-}
+const BUILD_SHA =
+  import.meta.env.VITE_BUILD_SHA ??
+  import.meta.env.VITE_GIT_SHA ??
+  import.meta.env.VITE_COMMIT_SHA ??
+  '';
 
 export interface FeedbackDialogProps {
   /** Whether the dialog is visible. */
@@ -34,42 +28,26 @@ export interface FeedbackDialogProps {
   onClose: () => void;
 }
 
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const STORAGE_KEY = 'finance_feedback_entries';
-
-const TYPE_OPTIONS: { value: FeedbackType; label: string }[] = [
-  { value: 'bug', label: 'Bug Report' },
-  { value: 'feedback', label: 'Feedback' },
-  { value: 'suggestion', label: 'Suggestion' },
-];
-
-// ---------------------------------------------------------------------------
-// Component
-// ---------------------------------------------------------------------------
-
-/**
- * Accessible feedback dialog with focus trapping and localStorage persistence.
- */
+/** Accessible feedback dialog with focus trapping and GitHub issue submission. */
 export const FeedbackDialog: React.FC<FeedbackDialogProps> = ({ isOpen, onClose }) => {
-  const [type, setType] = useState<FeedbackType>('feedback');
-  const [description, setDescription] = useState('');
-  const [email, setEmail] = useState('');
+  const [subject, setSubject] = useState('');
+  const [body, setBody] = useState('');
+  const [includeDiagnostics, setIncludeDiagnostics] = useState(true);
   const [submitted, setSubmitted] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const panelRef = useRef<HTMLDivElement>(null);
-  const firstInputRef = useRef<HTMLSelectElement>(null);
+  const firstInputRef = useRef<HTMLInputElement>(null);
 
   // Reset form state when dialog opens/closes
   useEffect(() => {
     if (isOpen) {
-      setType('feedback');
-      setDescription('');
-      setEmail('');
+      setSubject('');
+      setBody('');
+      setIncludeDiagnostics(true);
       setSubmitted(false);
+      setIsSubmitting(false);
       setError(null);
       // Focus first input on open
       requestAnimationFrame(() => {
@@ -116,41 +94,44 @@ export const FeedbackDialog: React.FC<FeedbackDialogProps> = ({ isOpen, onClose 
   }, [isOpen, onClose]);
 
   const handleSubmit = useCallback(
-    (e: React.FormEvent) => {
+    async (e: React.FormEvent) => {
       e.preventDefault();
       setError(null);
 
-      if (!description.trim()) {
-        setError('Please provide a description.');
+      if (!subject.trim()) {
+        setError('Please provide a subject.');
         return;
       }
 
-      // TODO: Replace localStorage with backend API integration when available
+      if (!body.trim()) {
+        setError('Please provide feedback details.');
+        return;
+      }
+
+      setIsSubmitting(true);
       try {
-        const entry: FeedbackEntry = {
-          id: crypto.randomUUID(),
-          type,
-          description: description.trim(),
-          email: email.trim(),
-          timestamp: new Date().toISOString(),
-        };
-
-        const existing = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]') as FeedbackEntry[];
-        existing.push(entry);
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(existing));
-
+        await submitFeedback({
+          subject,
+          body,
+          includeDiagnostics,
+          diagnostics: includeDiagnostics
+            ? buildFeedbackDiagnostics({ appVersion: packageJson.version, buildSha: BUILD_SHA })
+            : undefined,
+        });
         setSubmitted(true);
-      } catch {
-        setError('Failed to save feedback. Please try again.');
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Could not send feedback. Please try again.');
+      } finally {
+        setIsSubmitting(false);
       }
     },
-    [type, description, email],
+    [subject, body, includeDiagnostics],
   );
 
   if (!isOpen) return null;
 
   return (
-    <div className="form-backdrop" onClick={onClose} aria-hidden="true">
+    <div className="form-backdrop" onClick={onClose}>
       <div
         ref={panelRef}
         className="form-dialog"
@@ -160,13 +141,13 @@ export const FeedbackDialog: React.FC<FeedbackDialogProps> = ({ isOpen, onClose 
         onClick={(e) => e.stopPropagation()}
       >
         <h2 id="feedback-dialog-title" className="form-dialog__title">
-          Send Feedback
+          Send feedback
         </h2>
 
         {submitted ? (
           <div className="feedback-dialog__success" role="status" aria-live="polite">
             <p className="feedback-dialog__success-text">
-              Thank you! Your feedback has been recorded.
+              Thank you! Your feedback has been sent to GitHub triage.
             </p>
             <button type="button" className="form-button form-button--primary" onClick={onClose}>
               Close
@@ -181,55 +162,55 @@ export const FeedbackDialog: React.FC<FeedbackDialogProps> = ({ isOpen, onClose 
             )}
 
             <div className="form-group">
-              <label htmlFor="feedback-type" className="form-group__label">
-                Type
+              <label
+                htmlFor="feedback-subject"
+                className="form-group__label form-group__label--required"
+              >
+                Subject
               </label>
-              <select
-                id="feedback-type"
+              <input
+                id="feedback-subject"
                 ref={firstInputRef}
                 className="form-group__input"
-                value={type}
-                onChange={(e) => setType(e.target.value as FeedbackType)}
-              >
-                {TYPE_OPTIONS.map((opt) => (
-                  <option key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </option>
-                ))}
-              </select>
+                value={subject}
+                onChange={(e) => setSubject(e.target.value)}
+                maxLength={160}
+                placeholder="Briefly summarize your feedback"
+                aria-required="true"
+                aria-invalid={error && !subject.trim() ? 'true' : undefined}
+              />
             </div>
 
             <div className="form-group">
               <label
-                htmlFor="feedback-description"
+                htmlFor="feedback-body"
                 className="form-group__label form-group__label--required"
               >
-                Description
+                Details
               </label>
               <textarea
-                id="feedback-description"
+                id="feedback-body"
                 className="form-group__input form-group__textarea"
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                rows={4}
-                placeholder="Tell us what's on your mind..."
+                value={body}
+                onChange={(e) => setBody(e.target.value)}
+                rows={5}
+                maxLength={12000}
+                placeholder="Tell us what happened, what you expected, or what would help..."
                 aria-required="true"
-                aria-invalid={error ? 'true' : undefined}
+                aria-invalid={error && !body.trim() ? 'true' : undefined}
               />
             </div>
 
             <div className="form-group">
-              <label htmlFor="feedback-email" className="form-group__label">
-                Email (optional)
+              <label htmlFor="feedback-diagnostics" className="form-group__label">
+                <input
+                  id="feedback-diagnostics"
+                  type="checkbox"
+                  checked={includeDiagnostics}
+                  onChange={(e) => setIncludeDiagnostics(e.target.checked)}
+                />{' '}
+                Include diagnostic info
               </label>
-              <input
-                id="feedback-email"
-                type="email"
-                className="form-group__input"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                placeholder="your@email.com"
-              />
             </div>
 
             <div className="form-dialog__actions">
@@ -237,11 +218,16 @@ export const FeedbackDialog: React.FC<FeedbackDialogProps> = ({ isOpen, onClose 
                 type="button"
                 className="form-button form-button--secondary"
                 onClick={onClose}
+                disabled={isSubmitting}
               >
                 Cancel
               </button>
-              <button type="submit" className="form-button form-button--primary">
-                Submit
+              <button
+                type="submit"
+                className="form-button form-button--primary"
+                disabled={isSubmitting}
+              >
+                {isSubmitting ? 'Sending…' : 'Submit'}
               </button>
             </div>
           </form>

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -2,6 +2,7 @@
 
 import React, { useCallback, useState } from 'react';
 
+import FeedbackDialog from '../FeedbackDialog';
 import { KeyboardShortcutsModal, SyncStatusBar } from '../common';
 import { ConflictResolutionDialog } from '../common/ConflictResolutionDialog';
 import { useKeyboardShortcuts } from '../../hooks';
@@ -32,6 +33,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
   });
   const { conflictCount } = useSyncStatus();
   const [showConflicts, setShowConflicts] = useState(false);
+  const [showFeedback, setShowFeedback] = useState(false);
 
   // Navigate back on Escape key for detail pages (#1523)
   useEscapeBack();
@@ -56,6 +58,14 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
     setShowConflicts(false);
   }, []);
 
+  const openFeedbackDialog = useCallback(() => {
+    setShowFeedback(true);
+  }, []);
+
+  const closeFeedbackDialog = useCallback(() => {
+    setShowFeedback(false);
+  }, []);
+
   return (
     <div className="app-layout">
       <a href="#main-content" className="skip-link">
@@ -65,6 +75,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
         activePath={activePath}
         onNavigate={onNavigate}
         onOpenShortcuts={openKeyboardShortcuts}
+        onOpenFeedback={openFeedbackDialog}
       />
       <div className="app-shell">
         <SyncStatusBar />
@@ -141,11 +152,16 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
         <footer className="app-footer">
           <LegalLinks />
         </footer>
-        <BottomNavigation activePath={activePath} onNavigate={onNavigate} />
+        <BottomNavigation
+          activePath={activePath}
+          onNavigate={onNavigate}
+          onOpenFeedback={openFeedbackDialog}
+        />
       </div>
       <InstallBanner />
       <KeyboardShortcutsModal isOpen={showHelp} onClose={closeKeyboardShortcuts} />
       <ConflictResolutionDialog isOpen={showConflicts} onClose={closeConflictDialog} />
+      <FeedbackDialog isOpen={showFeedback} onClose={closeFeedbackDialog} />
     </div>
   );
 };

--- a/apps/web/src/components/layout/MoreNavSheet.tsx
+++ b/apps/web/src/components/layout/MoreNavSheet.tsx
@@ -36,6 +36,8 @@ export interface MoreNavSheetProps {
   onNavigate: (path: string) => void;
   /** Optional: open the keyboard-shortcuts modal. */
   onOpenShortcuts?: () => void;
+  /** Optional: open the feedback dialog. */
+  onOpenFeedback?: () => void;
   /** Optional: sign-out handler. */
   onSignOut?: () => void | Promise<void>;
 }
@@ -59,6 +61,7 @@ export const MoreNavSheet: React.FC<MoreNavSheetProps> = ({
   activePath,
   onNavigate,
   onOpenShortcuts,
+  onOpenFeedback,
   onSignOut,
 }) => {
   const dialogRef = useRef<HTMLDivElement>(null);
@@ -232,6 +235,29 @@ export const MoreNavSheet: React.FC<MoreNavSheetProps> = ({
                       <span className="more-sheet__item-label">Keyboard shortcuts</span>
                       <span className="more-sheet__item-description">
                         Speed up navigation and common actions.
+                      </span>
+                    </span>
+                  </button>
+                </li>
+              ) : null}
+              {onOpenFeedback ? (
+                <li>
+                  <button
+                    type="button"
+                    className="more-sheet__item"
+                    aria-label="Send feedback"
+                    onClick={() => {
+                      onClose();
+                      onOpenFeedback();
+                    }}
+                  >
+                    <span className="more-sheet__item-icon" aria-hidden="true">
+                      <KeyboardIcon />
+                    </span>
+                    <span className="more-sheet__item-text">
+                      <span className="more-sheet__item-label">Send feedback</span>
+                      <span className="more-sheet__item-description">
+                        Report bugs, ideas, and beta feedback.
                       </span>
                     </span>
                   </button>

--- a/apps/web/src/components/layout/Navigation.tsx
+++ b/apps/web/src/components/layout/Navigation.tsx
@@ -83,6 +83,7 @@ export const BottomNavigation: React.FC<NavigationProps> = ({
   activePath,
   onNavigate,
   onOpenShortcuts,
+  onOpenFeedback,
 }) => {
   const { logout } = useAuth();
   const [moreOpen, setMoreOpen] = useState(false);
@@ -140,6 +141,7 @@ export const BottomNavigation: React.FC<NavigationProps> = ({
         activePath={activePath}
         onNavigate={onNavigate}
         onOpenShortcuts={onOpenShortcuts}
+        onOpenFeedback={onOpenFeedback}
         onSignOut={handleSignOut}
       />
     </>

--- a/apps/web/src/lib/feedback.test.ts
+++ b/apps/web/src/lib/feedback.test.ts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { submitFeedback, type FeedbackDiagnostics } from './feedback';
+
+const diagnostics: FeedbackDiagnostics = {
+  appVersion: '0.1.0',
+  buildSha: 'abc123',
+  path: '/settings/about',
+  userAgent: 'vitest',
+  language: 'en-US',
+  viewport: '1024x768',
+  timezone: 'UTC',
+  timestamp: '2026-01-01T00:00:00.000Z',
+};
+
+describe('submitFeedback', () => {
+  it('posts trimmed feedback and diagnostics to the backend endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ issueUrl: 'https://github.com/jrmoulckers/finance/issues/1' }),
+        {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    );
+
+    const result = await submitFeedback(
+      {
+        subject: '  Budget chart typo  ',
+        body: '  The axis label is clipped.  ',
+        includeDiagnostics: true,
+        diagnostics,
+      },
+      fetchMock,
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/feedback', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        subject: 'Budget chart typo',
+        body: 'The axis label is clipped.',
+        includeDiagnostics: true,
+        diagnostics,
+      }),
+    });
+    expect(result.issueUrl).toBe('https://github.com/jrmoulckers/finance/issues/1');
+  });
+
+  it('does not call fetch when required fields are blank', async () => {
+    const fetchMock = vi.fn();
+
+    await expect(
+      submitFeedback({ subject: ' ', body: 'details', includeDiagnostics: false }, fetchMock),
+    ).rejects.toThrow('Please provide a subject.');
+    await expect(
+      submitFeedback({ subject: 'Subject', body: ' ', includeDiagnostics: false }, fetchMock),
+    ).rejects.toThrow('Please provide feedback details.');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('surfaces backend validation errors', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: 'Feedback is temporarily unavailable' }), {
+        status: 503,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await expect(
+      submitFeedback({ subject: 'Subject', body: 'Body', includeDiagnostics: false }, fetchMock),
+    ).rejects.toThrow('Feedback is temporarily unavailable');
+  });
+});

--- a/apps/web/src/lib/feedback.ts
+++ b/apps/web/src/lib/feedback.ts
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+export interface FeedbackDiagnostics {
+  appVersion: string;
+  buildSha: string;
+  path: string;
+  userAgent: string;
+  language: string;
+  viewport: string;
+  timezone: string;
+  timestamp: string;
+}
+
+export interface FeedbackSubmitPayload {
+  subject: string;
+  body: string;
+  includeDiagnostics: boolean;
+  diagnostics?: FeedbackDiagnostics;
+}
+
+export interface FeedbackSubmitResult {
+  issueUrl?: string;
+  issueNumber?: number;
+}
+
+export function buildFeedbackDiagnostics(options: {
+  appVersion: string;
+  buildSha: string;
+}): FeedbackDiagnostics {
+  const { appVersion, buildSha } = options;
+  return {
+    appVersion,
+    buildSha: buildSha || 'Not available in this build',
+    path: window.location.pathname,
+    userAgent: window.navigator.userAgent,
+    language: window.navigator.language,
+    viewport: `${window.innerWidth}x${window.innerHeight}`,
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+export async function submitFeedback(
+  payload: FeedbackSubmitPayload,
+  fetchImpl: typeof fetch = fetch,
+): Promise<FeedbackSubmitResult> {
+  const subject = payload.subject.trim();
+  const body = payload.body.trim();
+
+  if (!subject) {
+    throw new Error('Please provide a subject.');
+  }
+
+  if (!body) {
+    throw new Error('Please provide feedback details.');
+  }
+
+  const response = await fetchImpl('/api/feedback', {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      subject,
+      body,
+      includeDiagnostics: payload.includeDiagnostics,
+      ...(payload.includeDiagnostics && payload.diagnostics
+        ? { diagnostics: payload.diagnostics }
+        : {}),
+    }),
+  });
+
+  if (!response.ok) {
+    let message = 'Could not send feedback. Please try again later.';
+    try {
+      const errorBody = (await response.json()) as { error?: unknown };
+      if (typeof errorBody.error === 'string' && errorBody.error.trim()) {
+        message = errorBody.error;
+      }
+    } catch {
+      // Keep the generic error message for non-JSON failures.
+    }
+    throw new Error(message);
+  }
+
+  if (response.status === 204) {
+    return {};
+  }
+
+  try {
+    return (await response.json()) as FeedbackSubmitResult;
+  } catch {
+    return {};
+  }
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -192,6 +192,11 @@ export default defineConfig({
             .replace(/^\/api\/account\/delete-account$/, '/account-delete')
             .replace(/^\/api\/account\//, '/account-'),
       },
+      '/api/feedback': {
+        target: authProxyTarget,
+        changeOrigin: true,
+        rewrite: () => '/feedback',
+      },
     },
     headers: {
       // Strict CSP - no inline scripts, no eval

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -10,6 +10,7 @@
 #   /rest/v1/*       → PostgREST (API)
 #   /auth/v1/*       → GoTrue (authentication)
 #   /functions/v1/*  → Edge Functions (Deno)
+#   /api/feedback    → Feedback Edge Function
 #   /sync/*          → PowerSync sync engine
 #   /health          → Edge Functions health check
 #   /assets/*        → Immutable hashed static assets (1-year cache)
@@ -100,7 +101,7 @@
 	}
 
 	# -------------------------------------------------------------------------
-	# /api/auth/* and /api/account/* — same-origin façade for Edge Functions.
+	# /api/auth/*, /api/account/*, and /api/feedback — same-origin façade for Edge Functions.
 	#
 	# The Vite dev server proxies these to /functions/v1/auth-* and
 	# /functions/v1/account-* (apps/web/vite.config.ts). In production we
@@ -132,7 +133,15 @@
 	handle @apiAccountRoot {
 		uri replace /api/account /functions/v1/account-delete
 		reverse_proxy edge-functions:9000 {
-			header_up X-Real-IP {remote_host}
+		      header_up X-Real-IP {remote_host}
+		}
+	}
+
+	@apiFeedback path /api/feedback
+	handle @apiFeedback {
+		uri replace /api/feedback /functions/v1/feedback
+		reverse_proxy edge-functions:9000 {
+		      header_up X-Real-IP {remote_host}
 		}
 	}
 

--- a/deploy/Caddyfile.staging
+++ b/deploy/Caddyfile.staging
@@ -66,7 +66,7 @@
 	}
 
 	# -------------------------------------------------------------------------
-	# /api/auth/* and /api/account/* — same-origin façade for Edge Functions.
+	# /api/auth/*, /api/account/*, and /api/feedback — same-origin façade for Edge Functions.
 	# Mirrors the Vite dev proxy (apps/web/vite.config.ts). Without these
 	# rewrites the client fetches fall through to the SPA fallback and
 	# silently "succeed" with an HTML body — see #1960.
@@ -83,7 +83,15 @@
 	handle @apiAccountRoot {
 		uri replace /api/account /functions/v1/account-delete
 		reverse_proxy edge-functions:9000 {
-			header_up X-Real-IP {remote_host}
+		      header_up X-Real-IP {remote_host}
+		}
+	}
+
+	@apiFeedback path /api/feedback
+	handle @apiFeedback {
+		uri replace /api/feedback /functions/v1/feedback
+		reverse_proxy edge-functions:9000 {
+		      header_up X-Real-IP {remote_host}
 		}
 	}
 

--- a/services/api/.env.example
+++ b/services/api/.env.example
@@ -30,6 +30,7 @@ SUPABASE_DB_URL=postgresql://postgres:postgres@localhost:54322/postgres
 # ---------------------------------------------------------------------------
 AUTH_WEBHOOK_SECRET=YOUR_WEBHOOK_SECRET_HERE
 JWT_SECRET=YOUR_JWT_SECRET_HERE
+GITHUB_FEEDBACK_TOKEN=YOUR_GITHUB_FEEDBACK_TOKEN_HERE
 
 # ---------------------------------------------------------------------------
 # Web auth proxy (#1886)

--- a/services/api/scripts/serve-functions.ts
+++ b/services/api/scripts/serve-functions.ts
@@ -45,6 +45,7 @@ import { handler as authResetPassword } from '../supabase/functions/auth-reset-p
 import { handler as authOAuthStart } from '../supabase/functions/auth-oauth-start/index.ts';
 import { handler as authOAuthCallback } from '../supabase/functions/auth-oauth-callback/index.ts';
 import { handler as accountDeleteHandler } from '../supabase/functions/account-delete/index.ts';
+import { handler as feedbackHandler } from '../supabase/functions/feedback/index.ts';
 import { handler as passkeyRegister } from '../supabase/functions/passkey-register/index.ts';
 import { handler as passkeyAuthenticate } from '../supabase/functions/passkey-authenticate/index.ts';
 
@@ -62,6 +63,7 @@ const routes: Record<string, Handler> = {
   'auth-oauth-start': authOAuthStart,
   'auth-oauth-callback': authOAuthCallback,
   'account-delete': accountDeleteHandler,
+  feedback: feedbackHandler,
   'passkey-register': passkeyRegister,
   'passkey-authenticate': passkeyAuthenticate,
 };

--- a/services/api/supabase/config.toml
+++ b/services/api/supabase/config.toml
@@ -58,3 +58,6 @@ verify_jwt = false
 
 [functions.auth-oauth-callback]
 verify_jwt = false
+
+[functions.feedback]
+verify_jwt = false

--- a/services/api/supabase/functions/feedback/index.ts
+++ b/services/api/supabase/functions/feedback/index.ts
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * POST /api/feedback — create a GitHub issue from in-app feedback.
+ *
+ * The browser calls the same-origin `/api/feedback` facade, which is rewritten
+ * to this Supabase Edge Function. The GitHub token stays server-side in
+ * GITHUB_FEEDBACK_TOKEN and is never exposed to the web app.
+ */
+
+import { handleCorsPreflightRequest } from '../_shared/cors.ts';
+import { errorResponse, jsonResponse, methodNotAllowedResponse } from '../_shared/response.ts';
+
+const GITHUB_ISSUES_URL = 'https://api.github.com/repos/jrmoulckers/finance/issues';
+const FEEDBACK_LABELS = ['feedback', 'beta-triage'] as const;
+const MAX_SUBJECT_LENGTH = 160;
+const MAX_BODY_LENGTH = 12_000;
+
+interface FeedbackRequestBody {
+  subject?: unknown;
+  body?: unknown;
+  includeDiagnostics?: unknown;
+  diagnostics?: unknown;
+}
+
+interface GitHubIssueResponse {
+  html_url?: string;
+  number?: number;
+}
+
+interface FeedbackHandlerDeps {
+  fetchImpl?: typeof fetch;
+  getToken?: () => string | undefined;
+}
+
+export function createFeedbackHandler(deps: FeedbackHandlerDeps = {}) {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const getToken = deps.getToken ?? (() => Deno.env.get('GITHUB_FEEDBACK_TOKEN') ?? undefined);
+
+  return async function feedbackHandler(req: Request): Promise<Response> {
+    if (req.method === 'OPTIONS') {
+      return handleCorsPreflightRequest(req);
+    }
+
+    if (req.method !== 'POST') {
+      return methodNotAllowedResponse(req);
+    }
+
+    const token = getToken()?.trim();
+    if (!token) {
+      return errorResponse(req, 'Feedback is temporarily unavailable.', 503);
+    }
+
+    let payload: FeedbackRequestBody;
+    try {
+      payload = (await req.json()) as FeedbackRequestBody;
+    } catch {
+      return errorResponse(req, 'Request body must be valid JSON.');
+    }
+
+    const subject = coerceString(payload.subject).trim();
+    const body = coerceString(payload.body).trim();
+    const includeDiagnostics = payload.includeDiagnostics === true;
+
+    if (!subject) {
+      return errorResponse(req, 'Subject is required.');
+    }
+
+    if (!body) {
+      return errorResponse(req, 'Feedback details are required.');
+    }
+
+    if (subject.length > MAX_SUBJECT_LENGTH) {
+      return errorResponse(req, `Subject must be ${MAX_SUBJECT_LENGTH} characters or fewer.`);
+    }
+
+    if (body.length > MAX_BODY_LENGTH) {
+      return errorResponse(req, `Feedback details must be ${MAX_BODY_LENGTH} characters or fewer.`);
+    }
+
+    const issueBody = buildIssueBody(body, includeDiagnostics ? payload.diagnostics : undefined);
+
+    try {
+      const githubResponse = await fetchImpl(GITHUB_ISSUES_URL, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/vnd.github+json',
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+          'User-Agent': 'finance-feedback-edge-function',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+        body: JSON.stringify({
+          title: subject,
+          body: issueBody,
+          labels: FEEDBACK_LABELS,
+        }),
+      });
+
+      if (!githubResponse.ok) {
+        const responseText = await githubResponse.text();
+        console.error(
+          JSON.stringify({
+            level: 'error',
+            function: 'feedback',
+            status: githubResponse.status,
+            message: 'GitHub issue creation failed',
+            response: responseText.slice(0, 500),
+          }),
+        );
+        return errorResponse(req, 'Could not create feedback issue.', 502);
+      }
+
+      const issue = (await githubResponse.json()) as GitHubIssueResponse;
+      return jsonResponse(
+        req,
+        {
+          issueUrl: issue.html_url,
+          issueNumber: issue.number,
+        },
+        201,
+      );
+    } catch (err) {
+      console.error(
+        JSON.stringify({
+          level: 'error',
+          function: 'feedback',
+          message: err instanceof Error ? err.message : String(err),
+        }),
+      );
+      return errorResponse(req, 'Could not create feedback issue.', 502);
+    }
+  };
+}
+
+export const handler = createFeedbackHandler();
+
+if (import.meta.main) {
+  Deno.serve(handler);
+}
+
+function coerceString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function buildIssueBody(body: string, diagnostics: unknown): string {
+  const diagnosticBlock = sanitizeDiagnostics(diagnostics);
+  if (!diagnosticBlock) {
+    return body;
+  }
+
+  return `${body}\n\n---\n### Diagnostic info\n\`\`\`json\n${JSON.stringify(
+    diagnosticBlock,
+    null,
+    2,
+  )}\n\`\`\``;
+}
+
+function sanitizeDiagnostics(value: unknown): Record<string, string> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+
+  const safeDiagnostics: Record<string, string> = {};
+  for (const [key, rawValue] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof rawValue !== 'string') {
+      continue;
+    }
+
+    const safeKey = key.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 40);
+    const safeValue = rawValue.trim().slice(0, 500);
+    if (safeKey && safeValue) {
+      safeDiagnostics[safeKey] = safeValue;
+    }
+  }
+
+  return Object.keys(safeDiagnostics).length > 0 ? safeDiagnostics : null;
+}


### PR DESCRIPTION
Closes #2031

## Summary
- Replaces localStorage-only web feedback with a subject/body/diagnostics modal that POSTs to `/api/feedback`.
- Adds a Supabase Edge Function backend that creates GitHub issues in `jrmoulckers/finance` using server-side `GITHUB_FEEDBACK_TOKEN` and labels `feedback,beta-triage`.
- Wires dev/prod same-origin routing through Vite and Caddy, plus local function serving/config/env examples.

## Approach
Backend endpoint approach. The web app submits to `/api/feedback`; Vite/Caddy rewrite that route to the new `feedback` Edge Function. The GitHub token remains server-side and is not committed.

## Testing
- `npx prettier --write apps/web/src/components/FeedbackDialog.tsx apps/web/src/components/layout/AppLayout.tsx apps/web/src/components/layout/MoreNavSheet.tsx apps/web/src/components/layout/Navigation.tsx apps/web/src/lib/feedback.ts apps/web/src/lib/feedback.test.ts apps/web/vite.config.ts services/api/.env.example services/api/scripts/serve-functions.ts services/api/supabase/functions/feedback/index.ts`
- `npx eslint --fix apps/web/src/components/FeedbackDialog.tsx apps/web/src/components/layout/AppLayout.tsx apps/web/src/components/layout/MoreNavSheet.tsx apps/web/src/components/layout/Navigation.tsx apps/web/src/lib/feedback.ts apps/web/src/lib/feedback.test.ts apps/web/vite.config.ts services/api/scripts/serve-functions.ts services/api/supabase/functions/feedback/index.ts`
- `npm run test -w apps/web -- --run src/lib/feedback.test.ts`
- `npm run type-check -w apps/web`
- `deno check .\services\api\supabase\functions\feedback\index.ts`

## Risk
Low/medium. The change is isolated to the feedback UI and new backend function/routing. Deployments must set `GITHUB_FEEDBACK_TOKEN` for issue creation to work.