### PR TITLE
fix(web): demo seeding works against a real SQLite-WASM DB (#2797)

### DIFF
--- a/apps/web/src/db/__tests__/sqlite-wasm-savepoint.test.ts
+++ b/apps/web/src/db/__tests__/sqlite-wasm-savepoint.test.ts
@@ -3,9 +3,12 @@
 import { createRequire } from 'node:module';
 import initSqlJs from 'sql.js';
 import { describe, expect, it, vi } from 'vitest';
+import { seedDatabase } from '../seed';
 import {
   MIGRATIONS,
+  _createDbWrapperForTesting,
   _runMigrationsForTesting,
+  _shouldPersistIndexedDbAfterExecForTesting,
   releaseSavepoint,
   rollbackToSavepoint,
   type SqliteDb,
@@ -45,6 +48,51 @@ describe('sqlite-wasm savepoint migrations', () => {
         'account',
         'transaction',
       ]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('defers IndexedDB persistence while savepoints are active', () => {
+    expect(
+      _shouldPersistIndexedDbAfterExecForTesting([
+        'SAVEPOINT seed_init',
+        'INSERT INTO account (id) VALUES (?)',
+        'UPDATE account SET name = ? WHERE id = ?',
+        'ROLLBACK TO SAVEPOINT seed_init',
+        'RELEASE SAVEPOINT seed_init',
+        'INSERT INTO account (id) VALUES (?)',
+      ]),
+    ).toEqual([false, false, false, false, true, true]);
+  });
+
+  it('waits for the outer transaction before persisting nested savepoints', () => {
+    expect(
+      _shouldPersistIndexedDbAfterExecForTesting([
+        'BEGIN TRANSACTION',
+        'INSERT INTO account (id) VALUES (?)',
+        'SAVEPOINT inner_write',
+        'INSERT INTO category (id) VALUES (?)',
+        'RELEASE SAVEPOINT inner_write',
+        'COMMIT',
+      ]),
+    ).toEqual([false, false, false, false, false, true]);
+  });
+
+  it('seeds demo data through the IndexedDB wrapper without losing seed savepoint', async () => {
+    const db = new SQL.Database();
+
+    try {
+      await _runMigrationsForTesting(SQL, db, 'indexeddb');
+      const wrapper = _createDbWrapperForTesting(SQL, db, 'indexeddb');
+
+      await expect(seedDatabase(wrapper)).resolves.toBeUndefined();
+
+      const accountCount = wrapper.selectOne('SELECT COUNT(*) AS count FROM account;');
+      const transactionCount = wrapper.selectOne('SELECT COUNT(*) AS count FROM "transaction";');
+
+      expect(Number(accountCount?.count ?? 0)).toBeGreaterThan(0);
+      expect(Number(transactionCount?.count ?? 0)).toBeGreaterThan(0);
     } finally {
       db.close();
     }

--- a/apps/web/src/db/sqlite-wasm.ts
+++ b/apps/web/src/db/sqlite-wasm.ts
@@ -1123,6 +1123,58 @@ function execSavepointControl(
   }
 }
 
+type TransactionControlEffect = 'enter' | 'leave' | 'end' | 'rollbackTo' | null;
+
+function getTransactionControlEffect(sql: string): TransactionControlEffect {
+  const normalized = sql.trimStart();
+
+  if (/^BEGIN\b/i.test(normalized) || /^SAVEPOINT\b/i.test(normalized)) {
+    return 'enter';
+  }
+  if (/^RELEASE(?:\s+SAVEPOINT)?\b/i.test(normalized)) {
+    return 'leave';
+  }
+  if (/^ROLLBACK\s+TO(?:\s+SAVEPOINT)?\b/i.test(normalized)) {
+    return 'rollbackTo';
+  }
+  if (/^(?:COMMIT|END)\b/i.test(normalized) || /^ROLLBACK\b/i.test(normalized)) {
+    return 'end';
+  }
+
+  return null;
+}
+
+function createIndexedDbPersistenceGate(): (sql: string) => boolean {
+  let transactionDepth = 0;
+
+  return (sql: string): boolean => {
+    const controlEffect = getTransactionControlEffect(sql);
+
+    switch (controlEffect) {
+      case 'enter':
+        transactionDepth += 1;
+        return false;
+      case 'leave':
+        transactionDepth = Math.max(0, transactionDepth - 1);
+        return transactionDepth === 0;
+      case 'end':
+        transactionDepth = 0;
+        return true;
+      case 'rollbackTo':
+        return false;
+      default:
+        return transactionDepth === 0;
+    }
+  };
+}
+
+export function _shouldPersistIndexedDbAfterExecForTesting(
+  sqlStatements: readonly string[],
+): boolean[] {
+  const shouldPersist = createIndexedDbPersistenceGate();
+  return sqlStatements.map((sql) => shouldPersist(sql));
+}
+
 function releaseSavepointRaw(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   driver: any,
@@ -1316,6 +1368,16 @@ export async function _runMigrationsForTesting(
   await runMigrations(driver, db, backend);
 }
 
+export function _createDbWrapperForTesting(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  driver: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  db: any,
+  backend: StorageBackend = 'indexeddb',
+): SqliteDb {
+  return createDbWrapper(driver, db, backend);
+}
+
 // ---------------------------------------------------------------------------
 // IndexedDB persistence helpers (fallback only)
 // ---------------------------------------------------------------------------
@@ -1449,12 +1511,14 @@ function createDbWrapper(
   db: any,
   backend: StorageBackend,
 ): SqliteDb {
+  const shouldPersistAfterExec = backend === 'indexeddb' ? createIndexedDbPersistenceGate() : null;
+
   return {
     backend,
 
     exec(sql: string, params?: unknown[]): void {
       execRaw(driver, db, sql, backend, params);
-      if (backend === 'indexeddb') {
+      if (backend === 'indexeddb' && shouldPersistAfterExec?.(sql) === true) {
         void persistToIndexedDB(DB_NAME, exportDatabase(driver, db, backend));
       }
     },


### PR DESCRIPTION
## Summary
- Root cause: the IndexedDB SQLite wrapper persisted by calling sql.js export after every exec; exporting while seed_init was active discarded the SQLite savepoint, so RELEASE failed with no such savepoint.
- Fix: track transaction/savepoint depth in the IndexedDB wrapper and defer persistence until the outer savepoint/transaction completes, then persist once.
- Added regression coverage for the persistence gate and real sql.js wrapper demo seeding path.

## Verification
- npm ci
- npm run build:tokens (needed to generate design token artifacts for web build)
- PUBLIC_BASE_PATH=/finance/ VITE_SUPABASE_URL=https://placeholder.supabase.co VITE_SUPABASE_ANON_KEY=placeholder-anon-key npm run build -w apps/web
- Vite preview on port 4173 + Playwright browser smoke check forced to real IndexedDB SQLite-WASM: no page errors, no console errors, no seed/no such savepoint messages, #root not empty
- npx vitest run src/db --reporter=dot
- npx tsc --noEmit -p tsconfig.json
- npx eslint apps/web/src/db/sqlite-wasm.ts apps/web/src/db/__tests__/sqlite-wasm-savepoint.test.ts --max-warnings 0
- npx prettier --check apps/web/src/db/sqlite-wasm.ts apps/web/src/db/__tests__/sqlite-wasm-savepoint.test.ts