### PR TITLE
feat(core): shared KMP small-business P&L + margin engine (#2586)

### DIFF
--- a/packages/core/src/commonMain/kotlin/com/finance/core/pnl/SmallBusinessPnlEngine.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/pnl/SmallBusinessPnlEngine.kt
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.pnl
+
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.isoDayNumber
+import kotlinx.datetime.minus
+import kotlinx.datetime.plus
+import kotlinx.serialization.Serializable
+
+/**
+ * Shared Kotlin Multiplatform small-business profit-and-loss aggregation.
+ *
+ * Money is represented as integer cents ([Long]) in every public model. Ratios
+ * are represented in basis points where 10_000 = 100.00%; for example, 2_500
+ * basis points means 25.00%. Ratio division truncates toward zero. When revenue
+ * is zero, ratio fields return [ZERO_REVENUE_RATIO_BASIS_POINTS] instead of
+ * dividing by zero.
+ */
+object SmallBusinessPnlEngine {
+    const val BASIS_POINTS_PER_ONE = 10_000L
+    const val ZERO_REVENUE_RATIO_BASIS_POINTS = 0L
+
+    /** Aggregates dedicated revenue/COGS/labor/overhead inputs into a P&L report. */
+    fun aggregate(
+        inputs: PnlInputs,
+        grouping: PnlPeriodGrouping,
+        from: LocalDate? = null,
+        to: LocalDate? = null,
+    ): PnlReport = aggregate(inputs.toLineItems(), grouping, from, to)
+
+    /** Aggregates normalized line items into a P&L report. */
+    fun aggregate(
+        lineItems: List<PnlLineItem>,
+        grouping: PnlPeriodGrouping,
+        from: LocalDate? = null,
+        to: LocalDate? = null,
+    ): PnlReport {
+        require(from == null || to == null || from <= to) { "from ($from) must be <= to ($to)" }
+
+        val filtered = lineItems
+            .filter { item -> (from == null || item.date >= from) && (to == null || item.date <= to) }
+            .sortedWith(compareBy<PnlLineItem> { it.date }.thenBy { it.id })
+
+        val periods = filtered
+            .groupBy { item -> periodFor(item.date, grouping) }
+            .map { (period, items) ->
+                PnlPeriodReport(
+                    period = period,
+                    summary = summarize(items),
+                    lineItemIds = items.map { it.id },
+                )
+            }
+            .sortedBy { report -> report.period.startDate }
+
+        return PnlReport(
+            grouping = grouping,
+            summary = summarize(filtered),
+            periods = periods,
+        )
+    }
+
+    /** Summarizes a single ungrouped P&L bucket. */
+    fun summarize(lineItems: List<PnlLineItem>): PnlSummary {
+        val revenue = lineItems.sumByType(PnlLineItemType.REVENUE)
+        val cogs = lineItems.sumByType(PnlLineItemType.COST_OF_GOODS_SOLD)
+        val labor = lineItems.sumByType(PnlLineItemType.LABOR)
+        val overhead = lineItems.sumByType(PnlLineItemType.OVERHEAD)
+        val grossProfit = checkedSubtract(revenue, cogs)
+        val operatingExpenses = checkedAdd(labor, overhead)
+        val netProfit = checkedSubtract(grossProfit, operatingExpenses)
+
+        return PnlSummary(
+            revenueCents = revenue,
+            cogsCents = cogs,
+            laborCents = labor,
+            overheadCents = overhead,
+            grossProfitCents = grossProfit,
+            operatingExpenseCents = operatingExpenses,
+            netProfitCents = netProfit,
+            grossMarginBasisPoints = ratioBasisPoints(grossProfit, revenue),
+            netMarginBasisPoints = ratioBasisPoints(netProfit, revenue),
+            foodCostBasisPoints = ratioBasisPoints(cogs, revenue),
+            lineItemCount = lineItems.size,
+        )
+    }
+
+    fun periodFor(date: LocalDate, grouping: PnlPeriodGrouping): PnlPeriod = when (grouping) {
+        PnlPeriodGrouping.WEEKLY -> {
+            val start = date.minus(date.dayOfWeek.isoDayNumber - 1, DateTimeUnit.DAY)
+            PnlPeriod(
+                key = "W-$start",
+                grouping = grouping,
+                startDate = start,
+                endDate = start.plus(6, DateTimeUnit.DAY),
+            )
+        }
+        PnlPeriodGrouping.MONTHLY -> {
+            val start = LocalDate(date.year, date.month, 1)
+            PnlPeriod(
+                key = "${date.year}-${date.monthNumber.toString().padStart(2, '0')}",
+                grouping = grouping,
+                startDate = start,
+                endDate = start.plus(1, DateTimeUnit.MONTH).minus(1, DateTimeUnit.DAY),
+            )
+        }
+    }
+
+    internal fun ratioBasisPoints(numeratorCents: Long, revenueCents: Long): Long {
+        if (revenueCents == 0L) return ZERO_REVENUE_RATIO_BASIS_POINTS
+        if (numeratorCents > Long.MAX_VALUE / BASIS_POINTS_PER_ONE ||
+            numeratorCents < Long.MIN_VALUE / BASIS_POINTS_PER_ONE
+        ) {
+            throw ArithmeticException("Long overflow while scaling ratio to basis points")
+        }
+        return numeratorCents * BASIS_POINTS_PER_ONE / revenueCents
+    }
+}
+
+/** The supported P&L period groupings. Weekly periods start on Monday and end on Sunday. */
+@Serializable
+enum class PnlPeriodGrouping { WEEKLY, MONTHLY }
+
+/** Normalized line-item category used by the aggregation engine. */
+@Serializable
+enum class PnlLineItemType { REVENUE, COST_OF_GOODS_SOLD, LABOR, OVERHEAD }
+
+/** A normalized P&L line item. Amounts are integer cents and may be negative for refunds/credits. */
+@Serializable
+data class PnlLineItem(
+    val id: String,
+    val type: PnlLineItemType,
+    val amountCents: Long,
+    val date: LocalDate,
+    val memo: String? = null,
+) {
+    init {
+        require(id.isNotBlank()) { "id cannot be blank" }
+    }
+}
+
+/** Small-business revenue input owned by the P&L package. */
+@Serializable
+data class PnlRevenue(
+    val id: String,
+    val amountCents: Long,
+    val date: LocalDate,
+    val source: String? = null,
+) {
+    init {
+        require(id.isNotBlank()) { "id cannot be blank" }
+    }
+}
+
+/** Cost-of-goods-sold input owned by the P&L package. */
+@Serializable
+data class PnlCostOfGoodsSold(
+    val id: String,
+    val amountCents: Long,
+    val date: LocalDate,
+    val category: String? = null,
+) {
+    init {
+        require(id.isNotBlank()) { "id cannot be blank" }
+    }
+}
+
+/** Labor cost input owned by the P&L package. */
+@Serializable
+data class PnlLaborCost(
+    val id: String,
+    val amountCents: Long,
+    val date: LocalDate,
+    val role: String? = null,
+) {
+    init {
+        require(id.isNotBlank()) { "id cannot be blank" }
+    }
+}
+
+/** Overhead cost input owned by the P&L package. */
+@Serializable
+data class PnlOverheadCost(
+    val id: String,
+    val amountCents: Long,
+    val date: LocalDate,
+    val category: String? = null,
+) {
+    init {
+        require(id.isNotBlank()) { "id cannot be blank" }
+    }
+}
+
+/** Dedicated package-local inputs so callers do not depend on receipt/COGS contracts. */
+@Serializable
+data class PnlInputs(
+    val revenues: List<PnlRevenue> = emptyList(),
+    val costOfGoodsSold: List<PnlCostOfGoodsSold> = emptyList(),
+    val laborCosts: List<PnlLaborCost> = emptyList(),
+    val overheadCosts: List<PnlOverheadCost> = emptyList(),
+) {
+    fun toLineItems(): List<PnlLineItem> =
+        revenues.map { revenue ->
+            PnlLineItem(revenue.id, PnlLineItemType.REVENUE, revenue.amountCents, revenue.date, revenue.source)
+        } + costOfGoodsSold.map { cogs ->
+            PnlLineItem(
+                cogs.id,
+                PnlLineItemType.COST_OF_GOODS_SOLD,
+                cogs.amountCents,
+                cogs.date,
+                cogs.category,
+            )
+        } + laborCosts.map { labor ->
+            PnlLineItem(labor.id, PnlLineItemType.LABOR, labor.amountCents, labor.date, labor.role)
+        } + overheadCosts.map { overhead ->
+            PnlLineItem(overhead.id, PnlLineItemType.OVERHEAD, overhead.amountCents, overhead.date, overhead.category)
+        }
+}
+
+/** Inclusive period bounds for one P&L bucket. */
+@Serializable
+data class PnlPeriod(
+    val key: String,
+    val grouping: PnlPeriodGrouping,
+    val startDate: LocalDate,
+    val endDate: LocalDate,
+)
+
+/** P&L totals and basis-point ratios for one bucket. */
+@Serializable
+data class PnlSummary(
+    val revenueCents: Long,
+    val cogsCents: Long,
+    val laborCents: Long,
+    val overheadCents: Long,
+    val grossProfitCents: Long,
+    val operatingExpenseCents: Long,
+    val netProfitCents: Long,
+    val grossMarginBasisPoints: Long,
+    val netMarginBasisPoints: Long,
+    val foodCostBasisPoints: Long,
+    val lineItemCount: Int,
+) {
+    val hasRevenue: Boolean
+        get() = revenueCents != 0L
+}
+
+/** One period within a grouped P&L report. */
+@Serializable
+data class PnlPeriodReport(
+    val period: PnlPeriod,
+    val summary: PnlSummary,
+    val lineItemIds: List<String>,
+)
+
+/** Overall P&L report plus weekly/monthly period details. */
+@Serializable
+data class PnlReport(
+    val grouping: PnlPeriodGrouping,
+    val summary: PnlSummary,
+    val periods: List<PnlPeriodReport>,
+)
+
+private fun List<PnlLineItem>.sumByType(type: PnlLineItemType): Long =
+    filter { item -> item.type == type }
+        .fold(0L) { total, item -> checkedAdd(total, item.amountCents) }
+
+private fun checkedAdd(left: Long, right: Long): Long {
+    val result = left + right
+    if ((left xor right) >= 0 && (left xor result) < 0) {
+        throw ArithmeticException("Long overflow in P&L cents addition")
+    }
+    return result
+}
+
+private fun checkedSubtract(left: Long, right: Long): Long {
+    val result = left - right
+    if ((left xor right) < 0 && (left xor result) < 0) {
+        throw ArithmeticException("Long overflow in P&L cents subtraction")
+    }
+    return result
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/pnl/SmallBusinessPnlEngineTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/pnl/SmallBusinessPnlEngineTest.kt
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.pnl
+
+import kotlinx.datetime.LocalDate
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SmallBusinessPnlEngineTest {
+    private val json = Json { encodeDefaults = true }
+
+    @Test
+    fun aggregate_calculatesPnlTotalsAndMarginsInBasisPoints() {
+        val report = SmallBusinessPnlEngine.aggregate(
+            inputs = PnlInputs(
+                revenues = listOf(revenue("sales", 100_000L, LocalDate(2024, 6, 3))),
+                costOfGoodsSold = listOf(cogs("food", 30_000L, LocalDate(2024, 6, 3))),
+                laborCosts = listOf(labor("cook", 20_000L, LocalDate(2024, 6, 4))),
+                overheadCosts = listOf(overhead("rent", 10_000L, LocalDate(2024, 6, 5))),
+            ),
+            grouping = PnlPeriodGrouping.MONTHLY,
+        )
+
+        assertEquals(100_000L, report.summary.revenueCents)
+        assertEquals(30_000L, report.summary.cogsCents)
+        assertEquals(20_000L, report.summary.laborCents)
+        assertEquals(10_000L, report.summary.overheadCents)
+        assertEquals(70_000L, report.summary.grossProfitCents)
+        assertEquals(30_000L, report.summary.operatingExpenseCents)
+        assertEquals(40_000L, report.summary.netProfitCents)
+        assertEquals(7_000L, report.summary.grossMarginBasisPoints)
+        assertEquals(4_000L, report.summary.netMarginBasisPoints)
+        assertEquals(3_000L, report.summary.foodCostBasisPoints)
+        assertTrue(report.summary.hasRevenue)
+    }
+
+    @Test
+    fun aggregate_truncatesRatioMathTowardZeroWithoutFloats() {
+        val report = SmallBusinessPnlEngine.aggregate(
+            lineItems = listOf(
+                item("revenue", PnlLineItemType.REVENUE, 3L, LocalDate(2024, 6, 3)),
+                item("cogs", PnlLineItemType.COST_OF_GOODS_SOLD, 1L, LocalDate(2024, 6, 3)),
+            ),
+            grouping = PnlPeriodGrouping.MONTHLY,
+        )
+
+        assertEquals(6_666L, report.summary.grossMarginBasisPoints)
+        assertEquals(6_666L, report.summary.netMarginBasisPoints)
+        assertEquals(3_333L, report.summary.foodCostBasisPoints)
+    }
+
+    @Test
+    fun aggregate_groupsWeeklyUsingMondayStartAndSundayEnd() {
+        val report = SmallBusinessPnlEngine.aggregate(
+            lineItems = listOf(
+                item("mon-sale", PnlLineItemType.REVENUE, 10_000L, LocalDate(2024, 6, 3)),
+                item("sun-cogs", PnlLineItemType.COST_OF_GOODS_SOLD, 2_500L, LocalDate(2024, 6, 9)),
+                item("next-mon-sale", PnlLineItemType.REVENUE, 20_000L, LocalDate(2024, 6, 10)),
+                item("next-mon-labor", PnlLineItemType.LABOR, 5_000L, LocalDate(2024, 6, 10)),
+            ),
+            grouping = PnlPeriodGrouping.WEEKLY,
+        )
+
+        assertEquals(listOf("W-2024-06-03", "W-2024-06-10"), report.periods.map { it.period.key })
+        assertEquals(LocalDate(2024, 6, 3), report.periods[0].period.startDate)
+        assertEquals(LocalDate(2024, 6, 9), report.periods[0].period.endDate)
+        assertEquals(10_000L, report.periods[0].summary.revenueCents)
+        assertEquals(2_500L, report.periods[0].summary.cogsCents)
+        assertEquals(7_500L, report.periods[0].summary.netProfitCents)
+        assertEquals(listOf("mon-sale", "sun-cogs"), report.periods[0].lineItemIds)
+        assertEquals(20_000L, report.periods[1].summary.revenueCents)
+        assertEquals(15_000L, report.periods[1].summary.netProfitCents)
+    }
+
+    @Test
+    fun aggregate_groupsMonthlyAndCanFilterDateRange() {
+        val report = SmallBusinessPnlEngine.aggregate(
+            lineItems = listOf(
+                item("may-sale", PnlLineItemType.REVENUE, 50_000L, LocalDate(2024, 5, 31)),
+                item("june-sale", PnlLineItemType.REVENUE, 100_000L, LocalDate(2024, 6, 1)),
+                item("june-cogs", PnlLineItemType.COST_OF_GOODS_SOLD, 35_000L, LocalDate(2024, 6, 30)),
+                item("july-sale", PnlLineItemType.REVENUE, 999_999L, LocalDate(2024, 7, 1)),
+            ),
+            grouping = PnlPeriodGrouping.MONTHLY,
+            from = LocalDate(2024, 5, 1),
+            to = LocalDate(2024, 6, 30),
+        )
+
+        assertEquals(listOf("2024-05", "2024-06"), report.periods.map { it.period.key })
+        assertEquals(LocalDate(2024, 6, 1), report.periods[1].period.startDate)
+        assertEquals(LocalDate(2024, 6, 30), report.periods[1].period.endDate)
+        assertEquals(150_000L, report.summary.revenueCents)
+        assertEquals(35_000L, report.summary.cogsCents)
+        assertFalse(report.periods.any { it.period.key == "2024-07" })
+    }
+
+    @Test
+    fun aggregate_zeroRevenueReturnsDocumentedZeroRatioSentinel() {
+        val report = SmallBusinessPnlEngine.aggregate(
+            lineItems = listOf(
+                item("food", PnlLineItemType.COST_OF_GOODS_SOLD, 7_500L, LocalDate(2024, 6, 3)),
+                item("labor", PnlLineItemType.LABOR, 12_500L, LocalDate(2024, 6, 3)),
+                item("utilities", PnlLineItemType.OVERHEAD, 2_000L, LocalDate(2024, 6, 3)),
+            ),
+            grouping = PnlPeriodGrouping.WEEKLY,
+        )
+
+        assertEquals(0L, report.summary.revenueCents)
+        assertEquals(-22_000L, report.summary.netProfitCents)
+        assertEquals(SmallBusinessPnlEngine.ZERO_REVENUE_RATIO_BASIS_POINTS, report.summary.grossMarginBasisPoints)
+        assertEquals(SmallBusinessPnlEngine.ZERO_REVENUE_RATIO_BASIS_POINTS, report.summary.netMarginBasisPoints)
+        assertEquals(SmallBusinessPnlEngine.ZERO_REVENUE_RATIO_BASIS_POINTS, report.summary.foodCostBasisPoints)
+        assertFalse(report.summary.hasRevenue)
+    }
+
+    @Test
+    fun aggregate_negativeProfitProducesNegativeNetMargin() {
+        val report = SmallBusinessPnlEngine.aggregate(
+            lineItems = listOf(
+                item("sales", PnlLineItemType.REVENUE, 10_000L, LocalDate(2024, 6, 3)),
+                item("food", PnlLineItemType.COST_OF_GOODS_SOLD, 8_000L, LocalDate(2024, 6, 3)),
+                item("labor", PnlLineItemType.LABOR, 3_000L, LocalDate(2024, 6, 3)),
+                item("rent", PnlLineItemType.OVERHEAD, 1_000L, LocalDate(2024, 6, 3)),
+            ),
+            grouping = PnlPeriodGrouping.WEEKLY,
+        )
+
+        assertEquals(2_000L, report.summary.grossProfitCents)
+        assertEquals(-2_000L, report.summary.netProfitCents)
+        assertEquals(2_000L, report.summary.grossMarginBasisPoints)
+        assertEquals(-2_000L, report.summary.netMarginBasisPoints)
+        assertEquals(8_000L, report.summary.foodCostBasisPoints)
+    }
+
+    @Test
+    fun aggregate_acceptsNegativeRevenueAndCostAdjustments() {
+        val report = SmallBusinessPnlEngine.aggregate(
+            inputs = PnlInputs(
+                revenues = listOf(
+                    revenue("sale", 25_000L, LocalDate(2024, 6, 3)),
+                    revenue("refund", -5_000L, LocalDate(2024, 6, 4)),
+                ),
+                costOfGoodsSold = listOf(
+                    cogs("food", 10_000L, LocalDate(2024, 6, 3)),
+                    cogs("vendor-credit", -2_000L, LocalDate(2024, 6, 5)),
+                ),
+            ),
+            grouping = PnlPeriodGrouping.MONTHLY,
+        )
+
+        assertEquals(20_000L, report.summary.revenueCents)
+        assertEquals(8_000L, report.summary.cogsCents)
+        assertEquals(12_000L, report.summary.netProfitCents)
+        assertEquals(4_000L, report.summary.foodCostBasisPoints)
+    }
+
+    @Test
+    fun serialization_roundTripsInputsLineItemsAndReport() {
+        val inputs = PnlInputs(
+            revenues = listOf(revenue("sales", 100_000L, LocalDate(2024, 6, 3), source = "counter")),
+            costOfGoodsSold = listOf(cogs("food", 30_000L, LocalDate(2024, 6, 3), category = "ingredients")),
+            laborCosts = listOf(labor("payroll", 20_000L, LocalDate(2024, 6, 4), role = "kitchen")),
+            overheadCosts = listOf(overhead("rent", 10_000L, LocalDate(2024, 6, 5), category = "facility")),
+        )
+        val lineItem = item("manual", PnlLineItemType.OVERHEAD, 1_234L, LocalDate(2024, 6, 6), memo = "manual")
+        val report = SmallBusinessPnlEngine.aggregate(inputs, PnlPeriodGrouping.MONTHLY)
+
+        assertEquals(inputs, json.decodeFromString<PnlInputs>(json.encodeToString(inputs)))
+        assertEquals(lineItem, json.decodeFromString<PnlLineItem>(json.encodeToString(lineItem)))
+        assertEquals(report, json.decodeFromString<PnlReport>(json.encodeToString(report)))
+    }
+
+    @Test
+    fun validation_rejectsBlankIdsAndInvalidDateRange() {
+        assertFailsWith<IllegalArgumentException> {
+            PnlRevenue(id = " ", amountCents = 1L, date = LocalDate(2024, 6, 3))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            PnlLineItem(id = "", type = PnlLineItemType.REVENUE, amountCents = 1L, date = LocalDate(2024, 6, 3))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            SmallBusinessPnlEngine.aggregate(
+                lineItems = emptyList(),
+                grouping = PnlPeriodGrouping.MONTHLY,
+                from = LocalDate(2024, 6, 30),
+                to = LocalDate(2024, 6, 1),
+            )
+        }
+    }
+
+    private fun revenue(
+        id: String,
+        amountCents: Long,
+        date: LocalDate,
+        source: String? = null,
+    ): PnlRevenue = PnlRevenue(id, amountCents, date, source)
+
+    private fun cogs(
+        id: String,
+        amountCents: Long,
+        date: LocalDate,
+        category: String? = null,
+    ): PnlCostOfGoodsSold = PnlCostOfGoodsSold(id, amountCents, date, category)
+
+    private fun labor(
+        id: String,
+        amountCents: Long,
+        date: LocalDate,
+        role: String? = null,
+    ): PnlLaborCost = PnlLaborCost(id, amountCents, date, role)
+
+    private fun overhead(
+        id: String,
+        amountCents: Long,
+        date: LocalDate,
+        category: String? = null,
+    ): PnlOverheadCost = PnlOverheadCost(id, amountCents, date, category)
+
+    private fun item(
+        id: String,
+        type: PnlLineItemType,
+        amountCents: Long,
+        date: LocalDate,
+        memo: String? = null,
+    ): PnlLineItem = PnlLineItem(id, type, amountCents, date, memo)
+}


### PR DESCRIPTION
Closes #2586. Adds a pure commonMain P&L engine under com.finance.core.pnl with dedicated revenue, COGS, labor, and overhead inputs plus weekly/monthly aggregation. Money is integer cents (Long); margin and food-cost ratios are integer basis points (10,000 = 100%), truncating toward zero, with zero revenue returning 0 bps to avoid divide-by-zero. Tests cover margin math, food-cost %, weekly/monthly grouping, zero revenue, negative profit, adjustments, validation, and serialization round-trips. Verified with .\gradlew.bat :packages:core:jvmTest --console=plain.