### PR TITLE
feat(onboarding): Onboarding sub-feature cores (demo session, welcome-back, re-engagement consent)

### DIFF
--- a/apps/web/src/lib/onboarding/demo-mode-session.test.ts
+++ b/apps/web/src/lib/onboarding/demo-mode-session.test.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+import {
+  buildDemoModeBanner,
+  buildDemoModeEntryState,
+  resetDemoRecords,
+  tagDemoRecords,
+  type DemoTaggedRecord,
+} from './demo-mode-session';
+
+describe('demo mode session', () => {
+  it('tags and removes only demo records during reset', () => {
+    const tagged = tagDemoRecords<DemoTaggedRecord>([{ id: 'demo-account' }]);
+    const result = resetDemoRecords([...tagged, { id: 'real-account', tags: ['real'] }]);
+
+    expect(tagged[0].metadata?.demoMode).toBe(true);
+    expect(result.deletedDemoIds).toEqual(['demo-account']);
+    expect(result.keptRecords.map((record) => record.id)).toEqual(['real-account']);
+  });
+
+  it('builds accessible banner and protects real setup from demo mixing', () => {
+    expect(buildDemoModeBanner(true).ariaLabel).toContain('Fictional sample data');
+    expect(buildDemoModeEntryState({ hasRealAccounts: true, demoEnabled: false })).toMatchObject({
+      canStartDemo: false,
+      primaryLabel: 'Demo unavailable',
+    });
+  });
+});

--- a/apps/web/src/lib/onboarding/demo-mode-session.ts
+++ b/apps/web/src/lib/onboarding/demo-mode-session.ts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+export const DEMO_MODE_TAG = 'demo-mode';
+
+export interface DemoTaggedRecord {
+  readonly id: string;
+  readonly tags?: readonly string[];
+  readonly metadata?: Readonly<Record<string, string | boolean | number>>;
+}
+
+export interface DemoModeBanner {
+  readonly visible: boolean;
+  readonly tone: 'info';
+  readonly text: string;
+  readonly resetLabel: string;
+  readonly exitLabel: string;
+  readonly ariaLabel: string;
+}
+
+export interface DemoResetResult<T extends DemoTaggedRecord> {
+  readonly keptRecords: readonly T[];
+  readonly deletedDemoIds: readonly string[];
+}
+
+export function isDemoTagged(record: DemoTaggedRecord): boolean {
+  return record.tags?.includes(DEMO_MODE_TAG) === true || record.metadata?.demoMode === true;
+}
+
+export function buildDemoModeBanner(enabled: boolean): DemoModeBanner {
+  return {
+    visible: enabled,
+    tone: 'info',
+    text: enabled
+      ? 'Demo mode is using fictional sample finances. Reset or exit before adding real accounts.'
+      : 'Demo mode is off.',
+    resetLabel: 'Reset demo data',
+    exitLabel: 'Exit demo mode',
+    ariaLabel: enabled
+      ? 'Demo mode banner. Fictional sample data is active.'
+      : 'Demo mode is currently off.',
+  };
+}
+
+export function tagDemoRecords<T extends DemoTaggedRecord>(records: readonly T[]): T[] {
+  return records.map((record) => ({
+    ...record,
+    tags: Array.from(new Set([...(record.tags ?? []), DEMO_MODE_TAG])),
+    metadata: { ...(record.metadata ?? {}), demoMode: true },
+  }));
+}
+
+export function resetDemoRecords<T extends DemoTaggedRecord>(records: readonly T[]): DemoResetResult<T> {
+  const keptRecords = records.filter((record) => !isDemoTagged(record));
+  return {
+    keptRecords,
+    deletedDemoIds: records.filter(isDemoTagged).map((record) => record.id),
+  };
+}
+
+export function buildDemoModeEntryState(params: {
+  readonly hasRealAccounts: boolean;
+  readonly demoEnabled: boolean;
+}): {
+  readonly canStartDemo: boolean;
+  readonly primaryLabel: string;
+  readonly warning?: string;
+} {
+  if (params.demoEnabled) {
+    return { canStartDemo: false, primaryLabel: 'Continue demo' };
+  }
+  if (params.hasRealAccounts) {
+    return {
+      canStartDemo: false,
+      primaryLabel: 'Demo unavailable',
+      warning: 'Demo mode starts from a clean fictional workspace to avoid mixing with real records.',
+    };
+  }
+  return { canStartDemo: true, primaryLabel: 'Try demo mode' };
+}

--- a/apps/web/src/lib/onboarding/re-engagement-consent.test.ts
+++ b/apps/web/src/lib/onboarding/re-engagement-consent.test.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+import { buildSetupMilestones, decideReEngagement } from './re-engagement';
+import { buildReEngagementReminderPlan } from './re-engagement-consent';
+
+describe('re-engagement consent', () => {
+  it('allows reminders and analytics only when consent and visibility permit them', () => {
+    const decision = decideReEngagement({
+      now: new Date('2026-05-10T00:00:00Z'),
+      lastActiveAt: new Date('2026-05-01T00:00:00Z'),
+      milestones: buildSetupMilestones([]),
+      consent: { analytics: true, email: true, notifications: false },
+    });
+
+    const plan = buildReEngagementReminderPlan({
+      decision,
+      requestedChannels: ['email'],
+      now: new Date('2026-05-10T00:00:00Z'),
+    });
+
+    expect(plan.reminders[0]).toMatchObject({ allowed: true });
+    expect(plan.analyticsEvent?.properties.remainingSteps).toBeGreaterThan(0);
+  });
+
+  it('suppresses repeated interruptions after dismissal', () => {
+    const decision = decideReEngagement({
+      now: new Date('2026-05-10T00:00:00Z'),
+      lastActiveAt: new Date('2026-05-01T00:00:00Z'),
+      milestones: buildSetupMilestones([]),
+      consent: { analytics: true, email: true, notifications: true },
+    });
+
+    const plan = buildReEngagementReminderPlan({
+      decision,
+      requestedChannels: ['notification', 'email'],
+      dismissedUntil: new Date('2026-05-12T00:00:00Z'),
+      now: new Date('2026-05-10T00:00:00Z'),
+    });
+
+    expect(plan.interruptionSuppressed).toBe(true);
+    expect(plan.reminders.every((reminder) => !reminder.allowed)).toBe(true);
+    expect(plan.analyticsEvent).toBeNull();
+  });
+});

--- a/apps/web/src/lib/onboarding/re-engagement-consent.ts
+++ b/apps/web/src/lib/onboarding/re-engagement-consent.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import type { ReEngagementDecision } from './re-engagement';
+
+export type ReEngagementReminderChannel = 'notification' | 'email';
+
+export interface ReEngagementReminderPlan {
+  readonly reminders: readonly {
+    readonly channel: ReEngagementReminderChannel;
+    readonly allowed: boolean;
+    readonly reason: string;
+  }[];
+  readonly analyticsEvent:
+    | {
+        readonly name: 'onboarding_re_engagement_shown';
+        readonly properties: Readonly<Record<string, string | number | boolean>>;
+      }
+    | null;
+  readonly interruptionSuppressed: boolean;
+  readonly copy: string;
+}
+
+export function buildReEngagementReminderPlan(params: {
+  readonly decision: ReEngagementDecision;
+  readonly requestedChannels: readonly ReEngagementReminderChannel[];
+  readonly dismissedUntil?: Date;
+  readonly now: Date;
+}): ReEngagementReminderPlan {
+  const suppressed = params.dismissedUntil !== undefined && params.dismissedUntil > params.now;
+  const reminders = params.requestedChannels.map((channel) => {
+    const consentAllows = params.decision.canSendReminder;
+    const allowed = params.decision.shouldShow && consentAllows && !suppressed;
+    return {
+      channel,
+      allowed,
+      reason: allowed
+        ? 'Consent permits this gentle reminder.'
+        : suppressed
+          ? 'Reminder suppressed after dismissal.'
+          : consentAllows
+            ? 'Welcome-back surface is not currently eligible.'
+            : 'Reminder consent is not enabled.',
+    };
+  });
+
+  return {
+    reminders,
+    analyticsEvent:
+      params.decision.shouldShow && params.decision.canTrackAnalytics && !suppressed
+        ? {
+            name: 'onboarding_re_engagement_shown',
+            properties: {
+              inactiveDays: params.decision.inactiveDays,
+              remainingSteps: params.decision.remaining.length,
+              hasPrimaryAction: params.decision.primaryAction !== undefined,
+            },
+          }
+        : null,
+    interruptionSuppressed: suppressed,
+    copy: 'A short setup reminder is available when you want it. You can dismiss it any time.',
+  };
+}

--- a/apps/web/src/lib/onboarding/welcome-back-surface.test.ts
+++ b/apps/web/src/lib/onboarding/welcome-back-surface.test.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+import { buildSetupMilestones, decideReEngagement } from './re-engagement';
+import { buildWelcomeBackSurface, dismissWelcomeBack, getWelcomeBackActionHref, recordLastActive } from './welcome-back-surface';
+
+describe('welcome back surface', () => {
+  it('maps re-engagement decisions to accessible dashboard state and routes', () => {
+    const decision = decideReEngagement({
+      now: new Date('2026-04-10T00:00:00Z'),
+      lastActiveAt: new Date('2026-04-01T00:00:00Z'),
+      milestones: buildSetupMilestones(['comfort-settings']),
+      consent: { analytics: true, email: false, notifications: false },
+    });
+
+    const surface = buildWelcomeBackSurface(decision);
+
+    expect(surface.visible).toBe(true);
+    expect(surface.remainingCount).toBeGreaterThan(0);
+    expect(getWelcomeBackActionHref(surface.primaryAction)).toContain('/onboarding');
+  });
+
+  it('persists activity and dismissal timestamps in serializable state', () => {
+    const active = recordLastActive({}, new Date('2026-04-10T00:00:00Z'));
+    const dismissed = dismissWelcomeBack(active, new Date('2026-04-10T00:00:00Z'), 3);
+
+    expect(active.lastActiveAt).toBe('2026-04-10T00:00:00.000Z');
+    expect(dismissed.dismissedUntil).toBe('2026-04-13T00:00:00.000Z');
+  });
+});

--- a/apps/web/src/lib/onboarding/welcome-back-surface.ts
+++ b/apps/web/src/lib/onboarding/welcome-back-surface.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import {
+  nextDismissedUntil,
+  type ReEngagementAction,
+  type ReEngagementDecision,
+} from './re-engagement';
+
+export interface WelcomeBackSurface {
+  readonly visible: boolean;
+  readonly title: string;
+  readonly message: string;
+  readonly completedCount: number;
+  readonly remainingCount: number;
+  readonly primaryAction?: ReEngagementAction;
+  readonly secondaryAction: ReEngagementAction;
+  readonly ariaLabel: string;
+}
+
+export interface WelcomeBackState {
+  readonly lastActiveAt?: string;
+  readonly dismissedUntil?: string;
+}
+
+export function buildWelcomeBackSurface(decision: ReEngagementDecision): WelcomeBackSurface {
+  return {
+    visible: decision.shouldShow,
+    title: 'Welcome back',
+    message: decision.message,
+    completedCount: decision.completed.length,
+    remainingCount: decision.remaining.length,
+    primaryAction: decision.primaryAction,
+    secondaryAction: decision.secondaryAction,
+    ariaLabel: decision.shouldShow
+      ? `Welcome back. ${decision.remaining.length} setup step(s) remain.`
+      : 'Welcome back message is hidden.',
+  };
+}
+
+export function recordLastActive(state: WelcomeBackState, now: Date): WelcomeBackState {
+  return { ...state, lastActiveAt: now.toISOString() };
+}
+
+export function dismissWelcomeBack(state: WelcomeBackState, now: Date, snoozeDays = 7): WelcomeBackState {
+  return { ...state, dismissedUntil: nextDismissedUntil(now, snoozeDays).toISOString() };
+}
+
+export const RE_ENGAGEMENT_ACTION_ROUTES: Readonly<Record<Exclude<ReEngagementAction['id'], 'dismiss'>, string>> = {
+  'review-comfort-settings': '/onboarding?step=comfort-settings',
+  'choose-privacy-mode': '/onboarding?step=privacy-choice',
+  'pick-life-stage': '/onboarding?step=life-stage',
+  'create-budget': '/budgets?intent=create',
+  'create-goal': '/goals?intent=create',
+  'continue-learning': '/onboarding?step=first-lesson',
+  'open-checklist': '/onboarding?step=setup-checklist',
+};
+
+export function getWelcomeBackActionHref(action: ReEngagementAction | undefined): string | null {
+  if (!action || action.id === 'dismiss') return null;
+  return RE_ENGAGEMENT_ACTION_ROUTES[action.id];
+}


### PR DESCRIPTION
Wave-2 completable cores for onboarding (isolated, tested, local-first). Part of the beta sub-issue implementation pass.