### PR TITLE
feat(web): encrypt offline IDB storage + stop caching authed API (#2028)

### DIFF
--- a/apps/web/src/__tests__/service-worker-lifecycle.test.ts
+++ b/apps/web/src/__tests__/service-worker-lifecycle.test.ts
@@ -14,13 +14,16 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { getFetchStrategyForPathname } from '../sw/service-worker';
+
 // ---------------------------------------------------------------------------
 // Service worker caching strategy constants (mirrored from source)
 // ---------------------------------------------------------------------------
 
 const CACHE_VERSION = 'v2';
 const STATIC_CACHE = `finance-static-${CACHE_VERSION}`;
-const API_CACHE = `finance-api-${CACHE_VERSION}`;
+const SYNC_CACHE = `finance-sync-${CACHE_VERSION}`;
+const LEGACY_API_CACHE_PREFIX = 'finance-api-';
 const APP_SHELL: string[] = ['/', '/index.html', '/manifest.json'];
 const STATIC_EXTENSIONS = /\.(js|css|woff2?|ttf|otf|eot|png|jpe?g|gif|svg|ico|webp|avif|wasm)$/i;
 
@@ -33,17 +36,17 @@ describe('Cache version naming (#1330)', () => {
     expect(STATIC_CACHE).toBe('finance-static-v2');
   });
 
-  it('API cache includes version prefix', () => {
-    expect(API_CACHE).toBe('finance-api-v2');
+  it('sync cache includes version prefix', () => {
+    expect(SYNC_CACHE).toBe('finance-sync-v2');
   });
 
   it('changing CACHE_VERSION produces new cache names', () => {
     const nextVersion = 'v3';
     const nextStatic = `finance-static-${nextVersion}`;
-    const nextApi = `finance-api-${nextVersion}`;
+    const nextSync = `finance-sync-${nextVersion}`;
 
     expect(nextStatic).not.toBe(STATIC_CACHE);
-    expect(nextApi).not.toBe(API_CACHE);
+    expect(nextSync).not.toBe(SYNC_CACHE);
   });
 });
 
@@ -107,26 +110,16 @@ describe('Static asset detection (#1330)', () => {
 // ---------------------------------------------------------------------------
 
 describe('Fetch strategy routing (#1330)', () => {
-  it('auth API requests should use network-first strategy', () => {
-    const url = new URL('/api/auth/login', 'https://example.com');
-    const isAuthOrSync =
-      url.pathname.startsWith('/api/auth/') || url.pathname.startsWith('/api/sync/');
-    expect(isAuthOrSync).toBe(true);
-  });
-
   it('sync API requests should use network-first strategy', () => {
-    const url = new URL('/api/sync/push', 'https://example.com');
-    const isAuthOrSync =
-      url.pathname.startsWith('/api/auth/') || url.pathname.startsWith('/api/sync/');
-    expect(isAuthOrSync).toBe(true);
+    expect(getFetchStrategyForPathname('/api/sync/push')).toBe('network-first');
   });
 
-  it('other API requests should use stale-while-revalidate', () => {
-    const url = new URL('/api/accounts', 'https://example.com');
-    const isApi = url.pathname.startsWith('/api/');
-    const isAuthOrSync =
-      url.pathname.startsWith('/api/auth/') || url.pathname.startsWith('/api/sync/');
-    expect(isApi && !isAuthOrSync).toBe(true);
+  it('all non-sync API requests should use network-only no-store', () => {
+    expect(getFetchStrategyForPathname('/api/auth/login')).toBe('network-only-no-store');
+    expect(getFetchStrategyForPathname('/api/accounts')).toBe('network-only-no-store');
+    expect(getFetchStrategyForPathname('/api/transactions?month=2025-01')).toBe(
+      'network-only-no-store',
+    );
   });
 
   it('static assets use cache-first strategy', () => {
@@ -144,23 +137,31 @@ describe('Cache invalidation during activation (#1330)', () => {
     const allCacheKeys = [
       'finance-static-v0',
       'finance-api-v0',
+      'finance-api-v2',
       STATIC_CACHE,
-      API_CACHE,
+      SYNC_CACHE,
       'other-cache',
     ];
 
-    const staleCaches = allCacheKeys.filter((key) => key !== STATIC_CACHE && key !== API_CACHE);
+    const staleCaches = allCacheKeys.filter(
+      (key) =>
+        key.startsWith(LEGACY_API_CACHE_PREFIX) || (key !== STATIC_CACHE && key !== SYNC_CACHE),
+    );
 
     expect(staleCaches).toContain('finance-static-v0');
     expect(staleCaches).toContain('finance-api-v0');
+    expect(staleCaches).toContain('finance-api-v2');
     expect(staleCaches).toContain('other-cache');
     expect(staleCaches).not.toContain(STATIC_CACHE);
-    expect(staleCaches).not.toContain(API_CACHE);
+    expect(staleCaches).not.toContain(SYNC_CACHE);
   });
 
   it('current version caches are preserved', () => {
-    const allCacheKeys = [STATIC_CACHE, API_CACHE];
-    const staleCaches = allCacheKeys.filter((key) => key !== STATIC_CACHE && key !== API_CACHE);
+    const allCacheKeys = [STATIC_CACHE, SYNC_CACHE];
+    const staleCaches = allCacheKeys.filter(
+      (key) =>
+        key.startsWith(LEGACY_API_CACHE_PREFIX) || (key !== STATIC_CACHE && key !== SYNC_CACHE),
+    );
 
     expect(staleCaches).toHaveLength(0);
   });

--- a/apps/web/src/accessibility/__tests__/wcag-audit.test.ts
+++ b/apps/web/src/accessibility/__tests__/wcag-audit.test.ts
@@ -163,14 +163,13 @@ describe('High Contrast Token Integration', () => {
 describe('Service Worker Caching', () => {
   const swCode = readFileSync(resolve(__dirname, '../../../src/sw/service-worker.ts'), 'utf-8');
 
-  it('should implement stale-while-revalidate strategy', () => {
-    expect(swCode).toContain('staleWhileRevalidate');
+  it('should implement network-only no-store for authenticated API requests', () => {
+    expect(swCode).toContain('networkOnlyNoStore');
   });
 
-  it('should use stale-while-revalidate for API requests', () => {
-    // The fetch handler should route /api/ to staleWhileRevalidate
-    expect(swCode).toContain("url.pathname.startsWith('/api/')");
-    expect(swCode).toContain('staleWhileRevalidate(request)');
+  it('should route non-sync API requests away from Cache Storage', () => {
+    expect(swCode).toContain("pathname.startsWith('/api/'))");
+    expect(swCode).toContain("return 'network-only-no-store'");
   });
 
   it('should implement cache-first for static assets', () => {

--- a/apps/web/src/db/__tests__/encryption.test.ts
+++ b/apps/web/src/db/__tests__/encryption.test.ts
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import { describe, it, expect, beforeAll } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
 import {
-  encryptDatabase,
+  clearEncryptedData,
   decryptDatabase,
   deriveEncryptionKey,
+  encryptDatabase,
   isEncryptionSupported,
+  loadEncryptedDatabase,
+  saveEncryptedDatabase,
 } from '../encryption';
 
 describe('encryption', () => {
@@ -15,6 +18,10 @@ describe('encryption', () => {
   beforeAll(() => {
     expect(typeof crypto).toBe('object');
     expect(typeof crypto.subtle).toBe('object');
+  });
+
+  afterEach(async () => {
+    await clearEncryptedData();
   });
 
   describe('isEncryptionSupported', () => {
@@ -105,5 +112,37 @@ describe('encryption', () => {
       const decrypted = await decryptDatabase(encrypted.data, testSecret);
       expect(Array.from(decrypted)).toEqual(Array.from(largeData));
     });
+
+    it('round-trips persisted IndexedDB snapshots without storing plaintext', async () => {
+      await saveEncryptedDatabase(testData, testSecret);
+
+      const raw = await readRawEncryptedSnapshot();
+      expect(raw?.byteLength).toBeGreaterThan(testData.byteLength);
+      expect(new TextDecoder().decode(raw!)).not.toContain('SQLite format 3');
+
+      const restored = await loadEncryptedDatabase(testSecret);
+      expect(Array.from(restored ?? [])).toEqual(Array.from(testData));
+    });
   });
 });
+
+async function readRawEncryptedSnapshot(): Promise<ArrayBuffer | undefined> {
+  const db = await new Promise<IDBDatabase>((resolve, reject) => {
+    const request = indexedDB.open('finance-sqlite-encrypted', 1);
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction('encrypted', 'readonly');
+    const request = tx.objectStore('encrypted').get('db');
+    request.onsuccess = () => {
+      db.close();
+      resolve(request.result as ArrayBuffer | undefined);
+    };
+    request.onerror = () => {
+      db.close();
+      reject(request.error);
+    };
+  });
+}

--- a/apps/web/src/db/encryption.ts
+++ b/apps/web/src/db/encryption.ts
@@ -45,6 +45,15 @@ const SALT_STORE_NAME = 'keys';
 /** IndexedDB key for the persistent salt. */
 const SALT_IDB_KEY = 'db-salt';
 
+/** SessionStorage key for the per-tab database encryption passphrase. */
+const SESSION_PASSPHRASE_KEY = 'finance.sqliteEncryption.passphrase';
+
+/** SessionStorage key for an additional per-tab passphrase salt. */
+const SESSION_PASSPHRASE_SALT_KEY = 'finance.sqliteEncryption.salt';
+
+/** Random byte length for generated session passphrases and salts. */
+const SESSION_SECRET_BYTES = 32;
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -61,6 +70,41 @@ export interface KeyDerivationOptions {
   readonly secret: string;
   /** Optional salt — if not provided, a new random salt is generated. */
   readonly salt?: Uint8Array;
+}
+
+// ---------------------------------------------------------------------------
+// Byte helpers
+// ---------------------------------------------------------------------------
+
+function toExactArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
+function randomBase64Url(byteLength: number): string | null {
+  if (typeof crypto === 'undefined' || typeof crypto.getRandomValues !== 'function') {
+    return null;
+  }
+
+  const bytes = crypto.getRandomValues(new Uint8Array(byteLength));
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/u, '');
+}
+
+function getSessionStorageIfAvailable(): Storage | null {
+  try {
+    if (typeof sessionStorage === 'undefined') {
+      return null;
+    }
+    const probeKey = 'finance.sqliteEncryption.probe';
+    sessionStorage.setItem(probeKey, '1');
+    sessionStorage.removeItem(probeKey);
+    return sessionStorage;
+  } catch {
+    return null;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -87,7 +131,7 @@ export async function deriveEncryptionKey(secret: string, salt: Uint8Array): Pro
   return crypto.subtle.deriveKey(
     {
       name: 'PBKDF2',
-      salt: salt.buffer as ArrayBuffer,
+      salt: toExactArrayBuffer(salt),
       iterations: PBKDF2_ITERATIONS,
       hash: 'SHA-256',
     },
@@ -118,9 +162,9 @@ export async function encryptDatabase(
   const key = await deriveEncryptionKey(secret, salt);
 
   const ciphertext = await crypto.subtle.encrypt(
-    { name: 'AES-GCM', iv: iv.buffer as ArrayBuffer },
+    { name: 'AES-GCM', iv: toExactArrayBuffer(iv) },
     key,
-    plaintext.buffer as ArrayBuffer,
+    toExactArrayBuffer(plaintext),
   );
 
   // Pack: [salt (16)] [iv (12)] [ciphertext + auth tag]
@@ -153,9 +197,9 @@ export async function decryptDatabase(encrypted: Uint8Array, secret: string): Pr
 
   try {
     const plaintext = await crypto.subtle.decrypt(
-      { name: 'AES-GCM', iv: iv.buffer as ArrayBuffer },
+      { name: 'AES-GCM', iv: toExactArrayBuffer(iv) },
       key,
-      ciphertext.buffer as ArrayBuffer,
+      toExactArrayBuffer(ciphertext),
     );
     return new Uint8Array(plaintext);
   } catch {
@@ -163,6 +207,46 @@ export async function decryptDatabase(encrypted: Uint8Array, secret: string): Pr
       'Decryption failed. The encryption key may be incorrect or the data may have been tampered with.',
     );
   }
+}
+
+// ---------------------------------------------------------------------------
+// Session passphrase fallback
+// ---------------------------------------------------------------------------
+
+/**
+ * Return a per-tab encryption secret backed by sessionStorage.
+ *
+ * This fallback keeps the SQLite IndexedDB blob encrypted even before an auth
+ * token is available. The generated passphrase is intentionally scoped to the
+ * current browser session and is never written to localStorage or IndexedDB.
+ */
+export function getOrCreateSessionStoragePassphrase(): string | null {
+  const storage = getSessionStorageIfAvailable();
+  if (!storage) {
+    return null;
+  }
+
+  let passphrase = storage.getItem(SESSION_PASSPHRASE_KEY);
+  let salt = storage.getItem(SESSION_PASSPHRASE_SALT_KEY);
+
+  if (!passphrase || !salt) {
+    passphrase = randomBase64Url(SESSION_SECRET_BYTES);
+    salt = randomBase64Url(SESSION_SECRET_BYTES);
+    if (!passphrase || !salt) {
+      return null;
+    }
+    storage.setItem(SESSION_PASSPHRASE_KEY, passphrase);
+    storage.setItem(SESSION_PASSPHRASE_SALT_KEY, salt);
+  }
+
+  return salt + ':' + passphrase;
+}
+
+/** Clear the per-tab fallback passphrase. */
+export function clearSessionStoragePassphrase(): void {
+  const storage = getSessionStorageIfAvailable();
+  storage?.removeItem(SESSION_PASSPHRASE_KEY);
+  storage?.removeItem(SESSION_PASSPHRASE_SALT_KEY);
 }
 
 // ---------------------------------------------------------------------------
@@ -190,7 +274,7 @@ export async function persistSalt(salt: Uint8Array): Promise<void> {
   const db = await openSaltStore();
   return new Promise((resolve, reject) => {
     const tx = db.transaction(SALT_STORE_NAME, 'readwrite');
-    tx.objectStore(SALT_STORE_NAME).put(salt.buffer, SALT_IDB_KEY);
+    tx.objectStore(SALT_STORE_NAME).put(toExactArrayBuffer(salt), SALT_IDB_KEY);
     tx.oncomplete = () => {
       db.close();
       resolve();
@@ -252,7 +336,7 @@ export async function saveEncryptedDatabase(plaintext: Uint8Array, secret: strin
   const idb = await openEncryptedStore();
   return new Promise((resolve, reject) => {
     const tx = idb.transaction(ENCRYPTED_STORE, 'readwrite');
-    tx.objectStore(ENCRYPTED_STORE).put(data.buffer, ENCRYPTED_KEY);
+    tx.objectStore(ENCRYPTED_STORE).put(toExactArrayBuffer(data), ENCRYPTED_KEY);
     tx.oncomplete = () => {
       idb.close();
       resolve();

--- a/apps/web/src/db/sqlite-wasm.ts
+++ b/apps/web/src/db/sqlite-wasm.ts
@@ -15,6 +15,9 @@
  * References: issues #57, #95
  */
 
+import { getAccessTokenSync } from '../auth/token-storage';
+import { getOrCreateSessionStoragePassphrase, isEncryptionSupported } from './encryption';
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -128,9 +131,11 @@ const MIGRATIONS_TABLE = '_migrations';
  *
  * When set, IndexedDB-backed databases are encrypted at rest using
  * AES-256-GCM via the Web Crypto API.  Set via `setEncryptionSecret()`
- * before calling `initDatabase()`.
+ * before calling `initDatabase()`. When unset, the storage layer derives a
+ * secret from sessionStorage or the current Supabase access token.
  */
 let _encryptionSecret: string | null = null;
+let _resolvedEncryptionSecret: string | null | undefined;
 
 /**
  * Configure the encryption secret used to encrypt/decrypt the database
@@ -146,11 +151,66 @@ let _encryptionSecret: string | null = null;
  */
 export function setEncryptionSecret(secret: string | null): void {
   _encryptionSecret = secret;
+  _resolvedEncryptionSecret = undefined;
 }
 
 /** Check whether an encryption secret has been configured. */
 export function hasEncryptionSecret(): boolean {
   return _encryptionSecret !== null;
+}
+
+function isDevUnencryptedFallbackEnabled(): boolean {
+  return import.meta.env.DEV === true;
+}
+
+function encryptionUnavailableError(): StorageError {
+  return new StorageError(
+    'INDEXEDDB_FAILED',
+    'Encrypted database storage requires Web Crypto and session storage.',
+    { backend: 'indexeddb' },
+  );
+}
+
+/**
+ * Resolve the secret used for IndexedDB SQLite encryption.
+ *
+ * Prefer an explicitly configured secret, then a per-tab sessionStorage
+ * passphrase, then the in-memory Supabase access token. If none is available,
+ * plaintext IndexedDB is allowed only in Vite dev/test mode.
+ */
+export function resolveDatabaseEncryptionSecret(): string | null {
+  if (_resolvedEncryptionSecret !== undefined) {
+    return _resolvedEncryptionSecret;
+  }
+
+  const configuredSecret = _encryptionSecret?.trim();
+  if (configuredSecret) {
+    _resolvedEncryptionSecret = configuredSecret;
+    return _resolvedEncryptionSecret;
+  }
+
+  const sessionSecret = getOrCreateSessionStoragePassphrase();
+  if (sessionSecret) {
+    _resolvedEncryptionSecret = sessionSecret;
+    return _resolvedEncryptionSecret;
+  }
+
+  const accessToken = getAccessTokenSync()?.trim();
+  if (accessToken) {
+    _resolvedEncryptionSecret = accessToken;
+    return _resolvedEncryptionSecret;
+  }
+
+  if (isDevUnencryptedFallbackEnabled()) {
+    _resolvedEncryptionSecret = null;
+    return null;
+  }
+
+  throw encryptionUnavailableError();
+}
+
+function toExactArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
 }
 
 // ---------------------------------------------------------------------------
@@ -1161,48 +1221,106 @@ function openIDB(): Promise<IDBDatabase> {
 }
 
 async function loadFromIndexedDB(key: string): Promise<ArrayBuffer | null> {
-  // Try encrypted storage first when a secret is available
-  if (_encryptionSecret) {
-    try {
-      const { loadEncryptedDatabase } = await import('./encryption');
-      const decrypted = await loadEncryptedDatabase(_encryptionSecret);
-      if (decrypted) {
-        return decrypted.buffer as ArrayBuffer;
-      }
-    } catch {
-      // Fall through to unencrypted load — first use or migration
+  if (!isEncryptionSupported()) {
+    if (isDevUnencryptedFallbackEnabled()) {
+      return loadPlaintextFromIndexedDB(key);
+    }
+    throw encryptionUnavailableError();
+  }
+
+  const encryptionSecret = resolveDatabaseEncryptionSecret();
+  if (!encryptionSecret) {
+    return loadPlaintextFromIndexedDB(key);
+  }
+
+  try {
+    const { loadEncryptedDatabase } = await import('./encryption');
+    const decrypted = await loadEncryptedDatabase(encryptionSecret);
+    if (decrypted) {
+      return toExactArrayBuffer(decrypted);
+    }
+  } catch (error) {
+    if (!isDevUnencryptedFallbackEnabled()) {
+      throw error;
     }
   }
 
+  return loadPlaintextFromIndexedDB(key);
+}
+
+async function loadPlaintextFromIndexedDB(key: string): Promise<ArrayBuffer | null> {
   const idb = await openIDB();
   return new Promise((resolve, reject) => {
     const tx = idb.transaction(IDB_STORE, 'readonly');
     const store = tx.objectStore(IDB_STORE);
-    const req = store.get(`${key}:${IDB_KEY}`);
-    req.onsuccess = () => resolve(req.result ?? null);
-    req.onerror = () => reject(req.error);
+    const req = store.get(key + ':' + IDB_KEY);
+    req.onsuccess = () => {
+      idb.close();
+      resolve(req.result ?? null);
+    };
+    req.onerror = () => {
+      idb.close();
+      reject(req.error);
+    };
   });
 }
 
 async function persistToIndexedDB(key: string, data: Uint8Array): Promise<void> {
-  // Encrypt when a secret is available
-  if (_encryptionSecret) {
-    try {
-      const { saveEncryptedDatabase } = await import('./encryption');
-      await saveEncryptedDatabase(data, _encryptionSecret);
-      return;
-    } catch {
-      // Fall through to unencrypted save as safety net
+  if (!isEncryptionSupported()) {
+    if (isDevUnencryptedFallbackEnabled()) {
+      return persistPlaintextToIndexedDB(key, data);
     }
+    throw encryptionUnavailableError();
   }
 
+  const encryptionSecret = resolveDatabaseEncryptionSecret();
+  if (!encryptionSecret) {
+    return persistPlaintextToIndexedDB(key, data);
+  }
+
+  try {
+    const { saveEncryptedDatabase } = await import('./encryption');
+    await saveEncryptedDatabase(data, encryptionSecret);
+    await deletePlaintextFromIndexedDB(key);
+    return;
+  } catch (error) {
+    if (!isDevUnencryptedFallbackEnabled()) {
+      throw error;
+    }
+    return persistPlaintextToIndexedDB(key, data);
+  }
+}
+
+async function persistPlaintextToIndexedDB(key: string, data: Uint8Array): Promise<void> {
   const idb = await openIDB();
   return new Promise((resolve, reject) => {
     const tx = idb.transaction(IDB_STORE, 'readwrite');
     const store = tx.objectStore(IDB_STORE);
-    store.put(data.buffer, `${key}:${IDB_KEY}`);
-    tx.oncomplete = () => resolve();
-    tx.onerror = () => reject(tx.error);
+    store.put(toExactArrayBuffer(data), key + ':' + IDB_KEY);
+    tx.oncomplete = () => {
+      idb.close();
+      resolve();
+    };
+    tx.onerror = () => {
+      idb.close();
+      reject(tx.error);
+    };
+  });
+}
+
+async function deletePlaintextFromIndexedDB(key: string): Promise<void> {
+  const idb = await openIDB();
+  return new Promise((resolve) => {
+    const tx = idb.transaction(IDB_STORE, 'readwrite');
+    tx.objectStore(IDB_STORE).delete(key + ':' + IDB_KEY);
+    tx.oncomplete = () => {
+      idb.close();
+      resolve();
+    };
+    tx.onerror = () => {
+      idb.close();
+      resolve();
+    };
   });
 }
 

--- a/apps/web/src/sw/__tests__/service-worker-auth-bypass.test.ts
+++ b/apps/web/src/sw/__tests__/service-worker-auth-bypass.test.ts
@@ -59,6 +59,20 @@ describe('networkOnlyNoStore (service worker auth bypass)', () => {
     expect(mockCache.put).not.toHaveBeenCalled();
   });
 
+  it('keeps all non-sync API responses out of Cache Storage', async () => {
+    const successResponse = new Response(JSON.stringify({ balance: 123 }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+    globalThis.fetch = vi.fn().mockResolvedValue(successResponse);
+
+    await networkOnlyNoStore(new Request('http://localhost/api/accounts'));
+
+    expect(openMock).not.toHaveBeenCalled();
+    expect(mockCache.put).not.toHaveBeenCalled();
+    expect(mockCache.match).not.toHaveBeenCalled();
+  });
+
   it('returns 503 JSON with Cache-Control: no-store when the network fails', async () => {
     globalThis.fetch = vi.fn().mockRejectedValue(new Error('offline'));
 

--- a/apps/web/src/sw/service-worker.ts
+++ b/apps/web/src/sw/service-worker.ts
@@ -5,7 +5,12 @@
  *
  * Caching strategies:
  *   - Cache-first -- static assets (JS, CSS, images, fonts, WASM)
- *   - Network-first -- API calls (`/api/`)
+ *   - Network-first -- sync API calls (`/api/sync/`)
+ *   - Network-only/no-store -- all other API calls (`/api/*`)
+ *
+ * Authenticated API responses can contain bearer tokens, financial data, or
+ * user-specific state. Cache Storage is disk-backed and not covered by the
+ * encrypted SQLite IndexedDB layer, so non-sync API responses are never cached.
  *
  * Offline mutation replay:
  *   Listens for the Background Sync API `sync` event and replays queued
@@ -16,7 +21,7 @@
  * Cache versioning is enforced: when CACHE_VERSION changes, old caches
  * are automatically purged during activation.
  *
- * References: issues #58, #416
+ * References: issues #58, #416, #2028
  */
 
 /// <reference lib="webworker" />
@@ -44,7 +49,8 @@ const CACHE_VERSION = 'v2';
 
 /** Cache bucket names. */
 const STATIC_CACHE = `finance-static-${CACHE_VERSION}`;
-const API_CACHE = `finance-api-${CACHE_VERSION}`;
+const SYNC_CACHE = `finance-sync-${CACHE_VERSION}`;
+const LEGACY_API_CACHE_PREFIX = 'finance-api-';
 
 /**
  * Build-time precache manifest.
@@ -94,11 +100,7 @@ self.addEventListener('activate', (event: ExtendableEvent) => {
     caches
       .keys()
       .then((keys) =>
-        Promise.all(
-          keys
-            .filter((key) => key !== STATIC_CACHE && key !== API_CACHE)
-            .map((key) => caches.delete(key)),
-        ),
+        Promise.all(keys.filter(shouldDeleteCacheOnActivate).map((key) => caches.delete(key))),
       ),
   );
   // Take control of all open tabs immediately
@@ -118,43 +120,20 @@ self.addEventListener('fetch', (event: FetchEvent) => {
     return;
   }
 
-  // Auth API: strictly network-only, never cached (#1886).
-  // Auth responses carry bearer tokens (access_token in body, refresh
-  // token in HttpOnly cookie) so any caching path would persist
-  // credentials to disk-backed Cache Storage. The auth functions also
-  // emit `Cache-Control: no-store`, but defence-in-depth here protects
-  // against future strategy changes upstream.
-  if (url.pathname.startsWith('/api/auth/')) {
-    event.respondWith(networkOnlyNoStore(request));
-    return;
+  switch (getFetchStrategyForPathname(url.pathname, request.mode)) {
+    case 'network-first':
+      event.respondWith(networkFirst(request));
+      return;
+    case 'network-only-no-store':
+      event.respondWith(networkOnlyNoStore(request));
+      return;
+    case 'cache-first':
+      event.respondWith(cacheFirst(request));
+      return;
+    case 'navigation':
+      event.respondWith(navigationHandler(request));
+      return;
   }
-
-  // Sync API requests -> network-first (prefer fresh data, fall back to cache)
-  if (url.pathname.startsWith('/api/sync/')) {
-    event.respondWith(networkFirst(request));
-    return;
-  }
-
-  // Other API requests -> stale-while-revalidate (serve cached, update in background)
-  if (url.pathname.startsWith('/api/')) {
-    event.respondWith(staleWhileRevalidate(request));
-    return;
-  }
-
-  // Static assets & app shell -> cache-first
-  if (isStaticAsset(url.pathname)) {
-    event.respondWith(cacheFirst(request));
-    return;
-  }
-
-  // Navigation requests (HTML) -> network-first with app-shell fallback (SPA)
-  if (request.mode === 'navigate') {
-    event.respondWith(navigationHandler(request));
-    return;
-  }
-
-  // Everything else -- try cache, fall back to network
-  event.respondWith(cacheFirst(request));
 });
 
 // ---------------------------------------------------------------------------
@@ -286,19 +265,20 @@ async function cacheFirst(request: Request, fallbackUrl?: string): Promise<Respo
 }
 
 /**
- * **Network-only, no-store**: always go to the network for auth
- * requests, and never enter Cache Storage on any code path (success or
- * failure). Falls back to a JSON 503 when the network throws.
+ * **Network-only, no-store**: always go to the network for
+ * authenticated API requests, and never enter Cache Storage on any code
+ * path (success or failure). Falls back to a JSON 503 when the network
+ * throws.
  *
- * Exported so a regression test can assert that `/api/auth/*` is never
- * routed through a caching strategy (#1886).
+ * Exported so regression tests can assert that `/api/*` routes are never
+ * routed through a caching strategy (#1886, #2028).
  */
 export async function networkOnlyNoStore(request: Request): Promise<Response> {
   try {
     return await fetch(request);
   } catch {
     return new Response(
-      JSON.stringify({ error: 'offline', message: 'Network required for auth' }),
+      JSON.stringify({ error: 'offline', message: 'Network required for this API request' }),
       {
         status: 503,
         statusText: 'Service Unavailable',
@@ -313,10 +293,11 @@ export async function networkOnlyNoStore(request: Request): Promise<Response> {
 
 /**
  * **Network-first**: try the network, cache the response, and fall back
- * to a cached copy if offline.
+ * to a cached copy if offline. Used only for sync API endpoints, whose
+ * offline reconciliation payloads are intentionally available offline.
  */
 async function networkFirst(request: Request): Promise<Response> {
-  const cache = await caches.open(API_CACHE);
+  const cache = await caches.open(SYNC_CACHE);
 
   try {
     const response = await fetch(request);
@@ -340,53 +321,42 @@ async function networkFirst(request: Request): Promise<Response> {
   }
 }
 
-/**
- * **Stale-while-revalidate**: serve from cache immediately (if available),
- * then update the cache in the background from the network.
- *
- * This provides the best user experience for API requests: instant responses
- * from cache with eventual consistency from the network.
- */
-async function staleWhileRevalidate(request: Request): Promise<Response> {
-  const cache = await caches.open(API_CACHE);
-  const cached = await cache.match(request);
-
-  // Start the network request in the background
-  const networkPromise = fetch(request)
-    .then(async (response) => {
-      if (response.ok) {
-        await cache.put(request, response.clone());
-      }
-      return response;
-    })
-    .catch(() => null);
-
-  // If we have a cached response, return it immediately
-  if (cached) {
-    // Fire-and-forget: update cache in background
-    void networkPromise;
-    return cached;
-  }
-
-  // No cached response — wait for network
-  const networkResponse = await networkPromise;
-  if (networkResponse) {
-    return networkResponse;
-  }
-
-  return new Response(
-    JSON.stringify({ error: 'offline', message: 'No cached response available' }),
-    {
-      status: 503,
-      statusText: 'Service Unavailable',
-      headers: { 'Content-Type': 'application/json' },
-    },
-  );
-}
-
 /** Returns `true` when the pathname looks like a static asset. */
 function isStaticAsset(pathname: string): boolean {
   return STATIC_EXTENSIONS.test(pathname);
+}
+
+export type FetchStrategy =
+  | 'network-first'
+  | 'network-only-no-store'
+  | 'cache-first'
+  | 'navigation';
+
+export function getFetchStrategyForPathname(
+  pathname: string,
+  requestMode?: RequestMode,
+): FetchStrategy {
+  if (pathname.startsWith('/api/sync/')) {
+    return 'network-first';
+  }
+
+  if (pathname.startsWith('/api/')) {
+    return 'network-only-no-store';
+  }
+
+  if (isStaticAsset(pathname)) {
+    return 'cache-first';
+  }
+
+  if (requestMode === 'navigate') {
+    return 'navigation';
+  }
+
+  return 'cache-first';
+}
+
+function shouldDeleteCacheOnActivate(key: string): boolean {
+  return key.startsWith(LEGACY_API_CACHE_PREFIX) || (key !== STATIC_CACHE && key !== SYNC_CACHE);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #2028

## Summary
- encrypt SQLite IndexedDB snapshots with AES-GCM using PBKDF2-derived secrets
- route non-sync `/api/*` through network-only/no-store and purge legacy `finance-api-*` caches
- add Vitest coverage for encrypted persistence and API no-cache routing

## Tests
- npm exec --workspace apps/web -- vitest run src/__tests__/service-worker-lifecycle.test.ts src/db/__tests__/encryption.test.ts src/sw/__tests__/service-worker-auth-bypass.test.ts src/accessibility/__tests__/wcag-audit.test.ts --reporter=dot