### PR TITLE
fix(web): remove useless escape chars in crossTab.ts regex

### DIFF
--- a/apps/web/src/lib/sync/crossTab.ts
+++ b/apps/web/src/lib/sync/crossTab.ts
@@ -22,7 +22,7 @@ export interface NotifyDataChangeOptions {
 const CHANNEL_NAME = 'finance-live-sync';
 const STORAGE_EVENT_KEY = 'finance-live-sync:event';
 const TABLE_REFERENCE_PATTERN =
-  /\b(?:FROM|JOIN|UPDATE|INTO|DELETE\s+FROM)\s+(["'`\[]?[a-zA-Z_][\w]*["'`\]]?)/gi;
+  /\b(?:FROM|JOIN|UPDATE|INTO|DELETE\s+FROM)\s+(["'`[]?[a-zA-Z_][\w]*["'`\]]?)/gi;
 const MUTATION_SQL_PATTERN = /^\s*(?:INSERT|UPDATE|DELETE|REPLACE)\b/i;
 
 const listeners = new Set<(event: DataChangeEvent) => void>();
@@ -36,7 +36,7 @@ let isInitialized = false;
 
 function normalizeTableName(table: string): string {
   return table
-    .replace(/["'`\[\]]/g, '')
+    .replace(/["'`[\]]/g, '')
     .trim()
     .toLowerCase();
 }


### PR DESCRIPTION
## Summary
Removes unnecessary \\[\ escapes inside character classes that were flagged by ESLint's \
o-useless-escape\ rule.

## Impact
- Unblocks Lint & Format CI on main
- Unblocks staging auto-deploy (CI gate was failing due to lint)
- Unblocks Web CI (was being cancelled in cascade)

## Changes
- Line 25: \\[\ → \[\ inside character class
- Line 39: \\[\ → \[\ inside character class

Fixes #2106