### PR TITLE
feat(web): auto-deploy to GitHub Pages on green main

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,91 @@
+# =============================================================================
+# Deploy — Web (GitHub Pages)
+# =============================================================================
+#
+# A zero-infrastructure auto-deploy for the local-first web app. The app is a
+# static SPA (vite build) that works without a backend (local-first / demo
+# mode), so it can be served directly from GitHub Pages with no external host
+# or secrets.
+#
+# Trigger: automatically after a green **Web CI** run on `main` (so only
+# validated commits ship), plus manual workflow_dispatch.
+#
+# Build env:
+#   - PUBLIC_BASE_PATH=/finance/  -> vite base + router basename for the
+#     project-pages subpath (https://<owner>.github.io/finance/).
+#   - VITE_SUPABASE_URL / _ANON_KEY: use repo secrets if present (backend-
+#     connected), otherwise a `placeholder` URL that activates local-first /
+#     demo mode so the app still works.
+# =============================================================================
+
+name: Deploy — Web (Pages)
+
+on:
+  workflow_run:
+    workflows: ['Web CI']
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent Pages deployment; let in-flight ones finish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build (Pages)
+    # Only deploy when manually dispatched or when the triggering Web CI was green.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build -w packages/design-tokens
+
+      - name: Build web app (Pages subpath)
+        env:
+          PUBLIC_BASE_PATH: /finance/
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL || 'https://placeholder.supabase.co' }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY || 'placeholder-anon-key' }}
+        run: npm run build -w apps/web
+
+      - name: SPA fallback + Pages hygiene
+        run: |
+          # Client-side routing: serve index.html for unknown deep links.
+          cp apps/web/dist/index.html apps/web/dist/404.html
+          # Disable Jekyll so files/dirs starting with '_' are served as-is.
+          touch apps/web/dist/.nojekyll
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+        with:
+          path: apps/web/dist
+
+  deploy:
+    name: Deploy (Pages)
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/apps/web/src/db/DatabaseProvider.tsx
+++ b/apps/web/src/db/DatabaseProvider.tsx
@@ -353,7 +353,16 @@ export function DatabaseProvider({ children }: DatabaseProviderProps) {
       try {
         const result = await initDatabaseWithDiagnostics();
 
-        await seedDatabase(result.db);
+        try {
+          await seedDatabase(result.db);
+        } catch (seedError) {
+          // Demo/sample seeding is best-effort. A seeding failure must never
+          // prevent the app from booting — the user simply starts with an
+          // empty workspace. Real schema problems still surface through normal
+          // CRUD operations (and are covered by migrations/tests).
+          // eslint-disable-next-line no-console
+          console.warn('[db] Seed step failed; continuing with an empty database.', seedError);
+        }
 
         if (isDisposed) {
           // Provider truly unmounted (not just StrictMode replay) — leave

--- a/apps/web/src/db/sqlite-wasm.ts
+++ b/apps/web/src/db/sqlite-wasm.ts
@@ -639,6 +639,34 @@ export const MIGRATIONS: Migration[] = [
       `CREATE INDEX IF NOT EXISTS idx_transaction_retirement_contribution_year ON "transaction" (retirement_contribution_year);`,
     ],
   },
+  {
+    version: 13,
+    label: 'add-sort-order-to-category',
+    up: [
+      // The `category` table was created without a sort_order column, but the
+      // categories repository (and seeding) order by / insert sort_order — so a
+      // real (non-stub) database failed on first use with
+      // "table category has no column named sort_order". Add it here, matching
+      // the budget/goal sort_order migrations.
+      `ALTER TABLE category ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0;`,
+      `WITH ordered_category AS (
+        SELECT id,
+               ROW_NUMBER() OVER (
+                 ORDER BY (parent_id IS NOT NULL) ASC, parent_id ASC, name ASC, id ASC
+               ) - 1 AS sort_order
+          FROM category
+         WHERE deleted_at IS NULL
+      )
+      UPDATE category
+         SET sort_order = (
+           SELECT ordered_category.sort_order
+             FROM ordered_category
+            WHERE ordered_category.id = category.id
+         )
+       WHERE id IN (SELECT id FROM ordered_category);`,
+      `CREATE INDEX IF NOT EXISTS idx_category_sort ON category (sort_order);`,
+    ],
+  },
 ];
 // ---------------------------------------------------------------------------
 // OPFS / IndexedDB feature detection
@@ -991,7 +1019,7 @@ async function initIndexedDbBackend(): Promise<{
   try {
     const initSqlJs = (await import(/* webpackChunkName: "sql-js" */ 'sql.js')).default;
     SQL = await initSqlJs({
-      locateFile: (file: string) => `/assets/sql-wasm/${file}`,
+      locateFile: (file: string) => `${import.meta.env.BASE_URL}assets/sql-wasm/${file}`,
     });
   } catch (err) {
     throw new StorageError('WASM_LOAD_FAILED', getUserFriendlyStorageMessage('WASM_LOAD_FAILED'), {

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -181,7 +181,7 @@ createRoot(rootElement).render(
         <AuthProvider config={authConfig}>
           <MoneyDisplayProvider>
             <AccessibilityProvider>
-              <BrowserRouter>
+              <BrowserRouter basename={import.meta.env.BASE_URL.replace(/\/$/, '') || '/'}>
                 <NavigationGuard>
                   <ScrollToTop />
                   <UpdateBanner />

--- a/apps/web/src/sw/register.ts
+++ b/apps/web/src/sw/register.ts
@@ -47,7 +47,9 @@
  *   `Service-Worker-Allowed: /` on that response so the dev SW can also
  *   claim the root scope.
  */
-const SERVICE_WORKER_URL: string = import.meta.env.DEV ? '/src/sw/service-worker.ts' : '/sw.js';
+const SERVICE_WORKER_URL: string = import.meta.env.DEV
+  ? '/src/sw/service-worker.ts'
+  : `${import.meta.env.BASE_URL}sw.js`;
 
 /**
  * Track the registration so subscribers can wait for it without
@@ -80,7 +82,7 @@ export function registerAppServiceWorker(): Promise<ServiceWorkerRegistration | 
   }
 
   registrationPromise = navigator.serviceWorker
-    .register(SERVICE_WORKER_URL, { scope: '/', type: 'module' })
+    .register(SERVICE_WORKER_URL, { scope: import.meta.env.BASE_URL, type: 'module' })
     .then((registration) => registration)
     .catch((error: unknown) => {
       // SW registration is non-fatal — the app still works without it,

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -129,6 +129,10 @@ const authProxyTarget =
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  // Base public path. Defaults to '/' (root, e.g. the Azure VM / custom domain).
+  // GitHub Pages project sites serve under '/<repo>/', so the Pages deploy sets
+  // PUBLIC_BASE_PATH=/finance/. import.meta.env.BASE_URL reflects this at runtime.
+  base: process.env.PUBLIC_BASE_PATH ?? '/',
   plugins: [
     react(),
     copySqlJsWasm(),


### PR DESCRIPTION
Makes web deployment **actually automatic** with our pipelines. The Azure VM staging target isn't reachable (no `DEPLOY_HOST` configured), so this ships the local-first SPA to **GitHub Pages** — auto-triggered after a green **Web CI** run on `main`.

## What's added
- **`Deploy — Web (Pages)` workflow**: builds with `PUBLIC_BASE_PATH=/finance/` and Supabase secrets if present (else `placeholder` → local-first/demo), SPA 404 fallback + `.nojekyll`, deploys via `actions/deploy-pages`. Pages enabled (build type: workflow).
- **Subpath support** (defaults to `/` so the VM/root build is unchanged): vite `base`, `BrowserRouter` basename, SQLite-WASM `locateFile`, and service-worker URL/scope are now base-aware.

## Real bugs found by running the production build in a browser
CI only exercises a **stub DB**, so these were latent and would break **any** real deploy:
- **Missing migration `category.sort_order` (v13)** — the table was created without it (budget/goal got theirs), breaking real category seeding/queries (`no column named sort_order`).
- **Demo seeding made best-effort** so a seed failure can't brick app boot.

## Verified locally
Built with the Pages config and loaded in a real browser under `/finance/`: app mounts, routes to onboarding, **SQLite-WASM DB initializes**, consent/onboarding UI renders, no error screen. Unit tests for changed files pass; typecheck/eslint clean.

## Follow-up
- Service worker still logs a non-fatal eval error under the subpath (PWA/offline only) — will address separately.
- Once the Azure VM/`DEPLOY_*` secrets are fixed (#2794), the existing staging deploy can run in parallel; this Pages deploy is additive.