### PR TITLE
feat(security): SLSA build provenance for release artifacts

### DIFF
--- a/.github/workflows/canary-deploy.yml
+++ b/.github/workflows/canary-deploy.yml
@@ -126,6 +126,11 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      deployments: write
+      id-token: write
+      attestations: write
     environment:
       name: canary
     outputs:
@@ -160,6 +165,12 @@ jobs:
         run: |
           npm run build -w packages/design-tokens
           npm run build -w apps/web
+
+      - name: Attest build provenance
+        if: needs.prepare.outputs.deploy_web == 'true'
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: apps/web/dist/**
 
       - name: Deploy canary
         id: deploy
@@ -376,6 +387,11 @@ jobs:
     if: always() && (needs.monitor-canary.outputs.recommendation == 'promote' || github.event.inputs.skip_monitoring == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      deployments: write
+      id-token: write
+      attestations: write
     environment:
       name: production
 
@@ -396,21 +412,35 @@ jobs:
         if: needs.prepare.outputs.deploy_web == 'true'
         run: npm ci
 
-      - name: Promote web to production
+      - name: Build web for production promotion
+        id: production-web-build
         if: needs.prepare.outputs.deploy_web == 'true'
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
         run: |
           if [ -z "$VERCEL_TOKEN" ]; then
             echo "::warning::VERCEL_TOKEN not configured — skipping web promotion"
+            echo "built=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           npm run build -w packages/design-tokens
           npm run build -w apps/web
+          echo "built=true" >> "$GITHUB_OUTPUT"
 
+      - name: Attest build provenance
+        if: steps.production-web-build.outputs.built == 'true'
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: apps/web/dist/**
+
+      - name: Promote web to production
+        if: steps.production-web-build.outputs.built == 'true'
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
           npm i -g vercel@latest
           set -o pipefail
           DEPLOY_LOG=$(mktemp)

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -60,6 +60,11 @@ jobs:
     needs: approve
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      contents: read
+      actions: read
+      id-token: write
+      attestations: write
     outputs:
       version-name: ${{ steps.version.outputs.name }}
       version-code: ${{ steps.version.outputs.code }}
@@ -150,6 +155,14 @@ jobs:
           if [ -f app-release.keystore ]; then
             shred -u app-release.keystore 2>/dev/null || rm -f app-release.keystore
           fi
+
+      - name: Attest build provenance
+        if: inputs.dry-run != true && inputs.build-type != 'debug'
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: |
+            apps/android/build/outputs/bundle/release/*.aab
+            apps/android/build/outputs/apk/**/*.apk
 
       - name: Upload AAB artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -120,6 +120,10 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -218,6 +222,12 @@ jobs:
           sha256sum * > checksums-android.sha256
           cat checksums-android.sha256
 
+      - name: Attest build provenance
+        if: needs.prepare.outputs.dry_run != 'true'
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: release-artifacts/*
+
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -238,6 +248,10 @@ jobs:
     needs: prepare
     runs-on: macos-15
     timeout-minutes: 45
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     env:
       SPM_CACHE_DIR: apps/ios/.spm-packages
       DERIVED_DATA_DIR: apps/ios/.derivedData
@@ -340,6 +354,12 @@ jobs:
           shasum -a 256 * > checksums-ios.sha256
           cat checksums-ios.sha256
 
+      - name: Attest build provenance
+        if: needs.prepare.outputs.dry_run != 'true'
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: release-artifacts/*
+
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -356,6 +376,10 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
@@ -418,6 +442,12 @@ jobs:
           sha256sum * > checksums-web.sha256
           cat checksums-web.sha256
 
+      - name: Attest build provenance
+        if: needs.prepare.outputs.dry_run != 'true'
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: release-artifacts/*
+
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -434,6 +464,10 @@ jobs:
     needs: prepare
     runs-on: windows-latest
     timeout-minutes: 45
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -500,6 +534,12 @@ jobs:
           sha256sum * > checksums-windows.sha256
           cat checksums-windows.sha256
 
+      - name: Attest build provenance
+        if: needs.prepare.outputs.dry_run != 'true'
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: release-artifacts/*
+
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -518,6 +558,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: production # Requires manual approval in GitHub environment settings
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - name: Download all release artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -543,6 +587,11 @@ jobs:
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           cat CHECKSUMS.sha256 >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: all-artifacts/*
 
       - name: Upload assets to GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0

--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -52,6 +52,11 @@ jobs:
     needs: approve
     runs-on: macos-15
     timeout-minutes: 45
+    permissions:
+      contents: read
+      actions: read
+      id-token: write
+      attestations: write
     outputs:
       version: ${{ steps.version.outputs.version }}
       build-number: ${{ steps.version.outputs.build-number }}
@@ -199,6 +204,12 @@ jobs:
             -exportOptionsPlist ExportOptions.plist \
             -exportPath .build/Export \
             2>&1 | tail -10
+
+      - name: Attest build provenance
+        if: inputs.dry-run != true
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: apps/ios/.build/Export/*.ipa
 
       - name: Upload to App Store Connect (TestFlight)
         if: inputs.dry-run != true

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -49,6 +49,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment: ${{ inputs.environment || 'staging' }}
+    permissions:
+      contents: read
+      actions: read
+      id-token: write
+      attestations: write
     outputs:
       version: ${{ steps.version.outputs.version }}
       deploy-url: ${{ steps.deploy.outputs.url }}
@@ -120,6 +125,14 @@ jobs:
           budgetPath: apps/web/budget.json
           uploadArtifacts: true
           runs: 3
+
+      - name: Attest build provenance
+        if: inputs.dry-run != true
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: |
+            apps/web/dist/**
+            packages/design-tokens/build/**
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -55,6 +55,11 @@ jobs:
     needs: approve
     runs-on: windows-latest
     timeout-minutes: 45
+    permissions:
+      contents: read
+      actions: read
+      id-token: write
+      attestations: write
     outputs:
       version: ${{ steps.version.outputs.version }}
 
@@ -154,6 +159,14 @@ jobs:
         if: env.HAS_SIGNING_SECRETS != 'true'
         run: |
           echo "::warning::WINDOWS_SIGNING_CERT_BASE64 or WINDOWS_CERT_PASSWORD secret is empty — release MSI published unsigned."
+
+      - name: Attest build provenance
+        if: inputs.dry-run != true
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: |
+            apps/windows/build/compose/binaries/main/msi/*.msi
+            apps/windows/build/compose/binaries/main/app/**
 
       - name: Upload MSI artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -1,0 +1,23 @@
+# Supply-chain provenance
+
+Production releases publish signed in-toto SLSA build provenance for shipped artifacts using `actions/attest-build-provenance@v3`. These attestations provide SLSA Level 2+ supply-chain integrity signals by binding each artifact digest to the GitHub Actions workflow, commit, and repository that produced it.
+
+Downstream consumers can verify a downloaded artifact with GitHub CLI:
+
+```sh
+gh attestation verify <artifact> --repo jrmoulckers/finance
+```
+
+Attestations are visible at <https://github.com/jrmoulckers/finance/attestations>.
+
+## Attested artifacts
+
+- Web: production web bundles and design-token build output from `release-web.yml`; packaged web `.tar.gz`, `.zip`, and checksum files from `release-artifacts.yml`; canary and promoted web deployment build output from `canary-deploy.yml`.
+- Android: release APK and AAB artifacts, plus packaged APK/AAB/checksum files from `release-artifacts.yml`.
+- iOS: exported IPA, plus packaged IPA or xcarchive zip/checksum files from `release-artifacts.yml`.
+- Windows: signed MSI installer and standalone distributable output, plus packaged MSI/EXE/checksum files from `release-artifacts.yml`.
+- Release manifests: combined `CHECKSUMS.sha256` and all final GitHub Release assets assembled by `release-artifacts.yml`.
+
+## Policy
+
+Any release marked `production` must have a green provenance attestation for every shipped artifact. Release CI must fail if provenance generation fails; dry-run or non-publishing runs may skip attestation because no production artifact is shipped.


### PR DESCRIPTION
Closes #2058

Adds actions/attest-build-provenance@v3 to all release workflows. Downstream consumers can verify with gh attestation verify.