### PR TITLE
fix(e2e): settle lazy dashboard chunks before nav-reachability clicks (mobile-chrome)

### DIFF
--- a/apps/web/e2e/nav-reachability.spec.ts
+++ b/apps/web/e2e/nav-reachability.spec.ts
@@ -95,6 +95,19 @@ async function waitForAppShell(page: Page): Promise<void> {
     .catch(() => {
       // Loading indicator may have already disappeared — fine.
     });
+
+  // Wait for lazily-imported route/dashboard sections (code-split in #2782)
+  // to finish loading.  Otherwise their chunks resolve and mount *after* the
+  // shell is ready, reflowing the page while a test is mid-click.  On slower
+  // CI runners that ongoing reflow makes the bottom-nav "More" button's hit
+  // target unstable (content momentarily intercepts the pointer), so the click
+  // never lands and the mobile-chrome job overran its budget (#2781).  Waiting
+  // for network idle ensures all dynamic imports have loaded and the layout has
+  // settled before we interact.
+  await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {
+    // Background activity may keep the network busy — fall through; the
+    // per-action stability checks still apply.
+  });
 }
 
 /**


### PR DESCRIPTION
Follow-up to #2823 (which alone did not fix the nightly mobile-chrome cancellation). The captured Playwright call log showed moreButton.click() failing because card-grid (dashboard main content) and the bottom-nav alternately 'intercept pointer events' while the element is visible and stable — so reduced motion was not the cause. The #2782 dashboard code-split made those sections lazy, so their chunks mount AFTER the shell is ready and reflow the page mid-click; on slower CI the hit target never settles within the 20s action timeout, and with retries x2 across every More-sheet destination the job overran its 25-min budget. Fix: waitForAppShell now also waits for network idle so all dynamic imports have loaded and the layout is final before interacting. Verified the full nav-reachability suite passes on mobile-chrome against the prod preview build. Closes #2781.