### PR TITLE
feat(security): encrypt SQLite at rest in IndexedDB (#2727)

### DIFF
--- a/apps/web/src/db/__tests__/sqlite-at-rest-encryption.test.ts
+++ b/apps/web/src/db/__tests__/sqlite-at-rest-encryption.test.ts
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  __sqliteAtRestEncryptionForTesting,
+  clearSqliteAtRestEncryptionStores,
+  isSqliteAtRestEncryptionEnabled,
+} from '../sqlite-at-rest-encryption';
+import { __sqliteIndexedDbPersistenceForTesting } from '../sqlite-wasm';
+
+const DB_NAME = 'finance.db';
+const PLAINTEXT_DB_NAME = 'finance-sqlite';
+const PLAINTEXT_STORE_NAME = 'finance-sqlite';
+const PLAINTEXT_KEY = `${DB_NAME}:db`;
+
+const sampleDbBytes = new TextEncoder().encode('SQLite format 3\0\naccounts: checking=12345');
+
+async function deleteDatabase(name: string): Promise<void> {
+  await new Promise<void>((resolve) => {
+    const request = indexedDB.deleteDatabase(name);
+    request.onsuccess = () => resolve();
+    request.onerror = () => resolve();
+    request.onblocked = () => resolve();
+  });
+}
+
+async function readPlaintextSnapshot(): Promise<ArrayBuffer | undefined> {
+  const db = await openDatabase(PLAINTEXT_DB_NAME, PLAINTEXT_STORE_NAME);
+  try {
+    return readStoreValue<ArrayBuffer>(db, PLAINTEXT_STORE_NAME, PLAINTEXT_KEY);
+  } finally {
+    db.close();
+  }
+}
+
+async function readEncryptedSnapshot(): Promise<unknown> {
+  const { encryptedDbName, encryptedStoreName, encryptedDbKey } =
+    __sqliteAtRestEncryptionForTesting;
+  const db = await openDatabase(encryptedDbName, encryptedStoreName);
+  try {
+    return readStoreValue(db, encryptedStoreName, encryptedDbKey);
+  } finally {
+    db.close();
+  }
+}
+
+async function openDatabase(databaseName: string, storeName: string): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(databaseName, 1);
+    request.onupgradeneeded = () => {
+      if (!request.result.objectStoreNames.contains(storeName)) {
+        request.result.createObjectStore(storeName);
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function readStoreValue<T>(
+  db: IDBDatabase,
+  storeName: string,
+  key: IDBValidKey,
+): Promise<T | undefined> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(storeName, 'readonly');
+    const request = tx.objectStore(storeName).get(key);
+    request.onsuccess = () => resolve(request.result as T | undefined);
+    request.onerror = () => reject(request.error);
+    tx.onabort = () => reject(tx.error);
+  });
+}
+
+describe('SQLite IndexedDB encryption-at-rest wiring', () => {
+  afterEach(async () => {
+    localStorage.removeItem(__sqliteAtRestEncryptionForTesting.flagOverrideKey);
+    await clearSqliteAtRestEncryptionStores();
+    await deleteDatabase(PLAINTEXT_DB_NAME);
+  });
+
+  it('keeps the opt-in feature flag off by default', async () => {
+    expect(isSqliteAtRestEncryptionEnabled()).toBe(false);
+
+    await __sqliteIndexedDbPersistenceForTesting.persistToIndexedDB(DB_NAME, sampleDbBytes);
+
+    expect(await readEncryptedSnapshot()).toBeUndefined();
+    const plaintext = await readPlaintextSnapshot();
+    expect(Array.from(new Uint8Array(plaintext ?? new ArrayBuffer(0)))).toEqual(
+      Array.from(sampleDbBytes),
+    );
+  });
+
+  it('encrypts persisted SQLite bytes and reloads them across calls when enabled', async () => {
+    localStorage.setItem(__sqliteAtRestEncryptionForTesting.flagOverrideKey, 'true');
+
+    await __sqliteIndexedDbPersistenceForTesting.persistToIndexedDB(DB_NAME, sampleDbBytes);
+
+    expect(await readPlaintextSnapshot()).toBeUndefined();
+    const rawEncrypted = JSON.stringify(await readEncryptedSnapshot());
+    expect(rawEncrypted).toContain('finance.sqlite.snapshot.encrypted');
+    expect(rawEncrypted).not.toContain('checking=12345');
+
+    const restored = await __sqliteIndexedDbPersistenceForTesting.loadFromIndexedDB(DB_NAME);
+    expect(Array.from(new Uint8Array(restored ?? new ArrayBuffer(0)))).toEqual(
+      Array.from(sampleDbBytes),
+    );
+  });
+
+  it('loads legacy plaintext snapshots under the flag so migration can persist safely', async () => {
+    await __sqliteIndexedDbPersistenceForTesting.persistPlaintextToIndexedDB(
+      DB_NAME,
+      sampleDbBytes,
+    );
+    localStorage.setItem(__sqliteAtRestEncryptionForTesting.flagOverrideKey, 'true');
+
+    const restored = await __sqliteIndexedDbPersistenceForTesting.loadFromIndexedDB(DB_NAME);
+
+    expect(Array.from(new Uint8Array(restored ?? new ArrayBuffer(0)))).toEqual(
+      Array.from(sampleDbBytes),
+    );
+    expect(await readPlaintextSnapshot()).toBeDefined();
+  });
+
+  it('migrates plaintext to verified encrypted storage before deleting the legacy copy', async () => {
+    await __sqliteIndexedDbPersistenceForTesting.persistPlaintextToIndexedDB(
+      DB_NAME,
+      sampleDbBytes,
+    );
+    localStorage.setItem(__sqliteAtRestEncryptionForTesting.flagOverrideKey, 'true');
+
+    await __sqliteIndexedDbPersistenceForTesting.persistToIndexedDB(DB_NAME, sampleDbBytes);
+
+    expect(await readPlaintextSnapshot()).toBeUndefined();
+    expect(await readEncryptedSnapshot()).toBeDefined();
+    const restored = await __sqliteIndexedDbPersistenceForTesting.loadFromIndexedDB(DB_NAME);
+    expect(Array.from(new Uint8Array(restored ?? new ArrayBuffer(0)))).toEqual(
+      Array.from(sampleDbBytes),
+    );
+  });
+
+  it('still loads encrypted snapshots when the flag is later off to avoid lockout', async () => {
+    localStorage.setItem(__sqliteAtRestEncryptionForTesting.flagOverrideKey, 'true');
+    await __sqliteIndexedDbPersistenceForTesting.persistToIndexedDB(DB_NAME, sampleDbBytes);
+    localStorage.removeItem(__sqliteAtRestEncryptionForTesting.flagOverrideKey);
+
+    const restored = await __sqliteIndexedDbPersistenceForTesting.loadFromIndexedDB(DB_NAME);
+
+    expect(Array.from(new Uint8Array(restored ?? new ArrayBuffer(0)))).toEqual(
+      Array.from(sampleDbBytes),
+    );
+  });
+
+  it('fails closed when the encrypted snapshot cannot be unlocked with the device key', async () => {
+    localStorage.setItem(__sqliteAtRestEncryptionForTesting.flagOverrideKey, 'true');
+    await __sqliteIndexedDbPersistenceForTesting.persistToIndexedDB(DB_NAME, sampleDbBytes);
+    await deleteDatabase(__sqliteAtRestEncryptionForTesting.keyDbName);
+
+    await expect(
+      __sqliteIndexedDbPersistenceForTesting.loadFromIndexedDB(DB_NAME),
+    ).rejects.toThrow();
+  });
+});

--- a/apps/web/src/db/sqlite-at-rest-encryption.ts
+++ b/apps/web/src/db/sqlite-at-rest-encryption.ts
@@ -1,0 +1,358 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import {
+  decryptLocalBytes,
+  encryptLocalBytes,
+  generateLocalEncryptionKey,
+  isWebCryptoEncryptionSupported,
+  type LocalEncryptionEnvelope,
+} from '../lib/security/encryption-at-rest';
+
+const ENCRYPTION_FLAG_OVERRIDE_KEY = 'finance.sqliteAtRestEncryption.enabled';
+const ENCRYPTION_ENV_FLAG = 'VITE_SQLITE_AT_REST_ENCRYPTION';
+
+const KEY_DB_NAME = 'finance-encryption';
+const KEY_STORE_NAME = 'keys';
+const DEVICE_WRAPPING_KEY_ID = 'sqlite-device-wrapping-key:v1';
+const WRAPPED_DATA_KEY_ID = 'sqlite-data-key:v1';
+
+const ENCRYPTED_DB_NAME = 'finance-sqlite-encrypted';
+const ENCRYPTED_STORE_NAME = 'encrypted';
+const ENCRYPTED_DB_KEY = 'db';
+const ENCRYPTED_DB_PENDING_KEY = 'db:pending';
+
+const SNAPSHOT_MAGIC = 'finance.sqlite.snapshot.encrypted';
+const WRAPPED_KEY_MAGIC = 'finance.sqlite.data-key.wrapped';
+const FORMAT_VERSION = 1;
+const RAW_AES_KEY_BYTES = 32;
+
+interface EncryptedSqliteSnapshotRecord {
+  readonly magic: typeof SNAPSHOT_MAGIC;
+  readonly version: typeof FORMAT_VERSION;
+  readonly databaseName: string;
+  readonly keyId: typeof WRAPPED_DATA_KEY_ID;
+  readonly encryptedAt: string;
+  readonly envelope: LocalEncryptionEnvelope;
+}
+
+interface WrappedDataKeyRecord {
+  readonly magic: typeof WRAPPED_KEY_MAGIC;
+  readonly version: typeof FORMAT_VERSION;
+  readonly keyId: typeof WRAPPED_DATA_KEY_ID;
+  readonly wrappingKeyId: typeof DEVICE_WRAPPING_KEY_ID;
+  readonly createdAt: string;
+  readonly envelope: LocalEncryptionEnvelope;
+}
+
+/**
+ * Device-local encryption-at-rest for the sql.js IndexedDB fallback.
+ *
+ * Threat model for #2727 core: when the opt-in flag is enabled, raw SQLite
+ * bytes are never persisted to the legacy plaintext IndexedDB store. A
+ * non-extractable device wrapping key is stored by the browser as a CryptoKey,
+ * then used to wrap a random SQLite data key. This protects against casual
+ * at-rest inspection of the SQLite blob and preserves automatic unlock on the
+ * same browser profile. It does not protect against XSS running in this origin
+ * or a fully-compromised/unlocked browser profile; a passphrase/WebAuthn unlock
+ * flow should wrap this data key in a follow-up without changing the snapshot
+ * format.
+ */
+
+export function isSqliteAtRestEncryptionEnabled(): boolean {
+  const override = readLocalStorageFlag();
+  if (override !== null) {
+    return override;
+  }
+
+  return import.meta.env[ENCRYPTION_ENV_FLAG] === 'true';
+}
+
+export function isSqliteAtRestEncryptionSupported(): boolean {
+  return typeof indexedDB !== 'undefined' && isWebCryptoEncryptionSupported();
+}
+
+export async function hasEncryptedSqliteSnapshot(): Promise<boolean> {
+  if (typeof indexedDB === 'undefined') {
+    return false;
+  }
+  return (await readEncryptedSnapshotRecord()) !== null;
+}
+
+export async function loadEncryptedSqliteSnapshot(
+  databaseName: string,
+): Promise<Uint8Array | null> {
+  const record = await readEncryptedSnapshotRecord();
+  if (!record) {
+    return null;
+  }
+  validateSnapshotRecord(record, databaseName);
+
+  const dataKey = await getOrCreateSqliteDataKey();
+  return decryptLocalBytes(record.envelope, dataKey, {
+    additionalData: snapshotAdditionalData(databaseName, record.keyId),
+  });
+}
+
+export async function persistEncryptedSqliteSnapshot(
+  databaseName: string,
+  plaintext: Uint8Array,
+): Promise<void> {
+  const dataKey = await getOrCreateSqliteDataKey();
+  const record: EncryptedSqliteSnapshotRecord = {
+    magic: SNAPSHOT_MAGIC,
+    version: FORMAT_VERSION,
+    databaseName,
+    keyId: WRAPPED_DATA_KEY_ID,
+    encryptedAt: new Date().toISOString(),
+    envelope: await encryptLocalBytes(plaintext, dataKey, {
+      additionalData: snapshotAdditionalData(databaseName, WRAPPED_DATA_KEY_ID),
+    }),
+  };
+
+  await writeEncryptedSnapshotRecord(ENCRYPTED_DB_PENDING_KEY, record);
+  const persisted = await readEncryptedSnapshotRecord(ENCRYPTED_DB_PENDING_KEY);
+  if (!persisted) {
+    throw new Error('Encrypted SQLite snapshot verification failed before commit.');
+  }
+
+  validateSnapshotRecord(persisted, databaseName);
+  const verified = await decryptLocalBytes(persisted.envelope, dataKey, {
+    additionalData: snapshotAdditionalData(databaseName, persisted.keyId),
+  });
+  if (!bytesEqual(verified, plaintext)) {
+    throw new Error('Encrypted SQLite snapshot verification produced different bytes.');
+  }
+
+  await commitEncryptedSnapshotRecord(record);
+}
+
+export async function clearSqliteAtRestEncryptionStores(): Promise<void> {
+  await Promise.all([
+    deleteDatabaseBestEffort(ENCRYPTED_DB_NAME),
+    deleteDatabaseBestEffort(KEY_DB_NAME),
+  ]);
+}
+
+export const __sqliteAtRestEncryptionForTesting = {
+  encryptedDbName: ENCRYPTED_DB_NAME,
+  encryptedStoreName: ENCRYPTED_STORE_NAME,
+  encryptedDbKey: ENCRYPTED_DB_KEY,
+  flagOverrideKey: ENCRYPTION_FLAG_OVERRIDE_KEY,
+  keyDbName: KEY_DB_NAME,
+  clearStores: clearSqliteAtRestEncryptionStores,
+};
+
+function readLocalStorageFlag(): boolean | null {
+  try {
+    if (typeof localStorage === 'undefined') {
+      return null;
+    }
+    const value = localStorage.getItem(ENCRYPTION_FLAG_OVERRIDE_KEY);
+    if (value === 'true') {
+      return true;
+    }
+    if (value === 'false') {
+      return false;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+async function getOrCreateSqliteDataKey(): Promise<CryptoKey> {
+  const keyStore = await openKeyStore();
+  try {
+    const wrappingKey = await getOrCreateDeviceWrappingKey(keyStore);
+    const wrapped = await readValue<WrappedDataKeyRecord>(keyStore, WRAPPED_DATA_KEY_ID);
+    if (wrapped) {
+      validateWrappedDataKeyRecord(wrapped);
+      const rawKey = await decryptLocalBytes(wrapped.envelope, wrappingKey, {
+        additionalData: dataKeyAdditionalData(wrapped.keyId, wrapped.wrappingKeyId),
+      });
+      const dataKey = await importAesGcmDataKey(rawKey, false);
+      rawKey.fill(0);
+      return dataKey;
+    }
+
+    const rawKey = crypto.getRandomValues(new Uint8Array(RAW_AES_KEY_BYTES));
+    const dataKey = await importAesGcmDataKey(rawKey, false);
+    const wrappedRecord: WrappedDataKeyRecord = {
+      magic: WRAPPED_KEY_MAGIC,
+      version: FORMAT_VERSION,
+      keyId: WRAPPED_DATA_KEY_ID,
+      wrappingKeyId: DEVICE_WRAPPING_KEY_ID,
+      createdAt: new Date().toISOString(),
+      envelope: await encryptLocalBytes(rawKey, wrappingKey, {
+        additionalData: dataKeyAdditionalData(WRAPPED_DATA_KEY_ID, DEVICE_WRAPPING_KEY_ID),
+      }),
+    };
+    await writeValue(keyStore, WRAPPED_DATA_KEY_ID, wrappedRecord);
+    rawKey.fill(0);
+    return dataKey;
+  } finally {
+    keyStore.close();
+  }
+}
+
+async function getOrCreateDeviceWrappingKey(keyStore: IDBDatabase): Promise<CryptoKey> {
+  const existing = await readValue<CryptoKey>(keyStore, DEVICE_WRAPPING_KEY_ID);
+  if (existing) {
+    return existing;
+  }
+
+  const key = await generateLocalEncryptionKey();
+  await writeValue(keyStore, DEVICE_WRAPPING_KEY_ID, key);
+  return key;
+}
+
+function importAesGcmDataKey(rawKey: Uint8Array, extractable: boolean): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    'raw',
+    toExactArrayBuffer(rawKey),
+    { name: 'AES-GCM', length: 256 },
+    extractable,
+    ['encrypt', 'decrypt'],
+  );
+}
+
+function openKeyStore(): Promise<IDBDatabase> {
+  return openDatabase(KEY_DB_NAME, KEY_STORE_NAME);
+}
+
+function openEncryptedStore(): Promise<IDBDatabase> {
+  return openDatabase(ENCRYPTED_DB_NAME, ENCRYPTED_STORE_NAME);
+}
+
+function openDatabase(databaseName: string, storeName: string): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(databaseName, 1);
+    request.onupgradeneeded = () => {
+      if (!request.result.objectStoreNames.contains(storeName)) {
+        request.result.createObjectStore(storeName);
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function readEncryptedSnapshotRecord(
+  key = ENCRYPTED_DB_KEY,
+): Promise<EncryptedSqliteSnapshotRecord | null> {
+  const db = await openEncryptedStore();
+  try {
+    return (await readValue<EncryptedSqliteSnapshotRecord>(db, key)) ?? null;
+  } finally {
+    db.close();
+  }
+}
+
+async function writeEncryptedSnapshotRecord(
+  key: string,
+  record: EncryptedSqliteSnapshotRecord,
+): Promise<void> {
+  const db = await openEncryptedStore();
+  try {
+    await writeValue(db, key, record);
+  } finally {
+    db.close();
+  }
+}
+
+async function commitEncryptedSnapshotRecord(record: EncryptedSqliteSnapshotRecord): Promise<void> {
+  const db = await openEncryptedStore();
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(ENCRYPTED_STORE_NAME, 'readwrite');
+      const store = tx.objectStore(ENCRYPTED_STORE_NAME);
+      store.put(record, ENCRYPTED_DB_KEY);
+      store.delete(ENCRYPTED_DB_PENDING_KEY);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+      tx.onabort = () => reject(tx.error);
+    });
+  } finally {
+    db.close();
+  }
+}
+
+function readValue<T>(db: IDBDatabase, key: IDBValidKey): Promise<T | undefined> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(db.objectStoreNames[0], 'readonly');
+    const request = tx.objectStore(db.objectStoreNames[0]).get(key);
+    request.onsuccess = () => resolve(request.result as T | undefined);
+    request.onerror = () => reject(request.error);
+    tx.onabort = () => reject(tx.error);
+  });
+}
+
+function writeValue(db: IDBDatabase, key: IDBValidKey, value: unknown): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(db.objectStoreNames[0], 'readwrite');
+    tx.objectStore(db.objectStoreNames[0]).put(value, key);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error);
+  });
+}
+
+function validateSnapshotRecord(record: EncryptedSqliteSnapshotRecord, databaseName: string): void {
+  if (
+    record.magic !== SNAPSHOT_MAGIC ||
+    record.version !== FORMAT_VERSION ||
+    record.databaseName !== databaseName ||
+    record.keyId !== WRAPPED_DATA_KEY_ID
+  ) {
+    throw new Error('Unsupported encrypted SQLite snapshot format.');
+  }
+}
+
+function validateWrappedDataKeyRecord(record: WrappedDataKeyRecord): void {
+  if (
+    record.magic !== WRAPPED_KEY_MAGIC ||
+    record.version !== FORMAT_VERSION ||
+    record.keyId !== WRAPPED_DATA_KEY_ID ||
+    record.wrappingKeyId !== DEVICE_WRAPPING_KEY_ID
+  ) {
+    throw new Error('Unsupported SQLite data-key wrapping format.');
+  }
+}
+
+function snapshotAdditionalData(databaseName: string, keyId: string): Uint8Array {
+  return new TextEncoder().encode(`${SNAPSHOT_MAGIC}:v${FORMAT_VERSION}:${databaseName}:${keyId}`);
+}
+
+function dataKeyAdditionalData(keyId: string, wrappingKeyId: string): Uint8Array {
+  return new TextEncoder().encode(
+    `${WRAPPED_KEY_MAGIC}:v${FORMAT_VERSION}:${keyId}:${wrappingKeyId}`,
+  );
+}
+
+function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
+  if (left.byteLength !== right.byteLength) {
+    return false;
+  }
+  let diff = 0;
+  for (let index = 0; index < left.byteLength; index += 1) {
+    diff |= left[index] ^ right[index];
+  }
+  return diff === 0;
+}
+
+function toExactArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
+function deleteDatabaseBestEffort(name: string): Promise<void> {
+  if (typeof indexedDB === 'undefined') {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    const request = indexedDB.deleteDatabase(name);
+    request.onsuccess = () => resolve();
+    request.onerror = () => resolve();
+    request.onblocked = () => resolve();
+  });
+}

--- a/apps/web/src/db/sqlite-wasm.ts
+++ b/apps/web/src/db/sqlite-wasm.ts
@@ -15,9 +15,14 @@
  * References: issues #57, #95
  */
 
-import { getAccessTokenSync } from '../auth/token-storage';
 import { extractTablesFromSql, isMutationSql, notifyDataChange } from '../lib/sync/crossTab';
-import { getOrCreateSessionStoragePassphrase, isEncryptionSupported } from './encryption';
+import {
+  hasEncryptedSqliteSnapshot,
+  isSqliteAtRestEncryptionEnabled,
+  isSqliteAtRestEncryptionSupported,
+  loadEncryptedSqliteSnapshot,
+  persistEncryptedSqliteSnapshot,
+} from './sqlite-at-rest-encryption';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -127,87 +132,12 @@ export interface Migration {
 const DB_NAME = 'finance.db';
 const MIGRATIONS_TABLE = '_migrations';
 
-/**
- * Module-level encryption secret.
- *
- * When set, IndexedDB-backed databases are encrypted at rest using
- * AES-256-GCM via the Web Crypto API.  Set via `setEncryptionSecret()`
- * before calling `initDatabase()`. When unset, the storage layer derives a
- * secret from sessionStorage or the current Supabase access token.
- */
-let _encryptionSecret: string | null = null;
-let _resolvedEncryptionSecret: string | null | undefined;
-
-/**
- * Configure the encryption secret used to encrypt/decrypt the database
- * when using the IndexedDB fallback backend.
- *
- * Call this before `initDatabase()` — typically after the user authenticates.
- * Pass `null` to disable encryption (e.g. on logout).
- *
- * OPFS-backed databases use the browser's built-in OPFS security model
- * (origin-scoped, not readable by other origins).  For an additional
- * layer of defence, the encryption module can be used to encrypt OPFS
- * snapshots during export/backup operations.
- */
-export function setEncryptionSecret(secret: string | null): void {
-  _encryptionSecret = secret;
-  _resolvedEncryptionSecret = undefined;
-}
-
-/** Check whether an encryption secret has been configured. */
-export function hasEncryptionSecret(): boolean {
-  return _encryptionSecret !== null;
-}
-
-function isDevUnencryptedFallbackEnabled(): boolean {
-  return import.meta.env.DEV === true;
-}
-
 function encryptionUnavailableError(): StorageError {
   return new StorageError(
     'INDEXEDDB_FAILED',
-    'Encrypted database storage requires Web Crypto and session storage.',
+    'Encrypted SQLite storage requires IndexedDB and Web Crypto support.',
     { backend: 'indexeddb' },
   );
-}
-
-/**
- * Resolve the secret used for IndexedDB SQLite encryption.
- *
- * Prefer an explicitly configured secret, then a per-tab sessionStorage
- * passphrase, then the in-memory Supabase access token. If none is available,
- * plaintext IndexedDB is allowed only in Vite dev/test mode.
- */
-export function resolveDatabaseEncryptionSecret(): string | null {
-  if (_resolvedEncryptionSecret !== undefined) {
-    return _resolvedEncryptionSecret;
-  }
-
-  const configuredSecret = _encryptionSecret?.trim();
-  if (configuredSecret) {
-    _resolvedEncryptionSecret = configuredSecret;
-    return _resolvedEncryptionSecret;
-  }
-
-  const sessionSecret = getOrCreateSessionStoragePassphrase();
-  if (sessionSecret) {
-    _resolvedEncryptionSecret = sessionSecret;
-    return _resolvedEncryptionSecret;
-  }
-
-  const accessToken = getAccessTokenSync()?.trim();
-  if (accessToken) {
-    _resolvedEncryptionSecret = accessToken;
-    return _resolvedEncryptionSecret;
-  }
-
-  if (isDevUnencryptedFallbackEnabled()) {
-    _resolvedEncryptionSecret = null;
-    return null;
-  }
-
-  throw encryptionUnavailableError();
 }
 
 function toExactArrayBuffer(bytes: Uint8Array): ArrayBuffer {
@@ -1397,28 +1327,34 @@ function openIDB(): Promise<IDBDatabase> {
 }
 
 async function loadFromIndexedDB(key: string): Promise<ArrayBuffer | null> {
-  if (!isEncryptionSupported()) {
-    if (isDevUnencryptedFallbackEnabled()) {
-      return loadPlaintextFromIndexedDB(key);
+  if (!isSqliteAtRestEncryptionEnabled()) {
+    if (isSqliteAtRestEncryptionSupported()) {
+      try {
+        const decrypted = await loadEncryptedSqliteSnapshot(key);
+        if (decrypted) {
+          return toExactArrayBuffer(decrypted);
+        }
+      } catch (error) {
+        const plaintext = await loadPlaintextFromIndexedDB(key);
+        if (plaintext) {
+          return plaintext;
+        }
+        throw error;
+      }
+    } else if (await hasEncryptedSqliteSnapshot()) {
+      throw encryptionUnavailableError();
     }
-    throw encryptionUnavailableError();
-  }
 
-  const encryptionSecret = resolveDatabaseEncryptionSecret();
-  if (!encryptionSecret) {
     return loadPlaintextFromIndexedDB(key);
   }
 
-  try {
-    const { loadEncryptedDatabase } = await import('./encryption');
-    const decrypted = await loadEncryptedDatabase(encryptionSecret);
-    if (decrypted) {
-      return toExactArrayBuffer(decrypted);
-    }
-  } catch (error) {
-    if (!isDevUnencryptedFallbackEnabled()) {
-      throw error;
-    }
+  if (!isSqliteAtRestEncryptionSupported()) {
+    throw encryptionUnavailableError();
+  }
+
+  const decrypted = await loadEncryptedSqliteSnapshot(key);
+  if (decrypted) {
+    return toExactArrayBuffer(decrypted);
   }
 
   return loadPlaintextFromIndexedDB(key);
@@ -1442,29 +1378,16 @@ async function loadPlaintextFromIndexedDB(key: string): Promise<ArrayBuffer | nu
 }
 
 async function persistToIndexedDB(key: string, data: Uint8Array): Promise<void> {
-  if (!isEncryptionSupported()) {
-    if (isDevUnencryptedFallbackEnabled()) {
-      return persistPlaintextToIndexedDB(key, data);
-    }
+  if (!isSqliteAtRestEncryptionEnabled()) {
+    return persistPlaintextToIndexedDB(key, data);
+  }
+
+  if (!isSqliteAtRestEncryptionSupported()) {
     throw encryptionUnavailableError();
   }
 
-  const encryptionSecret = resolveDatabaseEncryptionSecret();
-  if (!encryptionSecret) {
-    return persistPlaintextToIndexedDB(key, data);
-  }
-
-  try {
-    const { saveEncryptedDatabase } = await import('./encryption');
-    await saveEncryptedDatabase(data, encryptionSecret);
-    await deletePlaintextFromIndexedDB(key);
-    return;
-  } catch (error) {
-    if (!isDevUnencryptedFallbackEnabled()) {
-      throw error;
-    }
-    return persistPlaintextToIndexedDB(key, data);
-  }
+  await persistEncryptedSqliteSnapshot(key, data);
+  await deletePlaintextFromIndexedDB(key);
 }
 
 async function persistPlaintextToIndexedDB(key: string, data: Uint8Array): Promise<void> {
@@ -1499,6 +1422,14 @@ async function deletePlaintextFromIndexedDB(key: string): Promise<void> {
     };
   });
 }
+
+export const __sqliteIndexedDbPersistenceForTesting = {
+  loadFromIndexedDB,
+  loadPlaintextFromIndexedDB,
+  persistToIndexedDB,
+  persistPlaintextToIndexedDB,
+  deletePlaintextFromIndexedDB,
+};
 
 // ---------------------------------------------------------------------------
 // Db wrapper factory


### PR DESCRIPTION
Part of #2727.

## Implemented
- Added opt-in SQLite IndexedDB encryption-at-rest wiring using the existing `apps/web/src/lib/security/encryption-at-rest.ts` AES-GCM helper.
- Added a device-local key hierarchy: non-extractable browser `CryptoKey` wraps a random SQLite data key; SQLite snapshots are encrypted with authenticated metadata.
- Default remains OFF for backward compatibility (`VITE_SQLITE_AT_REST_ENCRYPTION=true` or local override `finance.sqliteAtRestEncryption.enabled=true` enables it).
- Plaintext snapshots still load. When encryption is enabled, plaintext migrates by writing and decrypt-verifying an encrypted pending snapshot before deleting the plaintext copy. Encrypted snapshots still load if the flag is later disabled to avoid lockout.
- Wrong/unavailable key paths fail closed when encrypted data cannot be unlocked.

## Threat model
Protects the persisted SQLite blob from casual at-rest inspection in IndexedDB. This does not protect against same-origin XSS or a fully compromised/unlocked browser profile because the device-local wrapping key is available to the origin.

## Deferred follow-up
- #2806: passphrase/WebAuthn unlock UI, recovery copy, and data-key rewrapping.

## Verification
- `npm ci`
- `npx vitest run src/db src/lib/security src/storage --reporter=dot` (40 files, 482 tests)
- `npx tsc --noEmit -p tsconfig.json`
- `npx eslint src/db/sqlite-at-rest-encryption.ts src/db/sqlite-wasm.ts src/db/__tests__/sqlite-at-rest-encryption.test.ts --max-warnings 0`
- `npx prettier --check apps/web/src/db/sqlite-at-rest-encryption.ts apps/web/src/db/sqlite-wasm.ts apps/web/src/db/__tests__/sqlite-at-rest-encryption.test.ts`
- `npm run build` with required VITE_SUPABASE env and `node ../../tools/verify-build-env.mjs dist`
- Playwright Chromium against built `vite preview` on port 4181: flag OFF booted; flag ON booted, encrypted snapshot persisted, no plaintext snapshot, no SQLite header leak, reload succeeded.