### PR TITLE
feat(core): shared KMP operating cash forecast engine (#2588)

### DIFF
--- a/packages/core/src/commonMain/kotlin/com/finance/core/forecast/OperatingCashForecast.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/forecast/OperatingCashForecast.kt
@@ -1,0 +1,392 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.forecast
+
+import com.finance.models.types.Cents
+import kotlin.math.roundToLong
+import kotlin.math.sqrt
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.plus
+import kotlinx.serialization.Serializable
+
+/** Cadences supported by the shared operating cash forecast engine. */
+@Serializable
+enum class ForecastCadence {
+    DAILY,
+    WEEKLY,
+    BIWEEKLY,
+    SEMIMONTHLY,
+    MONTHLY,
+    QUARTERLY,
+    YEARLY,
+    EVERY_N_DAYS,
+}
+
+/** Direction of a forecast cash movement. Amounts remain positive; direction controls the sign. */
+@Serializable
+enum class ForecastCashFlowDirection { INFLOW, OUTFLOW }
+
+/** Business purpose for a recurring or scenario cash movement. */
+@Serializable
+enum class ForecastCashFlowKind {
+    PAYROLL,
+    TAX,
+    BILL,
+    TRANSFER,
+    SCENARIO,
+    OTHER,
+}
+
+/** Confidence preset used for horizon low/high bands. */
+@Serializable
+enum class ForecastConfidence {
+    LOW,
+    MEDIUM,
+    HIGH,
+}
+
+/** Origin of a concrete forecast occurrence. */
+@Serializable
+enum class ForecastOccurrenceSource { RECURRING_COMMITMENT, ONE_OFF_SCENARIO }
+
+/** A payroll, tax, bill, or other repeating operating cash commitment. */
+@Serializable
+data class RecurringForecastCommitment(
+    val id: String,
+    val description: String,
+    val amount: Cents,
+    val direction: ForecastCashFlowDirection,
+    val kind: ForecastCashFlowKind,
+    val cadence: ForecastCadence,
+    val nextDueDate: LocalDate,
+    val intervalDays: Int? = null,
+    val endsOn: LocalDate? = null,
+    val maxOccurrences: Int? = null,
+) {
+    init {
+        require(id.isNotBlank()) { "Recurring commitment id cannot be blank" }
+        require(description.isNotBlank()) { "Recurring commitment description cannot be blank" }
+        require(amount.amount >= 0) { "Recurring commitment amount must be non-negative" }
+        require(maxOccurrences == null || maxOccurrences > 0) { "maxOccurrences must be positive" }
+        require(cadence != ForecastCadence.EVERY_N_DAYS || (intervalDays != null && intervalDays > 0)) {
+            "EVERY_N_DAYS commitments require a positive intervalDays"
+        }
+        require(cadence == ForecastCadence.EVERY_N_DAYS || intervalDays == null) {
+            "intervalDays is only valid with EVERY_N_DAYS cadence"
+        }
+    }
+}
+
+/** A one-time what-if entry such as a repair, bonus, tax payment, or bill adjustment. */
+@Serializable
+data class OneOffForecastEntry(
+    val id: String,
+    val description: String,
+    val amount: Cents,
+    val direction: ForecastCashFlowDirection,
+    val kind: ForecastCashFlowKind = ForecastCashFlowKind.SCENARIO,
+    val date: LocalDate,
+) {
+    init {
+        require(id.isNotBlank()) { "One-off entry id cannot be blank" }
+        require(description.isNotBlank()) { "One-off entry description cannot be blank" }
+        require(amount.amount >= 0) { "One-off entry amount must be non-negative" }
+    }
+}
+
+/** A balance floor to detect the first forecast breach. Use zero for overdraft detection. */
+@Serializable
+data class ForecastBalanceThreshold(
+    val id: String,
+    val amount: Cents = Cents.ZERO,
+    val description: String = id,
+) {
+    init {
+        require(id.isNotBlank()) { "Threshold id cannot be blank" }
+    }
+
+    companion object {
+        val ZERO: ForecastBalanceThreshold = ForecastBalanceThreshold(
+            id = "zero",
+            amount = Cents.ZERO,
+            description = "Negative balance",
+        )
+    }
+}
+
+/** Input for a deterministic operating cash forecast. */
+@Serializable
+data class OperatingCashForecastInput(
+    val startDate: LocalDate,
+    val startingBalance: Cents,
+    val horizons: List<Int> = DEFAULT_HORIZONS,
+    val recurringCommitments: List<RecurringForecastCommitment> = emptyList(),
+    val oneOffEntries: List<OneOffForecastEntry> = emptyList(),
+    val thresholds: List<ForecastBalanceThreshold> = listOf(ForecastBalanceThreshold.ZERO),
+    val baselineDailyNet: Cents = Cents.ZERO,
+    val dailyNetDeviation: Cents = Cents.ZERO,
+    val confidence: ForecastConfidence = ForecastConfidence.MEDIUM,
+) {
+    init {
+        require(horizons.isNotEmpty()) { "At least one forecast horizon is required" }
+        require(horizons.all { it >= 0 }) { "Forecast horizons must be non-negative" }
+        require(dailyNetDeviation.amount >= 0) { "Daily net deviation must be non-negative" }
+        require(thresholds.map { it.id }.toSet().size == thresholds.size) { "Threshold ids must be unique" }
+    }
+
+    val maxHorizonDays: Int get() = horizons.maxOrNull() ?: 0
+
+    companion object {
+        val DEFAULT_HORIZONS: List<Int> = listOf(7, 30, 90)
+    }
+}
+
+/** A concrete dated cash movement produced by recurring expansion or one-off scenarios. */
+@Serializable
+data class ForecastOccurrence(
+    val id: String,
+    val sourceId: String,
+    val source: ForecastOccurrenceSource,
+    val description: String,
+    val date: LocalDate,
+    val amount: Cents,
+    val direction: ForecastCashFlowDirection,
+    val kind: ForecastCashFlowKind,
+) {
+    val signedAmount: Cents
+        get() = if (direction == ForecastCashFlowDirection.INFLOW) amount else -amount
+}
+
+/** Expected balance at a day boundary in the forecast timeline. */
+@Serializable
+data class ForecastBalancePoint(
+    val dayIndex: Int,
+    val date: LocalDate,
+    val startingBalance: Cents,
+    val committedInflow: Cents,
+    val committedOutflow: Cents,
+    val baselineNet: Cents,
+    val endingBalance: Cents,
+    val occurrences: List<ForecastOccurrence>,
+)
+
+/** First date a threshold is breached. */
+@Serializable
+data class ForecastThresholdBreach(
+    val thresholdId: String,
+    val thresholdAmount: Cents,
+    val date: LocalDate,
+    val projectedBalance: Cents,
+)
+
+/** Roll-up for a requested horizon using web-parity confidence band math. */
+@Serializable
+data class ForecastHorizonSnapshot(
+    val horizonDays: Int,
+    val targetDate: LocalDate,
+    val expectedBalance: Cents,
+    val lowBalance: Cents,
+    val highBalance: Cents,
+    val committedInflow: Cents,
+    val committedOutflow: Cents,
+    val baselineNet: Cents,
+    val confidence: ForecastConfidence,
+)
+
+/** Complete deterministic forecast output. */
+@Serializable
+data class OperatingCashForecastResult(
+    val startDate: LocalDate,
+    val endDate: LocalDate,
+    val startingBalance: Cents,
+    val balancePoints: List<ForecastBalancePoint>,
+    val horizonSnapshots: List<ForecastHorizonSnapshot>,
+    val occurrences: List<ForecastOccurrence>,
+    val thresholdBreaches: List<ForecastThresholdBreach>,
+) {
+    val endingBalance: Cents get() = balancePoints.lastOrNull()?.endingBalance ?: startingBalance
+}
+
+/** Shared KMP engine for operating cash forecasts. */
+object OperatingCashForecastEngine {
+    fun forecast(input: OperatingCashForecastInput): OperatingCashForecastResult {
+        val endDate = input.startDate.plus(input.maxHorizonDays, DateTimeUnit.DAY)
+        val occurrences = buildOccurrences(input, endDate)
+        val occurrencesByDate = occurrences.groupBy { it.date }
+        val thresholdBreachesById = linkedMapOf<String, ForecastThresholdBreach>()
+        val balancePoints = mutableListOf<ForecastBalancePoint>()
+
+        var currentBalance = input.startingBalance
+        val startPoint = ForecastBalancePoint(
+            dayIndex = 0,
+            date = input.startDate,
+            startingBalance = input.startingBalance,
+            committedInflow = Cents.ZERO,
+            committedOutflow = Cents.ZERO,
+            baselineNet = Cents.ZERO,
+            endingBalance = input.startingBalance,
+            occurrences = emptyList(),
+        )
+        balancePoints += startPoint
+        detectThresholdBreaches(input.thresholds, input.startDate, currentBalance, thresholdBreachesById)
+
+        for (day in 1..input.maxHorizonDays) {
+            val date = input.startDate.plus(day, DateTimeUnit.DAY)
+            val dayOccurrences = occurrencesByDate[date].orEmpty()
+            val inflow = dayOccurrences
+                .filter { it.direction == ForecastCashFlowDirection.INFLOW }
+                .fold(Cents.ZERO) { sum, occurrence -> sum + occurrence.amount }
+            val outflow = dayOccurrences
+                .filter { it.direction == ForecastCashFlowDirection.OUTFLOW }
+                .fold(Cents.ZERO) { sum, occurrence -> sum + occurrence.amount }
+            val startingBalance = currentBalance
+            currentBalance = currentBalance + inflow - outflow + input.baselineDailyNet
+
+            balancePoints += ForecastBalancePoint(
+                dayIndex = day,
+                date = date,
+                startingBalance = startingBalance,
+                committedInflow = inflow,
+                committedOutflow = outflow,
+                baselineNet = input.baselineDailyNet,
+                endingBalance = currentBalance,
+                occurrences = dayOccurrences,
+            )
+            detectThresholdBreaches(input.thresholds, date, currentBalance, thresholdBreachesById)
+        }
+
+        val pointsByDay = balancePoints.associateBy { it.dayIndex }
+        val horizonSnapshots = input.horizons.map { horizonDays ->
+            val point = requireNotNull(pointsByDay[horizonDays]) { "Missing balance point for horizon $horizonDays" }
+            val pointsThroughHorizon = balancePoints.filter { it.dayIndex in 1..horizonDays }
+            ForecastHorizonSnapshot(
+                horizonDays = horizonDays,
+                targetDate = point.date,
+                expectedBalance = point.endingBalance,
+                lowBalance = point.endingBalance - bandFor(input, horizonDays),
+                highBalance = point.endingBalance + bandFor(input, horizonDays),
+                committedInflow = pointsThroughHorizon.fold(Cents.ZERO) { sum, day -> sum + day.committedInflow },
+                committedOutflow = pointsThroughHorizon.fold(Cents.ZERO) { sum, day -> sum + day.committedOutflow },
+                baselineNet = input.baselineDailyNet * horizonDays,
+                confidence = input.confidence,
+            )
+        }
+
+        return OperatingCashForecastResult(
+            startDate = input.startDate,
+            endDate = endDate,
+            startingBalance = input.startingBalance,
+            balancePoints = balancePoints,
+            horizonSnapshots = horizonSnapshots,
+            occurrences = occurrences,
+            thresholdBreaches = thresholdBreachesById.values.toList(),
+        )
+    }
+
+    private fun buildOccurrences(
+        input: OperatingCashForecastInput,
+        endDate: LocalDate,
+    ): List<ForecastOccurrence> {
+        val recurring = input.recurringCommitments.flatMap { commitment ->
+            expandRecurringCommitment(commitment, input.startDate, endDate)
+        }
+        val oneOffs = input.oneOffEntries
+            .filter { entry -> entry.date > input.startDate && entry.date <= endDate }
+            .map { entry ->
+                ForecastOccurrence(
+                    id = "one-off:${entry.id}:${entry.date}",
+                    sourceId = entry.id,
+                    source = ForecastOccurrenceSource.ONE_OFF_SCENARIO,
+                    description = entry.description,
+                    date = entry.date,
+                    amount = entry.amount,
+                    direction = entry.direction,
+                    kind = entry.kind,
+                )
+            }
+
+        return (recurring + oneOffs).sortedWith(
+            compareBy<ForecastOccurrence> { it.date }
+                .thenBy { it.source.name }
+                .thenBy { it.sourceId }
+                .thenBy { it.id },
+        )
+    }
+
+    private fun expandRecurringCommitment(
+        commitment: RecurringForecastCommitment,
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): List<ForecastOccurrence> {
+        val occurrences = mutableListOf<ForecastOccurrence>()
+        var occurrenceDate = commitment.nextDueDate
+        var generatedCount = 0
+
+        while (occurrenceDate <= endDate) {
+            if (commitment.endsOn != null && occurrenceDate > commitment.endsOn) break
+            generatedCount += 1
+            if (commitment.maxOccurrences != null && generatedCount > commitment.maxOccurrences) break
+
+            if (occurrenceDate > startDate) {
+                occurrences += ForecastOccurrence(
+                    id = "recurring:${commitment.id}:$occurrenceDate:$generatedCount",
+                    sourceId = commitment.id,
+                    source = ForecastOccurrenceSource.RECURRING_COMMITMENT,
+                    description = commitment.description,
+                    date = occurrenceDate,
+                    amount = commitment.amount,
+                    direction = commitment.direction,
+                    kind = commitment.kind,
+                )
+            }
+            occurrenceDate = nextOccurrenceDate(commitment, occurrenceDate)
+        }
+
+        return occurrences
+    }
+
+    private fun nextOccurrenceDate(
+        commitment: RecurringForecastCommitment,
+        date: LocalDate,
+    ): LocalDate = when (commitment.cadence) {
+        ForecastCadence.DAILY -> date.plus(1, DateTimeUnit.DAY)
+        ForecastCadence.WEEKLY -> date.plus(7, DateTimeUnit.DAY)
+        ForecastCadence.BIWEEKLY -> date.plus(14, DateTimeUnit.DAY)
+        ForecastCadence.SEMIMONTHLY -> date.plus(15, DateTimeUnit.DAY)
+        ForecastCadence.MONTHLY -> date.plus(1, DateTimeUnit.MONTH)
+        ForecastCadence.QUARTERLY -> date.plus(3, DateTimeUnit.MONTH)
+        ForecastCadence.YEARLY -> date.plus(12, DateTimeUnit.MONTH)
+        ForecastCadence.EVERY_N_DAYS -> date.plus(requireNotNull(commitment.intervalDays), DateTimeUnit.DAY)
+    }
+
+    private fun detectThresholdBreaches(
+        thresholds: List<ForecastBalanceThreshold>,
+        date: LocalDate,
+        projectedBalance: Cents,
+        breachesById: MutableMap<String, ForecastThresholdBreach>,
+    ) {
+        for (threshold in thresholds) {
+            if (!breachesById.containsKey(threshold.id) && projectedBalance < threshold.amount) {
+                breachesById[threshold.id] = ForecastThresholdBreach(
+                    thresholdId = threshold.id,
+                    thresholdAmount = threshold.amount,
+                    date = date,
+                    projectedBalance = projectedBalance,
+                )
+            }
+        }
+    }
+
+    private fun bandFor(input: OperatingCashForecastInput, horizonDays: Int): Cents {
+        if (horizonDays == 0 || input.dailyNetDeviation.isZero()) return Cents.ZERO
+        val band = zScore(input.confidence) * input.dailyNetDeviation.amount.toDouble() * sqrt(horizonDays.toDouble())
+        return Cents(band.roundToLong())
+    }
+
+    private fun zScore(confidence: ForecastConfidence): Double = when (confidence) {
+        ForecastConfidence.HIGH -> 1.28
+        ForecastConfidence.MEDIUM -> 1.64
+        ForecastConfidence.LOW -> 1.96
+    }
+}

--- a/packages/core/src/commonTest/kotlin/com/finance/core/forecast/OperatingCashForecastEngineTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/forecast/OperatingCashForecastEngineTest.kt
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package com.finance.core.forecast
+
+import com.finance.models.types.Cents
+import kotlin.math.roundToLong
+import kotlin.math.sqrt
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlinx.datetime.LocalDate
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+class OperatingCashForecastEngineTest {
+    @Test
+    fun expandsPayrollTaxBillsAndOneOffScenariosThroughHorizon() {
+        val result = OperatingCashForecastEngine.forecast(
+            OperatingCashForecastInput(
+                startDate = LocalDate(2025, 4, 20),
+                startingBalance = Cents(100_000),
+                horizons = listOf(30),
+                recurringCommitments = listOf(
+                    payroll(nextDueDate = LocalDate(2025, 4, 25)),
+                    bill(nextDueDate = LocalDate(2025, 5, 1)),
+                    tax(nextDueDate = LocalDate(2025, 4, 30)),
+                ),
+                oneOffEntries = listOf(
+                    oneOffOutflow("repair", "Car repair", 15_000, LocalDate(2025, 4, 22)),
+                ),
+            ),
+        )
+
+        assertEquals(LocalDate(2025, 5, 20), result.endDate)
+        assertEquals(31, result.balancePoints.size)
+        assertEquals(Cents(335_000), result.endingBalance)
+        assertEquals(Cents(400_000), result.horizonSnapshots.single().committedInflow)
+        assertEquals(Cents(165_000), result.horizonSnapshots.single().committedOutflow)
+        assertEquals(
+            listOf(
+                LocalDate(2025, 4, 22),
+                LocalDate(2025, 4, 25),
+                LocalDate(2025, 4, 30),
+                LocalDate(2025, 5, 1),
+                LocalDate(2025, 5, 9),
+            ),
+            result.occurrences.map { it.date },
+        )
+    }
+
+    @Test
+    fun excludesAsOfDateEntriesAndIncludesHorizonBoundary() {
+        val result = OperatingCashForecastEngine.forecast(
+            OperatingCashForecastInput(
+                startDate = LocalDate(2025, 1, 1),
+                startingBalance = Cents(10_000),
+                horizons = listOf(10),
+                oneOffEntries = listOf(
+                    oneOffOutflow("same-day", "Already reflected", 999, LocalDate(2025, 1, 1)),
+                    oneOffOutflow("boundary", "Boundary bill", 3_000, LocalDate(2025, 1, 11)),
+                    oneOffOutflow("after", "After horizon", 9_000, LocalDate(2025, 1, 12)),
+                ),
+            ),
+        )
+
+        assertEquals(Cents(7_000), result.endingBalance)
+        assertEquals(listOf("boundary"), result.occurrences.map { it.sourceId })
+        assertEquals(LocalDate(2025, 1, 11), result.horizonSnapshots.single().targetDate)
+    }
+
+    @Test
+    fun detectsFirstNegativeAndSafetyBufferThresholdBreaches() {
+        val result = OperatingCashForecastEngine.forecast(
+            OperatingCashForecastInput(
+                startDate = LocalDate(2025, 1, 1),
+                startingBalance = Cents(10_000),
+                horizons = listOf(10),
+                thresholds = listOf(
+                    ForecastBalanceThreshold.ZERO,
+                    ForecastBalanceThreshold("buffer", Cents(5_000), "Safety buffer"),
+                ),
+                oneOffEntries = listOf(
+                    oneOffOutflow("utility", "Utility", 6_000, LocalDate(2025, 1, 3)),
+                    oneOffOutflow("rent", "Rent", 5_000, LocalDate(2025, 1, 4)),
+                    oneOffOutflow("ignored", "Later bill", 1_000, LocalDate(2025, 1, 8)),
+                ),
+            ),
+        )
+
+        assertEquals(
+            listOf(
+                ForecastThresholdBreach("buffer", Cents(5_000), LocalDate(2025, 1, 3), Cents(4_000)),
+                ForecastThresholdBreach("zero", Cents.ZERO, LocalDate(2025, 1, 4), Cents(-1_000)),
+            ),
+            result.thresholdBreaches,
+        )
+    }
+
+    @Test
+    fun reportsStartDateBreachForAlreadyLowStartingBalanceAndSupportsZeroDayHorizon() {
+        val result = OperatingCashForecastEngine.forecast(
+            OperatingCashForecastInput(
+                startDate = LocalDate(2025, 2, 1),
+                startingBalance = Cents(-2_500),
+                horizons = listOf(0),
+            ),
+        )
+
+        assertEquals(LocalDate(2025, 2, 1), result.endDate)
+        assertEquals(Cents(-2_500), result.endingBalance)
+        assertEquals(1, result.balancePoints.size)
+        assertEquals(
+            listOf(ForecastThresholdBreach("zero", Cents.ZERO, LocalDate(2025, 2, 1), Cents(-2_500))),
+            result.thresholdBreaches,
+        )
+    }
+
+    @Test
+    fun honorsRecurringEndDateAndOccurrenceLimit() {
+        val result = OperatingCashForecastEngine.forecast(
+            OperatingCashForecastInput(
+                startDate = LocalDate(2025, 1, 1),
+                startingBalance = Cents.ZERO,
+                horizons = listOf(60),
+                recurringCommitments = listOf(
+                    payroll(
+                        id = "limited-payroll",
+                        amount = 10_000,
+                        nextDueDate = LocalDate(2025, 1, 10),
+                        maxOccurrences = 2,
+                    ),
+                    bill(
+                        id = "ending-bill",
+                        amount = 1_000,
+                        nextDueDate = LocalDate(2025, 1, 15),
+                        endsOn = LocalDate(2025, 2, 15),
+                    ),
+                ),
+            ),
+        )
+
+        assertEquals(
+            listOf(
+                LocalDate(2025, 1, 10),
+                LocalDate(2025, 1, 15),
+                LocalDate(2025, 1, 24),
+                LocalDate(2025, 2, 15),
+            ),
+            result.occurrences.map { it.date },
+        )
+        assertEquals(Cents(18_000), result.endingBalance)
+    }
+
+    @Test
+    fun horizonSnapshotsUseWebParityDefaultHorizonsRecurringImpactAndConfidenceBands() {
+        val result = OperatingCashForecastEngine.forecast(
+            OperatingCashForecastInput(
+                startDate = LocalDate(2025, 4, 20),
+                startingBalance = Cents(100_000),
+                recurringCommitments = listOf(
+                    bill(
+                        id = "rent",
+                        amount = 50_000,
+                        nextDueDate = LocalDate(2025, 5, 1),
+                        cadence = ForecastCadence.EVERY_N_DAYS,
+                        intervalDays = 30,
+                    ),
+                ),
+                baselineDailyNet = Cents(6_600),
+                dailyNetDeviation = Cents(1_000),
+                confidence = ForecastConfidence.MEDIUM,
+            ),
+        )
+
+        val snapshots = result.horizonSnapshots.associateBy { it.horizonDays }
+        assertEquals(listOf(7, 30, 90), result.horizonSnapshots.map { it.horizonDays })
+        assertEquals(Cents(146_200), snapshots.getValue(7).expectedBalance)
+        assertEquals(Cents(248_000), snapshots.getValue(30).expectedBalance)
+        assertEquals(Cents(544_000), snapshots.getValue(90).expectedBalance)
+
+        val band30 = (1.64 * 1_000.0 * sqrt(30.0)).roundToLong()
+        assertEquals(Cents(248_000 - band30), snapshots.getValue(30).lowBalance)
+        assertEquals(Cents(248_000 + band30), snapshots.getValue(30).highBalance)
+    }
+
+    @Test
+    fun serializesInputAndResultRoundTrips() {
+        val json = Json { encodeDefaults = true }
+        val input = OperatingCashForecastInput(
+            startDate = LocalDate(2025, 6, 1),
+            startingBalance = Cents(50_000),
+            horizons = listOf(7),
+            recurringCommitments = listOf(payroll(nextDueDate = LocalDate(2025, 6, 6))),
+            oneOffEntries = listOf(oneOffOutflow("scenario", "Scenario", 1_234, LocalDate(2025, 6, 2))),
+            thresholds = listOf(ForecastBalanceThreshold.ZERO),
+            baselineDailyNet = Cents(-500),
+            dailyNetDeviation = Cents(250),
+            confidence = ForecastConfidence.LOW,
+        )
+
+        val decodedInput = json.decodeFromString<OperatingCashForecastInput>(json.encodeToString(input))
+        val result = OperatingCashForecastEngine.forecast(decodedInput)
+        val decodedResult = json.decodeFromString<OperatingCashForecastResult>(json.encodeToString(result))
+
+        assertEquals(input, decodedInput)
+        assertEquals(result, decodedResult)
+    }
+
+    @Test
+    fun validatesUnsupportedCadenceAndNegativeAmounts() {
+        assertFailsWith<IllegalArgumentException> {
+            RecurringForecastCommitment(
+                id = "custom",
+                description = "Custom cadence",
+                amount = Cents(1_000),
+                direction = ForecastCashFlowDirection.OUTFLOW,
+                kind = ForecastCashFlowKind.BILL,
+                cadence = ForecastCadence.EVERY_N_DAYS,
+                nextDueDate = LocalDate(2025, 1, 1),
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            oneOffOutflow("bad", "Bad", -1, LocalDate(2025, 1, 1))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            OperatingCashForecastInput(
+                startDate = LocalDate(2025, 1, 1),
+                startingBalance = Cents.ZERO,
+                horizons = emptyList(),
+            )
+        }
+        assertTrue(ForecastBalanceThreshold.ZERO.description.isNotBlank())
+    }
+
+    private fun payroll(
+        id: String = "payroll",
+        amount: Long = 200_000,
+        nextDueDate: LocalDate,
+        maxOccurrences: Int? = null,
+    ): RecurringForecastCommitment = RecurringForecastCommitment(
+        id = id,
+        description = "Payroll",
+        amount = Cents(amount),
+        direction = ForecastCashFlowDirection.INFLOW,
+        kind = ForecastCashFlowKind.PAYROLL,
+        cadence = ForecastCadence.BIWEEKLY,
+        nextDueDate = nextDueDate,
+        maxOccurrences = maxOccurrences,
+    )
+
+    private fun bill(
+        id: String = "rent",
+        amount: Long = 120_000,
+        nextDueDate: LocalDate,
+        cadence: ForecastCadence = ForecastCadence.MONTHLY,
+        intervalDays: Int? = null,
+        endsOn: LocalDate? = null,
+    ): RecurringForecastCommitment = RecurringForecastCommitment(
+        id = id,
+        description = "Bill",
+        amount = Cents(amount),
+        direction = ForecastCashFlowDirection.OUTFLOW,
+        kind = ForecastCashFlowKind.BILL,
+        cadence = cadence,
+        nextDueDate = nextDueDate,
+        intervalDays = intervalDays,
+        endsOn = endsOn,
+    )
+
+    private fun tax(nextDueDate: LocalDate): RecurringForecastCommitment = RecurringForecastCommitment(
+        id = "quarterly-tax",
+        description = "Quarterly tax",
+        amount = Cents(30_000),
+        direction = ForecastCashFlowDirection.OUTFLOW,
+        kind = ForecastCashFlowKind.TAX,
+        cadence = ForecastCadence.QUARTERLY,
+        nextDueDate = nextDueDate,
+    )
+
+    private fun oneOffOutflow(
+        id: String,
+        description: String,
+        amount: Long,
+        date: LocalDate,
+    ): OneOffForecastEntry = OneOffForecastEntry(
+        id = id,
+        description = description,
+        amount = Cents(amount),
+        direction = ForecastCashFlowDirection.OUTFLOW,
+        date = date,
+    )
+}


### PR DESCRIPTION
Closes #2588.

## Summary
- Adds `com.finance.core.forecast` with a pure commonMain operating cash forecast engine.
- Supports recurring payroll/tax/bill commitments, one-off scenario entries, configurable horizons, balance thresholds, and confidence bands.
- Keeps all money as integer cents via `Cents` and all dates as deterministic `kotlinx.datetime.LocalDate` steps.

## Web parity / source logic
- Ported default horizons `[7, 30, 90]`, recurring impact inclusion rules (`> asOf`, `<= horizon`), and confidence band formula from `apps/web/src/lib/ai/cash-flow-forecasts.ts`.
- Mirrored operating cash-flow recurrence concepts from `apps/web/src/lib/coaching/cashFlowProjection.ts`.
- Preserved BalancePredictionEngine-style integer-cent projected balances and horizon snapshots.

## Test coverage
- `:packages:core:jvmTest` passed (2,270 tests, 0 failures).
- New commonTest coverage for recurrence expansion, one-offs, first threshold breaches, edge/horizon boundaries, serialization round-trips, and the ported web fixture.