### PR TITLE
feat(core): shared KMP self-employment tax + take-home calculators (#2573)

### DIFF
--- a/packages/core/src/commonMain/kotlin/com/finance/core/tax/TaxCalculators.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/tax/TaxCalculators.kt
@@ -1,0 +1,614 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.tax
+
+import com.finance.models.types.Cents
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.daysUntil
+import kotlinx.datetime.minus
+import kotlinx.datetime.plus
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.math.abs
+import kotlin.math.roundToLong
+
+@Serializable
+data class SelfEmploymentTaxResult(
+    val netIncome: Cents,
+    val seTax: Cents,
+    val seDeduction: Cents,
+    val taxableBase: Cents,
+    val ssContribution: Cents,
+    val medicareContribution: Cents,
+)
+
+@Serializable
+data class SelfEmploymentTaxWithAdditionalMedicareResult(
+    val netIncome: Cents,
+    val seTax: Cents,
+    val seDeduction: Cents,
+    val taxableBase: Cents,
+    val ssContribution: Cents,
+    val medicareContribution: Cents,
+    val additionalMedicareTax: Cents,
+)
+
+object SelfEmploymentTaxCalculator {
+    const val SS_WAGE_BASE_2024_CENTS: Long = 168_600_00L
+    const val TAXABLE_BASE_PERCENT: Double = 0.9235
+    const val SS_RATE: Double = 0.124
+    const val MEDICARE_RATE: Double = 0.029
+    const val ADDITIONAL_MEDICARE_RATE: Double = 0.009
+    const val SE_TAX_DEDUCTION_RATE: Double = 0.5
+
+    fun calculateSETax(netIncome: Cents): SelfEmploymentTaxResult {
+        val taxableBase = roundCents(netIncome.amount * TAXABLE_BASE_PERCENT)
+        val ssWageBase = minOf(taxableBase.amount, SS_WAGE_BASE_2024_CENTS)
+        val ssContribution = roundCents(ssWageBase * SS_RATE)
+        val medicareContribution = roundCents(taxableBase.amount * MEDICARE_RATE)
+        val seTax = ssContribution + medicareContribution
+        val seDeduction = roundCents(seTax.amount * SE_TAX_DEDUCTION_RATE)
+
+        return SelfEmploymentTaxResult(
+            netIncome = netIncome,
+            seTax = seTax,
+            seDeduction = seDeduction,
+            taxableBase = taxableBase,
+            ssContribution = ssContribution,
+            medicareContribution = medicareContribution,
+        )
+    }
+
+    fun calculateAdditionalMedicareTax(
+        wages: Cents,
+        seIncome: Cents,
+        isMarriedFilingSeparately: Boolean = false,
+    ): Cents {
+        val threshold = if (isMarriedFilingSeparately) 125_000_00L else 200_000_00L
+        val combinedIncome = wages.amount + seIncome.amount
+        if (combinedIncome <= threshold) return Cents.ZERO
+
+        return roundCents((combinedIncome - threshold) * ADDITIONAL_MEDICARE_RATE)
+    }
+
+    fun calculateSETaxWithAdditionalMedicare(
+        netIncome: Cents,
+        wages: Cents = Cents.ZERO,
+        isMarriedFilingSeparately: Boolean = false,
+    ): SelfEmploymentTaxWithAdditionalMedicareResult {
+        val baseResult = calculateSETax(netIncome)
+        val additionalMedicareTax = calculateAdditionalMedicareTax(
+            wages = wages,
+            seIncome = netIncome,
+            isMarriedFilingSeparately = isMarriedFilingSeparately,
+        )
+        val totalSETax = baseResult.seTax + additionalMedicareTax
+
+        return SelfEmploymentTaxWithAdditionalMedicareResult(
+            netIncome = baseResult.netIncome,
+            seTax = totalSETax,
+            seDeduction = roundCents(totalSETax.amount * SE_TAX_DEDUCTION_RATE),
+            taxableBase = baseResult.taxableBase,
+            ssContribution = baseResult.ssContribution,
+            medicareContribution = baseResult.medicareContribution,
+            additionalMedicareTax = additionalMedicareTax,
+        )
+    }
+}
+
+@Serializable
+enum class MileagePurpose { BUSINESS, MEDICAL, CHARITY }
+
+@Serializable
+data class MileageRate(
+    val purpose: MileagePurpose,
+    val centsPerMile: Long,
+    val taxYear: Int,
+)
+
+@Serializable
+data class TripEntry(
+    val tripId: String,
+    val date: LocalDate,
+    val miles: Double,
+    val purpose: MileagePurpose,
+    val startLocation: String,
+    val endLocation: String,
+    val vehicle: String? = null,
+    val isBusinessUse: Boolean? = null,
+    val supportReference: String? = null,
+    val notes: String? = null,
+)
+
+@Serializable
+data class TripDeduction(
+    val trip: TripEntry,
+    val rate: Long,
+    val deduction: Cents,
+)
+
+@Serializable
+data class MileagePurposeSummary(
+    val purpose: MileagePurpose,
+    val totalMiles: Double,
+    val rate: Long,
+    val totalDeduction: Cents,
+    val tripCount: Int,
+)
+
+@Serializable
+data class AnnualMileageSummary(
+    val year: Int,
+    val byPurpose: List<MileagePurposeSummary>,
+    val totalMiles: Double,
+    val totalDeduction: Cents,
+    val totalTrips: Int,
+)
+
+object MileageDeductionCalculator {
+    val MILEAGE_RATES_2024: List<MileageRate> = listOf(
+        MileageRate(MileagePurpose.BUSINESS, 67L, 2024),
+        MileageRate(MileagePurpose.MEDICAL, 21L, 2024),
+        MileageRate(MileagePurpose.CHARITY, 14L, 2024),
+    )
+    val MILEAGE_RATES_2025: List<MileageRate> = listOf(
+        MileageRate(MileagePurpose.BUSINESS, 70L, 2025),
+        MileageRate(MileagePurpose.MEDICAL, 21L, 2025),
+        MileageRate(MileagePurpose.CHARITY, 14L, 2025),
+    )
+    val STANDARD_MILEAGE_RATES_BY_YEAR: Map<Int, List<MileageRate>> = mapOf(
+        2024 to MILEAGE_RATES_2024,
+        2025 to MILEAGE_RATES_2025,
+    )
+
+    fun getMileageRate(purpose: MileagePurpose, taxYear: Int = 2024): Long? =
+        STANDARD_MILEAGE_RATES_BY_YEAR[taxYear]
+            ?.firstOrNull { it.purpose == purpose }
+            ?.centsPerMile
+
+    fun calculateTripDeduction(trip: TripEntry, taxYear: Int = 2024): TripDeduction {
+        val rate = getMileageRate(trip.purpose, taxYear)
+            ?: throw IllegalArgumentException("No mileage rate found for ${trip.purpose} in $taxYear.")
+        val deduction = if (trip.isBusinessUse == false) {
+            Cents.ZERO
+        } else {
+            roundCents(trip.miles * rate)
+        }
+
+        return TripDeduction(trip = trip, rate = rate, deduction = deduction)
+    }
+
+    fun calculateTripDeductions(trips: List<TripEntry>, taxYear: Int = 2024): List<TripDeduction> =
+        trips.map { calculateTripDeduction(it, taxYear) }
+
+    fun filterTripsByYear(trips: List<TripEntry>, year: Int): List<TripEntry> =
+        trips.filter { it.date.year == year }
+
+    fun filterTripsByPurpose(trips: List<TripEntry>, purpose: MileagePurpose): List<TripEntry> =
+        trips.filter { it.purpose == purpose }
+
+    fun summarizeByPurpose(
+        trips: List<TripEntry>,
+        purpose: MileagePurpose,
+        taxYear: Int = 2024,
+    ): MileagePurposeSummary {
+        val purposeTrips = filterTripsByPurpose(trips, purpose)
+        val rate = getMileageRate(purpose, taxYear) ?: 0L
+        val totalMiles = purposeTrips.sumOf { it.miles }
+        val totalDeduction = roundCents(totalMiles * rate)
+
+        return MileagePurposeSummary(
+            purpose = purpose,
+            totalMiles = totalMiles,
+            rate = rate,
+            totalDeduction = totalDeduction,
+            tripCount = purposeTrips.size,
+        )
+    }
+
+    fun generateAnnualMileageSummary(trips: List<TripEntry>, year: Int): AnnualMileageSummary {
+        val yearTrips = filterTripsByYear(trips, year)
+        val byPurpose = listOf(MileagePurpose.BUSINESS, MileagePurpose.MEDICAL, MileagePurpose.CHARITY)
+            .map { summarizeByPurpose(yearTrips, it, year) }
+        val totalMiles = byPurpose.sumOf { it.totalMiles }
+        val totalDeduction = Cents(byPurpose.sumOf { it.totalDeduction.amount })
+        val totalTrips = byPurpose.sumOf { it.tripCount }
+
+        return AnnualMileageSummary(
+            year = year,
+            byPurpose = byPurpose,
+            totalMiles = totalMiles,
+            totalDeduction = totalDeduction,
+            totalTrips = totalTrips,
+        )
+    }
+
+    fun validateTripEntry(trip: TripEntry): List<String> {
+        val errors = mutableListOf<String>()
+        if (trip.miles <= 0.0) errors += "Miles must be greater than zero."
+        if (trip.miles > 10_000.0) errors += "Miles exceeds 10,000 for a single trip — please verify."
+        if (trip.startLocation.isBlank()) errors += "Start location is required."
+        if (trip.endLocation.isBlank()) errors += "End location is required."
+        return errors
+    }
+}
+
+@Serializable
+enum class TaxReserveTransactionType { EXPENSE, INCOME, TRANSFER }
+
+@Serializable
+enum class TaxReserveTransactionStatus { PENDING, CLEARED, RECONCILED, VOID }
+
+@Serializable
+enum class TaxReserveAccountPurpose {
+    @SerialName("personal")
+    PERSONAL,
+
+    @SerialName("business")
+    BUSINESS,
+
+    @SerialName("both")
+    BOTH,
+}
+
+@Serializable
+data class TaxReserveAccount(
+    val id: String,
+    val purpose: TaxReserveAccountPurpose,
+)
+
+@Serializable
+data class TaxReserveTransaction(
+    val id: String,
+    val accountId: String,
+    val type: TaxReserveTransactionType,
+    val amount: Cents,
+    val date: LocalDate,
+    val status: TaxReserveTransactionStatus = TaxReserveTransactionStatus.CLEARED,
+    val customFields: Map<String, String> = emptyMap(),
+)
+
+@Serializable
+data class TaxDateBounds(
+    val startDate: LocalDate? = null,
+    val endDate: LocalDate? = null,
+)
+
+@Serializable
+data class TaxReserveRateBreakdown(
+    val federalRate: Double,
+    val stateRate: Double,
+    val selfEmploymentRate: Double,
+)
+
+@Serializable
+data class TaxReserveSettings(
+    val rate: Double = TaxReserveCalculator.DEFAULT_TAX_RESERVE_RATE,
+    val bucketBalanceCents: Cents = Cents.ZERO,
+    val federalRate: Double? = null,
+    val stateRate: Double? = null,
+    val selfEmploymentRate: Double? = null,
+)
+
+@Serializable
+enum class TaxQuarter { Q1, Q2, Q3, Q4 }
+
+@Serializable
+enum class QuarterlyDueDateStatus {
+    @SerialName("future")
+    FUTURE,
+
+    @SerialName("due_soon")
+    DUE_SOON,
+
+    @SerialName("due_today")
+    DUE_TODAY,
+}
+
+@Serializable
+data class QuarterlyTaxDueDate(
+    val quarter: TaxQuarter,
+    val taxYear: Int,
+    val dueDate: LocalDate,
+    val periodStart: LocalDate,
+    val periodEnd: LocalDate,
+)
+
+@Serializable
+data class EstimatedTaxPaymentRecord(
+    val id: String,
+    val taxYear: Int,
+    val quarter: TaxQuarter,
+    val paidDate: LocalDate,
+    val amountCents: Cents,
+    val note: String? = null,
+)
+
+@Serializable
+data class TaxReserveSummary(
+    val rate: Double,
+    val rateBreakdown: TaxReserveRateBreakdown,
+    val bucketBalanceCents: Cents,
+    val currentMonthNetIncomeCents: Cents,
+    val currentMonthRecommendedCents: Cents,
+    val monthToDateReserveCents: Cents,
+    val quarterNetIncomeCents: Cents,
+    val quarterRecommendedCents: Cents,
+    val quarterToDateReserveCents: Cents,
+    val quarterPaidCents: Cents,
+    val recommendedPaymentCents: Cents,
+    val remainingRecommendedPaymentCents: Cents,
+    val reserveShortfallCents: Cents,
+    val nextDueDate: QuarterlyTaxDueDate,
+    val daysUntilDue: Int,
+    val dueDateStatus: QuarterlyDueDateStatus,
+    val paymentPeriodLabel: String,
+)
+
+@Serializable
+data class TaxReserveSummaryInput(
+    val currentMonthTransactions: List<TaxReserveTransaction>,
+    val quarterTransactions: List<TaxReserveTransaction>,
+    val accounts: List<TaxReserveAccount> = emptyList(),
+    val settings: TaxReserveSettings = TaxReserveSettings(),
+    val estimatedPayments: List<EstimatedTaxPaymentRecord> = emptyList(),
+    val asOf: LocalDate,
+)
+
+object TaxReserveCalculator {
+    const val DEFAULT_TAX_RESERVE_RATE: Double = 0.28
+    const val MIN_SUGGESTED_TAX_RESERVE_RATE: Double = 0.25
+    const val MAX_SUGGESTED_TAX_RESERVE_RATE: Double = 0.30
+
+    fun getNextQuarterlyTaxDueDate(asOf: LocalDate): QuarterlyTaxDueDate {
+        val candidates = buildDueDateCandidates(asOf.year)
+        return candidates.firstOrNull { it.dueDate >= asOf } ?: candidates.last()
+    }
+
+    fun getDaysUntilDue(dueDate: LocalDate, asOf: LocalDate): Int =
+        asOf.daysUntil(dueDate).coerceAtLeast(0)
+
+    fun getCurrentMonthBounds(asOf: LocalDate): TaxDateBounds {
+        val startDate = LocalDate(asOf.year, asOf.monthNumber, 1)
+        val endDate = startDate.plus(1, DateTimeUnit.MONTH).minus(1, DateTimeUnit.DAY)
+        return TaxDateBounds(startDate = startDate, endDate = endDate)
+    }
+
+    fun calculateNetSelfEmploymentIncomeCents(
+        transactions: List<TaxReserveTransaction>,
+        accounts: List<TaxReserveAccount> = emptyList(),
+        bounds: TaxDateBounds = TaxDateBounds(),
+    ): Cents {
+        val netIncome = transactions.fold(0L) { sum, transaction ->
+            if (!shouldIncludeTransaction(transaction, accounts, bounds)) {
+                sum
+            } else {
+                when (transaction.type) {
+                    TaxReserveTransactionType.INCOME -> sum + abs(transaction.amount.amount)
+                    TaxReserveTransactionType.EXPENSE -> sum - abs(transaction.amount.amount)
+                    TaxReserveTransactionType.TRANSFER -> sum
+                }
+            }
+        }
+
+        return Cents(netIncome.coerceAtLeast(0L))
+    }
+
+    fun calculateRecommendedTaxReserveCents(
+        netIncomeCents: Cents,
+        rate: Double = DEFAULT_TAX_RESERVE_RATE,
+    ): Cents = roundCents(netIncomeCents.amount.coerceAtLeast(0L) * normalizeRate(rate))
+
+    fun buildTaxReserveSummary(input: TaxReserveSummaryInput): TaxReserveSummary {
+        val rateBreakdown = normalizeRateBreakdown(input.settings)
+        val rate = sumRateBreakdown(rateBreakdown)
+        val bucketBalanceCents = Cents(input.settings.bucketBalanceCents.amount.coerceAtLeast(0L))
+        val currentMonthBounds = getCurrentMonthBounds(input.asOf)
+        val nextDueDate = getNextQuarterlyTaxDueDate(input.asOf)
+
+        val currentMonthNetIncomeCents = calculateNetSelfEmploymentIncomeCents(
+            transactions = input.currentMonthTransactions,
+            accounts = input.accounts,
+            bounds = currentMonthBounds,
+        )
+        val quarterNetIncomeCents = calculateNetSelfEmploymentIncomeCents(
+            transactions = input.quarterTransactions,
+            accounts = input.accounts,
+            bounds = TaxDateBounds(startDate = nextDueDate.periodStart, endDate = nextDueDate.periodEnd),
+        )
+        val currentMonthRecommendedCents = calculateRecommendedTaxReserveCents(currentMonthNetIncomeCents, rate)
+        val quarterRecommendedCents = calculateRecommendedTaxReserveCents(quarterNetIncomeCents, rate)
+        val reserveShortfallCents = Cents((quarterRecommendedCents.amount - bucketBalanceCents.amount).coerceAtLeast(0L))
+        val quarterPaidCents = Cents(
+            input.estimatedPayments
+                .filter { it.taxYear == nextDueDate.taxYear && it.quarter == nextDueDate.quarter }
+                .sumOf { it.amountCents.amount.coerceAtLeast(0L) },
+        )
+        val remainingRecommendedPaymentCents = Cents(
+            (reserveShortfallCents.amount - quarterPaidCents.amount).coerceAtLeast(0L),
+        )
+        val daysUntilDue = getDaysUntilDue(nextDueDate.dueDate, input.asOf)
+
+        return TaxReserveSummary(
+            rate = rate,
+            rateBreakdown = rateBreakdown,
+            bucketBalanceCents = bucketBalanceCents,
+            currentMonthNetIncomeCents = currentMonthNetIncomeCents,
+            currentMonthRecommendedCents = currentMonthRecommendedCents,
+            monthToDateReserveCents = currentMonthRecommendedCents,
+            quarterNetIncomeCents = quarterNetIncomeCents,
+            quarterRecommendedCents = quarterRecommendedCents,
+            quarterToDateReserveCents = quarterRecommendedCents,
+            quarterPaidCents = quarterPaidCents,
+            recommendedPaymentCents = remainingRecommendedPaymentCents,
+            remainingRecommendedPaymentCents = remainingRecommendedPaymentCents,
+            reserveShortfallCents = reserveShortfallCents,
+            nextDueDate = nextDueDate,
+            daysUntilDue = daysUntilDue,
+            dueDateStatus = getDueDateStatus(daysUntilDue),
+            paymentPeriodLabel = "${nextDueDate.quarter} ${nextDueDate.taxYear}: " +
+                "${nextDueDate.periodStart} through ${nextDueDate.periodEnd}",
+        )
+    }
+
+    private fun buildDueDateCandidates(year: Int): List<QuarterlyTaxDueDate> = listOf(
+        QuarterlyTaxDueDate(
+            quarter = TaxQuarter.Q4,
+            taxYear = year - 1,
+            dueDate = LocalDate(year, 1, 15),
+            periodStart = LocalDate(year - 1, 9, 1),
+            periodEnd = LocalDate(year - 1, 12, 31),
+        ),
+        QuarterlyTaxDueDate(
+            quarter = TaxQuarter.Q1,
+            taxYear = year,
+            dueDate = LocalDate(year, 4, 15),
+            periodStart = LocalDate(year, 1, 1),
+            periodEnd = LocalDate(year, 3, 31),
+        ),
+        QuarterlyTaxDueDate(
+            quarter = TaxQuarter.Q2,
+            taxYear = year,
+            dueDate = LocalDate(year, 6, 15),
+            periodStart = LocalDate(year, 4, 1),
+            periodEnd = LocalDate(year, 5, 31),
+        ),
+        QuarterlyTaxDueDate(
+            quarter = TaxQuarter.Q3,
+            taxYear = year,
+            dueDate = LocalDate(year, 9, 15),
+            periodStart = LocalDate(year, 6, 1),
+            periodEnd = LocalDate(year, 8, 31),
+        ),
+        QuarterlyTaxDueDate(
+            quarter = TaxQuarter.Q4,
+            taxYear = year,
+            dueDate = LocalDate(year + 1, 1, 15),
+            periodStart = LocalDate(year, 9, 1),
+            periodEnd = LocalDate(year, 12, 31),
+        ),
+    )
+
+    private fun shouldIncludeTransaction(
+        transaction: TaxReserveTransaction,
+        accounts: List<TaxReserveAccount>,
+        bounds: TaxDateBounds,
+    ): Boolean {
+        if (transaction.status == TaxReserveTransactionStatus.VOID) return false
+        if (bounds.startDate != null && transaction.date < bounds.startDate) return false
+        if (bounds.endDate != null && transaction.date > bounds.endDate) return false
+        if (isTaxReserveTaggedTransaction(transaction)) return true
+
+        val businessAccountIds = accounts
+            .filter { it.purpose == TaxReserveAccountPurpose.BUSINESS || it.purpose == TaxReserveAccountPurpose.BOTH }
+            .map { it.id }
+            .toSet()
+        if (businessAccountIds.isEmpty()) return true
+
+        return transaction.accountId in businessAccountIds
+    }
+
+    private fun isTaxReserveTaggedTransaction(transaction: TaxReserveTransaction): Boolean {
+        if (isSelfEmploymentIncomeTransaction(transaction)) return true
+
+        val fields = transaction.customFields
+        return fields["tax.deductibleStatus"] == "DEDUCTIBLE" ||
+            fields["tax.deductible"] == "true" ||
+            fields["tax.category"] == "SCHEDULE_C_EXPENSE"
+    }
+
+    private fun isSelfEmploymentIncomeTransaction(transaction: TaxReserveTransaction): Boolean {
+        if (transaction.type != TaxReserveTransactionType.INCOME) return false
+        val value = transaction.customFields["tax.selfEmploymentIncome"]
+            ?: transaction.customFields["tax.selfEmployment"]
+        return value == "true" || value == "1" || value == "yes"
+    }
+
+    private fun normalizeRateBreakdown(settings: TaxReserveSettings): TaxReserveRateBreakdown {
+        val hasBreakdown = settings.federalRate != null || settings.stateRate != null || settings.selfEmploymentRate != null
+        if (!hasBreakdown) {
+            return TaxReserveRateBreakdown(
+                federalRate = normalizeRate(settings.rate),
+                stateRate = 0.0,
+                selfEmploymentRate = 0.0,
+            )
+        }
+
+        return TaxReserveRateBreakdown(
+            federalRate = normalizeOptionalRate(settings.federalRate),
+            stateRate = normalizeOptionalRate(settings.stateRate),
+            selfEmploymentRate = normalizeOptionalRate(settings.selfEmploymentRate),
+        )
+    }
+
+    private fun sumRateBreakdown(breakdown: TaxReserveRateBreakdown): Double =
+        normalizeRate(breakdown.federalRate + breakdown.stateRate + breakdown.selfEmploymentRate)
+
+    private fun getDueDateStatus(daysUntilDue: Int): QuarterlyDueDateStatus = when {
+        daysUntilDue == 0 -> QuarterlyDueDateStatus.DUE_TODAY
+        daysUntilDue <= 7 -> QuarterlyDueDateStatus.DUE_SOON
+        else -> QuarterlyDueDateStatus.FUTURE
+    }
+}
+
+@Serializable
+data class GigTakeHomeInput(
+    val grossIncomeCents: Cents,
+    val businessExpenseCents: Cents = Cents.ZERO,
+    val mileageDeductions: List<TripDeduction> = emptyList(),
+    val reserveRate: Double = TaxReserveCalculator.DEFAULT_TAX_RESERVE_RATE,
+    val wagesCents: Cents = Cents.ZERO,
+    val isMarriedFilingSeparately: Boolean = false,
+)
+
+@Serializable
+data class GigTakeHomeResult(
+    val grossIncomeCents: Cents,
+    val businessExpenseCents: Cents,
+    val mileageDeductionCents: Cents,
+    val netSelfEmploymentIncomeCents: Cents,
+    val estimatedTaxReserveCents: Cents,
+    val estimatedSETax: SelfEmploymentTaxWithAdditionalMedicareResult,
+    val takeHomeCents: Cents,
+)
+
+object GigTakeHomeCalculator {
+    fun calculate(input: GigTakeHomeInput): GigTakeHomeResult {
+        val mileageDeductionCents = Cents(input.mileageDeductions.sumOf { it.deduction.amount })
+        val deductibleExpenses = input.businessExpenseCents.amount.coerceAtLeast(0L) +
+            mileageDeductionCents.amount.coerceAtLeast(0L)
+        val netSelfEmploymentIncomeCents = Cents(
+            (input.grossIncomeCents.amount.coerceAtLeast(0L) - deductibleExpenses).coerceAtLeast(0L),
+        )
+        val estimatedTaxReserveCents = TaxReserveCalculator.calculateRecommendedTaxReserveCents(
+            netIncomeCents = netSelfEmploymentIncomeCents,
+            rate = input.reserveRate,
+        )
+        val estimatedSETax = SelfEmploymentTaxCalculator.calculateSETaxWithAdditionalMedicare(
+            netIncome = netSelfEmploymentIncomeCents,
+            wages = input.wagesCents,
+            isMarriedFilingSeparately = input.isMarriedFilingSeparately,
+        )
+        val cashNetIncome = input.grossIncomeCents.amount.coerceAtLeast(0L) - input.businessExpenseCents.amount.coerceAtLeast(0L)
+        val takeHomeCents = Cents((cashNetIncome - estimatedTaxReserveCents.amount).coerceAtLeast(0L))
+
+        return GigTakeHomeResult(
+            grossIncomeCents = input.grossIncomeCents,
+            businessExpenseCents = input.businessExpenseCents,
+            mileageDeductionCents = mileageDeductionCents,
+            netSelfEmploymentIncomeCents = netSelfEmploymentIncomeCents,
+            estimatedTaxReserveCents = estimatedTaxReserveCents,
+            estimatedSETax = estimatedSETax,
+            takeHomeCents = takeHomeCents,
+        )
+    }
+}
+
+private fun normalizeRate(rate: Double): Double =
+    if (rate.isFinite()) rate.coerceIn(0.0, 1.0) else TaxReserveCalculator.DEFAULT_TAX_RESERVE_RATE
+
+private fun normalizeOptionalRate(rate: Double?): Double =
+    if (rate != null && rate.isFinite()) rate.coerceIn(0.0, 1.0) else 0.0
+
+private fun roundCents(value: Double): Cents = Cents(value.roundToLong())

--- a/packages/core/src/commonTest/kotlin/com/finance/core/tax/TaxCalculatorsTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/tax/TaxCalculatorsTest.kt
@@ -1,0 +1,379 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.tax
+
+import com.finance.models.types.Cents
+import kotlinx.datetime.LocalDate
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class TaxCalculatorsTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun selfEmploymentTax_matchesWebFixtureForEightyThousandDollars() {
+        val result = SelfEmploymentTaxCalculator.calculateSETax(Cents(8_000_000))
+
+        assertEquals(Cents(8_000_000), result.netIncome)
+        assertEquals(Cents(7_388_000), result.taxableBase)
+        assertEquals(Cents(916_112), result.ssContribution)
+        assertEquals(Cents(214_252), result.medicareContribution)
+        assertEquals(Cents(1_130_364), result.seTax)
+        assertEquals(Cents(565_182), result.seDeduction)
+    }
+
+    @Test
+    fun selfEmploymentTax_matchesWebFixtureForOneHundredTwentyThousandDollars() {
+        val result = SelfEmploymentTaxCalculator.calculateSETax(Cents(12_000_000))
+
+        assertEquals(Cents(11_082_000), result.taxableBase)
+        assertEquals(Cents(1_374_168), result.ssContribution)
+        assertEquals(Cents(321_378), result.medicareContribution)
+        assertEquals(Cents(1_695_546), result.seTax)
+        assertEquals(Cents(847_773), result.seDeduction)
+    }
+
+    @Test
+    fun selfEmploymentTax_handlesZeroIncome() {
+        val result = SelfEmploymentTaxCalculator.calculateSETax(Cents.ZERO)
+
+        assertEquals(Cents.ZERO, result.netIncome)
+        assertEquals(Cents.ZERO, result.taxableBase)
+        assertEquals(Cents.ZERO, result.ssContribution)
+        assertEquals(Cents.ZERO, result.medicareContribution)
+        assertEquals(Cents.ZERO, result.seTax)
+        assertEquals(Cents.ZERO, result.seDeduction)
+    }
+
+    @Test
+    fun selfEmploymentTax_capsSocialSecurityAtWageBase() {
+        val result = SelfEmploymentTaxCalculator.calculateSETax(Cents(20_000_000))
+
+        assertEquals(Cents(18_470_000), result.taxableBase)
+        assertEquals(Cents(2_090_640), result.ssContribution)
+        assertEquals(Cents(535_630), result.medicareContribution)
+        assertEquals(Cents(2_626_270), result.seTax)
+    }
+
+    @Test
+    fun additionalMedicare_matchesWebFixtures() {
+        assertEquals(
+            Cents.ZERO,
+            SelfEmploymentTaxCalculator.calculateAdditionalMedicareTax(
+                wages = Cents(100_000_00),
+                seIncome = Cents(50_000_00),
+            ),
+        )
+        assertEquals(
+            Cents(27_000),
+            SelfEmploymentTaxCalculator.calculateAdditionalMedicareTax(
+                wages = Cents(180_000_00),
+                seIncome = Cents(50_000_00),
+            ),
+        )
+        assertEquals(
+            Cents(22_500),
+            SelfEmploymentTaxCalculator.calculateAdditionalMedicareTax(
+                wages = Cents(100_000_00),
+                seIncome = Cents(50_000_00),
+                isMarriedFilingSeparately = true,
+            ),
+        )
+        assertEquals(
+            Cents(18_000),
+            SelfEmploymentTaxCalculator.calculateAdditionalMedicareTax(
+                wages = Cents(200_000_00),
+                seIncome = Cents(20_000_00),
+            ),
+        )
+    }
+
+    @Test
+    fun selfEmploymentTaxWithAdditionalMedicare_includesAdditionalTaxInDeduction() {
+        val result = SelfEmploymentTaxCalculator.calculateSETaxWithAdditionalMedicare(
+            netIncome = Cents(20_000_000),
+            wages = Cents(5_000_000),
+        )
+
+        assertEquals(Cents(45_000), result.additionalMedicareTax)
+        assertEquals(Cents(2_671_270), result.seTax)
+        assertEquals(Cents(1_335_635), result.seDeduction)
+    }
+
+    @Test
+    fun mileageDeduction_matchesWebTripFixtures() {
+        val trips = webMileageTrips()
+
+        assertEquals(Cents(3_350), MileageDeductionCalculator.calculateTripDeduction(trips[0]).deduction)
+        assertEquals(Cents(8_040), MileageDeductionCalculator.calculateTripDeduction(trips[1]).deduction)
+        assertEquals(Cents(630), MileageDeductionCalculator.calculateTripDeduction(trips[2]).deduction)
+        assertEquals(Cents(210), MileageDeductionCalculator.calculateTripDeduction(trips[3]).deduction)
+        assertEquals(Cents(838), MileageDeductionCalculator.calculateTripDeduction(trips[5]).deduction)
+    }
+
+    @Test
+    fun mileageSummary_matchesWebAnnualFixture() {
+        val summary = MileageDeductionCalculator.generateAnnualMileageSummary(webMileageTrips().take(5), 2024)
+
+        assertEquals(2024, summary.year)
+        assertEquals(215.0, summary.totalMiles)
+        assertEquals(4, summary.totalTrips)
+        assertEquals(Cents(12_230), summary.totalDeduction)
+        val business = summary.byPurpose.first { it.purpose == MileagePurpose.BUSINESS }
+        assertEquals(170.0, business.totalMiles)
+        assertEquals(67L, business.rate)
+        assertEquals(Cents(11_390), business.totalDeduction)
+        assertEquals(2, business.tripCount)
+    }
+
+    @Test
+    fun mileageDeduction_keepsPersonalTripsWithoutDeductionAndRejectsUnsupportedYears() {
+        val businessTrip = webMileageTrips().first()
+
+        assertEquals(
+            Cents.ZERO,
+            MileageDeductionCalculator.calculateTripDeduction(businessTrip.copy(isBusinessUse = false)).deduction,
+        )
+        assertFailsWith<IllegalArgumentException> {
+            MileageDeductionCalculator.calculateTripDeduction(businessTrip, 2026)
+        }
+    }
+
+    @Test
+    fun taxReserve_recommendedReserveMatchesWebFixture() {
+        val accounts = listOf(
+            TaxReserveAccount("business", TaxReserveAccountPurpose.BUSINESS),
+            TaxReserveAccount("personal", TaxReserveAccountPurpose.PERSONAL),
+        )
+        val transactions = listOf(
+            taxTransaction("income", "business", TaxReserveTransactionType.INCOME, 500_000, LocalDate(2025, 3, 6)),
+            taxTransaction("expense", "business", TaxReserveTransactionType.EXPENSE, 75_000, LocalDate(2025, 3, 7)),
+            taxTransaction("personal-income", "personal", TaxReserveTransactionType.INCOME, 250_000, LocalDate(2025, 3, 8)),
+            taxTransaction(
+                "voided",
+                "business",
+                TaxReserveTransactionType.INCOME,
+                100_000,
+                LocalDate(2025, 3, 9),
+                status = TaxReserveTransactionStatus.VOID,
+            ),
+        )
+
+        val netIncome = TaxReserveCalculator.calculateNetSelfEmploymentIncomeCents(
+            transactions = transactions,
+            accounts = accounts,
+            bounds = TaxDateBounds(LocalDate(2025, 3, 1), LocalDate(2025, 3, 31)),
+        )
+
+        assertEquals(Cents(425_000), netIncome)
+        assertEquals(Cents(119_000), TaxReserveCalculator.calculateRecommendedTaxReserveCents(netIncome, 0.28))
+    }
+
+    @Test
+    fun taxReserveSummary_buildsMonthlyAndQuarterlyGuidanceWithBucketShortfall() {
+        val accounts = listOf(TaxReserveAccount("business", TaxReserveAccountPurpose.BUSINESS))
+        val transactions = listOf(
+            taxTransaction("jan", "business", TaxReserveTransactionType.INCOME, 300_000, LocalDate(2025, 1, 20)),
+            taxTransaction("mar", "business", TaxReserveTransactionType.INCOME, 500_000, LocalDate(2025, 3, 6)),
+        )
+
+        val summary = TaxReserveCalculator.buildTaxReserveSummary(
+            TaxReserveSummaryInput(
+                currentMonthTransactions = transactions,
+                quarterTransactions = transactions,
+                accounts = accounts,
+                settings = TaxReserveSettings(rate = 0.28, bucketBalanceCents = Cents(100_000)),
+                asOf = LocalDate(2025, 3, 10),
+            ),
+        )
+
+        assertEquals(Cents(500_000), summary.currentMonthNetIncomeCents)
+        assertEquals(Cents(140_000), summary.currentMonthRecommendedCents)
+        assertEquals(Cents(224_000), summary.quarterRecommendedCents)
+        assertEquals(Cents(124_000), summary.recommendedPaymentCents)
+    }
+
+    @Test
+    fun taxReserveSummary_usesRateBreakdownPaymentsAndTaggedMixedAccountIncome() {
+        val taggedIncome = taxTransaction(
+            id = "client",
+            accountId = "personal",
+            type = TaxReserveTransactionType.INCOME,
+            amount = 600_000,
+            date = LocalDate(2025, 3, 6),
+            customFields = mapOf("tax.selfEmploymentIncome" to "true"),
+        )
+
+        val summary = TaxReserveCalculator.buildTaxReserveSummary(
+            TaxReserveSummaryInput(
+                currentMonthTransactions = listOf(taggedIncome),
+                quarterTransactions = listOf(taggedIncome),
+                accounts = listOf(TaxReserveAccount("personal", TaxReserveAccountPurpose.PERSONAL)),
+                settings = TaxReserveSettings(
+                    rate = 0.28,
+                    federalRate = 0.18,
+                    stateRate = 0.05,
+                    selfEmploymentRate = 0.153,
+                    bucketBalanceCents = Cents(50_000),
+                ),
+                estimatedPayments = listOf(
+                    EstimatedTaxPaymentRecord(
+                        id = "q1-payment",
+                        taxYear = 2025,
+                        quarter = TaxQuarter.Q1,
+                        paidDate = LocalDate(2025, 3, 20),
+                        amountCents = Cents(75_000),
+                    ),
+                ),
+                asOf = LocalDate(2025, 3, 10),
+            ),
+        )
+
+        assertEquals(0.383, summary.rate, 0.000_000_001)
+        assertEquals(Cents(229_800), summary.quarterRecommendedCents)
+        assertEquals(Cents(179_800), summary.reserveShortfallCents)
+        assertEquals(Cents(75_000), summary.quarterPaidCents)
+        assertEquals(Cents(104_800), summary.remainingRecommendedPaymentCents)
+        assertEquals("Q1 2025: 2025-01-01 through 2025-03-31", summary.paymentPeriodLabel)
+        assertEquals(QuarterlyDueDateStatus.FUTURE, summary.dueDateStatus)
+    }
+
+    @Test
+    fun quarterlyDueDates_matchWebDateFixtures() {
+        assertEquals(
+            QuarterlyTaxDueDate(
+                quarter = TaxQuarter.Q1,
+                taxYear = 2025,
+                dueDate = LocalDate(2025, 4, 15),
+                periodStart = LocalDate(2025, 1, 1),
+                periodEnd = LocalDate(2025, 3, 31),
+            ),
+            TaxReserveCalculator.getNextQuarterlyTaxDueDate(LocalDate(2025, 2, 1)),
+        )
+        assertEquals(TaxQuarter.Q2, TaxReserveCalculator.getNextQuarterlyTaxDueDate(LocalDate(2025, 4, 16)).quarter)
+        assertEquals(TaxQuarter.Q3, TaxReserveCalculator.getNextQuarterlyTaxDueDate(LocalDate(2025, 6, 16)).quarter)
+        assertEquals(
+            LocalDate(2026, 1, 15),
+            TaxReserveCalculator.getNextQuarterlyTaxDueDate(LocalDate(2025, 12, 20)).dueDate,
+        )
+        assertEquals(
+            TaxQuarter.Q4,
+            TaxReserveCalculator.getNextQuarterlyTaxDueDate(LocalDate(2026, 1, 10)).quarter,
+        )
+        assertEquals(
+            2025,
+            TaxReserveCalculator.getNextQuarterlyTaxDueDate(LocalDate(2026, 1, 10)).taxYear,
+        )
+    }
+
+    @Test
+    fun gigTakeHome_appliesMileageDeductionsToTaxableIncomeButNotCashTakeHome() {
+        val tripDeduction = MileageDeductionCalculator.calculateTripDeduction(webMileageTrips().first())
+        val result = GigTakeHomeCalculator.calculate(
+            GigTakeHomeInput(
+                grossIncomeCents = Cents(500_000),
+                businessExpenseCents = Cents(75_000),
+                mileageDeductions = listOf(tripDeduction),
+                reserveRate = 0.28,
+            ),
+        )
+
+        assertEquals(Cents(3_350), result.mileageDeductionCents)
+        assertEquals(Cents(421_650), result.netSelfEmploymentIncomeCents)
+        assertEquals(Cents(118_062), result.estimatedTaxReserveCents)
+        assertEquals(Cents(306_938), result.takeHomeCents)
+        assertTrue(result.estimatedSETax.seTax.amount > 0)
+    }
+
+    @Test
+    fun taxModels_serializeAndRoundTripAsPlatformNeutralJson() {
+        val result = GigTakeHomeCalculator.calculate(
+            GigTakeHomeInput(
+                grossIncomeCents = Cents(8_000_000),
+                businessExpenseCents = Cents(100_000),
+                mileageDeductions = listOf(MileageDeductionCalculator.calculateTripDeduction(webMileageTrips().first())),
+                reserveRate = 0.30,
+            ),
+        )
+
+        val encoded = json.encodeToString(result)
+        val decoded = json.decodeFromString<GigTakeHomeResult>(encoded)
+
+        assertEquals(result, decoded)
+        assertTrue(encoded.contains("\"grossIncomeCents\":8000000"))
+        assertTrue(encoded.contains("\"mileageDeductionCents\":3350"))
+    }
+
+    private fun taxTransaction(
+        id: String,
+        accountId: String,
+        type: TaxReserveTransactionType,
+        amount: Long,
+        date: LocalDate,
+        status: TaxReserveTransactionStatus = TaxReserveTransactionStatus.CLEARED,
+        customFields: Map<String, String> = emptyMap(),
+    ) = TaxReserveTransaction(
+        id = id,
+        accountId = accountId,
+        type = type,
+        amount = Cents(amount),
+        date = date,
+        status = status,
+        customFields = customFields,
+    )
+
+    private fun webMileageTrips() = listOf(
+        TripEntry(
+            tripId = "trip-1",
+            date = LocalDate(2024, 3, 15),
+            miles = 50.0,
+            purpose = MileagePurpose.BUSINESS,
+            startLocation = "Home Office",
+            endLocation = "Client Site",
+        ),
+        TripEntry(
+            tripId = "trip-2",
+            date = LocalDate(2024, 4, 20),
+            miles = 120.0,
+            purpose = MileagePurpose.BUSINESS,
+            startLocation = "Office",
+            endLocation = "Conference Center",
+        ),
+        TripEntry(
+            tripId = "trip-3",
+            date = LocalDate(2024, 5, 10),
+            miles = 30.0,
+            purpose = MileagePurpose.MEDICAL,
+            startLocation = "Home",
+            endLocation = "Hospital",
+        ),
+        TripEntry(
+            tripId = "trip-4",
+            date = LocalDate(2024, 6, 1),
+            miles = 15.0,
+            purpose = MileagePurpose.CHARITY,
+            startLocation = "Home",
+            endLocation = "Food Bank",
+        ),
+        TripEntry(
+            tripId = "trip-5",
+            date = LocalDate(2023, 12, 15),
+            miles = 80.0,
+            purpose = MileagePurpose.BUSINESS,
+            startLocation = "Office",
+            endLocation = "Client",
+        ),
+        TripEntry(
+            tripId = "frac-1",
+            date = LocalDate(2024, 1, 15),
+            miles = 12.5,
+            purpose = MileagePurpose.BUSINESS,
+            startLocation = "A",
+            endLocation = "B",
+        ),
+    )
+}


### PR DESCRIPTION
Closes #2573. Ports the web tax reserve, self-employment tax, and mileage deduction formulas into packages/core commonMain so KMP clients share the same integer-cent calculations. Adds serializable calculators for SE tax, additional Medicare, mileage deductions, tax-reserve summaries/due dates, and gig take-home estimates. Web parity coverage replicates TypeScript fixtures from apps/web/src/lib/tax-reserve.ts, apps/web/src/lib/tax/self-employment-tax.ts, and apps/web/src/lib/tax/mileage-log.ts; :packages:core:jvmTest passes.