### PR TITLE
ci: bypass husky hooks in update-visual-snapshots

### DIFF
--- a/.github/workflows/update-visual-snapshots.yml
+++ b/.github/workflows/update-visual-snapshots.yml
@@ -59,6 +59,10 @@ jobs:
             --project=chromium --update-snapshots
 
       - name: Commit refreshed baselines
+        env:
+          # Disable husky hooks: the repo's pre-push hook requires interactive
+          # confirmation, which hangs/fails in CI. --no-verify is belt-and-braces.
+          HUSKY: '0'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -67,5 +71,5 @@ jobs:
             exit 0
           fi
           git add apps/web/e2e/**/*.png
-          git commit -m "test(web): refresh Chromium visual baselines"
-          git push origin HEAD:${{ github.ref_name }}
+          git commit --no-verify -m "test(web): refresh Chromium visual baselines"
+          git push --no-verify origin HEAD:${{ github.ref_name }}


### PR DESCRIPTION
The update-visual-snapshots workflow's push failed because the repo pre-push hook requires interactive confirmation. Disable husky (HUSKY=0) and use --no-verify so the refreshed-baseline commit can be pushed in CI. Follow-up to #2786.