### PR TITLE
fix(web): stop Lighthouse reload loop by skipping onboarding auto-launch under audit

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -14,6 +14,7 @@ import { useRouteAnnouncer } from './hooks/useRouteAnnouncer';
 import { useSpendingPace } from './hooks/useSpendingPace';
 import type { HapticEventType } from './lib/haptics/types';
 import { isOnboardingComplete } from './lib/local-only-mode';
+import { isLighthouseAudit } from './lib/perf/lighthouse-audit';
 import type { DetectedMilestone } from './lib/milestones';
 import {
   detectScamAlerts,
@@ -369,7 +370,12 @@ export const App: FC = () => {
   const activePath = location.pathname === '/' ? '/' : location.pathname;
   const pageTitle = derivePageTitle(activePath);
   const isStandalonePage = isStandalonePath(activePath);
-  const shouldStartOnboarding = shouldAutoLaunchOnboarding(activePath, isOnboardingComplete());
+  // Skip the first-run onboarding auto-launch during a Lighthouse audit so the
+  // synthetic run measures the requested route (e.g. /login) instead of being
+  // redirected into the onboarding flow — which, with storage cleared between
+  // loads, otherwise causes navigation churn under audit (#2795).
+  const shouldStartOnboarding =
+    shouldAutoLaunchOnboarding(activePath, isOnboardingComplete()) && !isLighthouseAudit();
 
   // Announce route transitions to screen readers (#1684)
   useRouteAnnouncer();

--- a/apps/web/src/lib/perf/lighthouse-audit.ts
+++ b/apps/web/src/lib/perf/lighthouse-audit.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Lighthouse-audit detection.
+ *
+ * Synthetic Lighthouse runs load the app with no backend (api requests are
+ * served the SPA-fallback index.html).  Without special handling the app would
+ * perform navigation churn under audit — service-worker registration, an
+ * unauthenticated redirect, and the first-run onboarding auto-launch — none of
+ * which represent the page we actually want to measure.  Detecting the audit
+ * lets those behaviours be skipped so Lighthouse measures a stable page.
+ *
+ * Detection is intentionally robust across reloads: the `?lhci=1` query param is
+ * present on the initial navigation but may be dropped by a client-side route
+ * change, whereas the Lighthouse user-agent token persists for the whole run.
+ */
+export function isLighthouseAudit(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  if (window.location.search.includes('lhci=1')) {
+    return true;
+  }
+
+  return typeof navigator !== 'undefined' && /\bLighthouse\b/i.test(navigator.userAgent);
+}


### PR DESCRIPTION
Nightly Lighthouse failed script.count<=25 with 817 found. The LHCI trace showed 81 Document loads of /login in 45s (817 script reqs = 11 unique chunks x ~74 reloads) — a reload loop, not a dev bundle (prod build is 30 chunks). Root cause: on /login with onboarding incomplete, App auto-launches onboarding via Navigate to /onboarding; Lighthouse clears storage each load and the no-backend audit churns the redirect. isLighthouseAudit() already guards SW + auth redirect but not the onboarding auto-launch. Fix: add shared lib/perf/lighthouse-audit.ts and guard shouldStartOnboarding with it. Reproduced locally (vite preview + Lighthouse UA): page now settles on /login (script count ~11 < 25). tsc + OnboardingPage tests pass. Builds on #2821. Closes #2795.