### PR TITLE
feat(web): add /beta landing page (#2035)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -66,6 +66,7 @@ const STANDALONE_ROUTES: readonly string[] = [
   '/forgot-password',
   '/reset-password',
   '/legal',
+  '/beta',
   '/onboarding',
 ];
 

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -50,6 +50,7 @@ const PRE_AUTH_ROUTES = new Set([
   '/forgot-password',
   '/reset-password',
   '/legal',
+  '/beta',
 ]);
 
 function isPreAuthRoute(pathname: string): boolean {

--- a/apps/web/src/pages/BetaLanding.css
+++ b/apps/web/src/pages/BetaLanding.css
@@ -1,0 +1,230 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+.beta-landing {
+  min-height: 100dvh;
+  padding: var(--spacing-8) var(--spacing-4);
+  background:
+    radial-gradient(circle at top left, rgba(59, 130, 246, 0.16), transparent 28rem),
+    var(--semantic-background-primary);
+  color: var(--semantic-text-primary);
+}
+
+.beta-landing__hero,
+.beta-landing__section,
+.beta-landing__status,
+.beta-landing__feedback {
+  width: min(100%, 960px);
+  margin: 0 auto;
+}
+
+.beta-landing__hero {
+  display: grid;
+  gap: var(--spacing-4);
+  padding: var(--spacing-8);
+  background: var(--card-background);
+  border: 1px solid var(--card-border);
+  border-radius: var(--card-border-radius);
+  box-shadow: var(--card-shadow);
+}
+
+.beta-landing__eyebrow {
+  color: var(--semantic-interactive-default);
+  font-size: var(--type-scale-caption-font-size, 0.875rem);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.beta-landing__hero h1 {
+  max-width: 13ch;
+  font-size: clamp(2.5rem, 8vw, 5rem);
+  line-height: 0.95;
+}
+
+.beta-landing__tagline,
+.beta-landing__section-header p,
+.beta-landing__feedback p,
+.beta-landing__status-text,
+.beta-landing__empty-state,
+.beta-landing__download-description {
+  color: var(--semantic-text-secondary);
+}
+
+.beta-landing__tagline {
+  max-width: 58ch;
+  font-size: var(--type-scale-title-font-size, 1.25rem);
+  line-height: var(--line-height-relaxed, 1.625);
+}
+
+.beta-landing__primary-cta,
+.beta-landing__secondary-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  width: fit-content;
+  padding: var(--spacing-2) var(--spacing-4);
+  border-radius: var(--border-radius-md);
+  font-weight: var(--font-weight-semibold);
+  text-decoration: none;
+}
+
+.beta-landing__primary-cta {
+  background: var(--semantic-interactive-default);
+  border: 1px solid var(--semantic-interactive-default);
+  color: var(--semantic-text-inverse);
+}
+
+.beta-landing__primary-cta:hover {
+  background: var(--semantic-interactive-hover);
+  border-color: var(--semantic-interactive-hover);
+}
+
+.beta-landing__status {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-3);
+  align-items: center;
+  margin-top: var(--spacing-6);
+  padding: var(--spacing-4);
+  background: var(--semantic-background-elevated);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--card-border-radius);
+}
+
+.beta-landing__status-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 36px;
+  padding: var(--spacing-1) var(--spacing-3);
+  border-radius: 999px;
+  font-weight: var(--font-weight-semibold);
+}
+
+.beta-landing__status-badge--operational {
+  background: color-mix(in srgb, var(--semantic-status-positive) 14%, transparent);
+  color: var(--semantic-status-positive);
+}
+
+.beta-landing__status-badge--degraded {
+  background: color-mix(in srgb, var(--semantic-status-warning) 16%, transparent);
+  color: var(--semantic-status-warning);
+}
+
+.beta-landing__status-badge--down {
+  background: color-mix(in srgb, var(--semantic-status-negative) 14%, transparent);
+  color: var(--semantic-status-negative);
+}
+
+.beta-landing__section {
+  margin-top: var(--spacing-8);
+}
+
+.beta-landing__section-header {
+  display: grid;
+  gap: var(--spacing-2);
+  max-width: 680px;
+  margin-bottom: var(--spacing-4);
+}
+
+.beta-landing__section h2,
+.beta-landing__feedback h2 {
+  font-size: var(--type-scale-title-font-size, 1.5rem);
+}
+
+.beta-landing__download-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--spacing-4);
+}
+
+.beta-landing__download-card {
+  display: grid;
+  gap: var(--spacing-2);
+  min-height: 150px;
+  padding: var(--spacing-5);
+  background: var(--card-background);
+  border: 1px solid var(--card-border);
+  border-radius: var(--card-border-radius);
+  color: inherit;
+  text-decoration: none;
+  box-shadow: var(--card-shadow);
+  transition:
+    border-color var(--duration-fast, 100ms) ease,
+    transform var(--duration-fast, 100ms) ease;
+}
+
+.beta-landing__download-card:hover {
+  border-color: var(--semantic-interactive-default);
+  transform: translateY(-2px);
+}
+
+.beta-landing__download-title {
+  font-size: var(--type-scale-body-font-size, 1rem);
+  font-weight: var(--font-weight-semibold);
+}
+
+.beta-landing__empty-state {
+  padding: var(--spacing-5);
+  background: var(--semantic-background-elevated);
+  border: 1px dashed var(--semantic-border-default);
+  border-radius: var(--card-border-radius);
+}
+
+.beta-landing__feedback {
+  display: flex;
+  gap: var(--spacing-4);
+  align-items: center;
+  justify-content: space-between;
+  margin-top: var(--spacing-8);
+  padding: var(--spacing-6);
+  background: var(--semantic-background-elevated);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--card-border-radius);
+}
+
+.beta-landing__feedback div {
+  display: grid;
+  gap: var(--spacing-2);
+  max-width: 640px;
+}
+
+.beta-landing__secondary-cta {
+  border: 1px solid var(--semantic-border-default);
+  color: var(--semantic-interactive-default);
+}
+
+.beta-landing__secondary-cta:hover {
+  border-color: var(--semantic-interactive-default);
+  color: var(--semantic-interactive-hover);
+}
+
+@media (max-width: 640px) {
+  .beta-landing {
+    padding: var(--spacing-4);
+  }
+
+  .beta-landing__hero {
+    padding: var(--spacing-6);
+  }
+
+  .beta-landing__feedback {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .beta-landing__primary-cta,
+  .beta-landing__secondary-cta {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .beta-landing__download-card {
+    transition: none;
+  }
+
+  .beta-landing__download-card:hover {
+    transform: none;
+  }
+}

--- a/apps/web/src/pages/BetaLanding.test.tsx
+++ b/apps/web/src/pages/BetaLanding.test.tsx
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AppRoutes } from '../routes';
+import { BetaLanding } from './BetaLanding';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function renderBetaLanding() {
+  return render(
+    <MemoryRouter>
+      <BetaLanding />
+    </MemoryRouter>,
+  );
+}
+
+describe('BetaLanding', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ status: 'ok' })));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it('mounts at the /beta route', async () => {
+    render(
+      <MemoryRouter initialEntries={['/beta']}>
+        <AppRoutes />
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByRole('heading', { level: 1, name: 'Finance — Now in Beta' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Sign up for the beta' })).toHaveAttribute(
+      'href',
+      '/login',
+    );
+  });
+
+  it('transitions the status badge from degraded to operational when health passes', async () => {
+    renderBetaLanding();
+
+    expect(screen.getByText('🟡 Degraded')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText('🟢 All systems operational')).toBeInTheDocument();
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/health',
+      expect.objectContaining({ headers: { Accept: 'application/json' } }),
+    );
+  });
+
+  it('shows a degraded badge when the health endpoint reports partial availability', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse({ status: 'degraded' }));
+
+    renderBetaLanding();
+
+    await waitFor(() => {
+      expect(screen.getByText('🟡 Degraded')).toBeInTheDocument();
+    });
+  });
+
+  it('shows a down badge when the health endpoint cannot be reached', async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new TypeError('Failed to fetch'));
+
+    renderBetaLanding();
+
+    await waitFor(() => {
+      expect(screen.getByText('🔴 Down')).toBeInTheDocument();
+    });
+  });
+
+  it('only renders download cards for configured native URLs', async () => {
+    vi.stubEnv('VITE_NATIVE_IOS_URL', 'https://example.com/testflight');
+    vi.stubEnv('VITE_NATIVE_ANDROID_URL', '');
+    vi.stubEnv('VITE_NATIVE_WINDOWS_URL', 'https://example.com/finance.msi');
+    vi.stubEnv('VITE_NATIVE_MACOS_URL', '');
+
+    renderBetaLanding();
+
+    expect(screen.getByRole('link', { name: /iOS TestFlight/i })).toHaveAttribute(
+      'href',
+      'https://example.com/testflight',
+    );
+    expect(screen.getByRole('link', { name: /Windows MSI/i })).toHaveAttribute(
+      'href',
+      'https://example.com/finance.msi',
+    );
+    expect(screen.queryByRole('link', { name: /Android internal track/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /macOS DMG/i })).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText('🟢 All systems operational')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/pages/BetaLanding.tsx
+++ b/apps/web/src/pages/BetaLanding.tsx
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { useEffect, useMemo, useState } from 'react';
+import type { FC } from 'react';
+import { Link } from 'react-router-dom';
+
+import './BetaLanding.css';
+
+type SystemStatus = 'operational' | 'degraded' | 'down';
+
+interface DownloadCard {
+  id: string;
+  title: string;
+  description: string;
+  url: string;
+}
+
+const DOWNLOAD_DEFINITIONS = [
+  {
+    id: 'ios',
+    title: 'iOS TestFlight',
+    description: 'Join the iPhone and iPad beta through Apple TestFlight.',
+    envKey: 'VITE_NATIVE_IOS_URL',
+  },
+  {
+    id: 'android',
+    title: 'Android internal track',
+    description: 'Install the Android beta from the Play Store internal test track.',
+    envKey: 'VITE_NATIVE_ANDROID_URL',
+  },
+  {
+    id: 'windows',
+    title: 'Windows MSI',
+    description: 'Try the desktop beta on Windows with the MSI installer.',
+    envKey: 'VITE_NATIVE_WINDOWS_URL',
+  },
+  {
+    id: 'macos',
+    title: 'macOS DMG',
+    description: 'Download the macOS beta build as a signed DMG.',
+    envKey: 'VITE_NATIVE_MACOS_URL',
+  },
+] as const;
+
+function normalizeHealthStatus(payload: unknown, responseOk: boolean): SystemStatus {
+  if (!responseOk) {
+    return 'degraded';
+  }
+
+  if (payload && typeof payload === 'object') {
+    const record = payload as Record<string, unknown>;
+    const rawStatus = record.status ?? record.state ?? record.health;
+
+    if (typeof rawStatus === 'string') {
+      const value = rawStatus.toLowerCase();
+
+      if (value.includes('down') || value.includes('fail') || value.includes('unhealthy')) {
+        return 'down';
+      }
+
+      if (value.includes('degraded') || value.includes('warn') || value.includes('partial')) {
+        return 'degraded';
+      }
+    }
+
+    if (record.ok === false || record.healthy === false) {
+      return 'degraded';
+    }
+  }
+
+  return 'operational';
+}
+
+function getDownloadCards(): DownloadCard[] {
+  return DOWNLOAD_DEFINITIONS.flatMap(({ envKey, ...card }) => {
+    const url = import.meta.env[envKey]?.trim();
+    return url ? [{ ...card, url }] : [];
+  });
+}
+
+const STATUS_COPY: Record<SystemStatus, string> = {
+  operational: '🟢 All systems operational',
+  degraded: '🟡 Degraded',
+  down: '🔴 Down',
+};
+
+export const BetaLanding: FC = () => {
+  const [systemStatus, setSystemStatus] = useState<SystemStatus>('degraded');
+  const downloadCards = useMemo(() => getDownloadCards(), []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function checkHealth() {
+      try {
+        const response = await fetch('/api/health', {
+          headers: { Accept: 'application/json' },
+        });
+        let payload: unknown = null;
+
+        try {
+          payload = await response.json();
+        } catch {
+          payload = null;
+        }
+
+        if (!cancelled) {
+          setSystemStatus(normalizeHealthStatus(payload, response.ok));
+        }
+      } catch {
+        if (!cancelled) {
+          setSystemStatus('down');
+        }
+      }
+    }
+
+    void checkHealth();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <main className="beta-landing">
+      <section className="beta-landing__hero" aria-labelledby="beta-landing-title">
+        <p className="beta-landing__eyebrow">Private preview</p>
+        <h1 id="beta-landing-title">Finance — Now in Beta</h1>
+        <p className="beta-landing__tagline">
+          Secure household budgeting, goals, and insights are ready for early testers. Help shape
+          Finance before the public launch.
+        </p>
+        <Link className="beta-landing__primary-cta" to="/login">
+          Sign up for the beta
+        </Link>
+      </section>
+
+      <section className="beta-landing__status" aria-label="System status">
+        <span className={`beta-landing__status-badge beta-landing__status-badge--${systemStatus}`}>
+          {STATUS_COPY[systemStatus]}
+        </span>
+        <span className="beta-landing__status-text">Live status from /api/health</span>
+      </section>
+
+      <section className="beta-landing__section" aria-labelledby="beta-downloads-title">
+        <div className="beta-landing__section-header">
+          <p className="beta-landing__eyebrow">Native apps</p>
+          <h2 id="beta-downloads-title">Download beta builds</h2>
+          <p>Installers appear here as soon as each beta channel is available.</p>
+        </div>
+
+        {downloadCards.length > 0 ? (
+          <div className="beta-landing__download-grid">
+            {downloadCards.map((card) => (
+              <a
+                className="beta-landing__download-card"
+                href={card.url}
+                key={card.id}
+                rel="noreferrer"
+                target="_blank"
+              >
+                <span className="beta-landing__download-title">{card.title}</span>
+                <span className="beta-landing__download-description">{card.description}</span>
+              </a>
+            ))}
+          </div>
+        ) : (
+          <p className="beta-landing__empty-state">
+            Native download links are not published yet. Check back soon for TestFlight, Android,
+            Windows, and macOS builds.
+          </p>
+        )}
+      </section>
+
+      <section className="beta-landing__feedback" aria-labelledby="beta-feedback-title">
+        <div>
+          <p className="beta-landing__eyebrow">Feedback</p>
+          <h2 id="beta-feedback-title">Tell us what to improve</h2>
+          <p>
+            Found a bug or missing workflow? Send feedback from the app and review the beta terms in
+            the legal index.
+          </p>
+        </div>
+        <Link className="beta-landing__secondary-cta" to="/legal">
+          View legal index
+        </Link>
+      </section>
+    </main>
+  );
+};
+
+export default BetaLanding;

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -44,6 +44,7 @@ const LegalIndex = lazy(() =>
 const LegalDocument = lazy(() =>
   import('./pages/legal/LegalPage').then((module) => ({ default: module.LegalDocumentPage })),
 );
+const BetaLanding = lazy(() => import('./pages/BetaLanding'));
 const NotFound = lazy(() => import('./pages/NotFoundPage'));
 const Watchlists = lazy(() => import('./pages/WatchlistsPage'));
 const Household = lazy(() => import('./pages/HouseholdPage'));
@@ -222,6 +223,14 @@ export const AppRoutes: FC = () => (
       element={
         <RouteBoundary name="California Privacy Notice">
           <LegalDocument documentId="ccpa" />
+        </RouteBoundary>
+      }
+    />
+    <Route
+      path="/beta"
+      element={
+        <RouteBoundary name="Beta">
+          <BetaLanding />
         </RouteBoundary>
       }
     />


### PR DESCRIPTION
## Summary
- Add pre-auth /beta landing route and standalone beta page
- Add live /api/health status banner and env-driven native download cards
- Cover route mount, status states, and download card visibility with Vitest

## Tests
- npm exec --yes -- prettier --check apps\\web\\src\\main.tsx apps\\web\\src\\App.tsx apps\\web\\src\\routes.tsx apps\\web\\src\\pages\\BetaLanding.tsx apps\\web\\src\\pages\\BetaLanding.css apps\\web\\src\\pages\\BetaLanding.test.tsx
- npm exec --yes -- eslint apps\\web\\src\\main.tsx apps\\web\\src\\App.tsx apps\\web\\src\\routes.tsx apps\\web\\src\\pages\\BetaLanding.tsx apps\\web\\src\\pages\\BetaLanding.test.tsx
- npm run test -w apps/web -- BetaLanding.test.tsx

Closes #2035