### PR TITLE
feat(performance): Lazy offline-safe receipt images (#2317)

### DIFF
--- a/apps/web/src/components/transactions/LazyReceiptImage.tsx
+++ b/apps/web/src/components/transactions/LazyReceiptImage.tsx
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+
+import { useOfflineStatus } from '../../hooks/useOfflineStatus';
+import type { Transaction } from '../../kmp/bridge';
+import { getReceiptImageMetadata } from '../../lib/receiptImagePolicy';
+
+export interface LazyReceiptImageProps {
+  readonly transaction: Transaction;
+  readonly className?: string;
+}
+
+const LOAD_ROOT_MARGIN = '200% 0px';
+const INITIAL_RETRY_MS = 1_000;
+const MAX_RETRY_MS = 16_000;
+
+export const LazyReceiptImage: React.FC<LazyReceiptImageProps> = ({ transaction, className }) => {
+  const { isOffline, shouldDeferHeavyAssets } = useOfflineStatus();
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [isNearViewport, setIsNearViewport] = useState(false);
+  const [retryAttempt, setRetryAttempt] = useState(0);
+  const [loadFailed, setLoadFailed] = useState(false);
+
+  const metadata = useMemo(
+    () => getReceiptImageMetadata(transaction.customFields, `Receipt for ${transaction.payee ?? 'transaction'}`),
+    [transaction.customFields, transaction.payee],
+  );
+
+  useEffect(() => {
+    const node = wrapperRef.current;
+    if (!node || typeof IntersectionObserver === 'undefined') {
+      setIsNearViewport(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting) {
+          setIsNearViewport(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: LOAD_ROOT_MARGIN },
+    );
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [metadata.url]);
+
+  useEffect(
+    () => () => {
+      if (retryTimerRef.current !== null) clearTimeout(retryTimerRef.current);
+    },
+    [],
+  );
+
+  if (metadata.status === 'none') {
+    return null;
+  }
+
+  if (metadata.status === 'pending-upload') {
+    return <ReceiptPlaceholder className={className} label="Receipt pending upload" />;
+  }
+
+  if (metadata.status === 'unavailable' || !metadata.url) {
+    return <ReceiptPlaceholder className={className} label="Receipt unavailable offline" />;
+  }
+
+  const canLoadImage = isNearViewport && !(shouldDeferHeavyAssets && metadata.status !== 'cached');
+  const showOfflinePlaceholder = isOffline && metadata.status !== 'cached' && !canLoadImage;
+
+  const handleError = () => {
+    setLoadFailed(true);
+    const delay = Math.min(INITIAL_RETRY_MS * 2 ** retryAttempt, MAX_RETRY_MS);
+    retryTimerRef.current = setTimeout(() => {
+      setRetryAttempt((attempt) => attempt + 1);
+      setLoadFailed(false);
+    }, delay);
+  };
+
+  return (
+    <div ref={wrapperRef} className={className ?? 'receipt-thumb'} data-retry-attempt={retryAttempt}>
+      {showOfflinePlaceholder || !canLoadImage ? (
+        <ReceiptPlaceholder label={showOfflinePlaceholder ? 'Receipt unavailable offline' : 'Receipt deferred'} />
+      ) : loadFailed ? (
+        <ReceiptPlaceholder label="Receipt retrying" />
+      ) : (
+        <img
+          key={`${metadata.url}:${retryAttempt}`}
+          src={metadata.url}
+          alt={metadata.alt}
+          loading="lazy"
+          decoding="async"
+          fetchPriority="low"
+          onError={handleError}
+        />
+      )}
+    </div>
+  );
+};
+
+const ReceiptPlaceholder: React.FC<{ readonly className?: string; readonly label: string }> = ({
+  className,
+  label,
+}) => (
+  <span className={className ?? 'receipt-thumb__placeholder'} role="img" aria-label={label}>
+    🧾
+  </span>
+);
+
+export default LazyReceiptImage;

--- a/apps/web/src/lib/receiptImagePolicy.ts
+++ b/apps/web/src/lib/receiptImagePolicy.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+export const RECEIPT_CACHE_NAME_PREFIX = 'finance-receipts';
+export const RECEIPT_CACHE_MAX_ENTRIES = 120;
+
+const RECEIPT_PATH_PATTERN = /\/(receipts?|attachments?)\//i;
+const RECEIPT_IMAGE_EXTENSION_PATTERN = /\.(avif|gif|jpe?g|png|webp)$/i;
+const SENSITIVE_QUERY_PARAMS = new Set([
+  'access_token',
+  'authorization',
+  'expires',
+  'key',
+  'policy',
+  'signature',
+  'sig',
+  'token',
+  'x-amz-credential',
+  'x-amz-security-token',
+  'x-amz-signature',
+]);
+
+export interface ReceiptImageMetadata {
+  readonly url: string | null;
+  readonly status: 'cached' | 'pending-upload' | 'unavailable' | 'remote' | 'none';
+  readonly alt: string;
+}
+
+export function isReceiptImagePath(pathname: string): boolean {
+  return RECEIPT_PATH_PATTERN.test(pathname) && RECEIPT_IMAGE_EXTENSION_PATTERN.test(pathname);
+}
+
+export function sanitizeReceiptCacheUrl(input: URL): string {
+  const url = new URL(input.toString());
+  for (const key of Array.from(url.searchParams.keys())) {
+    if (SENSITIVE_QUERY_PARAMS.has(key.toLowerCase())) {
+      url.searchParams.delete(key);
+    }
+  }
+  url.hash = '';
+  return url.toString();
+}
+
+export function hasSensitiveReceiptToken(input: URL): boolean {
+  for (const key of input.searchParams.keys()) {
+    if (SENSITIVE_QUERY_PARAMS.has(key.toLowerCase())) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function getReceiptImageMetadata(
+  customFields: Readonly<Record<string, string>> | null | undefined,
+  fallbackAlt: string,
+): ReceiptImageMetadata {
+  const fields = customFields ?? {};
+  const url =
+    fields.receiptThumbnailUrl ??
+    fields.receiptThumbnailURL ??
+    fields.receiptImageUrl ??
+    fields.receiptImageURL ??
+    fields.receiptUrl ??
+    fields.receiptURL ??
+    fields.merchantLogoUrl ??
+    null;
+
+  const rawStatus = (fields.receiptUploadStatus ?? fields.receiptStatus ?? '').toLowerCase();
+  const status =
+    rawStatus === 'pending' || rawStatus === 'pending-upload'
+      ? 'pending-upload'
+      : rawStatus === 'cached'
+        ? 'cached'
+        : rawStatus === 'unavailable' || rawStatus === 'missing'
+          ? 'unavailable'
+          : url
+            ? 'remote'
+            : 'none';
+
+  return {
+    url,
+    status,
+    alt: fields.receiptAltText ?? fields.receiptDescription ?? fallbackAlt,
+  };
+}

--- a/apps/web/src/pages/TransactionDetailPage.tsx
+++ b/apps/web/src/pages/TransactionDetailPage.tsx
@@ -6,6 +6,7 @@ import { AppIcon } from '../components/icons';
 
 import { ConfirmDialog, CurrencyDisplay, ErrorBanner, LoadingSpinner } from '../components/common';
 import { TransactionForm } from '../components/forms';
+import { LazyReceiptImage } from '../components/transactions';
 import { Breadcrumb } from '../components/navigation';
 import { TagList } from '../components/tags';
 import type { CreateTransactionInput } from '../db/repositories/transactions';
@@ -335,6 +336,8 @@ export const TransactionDetailPage: React.FC = () => {
           )}
         </dl>
       </article>
+
+      <LazyReceiptImage transaction={transaction} className="receipt-detail-image" />
 
       {splitDetails.length > 0 && (
         <article


### PR DESCRIPTION
Implements #2317 (performance beta feature). Closes #2317