### PR TITLE
feat(core): shared KMP mileage log + shift deduction logic (#2575)

### DIFF
--- a/packages/core/src/commonMain/kotlin/com/finance/core/mileage/MileageCalculator.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/mileage/MileageCalculator.kt
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.mileage
+
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import kotlin.math.roundToInt
+import kotlin.math.roundToLong
+
+/** Shared IRS mileage rates and platform-neutral mileage/shift deduction calculators. */
+object MileageCalculator {
+    val mileageRates2024: List<MileageRate> = listOf(
+        MileageRate(2024, MileagePurpose.BUSINESS, 67L),
+        MileageRate(2024, MileagePurpose.MEDICAL, 21L),
+        MileageRate(2024, MileagePurpose.MOVING, 21L),
+        MileageRate(2024, MileagePurpose.CHARITY, 14L),
+    )
+
+    val mileageRates2025: List<MileageRate> = listOf(
+        MileageRate(2025, MileagePurpose.BUSINESS, 70L),
+        MileageRate(2025, MileagePurpose.MEDICAL, 21L),
+        MileageRate(2025, MileagePurpose.MOVING, 21L),
+        MileageRate(2025, MileagePurpose.CHARITY, 14L),
+    )
+
+    val standardMileageRatesByYear: Map<Int, List<MileageRate>> = listOf(
+        mileageRates2024,
+        mileageRates2025,
+    ).associateBy { rates -> rates.first().taxYear }
+
+    fun getMileageRate(purpose: MileagePurpose, taxYear: Int): MileageRate? {
+        if (purpose == MileagePurpose.PERSONAL) return MileageRate(taxYear, MileagePurpose.PERSONAL, 0L)
+        return standardMileageRatesByYear[taxYear]?.firstOrNull { it.purpose == purpose }
+    }
+
+    fun calculateMileageDeduction(
+        miles: Double,
+        purpose: MileagePurpose,
+        taxYear: Int,
+        businessUsePercent: Int = 100,
+    ): MileageCalculation {
+        require(businessUsePercent in 0..100) { "businessUsePercent must be in 0..100" }
+        val rate = requireNotNull(getMileageRate(purpose, taxYear)) {
+            "No mileage rate found for $purpose in $taxYear."
+        }
+
+        if (!miles.isFinite() || miles <= 0.0 || purpose == MileagePurpose.PERSONAL) {
+            return MileageCalculation(rate.centsPerMile, 0L, taxYear)
+        }
+
+        val roundedMiles = roundMiles(miles)
+        val effectiveMiles = if (purpose == MileagePurpose.BUSINESS) {
+            roundedMiles * (businessUsePercent / 100.0)
+        } else {
+            roundedMiles
+        }
+
+        return MileageCalculation(
+            rateCentsPerMile = rate.centsPerMile,
+            deductionCents = (effectiveMiles * rate.centsPerMile).roundToLong(),
+            appliedYear = taxYear,
+        )
+    }
+
+    fun calculateTripDeduction(trip: MileageTripEntry): MileageCalculation =
+        calculateMileageDeduction(
+            miles = trip.miles,
+            purpose = trip.purpose,
+            taxYear = trip.date.year,
+            businessUsePercent = trip.businessUsePercent,
+        )
+
+    fun calculateTripMiles(input: MileageDistanceInput): Double {
+        input.miles?.let { miles ->
+            require(miles.isFinite() && miles >= 0.0) { "Miles must be finite and non-negative" }
+            if (miles > 0.0) return roundMiles(miles)
+        }
+
+        val start = input.odometerStart
+        val end = input.odometerEnd
+        require(start != null) { "Enter miles directly or provide odometer readings" }
+        require(end != null) { "Ending odometer is required when using odometer readings" }
+        require(start.isFinite() && end.isFinite()) { "Odometer values must be finite" }
+        require(end >= start) { "Ending odometer must be greater than or equal to starting odometer" }
+        return roundMiles(end - start)
+    }
+
+    fun createTripEntry(
+        id: String,
+        date: kotlinx.datetime.LocalDate,
+        startLocation: String,
+        endLocation: String,
+        distance: MileageDistanceInput,
+        purpose: MileagePurpose,
+        audit: MileageAuditMetadata,
+        businessUsePercent: Int = 100,
+        routePresetId: String? = null,
+        vehicle: String? = null,
+        notes: String = "",
+    ): MileageTripEntry = MileageTripEntry(
+        id = id,
+        date = date,
+        startLocation = startLocation.trim(),
+        endLocation = endLocation.trim(),
+        miles = calculateTripMiles(distance),
+        purpose = purpose,
+        odometerStart = distance.odometerStart,
+        odometerEnd = distance.odometerEnd,
+        businessUsePercent = normalizeBusinessUsePercent(purpose, businessUsePercent),
+        routePresetId = routePresetId,
+        vehicle = vehicle?.trim()?.takeIf { it.isNotEmpty() },
+        notes = notes.trim(),
+        audit = audit,
+    )
+
+    fun createTripEntryFromPreset(
+        id: String,
+        date: kotlinx.datetime.LocalDate,
+        preset: RoutePreset,
+        audit: MileageAuditMetadata,
+        milesOverride: Double? = null,
+        notes: String = preset.notes,
+    ): MileageTripEntry {
+        val miles = milesOverride ?: preset.defaultMiles
+        require(miles != null) { "Route preset requires defaultMiles or milesOverride" }
+        return createTripEntry(
+            id = id,
+            date = date,
+            startLocation = preset.startLocation,
+            endLocation = preset.endLocation,
+            distance = MileageDistanceInput(miles = miles),
+            purpose = preset.defaultPurpose,
+            audit = audit,
+            businessUsePercent = preset.defaultBusinessUsePercent,
+            routePresetId = preset.id,
+            notes = notes,
+        )
+    }
+
+    fun generateAnnualMileageSummary(
+        trips: List<MileageTripEntry>,
+        year: Int,
+    ): AnnualMileageSummary {
+        val yearTrips = trips.filter { it.date.year == year }
+        val purposeSummaries = IRS_DEDUCTIBLE_MILEAGE_PURPOSES.map { purpose ->
+            summarizePurpose(yearTrips, purpose, year)
+        }
+        val deductibleTrips = yearTrips.filter { it.purpose != MileagePurpose.PERSONAL }
+
+        return AnnualMileageSummary(
+            year = year,
+            byPurpose = purposeSummaries,
+            totalLoggedMiles = roundMiles(yearTrips.sumOf { it.miles }),
+            totalDeductibleMiles = roundMiles(deductibleTrips.sumOf { effectiveDeductibleMiles(it) }),
+            totalDeductionCents = purposeSummaries.sumOf { it.deductionCents },
+            totalTripCount = yearTrips.size,
+            deductibleTripCount = deductibleTrips.size,
+        )
+    }
+
+    fun summarizeShift(
+        shift: WorkShiftSession,
+        trips: List<MileageTripEntry>,
+    ): ShiftDeductionSummary {
+        val tripIdSet = shift.tripIds.toSet()
+        val matchingTrips = trips.filter { trip ->
+            trip.id in tripIdSet || trip.audit.externalShiftId == shift.id
+        }
+        val deductionCents = matchingTrips.sumOf { calculateTripDeduction(it).deductionCents }
+
+        return ShiftDeductionSummary(
+            shiftId = shift.id,
+            platform = shift.platform ?: matchingTrips.firstOrNull { it.audit.platform != null }?.audit?.platform,
+            tripCount = matchingTrips.size,
+            totalMiles = roundMiles(matchingTrips.sumOf { it.miles }),
+            deductibleMiles = roundMiles(matchingTrips.sumOf { effectiveDeductibleMiles(it) }),
+            mileageDeductionCents = deductionCents,
+            grossEarningsCents = shift.grossEarningsCents,
+        )
+    }
+
+    fun validateTripEntry(trip: MileageTripEntry): List<String> = buildList {
+        if (trip.miles <= 0.0) add("Miles must be greater than zero.")
+        if (trip.miles > 10_000.0) add("Miles exceeds 10,000 for a single trip — please verify.")
+        if (trip.startLocation.isBlank()) add("Start location is required.")
+        if (trip.endLocation.isBlank()) add("End location is required.")
+        if (getMileageRate(trip.purpose, trip.date.year) == null) {
+            add("No mileage rate found for ${trip.purpose} in ${trip.date.year}.")
+        }
+    }
+
+    fun taxYearFor(instant: Instant, timeZone: TimeZone = TimeZone.UTC): Int =
+        instant.toLocalDateTime(timeZone).date.year
+
+    private fun summarizePurpose(
+        trips: List<MileageTripEntry>,
+        purpose: MileagePurpose,
+        year: Int,
+    ): MileagePurposeSummary {
+        val matchingTrips = trips.filter { it.purpose == purpose }
+        val rate = getMileageRate(purpose, year)?.centsPerMile ?: 0L
+        return MileagePurposeSummary(
+            purpose = purpose,
+            totalMiles = roundMiles(matchingTrips.sumOf { effectiveDeductibleMiles(it) }),
+            tripCount = matchingTrips.size,
+            rateCentsPerMile = rate,
+            deductionCents = matchingTrips.sumOf { calculateTripDeduction(it).deductionCents },
+        )
+    }
+
+    private fun normalizeBusinessUsePercent(purpose: MileagePurpose, percent: Int): Int =
+        if (purpose == MileagePurpose.BUSINESS) percent.coerceIn(0, 100) else 100
+
+    private fun effectiveDeductibleMiles(trip: MileageTripEntry): Double = when (trip.purpose) {
+        MileagePurpose.BUSINESS -> roundMiles(trip.miles) * (trip.businessUsePercent.coerceIn(0, 100) / 100.0)
+        MileagePurpose.MEDICAL,
+        MileagePurpose.MOVING,
+        MileagePurpose.CHARITY -> roundMiles(trip.miles)
+        MileagePurpose.PERSONAL -> 0.0
+    }
+
+    private fun roundMiles(value: Double): Double = (value * 10.0).roundToInt() / 10.0
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/mileage/MileageModels.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/mileage/MileageModels.kt
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.mileage
+
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.serialization.Serializable
+
+/** Purpose category for IRS standard mileage deduction calculations. */
+@Serializable
+enum class MileagePurpose {
+    BUSINESS,
+    MEDICAL,
+    MOVING,
+    CHARITY,
+    PERSONAL,
+}
+
+/** Mileage purposes with an IRS standard cents-per-mile rate. */
+val IRS_DEDUCTIBLE_MILEAGE_PURPOSES: List<MileagePurpose> = listOf(
+    MileagePurpose.BUSINESS,
+    MileagePurpose.MEDICAL,
+    MileagePurpose.MOVING,
+    MileagePurpose.CHARITY,
+)
+
+/** IRS standard mileage rate for one tax year and purpose, in integer cents per mile. */
+@Serializable
+data class MileageRate(
+    val taxYear: Int,
+    val purpose: MileagePurpose,
+    val centsPerMile: Long,
+) {
+    init {
+        require(taxYear > 0) { "taxYear must be positive" }
+        require(centsPerMile >= 0) { "centsPerMile must be non-negative" }
+        require(purpose != MileagePurpose.PERSONAL || centsPerMile == 0L) {
+            "Personal mileage rates must be zero"
+        }
+    }
+}
+
+/** Deduction calculation for a mileage entry. */
+@Serializable
+data class MileageCalculation(
+    val rateCentsPerMile: Long,
+    val deductionCents: Long,
+    val appliedYear: Int,
+)
+
+/** External gig-work platform metadata attached to shifts, routes, and imported trips. */
+@Serializable
+data class GigPlatformLink(
+    val platformId: String,
+    val displayName: String,
+    val accountId: String? = null,
+) {
+    init {
+        require(platformId.isNotBlank()) { "platformId is required" }
+        require(displayName.isNotBlank()) { "displayName is required" }
+    }
+}
+
+/** Origin of a mileage-log audit event. */
+@Serializable
+enum class MileageAuditSource {
+    MANUAL,
+    PLATFORM_IMPORT,
+    CALENDAR,
+    ODOMETER,
+    ROUTE_PRESET,
+}
+
+/** Platform-neutral audit metadata for substantiating mileage and shift records. */
+@Serializable
+data class MileageAuditMetadata(
+    val source: MileageAuditSource = MileageAuditSource.MANUAL,
+    val platform: GigPlatformLink? = null,
+    val externalTripId: String? = null,
+    val externalShiftId: String? = null,
+    val supportReference: String? = null,
+    val createdAt: Instant,
+    val updatedAt: Instant = createdAt,
+    val importedAt: Instant? = null,
+) {
+    init {
+        require(updatedAt >= createdAt) { "updatedAt must be on or after createdAt" }
+    }
+}
+
+/** Reusable route template for frequent gig, client, medical, charity, or commute-like trips. */
+@Serializable
+data class RoutePreset(
+    val id: String,
+    val name: String,
+    val startLocation: String,
+    val endLocation: String,
+    val defaultMiles: Double? = null,
+    val defaultPurpose: MileagePurpose = MileagePurpose.BUSINESS,
+    val defaultBusinessUsePercent: Int = 100,
+    val platform: GigPlatformLink? = null,
+    val notes: String = "",
+) {
+    init {
+        require(id.isNotBlank()) { "Route preset id is required" }
+        require(name.isNotBlank()) { "Route preset name is required" }
+        require(startLocation.isNotBlank()) { "Start location is required" }
+        require(endLocation.isNotBlank()) { "End location is required" }
+        require(defaultMiles == null || (defaultMiles.isFinite() && defaultMiles >= 0.0)) {
+            "defaultMiles must be finite and non-negative"
+        }
+        require(defaultBusinessUsePercent in 0..100) { "defaultBusinessUsePercent must be in 0..100" }
+    }
+}
+
+/** Draft distance fields used to derive logged trip miles. */
+@Serializable
+data class MileageDistanceInput(
+    val miles: Double? = null,
+    val odometerStart: Double? = null,
+    val odometerEnd: Double? = null,
+)
+
+/** A single mileage-log trip entry. */
+@Serializable
+data class MileageTripEntry(
+    val id: String,
+    val date: LocalDate,
+    val startLocation: String,
+    val endLocation: String,
+    val miles: Double,
+    val purpose: MileagePurpose,
+    val odometerStart: Double? = null,
+    val odometerEnd: Double? = null,
+    val businessUsePercent: Int = 100,
+    val routePresetId: String? = null,
+    val vehicle: String? = null,
+    val notes: String = "",
+    val audit: MileageAuditMetadata,
+) {
+    init {
+        require(id.isNotBlank()) { "Trip id is required" }
+        require(startLocation.isNotBlank()) { "Start location is required" }
+        require(endLocation.isNotBlank()) { "End location is required" }
+        require(miles.isFinite() && miles >= 0.0) { "Miles must be finite and non-negative" }
+        require(businessUsePercent in 0..100) { "businessUsePercent must be in 0..100" }
+        if (odometerStart != null || odometerEnd != null) {
+            require(odometerStart != null && odometerEnd != null) {
+                "Both odometerStart and odometerEnd are required when using odometer readings"
+            }
+            require(odometerStart.isFinite() && odometerEnd.isFinite()) { "Odometer values must be finite" }
+            require(odometerEnd >= odometerStart) { "Ending odometer must be greater than or equal to starting odometer" }
+        }
+    }
+}
+
+/** Gig-work shift/session that can group imported or manually-entered mileage trips. */
+@Serializable
+data class WorkShiftSession(
+    val id: String,
+    val platform: GigPlatformLink? = null,
+    val startedAt: Instant,
+    val endedAt: Instant? = null,
+    val startingOdometer: Double? = null,
+    val endingOdometer: Double? = null,
+    val tripIds: List<String> = emptyList(),
+    val grossEarningsCents: Long? = null,
+    val notes: String = "",
+    val audit: MileageAuditMetadata,
+) {
+    init {
+        require(id.isNotBlank()) { "Shift id is required" }
+        require(endedAt == null || endedAt >= startedAt) { "endedAt must be on or after startedAt" }
+        require(grossEarningsCents == null || grossEarningsCents >= 0L) { "grossEarningsCents must be non-negative" }
+        if (startingOdometer != null || endingOdometer != null) {
+            require(startingOdometer != null && endingOdometer != null) {
+                "Both startingOdometer and endingOdometer are required when using odometer readings"
+            }
+            require(startingOdometer.isFinite() && endingOdometer.isFinite()) { "Odometer values must be finite" }
+            require(endingOdometer >= startingOdometer) {
+                "Ending odometer must be greater than or equal to starting odometer"
+            }
+        }
+    }
+
+    val isClosed: Boolean get() = endedAt != null
+}
+
+/** Mileage totals for one deductible purpose within a year. */
+@Serializable
+data class MileagePurposeSummary(
+    val purpose: MileagePurpose,
+    val totalMiles: Double,
+    val tripCount: Int,
+    val rateCentsPerMile: Long,
+    val deductionCents: Long,
+)
+
+/** Annual tax-ready mileage summary. */
+@Serializable
+data class AnnualMileageSummary(
+    val year: Int,
+    val byPurpose: List<MileagePurposeSummary>,
+    val totalLoggedMiles: Double,
+    val totalDeductibleMiles: Double,
+    val totalDeductionCents: Long,
+    val totalTripCount: Int,
+    val deductibleTripCount: Int,
+)
+
+/** Shift-level mileage deduction summary for gig-work sessions. */
+@Serializable
+data class ShiftDeductionSummary(
+    val shiftId: String,
+    val platform: GigPlatformLink? = null,
+    val tripCount: Int,
+    val totalMiles: Double,
+    val deductibleMiles: Double,
+    val mileageDeductionCents: Long,
+    val grossEarningsCents: Long? = null,
+    val netAfterMileageDeductionCents: Long? = grossEarningsCents?.minus(mileageDeductionCents),
+)

--- a/packages/core/src/commonTest/kotlin/com/finance/core/mileage/MileageCalculatorTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/mileage/MileageCalculatorTest.kt
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.mileage
+
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class MileageCalculatorTest {
+    private val json = Json { encodeDefaults = true }
+    private val now = Instant.parse("2025-01-02T12:00:00Z")
+    private val platform = GigPlatformLink(
+        platformId = "doordash",
+        displayName = "DoorDash",
+        accountId = "dasher-123",
+    )
+
+    private fun audit(
+        source: MileageAuditSource = MileageAuditSource.MANUAL,
+        externalTripId: String? = null,
+        externalShiftId: String? = null,
+    ): MileageAuditMetadata = MileageAuditMetadata(
+        source = source,
+        platform = if (source == MileageAuditSource.PLATFORM_IMPORT) platform else null,
+        externalTripId = externalTripId,
+        externalShiftId = externalShiftId,
+        supportReference = "calendar:event-1",
+        createdAt = now,
+        updatedAt = now,
+        importedAt = if (source == MileageAuditSource.PLATFORM_IMPORT) now else null,
+    )
+
+    private fun trip(
+        id: String,
+        date: LocalDate,
+        miles: Double,
+        purpose: MileagePurpose = MileagePurpose.BUSINESS,
+        businessUsePercent: Int = 100,
+        externalShiftId: String? = null,
+    ): MileageTripEntry = MileageTripEntry(
+        id = id,
+        date = date,
+        startLocation = "Home Office",
+        endLocation = "Client Site",
+        miles = miles,
+        purpose = purpose,
+        businessUsePercent = businessUsePercent,
+        audit = audit(
+            source = if (externalShiftId == null) MileageAuditSource.MANUAL else MileageAuditSource.PLATFORM_IMPORT,
+            externalTripId = "platform-$id",
+            externalShiftId = externalShiftId,
+        ),
+    )
+
+    @Test
+    fun irsStandardMileageRatesUseIntegerCentsPerMile() {
+        assertEquals(67L, MileageCalculator.getMileageRate(MileagePurpose.BUSINESS, 2024)?.centsPerMile)
+        assertEquals(21L, MileageCalculator.getMileageRate(MileagePurpose.MEDICAL, 2024)?.centsPerMile)
+        assertEquals(21L, MileageCalculator.getMileageRate(MileagePurpose.MOVING, 2024)?.centsPerMile)
+        assertEquals(14L, MileageCalculator.getMileageRate(MileagePurpose.CHARITY, 2024)?.centsPerMile)
+        assertEquals(70L, MileageCalculator.getMileageRate(MileagePurpose.BUSINESS, 2025)?.centsPerMile)
+    }
+
+    @Test
+    fun unsupportedYearReturnsNullForDeductiblePurposes() {
+        assertEquals(null, MileageCalculator.getMileageRate(MileagePurpose.BUSINESS, 2026))
+        assertEquals(0L, MileageCalculator.getMileageRate(MileagePurpose.PERSONAL, 2026)?.centsPerMile)
+    }
+
+    @Test
+    fun calculatesWebParityMileageDeductionsInCents() {
+        assertEquals(
+            3_350L,
+            MileageCalculator.calculateMileageDeduction(50.0, MileagePurpose.BUSINESS, 2024).deductionCents,
+        )
+        assertEquals(
+            8_040L,
+            MileageCalculator.calculateMileageDeduction(120.0, MileagePurpose.BUSINESS, 2024).deductionCents,
+        )
+        assertEquals(
+            630L,
+            MileageCalculator.calculateMileageDeduction(30.0, MileagePurpose.MEDICAL, 2024).deductionCents,
+        )
+        assertEquals(
+            210L,
+            MileageCalculator.calculateMileageDeduction(15.0, MileagePurpose.CHARITY, 2024).deductionCents,
+        )
+    }
+
+    @Test
+    fun roundsFractionalMilesBeforeCalculatingIntegerCents() {
+        assertEquals(
+            838L,
+            MileageCalculator.calculateMileageDeduction(12.5, MileagePurpose.BUSINESS, 2024).deductionCents,
+        )
+        assertEquals(
+            824L,
+            MileageCalculator.calculateMileageDeduction(12.25, MileagePurpose.BUSINESS, 2024).deductionCents,
+        )
+    }
+
+    @Test
+    fun appliesBusinessUsePercentOnlyToBusinessTrips() {
+        assertEquals(
+            930L,
+            MileageCalculator.calculateMileageDeduction(
+                miles = 18.5,
+                purpose = MileagePurpose.BUSINESS,
+                taxYear = 2024,
+                businessUsePercent = 75,
+            ).deductionCents,
+        )
+        assertEquals(
+            389L,
+            MileageCalculator.calculateMileageDeduction(
+                miles = 18.5,
+                purpose = MileagePurpose.MEDICAL,
+                taxYear = 2024,
+                businessUsePercent = 1,
+            ).deductionCents,
+        )
+    }
+
+    @Test
+    fun personalAndNonPositiveTripsDeductZero() {
+        assertEquals(
+            0L,
+            MileageCalculator.calculateMileageDeduction(25.0, MileagePurpose.PERSONAL, 2024).deductionCents,
+        )
+        assertEquals(
+            0L,
+            MileageCalculator.calculateMileageDeduction(0.0, MileagePurpose.BUSINESS, 2024).deductionCents,
+        )
+        assertEquals(
+            0L,
+            MileageCalculator.calculateMileageDeduction(-1.0, MileagePurpose.BUSINESS, 2024).deductionCents,
+        )
+    }
+
+    @Test
+    fun tripDateSelectsCorrectYearBoundaryRate() {
+        val lastDay2024 = trip("year-end", LocalDate(2024, 12, 31), 10.0)
+        val firstDay2025 = trip("new-year", LocalDate(2025, 1, 1), 10.0)
+
+        assertEquals(67L, MileageCalculator.calculateTripDeduction(lastDay2024).rateCentsPerMile)
+        assertEquals(670L, MileageCalculator.calculateTripDeduction(lastDay2024).deductionCents)
+        assertEquals(70L, MileageCalculator.calculateTripDeduction(firstDay2025).rateCentsPerMile)
+        assertEquals(700L, MileageCalculator.calculateTripDeduction(firstDay2025).deductionCents)
+    }
+
+    @Test
+    fun calculatesTripMilesFromDirectMilesOrOdometerReadings() {
+        assertEquals(12.3, MileageCalculator.calculateTripMiles(MileageDistanceInput(miles = 12.25)))
+        assertEquals(
+            18.5,
+            MileageCalculator.calculateTripMiles(
+                MileageDistanceInput(odometerStart = 12_500.1, odometerEnd = 12_518.6),
+            ),
+        )
+        assertFailsWith<IllegalArgumentException> {
+            MileageCalculator.calculateTripMiles(MileageDistanceInput(odometerStart = 20.0, odometerEnd = 19.9))
+        }
+    }
+
+    @Test
+    fun createsTripEntriesFromRoutePresets() {
+        val preset = RoutePreset(
+            id = "home-client",
+            name = "Home to Client",
+            startLocation = "Home",
+            endLocation = "Client HQ",
+            defaultMiles = 42.24,
+            defaultPurpose = MileagePurpose.BUSINESS,
+            defaultBusinessUsePercent = 80,
+            platform = platform,
+        )
+
+        val created = MileageCalculator.createTripEntryFromPreset(
+            id = "trip-preset",
+            date = LocalDate(2025, 2, 3),
+            preset = preset,
+            audit = audit(MileageAuditSource.ROUTE_PRESET),
+        )
+
+        assertEquals("home-client", created.routePresetId)
+        assertEquals(42.2, created.miles)
+        assertEquals(2_363L, MileageCalculator.calculateTripDeduction(created).deductionCents)
+    }
+
+    @Test
+    fun generatesAnnualMileageSummaryMatchingWebFixture() {
+        val trips = listOf(
+            trip("trip-1", LocalDate(2024, 3, 15), 50.0),
+            trip("trip-2", LocalDate(2024, 4, 20), 120.0),
+            trip("trip-3", LocalDate(2024, 5, 10), 30.0, MileagePurpose.MEDICAL),
+            trip("trip-4", LocalDate(2024, 6, 1), 15.0, MileagePurpose.CHARITY),
+            trip("trip-5", LocalDate(2023, 12, 15), 80.0),
+            trip("personal", LocalDate(2024, 7, 1), 10.0, MileagePurpose.PERSONAL),
+        )
+
+        val summary = MileageCalculator.generateAnnualMileageSummary(trips, 2024)
+
+        assertEquals(2024, summary.year)
+        assertEquals(225.0, summary.totalLoggedMiles)
+        assertEquals(215.0, summary.totalDeductibleMiles)
+        assertEquals(5, summary.totalTripCount)
+        assertEquals(4, summary.deductibleTripCount)
+        assertEquals(12_230L, summary.totalDeductionCents)
+        assertEquals(11_390L, summary.byPurpose.first { it.purpose == MileagePurpose.BUSINESS }.deductionCents)
+    }
+
+    @Test
+    fun handlesEmptyAnnualSummary() {
+        val summary = MileageCalculator.generateAnnualMileageSummary(emptyList(), 2024)
+
+        assertEquals(0.0, summary.totalLoggedMiles)
+        assertEquals(0.0, summary.totalDeductibleMiles)
+        assertEquals(0L, summary.totalDeductionCents)
+        assertEquals(0, summary.totalTripCount)
+        assertEquals(IRS_DEDUCTIBLE_MILEAGE_PURPOSES.size, summary.byPurpose.size)
+        assertTrue(summary.byPurpose.all { it.tripCount == 0 && it.deductionCents == 0L })
+    }
+
+    @Test
+    fun summarizesGigShiftUsingTripIdsAndPlatformAuditLinks() {
+        val shift = WorkShiftSession(
+            id = "shift-1",
+            platform = platform,
+            startedAt = Instant.parse("2025-03-01T15:00:00Z"),
+            endedAt = Instant.parse("2025-03-01T20:00:00Z"),
+            tripIds = listOf("trip-a"),
+            grossEarningsCents = 12_500L,
+            audit = audit(MileageAuditSource.PLATFORM_IMPORT, externalShiftId = "shift-1"),
+        )
+        val trips = listOf(
+            trip("trip-a", LocalDate(2025, 3, 1), 25.0),
+            trip("trip-b", LocalDate(2025, 3, 1), 10.0, MileagePurpose.CHARITY, externalShiftId = "shift-1"),
+            trip("trip-c", LocalDate(2025, 3, 2), 99.0),
+        )
+
+        val summary = MileageCalculator.summarizeShift(shift, trips)
+
+        assertEquals("shift-1", summary.shiftId)
+        assertEquals(platform, summary.platform)
+        assertEquals(2, summary.tripCount)
+        assertEquals(35.0, summary.totalMiles)
+        assertEquals(35.0, summary.deductibleMiles)
+        assertEquals(1_890L, summary.mileageDeductionCents)
+        assertEquals(10_610L, summary.netAfterMileageDeductionCents)
+    }
+
+    @Test
+    fun validatesMileageTripEdgeCases() {
+        val zeroMiles = trip("zero", LocalDate(2024, 1, 1), 0.0)
+        val highMiles = trip("high", LocalDate(2024, 1, 1), 15_000.0)
+
+        assertTrue(MileageCalculator.validateTripEntry(zeroMiles).contains("Miles must be greater than zero."))
+        assertTrue(MileageCalculator.validateTripEntry(highMiles).any { it.contains("10,000") })
+        assertFalse(MileageCalculator.validateTripEntry(trip("ok", LocalDate(2024, 1, 1), 1.0)).isNotEmpty())
+    }
+
+    @Test
+    fun serializesMileageTripRoutePresetAndShiftContracts() {
+        val routePreset = RoutePreset(
+            id = "airport",
+            name = "Airport pickup",
+            startLocation = "Airport",
+            endLocation = "Downtown",
+            defaultMiles = 14.4,
+            platform = platform,
+        )
+        val mileageTrip = trip(
+            id = "trip-json",
+            date = LocalDate(2025, 4, 10),
+            miles = 14.4,
+            externalShiftId = "shift-json",
+        )
+        val shift = WorkShiftSession(
+            id = "shift-json",
+            platform = platform,
+            startedAt = Instant.parse("2025-04-10T09:00:00Z"),
+            endedAt = Instant.parse("2025-04-10T11:00:00Z"),
+            tripIds = listOf(mileageTrip.id),
+            grossEarningsCents = 5_000L,
+            audit = audit(MileageAuditSource.PLATFORM_IMPORT, externalShiftId = "shift-json"),
+        )
+
+        val decodedPreset = json.decodeFromString<RoutePreset>(json.encodeToString(routePreset))
+        val decodedTrip = json.decodeFromString<MileageTripEntry>(json.encodeToString(mileageTrip))
+        val decodedShift = json.decodeFromString<WorkShiftSession>(json.encodeToString(shift))
+
+        assertEquals(routePreset, decodedPreset)
+        assertEquals(mileageTrip, decodedTrip)
+        assertEquals(shift, decodedShift)
+        assertNotNull(decodedTrip.audit.platform)
+    }
+
+    @Test
+    fun serializesAnnualAndShiftSummaries() {
+        val annualSummary = MileageCalculator.generateAnnualMileageSummary(
+            listOf(trip("trip-2025", LocalDate(2025, 5, 5), 10.0)),
+            2025,
+        )
+        val shiftSummary = ShiftDeductionSummary(
+            shiftId = "summary-shift",
+            platform = platform,
+            tripCount = 1,
+            totalMiles = 10.0,
+            deductibleMiles = 10.0,
+            mileageDeductionCents = 700L,
+            grossEarningsCents = 2_500L,
+        )
+
+        assertEquals(annualSummary, json.decodeFromString<AnnualMileageSummary>(json.encodeToString(annualSummary)))
+        assertEquals(shiftSummary, json.decodeFromString<ShiftDeductionSummary>(json.encodeToString(shiftSummary)))
+    }
+}


### PR DESCRIPTION
Closes #2575.

Summary:
- Adds shared KMP mileage models for IRS rates, trips, route presets, gig platform audit links, and work shift sessions.
- Adds mileage and shift deduction calculators with annual summaries, year-boundary rate selection, odometer/direct-mile rounding, and route-preset creation.
- Keeps money results in integer cents and IRS rates in integer cents-per-mile.

Test coverage:
- ./gradlew.bat :packages:core:jvmTest --console=plain (2225 tests passed, including 15 new mileage tests).
- ./gradlew.bat :packages:core:check --console=plain reached JS browser tests but failed because ChromeHeadless is not installed (CHROME_BIN unset).