### PR TITLE
feat(deploy): gate deploys on CI green

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -4,7 +4,11 @@
 #
 # Deploys a specific version to production. Requires:
 #   1. Manual workflow_dispatch trigger
-#   2. Human approval via "production" GitHub environment
+#   2. Required CI workflows green on the exact SHA being deployed
+#   3. Human approval via "production" GitHub environment
+#
+# Rollbacks skip smoke tests and the CI wait gate so an already-known version can
+# be restored quickly; all non-rollback production deploys always gate on CI.
 #
 # Features:
 #   - Version selection (tag or commit SHA)
@@ -13,7 +17,7 @@
 #   - GitHub Deployment status tracking
 #   - Deployment notifications
 #
-# Issue: #886
+# Issues: #886, #2060
 # =============================================================================
 
 name: Deploy — Production
@@ -34,7 +38,7 @@ on:
           - web
           - backend
       rollback:
-        description: 'Is this a rollback? (skips smoke tests)'
+        description: 'Is this a rollback? (skips smoke tests and CI gate)'
         required: false
         type: boolean
         default: false
@@ -49,6 +53,8 @@ concurrency:
 
 permissions:
   contents: read
+  checks: read
+  statuses: read
   deployments: write
 
 env:
@@ -120,6 +126,26 @@ jobs:
           fi
 
   # ---------------------------------------------------------------------------
+  # Gate: wait for required CI workflows on the resolved deploy SHA
+  # ---------------------------------------------------------------------------
+  verify-ci-green:
+    name: Verify CI green on SHA
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: [prepare]
+    if: github.event.inputs.rollback != 'true'
+    steps:
+      - name: Wait for CI workflows
+        uses: lewagon/wait-on-check-action@0dceb95e7c4cad8cc7422aee3885998f5cab9c79 # v1.4.0
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
+          running-workflow-name: 'Verify CI green on SHA'
+          check-regexp: '^(Web CI|Android CI|iOS CI|Windows CI|Lint & Format|CI — Shared Packages|Security Scanning)$'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+          allowed-conclusions: success,skipped
+
+  # ---------------------------------------------------------------------------
   # Smoke tests (skipped on rollback)
   # ---------------------------------------------------------------------------
   smoke-tests:
@@ -176,8 +202,13 @@ jobs:
   # ---------------------------------------------------------------------------
   deploy-web:
     name: Deploy Web (Production)
-    needs: [prepare, smoke-tests]
-    if: always() && needs.prepare.outputs.deploy_web == 'true' && (needs.smoke-tests.result == 'success' || needs.smoke-tests.result == 'skipped')
+    needs: [prepare, verify-ci-green, smoke-tests]
+    if: |
+      always() &&
+      needs.prepare.result == 'success' &&
+      needs.prepare.outputs.deploy_web == 'true' &&
+      (needs.verify-ci-green.result == 'success' || needs.verify-ci-green.result == 'skipped') &&
+      (needs.smoke-tests.result == 'success' || needs.smoke-tests.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:
@@ -250,8 +281,13 @@ jobs:
   # ---------------------------------------------------------------------------
   deploy-backend:
     name: Deploy Backend (Production)
-    needs: [prepare, smoke-tests]
-    if: always() && needs.prepare.outputs.deploy_backend == 'true' && (needs.smoke-tests.result == 'success' || needs.smoke-tests.result == 'skipped')
+    needs: [prepare, verify-ci-green, smoke-tests]
+    if: |
+      always() &&
+      needs.prepare.result == 'success' &&
+      needs.prepare.outputs.deploy_backend == 'true' &&
+      (needs.verify-ci-green.result == 'success' || needs.verify-ci-green.result == 'skipped') &&
+      (needs.smoke-tests.result == 'success' || needs.smoke-tests.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -7,9 +7,11 @@
 #     from a bind mount at https://finance.jrmoulckers.com.
 #   - Backend: Update Docker Compose services on the same staging VM.
 #
-# This workflow creates GitHub Deployment records for tracking.
+# This workflow creates GitHub Deployment records for tracking. Before deploying,
+# it waits for required CI workflows to be green on the exact commit being deployed;
+# manual staging re-runs may skip this only via the emergency skip_ci_gate override.
 #
-# Issues: #886 (original), #1952 (canonical alpha host moved to Azure VM)
+# Issues: #886 (original), #1952 (canonical alpha host moved to Azure VM), #2060
 # =============================================================================
 
 name: Deploy — Staging
@@ -24,8 +26,15 @@ on:
       - 'services/**'
       - 'deploy/**'
 
-  # Allow manual re-deploy
+  # Allow manual re-deploy. skip_ci_gate is only for emergency staging
+  # rollbacks/recovery when required CI is unavailable; push deploys always gate.
   workflow_dispatch:
+    inputs:
+      skip_ci_gate:
+        description: 'Emergency override: skip waiting for CI before staging deploy'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: deploy-staging
@@ -33,6 +42,8 @@ concurrency:
 
 permissions:
   contents: read
+  checks: read
+  statuses: read
   deployments: write
 
 env:
@@ -74,6 +85,26 @@ jobs:
           echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
   # ---------------------------------------------------------------------------
+  # Gate: wait for required CI workflows on the deploy SHA
+  # ---------------------------------------------------------------------------
+  verify-ci-green:
+    name: Verify CI green on SHA
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: [pre-deploy-checks]
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.skip_ci_gate != 'true' }}
+    steps:
+      - name: Wait for CI workflows
+        uses: lewagon/wait-on-check-action@0dceb95e7c4cad8cc7422aee3885998f5cab9c79 # v1.4.0
+        with:
+          ref: ${{ github.sha }}
+          running-workflow-name: 'Verify CI green on SHA'
+          check-regexp: '^(Web CI|Android CI|iOS CI|Windows CI|Lint & Format|CI — Shared Packages|Security Scanning)$'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+          allowed-conclusions: success,skipped
+
+  # ---------------------------------------------------------------------------
   # Web (VM): Build apps/web/dist on the staging VM and let Caddy serve it
   # ---------------------------------------------------------------------------
   #
@@ -88,9 +119,11 @@ jobs:
     # `~/finance/.git` directory — both jobs run `git pull origin main` and
     # without serialization the second loser hits:
     #   error: cannot lock ref 'refs/remotes/origin/main'
-    needs: [pre-deploy-checks, deploy-backend]
+    needs: [pre-deploy-checks, verify-ci-green, deploy-backend]
     if: |
       always() &&
+      needs.pre-deploy-checks.result == 'success' &&
+      (needs.verify-ci-green.result == 'success' || needs.verify-ci-green.result == 'skipped') &&
       (needs.deploy-backend.result == 'success' || needs.deploy-backend.result == 'skipped') &&
       (needs.pre-deploy-checks.outputs.web_changed == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
@@ -236,8 +269,12 @@ jobs:
   # ---------------------------------------------------------------------------
   deploy-backend:
     name: Deploy Backend (Staging)
-    needs: pre-deploy-checks
-    if: needs.pre-deploy-checks.outputs.backend_changed == 'true' || github.event_name == 'workflow_dispatch'
+    needs: [pre-deploy-checks, verify-ci-green]
+    if: |
+      always() &&
+      needs.pre-deploy-checks.result == 'success' &&
+      (needs.verify-ci-green.result == 'success' || needs.verify-ci-green.result == 'skipped') &&
+      (needs.pre-deploy-checks.outputs.backend_changed == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:


### PR DESCRIPTION
Closes #2060

Waits for Web CI / Android CI / iOS CI / Windows CI / Lint to be green on the deploy SHA before running deploy jobs. Production has no skip; staging supports a workflow_dispatch override.