### PR TITLE
feat(core): shared KMP vehicle cost-per-mile engine (#2578)

### DIFF
--- a/packages/core/src/commonMain/kotlin/com/finance/core/vehicle/VehicleCostCalculator.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/vehicle/VehicleCostCalculator.kt
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.vehicle
+
+import kotlin.math.floor
+
+/** Shared KMP engine for actual vehicle operating cost-per-mile calculations. */
+object VehicleCostCalculator {
+    fun aggregate(
+        vehicle: Vehicle,
+        milesDriven: Double,
+        fixedCosts: List<VehicleFixedCost> = emptyList(),
+        variableCosts: List<VehicleVariableCost> = emptyList(),
+        fillUps: List<VehicleFillUp> = emptyList(),
+        repairs: List<VehicleRepair> = emptyList(),
+        maintenanceIntervals: List<VehicleMaintenanceInterval> = emptyList(),
+        businessUseAllocation: BusinessUseAllocation = BusinessUseAllocation(),
+    ): VehicleCostSummary {
+        require(milesDriven.isFinite() && milesDriven >= 0.0) { "milesDriven must be finite and non-negative" }
+
+        val vehicleFixedCosts = fixedCosts.filter { it.vehicleId == vehicle.id }
+        val vehicleVariableCosts = variableCosts.filter { it.vehicleId == vehicle.id }
+        val vehicleFillUps = fillUps.filter { it.vehicleId == vehicle.id }
+        val vehicleRepairs = repairs.filter { it.vehicleId == vehicle.id }
+        val vehicleMaintenanceIntervals = maintenanceIntervals.filter { it.vehicleId == vehicle.id }
+
+        val fixedCostCents = vehicleFixedCosts.sumOf { it.amountCents }
+        val variableCostCents = vehicleVariableCosts.sumOf { it.amountCents }
+        val fuelCostCents = vehicleFillUps.sumOf { it.totalCostCents }
+        val repairCostCents = vehicleRepairs.sumOf { it.totalCostCents }
+        val maintenanceReserveCents = calculateMaintenanceReserveCents(milesDriven, vehicleMaintenanceIntervals)
+        val totalOperatingCostCents = fixedCostCents +
+            variableCostCents +
+            fuelCostCents +
+            repairCostCents +
+            maintenanceReserveCents
+        val businessAllocatedCostCents = allocateBusinessCost(
+            totalOperatingCostCents,
+            businessUseAllocation,
+        )
+
+        return VehicleCostSummary(
+            vehicleId = vehicle.id,
+            totalMiles = milesDriven,
+            fixedCostCents = fixedCostCents,
+            variableCostCents = variableCostCents,
+            fuelCostCents = fuelCostCents,
+            repairCostCents = repairCostCents,
+            maintenanceReserveCents = maintenanceReserveCents,
+            totalOperatingCostCents = totalOperatingCostCents,
+            costPerMileCents = calculateCostPerMile(totalOperatingCostCents, milesDriven),
+            businessUsePercent = businessUseAllocation.businessUsePercent,
+            businessAllocatedCostCents = businessAllocatedCostCents,
+            businessAllocatedCostPerMileCents = calculateCostPerMile(businessAllocatedCostCents, milesDriven),
+            fixedCostCount = vehicleFixedCosts.size,
+            variableCostCount = vehicleVariableCosts.size,
+            fillUpCount = vehicleFillUps.size,
+            repairCount = vehicleRepairs.size,
+            maintenanceIntervalCount = vehicleMaintenanceIntervals.size,
+        )
+    }
+
+    /** Integer cents per mile rounded half-up; zero miles returns 0 to avoid division by zero. */
+    fun calculateCostPerMile(totalCostCents: Long, milesDriven: Double): Long {
+        require(totalCostCents >= 0L) { "totalCostCents must be non-negative" }
+        require(milesDriven.isFinite() && milesDriven >= 0.0) { "milesDriven must be finite and non-negative" }
+        if (totalCostCents == 0L || milesDriven == 0.0) return 0L
+        return roundHalfUp(totalCostCents / milesDriven)
+    }
+
+    fun allocateBusinessCost(totalCostCents: Long, allocation: BusinessUseAllocation): Long {
+        require(totalCostCents >= 0L) { "totalCostCents must be non-negative" }
+        return roundHalfUpRatio(totalCostCents, allocation.businessUsePercent, 100L)
+    }
+
+    fun calculateMaintenanceReserveCents(
+        milesDriven: Double,
+        intervals: List<VehicleMaintenanceInterval>,
+    ): Long {
+        require(milesDriven.isFinite() && milesDriven >= 0.0) { "milesDriven must be finite and non-negative" }
+        if (milesDriven == 0.0) return 0L
+        return intervals.sumOf { interval ->
+            roundHalfUp(interval.expectedCostCents * (milesDriven / interval.intervalMiles))
+        }
+    }
+
+    private fun roundHalfUp(value: Double): Long {
+        require(value.isFinite() && value >= 0.0) { "value must be finite and non-negative" }
+        return floor(value + 0.5).toLong()
+    }
+
+    private fun roundHalfUpRatio(amount: Long, numerator: Int, denominator: Long): Long {
+        require(amount >= 0L) { "amount must be non-negative" }
+        require(numerator >= 0) { "numerator must be non-negative" }
+        require(denominator > 0L) { "denominator must be positive" }
+        return ((amount * numerator) + (denominator / 2L)) / denominator
+    }
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/vehicle/VehicleModels.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/vehicle/VehicleModels.kt
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.vehicle
+
+import kotlinx.datetime.LocalDate
+import kotlinx.serialization.Serializable
+
+/** A vehicle whose actual operating costs are tracked for profitability views. */
+@Serializable
+data class Vehicle(
+    val id: String,
+    val displayName: String,
+    val make: String? = null,
+    val model: String? = null,
+    val year: Int? = null,
+) {
+    init {
+        require(id.isNotBlank()) { "Vehicle id is required" }
+        require(displayName.isNotBlank()) { "Vehicle displayName is required" }
+        require(year == null || year > 0) { "Vehicle year must be positive" }
+    }
+}
+
+@Serializable
+enum class VehicleFixedCostCategory {
+    INSURANCE,
+    REGISTRATION,
+    LOAN_OR_LEASE,
+    DEPRECIATION,
+    PERMIT,
+    PARKING_SUBSCRIPTION,
+    OTHER,
+}
+
+@Serializable
+enum class VehicleVariableCostCategory {
+    TOLLS,
+    PARKING,
+    CAR_WASH,
+    SUPPLIES,
+    OTHER,
+}
+
+@Serializable
+enum class VehicleRepairCategory {
+    MECHANICAL,
+    BODY,
+    TIRES,
+    DIAGNOSTIC,
+    OTHER,
+}
+
+/** Fixed vehicle cost incurred for the aggregation window, stored in integer cents. */
+@Serializable
+data class VehicleFixedCost(
+    val id: String,
+    val vehicleId: String,
+    val name: String,
+    val amountCents: Long,
+    val category: VehicleFixedCostCategory = VehicleFixedCostCategory.OTHER,
+    val dueDate: LocalDate? = null,
+) {
+    init {
+        require(id.isNotBlank()) { "Fixed cost id is required" }
+        require(vehicleId.isNotBlank()) { "vehicleId is required" }
+        require(name.isNotBlank()) { "Fixed cost name is required" }
+        require(amountCents >= 0L) { "Fixed cost amountCents must be non-negative" }
+    }
+}
+
+/** Non-fuel variable vehicle cost incurred for the aggregation window, stored in integer cents. */
+@Serializable
+data class VehicleVariableCost(
+    val id: String,
+    val vehicleId: String,
+    val name: String,
+    val amountCents: Long,
+    val category: VehicleVariableCostCategory = VehicleVariableCostCategory.OTHER,
+    val date: LocalDate? = null,
+) {
+    init {
+        require(id.isNotBlank()) { "Variable cost id is required" }
+        require(vehicleId.isNotBlank()) { "vehicleId is required" }
+        require(name.isNotBlank()) { "Variable cost name is required" }
+        require(amountCents >= 0L) { "Variable cost amountCents must be non-negative" }
+    }
+}
+
+/** A fuel fill-up record used as an actual vehicle operating cost. */
+@Serializable
+data class VehicleFillUp(
+    val id: String,
+    val vehicleId: String,
+    val date: LocalDate,
+    val totalCostCents: Long,
+    val gallons: Double,
+    val odometerMiles: Double? = null,
+    val vendor: String? = null,
+    val fullTank: Boolean = true,
+) {
+    init {
+        require(id.isNotBlank()) { "Fill-up id is required" }
+        require(vehicleId.isNotBlank()) { "vehicleId is required" }
+        require(totalCostCents >= 0L) { "Fill-up totalCostCents must be non-negative" }
+        require(gallons.isFinite() && gallons > 0.0) { "Fill-up gallons must be finite and greater than zero" }
+        require(odometerMiles == null || (odometerMiles.isFinite() && odometerMiles >= 0.0)) {
+            "Fill-up odometerMiles must be finite and non-negative"
+        }
+    }
+}
+
+/** A repair cost incurred for the vehicle in integer cents. */
+@Serializable
+data class VehicleRepair(
+    val id: String,
+    val vehicleId: String,
+    val date: LocalDate,
+    val description: String,
+    val totalCostCents: Long,
+    val category: VehicleRepairCategory = VehicleRepairCategory.OTHER,
+    val odometerMiles: Double? = null,
+) {
+    init {
+        require(id.isNotBlank()) { "Repair id is required" }
+        require(vehicleId.isNotBlank()) { "vehicleId is required" }
+        require(description.isNotBlank()) { "Repair description is required" }
+        require(totalCostCents >= 0L) { "Repair totalCostCents must be non-negative" }
+        require(odometerMiles == null || (odometerMiles.isFinite() && odometerMiles >= 0.0)) {
+            "Repair odometerMiles must be finite and non-negative"
+        }
+    }
+}
+
+/** Expected recurring maintenance reserve, prorated by miles driven in an aggregation. */
+@Serializable
+data class VehicleMaintenanceInterval(
+    val id: String,
+    val vehicleId: String,
+    val name: String,
+    val intervalMiles: Double,
+    val expectedCostCents: Long,
+    val lastServicedOdometerMiles: Double? = null,
+) {
+    init {
+        require(id.isNotBlank()) { "Maintenance interval id is required" }
+        require(vehicleId.isNotBlank()) { "vehicleId is required" }
+        require(name.isNotBlank()) { "Maintenance interval name is required" }
+        require(intervalMiles.isFinite() && intervalMiles > 0.0) {
+            "Maintenance intervalMiles must be finite and greater than zero"
+        }
+        require(expectedCostCents >= 0L) { "Maintenance expectedCostCents must be non-negative" }
+        require(lastServicedOdometerMiles == null ||
+            (lastServicedOdometerMiles.isFinite() && lastServicedOdometerMiles >= 0.0)) {
+            "Maintenance lastServicedOdometerMiles must be finite and non-negative"
+        }
+    }
+}
+
+/** Percentage of operating costs allocated to business use. */
+@Serializable
+data class BusinessUseAllocation(
+    val businessUsePercent: Int = 100,
+) {
+    init {
+        require(businessUsePercent in 0..100) { "businessUsePercent must be in 0..100" }
+    }
+}
+
+/**
+ * Aggregated actual operating-cost output for one vehicle.
+ *
+ * Cost-per-mile fields are integer cents per mile rounded half-up from non-negative decimal values.
+ * For example, 101 cents over 2 miles becomes 51 cents per mile.
+ */
+@Serializable
+data class VehicleCostSummary(
+    val vehicleId: String,
+    val totalMiles: Double,
+    val fixedCostCents: Long,
+    val variableCostCents: Long,
+    val fuelCostCents: Long,
+    val repairCostCents: Long,
+    val maintenanceReserveCents: Long,
+    val totalOperatingCostCents: Long,
+    val costPerMileCents: Long,
+    val businessUsePercent: Int,
+    val businessAllocatedCostCents: Long,
+    val businessAllocatedCostPerMileCents: Long,
+    val fixedCostCount: Int,
+    val variableCostCount: Int,
+    val fillUpCount: Int,
+    val repairCount: Int,
+    val maintenanceIntervalCount: Int,
+)

--- a/packages/core/src/commonTest/kotlin/com/finance/core/vehicle/VehicleCostCalculatorTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/vehicle/VehicleCostCalculatorTest.kt
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.vehicle
+
+import kotlinx.datetime.LocalDate
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class VehicleCostCalculatorTest {
+    private val json = Json { encodeDefaults = true }
+    private val vehicle = Vehicle(
+        id = "vehicle-1",
+        displayName = "Delivery Van",
+        make = "Ford",
+        model = "Transit",
+        year = 2024,
+    )
+    private val date = LocalDate(2026, 1, 15)
+
+    @Test
+    fun roundsCostPerMileAndMaintenanceReserveHalfUp() {
+        assertEquals(51L, VehicleCostCalculator.calculateCostPerMile(101L, 2.0))
+        assertEquals(50L, VehicleCostCalculator.calculateCostPerMile(100L, 2.0))
+
+        val interval = VehicleMaintenanceInterval(
+            id = "oil",
+            vehicleId = vehicle.id,
+            name = "Oil change",
+            intervalMiles = 40.0,
+            expectedCostCents = 100L,
+        )
+
+        assertEquals(3L, VehicleCostCalculator.calculateMaintenanceReserveCents(1.0, listOf(interval)))
+    }
+
+    @Test
+    fun aggregatesFixedVariableFillUpRepairAndMaintenanceCosts() {
+        val summary = VehicleCostCalculator.aggregate(
+            vehicle = vehicle,
+            milesDriven = 100.0,
+            fixedCosts = listOf(
+                VehicleFixedCost("insurance", vehicle.id, "Insurance", 10_000L),
+                VehicleFixedCost("other-insurance", "other-vehicle", "Other insurance", 99_999L),
+            ),
+            variableCosts = listOf(
+                VehicleVariableCost("toll", vehicle.id, "Bridge toll", 500L, VehicleVariableCostCategory.TOLLS),
+            ),
+            fillUps = listOf(
+                VehicleFillUp("fuel", vehicle.id, date, totalCostCents = 4_500L, gallons = 12.0),
+            ),
+            repairs = listOf(
+                VehicleRepair("brakes", vehicle.id, date, "Brake pads", 20_000L, VehicleRepairCategory.MECHANICAL),
+            ),
+            maintenanceIntervals = listOf(
+                VehicleMaintenanceInterval("tires", vehicle.id, "Tires", intervalMiles = 10_000.0, expectedCostCents = 8_000L),
+            ),
+            businessUseAllocation = BusinessUseAllocation(75),
+        )
+
+        assertEquals(10_000L, summary.fixedCostCents)
+        assertEquals(500L, summary.variableCostCents)
+        assertEquals(4_500L, summary.fuelCostCents)
+        assertEquals(20_000L, summary.repairCostCents)
+        assertEquals(80L, summary.maintenanceReserveCents)
+        assertEquals(35_080L, summary.totalOperatingCostCents)
+        assertEquals(351L, summary.costPerMileCents)
+        assertEquals(26_310L, summary.businessAllocatedCostCents)
+        assertEquals(263L, summary.businessAllocatedCostPerMileCents)
+        assertEquals(1, summary.fixedCostCount)
+    }
+
+    @Test
+    fun zeroMilesKeepsCostsButReturnsZeroCostPerMile() {
+        val summary = VehicleCostCalculator.aggregate(
+            vehicle = vehicle,
+            milesDriven = 0.0,
+            fixedCosts = listOf(VehicleFixedCost("registration", vehicle.id, "Registration", 1_001L)),
+            businessUseAllocation = BusinessUseAllocation(50),
+        )
+
+        assertEquals(1_001L, summary.totalOperatingCostCents)
+        assertEquals(0L, summary.costPerMileCents)
+        assertEquals(501L, summary.businessAllocatedCostCents)
+        assertEquals(0L, summary.businessAllocatedCostPerMileCents)
+    }
+
+    @Test
+    fun businessUseAllocationRoundsHalfUpAndValidatesPercent() {
+        assertEquals(5_003L, VehicleCostCalculator.allocateBusinessCost(10_005L, BusinessUseAllocation(50)))
+        assertEquals(0L, VehicleCostCalculator.allocateBusinessCost(10_005L, BusinessUseAllocation(0)))
+        assertEquals(10_005L, VehicleCostCalculator.allocateBusinessCost(10_005L, BusinessUseAllocation(100)))
+
+        assertFailsWith<IllegalArgumentException> {
+            BusinessUseAllocation(101)
+        }
+    }
+
+    @Test
+    fun emptyInputsProduceZeroCostSummary() {
+        val summary = VehicleCostCalculator.aggregate(vehicle = vehicle, milesDriven = 25.0)
+
+        assertEquals(vehicle.id, summary.vehicleId)
+        assertEquals(25.0, summary.totalMiles)
+        assertEquals(0L, summary.totalOperatingCostCents)
+        assertEquals(0L, summary.costPerMileCents)
+        assertEquals(0L, summary.businessAllocatedCostCents)
+        assertEquals(0, summary.fixedCostCount)
+        assertEquals(0, summary.variableCostCount)
+        assertEquals(0, summary.fillUpCount)
+        assertEquals(0, summary.repairCount)
+        assertEquals(0, summary.maintenanceIntervalCount)
+    }
+
+    @Test
+    fun serializesVehicleOperatingCostContracts() {
+        val fixedCost = VehicleFixedCost(
+            id = "loan",
+            vehicleId = vehicle.id,
+            name = "Loan payment",
+            amountCents = 42_000L,
+            category = VehicleFixedCostCategory.LOAN_OR_LEASE,
+            dueDate = date,
+        )
+        val variableCost = VehicleVariableCost(
+            id = "wash",
+            vehicleId = vehicle.id,
+            name = "Car wash",
+            amountCents = 1_200L,
+            category = VehicleVariableCostCategory.CAR_WASH,
+            date = date,
+        )
+        val fillUp = VehicleFillUp(
+            id = "fill-up",
+            vehicleId = vehicle.id,
+            date = date,
+            totalCostCents = 6_400L,
+            gallons = 16.0,
+            odometerMiles = 12_345.6,
+            vendor = "Fuel Stop",
+        )
+        val repair = VehicleRepair(
+            id = "repair",
+            vehicleId = vehicle.id,
+            date = date,
+            description = "Starter replacement",
+            totalCostCents = 55_000L,
+            category = VehicleRepairCategory.MECHANICAL,
+            odometerMiles = 12_500.0,
+        )
+        val interval = VehicleMaintenanceInterval(
+            id = "rotation",
+            vehicleId = vehicle.id,
+            name = "Tire rotation",
+            intervalMiles = 5_000.0,
+            expectedCostCents = 8_000L,
+            lastServicedOdometerMiles = 10_000.0,
+        )
+        val allocation = BusinessUseAllocation(60)
+        val summary = VehicleCostCalculator.aggregate(
+            vehicle = vehicle,
+            milesDriven = 500.0,
+            fixedCosts = listOf(fixedCost),
+            variableCosts = listOf(variableCost),
+            fillUps = listOf(fillUp),
+            repairs = listOf(repair),
+            maintenanceIntervals = listOf(interval),
+            businessUseAllocation = allocation,
+        )
+
+        assertEquals(vehicle, json.decodeFromString<Vehicle>(json.encodeToString(vehicle)))
+        assertEquals(fixedCost, json.decodeFromString<VehicleFixedCost>(json.encodeToString(fixedCost)))
+        assertEquals(variableCost, json.decodeFromString<VehicleVariableCost>(json.encodeToString(variableCost)))
+        assertEquals(fillUp, json.decodeFromString<VehicleFillUp>(json.encodeToString(fillUp)))
+        assertEquals(repair, json.decodeFromString<VehicleRepair>(json.encodeToString(repair)))
+        assertEquals(interval, json.decodeFromString<VehicleMaintenanceInterval>(json.encodeToString(interval)))
+        assertEquals(allocation, json.decodeFromString<BusinessUseAllocation>(json.encodeToString(allocation)))
+        assertEquals(summary, json.decodeFromString<VehicleCostSummary>(json.encodeToString(summary)))
+    }
+}


### PR DESCRIPTION
Closes #2578.

Summary:
- Adds a new shared KMP `com.finance.core.vehicle` package for actual vehicle operating-cost calculations.
- Models vehicles, fixed costs, variable costs, fill-ups, repairs, maintenance intervals, and business-use allocation.
- Aggregates costs into integer-cent totals, round-half-up cents-per-mile output, and business-allocated cost for profitability views.

Test coverage:
- Rounding and round-half-up cents-per-mile behavior
- Zero-mile edge case
- Business-use allocation
- Empty inputs
- Serialization round-trips for public contracts

Validation:
- `./gradlew.bat :packages:core:jvmTest --console=plain` passed (2268 tests, 0 failures, 0 errors).