### PR TITLE
feat(web): legal/privacy/terms/ccpa routes (#2027)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -44,6 +44,10 @@ const PAGE_TITLES: Record<string, string> = {
   '/net-worth': 'Net Worth',
   '/subscriptions': 'Subscriptions',
   '/bank-connections': 'Bank Connections',
+  '/legal': 'Legal',
+  '/legal/privacy': 'Privacy Policy',
+  '/legal/terms': 'Terms of Service',
+  '/legal/ccpa': 'California Privacy Notice',
 };
 
 /**
@@ -61,6 +65,7 @@ const STANDALONE_ROUTES: readonly string[] = [
   '/signup',
   '/forgot-password',
   '/reset-password',
+  '/legal',
   '/onboarding',
 ];
 

--- a/apps/web/src/components/layout/AppLayout.test.tsx
+++ b/apps/web/src/components/layout/AppLayout.test.tsx
@@ -121,6 +121,25 @@ describe('AppLayout', () => {
     expect(screen.getByRole('navigation', { name: 'Main navigation' })).toBeInTheDocument();
   });
 
+  it('renders hosted legal links in the app footer', () => {
+    render(<AppLayout {...defaultProps} />);
+
+    const legalNav = screen.getByRole('navigation', { name: 'Legal links' });
+    expect(within(legalNav).getByRole('link', { name: 'Legal' })).toHaveAttribute('href', '/legal');
+    expect(within(legalNav).getByRole('link', { name: 'Privacy' })).toHaveAttribute(
+      'href',
+      '/legal/privacy',
+    );
+    expect(within(legalNav).getByRole('link', { name: 'Terms' })).toHaveAttribute(
+      'href',
+      '/legal/terms',
+    );
+    expect(within(legalNav).getByRole('link', { name: 'CCPA' })).toHaveAttribute(
+      'href',
+      '/legal/ccpa',
+    );
+  });
+
   it('renders a Settings button in the header', () => {
     render(<AppLayout {...defaultProps} />);
 

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -11,6 +11,7 @@ import { useSyncStatus } from '../../hooks/useSyncStatus';
 
 import { BottomNavigation, SidebarNavigation } from './Navigation';
 import { InstallBanner } from '../common/InstallBanner';
+import { LegalLinks } from '../legal/LegalLinks';
 
 export interface AppLayoutProps {
   activePath: string;
@@ -137,6 +138,9 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
         <main id="main-content" className="app-main" aria-label={pageTitle}>
           {children}
         </main>
+        <footer className="app-footer">
+          <LegalLinks />
+        </footer>
         <BottomNavigation activePath={activePath} onNavigate={onNavigate} />
       </div>
       <InstallBanner />

--- a/apps/web/src/components/legal/LegalLinks.tsx
+++ b/apps/web/src/components/legal/LegalLinks.tsx
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import type { FC } from 'react';
+
+import './legal-links.css';
+
+const LEGAL_LINKS = [
+  { to: '/legal', label: 'Legal' },
+  { to: '/legal/privacy', label: 'Privacy' },
+  { to: '/legal/terms', label: 'Terms' },
+  { to: '/legal/ccpa', label: 'CCPA' },
+] as const;
+
+interface LegalLinksProps {
+  className?: string;
+}
+
+export const LegalLinks: FC<LegalLinksProps> = ({ className }) => (
+  <nav className={['legal-links', className].filter(Boolean).join(' ')} aria-label="Legal links">
+    {LEGAL_LINKS.map((link) => (
+      <a key={link.to} href={link.to} className="legal-links__link">
+        {link.label}
+      </a>
+    ))}
+  </nav>
+);
+
+export default LegalLinks;

--- a/apps/web/src/components/legal/legal-links.css
+++ b/apps/web/src/components/legal/legal-links.css
@@ -1,0 +1,45 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+.legal-links {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-2) var(--spacing-4);
+  font-size: var(--type-scale-caption-font-size, 0.875rem);
+  color: var(--semantic-text-secondary);
+}
+
+.legal-links__link {
+  color: var(--semantic-interactive-default);
+  text-decoration: none;
+  font-weight: var(--font-weight-medium, 500);
+}
+
+.legal-links__link:hover {
+  color: var(--semantic-interactive-hover);
+  text-decoration: underline;
+}
+
+.legal-links__link:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+  border-radius: var(--border-radius-sm, 2px);
+}
+
+.app-footer {
+  border-top: 1px solid var(--semantic-border-default, var(--navigation-border));
+  padding: var(--spacing-3) var(--layout-content-padding)
+    calc(var(--layout-bottom-nav-height) + var(--spacing-3));
+  background: var(--semantic-background-primary);
+}
+
+.auth-footer--legal {
+  margin-top: var(--spacing-3);
+}
+
+@media (min-width: 768px) {
+  .app-footer {
+    padding: var(--spacing-4) var(--spacing-6);
+  }
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -44,6 +44,20 @@ const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY?.trim()
     ? requiredProductionEnv('VITE_SUPABASE_ANON_KEY')
     : 'placeholder-anon-key';
 
+const PRE_AUTH_ROUTES = new Set([
+  '/login',
+  '/signup',
+  '/forgot-password',
+  '/reset-password',
+  '/legal',
+]);
+
+function isPreAuthRoute(pathname: string): boolean {
+  return Array.from(PRE_AUTH_ROUTES).some(
+    (route) => pathname === route || pathname.startsWith(`${route}/`),
+  );
+}
+
 const authConfig = {
   supabaseUrl,
   supabaseAnonKey,
@@ -51,9 +65,8 @@ const authConfig = {
   refreshEndpoint: import.meta.env.VITE_REFRESH_ENDPOINT ?? '/api/auth/refresh',
   logoutEndpoint: import.meta.env.VITE_LOGOUT_ENDPOINT ?? '/api/auth/logout',
   onUnauthenticated: () => {
-    // Redirect to login when session expires or user is not authenticated
-    const publicAuthPaths = new Set(['/login', '/signup', '/forgot-password', '/reset-password']);
-    if (!publicAuthPaths.has(window.location.pathname)) {
+    // Redirect to login when session expires or user is not authenticated.
+    if (!isPreAuthRoute(window.location.pathname)) {
       window.location.href = '/login';
     }
   },
@@ -125,8 +138,6 @@ if (typeof window !== 'undefined') {
  * and cause the E2E authenticatedPage fixture to time out before the login
  * form ever appears.
  */
-const PRE_AUTH_ROUTES = new Set(['/login', '/signup', '/forgot-password', '/reset-password']);
-
 /**
  * Conditionally wraps children in DatabaseProvider.
  *

--- a/apps/web/src/pages/LoginPage.test.tsx
+++ b/apps/web/src/pages/LoginPage.test.tsx
@@ -112,6 +112,15 @@ describe('LoginPage', () => {
     expect(screen.getByRole('link', { name: 'Sign up' })).toHaveAttribute('href', '/signup');
   });
 
+  it('shows hosted legal links in the login footer', () => {
+    renderLoginPage();
+
+    expect(screen.getByRole('link', { name: 'Legal' })).toHaveAttribute('href', '/legal');
+    expect(screen.getByRole('link', { name: 'Privacy' })).toHaveAttribute('href', '/legal/privacy');
+    expect(screen.getByRole('link', { name: 'Terms' })).toHaveAttribute('href', '/legal/terms');
+    expect(screen.getByRole('link', { name: 'CCPA' })).toHaveAttribute('href', '/legal/ccpa');
+  });
+
   it('shows forgot password link without requiring a login error', () => {
     renderLoginPage();
 

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -7,6 +7,7 @@ import { useAuth } from '../auth/auth-context';
 import { getPreferredAuthMethod, setPreferredAuthMethod } from '../auth/preferred-auth-method';
 import { PasskeySetupPrompt } from '../components/auth/PasskeySetupPrompt';
 import { LoadingSpinner } from '../components/common/LoadingSpinner';
+import { LegalLinks } from '../components/legal/LegalLinks';
 import { hasRegisteredPasskey } from '../lib/passkey-preferences';
 import { loginSchema } from '../lib/validation';
 
@@ -479,6 +480,9 @@ export const LoginPage: React.FC = () => {
             Sign up
           </Link>
         </p>
+        <footer className="auth-footer auth-footer--legal">
+          <LegalLinks />
+        </footer>
       </section>
 
       {/* Passkey setup prompt modal */}

--- a/apps/web/src/pages/SettingsPage.test.tsx
+++ b/apps/web/src/pages/SettingsPage.test.tsx
@@ -518,6 +518,10 @@ describe('SettingsPage', () => {
       expect(screen.getByRole('heading', { name: 'About', level: 2 })).toBeInTheDocument();
       expect(screen.getByText('0.1.0')).toBeInTheDocument();
       expect(screen.getByText('Not available in this build')).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: /open legal index/i })).toHaveAttribute(
+        'href',
+        '/legal',
+      );
       expect(screen.getByRole('link', { name: /open business source license/i })).toHaveAttribute(
         'href',
         'https://github.com/jrmoulckers/finance/blob/main/LICENSE',

--- a/apps/web/src/pages/legal/LegalPage.tsx
+++ b/apps/web/src/pages/legal/LegalPage.tsx
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import type { FC } from 'react';
+import { Link } from 'react-router-dom';
+
+import './legal.css';
+
+const DRAFT_NOTICE = 'DRAFT — pending legal review by jrmoulckers';
+
+type LegalDocumentId = 'privacy' | 'terms' | 'ccpa';
+
+interface LegalDocument {
+  title: string;
+  updatedLabel: string;
+  sections: ReadonlyArray<{
+    heading: string;
+    body: string;
+  }>;
+}
+
+const LEGAL_DOCUMENTS: Record<LegalDocumentId, LegalDocument> = {
+  privacy: {
+    title: 'Privacy Policy',
+    updatedLabel: 'Placeholder draft for beta readiness',
+    sections: [
+      {
+        heading: 'Purpose of this placeholder',
+        body: 'This draft is placeholder boilerplate for a beta application and is not a final privacy policy. It should be replaced or approved by qualified legal counsel before production use.',
+      },
+      {
+        heading: 'Information practices to confirm',
+        body: 'The final policy should accurately describe what account, financial, device, usage, support, and diagnostic information the service collects, how it is used, and how long it is retained. Those facts are intentionally not asserted here.',
+      },
+      {
+        heading: 'User choices to confirm',
+        body: 'The final policy should describe any available export, deletion, consent, communication, cookie, analytics, and security controls after those details are reviewed.',
+      },
+    ],
+  },
+  terms: {
+    title: 'Terms of Service',
+    updatedLabel: 'Placeholder draft for beta readiness',
+    sections: [
+      {
+        heading: 'Purpose of this placeholder',
+        body: 'This draft is placeholder boilerplate for beta access and is not a final agreement. It should be replaced or approved by qualified legal counsel before production use.',
+      },
+      {
+        heading: 'Service terms to confirm',
+        body: 'The final terms should accurately describe eligibility, account responsibilities, acceptable use, beta limitations, subscription or payment terms if any, support expectations, and termination rights. Those facts are intentionally not asserted here.',
+      },
+      {
+        heading: 'Disclaimers to confirm',
+        body: 'The final terms should include appropriate disclaimers, liability limits, dispute terms, governing law, and other clauses only after legal review.',
+      },
+    ],
+  },
+  ccpa: {
+    title: 'California Privacy Notice',
+    updatedLabel: 'Placeholder draft for beta readiness',
+    sections: [
+      {
+        heading: 'Purpose of this placeholder',
+        body: 'This draft is placeholder boilerplate for beta readiness and is not a final CCPA/CPRA notice. It should be replaced or approved by qualified legal counsel before production use.',
+      },
+      {
+        heading: 'Disclosures to confirm',
+        body: 'The final notice should accurately describe applicable categories of personal information, sources, purposes, sharing, selling, retention, and sensitive personal information practices. Those facts are intentionally not asserted here.',
+      },
+      {
+        heading: 'Rights process to confirm',
+        body: 'The final notice should describe any applicable access, deletion, correction, opt-out, limitation, appeal, and authorized-agent processes after those details are reviewed.',
+      },
+    ],
+  },
+};
+
+const legalDocumentIds = Object.keys(LEGAL_DOCUMENTS) as LegalDocumentId[];
+
+const documentPath = (documentId: LegalDocumentId) => `/legal/${documentId}`;
+
+const DraftNotice: FC = () => (
+  <p className="legal-page__draft" role="note">
+    {DRAFT_NOTICE}
+  </p>
+);
+
+export const LegalIndexPage: FC = () => (
+  <main className="legal-page" aria-labelledby="legal-index-title">
+    <DraftNotice />
+    <div className="legal-page__card">
+      <h1 id="legal-index-title">Legal</h1>
+      <p className="legal-page__lede">
+        Hosted legal placeholders for beta readiness. These pages are draft boilerplate only and do
+        not state final legal, privacy, data, or compliance facts.
+      </p>
+      <ul className="legal-page__index-list" aria-label="Legal documents">
+        {legalDocumentIds.map((documentId) => (
+          <li key={documentId}>
+            <Link to={documentPath(documentId)}>{LEGAL_DOCUMENTS[documentId].title}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  </main>
+);
+
+interface LegalDocumentPageProps {
+  documentId: LegalDocumentId;
+}
+
+export const LegalDocumentPage: FC<LegalDocumentPageProps> = ({ documentId }) => {
+  const document = LEGAL_DOCUMENTS[documentId];
+
+  return (
+    <main className="legal-page" aria-labelledby={`${documentId}-legal-title`}>
+      <DraftNotice />
+      <article className="legal-page__card">
+        <Link to="/legal" className="legal-page__back-link">
+          ← Legal index
+        </Link>
+        <h1 id={`${documentId}-legal-title`}>{document.title}</h1>
+        <p className="legal-page__updated">{document.updatedLabel}</p>
+        {document.sections.map((section) => (
+          <section key={section.heading} className="legal-page__section">
+            <h2>{section.heading}</h2>
+            <p>{section.body}</p>
+          </section>
+        ))}
+      </article>
+    </main>
+  );
+};
+
+export default LegalIndexPage;

--- a/apps/web/src/pages/legal/LegalRoutes.test.tsx
+++ b/apps/web/src/pages/legal/LegalRoutes.test.tsx
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+
+import { LegalLinks } from '../../components/legal/LegalLinks';
+import { AppRoutes } from '../../routes';
+
+function renderRoute(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <AppRoutes />
+    </MemoryRouter>,
+  );
+}
+
+describe('legal routes', () => {
+  it.each([
+    ['/legal', 'Legal'],
+    ['/legal/privacy', 'Privacy Policy'],
+    ['/legal/terms', 'Terms of Service'],
+    ['/legal/ccpa', 'California Privacy Notice'],
+  ])('mounts %s before auth', async (path, heading) => {
+    renderRoute(path);
+
+    expect(await screen.findByRole('heading', { name: heading, level: 1 })).toBeInTheDocument();
+    expect(screen.getByText('DRAFT — pending legal review by jrmoulckers')).toBeInTheDocument();
+  });
+
+  it('renders links from the legal index to each hosted document', async () => {
+    renderRoute('/legal');
+
+    await screen.findByRole('heading', { name: 'Legal', level: 1 });
+    expect(screen.getByRole('link', { name: 'Privacy Policy' })).toHaveAttribute(
+      'href',
+      '/legal/privacy',
+    );
+    expect(screen.getByRole('link', { name: 'Terms of Service' })).toHaveAttribute(
+      'href',
+      '/legal/terms',
+    );
+    expect(screen.getByRole('link', { name: 'California Privacy Notice' })).toHaveAttribute(
+      'href',
+      '/legal/ccpa',
+    );
+  });
+});
+
+describe('LegalLinks', () => {
+  it('renders footer links for the legal index and hosted legal documents', () => {
+    render(<LegalLinks />);
+
+    expect(screen.getByRole('navigation', { name: 'Legal links' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Legal' })).toHaveAttribute('href', '/legal');
+    expect(screen.getByRole('link', { name: 'Privacy' })).toHaveAttribute('href', '/legal/privacy');
+    expect(screen.getByRole('link', { name: 'Terms' })).toHaveAttribute('href', '/legal/terms');
+    expect(screen.getByRole('link', { name: 'CCPA' })).toHaveAttribute('href', '/legal/ccpa');
+  });
+});

--- a/apps/web/src/pages/legal/legal.css
+++ b/apps/web/src/pages/legal/legal.css
@@ -1,0 +1,82 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+.legal-page {
+  min-height: 100dvh;
+  padding: var(--spacing-6) var(--spacing-4);
+  background: var(--semantic-background-primary);
+  color: var(--semantic-text-primary);
+}
+
+.legal-page__draft,
+.legal-page__card {
+  width: min(100%, 760px);
+  margin-inline: auto;
+}
+
+.legal-page__draft {
+  margin-bottom: var(--spacing-4);
+  padding: var(--spacing-3) var(--spacing-4);
+  border: 1px solid var(--semantic-border-warning, var(--semantic-border-default));
+  border-radius: var(--border-radius-md, 8px);
+  background: var(--semantic-background-warning, var(--semantic-background-secondary));
+  color: var(--semantic-text-primary);
+  font-weight: var(--font-weight-semibold, 600);
+}
+
+.legal-page__card {
+  padding: var(--spacing-6);
+  border: 1px solid var(--card-border, var(--semantic-border-default));
+  border-radius: var(--card-border-radius, 12px);
+  background: var(--card-background, var(--semantic-background-primary));
+  box-shadow: var(--card-shadow, none);
+}
+
+.legal-page h1 {
+  margin: 0 0 var(--spacing-3);
+  font-size: var(--type-scale-headline-font-size, 2rem);
+  font-weight: var(--type-scale-headline-font-weight, 700);
+}
+
+.legal-page h2 {
+  margin: 0 0 var(--spacing-2);
+  font-size: var(--type-scale-title-font-size, 1.25rem);
+}
+
+.legal-page p {
+  line-height: 1.65;
+}
+
+.legal-page__lede,
+.legal-page__updated {
+  color: var(--semantic-text-secondary);
+}
+
+.legal-page__index-list {
+  display: grid;
+  gap: var(--spacing-3);
+  padding-left: var(--spacing-5);
+  margin: var(--spacing-5) 0 0;
+}
+
+.legal-page__section {
+  margin-top: var(--spacing-5);
+}
+
+.legal-page__back-link {
+  display: inline-flex;
+  margin-bottom: var(--spacing-4);
+  color: var(--semantic-interactive-default);
+  text-decoration: none;
+  font-weight: var(--font-weight-medium, 500);
+}
+
+.legal-page a:hover {
+  color: var(--semantic-interactive-hover);
+  text-decoration: underline;
+}
+
+.legal-page a:focus-visible {
+  outline: 2px solid var(--semantic-border-focus);
+  outline-offset: 2px;
+  border-radius: var(--border-radius-sm, 2px);
+}

--- a/apps/web/src/pages/settings/SettingsAboutPage.tsx
+++ b/apps/web/src/pages/settings/SettingsAboutPage.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 import packageJson from '../../../package.json';
 
@@ -36,6 +37,14 @@ export const SettingsAboutPage: React.FC = () => (
     <section aria-label="Legal" className="page-section">
       <div className="settings-group">
         <h3 className="settings-group__title">Legal</h3>
+        <Link
+          className="settings-item settings-item--button"
+          to="/legal"
+          aria-label="Open Legal index"
+        >
+          <span className="settings-item__label">Legal documents</span>
+          <span className="settings-item__value">Privacy, Terms, CCPA</span>
+        </Link>
         <a
           className="settings-item settings-item--button"
           href="https://github.com/jrmoulckers/finance/blob/main/LICENSE"

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -38,6 +38,12 @@ const Login = lazy(() => import('./pages/LoginPage'));
 const Signup = lazy(() => import('./pages/SignupPage'));
 const ForgotPassword = lazy(() => import('./pages/ForgotPasswordPage'));
 const ResetPassword = lazy(() => import('./pages/ResetPasswordPage'));
+const LegalIndex = lazy(() =>
+  import('./pages/legal/LegalPage').then((module) => ({ default: module.LegalIndexPage })),
+);
+const LegalDocument = lazy(() =>
+  import('./pages/legal/LegalPage').then((module) => ({ default: module.LegalDocumentPage })),
+);
 const NotFound = lazy(() => import('./pages/NotFoundPage'));
 const Watchlists = lazy(() => import('./pages/WatchlistsPage'));
 const Household = lazy(() => import('./pages/HouseholdPage'));
@@ -184,6 +190,38 @@ export const AppRoutes: FC = () => (
       element={
         <RouteBoundary name="Reset Password">
           <ResetPassword />
+        </RouteBoundary>
+      }
+    />
+    <Route
+      path="/legal"
+      element={
+        <RouteBoundary name="Legal">
+          <LegalIndex />
+        </RouteBoundary>
+      }
+    />
+    <Route
+      path="/legal/privacy"
+      element={
+        <RouteBoundary name="Privacy Policy">
+          <LegalDocument documentId="privacy" />
+        </RouteBoundary>
+      }
+    />
+    <Route
+      path="/legal/terms"
+      element={
+        <RouteBoundary name="Terms of Service">
+          <LegalDocument documentId="terms" />
+        </RouteBoundary>
+      }
+    />
+    <Route
+      path="/legal/ccpa"
+      element={
+        <RouteBoundary name="California Privacy Notice">
+          <LegalDocument documentId="ccpa" />
         </RouteBoundary>
       }
     />


### PR DESCRIPTION
## Summary
- Add public hosted legal placeholder routes for /legal, /legal/privacy, /legal/terms, and /legal/ccpa
- Add reusable LegalLinks to app and login footers
- Link Settings > About to the hosted legal index

## Testing
- npx prettier --write <changed files>
- npx eslint --fix <changed TS files>
- npm run test -w apps/web -- src/pages/legal/LegalRoutes.test.tsx src/pages/LoginPage.test.tsx src/components/layout/AppLayout.test.tsx src/pages/SettingsPage.test.tsx

Closes #2027