### PR TITLE
docs: harden fleet branch & merge policy (programs must land on main)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,10 +44,12 @@ For docs-only PRs, use the quick check: **`npm run ci:check:quick`**
 
 ### Definition of Done — task is NOT complete until BOTH gates pass
 
-| Gate                   | Verification                                                                              |
-| ---------------------- | ----------------------------------------------------------------------------------------- |
-| **CI green**           | `gh pr checks <N>` — no failures                                                          |
-| **No merge conflicts** | `gh pr view <N> --json mergeable,mergeStateStatus` — `MERGEABLE` and not `DIRTY`/`BEHIND` |
+| Gate                   | Verification                                                                                                  |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------- |
+| **Base is `main`**     | PR opened with `--base main` (`gh pr view <N> --json baseRefName` → `main`)                                   |
+| **CI green**           | `gh pr checks <N>` — no failures                                                                              |
+| **No merge conflicts** | `gh pr view <N> --json mergeable,mergeStateStatus` — `MERGEABLE` and not `DIRTY`/`BEHIND`                     |
+| **Landed on `main`**   | Program is merged to `main`, or has a green, `MERGEABLE` PR to `main` (a branch-only program is **not done**) |
 
 **Merge conflicts carry the same P0 weight as red CI checks.** A green-CI PR sitting in a `CONFLICTING` state is not done. See the **Merge Conflict Protocol** in `.github/instructions/workflow.instructions.md` for the auto-resolve cycle (rebase, lockfile / generated-file auto-resolve, force-with-lease push). Force-with-lease on the agent's own branch is auto-approved when used to resolve conflicts.
 
@@ -68,10 +70,10 @@ All work in this repository follows an issue-first, feature-branch + worktree wo
    - Main worktree (`finance-human/`) is reserved for human work
 3. **Commit messages must include issue references** in the format `type(scope): description (#N)`.
 4. **Push automatically** — `git push origin <branch>` is auto-approved.
-5. **Open a PR automatically** with `gh pr create` — include `Closes #N` for resolved issues.
+5. **Open a PR automatically** with `gh pr create --base main` — **always target `main`** (never a long-lived feature branch) and include `Closes #N` for resolved issues. See the **Branch & Merge Policy** in `docs/ai/fleet-operations.md` (the canonical rules).
 6. **Verify the PR exists** — `gh pr view <branch>` must return a PR number before you move on. If it doesn't, re-run `gh pr create`. This catches the silent-failure mode where `gh pr create` errored but the agent assumed success.
 7. **Monitor the PR** — poll `gh pr checks` until all checks pass AND `gh pr view --json mergeable,mergeStateStatus` shows `MERGEABLE` / not `DIRTY`. **Merge conflicts carry the same P0 weight as red CI checks** — self-heal via the Merge Conflict Protocol in `.github/instructions/workflow.instructions.md`. Both gates must clear before declaring done.
-8. **Never merge PRs** — humans review and merge. The agent's job is to get the PR to merge-ready state.
+8. **Landing the work:** Individual sub-agents do **not** merge — they get their PR merge-ready. The **fleet orchestrator** is responsible for reconciling with `origin/main` and **landing the program on `main` within the work session** (merging the PRs, or leaving a single green, mergeable PR to `main` for a human with a clear note). Use `--admin` to override a protection-`BLOCKED` state **only** after verifying type-check + lint + affected tests are green locally; document the override. A program left only on a side branch is **not done** — it breaks staging auto-deploy and `Closes #N`.
 9. **Clean up the worktree** after the PR is confirmed merged: `git worktree remove <path>`.
 
 See `docs/ai/worktrees.md` for the full worktree setup and lifecycle guide.

--- a/docs/ai/fleet-operations.md
+++ b/docs/ai/fleet-operations.md
@@ -9,6 +9,7 @@ This document describes how the AI agent fleet operates in parallel, including d
 ## Table of Contents
 
 - [Overview](#overview)
+- [Branch & Merge Policy (MANDATORY)](#branch--merge-policy-mandatory)
 - [Fleet Dispatch Pattern](#fleet-dispatch-pattern)
 - [Worktree Isolation Model](#worktree-isolation-model)
 - [File Ownership Rules](#file-ownership-rules)
@@ -40,6 +41,47 @@ Fleet mode works best for tasks with **naturally separable concerns**:
 - CI/CD pipeline + infrastructure + documentation updates
 
 Fleet mode is **not appropriate** for tasks where the work is tightly coupled and requires frequent back-and-forth coordination (e.g., iterating on a single API contract that multiple agents consume simultaneously).
+
+---
+
+## Branch & Merge Policy (MANDATORY)
+
+> **Why this section exists:** A multi-session fleet program once accumulated ~100 feature PRs onto a stale, misleadingly-named feature branch (`feat/2030-account-deletion`) instead of `main`. Nothing auto-deployed (staging deploys from `main`), `Closes #` never fired, and reconciling the divergence later required resolving 58 conflicts. **This must never happen again.** The rules below are non-negotiable.
+
+### Rule A — The base branch for every fleet PR is `main`
+
+- Every `gh pr create` **MUST** pass `--base main`. Do not omit `--base` (it defaults to the repo default, which is correct only by luck) and **never** point fleet PRs at a long-lived feature branch.
+- The "latest green commit" staging deploy and `Closes #N` auto-close **only work when PRs merge into `main`** (the default branch). Merging into any other base silently breaks both.
+
+### Rule B — Integration branches are short-lived and single-PR
+
+You may use one short-lived integration branch **only** when a set of PRs is genuinely dependent and must land together. If you do:
+
+1. Name it `release/<program>` or `integration/<program>` — **never** reuse an unrelated feature branch.
+2. It carries **exactly one** tracking PR to `main`.
+3. It is **reconciled with `origin/main` and merged to `main` within the same work session.** A program is **not done** while it lives only on a side branch.
+4. Prefer **not** using one at all: independent PRs straight to `main` (merged as they go green) are the default.
+
+### Rule C — Reconcile with `main` before the final merge (orchestrator's job)
+
+- Before declaring a fleet complete, the orchestrator **MUST** merge `origin/main` into the work and resolve all conflicts, then validate green (type-check + lint + the conflict-affected test areas).
+- The longer a branch lives off `main`, the worse the conflicts. Reconcile **early and often**; do a final reconcile immediately before merge.
+
+### Rule D — "Done" means it's on `main` (or has a green, mergeable PR to `main`)
+
+- A fleet task is **not complete** while its work exists only on a branch. The Definition of Done is: **merged to `main`, OR an open PR to `main` that is `MERGEABLE` and green**, with a clear note if a human must click merge.
+- If you closed issues against a non-default base (so auto-close didn't fire), you **MUST** close them explicitly **and** state that in the summary.
+
+### Rule E — Landing on `main` is the deploy action
+
+- Merging to `main` **auto-triggers the staging deploy** (`deploy-staging.yml`, `workflow_run` after _Web CI_ + _Lint & Format_ pass on `main`). Treat every merge to `main` with that weight.
+- **Production is never automatic** — it requires `workflow_dispatch` + human approval via the `production` GitHub environment. Agents do not deploy to production.
+- See [branch-protection.md](../architecture/branch-protection.md) and [deployment-pipeline.md](../deployment-pipeline.md) for the gating and environments.
+
+### Rule F — Merge mechanics
+
+- Use `gh pr merge <n> --squash` for a single feature PR (clean `main` history), or `--merge` for an integration branch that should preserve its feature commits.
+- Branch protection may report `MERGEABLE (BLOCKED)` (required checks/reviews). Only use `--admin` to override when you have **explicitly verified locally** (type-check + lint + the affected tests are green) and the block is protection-state, not a real CI failure. Document the override in the merge summary.
 
 ---
 
@@ -333,11 +375,19 @@ If any agent encounters a financial logic decision during fleet work, it must:
 
 Agents don't rely on a central monitor. Each agent polls `gh pr checks` on its own PR and self-heals CI failures independently.
 
+### Rule 7: Every PR targets `main` — programs land on `main`, not side branches
+
+All fleet PRs use `--base main` (see [Branch & Merge Policy](#branch--merge-policy-mandatory)). The orchestrator is responsible for reconciling with `origin/main` and ensuring the program is **merged to `main` (or has a green, mergeable PR to `main`) before declaring the fleet done.** Accumulating a multi-PR program on a long-lived feature branch is a process failure — it breaks staging auto-deploy and `Closes #N` auto-close.
+
 ---
 
 ## Wave 3 Learnings
 
 Lessons from the third fleet deployment wave:
+
+### Branch policy: programs must land on `main` (incident)
+
+A later multi-session program accumulated ~100 feature PRs onto a stale, misleadingly-named feature branch instead of `main`. Consequences: **no staging auto-deploy** (staging deploys from `main`), **`Closes #N` never auto-fired** (only works on the default branch), and a later reconcile required resolving **58 conflicts** across core files. **Fix codified:** see [Branch & Merge Policy](#branch--merge-policy-mandatory) and [Rule 7](#rule-7-every-pr-targets-main--programs-land-on-main-not-side-branches). Orchestrators must target `main` for every PR and land the program on `main` within the work session.
 
 ### Doc agents need human commit
 
@@ -429,7 +479,9 @@ $env:HUSKY = "0" ; git push --no-verify origin <branch-name>
 ```bash
 $env:HUSKY = "0" ; git push --no-verify origin <branch>
 
+# ALWAYS target main as the base (see Branch & Merge Policy, Rule A).
 gh pr create \
+  --base main \
   --title "type(scope): description (#N)" \
   --body "## Summary
 <description of changes>


### PR DESCRIPTION
Codifies the rule that all fleet PRs target main and programs must land on main within the work session.

- **fleet-operations.md**: new mandatory **Branch & Merge Policy** section (Rules A–F), new **Rule 7**, and an incident learning entry documenting the stale-feature-branch accumulation.
- **AGENTS.md**: Definition of Done gains **Base is main** + **Landed on main** gates; the outdated 'never merge PRs' rule is replaced with **orchestrator merge authority** under the policy (with the --admin-only-after-local-green caveat).

Prettier-clean.

Closes #2779