### PR TITLE
feat(core): shared KMP business/personal expense split (#2582)

### DIFF
--- a/packages/core/src/commonMain/kotlin/com/finance/core/expensesplit/BusinessExpenseRules.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/expensesplit/BusinessExpenseRules.kt
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.expensesplit
+
+import kotlin.math.roundToInt
+
+const val BUSINESS_EXPENSE_TAG = "business-expense"
+
+object BusinessExpenseFields {
+    const val CATEGORY = "businessExpenseCategory"
+    const val BUSINESS_USE_PERCENT = "businessExpensePercent"
+    const val DEDUCTIBLE_PERCENT = "businessExpenseDeductionPercent"
+    const val NOTE = "businessExpenseNote"
+    const val SOURCE = "businessExpenseSource"
+    const val TAGGED_AT = "businessExpenseTaggedAt"
+}
+
+/** KMP port of apps/web/src/lib/mileage/expenseRules.ts business expense rules. */
+object BusinessExpenseRules {
+    private val rules = linkedMapOf(
+        ExpenseCategory.TRAVEL to ExpenseCategoryRule(
+            label = "Travel",
+            deductiblePercent = 100,
+            keywords = listOf("travel", "hotel", "airfare", "flight", "parking", "toll", "uber", "lyft"),
+            description = "Business trips, lodging, parking, tolls, and other travel costs.",
+        ),
+        ExpenseCategory.MEALS to ExpenseCategoryRule(
+            label = "Meals (50%)",
+            deductiblePercent = 50,
+            keywords = listOf("meal", "restaurant", "coffee", "lunch", "dinner", "catering", "cafe"),
+            description = "Business meals are typically only 50% deductible.",
+        ),
+        ExpenseCategory.EQUIPMENT to ExpenseCategoryRule(
+            label = "Equipment",
+            deductiblePercent = 100,
+            keywords = listOf("equipment", "computer", "laptop", "monitor", "printer", "office depot"),
+            description = "Work equipment, devices, and office hardware.",
+        ),
+        ExpenseCategory.HOME_OFFICE to ExpenseCategoryRule(
+            label = "Home Office",
+            deductiblePercent = 100,
+            keywords = listOf("home office", "internet", "utilities", "rent", "desk", "chair"),
+            description = "Dedicated workspace expenses and home office overhead.",
+        ),
+        ExpenseCategory.PROFESSIONAL_SERVICES to ExpenseCategoryRule(
+            label = "Professional Services",
+            deductiblePercent = 100,
+            keywords = listOf("accounting", "bookkeeping", "legal", "consulting", "payroll", "tax prep"),
+            description = "Professional fees for legal, accounting, and other services.",
+        ),
+        ExpenseCategory.SUBSCRIPTIONS to ExpenseCategoryRule(
+            label = "Subscriptions",
+            deductiblePercent = 100,
+            keywords = listOf("subscription", "saas", "software", "adobe", "github", "notion", "zoom"),
+            description = "Recurring software and business service subscriptions.",
+        ),
+    )
+
+    fun getExpenseCategoryLabel(category: ExpenseCategory): String = ruleFor(category).label
+
+    fun getDeductiblePercentForCategory(category: ExpenseCategory): Int = ruleFor(category).deductiblePercent
+
+    fun getExpenseCategoryOptions(): List<ExpenseCategoryOption> = rules.map { (category, rule) ->
+        ExpenseCategoryOption(
+            value = category,
+            label = rule.label,
+            deductiblePercent = rule.deductiblePercent,
+            description = rule.description,
+        )
+    }
+
+    fun inferExpenseCategory(
+        payee: String?,
+        note: String? = null,
+        tags: List<String> = emptyList(),
+        categoryName: String? = null,
+    ): ExpenseCategory? {
+        val normalizedText = listOf(payee, note, categoryName, tags.joinToString(" "))
+            .filterNot { it.isNullOrBlank() }
+            .joinToString(" ")
+            .lowercase()
+
+        if (normalizedText.isEmpty()) return null
+
+        var bestMatch: Pair<ExpenseCategory, Int>? = null
+        for ((category, rule) in rules) {
+            val score = rule.keywords.count { keyword -> normalizedText.contains(keyword) }
+            if (score > 0 && (bestMatch == null || score > bestMatch.second)) {
+                bestMatch = category to score
+            }
+        }
+        return bestMatch?.first
+    }
+
+    fun parseBusinessExpenseMetadata(transaction: BusinessExpenseTransactionInput): BusinessExpenseMetadata? {
+        val customFields = transaction.customFields.orEmpty()
+        val storedCategory = parseExpenseCategory(customFields[BusinessExpenseFields.CATEGORY])
+        val category = storedCategory ?: inferExpenseCategory(
+            payee = transaction.payee,
+            note = transaction.note,
+            tags = transaction.tags,
+            categoryName = transaction.categoryName,
+        )
+        val hasBusinessFlag = transaction.tags.contains(BUSINESS_EXPENSE_TAG) ||
+            customFields.containsKey(BusinessExpenseFields.CATEGORY)
+
+        if (!hasBusinessFlag || category == null) return null
+
+        val deductiblePercent = parsePercent(customFields[BusinessExpenseFields.DEDUCTIBLE_PERCENT])
+            ?: getDeductiblePercentForCategory(category)
+
+        return BusinessExpenseMetadata(
+            category = category,
+            businessUsePercent = parsePercent(customFields[BusinessExpenseFields.BUSINESS_USE_PERCENT]) ?: 100,
+            deductiblePercent = deductiblePercent,
+            note = customFields[BusinessExpenseFields.NOTE].orEmpty(),
+            source = parseSource(customFields[BusinessExpenseFields.SOURCE]) ?: BusinessExpenseSource.MANUAL,
+            taggedAt = customFields[BusinessExpenseFields.TAGGED_AT].orEmpty(),
+        )
+    }
+
+    fun getBusinessExpenseDefaults(transaction: BusinessExpenseTransactionInput): BusinessExpenseMetadata {
+        parseBusinessExpenseMetadata(transaction)?.let { return it }
+        val inferredCategory = inferExpenseCategory(
+            payee = transaction.payee,
+            note = transaction.note,
+            tags = transaction.tags,
+            categoryName = transaction.categoryName,
+        ) ?: ExpenseCategory.TRAVEL
+        return BusinessExpenseMetadata(
+            category = inferredCategory,
+            businessUsePercent = 100,
+            deductiblePercent = getDeductiblePercentForCategory(inferredCategory),
+            note = "",
+            source = BusinessExpenseSource.RULE,
+            taggedAt = "",
+        )
+    }
+
+    fun classifyBusinessExpense(transaction: BusinessExpenseTransactionInput): BusinessExpenseClassification? {
+        if (transaction.type != TransactionKind.EXPENSE) return null
+        val metadata = parseBusinessExpenseMetadata(transaction) ?: return null
+        val amountCents = absoluteValue(transaction.amountCents)
+        val deductibleAmountCents = roundHalfUp(
+            amountCents * metadata.businessUsePercent.toLong() * metadata.deductiblePercent.toLong(),
+            10_000L,
+        )
+
+        return BusinessExpenseClassification(
+            transactionId = transaction.id,
+            date = transaction.date,
+            payee = transaction.payee?.trim()?.takeIf { it.isNotEmpty() }
+                ?: transaction.note?.trim()?.takeIf { it.isNotEmpty() }
+                ?: "Business expense",
+            amountCents = amountCents,
+            deductibleAmountCents = deductibleAmountCents,
+            categoryLabel = getExpenseCategoryLabel(metadata.category),
+            category = metadata.category,
+            businessUsePercent = metadata.businessUsePercent,
+            deductiblePercent = metadata.deductiblePercent,
+            note = metadata.note,
+            source = metadata.source,
+            taggedAt = metadata.taggedAt,
+        )
+    }
+
+    fun isBusinessExpenseTransaction(transaction: BusinessExpenseTransactionInput): Boolean =
+        parseBusinessExpenseMetadata(transaction) != null
+
+    private fun ruleFor(category: ExpenseCategory): ExpenseCategoryRule =
+        rules.getValue(category)
+
+    private fun parsePercent(raw: String?): Int? {
+        if (raw.isNullOrBlank()) return null
+        val parsed = raw.toDoubleOrNull() ?: return null
+        return if (parsed.isFinite()) normalizePercent(parsed) else null
+    }
+
+    private fun normalizePercent(value: Double): Int = value.roundToInt().coerceIn(0, 100)
+
+    private fun parseExpenseCategory(raw: String?): ExpenseCategory? = when (raw) {
+        "travel" -> ExpenseCategory.TRAVEL
+        "meals" -> ExpenseCategory.MEALS
+        "equipment" -> ExpenseCategory.EQUIPMENT
+        "home-office" -> ExpenseCategory.HOME_OFFICE
+        "professional-services" -> ExpenseCategory.PROFESSIONAL_SERVICES
+        "subscriptions" -> ExpenseCategory.SUBSCRIPTIONS
+        else -> null
+    }
+
+    private fun parseSource(raw: String?): BusinessExpenseSource? = when (raw) {
+        "manual" -> BusinessExpenseSource.MANUAL
+        "rule" -> BusinessExpenseSource.RULE
+        else -> null
+    }
+
+    private fun roundHalfUp(numerator: Long, denominator: Long): Long =
+        (numerator + denominator / 2L) / denominator
+
+    private fun absoluteValue(value: Long): Long = if (value < 0L) -value else value
+}
+
+data class ExpenseCategoryRule(
+    val label: String,
+    val deductiblePercent: Int,
+    val keywords: List<String>,
+    val description: String,
+)
+
+data class ExpenseCategoryOption(
+    val value: ExpenseCategory,
+    val label: String,
+    val deductiblePercent: Int,
+    val description: String,
+)

--- a/packages/core/src/commonMain/kotlin/com/finance/core/expensesplit/ExpenseSplitEngine.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/expensesplit/ExpenseSplitEngine.kt
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.expensesplit
+
+import kotlinx.datetime.LocalDate
+
+/**
+ * Pure KMP port of the web expense-separation engine.
+ *
+ * Amounts are integer cents. Split business cents use banker's rounding for web parity.
+ * The personal side is then calculated as `total - business`, so split portions always
+ * sum back exactly to the original total; any rounding remainder cent is assigned to personal.
+ */
+object ExpenseSplitEngine {
+
+    fun businessPortion(
+        amountCents: Long,
+        expenseType: ExpenseType,
+        splitRatio: SplitRatio? = null,
+    ): Long = when (expenseType) {
+        ExpenseType.PERSONAL -> 0L
+        ExpenseType.BUSINESS -> amountCents
+        ExpenseType.SPLIT -> {
+            val ratio = requireValidSplitRatio(splitRatio)
+            roundedPercent(amountCents, ratio.businessPercent)
+        }
+    }
+
+    fun personalPortion(
+        amountCents: Long,
+        expenseType: ExpenseType,
+        splitRatio: SplitRatio? = null,
+    ): Long = splitAmounts(amountCents, expenseType, splitRatio).personalCents
+
+    fun splitAmounts(
+        totalCents: Long,
+        expenseType: ExpenseType,
+        splitRatio: SplitRatio? = null,
+    ): SplitAmounts = when (expenseType) {
+        ExpenseType.BUSINESS -> SplitAmounts(
+            totalCents = totalCents,
+            businessCents = totalCents,
+            personalCents = 0L,
+            remainderAssignedTo = RemainderTarget.NONE,
+        )
+
+        ExpenseType.PERSONAL -> SplitAmounts(
+            totalCents = totalCents,
+            businessCents = 0L,
+            personalCents = totalCents,
+            remainderAssignedTo = RemainderTarget.NONE,
+        )
+
+        ExpenseType.SPLIT -> {
+            val ratio = requireValidSplitRatio(splitRatio)
+            val business = roundedPercent(totalCents, ratio.businessPercent)
+            val directPersonal = roundedPercent(totalCents, ratio.personalPercent)
+            val personal = totalCents - business
+            SplitAmounts(
+                totalCents = totalCents,
+                businessCents = business,
+                personalCents = personal,
+                remainderAssignedTo = if (business + directPersonal == totalCents) {
+                    RemainderTarget.NONE
+                } else {
+                    RemainderTarget.PERSONAL
+                },
+            )
+        }
+    }
+
+    fun classifyTransaction(
+        transaction: ExpenseSplitTransaction,
+        expenseType: ExpenseType,
+        splitRatio: SplitRatio? = null,
+        isDeductible: Boolean = false,
+        deductionCategory: String? = null,
+    ): ClassifiedExpense {
+        if (expenseType == ExpenseType.SPLIT) {
+            requireValidSplitRatio(splitRatio)
+        }
+
+        return ClassifiedExpense(
+            transaction = transaction,
+            expenseType = expenseType,
+            splitRatio = if (expenseType == ExpenseType.SPLIT) splitRatio else null,
+            isDeductible = isDeductible && expenseType != ExpenseType.PERSONAL,
+            deductionCategory = deductionCategory?.takeIf { it.isNotBlank() },
+        )
+    }
+
+    fun businessExpenses(classified: List<ClassifiedExpense>): List<ClassifiedExpense> =
+        classified.filter { it.expenseType != ExpenseType.PERSONAL }
+
+    fun personalExpenses(classified: List<ClassifiedExpense>): List<ClassifiedExpense> =
+        classified.filter { it.expenseType == ExpenseType.PERSONAL }
+
+    fun taxDeductibleExpenses(classified: List<ClassifiedExpense>): List<ClassifiedExpense> =
+        classified.filter { it.isDeductible && it.expenseType != ExpenseType.PERSONAL }
+
+    fun filterByDateRange(
+        classified: List<ClassifiedExpense>,
+        periodStart: LocalDate,
+        periodEnd: LocalDate,
+    ): List<ClassifiedExpense> {
+        require(periodStart <= periodEnd) { "periodStart must be <= periodEnd" }
+        return classified.filter { it.transaction.date in periodStart..periodEnd }
+    }
+
+    fun generateBusinessExpenseReport(
+        classified: List<ClassifiedExpense>,
+        periodStart: LocalDate,
+        periodEnd: LocalDate,
+    ): BusinessExpenseReport {
+        require(periodStart <= periodEnd) { "periodStart must be <= periodEnd" }
+        val inRange = classified.filter {
+            it.transaction.date in periodStart..periodEnd && it.expenseType != ExpenseType.PERSONAL
+        }
+
+        var totalBusinessCents = 0L
+        var totalDeductibleCents = 0L
+        var totalSplitBusinessPortionCents = 0L
+        val categoryBreakdown = mutableMapOf<String, Long>()
+
+        for (item in inRange) {
+            val business = businessPortion(
+                amountCents = item.transaction.amountCents,
+                expenseType = item.expenseType,
+                splitRatio = item.splitRatio,
+            )
+            totalBusinessCents += business
+            if (item.isDeductible) {
+                totalDeductibleCents += business
+            }
+            if (item.expenseType == ExpenseType.SPLIT) {
+                totalSplitBusinessPortionCents += business
+            }
+            categoryBreakdown[item.transaction.category] =
+                (categoryBreakdown[item.transaction.category] ?: 0L) + business
+        }
+
+        return BusinessExpenseReport(
+            periodStart = periodStart,
+            periodEnd = periodEnd,
+            totalBusinessCents = totalBusinessCents,
+            totalDeductibleCents = totalDeductibleCents,
+            totalSplitBusinessPortionCents = totalSplitBusinessPortionCents,
+            transactions = inRange,
+            categoryBreakdown = categoryBreakdown,
+        )
+    }
+
+    fun quarterlyBusinessSummary(
+        classified: List<ClassifiedExpense>,
+        year: Int,
+    ): List<QuarterlyBusinessSummary> = Quarter.entries.map { quarter ->
+        val inQuarter = classified.filter { item ->
+            item.transaction.date.year == year &&
+                item.transaction.date.monthNumber in quarterStartMonth(quarter)..quarterEndMonth(quarter) &&
+                item.expenseType != ExpenseType.PERSONAL
+        }
+
+        var totalBusinessCents = 0L
+        var totalDeductibleCents = 0L
+        val categoryBreakdown = mutableMapOf<String, Long>()
+
+        for (item in inQuarter) {
+            val business = businessPortion(item.transaction.amountCents, item.expenseType, item.splitRatio)
+            totalBusinessCents += business
+            if (item.isDeductible) {
+                totalDeductibleCents += business
+            }
+            categoryBreakdown[item.transaction.category] =
+                (categoryBreakdown[item.transaction.category] ?: 0L) + business
+        }
+
+        QuarterlyBusinessSummary(
+            quarter = quarter,
+            year = year,
+            totalBusinessCents = totalBusinessCents,
+            totalDeductibleCents = totalDeductibleCents,
+            categoryBreakdown = categoryBreakdown,
+        )
+    }
+
+    fun quarterFromDate(date: LocalDate): Quarter = when (date.monthNumber) {
+        in 1..3 -> Quarter.Q1
+        in 4..6 -> Quarter.Q2
+        in 7..9 -> Quarter.Q3
+        else -> Quarter.Q4
+    }
+
+    fun yearFromDate(date: LocalDate): Int = date.year
+
+    fun calculateAllocation(config: AllocationConfig): Long {
+        if (config.quantity <= 0L || config.rateOrPercent <= 0L) return 0L
+        return when (config.type) {
+            AllocationType.MILEAGE -> bankersRound(config.rateOrPercent * config.quantity, 1L)
+            AllocationType.HOME_OFFICE -> bankersRound(config.quantity * config.rateOrPercent, 100L)
+        }
+    }
+
+    fun validateSplitRatio(splitRatio: SplitRatio?): ExpenseSplitValidationResult {
+        val errors = mutableListOf<String>()
+        if (splitRatio == null) {
+            errors.add("Split ratio is required for split expenses")
+        } else {
+            if (splitRatio.businessPercent !in 0..100) {
+                errors.add("Business percent must be between 0 and 100")
+            }
+            if (splitRatio.personalPercent !in 0..100) {
+                errors.add("Personal percent must be between 0 and 100")
+            }
+            val sum = splitRatio.businessPercent + splitRatio.personalPercent
+            if (sum != 100) {
+                errors.add("Split ratio must sum to 100, got $sum")
+            }
+        }
+        return if (errors.isEmpty()) {
+            ExpenseSplitValidationResult.Valid
+        } else {
+            ExpenseSplitValidationResult(isValid = false, errors = errors)
+        }
+    }
+
+    fun validateClassification(classifiedExpense: ClassifiedExpense): ExpenseSplitValidationResult {
+        val errors = mutableListOf<String>()
+        if (classifiedExpense.expenseType == ExpenseType.SPLIT) {
+            errors.addAll(validateSplitRatio(classifiedExpense.splitRatio).errors)
+        } else if (classifiedExpense.splitRatio != null) {
+            errors.add("Split ratio is only allowed for split expenses")
+        }
+        if (classifiedExpense.expenseType == ExpenseType.PERSONAL && classifiedExpense.isDeductible) {
+            errors.add("Personal expenses cannot be deductible")
+        }
+        return if (errors.isEmpty()) {
+            ExpenseSplitValidationResult.Valid
+        } else {
+            ExpenseSplitValidationResult(isValid = false, errors = errors)
+        }
+    }
+
+    private fun requireValidSplitRatio(splitRatio: SplitRatio?): SplitRatio {
+        val validation = validateSplitRatio(splitRatio)
+        require(validation.isValid) { validation.errors.joinToString("; ") }
+        return splitRatio!!
+    }
+
+    private fun roundedPercent(amountCents: Long, percent: Int): Long =
+        bankersRound(amountCents * percent.toLong(), 100L)
+
+    private fun bankersRound(numerator: Long, denominator: Long): Long {
+        require(denominator > 0L) { "denominator must be > 0" }
+        if (numerator == 0L) return 0L
+
+        val sign = if (numerator < 0L) -1L else 1L
+        val absoluteNumerator = if (numerator < 0L) -numerator else numerator
+        val quotient = absoluteNumerator / denominator
+        val remainder = absoluteNumerator % denominator
+        val doubledRemainder = remainder * 2L
+        val roundedMagnitude = when {
+            doubledRemainder < denominator -> quotient
+            doubledRemainder > denominator -> quotient + 1L
+            quotient % 2L == 0L -> quotient
+            else -> quotient + 1L
+        }
+        return roundedMagnitude * sign
+    }
+
+    private fun quarterStartMonth(quarter: Quarter): Int = when (quarter) {
+        Quarter.Q1 -> 1
+        Quarter.Q2 -> 4
+        Quarter.Q3 -> 7
+        Quarter.Q4 -> 10
+    }
+
+    private fun quarterEndMonth(quarter: Quarter): Int = when (quarter) {
+        Quarter.Q1 -> 3
+        Quarter.Q2 -> 6
+        Quarter.Q3 -> 9
+        Quarter.Q4 -> 12
+    }
+}

--- a/packages/core/src/commonMain/kotlin/com/finance/core/expensesplit/ExpenseSplitModels.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/expensesplit/ExpenseSplitModels.kt
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.expensesplit
+
+import kotlinx.datetime.LocalDate
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/** Business/personal classification for an expense. */
+@Serializable
+enum class ExpenseType {
+    @SerialName("business")
+    BUSINESS,
+
+    @SerialName("personal")
+    PERSONAL,
+
+    @SerialName("split")
+    SPLIT,
+}
+
+/** Ratio for split expenses. Percentages are whole numbers and must sum to 100 when valid. */
+@Serializable
+data class SplitRatio(
+    val businessPercent: Int,
+    val personalPercent: Int,
+)
+
+/** Lightweight platform-neutral transaction input for expense split calculations. */
+@Serializable
+data class ExpenseSplitTransaction(
+    val id: String,
+    val merchant: String,
+    val category: String,
+    val amountCents: Long,
+    val date: LocalDate,
+    val tags: List<String> = emptyList(),
+    val note: String = "",
+)
+
+/** A transaction tagged with business, personal, or split treatment. */
+@Serializable
+data class ClassifiedExpense(
+    val transaction: ExpenseSplitTransaction,
+    val expenseType: ExpenseType,
+    val splitRatio: SplitRatio? = null,
+    val isDeductible: Boolean = false,
+    val deductionCategory: String? = null,
+)
+
+/** Exact split of a transaction amount. */
+@Serializable
+data class SplitAmounts(
+    val totalCents: Long,
+    val businessCents: Long,
+    val personalCents: Long,
+    val remainderAssignedTo: RemainderTarget,
+)
+
+/** Which side receives any cent needed to make rounded split portions sum exactly to total. */
+@Serializable
+enum class RemainderTarget {
+    NONE,
+    BUSINESS,
+    PERSONAL,
+}
+
+@Serializable
+enum class Quarter {
+    Q1,
+    Q2,
+    Q3,
+    Q4,
+}
+
+/** Business expense report for an inclusive date range. */
+@Serializable
+data class BusinessExpenseReport(
+    val periodStart: LocalDate,
+    val periodEnd: LocalDate,
+    val totalBusinessCents: Long,
+    val totalDeductibleCents: Long,
+    val totalSplitBusinessPortionCents: Long,
+    val transactions: List<ClassifiedExpense>,
+    val categoryBreakdown: Map<String, Long>,
+)
+
+/** Business totals for a calendar quarter. */
+@Serializable
+data class QuarterlyBusinessSummary(
+    val quarter: Quarter,
+    val year: Int,
+    val totalBusinessCents: Long,
+    val totalDeductibleCents: Long,
+    val categoryBreakdown: Map<String, Long>,
+)
+
+@Serializable
+enum class AllocationType {
+    @SerialName("mileage")
+    MILEAGE,
+
+    @SerialName("home-office")
+    HOME_OFFICE,
+}
+
+/** Mileage or home-office allocation input. */
+@Serializable
+data class AllocationConfig(
+    val type: AllocationType,
+    val rateOrPercent: Long,
+    val quantity: Long,
+)
+
+/** Validation outcome that keeps all errors instead of failing fast. */
+@Serializable
+data class ExpenseSplitValidationResult(
+    val isValid: Boolean,
+    val errors: List<String> = emptyList(),
+) {
+    companion object {
+        val Valid = ExpenseSplitValidationResult(isValid = true)
+    }
+}
+
+@Serializable
+enum class TransactionKind {
+    EXPENSE,
+    INCOME,
+    TRANSFER,
+}
+
+@Serializable
+enum class ExpenseCategory {
+    @SerialName("travel")
+    TRAVEL,
+
+    @SerialName("meals")
+    MEALS,
+
+    @SerialName("equipment")
+    EQUIPMENT,
+
+    @SerialName("home-office")
+    HOME_OFFICE,
+
+    @SerialName("professional-services")
+    PROFESSIONAL_SERVICES,
+
+    @SerialName("subscriptions")
+    SUBSCRIPTIONS,
+}
+
+@Serializable
+enum class BusinessExpenseSource {
+    @SerialName("manual")
+    MANUAL,
+
+    @SerialName("rule")
+    RULE,
+}
+
+/** Metadata stored by the web business-expense tagger. */
+@Serializable
+data class BusinessExpenseMetadata(
+    val category: ExpenseCategory,
+    val businessUsePercent: Int,
+    val deductiblePercent: Int,
+    val note: String = "",
+    val source: BusinessExpenseSource = BusinessExpenseSource.MANUAL,
+    val taggedAt: String = "",
+)
+
+/** Transaction shape used by the web business-expense rules. */
+@Serializable
+data class BusinessExpenseTransactionInput(
+    val id: String,
+    val date: LocalDate,
+    val payee: String? = null,
+    val note: String? = null,
+    val amountCents: Long,
+    val type: TransactionKind,
+    val tags: List<String> = emptyList(),
+    val customFields: Map<String, String>? = null,
+    val categoryName: String? = null,
+)
+
+/** Deductible business-expense classification derived from tags/custom fields. */
+@Serializable
+data class BusinessExpenseClassification(
+    val transactionId: String,
+    val date: LocalDate,
+    val payee: String,
+    val amountCents: Long,
+    val deductibleAmountCents: Long,
+    val deductionType: String = "business-expense",
+    val categoryLabel: String,
+    val category: ExpenseCategory,
+    val businessUsePercent: Int,
+    val deductiblePercent: Int,
+    val note: String = "",
+    val source: BusinessExpenseSource = BusinessExpenseSource.MANUAL,
+    val taggedAt: String = "",
+)

--- a/packages/core/src/commonTest/kotlin/com/finance/core/expensesplit/ExpenseSplitEngineTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/expensesplit/ExpenseSplitEngineTest.kt
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.expensesplit
+
+import kotlinx.datetime.LocalDate
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.test.assertFailsWith
+
+class ExpenseSplitEngineTest {
+    private val tx1 = ExpenseSplitTransaction(
+        id = "t1",
+        merchant = "Office Depot",
+        category = "Office Supplies",
+        amountCents = 5_000L,
+        date = LocalDate.parse("2024-02-15"),
+    )
+    private val tx2 = ExpenseSplitTransaction(
+        id = "t2",
+        merchant = "Whole Foods",
+        category = "Groceries",
+        amountCents = 8_000L,
+        date = LocalDate.parse("2024-05-20"),
+    )
+    private val tx3 = ExpenseSplitTransaction(
+        id = "t3",
+        merchant = "WeWork",
+        category = "Office Rent",
+        amountCents = 200_000L,
+        date = LocalDate.parse("2024-07-01"),
+    )
+
+    @Test
+    fun businessPortion_matchesWebFixtures() {
+        assertEquals(10_000L, ExpenseSplitEngine.businessPortion(10_000L, ExpenseType.BUSINESS))
+        assertEquals(0L, ExpenseSplitEngine.businessPortion(10_000L, ExpenseType.PERSONAL))
+        assertEquals(
+            6_000L,
+            ExpenseSplitEngine.businessPortion(10_000L, ExpenseType.SPLIT, SplitRatio(60, 40)),
+        )
+        assertEquals(
+            3_300L,
+            ExpenseSplitEngine.businessPortion(10_001L, ExpenseType.SPLIT, SplitRatio(33, 67)),
+        )
+    }
+
+    @Test
+    fun splitAmounts_alwaysSumExactlyAndAssignRemainderToPersonal() {
+        for (amount in -10_003L..10_003L) {
+            for (businessPercent in 0..100) {
+                val split = ExpenseSplitEngine.splitAmounts(
+                    totalCents = amount,
+                    expenseType = ExpenseType.SPLIT,
+                    splitRatio = SplitRatio(businessPercent, 100 - businessPercent),
+                )
+
+                assertEquals(amount, split.businessCents + split.personalCents)
+                if (split.remainderAssignedTo == RemainderTarget.PERSONAL) {
+                    val directPersonal = ExpenseSplitEngine.businessPortion(
+                        amount,
+                        ExpenseType.SPLIT,
+                        SplitRatio(100 - businessPercent, businessPercent),
+                    )
+                    assertFalse(split.personalCents == directPersonal)
+                }
+            }
+        }
+
+        val halfCent = ExpenseSplitEngine.splitAmounts(1L, ExpenseType.SPLIT, SplitRatio(50, 50))
+        assertEquals(0L, halfCent.businessCents)
+        assertEquals(1L, halfCent.personalCents)
+        assertEquals(RemainderTarget.PERSONAL, halfCent.remainderAssignedTo)
+    }
+
+    @Test
+    fun classifyTransaction_derivesPersonalAsNonDeductibleAndKeepsSplitRatio() {
+        val business = ExpenseSplitEngine.classifyTransaction(
+            tx1,
+            ExpenseType.BUSINESS,
+            isDeductible = true,
+            deductionCategory = "Supplies",
+        )
+        assertEquals(ExpenseType.BUSINESS, business.expenseType)
+        assertTrue(business.isDeductible)
+        assertEquals("Supplies", business.deductionCategory)
+        assertNull(business.splitRatio)
+
+        val personal = ExpenseSplitEngine.classifyTransaction(tx2, ExpenseType.PERSONAL, isDeductible = true)
+        assertEquals(ExpenseType.PERSONAL, personal.expenseType)
+        assertFalse(personal.isDeductible)
+
+        val split = ExpenseSplitEngine.classifyTransaction(
+            tx3,
+            ExpenseType.SPLIT,
+            splitRatio = SplitRatio(70, 30),
+            isDeductible = true,
+        )
+        assertEquals(ExpenseType.SPLIT, split.expenseType)
+        assertEquals(SplitRatio(70, 30), split.splitRatio)
+        assertTrue(split.isDeductible)
+    }
+
+    @Test
+    fun classifyTransaction_rejectsInvalidSplitRatio() {
+        val error = assertFailsWith<IllegalArgumentException> {
+            ExpenseSplitEngine.classifyTransaction(tx1, ExpenseType.SPLIT, SplitRatio(60, 60))
+        }
+        assertTrue(error.message!!.contains("Split ratio must sum to 100"))
+    }
+
+    @Test
+    fun validationReportsBoundsAndConsistencyEdges() {
+        val missing = ExpenseSplitEngine.validateSplitRatio(null)
+        assertFalse(missing.isValid)
+        assertTrue(missing.errors.any { it.contains("required") })
+
+        val invalidRatio = ExpenseSplitEngine.validateSplitRatio(SplitRatio(-1, 102))
+        assertFalse(invalidRatio.isValid)
+        assertEquals(3, invalidRatio.errors.size)
+
+        val nonSplitWithRatio = ExpenseSplitEngine.validateClassification(
+            ClassifiedExpense(tx1, ExpenseType.BUSINESS, splitRatio = SplitRatio(50, 50)),
+        )
+        assertFalse(nonSplitWithRatio.isValid)
+        assertTrue(nonSplitWithRatio.errors.any { it.contains("only allowed") })
+
+        val personalDeductible = ExpenseSplitEngine.validateClassification(
+            ClassifiedExpense(tx2, ExpenseType.PERSONAL, isDeductible = true),
+        )
+        assertFalse(personalDeductible.isValid)
+        assertTrue(personalDeductible.errors.any { it.contains("Personal expenses") })
+    }
+
+    @Test
+    fun reportingFilters_returnExpectedExpenseSets() {
+        val classified = listOf(
+            ExpenseSplitEngine.classifyTransaction(tx1, ExpenseType.BUSINESS, isDeductible = true),
+            ExpenseSplitEngine.classifyTransaction(tx2, ExpenseType.PERSONAL),
+            ExpenseSplitEngine.classifyTransaction(tx3, ExpenseType.SPLIT, SplitRatio(50, 50), true),
+        )
+
+        assertEquals(listOf("t1", "t3"), ExpenseSplitEngine.businessExpenses(classified).map { it.transaction.id })
+        assertEquals(listOf("t2"), ExpenseSplitEngine.personalExpenses(classified).map { it.transaction.id })
+        assertEquals(listOf("t1", "t3"), ExpenseSplitEngine.taxDeductibleExpenses(classified).map { it.transaction.id })
+        assertEquals(
+            listOf("t1", "t2"),
+            ExpenseSplitEngine.filterByDateRange(
+                classified,
+                LocalDate.parse("2024-01-01"),
+                LocalDate.parse("2024-06-30"),
+            ).map { it.transaction.id },
+        )
+    }
+
+    @Test
+    fun generateBusinessExpenseReport_matchesWebTotals() {
+        val classified = listOf(
+            ExpenseSplitEngine.classifyTransaction(tx1, ExpenseType.BUSINESS, isDeductible = true, deductionCategory = "Supplies"),
+            ExpenseSplitEngine.classifyTransaction(tx2, ExpenseType.PERSONAL),
+            ExpenseSplitEngine.classifyTransaction(tx3, ExpenseType.SPLIT, SplitRatio(50, 50), true),
+        )
+
+        val report = ExpenseSplitEngine.generateBusinessExpenseReport(
+            classified,
+            LocalDate.parse("2024-01-01"),
+            LocalDate.parse("2024-12-31"),
+        )
+
+        assertEquals(2, report.transactions.size)
+        assertEquals(105_000L, report.totalBusinessCents)
+        assertEquals(105_000L, report.totalDeductibleCents)
+        assertEquals(100_000L, report.totalSplitBusinessPortionCents)
+        assertEquals(5_000L, report.categoryBreakdown["Office Supplies"])
+        assertEquals(100_000L, report.categoryBreakdown["Office Rent"])
+    }
+
+    @Test
+    fun quarterlyBusinessSummary_matchesWebFixtures() {
+        val classified = listOf(
+            ExpenseSplitEngine.classifyTransaction(tx1, ExpenseType.BUSINESS, isDeductible = true),
+            ExpenseSplitEngine.classifyTransaction(tx3, ExpenseType.BUSINESS, isDeductible = false),
+        )
+
+        val summaries = ExpenseSplitEngine.quarterlyBusinessSummary(classified, 2024)
+        assertEquals(4, summaries.size)
+        assertEquals(5_000L, summaries.single { it.quarter == Quarter.Q1 }.totalBusinessCents)
+        assertEquals(5_000L, summaries.single { it.quarter == Quarter.Q1 }.totalDeductibleCents)
+        assertEquals(200_000L, summaries.single { it.quarter == Quarter.Q3 }.totalBusinessCents)
+        assertEquals(0L, summaries.single { it.quarter == Quarter.Q3 }.totalDeductibleCents)
+        assertEquals(0L, summaries.single { it.quarter == Quarter.Q2 }.totalBusinessCents)
+        assertEquals(0L, summaries.single { it.quarter == Quarter.Q4 }.totalBusinessCents)
+    }
+
+    @Test
+    fun quarterAndYearFromDate_matchWebFixtures() {
+        assertEquals(Quarter.Q1, ExpenseSplitEngine.quarterFromDate(LocalDate.parse("2024-01-15")))
+        assertEquals(Quarter.Q1, ExpenseSplitEngine.quarterFromDate(LocalDate.parse("2024-03-31")))
+        assertEquals(Quarter.Q2, ExpenseSplitEngine.quarterFromDate(LocalDate.parse("2024-04-01")))
+        assertEquals(Quarter.Q2, ExpenseSplitEngine.quarterFromDate(LocalDate.parse("2024-06-30")))
+        assertEquals(Quarter.Q3, ExpenseSplitEngine.quarterFromDate(LocalDate.parse("2024-07-01")))
+        assertEquals(Quarter.Q3, ExpenseSplitEngine.quarterFromDate(LocalDate.parse("2024-09-30")))
+        assertEquals(Quarter.Q4, ExpenseSplitEngine.quarterFromDate(LocalDate.parse("2024-10-01")))
+        assertEquals(Quarter.Q4, ExpenseSplitEngine.quarterFromDate(LocalDate.parse("2024-12-31")))
+        assertEquals(2024, ExpenseSplitEngine.yearFromDate(LocalDate.parse("2024-07-01")))
+    }
+
+    @Test
+    fun calculateAllocation_matchesWebFixtures() {
+        assertEquals(67_000L, ExpenseSplitEngine.calculateAllocation(AllocationConfig(AllocationType.MILEAGE, 67, 1_000)))
+        assertEquals(
+            50_000L,
+            ExpenseSplitEngine.calculateAllocation(AllocationConfig(AllocationType.HOME_OFFICE, 25, 200_000)),
+        )
+        assertEquals(0L, ExpenseSplitEngine.calculateAllocation(AllocationConfig(AllocationType.MILEAGE, 67, 0)))
+        assertEquals(0L, ExpenseSplitEngine.calculateAllocation(AllocationConfig(AllocationType.HOME_OFFICE, 0, 100_000)))
+    }
+
+    @Test
+    fun businessExpenseRules_matchWebInferenceAndDeductionFixture() {
+        val baseTransaction = BusinessExpenseTransactionInput(
+            id = "txn-1",
+            date = LocalDate.parse("2024-06-10"),
+            payee = "Downtown Restaurant",
+            note = "Client lunch",
+            amountCents = -10_000L,
+            type = TransactionKind.EXPENSE,
+            categoryName = "Restaurants",
+        )
+
+        val defaults = BusinessExpenseRules.getBusinessExpenseDefaults(baseTransaction)
+        assertEquals(ExpenseCategory.MEALS, defaults.category)
+        assertEquals(50, defaults.deductiblePercent)
+
+        val classified = BusinessExpenseRules.classifyBusinessExpense(
+            baseTransaction.copy(
+                tags = listOf(BUSINESS_EXPENSE_TAG),
+                customFields = mapOf(
+                    BusinessExpenseFields.CATEGORY to "meals",
+                    BusinessExpenseFields.BUSINESS_USE_PERCENT to "80",
+                    BusinessExpenseFields.DEDUCTIBLE_PERCENT to "50",
+                    BusinessExpenseFields.NOTE to "Lunch with client after onsite workshop",
+                    BusinessExpenseFields.SOURCE to "manual",
+                ),
+            ),
+        )
+
+        assertNotNull(classified)
+        assertEquals(ExpenseCategory.MEALS, classified.category)
+        assertEquals(4_000L, classified.deductibleAmountCents)
+        assertTrue(classified.note.contains("onsite workshop"))
+        assertEquals("Meals (50%)", classified.categoryLabel)
+    }
+
+    @Test
+    fun businessExpenseRules_ignoreNonExpenseAndUntaggedTransactions() {
+        val income = BusinessExpenseTransactionInput(
+            id = "income-1",
+            date = LocalDate.parse("2024-06-10"),
+            payee = "Client",
+            amountCents = 10_000L,
+            type = TransactionKind.INCOME,
+            tags = listOf(BUSINESS_EXPENSE_TAG),
+            customFields = mapOf(BusinessExpenseFields.CATEGORY to "travel"),
+        )
+        assertNull(BusinessExpenseRules.classifyBusinessExpense(income))
+
+        val untagged = income.copy(id = "expense-1", type = TransactionKind.EXPENSE, tags = emptyList(), customFields = null)
+        assertNull(BusinessExpenseRules.classifyBusinessExpense(untagged))
+        assertFalse(BusinessExpenseRules.isBusinessExpenseTransaction(untagged))
+    }
+
+    @Test
+    fun serializesClassifiedExpenseRoundTrip() {
+        val json = Json { encodeDefaults = true }
+        val classified = ExpenseSplitEngine.classifyTransaction(
+            tx3,
+            ExpenseType.SPLIT,
+            splitRatio = SplitRatio(33, 67),
+            isDeductible = true,
+            deductionCategory = "Office Rent",
+        )
+
+        assertEquals(classified, json.decodeFromString<ClassifiedExpense>(json.encodeToString(classified)))
+    }
+
+    @Test
+    fun serializesReportsAndBusinessExpenseClassificationRoundTrip() {
+        val json = Json { encodeDefaults = true }
+        val classified = listOf(
+            ExpenseSplitEngine.classifyTransaction(tx1, ExpenseType.BUSINESS, isDeductible = true),
+            ExpenseSplitEngine.classifyTransaction(tx3, ExpenseType.SPLIT, SplitRatio(50, 50), true),
+        )
+        val report = ExpenseSplitEngine.generateBusinessExpenseReport(
+            classified,
+            LocalDate.parse("2024-01-01"),
+            LocalDate.parse("2024-12-31"),
+        )
+        assertEquals(report, json.decodeFromString<BusinessExpenseReport>(json.encodeToString(report)))
+
+        val businessClassification = BusinessExpenseClassification(
+            transactionId = "txn-1",
+            date = LocalDate.parse("2024-06-10"),
+            payee = "Downtown Restaurant",
+            amountCents = 10_000L,
+            deductibleAmountCents = 4_000L,
+            categoryLabel = "Meals (50%)",
+            category = ExpenseCategory.MEALS,
+            businessUsePercent = 80,
+            deductiblePercent = 50,
+            note = "Client lunch",
+        )
+        assertEquals(
+            businessClassification,
+            json.decodeFromString<BusinessExpenseClassification>(json.encodeToString(businessClassification)),
+        )
+    }
+}


### PR DESCRIPTION
Closes #2582.

Summary:
- Adds shared KMP expense split APIs in `com.finance.core.expensesplit` for BUSINESS/PERSONAL/SPLIT classification, split ratios, exact-sum Long-cent allocations, deductible flags, reporting filters, quarterly/business reports, validation, and serialization-safe models.
- Ports web parity from `apps/web/src/lib/expenses/expense-separation.ts` and fixtures, plus business-expense deduction category inference from `apps/web/src/lib/mileage/expenseRules.ts`.
- Split rounding uses banker rounding for the business portion and assigns any remainder cent to the personal portion so business + personal always equals the original total.

Test coverage:
- `./gradlew.bat :packages:core:jvmTest --console=plain` passes: 2276 tests, 0 failures, 0 errors, 0 skipped.