### PR TITLE
feat: full backup/restore round-trip (#2029)

### DIFF
--- a/apps/web/e2e/backup-restore.spec.ts
+++ b/apps/web/e2e/backup-restore.spec.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { readFile } from 'node:fs/promises';
+import { test, expect } from './fixtures';
+
+const REQUIRED_ENTITIES = [
+  'accounts',
+  'transactions',
+  'categories',
+  'budgets',
+  'goals',
+  'recurringTemplates',
+  'preferences',
+  'settings',
+  'consentRecords',
+] as const;
+
+test.describe('Backup restore round-trip', () => {
+  test('exports populated data, wipes local data, restores, and reports matching counts', async ({
+    authenticatedPage: page,
+  }, testInfo) => {
+    await page.goto('/login');
+    await page.evaluate(async () => {
+      const email = 'test@example.com';
+      const data = new TextEncoder().encode('password123');
+      const digest = await crypto.subtle.digest('SHA-256', data);
+      const passwordHash = Array.from(new Uint8Array(digest))
+        .map((byte) => byte.toString(16).padStart(2, '0'))
+        .join('');
+      localStorage.setItem('finance_demo_users', JSON.stringify([{ email, passwordHash }]));
+      localStorage.setItem('finance_demo_session', email);
+    });
+    await page.goto('/settings/privacy');
+
+    const downloadPromise = page.waitForEvent('download');
+    await page.getByRole('button', { name: /download all data \(json\)/i }).click();
+    const download = await downloadPromise;
+    const backupPath = testInfo.outputPath('finance-backup.json');
+    await download.saveAs(backupPath);
+
+    const backup = JSON.parse(await readFile(backupPath, 'utf8')) as Record<string, unknown[]> & {
+      version: number;
+    };
+    expect(backup.version).toBe(1);
+    const expectedCounts = Object.fromEntries(
+      REQUIRED_ENTITIES.map((entity) => [
+        entity,
+        Array.isArray(backup[entity]) ? backup[entity].length : 0,
+      ]),
+    );
+    expect(expectedCounts.accounts).toBeGreaterThan(0);
+    expect(expectedCounts.transactions).toBeGreaterThan(0);
+    expect(expectedCounts.categories).toBeGreaterThan(0);
+    expect(expectedCounts.budgets).toBeGreaterThan(0);
+    expect(expectedCounts.goals).toBeGreaterThan(0);
+
+    await page.evaluate(async () => {
+      await window.__financeWipeLocalDataForE2E__?.();
+      localStorage.setItem('finance_demo_session', 'test@example.com');
+      localStorage.setItem(
+        'finance-gdpr-consent',
+        JSON.stringify({
+          categories: { essential: true },
+          timestamp: new Date().toISOString(),
+          policyVersion: '1.0.0',
+          method: 'e2e_restore',
+          hasCompletedFirstRun: true,
+        }),
+      );
+    });
+
+    await page.goto('/import/wizard');
+    await page.locator('input[type="file"]').setInputFiles(backupPath);
+    await expect(page.getByRole('heading', { name: /dry-run restore preview/i })).toBeVisible();
+
+    await page.getByLabel(/wipe local data first/i).check();
+    for (const entity of REQUIRED_ENTITIES) {
+      const row = page.getByRole('row').filter({ hasText: entity });
+      await expect(row).toContainText(String(expectedCounts[entity]));
+    }
+
+    await page.getByRole('button', { name: /restore backup/i }).click();
+    await expect(page.getByText(/restore complete/i)).toBeVisible();
+
+    for (const entity of REQUIRED_ENTITIES) {
+      const row = page.getByRole('row').filter({ hasText: entity });
+      await expect(row).toContainText(String(expectedCounts[entity]));
+      await expect(row).toContainText('0');
+    }
+  });
+});

--- a/apps/web/src/components/DataExport.tsx
+++ b/apps/web/src/components/DataExport.tsx
@@ -15,12 +15,12 @@ import {
   type DataAccessManifest,
   type DataAccessPackageResult,
 } from '../lib/data-access-package';
+import { buildBackupPackage, serializeBackupPackage } from '../lib/export/backup-package';
 import {
   buildAllCsvZip,
   buildDatedExportFileName,
   buildFullJsonExport,
   buildTransactionsCsv,
-  serializeFullJsonExport,
 } from '../lib/export/simple-export';
 import './data-export.css';
 
@@ -359,15 +359,13 @@ export const DataExport: React.FC<DataExportProps> = ({ className = '' }) => {
       if (!db)
         throw new Error('Database is still initializing. Please wait a moment and try again.');
       const generatedAt = new Date();
-      const exportData = buildFullJsonExport(db, {
+      const exportData = buildBackupPackage(db, {
         appVersion: APP_VERSION,
         generatedAt,
-        preferences: readLocalStorageRecords('finance-'),
-        settings: readLocalStorageRecords('settings-'),
       });
       triggerBrowserDownload(
-        serializeFullJsonExport(exportData),
-        buildDatedExportFileName('finance-data', 'json', generatedAt),
+        serializeBackupPackage(exportData),
+        buildDatedExportFileName('finance-backup', 'json', generatedAt),
         'application/json;charset=utf-8',
       );
       setSimpleDownloadMessage('JSON download started.');

--- a/apps/web/src/db/DatabaseProvider.tsx
+++ b/apps/web/src/db/DatabaseProvider.tsx
@@ -69,19 +69,205 @@ declare global {
   }
 }
 
-/**
- * Minimal in-memory database stub used during E2E tests.
- *
- * Returns empty results for all queries.  Page components render their
- * "no data" / empty states, which is sufficient for E2E structural and
- * navigation tests that don't depend on seed data.
- */
-const E2E_STUB_DB: SqliteDb = {
-  exec: () => {},
-  selectAll: () => [],
-  selectOne: () => null,
-  close: async () => {},
-};
+/** Minimal in-memory database stub used during E2E tests. */
+function createE2eTableData(): Record<string, Array<Record<string, unknown>>> {
+  const now = new Date('2026-05-26T12:00:00.000Z').toISOString();
+  return {
+    user: [
+      {
+        id: 'e2e-user-1',
+        email: 'demo@finance.local',
+        display_name: 'E2E User',
+        avatar_url: null,
+        default_currency: 'USD',
+        created_at: now,
+        updated_at: now,
+        deleted_at: null,
+        sync_version: 1,
+        is_synced: 0,
+      },
+    ],
+    household: [
+      {
+        id: 'e2e-household-1',
+        name: 'E2E Household',
+        owner_id: 'e2e-user-1',
+        created_at: now,
+        updated_at: now,
+        deleted_at: null,
+        sync_version: 1,
+        is_synced: 0,
+      },
+    ],
+    household_member: [
+      {
+        id: 'e2e-member-1',
+        household_id: 'e2e-household-1',
+        user_id: 'e2e-user-1',
+        role: 'OWNER',
+        joined_at: now,
+        created_at: now,
+        updated_at: now,
+        deleted_at: null,
+        sync_version: 1,
+        is_synced: 0,
+      },
+    ],
+    account: [
+      {
+        id: 'e2e-account-1',
+        household_id: 'e2e-household-1',
+        name: 'Checking',
+        type: 'CHECKING',
+        currency: 'USD',
+        current_balance: 250000,
+        is_archived: 0,
+        sort_order: 1,
+        icon: 'bank',
+        color: '#2563EB',
+        created_at: now,
+        updated_at: now,
+        deleted_at: null,
+        sync_version: 1,
+        is_synced: 0,
+      },
+    ],
+    category: [
+      {
+        id: 'e2e-category-1',
+        household_id: 'e2e-household-1',
+        name: 'Food',
+        icon: 'utensils',
+        color: '#16A34A',
+        parent_id: null,
+        is_income: 0,
+        is_system: 0,
+        sort_order: 1,
+        is_biometric_protected: 0,
+        created_at: now,
+        updated_at: now,
+        deleted_at: null,
+        sync_version: 1,
+        is_synced: 0,
+      },
+    ],
+    budget: [
+      {
+        id: 'e2e-budget-1',
+        household_id: 'e2e-household-1',
+        category_id: 'e2e-category-1',
+        name: 'Groceries',
+        amount: 50000,
+        currency: 'USD',
+        period: 'MONTHLY',
+        start_date: '2026-05-01',
+        end_date: null,
+        is_rollover: 0,
+        created_at: now,
+        updated_at: now,
+        deleted_at: null,
+        sync_version: 1,
+        is_synced: 0,
+      },
+    ],
+    goal: [
+      {
+        id: 'e2e-goal-1',
+        household_id: 'e2e-household-1',
+        name: 'Emergency fund',
+        description: 'Three months expenses',
+        target_amount: 1000000,
+        current_amount: 250000,
+        currency: 'USD',
+        target_date: '2026-12-31',
+        status: 'ACTIVE',
+        icon: 'piggy-bank',
+        color: '#059669',
+        account_id: 'e2e-account-1',
+        created_at: now,
+        updated_at: now,
+        deleted_at: null,
+        sync_version: 1,
+        is_synced: 0,
+      },
+    ],
+    transaction: [
+      {
+        id: 'e2e-transaction-1',
+        household_id: 'e2e-household-1',
+        account_id: 'e2e-account-1',
+        category_id: 'e2e-category-1',
+        type: 'EXPENSE',
+        status: 'CLEARED',
+        amount: -6742,
+        currency: 'USD',
+        payee: 'Grocery Store',
+        note: 'Weekly shop',
+        date: '2026-05-25',
+        transfer_account_id: null,
+        transfer_transaction_id: null,
+        is_recurring: 0,
+        recurring_rule_id: null,
+        tags: '[]',
+        mood_tag: null,
+        merchant_address: null,
+        merchant_city: null,
+        merchant_state: null,
+        merchant_zip: null,
+        merchant_country: null,
+        external_reference_id: null,
+        statement_description: null,
+        custom_fields: null,
+        extra_notes: null,
+        counterparty_name: null,
+        counterparty_account_id: null,
+        created_at: now,
+        updated_at: now,
+        deleted_at: null,
+        sync_version: 1,
+        is_synced: 0,
+      },
+    ],
+    goal_progress_contribution: [],
+  };
+}
+
+function tableNameFromSql(sql: string): string | null {
+  return /(?:FROM|INTO|DELETE FROM)\s+"?([a-zA-Z_][\w]*)"?/i.exec(sql)?.[1] ?? null;
+}
+
+function createE2eStubDb(): SqliteDb {
+  const tables = createE2eTableData();
+  return {
+    exec: (sql, params) => {
+      const deleteTable = /^DELETE FROM\s+"?([a-zA-Z_][\w]*)"?/i.exec(sql)?.[1];
+      if (deleteTable) {
+        tables[deleteTable] = [];
+        return;
+      }
+      const insert = /^INSERT INTO\s+"?([a-zA-Z_][\w]*)"?\s+\((.+)\)\s+VALUES/i.exec(sql);
+      if (insert) {
+        const columns = [...insert[2].matchAll(/"([^"]+)"/g)].map((match) => match[1]);
+        const row = Object.fromEntries(columns.map((column, index) => [column, params?.[index]]));
+        tables[insert[1]] = [...(tables[insert[1]] ?? []), row];
+      }
+    },
+    selectAll: (sql) => {
+      const table = tableNameFromSql(sql);
+      if (!table) return [];
+      const rows = (tables[table] ?? []).filter((row) => row.deleted_at == null);
+      if (/SELECT\s+id\s+FROM/i.test(sql)) return rows.map((row) => ({ id: row.id }));
+      return rows;
+    },
+    selectOne: (sql) => {
+      const rows = E2E_STUB_DB.selectAll(sql);
+      return rows[0] ?? null;
+    },
+    close: async () => {},
+  };
+}
+
+const E2E_STUB_DB: SqliteDb = createE2eStubDb();
 
 const E2E_STUB_DIAGNOSTICS: StorageDiagnostics = {
   backend: 'indexeddb',

--- a/apps/web/src/lib/export/backup-package.test.ts
+++ b/apps/web/src/lib/export/backup-package.test.ts
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SqliteDb } from '../../db/sqlite-wasm';
+import {
+  BACKUP_PACKAGE_VERSION,
+  buildBackupPackage,
+  buildRestorePreview,
+  parseBackupPackage,
+  restoreBackupPackage,
+  serializeBackupPackage,
+} from './backup-package';
+
+function createMockDb(initialRows: Record<string, Array<Record<string, unknown>>>): SqliteDb {
+  const rows = new Map(
+    Object.entries(initialRows).map(([table, tableRows]) => [table, [...tableRows]]),
+  );
+  return {
+    selectAll: vi.fn((sql: string) => {
+      const tableMatch = /FROM\s+"([^"]+)"/i.exec(sql);
+      const table = tableMatch?.[1];
+      if (!table) return [];
+      const tableRows = rows.get(table) ?? [];
+      if (/SELECT\s+id\s+FROM/i.test(sql)) return tableRows.map((row) => ({ id: row.id }));
+      return tableRows.filter((row) => row.deleted_at == null);
+    }),
+    selectOne: vi.fn(() => null),
+    exec: vi.fn((sql: string, params?: unknown[]) => {
+      if (/^BEGIN|^COMMIT|^ROLLBACK/i.test(sql)) return;
+      const deleteMatch = /^DELETE FROM "([^"]+)"/i.exec(sql);
+      if (deleteMatch) {
+        rows.set(deleteMatch[1], []);
+        return;
+      }
+      const insertMatch = /^INSERT INTO "([^"]+)" \((.+)\) VALUES/i.exec(sql);
+      if (!insertMatch) return;
+      const table = insertMatch[1];
+      const columns = [...insertMatch[2].matchAll(/"([^"]+)"/g)].map((match) => match[1]);
+      const row = Object.fromEntries(columns.map((column, index) => [column, params?.[index]]));
+      rows.set(table, [...(rows.get(table) ?? []), row]);
+    }),
+    close: vi.fn(async () => undefined),
+  } as unknown as SqliteDb;
+}
+
+describe('backup-package', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('serializes and deserializes the canonical versioned package', () => {
+    const db = createMockDb({
+      user: [{ id: 'user-1', email: 'demo@example.com', deleted_at: null }],
+      household: [{ id: 'hh-1', name: 'Home', owner_id: 'user-1', deleted_at: null }],
+      household_member: [],
+      account: [{ id: 'acc-1', household_id: 'hh-1', name: 'Checking', deleted_at: null }],
+      category: [{ id: 'cat-1', household_id: 'hh-1', name: 'Food', deleted_at: null }],
+      budget: [{ id: 'budget-1', household_id: 'hh-1', category_id: 'cat-1', deleted_at: null }],
+      goal: [{ id: 'goal-1', household_id: 'hh-1', name: 'Emergency', deleted_at: null }],
+      transaction: [{ id: 'txn-1', household_id: 'hh-1', account_id: 'acc-1', deleted_at: null }],
+    });
+    localStorage.setItem('finance-gdpr-consent', '{"essential":true}');
+    localStorage.setItem('finance-recurring-rent', '{"id":"rent"}');
+
+    const pkg = buildBackupPackage(db, {
+      appVersion: '0.1.0',
+      generatedAt: new Date('2026-05-26T12:00:00Z'),
+    });
+    const parsed = parseBackupPackage(serializeBackupPackage(pkg));
+
+    expect(parsed.version).toBe(BACKUP_PACKAGE_VERSION);
+    expect(parsed.metadata.generatedAt).toBe('2026-05-26T12:00:00.000Z');
+    expect(parsed.accounts).toEqual([
+      { id: 'acc-1', household_id: 'hh-1', name: 'Checking', deleted_at: null },
+    ]);
+    expect(parsed.consentRecords).toEqual([
+      { key: 'finance-gdpr-consent', value: '{"essential":true}' },
+    ]);
+    expect(parsed.recurringTemplates).toHaveLength(1);
+  });
+
+  it('rejects missing or unsupported backup versions', () => {
+    expect(() => parseBackupPackage('{"accounts":[]}')).toThrow(/Unsupported backup version/);
+    expect(() => parseBackupPackage('{"version":999,"metadata":{"generatedAt":"now"}}')).toThrow(
+      /Unsupported backup version/,
+    );
+  });
+
+  it('previews duplicate ids and local-storage keys before restore', () => {
+    const db = createMockDb({
+      user: [],
+      household: [],
+      household_member: [],
+      account: [{ id: 'acc-1', deleted_at: null }],
+      category: [],
+      budget: [],
+      goal: [],
+      transaction: [],
+    });
+    localStorage.setItem('finance-gdpr-consent', 'old');
+
+    const pkg = parseBackupPackage(
+      JSON.stringify({
+        version: 1,
+        metadata: { generatedAt: '2026-05-26T12:00:00.000Z' },
+        accounts: [{ id: 'acc-1' }, { id: 'acc-2' }],
+        consentRecords: [{ key: 'finance-gdpr-consent', value: 'new' }],
+      }),
+    );
+
+    const preview = buildRestorePreview(db, pkg);
+    expect(preview.entities.find((entity) => entity.entity === 'accounts')).toMatchObject({
+      total: 2,
+      imported: 1,
+      skippedDuplicates: 1,
+    });
+    expect(preview.entities.find((entity) => entity.entity === 'consentRecords')).toMatchObject({
+      total: 1,
+      imported: 0,
+      skippedDuplicates: 1,
+    });
+  });
+
+  it('restores non-duplicate rows and supports clean restore wipes', () => {
+    const db = createMockDb({
+      user: [],
+      household: [],
+      household_member: [],
+      account: [{ id: 'acc-existing', deleted_at: null }],
+      category: [],
+      budget: [],
+      goal: [],
+      transaction: [],
+    });
+    const pkg = parseBackupPackage(
+      JSON.stringify({
+        version: 1,
+        metadata: { generatedAt: '2026-05-26T12:00:00.000Z' },
+        accounts: [{ id: 'acc-1', household_id: 'hh-1', deleted_at: null }],
+        preferences: [{ key: 'finance-pref', value: 'on' }],
+      }),
+    );
+
+    const result = restoreBackupPackage(db, pkg, { wipeLocalDataFirst: true });
+
+    expect(result.entities.find((entity) => entity.entity === 'accounts')).toMatchObject({
+      imported: 1,
+      skippedDuplicates: 0,
+    });
+    expect(db.exec).toHaveBeenCalledWith(expect.stringMatching(/^DELETE FROM "account"/));
+    expect(db.exec).toHaveBeenCalledWith(expect.stringMatching(/^INSERT INTO "account"/), [
+      'acc-1',
+      'hh-1',
+      null,
+    ]);
+    expect(localStorage.getItem('finance-pref')).toBe('on');
+  });
+});

--- a/apps/web/src/lib/export/backup-package.ts
+++ b/apps/web/src/lib/export/backup-package.ts
@@ -1,0 +1,635 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import type { SqliteDb } from '../../db/sqlite-wasm';
+import {
+  BACKUP_PACKAGE_VERSION,
+  type BackupEntityKey,
+  type BackupEntityPreview,
+  type BackupEntityRecord,
+  type BackupKeyValueRecord,
+  type BackupPackage,
+  type BackupRestorePreview,
+  type BackupRestoreResult,
+} from '../../types/backup';
+
+export { BACKUP_PACKAGE_VERSION } from '../../types/backup';
+
+const APP_BACKUP_KEYS: readonly BackupEntityKey[] = [
+  'users',
+  'households',
+  'householdMembers',
+  'accounts',
+  'categories',
+  'budgets',
+  'goals',
+  'transactions',
+  'recurringTemplates',
+  'preferences',
+  'settings',
+  'consentRecords',
+] as const;
+
+type SqlEntityKey = Extract<
+  BackupEntityKey,
+  | 'users'
+  | 'households'
+  | 'householdMembers'
+  | 'accounts'
+  | 'categories'
+  | 'budgets'
+  | 'goals'
+  | 'transactions'
+>;
+
+interface TableConfig {
+  readonly entity: SqlEntityKey;
+  readonly table: string;
+  readonly columns: readonly string[];
+}
+
+const TABLES: readonly TableConfig[] = [
+  {
+    entity: 'users',
+    table: 'user',
+    columns: [
+      'id',
+      'email',
+      'display_name',
+      'avatar_url',
+      'default_currency',
+      'created_at',
+      'updated_at',
+      'deleted_at',
+      'sync_version',
+      'is_synced',
+    ],
+  },
+  {
+    entity: 'households',
+    table: 'household',
+    columns: [
+      'id',
+      'name',
+      'owner_id',
+      'created_at',
+      'updated_at',
+      'deleted_at',
+      'sync_version',
+      'is_synced',
+    ],
+  },
+  {
+    entity: 'householdMembers',
+    table: 'household_member',
+    columns: [
+      'id',
+      'household_id',
+      'user_id',
+      'role',
+      'joined_at',
+      'created_at',
+      'updated_at',
+      'deleted_at',
+      'sync_version',
+      'is_synced',
+    ],
+  },
+  {
+    entity: 'accounts',
+    table: 'account',
+    columns: [
+      'id',
+      'household_id',
+      'name',
+      'type',
+      'currency',
+      'current_balance',
+      'is_archived',
+      'sort_order',
+      'icon',
+      'color',
+      'created_at',
+      'updated_at',
+      'deleted_at',
+      'sync_version',
+      'is_synced',
+    ],
+  },
+  {
+    entity: 'categories',
+    table: 'category',
+    columns: [
+      'id',
+      'household_id',
+      'name',
+      'icon',
+      'color',
+      'parent_id',
+      'is_income',
+      'is_system',
+      'sort_order',
+      'is_biometric_protected',
+      'created_at',
+      'updated_at',
+      'deleted_at',
+      'sync_version',
+      'is_synced',
+    ],
+  },
+  {
+    entity: 'budgets',
+    table: 'budget',
+    columns: [
+      'id',
+      'household_id',
+      'category_id',
+      'name',
+      'amount',
+      'currency',
+      'period',
+      'start_date',
+      'end_date',
+      'is_rollover',
+      'created_at',
+      'updated_at',
+      'deleted_at',
+      'sync_version',
+      'is_synced',
+    ],
+  },
+  {
+    entity: 'goals',
+    table: 'goal',
+    columns: [
+      'id',
+      'household_id',
+      'name',
+      'description',
+      'target_amount',
+      'current_amount',
+      'currency',
+      'target_date',
+      'status',
+      'icon',
+      'color',
+      'account_id',
+      'created_at',
+      'updated_at',
+      'deleted_at',
+      'sync_version',
+      'is_synced',
+    ],
+  },
+  {
+    entity: 'transactions',
+    table: 'transaction',
+    columns: [
+      'id',
+      'household_id',
+      'account_id',
+      'category_id',
+      'type',
+      'status',
+      'amount',
+      'currency',
+      'payee',
+      'note',
+      'date',
+      'transfer_account_id',
+      'transfer_transaction_id',
+      'is_recurring',
+      'recurring_rule_id',
+      'tags',
+      'mood_tag',
+      'merchant_address',
+      'merchant_city',
+      'merchant_state',
+      'merchant_zip',
+      'merchant_country',
+      'external_reference_id',
+      'statement_description',
+      'custom_fields',
+      'extra_notes',
+      'counterparty_name',
+      'counterparty_account_id',
+      'created_at',
+      'updated_at',
+      'deleted_at',
+      'sync_version',
+      'is_synced',
+    ],
+  },
+];
+
+const TABLE_BY_ENTITY = new Map(TABLES.map((table) => [table.entity, table]));
+const SQL_RESTORE_ORDER = TABLES.map((table) => table.entity);
+const SQL_WIPE_ORDER: readonly string[] = [
+  'goal_progress_contribution',
+  'transaction',
+  'budget',
+  'goal',
+  'category',
+  'account',
+  'household_member',
+  'household',
+  'user',
+];
+
+const LOCAL_STORAGE_ENTITIES = [
+  'recurringTemplates',
+  'preferences',
+  'settings',
+  'consentRecords',
+] as const;
+
+export interface BuildBackupPackageOptions {
+  readonly appVersion?: string | null;
+  readonly generatedAt?: Date;
+}
+
+export interface RestoreBackupOptions {
+  readonly wipeLocalDataFirst?: boolean;
+}
+
+export function buildBackupPackage(
+  db: SqliteDb,
+  options: BuildBackupPackageOptions = {},
+): BackupPackage {
+  return {
+    version: BACKUP_PACKAGE_VERSION,
+    metadata: {
+      generatedAt: (options.generatedAt ?? new Date()).toISOString(),
+      appVersion: options.appVersion ?? null,
+      source: 'web',
+    },
+    users: readSqlRecords(db, tableFor('users')),
+    households: readSqlRecords(db, tableFor('households')),
+    householdMembers: readSqlRecords(db, tableFor('householdMembers')),
+    accounts: readSqlRecords(db, tableFor('accounts')),
+    transactions: readSqlRecords(db, tableFor('transactions')),
+    categories: readSqlRecords(db, tableFor('categories')),
+    budgets: readSqlRecords(db, tableFor('budgets')),
+    goals: readSqlRecords(db, tableFor('goals')),
+    recurringTemplates: readLocalStorageRecords((key) => key.startsWith('finance-recurring-')),
+    preferences: readLocalStorageRecords(
+      (key) =>
+        key.startsWith('finance-') && !isConsentKey(key) && !key.startsWith('finance-recurring-'),
+    ),
+    settings: readLocalStorageRecords(
+      (key) => key.startsWith('settings-') || key.includes('display-settings'),
+    ),
+    consentRecords: readLocalStorageRecords(isConsentKey),
+  };
+}
+
+export function serializeBackupPackage(pkg: BackupPackage): string {
+  return `${JSON.stringify(pkg, null, 2)}\n`;
+}
+
+export function parseBackupPackage(input: string): BackupPackage {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(input);
+  } catch (error) {
+    throw new Error(
+      `Backup file is not valid JSON: ${error instanceof Error ? error.message : 'parse failed'}`,
+      { cause: error },
+    );
+  }
+  return validateBackupPackage(parsed);
+}
+
+export async function parseBackupFile(file: File): Promise<BackupPackage> {
+  if (file.name.toLowerCase().endsWith('.zip') || file.type === 'application/zip') {
+    const text = extractJsonFromStoredZip(new Uint8Array(await file.arrayBuffer()));
+    return parseBackupPackage(text);
+  }
+  return parseBackupPackage(await file.text());
+}
+
+export function validateBackupPackage(value: unknown): BackupPackage {
+  if (!isRecord(value)) throw new Error('Backup package must be a JSON object.');
+  if (value.version !== BACKUP_PACKAGE_VERSION) {
+    throw new Error(
+      `Unsupported backup version: ${String(value.version ?? 'missing')}. Expected ${BACKUP_PACKAGE_VERSION}.`,
+    );
+  }
+  if (!isRecord(value.metadata) || typeof value.metadata.generatedAt !== 'string') {
+    throw new Error('Backup package metadata.generatedAt is required.');
+  }
+
+  const pkg = value as Record<string, unknown>;
+  for (const key of APP_BACKUP_KEYS) {
+    if (pkg[key] !== undefined && !Array.isArray(pkg[key])) {
+      throw new Error(`Backup package field ${key} must be an array.`);
+    }
+  }
+
+  return {
+    version: BACKUP_PACKAGE_VERSION,
+    metadata: {
+      generatedAt: value.metadata.generatedAt,
+      appVersion: typeof value.metadata.appVersion === 'string' ? value.metadata.appVersion : null,
+      source: 'web',
+    },
+    users: records(pkg.users),
+    households: records(pkg.households),
+    householdMembers: records(pkg.householdMembers),
+    accounts: records(pkg.accounts),
+    transactions: records(pkg.transactions),
+    categories: records(pkg.categories),
+    budgets: records(pkg.budgets),
+    goals: records(pkg.goals),
+    recurringTemplates: records(pkg.recurringTemplates),
+    preferences: keyValueRecords(pkg.preferences),
+    settings: keyValueRecords(pkg.settings),
+    consentRecords: keyValueRecords(pkg.consentRecords),
+  };
+}
+
+export function buildRestorePreview(
+  db: SqliteDb,
+  pkg: BackupPackage,
+  options: RestoreBackupOptions = {},
+): BackupRestorePreview {
+  const wipe = options.wipeLocalDataFirst === true;
+  return {
+    version: pkg.version,
+    wipeLocalDataFirst: wipe,
+    entities: APP_BACKUP_KEYS.map((entity) => previewEntity(db, pkg, entity, wipe)),
+  };
+}
+
+export function restoreBackupPackage(
+  db: SqliteDb,
+  pkg: BackupPackage,
+  options: RestoreBackupOptions = {},
+): BackupRestoreResult {
+  const wipe = options.wipeLocalDataFirst === true;
+  const preview = buildRestorePreview(db, pkg, options);
+
+  db.exec('BEGIN IMMEDIATE TRANSACTION');
+  try {
+    if (wipe) wipeSqlData(db);
+    for (const entity of SQL_RESTORE_ORDER) {
+      restoreSqlEntity(db, entity, pkg[entity] as readonly BackupEntityRecord[], wipe);
+    }
+    db.exec('COMMIT');
+  } catch (error) {
+    db.exec('ROLLBACK');
+    throw error;
+  }
+
+  if (wipe) wipeLocalStorageData();
+  for (const entity of LOCAL_STORAGE_ENTITIES) {
+    restoreKeyValueRecords(pkg[entity] as readonly BackupKeyValueRecord[], wipe);
+  }
+
+  return { ...preview, restoredAt: new Date().toISOString() };
+}
+
+function previewEntity(
+  db: SqliteDb,
+  pkg: BackupPackage,
+  entity: BackupEntityKey,
+  wipe: boolean,
+): BackupEntityPreview {
+  const recordsForEntity = pkg[entity] as readonly (BackupEntityRecord | BackupKeyValueRecord)[];
+  if (wipe || recordsForEntity.length === 0) {
+    return {
+      entity,
+      total: recordsForEntity.length,
+      imported: recordsForEntity.length,
+      skippedDuplicates: 0,
+    };
+  }
+
+  const duplicateCount = isLocalStorageEntity(entity)
+    ? countDuplicateKeys(recordsForEntity as readonly BackupKeyValueRecord[])
+    : countDuplicateIds(
+        db,
+        entity as SqlEntityKey,
+        recordsForEntity as readonly BackupEntityRecord[],
+      );
+  return {
+    entity,
+    total: recordsForEntity.length,
+    imported: recordsForEntity.length - duplicateCount,
+    skippedDuplicates: duplicateCount,
+  };
+}
+
+function restoreSqlEntity(
+  db: SqliteDb,
+  entity: SqlEntityKey,
+  rows: readonly BackupEntityRecord[],
+  wipe: boolean,
+): void {
+  const config = tableFor(entity);
+  const existingIds = wipe ? new Set<string>() : getExistingSqlIds(db, config);
+  for (const row of rows) {
+    const id = recordId(row);
+    if (!id || existingIds.has(id)) continue;
+    insertSqlRecord(db, config, row);
+    existingIds.add(id);
+  }
+}
+
+function insertSqlRecord(db: SqliteDb, config: TableConfig, record: BackupEntityRecord): void {
+  const columns = config.columns.filter((column) => getRecordValue(record, column) !== undefined);
+  if (!columns.includes('id'))
+    throw new Error(`Cannot restore ${config.entity}: record is missing id.`);
+  const placeholders = columns.map(() => '?').join(', ');
+  const quotedColumns = columns.map(quoteIdentifier).join(', ');
+  db.exec(
+    `INSERT INTO ${quoteIdentifier(config.table)} (${quotedColumns}) VALUES (${placeholders})`,
+    columns.map((column) => normalizeSqlValue(getRecordValue(record, column))),
+  );
+}
+
+function wipeSqlData(db: SqliteDb): void {
+  for (const table of SQL_WIPE_ORDER) {
+    try {
+      db.exec(`DELETE FROM ${quoteIdentifier(table)}`);
+    } catch {
+      // Optional future tables may not exist in older local databases.
+    }
+  }
+}
+
+function wipeLocalStorageData(): void {
+  try {
+    for (const record of [
+      ...readLocalStorageRecords((key) => key.startsWith('finance-recurring-')),
+      ...readLocalStorageRecords(
+        (key) =>
+          key.startsWith('finance-') && !isConsentKey(key) && !key.startsWith('finance-recurring-'),
+      ),
+      ...readLocalStorageRecords(
+        (key) => key.startsWith('settings-') || key.includes('display-settings'),
+      ),
+      ...readLocalStorageRecords(isConsentKey),
+    ]) {
+      localStorage.removeItem(record.key);
+    }
+  } catch {
+    // Best-effort: restore can still proceed for SQLite data.
+  }
+}
+
+function restoreKeyValueRecords(
+  recordsToRestore: readonly BackupKeyValueRecord[],
+  wipe: boolean,
+): void {
+  try {
+    for (const record of recordsToRestore) {
+      if (!wipe && localStorage.getItem(record.key) !== null) continue;
+      if (record.value === null) localStorage.removeItem(record.key);
+      else localStorage.setItem(record.key, record.value);
+    }
+  } catch {
+    // Ignore storage quota/private-mode failures; SQL restore has already succeeded.
+  }
+}
+
+function readSqlRecords(db: SqliteDb, config: TableConfig): BackupEntityRecord[] {
+  try {
+    return db.selectAll(
+      `SELECT ${config.columns.map(quoteIdentifier).join(', ')} FROM ${quoteIdentifier(config.table)} WHERE deleted_at IS NULL`,
+    ) as BackupEntityRecord[];
+  } catch {
+    return [];
+  }
+}
+
+function readLocalStorageRecords(predicate: (key: string) => boolean): BackupKeyValueRecord[] {
+  try {
+    const recordsToExport: BackupKeyValueRecord[] = [];
+    for (let index = 0; index < localStorage.length; index += 1) {
+      const key = localStorage.key(index);
+      if (!key || !predicate(key)) continue;
+      recordsToExport.push({ key, value: localStorage.getItem(key) });
+    }
+    return recordsToExport.sort((a, b) => a.key.localeCompare(b.key));
+  } catch {
+    return [];
+  }
+}
+
+function countDuplicateIds(
+  db: SqliteDb,
+  entity: SqlEntityKey,
+  rows: readonly BackupEntityRecord[],
+): number {
+  const existingIds = getExistingSqlIds(db, tableFor(entity));
+  return rows.filter((row) => {
+    const id = recordId(row);
+    return id ? existingIds.has(id) : false;
+  }).length;
+}
+
+function countDuplicateKeys(rows: readonly BackupKeyValueRecord[]): number {
+  try {
+    return rows.filter((row) => localStorage.getItem(row.key) !== null).length;
+  } catch {
+    return 0;
+  }
+}
+
+function getExistingSqlIds(db: SqliteDb, config: TableConfig): Set<string> {
+  try {
+    return new Set(
+      db
+        .selectAll(`SELECT id FROM ${quoteIdentifier(config.table)} WHERE deleted_at IS NULL`)
+        .map((row) => String(row.id)),
+    );
+  } catch {
+    return new Set();
+  }
+}
+
+function isLocalStorageEntity(
+  entity: BackupEntityKey,
+): entity is (typeof LOCAL_STORAGE_ENTITIES)[number] {
+  return (LOCAL_STORAGE_ENTITIES as readonly BackupEntityKey[]).includes(entity);
+}
+
+function tableFor(entity: SqlEntityKey): TableConfig {
+  const table = TABLE_BY_ENTITY.get(entity);
+  if (!table) throw new Error(`No table mapping for backup entity ${entity}.`);
+  return table;
+}
+
+function quoteIdentifier(identifier: string): string {
+  return `"${identifier.replaceAll('"', '""')}"`;
+}
+
+function getRecordValue(record: BackupEntityRecord, column: string): unknown {
+  if (column in record) return record[column];
+  const camelKey = column.replace(/_([a-z])/g, (_, letter: string) => letter.toUpperCase());
+  return record[camelKey];
+}
+
+function normalizeSqlValue(value: unknown): unknown {
+  if (typeof value === 'boolean') return value ? 1 : 0;
+  if (value && typeof value === 'object') return JSON.stringify(value);
+  return value;
+}
+
+function recordId(record: BackupEntityRecord): string | null {
+  return typeof record.id === 'string' && record.id.length > 0 ? record.id : null;
+}
+
+function records(value: unknown): BackupEntityRecord[] {
+  return Array.isArray(value) ? value.filter(isRecord) : [];
+}
+
+function keyValueRecords(value: unknown): BackupKeyValueRecord[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((record): BackupKeyValueRecord[] => {
+    if (!isRecord(record) || typeof record.key !== 'string') return [];
+    return [{ key: record.key, value: record.value == null ? null : String(record.value) }];
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isConsentKey(key: string): boolean {
+  const lower = key.toLowerCase();
+  return lower.includes('consent') || lower.includes('gdpr');
+}
+
+function extractJsonFromStoredZip(bytes: Uint8Array): string {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const decoder = new TextDecoder();
+  let offset = 0;
+  const candidates: string[] = [];
+
+  while (offset + 30 <= bytes.length && view.getUint32(offset, true) === 0x04034b50) {
+    const compression = view.getUint16(offset + 8, true);
+    const compressedSize = view.getUint32(offset + 18, true);
+    const fileNameLength = view.getUint16(offset + 26, true);
+    const extraLength = view.getUint16(offset + 28, true);
+    const nameStart = offset + 30;
+    const dataStart = nameStart + fileNameLength + extraLength;
+    const dataEnd = dataStart + compressedSize;
+    const name = decoder.decode(bytes.slice(nameStart, nameStart + fileNameLength));
+
+    if (compression === 0 && dataEnd <= bytes.length && name.toLowerCase().endsWith('.json')) {
+      candidates.push(decoder.decode(bytes.slice(dataStart, dataEnd)));
+    }
+    offset = dataEnd;
+  }
+
+  for (const candidate of candidates) {
+    try {
+      const parsed = JSON.parse(candidate) as unknown;
+      if (isRecord(parsed) && parsed.version === BACKUP_PACKAGE_VERSION) return candidate;
+    } catch {
+      // Keep looking for a canonical JSON member.
+    }
+  }
+  throw new Error('ZIP backup does not contain an uncompressed canonical backup JSON file.');
+}

--- a/apps/web/src/pages/DataImportWizardPage.css
+++ b/apps/web/src/pages/DataImportWizardPage.css
@@ -403,6 +403,31 @@
   font-weight: var(--font-weight-medium);
 }
 
+.import-banner--success {
+  padding: var(--spacing-3);
+  background: var(--color-green-50, #f0fdf4);
+  border: 1px solid var(--semantic-status-positive);
+  border-radius: var(--border-radius-md);
+  color: var(--semantic-status-positive);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-medium);
+}
+
+.import-backup-preview {
+  margin-top: var(--spacing-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+}
+
+.import-checkbox-row {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  color: var(--semantic-text-primary);
+  font-size: var(--type-scale-body-font-size);
+}
+
 /* Hidden utility */
 .import-hidden {
   position: absolute;

--- a/apps/web/src/pages/DataImportWizardPage.tsx
+++ b/apps/web/src/pages/DataImportWizardPage.tsx
@@ -14,6 +14,7 @@
 import { useCallback, useRef, useState } from 'react';
 import type { DragEvent, ChangeEvent } from 'react';
 import { AppIcon } from '../components/icons';
+import { useDatabase } from '../db/DatabaseProvider';
 
 import { useDataImportWizard } from '../hooks/useDataImportWizard';
 import type {
@@ -22,6 +23,12 @@ import type {
   DuplicateComparison,
   DuplicateAction,
 } from '../hooks/useDataImportWizard';
+import {
+  buildRestorePreview,
+  parseBackupFile,
+  restoreBackupPackage,
+} from '../lib/export/backup-package';
+import type { BackupPackage, BackupRestorePreview, BackupRestoreResult } from '../types/backup';
 
 import './DataImportWizardPage.css';
 
@@ -354,19 +361,55 @@ export function DataImportWizardPage() {
     reset,
   } = useDataImportWizard();
 
+  const db = useDatabase();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [dragActive, setDragActive] = useState(false);
+  const [backupPackage, setBackupPackage] = useState<BackupPackage | null>(null);
+  const [backupPreview, setBackupPreview] = useState<BackupRestorePreview | null>(null);
+  const [backupResult, setBackupResult] = useState<BackupRestoreResult | null>(null);
+  const [backupError, setBackupError] = useState('');
+  const [backupWipeFirst, setBackupWipeFirst] = useState(false);
+  const [backupRestoring, setBackupRestoring] = useState(false);
 
   // -- File handling -------------------------------------------------------
 
   const handleFile = useCallback(
     async (file: File) => {
-      if (!file.name.endsWith('.csv') && file.type !== 'text/csv') {
+      const lowerName = file.name.toLowerCase();
+      const isBackup =
+        lowerName.endsWith('.json') ||
+        lowerName.endsWith('.zip') ||
+        file.type === 'application/json' ||
+        file.type === 'application/zip';
+
+      if (isBackup) {
+        try {
+          const parsed = await parseBackupFile(file);
+          const preview = buildRestorePreview(db, parsed, { wipeLocalDataFirst: backupWipeFirst });
+          setBackupPackage(parsed);
+          setBackupPreview(preview);
+          setBackupResult(null);
+          setBackupError('');
+        } catch (error) {
+          setBackupPackage(null);
+          setBackupPreview(null);
+          setBackupResult(null);
+          setBackupError(error instanceof Error ? error.message : 'Unable to parse backup file.');
+        }
         return;
       }
+
+      if (!lowerName.endsWith('.csv') && file.type !== 'text/csv') {
+        setBackupError('Choose a .json backup, .zip backup, or .csv transaction import file.');
+        return;
+      }
+      setBackupPackage(null);
+      setBackupPreview(null);
+      setBackupResult(null);
+      setBackupError('');
       await uploadFile(file);
     },
-    [uploadFile],
+    [backupWipeFirst, db, uploadFile],
   );
 
   const handleFileChange = useCallback(
@@ -406,6 +449,43 @@ export function DataImportWizardPage() {
     [handleFile],
   );
 
+  const handleBackupWipeChange = useCallback(
+    (checked: boolean) => {
+      setBackupWipeFirst(checked);
+      if (backupPackage) {
+        setBackupPreview(buildRestorePreview(db, backupPackage, { wipeLocalDataFirst: checked }));
+        setBackupResult(null);
+      }
+    },
+    [backupPackage, db],
+  );
+
+  const handleRestoreBackup = useCallback(() => {
+    if (!backupPackage) return;
+    setBackupRestoring(true);
+    setBackupError('');
+    try {
+      const restored = restoreBackupPackage(db, backupPackage, {
+        wipeLocalDataFirst: backupWipeFirst,
+      });
+      setBackupResult(restored);
+      setBackupPreview(restored);
+    } catch (error) {
+      setBackupError(error instanceof Error ? error.message : 'Backup restore failed.');
+    } finally {
+      setBackupRestoring(false);
+    }
+  }, [backupPackage, backupWipeFirst, db]);
+
+  const resetBackupImport = useCallback(() => {
+    setBackupPackage(null);
+    setBackupPreview(null);
+    setBackupResult(null);
+    setBackupError('');
+    setBackupWipeFirst(false);
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  }, []);
+
   // -- Step indicator -------------------------------------------------------
 
   const steps = ['upload', 'mapping', 'preview', 'importing', 'complete'];
@@ -420,7 +500,7 @@ export function DataImportWizardPage() {
   return (
     <div className="import-wizard" aria-labelledby="import-wizard-title">
       <h2 id="import-wizard-title" className="import-wizard__title">
-        Import Transactions
+        Import & Restore Data
       </h2>
 
       {/* Step indicator */}
@@ -441,9 +521,9 @@ export function DataImportWizardPage() {
         </ol>
       </nav>
 
-      {error && (
+      {(error || backupError) && (
         <div className="import-banner--error" role="alert">
-          {error}
+          {error || backupError}
         </div>
       )}
 
@@ -454,8 +534,8 @@ export function DataImportWizardPage() {
             Upload CSV File
           </h2>
           <p className="import-card__description">
-            Drag and drop a CSV file, or click to browse. Supports Mint, YNAB, Chase, American
-            Express, Wells Fargo, Citi, and custom formats.
+            Drag and drop a JSON backup for full restore, a ZIP backup wrapper, or a CSV file for
+            transaction-only import.
           </p>
 
           <div
@@ -479,23 +559,97 @@ export function DataImportWizardPage() {
               <AppIcon name="folder" />
             </span>
             <span className="import-dropzone__text">
-              {dragActive ? 'Drop your file here' : 'Click or drag CSV file here'}
+              {dragActive ? 'Drop your file here' : 'Click or drag backup/CSV file here'}
             </span>
             <span className="import-dropzone__hint">
-              Supported: .csv files from Mint, YNAB, Chase, Amex, Wells Fargo, Citi, or custom
-              exports
+              Supported: .json/.zip Finance backups, plus .csv files from Mint, YNAB, Chase, Amex,
+              Wells Fargo, Citi, or custom exports
             </span>
           </div>
 
           <input
             ref={fileInputRef}
             type="file"
-            accept=".csv,text/csv"
+            accept=".json,.zip,.csv,application/json,application/zip,text/csv"
             onChange={handleFileChange}
             className="import-hidden"
             aria-hidden="true"
             tabIndex={-1}
           />
+
+          {backupPreview && (
+            <div className="import-backup-preview" aria-live="polite">
+              <div className="import-card__header">
+                <h3 className="import-card__title">Dry-run restore preview</h3>
+                <span className="import-format-badge">Backup v{backupPreview.version}</span>
+              </div>
+              <p className="import-card__description">
+                Review what will be imported. Existing records with the same id are skipped unless
+                you choose a clean restore.
+              </p>
+              <label className="import-checkbox-row">
+                <input
+                  type="checkbox"
+                  checked={backupWipeFirst}
+                  onChange={(event) => handleBackupWipeChange(event.target.checked)}
+                />
+                <span>Wipe local data first</span>
+              </label>
+              <div
+                className="import-mapping-table-wrapper"
+                role="region"
+                aria-label="Backup preview"
+              >
+                <table className="import-mapping-table">
+                  <thead>
+                    <tr>
+                      <th scope="col">Entity</th>
+                      <th scope="col">Total</th>
+                      <th scope="col">Will import</th>
+                      <th scope="col">Skipped duplicates</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {backupPreview.entities.map((entity) => (
+                      <tr key={entity.entity}>
+                        <td className="import-mapping-table__col-name">{entity.entity}</td>
+                        <td>{entity.total}</td>
+                        <td>{entity.imported}</td>
+                        <td>{entity.skippedDuplicates}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              {backupResult && (
+                <div className="import-banner--success" role="status">
+                  Restore complete:{' '}
+                  {backupResult.entities.reduce((sum, entity) => sum + entity.imported, 0)} records
+                  imported,{' '}
+                  {backupResult.entities.reduce((sum, entity) => sum + entity.skippedDuplicates, 0)}{' '}
+                  duplicates skipped.
+                </div>
+              )}
+              <div className="import-actions">
+                <button
+                  className="import-button import-button--secondary"
+                  onClick={resetBackupImport}
+                >
+                  Choose another file
+                </button>
+                <button
+                  className="import-button import-button--primary"
+                  onClick={handleRestoreBackup}
+                  disabled={
+                    backupRestoring ||
+                    backupPreview.entities.every((entity) => entity.imported === 0)
+                  }
+                >
+                  {backupRestoring ? 'Restoring…' : 'Restore backup'}
+                </button>
+              </div>
+            </div>
+          )}
         </section>
       )}
 

--- a/apps/web/src/storage/wipeLocalData.ts
+++ b/apps/web/src/storage/wipeLocalData.ts
@@ -31,6 +31,13 @@ interface StorageWithDirectory {
   getDirectory?: () => Promise<OpfsDirectoryHandle>;
 }
 
+declare global {
+  interface Window {
+    __PLAYWRIGHT_E2E__?: boolean;
+    __financeWipeLocalDataForE2E__?: () => Promise<void>;
+  }
+}
+
 /**
  * Best-effort browser data wipe used after server-confirmed account deletion.
  */
@@ -145,4 +152,8 @@ async function deleteAllCaches(): Promise<void> {
   } catch {
     // Best-effort wipe: cache APIs can be blocked by browser policy.
   }
+}
+
+if (typeof window !== 'undefined' && window.__PLAYWRIGHT_E2E__ === true) {
+  window.__financeWipeLocalDataForE2E__ = wipeLocalData;
 }

--- a/apps/web/src/types/backup.ts
+++ b/apps/web/src/types/backup.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/** Canonical browser backup package schema. Mirrors packages/core ExportData.kt. */
+export const BACKUP_PACKAGE_VERSION = 1 as const;
+
+export type BackupPackageVersion = typeof BACKUP_PACKAGE_VERSION;
+export type BackupEntityRecord = Readonly<Record<string, unknown>> & { readonly id?: string };
+export type BackupKeyValueRecord = Readonly<{
+  key: string;
+  value: string | null;
+}>;
+
+export interface BackupPackageMetadata {
+  readonly generatedAt: string;
+  readonly appVersion: string | null;
+  readonly source: 'web';
+}
+
+export interface BackupPackage {
+  readonly version: BackupPackageVersion;
+  readonly metadata: BackupPackageMetadata;
+
+  /** Supporting ownership tables required for a clean restore with FK checks on. */
+  readonly users: readonly BackupEntityRecord[];
+  readonly households: readonly BackupEntityRecord[];
+  readonly householdMembers: readonly BackupEntityRecord[];
+
+  readonly accounts: readonly BackupEntityRecord[];
+  readonly transactions: readonly BackupEntityRecord[];
+  readonly categories: readonly BackupEntityRecord[];
+  readonly budgets: readonly BackupEntityRecord[];
+  readonly goals: readonly BackupEntityRecord[];
+  readonly recurringTemplates: readonly BackupEntityRecord[];
+  readonly preferences: readonly BackupKeyValueRecord[];
+  readonly settings: readonly BackupKeyValueRecord[];
+  readonly consentRecords: readonly BackupKeyValueRecord[];
+}
+
+export type BackupEntityKey = Exclude<keyof BackupPackage, 'version' | 'metadata'>;
+
+export interface BackupEntityPreview {
+  readonly entity: BackupEntityKey;
+  readonly total: number;
+  readonly imported: number;
+  readonly skippedDuplicates: number;
+}
+
+export interface BackupRestorePreview {
+  readonly version: BackupPackageVersion;
+  readonly wipeLocalDataFirst: boolean;
+  readonly entities: readonly BackupEntityPreview[];
+}
+
+export interface BackupRestoreResult extends BackupRestorePreview {
+  readonly restoredAt: string;
+}

--- a/docs/ops/backup-disaster-recovery.md
+++ b/docs/ops/backup-disaster-recovery.md
@@ -27,6 +27,41 @@
 
 ## 1. Backup Scope
 
+### Web user backup package (issue #2029)
+
+The web app exports a canonical plain JSON backup package for user-initiated backup/restore round-trips. Native iOS/Android/Windows export remains TODO and is out of scope for the current web-focused implementation.
+
+```json
+{
+  "version": 1,
+  "metadata": {
+    "generatedAt": "2026-05-26T12:00:00.000Z",
+    "appVersion": "0.1.0",
+    "source": "web"
+  },
+  "users": [],
+  "households": [],
+  "householdMembers": [],
+  "accounts": [],
+  "transactions": [],
+  "categories": [],
+  "budgets": [],
+  "goals": [],
+  "recurringTemplates": [],
+  "preferences": [],
+  "settings": [],
+  "consentRecords": []
+}
+```
+
+Rules:
+
+- `version` is required; restores reject missing or unsupported versions.
+- SQL-backed records are exported with stable primary keys so restore can dedupe by `id`.
+- `preferences`, `settings`, `consentRecords`, and local recurring templates are key/value records and dedupe by `key`.
+- `users`, `households`, and `householdMembers` are included to keep clean restores valid with local foreign-key checks.
+- Duplicate local records are skipped and reported unless the user selects **Wipe local data first**.
+
 ### Included
 
 | Data                                               | Source                          | Method                        |
@@ -186,6 +221,18 @@ Apply these settings to the backup bucket:
 > **⚠️ WARNING:** Restoring a backup replaces the current database contents. This is a destructive operation that requires human authorization.
 
 ### Step-by-Step Restore
+
+#### From a Web JSON Backup
+
+1. Open **Settings → Privacy & Data** and select **Download all data (JSON)**.
+2. Store the downloaded `finance-backup-YYYY-MM-DD.json` somewhere safe.
+3. To restore, open **Import → Import Wizard** and choose the JSON file.
+4. Verify the dry-run preview counts for each entity and review duplicate skips.
+5. Optional: select **Wipe local data first** for a clean restore.
+6. Select **Restore backup** and confirm the completion totals.
+7. Re-open Accounts, Transactions, Categories, Budgets, and Goals to spot-check restored counts.
+
+ZIP restore is supported only when the ZIP contains an uncompressed canonical backup JSON member. The default web export uses plain JSON for simplicity.
 
 #### From a Local Backup
 

--- a/packages/core/src/commonMain/kotlin/com/finance/core/export/ExportData.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/export/ExportData.kt
@@ -3,6 +3,8 @@
 package com.finance.core.export
 
 import com.finance.models.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
 
 /**
  * Container for all financial data to be exported.
@@ -26,6 +28,7 @@ import com.finance.models.*
  * )
  * ```
  */
+@Serializable
 data class ExportData(
     /** Active (non-deleted) accounts to include in the export. */
     val accounts: List<Account>,
@@ -37,6 +40,14 @@ data class ExportData(
     val budgets: List<Budget>,
     /** Active (non-deleted) goals to include in the export. */
     val goals: List<Goal>,
+    /** Recurring transaction templates/rules, represented as canonical JSON records. */
+    val recurringTemplates: List<ExportJsonRecord> = emptyList(),
+    /** User preferences captured outside SQLDelight-backed entities. */
+    val preferences: List<ExportKeyValueRecord> = emptyList(),
+    /** Application settings captured outside SQLDelight-backed entities. */
+    val settings: List<ExportKeyValueRecord> = emptyList(),
+    /** Consent/audit records required for privacy compliance restores. */
+    val consentRecords: List<ExportKeyValueRecord> = emptyList(),
     /** Include optional mood tags in transaction export output. Defaults to private. */
     val includeMoodTags: Boolean = false,
 ) {
@@ -46,10 +57,64 @@ data class ExportData(
             transactions.isEmpty() &&
             categories.isEmpty() &&
             budgets.isEmpty() &&
-            goals.isEmpty()
+            goals.isEmpty() &&
+            recurringTemplates.isEmpty() &&
+            preferences.isEmpty() &&
+            settings.isEmpty() &&
+            consentRecords.isEmpty()
 
     /** Total number of records across all entity types. */
     val totalRecords: Int
         get() = accounts.size + transactions.size + categories.size +
-            budgets.size + goals.size
+            budgets.size + goals.size + recurringTemplates.size +
+            preferences.size + settings.size + consentRecords.size
 }
+
+/** Current canonical backup package version for full export/restore artifacts. */
+const val BACKUP_PACKAGE_VERSION: Int = 1
+
+/** Flexible JSON object record used for web-only/restoration-support entities. */
+@Serializable
+data class ExportJsonRecord(
+    val id: String? = null,
+    val fields: Map<String, JsonElement> = emptyMap(),
+)
+
+/** Local key/value record used for preferences, settings, recurring rules, and consent records. */
+@Serializable
+data class ExportKeyValueRecord(
+    val key: String,
+    val value: String? = null,
+)
+
+/** Metadata attached to a canonical full-backup package. */
+@Serializable
+data class BackupPackageMetadata(
+    val generatedAt: String,
+    val appVersion: String? = null,
+    val source: String = "web",
+)
+
+/**
+ * Canonical JSON backup package schema for full web backup/restore round-trips.
+ *
+ * The root [version] field is mandatory and must be validated before restore.
+ * Extra ownership tables are included so clean restores can satisfy local FK checks.
+ */
+@Serializable
+data class BackupPackage(
+    val version: Int = BACKUP_PACKAGE_VERSION,
+    val metadata: BackupPackageMetadata,
+    val users: List<ExportJsonRecord> = emptyList(),
+    val households: List<ExportJsonRecord> = emptyList(),
+    val householdMembers: List<ExportJsonRecord> = emptyList(),
+    val accounts: List<ExportJsonRecord> = emptyList(),
+    val transactions: List<ExportJsonRecord> = emptyList(),
+    val categories: List<ExportJsonRecord> = emptyList(),
+    val budgets: List<ExportJsonRecord> = emptyList(),
+    val goals: List<ExportJsonRecord> = emptyList(),
+    val recurringTemplates: List<ExportJsonRecord> = emptyList(),
+    val preferences: List<ExportKeyValueRecord> = emptyList(),
+    val settings: List<ExportKeyValueRecord> = emptyList(),
+    val consentRecords: List<ExportKeyValueRecord> = emptyList(),
+)


### PR DESCRIPTION
Closes #2029

## Summary
- Add canonical versioned JSON backup package schema for core and web.
- Export all web backup entities and restore with dry-run preview, duplicate skipping, and clean-restore option.
- Add backup serializer/restore unit tests, Playwright round-trip coverage, and restore docs.

## Validation
- npm run test -w apps/web -- src/lib/export/backup-package.test.ts
- npm run type-check -w apps/web
- npm run test:e2e -w apps/web -- e2e/backup-restore.spec.ts --project=chromium
- npm run test:kmp
- npx prettier --write <changed web/doc files>
- npx eslint --fix <changed web TS/TSX files>