### PR TITLE
feat(web): swipe actions for transaction triage

### DIFF
--- a/apps/web/src/components/common/SwipeableRow.test.tsx
+++ b/apps/web/src/components/common/SwipeableRow.test.tsx
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SwipeableRow, type SwipeAction } from './SwipeableRow';
+
+function setRowWidth(element: HTMLElement, width = 300) {
+  Object.defineProperty(element, 'getBoundingClientRect', {
+    configurable: true,
+    value: () => ({
+      width,
+      height: 64,
+      top: 20,
+      left: 10,
+      right: 10 + width,
+      bottom: 84,
+      x: 10,
+      y: 20,
+      toJSON: () => ({}),
+    }),
+  });
+}
+
+function renderRow(options: { leftActions?: SwipeAction[]; rightActions?: SwipeAction[] } = {}) {
+  const leftHandler = vi.fn();
+  const rightHandler = vi.fn();
+
+  const leftActions = options.leftActions ?? [
+    {
+      id: 'delete',
+      label: 'Delete',
+      onAction: leftHandler,
+      variant: 'danger' as const,
+    },
+  ];
+
+  const rightActions = options.rightActions ?? [
+    {
+      id: 'categorize',
+      label: 'Categorize',
+      onAction: rightHandler,
+      variant: 'success' as const,
+      quick: true,
+    },
+  ];
+
+  const view = render(
+    <SwipeableRow
+      data-testid="swipeable-row"
+      aria-label="Transaction row actions"
+      leftActions={leftActions}
+      rightActions={rightActions}
+    >
+      <div>Weekly groceries</div>
+    </SwipeableRow>,
+  );
+
+  const row = screen.getByTestId('swipeable-row');
+  setRowWidth(row);
+
+  return {
+    ...view,
+    row,
+    leftHandler,
+    rightHandler,
+    content: row.querySelector('.swipeable-row__content') as HTMLDivElement,
+  };
+}
+
+describe('SwipeableRow', () => {
+  const originalPointerEvent = window.PointerEvent;
+
+  beforeEach(() => {
+    HTMLElement.prototype.setPointerCapture = vi.fn();
+    HTMLElement.prototype.releasePointerCapture = vi.fn();
+  });
+
+  afterEach(() => {
+    window.PointerEvent = originalPointerEvent;
+    vi.restoreAllMocks();
+  });
+
+  it('springs back when released before the threshold', () => {
+    const { row, content, rightHandler } = renderRow();
+
+    fireEvent.pointerDown(content, { pointerId: 1, clientX: 40, clientY: 20, button: 0 });
+    fireEvent.pointerMove(content, { pointerId: 1, clientX: 100, clientY: 22 });
+    fireEvent.pointerUp(content, { pointerId: 1, clientX: 100, clientY: 22 });
+
+    expect(rightHandler).not.toHaveBeenCalled();
+    expect(content.style.transform).toBe('translateX(0px)');
+    expect(row.className).not.toContain('swipeable-row--open-right');
+  });
+
+  it('reveals left-side actions after a large left swipe', () => {
+    const { row, content, leftHandler } = renderRow();
+
+    fireEvent.pointerDown(content, { pointerId: 1, clientX: 240, clientY: 20, button: 0 });
+    fireEvent.pointerMove(content, { pointerId: 1, clientX: 120, clientY: 20 });
+    fireEvent.pointerUp(content, { pointerId: 1, clientX: 120, clientY: 20 });
+
+    expect(row.className).toContain('swipeable-row--open-left');
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(leftHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('triggers the quick right action after crossing the threshold', () => {
+    const { content, rightHandler } = renderRow();
+
+    fireEvent.pointerDown(content, { pointerId: 1, clientX: 48, clientY: 18, button: 0 });
+    fireEvent.pointerMove(content, { pointerId: 1, clientX: 170, clientY: 18 });
+    fireEvent.pointerUp(content, { pointerId: 1, clientX: 170, clientY: 18 });
+
+    expect(rightHandler).toHaveBeenCalledTimes(1);
+    expect(content.style.transform).toBe('translateX(0px)');
+  });
+
+  it('opens the accessible context menu on right click', () => {
+    const { row, leftHandler } = renderRow();
+
+    fireEvent.contextMenu(row, { clientX: 64, clientY: 44 });
+
+    expect(screen.getByRole('menu', { name: 'Row actions' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
+    expect(leftHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('supports the touch-event fallback when pointer events are unavailable', () => {
+    // @ts-expect-error test override
+    window.PointerEvent = undefined;
+    const { rightHandler, content } = renderRow();
+
+    fireEvent.touchStart(content, {
+      touches: [{ clientX: 32, clientY: 16 }],
+    });
+    fireEvent.touchMove(content, {
+      touches: [{ clientX: 160, clientY: 16 }],
+    });
+    fireEvent.touchEnd(content);
+
+    expect(rightHandler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/common/SwipeableRow.tsx
+++ b/apps/web/src/components/common/SwipeableRow.tsx
@@ -1,0 +1,605 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import React, {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type HTMLAttributes,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+  type TouchEvent as ReactTouchEvent,
+} from 'react';
+
+import './swipeable-row.css';
+
+export type SwipeActionVariant = 'default' | 'success' | 'warning' | 'danger';
+
+export interface SwipeAction {
+  id: string;
+  label: string;
+  icon?: ReactNode;
+  onAction: () => void | Promise<void>;
+  variant?: SwipeActionVariant;
+  quick?: boolean;
+  disabled?: boolean;
+}
+
+export interface SwipeableRowProps extends Omit<HTMLAttributes<HTMLDivElement>, 'children'> {
+  children: ReactNode;
+  leftActions?: readonly SwipeAction[];
+  rightActions?: readonly SwipeAction[];
+  contentClassName?: string;
+  activationThreshold?: number;
+  actionWidth?: number;
+  longPressDuration?: number;
+  disabled?: boolean;
+}
+
+type OpenSide = 'left' | 'right' | null;
+
+type GestureSource = 'pointer' | 'touch';
+
+interface GestureState {
+  source: GestureSource;
+  startX: number;
+  startY: number;
+  baseOffset: number;
+  rowWidth: number;
+  dragging: boolean;
+}
+
+interface MenuState {
+  x: number;
+  y: number;
+}
+
+const DRAG_START_THRESHOLD = 8;
+const DEFAULT_ACTION_WIDTH = 84;
+
+function supportsPointerEvents(): boolean {
+  return typeof window !== 'undefined' && typeof window.PointerEvent === 'function';
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function isPrimaryPointerButton(event: ReactPointerEvent<HTMLDivElement>): boolean {
+  return event.pointerType !== 'mouse' || event.button === 0;
+}
+
+function joinClassNames(...values: Array<string | false | null | undefined>): string {
+  return values.filter(Boolean).join(' ');
+}
+
+export function SwipeableRow({
+  children,
+  leftActions = [],
+  rightActions = [],
+  className,
+  contentClassName,
+  activationThreshold = 0.3,
+  actionWidth = DEFAULT_ACTION_WIDTH,
+  longPressDuration = 550,
+  disabled = false,
+  role,
+  onContextMenu,
+  onKeyDown,
+  ...rest
+}: SwipeableRowProps) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const dragRef = useRef<GestureState | null>(null);
+  const offsetRef = useRef(0);
+  const suppressClickRef = useRef(false);
+  const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hintId = useId();
+
+  const [offsetX, setOffsetX] = useState(0);
+  const [openSide, setOpenSide] = useState<OpenSide>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [menuState, setMenuState] = useState<MenuState | null>(null);
+
+  const setOffset = useCallback((value: number) => {
+    offsetRef.current = value;
+    setOffsetX(value);
+  }, []);
+
+  const enabledLeftActions = useMemo(
+    () => leftActions.filter((action) => !action.disabled),
+    [leftActions],
+  );
+  const enabledRightActions = useMemo(
+    () => rightActions.filter((action) => !action.disabled),
+    [rightActions],
+  );
+
+  const contextMenuActions = useMemo(() => {
+    const deduped = new Map<string, SwipeAction>();
+
+    [...enabledRightActions, ...enabledLeftActions].forEach((action) => {
+      if (!deduped.has(action.id)) {
+        deduped.set(action.id, action);
+      }
+    });
+
+    return Array.from(deduped.values());
+  }, [enabledLeftActions, enabledRightActions]);
+
+  const leftRevealWidth = enabledLeftActions.length * actionWidth;
+  const rightRevealWidth = enabledRightActions.length * actionWidth;
+
+  const clearLongPressTimer = useCallback(() => {
+    if (longPressTimerRef.current !== null) {
+      clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+  }, []);
+
+  const closeRow = useCallback(() => {
+    setOpenSide(null);
+    setOffset(0);
+    setIsDragging(false);
+  }, [setOffset]);
+
+  const openContextMenu = useCallback(
+    (x: number, y: number) => {
+      if (contextMenuActions.length === 0 || disabled) {
+        return;
+      }
+
+      setMenuState({ x, y });
+      closeRow();
+    },
+    [closeRow, contextMenuActions.length, disabled],
+  );
+
+  const runAction = useCallback(
+    (action: SwipeAction) => {
+      clearLongPressTimer();
+      suppressClickRef.current = true;
+      setMenuState(null);
+      closeRow();
+      void Promise.resolve(action.onAction());
+    },
+    [clearLongPressTimer, closeRow],
+  );
+
+  useEffect(() => {
+    if (menuState === null) {
+      return undefined;
+    }
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setMenuState(null);
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setMenuState(null);
+      }
+    };
+
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [menuState]);
+
+  useEffect(() => {
+    return () => {
+      clearLongPressTimer();
+    };
+  }, [clearLongPressTimer]);
+
+  const settleGesture = useCallback(
+    (rowWidth: number) => {
+      const finalOffset = offsetRef.current;
+      const absOffset = Math.abs(finalOffset);
+      const thresholdPx = rowWidth * activationThreshold;
+
+      if (finalOffset < 0 && enabledLeftActions.length > 0 && absOffset >= thresholdPx) {
+        setOpenSide('left');
+        setOffset(-leftRevealWidth);
+        return;
+      }
+
+      if (finalOffset > 0 && enabledRightActions.length > 0 && absOffset >= thresholdPx) {
+        const quickAction =
+          enabledRightActions.find((action) => action.quick) ?? enabledRightActions[0];
+
+        if (quickAction.quick ?? true) {
+          runAction(quickAction);
+          return;
+        }
+
+        setOpenSide('right');
+        setOffset(rightRevealWidth);
+        return;
+      }
+
+      closeRow();
+    },
+    [
+      activationThreshold,
+      closeRow,
+      enabledLeftActions,
+      enabledRightActions,
+      leftRevealWidth,
+      rightRevealWidth,
+      runAction,
+      setOffset,
+    ],
+  );
+
+  const beginGesture = useCallback(
+    (clientX: number, clientY: number, source: GestureSource) => {
+      if (disabled) {
+        return;
+      }
+
+      clearLongPressTimer();
+      setMenuState(null);
+
+      const rowWidth = rootRef.current?.getBoundingClientRect().width ?? 0;
+      const baseOffset =
+        openSide === 'left' ? -leftRevealWidth : openSide === 'right' ? rightRevealWidth : 0;
+
+      dragRef.current = {
+        source,
+        startX: clientX,
+        startY: clientY,
+        baseOffset,
+        rowWidth,
+        dragging: false,
+      };
+
+      if (contextMenuActions.length > 0) {
+        longPressTimerRef.current = setTimeout(() => {
+          const rect = rootRef.current?.getBoundingClientRect();
+          const fallbackX = rect ? rect.left + rect.width / 2 : clientX;
+          const fallbackY = rect ? rect.top + rect.height / 2 : clientY;
+          dragRef.current = null;
+          openContextMenu(fallbackX, fallbackY);
+        }, longPressDuration);
+      }
+    },
+    [
+      clearLongPressTimer,
+      contextMenuActions.length,
+      disabled,
+      leftRevealWidth,
+      longPressDuration,
+      openContextMenu,
+      openSide,
+      rightRevealWidth,
+    ],
+  );
+
+  const updateGesture = useCallback(
+    (clientX: number, clientY: number) => {
+      const gesture = dragRef.current;
+      if (!gesture) {
+        return;
+      }
+
+      const deltaX = clientX - gesture.startX;
+      const deltaY = clientY - gesture.startY;
+
+      if (
+        !gesture.dragging &&
+        Math.abs(deltaY) > Math.abs(deltaX) &&
+        Math.abs(deltaY) > DRAG_START_THRESHOLD
+      ) {
+        clearLongPressTimer();
+        dragRef.current = null;
+        return;
+      }
+
+      if (!gesture.dragging && Math.abs(deltaX) < DRAG_START_THRESHOLD) {
+        return;
+      }
+
+      gesture.dragging = true;
+      clearLongPressTimer();
+      setIsDragging(true);
+      setOpenSide(null);
+
+      const horizontalLimit = Math.max(
+        leftRevealWidth,
+        rightRevealWidth,
+        gesture.rowWidth * activationThreshold,
+      );
+
+      setOffset(
+        clamp(
+          gesture.baseOffset + deltaX,
+          -Math.min(horizontalLimit + 24, gesture.rowWidth * 0.85 || horizontalLimit + 24),
+          Math.min(horizontalLimit + 24, gesture.rowWidth * 0.85 || horizontalLimit + 24),
+        ),
+      );
+    },
+    [activationThreshold, clearLongPressTimer, leftRevealWidth, rightRevealWidth, setOffset],
+  );
+
+  const endGesture = useCallback(() => {
+    const gesture = dragRef.current;
+    clearLongPressTimer();
+    dragRef.current = null;
+
+    if (!gesture) {
+      setIsDragging(false);
+      return;
+    }
+
+    if (!gesture.dragging) {
+      setIsDragging(false);
+      return;
+    }
+
+    suppressClickRef.current = true;
+    setIsDragging(false);
+    settleGesture(gesture.rowWidth);
+  }, [clearLongPressTimer, settleGesture]);
+
+  const handlePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (!isPrimaryPointerButton(event) || disabled) {
+        return;
+      }
+
+      beginGesture(event.clientX, event.clientY, 'pointer');
+
+      if (typeof event.currentTarget.setPointerCapture === 'function') {
+        try {
+          event.currentTarget.setPointerCapture(event.pointerId);
+        } catch {
+          // Ignore environments that do not fully implement pointer capture.
+        }
+      }
+    },
+    [beginGesture, disabled],
+  );
+
+  const handlePointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (dragRef.current?.source !== 'pointer') {
+        return;
+      }
+
+      updateGesture(event.clientX, event.clientY);
+    },
+    [updateGesture],
+  );
+
+  const handlePointerUp = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (dragRef.current?.source !== 'pointer') {
+        return;
+      }
+
+      if (typeof event.currentTarget.releasePointerCapture === 'function') {
+        try {
+          event.currentTarget.releasePointerCapture(event.pointerId);
+        } catch {
+          // Ignore environments that do not fully implement pointer capture.
+        }
+      }
+
+      endGesture();
+    },
+    [endGesture],
+  );
+
+  const handlePointerCancel = useCallback(() => {
+    if (dragRef.current?.source !== 'pointer') {
+      return;
+    }
+
+    closeRow();
+    clearLongPressTimer();
+    dragRef.current = null;
+    setIsDragging(false);
+  }, [clearLongPressTimer, closeRow]);
+
+  const handleTouchStart = useCallback(
+    (event: ReactTouchEvent<HTMLDivElement>) => {
+      if (supportsPointerEvents()) {
+        return;
+      }
+
+      const touch = event.touches[0];
+      if (!touch || disabled) {
+        return;
+      }
+
+      beginGesture(touch.clientX, touch.clientY, 'touch');
+    },
+    [beginGesture, disabled],
+  );
+
+  const handleTouchMove = useCallback(
+    (event: ReactTouchEvent<HTMLDivElement>) => {
+      if (dragRef.current?.source !== 'touch') {
+        return;
+      }
+
+      const touch = event.touches[0];
+      if (!touch) {
+        return;
+      }
+
+      updateGesture(touch.clientX, touch.clientY);
+    },
+    [updateGesture],
+  );
+
+  const handleTouchEnd = useCallback(() => {
+    if (dragRef.current?.source !== 'touch') {
+      return;
+    }
+
+    endGesture();
+  }, [endGesture]);
+
+  const handleClickCapture = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    if (suppressClickRef.current) {
+      event.preventDefault();
+      event.stopPropagation();
+      suppressClickRef.current = false;
+    }
+  }, []);
+
+  const handleContextMenu = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      onContextMenu?.(event);
+      if (event.defaultPrevented || contextMenuActions.length === 0 || disabled) {
+        return;
+      }
+
+      event.preventDefault();
+      openContextMenu(event.clientX, event.clientY);
+    },
+    [contextMenuActions.length, disabled, onContextMenu, openContextMenu],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLDivElement>) => {
+      onKeyDown?.(event);
+      if (event.defaultPrevented || contextMenuActions.length === 0 || disabled) {
+        return;
+      }
+
+      if (event.key === 'ContextMenu' || (event.shiftKey && event.key === 'F10')) {
+        event.preventDefault();
+        const rect = rootRef.current?.getBoundingClientRect();
+        openContextMenu(rect?.left ?? 0, rect?.bottom ?? 0);
+      }
+    },
+    [contextMenuActions.length, disabled, onKeyDown, openContextMenu],
+  );
+
+  const rootClassName = joinClassNames(
+    'swipeable-row',
+    isDragging && 'swipeable-row--dragging',
+    openSide === 'left' && 'swipeable-row--open-left',
+    openSide === 'right' && 'swipeable-row--open-right',
+    className,
+  );
+
+  const contentClasses = joinClassNames('swipeable-row__content', contentClassName);
+  const actionHint = contextMenuActions.length > 0 ? `${hintId}-hint` : undefined;
+
+  return (
+    <div
+      {...rest}
+      ref={rootRef}
+      className={rootClassName}
+      role={role ?? 'group'}
+      aria-describedby={actionHint}
+      onContextMenu={handleContextMenu}
+      onKeyDown={handleKeyDown}
+    >
+      {(enabledLeftActions.length > 0 || enabledRightActions.length > 0) && (
+        <div className="swipeable-row__actions" aria-hidden={openSide === null && !isDragging}>
+          {enabledRightActions.length > 0 && (
+            <div className="swipeable-row__action-strip swipeable-row__action-strip--right">
+              {enabledRightActions.map((action) => (
+                <button
+                  key={action.id}
+                  type="button"
+                  className={joinClassNames(
+                    'swipeable-row__action',
+                    `swipeable-row__action--${action.variant ?? 'default'}`,
+                  )}
+                  style={{ width: `${actionWidth}px` }}
+                  onClick={() => runAction(action)}
+                  tabIndex={openSide === 'right' ? 0 : -1}
+                >
+                  {action.icon && <span className="swipeable-row__action-icon">{action.icon}</span>}
+                  <span className="swipeable-row__action-label">{action.label}</span>
+                </button>
+              ))}
+            </div>
+          )}
+          {enabledLeftActions.length > 0 && (
+            <div className="swipeable-row__action-strip swipeable-row__action-strip--left">
+              {enabledLeftActions.map((action) => (
+                <button
+                  key={action.id}
+                  type="button"
+                  className={joinClassNames(
+                    'swipeable-row__action',
+                    `swipeable-row__action--${action.variant ?? 'default'}`,
+                  )}
+                  style={{ width: `${actionWidth}px` }}
+                  onClick={() => runAction(action)}
+                  tabIndex={openSide === 'left' ? 0 : -1}
+                >
+                  {action.icon && <span className="swipeable-row__action-icon">{action.icon}</span>}
+                  <span className="swipeable-row__action-label">{action.label}</span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      <div
+        className={contentClasses}
+        style={{ transform: `translateX(${offsetX}px)` }}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerCancel}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+        onTouchCancel={handleTouchEnd}
+        onClickCapture={handleClickCapture}
+      >
+        {children}
+      </div>
+
+      {contextMenuActions.length > 0 && (
+        <span id={actionHint} className="sr-only">
+          Swipe horizontally, right-click, or long-press to access transaction actions.
+        </span>
+      )}
+
+      {menuState !== null && (
+        <div
+          className="swipeable-row__menu"
+          role="menu"
+          aria-label="Row actions"
+          style={{ left: `${menuState.x}px`, top: `${menuState.y}px` }}
+        >
+          {contextMenuActions.map((action) => (
+            <button
+              key={action.id}
+              type="button"
+              className={joinClassNames(
+                'swipeable-row__menu-item',
+                `swipeable-row__menu-item--${action.variant ?? 'default'}`,
+              )}
+              role="menuitem"
+              onClick={() => runAction(action)}
+            >
+              {action.icon && <span className="swipeable-row__menu-icon">{action.icon}</span>}
+              <span>{action.label}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default SwipeableRow;

--- a/apps/web/src/components/common/swipeable-row.css
+++ b/apps/web/src/components/common/swipeable-row.css
@@ -1,0 +1,140 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+.swipeable-row {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  border-radius: inherit;
+}
+
+.swipeable-row__actions {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  justify-content: space-between;
+  pointer-events: none;
+}
+
+.swipeable-row__action-strip {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  display: inline-flex;
+  align-items: stretch;
+}
+
+.swipeable-row__action-strip--right {
+  left: 0;
+}
+
+.swipeable-row__action-strip--left {
+  right: 0;
+}
+
+.swipeable-row__action {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-1, 4px);
+  height: 100%;
+  border: none;
+  color: var(--semantic-text-inverse);
+  font-size: var(--type-scale-caption-font-size, 0.75rem);
+  font-weight: var(--font-weight-medium, 500);
+  cursor: pointer;
+  pointer-events: auto;
+}
+
+.swipeable-row__action--default {
+  background: var(--semantic-background-secondary, #4b5563);
+}
+
+.swipeable-row__action--success {
+  background: var(--semantic-status-positive, #15803d);
+}
+
+.swipeable-row__action--warning {
+  background: var(--semantic-status-warning, #d97706);
+}
+
+.swipeable-row__action--danger {
+  background: var(--semantic-status-negative, #dc2626);
+}
+
+.swipeable-row__action-icon,
+.swipeable-row__menu-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.swipeable-row__content {
+  position: relative;
+  z-index: 1;
+  background: var(--semantic-background-primary, #ffffff);
+  will-change: transform;
+  transition: transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
+  touch-action: pan-y;
+}
+
+.swipeable-row--dragging .swipeable-row__content {
+  transition: none;
+}
+
+.swipeable-row__menu {
+  position: fixed;
+  z-index: 50;
+  display: flex;
+  min-width: 176px;
+  flex-direction: column;
+  gap: var(--spacing-1, 4px);
+  padding: var(--spacing-2, 8px);
+  border: 1px solid var(--semantic-border-default, #d1d5db);
+  border-radius: var(--radius-md, 8px);
+  background: var(--semantic-background-primary, #ffffff);
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.18);
+  transform: translate(-12px, 8px);
+}
+
+.swipeable-row__menu-item {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2, 8px);
+  width: 100%;
+  padding: var(--spacing-2, 8px) var(--spacing-3, 12px);
+  border: none;
+  border-radius: var(--radius-sm, 6px);
+  background: transparent;
+  color: var(--semantic-text-primary, #111827);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.swipeable-row__menu-item:hover,
+.swipeable-row__menu-item:focus-visible {
+  background: var(--semantic-background-secondary, #f3f4f6);
+}
+
+.swipeable-row__menu-item--danger {
+  color: var(--semantic-status-negative, #b91c1c);
+}
+
+.swipeable-row__menu-item--success {
+  color: var(--semantic-status-positive, #166534);
+}
+
+.swipeable-row__menu-item--warning {
+  color: var(--semantic-status-warning, #b45309);
+}
+
+.list-group > li:last-child .swipeable-row__content.list-item {
+  border-bottom: none;
+}
+
+@media (max-width: 639px) {
+  .swipeable-row .transaction-item__actions {
+    display: none;
+  }
+}

--- a/apps/web/src/pages/TransactionsPage.tsx
+++ b/apps/web/src/pages/TransactionsPage.tsx
@@ -10,7 +10,9 @@ import {
   EmptyState,
   ErrorBanner,
   LoadingSpinner,
+  useToast,
 } from '../components/common';
+import { SwipeableRow } from '../components/common/SwipeableRow';
 import { TransactionForm } from '../components/forms';
 import { OfflineBanner } from '../components/OfflineBanner';
 import {
@@ -23,6 +25,7 @@ import type { AdvancedFilters } from '../components/transactions';
 import type { SortConfig, SortField } from '../components/transactions';
 import type { CreateTransactionInput } from '../db/repositories/transactions';
 import { useAccounts } from '../hooks/useAccounts';
+import { useAutoCategory } from '../hooks/useAutoCategory';
 import { useCategories } from '../hooks/useCategories';
 import { useTransactions } from '../hooks/useTransactions';
 import type { Transaction } from '../kmp/bridge';
@@ -133,6 +136,14 @@ function getTransactionLabel(transaction: Transaction): string {
     transaction.note?.trim() ||
     (transaction.type === 'TRANSFER' ? 'Transfer' : 'Transaction')
   );
+}
+
+function useOptionalToast(): ReturnType<typeof useToast> | null {
+  try {
+    return useToast();
+  } catch {
+    return null;
+  }
 }
 
 function PlusIcon() {
@@ -316,12 +327,32 @@ export const TransactionsPage: React.FC = () => {
     () => new Map(accounts.map((account) => [account.id, account.name])),
     [accounts],
   );
+  const { suggestCategory } = useAutoCategory(categories);
+  const toast = useOptionalToast();
 
   // Apply advanced local filters, then sort
   const transactions = useMemo(() => {
     const filtered = applyAdvancedFilters(rawTransactions, advancedFilters);
     return sortTransactions(filtered, sortConfig, categoryNames);
   }, [rawTransactions, advancedFilters, sortConfig, categoryNames]);
+
+  useEffect(() => {
+    if (transactions.length === 0 || toast === null || typeof window === 'undefined') {
+      return;
+    }
+
+    const tipStorageKey = 'transactions-swipe-actions-tip-shown';
+    if (window.localStorage.getItem(tipStorageKey) === 'true') {
+      return;
+    }
+
+    toast.showToast({
+      type: 'info',
+      message: 'Tip: swipe right to triage quickly, or swipe left for more actions.',
+      duration: 7000,
+    });
+    window.localStorage.setItem(tipStorageKey, 'true');
+  }, [toast, transactions.length]);
 
   // Group by date for display
   const groupedTransactions = useMemo(() => {
@@ -456,6 +487,51 @@ export const TransactionsPage: React.FC = () => {
     }
   }, [deleteTransaction, deletingTransaction, refreshTransactions]);
 
+  const handleQuickCategorize = useCallback(
+    (transaction: Transaction, categoryId: string, categoryName: string) => {
+      const result = updateTransaction(transaction.id, { categoryId });
+      if (result === null) {
+        toast?.showToast({
+          type: 'error',
+          message: `Could not categorize ${getTransactionLabel(transaction)}.`,
+        });
+        return;
+      }
+
+      refreshTransactions();
+      toast?.showToast({
+        type: 'success',
+        message: `Categorized ${getTransactionLabel(transaction)} as ${categoryName}.`,
+      });
+    },
+    [refreshTransactions, toast, updateTransaction],
+  );
+
+  const handleMarkReviewed = useCallback(
+    (transaction: Transaction) => {
+      const nextStatus = transaction.status === 'PENDING' ? 'CLEARED' : 'RECONCILED';
+      if (nextStatus === transaction.status) {
+        return;
+      }
+
+      const result = updateTransaction(transaction.id, { status: nextStatus });
+      if (result === null) {
+        toast?.showToast({
+          type: 'error',
+          message: `Could not mark ${getTransactionLabel(transaction)} as reviewed.`,
+        });
+        return;
+      }
+
+      refreshTransactions();
+      toast?.showToast({
+        type: 'success',
+        message: `Marked ${getTransactionLabel(transaction)} as reviewed.`,
+      });
+    },
+    [refreshTransactions, toast, updateTransaction],
+  );
+
   const hasActiveFilters =
     query.trim() !== '' ||
     advancedFilters.startDate !== '' ||
@@ -587,58 +663,135 @@ export const TransactionsPage: React.FC = () => {
                 <ul className="list-group" role="list">
                   {group.transactions.map((transaction) => {
                     const transactionLabel = getTransactionLabel(transaction);
+                    const autoCategory = suggestCategory(
+                      transaction.payee?.trim() ||
+                        transaction.note?.trim() ||
+                        transaction.counterpartyName?.trim() ||
+                        '',
+                      Math.abs(transaction.amount.amount),
+                    );
+                    const canQuickCategorize =
+                      autoCategory !== null && autoCategory.categoryId !== transaction.categoryId;
+                    const leftSwipeActions = [
+                      ...(canQuickCategorize && autoCategory !== null
+                        ? [
+                            {
+                              id: 'categorize',
+                              label: `Categorize`,
+                              icon: <AppIcon name="tag" />,
+                              variant: 'success' as const,
+                              onAction: () =>
+                                handleQuickCategorize(
+                                  transaction,
+                                  autoCategory.categoryId,
+                                  autoCategory.categoryName,
+                                ),
+                            },
+                          ]
+                        : []),
+                      {
+                        id: 'edit',
+                        label: 'Edit',
+                        icon: <AppIcon name="edit" />,
+                        onAction: () => handleEditTransaction(transaction),
+                      },
+                      {
+                        id: 'delete',
+                        label: 'Delete',
+                        icon: <AppIcon name="trash" />,
+                        variant: 'danger' as const,
+                        onAction: () => setDeletingTransaction(transaction),
+                      },
+                    ];
+                    const rightSwipeActions =
+                      canQuickCategorize && autoCategory !== null
+                        ? [
+                            {
+                              id: 'categorize',
+                              label: `Categorize`,
+                              icon: <AppIcon name="tag" />,
+                              variant: 'success' as const,
+                              quick: true,
+                              onAction: () =>
+                                handleQuickCategorize(
+                                  transaction,
+                                  autoCategory.categoryId,
+                                  autoCategory.categoryName,
+                                ),
+                            },
+                          ]
+                        : transaction.status !== 'RECONCILED'
+                          ? [
+                              {
+                                id: 'review',
+                                label: 'Mark reviewed',
+                                icon: <AppIcon name="check-circle" />,
+                                variant: 'default' as const,
+                                quick: true,
+                                onAction: () => handleMarkReviewed(transaction),
+                              },
+                            ]
+                          : [];
 
                     return (
-                      <li key={transaction.id} className="list-item" role="listitem">
-                        <div className="list-item__content">
-                          <Link
-                            to={`/transactions/${transaction.id}`}
-                            style={{ textDecoration: 'none', color: 'inherit' }}
-                            aria-label={`View details for ${transactionLabel}`}
-                          >
-                            <p className="list-item__primary">{transactionLabel}</p>
-                          </Link>
-                          <p className="list-item__secondary">
-                            {transaction.counterpartyName
-                              ? `${transaction.counterpartyName} · `
-                              : ''}
-                            {transaction.categoryId !== null
-                              ? (categoryNames.get(transaction.categoryId) ?? 'Uncategorized')
-                              : 'Uncategorized'}{' '}
-                            &middot; {accountNames.get(transaction.accountId) ?? 'Unknown account'}
-                          </p>
-                        </div>
-                        <div className="list-item__trailing transaction-list-item__trailing">
-                          <div className="transaction-list-item__amount">
-                            <CurrencyDisplay
-                              amount={getTransactionDisplayAmount(transaction)}
-                              currency={transaction.currency.code}
-                              colorize
-                              showSign
-                            />
-                          </div>
-                          <div
-                            className="transaction-item__actions"
-                            aria-label="Transaction actions"
-                          >
-                            <button
-                              type="button"
-                              className="icon-button transaction-item__action"
-                              onClick={() => handleEditTransaction(transaction)}
-                              aria-label={`Edit ${transactionLabel}`}
+                      <li key={transaction.id} role="listitem">
+                        <SwipeableRow
+                          aria-label={`Actions for ${transactionLabel}`}
+                          contentClassName="list-item"
+                          leftActions={leftSwipeActions}
+                          rightActions={rightSwipeActions}
+                        >
+                          <div className="list-item__content">
+                            <Link
+                              to={`/transactions/${transaction.id}`}
+                              style={{ textDecoration: 'none', color: 'inherit' }}
+                              aria-label={`View details for ${transactionLabel}`}
                             >
-                              <AppIcon name="edit" />
-                            </button>
-                            <button
-                              type="button"
-                              className="icon-button transaction-item__action transaction-item__action--delete"
-                              onClick={() => setDeletingTransaction(transaction)}
-                              aria-label={`Delete ${transactionLabel}`}
-                            >
-                              <AppIcon name="trash" />
-                            </button>
+                              <p className="list-item__primary">{transactionLabel}</p>
+                            </Link>
+                            <p className="list-item__secondary">
+                              {transaction.counterpartyName
+                                ? `${transaction.counterpartyName} · `
+                                : ''}
+                              {transaction.categoryId !== null
+                                ? (categoryNames.get(transaction.categoryId) ?? 'Uncategorized')
+                                : 'Uncategorized'}{' '}
+                              &middot;{' '}
+                              {accountNames.get(transaction.accountId) ?? 'Unknown account'}
+                            </p>
                           </div>
-                        </div>
+                          <div className="list-item__trailing transaction-list-item__trailing">
+                            <div className="transaction-list-item__amount">
+                              <CurrencyDisplay
+                                amount={getTransactionDisplayAmount(transaction)}
+                                currency={transaction.currency.code}
+                                colorize
+                                showSign
+                              />
+                            </div>
+                            <div
+                              className="transaction-item__actions"
+                              aria-label="Transaction actions"
+                            >
+                              <button
+                                type="button"
+                                className="icon-button transaction-item__action"
+                                onClick={() => handleEditTransaction(transaction)}
+                                aria-label={`Edit ${transactionLabel}`}
+                              >
+                                <AppIcon name="edit" />
+                              </button>
+                              <button
+                                type="button"
+                                className="icon-button transaction-item__action transaction-item__action--delete"
+                                onClick={() => setDeletingTransaction(transaction)}
+                                aria-label={`Delete ${transactionLabel}`}
+                              >
+                                <AppIcon name="trash" />
+                              </button>
+                            </div>
+                          </div>
+                        </SwipeableRow>
                       </li>
                     );
                   })}


### PR DESCRIPTION
Closes #1760

- SwipeableRow component with pointer events
- Left swipe: delete/edit/categorize actions
- Right swipe: quick categorize or mark reviewed
- Threshold activation, spring-back animation
- Desktop fallback: context menu + first-use tip
- Unit tests