### PR TITLE
fix(ci): audit prod dist directly in nightly Lighthouse via staticDistDir

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -249,6 +249,20 @@ jobs:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nightly-web-build
+      - name: Verify production build artifact
+        # Guards against a corrupt/incomplete artifact (digest mismatch) or a
+        # non-production index.html.  Lighthouse audits apps/web/dist directly
+        # via staticDistDir, so a bad dist would otherwise be measured silently
+        # (e.g. a dev-mode page yielding hundreds of unbundled module scripts).
+        run: |
+          test -f apps/web/dist/index.html || { echo "ERROR: apps/web/dist/index.html missing — artifact not restored"; exit 1; }
+          if grep -q "/src/main.tsx" apps/web/dist/index.html; then
+            echo "ERROR: dist/index.html references dev source (/src/main.tsx) — not a production build"; exit 1
+          fi
+          if ! grep -qE "/assets/[^\"']*\.js" apps/web/dist/index.html; then
+            echo "ERROR: dist/index.html does not reference built /assets/*.js — not a production build"; exit 1
+          fi
+          echo "Production build verified: dist/index.html references hashed /assets bundles."
       - name: Lighthouse Audit
         # apps/web/lighthouserc.json starts Vite preview and audits /login so
         # LHCI does not scan static index.html and fail on the SPA redirect.

--- a/apps/web/lighthouserc.json
+++ b/apps/web/lighthouserc.json
@@ -1,10 +1,9 @@
 {
   "ci": {
     "collect": {
-      "url": ["http://localhost:5173/login?lhci=1"],
-      "startServerCommand": "npm run -w apps/web preview -- --host 127.0.0.1 --port 5173 --strictPort",
-      "startServerReadyPattern": "http://127.0.0.1:5173/",
-      "startServerReadyTimeout": 15000,
+      "url": ["http://localhost/login?lhci=1"],
+      "staticDistDir": "apps/web/dist",
+      "isSinglePageApplication": true,
       "settings": {
         "chromeFlags": "--headless=new --no-sandbox --disable-gpu",
         "blockedUrlPatterns": ["*/api/auth/refresh", "*/sw.js"],


### PR DESCRIPTION
## Problem
The nightly **Lighthouse Audit** job has been failing with:
\\\
resource-summary.script.count failure for maxNumericValue assertion
expected: <=25, but found 826
WARNING: Timed out waiting for the server to start listening.
\\\
826 scripts = an unbundled **dev-mode** page (Vite dev serves each ES module as a separate script), not the ~23-chunk production build. The job audited the build by spawning \ite preview\ with a 15s \startServerReadyTimeout\; when that startup raced/failed, Lighthouse measured the wrong content. The **same artifact audited fine in the E2E jobs** in the same run, confirming the build itself was valid — the preview-server startup was the flaky part. PR #2807 recalibrated budgets but couldn't fix this because it only reproduces in the nightly CI environment.

## Fix
- **\pps/web/lighthouserc.json\**: serve the built \pps/web/dist\ directly via LHCI \staticDistDir\ + \isSinglePageApplication\, removing the \ite preview\ startup race entirely.
- **\.github/workflows/nightly.yml\**: add a preflight step that fails loudly if \dist/index.html\ is missing or references dev source (\/src/main.tsx\) instead of hashed \/assets/*.js\ bundles — so a corrupt artifact can never be measured silently.

## Validation
Will be confirmed by a \workflow_dispatch\ nightly e2e run after merge.

Closes #2795.