### PR TITLE
feat(a11y): Color-independent financial statuses (#2261)

### DIFF
--- a/apps/web/src/components/common/CurrencyDisplay.tsx
+++ b/apps/web/src/components/common/CurrencyDisplay.tsx
@@ -4,6 +4,8 @@ import React from 'react';
 
 import { formatCurrencyForScreenReader } from '../../lib/a11y';
 import { useEffectiveMaskingMode, useIsPrivacyModeActive } from '../../contexts/PrivacyModeContext';
+import { useLocalePreferences } from '../../hooks/useLocalePreferences';
+import { getCurrencyFractionDigits } from '../../lib/currency-metadata';
 import { getAmountColor, useMoneyDisplay } from '../../lib/display-settings';
 import { formatAmount, MaskingMode } from '../../lib/ui/privacy';
 
@@ -43,16 +45,15 @@ export interface CurrencyDisplayProps {
  * placeholder (e.g., `$•••.••`) and the accessible label indicates
  * "Amount hidden".
  *
- * Accessibility: when `negativeFormat` is `'color-only'`, the visible
- * text omits the minus sign but the `aria-label` always includes
- * "negative" for screen readers so information is never conveyed by
+ * Accessibility: legacy `negativeFormat` value `'color-only'` is rendered
+ * with a visible "Negative" text cue so information is never conveyed by
  * color alone. The optional `context` prop appends a description
  * (e.g., "Dining category") so amounts announce their meaning.
  */
 export const CurrencyDisplay: React.FC<CurrencyDisplayProps> = ({
   amount,
   currency = 'USD',
-  locale = 'en-US',
+  locale,
   colorize = false,
   showSign = false,
   className = '',
@@ -62,19 +63,22 @@ export const CurrencyDisplay: React.FC<CurrencyDisplayProps> = ({
   const displaySettings = useMoneyDisplay();
   const isPrivacyMode = useIsPrivacyModeActive();
   const maskingMode = useEffectiveMaskingMode();
+  const { locale: preferredLocale } = useLocalePreferences();
+  const resolvedLocale = locale ?? preferredLocale;
 
   // Format the visible text using the canonical privacy-aware formatter.
+  const currencyFractionDigits = getCurrencyFractionDigits(currency);
   const baseFormatOptions = {
     currency,
     currencyDisplay: displaySettings.currencyDisplay,
-    minimumFractionDigits: displaySettings.showDecimals ? 2 : 0,
-    maximumFractionDigits: displaySettings.showDecimals ? 2 : 0,
+    minimumFractionDigits: displaySettings.showDecimals ? currencyFractionDigits : 0,
+    maximumFractionDigits: displaySettings.showDecimals ? currencyFractionDigits : 0,
   } as const;
-  const formattedBase = formatAmount(amount, maskingMode, locale, {
+  const formattedBase = formatAmount(amount, maskingMode, resolvedLocale, {
     ...baseFormatOptions,
     signDisplay: showSign ? 'exceptZero' : 'auto',
   });
-  const formattedAbsolute = formatAmount(Math.abs(amount), MaskingMode.Visible, locale, {
+  const formattedAbsolute = formatAmount(Math.abs(amount), MaskingMode.Visible, resolvedLocale, {
     ...baseFormatOptions,
     signDisplay: 'never',
   });
@@ -83,7 +87,7 @@ export const CurrencyDisplay: React.FC<CurrencyDisplayProps> = ({
       ? displaySettings.negativeFormat === 'parentheses'
         ? `(${formattedAbsolute})`
         : displaySettings.negativeFormat === 'color-only'
-          ? formattedAbsolute
+          ? `Negative ${formattedAbsolute}`
           : formattedBase
       : formattedBase;
 
@@ -104,7 +108,7 @@ export const CurrencyDisplay: React.FC<CurrencyDisplayProps> = ({
   // sign and meaning regardless of visual negative format.
   const label = isPrivacyMode
     ? 'Amount hidden'
-    : (ariaLabel ?? formatCurrencyForScreenReader(amount, currency, context));
+    : (ariaLabel ?? formatCurrencyForScreenReader(amount, currency, context, resolvedLocale));
 
   return (
     <span

--- a/apps/web/src/components/common/Toast.tsx
+++ b/apps/web/src/components/common/Toast.tsx
@@ -151,6 +151,13 @@ interface ToastItemProps {
 }
 
 /** Icon SVGs for each toast type. */
+const TOAST_TYPE_LABELS: Record<ToastType, string> = {
+  success: 'Success',
+  error: 'Error',
+  warning: 'Warning',
+  info: 'Info',
+};
+
 const TOAST_ICONS: Record<ToastType, React.ReactNode> = {
   success: (
     <svg
@@ -255,8 +262,9 @@ const ToastItem: React.FC<ToastItemProps> = ({ toast, onDismiss }) => {
   const role = toast.type === 'error' ? 'alert' : 'status';
 
   return (
-    <div className={`toast toast--${toast.type}`} role={role}>
+    <div className={`toast toast--${toast.type}`} role={role} aria-label={`${TOAST_TYPE_LABELS[toast.type]}: ${toast.message}`}>
       <span className="toast__icon">{TOAST_ICONS[toast.type]}</span>
+      <span className="toast__type-label">{TOAST_TYPE_LABELS[toast.type]}</span>
       <p className="toast__message">{toast.message}</p>
       <button
         type="button"

--- a/apps/web/src/components/common/toast.css
+++ b/apps/web/src/components/common/toast.css
@@ -44,6 +44,12 @@
   margin-top: 2px;
 }
 
+.toast__type-label {
+  flex-shrink: 0;
+  font-weight: var(--font-weight-semibold, 600);
+  color: var(--semantic-text-primary);
+}
+
 .toast__message {
   flex: 1;
   margin: 0;
@@ -120,6 +126,11 @@
   }
 }
 
+html[data-reduced-motion='true'] .toast {
+  animation: none;
+  transition: none;
+}
+
 /* --- Responsive: mobile - full width --------------------------------- */
 
 @media (max-width: 480px) {
@@ -133,7 +144,7 @@
 
 /* --- High contrast --------------------------------------------------- */
 
-@media (prefers-contrast: more) {
+@media (prefers-contrast: more), (forced-colors: active) {
   .toast {
     border-width: 2px;
   }

--- a/apps/web/src/lib/display-settings.ts
+++ b/apps/web/src/lib/display-settings.ts
@@ -21,6 +21,8 @@ import {
   useState,
 } from 'react';
 import type { FC, ReactNode } from 'react';
+import { getCurrencyFractionDigits, minorUnitFactor } from './currency-metadata';
+import { getCurrentLocale } from './i18n';
 import { formatAmount, MaskingMode } from './ui/privacy';
 
 // ---------------------------------------------------------------------------
@@ -162,16 +164,16 @@ export function formatAmountWithSettings(
   settings: MoneyDisplaySettings,
   options: { currency?: string; locale?: string; signDisplay?: string } = {},
 ): string {
-  const { currency = 'USD', locale = 'en-US' } = options;
+  const { currency = 'USD', locale = getCurrentLocale() } = options;
 
-  const fractionDigits = settings.showDecimals ? 2 : 0;
+  const fractionDigits = settings.showDecimals ? getCurrencyFractionDigits(currency) : 0;
 
   // Determine the absolute value for formatting when we need custom sign handling
   const isNegative = amountInCents < 0;
   const absAmountInCents = Math.abs(amountInCents);
-  const absValue = absAmountInCents / 100 || 0;
+  const absValue = absAmountInCents / minorUnitFactor(currency) || 0;
 
-  const formatted = formatAmount(Math.round(absValue * 100), MaskingMode.Visible, locale, {
+  const formatted = formatAmount(Math.round(absValue * minorUnitFactor(currency)), MaskingMode.Visible, locale, {
     currency,
     minimumFractionDigits: fractionDigits,
     maximumFractionDigits: fractionDigits,
@@ -188,9 +190,7 @@ export function formatAmountWithSettings(
     case 'parentheses':
       return `(${formatted})`;
     case 'color-only':
-      // Still provide a textual hint for accessibility — the aria-label
-      // on the component carries the sign, but the visual text is unsigned.
-      return formatted;
+      return `Negative ${formatted}`;
     case 'minus':
     default:
       return `-${formatted}`;

--- a/apps/web/src/pages/settings/SettingsPreferencesPage.tsx
+++ b/apps/web/src/pages/settings/SettingsPreferencesPage.tsx
@@ -8,6 +8,7 @@ import { CurrencyRatesSettings } from '../../components/settings/CurrencyRatesSe
 import '../../components/settings/currency-rates-settings.css';
 import { useFontScale } from '../../hooks/useFontScale';
 import type { FontScalePreference } from '../../hooks/useFontScale';
+import { useLocalePreferences } from '../../hooks/useLocalePreferences';
 import { useTheme } from '../../hooks/useTheme';
 import type { DisplayDensity, ThemeValue } from '../../hooks/useTheme';
 import {
@@ -16,21 +17,22 @@ import {
 } from '../../lib/bnpl-liability';
 import type { CurrencyDisplayMode, NegativeFormat } from '../../lib/display-settings';
 import { formatAmountWithSettings, useMoneyDisplay } from '../../lib/display-settings';
+import {
+  getStoredSingleKeyShortcutsPreference,
+  setSingleKeyShortcutsPreference,
+} from '../../lib/accessibility-preferences';
+import { SUPPORTED_CURRENCY_METADATA } from '../../lib/currency-metadata';
+import { translate } from '../../lib/i18n';
 import { setOnboardingComplete } from '../../lib/local-only-mode';
 
 const CURRENCY_STORAGE_KEY = 'finance-currency';
 const NOTIFICATIONS_STORAGE_KEY = 'finance-notifications';
 
-type CurrencyPreference = 'USD' | 'EUR' | 'GBP' | 'CAD' | 'AUD' | 'JPY';
+type CurrencyPreference = string;
 
-const currencyOptions: Array<{ value: CurrencyPreference; label: string }> = [
-  { value: 'USD', label: 'USD ($)' },
-  { value: 'EUR', label: 'EUR (€)' },
-  { value: 'GBP', label: 'GBP (£)' },
-  { value: 'CAD', label: 'CAD (C$)' },
-  { value: 'AUD', label: 'AUD (A$)' },
-  { value: 'JPY', label: 'JPY (¥)' },
-];
+const currencyOptions: Array<{ value: CurrencyPreference; label: string }> = SUPPORTED_CURRENCY_METADATA.map(
+  ({ code, label }) => ({ value: code, label }),
+);
 
 /** Labels for theme select options. */
 const THEME_LABELS: Record<ThemeValue, string> = {
@@ -63,7 +65,7 @@ function resolveColorForPicker(color: string, fallback: string): string {
 const NEGATIVE_FORMAT_OPTIONS: Array<{ value: NegativeFormat; label: string }> = [
   { value: 'minus', label: 'Standard' },
   { value: 'parentheses', label: 'Accounting' },
-  { value: 'color-only', label: 'Color Only' },
+  { value: 'color-only', label: 'Text label' },
 ];
 
 /** Labels for currency display mode options. */
@@ -80,12 +82,16 @@ const CURRENCY_DISPLAY_OPTIONS: Array<{ value: CurrencyDisplayMode; label: strin
 export const SettingsPreferencesPage: React.FC = () => {
   const { theme, setTheme, themes, displayDensity, setDisplayDensity, densities } = useTheme();
   const fontScale = useFontScale();
+  const localePreferences = useLocalePreferences();
   const displaySettings = useMoneyDisplay();
   const [currency, setCurrency] = useState<CurrencyPreference>(
     () => (localStorage.getItem(CURRENCY_STORAGE_KEY) as CurrencyPreference) || 'USD',
   );
   const [notificationsEnabled, setNotificationsEnabled] = useState(
     () => localStorage.getItem(NOTIFICATIONS_STORAGE_KEY) !== 'false',
+  );
+  const [singleKeyShortcutsEnabled, setSingleKeyShortcutsEnabled] = useState(
+    getStoredSingleKeyShortcutsPreference,
   );
   const [bnplStackingThreshold, setBnplStackingThreshold] = useState(() =>
     String(loadBnplStackingThresholdCents() / 100),
@@ -111,6 +117,20 @@ export const SettingsPreferencesPage: React.FC = () => {
     setCurrency(nextCurrency);
   }, []);
 
+  const handleLocaleChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      localePreferences.setLocale(event.target.value);
+    },
+    [localePreferences],
+  );
+
+  const handleTimeZoneChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      localePreferences.setTimeZone(event.target.value);
+    },
+    [localePreferences],
+  );
+
   const handleFontScaleChange = useCallback(
     (event: React.ChangeEvent<HTMLSelectElement>) => {
       fontScale.setPreference(event.target.value as FontScalePreference);
@@ -122,6 +142,12 @@ export const SettingsPreferencesPage: React.FC = () => {
     const nextNotificationsEnabled = event.target.checked;
     localStorage.setItem(NOTIFICATIONS_STORAGE_KEY, String(nextNotificationsEnabled));
     setNotificationsEnabled(nextNotificationsEnabled);
+  }, []);
+
+  const handleSingleKeyShortcutsChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    const enabled = event.target.checked;
+    setSingleKeyShortcutsPreference(enabled);
+    setSingleKeyShortcutsEnabled(enabled);
   }, []);
 
   const handleBnplThresholdChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
@@ -160,6 +186,53 @@ export const SettingsPreferencesPage: React.FC = () => {
                   {currencyOptions.map((option) => (
                     <option key={option.value} value={option.value}>
                       {option.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+          </SettingInfoWidget>
+          <SettingInfoWidget settingKey="language">
+            <div className="settings-item settings-item--static">
+              <label className="settings-item__label" htmlFor="settings-language">
+                {translate('settings.language', {}, localePreferences.locale).text}
+              </label>
+              <div className="settings-item__control">
+                <select
+                  id="settings-language"
+                  aria-label="Language"
+                  className="settings-item__select"
+                  value={localePreferences.locale}
+                  onChange={handleLocaleChange}
+                >
+                  {localePreferences.supportedLocales.map((option) => (
+                    <option key={option.code} value={option.code}>
+                      {option.nativeLabel} — {option.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <p className="settings-item__description">
+                {translate('settings.languageDescription', {}, localePreferences.locale).text}
+              </p>
+            </div>
+          </SettingInfoWidget>
+          <SettingInfoWidget settingKey="time-zone">
+            <div className="settings-item settings-item--static">
+              <label className="settings-item__label" htmlFor="settings-time-zone">
+                {translate('settings.timeZone', {}, localePreferences.locale).text}
+              </label>
+              <div className="settings-item__control">
+                <select
+                  id="settings-time-zone"
+                  aria-label="Home time zone"
+                  className="settings-item__select"
+                  value={localePreferences.timeZone}
+                  onChange={handleTimeZoneChange}
+                >
+                  {localePreferences.timeZoneOptions.map((option) => (
+                    <option key={option} value={option}>
+                      {option}
                     </option>
                   ))}
                 </select>
@@ -225,6 +298,23 @@ export const SettingsPreferencesPage: React.FC = () => {
               />
             </div>
           </SettingInfoWidget>
+          <div className="settings-item settings-item--static">
+            <label className="settings-item__label" htmlFor="settings-single-key-shortcuts">
+              Single-key shortcuts
+            </label>
+            <input
+              type="checkbox"
+              id="settings-single-key-shortcuts"
+              checked={singleKeyShortcutsEnabled}
+              onChange={handleSingleKeyShortcutsChange}
+              aria-describedby="settings-single-key-shortcuts-help"
+              className="settings-item__checkbox"
+            />
+            <p id="settings-single-key-shortcuts-help" className="settings-item__description">
+              Turn off character-key shortcuts like N, /, ?, and G then D if they conflict with
+              assistive technology. Ctrl/Cmd+K remains available.
+            </p>
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
Implements #2261 (a11y beta feature). Closes #2261