### PR TITLE
fix(web): mobile More-sheet navigation works on touch viewports (#2795)

### DIFF
--- a/apps/web/src/components/layout/MoreNavSheet.tsx
+++ b/apps/web/src/components/layout/MoreNavSheet.tsx
@@ -108,6 +108,19 @@ export const MoreNavSheet: React.FC<MoreNavSheetProps> = ({
     };
   }, [open]);
 
+  useEffect(() => {
+    if (!open) return;
+    const handleDocumentKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape' || event.defaultPrevented) return;
+      event.preventDefault();
+      onClose();
+    };
+    document.addEventListener('keydown', handleDocumentKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleDocumentKeyDown);
+    };
+  }, [open, onClose]);
+
   const handleNavigate = useCallback(
     (path: string) => {
       onClose();

--- a/apps/web/src/components/layout/Navigation.test.tsx
+++ b/apps/web/src/components/layout/Navigation.test.tsx
@@ -178,6 +178,18 @@ describe('BottomNavigation', () => {
     expect(moreButton).toHaveFocus();
   });
 
+  it('closes the More sheet on document Escape when focus is outside the sheet', () => {
+    render(<BottomNavigation {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'More destinations' }));
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
   it('every destination not on the bottom-nav is reachable from the More sheet', () => {
     render(<BottomNavigation {...defaultProps} />);
 

--- a/apps/web/src/styles/navigation-chrome.css
+++ b/apps/web/src/styles/navigation-chrome.css
@@ -268,7 +268,9 @@
 
 .more-sheet__body {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
+  overscroll-behavior: contain;
   padding: var(--spacing-2) var(--spacing-3) var(--spacing-4);
   -webkit-overflow-scrolling: touch;
 }


### PR DESCRIPTION
## Root cause
- The More sheet body was a flex child without `min-height: 0`, so on small touch viewports the destination list could be clipped instead of scrolling inside the sheet.
- Mobile WebKit can leave focus outside the dialog after touch activation, so Escape was not reliably delivered to the panel key handler.

## Fix
- Allow the More sheet body to shrink and own touch scrolling (`min-height: 0`, contained overscroll).
- Add a document-level Escape fallback while the sheet is open.
- Add unit coverage for document Escape.

## Verification
- `npm run build`
- `npx vitest run src\components\layout\Navigation.test.tsx --reporter=dot`
- `npx tsc --noEmit -p tsconfig.json`
- `npx eslint src\ --ext .ts,.tsx --max-warnings 0`
- `npx prettier --check src\styles\navigation-chrome.css src\components\layout\MoreNavSheet.tsx src\components\layout\Navigation.test.tsx`
- `npx playwright test e2e/nav-reachability.spec.ts --project=mobile-chrome --reporter=line`
- `CI=true npx playwright test e2e/nav-reachability.spec.ts --project=chromium --retries=0 --reporter=line`
- `CI=true npx playwright test e2e/nav-reachability.spec.ts --project=mobile-safari --retries=0 --reporter=line`