### PR TITLE
feat: real Sentry + uptime monitoring (#2033)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -113,6 +113,7 @@ jobs:
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
           POWERSYNC_URL: ${{ secrets.POWERSYNC_URL }}
           BETA_ALLOWED_EMAILS: ${{ secrets.BETA_ALLOWED_EMAILS }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
           set -euo pipefail
 
@@ -138,6 +139,7 @@ jobs:
           SUPABASE_ANON_KEY_B64=$(printf '%s' "$SUPABASE_ANON_KEY" | base64 -w 0)
           POWERSYNC_URL_B64=$(printf '%s' "$POWERSYNC_URL" | base64 -w 0)
           BETA_ALLOWED_EMAILS_B64=$(printf '%s' "$BETA_ALLOWED_EMAILS" | base64 -w 0)
+          SENTRY_DSN_B64=$(printf '%s' "$SENTRY_DSN" | base64 -w 0)
 
           # SSH in and rebuild. Each line is a separate command so an early
           # failure aborts the build (set -e inside the heredoc). Use
@@ -145,12 +147,15 @@ jobs:
           # from any stale refs (e.g. if a prior backend deploy already
           # advanced origin/main before this fetch read its expected value).
           ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" \
-            "SUPABASE_URL_B64='$SUPABASE_URL_B64' SUPABASE_ANON_KEY_B64='$SUPABASE_ANON_KEY_B64' POWERSYNC_URL_B64='$POWERSYNC_URL_B64' BETA_ALLOWED_EMAILS_B64='$BETA_ALLOWED_EMAILS_B64' bash -s" <<'DEPLOY'
+            "SUPABASE_URL_B64='$SUPABASE_URL_B64' SUPABASE_ANON_KEY_B64='$SUPABASE_ANON_KEY_B64' POWERSYNC_URL_B64='$POWERSYNC_URL_B64' BETA_ALLOWED_EMAILS_B64='$BETA_ALLOWED_EMAILS_B64' SENTRY_DSN_B64='$SENTRY_DSN_B64' SHA_SHORT='$SHA_SHORT' bash -s" <<'DEPLOY'
             set -euo pipefail
             export VITE_SUPABASE_URL="$(printf '%s' "$SUPABASE_URL_B64" | base64 -d)"
             export VITE_SUPABASE_ANON_KEY="$(printf '%s' "$SUPABASE_ANON_KEY_B64" | base64 -d)"
             export VITE_POWERSYNC_URL="$(printf '%s' "$POWERSYNC_URL_B64" | base64 -d)"
             export VITE_BETA_ALLOWED_EMAILS="$(printf '%s' "$BETA_ALLOWED_EMAILS_B64" | base64 -d)"
+            export VITE_SENTRY_DSN="$(printf '%s' "$SENTRY_DSN_B64" | base64 -d)"
+            export VITE_ENVIRONMENT=staging
+            export VITE_APP_VERSION="$SHA_SHORT"
             cd ~/finance
             echo "→ git fetch --force --prune origin main"
             git fetch --force --prune origin main
@@ -176,6 +181,52 @@ jobs:
           echo "**Commit:** \`$SHA_SHORT\`" >> "$GITHUB_STEP_SUMMARY"
           echo "**Served at:** https://finance.jrmoulckers.com" >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Verify monitoring configured
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PATH: ${{ vars.DEPLOY_PATH || '~/finance' }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$SENTRY_DSN" ]; then
+            echo "::warning::SENTRY_DSN is not configured for staging; Sentry will no-op after deploy"
+            exit 0
+          fi
+
+          if [ -z "$DEPLOY_HOST" ] || [ -z "$DEPLOY_USER" ] || [ -z "$DEPLOY_SSH_KEY" ]; then
+            echo "::warning::Deployment SSH secrets are missing; cannot verify monitoring bundle"
+            exit 0
+          fi
+
+          if [ ! -f ~/.ssh/deploy_key ]; then
+            mkdir -p ~/.ssh
+            echo "$DEPLOY_SSH_KEY" > ~/.ssh/deploy_key
+            chmod 600 ~/.ssh/deploy_key
+            ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
+          fi
+
+          SENTRY_DSN_B64=$(printf '%s' "$SENTRY_DSN" | base64 -w 0)
+
+          if ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" \
+            "DEPLOY_PATH='$DEPLOY_PATH' SENTRY_DSN_B64='$SENTRY_DSN_B64' bash -s" <<'VERIFY'
+            set -euo pipefail
+            case "$DEPLOY_PATH" in "~"|"~/"*) DEPLOY_PATH="${HOME}${DEPLOY_PATH#~}" ;; esac
+            cd "$DEPLOY_PATH"
+            expected_dsn="$(printf '%s' "$SENTRY_DSN_B64" | base64 -d)"
+            if grep -R --fixed-strings --quiet "$expected_dsn" apps/web/dist/index.html apps/web/dist/assets 2>/dev/null; then
+              echo "Monitoring DSN found in deployed web bundle."
+            else
+              echo "::warning::SENTRY_DSN was not found in the deployed web bundle; Sentry may be disabled"
+            fi
+          VERIFY
+          then
+            true
+          else
+            echo "::warning::Unable to verify monitoring configuration in deployed bundle"
+          fi
       - name: Clean up SSH key
         if: always()
         run: rm -f ~/.ssh/deploy_key

--- a/.github/workflows/uptime-check.yml
+++ b/.github/workflows/uptime-check.yml
@@ -1,0 +1,98 @@
+# =============================================================================
+# Uptime Check — Beta health endpoint
+# =============================================================================
+
+name: Uptime Check
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: uptime-check
+  cancel-in-progress: true
+
+jobs:
+  health:
+    name: Check beta health endpoint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check /health
+        id: check
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+        run: |
+          set +e
+
+          if [ -n "${DEPLOY_HOST:-}" ]; then
+            if [[ "$DEPLOY_HOST" == http://* || "$DEPLOY_HOST" == https://* ]]; then
+              url="${DEPLOY_HOST%/}/health"
+            else
+              url="https://${DEPLOY_HOST%/}/health"
+            fi
+          else
+            url="https://finance.jrmoulckers.com/health"
+          fi
+
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+          curl_output=$(curl --silent --show-error --location --max-time 10 --output /dev/null --write-out '%{http_code}' "$url" 2>&1)
+          curl_status=$?
+          status_code="${curl_output: -3}"
+
+          echo "status_code=$status_code" >> "$GITHUB_OUTPUT"
+          echo "curl_status=$curl_status" >> "$GITHUB_OUTPUT"
+
+          if [ "$curl_status" -ne 0 ] || [ "$status_code" = "000" ] || [ "$status_code" -ge 500 ]; then
+            echo "failed=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "### Uptime check failed"
+              echo ""
+              echo "- URL: $url"
+              echo "- HTTP status: $status_code"
+              echo "- curl exit: $curl_status"
+              echo "- Checked at: $(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "failed=false" >> "$GITHUB_OUTPUT"
+            echo "Health check passed with HTTP $status_code for $url" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Open or update uptime issue
+        if: steps.check.outputs.failed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEALTH_URL: ${{ steps.check.outputs.url }}
+          STATUS_CODE: ${{ steps.check.outputs.status_code }}
+          CURL_STATUS: ${{ steps.check.outputs.curl_status }}
+        run: |
+          set -euo pipefail
+
+          gh label create uptime --repo "$GITHUB_REPOSITORY" --color D73A4A --description "Uptime monitor alerts" --force >/dev/null
+          gh label create beta --repo "$GITHUB_REPOSITORY" --color 1D76DB --description "Beta environment" --force >/dev/null
+
+          body="Automated beta uptime check failed.
+
+          - URL: ${HEALTH_URL}
+          - HTTP status: ${STATUS_CODE}
+          - curl exit: ${CURL_STATUS}
+          - Workflow run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+          - Checked at: $(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+
+          existing_issue=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --label uptime --label beta --json number --jq '.[0].number // empty')
+          if [ -n "$existing_issue" ]; then
+            gh issue comment "$existing_issue" --repo "$GITHUB_REPOSITORY" --body "$body"
+          else
+            gh issue create \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "Beta uptime check failing" \
+              --label uptime \
+              --label beta \
+              --body "$body"
+          fi

--- a/apps/android/src/main/kotlin/com/finance/android/FinanceApplication.kt
+++ b/apps/android/src/main/kotlin/com/finance/android/FinanceApplication.kt
@@ -27,6 +27,8 @@ class FinanceApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        // TODO(#2033): Wire Sentry SDK for Android here.
+        // See docs/ops/monitoring-setup.md for DSN, consent, and scrubbing requirements.
         initLogging()
         initDependencyInjection()
         initSecurityChecks()

--- a/apps/ios/Finance/FinanceApp.swift
+++ b/apps/ios/Finance/FinanceApp.swift
@@ -14,6 +14,8 @@ import WatchConnectivity
 /// full-screen lock overlay on launch and when returning from background.
 @main
 struct FinanceApp: App {
+    // TODO(#2033): Wire Sentry SDK for iOS here.
+    // See docs/ops/monitoring-setup.md for DSN, consent, and scrubbing requirements.
     @State private var biometricManager = BiometricAuthManager()
     @State private var deepLinkHandler = DeepLinkHandler()
     @State private var networkMonitor = NetworkMonitor()

--- a/apps/ios/FinanceClip/FinanceClipApp.swift
+++ b/apps/ios/FinanceClip/FinanceClipApp.swift
@@ -5,6 +5,8 @@ import os
 import SwiftUI
 @main
 struct FinanceClipApp: App {
+    // TODO(#2033): Wire Sentry SDK for iOS App Clip here.
+    // See docs/ops/monitoring-setup.md for DSN, consent, and scrubbing requirements.
     @State private var initialAmountMinorUnits: Int64?
     @State private var initialCategoryId: String?
     private static let logger = Logger(subsystem: "com.finance.clip", category: "FinanceClipApp")

--- a/apps/ios/FinanceWatch/FinanceWatchApp.swift
+++ b/apps/ios/FinanceWatch/FinanceWatchApp.swift
@@ -9,6 +9,8 @@ import WidgetKit
 
 @main
 struct FinanceWatchApp: App {
+    // TODO(#2033): Wire Sentry SDK for watchOS here.
+    // See docs/ops/monitoring-setup.md for DSN, consent, and scrubbing requirements.
     @WKExtensionDelegateAdaptor(ExtensionDelegate.self) private var delegate
     @State private var connectivityManager = WatchConnectivityManager()
     var body: some Scene {
@@ -143,4 +145,3 @@ struct WatchBudgetStatus: Identifiable, Sendable {
         self.id = id; self.name = name; self.spentMinorUnits = sp; self.budgetedMinorUnits = bu
     }
 }
-

--- a/apps/ios/FinanceWidget/FinanceWidgetBundle.swift
+++ b/apps/ios/FinanceWidget/FinanceWidgetBundle.swift
@@ -6,6 +6,8 @@ import WidgetKit
 
 @main
 struct FinanceWidgetBundle: WidgetBundle {
+    // TODO(#2033): Wire Sentry SDK for iOS widgets here.
+    // See docs/ops/monitoring-setup.md for DSN, consent, and scrubbing requirements.
     var body: some Widget {
         BalanceWidget()
         BudgetProgressWidget()

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@sentry/react": "^8.55.2",
     "d3": "^7.9.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/apps/web/src/lib/monitoring.test.ts
+++ b/apps/web/src/lib/monitoring.test.ts
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import { scrubSentryEvent, scrubSensitiveMonitoringPayload } from './monitoring';
+
+describe('scrubSensitiveMonitoringPayload', () => {
+  it('scrubs sensitive keys in nested objects and arrays', () => {
+    const payload = {
+      user: {
+        email: 'user@example.com',
+        profile: {
+          password: 'secret',
+          keep: 'safe',
+        },
+      },
+      accounts: [
+        { accountNumber: '123456789', routingNumber: '021000021', name: 'Checking' },
+        { iban: 'GB82WEST12345698765432', balance: 1234.56, amount: 100 },
+      ],
+      auth: [{ token: 'token-value', accessToken: 'access', refreshToken: 'refresh' }],
+      card: { pan: '4111111111111111' },
+    };
+
+    expect(scrubSensitiveMonitoringPayload(payload)).toEqual({
+      user: {
+        email: '[scrubbed]',
+        profile: {
+          password: '[scrubbed]',
+          keep: 'safe',
+        },
+      },
+      accounts: [
+        { accountNumber: '[scrubbed]', routingNumber: '[scrubbed]', name: 'Checking' },
+        { iban: '[scrubbed]', balance: '[scrubbed]', amount: '[scrubbed]' },
+      ],
+      auth: [{ token: '[scrubbed]', accessToken: '[scrubbed]', refreshToken: '[scrubbed]' }],
+      card: { pan: '[scrubbed]' },
+    });
+  });
+
+  it('does not mutate the original payload', () => {
+    const payload = { email: 'user@example.com', nested: { amount: 42 } };
+
+    scrubSensitiveMonitoringPayload(payload);
+
+    expect(payload).toEqual({ email: 'user@example.com', nested: { amount: 42 } });
+  });
+});
+
+describe('scrubSentryEvent', () => {
+  it('scrubs breadcrumb data and nested event contexts', () => {
+    const event = {
+      user: { email: 'user@example.com' },
+      contexts: {
+        transaction: {
+          amount: 99,
+          nested: [{ refreshToken: 'refresh' }],
+        },
+      },
+      breadcrumbs: [
+        {
+          category: 'auth',
+          message: 'login',
+          data: {
+            token: 'token-value',
+            accountNumber: '123456789',
+            safe: 'value',
+          },
+        },
+      ],
+    };
+
+    expect(scrubSentryEvent(event)).toEqual({
+      user: { email: '[scrubbed]' },
+      contexts: {
+        transaction: {
+          amount: '[scrubbed]',
+          nested: [{ refreshToken: '[scrubbed]' }],
+        },
+      },
+      breadcrumbs: [
+        {
+          category: 'auth',
+          message: 'login',
+          data: {
+            token: '[scrubbed]',
+            accountNumber: '[scrubbed]',
+            safe: 'value',
+          },
+        },
+      ],
+    });
+  });
+});

--- a/apps/web/src/lib/monitoring.ts
+++ b/apps/web/src/lib/monitoring.ts
@@ -3,30 +3,36 @@
 /* eslint-disable no-console */
 
 /**
- * Monitoring and error tracking configuration for the Finance web app (#410).
+ * Monitoring and error tracking configuration for the Finance web app (#410, #2033).
  *
  * Privacy-first design:
- * - NEVER sends PII (email, name, IP) to error tracking services
- * - NEVER includes financial data (amounts, balances, account names) in reports
- * - NEVER includes authentication tokens or encryption keys
  * - Consent-gated: only initializes when the user has opted in
+ * - DSN-gated: missing Sentry config is a no-op with a single info log
+ * - Sentry beforeSend strips PII, auth material, and financial values
  * - Uses pseudonymous user IDs only
- *
- * Integration:
- *   Call `initMonitoring()` from `main.tsx` before rendering the app.
- *   Call `setMonitoringUser()` on login with a pseudonymous ID.
- *   Call `clearMonitoringUser()` on logout.
- *
- * Environment Variables:
- *   VITE_SENTRY_DSN         — Sentry project DSN (set in .env, never committed)
- *   VITE_SENTRY_ENVIRONMENT — Environment name (development, staging, production)
  */
 
-// ============================================================================
-// Types
-// ============================================================================
+import * as Sentry from '@sentry/react';
+import type { Event } from '@sentry/react';
 
-/** Keys that must be stripped from any error context or breadcrumb data. */
+/** Keys that must be stripped from Sentry event payloads. */
+const SENTRY_SENSITIVE_KEYS = new Set(
+  [
+    'email',
+    'password',
+    'token',
+    'accessToken',
+    'refreshToken',
+    'accountNumber',
+    'routingNumber',
+    'iban',
+    'balance',
+    'amount',
+    'pan',
+  ].map((key) => key.toLowerCase()),
+);
+
+/** Keys that must be stripped from any local diagnostic context. */
 const SENSITIVE_KEYS = new Set([
   'email',
   'name',
@@ -60,6 +66,8 @@ const SENSITIVE_KEYS = new Set([
   'account_number',
   'routingNumber',
   'routing_number',
+  'iban',
+  'pan',
 ]);
 
 /** Keys whose values represent financial amounts that must be stripped. */
@@ -83,27 +91,83 @@ const FINANCIAL_VALUE_KEYS = new Set([
   'price',
 ]);
 
-/** Pattern matching currency amounts like $1,234.56, €100.00, £50 */
+/** Pattern matching currency amounts like $1,234.56, €100.00, £50. */
 const CURRENCY_PATTERN =
   /[$€£¥₹]\s?\d[\d,]*\.?\d{0,2}|\d[\d,]*\.?\d{0,2}\s?[$€£¥₹]|\b\d{1,3}(,\d{3})*\.\d{2}\b/g;
 
 /** Pattern matching sequences of 4+ digits that could be account numbers. */
 const ACCOUNT_NUMBER_PATTERN = /\b\d{4,}\b/g;
 
-// ============================================================================
-// Privacy Scrubbing
-// ============================================================================
+const SCRUBBED_VALUE = '[scrubbed]';
+
+/** Storage key for the user's optional monitoring consent preference. */
+const MONITORING_CONSENT_KEY = 'finance-monitoring-consent';
+
+/** Whether monitoring has been initialized with Sentry. */
+let isInitialized = false;
+
+/** Ensures missing DSN no-op logging happens once per browser session. */
+let missingDsnLogged = false;
+
+/**
+ * Determine whether the user has opted in to anonymous error reporting.
+ *
+ * @returns True when monitoring consent is enabled in local storage.
+ */
+function hasMonitoringConsent(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  return window.localStorage.getItem(MONITORING_CONSENT_KEY) === 'true';
+}
+
+/**
+ * Scrub Sentry-specific sensitive fields from an arbitrary payload.
+ *
+ * Sentry events are plain JSON-like objects, so this returns a scrubbed copy
+ * without mutating the original event passed to beforeSend.
+ */
+export function scrubSensitiveMonitoringPayload<T>(payload: T): T {
+  return scrubSensitiveFields(payload, new WeakSet<object>()) as T;
+}
+
+function scrubSensitiveFields(value: unknown, seen: WeakSet<object>): unknown {
+  if (value === null || value === undefined || typeof value !== 'object') {
+    return value;
+  }
+
+  if (seen.has(value)) {
+    return value;
+  }
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.map((item) => scrubSensitiveFields(item, seen));
+  }
+
+  const scrubbed: Record<string, unknown> = {};
+  for (const [key, nestedValue] of Object.entries(value as Record<string, unknown>)) {
+    if (SENTRY_SENSITIVE_KEYS.has(key.toLowerCase())) {
+      scrubbed[key] = SCRUBBED_VALUE;
+      continue;
+    }
+
+    scrubbed[key] = scrubSensitiveFields(nestedValue, seen);
+  }
+
+  return scrubbed;
+}
+
+/** Sentry beforeSend hook that strips PII and financial data before upload. */
+export function scrubSentryEvent<T extends Event>(event: T): T {
+  return scrubSensitiveMonitoringPayload(event);
+}
 
 /**
  * Scrub financial data and PII patterns from an arbitrary object.
  *
- * This function recursively walks the object and:
- * 1. Removes keys that are in the SENSITIVE_KEYS or FINANCIAL_VALUE_KEYS sets
- * 2. Replaces string values matching currency patterns with "[REDACTED]"
- * 3. Replaces string values matching account number patterns with "[REDACTED]"
- *
- * @param obj - The object to scrub (modified in place and returned).
- * @returns The scrubbed object.
+ * This legacy local scrubber is still used by opt-in preview UI helpers.
  */
 export function scrubFinancialData<T>(obj: T): T {
   if (obj === null || obj === undefined) return obj;
@@ -122,19 +186,16 @@ export function scrubFinancialData<T>(obj: T): T {
   for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
     const lowerKey = key.toLowerCase();
 
-    // Strip sensitive keys entirely
     if (SENSITIVE_KEYS.has(key) || SENSITIVE_KEYS.has(lowerKey)) {
       scrubbed[key] = '[REDACTED]';
       continue;
     }
 
-    // Strip financial value keys
     if (FINANCIAL_VALUE_KEYS.has(key) || FINANCIAL_VALUE_KEYS.has(lowerKey)) {
       scrubbed[key] = '[REDACTED]';
       continue;
     }
 
-    // Recurse into nested objects
     if (typeof value === 'object' && value !== null) {
       scrubbed[key] = scrubFinancialData(value);
     } else if (typeof value === 'string') {
@@ -147,9 +208,7 @@ export function scrubFinancialData<T>(obj: T): T {
   return scrubbed as unknown as T;
 }
 
-/**
- * Scrub sensitive patterns from a string value.
- */
+/** Scrub sensitive patterns from a string value. */
 function scrubString(value: string): string {
   let scrubbed = value;
   scrubbed = scrubbed.replace(CURRENCY_PATTERN, '[REDACTED_AMOUNT]');
@@ -157,108 +216,43 @@ function scrubString(value: string): string {
   return scrubbed;
 }
 
-// ============================================================================
-// Monitoring Initialization
-// ============================================================================
-
-/** Storage key for the user's optional monitoring consent preference. */
-const MONITORING_CONSENT_KEY = 'finance-monitoring-consent';
-
-/**
- * The web app always provides consent-aware monitoring helpers and privacy scrubbing.
- * A Sentry transport can be layered on top of these helpers when the optional SDK is installed.
- * Install @sentry/react to enable production error tracking.
- */
-
-/** Whether monitoring has been initialized. */
-let isInitialized = false;
-
-/**
- * Determine whether the user has opted in to anonymous error reporting.
- *
- * @returns True when monitoring consent is enabled in local storage.
- */
-function hasMonitoringConsent(): boolean {
-  if (typeof window === 'undefined') {
-    return false;
-  }
-
-  return window.localStorage.getItem(MONITORING_CONSENT_KEY) === 'true';
-}
-
-/**
- * Write a scrubbed local fallback message while the optional Sentry transport is unavailable.
- *
- * @param method - Console method to use for the fallback message.
- * @param message - Human-readable message describing the monitoring event.
- * @param details - Optional scrubbed metadata for local diagnostics.
- */
-function logMonitoringFallback(
-  method: 'info' | 'debug' | 'error',
-  message: string,
-  details?: unknown,
-): void {
-  if (!hasMonitoringConsent()) {
-    return;
-  }
-
-  if (method === 'error') {
-    if (details === undefined) {
-      console.error(message);
-      return;
-    }
-
-    console.error(message, details);
-    return;
-  }
-
-  if (method === 'debug') {
-    if (details === undefined) {
-      console.debug(message);
-      return;
-    }
-
-    console.debug(message, details);
-    return;
-  }
-
-  if (details === undefined) {
-    console.info(message);
-    return;
-  }
-
-  console.info(message, details);
-}
-
 /**
  * Initialize monitoring and error tracking.
  *
- * Call this once from `main.tsx` before rendering the React app.
- * Initialization runs only after the user has explicitly opted in.
+ * Call this once from `main.tsx` before rendering the React app. Initialization
+ * runs only after the user has explicitly opted in and Sentry is configured.
  */
 export function initMonitoring(): void {
   if (isInitialized || !hasMonitoringConsent()) {
     return;
   }
 
-  const environment = import.meta.env.VITE_SENTRY_ENVIRONMENT ?? import.meta.env.MODE;
-  const dsnConfigured = Boolean(import.meta.env.VITE_SENTRY_DSN);
+  const dsn = import.meta.env.VITE_SENTRY_DSN?.trim();
+  if (!dsn) {
+    if (!missingDsnLogged) {
+      console.info('[Monitoring] Sentry DSN is not configured; error tracking is disabled.');
+      missingDsnLogged = true;
+    }
+    return;
+  }
 
-  logMonitoringFallback(
-    'info',
-    '[Monitoring] Consent granted, but Sentry is not configured. Install @sentry/react to enable production error tracking.',
-    { environment, dsnConfigured },
-  );
+  Sentry.init({
+    dsn,
+    environment: import.meta.env.VITE_ENVIRONMENT ?? import.meta.env.MODE,
+    release: import.meta.env.VITE_APP_VERSION,
+    sampleRate: 1.0,
+    tracesSampleRate: 0.1,
+    sendDefaultPii: false,
+    beforeSend: scrubSentryEvent,
+  });
 
-  // Start Web Vitals observation when monitoring is enabled.
-  // Lazy-loaded to avoid adding to the critical path.
+  isInitialized = true;
+
   void import('./web-vitals').then(({ observeWebVitals }) => {
     observeWebVitals((metric) => {
       addBreadcrumb(`${metric.name}: ${metric.value} (${metric.rating})`, 'web-vital');
     });
   });
-
-  isInitialized = true;
 }
 
 /**
@@ -268,75 +262,55 @@ export function initMonitoring(): void {
  *   MUST be a UUID or hash — NEVER an email, account ID, or real name.
  */
 export function setMonitoringUser(pseudonymousId: string): void {
-  if (!hasMonitoringConsent()) {
+  if (!isInitialized || !hasMonitoringConsent()) {
     return;
   }
 
-  logMonitoringFallback(
-    'debug',
-    '[Monitoring] User context updated for the local fallback logger.',
-    {
-      hasPseudonymousId: pseudonymousId.length > 0,
-    },
-  );
+  Sentry.setUser({ id: pseudonymousId });
 }
 
-/**
- * Clear the current user context (call on logout).
- */
+/** Clear the current user context (call on logout). */
 export function clearMonitoringUser(): void {
-  logMonitoringFallback(
-    'debug',
-    '[Monitoring] User context cleared for the local fallback logger.',
-  );
+  if (!isInitialized) {
+    return;
+  }
+
+  Sentry.setUser(null);
 }
 
 /**
  * Capture an error manually.
  *
- * Use this for caught exceptions that should be reported but
- * don't crash the app.
- *
- * @param error - The error to report.
- * @param context - Optional diagnostic context (must not contain PII or financial data).
+ * Use this for caught exceptions that should be reported but don't crash the app.
  */
 export function captureError(error: Error, context?: Record<string, string>): void {
-  if (!hasMonitoringConsent()) {
+  if (!isInitialized || !hasMonitoringConsent()) {
     return;
   }
 
-  logMonitoringFallback(
-    'error',
-    '[Monitoring] Captured error locally. Install @sentry/react to enable production error tracking.',
-    {
-      name: error.name,
-      message: scrubString(error.message),
-      context: context ? scrubFinancialData(context) : undefined,
-    },
-  );
+  Sentry.captureException(error, {
+    extra: context ? scrubSensitiveMonitoringPayload(context) : undefined,
+  });
 }
 
 /**
  * Record a breadcrumb for diagnostic context.
  *
- * Breadcrumbs are attached to subsequent error reports to help
- * reconstruct the sequence of events leading to an error.
- *
- * @param message - Descriptive message (must not contain PII or financial data).
- * @param category - Category for grouping (e.g., "navigation", "sync", "auth").
- * @param data - Optional metadata (will be scrubbed before sending).
+ * Breadcrumbs are attached to subsequent error reports to help reconstruct the
+ * sequence of events leading to an error.
  */
 export function addBreadcrumb(
   message: string,
   category: string,
   data?: Record<string, string>,
 ): void {
-  if (!hasMonitoringConsent()) {
+  if (!isInitialized || !hasMonitoringConsent()) {
     return;
   }
 
-  logMonitoringFallback('debug', `[Monitoring] Breadcrumb [${category}]`, {
+  Sentry.addBreadcrumb({
     message: scrubString(message),
-    data: data ? scrubFinancialData(data) : undefined,
+    category,
+    data: data ? scrubSensitiveMonitoringPayload(data) : undefined,
   });
 }

--- a/apps/windows/src/main/kotlin/com/finance/desktop/Main.kt
+++ b/apps/windows/src/main/kotlin/com/finance/desktop/Main.kt
@@ -29,6 +29,8 @@ import javax.swing.JOptionPane
 import kotlin.system.exitProcess
 
 fun main() {
+    // TODO(#2033): Wire Sentry SDK for Windows here.
+    // See docs/ops/monitoring-setup.md for DSN, consent, and scrubbing requirements.
     validateStartupConfiguration()
     PerformanceTracker.recordAppStart()
 

--- a/docs/ops/monitoring-setup.md
+++ b/docs/ops/monitoring-setup.md
@@ -27,16 +27,16 @@ This document covers the full monitoring setup for the Finance monorepo: CI/CD h
 
 ### Overview
 
-Finance uses [Sentry](https://sentry.io) for error tracking on all four platforms. The SDK wiring is already in the codebase — this section describes how to create projects, configure DSNs, and verify the privacy contract.
+Finance uses [Sentry](https://sentry.io) for beta web error tracking. Native SDK wiring is intentionally deferred; each native entrypoint contains a TODO hook that points back to this document.
 
 **Architecture summary:**
 
-| Platform | SDK                        | DSN Source               | Config File                                        |
-| -------- | -------------------------- | ------------------------ | -------------------------------------------------- |
-| Web      | `@sentry/react`            | `VITE_SENTRY_DSN`        | `apps/web/src/lib/monitoring.ts`                   |
-| Android  | `io.sentry:sentry-android` | `BuildConfig.SENTRY_DSN` | `apps/android/src/main/kotlin/.../SentryConfig.kt` |
-| iOS      | `sentry-cocoa`             | `SENTRY_DSN` env / plist | (Planned — see iOS section below)                  |
-| Windows  | `Sentry.NET`               | `SENTRY_DSN` env         | (Planned — see Windows section below)              |
+| Platform | SDK             | DSN Source        | Config File                       |
+| -------- | --------------- | ----------------- | --------------------------------- |
+| Web      | `@sentry/react` | `VITE_SENTRY_DSN` | `apps/web/src/lib/monitoring.ts`  |
+| Android  | Planned         | `SENTRY_DSN`      | `FinanceApplication.kt` TODO hook |
+| iOS      | Planned         | `SENTRY_DSN`      | Swift `@main` TODO hooks          |
+| Windows  | Planned         | `SENTRY_DSN`      | `Main.kt` TODO hook               |
 
 All platforms share the same privacy contract enforced by the `CrashReporter` interface in `packages/core/`.
 
@@ -78,12 +78,13 @@ SENTRY_ENVIRONMENT=production
 
 #### Web (`apps/web/`)
 
-The web app reads `VITE_SENTRY_DSN` and `VITE_SENTRY_ENVIRONMENT` via Vite's env system:
+The web app reads `VITE_SENTRY_DSN`, `VITE_ENVIRONMENT`, and `VITE_APP_VERSION` via Vite's env system:
 
 ```env
 # apps/web/.env.local (not committed)
 VITE_SENTRY_DSN=https://examplePublicKey@o0.ingest.sentry.io/0
-VITE_SENTRY_ENVIRONMENT=development
+VITE_ENVIRONMENT=development
+VITE_APP_VERSION=local
 ```
 
 #### Android (`apps/android/`)
@@ -160,10 +161,9 @@ Events are tagged with the deployment environment so you can filter dashboards a
 **Debug builds should NOT send events to Sentry.** The SDK should only initialize when:
 
 1. The DSN is non-empty, AND
-2. The environment is `staging` or `production`, AND
-3. The user has granted monitoring consent
+2. The user has granted monitoring consent
 
-This is already enforced in the web and Android implementations.
+The web implementation no-ops when `VITE_SENTRY_DSN` is missing and logs one informational message. Deployments set `VITE_ENVIRONMENT` to `staging` or `production`; local development should leave the DSN empty unless explicitly testing Sentry.
 
 ### 5. Source Map Upload (Web)
 
@@ -278,18 +278,32 @@ Configure these alert rules in each Sentry project under **Alerts** → **Create
 
 ### 9. GitHub Actions Secrets
 
-Add these secrets in **Settings** → **Secrets and variables** → **Actions**:
+Set the web DSN as an **environment-scoped** GitHub secret so staging and production can point at separate Sentry projects:
 
-| Secret               | Scope       | Description                                                 |
-| -------------------- | ----------- | ----------------------------------------------------------- |
-| `SENTRY_ORG`         | Repository  | Sentry organization slug                                    |
-| `SENTRY_AUTH_TOKEN`  | Repository  | Org-level auth token (scopes: `project:releases`, `org:ci`) |
-| `SENTRY_DSN_WEB`     | Environment | Web project DSN (scoped to `staging` / `production`)        |
-| `SENTRY_DSN_ANDROID` | Environment | Android project DSN (scoped to `staging` / `production`)    |
-| `SENTRY_DSN_IOS`     | Environment | iOS project DSN (scoped to `staging` / `production`)        |
-| `SENTRY_DSN_WINDOWS` | Environment | Windows project DSN (scoped to `staging` / `production`)    |
+1. Go to **Settings** → **Environments** → `staging` → **Environment secrets**.
+2. Add `SENTRY_DSN` with the staging `finance-web` project DSN.
+3. Repeat for **Environments** → `production` with the production Sentry project DSN.
+4. Keep `SENTRY_DSN` unset for local builds unless intentionally testing Sentry.
 
-> **Environment-scoped secrets:** Use GitHub Environments (`staging`, `production`) to scope DSNs so staging builds never send events to production Sentry projects.
+Optional source-map upload later requires repository-level `SENTRY_ORG` and `SENTRY_AUTH_TOKEN` (scopes: `project:releases`, `org:ci`). Source maps remain out of scope for #2033.
+
+### 10. Beta crash-free rate
+
+View beta crash-free rate in Sentry at:
+
+- `https://sentry.io/organizations/<org-slug>/projects/finance-web/?environment=staging`
+
+Replace `<org-slug>` with the Finance Sentry organization slug. Filter to `environment:staging` and the release matching `VITE_APP_VERSION` (the staging deploy short SHA).
+
+### 11. Native Sentry TODO hooks
+
+Native SDK dependencies are intentionally deferred for a follow-up PR. Hook points are marked in source with TODO comments:
+
+- Android: `apps/android/src/main/kotlin/com/finance/android/FinanceApplication.kt` — `// TODO(#2033): Wire Sentry SDK for Android`
+- iOS app / clip / watch / widgets: Swift `@main` entrypoints under `apps/ios/` — `// TODO(#2033): Wire Sentry SDK for <platform>`
+- Windows: `apps/windows/src/main/kotlin/com/finance/desktop/Main.kt` — `// TODO(#2033): Wire Sentry SDK for Windows`
+
+When implementing native SDKs, preserve the same DSN gating, consent gating, `sendDefaultPii=false`, and recursive scrubber semantics used by `apps/web/src/lib/monitoring.ts`.
 
 ---
 
@@ -300,6 +314,15 @@ CI health is monitored through three complementary mechanisms:
 1. **GitHub Actions workflows** — `ci-health.yml` and `build-perf.yml` run on schedule
 2. **Local tooling** — `tools/ci-health-dashboard.js` for on-demand checks
 3. **GitHub Security tab** — CodeQL and dependency scanning results
+
+### Beta uptime checks
+
+The beta uptime monitor lives at `.github/workflows/uptime-check.yml` and runs every 15 minutes (`*/15 * * * *`). It curls the public Caddy health route:
+
+- Default URL: `https://finance.jrmoulckers.com/health`
+- Override: set repository or environment secret `DEPLOY_HOST` to a host or full URL when beta moves
+
+On timeout, connection failure, or HTTP 5xx, the workflow opens a GitHub issue labeled `uptime` and `beta`. If an open `uptime` + `beta` issue already exists, the workflow adds a new failure comment instead of creating duplicates.
 
 ### Monitored Workflows
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,10 +35,11 @@
       "name": "@finance/web",
       "version": "0.1.0",
       "dependencies": {
+        "@sentry/react": "^8.55.2",
         "d3": "^7.9.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
-        "react-router-dom": "^7.17.0",
+        "react-router-dom": "^7.16.0",
         "recharts": "^3.8.1",
         "sql.js": "^1.14.1",
         "tesseract.js": "^7.0.0",
@@ -4804,6 +4805,98 @@
         }
       }
     },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "8.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.55.2.tgz",
+      "integrity": "sha512-GnKod+gL/Y+1FUM/RGV8q6le1CoyiGbT40MitEK7eVwWe+bfTRq1gN7ioupyHFMUg1RlQkDQ4/sENmio/uow5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "8.55.2"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "8.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.55.2.tgz",
+      "integrity": "sha512-XQy//NWbL0mLLM5w8wNDWMNpXz39VUyW2397dUrH8++kR63WhUVAvTOtL0o0GMVadSAzl1b08oHP9zSUNFQwcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "8.55.2"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "8.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-8.55.2.tgz",
+      "integrity": "sha512-+W43Z697EVe/OgpGW07B773sa8xO1UbpnW0Cr+E+3FMDb6ZbXlaBUoagPTUkkQPdwBe35SDh6r8y2M3EOPGbxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "8.55.2",
+        "@sentry/core": "8.55.2"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "8.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-8.55.2.tgz",
+      "integrity": "sha512-P/jGiuR7dRLG9IzD/463fLgiibyYceauav/9prRG0ZxJm1AtuO02OKball2Fs3bbzdzwHCTlcsUuL2ivDF4b5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "8.55.2",
+        "@sentry/core": "8.55.2"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "8.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.55.2.tgz",
+      "integrity": "sha512-xHuPIEKhx9zw5quWvv4YgZprnwoVMCfxIhmOIf6KJ9iizyUHeUDcKpLS59xERroqwX4RpvK+l/27AZu4zfZlzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "8.55.2",
+        "@sentry-internal/feedback": "8.55.2",
+        "@sentry-internal/replay": "8.55.2",
+        "@sentry-internal/replay-canvas": "8.55.2",
+        "@sentry/core": "8.55.2"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "8.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.55.2.tgz",
+      "integrity": "sha512-YlEBwybUcOQ/KjMHDmof1vwweVnBtBxYlQp7DE3fOdtW4pqqdHWTnTntQs4VgYfxzjJYgtkd9LHlGtg8qy+JVQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "8.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-8.55.2.tgz",
+      "integrity": "sha512-1TPfKZYkJal2Dyt2W0tf1roOZmu7sqr6/dTqjdsuu2WgGTilMEreK26YqB8ROOYdMjkVJpNCcIKXQHyMp2eCwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "8.55.2",
+        "@sentry/core": "8.55.2",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
     "node_modules/@simple-libs/child-process-utils": {
       "version": "1.0.2",
       "dev": true,
@@ -7954,6 +8047,21 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
@@ -11952,7 +12060,7 @@
       "version": "0.0.0",
       "license": "BUSL-1.1",
       "devDependencies": {
-        "@redocly/cli": "^2.31.6",
+        "@redocly/cli": "^2.31.5",
         "yaml": "^2.9.0"
       }
     },


### PR DESCRIPTION
## Summary
- Replace local web monitoring fallback with consent-gated Sentry initialization and recursive sensitive-field scrubbing.
- Add beta uptime workflow that opens/updates GitHub issues on 5xx/timeouts.
- Inject and soft-verify staging Sentry DSN after deploy; document setup and native TODO hooks.

## Validation
- npm run test -w apps/web -- --run src/lib/monitoring.test.ts src/lib/crash-report-scrubber.test.ts
- npx eslint apps/web/src/lib/monitoring.ts apps/web/src/lib/monitoring.test.ts
- npm run type-check -w apps/web
- npx prettier --write changed supported files
- node YAML parse check for deploy-staging.yml and uptime-check.yml

Closes #2033