### PR TITLE
feat(a11y): final accessibility wiring + audit docs

### DIFF
--- a/apps/web/docs/a11y/chart-screen-reader-audit.md
+++ b/apps/web/docs/a11y/chart-screen-reader-audit.md
@@ -1,0 +1,13 @@
+# Finance chart screen-reader audit
+
+Scope: dashboard spending trends, planning trend charts, spending/category charts, and budget donut charts. Manual AT matrix to run: NVDA/Firefox, JAWS/Chrome, VoiceOver/Safari.
+
+| Chart | Routes | SR support status | Remaining gaps |
+| --- | --- | --- | --- |
+| SpendingTrendChart | Dashboard | Figure name, hidden summary, keyboard data navigator, data table fallback, and focused-point live announcements are wired. | Confirm Recharts SVG names in all browser/AT pairs. |
+| TrendLineChart | Planning and shared chart surfaces | Figure name, hidden summary, keyboard data navigator, data table fallback, and focused-point live announcements are wired. | Add route-specific summaries where pages provide comparison context. |
+| SpendingBarChart | Dashboard visualizations | Figure name, hidden summary, focusable categories, and live-region point announcement support are present. | Validate real Recharts cells receive roving tabindex in browser. |
+| CategoryPieChart | Dashboard visualizations | Figure name, hidden summary, keyboardable D3 slices, visible legend, and focused-slice live announcements are wired. | Confirm slice focus order matches legend order with VoiceOver. |
+| BudgetDonutChart | Budget surfaces | Figure name, hidden summary, focusable slices, center label, and live-region slice announcement support are present. | Add an always-visible data table if budget slices grow beyond legend readability. |
+
+Clear low-risk fixes completed in this pass: added live regions for focused bar, pie, and donut chart points, and connected trend chart keyboard announcements to the shared chart-summary helper.

--- a/apps/web/docs/a11y/onboarding-at-qa-checklist.md
+++ b/apps/web/docs/a11y/onboarding-at-qa-checklist.md
@@ -1,0 +1,35 @@
+# Onboarding assistive-technology QA checklist
+
+Use this checklist for every onboarding change. Test with keyboard only plus NVDA/Firefox, JAWS/Chrome, and VoiceOver/Safari when available.
+
+## Structure and navigation
+- Page exposes one main landmark with the current step label.
+- Heading order starts at one h1 and does not skip levels.
+- Tab order follows the visual order: comfort settings, path choice, privacy, template, complete.
+- Skip/continue/back-equivalent paths do not trap focus or strand the user.
+
+## Labels and instructions
+- Text-size slider, reduced motion, simplified mode, high contrast, path buttons, privacy buttons, template controls, lesson choices, and goal fields have clear accessible names.
+- Helper text is programmatically associated where it changes how to complete a control.
+- Duplicate actions include context, such as which checklist item or lesson they affect.
+
+## Announcements and focus
+- Step changes update the `Onboarding progress` polite live region.
+- Saving, completion, and validation/error states are announced once without repeating on unrelated state changes.
+- Dialogs move focus inside, expose `aria-modal`, and restore or provide a predictable next focus target when closed.
+- Validation errors use alert/assertive behavior only when immediate attention is required.
+
+## Visual accessibility
+- Visible focus is present on every interactive control.
+- Reduced motion removes nonessential animations and does not hide state changes.
+- High contrast mode keeps text, borders, focus rings, and disabled states distinguishable.
+- Huge text (200%) preserves single-axis reading without clipped controls.
+
+## Screen-reader spot checks
+- Comfort step: each preference announces name, state/value, and purpose.
+- Setup path step: Local Only and Create Account cards announce headings, descriptions, and button names.
+- Privacy step: both choices announce the privacy consequence before activation.
+- Template step: life-stage checkboxes, lesson choices, goal fields, preview, save, and glossary dialog are discoverable.
+- Complete step: checklist progress, coach marks, restore/dismiss actions, and Dashboard/Budgets/Goals links are announced with context.
+
+Record AT/browser, pass/fail, bugs filed, and any intentional gaps in the PR notes.

--- a/apps/web/src/components/charts/BudgetDonutChart.test.tsx
+++ b/apps/web/src/components/charts/BudgetDonutChart.test.tsx
@@ -105,4 +105,13 @@ describe('BudgetDonutChart', () => {
     expect(srOnly).toBeInTheDocument();
     expect(srOnly!.textContent).toContain('3 categories');
   });
+
+  it('provides a live region for focused slice announcements', () => {
+    render(<BudgetDonutChart data={sampleData} />);
+
+    expect(screen.getByRole('status', { name: /chart point announcement/i })).toHaveAttribute(
+      'aria-live',
+      'polite',
+    );
+  });
 });

--- a/apps/web/src/components/charts/BudgetDonutChart.tsx
+++ b/apps/web/src/components/charts/BudgetDonutChart.tsx
@@ -4,7 +4,7 @@
  * BudgetDonutChart — Recharts donut chart for budget allocation.
  * @module components/charts/BudgetDonutChart
  */
-import { type FC, useId, useMemo, useRef } from 'react';
+import { type FC, useCallback, useId, useMemo, useRef, useState } from 'react';
 import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer, Label } from 'recharts';
 import { CHART_COLORS, buildChartDescription, formatChartCurrency } from './chart-palette';
 import { useArrowKeyNavigation } from '../../accessibility/aria';
@@ -35,6 +35,7 @@ export const BudgetDonutChart: FC<BudgetDonutChartProps> = ({
 }) => {
   const chartId = useId();
   const containerRef = useRef<HTMLDivElement>(null);
+  const [announcement, setAnnouncement] = useState('');
   const disableAnimation = prefersReducedMotion();
   const total = useMemo(() => data.reduce((sum, d) => sum + d.value, 0), [data]);
   const description = useMemo(
@@ -46,7 +47,20 @@ export const BudgetDonutChart: FC<BudgetDonutChartProps> = ({
       ),
     [data, currency],
   );
-  const { handleKeyDown } = useArrowKeyNavigation(containerRef, { orientation: 'both' });
+  const pointAnnouncements = useMemo(
+    () =>
+      data.map((entry, index) =>
+        `${title}. Focused slice ${index + 1} of ${data.length}. ${entry.name}: ${formatChartCurrency(entry.value, currency)} (${total > 0 ? ((entry.value / total) * 100).toFixed(1) : '0.0'}%).`,
+      ),
+    [currency, data, title, total],
+  );
+  const { handleKeyDown } = useArrowKeyNavigation(containerRef, {
+    orientation: 'both',
+    onFocus: useCallback(
+      (index: number) => setAnnouncement(pointAnnouncements[index] ?? ''),
+      [pointAnnouncements],
+    ),
+  });
 
   return (
     <div
@@ -62,6 +76,9 @@ export const BudgetDonutChart: FC<BudgetDonutChartProps> = ({
       <p id={`${chartId}-desc`} className="sr-only">
         {description}
       </p>
+      <div className="sr-only" role="status" aria-live="polite" aria-atomic="true" aria-label="Chart point announcement">
+        {announcement}
+      </div>
       <ResponsiveContainer width="100%" height={height}>
         <PieChart
           role="img"

--- a/apps/web/src/components/charts/CategoryPieChart.test.tsx
+++ b/apps/web/src/components/charts/CategoryPieChart.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { CategoryPieChart, type CategorySlice } from './CategoryPieChart';
 
@@ -114,5 +114,17 @@ describe('CategoryPieChart', () => {
     const srOnly = document.querySelector('.sr-only');
     expect(srOnly).toBeInTheDocument();
     expect(srOnly!.textContent).toContain('3 categories');
+  });
+
+  it('announces focused slices through a live region', () => {
+    const { container } = render(<CategoryPieChart data={sampleData} />);
+    const firstSlice = container.querySelector<SVGPathElement>('path[data-chart-point]');
+
+    expect(firstSlice).not.toBeNull();
+    fireEvent.focus(firstSlice!);
+
+    expect(screen.getByRole('status', { name: /chart point announcement/i })).toHaveTextContent(
+      'Food: $450 (56.3%)',
+    );
   });
 });

--- a/apps/web/src/components/charts/CategoryPieChart.tsx
+++ b/apps/web/src/components/charts/CategoryPieChart.tsx
@@ -8,7 +8,7 @@
  *
  * @module components/charts/CategoryPieChart
  */
-import { type FC, useCallback, useEffect, useId, useRef } from 'react';
+import { type FC, useCallback, useEffect, useId, useRef, useState } from 'react';
 import * as d3 from 'd3';
 import { CHART_COLORS, buildChartDescription, formatChartCurrency } from './chart-palette';
 import { useEffectiveMaskingMode } from '../../contexts/PrivacyModeContext';
@@ -35,6 +35,7 @@ export const CategoryPieChart: FC<CategoryPieChartProps> = ({
   const chartId = useId();
   const svgRef = useRef<SVGSVGElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const [announcement, setAnnouncement] = useState('');
   const maskingMode = useEffectiveMaskingMode();
   const total = data.reduce((sum, d) => sum + d.value, 0);
   const description = buildChartDescription(
@@ -82,6 +83,7 @@ export const CategoryPieChart: FC<CategoryPieChartProps> = ({
       .style('outline', 'none');
     slices
       .on('focus', function () {
+        setAnnouncement(this.getAttribute('aria-label') ?? '');
         d3.select(this)
           .attr('stroke', 'var(--semantic-border-focus, #3B82F6)')
           .attr('stroke-width', 3);
@@ -137,6 +139,9 @@ export const CategoryPieChart: FC<CategoryPieChartProps> = ({
       <p id={`${chartId}-desc`} className="sr-only">
         {description}
       </p>
+      <div className="sr-only" role="status" aria-live="polite" aria-atomic="true" aria-label="Chart point announcement">
+        {announcement}
+      </div>
       <div className="pie-chart-layout">
         <svg
           ref={svgRef}

--- a/apps/web/src/components/charts/SpendingBarChart.test.tsx
+++ b/apps/web/src/components/charts/SpendingBarChart.test.tsx
@@ -107,4 +107,13 @@ describe('SpendingBarChart', () => {
     expect(srOnly).toBeInTheDocument();
     expect(srOnly!.textContent).toContain('3 categories');
   });
+
+  it('provides a live region for focused category announcements', () => {
+    render(<SpendingBarChart data={sampleData} />);
+
+    expect(screen.getByRole('status', { name: /chart point announcement/i })).toHaveAttribute(
+      'aria-live',
+      'polite',
+    );
+  });
 });

--- a/apps/web/src/components/charts/SpendingBarChart.tsx
+++ b/apps/web/src/components/charts/SpendingBarChart.tsx
@@ -6,7 +6,7 @@
  * @module components/charts/SpendingBarChart
  */
 
-import { type FC, useCallback, useId, useMemo, useRef } from 'react';
+import { type FC, useCallback, useId, useMemo, useRef, useState } from 'react';
 import {
   BarChart,
   Bar,
@@ -47,6 +47,7 @@ export const SpendingBarChart: FC<SpendingBarChartProps> = ({
   const chartId = useId();
   const containerRef = useRef<HTMLDivElement>(null);
   const maskingMode = useEffectiveMaskingMode();
+  const [announcement, setAnnouncement] = useState('');
 
   const description = useMemo(
     () =>
@@ -59,9 +60,20 @@ export const SpendingBarChart: FC<SpendingBarChartProps> = ({
     [data, currency, maskingMode],
   );
 
+  const pointAnnouncements = useMemo(
+    () =>
+      data.map(
+        (entry, index) =>
+          `${title}. Focused category ${index + 1} of ${data.length}. ${entry.name}: ${formatChartCurrency(entry.amount, currency, 'en-US', maskingMode)}.`,
+      ),
+    [currency, data, maskingMode, title],
+  );
   const { handleKeyDown } = useArrowKeyNavigation(containerRef, {
     orientation: 'horizontal',
-    onFocus: useCallback(() => {}, []),
+    onFocus: useCallback(
+      (index: number) => setAnnouncement(pointAnnouncements[index] ?? ''),
+      [pointAnnouncements],
+    ),
   });
 
   const disableAnimation = prefersReducedMotion();
@@ -80,6 +92,9 @@ export const SpendingBarChart: FC<SpendingBarChartProps> = ({
       <p id={`${chartId}-desc`} className="sr-only">
         {description}
       </p>
+      <div className="sr-only" role="status" aria-live="polite" aria-atomic="true" aria-label="Chart point announcement">
+        {announcement}
+      </div>
       <ResponsiveContainer width="100%" height={height}>
         <BarChart
           data={data}

--- a/apps/web/src/components/charts/SpendingTrendChart.test.tsx
+++ b/apps/web/src/components/charts/SpendingTrendChart.test.tsx
@@ -175,10 +175,12 @@ describe('SpendingTrendChart', () => {
 
     const navigator = screen.getByRole('group', { name: /Spending Trend data navigator/i });
     fireEvent.focus(navigator);
-    expect(screen.getByRole('status')).toHaveTextContent('Jan 1: $50');
+    expect(screen.getByRole('status')).toHaveTextContent('Focused point 1 of 3.');
+    expect(screen.getByRole('status')).toHaveTextContent('Spending Jan 1: $50');
 
     fireEvent.keyDown(navigator, { key: 'ArrowRight' });
-    expect(screen.getByRole('status')).toHaveTextContent('Jan 2: $30');
+    expect(screen.getByRole('status')).toHaveTextContent('Focused point 2 of 3.');
+    expect(screen.getByRole('status')).toHaveTextContent('Spending Jan 2: $30');
   });
 
   it('hides comparison when null', () => {

--- a/apps/web/src/components/charts/SpendingTrendChart.tsx
+++ b/apps/web/src/components/charts/SpendingTrendChart.tsx
@@ -37,6 +37,7 @@ import {
   CHART_KEYBOARD_INSTRUCTIONS,
   useChartKeyboardNavigation,
 } from './chart-accessibility';
+import { buildChartTextSummary } from '../../lib/a11y/chart-table-audit';
 import { useEffectiveMaskingMode } from '../../contexts/PrivacyModeContext';
 import './spending-trend.css';
 
@@ -258,9 +259,26 @@ export const SpendingTrendChart: FC<SpendingTrendChartProps> = ({
           rowHeader: point.label,
           cells: [formattedValue],
           ariaLabel: `${point.label}: ${formattedValue}`,
+          announcement: buildChartTextSummary({
+            title,
+            timeframe: point.label,
+            trendDescription: `Focused point ${index + 1} of ${data.length}.`,
+            points: [
+              {
+                label: point.label,
+                series: 'Spending',
+                value: formattedValue,
+                comparison:
+                  comparison != null
+                    ? `${formatPercentChange(Math.abs(comparison.percentChange))} vs last period`
+                    : undefined,
+              },
+            ],
+            maxPoints: 1,
+          }),
         };
       }),
-    [chartId, currency, data, maskingMode],
+    [chartId, comparison, currency, data, maskingMode, title],
   );
 
   const { announcement, handleFocus, handleKeyDown } = useChartKeyboardNavigation(dataPointRows);

--- a/apps/web/src/components/charts/TrendLineChart.test.tsx
+++ b/apps/web/src/components/charts/TrendLineChart.test.tsx
@@ -131,9 +131,11 @@ describe('TrendLineChart', () => {
 
     const navigator = screen.getByRole('group', { name: /Trend over time data navigator/i });
     fireEvent.focus(navigator);
-    expect(screen.getByRole('status')).toHaveTextContent('Jan: Income $4,000, Expenses $2,400');
+    expect(screen.getByRole('status')).toHaveTextContent('Focused point 1 of 3.');
+    expect(screen.getByRole('status')).toHaveTextContent('Income Jan: $4,000');
 
     fireEvent.keyDown(navigator, { key: 'ArrowRight' });
-    expect(screen.getByRole('status')).toHaveTextContent('Feb: Income $3,000, Expenses $1,398');
+    expect(screen.getByRole('status')).toHaveTextContent('Focused point 2 of 3.');
+    expect(screen.getByRole('status')).toHaveTextContent('Expenses Feb: $1,398');
   });
 });

--- a/apps/web/src/components/charts/TrendLineChart.tsx
+++ b/apps/web/src/components/charts/TrendLineChart.tsx
@@ -23,6 +23,7 @@ import {
   CHART_KEYBOARD_INSTRUCTIONS,
   useChartKeyboardNavigation,
 } from './chart-accessibility';
+import { buildChartTextSummary } from '../../lib/a11y/chart-table-audit';
 
 export interface TrendDataPoint {
   label: string;
@@ -89,9 +90,20 @@ export const TrendLineChart: FC<TrendLineChartProps> = ({
           rowHeader: point.label,
           cells: values.map((value) => value.formattedValue),
           ariaLabel: `${point.label}: ${values.map((value) => `${value.name} ${value.formattedValue}`).join(', ')}`,
+          announcement: buildChartTextSummary({
+            title,
+            timeframe: point.label,
+            trendDescription: `Focused point ${index + 1} of ${data.length}.`,
+            points: values.map((value) => ({
+              label: point.label,
+              series: value.name,
+              value: value.formattedValue,
+            })),
+            maxPoints: values.length,
+          }),
         };
       }),
-    [chartId, currency, data, series],
+    [chartId, currency, data, series, title],
   );
 
   const { announcement, handleFocus, handleKeyDown } = useChartKeyboardNavigation(dataPointRows);

--- a/apps/web/src/components/charts/chart-accessibility.tsx
+++ b/apps/web/src/components/charts/chart-accessibility.tsx
@@ -12,6 +12,7 @@ export interface AccessibleChartTableRow {
   rowHeader: string;
   cells: string[];
   ariaLabel: string;
+  announcement?: string;
 }
 
 export const CHART_KEYBOARD_INSTRUCTIONS =
@@ -20,6 +21,10 @@ export const CHART_KEYBOARD_INSTRUCTIONS =
 function clampIndex(index: number, length: number): number {
   if (length === 0) return 0;
   return ((index % length) + length) % length;
+}
+
+function getRowAnnouncement(row: AccessibleChartTableRow): string {
+  return row.announcement ?? row.ariaLabel;
 }
 
 export function useChartKeyboardNavigation(rows: AccessibleChartTableRow[]) {
@@ -38,14 +43,14 @@ export function useChartKeyboardNavigation(rows: AccessibleChartTableRow[]) {
       if (rows.length === 0) return;
       const next = clampIndex(index, rows.length);
       setActiveIndex(next);
-      setAnnouncement(rows[next].ariaLabel);
+      setAnnouncement(getRowAnnouncement(rows[next]));
     },
     [rows],
   );
 
   const handleFocus = useCallback(() => {
     if (rows.length === 0) return;
-    setAnnouncement(rows[Math.min(activeIndex, rows.length - 1)].ariaLabel);
+    setAnnouncement(getRowAnnouncement(rows[Math.min(activeIndex, rows.length - 1)]));
   }, [activeIndex, rows]);
 
   const handleKeyDown = useCallback(

--- a/apps/web/src/components/forms/TransactionForm.test.tsx
+++ b/apps/web/src/components/forms/TransactionForm.test.tsx
@@ -127,8 +127,10 @@ describe('TransactionForm', () => {
     renderTransactionForm();
 
     expect(screen.getByRole('dialog', { name: 'New Transaction' })).toBeInTheDocument();
-    expect(screen.getByLabelText('Amount')).toBeInTheDocument();
-    expect(screen.getByLabelText('Payee')).toBeInTheDocument();
+    expect(screen.getByLabelText('Amount')).toHaveAttribute('data-dictation-label', 'Amount');
+    expect(screen.getByLabelText('Amount')).toHaveAttribute('name', 'txn-amount');
+    expect(screen.getByLabelText('Payee')).toHaveAttribute('data-dictation-label', 'Payee');
+    expect(screen.getByLabelText('Payee')).toHaveAttribute('name', 'txn-description');
     expect(screen.getByText(/What appears on your statement/i)).toBeInTheDocument();
     expect(screen.getByText(/The actual merchant or person/i)).toBeInTheDocument();
     expect(screen.getByLabelText('Category')).toBeInTheDocument();

--- a/apps/web/src/components/forms/TransactionForm.tsx
+++ b/apps/web/src/components/forms/TransactionForm.tsx
@@ -59,6 +59,7 @@ import {
   isMoodTagsEnabled,
   normalizeMoodTag,
 } from '../../lib/mood-tags';
+import { buildDictationControlProps } from '../../lib/a11y/dictation-entry';
 import { validateTransactionSplits } from '../../lib/transactions/splits';
 import { transactionSchema } from '../../lib/validation';
 import { DateInput } from '../common';
@@ -712,6 +713,16 @@ export function TransactionForm({
     hasAccountError ? { fieldId: 'txn-account', label: 'Account', message: errors.accountId! } : null,
     hasSplitError ? { fieldId: 'txn-splits-status', label: 'Splits', message: errors.splits! } : null,
   ].filter((item): item is FormErrorSummaryItem => item !== null);
+  const dictationControls = {
+    amount: buildDictationControlProps({ id: 'txn-amount', visibleLabel: 'Amount' }),
+    payee: buildDictationControlProps({ id: 'txn-description', visibleLabel: 'Payee' }),
+    status: buildDictationControlProps({ id: 'txn-status', visibleLabel: 'Status' }),
+    category: buildDictationControlProps({ id: 'txn-category', visibleLabel: 'Category' }),
+    account: buildDictationControlProps({ id: 'txn-account', visibleLabel: 'Account' }),
+    date: buildDictationControlProps({ id: 'txn-date', visibleLabel: 'Date' }),
+    notes: buildDictationControlProps({ id: 'txn-notes', visibleLabel: 'Notes' }),
+    tags: buildDictationControlProps({ id: 'txn-tags', visibleLabel: 'Tags' }),
+  } as const;
 
   return (
     <div className="form-dialog" role="presentation" onKeyDown={handleKeyDown}>
@@ -757,7 +768,10 @@ export function TransactionForm({
               </label>
               <input
                 ref={firstInputRef}
-                id="txn-amount"
+                id={dictationControls.amount.id}
+                name={dictationControls.amount.name}
+                aria-label={dictationControls.amount['aria-label']}
+                data-dictation-label={dictationControls.amount.label}
                 className={`form-input${hasAmountError ? ' form-input--error' : ''}`}
                 type="text"
                 inputMode="numeric"
@@ -789,7 +803,10 @@ export function TransactionForm({
                 What appears on your statement (e.g. “AMZN MKTPL*XYZ”).
               </p>
               <input
-                id="txn-description"
+                id={dictationControls.payee.id}
+                name={dictationControls.payee.name}
+                aria-label={dictationControls.payee['aria-label']}
+                data-dictation-label={dictationControls.payee.label}
                 className={`form-input${hasDescriptionError ? ' form-input--error' : ''}`}
                 type="text"
                 value={description}
@@ -833,7 +850,10 @@ export function TransactionForm({
                 Status
               </label>
               <select
-                id="txn-status"
+                id={dictationControls.status.id}
+                name={dictationControls.status.name}
+                aria-label={dictationControls.status['aria-label']}
+                data-dictation-label={dictationControls.status.label}
                 className="form-select"
                 value={status}
                 onChange={(e) => setStatus(e.target.value as TransactionStatus)}
@@ -896,7 +916,10 @@ export function TransactionForm({
                 Category
               </label>
               <select
-                id="txn-category"
+                id={dictationControls.category.id}
+                name={dictationControls.category.name}
+                aria-label={dictationControls.category['aria-label']}
+                data-dictation-label={dictationControls.category.label}
                 className="form-select"
                 value={categoryId}
                 onChange={(e) => setCategoryId(e.target.value)}
@@ -1040,7 +1063,10 @@ export function TransactionForm({
                 Account
               </label>
               <select
-                id="txn-account"
+                id={dictationControls.account.id}
+                name={dictationControls.account.name}
+                aria-label={dictationControls.account['aria-label']}
+                data-dictation-label={dictationControls.account.label}
                 className={`form-select${hasAccountError ? ' form-select--error' : ''}`}
                 value={accountId}
                 onChange={(e) => setAccountId(e.target.value)}
@@ -1129,7 +1155,10 @@ export function TransactionForm({
                 Date
               </label>
               <DateInput
-                id="txn-date"
+                id={dictationControls.date.id}
+                name={dictationControls.date.name}
+                aria-label={dictationControls.date['aria-label']}
+                data-dictation-label={dictationControls.date.label}
                 className="form-input"
                 value={date}
                 onChange={(e) => setDate(e.target.value)}
@@ -1142,7 +1171,10 @@ export function TransactionForm({
                 Notes
               </label>
               <textarea
-                id="txn-notes"
+                id={dictationControls.notes.id}
+                name={dictationControls.notes.name}
+                aria-label={dictationControls.notes['aria-label']}
+                data-dictation-label={dictationControls.notes.label}
                 className="form-textarea"
                 value={notes}
                 onChange={(e) => setNotes(e.target.value)}
@@ -1156,7 +1188,10 @@ export function TransactionForm({
                 Tags
               </label>
               <input
-                id="txn-tags"
+                id={dictationControls.tags.id}
+                name={dictationControls.tags.name}
+                aria-label={dictationControls.tags['aria-label']}
+                data-dictation-label={dictationControls.tags.label}
                 className="form-input"
                 type="text"
                 value={tagsInput}

--- a/apps/web/src/components/layout/AppLayout.test.tsx
+++ b/apps/web/src/components/layout/AppLayout.test.tsx
@@ -85,6 +85,7 @@ const mockSetShowHelp = vi.fn();
 
 describe('AppLayout', () => {
   beforeEach(() => {
+    localStorage.clear();
     vi.mocked(useKeyboardShortcuts).mockReturnValue({
       showHelp: false,
       setShowHelp: mockSetShowHelp,
@@ -192,5 +193,18 @@ describe('AppLayout', () => {
     render(<AppLayout {...defaultProps} />);
 
     expect(screen.getByTestId('install-banner')).toBeInTheDocument();
+  });
+
+  it('applies the simple-mode route plan to core route content', () => {
+    localStorage.setItem('finance-simplified-mode', 'true');
+
+    render(<AppLayout {...defaultProps} activePath="/transactions" pageTitle="Transactions" />);
+
+    const main = screen.getByRole('main', { name: 'Transactions' });
+    expect(main).toHaveAttribute('data-simple-mode', 'true');
+    expect(main).toHaveAttribute('data-simple-mode-surface', 'transactions');
+    expect(
+      screen.getByRole('region', { name: /transactions simple mode plan/i }),
+    ).toHaveTextContent('Primary action: Add transaction.');
   });
 });

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -11,6 +11,11 @@ import { detectScamAlerts, scamAlertsToNotifications } from '../../lib/notificat
 import { usePrivacyMode } from '../../contexts/PrivacyModeContext';
 import { useEscapeBack } from '../../hooks/useEscapeBack';
 import { useSyncStatus } from '../../hooks/useSyncStatus';
+import {
+  getStoredSimplifiedModePreference,
+  SIMPLIFIED_MODE_STORAGE_KEY,
+} from '../../lib/accessibility-preferences';
+import { getSimpleModePlan, type SimpleModeSurface } from '../../lib/a11y/simple-mode';
 
 import { BottomNavigation, SidebarNavigation } from './Navigation';
 import { NAV_CONFIG } from './navConfig';
@@ -23,6 +28,24 @@ export interface AppLayoutProps {
   onNavigate: (path: string) => void;
   pageTitle: string;
   children: React.ReactNode;
+}
+
+const SIMPLE_MODE_SURFACES: Array<{ surface: SimpleModeSurface; paths: readonly string[] }> = [
+  { surface: 'dashboard', paths: ['/', '/dashboard'] },
+  { surface: 'transactions', paths: ['/transactions'] },
+  { surface: 'budgets', paths: ['/budgets'] },
+  { surface: 'bills', paths: ['/bills'] },
+  { surface: 'goals', paths: ['/goals'] },
+  { surface: 'reports', paths: ['/report-builder', '/cash-flow', '/net-worth', '/insights'] },
+  { surface: 'settings', paths: ['/settings'] },
+];
+
+function getSimpleModeSurface(pathname: string): SimpleModeSurface | null {
+  return (
+    SIMPLE_MODE_SURFACES.find(({ paths }) =>
+      paths.some((path) => pathname === path || pathname.startsWith(`${path}/`)),
+    )?.surface ?? null
+  );
 }
 
 const NAV_SHORTCUT_BY_ID: Record<string, string> = {
@@ -50,6 +73,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
 }) => {
   const { isPrivacyMode, togglePrivacyMode } = usePrivacyMode();
   const [showCommandPalette, setShowCommandPalette] = useState(false);
+  const [simpleModeEnabled, setSimpleModeEnabled] = useState(getStoredSimplifiedModePreference);
   const { showHelp, setShowHelp, singleKeyShortcutsEnabled } = useKeyboardShortcuts({
     onNavigate,
     onNewTransaction: () => onNavigate('/transactions?new=transaction'),
@@ -71,6 +95,24 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
     () => scamAlertsToNotifications(detectScamAlerts(scamNotificationTransactions)),
     [scamNotificationTransactions],
   );
+  const simpleModeSurface = getSimpleModeSurface(activePath);
+  const simpleModePlan = simpleModeEnabled && simpleModeSurface
+    ? getSimpleModePlan(simpleModeSurface)
+    : null;
+
+  useEffect(() => {
+    setSimpleModeEnabled(getStoredSimplifiedModePreference());
+  }, [activePath]);
+
+  useEffect(() => {
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === SIMPLIFIED_MODE_STORAGE_KEY) {
+        setSimpleModeEnabled(getStoredSimplifiedModePreference());
+      }
+    };
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, []);
 
   useEffect(() => {
     const knownNotificationKeys = new Set(
@@ -171,6 +213,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
         activePath={activePath}
         onNavigate={onNavigate}
         onOpenShortcuts={openKeyboardShortcuts}
+        simpleMode={simpleModeEnabled}
       />
       <div className="app-shell">
         <SyncStatusBar />
@@ -259,10 +302,33 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
             </button>
           </div>
         </header>
-        <main id="main-content" className="app-main" aria-label={pageTitle} tabIndex={-1}>
+        <main
+          id="main-content"
+          className="app-main"
+          aria-label={pageTitle}
+          tabIndex={-1}
+          data-simple-mode={simpleModeEnabled || undefined}
+          data-simple-mode-surface={simpleModePlan?.surface}
+        >
+          {simpleModePlan && (
+            <section
+              className="simple-mode-summary"
+              aria-label={`${simpleModePlan.heading} simple mode plan`}
+              data-simple-mode-plan={simpleModePlan.surface}
+            >
+              <p>
+                <strong>Simple Mode:</strong> {simpleModePlan.heading}. Primary action:{' '}
+                {simpleModePlan.primaryAction}.
+              </p>
+              <p className="sr-only">
+                Visible regions: {simpleModePlan.visibleRegions.join(', ')}. Advanced regions collapsed:{' '}
+                {simpleModePlan.collapsedRegions.join(', ')}.
+              </p>
+            </section>
+          )}
           {children}
         </main>
-        <BottomNavigation activePath={activePath} onNavigate={onNavigate} />
+        <BottomNavigation activePath={activePath} onNavigate={onNavigate} simpleMode={simpleModeEnabled} />
       </div>
       <InstallBanner />
       <CommandPalette

--- a/apps/web/src/components/layout/Navigation.test.tsx
+++ b/apps/web/src/components/layout/Navigation.test.tsx
@@ -79,6 +79,15 @@ describe('BottomNavigation', () => {
     expect(moreButton).toHaveAttribute('aria-expanded', 'false');
   });
 
+  it('uses simple-mode priority destinations when enabled', () => {
+    render(<BottomNavigation {...defaultProps} simpleMode />);
+
+    const nav = screen.getByRole('navigation', { name: 'Main navigation' });
+    expect(nav).toHaveAttribute('data-simple-mode', 'true');
+    expect(within(nav).getByRole('button', { name: 'Bills' })).toBeInTheDocument();
+    expect(within(nav).queryByRole('button', { name: 'Debt' })).not.toBeInTheDocument();
+  });
+
   it('promotes Debt to the bottom nav instead of the More sheet', () => {
     render(<BottomNavigation {...defaultProps} />);
 

--- a/apps/web/src/components/layout/Navigation.tsx
+++ b/apps/web/src/components/layout/Navigation.tsx
@@ -65,6 +65,7 @@ export interface NavigationProps {
   onNavigate: (path: string) => void;
   onOpenShortcuts?: () => void;
   onOpenFeedback?: () => void;
+  simpleMode?: boolean;
 }
 
 function isActive(activePath: string, href: string): boolean {
@@ -81,22 +82,33 @@ function isActive(activePath: string, href: string): boolean {
  * Bottom tab bar for narrow viewports. Renders the four highest-priority
  * destinations plus a "More" tab that opens {@link MoreNavSheet}.
  */
+const SIMPLE_MODE_BOTTOM_NAV_IDS = new Set(['dashboard', 'transactions', 'budgets', 'bills']);
+
 export const BottomNavigation: React.FC<NavigationProps> = ({
   activePath,
   onNavigate,
   onOpenShortcuts,
+  simpleMode = false,
 }) => {
   const { logout } = useAuth();
   const [moreOpen, setMoreOpen] = useState(false);
 
+  const bottomNavItems = useMemo(
+    () =>
+      simpleMode
+        ? NAV_CONFIG.filter((item) => SIMPLE_MODE_BOTTOM_NAV_IDS.has(item.id))
+        : BOTTOM_NAV_PRIORITY_ITEMS,
+    [simpleMode],
+  );
+
   const isMoreActive = useMemo(() => {
     // The "More" tab should appear active when the user is on any route
     // that is reachable only via the sheet (i.e. not a priority item).
-    if (BOTTOM_NAV_PRIORITY_ITEMS.some((item) => isActive(activePath, item.href))) {
+    if (bottomNavItems.some((item) => isActive(activePath, item.href))) {
       return false;
     }
     return NAV_CONFIG.some((item) => isActive(activePath, item.href));
-  }, [activePath]);
+  }, [activePath, bottomNavItems]);
 
   const handleSignOut = useCallback(async () => {
     await logout();
@@ -104,8 +116,8 @@ export const BottomNavigation: React.FC<NavigationProps> = ({
 
   return (
     <>
-      <nav className="bottom-nav" aria-label="Main navigation">
-        {BOTTOM_NAV_PRIORITY_ITEMS.map((item) => {
+      <nav className="bottom-nav" aria-label="Main navigation" data-simple-mode={simpleMode || undefined}>
+        {bottomNavItems.map((item) => {
           const active = isActive(activePath, item.href);
           return (
             <button
@@ -247,6 +259,7 @@ export const SidebarNavigation: React.FC<NavigationProps> = ({
   onNavigate,
   onOpenShortcuts,
   onOpenFeedback,
+  simpleMode = false,
 }) => {
   const { logout } = useAuth();
   const isSettingsActive = isActive(activePath, '/settings');
@@ -256,7 +269,7 @@ export const SidebarNavigation: React.FC<NavigationProps> = ({
   }, [logout]);
 
   return (
-    <aside className="app-sidebar" aria-label="Main navigation">
+    <aside className="app-sidebar" aria-label="Main navigation" data-simple-mode={simpleMode || undefined}>
       <div className="app-sidebar__header">
         <span className="app-sidebar__logo">Finance</span>
       </div>
@@ -294,7 +307,7 @@ export const SidebarNavigation: React.FC<NavigationProps> = ({
             items={getItemsByGroup(group)}
             activePath={activePath}
             onNavigate={onNavigate}
-            defaultExpanded={group === 'money' || group === 'plan'}
+            defaultExpanded={!simpleMode && (group === 'money' || group === 'plan')}
           />
         ))}
       </nav>

--- a/apps/web/src/pages/OnboardingPage.test.tsx
+++ b/apps/web/src/pages/OnboardingPage.test.tsx
@@ -257,6 +257,20 @@ describe('OnboardingPage', () => {
     expect(screen.getByRole('heading', { name: /local only/i })).toBeInTheDocument();
   });
 
+  it('announces onboarding progress as steps change', () => {
+    renderWithRouter(<OnboardingPage />);
+
+    expect(screen.getByRole('status', { name: /onboarding progress/i })).toHaveTextContent(
+      'Step 1 of 5: Comfort preferences. Current step.',
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+    expect(screen.getByRole('status', { name: /onboarding progress/i })).toHaveTextContent(
+      'Step 2 of 5: Choose setup path. Current step.',
+    );
+  });
+
   it('stores comfort preferences and lets the user skip ahead', () => {
     renderWithRouter(<OnboardingPage />);
 

--- a/apps/web/src/pages/OnboardingPage.tsx
+++ b/apps/web/src/pages/OnboardingPage.tsx
@@ -27,6 +27,7 @@ import { useLocalOnlyMode } from '../hooks/useLocalOnlyMode';
 import { setReducedMotionPreference } from '../hooks/useReducedMotion';
 import { applyTheme, THEME_STORAGE_KEY } from '../hooks/useTheme';
 import { setSimplifiedModePreference } from '../lib/accessibility-preferences';
+import { buildOnboardingProgressAnnouncement } from '../lib/a11y/onboarding-progress';
 import { getBudgetStarterTemplates } from '../lib/budgeting/starter-budget-templates';
 import type { FeatureAvailability } from '../lib/local-only-mode';
 
@@ -42,6 +43,22 @@ const SIMPLE_MODE_FONT_SCALE_INDEX = Math.max(
 );
 
 type OnboardingStep = 'comfort' | 'choose' | 'privacy' | 'template' | 'complete';
+
+const ONBOARDING_STEP_ORDER: readonly OnboardingStep[] = [
+  'comfort',
+  'choose',
+  'privacy',
+  'template',
+  'complete',
+];
+
+const ONBOARDING_STEP_LABELS: Record<OnboardingStep, string> = {
+  comfort: 'Comfort preferences',
+  choose: 'Choose setup path',
+  privacy: 'Privacy preferences',
+  template: 'Starter budget template',
+  complete: 'Setup complete',
+};
 
 type LifeStageId = 'student' | 'first-job' | 'household' | 'caregiver' | 'freelancer' | 'retiree';
 type GlossaryTermId = 'cashFlow' | 'recurringExpense' | 'savingsGoal' | 'budgetVariance';
@@ -380,6 +397,24 @@ const OnboardingPage: React.FC = () => {
   const fullySetUp =
     (starterBudgetCreated || savedGoals.length > 0) &&
     (allLessonsComplete || selectedLifeStages.length > 0);
+  const onboardingProgressAnnouncement = buildOnboardingProgressAnnouncement({
+    stepLabel: ONBOARDING_STEP_LABELS[step],
+    stepIndex: Math.max(ONBOARDING_STEP_ORDER.indexOf(step), 0),
+    totalSteps: ONBOARDING_STEP_ORDER.length,
+    status: templateError ? 'error' : isApplyingTemplate ? 'saving' : step === 'complete' ? 'complete' : 'current',
+    errorCount: templateError ? 1 : 0,
+  });
+  const onboardingProgressLiveRegion = (
+    <p
+      className="sr-only"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      aria-label="Onboarding progress"
+    >
+      {onboardingProgressAnnouncement}
+    </p>
+  );
 
   const onboardingClassName = [
     'onboarding',
@@ -626,6 +661,7 @@ const OnboardingPage: React.FC = () => {
   if (step === 'comfort') {
     return (
       <main className={onboardingClassName} aria-label="Comfort Preferences">
+        {onboardingProgressLiveRegion}
         <div className="onboarding__container onboarding__container--narrow">
           <header className="onboarding__header">
             <h1 className="onboarding__title">Welcome to Finance</h1>
@@ -767,6 +803,7 @@ const OnboardingPage: React.FC = () => {
   if (step === 'choose') {
     return (
       <main className={onboardingClassName} aria-label="Get Started">
+        {onboardingProgressLiveRegion}
         <div className="onboarding__container">
           <header className="onboarding__header">
             <h1 className="onboarding__title">Welcome to Finance</h1>
@@ -873,6 +910,7 @@ const OnboardingPage: React.FC = () => {
   if (step === 'privacy') {
     return (
       <main className={onboardingClassName} aria-label="Privacy Preferences">
+        {onboardingProgressLiveRegion}
         <div className="onboarding__container onboarding__container--narrow">
           <header className="onboarding__header">
             <h1 className="onboarding__title">Privacy Preferences</h1>
@@ -914,6 +952,7 @@ const OnboardingPage: React.FC = () => {
   if (step === 'template' && studentTemplate) {
     return (
       <main className={onboardingClassName} aria-label="Starter Budget Template">
+        {onboardingProgressLiveRegion}
         <div className="onboarding__container onboarding__container--narrow">
           <header className="onboarding__header">
             <h1 className="onboarding__title">Want a starter budget? Choose a template:</h1>
@@ -1222,6 +1261,7 @@ const OnboardingPage: React.FC = () => {
 
   return (
     <main className={onboardingClassName} aria-label="Setup Complete">
+      {onboardingProgressLiveRegion}
       <div className="onboarding__container onboarding__container--narrow">
         <div className="onboarding__complete">
           <div className="onboarding__complete-icon" aria-hidden="true">

--- a/apps/web/src/pages/TransactionsPage.test.tsx
+++ b/apps/web/src/pages/TransactionsPage.test.tsx
@@ -17,6 +17,7 @@ import { TransactionsPage } from './TransactionsPage';
 const repositoryMocks = vi.hoisted(() => ({
   updateTransaction: vi.fn(),
   deleteTransaction: vi.fn(),
+  fontScale: { value: 1 },
 }));
 
 // Mock each hook file individually — the page imports from the individual
@@ -24,6 +25,9 @@ const repositoryMocks = vi.hoisted(() => ({
 vi.mock('../hooks/useTransactions', () => ({ useTransactions: vi.fn() }));
 vi.mock('../hooks/useCategories', () => ({ useCategories: vi.fn() }));
 vi.mock('../hooks/useAccounts', () => ({ useAccounts: vi.fn() }));
+vi.mock('../hooks/useFontScale', () => ({
+  useFontScale: () => ({ scale: repositoryMocks.fontScale.value }),
+}));
 vi.mock('../db/DatabaseProvider', () => ({ useDatabase: () => ({}) }));
 vi.mock('../db/repositories/transactions', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../db/repositories/transactions')>();
@@ -126,6 +130,7 @@ describe('TransactionsPage', () => {
     deleteTransactionMock.mockReset();
     repositoryMocks.updateTransaction.mockReset();
     repositoryMocks.deleteTransaction.mockReset();
+    repositoryMocks.fontScale.value = 1;
     deleteTransactionMock.mockReturnValue(true);
     repositoryMocks.updateTransaction.mockReturnValue({ id: 'updated-transaction' });
     repositoryMocks.deleteTransaction.mockReturnValue(true);
@@ -590,6 +595,19 @@ describe('TransactionsPage', () => {
 
     expect(screen.getByRole('checkbox', { name: /select monthly salary/i })).toBeChecked();
     expect(screen.getByText('2 selected')).toBeInTheDocument();
+  });
+
+  it('renders transaction cards instead of dense rows at huge text scale', () => {
+    repositoryMocks.fontScale.value = 2;
+
+    render(
+      <MemoryRouter>
+        <TransactionsPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText(/showing 3 transactions as cards for large text/i)).toBeInTheDocument();
+    expect(screen.getAllByRole('list', { name: /large text transaction card list/i })).toHaveLength(2);
   });
 
   it('virtualizes large transaction registers instead of rendering every row', () => {

--- a/apps/web/src/pages/TransactionsPage.tsx
+++ b/apps/web/src/pages/TransactionsPage.tsx
@@ -30,6 +30,7 @@ import { useBulkTransactions } from '../hooks/useBulkTransactions';
 import { useCategories } from '../hooks/useCategories';
 import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts';
 import { recordPwaMeaningfulAction } from '../hooks/useInstallPrompt';
+import { useFontScale } from '../hooks/useFontScale';
 import { useTransactions } from '../hooks/useTransactions';
 import { useVirtualList } from '../hooks/useVirtualList';
 import type { Transaction } from '../kmp/bridge';
@@ -38,6 +39,7 @@ import {
   filterTransactionsByAccountPurpose,
   type AccountPurposeFilter,
 } from '../lib/accountPurpose';
+import { chooseLargeTextReflow } from '../lib/a11y/large-text-reflow';
 
 // ---------------------------------------------------------------------------
 // URL param helpers for filter/sort persistence
@@ -316,6 +318,10 @@ export const TransactionsPage: React.FC = () => {
   const [addMenuOpen, setAddMenuOpen] = useState(false);
   const [activeTransactionId, setActiveTransactionId] = useState<string | null>(null);
   const [bulkDeleteDialogOpen, setBulkDeleteDialogOpen] = useState(false);
+  const { scale: inAppTextScale } = useFontScale();
+  const [viewportWidth, setViewportWidth] = useState(() =>
+    typeof window === 'undefined' ? 1024 : window.innerWidth,
+  );
   const addMenuRef = useRef<HTMLDivElement>(null);
   const selectAllCheckboxRef = useRef<HTMLInputElement>(null);
   const transactionRowRefs = useRef(new Map<string, HTMLElement>());
@@ -451,6 +457,11 @@ export const TransactionsPage: React.FC = () => {
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, []);
+  useEffect(() => {
+    const handleResize = () => setViewportWidth(window.innerWidth);
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
 
   const virtualRegister = useVirtualList({
     items: transactionRegisterRows,
@@ -458,7 +469,19 @@ export const TransactionsPage: React.FC = () => {
     containerHeight: registerViewportHeight,
     overscan: VIRTUAL_REGISTER_OVERSCAN,
   });
-  const useVirtualRegister = transactionRegisterRows.length > VIRTUAL_REGISTER_THRESHOLD;
+  const largeTextReflow = useMemo(
+    () =>
+      chooseLargeTextReflow({
+        viewportWidth,
+        browserZoomPercent: 100,
+        inAppScale: inAppTextScale,
+        hasDenseData: true,
+      }),
+    [inAppTextScale, viewportWidth],
+  );
+  const useCardRegister = largeTextReflow.mode === 'card-alternative';
+  const useVirtualRegister =
+    !useCardRegister && transactionRegisterRows.length > VIRTUAL_REGISTER_THRESHOLD;
   const virtualRowIndexByTransactionId = useMemo(() => {
     const indexes = new Map<string, number>();
     transactionRegisterRows.forEach((row, index) => {
@@ -996,7 +1019,28 @@ export const TransactionsPage: React.FC = () => {
             onRequestBulkDelete={() => setBulkDeleteDialogOpen(true)}
           />
 
-          {useVirtualRegister ? (
+          {useCardRegister ? (
+            <div className="card transaction-card-list-fallback">
+              <p className="sr-only" role="status">
+                Showing {transactions.length} transactions as cards for large text.{' '}
+                {largeTextReflow.reasons.join(' ')}
+              </p>
+              {groupedTransactions.map((group) => (
+                <section key={group.date} className="page-section" aria-label={`${group.label} transaction cards`}>
+                  <h3 className="list-group__header">{group.label}</h3>
+                  <ul className="list-group transaction-card-list" role="list" aria-label="Large text transaction card list">
+                    {group.transactions.map((transaction) =>
+                      renderTransactionRow(
+                        transaction,
+                        undefined,
+                        transactionPositionById.get(transaction.id),
+                      ),
+                    )}
+                  </ul>
+                </section>
+              ))}
+            </div>
+          ) : useVirtualRegister ? (
             <div className="card">
               <p className="sr-only" role="status">
                 Showing {transactions.length} transactions with virtual scrolling

--- a/apps/web/src/styles/accessibility.css
+++ b/apps/web/src/styles/accessibility.css
@@ -1,5 +1,17 @@
 /* SPDX-License-Identifier: BUSL-1.1 */
 
+.simple-mode-summary {
+  margin-bottom: var(--spacing-4, 1rem);
+  padding: var(--spacing-3, 0.75rem);
+  border: 2px solid var(--semantic-border-focus, #3b82f6);
+  border-radius: var(--border-radius-md, 0.5rem);
+  background: var(--semantic-background-elevated, #fff);
+}
+
+.simple-mode-summary p {
+  margin: 0;
+}
+
 /* -------------------------------------------------------------------
  * WCAG 2.2 AA Accessibility Enhancements
  *


### PR DESCRIPTION
Wires existing a11y cores into live UI: chart keyboard announcements (#2502), dictation labels (#2488), simple-mode across routes (#2489), onboarding announcements (#2490), dense-table card alternatives at huge text (#2503), chart SR audit doc (#2486), onboarding AT QA checklist (#2508). Green: 7472 tests.