### PR TITLE
fix(web): service worker works under a Pages subpath (#2797)

### DIFF
--- a/apps/web/src/__tests__/service-worker-lifecycle.test.ts
+++ b/apps/web/src/__tests__/service-worker-lifecycle.test.ts
@@ -14,7 +14,12 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { getFetchStrategyForPathname } from '../sw/service-worker';
+import {
+  getAppShellPrecacheUrls,
+  getFetchStrategyForPathname,
+  normalizeServiceWorkerBasePath,
+  withServiceWorkerBasePath,
+} from '../sw/service-worker';
 
 // ---------------------------------------------------------------------------
 // Service worker caching strategy constants (mirrored from source)
@@ -24,7 +29,7 @@ const CACHE_VERSION = 'v2';
 const STATIC_CACHE = `finance-static-${CACHE_VERSION}`;
 const SYNC_CACHE = `finance-sync-${CACHE_VERSION}`;
 const LEGACY_API_CACHE_PREFIX = 'finance-api-';
-const APP_SHELL: string[] = ['/', '/index.html', '/manifest.json'];
+const APP_SHELL = getAppShellPrecacheUrls('/');
 const STATIC_EXTENSIONS = /\.(js|css|woff2?|ttf|otf|eot|png|jpe?g|gif|svg|ico|webp|avif|wasm)$/i;
 
 // ---------------------------------------------------------------------------
@@ -65,6 +70,27 @@ describe('App shell pre-cache list (#1330)', () => {
 
   it('includes manifest.json', () => {
     expect(APP_SHELL).toContain('/manifest.json');
+  });
+
+  it('normalizes Vite base paths with leading and trailing slashes', () => {
+    expect(normalizeServiceWorkerBasePath('/finance')).toBe('/finance/');
+    expect(normalizeServiceWorkerBasePath('finance/')).toBe('/finance/');
+    expect(normalizeServiceWorkerBasePath('/')).toBe('/');
+  });
+
+  it('builds subpath app shell URLs for GitHub Pages project sites', () => {
+    expect(getAppShellPrecacheUrls('/finance/')).toEqual([
+      '/finance/',
+      '/finance/index.html',
+      '/finance/manifest.json',
+    ]);
+  });
+
+  it('prefixes precached asset URLs with the service worker base path', () => {
+    expect(withServiceWorkerBasePath('/finance/', 'assets/main.js')).toBe(
+      '/finance/assets/main.js',
+    );
+    expect(withServiceWorkerBasePath('/', 'assets/main.js')).toBe('/assets/main.js');
   });
 });
 

--- a/apps/web/src/accessibility/__tests__/wcag-audit.test.ts
+++ b/apps/web/src/accessibility/__tests__/wcag-audit.test.ts
@@ -178,7 +178,7 @@ describe('Service Worker Caching', () => {
 
   it('should pre-cache app shell on install', () => {
     expect(swCode).toContain('PRECACHE_MANIFEST');
-    expect(swCode).toContain("cache.addAll(['/', '/index.html', '/manifest.json'])");
+    expect(swCode).toContain('cache.addAll(APP_SHELL_PRECACHE_URLS)');
   });
 
   it('should purge stale caches on activate', () => {
@@ -187,7 +187,7 @@ describe('Service Worker Caching', () => {
 
   it('should handle Background Sync', () => {
     expect(swCode).toContain('SYNC_TAG');
-    expect(swCode).toContain('replayMutations');
+    expect(swCode).toContain('replayPendingMutations');
   });
 });
 

--- a/apps/web/src/sw/service-worker.ts
+++ b/apps/web/src/sw/service-worker.ts
@@ -27,14 +27,7 @@
 /// <reference lib="webworker" />
 declare const self: ServiceWorkerGlobalScope;
 
-import { replayMutations } from '../db/sync/replayMutations';
-import { SYNC_TAG, type ClientToSwMessage, type SwToClientMessage } from '../db/sync/types';
-import {
-  RECEIPT_CACHE_MAX_ENTRIES,
-  hasSensitiveReceiptToken,
-  isReceiptImagePath,
-  sanitizeReceiptCacheUrl,
-} from '../lib/receiptImagePolicy';
+import type { ClientToSwMessage, QueuedMutation, SwToClientMessage } from '../db/sync/types';
 
 // ---------------------------------------------------------------------------
 // Cache configuration
@@ -58,6 +51,31 @@ const STATIC_CACHE = `finance-static-${CACHE_VERSION}`;
 const SYNC_CACHE = `finance-sync-${CACHE_VERSION}`;
 const RECEIPT_CACHE = `finance-receipts-${CACHE_VERSION}`;
 const LEGACY_API_CACHE_PREFIX = 'finance-api-';
+const SYNC_TAG = 'finance-offline-mutations';
+const MUTATION_QUEUE_DB_NAME = 'finance-mutation-queue';
+const MUTATION_QUEUE_STORE_NAME = 'mutations';
+const MUTATION_QUEUE_DB_VERSION = 1;
+const MAX_RETRY_COUNT = 5;
+const REPLAY_BATCH_SIZE = 50;
+const CONFLICT_DB_NAME = 'finance-sync-conflicts';
+const CONFLICT_STORE_NAME = 'conflicts';
+const CONFLICT_DB_VERSION = 1;
+const RECEIPT_CACHE_MAX_ENTRIES = 120;
+const RECEIPT_PATH_PATTERN = /\/(receipts?|attachments?)\//i;
+const RECEIPT_IMAGE_EXTENSION_PATTERN = /\.(avif|gif|jpe?g|png|webp)$/i;
+const SENSITIVE_RECEIPT_QUERY_PARAMS = new Set([
+  'access_token',
+  'authorization',
+  'expires',
+  'key',
+  'policy',
+  'signature',
+  'sig',
+  'token',
+  'x-amz-credential',
+  'x-amz-security-token',
+  'x-amz-signature',
+]);
 
 /**
  * Build-time precache manifest.
@@ -70,11 +88,302 @@ declare const __PRECACHE_MANIFEST__: string[];
 const PRECACHE_MANIFEST: string[] =
   typeof __PRECACHE_MANIFEST__ !== 'undefined' ? __PRECACHE_MANIFEST__ : [];
 
+const BASE_PATH = normalizeServiceWorkerBasePath(import.meta.env.BASE_URL);
+const APP_INDEX_URL = withServiceWorkerBasePath(BASE_PATH, 'index.html');
+const APP_SHELL_PRECACHE_URLS = getAppShellPrecacheUrls(BASE_PATH);
+
+export function normalizeServiceWorkerBasePath(basePath: string | undefined): string {
+  const trimmed = basePath?.trim();
+  if (!trimmed || trimmed === '/' || trimmed === '.' || trimmed === './') {
+    return '/';
+  }
+
+  let pathname = trimmed;
+  if (/^[a-z][a-z\d+.-]*:/i.test(trimmed)) {
+    pathname = new URL(trimmed).pathname;
+  }
+
+  const withLeadingSlash = pathname.startsWith('/') ? pathname : `/${pathname}`;
+  return withLeadingSlash.endsWith('/') ? withLeadingSlash : `${withLeadingSlash}/`;
+}
+
+export function withServiceWorkerBasePath(basePath: string, path: string): string {
+  return `${normalizeServiceWorkerBasePath(basePath)}${path.replace(/^\/+/, '')}`;
+}
+
+export function getAppShellPrecacheUrls(basePath: string = BASE_PATH): string[] {
+  return [
+    withServiceWorkerBasePath(basePath, ''),
+    withServiceWorkerBasePath(basePath, 'index.html'),
+    withServiceWorkerBasePath(basePath, 'manifest.json'),
+  ];
+}
+
 /**
  * File-extension patterns that qualify for cache-first treatment.
  * Matched against the URL pathname.
  */
 const STATIC_EXTENSIONS = /\.(js|css|woff2?|ttf|otf|eot|png|jpe?g|gif|svg|ico|webp|avif|wasm)$/i;
+
+function isReceiptImagePath(pathname: string): boolean {
+  return RECEIPT_PATH_PATTERN.test(pathname) && RECEIPT_IMAGE_EXTENSION_PATTERN.test(pathname);
+}
+
+function sanitizeReceiptCacheUrl(input: URL): string {
+  const url = new URL(input.toString());
+  for (const key of Array.from(url.searchParams.keys())) {
+    if (SENSITIVE_RECEIPT_QUERY_PARAMS.has(key.toLowerCase())) {
+      url.searchParams.delete(key);
+    }
+  }
+  url.hash = '';
+  return url.toString();
+}
+
+function hasSensitiveReceiptToken(input: URL): boolean {
+  for (const key of input.searchParams.keys()) {
+    if (SENSITIVE_RECEIPT_QUERY_PARAMS.has(key.toLowerCase())) {
+      return true;
+    }
+  }
+  return false;
+}
+
+interface SyncConflict {
+  readonly mutationId: string;
+  readonly tableName: string;
+  readonly recordId: string;
+  readonly clientData: Record<string, unknown>;
+  readonly serverData: Record<string, unknown>;
+  resolvedAt: number | null;
+  resolution: 'client' | 'server' | null;
+}
+
+interface PushResult {
+  acknowledged: string[];
+  conflicts: SyncConflict[];
+  authError: boolean;
+}
+
+async function replayPendingMutations(
+  broadcastResult?: (message: SwToClientMessage) => void,
+): Promise<void> {
+  const pending = await getMutationBatch(REPLAY_BATCH_SIZE);
+  if (pending.length === 0) {
+    return;
+  }
+
+  broadcastResult?.({ type: 'SYNC_STARTED' });
+  const result = await pushMutationsToServer(pending);
+
+  if (result.authError) {
+    broadcastResult?.({
+      type: 'SYNC_FAILED',
+      error: 'Authentication required. Please sign in again.',
+      authError: true,
+    });
+    return;
+  }
+
+  if (result.conflicts.length > 0) {
+    await storeConflicts(result.conflicts);
+  }
+
+  const acknowledged = new Set(result.acknowledged);
+  const conflictIds = new Set(result.conflicts.map((conflict) => conflict.mutationId));
+  if (acknowledged.size > 0) {
+    await deleteMutations([...acknowledged]);
+  }
+  if (conflictIds.size > 0) {
+    await deleteMutations([...conflictIds]);
+  }
+
+  const failed = pending.filter(
+    (mutation) => !acknowledged.has(mutation.id) && !conflictIds.has(mutation.id),
+  );
+  await Promise.all(failed.map((mutation) => retryMutation(mutation)));
+
+  broadcastResult?.({
+    type: 'SYNC_COMPLETED',
+    syncedCount: acknowledged.size,
+    failedCount: failed.length,
+    conflictCount: result.conflicts.length,
+  });
+}
+
+async function pushMutationsToServer(mutations: QueuedMutation[]): Promise<PushResult> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 30_000);
+
+  try {
+    const response = await fetch(`${self.location.origin}/api/sync/push`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mutations }),
+      credentials: 'include',
+      signal: controller.signal,
+    });
+
+    if (response.status === 401 || response.status === 403) {
+      return { acknowledged: [], conflicts: [], authError: true };
+    }
+
+    if (response.status === 409) {
+      const body = (await response.json()) as {
+        acknowledged?: string[];
+        conflicts?: SyncConflict[];
+      };
+      return {
+        acknowledged: body.acknowledged ?? [],
+        conflicts: body.conflicts ?? [],
+        authError: false,
+      };
+    }
+
+    if (!response.ok) {
+      return { acknowledged: [], conflicts: [], authError: false };
+    }
+
+    const body = (await response.json()) as {
+      acknowledged?: string[];
+      conflicts?: SyncConflict[];
+    };
+    return {
+      acknowledged: body.acknowledged ?? mutations.map((mutation) => mutation.id),
+      conflicts: body.conflicts ?? [],
+      authError: false,
+    };
+  } catch {
+    return { acknowledged: [], conflicts: [], authError: false };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+function openMutationDb(): Promise<IDBDatabase> {
+  return new Promise<IDBDatabase>((resolve, reject) => {
+    const request = indexedDB.open(MUTATION_QUEUE_DB_NAME, MUTATION_QUEUE_DB_VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(MUTATION_QUEUE_STORE_NAME)) {
+        const store = db.createObjectStore(MUTATION_QUEUE_STORE_NAME, { keyPath: 'id' });
+        store.createIndex('by_timestamp', 'timestamp', { unique: false });
+        store.createIndex('by_table', 'tableName', { unique: false });
+        store.createIndex('by_household', 'householdId', { unique: false });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function getMutationBatch(count: number): Promise<QueuedMutation[]> {
+  const db = await openMutationDb();
+  try {
+    return await new Promise<QueuedMutation[]>((resolve, reject) => {
+      const tx = db.transaction(MUTATION_QUEUE_STORE_NAME, 'readonly');
+      const store = tx.objectStore(MUTATION_QUEUE_STORE_NAME);
+      const index = store.index('by_timestamp');
+      const mutations: QueuedMutation[] = [];
+      const request = index.openCursor();
+      request.onsuccess = () => {
+        const cursor = request.result;
+        if (cursor && mutations.length < count) {
+          mutations.push(cursor.value as QueuedMutation);
+          cursor.continue();
+          return;
+        }
+        resolve(mutations);
+      };
+      request.onerror = () => reject(request.error);
+    });
+  } finally {
+    db.close();
+  }
+}
+
+async function countPendingMutations(): Promise<number> {
+  const db = await openMutationDb();
+  try {
+    return await new Promise<number>((resolve, reject) => {
+      const tx = db.transaction(MUTATION_QUEUE_STORE_NAME, 'readonly');
+      const request = tx.objectStore(MUTATION_QUEUE_STORE_NAME).count();
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+  } finally {
+    db.close();
+  }
+}
+
+async function deleteMutations(ids: readonly string[]): Promise<void> {
+  if (ids.length === 0) return;
+
+  const db = await openMutationDb();
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(MUTATION_QUEUE_STORE_NAME, 'readwrite');
+      const store = tx.objectStore(MUTATION_QUEUE_STORE_NAME);
+      ids.forEach((id) => store.delete(id));
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+      tx.onabort = () => reject(tx.error ?? new Error('Transaction aborted'));
+    });
+  } finally {
+    db.close();
+  }
+}
+
+async function retryMutation(mutation: QueuedMutation): Promise<void> {
+  const nextRetryCount = mutation.retryCount + 1;
+  if (nextRetryCount > MAX_RETRY_COUNT) {
+    await deleteMutations([mutation.id]);
+    return;
+  }
+
+  const db = await openMutationDb();
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(MUTATION_QUEUE_STORE_NAME, 'readwrite');
+      tx.objectStore(MUTATION_QUEUE_STORE_NAME).put({ ...mutation, retryCount: nextRetryCount });
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+      tx.onabort = () => reject(tx.error ?? new Error('Transaction aborted'));
+    });
+  } finally {
+    db.close();
+  }
+}
+
+async function storeConflicts(conflicts: SyncConflict[]): Promise<void> {
+  if (conflicts.length === 0) return;
+
+  const db = await new Promise<IDBDatabase>((resolve, reject) => {
+    const request = indexedDB.open(CONFLICT_DB_NAME, CONFLICT_DB_VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(CONFLICT_STORE_NAME)) {
+        const store = db.createObjectStore(CONFLICT_STORE_NAME, { keyPath: 'mutationId' });
+        store.createIndex('by_table', 'tableName', { unique: false });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(CONFLICT_STORE_NAME, 'readwrite');
+      const store = tx.objectStore(CONFLICT_STORE_NAME);
+      conflicts.forEach((conflict) => store.put(conflict));
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+      tx.onabort = () => reject(tx.error ?? new Error('Transaction aborted'));
+    });
+  } finally {
+    db.close();
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Install -- pre-cache app shell
@@ -83,8 +392,8 @@ const STATIC_EXTENSIONS = /\.(js|css|woff2?|ttf|otf|eot|png|jpe?g|gif|svg|ico|we
 self.addEventListener('install', (event: ExtendableEvent) => {
   event.waitUntil(
     caches.open(STATIC_CACHE).then(async (cache) => {
-      // Always precache core app shell
-      await cache.addAll(['/', '/index.html', '/manifest.json']);
+      // Always precache the core app shell at the Vite public base path.
+      await cache.addAll(APP_SHELL_PRECACHE_URLS);
       // Precache build chunks individually — a single failure should not
       // block installation (e.g. dev mode without manifest).
       await Promise.allSettled(
@@ -152,7 +461,7 @@ self.addEventListener('fetch', (event: FetchEvent) => {
 
 self.addEventListener('sync', (event: SyncEvent) => {
   if (event.tag === SYNC_TAG) {
-    event.waitUntil(replayMutations((message) => broadcastToClients(message)));
+    event.waitUntil(replayPendingMutations((message) => broadcastToClients(message)));
   }
 });
 
@@ -192,15 +501,13 @@ self.addEventListener('message', (event: ExtendableMessageEvent) => {
       break;
 
     case 'SYNC_NOW':
-      event.waitUntil(replayMutations((message) => broadcastToClients(message)));
+      event.waitUntil(replayPendingMutations((message) => broadcastToClients(message)));
       break;
 
     case 'GET_PENDING_COUNT': {
       event.waitUntil(
         (async () => {
-          const { WebMutationQueue } = await import('../db/sync/MutationQueue');
-          const queue = new WebMutationQueue();
-          const count = await queue.getPendingCount();
+          const count = await countPendingMutations();
           broadcastToClients({ type: 'PENDING_COUNT', count });
         })(),
       );
@@ -228,7 +535,7 @@ async function navigationHandler(request: Request): Promise<Response> {
   } catch {
     // Offline — serve the cached app shell so the SPA router can handle the path
     const cache = await caches.open(STATIC_CACHE);
-    const cached = await cache.match('/index.html');
+    const cached = await cache.match(APP_INDEX_URL);
     if (cached) {
       return cached;
     }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -4,7 +4,7 @@ import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 import react from '@vitejs/plugin-react';
-import { defineConfig, type Connect, type Plugin } from 'vite';
+import { defineConfig, type Connect, type Plugin, type ResolvedConfig } from 'vite';
 
 import { getRouteChunkName } from './src/lib/perf/route-chunks';
 
@@ -52,22 +52,46 @@ function copySqlJsWasm(): Plugin {
  * as a global constant in the service worker entry, enabling offline-first
  * precaching of all route chunks during SW installation.
  */
+function normalizeServiceWorkerBasePath(basePath: string): string {
+  const trimmed = basePath.trim();
+  if (!trimmed || trimmed === '/' || trimmed === '.' || trimmed === './') {
+    return '/';
+  }
+
+  let pathname = trimmed;
+  if (/^[a-z][a-z\d+.-]*:/i.test(trimmed)) {
+    pathname = new URL(trimmed).pathname;
+  }
+
+  const withLeadingSlash = pathname.startsWith('/') ? pathname : `/${pathname}`;
+  return withLeadingSlash.endsWith('/') ? withLeadingSlash : `${withLeadingSlash}/`;
+}
+
+function withServiceWorkerBasePath(basePath: string, fileName: string): string {
+  return `${basePath}${fileName.replace(/^\/+/, '')}`;
+}
+
 function swPrecacheManifest(): Plugin {
+  let resolvedBasePath = '/';
+
   return {
     name: 'sw-precache-manifest',
     apply: 'build',
+    configResolved(config: ResolvedConfig) {
+      resolvedBasePath = normalizeServiceWorkerBasePath(config.base);
+    },
     generateBundle(_options, bundle) {
       // Collect all JS and CSS asset paths from the build output
       const assetPaths: string[] = [];
       for (const [fileName, chunk] of Object.entries(bundle)) {
         if (fileName === 'sw.js') continue; // Don't precache the SW itself
         if (fileName.endsWith('.js') || fileName.endsWith('.css')) {
-          assetPaths.push(`/${fileName}`);
+          assetPaths.push(withServiceWorkerBasePath(resolvedBasePath, fileName));
         }
         // Also include CSS assets referenced by chunks
         if (chunk.type === 'chunk' && chunk.viteMetadata?.importedCss) {
           for (const css of chunk.viteMetadata.importedCss) {
-            const cssPath = `/${css}`;
+            const cssPath = withServiceWorkerBasePath(resolvedBasePath, css);
             if (!assetPaths.includes(cssPath)) {
               assetPaths.push(cssPath);
             }


### PR DESCRIPTION
## Root cause
- The generated service-worker precache manifest and app-shell cache list used root-relative URLs (`/assets/*`, `/index.html`, `/manifest.json`), which are wrong for GitHub Pages project-site builds served under `/finance/`.
- The SW bundle also evaluated app route chunks via shared imports, so module service-worker registration could fail with `ServiceWorker script evaluation failed`.

## Fix
- Prefix precache manifest entries and app-shell URLs with Vite's resolved `base` / `import.meta.env.BASE_URL`.
- Keep the service worker self-contained for registration-time code paths so it no longer evaluates route chunks.
- Added lifecycle tests for base-path URL normalization and subpath app-shell URLs.

## Verification
- `npm ci`
- `npm run build:tokens` (prerequisite generated CSS tokens)
- `/finance/` build: `PUBLIC_BASE_PATH=/finance/ VITE_SUPABASE_URL=https://placeholder.supabase.co VITE_SUPABASE_ANON_KEY=placeholder-anon-key npm run build -w apps/web`
- `/finance/` preview on 4174 + Playwright: SW registered with scope `http://localhost:4174/finance/`; no SW registration/evaluation errors.
- Root build without `PUBLIC_BASE_PATH`: `npm run build -w apps/web`
- Root preview on 4175 + Playwright: SW registered with scope `http://localhost:4175/`; no SW registration/evaluation errors.
- `npx vitest run src/sw src/__tests__/service-worker-lifecycle.test.ts --reporter=dot`
- `npx tsc --noEmit -p tsconfig.json`
- `npx eslint src\sw\service-worker.ts src\__tests__\service-worker-lifecycle.test.ts vite.config.ts --max-warnings 0`
- `npx prettier --check src\sw\service-worker.ts src\__tests__\service-worker-lifecycle.test.ts vite.config.ts`