### PR TITLE
docs(design): iOS one-thumb quick-add expense capture (#2167)

### DIFF
--- a/docs/design/ios-one-thumb-quick-add.md
+++ b/docs/design/ios-one-thumb-quick-add.md
@@ -1,6 +1,6 @@
 # iOS One-Thumb Quick-Add Expense Capture — Finance
 
-> **Status:** PROPOSED — design decisions resolved in-session 2026-06-20; pending human review & merge
+> **Status:** PROPOSED — design decisions resolved & maintainer-confirmed 2026-06-20 (payee-optional confirmed); pending human review & merge
 > **Epic:** #2167 · **Closes:** #2599 · **Refs:** #2113 (sibling pilot), #1239 (native blocker)
 > **WCAG Target:** 2.2 Level AA (AAA where practical)
 > **Priority:** P1 (`priority:high`)
@@ -169,14 +169,25 @@ custom keypad is **not** a VoiceOver dead-end (§3.4).
 | **Status**   | Defaulted to **pending** for fast capture (clears later on reconcile).                             | `selectedStatus = .pending` `TransactionCreateViewModel.swift:51`                                                     |
 | **Note**     | **Optional**, not shown in quick-add; available via "More details".                                | `note` `Transaction.kt:30`; `TransactionCreateView.swift:258-262`                                                     |
 
-**Payee is optional in quick-add** (resolved decision, §8): the shared `TransactionValidator` does
-**not** require it (`TransactionValidator.kt` only length-checks payee, `:64-68`), the model field is
-nullable (`Transaction.kt:29`), and `LogTransactionIntent.makeTransaction` already establishes the
-blank-payee → category-name fallback (`LogTransactionIntent.swift:117-120`). Requiring a text field
-would force the system keyboard up and break the thumb-zone numeric flow, defeating "one-thumb." A
-"More details" affordance promotes the entry into the full three-step
-`TransactionCreateView`/`TransactionCreateViewModel` (payee, category picker, status, tags, mood,
-note, date) without re-keying the amount.
+**Payee is optional in quick-add** (maintainer-confirmed decision, 2026-06-20; §8): the shared
+`TransactionValidator` does **not** require it (`TransactionValidator.kt` only length-checks payee,
+`:64-68`), the model field is nullable (`Transaction.kt:29`), and
+`LogTransactionIntent.makeTransaction` already establishes the blank-payee → category-name fallback
+(`LogTransactionIntent.swift:117-120`). Requiring a text field would force the system keyboard up and
+break the thumb-zone numeric flow, defeating "one-thumb." A "More details" affordance promotes the
+entry into the full three-step `TransactionCreateView`/`TransactionCreateViewModel` (payee, category
+picker, status, tags, mood, note, date) without re-keying the amount.
+
+> **Deliberate divergence — by design, not an oversight.** Quick-add is the **only** create surface
+> where payee is optional. **Both** other create surfaces currently **require** a payee/description:
+> the web **Quick Add** panel blocks save on an empty description (`QuickEntry.tsx:246-249`) and the
+> full iOS `TransactionCreateView` requires a non-empty payee
+> (`TransactionCreateViewModel.swift:81` `canAdvance`, `:288-292` `validate`). The one-thumb flow
+> **intentionally** drops that requirement — its design constraint (no forced keyboard in the thumb
+> zone) did not exist when those surfaces were built, and the shared schema/validator side with
+> optional. A future reader should treat this inconsistency as the deliberate quick-add affordance it
+> is, not a bug to "fix" by re-adding a required payee. (If the web Quick Add and the full iOS form
+> are ever relaxed to match, that is a separate alignment task, not a change to this flow.)
 
 ### 3.4 The non-pointer path (VoiceOver / Switch Control) — never regress assistive tech
 
@@ -212,14 +223,15 @@ is read; it only produces a row that conforms to that contract.
 
 Quick-add composes **only** fields that exist on the shared model
 (`packages/models/.../Transaction.kt:19-53`) and routes its save through the shared validator
-(`packages/core/.../validation/TransactionValidator.kt`). The two pieces of logic that should live in
-`packages/core` (so all platforms behave identically and are unit-testable today) are:
+(`packages/core/.../validation/TransactionValidator.kt`). This design doc **edits no shared code**;
+the two pieces of logic below are **proposed additions for `packages/core`, owned by
+@kmp-engineer** (so all platforms behave identically and the rules are unit-testable today):
 
 1. **Default-selection** — `lastUsedAccountId ?? firstAccount`, `lastUsedType ?? EXPENSE`,
    `date = today`, `status = PENDING`, `categoryId = suggest(payee) ?? null`. Web implements these
    ad hoc in the component (`QuickEntry.tsx:106-178`); iOS has them split across the view model and
-   `LogTransactionIntent`. Promoting a single `QuickAddDefaults` resolver into `packages/core` is the
-   smallest shared change and removes three divergent copies.
+   `LogTransactionIntent`. A single `QuickAddDefaults` resolver in `packages/core` (proposed for
+   @kmp-engineer) is the smallest shared change and removes three divergent copies.
 2. **Minimum-field / save rule** — amount non-zero **is the only blocking rule**; payee falls back to
    `categoryName → "Expense"/"Income"` (`LogTransactionIntent.swift:117-120`); category may be null.
    This mirrors `TransactionValidator.validate` (`TransactionValidator.kt:21-77`), which already
@@ -349,14 +361,17 @@ null` (parity with `QuickEntry.tsx:106-178`).
 
 **Resolved design decisions (in-session, 2026-06-20):**
 
-1. **Payee is optional in one-thumb quick-add** — only the amount blocks a save. A blank payee falls
-   back to the suggested category name, then "Expense"/"Income"
-   (`LogTransactionIntent.swift:117-120`; nullable `payee` `Transaction.kt:29`; not required by
-   `TransactionValidator.kt`). Requiring a text field would force the system keyboard and break the
-   thumb-zone numeric flow. _(iOS deliberately diverges from web Quick Add, which requires a
-   description — `QuickEntry.tsx:246-249` — because that web choice predates the one-thumb
-   constraint; the shared validator sides with optional. Recommended default flagged to the
-   orchestrator 2026-06-20; this section is updated if the maintainer decides otherwise.)_
+1. **Payee is optional in one-thumb quick-add** — **maintainer-confirmed 2026-06-20.** Only the
+   amount blocks a save. A blank payee falls back to the suggested category name, then
+   "Expense"/"Income" (`LogTransactionIntent.swift:117-120`; nullable `payee` `Transaction.kt:29`;
+   not required by `TransactionValidator.kt`). Requiring a text field would force the system keyboard
+   and break the thumb-zone numeric flow. **Deliberate, by-design divergence:** this is the only
+   create surface where payee is optional — **both** the web Quick Add (`QuickEntry.tsx:246-249`)
+   **and** the full iOS `TransactionCreateView` (`TransactionCreateViewModel.swift:81`,`:288-292`)
+   currently **require** a payee. The one-thumb flow intentionally drops that requirement because its
+   no-forced-keyboard constraint postdates those surfaces and the shared schema/validator side with
+   optional; the inconsistency is documented here so a future reader does not "fix" it by re-adding a
+   required payee (§3.3). Aligning web/full-form to match would be a separate task, out of scope here.
 2. **Custom cents-first keypad, not the system decimal keypad** — resolved by precedent: the app
    already ships the #1486 Venmo-style keypad (`TransactionCreateView.swift:142-164`) and the web
    uses the same incremental cents-first model (`QuickEntry.tsx:156-162`). A custom keypad keeps the
@@ -373,12 +388,11 @@ null` (parity with `QuickEntry.tsx:106-178`).
    (`Transaction.kt:49-51`; `TransactionValidator.kt:44-54`), beyond the minimum field set; quick-add
    is expense/income only and defers transfers to the full form (§5).
 
-**Open dependency (flagged, not decided here):**
+**Proposed shared-code follow-up (for @kmp-engineer — not done here):**
 
-- The **payee-optional** decision (#1) is the one genuine product call; it was raised to the
-  orchestrator with the recommended default baked in above. If the maintainer rules that quick-add
-  must require a payee, only §3.3, §6 (validation), §7 (the blank-payee test), and decision #1 change
-  — the rest of the flow is unaffected.
-- Promoting the shared `QuickAddDefaults` / `resolveQuickAddPayee` helpers into `packages/core` (§4)
-  is a small shared-code change that removes three divergent copies (web component, iOS view model,
-  `LogTransactionIntent`); it is implementation work to be scheduled, not a design question.
+- The **payee-optional** product call is **resolved** (decision #1, maintainer-confirmed); it is no
+  longer open.
+- The shared `QuickAddDefaults` / `resolveQuickAddPayee` helpers (§4) are **proposed additions for
+  `packages/core`, owned by @kmp-engineer** — a small shared-code change that removes three divergent
+  copies (web component, iOS view model, `LogTransactionIntent`). This design-only doc does not edit
+  `packages/*`; the work should be scheduled as a separate KMP task, not treated as a design question.

--- a/docs/design/ios-one-thumb-quick-add.md
+++ b/docs/design/ios-one-thumb-quick-add.md
@@ -1,406 +1,384 @@
-# One-Thumb Quick-Add Transaction Entry — iOS
+# iOS One-Thumb Quick-Add Expense Capture — Finance
 
-> Design specification for a fast, one-handed "quick-add" transaction entry on
-> the **Transactions** tab: a thumb-reachable capture affordance, a
-> bottom-anchored sheet that opens straight to the amount keypad, remembered
-> defaults (account, type, category), optional payee skipping, and a low-effort
-> save confirmation with undo. The goal is _amount → save_ in a single thumb
-> arc, without sacrificing accessibility, privacy, or the shared validation
-> contract.
+> **Status:** PROPOSED — design decisions resolved in-session 2026-06-20; pending human review & merge
+> **Epic:** #2167 · **Closes:** #2599 · **Refs:** #2113 (sibling pilot), #1239 (native blocker)
+> **WCAG Target:** 2.2 Level AA (AAA where practical)
+> **Priority:** P1 (`priority:high`)
+> **Last Updated:** 2026-06-20
+> **Platforms:** iOS (SwiftUI) — design-only
 
-**Status:** Design (implementation-ready) · pre-implementation
-**Issue:** [#2599](https://github.com/jrmoulckers/finance/issues/2599) — In-app one-thumb quick-add entry design for iOS
-**Part of:** [#2167](https://github.com/jrmoulckers/finance/issues/2167)
-**Platforms:** iOS · iPadOS · macOS (SwiftUI) — with hooks for App Clip and Lock Screen widget quick entry
-**WCAG target:** 2.2 Level AA — SC 2.5.5 Target Size, SC 2.5.1 Pointer Gestures, SC 1.4.4 Resize Text
-**Related:** [accessibility-patterns.md](./accessibility-patterns.md) · [cognitive-accessibility.md](./cognitive-accessibility.md) · [ux-principles.md](./ux-principles.md) · [responsive-breakpoints.md](./responsive-breakpoints.md) · [ios-compact-transaction-stepper.md](./ios-compact-transaction-stepper.md) · [ios-wallet-adjacent-capture-inbox.md](./ios-wallet-adjacent-capture-inbox.md) · [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md)
+---
+
+## Status & boundary note
+
+Native Swift/SwiftUI implementation is **blocked by Apple Developer enrollment #1239**.
+This document is a **design/breakdown deliverable only** — it specifies the one-thumb quick-add
+flow and its per-surface application so that, once unblocked, a native implementation can proceed
+without re-deriving the contract. **No Swift code ships with this doc**; the Swift fragments below
+are illustrative shapes, not compiled source.
+
+**Native/KMP boundary (applies to every surface below):**
+
+- **Platform-neutral business rules** — the minimum-field rule, default-selection logic
+  (last-used account, today's date, default type/status), category auto-suggestion, and the
+  save / save-and-add-another contract — belong in `packages/core` / `packages/models` so web,
+  Android, iOS, and Windows compose the same quick-add from one source of truth.
+- **Apple-framework integration** — thumb-zone layout, the custom numeric keypad, sheet
+  presentation detents, haptics, Dynamic Type layout, and the VoiceOver / Switch Control path —
+  live in `apps/ios` (the surfaces named in §5; planned per #1239).
+
+This doc mirrors the structure resolved for sibling epic #2113 in
+`docs/design/ios-chart-accessibility.md` (PR #2834): a status header, a native/KMP boundary note,
+a shared-model section, a per-surface application map, a state-coverage table, and a test plan that
+separates runnable-today shared `commonTest` work from native iOS tests deferred until #1239.
 
 ---
 
 ## Table of Contents
 
-1. [Problem & Goals](#1-problem--goals)
-2. [The One-Thumb Flow](#2-the-one-thumb-flow)
-3. [Transactions Tab Affordance](#3-transactions-tab-affordance)
-4. [The Quick-Add Bottom Sheet](#4-the-quick-add-bottom-sheet)
-5. [Remembered Defaults & Optional Payee](#5-remembered-defaults--optional-payee)
-6. [Save Confirmation & Undo](#6-save-confirmation--undo)
-7. [Affected iOS Surfaces](#7-affected-ios-surfaces)
-8. [Shared Dependencies & the Validation Boundary](#8-shared-dependencies--the-validation-boundary)
-9. [Accessibility, Dynamic Type & Reachability](#9-accessibility-dynamic-type--reachability)
-10. [Privacy](#10-privacy)
-11. [Stale, Error & Empty States](#11-stale-error--empty-states)
-12. [Test Plan](#12-test-plan)
-13. [Implementation Readiness](#13-implementation-readiness)
-14. [Open Questions](#14-open-questions)
+1. [Why this pattern](#1-why-this-pattern)
+2. [The cross-platform contract we are mirroring](#2-the-cross-platform-contract-we-are-mirroring)
+3. [The iOS one-thumb flow: reachability, amount, minimum fields, non-pointer path](#3-the-ios-one-thumb-flow-reachability-amount-minimum-fields-non-pointer-path)
+4. [Shared model & defaults (packages/core)](#4-shared-model--defaults-packagescore)
+5. [Surface application map](#5-surface-application-map)
+6. [State coverage](#6-state-coverage-dynamic-type-validation-empty-success-save-and-add-another-offline-error)
+7. [Test plan](#7-test-plan)
+8. [Cross-references & resolved decisions](#8-cross-references--resolved-decisions)
 
 ---
 
-## 1. Problem & Goals
+## 1. Why this pattern
 
-Today the only way to add a transaction from the **Transactions** tab is the
-`Add transaction` menu anchored in the **top-trailing toolbar** of
-`apps/ios/Finance/Screens/TransactionsView.swift`. On a 6.1"+ phone held in one
-hand, that target sits outside the comfortable thumb arc, and the resulting
-`TransactionCreateView` is a three-step `Type → Details → Review` wizard
-(`apps/ios/Finance/Screens/TransactionCreateView.swift`) that requires several
-deliberate taps before a value is even entered. For the dominant use case —
-"I just spent $4.50 on coffee, log it before I forget" — this is too much
-ceremony.
+The highest-frequency action in a personal-finance app is capturing a single expense in the moment
+— at the register, in the cab, leaving the café. On a modern large-screen iPhone the user is
+usually holding the phone in one hand, and the **primary save action and the digits must sit inside
+the thumb's reachable arc** (the bottom ~⅓ of the screen). Today's iOS create flow is a
+**three-step sheet** — type → details → review — that requires a top-bar "Next" tap on each step
+and a final "Save Transaction" on a review screen
+(`apps/ios/Finance/Screens/TransactionCreateView.swift:28-37`, bottom bar `:308-345`). That is the
+right surface for a deliberate, fully-specified entry, but it is too many round-trips for a
+one-handed "log $4.50 coffee" capture.
 
-The infrastructure for fast entry already exists but is fragmented:
+The web app already solved the minimal-friction case with a dedicated **Quick Add** panel
+(`apps/web/src/components/forms/QuickEntry.tsx`, issue #319) whose stated goal is _"2-tap entry:
+type amount → tap Add"_ (`QuickEntry.tsx:13`). iOS needs the native equivalent, **optimized for the
+thumb** and — critically — built so the one-thumb optimizations never regress assistive tech: a
+VoiceOver or Switch Control user must reach every control without depending on the thumb-zone
+geometry or a custom-keypad gesture.
 
-- A Venmo-style cents-first digit pad lives in `TransactionCreateViewModel`
-  (`amountCents`, `appendAmountDigit`, `formattedAmount`).
-- `applyQuickEntry(action:)` can pre-seed payee/category for a named shortcut
-  (`lunch`, `coffee`, `groceries`, `gas`).
-- The Lock Screen `QuickEntryWidget` and `DeepLinkHandler` already route into a
-  biometric-gated create sheet.
-- The App Clip `QuickTransactionView` already proves a single-screen
-  amount-first capture pattern.
+This doc defines that single reusable iOS quick-add flow required by #2599 under epic #2167. It
+reuses infrastructure that **already ships** — the Venmo-style cents-first keypad (#1486,
+`TransactionCreateView.swift:142-164`), the `applyQuickEntry` fast-path
+(`TransactionCreateViewModel.swift:204-224`), and the `LogTransactionIntent` defaults
+(`apps/ios/Finance/Intents/LogTransactionIntent.swift:108-133`) — rather than inventing a parallel
+entry stack.
 
-**Goals**
+## 2. The cross-platform contract we are mirroring
 
-1. **One thumb, one screen, two seconds.** Put a capture affordance in the
-   bottom thumb arc and open straight to the amount keypad.
-2. **Remember the boring parts.** Default the account, type, and category to the
-   user's recent behavior so only the amount changes between captures.
-3. **Make payee optional.** Allow save without a payee, deriving a sensible
-   label from the category (mirroring `AddExpenseIntent`'s
-   `resolvedPayee = payee ?? category.categoryName`).
-4. **Confirm without blocking.** A haptic + inline confirmation with **Undo**,
-   not a modal that interrupts the next capture.
+The web **Quick Add** panel is the canonical minimal-friction contract; iOS expresses the same
+intent through native controls.
 
-**Non-goals.** This design does not replace the full `Type → Details → Review`
-wizard (kept for complex entries — transfers, BNPL, tags, mood) and does not
-change shared business rules. It is an _express lane_ that composes the same
-view model and the same KMP validator.
+- **Minimum field set** — _"reduces the full TransactionForm to just the essential fields: amount,
+  description, and transaction type. All other fields (account, category, date) are auto-populated
+  from sensible defaults and auto-categorization."_ (`QuickEntry.tsx:5-10`). iOS adopts the same
+  reduction.
+- **Default selection (platform-neutral rules):**
+  - **Account** — auto-select the **last-used** account, falling back to the first available
+    (`QuickEntry.tsx:174-177`; persisted under `LAST_ACCOUNT_KEY`, `:48`,`:90-104`).
+  - **Type** — remember the **last-used** type, defaulting to `EXPENSE`
+    (`QuickEntry.tsx:106-116`,`:178`; `LAST_TYPE_KEY` `:51`).
+  - **Date** — **today** (`todayISO()` `:85-88`, applied at submit `:279`).
+  - **Category** — **auto-suggested** from the description and applied only when present; otherwise
+    left `null` (`QuickEntry.tsx:203-211`,`:258-261`,`:280`).
+- **Validation** — amount must be non-zero; account must resolve
+  (`QuickEntry.tsx:240-243`,`:251-255`). (Web additionally requires a description — the one point
+  where iOS deliberately diverges; see §4 and the resolved decision in §8.)
+- **Save-and-add-another** — the panel **stays open** after submit, resets the amount/description,
+  keeps the type+account for rapid re-entry, and shows a live _"N added"_ counter
+  (`QuickEntry.tsx:223-233`,`:288-289`, counter `:323-327`).
+- **Accessibility** — focus trap + restore, `Escape` closes / `Enter` submits, `role="dialog"`
+  `aria-modal`, `aria-required` amount, and a polite `role="status"` live region for the counter
+  (`QuickEntry.tsx:169`,`:213-221`,`:312-327`,`:374-377`).
 
----
+iOS already mirrors the web's **incremental cents-first amount model**: the web uses
+`useAmountInput({ mode: 'incremental', maxCents: 99_999_999 })` (`QuickEntry.tsx:156-162`) and iOS
+ships the identical model in `appendAmountDigit` / `removeLastAmountDigit` with the same
+`99_999_999` cap (`TransactionCreateViewModel.swift:96-107`). The quick-add flow reuses it directly.
 
-## 2. The One-Thumb Flow
+## 3. The iOS one-thumb flow: reachability, amount, minimum fields, non-pointer path
 
-```mermaid
-flowchart TD
-    A[Transactions tab] -->|tap bottom Quick Add| B[Quick-Add sheet
-    opens at .medium detent
-    amount keypad focused]
-    B -->|type digits| C[Amount shows Venmo-style]
-    C -->|defaults already filled| D{Need to change
-    account / category / payee?}
-    D -->|no| E[Save]
-    D -->|yes, tap chip| F[Inline pickers / payee field]
-    F --> E
-    E -->|success haptic| G[Inline confirmation toast + Undo]
-    G -->|auto-dismiss 4s| A
-    G -->|Undo| H[Soft-delete draft, reopen sheet]
-    E -->|need full options| I[Expand → full Type/Details/Review wizard]
+The quick-add surface is a **bottom sheet** (a medium presentation detent) that opens with the
+amount focused and the keypad already up. It has four design pillars.
+
+### 3.1 Thumb-zone reachability
+
+All **primary** actions live in the bottom reachable arc; the top of the sheet is reserved for
+non-critical chrome only.
+
+- **Bottom (reachable) — primary:** the large amount readout, the custom numeric keypad, and a
+  full-width **Save** (primary) plus **Save & add another** (secondary) action row pinned to the
+  safe-area bottom. This is the same bottom-bar slot today's review step uses for its primary action
+  (`TransactionCreateView.swift:308-345`).
+- **Top (non-reachable) — non-critical only:** a **Cancel/close** affordance and the expense/income
+  segmented control. Reachability is a convenience, **not** the only path — every top control is
+  also reachable by VoiceOver/Switch Control (§3.4) and one-handed via the system Reachability
+  gesture, so nothing is _lost_ by being at the top, it is merely _less convenient_ to reach by
+  thumb.
+- **Tap targets** keep a ≥ 44×44pt hit area (the keypad keys already use `minHeight: 44`,
+  `TransactionCreateView.swift:156`); per the Dynamic Type audit
+  (`docs/design/ios-dynamic-type-reflow.md` §3, rule R5) targets that hold scaling glyphs grow with
+  `@ScaledMetric` rather than a hardcoded 44 the label can outgrow.
+
+```
+// Illustrative bottom-anchored layout — implementation deferred per #1239. Not compiled source.
+VStack(spacing: 0) {
+  TypeToggle(selection: $vm.transactionType)        // top: non-critical
+  Spacer()
+  AmountReadout(text: vm.formattedAmount)            // reachable arc begins
+  QuickAddKeypad(onDigit: vm.appendAmountDigit,      // reuses #1486 keypad
+                 onDelete: vm.removeLastAmountDigit)
+  HStack { SaveButton(); SaveAndAddAnotherButton() } // pinned to safe-area bottom
+}
 ```
 
-Every primary control in the flow (keypad, default chips, Save, Undo) sits in
-the lower half of the screen. "Expand to full form" is the documented escape
-hatch to the existing wizard and to the compact-stepper behavior specified in
-[ios-compact-transaction-stepper.md](./ios-compact-transaction-stepper.md).
+### 3.2 Amount entry — the custom cents-first keypad (resolved: custom, not system)
 
----
+The amount is entered with the **existing custom Venmo-style cents-first keypad** (#1486,
+`TransactionCreateView.swift:142-164`), **not** the system decimal keyboard. This is a **resolved
+decision by precedent** (§8): the app already ships this keypad, the web Quick Add uses the same
+incremental cents-first model (`QuickEntry.tsx:156-162`), and a custom keypad (a) keeps the digits
+inside the thumb arc at a known position, (b) needs no decimal point (cents-first: "4","5","0" →
+`$4.50`, `TransactionCreateViewModel.swift:88-93`), and (c) frees the bottom safe-area for the Save
+actions instead of yielding it to the system keyboard. The readout uses a `monospacedDigit` style so
+the figure does not reflow as digits are added (`TransactionCreateView.swift:134`).
 
-## 3. Transactions Tab Affordance
+The keypad keys already carry full labels/hints — `accessibilityLabel(key)` and
+`"Adds digit \(key)"` / `"Removes the last digit"` (`TransactionCreateView.swift:160-161`) — so the
+custom keypad is **not** a VoiceOver dead-end (§3.4).
 
-**Decision: a bottom-trailing floating capture button**, layered above the list
-within `TransactionsView`, in addition to (not replacing) the existing toolbar
-menu.
+### 3.3 The minimum fields to save
 
-- **Placement.** Bottom-trailing, inset 16pt from the trailing and bottom safe
-  areas, so it rests inside the right-hand thumb arc for the majority of users
-  while staying clear of the home indicator and the tab bar. A left-handed
-  accommodation is covered in §9.
-- **Form.** A 56×56pt circular button using the shared `IconView(.add)` token
-  (consistent with the toolbar `add` icon already used in `TransactionsView`),
-  with a subtle shadow and `.fill` material background so it reads on both light
-  and OLED dark backgrounds.
-- **Single tap** opens the Quick-Add sheet (§4). **Long-press / context menu**
-  exposes the named shortcuts already modeled by `QuickEntryShortcut`
-  (`Log coffee`, `Log lunch`, `Log groceries`, `Log gas`) and a "Full form…"
-  item that opens the existing wizard.
-- **Coexistence.** The top-trailing `Add transaction` menu stays for
-  discoverability, pointer/keyboard users, and the `Quick Add (NLP)` entry into
-  `NlpInputView`. The floating button is purely a reachability addition.
-- **iPad / Mac.** On regular width the floating button is suppressed in favor of
-  the toolbar affordance and a keyboard shortcut (`⌘N`), because thumb
-  reachability is not the constraint there.
+| Field        | Quick-add behavior                                                                                 | Grounding                                                                                                             |
+| ------------ | -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| **Amount**   | **Required.** Non-zero, cents-first keypad. The _only_ field that blocks save.                     | `Transaction.kt:45` (`amount != 0`); `TransactionValidator.kt:29-31`; `TransactionCreateViewModel.swift:283-287`      |
+| **Type**     | Defaulted to **last-used**, else `expense`; toggled by the top segmented control.                  | `QuickEntry.tsx:106-116`; `TransactionCreateViewModel.swift:40`; `TransactionType` `Transaction.kt:13`                |
+| **Account**  | Defaulted to **last-used**, else first available; inline picker, never blocks if a default exists. | `QuickEntry.tsx:174-177`; `TransactionValidator.kt:33-36` (account must exist)                                        |
+| **Category** | **Optional** — auto-suggested from payee via the categorization engine; left null if none.         | `categorizationEngine.suggest` `TransactionCreateViewModel.swift:195-200`; `categoryId: SyncId?` `Transaction.kt:24`  |
+| **Date**     | Defaulted to **today**; editable only via "More details".                                          | `date = Date()` `TransactionCreateViewModel.swift:45`; `todayISO()` `QuickEntry.tsx:85-88`                            |
+| **Payee**    | **Optional** — if blank, falls back to the suggested category name, then "Expense"/"Income".       | `LogTransactionIntent.swift:117-120`; `payee: String?` `Transaction.kt:29`; not required by `TransactionValidator.kt` |
+| **Status**   | Defaulted to **pending** for fast capture (clears later on reconcile).                             | `selectedStatus = .pending` `TransactionCreateViewModel.swift:51`                                                     |
+| **Note**     | **Optional**, not shown in quick-add; available via "More details".                                | `note` `Transaction.kt:30`; `TransactionCreateView.swift:258-262`                                                     |
 
-The button must not obscure the last row of the list; the `List` gains a
-bottom content inset equal to the button height + inset so pull-to-refresh and
-the final transaction stay tappable.
+**Payee is optional in quick-add** (resolved decision, §8): the shared `TransactionValidator` does
+**not** require it (`TransactionValidator.kt` only length-checks payee, `:64-68`), the model field is
+nullable (`Transaction.kt:29`), and `LogTransactionIntent.makeTransaction` already establishes the
+blank-payee → category-name fallback (`LogTransactionIntent.swift:117-120`). Requiring a text field
+would force the system keyboard up and break the thumb-zone numeric flow, defeating "one-thumb." A
+"More details" affordance promotes the entry into the full three-step
+`TransactionCreateView`/`TransactionCreateViewModel` (payee, category picker, status, tags, mood,
+note, date) without re-keying the amount.
 
----
+### 3.4 The non-pointer path (VoiceOver / Switch Control) — never regress assistive tech
 
-## 4. The Quick-Add Bottom Sheet
+"One-thumb" is a pointer-ergonomics optimization; it must add zero cost for users who do not drive
+the screen by touch position.
 
-A dedicated `QuickAddView` presented with `.sheet`, distinct from
-`TransactionCreateView` but driven by the **same** `TransactionCreateViewModel`
-seeded into a new "quick" mode (so validation, persistence, and the
-categorization engine are shared, not duplicated).
+- **Logical focus order**, not spatial: type → amount → keypad (or numeric value) → account →
+  Save / Save & add another. VoiceOver moves through this order regardless of where controls sit in
+  the thumb arc.
+- **Keypad is fully labeled** (`TransactionCreateView.swift:160-161`); additionally, VoiceOver and
+  Switch Control users may enter the amount via the standard numeric value (the model accepts any
+  integer-cents input, `TransactionCreateViewModel.swift:96-102`) — the custom keypad is an
+  _accelerator_, never the _only_ way to set the amount.
+- **Save & add another** announces success via a polite live region — the web counter analogue
+  (`role="status" aria-live="polite"`, `QuickEntry.tsx:324`) — so a non-visual user hears
+  _"Saved. 3 added."_ and focus returns to the amount, mirroring the web reset-and-refocus
+  (`QuickEntry.tsx:230-232`). Use the established announcement pattern
+  (`docs/design/accessibility-patterns.md`, polite live region) rather than moving focus abruptly.
+- **Switch Control / Full Keyboard Access** reach every control because they are real focusable
+  buttons (not gesture-only); there are **no** swipe-only or reachability-only actions in the
+  critical path.
+- **Dynamic Type** — the sheet reflows at large sizes per `docs/design/ios-dynamic-type-reflow.md`
+  (§3 rules R1/R3/R6): the amount never truncates, the type/account rows collapse to vertical stacks
+  at `dynamicTypeSize.isAccessibilitySize`, and no fixed-height container clips the keypad or the
+  Save row. At accessibility sizes the bottom action row may wrap to two full-width rows rather than
+  clip.
 
-- **Detents.** `.presentationDetents([.medium, .large])` with
-  `.presentationDragIndicator(.visible)`. It opens at `.medium`; dragging to
-  `.large` reveals the optional fields. `.presentationBackgroundInteraction` is
-  disabled so the list underneath cannot steal focus.
-- **Layout, top to bottom (essentials only at `.medium`):**
-  1. **Amount display** — large monospaced-digit currency, reusing
-     `formattedAmount` + the currency symbol logic already in
-     `TransactionCreateView`.
-  2. **Default chips row** — Account · Category · Type, each a tappable chip
-     pre-filled from remembered defaults (§5). Tapping a chip reveals an inline
-     `Menu`/`Picker`, never a full push navigation.
-  3. **Venmo-style digit pad** — the existing 3-column `LazyVGrid` keypad
-     (`1–9`, `0`, `⌫`) bound to `appendAmountDigit` / `removeLastAmountDigit`,
-     anchored at the bottom so all keys are thumb-reachable.
-  4. **Save** — full-width `borderedProminent` button pinned to the bottom,
-     above the home indicator.
-- **Optional payee** is a single collapsed field directly under the chips;
-  empty is allowed (§5).
-- **Expand affordance.** Dragging to `.large` (or a "More options" disclosure)
-  surfaces date, note, status, tags, BNPL, and mood — the same `Form` sections
-  as the wizard's Details step — without navigating away.
-- **Keypad ≠ system keyboard.** The cents-first pad means no decimal point and
-  no system keyboard for the amount, keeping the whole interaction in the thumb
-  zone. The payee field still uses the system keyboard when tapped.
+A saved quick-add transaction is then announced in lists by the transaction-row VoiceOver contract
+(`docs/design/ios-transaction-row-voiceover.md`, #2117) — this doc does not redefine how a saved row
+is read; it only produces a row that conforms to that contract.
 
----
+## 4. Shared model & defaults (packages/core)
 
-## 5. Remembered Defaults & Optional Payee
+Quick-add composes **only** fields that exist on the shared model
+(`packages/models/.../Transaction.kt:19-53`) and routes its save through the shared validator
+(`packages/core/.../validation/TransactionValidator.kt`). The two pieces of logic that should live in
+`packages/core` (so all platforms behave identically and are unit-testable today) are:
 
-**Remembered defaults** make repeat capture near-instant:
+1. **Default-selection** — `lastUsedAccountId ?? firstAccount`, `lastUsedType ?? EXPENSE`,
+   `date = today`, `status = PENDING`, `categoryId = suggest(payee) ?? null`. Web implements these
+   ad hoc in the component (`QuickEntry.tsx:106-178`); iOS has them split across the view model and
+   `LogTransactionIntent`. Promoting a single `QuickAddDefaults` resolver into `packages/core` is the
+   smallest shared change and removes three divergent copies.
+2. **Minimum-field / save rule** — amount non-zero **is the only blocking rule**; payee falls back to
+   `categoryName → "Expense"/"Income"` (`LogTransactionIntent.swift:117-120`); category may be null.
+   This mirrors `TransactionValidator.validate` (`TransactionValidator.kt:21-77`), which already
+   blocks only on zero amount, unknown account, and (when provided) unknown category — **not** on a
+   missing payee.
 
-| Default              | Source of "remembered" value                                                                 | Storage                                                  |
-| -------------------- | -------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
-| Transaction **type** | Last saved type, falling back to `.expense`                                                  | `UserDefaults` (App Group) — non-sensitive preference    |
-| **Account**          | Most-recently-used account id; else the first account from `AccountRepository.getAccounts()` | `UserDefaults` (App Group) — id only, not balances       |
-| **Category**         | `CategorizationEngine.suggest(payee:)` once a payee is typed; else last-used category id     | Suggestion is shared (KMP); last-used id in UserDefaults |
-| **Currency**         | Account's currency, else `USD`                                                               | Derived, not stored separately                           |
+**Proposed shared shape (Kotlin, illustrative):**
 
-Rules:
+```kotlin
+// packages/core/.../quickadd — illustrative; not compiled with this doc.
+data class QuickAddDefaults(
+    val accountId: SyncId,                 // last-used ?? first
+    val type: TransactionType,             // last-used ?? EXPENSE
+    val date: LocalDate,                   // today
+    val status: TransactionStatus,         // PENDING
+    val suggestedCategoryId: SyncId?,      // categorization engine ?? null
+)
 
-- Remembered values are **preferences, not secrets** — account/category **ids**
-  and an enum, never amounts, payees, balances, or tokens. They therefore live
-  in App Group `UserDefaults` (shared with the widget/clip), **never** the
-  Keychain (the Keychain remains reserved for credentials per project policy).
-- Defaults are applied at sheet construction so the user lands on a fully valid
-  draft that needs only an amount.
-- Editing a default chip updates the remembered value for next time.
+// payee resolution shared by web QuickEntry, iOS quick-add, and LogTransactionIntent
+fun resolveQuickAddPayee(raw: String?, categoryName: String?, type: TransactionType): String? =
+    raw?.trim()?.takeIf { it.isNotEmpty() }
+        ?: categoryName
+        ?: null   // a null payee is valid; the row falls back to "Expense"/"Income" (#2117 §2)
+```
 
-**Optional payee skipping:**
+The amount itself is `Cents` (`Transaction.kt:27`), entered as integer minor units by the cents-first
+keypad (`amountCents`, `TransactionCreateViewModel.swift:62`), exactly as the web incremental input
+produces `amountInput.cents` (`QuickEntry.tsx:209`,`:239`).
 
-- The current iOS form over-constrains entry: `canAdvance` for the Details step
-  requires `!payee.isEmpty`. The **shared** contract is more permissive —
-  `KMPTransaction.payee` is nullable and `TransactionValidator` does not require
-  a payee. Quick-Add aligns the iOS rule with the shared rule.
-- When payee is empty on save, derive a display label from the chosen category
-  (e.g. "Dining Out") exactly as `AddExpenseIntent` already does, so the saved
-  record is never blank in the list. This derivation is an **iOS presentation
-  concern** and stays in the view model.
-- Save remains gated on the genuinely required fields: `amountCents > 0` and a
-  selected account — both already enforced by `TransactionValidator`
-  (`ZeroAmount`, `AccountNotFound`).
+## 5. Surface application map
 
----
+Every entry point routes into the **same** quick-add sheet and the same shared defaults (§4). The
+quick-add sheet is an _additional_, friction-reduced surface — it does **not** remove the existing
+three-step `TransactionCreateView`, which remains the "More details" target.
 
-## 6. Save Confirmation & Undo
+| Surface                      | iOS entry point (file:line)                                                                                                                   | What quick-add does                                                                                              |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| **Transactions toolbar `+`** | `TransactionsView.swift:73-94` (Menu: "Manual Entry" / "Quick Add (NLP)")                                                                     | Add a third item — **"Quick Add"** — that presents the one-thumb sheet; "Manual Entry" still opens the full form |
+| **Quick-add sheet**          | new sheet beside `TransactionsView.swift:96-105` (`showingCreateTransaction`)                                                                 | Medium detent, amount focused, keypad up, Save / Save & add another in the bottom arc (§3)                       |
+| **Empty state CTA**          | `TransactionsView.swift:32-38` ("Add your first transaction")                                                                                 | Route the CTA to quick-add for the fastest first capture                                                         |
+| **Lock-screen / deep-link**  | `applyQuickEntry(action:)` `TransactionCreateViewModel.swift:204-224`; `deepLinkHandler.pendingQuickEntryAction` `TransactionsView.swift:103` | Already jumps to the amount step with payee/category pre-filled; re-target it to the quick-add sheet             |
+| **App Intent / Shortcuts**   | `LogTransactionIntent.swift:31-98` (widgets, Spotlight, Shortcuts)                                                                            | Headless analogue: same defaults + blank-payee fallback (`:108-133`); no UI, but the same shared resolver        |
 
-Confirmation must reassure without blocking the next capture.
+- **Type-direction icons** come from `TransactionTypeUI` (`TransactionItem.swift:25-47`:
+  `.expense → arrow.up.right`/red, `.income → arrow.down.left`/green, `.transfer →
+arrow.left.arrow.right`/blue) and the `IconToken` map in
+  `apps/ios/Finance/Components/SFSymbolsMapping.swift:30-32`. The segmented control must convey
+  direction by **label + icon**, never color alone (WCAG 1.4.1). _(Named for reference; this doc
+  edits no Swift.)_
+- **Transfer is out of scope for quick-add.** A transfer needs a destination account
+  (`Transaction.kt:49-51`; `TransactionValidator.kt:44-54`), which is more than the minimum field
+  set; quick-add offers expense/income only (parity with web Quick Add's two-way toggle,
+  `QuickEntry.tsx:346-365`) and defers transfers to the full form.
 
-- **On success:** fire `HapticManager.shared.transactionSaved()` (already wired
-  in the wizard), dismiss the sheet, and present a **non-modal inline
-  confirmation** anchored at the bottom of the Transactions tab: a checkmark +
-  "Saved" + an **Undo** action, auto-dismissing after ~4 seconds.
-- **Undo** soft-deletes the just-saved transaction through
-  `TransactionRepository` and reopens the Quick-Add sheet pre-filled with the
-  prior values, so a misfire costs one tap to recover.
-- **On validation failure:** fire `HapticManager.shared.validationWarning()` and
-  show the message **inline within the sheet** (not the wizard's separate
-  `.alert`), keeping the user in the keypad context.
-- The confirmation deliberately avoids announcing the **amount** in a persistent
-  on-screen banner (see §10) — it confirms _that_ a save happened, while
-  VoiceOver users get the amount through the focused element, not a broadcast.
+## 6. State coverage (Dynamic Type, validation, empty, success, save-and-add-another, offline, error)
 
----
+| State                   | Requirement                                                                                                                                                                                                                                                                                                                                                           |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Dynamic Type**        | Amount readout, keypad keys, and the Save row use scalable text styles and never truncate (`docs/design/ios-dynamic-type-reflow.md` R1/R6). At `isAccessibilitySize` the type/account rows collapse to vertical stacks (R3) and the Save / Save & add another row wraps to two full-width buttons rather than clip.                                                   |
+| **Validation (amount)** | Save is disabled while `amountCents == 0`; the existing rule `amountCents > 0` (`TransactionCreateViewModel.swift:81`,`:283-287`) gates it, paired with a non-color inline hint ("Enter an amount", mirroring web `"Enter a valid amount."` `QuickEntry.tsx:241`) and a `HapticManager.validationWarning()` on a blocked attempt (`TransactionCreateView.swift:325`). |
+| **Empty**               | First-ever capture: the Transactions empty state (`TransactionsView.swift:32-38`) routes to quick-add; the account picker defaults to the first available account, so a brand-new user with one account types an amount and saves with no picker interaction.                                                                                                         |
+| **Save success**        | On a successful single save the sheet dismisses and the list reloads (`TransactionsView.swift:96-99`), with `HapticManager.transactionSaved()` (`TransactionCreateView.swift:322`); VoiceOver hears a polite "Saved" announcement.                                                                                                                                    |
+| **Save & add another**  | The sheet **stays open**, resets amount (and payee) but **keeps type + account** for rapid re-entry (web parity, `QuickEntry.tsx:223-233`), increments a polite live-region "N added" counter (`QuickEntry.tsx:288-289`,`:323-327`), and returns focus to the amount.                                                                                                 |
+| **Offline**             | Saves are local-first: `createTransaction` persists to the local store and syncs later (`isSynced` defaults false, `Transaction.kt:41`); quick-add must succeed offline with no spinner-block, and the "N added" counter increments normally. No network state gates a quick-add save.                                                                                |
+| **Error**               | A repository failure surfaces the existing validation alert (`validationMessage` / `showingValidationError`, `TransactionCreateViewModel.swift:274-278`; alert `TransactionCreateView.swift:47-51`) as a focusable, announced `role="alert"`-equivalent; the entered amount is **retained**, never silently dropped.                                                  |
 
-## 7. Affected iOS Surfaces
+## 7. Test plan
 
-| Surface                                                        | Change                                                                                            |
-| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| `apps/ios/Finance/Screens/TransactionsView.swift`              | Add bottom-trailing floating capture button (compact width only), bottom content inset, new sheet |
-| `apps/ios/Finance/Screens/TransactionCreateView.swift`         | Extract shared step components; add an "Expand to full form" entry path from Quick-Add            |
-| **New** `apps/ios/Finance/Screens/QuickAddView.swift`          | Bottom-sheet express entry: amount, default chips, keypad, optional payee, Save                   |
-| `apps/ios/Finance/ViewModels/TransactionCreateViewModel.swift` | Add quick mode, remembered-defaults load/persist, payee-derivation, `canSaveQuick` gate           |
-| `apps/ios/Finance/Components/` (Haptics, IconView, chips)      | Reuse existing `HapticManager`, `IconView`, tag/chip components                                   |
-| `apps/ios/FinanceWidget/QuickEntryWidget.swift`                | No change to the widget; Quick-Add becomes the destination for its deep link                      |
-| `apps/ios/FinanceClip/QuickTransactionView.swift`              | Aligns conceptually; no code change — the clip remains the reduced standalone capture             |
-| `apps/ios/Tests/TransactionCreateViewModelTests.swift`         | Extend for quick mode, defaults, optional payee, undo                                             |
+Smallest set required before a native quick-add implementation is accepted. The shared tests are
+**runnable today** (not blocked by #1239); the gesture/reachability tests are native and deferred.
 
----
+**Shared (KMP `commonTest`, runnable today — not blocked by #1239):**
 
-## 8. Shared Dependencies & the Validation Boundary
+Place beside existing model/validation tests
+(`packages/core/src/commonTest/.../validation`, `packages/models/src/commonTest/.../TransactionTest`):
 
-The boundary is deliberate and **unchanged** by this design:
+- **Default-selection** — `QuickAddDefaults` resolves account = last-used ?? first, type = last-used
+  ?? `EXPENSE`, date = today (fixed-clock fixture), status = `PENDING`, category = `suggest(payee) ??
+null` (parity with `QuickEntry.tsx:106-178`).
+- **Minimum-field / save rule** — amount non-zero is the **only** blocking rule; assert a save with
+  a valid amount, a defaulted account, and a **blank payee** is accepted (no error), matching
+  `TransactionValidator.validate` (`TransactionValidator.kt:21-77`) which blocks only on zero amount /
+  unknown account / unknown category.
+- **Payee fallback** — `resolveQuickAddPayee(blank, categoryName, type)` → category name; with no
+  category → null; with text → trimmed text (mirrors `LogTransactionIntent.swift:117-120`).
+- **Amount model** — cents-first append/delete produces correct minor units and respects the
+  `99_999_999` cap (parity between `appendAmountDigit` `TransactionCreateViewModel.swift:96-102` and
+  web `useAmountInput` `QuickEntry.tsx:160`).
+- **Sign by type** — expense stores a negative amount, income positive
+  (`TransactionCreateViewModel.swift:252`; web `normalizeTransactionAmount` `QuickEntry.tsx:126-136`).
+- **Validator integration** — the composed quick-add candidate passes `TransactionValidator` for a
+  valid fixture and fails with the expected `ValidationError` for zero amount / unknown account.
 
-- **Shared (Kotlin, `packages/core` / `packages/models`) owns the rules.**
-  - `packages/core/src/.../validation/TransactionValidator.kt` is the single
-    source of truth for what makes a transaction savable (non-zero amount,
-    existing account, optional category, future-date bounds). Quick-Add calls it
-    through `KMPTransactionValidatorProtocol` exactly as the wizard does.
-  - `packages/core/src/.../categorization/CategorizationEngine.kt` provides
-    `suggest(payee:)` and `learnFromHistory(payee:categoryId:)` — the source of
-    the remembered/suggested category.
-  - `packages/models/.../models/Transaction.kt` defines the draft shape; payee
-    nullability there is what _permits_ optional-payee entry.
-- **iOS owns presentation only:** sheet layout, detents, the floating affordance,
-  thumb-reachability, default-chip UI, payee-from-category display derivation,
-  haptics, and the confirmation/undo UX.
+**Native (iOS, deferred until #1239 unblocks):**
 
-This design requires **no change to `packages/`**. If a future iteration wants
-"remembered defaults" computed from shared history (rather than an iOS-local
-preference), that would be a shared-logic change proposed to `@kmp-engineer` via
-ADR — out of scope here. The boundary stays: **rules in KMP, pixels in SwiftUI.**
+- **Thumb-zone layout** — snapshot test asserting Save, Save & add another, the keypad, and the
+  amount readout all render within the bottom reachable arc at common device sizes.
+- **Save & add another** — UI test: submit keeps the sheet open, resets the amount, keeps type +
+  account, and increments the "N added" live region.
+- **Non-pointer path** — VoiceOver focus order is type → amount → keypad/value → account → Save;
+  every keypad key and both Save actions are reachable; Switch Control reaches all controls (no
+  gesture-only critical path).
+- **Custom keypad a11y** — each key exposes its digit label and the delete key its "Removes the last
+  digit" hint (`TransactionCreateView.swift:160-161`); the amount is also settable via the standard
+  numeric value.
+- **Dynamic Type XXL/AX5** — amount never truncates; type/account rows stack; the Save row wraps,
+  not clips (`docs/design/ios-dynamic-type-reflow.md` R1/R3/R6).
+- **Offline save** — with the network disabled, a quick-add save succeeds locally and the counter
+  increments.
 
----
+## 8. Cross-references & resolved decisions
 
-## 9. Accessibility, Dynamic Type & Reachability
+**Related work (do not duplicate its scope):**
 
-- **VoiceOver.** Every interactive element gets an explicit label/hint following
-  the patterns already in `TransactionCreateView`:
-  - Floating button: `accessibilityLabel("Quick add transaction")`,
-    `accessibilityHint("Opens the quick entry sheet")`.
-  - Each keypad key keeps its existing per-digit label and `⌫` "Delete" label.
-  - Default chips combine into `"Account: Checking, double-tap to change"`.
-  - The confirmation exposes an Undo action via `.accessibilityAction`.
-- **One-handed reachability beyond placement.** The bottom-trailing position
-  helps right thumbs; we additionally:
-  - Respect the system **Reachability** gesture (no custom interception).
-  - Keep _all_ required controls within the `.medium` detent so a user never has
-    to stretch to the top of the screen to complete a save.
-  - Offer a setting (or honor layout direction) so the button mirrors to
-    bottom-_leading_ for left-handed/RTL users.
-- **Dynamic Type.** No hardcoded font sizes for text; amount uses
-  `.monospacedDigit()` title styles that scale. At accessibility sizes the
-  keypad keys grow and the chips wrap (defer detailed thresholds to
-  [ios-compact-transaction-stepper.md](./ios-compact-transaction-stepper.md)).
-  Tap targets stay ≥ 44×44pt.
-- **Reduce Motion.** The sheet present/expand and the confirmation toast use
-  the system sheet transition; when Reduce Motion is on, the toast cross-fades
-  instead of sliding, and Undo does not animate the reopen.
-- **Switch Control / keyboard.** Focus order is amount → chips → payee → Save;
-  `⌘N` opens Quick-Add and `Return` saves when the draft is valid.
+- **#2113 (#2534, #2537)** — chart text-alternative pattern; the pilot whose structure this doc
+  mirrors (`docs/design/ios-chart-accessibility.md`, PR #2834).
+- **#2117 (#2544)** — transaction-row VoiceOver contract; how a **saved** quick-add row is announced
+  (`docs/design/ios-transaction-row-voiceover.md`). Quick-add produces rows that conform to it; it
+  does not redefine the row announcement.
+- **#2119 (#2548)** — Dynamic Type reflow audit; the reflow rules the quick-add sheet must satisfy
+  (`docs/design/ios-dynamic-type-reflow.md`).
+- **Web reference contract** — `apps/web/src/components/forms/QuickEntry.tsx` (#319, minimal-friction
+  Quick Add), `apps/web/src/components/forms/TransactionForm.tsx` (full form analogue).
+- **Existing iOS infrastructure reused** — the #1486 cents-first keypad and `applyQuickEntry`
+  fast-path (`TransactionCreateView.swift:142-164`, `TransactionCreateViewModel.swift:204-224`), and
+  `LogTransactionIntent` defaults/fallback (`LogTransactionIntent.swift:108-133`).
 
----
+**Resolved design decisions (in-session, 2026-06-20):**
 
-## 10. Privacy
+1. **Payee is optional in one-thumb quick-add** — only the amount blocks a save. A blank payee falls
+   back to the suggested category name, then "Expense"/"Income"
+   (`LogTransactionIntent.swift:117-120`; nullable `payee` `Transaction.kt:29`; not required by
+   `TransactionValidator.kt`). Requiring a text field would force the system keyboard and break the
+   thumb-zone numeric flow. _(iOS deliberately diverges from web Quick Add, which requires a
+   description — `QuickEntry.tsx:246-249` — because that web choice predates the one-thumb
+   constraint; the shared validator sides with optional. Recommended default flagged to the
+   orchestrator 2026-06-20; this section is updated if the maintainer decides otherwise.)_
+2. **Custom cents-first keypad, not the system decimal keypad** — resolved by precedent: the app
+   already ships the #1486 Venmo-style keypad (`TransactionCreateView.swift:142-164`) and the web
+   uses the same incremental cents-first model (`QuickEntry.tsx:156-162`). A custom keypad keeps the
+   digits in the thumb arc, needs no decimal point, and frees the bottom safe-area for the Save
+   actions (§3.2). It is fully labeled for VoiceOver and is an accelerator, not the only input path.
+3. **Category is optional and never blocks save** — auto-suggested from the payee via the
+   categorization engine (`TransactionCreateViewModel.swift:195-200`) and left `null` ("Uncategorized")
+   when there is no suggestion, matching the nullable schema field (`Transaction.kt:24`) and the web
+   behavior (`QuickEntry.tsx:258-261`,`:280`). No "select a category" gate.
+4. **Quick-add is additive, not a replacement** — the existing three-step `TransactionCreateView`
+   remains the "More details" target for payee/category/status/tags/mood/note/date; quick-add adds a
+   fast path and shares the same defaults and shared validator (§4, §5).
+5. **Transfers are out of scope for quick-add** — a transfer requires a destination account
+   (`Transaction.kt:49-51`; `TransactionValidator.kt:44-54`), beyond the minimum field set; quick-add
+   is expense/income only and defers transfers to the full form (§5).
 
-- **No secrets outside the Keychain.** Remembered defaults are non-sensitive
-  ids/enums in App Group `UserDefaults`; nothing in this flow writes tokens,
-  credentials, or balances to `UserDefaults`.
-- **Financial values are `.private`.** Per project logging policy, the amount,
-  payee, and any balance are `.private` in `os.Logger`; only coarse events
-  ("quick add opened", "quick add saved") are logged, never the value.
-- **Lock Screen & widget path stays biometric-gated.** Quick-Add reached via the
-  Lock Screen `QuickEntryWidget` / `DeepLinkHandler` continues through the
-  existing `BiometricAuthManager` gate before any amount field is shown — the
-  widget itself never renders money.
-- **Confirmation restraint.** The success toast confirms the action without
-  persistently displaying the amount on screen, reducing shoulder-surfing risk
-  while still being fully available to VoiceOver on the focused element.
+**Open dependency (flagged, not decided here):**
 
----
-
-## 11. Stale, Error & Empty States
-
-- **Empty — no accounts yet.** If `AccountRepository.getAccounts()` returns
-  empty, Quick-Add cannot satisfy the shared `AccountNotFound` rule. Show an
-  inline empty state ("Add an account to start logging") with a button to the
-  account-creation flow, rather than presenting a dead keypad.
-- **Empty — no categories.** Category is optional per shared rules; the chip
-  shows "Uncategorized" and save still succeeds.
-- **Stale defaults.** If a remembered account/category id no longer exists
-  (deleted/merged), silently fall back to the first available account / clear the
-  category, and refresh the remembered value — never block on a stale id.
-- **Save error (offline / repository failure).** The app is local-first;
-  persistence is optimistic. If `createTransaction` throws, show the message
-  inline in the sheet with **Retry**, keep the keypad state intact, and do not
-  fire the success haptic.
-- **Validation error.** Surfaced inline (not a blocking alert) with the message
-  returned by `TransactionValidator`, so the user can correct without losing the
-  amount.
-
----
-
-## 12. Test Plan
-
-Smallest meaningful tests first; UI snapshot tests gate every visual PR.
-
-### 12.1 Shared (Kotlin · `packages/core` · `commonTest`)
-
-- `TransactionValidatorTest`: a transaction with **null/empty payee** but valid
-  amount + account is **valid** (proves optional-payee is a shared guarantee,
-  not just an iOS choice).
-- `TransactionValidatorTest`: zero amount → `ZeroAmount`; missing account →
-  `AccountNotFound` (the two gates Quick-Add relies on).
-- `CategorizationEngineTest`: `suggest(payee:)` returns the learned category
-  after `learnFromHistory`, validating the default-category source.
-
-### 12.2 Native (Swift · iOS Simulator · XCTest)
-
-- `TransactionCreateViewModelTests` (extend existing
-  `apps/ios/Tests/TransactionCreateViewModelTests.swift`):
-  - Quick mode seeds remembered type/account/category from preferences.
-  - `appendAmountDigit` / `removeLastAmountDigit` produce the expected
-    `amountCents` and `formattedAmount` (cents-first behavior).
-  - Save with empty payee derives the category-based label and succeeds.
-  - `canSaveQuick` is false with zero amount or no account, true otherwise.
-  - Undo path soft-deletes and restores prior field values.
-- A `QuickAddView` snapshot test at default and AX3 Dynamic Type, light + OLED
-  dark, verifying keypad + Save remain within the `.medium` detent.
-- Accessibility test asserting the floating button and keypad keys expose
-  non-empty labels (mirrors existing `accessibilityIdentifier` usage).
-
-### 12.3 Manual / QA gate (every UI PR)
-
-- iPhone SE (smallest) and a Pro Max: confirm Save + keypad are thumb-reachable
-  one-handed; left-handed mirror works.
-- VoiceOver walkthrough: open → enter amount → save → Undo.
-- Reduce Motion on: confirmation cross-fades, no slide.
-
----
-
-## 13. Implementation Readiness
-
-### ✅ Buildable now — no enrollment required
-
-The entire Quick-Add flow — `QuickAddView`, view-model quick mode, remembered
-defaults, optional-payee derivation, confirmation/undo, and all unit/UI tests —
-builds and runs today on a device or simulator using **free Personal Team
-signing** (Xcode + a free Apple ID). It depends only on already-shipping shared
-logic (`TransactionValidator`, `CategorizationEngine`) reached through the
-existing `KMPBridge`, plus existing iOS components (`HapticManager`, `IconView`,
-the Venmo-style keypad). No paid entitlements are required: the App Group used
-for remembered defaults already backs the widget/clip.
-
-### 🔒 Distribution tail — gated by [#1239](https://github.com/jrmoulckers/finance/issues/1239) (human action)
-
-Only the **distribution** step is human-gated: TestFlight/App Store builds,
-release signing, and CI release workflows require Apple Developer Program
-enrollment and signing secrets. Per
-[Human-Gated Prerequisites](../ops/human-gated-prerequisites.md) §2, feature
-implementation is decoupled from distribution and is **not** blocked. No
-provisioning, certificates, or secrets are created as part of this work.
-
----
-
-## 14. Open Questions
-
-1. Should "remembered defaults" eventually move to shared history scoring (KMP)
-   so they sync across devices? If so, that is an ADR to `@kmp-engineer`.
-2. Left-handed mirroring: explicit setting vs. inferred from interaction
-   heatmap vs. RTL-only? Default proposal is an explicit accessibility setting.
-3. Undo window length (4s) and whether it should pause while VoiceOver focus is
-   on the toast — likely yes, to avoid timing out assistive users.
+- The **payee-optional** decision (#1) is the one genuine product call; it was raised to the
+  orchestrator with the recommended default baked in above. If the maintainer rules that quick-add
+  must require a payee, only §3.3, §6 (validation), §7 (the blank-payee test), and decision #1 change
+  — the rest of the flow is unaffected.
+- Promoting the shared `QuickAddDefaults` / `resolveQuickAddPayee` helpers into `packages/core` (§4)
+  is a small shared-code change that removes three divergent copies (web component, iOS view model,
+  `LogTransactionIntent`); it is implementation work to be scheduled, not a design question.


### PR DESCRIPTION
## Summary

Design-only deliverable for v1.0 epic #2167 — a **one-thumb quick-add** flow for fast, reachable, minimal-friction expense capture on iOS. Native implementation is **blocked by Apple Developer enrollment #1239**; this is a single design spec under `docs/design/` (no Swift ships).

Mirrors the #2834 chart-accessibility pilot structure and grounds every claim in real code: the shared `Transaction` schema, the KMP `TransactionValidator`, the existing #1486 Venmo-style cents-first keypad, the lock-screen `applyQuickEntry` fast-path, `LogTransactionIntent` defaults, and the web `QuickEntry` (#319) cross-platform contract.

## Changes

- New file: `docs/design/ios-one-thumb-quick-add.md`
  - Thumb-zone reachability (primary Save / Save & add another + keypad in the bottom arc; top reserved for non-critical chrome)
  - Amount entry via the **existing custom cents-first keypad** (resolved by precedent over the system decimal keypad)
  - Minimum-field rule (amount required; type/account/date/status defaulted; category + payee optional) grounded in the nullable schema + shared validator
  - A non-pointer (VoiceOver / Switch Control) path so one-thumb optimizations never regress assistive tech, plus Dynamic Type reflow (refs `ios-dynamic-type-reflow.md`)
  - Per-surface application map (toolbar `+`, quick-add sheet, empty-state CTA, lock-screen deep link, App Intent)
  - State coverage (Dynamic Type, validation, empty, save success, save-and-add-another, offline, error)
  - Test plan splitting runnable-today KMP `commonTest` (validation + default-selection + payee fallback) from native-deferred gesture/reachability tests

## Key design decision (flagged to orchestrator)

**Payee is optional in quick-add** — only the amount blocks a save; a blank payee falls back to the suggested category name then "Expense"/"Income" (matches `LogTransactionIntent` + the nullable schema; the shared validator does not require payee). iOS deliberately diverges from web Quick Add (which requires a description) because requiring a text field forces the keyboard and breaks the thumb-zone numeric flow. Recommended default baked in; doc updates if the maintainer rules otherwise.

## Issues

Closes #2599
Refs #2167
Refs #1239

## Testing

- [x] `npx prettier --check docs/design/ios-one-thumb-quick-add.md` passes
- [x] Design-only; no code changed (one new doc file)