### PR TITLE
feat(security): Security sub-feature cores (encryption status, app-lock settings, WebAuthn challenge, deletion/wipe, privacy triggers)

### DIFF
--- a/apps/web/src/lib/security/app-lock-settings.test.ts
+++ b/apps/web/src/lib/security/app-lock-settings.test.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_APP_LOCK_STATE,
+  buildPrivacySafeShell,
+  normalizeAppLockSettings,
+  reduceAppLockEvent,
+} from './app-lock-settings';
+
+describe('app lock settings helpers', () => {
+  it('normalizes safe defaults and minimum idle timeout', () => {
+    expect(normalizeAppLockSettings({ enabled: true, idleTimeoutMs: 1_000 })).toMatchObject({
+      enabled: true,
+      idleTimeoutMs: 30_000,
+      lockOnResume: true,
+      requirePasskey: true,
+    });
+  });
+
+  it('locks manually with a privacy-safe shell and scrubbed audit metadata', () => {
+    const settings = normalizeAppLockSettings({ enabled: true });
+    const transition = reduceAppLockEvent(settings, DEFAULT_APP_LOCK_STATE, 'manual_lock', 1_000);
+
+    expect(transition.state).toMatchObject({ locked: true, reason: 'manual' });
+    expect(transition.shell.hideSensitiveValues).toBe(true);
+    expect(transition.shell.body).toContain('separate from signing in');
+    expect(transition.audit).toEqual({ event: 'app_locked', severity: 'info', metadata: { reason: 'manual' } });
+  });
+
+  it('locks on idle and resume policies without exposing sensitive metadata', () => {
+    const settings = normalizeAppLockSettings({ enabled: true, idleTimeoutMs: 60_000, lockOnResume: true });
+    const unlocked = reduceAppLockEvent(settings, DEFAULT_APP_LOCK_STATE, 'unlock_success', 1_000).state;
+
+    expect(reduceAppLockEvent(settings, unlocked, 'idle_check', 30_000).state.locked).toBe(false);
+    expect(reduceAppLockEvent(settings, unlocked, 'idle_check', 61_000).state.reason).toBe('idle_timeout');
+    expect(reduceAppLockEvent(settings, unlocked, 'resume', 2_000).state.reason).toBe('resume');
+  });
+
+  it('explains disabled app lock separately from account login', () => {
+    const settings = normalizeAppLockSettings({ enabled: false });
+
+    expect(buildPrivacySafeShell(DEFAULT_APP_LOCK_STATE, settings)).toMatchObject({
+      hideSensitiveValues: false,
+      primaryAction: 'enable_app_lock',
+    });
+    expect(reduceAppLockEvent(settings, DEFAULT_APP_LOCK_STATE, 'manual_lock', 1_000).audit).toMatchObject({
+      event: 'app_lock_bypassed',
+      severity: 'warning',
+    });
+  });
+});

--- a/apps/web/src/lib/security/app-lock-settings.ts
+++ b/apps/web/src/lib/security/app-lock-settings.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+export type AppLockEvent = 'manual_lock' | 'unlock_success' | 'activity' | 'idle_check' | 'resume';
+export type AppLockAuditEvent = 'app_lock_enabled' | 'app_locked' | 'app_unlocked' | 'app_lock_bypassed';
+export type AppLockReason = 'disabled' | 'manual' | 'idle_timeout' | 'resume' | 'unlock_success';
+
+export interface AppLockSettings {
+  readonly enabled: boolean;
+  readonly idleTimeoutMs: number;
+  readonly lockOnResume: boolean;
+  readonly requirePasskey: boolean;
+}
+
+export interface AppLockRuntimeState {
+  readonly locked: boolean;
+  readonly reason: AppLockReason;
+  readonly lastUnlockedAtMs: number | null;
+}
+
+export interface PrivacySafeShell {
+  readonly hideSensitiveValues: boolean;
+  readonly heading: string;
+  readonly body: string;
+  readonly primaryAction: 'unlock_app' | 'enable_app_lock' | 'none';
+}
+
+export interface AppLockAuditEntry {
+  readonly event: AppLockAuditEvent;
+  readonly severity: 'info' | 'warning';
+  readonly metadata: Readonly<Record<string, string>>;
+}
+
+export interface AppLockTransition {
+  readonly state: AppLockRuntimeState;
+  readonly shell: PrivacySafeShell;
+  readonly audit?: AppLockAuditEntry;
+}
+
+export const DEFAULT_APP_LOCK_SETTINGS: AppLockSettings = {
+  enabled: false,
+  idleTimeoutMs: 5 * 60 * 1000,
+  lockOnResume: true,
+  requirePasskey: true,
+};
+
+export const DEFAULT_APP_LOCK_STATE: AppLockRuntimeState = {
+  locked: false,
+  reason: 'disabled',
+  lastUnlockedAtMs: null,
+};
+
+export function normalizeAppLockSettings(settings: Partial<AppLockSettings>): AppLockSettings {
+  return {
+    enabled: settings.enabled ?? DEFAULT_APP_LOCK_SETTINGS.enabled,
+    idleTimeoutMs: Math.max(settings.idleTimeoutMs ?? DEFAULT_APP_LOCK_SETTINGS.idleTimeoutMs, 30_000),
+    lockOnResume: settings.lockOnResume ?? DEFAULT_APP_LOCK_SETTINGS.lockOnResume,
+    requirePasskey: settings.requirePasskey ?? DEFAULT_APP_LOCK_SETTINGS.requirePasskey,
+  };
+}
+
+export function reduceAppLockEvent(
+  settings: AppLockSettings,
+  state: AppLockRuntimeState,
+  event: AppLockEvent,
+  nowMs: number,
+): AppLockTransition {
+  if (!settings.enabled) {
+    const unlocked = { locked: false, reason: 'disabled', lastUnlockedAtMs: nowMs } as const;
+    return {
+      state: unlocked,
+      shell: buildPrivacySafeShell(unlocked, settings),
+      audit: event === 'manual_lock' ? audit('app_lock_bypassed', { reason: 'disabled' }, 'warning') : undefined,
+    };
+  }
+
+  if (event === 'manual_lock') {
+    const locked = { locked: true, reason: 'manual', lastUnlockedAtMs: state.lastUnlockedAtMs } as const;
+    return { state: locked, shell: buildPrivacySafeShell(locked, settings), audit: audit('app_locked', { reason: 'manual' }) };
+  }
+
+  if (event === 'unlock_success' || event === 'activity') {
+    const unlocked = { locked: false, reason: 'unlock_success', lastUnlockedAtMs: nowMs } as const;
+    return {
+      state: unlocked,
+      shell: buildPrivacySafeShell(unlocked, settings),
+      audit: event === 'unlock_success' ? audit('app_unlocked', { method: settings.requirePasskey ? 'passkey' : 'local' }) : undefined,
+    };
+  }
+
+  if (event === 'resume' && settings.lockOnResume) {
+    const locked = { locked: true, reason: 'resume', lastUnlockedAtMs: state.lastUnlockedAtMs } as const;
+    return { state: locked, shell: buildPrivacySafeShell(locked, settings), audit: audit('app_locked', { reason: 'resume' }) };
+  }
+
+  if (state.lastUnlockedAtMs === null || nowMs - state.lastUnlockedAtMs >= settings.idleTimeoutMs) {
+    const locked = { locked: true, reason: 'idle_timeout', lastUnlockedAtMs: state.lastUnlockedAtMs } as const;
+    return {
+      state: locked,
+      shell: buildPrivacySafeShell(locked, settings),
+      audit: audit('app_locked', { reason: 'idle_timeout' }),
+    };
+  }
+
+  return { state, shell: buildPrivacySafeShell(state, settings) };
+}
+
+export function buildPrivacySafeShell(state: AppLockRuntimeState, settings: AppLockSettings): PrivacySafeShell {
+  if (!settings.enabled) {
+    return {
+      hideSensitiveValues: false,
+      heading: 'App lock is off',
+      body: 'Use your account session for sign-in; app lock adds a local privacy gate on this device.',
+      primaryAction: 'enable_app_lock',
+    };
+  }
+
+  if (state.locked) {
+    return {
+      hideSensitiveValues: true,
+      heading: 'Finance is locked',
+      body: 'Unlock this local app lock to show balances and transactions. This is separate from signing in.',
+      primaryAction: 'unlock_app',
+    };
+  }
+
+  return {
+    hideSensitiveValues: false,
+    heading: 'Finance is unlocked',
+    body: 'Sensitive values are visible until you lock manually, go idle, or resume the app.',
+    primaryAction: 'none',
+  };
+}
+
+function audit(
+  event: AppLockAuditEvent,
+  metadata: Readonly<Record<string, string>>,
+  severity: AppLockAuditEntry['severity'] = 'info',
+): AppLockAuditEntry {
+  return { event, severity, metadata };
+}

--- a/apps/web/src/lib/security/deletion-endpoint.test.ts
+++ b/apps/web/src/lib/security/deletion-endpoint.test.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { mapAccountDeletionEndpointResponse, submitAccountDeletion } from './deletion-endpoint';
+
+function response(status: number, contentType = 'application/json'): Pick<Response, 'ok' | 'status' | 'headers'> {
+  return { ok: status >= 200 && status < 300, status, headers: new Headers({ 'content-type': contentType }) };
+}
+
+describe('account deletion endpoint contract', () => {
+  const nowIso = '2025-01-01T00:00:00.000Z';
+
+  it('requires step-up reauthentication before issuing DELETE', async () => {
+    const fetchImpl = vi.fn();
+
+    await expect(submitAccountDeletion({ endpoint: '/api/account', stepUpToken: null, fetchImpl, nowIso })).resolves.toMatchObject({
+      status: 'auth_required',
+      retryable: true,
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('maps success and partial-failure receipts without sensitive detail', () => {
+    expect(
+      mapAccountDeletionEndpointResponse(
+        response(200),
+        JSON.stringify({ requestId: 'r1', deletedDomains: ['server-account', 'local-storage'], failedDomains: [] }),
+        nowIso,
+      ),
+    ).toMatchObject({ status: 'success', requestId: 'r1', deletedDomains: ['server-account', 'local-storage'] });
+
+    expect(
+      mapAccountDeletionEndpointResponse(
+        response(202),
+        JSON.stringify({ requestId: 'r2', deletedDomains: ['server-account'], failedDomains: ['server-passkeys'] }),
+        nowIso,
+      ),
+    ).toMatchObject({ status: 'partial_failure', retryable: true, failedDomains: ['server-passkeys'] });
+  });
+
+  it('distinguishes auth failure, HTML fallback, retryable, and fatal errors', () => {
+    expect(mapAccountDeletionEndpointResponse(response(401), '{}', nowIso).status).toBe('auth_required');
+    expect(mapAccountDeletionEndpointResponse(response(200, 'text/html'), '<html></html>', nowIso).status).toBe('html_fallback');
+    expect(mapAccountDeletionEndpointResponse(response(503), '{}', nowIso).status).toBe('retryable_error');
+    expect(mapAccountDeletionEndpointResponse(response(400), 'not-json', nowIso).status).toBe('fatal_error');
+  });
+
+  it('sends a typed DELETE request with the step-up token', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      text: vi.fn().mockResolvedValue(JSON.stringify({ requestId: 'r3', deletedDomains: ['server-account'] })),
+    });
+
+    await submitAccountDeletion({ endpoint: '/api/account', stepUpToken: 'step-up', fetchImpl, nowIso });
+
+    expect(fetchImpl).toHaveBeenCalledWith('/api/account', expect.objectContaining({ method: 'DELETE' }));
+    expect(fetchImpl.mock.calls[0]?.[1]?.headers).toMatchObject({ 'X-Step-Up-Token': 'step-up' });
+  });
+});

--- a/apps/web/src/lib/security/deletion-endpoint.ts
+++ b/apps/web/src/lib/security/deletion-endpoint.ts
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import type { DeletionDomain } from './deletion-verification';
+
+export type DeletionEndpointStatus =
+  | 'success'
+  | 'auth_required'
+  | 'html_fallback'
+  | 'partial_failure'
+  | 'retryable_error'
+  | 'fatal_error';
+
+export interface AccountDeletionReceiptContract {
+  readonly requestId: string;
+  readonly completedAt: string;
+  readonly status: DeletionEndpointStatus;
+  readonly deletedDomains: readonly DeletionDomain[];
+  readonly failedDomains: readonly DeletionDomain[];
+  readonly retryable: boolean;
+  readonly privacySafeMessage: string;
+}
+
+export interface SubmitAccountDeletionOptions {
+  readonly endpoint: string;
+  readonly stepUpToken: string | null;
+  readonly fetchImpl?: typeof fetch;
+  readonly nowIso: string;
+}
+
+interface RawDeletionResponse {
+  readonly requestId?: unknown;
+  readonly deletedDomains?: unknown;
+  readonly failedDomains?: unknown;
+  readonly status?: unknown;
+  readonly message?: unknown;
+}
+
+export async function submitAccountDeletion({
+  endpoint,
+  stepUpToken,
+  fetchImpl = globalThis.fetch,
+  nowIso,
+}: SubmitAccountDeletionOptions): Promise<AccountDeletionReceiptContract> {
+  if (!stepUpToken) return authRequiredReceipt(nowIso);
+
+  try {
+    const response = await fetchImpl(endpoint, {
+      method: 'DELETE',
+      credentials: 'include',
+      headers: {
+        Accept: 'application/json',
+        'X-Step-Up-Token': stepUpToken,
+      },
+    });
+    const bodyText = await response.text();
+    return mapAccountDeletionEndpointResponse(response, bodyText, nowIso);
+  } catch {
+    return receipt('retryable_error', 'delete-unavailable', nowIso, [], [], true, 'Deletion could not be reached. Try again later.');
+  }
+}
+
+export function mapAccountDeletionEndpointResponse(
+  response: Pick<Response, 'ok' | 'status' | 'headers'>,
+  bodyText: string,
+  nowIso: string,
+): AccountDeletionReceiptContract {
+  if (response.status === 401 || response.status === 403) return authRequiredReceipt(nowIso);
+  if (isHtmlFallback(response, bodyText)) {
+    return receipt('html_fallback', 'delete-html-fallback', nowIso, [], [], true, 'Deletion endpoint returned an app shell instead of a receipt.');
+  }
+  if (response.status === 429 || response.status >= 500) {
+    return receipt('retryable_error', 'delete-retryable', nowIso, [], [], true, 'Deletion is temporarily unavailable. Try again later.');
+  }
+
+  const payload = parseJson(bodyText);
+  if (!response.ok || payload === null) {
+    return receipt('fatal_error', 'delete-failed', nowIso, [], [], false, 'Deletion failed before a privacy-safe receipt was created.');
+  }
+
+  const deletedDomains = readDomains(payload.deletedDomains);
+  const failedDomains = readDomains(payload.failedDomains);
+  const requestId = typeof payload.requestId === 'string' && payload.requestId.length > 0 ? payload.requestId : 'delete-receipt';
+  const partial = failedDomains.length > 0 || payload.status === 'partial_failure';
+
+  return receipt(
+    partial ? 'partial_failure' : 'success',
+    requestId,
+    nowIso,
+    deletedDomains,
+    failedDomains,
+    partial,
+    partial
+      ? 'Deletion completed with some domains still requiring retry or support follow-up.'
+      : 'Deletion completed and the receipt contains only domain-level status.',
+  );
+}
+
+function authRequiredReceipt(nowIso: string): AccountDeletionReceiptContract {
+  return receipt('auth_required', 'delete-auth-required', nowIso, [], [], true, 'Confirm your identity again before deleting the account.');
+}
+
+function receipt(
+  status: DeletionEndpointStatus,
+  requestId: string,
+  completedAt: string,
+  deletedDomains: readonly DeletionDomain[],
+  failedDomains: readonly DeletionDomain[],
+  retryable: boolean,
+  privacySafeMessage: string,
+): AccountDeletionReceiptContract {
+  return { requestId, completedAt, status, deletedDomains, failedDomains, retryable, privacySafeMessage };
+}
+
+function isHtmlFallback(response: Pick<Response, 'headers'>, bodyText: string): boolean {
+  const contentType = response.headers.get('content-type')?.toLowerCase() ?? '';
+  return contentType.includes('text/html') || /^\s*<!doctype html|^\s*<html/i.test(bodyText);
+}
+
+function parseJson(bodyText: string): RawDeletionResponse | null {
+  try {
+    const parsed = JSON.parse(bodyText) as RawDeletionResponse;
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function readDomains(value: unknown): readonly DeletionDomain[] {
+  return Array.isArray(value) ? value.filter((item): item is DeletionDomain => typeof item === 'string') : [];
+}

--- a/apps/web/src/lib/security/encryption-status.test.ts
+++ b/apps/web/src/lib/security/encryption-status.test.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import { buildEncryptionStatusDashboard, summarizeEncryptionRecovery } from './encryption-status';
+
+const supportedCrypto = { subtle: { encrypt: () => undefined }, getRandomValues: () => new Uint8Array(1) } as unknown as Crypto;
+
+describe('encryption status dashboard helpers', () => {
+  it('reports first-run setup, unlock, encrypted, and not-applicable states', () => {
+    const dashboard = buildEncryptionStatusDashboard(
+      [
+        {
+          category: 'accounts',
+          label: 'Accounts',
+          applicable: true,
+          totalRecords: 2,
+          encryptedRecords: 0,
+          keyState: 'not_configured',
+        },
+        {
+          category: 'transactions',
+          label: 'Transactions',
+          applicable: true,
+          totalRecords: 5,
+          encryptedRecords: 5,
+          keyState: 'unlocked',
+        },
+        {
+          category: 'memos',
+          label: 'Memos',
+          applicable: true,
+          totalRecords: 1,
+          encryptedRecords: 1,
+          keyState: 'locked',
+        },
+        {
+          category: 'attachments',
+          label: 'Attachments',
+          applicable: false,
+          totalRecords: 0,
+          encryptedRecords: 0,
+          keyState: 'not_configured',
+        },
+      ],
+      { crypto: supportedCrypto, indexedDbAvailable: true, persistentStorageAvailable: false },
+    );
+
+    expect(dashboard.firstRunSetupRequired).toBe(true);
+    expect(dashboard.rows.map((row) => row.status)).toEqual([
+      'not_encrypted',
+      'encrypted',
+      'locked',
+      'not_applicable',
+    ]);
+    expect(dashboard.rows[0]?.action).toBe('set_up');
+    expect(dashboard.rows[2]?.action).toBe('unlock');
+  });
+
+  it('uses unavailable fallback copy when Web Crypto or storage is missing', () => {
+    const dashboard = buildEncryptionStatusDashboard(
+      [
+        {
+          category: 'budgets',
+          label: 'Budgets',
+          applicable: true,
+          totalRecords: 1,
+          encryptedRecords: 0,
+          keyState: 'not_configured',
+        },
+      ],
+      { crypto: {} as Crypto, indexedDbAvailable: false, persistentStorageAvailable: false },
+    );
+
+    expect(dashboard.webCryptoAvailable).toBe(false);
+    expect(dashboard.rows[0]).toMatchObject({ status: 'unavailable', action: 'review' });
+    expect(summarizeEncryptionRecovery('unavailable')).toContain('Web Crypto');
+  });
+
+  it('flags partially encrypted migrations for review', () => {
+    const dashboard = buildEncryptionStatusDashboard(
+      [
+        {
+          category: 'audit-log',
+          label: 'Audit log',
+          applicable: true,
+          totalRecords: 3,
+          encryptedRecords: 2,
+          keyState: 'unlocked',
+        },
+      ],
+      { crypto: supportedCrypto, indexedDbAvailable: true, persistentStorageAvailable: true },
+    );
+
+    expect(dashboard.rows[0]).toMatchObject({ status: 'partially_encrypted', action: 'review' });
+    expect(dashboard.rows[0]?.detail).toContain('2 of 3');
+  });
+});

--- a/apps/web/src/lib/security/encryption-status.ts
+++ b/apps/web/src/lib/security/encryption-status.ts
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { isWebCryptoEncryptionSupported } from './encryption-at-rest';
+
+export type EncryptionCategory =
+  | 'accounts'
+  | 'transactions'
+  | 'budgets'
+  | 'goals'
+  | 'memos'
+  | 'attachments'
+  | 'settings'
+  | 'audit-log';
+
+export type EncryptionKeyState = 'not_configured' | 'locked' | 'unlocked' | 'unavailable';
+export type EncryptionStatus =
+  | 'encrypted'
+  | 'partially_encrypted'
+  | 'not_encrypted'
+  | 'locked'
+  | 'not_applicable'
+  | 'unavailable';
+
+export interface EncryptionCategorySnapshot {
+  readonly category: EncryptionCategory;
+  readonly label: string;
+  readonly applicable: boolean;
+  readonly totalRecords: number;
+  readonly encryptedRecords: number;
+  readonly keyState: EncryptionKeyState;
+  readonly lastEncryptedAt?: string;
+}
+
+export interface EncryptionStatusEnvironment {
+  readonly crypto?: Crypto;
+  readonly indexedDbAvailable: boolean;
+  readonly persistentStorageAvailable: boolean;
+}
+
+export interface EncryptionStatusRow {
+  readonly category: EncryptionCategory;
+  readonly label: string;
+  readonly status: EncryptionStatus;
+  readonly detail: string;
+  readonly recoveryConsequence: string;
+  readonly action: 'set_up' | 'unlock' | 'review' | 'none';
+}
+
+export interface EncryptionStatusDashboard {
+  readonly webCryptoAvailable: boolean;
+  readonly storageAvailable: boolean;
+  readonly firstRunSetupRequired: boolean;
+  readonly rows: readonly EncryptionStatusRow[];
+}
+
+const RECOVERY_COPY =
+  'If the recovery secret is lost, encrypted local data cannot be decrypted and must be reset from the last trusted sync or deleted.';
+
+export function buildEncryptionStatusDashboard(
+  snapshots: readonly EncryptionCategorySnapshot[],
+  environment: EncryptionStatusEnvironment,
+): EncryptionStatusDashboard {
+  const webCryptoAvailable = isWebCryptoEncryptionSupported(environment.crypto);
+  const storageAvailable = environment.indexedDbAvailable || environment.persistentStorageAvailable;
+  const rows = snapshots.map((snapshot) => buildEncryptionStatusRow(snapshot, webCryptoAvailable, storageAvailable));
+
+  return {
+    webCryptoAvailable,
+    storageAvailable,
+    firstRunSetupRequired: rows.some((row) => row.action === 'set_up'),
+    rows,
+  };
+}
+
+export function buildEncryptionStatusRow(
+  snapshot: EncryptionCategorySnapshot,
+  webCryptoAvailable: boolean,
+  storageAvailable: boolean,
+): EncryptionStatusRow {
+  if (!snapshot.applicable || snapshot.totalRecords === 0) {
+    return row(snapshot, 'not_applicable', 'No local sensitive records are stored for this category.', 'none');
+  }
+  if (!webCryptoAvailable || !storageAvailable || snapshot.keyState === 'unavailable') {
+    return row(
+      snapshot,
+      'unavailable',
+      'Browser encryption is unavailable; keep this data out of shared devices or use a supported browser.',
+      'review',
+    );
+  }
+  if (snapshot.keyState === 'not_configured') {
+    return row(snapshot, 'not_encrypted', 'Encryption has not been set up for this category.', 'set_up');
+  }
+  if (snapshot.keyState === 'locked') {
+    return row(snapshot, 'locked', 'Encrypted data is present but locked until the recovery secret is provided.', 'unlock');
+  }
+  if (snapshot.encryptedRecords >= snapshot.totalRecords) {
+    return row(snapshot, 'encrypted', 'All local records in this category are encrypted at rest.', 'none');
+  }
+  if (snapshot.encryptedRecords === 0) {
+    return row(snapshot, 'not_encrypted', 'Local records in this category are not encrypted yet.', 'set_up');
+  }
+  return row(
+    snapshot,
+    'partially_encrypted',
+    `${snapshot.encryptedRecords} of ${snapshot.totalRecords} local records are encrypted; finish migration before relying on protection.`,
+    'review',
+  );
+}
+
+export function summarizeEncryptionRecovery(status: EncryptionStatus): string {
+  if (status === 'not_applicable') return 'No recovery action is required for categories with no local sensitive data.';
+  if (status === 'unavailable') return 'Recovery is unavailable until Web Crypto and persistent browser storage are available.';
+  return RECOVERY_COPY;
+}
+
+function row(
+  snapshot: EncryptionCategorySnapshot,
+  status: EncryptionStatus,
+  detail: string,
+  action: EncryptionStatusRow['action'],
+): EncryptionStatusRow {
+  return {
+    category: snapshot.category,
+    label: snapshot.label,
+    status,
+    detail,
+    recoveryConsequence: summarizeEncryptionRecovery(status),
+    action,
+  };
+}

--- a/apps/web/src/lib/security/index.ts
+++ b/apps/web/src/lib/security/index.ts
@@ -104,3 +104,11 @@ export {
   processMemoForExport,
   redactMemo,
 } from './encrypted-memo';
+
+export * from './app-lock-settings';
+export * from './deletion-endpoint';
+export * from './encryption-status';
+export * from './local-wipe-verification';
+export * from './privacy-coverage';
+export * from './privacy-screen-triggers';
+export * from './webauthn-challenge';

--- a/apps/web/src/lib/security/local-wipe-verification.test.ts
+++ b/apps/web/src/lib/security/local-wipe-verification.test.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  REQUIRED_LOCAL_WIPE_AREAS,
+  buildDeletionModeCopy,
+  buildLocalWipeReceipt,
+  localWipeOutcome,
+} from './local-wipe-verification';
+
+describe('local wipe verification helpers', () => {
+  it('verifies deleted and not-applicable local wipe areas', () => {
+    const receipt = buildLocalWipeReceipt(
+      'online',
+      REQUIRED_LOCAL_WIPE_AREAS.map((area) => localWipeOutcome(area, area === 'service-workers' ? 'not_applicable' : 'deleted')),
+    );
+
+    expect(receipt.verified).toBe(true);
+    expect(receipt.deleted).toContain('indexeddb');
+    expect(receipt.notApplicable).toEqual(['service-workers']);
+    expect(receipt.serverDeletionClaim).toBe('confirmed');
+  });
+
+  it('turns missing and failed instrumentation into failed receipt rows', () => {
+    const receipt = buildLocalWipeReceipt('online', [localWipeOutcome('opfs', 'failed', 'quota manager denied wipe')], [
+      'opfs',
+      'indexeddb',
+    ]);
+
+    expect(receipt.verified).toBe(false);
+    expect(receipt.failed).toEqual([
+      { area: 'opfs', detail: 'quota manager denied wipe' },
+      { area: 'indexeddb', detail: 'No wipe verification was recorded.' },
+    ]);
+  });
+
+  it('does not claim server deletion for offline or demo mode', () => {
+    expect(buildLocalWipeReceipt('offline', [], []).serverDeletionClaim).toBe('not_claimed');
+    expect(buildLocalWipeReceipt('demo', [], []).userCopy).toContain('No production server deletion is claimed');
+    expect(buildDeletionModeCopy('offline', 0)).toContain('Server deletion has not been claimed');
+  });
+});

--- a/apps/web/src/lib/security/local-wipe-verification.ts
+++ b/apps/web/src/lib/security/local-wipe-verification.ts
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+export type LocalWipeArea =
+  | 'opfs'
+  | 'indexeddb'
+  | 'caches'
+  | 'service-workers'
+  | 'local-storage'
+  | 'session-storage'
+  | 'sync-queues'
+  | 'audit-log'
+  | 'consent-records';
+
+export type LocalWipeStatus = 'deleted' | 'failed' | 'not_applicable';
+export type DeletionRunMode = 'online' | 'offline' | 'demo';
+
+export interface LocalWipeOutcome {
+  readonly area: LocalWipeArea;
+  readonly status: LocalWipeStatus;
+  readonly detail?: string;
+}
+
+export interface LocalWipeReceipt {
+  readonly mode: DeletionRunMode;
+  readonly verified: boolean;
+  readonly deleted: readonly LocalWipeArea[];
+  readonly failed: readonly Pick<LocalWipeOutcome, 'area' | 'detail'>[];
+  readonly notApplicable: readonly LocalWipeArea[];
+  readonly serverDeletionClaim: 'confirmed' | 'not_claimed';
+  readonly userCopy: string;
+}
+
+export const REQUIRED_LOCAL_WIPE_AREAS: readonly LocalWipeArea[] = [
+  'opfs',
+  'indexeddb',
+  'caches',
+  'service-workers',
+  'local-storage',
+  'session-storage',
+  'sync-queues',
+  'audit-log',
+  'consent-records',
+];
+
+export function buildLocalWipeReceipt(
+  mode: DeletionRunMode,
+  outcomes: readonly LocalWipeOutcome[],
+  requiredAreas: readonly LocalWipeArea[] = REQUIRED_LOCAL_WIPE_AREAS,
+): LocalWipeReceipt {
+  const byArea = new Map(outcomes.map((outcome) => [outcome.area, outcome]));
+  const missingOutcomes = requiredAreas
+    .filter((area) => !byArea.has(area))
+    .map((area) => ({ area, status: 'failed', detail: 'No wipe verification was recorded.' }) as const);
+  const completeOutcomes = [...outcomes, ...missingOutcomes].filter((outcome) => requiredAreas.includes(outcome.area));
+  const failed = completeOutcomes
+    .filter((outcome) => outcome.status === 'failed')
+    .map((outcome) => ({ area: outcome.area, detail: outcome.detail }));
+  const deleted = completeOutcomes.filter((outcome) => outcome.status === 'deleted').map((outcome) => outcome.area);
+  const notApplicable = completeOutcomes
+    .filter((outcome) => outcome.status === 'not_applicable')
+    .map((outcome) => outcome.area);
+
+  return {
+    mode,
+    verified: failed.length === 0,
+    deleted,
+    failed,
+    notApplicable,
+    serverDeletionClaim: mode === 'online' ? 'confirmed' : 'not_claimed',
+    userCopy: buildDeletionModeCopy(mode, failed.length),
+  };
+}
+
+export function buildDeletionModeCopy(mode: DeletionRunMode, failureCount: number): string {
+  if (mode === 'demo') {
+    return 'Demo data was cleared locally only. No production server deletion is claimed.';
+  }
+  if (mode === 'offline') {
+    return 'Local data was cleared on this device while offline. Server deletion has not been claimed.';
+  }
+  if (failureCount > 0) {
+    return 'Some local areas could not be verified; retry before treating this device as wiped.';
+  }
+  return 'Local browser data was verified as deleted or not applicable for this device.';
+}
+
+export function localWipeOutcome(area: LocalWipeArea, status: LocalWipeStatus, detail?: string): LocalWipeOutcome {
+  return { area, status, detail };
+}

--- a/apps/web/src/lib/security/privacy-coverage.test.ts
+++ b/apps/web/src/lib/security/privacy-coverage.test.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import { REQUIRED_PRIVACY_SURFACE_AREAS, auditPrivacySurfaceCoverage, privacySurface } from './privacy-coverage';
+
+describe('privacy surface coverage audit', () => {
+  it('passes when all sensitive surface areas are masked and exports are explicitly redacted', () => {
+    const audit = auditPrivacySurfaceCoverage([
+      privacySurface('dashboard-balance', 'dashboard', ['balance'], 'masked'),
+      privacySurface('cashflow-chart', 'chart', ['amount', 'chart-label'], 'bucketed'),
+      privacySurface('transaction-detail', 'detail', ['amount', 'merchant-name'], 'masked'),
+      privacySurface('csv-export', 'export', ['amount'], 'redacted_on_export', true),
+      privacySurface('bill-notification', 'notification', ['notification'], 'masked'),
+      privacySurface('search-result', 'search', ['search-result'], 'masked'),
+      privacySurface('account-nav', 'navigation', ['account-name'], 'masked'),
+    ]);
+
+    expect(audit.complete).toBe(true);
+    expect(audit.coveredAreas).toEqual(REQUIRED_PRIVACY_SURFACE_AREAS);
+  });
+
+  it('flags unmasked sensitive surfaces and implicit export redaction', () => {
+    const audit = auditPrivacySurfaceCoverage([
+      privacySurface('dashboard-balance', 'dashboard', ['balance'], 'none'),
+      privacySurface('csv-export', 'export', ['amount'], 'redacted_on_export', false),
+    ]);
+
+    expect(audit.complete).toBe(false);
+    expect(audit.missingMaskingIds).toEqual(['dashboard-balance']);
+    expect(audit.missingExportRedactionIds).toEqual(['csv-export']);
+    expect(audit.uncoveredAreas).toEqual(['chart', 'detail', 'notification', 'search', 'navigation']);
+  });
+});

--- a/apps/web/src/lib/security/privacy-coverage.ts
+++ b/apps/web/src/lib/security/privacy-coverage.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import type { SensitiveSurfaceCategory } from './privacy-screen';
+
+export type SensitiveSurfaceArea =
+  | 'dashboard'
+  | 'chart'
+  | 'detail'
+  | 'export'
+  | 'notification'
+  | 'search'
+  | 'navigation';
+
+export interface PrivacySurfaceCoverageItem {
+  readonly id: string;
+  readonly area: SensitiveSurfaceArea;
+  readonly categories: readonly SensitiveSurfaceCategory[];
+  readonly maskingBehavior: 'masked' | 'bucketed' | 'redacted_on_export' | 'none';
+  readonly exportRedactionExplicit?: boolean;
+}
+
+export interface PrivacyCoverageAudit {
+  readonly complete: boolean;
+  readonly missingMaskingIds: readonly string[];
+  readonly missingExportRedactionIds: readonly string[];
+  readonly coveredAreas: readonly SensitiveSurfaceArea[];
+  readonly uncoveredAreas: readonly SensitiveSurfaceArea[];
+}
+
+export const REQUIRED_PRIVACY_SURFACE_AREAS: readonly SensitiveSurfaceArea[] = [
+  'dashboard',
+  'chart',
+  'detail',
+  'export',
+  'notification',
+  'search',
+  'navigation',
+];
+
+export function auditPrivacySurfaceCoverage(
+  surfaces: readonly PrivacySurfaceCoverageItem[],
+  requiredAreas: readonly SensitiveSurfaceArea[] = REQUIRED_PRIVACY_SURFACE_AREAS,
+): PrivacyCoverageAudit {
+  const coveredAreas = requiredAreas.filter((area) => surfaces.some((surface) => surface.area === area));
+  const uncoveredAreas = requiredAreas.filter((area) => !coveredAreas.includes(area));
+  const sensitiveSurfaces = surfaces.filter((surface) => surface.categories.length > 0);
+  const missingMaskingIds = sensitiveSurfaces
+    .filter((surface) => surface.area !== 'export' && surface.maskingBehavior === 'none')
+    .map((surface) => surface.id);
+  const missingExportRedactionIds = sensitiveSurfaces
+    .filter((surface) => surface.area === 'export')
+    .filter((surface) => surface.maskingBehavior !== 'redacted_on_export' || surface.exportRedactionExplicit !== true)
+    .map((surface) => surface.id);
+
+  return {
+    complete: uncoveredAreas.length === 0 && missingMaskingIds.length === 0 && missingExportRedactionIds.length === 0,
+    missingMaskingIds,
+    missingExportRedactionIds,
+    coveredAreas,
+    uncoveredAreas,
+  };
+}
+
+export function privacySurface(
+  id: string,
+  area: SensitiveSurfaceArea,
+  categories: readonly SensitiveSurfaceCategory[],
+  maskingBehavior: PrivacySurfaceCoverageItem['maskingBehavior'],
+  exportRedactionExplicit = false,
+): PrivacySurfaceCoverageItem {
+  return { id, area, categories, maskingBehavior, exportRedactionExplicit };
+}

--- a/apps/web/src/lib/security/privacy-screen-triggers.test.ts
+++ b/apps/web/src/lib/security/privacy-screen-triggers.test.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_PRIVACY_SCREEN_TRIGGER_SETTINGS,
+  DEFAULT_PRIVACY_SCREEN_TRIGGER_STATE,
+  inferScreenShareActive,
+  matchesPrivacyScreenShortcut,
+  reducePrivacyScreenTrigger,
+} from './privacy-screen-triggers';
+
+describe('privacy screen triggers', () => {
+  it('toggles immediately without transition-frame sensitive rendering', () => {
+    const on = reducePrivacyScreenTrigger(
+      DEFAULT_PRIVACY_SCREEN_TRIGGER_SETTINGS,
+      DEFAULT_PRIVACY_SCREEN_TRIGGER_STATE,
+      'manual_toggle',
+    );
+
+    expect(on.state.masked).toBe(true);
+    expect(on.state.renderSensitiveValues).toBe(false);
+    expect(on.announce).toContain('Sensitive values are hidden');
+
+    const off = reducePrivacyScreenTrigger(DEFAULT_PRIVACY_SCREEN_TRIGGER_SETTINGS, on.state, 'keyboard_shortcut');
+    expect(off.state.masked).toBe(false);
+    expect(off.state.renderSensitiveValues).toBe(true);
+  });
+
+  it('masks on background, resume, and screen-share heuristics by default', () => {
+    let result = reducePrivacyScreenTrigger(DEFAULT_PRIVACY_SCREEN_TRIGGER_SETTINGS, DEFAULT_PRIVACY_SCREEN_TRIGGER_STATE, 'background');
+    expect(result.state.masked).toBe(true);
+
+    result = reducePrivacyScreenTrigger(DEFAULT_PRIVACY_SCREEN_TRIGGER_SETTINGS, DEFAULT_PRIVACY_SCREEN_TRIGGER_STATE, 'resume');
+    expect(result.state.renderSensitiveValues).toBe(false);
+
+    result = reducePrivacyScreenTrigger(DEFAULT_PRIVACY_SCREEN_TRIGGER_SETTINGS, DEFAULT_PRIVACY_SCREEN_TRIGGER_STATE, 'screen_share_start');
+    expect(result.state.masked).toBe(true);
+    expect(reducePrivacyScreenTrigger(DEFAULT_PRIVACY_SCREEN_TRIGGER_SETTINGS, result.state, 'screen_share_stop').state.masked).toBe(false);
+  });
+
+  it('recognizes accessible shortcut and display-surface signals', () => {
+    expect(matchesPrivacyScreenShortcut({ altKey: true, shiftKey: true, ctrlKey: false, metaKey: false, key: 'P' })).toBe(true);
+    expect(matchesPrivacyScreenShortcut({ altKey: false, shiftKey: true, ctrlKey: false, metaKey: false, key: 'P' })).toBe(false);
+    expect(inferScreenShareActive({ displaySurface: 'monitor' })).toBe(true);
+    expect(inferScreenShareActive(undefined)).toBe(false);
+  });
+
+  it('keeps safe defaults when privacy screen is disabled', () => {
+    const result = reducePrivacyScreenTrigger(
+      { ...DEFAULT_PRIVACY_SCREEN_TRIGGER_SETTINGS, enabled: false },
+      { ...DEFAULT_PRIVACY_SCREEN_TRIGGER_STATE, masked: true, renderSensitiveValues: false },
+      'background',
+    );
+
+    expect(result.state.masked).toBe(false);
+    expect(result.state.renderSensitiveValues).toBe(true);
+  });
+});

--- a/apps/web/src/lib/security/privacy-screen-triggers.ts
+++ b/apps/web/src/lib/security/privacy-screen-triggers.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+export type PrivacyScreenTriggerEvent =
+  | 'manual_toggle'
+  | 'keyboard_shortcut'
+  | 'background'
+  | 'resume'
+  | 'screen_share_start'
+  | 'screen_share_stop';
+
+export interface PrivacyScreenTriggerSettings {
+  readonly enabled: boolean;
+  readonly quickToggleEnabled: boolean;
+  readonly shortcut: string;
+  readonly maskOnBackground: boolean;
+  readonly maskOnResume: boolean;
+  readonly maskOnScreenShare: boolean;
+}
+
+export interface PrivacyScreenTriggerState {
+  readonly masked: boolean;
+  readonly lastTrigger: PrivacyScreenTriggerEvent | null;
+  readonly renderSensitiveValues: boolean;
+}
+
+export interface PrivacyScreenTriggerResult {
+  readonly state: PrivacyScreenTriggerState;
+  readonly announce: string;
+}
+
+export const DEFAULT_PRIVACY_SCREEN_TRIGGER_SETTINGS: PrivacyScreenTriggerSettings = {
+  enabled: true,
+  quickToggleEnabled: true,
+  shortcut: 'Alt+Shift+P',
+  maskOnBackground: true,
+  maskOnResume: true,
+  maskOnScreenShare: true,
+};
+
+export const DEFAULT_PRIVACY_SCREEN_TRIGGER_STATE: PrivacyScreenTriggerState = {
+  masked: false,
+  lastTrigger: null,
+  renderSensitiveValues: true,
+};
+
+export function reducePrivacyScreenTrigger(
+  settings: PrivacyScreenTriggerSettings,
+  state: PrivacyScreenTriggerState,
+  event: PrivacyScreenTriggerEvent,
+): PrivacyScreenTriggerResult {
+  if (!settings.enabled) return result({ ...state, masked: false, renderSensitiveValues: true, lastTrigger: event }, 'Privacy screen is off.');
+
+  if ((event === 'manual_toggle' || event === 'keyboard_shortcut') && settings.quickToggleEnabled) {
+    return buildMaskedState(!state.masked, event);
+  }
+  if (event === 'background' && settings.maskOnBackground) return buildMaskedState(true, event);
+  if (event === 'resume' && settings.maskOnResume) return buildMaskedState(true, event);
+  if (event === 'screen_share_start' && settings.maskOnScreenShare) return buildMaskedState(true, event);
+  if (event === 'screen_share_stop' && state.lastTrigger === 'screen_share_start') return buildMaskedState(false, event);
+
+  return result(state, state.masked ? 'Privacy screen remains on.' : 'Privacy screen remains off.');
+}
+
+export function matchesPrivacyScreenShortcut(
+  event: Pick<KeyboardEvent, 'altKey' | 'shiftKey' | 'ctrlKey' | 'metaKey' | 'key'>,
+  shortcut = 'Alt+Shift+P',
+): boolean {
+  const normalized = shortcut.toLowerCase();
+  return (
+    normalized === 'alt+shift+p' &&
+    event.altKey &&
+    event.shiftKey &&
+    !event.ctrlKey &&
+    !event.metaKey &&
+    event.key.toLowerCase() === 'p'
+  );
+}
+
+export function inferScreenShareActive(trackSettings: Pick<MediaTrackSettings, 'displaySurface'> | undefined): boolean {
+  return trackSettings?.displaySurface === 'monitor' || trackSettings?.displaySurface === 'window' || trackSettings?.displaySurface === 'browser';
+}
+
+function buildMaskedState(masked: boolean, trigger: PrivacyScreenTriggerEvent): PrivacyScreenTriggerResult {
+  return result(
+    { masked, lastTrigger: trigger, renderSensitiveValues: !masked },
+    masked ? 'Privacy screen on. Sensitive values are hidden.' : 'Privacy screen off. Sensitive values are visible.',
+  );
+}
+
+function result(state: PrivacyScreenTriggerState, announce: string): PrivacyScreenTriggerResult {
+  return { state: { ...state, renderSensitiveValues: !state.masked }, announce };
+}

--- a/apps/web/src/lib/security/webauthn-challenge.test.ts
+++ b/apps/web/src/lib/security/webauthn-challenge.test.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  completeWebAuthnAppLockChallenge,
+  createWebAuthnAppLockChallenge,
+  evaluateChallengePreflight,
+} from './webauthn-challenge';
+
+describe('WebAuthn app-lock challenge service', () => {
+  const publicKeyCredential = function PublicKeyCredential() {} as unknown as typeof PublicKeyCredential;
+
+  it('creates short-lived user-verifying challenges from strong random bytes', () => {
+    const challenge = createWebAuthnAppLockChallenge({ nowMs: 1_000, ttlMs: 30_000, randomBytes: new Uint8Array(32).fill(7) });
+
+    expect(challenge.expiresAtMs).toBe(31_000);
+    expect(challenge.timeoutMs).toBe(30_000);
+    expect(challenge.challengeBase64Url.length).toBeGreaterThan(20);
+  });
+
+  it('rejects unsupported, expired, and replayed challenge paths before invoking WebAuthn', () => {
+    const challenge = createWebAuthnAppLockChallenge({ nowMs: 1_000, ttlMs: 10, randomBytes: new Uint8Array(32).fill(1) });
+    const credentials = { get: vi.fn() } as unknown as CredentialsContainer;
+
+    expect(evaluateChallengePreflight(challenge, 1_001, undefined, undefined)?.status).toBe('unsupported');
+    expect(evaluateChallengePreflight(challenge, 2_000, credentials, publicKeyCredential)?.status).toBe('expired');
+    expect(
+      evaluateChallengePreflight({ ...challenge, usedAtMs: 1_002 }, 1_003, credentials, publicKeyCredential)?.status,
+    ).toBe('replayed');
+    expect((credentials.get as unknown as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+  });
+
+  it('marks a successful challenge as used to prevent replay', async () => {
+    const challenge = createWebAuthnAppLockChallenge({ nowMs: 1_000, randomBytes: new Uint8Array(32).fill(2) });
+    const credential = { type: 'public-key', rawId: new ArrayBuffer(1) } as PublicKeyCredential;
+
+    const result = await completeWebAuthnAppLockChallenge({
+      challenge,
+      nowMs: 1_100,
+      credentials: { get: vi.fn().mockResolvedValue(credential) } as unknown as CredentialsContainer,
+      publicKeyCredential,
+    });
+
+    expect(result).toMatchObject({ status: 'verified', credential });
+    expect(result.challenge.usedAtMs).toBe(1_100);
+    expect(evaluateChallengePreflight(result.challenge, 1_101, { get: vi.fn() } as unknown as CredentialsContainer, publicKeyCredential)?.status).toBe('replayed');
+  });
+
+  it('maps cancelled and failed WebAuthn results to recovery copy', async () => {
+    const challenge = createWebAuthnAppLockChallenge({ nowMs: 1_000, randomBytes: new Uint8Array(32).fill(3) });
+
+    await expect(
+      completeWebAuthnAppLockChallenge({
+        challenge,
+        nowMs: 1_100,
+        credentials: { get: vi.fn().mockRejectedValue(new DOMException('cancelled', 'AbortError')) } as unknown as CredentialsContainer,
+        publicKeyCredential,
+      }),
+    ).resolves.toMatchObject({ status: 'cancelled' });
+
+    await expect(
+      completeWebAuthnAppLockChallenge({
+        challenge,
+        nowMs: 1_100,
+        credentials: { get: vi.fn().mockResolvedValue(null) } as unknown as CredentialsContainer,
+        publicKeyCredential,
+      }),
+    ).resolves.toMatchObject({ status: 'failed' });
+  });
+});

--- a/apps/web/src/lib/security/webauthn-challenge.ts
+++ b/apps/web/src/lib/security/webauthn-challenge.ts
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { buildPasskeyGateRequestOptions, isPasskeyAppLockSupported, type PasskeyGateChallenge } from './passkey-gate';
+
+export type WebAuthnChallengeStatus =
+  | 'created'
+  | 'verified'
+  | 'unsupported'
+  | 'cancelled'
+  | 'failed'
+  | 'expired'
+  | 'replayed';
+
+export interface WebAuthnAppLockChallenge extends PasskeyGateChallenge {
+  readonly id: string;
+  readonly issuedAtMs: number;
+  readonly expiresAtMs: number;
+  readonly usedAtMs?: number;
+}
+
+export interface CreateWebAuthnChallengeOptions {
+  readonly nowMs: number;
+  readonly ttlMs?: number;
+  readonly randomBytes?: Uint8Array;
+  readonly crypto?: Crypto;
+  readonly rpId?: string;
+  readonly credentialIdsBase64Url?: readonly string[];
+}
+
+export interface CompleteWebAuthnChallengeOptions {
+  readonly challenge: WebAuthnAppLockChallenge;
+  readonly nowMs: number;
+  readonly credentials?: CredentialsContainer;
+  readonly publicKeyCredential?: typeof PublicKeyCredential;
+}
+
+export interface WebAuthnChallengeResult {
+  readonly status: WebAuthnChallengeStatus;
+  readonly challenge: WebAuthnAppLockChallenge;
+  readonly credential?: PublicKeyCredential;
+  readonly recoveryCopy: string;
+  readonly error?: string;
+}
+
+export function createWebAuthnAppLockChallenge({
+  nowMs,
+  ttlMs = 60_000,
+  randomBytes,
+  crypto = globalThis.crypto,
+  rpId,
+  credentialIdsBase64Url,
+}: CreateWebAuthnChallengeOptions): WebAuthnAppLockChallenge {
+  if (ttlMs <= 0) throw new Error('WebAuthn challenge TTL must be positive.');
+  const bytes = randomBytes ?? crypto.getRandomValues(new Uint8Array(32));
+  if (bytes.byteLength < 16) throw new Error('WebAuthn challenges must contain at least 16 random bytes.');
+  const challengeBase64Url = bytesToBase64Url(bytes);
+
+  return {
+    id: challengeBase64Url.slice(0, 22),
+    challengeBase64Url,
+    issuedAtMs: nowMs,
+    expiresAtMs: nowMs + ttlMs,
+    timeoutMs: ttlMs,
+    rpId,
+    credentialIdsBase64Url,
+  };
+}
+
+export async function completeWebAuthnAppLockChallenge({
+  challenge,
+  nowMs,
+  credentials = globalThis.navigator?.credentials,
+  publicKeyCredential = globalThis.PublicKeyCredential,
+}: CompleteWebAuthnChallengeOptions): Promise<WebAuthnChallengeResult> {
+  const preflight = evaluateChallengePreflight(challenge, nowMs, credentials, publicKeyCredential);
+  if (preflight) return preflight;
+
+  try {
+    const credential = await credentials.get({
+      publicKey: buildPasskeyGateRequestOptions(challenge),
+      mediation: 'optional',
+    });
+
+    if (!isPublicKeyCredential(credential)) {
+      return finishChallenge(challenge, nowMs, 'failed', undefined, 'Passkey unlock did not return a public-key credential.');
+    }
+
+    return finishChallenge(challenge, nowMs, 'verified', credential);
+  } catch (error) {
+    const name = error instanceof DOMException ? error.name : '';
+    if (name === 'NotAllowedError' || name === 'AbortError') {
+      return finishChallenge(challenge, nowMs, 'cancelled', undefined, 'Passkey unlock was cancelled.');
+    }
+    return finishChallenge(
+      challenge,
+      nowMs,
+      'failed',
+      undefined,
+      error instanceof Error ? error.message : 'Passkey unlock failed.',
+    );
+  }
+}
+
+export function evaluateChallengePreflight(
+  challenge: WebAuthnAppLockChallenge,
+  nowMs: number,
+  credentials: CredentialsContainer | undefined = globalThis.navigator?.credentials,
+  publicKeyCredential: typeof PublicKeyCredential | undefined = globalThis.PublicKeyCredential,
+): WebAuthnChallengeResult | null {
+  if (!isPasskeyAppLockSupported(credentials, publicKeyCredential)) {
+    return finishChallenge(challenge, nowMs, 'unsupported', undefined, 'Passkey app lock is not supported in this browser.');
+  }
+  if (challenge.usedAtMs !== undefined) {
+    return finishChallenge(challenge, nowMs, 'replayed', undefined, 'This passkey challenge was already used.');
+  }
+  if (nowMs > challenge.expiresAtMs) {
+    return finishChallenge(challenge, nowMs, 'expired', undefined, 'This passkey challenge expired.');
+  }
+  return null;
+}
+
+function finishChallenge(
+  challenge: WebAuthnAppLockChallenge,
+  nowMs: number,
+  status: Exclude<WebAuthnChallengeStatus, 'created'>,
+  credential?: PublicKeyCredential,
+  error?: string,
+): WebAuthnChallengeResult {
+  return {
+    status,
+    challenge: status === 'verified' ? { ...challenge, usedAtMs: nowMs } : challenge,
+    credential,
+    recoveryCopy:
+      status === 'unsupported'
+        ? 'Use the configured recovery method or disable app lock from a trusted session on this device.'
+        : 'If passkey unlock fails, use the recovery method configured when app lock was enabled.',
+    error,
+  };
+}
+
+function isPublicKeyCredential(value: Credential | null): value is PublicKeyCredential {
+  return value !== null && value.type === 'public-key' && 'rawId' in value;
+}
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}


### PR DESCRIPTION
Wave-2 completable cores for security (isolated, tested, local-first). Part of the beta sub-issue implementation pass.