### PR TITLE
feat(web): passphrase/WebAuthn unlock UI for SQLite at-rest encryption (#2806)

### DIFF
--- a/apps/web/src/components/settings/EncryptionUnlockSettings.test.tsx
+++ b/apps/web/src/components/settings/EncryptionUnlockSettings.test.tsx
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { WrongPassphraseError } from '../../db/data-key-wrapping';
+import type { EncryptionFactorStatus } from '../../db/sqlite-encryption-vault';
+import type { UseSqliteEncryptionResult } from '../../hooks/useSqliteEncryption';
+
+vi.mock('../../hooks/useSqliteEncryption', () => ({
+  useSqliteEncryption: vi.fn(),
+}));
+
+import { useSqliteEncryption } from '../../hooks/useSqliteEncryption';
+import { EncryptionUnlockSettings } from './EncryptionUnlockSettings';
+
+const baseStatus: EncryptionFactorStatus = {
+  supported: true,
+  webAuthnSupported: true,
+  deviceUnlock: true,
+  passphrase: false,
+  recovery: false,
+  webauthn: { enabled: false },
+  factorCount: 0,
+};
+
+function buildHook(overrides: Partial<UseSqliteEncryptionResult> = {}): UseSqliteEncryptionResult {
+  return {
+    supported: true,
+    enabled: true,
+    loading: false,
+    status: baseStatus,
+    refresh: vi.fn().mockResolvedValue(undefined),
+    setEncryptionEnabled: vi.fn().mockResolvedValue(undefined),
+    setPassphrase: vi.fn().mockResolvedValue(undefined),
+    changePassphrase: vi.fn().mockResolvedValue(undefined),
+    removePassphrase: vi.fn().mockResolvedValue(undefined),
+    unlockWithPassphrase: vi.fn().mockResolvedValue(undefined),
+    createRecoveryCode: vi.fn().mockResolvedValue('ABCDE-FGHJK-LMNPQ-RSTUV-WXYZ2'),
+    removeRecoveryCode: vi.fn().mockResolvedValue(undefined),
+    unlockWithRecoveryCode: vi.fn().mockResolvedValue(undefined),
+    enrollWebAuthn: vi.fn().mockResolvedValue(undefined),
+    removeWebAuthn: vi.fn().mockResolvedValue(undefined),
+    unlockWithWebAuthn: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe('EncryptionUnlockSettings (#2806)', () => {
+  beforeEach(() => {
+    vi.mocked(useSqliteEncryption).mockReturnValue(buildHook());
+  });
+
+  it('renders the unlock factors and the encryption toggle', () => {
+    render(<EncryptionUnlockSettings />);
+
+    expect(screen.getByRole('heading', { name: 'Encryption unlock' })).toBeInTheDocument();
+    expect(screen.getByText('Automatic unlock on this device')).toBeInTheDocument();
+    expect(screen.getByText('Passphrase')).toBeInTheDocument();
+    expect(screen.getByRole('switch', { name: /encrypt local database/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Set passphrase' })).toBeInTheDocument();
+  });
+
+  it('shows an unsupported message when encryption is unavailable', () => {
+    vi.mocked(useSqliteEncryption).mockReturnValue(buildHook({ supported: false, status: null }));
+    render(<EncryptionUnlockSettings />);
+
+    expect(screen.getByText(/missing the Web Crypto or storage features/i)).toBeInTheDocument();
+  });
+
+  it('toggles encryption on', async () => {
+    const setEncryptionEnabled = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(useSqliteEncryption).mockReturnValue(
+      buildHook({ enabled: false, setEncryptionEnabled }),
+    );
+    render(<EncryptionUnlockSettings />);
+
+    await userEvent.click(screen.getByRole('switch', { name: /encrypt local database/i }));
+
+    expect(setEncryptionEnabled).toHaveBeenCalledWith(true);
+  });
+
+  it('sets a passphrase through the dialog', async () => {
+    const setPassphrase = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(useSqliteEncryption).mockReturnValue(buildHook({ setPassphrase }));
+    render(<EncryptionUnlockSettings />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Set passphrase' }));
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+    await userEvent.type(screen.getByLabelText('New passphrase'), 'a-very-strong-pass');
+    await userEvent.type(screen.getByLabelText('Confirm passphrase'), 'a-very-strong-pass');
+    await userEvent.click(screen.getByRole('button', { name: 'Save passphrase' }));
+
+    await waitFor(() => expect(setPassphrase).toHaveBeenCalledWith('a-very-strong-pass'));
+  });
+
+  it('announces a friendly error when the wrong passphrase is entered', async () => {
+    const changePassphrase = vi.fn().mockRejectedValue(new WrongPassphraseError('passphrase'));
+    vi.mocked(useSqliteEncryption).mockReturnValue(
+      buildHook({
+        status: { ...baseStatus, passphrase: true, factorCount: 1 },
+        changePassphrase,
+      }),
+    );
+    render(<EncryptionUnlockSettings />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Change' }));
+    await userEvent.type(screen.getByLabelText('Current passphrase'), 'wrong-current-pass');
+    await userEvent.type(screen.getByLabelText('New passphrase'), 'a-brand-new-passphrase');
+    await userEvent.type(screen.getByLabelText('Confirm passphrase'), 'a-brand-new-passphrase');
+    await userEvent.click(screen.getByRole('button', { name: 'Update passphrase' }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/not correct/i);
+    expect(changePassphrase).toHaveBeenCalled();
+  });
+
+  it('blocks submitting a too-short passphrase with an inline error', async () => {
+    render(<EncryptionUnlockSettings />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Set passphrase' }));
+    await userEvent.type(screen.getByLabelText('New passphrase'), 'short');
+    await userEvent.type(screen.getByLabelText('Confirm passphrase'), 'short');
+    await userEvent.click(screen.getByRole('button', { name: 'Save passphrase' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/at least 12 characters/i);
+  });
+
+  it('reveals a generated recovery code once', async () => {
+    render(<EncryptionUnlockSettings />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Generate code' }));
+
+    expect(await screen.findByLabelText('Recovery code')).toHaveTextContent(
+      'ABCDE-FGHJK-LMNPQ-RSTUV-WXYZ2',
+    );
+  });
+});

--- a/apps/web/src/components/settings/EncryptionUnlockSettings.tsx
+++ b/apps/web/src/components/settings/EncryptionUnlockSettings.tsx
@@ -1,0 +1,383 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * EncryptionUnlockSettings — user-controlled at-rest encryption unlock (#2806).
+ *
+ * Lets people intentionally turn encryption on/off and protect the SQLite data
+ * key with a passphrase, a passkey (WebAuthn PRF), and/or a recovery code. Each
+ * action re-wraps the same data key; none re-encrypt the database or change the
+ * snapshot format.
+ *
+ * Data access is hooks-only via {@link useSqliteEncryption}; this component
+ * never imports the vault/repository directly.
+ */
+
+import React, { useCallback, useState } from 'react';
+
+import { useSqliteEncryption } from '../../hooks/useSqliteEncryption';
+
+import { PassphraseDialog, type PassphraseDialogSubmitValues } from './PassphraseDialog';
+import { RecoveryCodeDialog } from './RecoveryCodeDialog';
+
+import './encryption-unlock.css';
+
+type ActiveDialog =
+  | { readonly type: 'set-passphrase' }
+  | { readonly type: 'change-passphrase' }
+  | { readonly type: 'verify-passphrase' }
+  | { readonly type: 'recovery-code'; readonly code: string }
+  | null;
+
+interface StatusChipProps {
+  readonly on: boolean;
+  readonly onLabel?: string;
+  readonly offLabel?: string;
+}
+
+const StatusChip: React.FC<StatusChipProps> = ({ on, onLabel = 'On', offLabel = 'Off' }) => (
+  <span
+    className={`encryption-chip ${on ? 'encryption-chip--on' : 'encryption-chip--off'}`}
+    data-state={on ? 'on' : 'off'}
+  >
+    <span aria-hidden="true" className="encryption-chip__dot" />
+    {on ? onLabel : offLabel}
+  </span>
+);
+
+export const EncryptionUnlockSettings: React.FC = () => {
+  const encryption = useSqliteEncryption();
+  const { status } = encryption;
+
+  const [dialog, setDialog] = useState<ActiveDialog>(null);
+  const [announcement, setAnnouncement] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const announce = useCallback((message: string) => {
+    setError(null);
+    setAnnouncement(message);
+  }, []);
+
+  const run = useCallback(async (label: string, action: () => Promise<void>) => {
+    setBusy(true);
+    setError(null);
+    try {
+      await action();
+      setAnnouncement(label);
+    } catch (actionError) {
+      setAnnouncement('');
+      setError(
+        actionError instanceof Error ? actionError.message : 'Something went wrong. Try again.',
+      );
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  const handleToggleEncryption = useCallback(
+    (next: boolean) => {
+      void run(
+        next ? 'Encryption at rest is now on for future writes.' : 'Encryption at rest is now off.',
+        () => encryption.setEncryptionEnabled(next),
+      );
+    },
+    [encryption, run],
+  );
+
+  const handleSetPassphrase = useCallback(
+    async (values: PassphraseDialogSubmitValues) => {
+      await encryption.setPassphrase(values.passphrase);
+      announce('Passphrase saved. Your data key is now protected by your passphrase.');
+    },
+    [announce, encryption],
+  );
+
+  const handleChangePassphrase = useCallback(
+    async (values: PassphraseDialogSubmitValues) => {
+      await encryption.changePassphrase(values.current ?? '', values.passphrase);
+      announce('Passphrase updated.');
+    },
+    [announce, encryption],
+  );
+
+  const handleVerifyPassphrase = useCallback(
+    async (values: PassphraseDialogSubmitValues) => {
+      await encryption.unlockWithPassphrase(values.passphrase);
+      announce('Passphrase verified — it can unlock your data.');
+    },
+    [announce, encryption],
+  );
+
+  const handleGenerateRecovery = useCallback(() => {
+    void run('Recovery code generated.', async () => {
+      const code = await encryption.createRecoveryCode();
+      setDialog({ type: 'recovery-code', code });
+    });
+  }, [encryption, run]);
+
+  const handleEnrollPasskey = useCallback(() => {
+    void run('Passkey enrolled. You can now unlock with your passkey.', () =>
+      encryption.enrollWebAuthn(),
+    );
+  }, [encryption, run]);
+
+  if (!encryption.supported) {
+    return (
+      <section className="encryption-unlock" aria-labelledby="encryption-unlock-title">
+        <h3 id="encryption-unlock-title" className="encryption-unlock__title">
+          Encryption unlock
+        </h3>
+        <p className="encryption-unlock__intro">
+          This browser is missing the Web Crypto or storage features required for at-rest
+          encryption, so unlock factors are unavailable here.
+        </p>
+      </section>
+    );
+  }
+
+  const enabled = encryption.enabled;
+  const passphraseSet = Boolean(status?.passphrase);
+  const recoverySet = Boolean(status?.recovery);
+  const passkeySet = Boolean(status?.webauthn.enabled);
+  const webAuthnSupported = Boolean(status?.webAuthnSupported);
+  const controlsDisabled = busy || encryption.loading;
+
+  return (
+    <section className="encryption-unlock" aria-labelledby="encryption-unlock-title">
+      <h3 id="encryption-unlock-title" className="encryption-unlock__title">
+        Encryption unlock
+      </h3>
+      <p className="encryption-unlock__intro">
+        Encrypt the local SQLite database and choose how to unlock it. Adding a passphrase, passkey,
+        or recovery code re-wraps the existing encryption key — your data is never re-encrypted or
+        moved.
+      </p>
+
+      {/* Live regions for non-visual feedback */}
+      <p className="encryption-unlock__sr-status" role="status" aria-live="polite">
+        {announcement}
+      </p>
+      {error && (
+        <p className="encryption-unlock__error" role="alert" aria-live="assertive">
+          <span aria-hidden="true">⚠ </span>
+          {error}
+        </p>
+      )}
+
+      {/* Enable / disable */}
+      <div className="encryption-row">
+        <div className="encryption-row__text">
+          <label className="encryption-row__label" htmlFor="encryption-enabled-toggle">
+            Encrypt local database (at rest)
+          </label>
+          <p className="encryption-row__hint">
+            When on, database snapshots are stored as AES-256-GCM ciphertext. Existing encrypted
+            data stays readable if you turn this off, so you are never locked out.
+          </p>
+        </div>
+        <div className="encryption-row__control">
+          <StatusChip on={enabled} />
+          <button
+            id="encryption-enabled-toggle"
+            type="button"
+            role="switch"
+            aria-checked={enabled}
+            className="encryption-switch"
+            disabled={controlsDisabled}
+            onClick={() => handleToggleEncryption(!enabled)}
+          >
+            <span className="encryption-switch__track" aria-hidden="true">
+              <span className="encryption-switch__thumb" />
+            </span>
+            <span className="encryption-switch__text">{enabled ? 'Turn off' : 'Turn on'}</span>
+          </button>
+        </div>
+      </div>
+
+      <fieldset className="encryption-factors" disabled={!enabled || controlsDisabled}>
+        <legend className="encryption-factors__legend">Unlock factors</legend>
+        {!enabled && (
+          <p className="encryption-row__hint">Turn on encryption above to manage unlock factors.</p>
+        )}
+
+        {/* Device automatic unlock */}
+        <div className="encryption-row">
+          <div className="encryption-row__text">
+            <span className="encryption-row__label">Automatic unlock on this device</span>
+            <p className="encryption-row__hint">
+              A non-extractable device key unlocks your data automatically in this browser profile.
+              This is the default and cannot be exported.
+            </p>
+          </div>
+          <div className="encryption-row__control">
+            <StatusChip on={Boolean(status?.deviceUnlock)} onLabel="Active" offLabel="Not set" />
+          </div>
+        </div>
+
+        {/* Passphrase */}
+        <div className="encryption-row">
+          <div className="encryption-row__text">
+            <span className="encryption-row__label">Passphrase</span>
+            <p className="encryption-row__hint">
+              Protect and recover your data key with a passphrase you remember. Wrong passphrases
+              are rejected without revealing any data.
+            </p>
+          </div>
+          <div className="encryption-row__control encryption-row__control--stack">
+            <StatusChip on={passphraseSet} onLabel="Set" offLabel="Not set" />
+            {passphraseSet ? (
+              <div className="encryption-button-group">
+                <button
+                  type="button"
+                  className="encryption-button encryption-button--secondary"
+                  onClick={() => setDialog({ type: 'change-passphrase' })}
+                >
+                  Change
+                </button>
+                <button
+                  type="button"
+                  className="encryption-button encryption-button--secondary"
+                  onClick={() => setDialog({ type: 'verify-passphrase' })}
+                >
+                  Verify
+                </button>
+                <button
+                  type="button"
+                  className="encryption-button encryption-button--danger"
+                  onClick={() => {
+                    void run('Passphrase removed.', encryption.removePassphrase);
+                  }}
+                >
+                  Remove
+                </button>
+              </div>
+            ) : (
+              <button
+                type="button"
+                className="encryption-button encryption-button--primary"
+                onClick={() => setDialog({ type: 'set-passphrase' })}
+              >
+                Set passphrase
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Passkey */}
+        <div className="encryption-row">
+          <div className="encryption-row__text">
+            <span className="encryption-row__label">Passkey (Touch ID / Windows Hello)</span>
+            <p className="encryption-row__hint">
+              {webAuthnSupported
+                ? 'Use a hardware-backed passkey to unlock without typing a passphrase.'
+                : 'Passkeys are not available in this browser.'}
+            </p>
+          </div>
+          <div className="encryption-row__control encryption-row__control--stack">
+            <StatusChip on={passkeySet} onLabel="Enrolled" offLabel="Not set" />
+            {passkeySet ? (
+              <button
+                type="button"
+                className="encryption-button encryption-button--danger"
+                onClick={() => {
+                  void run('Passkey removed.', encryption.removeWebAuthn);
+                }}
+              >
+                Remove passkey
+              </button>
+            ) : (
+              <button
+                type="button"
+                className="encryption-button encryption-button--primary"
+                disabled={!webAuthnSupported}
+                onClick={handleEnrollPasskey}
+              >
+                Add passkey
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Recovery code */}
+        <div className="encryption-row">
+          <div className="encryption-row__text">
+            <span className="encryption-row__label">Recovery code</span>
+            <p className="encryption-row__hint">
+              A one-time code that unlocks your data if you forget your passphrase. Generate one and
+              store it somewhere safe.
+            </p>
+          </div>
+          <div className="encryption-row__control encryption-row__control--stack">
+            <StatusChip on={recoverySet} onLabel="Set" offLabel="Not set" />
+            <div className="encryption-button-group">
+              <button
+                type="button"
+                className="encryption-button encryption-button--primary"
+                onClick={handleGenerateRecovery}
+              >
+                {recoverySet ? 'Replace code' : 'Generate code'}
+              </button>
+              {recoverySet && (
+                <button
+                  type="button"
+                  className="encryption-button encryption-button--danger"
+                  onClick={() => {
+                    void run('Recovery code removed.', encryption.removeRecoveryCode);
+                  }}
+                >
+                  Remove
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      </fieldset>
+
+      <div className="encryption-unlock__note" role="note">
+        <h4 className="encryption-unlock__note-title">If you lose access</h4>
+        <p>
+          Your data key can be unlocked by any factor you set up. If you forget your passphrase, use
+          your recovery code or passkey. If every factor that protects this device is lost, the
+          encrypted data on this device cannot be recovered — there is no backdoor. Keep at least
+          one recovery factor in a safe place.
+        </p>
+      </div>
+
+      {dialog?.type === 'set-passphrase' && (
+        <PassphraseDialog
+          mode="set"
+          title="Set an unlock passphrase"
+          description="Choose a passphrase to protect your local encryption key. You'll be able to unlock with it on this device."
+          submitLabel="Save passphrase"
+          onSubmit={handleSetPassphrase}
+          onClose={() => setDialog(null)}
+        />
+      )}
+      {dialog?.type === 'change-passphrase' && (
+        <PassphraseDialog
+          mode="change"
+          title="Change your passphrase"
+          description="Enter your current passphrase, then choose a new one. Your encryption key is re-wrapped — your data is not re-encrypted."
+          submitLabel="Update passphrase"
+          onSubmit={handleChangePassphrase}
+          onClose={() => setDialog(null)}
+        />
+      )}
+      {dialog?.type === 'verify-passphrase' && (
+        <PassphraseDialog
+          mode="unlock"
+          title="Verify your passphrase"
+          description="Enter your passphrase to confirm it can unlock your data. Nothing is changed."
+          submitLabel="Verify"
+          onSubmit={handleVerifyPassphrase}
+          onClose={() => setDialog(null)}
+        />
+      )}
+      {dialog?.type === 'recovery-code' && (
+        <RecoveryCodeDialog code={dialog.code} onClose={() => setDialog(null)} />
+      )}
+    </section>
+  );
+};
+
+export default EncryptionUnlockSettings;

--- a/apps/web/src/components/settings/PassphraseDialog.test.tsx
+++ b/apps/web/src/components/settings/PassphraseDialog.test.tsx
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { WrongPassphraseError } from '../../db/data-key-wrapping';
+
+import { PassphraseDialog } from './PassphraseDialog';
+
+describe('PassphraseDialog (#2806)', () => {
+  it('moves focus to the first field on open (unlock mode)', () => {
+    render(
+      <PassphraseDialog
+        mode="unlock"
+        title="Verify your passphrase"
+        description="Enter your passphrase."
+        submitLabel="Verify"
+        onSubmit={vi.fn().mockResolvedValue(undefined)}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText('Passphrase')).toHaveFocus();
+  });
+
+  it('rejects mismatched confirmation without calling onSubmit', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(
+      <PassphraseDialog
+        mode="set"
+        title="Set an unlock passphrase"
+        description="Choose a passphrase."
+        submitLabel="Save passphrase"
+        onSubmit={onSubmit}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await userEvent.type(screen.getByLabelText('New passphrase'), 'first-passphrase-1');
+    await userEvent.type(screen.getByLabelText('Confirm passphrase'), 'second-passphrase-2');
+    await userEvent.click(screen.getByRole('button', { name: 'Save passphrase' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/do not match/i);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('submits the new passphrase when valid', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const onClose = vi.fn();
+    render(
+      <PassphraseDialog
+        mode="set"
+        title="Set an unlock passphrase"
+        description="Choose a passphrase."
+        submitLabel="Save passphrase"
+        onSubmit={onSubmit}
+        onClose={onClose}
+      />,
+    );
+
+    await userEvent.type(screen.getByLabelText('New passphrase'), 'a-good-strong-passphrase');
+    await userEvent.type(screen.getByLabelText('Confirm passphrase'), 'a-good-strong-passphrase');
+    await userEvent.click(screen.getByRole('button', { name: 'Save passphrase' }));
+
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith({ passphrase: 'a-good-strong-passphrase' }),
+    );
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it('surfaces a wrong-passphrase error from onSubmit (fails closed)', async () => {
+    const onSubmit = vi.fn().mockRejectedValue(new WrongPassphraseError('passphrase'));
+    const onClose = vi.fn();
+    render(
+      <PassphraseDialog
+        mode="unlock"
+        title="Verify your passphrase"
+        description="Enter your passphrase."
+        submitLabel="Verify"
+        onSubmit={onSubmit}
+        onClose={onClose}
+      />,
+    );
+
+    await userEvent.type(screen.getByLabelText('Passphrase'), 'whatever-passphrase');
+    await userEvent.click(screen.getByRole('button', { name: 'Verify' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/not correct/i);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('closes on Escape and via Cancel', async () => {
+    const onClose = vi.fn();
+    render(
+      <PassphraseDialog
+        mode="set"
+        title="Set an unlock passphrase"
+        description="Choose a passphrase."
+        submitLabel="Save passphrase"
+        onSubmit={vi.fn().mockResolvedValue(undefined)}
+        onClose={onClose}
+      />,
+    );
+
+    await userEvent.keyboard('{Escape}');
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/src/components/settings/PassphraseDialog.tsx
+++ b/apps/web/src/components/settings/PassphraseDialog.tsx
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * PassphraseDialog — accessible modal for setting, changing, or entering the
+ * encryption passphrase (#2806).
+ *
+ * Accessibility (WCAG 2.2 AA):
+ *   - `role="dialog"` + `aria-modal`, labelled & described.
+ *   - Focus moves to the first field on open and is trapped within the dialog.
+ *   - Focus returns to the trigger element on close.
+ *   - Errors are announced via an assertive live region (`role="alert"`).
+ *   - Validation hints are tied to inputs with `aria-describedby`; the submit
+ *     button reflects `aria-disabled`. No information is conveyed by colour
+ *     alone (icons + text are used together).
+ */
+
+import React, { useCallback, useEffect, useId, useRef, useState } from 'react';
+
+import { MIN_PASSPHRASE_LENGTH } from '../../db/data-key-wrapping';
+
+import './encryption-unlock.css';
+
+export type PassphraseDialogMode = 'set' | 'change' | 'unlock';
+
+export interface PassphraseDialogSubmitValues {
+  /** Existing passphrase — present for `change` and `unlock`. */
+  readonly current?: string;
+  /** The passphrase to set (`set`/`change`) or verify (`unlock`). */
+  readonly passphrase: string;
+}
+
+export interface PassphraseDialogProps {
+  readonly mode: PassphraseDialogMode;
+  readonly title: string;
+  readonly description: string;
+  readonly submitLabel: string;
+  readonly onSubmit: (values: PassphraseDialogSubmitValues) => Promise<void>;
+  readonly onClose: () => void;
+}
+
+function nonWhitespaceLength(value: string): number {
+  return value.replace(/\s+/g, '').length;
+}
+
+const FOCUSABLE_SELECTOR =
+  'button:not([disabled]), [href], input:not([disabled]), select, textarea, [tabindex]:not([tabindex="-1"])';
+
+export const PassphraseDialog: React.FC<PassphraseDialogProps> = ({
+  mode,
+  title,
+  description,
+  submitLabel,
+  onSubmit,
+  onClose,
+}) => {
+  const titleId = useId();
+  const descriptionId = useId();
+  const errorId = useId();
+  const hintId = useId();
+
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const firstFieldRef = useRef<HTMLInputElement>(null);
+  const previouslyFocused = useRef<HTMLElement | null>(null);
+
+  const [current, setCurrent] = useState('');
+  const [passphrase, setPassphrase] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [reveal, setReveal] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const requiresNew = mode === 'set' || mode === 'change';
+  const requiresCurrent = mode === 'change' || mode === 'unlock';
+
+  useEffect(() => {
+    previouslyFocused.current = document.activeElement as HTMLElement | null;
+    firstFieldRef.current?.focus();
+    return () => {
+      previouslyFocused.current?.focus?.();
+    };
+  }, []);
+
+  const close = useCallback(() => {
+    if (submitting) {
+      return;
+    }
+    onClose();
+  }, [onClose, submitting]);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        close();
+        return;
+      }
+      if (event.key !== 'Tab') {
+        return;
+      }
+      const dialog = dialogRef.current;
+      if (!dialog) {
+        return;
+      }
+      const focusable = Array.from(dialog.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+      if (focusable.length === 0) {
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    },
+    [close],
+  );
+
+  const validate = useCallback((): string | null => {
+    if (mode === 'change' && current.length === 0) {
+      return 'Enter your current passphrase.';
+    }
+    if (requiresNew) {
+      if (nonWhitespaceLength(passphrase) < MIN_PASSPHRASE_LENGTH) {
+        return `Use at least ${MIN_PASSPHRASE_LENGTH} characters for a strong passphrase.`;
+      }
+      if (passphrase !== confirm) {
+        return 'The two passphrases do not match.';
+      }
+    } else if (passphrase.length === 0) {
+      return 'Enter your passphrase.';
+    }
+    return null;
+  }, [confirm, current, mode, passphrase, requiresNew]);
+
+  const handleSubmit = useCallback(
+    async (event: React.FormEvent) => {
+      event.preventDefault();
+      const validationError = validate();
+      if (validationError) {
+        setError(validationError);
+        return;
+      }
+      setError(null);
+      setSubmitting(true);
+      try {
+        await onSubmit({
+          passphrase,
+          ...(mode === 'change' ? { current } : {}),
+        });
+        onClose();
+      } catch (submitError) {
+        setError(
+          submitError instanceof Error
+            ? submitError.message
+            : 'Something went wrong. Please try again.',
+        );
+        setSubmitting(false);
+      }
+    },
+    [current, mode, onClose, onSubmit, passphrase, validate],
+  );
+
+  const inputType = reveal ? 'text' : 'password';
+
+  return (
+    <div className="encryption-dialog__overlay" role="presentation" onMouseDown={close}>
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        className="encryption-dialog"
+        onKeyDown={handleKeyDown}
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        <form onSubmit={handleSubmit} className="encryption-dialog__form" noValidate>
+          <h3 id={titleId} className="encryption-dialog__title">
+            {title}
+          </h3>
+          <p id={descriptionId} className="encryption-dialog__description">
+            {description}
+          </p>
+
+          {requiresCurrent && (
+            <div className="encryption-field">
+              <label className="encryption-field__label" htmlFor={`${titleId}-current`}>
+                {mode === 'unlock' ? 'Passphrase' : 'Current passphrase'}
+              </label>
+              <input
+                ref={firstFieldRef}
+                id={`${titleId}-current`}
+                className="encryption-field__input"
+                type={inputType}
+                value={mode === 'unlock' ? passphrase : current}
+                onChange={(event) =>
+                  mode === 'unlock'
+                    ? setPassphrase(event.target.value)
+                    : setCurrent(event.target.value)
+                }
+                autoComplete="current-password"
+                autoCapitalize="off"
+                autoCorrect="off"
+                spellCheck={false}
+                disabled={submitting}
+                aria-describedby={error ? errorId : undefined}
+              />
+            </div>
+          )}
+
+          {requiresNew && (
+            <>
+              <div className="encryption-field">
+                <label className="encryption-field__label" htmlFor={`${titleId}-new`}>
+                  New passphrase
+                </label>
+                <input
+                  ref={requiresCurrent ? undefined : firstFieldRef}
+                  id={`${titleId}-new`}
+                  className="encryption-field__input"
+                  type={inputType}
+                  value={passphrase}
+                  onChange={(event) => setPassphrase(event.target.value)}
+                  autoComplete="new-password"
+                  autoCapitalize="off"
+                  autoCorrect="off"
+                  spellCheck={false}
+                  disabled={submitting}
+                  aria-describedby={hintId}
+                />
+              </div>
+              <div className="encryption-field">
+                <label className="encryption-field__label" htmlFor={`${titleId}-confirm`}>
+                  Confirm passphrase
+                </label>
+                <input
+                  id={`${titleId}-confirm`}
+                  className="encryption-field__input"
+                  type={inputType}
+                  value={confirm}
+                  onChange={(event) => setConfirm(event.target.value)}
+                  autoComplete="new-password"
+                  autoCapitalize="off"
+                  autoCorrect="off"
+                  spellCheck={false}
+                  disabled={submitting}
+                  aria-describedby={error ? errorId : undefined}
+                />
+              </div>
+              <p id={hintId} className="encryption-field__hint">
+                Use at least {MIN_PASSPHRASE_LENGTH} characters. If you forget it and have no
+                recovery code, the encrypted data on this device cannot be recovered.
+              </p>
+            </>
+          )}
+
+          <label className="encryption-field__reveal">
+            <input
+              type="checkbox"
+              checked={reveal}
+              onChange={(event) => setReveal(event.target.checked)}
+              disabled={submitting}
+            />
+            Show passphrase
+          </label>
+
+          {error && (
+            <p id={errorId} className="encryption-dialog__error" role="alert" aria-live="assertive">
+              <span aria-hidden="true">⚠ </span>
+              {error}
+            </p>
+          )}
+
+          <div className="encryption-dialog__actions">
+            <button
+              type="button"
+              className="encryption-button encryption-button--secondary"
+              onClick={close}
+              disabled={submitting}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="encryption-button encryption-button--primary"
+              disabled={submitting}
+              aria-disabled={submitting}
+            >
+              {submitting ? 'Working…' : submitLabel}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default PassphraseDialog;

--- a/apps/web/src/components/settings/RecoveryCodeDialog.tsx
+++ b/apps/web/src/components/settings/RecoveryCodeDialog.tsx
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * RecoveryCodeDialog — shows a freshly generated recovery code exactly once
+ * (#2806). The code is a second wrapping factor: it can unlock the same data
+ * key if the passphrase is forgotten, so it must be stored somewhere safe.
+ *
+ * Accessibility: focus moves to the dialog on open, focus is trapped, the code
+ * is exposed to assistive tech, and the "Done" action stays disabled until the
+ * user confirms they saved the code (not colour-dependent).
+ */
+
+import React, { useCallback, useEffect, useId, useRef, useState } from 'react';
+
+import './encryption-unlock.css';
+
+export interface RecoveryCodeDialogProps {
+  readonly code: string;
+  readonly onClose: () => void;
+}
+
+const FOCUSABLE_SELECTOR =
+  'button:not([disabled]), [href], input:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+export const RecoveryCodeDialog: React.FC<RecoveryCodeDialogProps> = ({ code, onClose }) => {
+  const titleId = useId();
+  const descriptionId = useId();
+  const statusId = useId();
+
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const previouslyFocused = useRef<HTMLElement | null>(null);
+
+  const [confirmed, setConfirmed] = useState(false);
+  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle');
+
+  useEffect(() => {
+    previouslyFocused.current = document.activeElement as HTMLElement | null;
+    closeButtonRef.current?.focus();
+    return () => {
+      previouslyFocused.current?.focus?.();
+    };
+  }, []);
+
+  const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== 'Tab') {
+      return;
+    }
+    const dialog = dialogRef.current;
+    if (!dialog) {
+      return;
+    }
+    const focusable = Array.from(dialog.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+    if (focusable.length === 0) {
+      return;
+    }
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }, []);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopyState('copied');
+    } catch {
+      setCopyState('failed');
+    }
+  }, [code]);
+
+  return (
+    <div className="encryption-dialog__overlay" role="presentation">
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        className="encryption-dialog"
+        onKeyDown={handleKeyDown}
+      >
+        <h3 id={titleId} className="encryption-dialog__title">
+          Save your recovery code
+        </h3>
+        <p id={descriptionId} className="encryption-dialog__description">
+          This is the only time we can show this code. Store it in a password manager or another
+          safe place. Anyone with this code can unlock your encrypted data, and if you lose both
+          your passphrase and this code, the data on this device cannot be recovered.
+        </p>
+
+        <pre className="encryption-recovery-code" aria-label="Recovery code" tabIndex={0}>
+          {code}
+        </pre>
+
+        <div className="encryption-dialog__actions encryption-dialog__actions--start">
+          <button
+            type="button"
+            className="encryption-button encryption-button--secondary"
+            onClick={() => {
+              void handleCopy();
+            }}
+          >
+            Copy code
+          </button>
+        </div>
+
+        <p id={statusId} className="encryption-field__hint" role="status" aria-live="polite">
+          {copyState === 'copied'
+            ? 'Recovery code copied to the clipboard.'
+            : copyState === 'failed'
+              ? 'Could not copy automatically — select the code above and copy it manually.'
+              : ''}
+        </p>
+
+        <label className="encryption-field__reveal">
+          <input
+            type="checkbox"
+            checked={confirmed}
+            onChange={(event) => setConfirmed(event.target.checked)}
+          />
+          I have saved my recovery code somewhere safe.
+        </label>
+
+        <div className="encryption-dialog__actions">
+          <button
+            ref={closeButtonRef}
+            type="button"
+            className="encryption-button encryption-button--primary"
+            onClick={onClose}
+            disabled={!confirmed}
+            aria-disabled={!confirmed}
+          >
+            Done
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RecoveryCodeDialog;

--- a/apps/web/src/components/settings/encryption-unlock.css
+++ b/apps/web/src/components/settings/encryption-unlock.css
@@ -1,0 +1,373 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/* Encryption unlock settings (#2806) — tokens only, no hard-coded values. */
+
+.encryption-unlock {
+  display: grid;
+  gap: var(--spacing-4);
+}
+
+.encryption-unlock__title {
+  margin: 0;
+  color: var(--semantic-text-primary);
+  font-size: var(--type-scale-title-font-size, 1.125rem);
+  font-weight: var(--font-weight-bold, 700);
+}
+
+.encryption-unlock__intro,
+.encryption-row__hint {
+  margin: 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size, 0.875rem);
+  line-height: 1.5;
+}
+
+/* Visually hidden, but still announced to screen readers. */
+.encryption-unlock__sr-status {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.encryption-unlock__error {
+  margin: 0;
+  padding: var(--spacing-3);
+  border: 1px solid var(--semantic-border-error, var(--semantic-status-negative));
+  border-radius: var(--card-border-radius, 0.5rem);
+  color: var(--semantic-status-negative, #b91c1c);
+  background: color-mix(in srgb, var(--semantic-status-negative, #b91c1c) 8%, transparent);
+  font-size: var(--type-scale-caption-font-size, 0.875rem);
+}
+
+.encryption-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-3);
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: var(--spacing-4) 0;
+  border-top: 1px solid var(--semantic-border-default, var(--card-border));
+}
+
+.encryption-row__text {
+  display: grid;
+  gap: var(--spacing-2);
+  flex: 1 1 16rem;
+  min-width: 0;
+}
+
+.encryption-row__label {
+  color: var(--semantic-text-primary);
+  font-weight: var(--font-weight-medium, 600);
+}
+
+.encryption-row__control {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-3);
+}
+
+.encryption-row__control--stack {
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--spacing-2);
+}
+
+.encryption-factors {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.encryption-factors:disabled {
+  opacity: 0.6;
+}
+
+.encryption-factors__legend {
+  padding: 0;
+  color: var(--semantic-text-primary);
+  font-weight: var(--font-weight-bold, 700);
+}
+
+/* Status chip — text label + dot (never colour-only). */
+.encryption-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-1, 0.25rem) var(--spacing-2);
+  border-radius: var(--radius-full, 999px);
+  border: 1px solid var(--semantic-border-default, var(--card-border));
+  font-size: var(--type-scale-caption-font-size, 0.8125rem);
+  font-weight: var(--font-weight-medium, 600);
+  white-space: nowrap;
+}
+
+.encryption-chip__dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: var(--radius-full, 999px);
+  background: var(--semantic-text-secondary);
+}
+
+.encryption-chip--on {
+  color: var(--semantic-status-positive, #15803d);
+  border-color: var(--semantic-status-positive, #15803d);
+}
+
+.encryption-chip--on .encryption-chip__dot {
+  background: var(--semantic-status-positive, #15803d);
+}
+
+.encryption-chip--off {
+  color: var(--semantic-text-secondary);
+}
+
+/* Switch */
+.encryption-switch {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 1px solid var(--semantic-border-default, var(--card-border));
+  border-radius: var(--radius-md, 0.5rem);
+  background: var(--theme-surface, var(--card-background));
+  color: var(--semantic-text-primary);
+  cursor: pointer;
+  font-size: var(--type-scale-caption-font-size, 0.875rem);
+}
+
+.encryption-switch[aria-checked='true'] {
+  border-color: var(--semantic-interactive-default, #2563eb);
+}
+
+.encryption-switch__track {
+  position: relative;
+  width: 2.25rem;
+  height: 1.25rem;
+  border-radius: var(--radius-full, 999px);
+  background: var(--semantic-interactive-disabled, #9ca3af);
+  transition: background-color 150ms ease;
+}
+
+.encryption-switch[aria-checked='true'] .encryption-switch__track {
+  background: var(--semantic-interactive-default, #2563eb);
+}
+
+.encryption-switch__thumb {
+  position: absolute;
+  top: 0.125rem;
+  left: 0.125rem;
+  width: 1rem;
+  height: 1rem;
+  border-radius: var(--radius-full, 999px);
+  background: var(--semantic-text-inverse, #ffffff);
+  transition: transform 150ms ease;
+}
+
+.encryption-switch[aria-checked='true'] .encryption-switch__thumb {
+  transform: translateX(1rem);
+}
+
+/* Buttons */
+.encryption-button-group {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-2);
+  justify-content: flex-end;
+}
+
+.encryption-button {
+  min-height: 2.25rem;
+  padding: var(--spacing-2) var(--spacing-4);
+  border-radius: var(--radius-md, 0.5rem);
+  border: 1px solid transparent;
+  font-size: var(--type-scale-caption-font-size, 0.875rem);
+  font-weight: var(--font-weight-medium, 600);
+  cursor: pointer;
+}
+
+.encryption-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.encryption-button--primary {
+  background: var(--semantic-interactive-default, #2563eb);
+  color: var(--semantic-text-inverse, #ffffff);
+}
+
+.encryption-button--primary:hover:not(:disabled) {
+  background: var(--semantic-interactive-hover, #1d4ed8);
+}
+
+.encryption-button--secondary {
+  background: transparent;
+  border-color: var(--semantic-border-default, var(--card-border));
+  color: var(--semantic-text-primary);
+}
+
+.encryption-button--secondary:hover:not(:disabled) {
+  background: var(--theme-surface-elevated, var(--card-background));
+}
+
+.encryption-button--danger {
+  background: transparent;
+  border-color: var(--semantic-status-negative, #b91c1c);
+  color: var(--semantic-status-negative, #b91c1c);
+}
+
+.encryption-button--danger:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--semantic-status-negative, #b91c1c) 10%, transparent);
+}
+
+.encryption-button:focus-visible,
+.encryption-switch:focus-visible,
+.encryption-field__input:focus-visible,
+.encryption-recovery-code:focus-visible {
+  outline: 2px solid var(--semantic-border-focus, #2563eb);
+  outline-offset: 2px;
+}
+
+/* Informational note */
+.encryption-unlock__note {
+  padding: var(--spacing-4);
+  border: 1px solid var(--semantic-status-warning, #d97706);
+  border-radius: var(--card-border-radius, 0.5rem);
+  background: color-mix(in srgb, var(--semantic-status-warning, #d97706) 8%, transparent);
+}
+
+.encryption-unlock__note-title {
+  margin: 0 0 var(--spacing-2);
+  color: var(--semantic-text-primary);
+  font-size: var(--type-scale-label-font-size, 0.9375rem);
+}
+
+.encryption-unlock__note p {
+  margin: 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size, 0.875rem);
+  line-height: 1.5;
+}
+
+/* Dialog */
+.encryption-dialog__overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: grid;
+  place-items: center;
+  padding: var(--spacing-4);
+  background: rgba(15, 23, 42, 0.72);
+}
+
+.encryption-dialog {
+  width: min(100%, 32rem);
+  max-height: 90vh;
+  overflow-y: auto;
+  padding: var(--spacing-6, 1.5rem);
+  border-radius: var(--card-border-radius, 0.75rem);
+  background: var(--theme-surface, var(--card-background, #ffffff));
+  color: var(--semantic-text-primary);
+  box-shadow: var(--shadow-xl, 0 24px 64px rgba(0, 0, 0, 0.28));
+}
+
+.encryption-dialog__form {
+  display: grid;
+  gap: var(--spacing-3);
+}
+
+.encryption-dialog__title {
+  margin: 0;
+  font-size: var(--type-scale-title-font-size, 1.125rem);
+  font-weight: var(--font-weight-bold, 700);
+}
+
+.encryption-dialog__description {
+  margin: 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size, 0.875rem);
+  line-height: 1.5;
+}
+
+.encryption-field {
+  display: grid;
+  gap: var(--spacing-2);
+}
+
+.encryption-field__label {
+  font-weight: var(--font-weight-medium, 600);
+  font-size: var(--type-scale-caption-font-size, 0.875rem);
+}
+
+.encryption-field__input {
+  width: 100%;
+  min-height: 2.5rem;
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 1px solid var(--semantic-border-default, var(--card-border));
+  border-radius: var(--radius-md, 0.5rem);
+  background: var(--theme-surface, var(--card-background));
+  color: var(--semantic-text-primary);
+  font-size: var(--type-scale-body-font-size, 1rem);
+}
+
+.encryption-field__hint {
+  margin: 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size, 0.8125rem);
+  line-height: 1.5;
+}
+
+.encryption-field__reveal {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  font-size: var(--type-scale-caption-font-size, 0.875rem);
+  color: var(--semantic-text-secondary);
+}
+
+.encryption-dialog__error {
+  margin: 0;
+  color: var(--semantic-status-negative, #b91c1c);
+  font-size: var(--type-scale-caption-font-size, 0.875rem);
+  font-weight: var(--font-weight-medium, 600);
+}
+
+.encryption-dialog__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-3);
+  margin-top: var(--spacing-2);
+}
+
+.encryption-dialog__actions--start {
+  justify-content: flex-start;
+  margin-top: 0;
+}
+
+.encryption-recovery-code {
+  margin: 0;
+  padding: var(--spacing-4);
+  border: 1px dashed var(--semantic-border-default, var(--card-border));
+  border-radius: var(--radius-md, 0.5rem);
+  background: var(--theme-surface-elevated, var(--card-background));
+  color: var(--semantic-text-primary);
+  font-family: var(--font-family-mono, ui-monospace, monospace);
+  font-size: var(--type-scale-title-font-size, 1.125rem);
+  letter-spacing: 0.08em;
+  text-align: center;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .encryption-switch__track,
+  .encryption-switch__thumb {
+    transition: none;
+  }
+}

--- a/apps/web/src/components/settings/index.ts
+++ b/apps/web/src/components/settings/index.ts
@@ -6,5 +6,6 @@ export { HapticSettings } from './HapticSettings';
 export { SettingInfoWidget } from './SettingInfoWidget';
 export type { SettingInfoWidgetProps } from './SettingInfoWidget';
 export { EncryptionDetails } from './EncryptionDetails';
+export { EncryptionUnlockSettings } from './EncryptionUnlockSettings';
 export { SETTING_DESCRIPTIONS } from './setting-descriptions';
 export type { SettingDescription } from './setting-descriptions';

--- a/apps/web/src/db/__tests__/data-key-wrapping.test.ts
+++ b/apps/web/src/db/__tests__/data-key-wrapping.test.ts
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  DataKeyUnlockError,
+  WrongPassphraseError,
+  RAW_DATA_KEY_BYTES,
+  generateRecoveryCode,
+  normalizeRecoveryCode,
+  unwrapDataKeyWithPassphrase,
+  unwrapDataKeyWithRecoveryCode,
+  unwrapDataKeyWithWebAuthnSecret,
+  wrapDataKeyWithPassphrase,
+  wrapDataKeyWithRecoveryCode,
+  wrapDataKeyWithWebAuthnSecret,
+} from '../data-key-wrapping';
+
+const PASSPHRASE = 'correct horse battery staple';
+const OTHER_PASSPHRASE = 'totally-different-secret';
+
+function makeDataKey(seed = 7): Uint8Array {
+  const bytes = new Uint8Array(RAW_DATA_KEY_BYTES);
+  for (let index = 0; index < bytes.length; index += 1) {
+    bytes[index] = (seed * 31 + index * 13) % 256;
+  }
+  return bytes;
+}
+
+function toArray(bytes: Uint8Array): number[] {
+  return Array.from(bytes);
+}
+
+describe('data-key-wrapping (#2806)', () => {
+  it('wraps and unwraps the data key with the same passphrase', async () => {
+    const dataKey = makeDataKey();
+    const slot = await wrapDataKeyWithPassphrase(dataKey, PASSPHRASE, { iterations: 100_000 });
+
+    const unwrapped = await unwrapDataKeyWithPassphrase(slot, PASSPHRASE);
+
+    expect(toArray(unwrapped)).toEqual(toArray(dataKey));
+  });
+
+  it('keeps the snapshot/envelope wrapping format stable', async () => {
+    const slot = await wrapDataKeyWithPassphrase(makeDataKey(), PASSPHRASE, {
+      iterations: 100_000,
+    });
+
+    expect(slot.magic).toBe('finance.sqlite.data-key.slot');
+    expect(slot.version).toBe(1);
+    expect(slot.kind).toBe('passphrase');
+    expect(slot.kdf.algorithm).toBe('PBKDF2-SHA-256');
+    expect(slot.envelope.version).toBe(1);
+    expect(slot.envelope.algorithm).toBe('AES-GCM');
+    // The wrapped key material must never be present in plaintext.
+    expect(JSON.stringify(slot)).not.toContain(toArray(makeDataKey()).join(','));
+  });
+
+  it('rejects the wrong passphrase without leaking key material', async () => {
+    const dataKey = makeDataKey();
+    const slot = await wrapDataKeyWithPassphrase(dataKey, PASSPHRASE, { iterations: 100_000 });
+
+    await expect(unwrapDataKeyWithPassphrase(slot, OTHER_PASSPHRASE)).rejects.toBeInstanceOf(
+      WrongPassphraseError,
+    );
+    await expect(unwrapDataKeyWithPassphrase(slot, OTHER_PASSPHRASE)).rejects.toMatchObject({
+      factor: 'passphrase',
+    });
+  });
+
+  it('rotates the passphrase in place while preserving the same data key', async () => {
+    const dataKey = makeDataKey(3);
+    const original = await wrapDataKeyWithPassphrase(dataKey, PASSPHRASE, { iterations: 100_000 });
+
+    // Re-wrap: recover the same key with the old passphrase, wrap with the new.
+    const recovered = await unwrapDataKeyWithPassphrase(original, PASSPHRASE);
+    const rotated = await wrapDataKeyWithPassphrase(recovered, OTHER_PASSPHRASE, {
+      slotId: original.slotId,
+      createdAt: original.createdAt,
+      iterations: 100_000,
+    });
+
+    expect(rotated.slotId).toBe(original.slotId);
+    const afterRotation = await unwrapDataKeyWithPassphrase(rotated, OTHER_PASSPHRASE);
+    expect(toArray(afterRotation)).toEqual(toArray(dataKey));
+    // Old passphrase no longer unwraps the rotated slot.
+    await expect(unwrapDataKeyWithPassphrase(rotated, PASSPHRASE)).rejects.toBeInstanceOf(
+      WrongPassphraseError,
+    );
+  });
+
+  it('switches wrapping modes (passphrase -> recovery -> webauthn) on the same key', async () => {
+    const dataKey = makeDataKey(11);
+
+    const passphraseSlot = await wrapDataKeyWithPassphrase(dataKey, PASSPHRASE, {
+      iterations: 100_000,
+    });
+    const viaPassphrase = await unwrapDataKeyWithPassphrase(passphraseSlot, PASSPHRASE);
+
+    const code = generateRecoveryCode();
+    const recoverySlot = await wrapDataKeyWithRecoveryCode(viaPassphrase, code, {
+      iterations: 100_000,
+    });
+    const viaRecovery = await unwrapDataKeyWithRecoveryCode(recoverySlot, code);
+
+    const prfSecret = makeDataKey(99);
+    const webauthnSlot = await wrapDataKeyWithWebAuthnSecret(viaRecovery, prfSecret, {
+      credentialIdBase64Url: 'cred-id',
+      prfSaltBase64Url: 'salt',
+    });
+    const viaWebauthn = await unwrapDataKeyWithWebAuthnSecret(webauthnSlot, prfSecret);
+
+    // Every factor unwraps to the identical original data key.
+    expect(toArray(viaPassphrase)).toEqual(toArray(dataKey));
+    expect(toArray(viaRecovery)).toEqual(toArray(dataKey));
+    expect(toArray(viaWebauthn)).toEqual(toArray(dataKey));
+  });
+
+  it('rejects an incorrect recovery code', async () => {
+    const slot = await wrapDataKeyWithRecoveryCode(makeDataKey(), generateRecoveryCode(), {
+      iterations: 100_000,
+    });
+
+    await expect(
+      unwrapDataKeyWithRecoveryCode(slot, 'AAAAA-BBBBB-CCCCC-DDDDD-EEEEE'),
+    ).rejects.toMatchObject({ factor: 'recovery' });
+  });
+
+  it('rejects a wrong WebAuthn PRF secret', async () => {
+    const slot = await wrapDataKeyWithWebAuthnSecret(makeDataKey(), makeDataKey(1), {
+      credentialIdBase64Url: 'cred-id',
+      prfSaltBase64Url: 'salt',
+    });
+
+    await expect(unwrapDataKeyWithWebAuthnSecret(slot, makeDataKey(2))).rejects.toBeInstanceOf(
+      DataKeyUnlockError,
+    );
+  });
+
+  it('generates and normalises a recovery code', () => {
+    const code = generateRecoveryCode();
+    expect(code).toMatch(/^[A-Z2-9]{5}(-[A-Z2-9]{5}){4}$/);
+    expect(normalizeRecoveryCode(code)).toHaveLength(25);
+    expect(normalizeRecoveryCode('abcde-fghjk')).toBe('ABCDEFGHJK');
+  });
+
+  it('refuses to wrap with a too-short passphrase', async () => {
+    await expect(wrapDataKeyWithPassphrase(makeDataKey(), 'short')).rejects.toThrow();
+  });
+});

--- a/apps/web/src/db/__tests__/sqlite-encryption-vault.test.ts
+++ b/apps/web/src/db/__tests__/sqlite-encryption-vault.test.ts
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// WebAuthn PRF is browser/hardware dependent — stub it deterministically so the
+// vault's enroll/unlock orchestration can be exercised in jsdom.
+const PRF_SECRET = new Uint8Array(32).fill(42);
+vi.mock('../webauthn-prf', () => ({
+  isWebAuthnPrfSupported: () => true,
+  createWebAuthnPrfCredential: vi.fn(async (label = 'Passkey') => ({
+    credentialIdBase64Url: 'test-credential',
+    prfSaltBase64Url: 'test-salt',
+    prfSecret: new Uint8Array(PRF_SECRET),
+    label,
+  })),
+  evaluateWebAuthnPrf: vi.fn(async () => new Uint8Array(PRF_SECRET)),
+}));
+
+import { WrongPassphraseError, unwrapDataKeyWithPassphrase } from '../data-key-wrapping';
+import {
+  __sqliteAtRestEncryptionForTesting,
+  clearSqliteAtRestEncryptionStores,
+  loadEncryptedSqliteSnapshot,
+  persistEncryptedSqliteSnapshot,
+  readDeviceWrappedDataKeyBytes,
+} from '../sqlite-at-rest-encryption';
+import {
+  __sqliteEncryptionVaultForTesting,
+  changePassphrase,
+  createRecoveryCode,
+  enrollWebAuthn,
+  getEncryptionFactorStatus,
+  removePassphrase,
+  setPassphrase,
+  unlockWithPassphrase,
+  unlockWithRecoveryCode,
+  unlockWithWebAuthn,
+} from '../sqlite-encryption-vault';
+
+const DB_NAME = 'finance.db';
+const PASSPHRASE = 'super-secret-passphrase';
+const NEW_PASSPHRASE = 'another-strong-passphrase';
+const sampleBytes = new TextEncoder().encode('SQLite format 3\0 vault test data');
+
+async function openDatabase(databaseName: string, storeName: string): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(databaseName, 1);
+    request.onupgradeneeded = () => {
+      if (!request.result.objectStoreNames.contains(storeName)) {
+        request.result.createObjectStore(storeName);
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function readEncryptedSnapshotRecord(): Promise<unknown> {
+  const { encryptedDbName, encryptedStoreName, encryptedDbKey } =
+    __sqliteAtRestEncryptionForTesting;
+  const db = await openDatabase(encryptedDbName, encryptedStoreName);
+  try {
+    return await new Promise((resolve, reject) => {
+      const tx = db.transaction(encryptedStoreName, 'readonly');
+      const request = tx.objectStore(encryptedStoreName).get(encryptedDbKey);
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+  } finally {
+    db.close();
+  }
+}
+
+function toArray(bytes: Uint8Array | null): number[] {
+  return bytes ? Array.from(bytes) : [];
+}
+
+describe('sqlite-encryption-vault (#2806)', () => {
+  beforeEach(() => {
+    localStorage.setItem(__sqliteAtRestEncryptionForTesting.flagOverrideKey, 'true');
+  });
+
+  afterEach(async () => {
+    localStorage.removeItem(__sqliteAtRestEncryptionForTesting.flagOverrideKey);
+    await clearSqliteAtRestEncryptionStores();
+  });
+
+  it('wraps the same data key under a passphrase and unlocks with it', async () => {
+    await persistEncryptedSqliteSnapshot(DB_NAME, sampleBytes);
+    const deviceKey = await readDeviceWrappedDataKeyBytes();
+
+    await setPassphrase(PASSPHRASE);
+
+    const vault = await __sqliteEncryptionVaultForTesting.readVault();
+    const slot = vault.slots.find((entry) => entry.kind === 'passphrase');
+    expect(slot).toBeDefined();
+    if (!slot || slot.kind !== 'passphrase') {
+      throw new Error('expected a passphrase slot');
+    }
+
+    const viaPassphrase = await unwrapDataKeyWithPassphrase(slot, PASSPHRASE);
+    // The passphrase slot must unwrap to exactly the same key as the device slot.
+    expect(toArray(viaPassphrase)).toEqual(toArray(deviceKey));
+
+    // Unlocking succeeds with the correct passphrase, rejects the wrong one.
+    await expect(unlockWithPassphrase(PASSPHRASE)).resolves.toBeUndefined();
+    await expect(unlockWithPassphrase('the-wrong-passphrase')).rejects.toBeInstanceOf(
+      WrongPassphraseError,
+    );
+  });
+
+  it('rotates the passphrase in place without changing the data key', async () => {
+    await persistEncryptedSqliteSnapshot(DB_NAME, sampleBytes);
+    const deviceKeyBefore = await readDeviceWrappedDataKeyBytes();
+
+    await setPassphrase(PASSPHRASE);
+    await changePassphrase(PASSPHRASE, NEW_PASSPHRASE);
+
+    const deviceKeyAfter = await readDeviceWrappedDataKeyBytes();
+    expect(toArray(deviceKeyAfter)).toEqual(toArray(deviceKeyBefore));
+
+    await expect(unlockWithPassphrase(NEW_PASSPHRASE)).resolves.toBeUndefined();
+    await expect(unlockWithPassphrase(PASSPHRASE)).rejects.toBeInstanceOf(WrongPassphraseError);
+    // Rejecting the old passphrase during rotation also fails closed.
+    await expect(changePassphrase('not-the-passphrase', 'irrelevant-value')).rejects.toBeInstanceOf(
+      WrongPassphraseError,
+    );
+  });
+
+  it('recovers the data key with a generated recovery code', async () => {
+    await persistEncryptedSqliteSnapshot(DB_NAME, sampleBytes);
+
+    const code = await createRecoveryCode();
+    expect(code).toMatch(/^[A-Z2-9]{5}(-[A-Z2-9]{5}){4}$/);
+
+    await expect(unlockWithRecoveryCode(code)).resolves.toBeUndefined();
+    await expect(unlockWithRecoveryCode('AAAAA-BBBBB-CCCCC-DDDDD-EEEEE')).rejects.toMatchObject({
+      factor: 'recovery',
+    });
+  });
+
+  it('enrolls and unlocks with a WebAuthn passkey factor', async () => {
+    await persistEncryptedSqliteSnapshot(DB_NAME, sampleBytes);
+
+    await enrollWebAuthn('My passkey');
+    const status = await getEncryptionFactorStatus();
+    expect(status.webauthn.enabled).toBe(true);
+    expect(status.webauthn.label).toBe('My passkey');
+
+    await expect(unlockWithWebAuthn()).resolves.toBeUndefined();
+  });
+
+  it('does NOT change the encrypted snapshot format when factors are added', async () => {
+    await persistEncryptedSqliteSnapshot(DB_NAME, sampleBytes);
+    const snapshotBefore = JSON.stringify(await readEncryptedSnapshotRecord());
+
+    await setPassphrase(PASSPHRASE);
+    await createRecoveryCode();
+
+    const snapshotAfter = JSON.stringify(await readEncryptedSnapshotRecord());
+    // The snapshot blob (and its envelope) is byte-for-byte unchanged.
+    expect(snapshotAfter).toBe(snapshotBefore);
+
+    // The data still decrypts after re-wrapping the key under new factors.
+    const restored = await loadEncryptedSqliteSnapshot(DB_NAME);
+    expect(toArray(restored)).toEqual(Array.from(sampleBytes));
+  });
+
+  it('reports and clears factor status', async () => {
+    await persistEncryptedSqliteSnapshot(DB_NAME, sampleBytes);
+
+    let status = await getEncryptionFactorStatus();
+    expect(status.supported).toBe(true);
+    expect(status.deviceUnlock).toBe(true);
+    expect(status.passphrase).toBe(false);
+    expect(status.factorCount).toBe(0);
+
+    await setPassphrase(PASSPHRASE);
+    status = await getEncryptionFactorStatus();
+    expect(status.passphrase).toBe(true);
+    expect(status.factorCount).toBe(1);
+
+    await removePassphrase();
+    status = await getEncryptionFactorStatus();
+    expect(status.passphrase).toBe(false);
+    expect(status.factorCount).toBe(0);
+  });
+});

--- a/apps/web/src/db/data-key-wrapping.ts
+++ b/apps/web/src/db/data-key-wrapping.ts
@@ -1,0 +1,380 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Envelope wrapping for the SQLite at-rest **data key** (#2806, follow-up to
+ * #2727).
+ *
+ * The core at-rest encryption (`sqlite-at-rest-encryption.ts`) stores a single
+ * random 256-bit AES-GCM *data key* and uses it to encrypt the SQLite snapshot
+ * envelope. This module adds user-controlled wrapping factors —
+ * passphrase, WebAuthn (PRF) and recovery code — that each *re-wrap the very
+ * same raw data key* into an independent "key slot".
+ *
+ * Security invariants:
+ *   - The raw data key is **never regenerated** when switching/rotating
+ *     factors; only the wrapping changes (envelope re-wrap). This preserves the
+ *     on-disk snapshot format and avoids re-encrypting the whole database.
+ *   - The raw data key is never persisted in plaintext. Each slot stores only a
+ *     KDF descriptor (salt + iterations, non-secret) and an AES-GCM envelope.
+ *   - Unwrapping with the wrong passphrase fails closed via the AES-GCM
+ *     authentication tag — no partial plaintext and no key material leak.
+ *
+ * This file is intentionally free of IndexedDB / DOM concerns so it can be unit
+ * tested in isolation. Persistence lives in `sqlite-encryption-vault.ts`.
+ */
+
+import {
+  bytesToBase64Url,
+  base64UrlToBytes,
+  decryptLocalBytes,
+  deriveLocalEncryptionKeyFromPassphrase,
+  encryptLocalBytes,
+  type LocalEncryptionEnvelope,
+} from '../lib/security/encryption-at-rest';
+
+export const DATA_KEY_SLOT_MAGIC = 'finance.sqlite.data-key.slot' as const;
+export const DATA_KEY_SLOT_VERSION = 1 as const;
+
+/** Length of the raw AES-256 data key in bytes. */
+export const RAW_DATA_KEY_BYTES = 32;
+
+/** Minimum passphrase length (non-whitespace) enforced before wrapping. */
+export const MIN_PASSPHRASE_LENGTH = 12;
+
+/** The user-controllable wrapping factors that can protect the data key. */
+export type WrappingFactorKind = 'passphrase' | 'webauthn' | 'recovery';
+
+interface BaseDataKeySlot {
+  readonly magic: typeof DATA_KEY_SLOT_MAGIC;
+  readonly version: typeof DATA_KEY_SLOT_VERSION;
+  readonly kind: WrappingFactorKind;
+  /** Stable identifier for the slot — reused across in-place rotations. */
+  readonly slotId: string;
+  readonly label?: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  /** AES-GCM envelope wrapping the raw data key bytes. */
+  readonly envelope: LocalEncryptionEnvelope;
+}
+
+interface KdfDescriptor {
+  readonly algorithm: 'PBKDF2-SHA-256';
+  readonly saltBase64Url: string;
+  readonly iterations: number;
+}
+
+/** Slot wrapped by a user passphrase (PBKDF2-derived key). */
+export interface PassphraseDataKeySlot extends BaseDataKeySlot {
+  readonly kind: 'passphrase';
+  readonly kdf: KdfDescriptor;
+}
+
+/** Slot wrapped by a generated recovery code (PBKDF2-derived key). */
+export interface RecoveryDataKeySlot extends BaseDataKeySlot {
+  readonly kind: 'recovery';
+  readonly kdf: KdfDescriptor;
+}
+
+/** Slot wrapped by a WebAuthn authenticator-derived PRF secret. */
+export interface WebAuthnDataKeySlot extends BaseDataKeySlot {
+  readonly kind: 'webauthn';
+  readonly credentialIdBase64Url: string;
+  readonly prfSaltBase64Url: string;
+}
+
+export type DataKeySlot = PassphraseDataKeySlot | RecoveryDataKeySlot | WebAuthnDataKeySlot;
+
+const DEFAULT_PBKDF2_ITERATIONS = 310_000;
+
+/** Raised when a wrapping factor cannot unwrap the data key. */
+export class DataKeyUnlockError extends Error {
+  readonly factor: WrappingFactorKind;
+
+  constructor(factor: WrappingFactorKind, message: string) {
+    super(message);
+    this.name = 'DataKeyUnlockError';
+    this.factor = factor;
+  }
+}
+
+/** Raised specifically when a passphrase / recovery code is incorrect. */
+export class WrongPassphraseError extends DataKeyUnlockError {
+  constructor(factor: 'passphrase' | 'recovery' = 'passphrase') {
+    super(
+      factor,
+      factor === 'recovery'
+        ? 'That recovery code is not correct. Check for typos and try again.'
+        : 'That passphrase is not correct. Check for typos and try again.',
+    );
+    this.name = 'WrongPassphraseError';
+  }
+}
+
+export interface WrapWithPassphraseOptions {
+  readonly slotId?: string;
+  readonly label?: string;
+  readonly iterations?: number;
+  readonly createdAt?: string;
+  readonly now?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Passphrase factor
+// ---------------------------------------------------------------------------
+
+export async function wrapDataKeyWithPassphrase(
+  rawDataKey: Uint8Array,
+  passphrase: string,
+  options: WrapWithPassphraseOptions = {},
+): Promise<PassphraseDataKeySlot> {
+  return wrapWithKdf(
+    'passphrase',
+    rawDataKey,
+    passphrase,
+    options,
+  ) as Promise<PassphraseDataKeySlot>;
+}
+
+export async function unwrapDataKeyWithPassphrase(
+  slot: PassphraseDataKeySlot,
+  passphrase: string,
+): Promise<Uint8Array> {
+  return unwrapWithKdf(slot, passphrase);
+}
+
+// ---------------------------------------------------------------------------
+// Recovery-code factor
+// ---------------------------------------------------------------------------
+
+export async function wrapDataKeyWithRecoveryCode(
+  rawDataKey: Uint8Array,
+  recoveryCode: string,
+  options: WrapWithPassphraseOptions = {},
+): Promise<RecoveryDataKeySlot> {
+  return wrapWithKdf(
+    'recovery',
+    rawDataKey,
+    normalizeRecoveryCode(recoveryCode),
+    options,
+  ) as Promise<RecoveryDataKeySlot>;
+}
+
+export async function unwrapDataKeyWithRecoveryCode(
+  slot: RecoveryDataKeySlot,
+  recoveryCode: string,
+): Promise<Uint8Array> {
+  return unwrapWithKdf(slot, normalizeRecoveryCode(recoveryCode));
+}
+
+// ---------------------------------------------------------------------------
+// WebAuthn (PRF) factor
+// ---------------------------------------------------------------------------
+
+export interface WrapWithWebAuthnOptions {
+  readonly credentialIdBase64Url: string;
+  readonly prfSaltBase64Url: string;
+  readonly slotId?: string;
+  readonly label?: string;
+  readonly createdAt?: string;
+  readonly now?: string;
+}
+
+export async function wrapDataKeyWithWebAuthnSecret(
+  rawDataKey: Uint8Array,
+  prfSecret: Uint8Array,
+  options: WrapWithWebAuthnOptions,
+): Promise<WebAuthnDataKeySlot> {
+  assertRawDataKey(rawDataKey);
+  const key = await importAesGcmKeyFromSecret(prfSecret);
+  const slotId = options.slotId ?? randomSlotId();
+  const now = options.now ?? new Date().toISOString();
+  const envelope = await encryptLocalBytes(rawDataKey, key, {
+    additionalData: slotAdditionalData('webauthn', slotId),
+  });
+
+  return {
+    magic: DATA_KEY_SLOT_MAGIC,
+    version: DATA_KEY_SLOT_VERSION,
+    kind: 'webauthn',
+    slotId,
+    ...(options.label ? { label: options.label } : {}),
+    createdAt: options.createdAt ?? now,
+    updatedAt: now,
+    credentialIdBase64Url: options.credentialIdBase64Url,
+    prfSaltBase64Url: options.prfSaltBase64Url,
+    envelope,
+  };
+}
+
+export async function unwrapDataKeyWithWebAuthnSecret(
+  slot: WebAuthnDataKeySlot,
+  prfSecret: Uint8Array,
+): Promise<Uint8Array> {
+  const key = await importAesGcmKeyFromSecret(prfSecret);
+  try {
+    const raw = await decryptLocalBytes(slot.envelope, key, {
+      additionalData: slotAdditionalData('webauthn', slot.slotId),
+    });
+    assertRawDataKey(raw);
+    return raw;
+  } catch (error) {
+    if (error instanceof DataKeyUnlockError) {
+      throw error;
+    }
+    throw new DataKeyUnlockError(
+      'webauthn',
+      'This passkey could not unlock your data. It may be the wrong passkey for this device.',
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Recovery-code generation
+// ---------------------------------------------------------------------------
+
+const RECOVERY_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; // Crockford-ish, no I/O/0/1 (32 chars = 2^5)
+const RECOVERY_GROUPS = 5;
+const RECOVERY_GROUP_LENGTH = 5;
+// The alphabet length is a power of two, so masking the low bits of a uniform
+// random byte selects an index uniformly with no modulo bias. We mask instead
+// of using `% length` to make the lack of bias explicit and statically provable.
+const RECOVERY_ALPHABET_MASK = RECOVERY_ALPHABET.length - 1;
+
+/**
+ * Generate a human-readable, high-entropy recovery code such as
+ * `ABCDE-FGHJK-LMNPQ-RSTUV-WXYZ2` (25 chars, ~128 bits of entropy).
+ */
+export function generateRecoveryCode(cryptoImpl: Crypto = globalThis.crypto): string {
+  // Guard against a future edit changing the alphabet to a non-power-of-two
+  // length, which would reintroduce modulo/masking bias.
+  if ((RECOVERY_ALPHABET.length & RECOVERY_ALPHABET_MASK) !== 0) {
+    throw new Error('RECOVERY_ALPHABET length must be a power of two for unbiased sampling.');
+  }
+  const total = RECOVERY_GROUPS * RECOVERY_GROUP_LENGTH;
+  const randomValues = cryptoImpl.getRandomValues(new Uint8Array(total));
+  const chars: string[] = [];
+  for (let index = 0; index < total; index += 1) {
+    chars.push(RECOVERY_ALPHABET[randomValues[index] & RECOVERY_ALPHABET_MASK]);
+  }
+  const groups: string[] = [];
+  for (let group = 0; group < RECOVERY_GROUPS; group += 1) {
+    groups.push(
+      chars.slice(group * RECOVERY_GROUP_LENGTH, (group + 1) * RECOVERY_GROUP_LENGTH).join(''),
+    );
+  }
+  return groups.join('-');
+}
+
+/** Strip separators / whitespace and upper-case for stable KDF input. */
+export function normalizeRecoveryCode(recoveryCode: string): string {
+  return recoveryCode.replace(/[\s-]+/g, '').toUpperCase();
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+async function wrapWithKdf(
+  kind: 'passphrase' | 'recovery',
+  rawDataKey: Uint8Array,
+  secret: string,
+  options: WrapWithPassphraseOptions,
+): Promise<PassphraseDataKeySlot | RecoveryDataKeySlot> {
+  assertRawDataKey(rawDataKey);
+  const iterations = options.iterations ?? DEFAULT_PBKDF2_ITERATIONS;
+  const material = await deriveLocalEncryptionKeyFromPassphrase(secret, { iterations });
+  const slotId = options.slotId ?? randomSlotId();
+  const now = options.now ?? new Date().toISOString();
+  const envelope = await encryptLocalBytes(rawDataKey, material.key, {
+    additionalData: slotAdditionalData(kind, slotId),
+  });
+
+  return {
+    magic: DATA_KEY_SLOT_MAGIC,
+    version: DATA_KEY_SLOT_VERSION,
+    kind,
+    slotId,
+    ...(options.label ? { label: options.label } : {}),
+    createdAt: options.createdAt ?? now,
+    updatedAt: now,
+    kdf: {
+      algorithm: 'PBKDF2-SHA-256',
+      saltBase64Url: bytesToBase64Url(material.salt),
+      iterations: material.iterations,
+    },
+    envelope,
+  };
+}
+
+async function unwrapWithKdf(
+  slot: PassphraseDataKeySlot | RecoveryDataKeySlot,
+  secret: string,
+): Promise<Uint8Array> {
+  const salt = base64UrlToBytes(slot.kdf.saltBase64Url);
+  const material = await deriveLocalEncryptionKeyFromPassphrase(secret, {
+    salt,
+    iterations: slot.kdf.iterations,
+  });
+
+  try {
+    const raw = await decryptLocalBytes(slot.envelope, material.key, {
+      additionalData: slotAdditionalData(slot.kind, slot.slotId),
+    });
+    assertRawDataKey(raw);
+    return raw;
+  } catch {
+    // AES-GCM tag mismatch (wrong secret) or unexpected payload — fail closed.
+    throw new WrongPassphraseError(slot.kind);
+  }
+}
+
+async function importAesGcmKeyFromSecret(secret: Uint8Array): Promise<CryptoKey> {
+  // PRF output is already a uniformly-random secret. Normalise to 32 bytes via
+  // SHA-256 (universally supported) so any authenticator PRF length works.
+  const material =
+    secret.byteLength === RAW_DATA_KEY_BYTES
+      ? secret
+      : new Uint8Array(await crypto.subtle.digest('SHA-256', toArrayBuffer(secret)));
+  return crypto.subtle.importKey(
+    'raw',
+    toArrayBuffer(material),
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+}
+
+function slotAdditionalData(kind: WrappingFactorKind, slotId: string): Uint8Array {
+  return new TextEncoder().encode(
+    `${DATA_KEY_SLOT_MAGIC}:v${DATA_KEY_SLOT_VERSION}:${kind}:${slotId}`,
+  );
+}
+
+function randomSlotId(): string {
+  const bytes = globalThis.crypto.getRandomValues(new Uint8Array(8));
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function assertRawDataKey(bytes: Uint8Array): void {
+  if (bytes.byteLength !== RAW_DATA_KEY_BYTES) {
+    throw new Error('Unexpected SQLite data-key length.');
+  }
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
+export function isDataKeySlot(value: unknown): value is DataKeySlot {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const record = value as Partial<BaseDataKeySlot>;
+  return (
+    record.magic === DATA_KEY_SLOT_MAGIC &&
+    record.version === DATA_KEY_SLOT_VERSION &&
+    (record.kind === 'passphrase' || record.kind === 'webauthn' || record.kind === 'recovery') &&
+    typeof record.slotId === 'string' &&
+    typeof record.envelope === 'object'
+  );
+}

--- a/apps/web/src/db/sqlite-at-rest-encryption.ts
+++ b/apps/web/src/db/sqlite-at-rest-encryption.ts
@@ -67,6 +67,29 @@ export function isSqliteAtRestEncryptionEnabled(): boolean {
   return import.meta.env[ENCRYPTION_ENV_FLAG] === 'true';
 }
 
+/**
+ * Intentionally enable or disable the opt-in at-rest encryption flag.
+ *
+ * Passing `null` clears the local override so the build-time env flag applies.
+ * This only flips the persistence path for *future* writes — existing encrypted
+ * snapshots remain readable so users are never locked out (see the load path in
+ * `sqlite-wasm.ts`).
+ */
+export function setSqliteAtRestEncryptionEnabled(enabled: boolean | null): void {
+  try {
+    if (typeof localStorage === 'undefined') {
+      return;
+    }
+    if (enabled === null) {
+      localStorage.removeItem(ENCRYPTION_FLAG_OVERRIDE_KEY);
+      return;
+    }
+    localStorage.setItem(ENCRYPTION_FLAG_OVERRIDE_KEY, enabled ? 'true' : 'false');
+  } catch {
+    // localStorage may be unavailable (private mode / disabled). Ignore.
+  }
+}
+
 export function isSqliteAtRestEncryptionSupported(): boolean {
   return typeof indexedDB !== 'undefined' && isWebCryptoEncryptionSupported();
 }
@@ -131,6 +154,84 @@ export async function clearSqliteAtRestEncryptionStores(): Promise<void> {
     deleteDatabaseBestEffort(ENCRYPTED_DB_NAME),
     deleteDatabaseBestEffort(KEY_DB_NAME),
   ]);
+}
+
+/**
+ * Read the raw bytes of the SQLite data key by unwrapping the device slot.
+ *
+ * Returns `null` when no data key has been provisioned yet (no device wrapping
+ * key or no wrapped record). Callers must zero the returned bytes once the data
+ * key has been re-wrapped — the raw key is sensitive material.
+ */
+export async function readDeviceWrappedDataKeyBytes(): Promise<Uint8Array | null> {
+  const keyStore = await openKeyStore();
+  try {
+    const wrappingKey = await readValue<CryptoKey>(keyStore, DEVICE_WRAPPING_KEY_ID);
+    const wrapped = await readValue<WrappedDataKeyRecord>(keyStore, WRAPPED_DATA_KEY_ID);
+    if (!wrappingKey || !wrapped) {
+      return null;
+    }
+    validateWrappedDataKeyRecord(wrapped);
+    return await decryptLocalBytes(wrapped.envelope, wrappingKey, {
+      additionalData: dataKeyAdditionalData(wrapped.keyId, wrapped.wrappingKeyId),
+    });
+  } finally {
+    keyStore.close();
+  }
+}
+
+/**
+ * Ensure the device-local data key exists and return its raw bytes.
+ *
+ * This provisions the device wrapping key + wrapped data-key record (the same
+ * path used by the snapshot encryption) if they are not present yet, so users
+ * can add a passphrase / passkey before the first encrypted snapshot is
+ * written. Callers must zero the returned bytes after re-wrapping.
+ */
+export async function ensureSqliteDataKeyBytes(): Promise<Uint8Array> {
+  // Provisions the device wrapping key + wrapped data-key record if needed.
+  await getOrCreateSqliteDataKey();
+  const bytes = await readDeviceWrappedDataKeyBytes();
+  if (!bytes) {
+    throw new Error('Failed to materialise the SQLite data key.');
+  }
+  return bytes;
+}
+
+/** Read an auxiliary record from the encryption key store (used by the vault). */
+export async function readEncryptionKeyStoreRecord<T>(id: string): Promise<T | null> {
+  const keyStore = await openKeyStore();
+  try {
+    return (await readValue<T>(keyStore, id)) ?? null;
+  } finally {
+    keyStore.close();
+  }
+}
+
+/** Write an auxiliary record to the encryption key store (used by the vault). */
+export async function writeEncryptionKeyStoreRecord(id: string, value: unknown): Promise<void> {
+  const keyStore = await openKeyStore();
+  try {
+    await writeValue(keyStore, id, value);
+  } finally {
+    keyStore.close();
+  }
+}
+
+/** Delete an auxiliary record from the encryption key store (used by the vault). */
+export async function deleteEncryptionKeyStoreRecord(id: string): Promise<void> {
+  const keyStore = await openKeyStore();
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const tx = keyStore.transaction(KEY_STORE_NAME, 'readwrite');
+      tx.objectStore(KEY_STORE_NAME).delete(id);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+      tx.onabort = () => reject(tx.error);
+    });
+  } finally {
+    keyStore.close();
+  }
 }
 
 export const __sqliteAtRestEncryptionForTesting = {

--- a/apps/web/src/db/sqlite-encryption-vault.ts
+++ b/apps/web/src/db/sqlite-encryption-vault.ts
@@ -1,0 +1,313 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * SQLite data-key vault (#2806).
+ *
+ * Persists the user-controlled wrapping factors (passphrase, WebAuthn, recovery
+ * code) alongside the existing device-local wrapping in the encryption key
+ * store. Every factor wraps the **same** raw data key, so enabling, rotating or
+ * switching a factor only re-wraps the key — it never regenerates it and never
+ * touches the encrypted snapshot blob.
+ *
+ * Storage layout (IndexedDB `finance-encryption` / `keys`):
+ *   - `sqlite-device-wrapping-key:v1`  — device CryptoKey (unchanged, #2727)
+ *   - `sqlite-data-key:v1`             — device-wrapped data key (unchanged)
+ *   - `sqlite-data-key-vault:v1`       — this vault: extra factor slots (new)
+ *
+ * The device slot is retained so automatic same-device unlock keeps working
+ * and users are never locked out. Passphrase / passkey / recovery slots add a
+ * portable, user-controlled way to unlock and recover the same key.
+ */
+
+import {
+  generateRecoveryCode,
+  unwrapDataKeyWithPassphrase,
+  unwrapDataKeyWithRecoveryCode,
+  unwrapDataKeyWithWebAuthnSecret,
+  wrapDataKeyWithPassphrase,
+  wrapDataKeyWithRecoveryCode,
+  wrapDataKeyWithWebAuthnSecret,
+  type DataKeySlot,
+  type PassphraseDataKeySlot,
+  type RecoveryDataKeySlot,
+  type WebAuthnDataKeySlot,
+  type WrappingFactorKind,
+} from './data-key-wrapping';
+import {
+  deleteEncryptionKeyStoreRecord,
+  ensureSqliteDataKeyBytes,
+  isSqliteAtRestEncryptionSupported,
+  readDeviceWrappedDataKeyBytes,
+  readEncryptionKeyStoreRecord,
+  writeEncryptionKeyStoreRecord,
+} from './sqlite-at-rest-encryption';
+import {
+  createWebAuthnPrfCredential,
+  evaluateWebAuthnPrf,
+  isWebAuthnPrfSupported,
+} from './webauthn-prf';
+
+const VAULT_RECORD_ID = 'sqlite-data-key-vault:v1';
+const VAULT_MAGIC = 'finance.sqlite.data-key.vault';
+const VAULT_VERSION = 1;
+
+interface DataKeyVaultRecord {
+  readonly magic: typeof VAULT_MAGIC;
+  readonly version: typeof VAULT_VERSION;
+  readonly updatedAt: string;
+  readonly slots: readonly DataKeySlot[];
+}
+
+/** Snapshot of which wrapping factors currently protect the data key. */
+export interface EncryptionFactorStatus {
+  /** Web Crypto + IndexedDB available for at-rest encryption. */
+  readonly supported: boolean;
+  /** WebAuthn available for the passkey factor. */
+  readonly webAuthnSupported: boolean;
+  /** Device-local automatic unlock is provisioned. */
+  readonly deviceUnlock: boolean;
+  /** A passphrase factor is configured. */
+  readonly passphrase: boolean;
+  /** A recovery code factor is configured. */
+  readonly recovery: boolean;
+  /** Passkey factor configuration. */
+  readonly webauthn: { readonly enabled: boolean; readonly label?: string };
+  /** Number of user-controlled factors (passphrase + recovery + passkey). */
+  readonly factorCount: number;
+}
+
+// In-memory unlocked-key cache for the current tab session. Used to confirm an
+// unlock succeeded without persisting plaintext. Cleared on lock / reload.
+let sessionUnlocked = false;
+
+export function isEncryptionSessionUnlocked(): boolean {
+  return sessionUnlocked;
+}
+
+export function lockEncryptionSession(): void {
+  sessionUnlocked = false;
+}
+
+export async function getEncryptionFactorStatus(): Promise<EncryptionFactorStatus> {
+  const supported = isSqliteAtRestEncryptionSupported();
+  if (!supported) {
+    return {
+      supported: false,
+      webAuthnSupported: false,
+      deviceUnlock: false,
+      passphrase: false,
+      recovery: false,
+      webauthn: { enabled: false },
+      factorCount: 0,
+    };
+  }
+
+  const [deviceBytes, vault] = await Promise.all([
+    readDeviceWrappedDataKeyBytes().catch(() => null),
+    readVault(),
+  ]);
+  if (deviceBytes) {
+    deviceBytes.fill(0);
+  }
+
+  const passphraseSlot = findSlot(vault, 'passphrase');
+  const recoverySlot = findSlot(vault, 'recovery');
+  const webauthnSlot = findSlot(vault, 'webauthn') as WebAuthnDataKeySlot | undefined;
+  const factorCount = [passphraseSlot, recoverySlot, webauthnSlot].filter(Boolean).length;
+
+  return {
+    supported: true,
+    webAuthnSupported: isWebAuthnPrfSupported(),
+    deviceUnlock: deviceBytes !== null,
+    passphrase: Boolean(passphraseSlot),
+    recovery: Boolean(recoverySlot),
+    webauthn: {
+      enabled: Boolean(webauthnSlot),
+      ...(webauthnSlot?.label ? { label: webauthnSlot.label } : {}),
+    },
+    factorCount,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Passphrase factor
+// ---------------------------------------------------------------------------
+
+export async function setPassphrase(passphrase: string): Promise<void> {
+  const raw = await ensureSqliteDataKeyBytes();
+  try {
+    const existing = findSlot(await readVault(), 'passphrase') as PassphraseDataKeySlot | undefined;
+    const slot = await wrapDataKeyWithPassphrase(raw, passphrase, {
+      slotId: existing?.slotId,
+      createdAt: existing?.createdAt,
+      label: 'Passphrase',
+    });
+    await upsertSlot(slot);
+    sessionUnlocked = true;
+  } finally {
+    raw.fill(0);
+  }
+}
+
+export async function changePassphrase(current: string, next: string): Promise<void> {
+  const slot = findSlot(await readVault(), 'passphrase') as PassphraseDataKeySlot | undefined;
+  if (!slot) {
+    throw new Error('No passphrase is set on this device yet.');
+  }
+  // Verifies the current passphrase (throws WrongPassphraseError on mismatch)
+  // and recovers the *same* raw data key to re-wrap with the new passphrase.
+  const raw = await unwrapDataKeyWithPassphrase(slot, current);
+  try {
+    const rotated = await wrapDataKeyWithPassphrase(raw, next, {
+      slotId: slot.slotId,
+      createdAt: slot.createdAt,
+      label: slot.label ?? 'Passphrase',
+    });
+    await upsertSlot(rotated);
+    sessionUnlocked = true;
+  } finally {
+    raw.fill(0);
+  }
+}
+
+export async function unlockWithPassphrase(passphrase: string): Promise<void> {
+  const slot = findSlot(await readVault(), 'passphrase') as PassphraseDataKeySlot | undefined;
+  if (!slot) {
+    throw new Error('No passphrase is set on this device yet.');
+  }
+  const raw = await unwrapDataKeyWithPassphrase(slot, passphrase);
+  raw.fill(0);
+  sessionUnlocked = true;
+}
+
+export async function removePassphrase(): Promise<void> {
+  await removeFactor('passphrase');
+}
+
+// ---------------------------------------------------------------------------
+// Recovery-code factor
+// ---------------------------------------------------------------------------
+
+/** Provision (or rotate) the recovery code. Returns the plaintext code once. */
+export async function createRecoveryCode(): Promise<string> {
+  const raw = await ensureSqliteDataKeyBytes();
+  try {
+    const code = generateRecoveryCode();
+    const existing = findSlot(await readVault(), 'recovery') as RecoveryDataKeySlot | undefined;
+    const slot = await wrapDataKeyWithRecoveryCode(raw, code, {
+      slotId: existing?.slotId,
+      createdAt: existing?.createdAt,
+      label: 'Recovery code',
+    });
+    await upsertSlot(slot);
+    return code;
+  } finally {
+    raw.fill(0);
+  }
+}
+
+export async function unlockWithRecoveryCode(recoveryCode: string): Promise<void> {
+  const slot = findSlot(await readVault(), 'recovery') as RecoveryDataKeySlot | undefined;
+  if (!slot) {
+    throw new Error('No recovery code is set on this device yet.');
+  }
+  const raw = await unwrapDataKeyWithRecoveryCode(slot, recoveryCode);
+  raw.fill(0);
+  sessionUnlocked = true;
+}
+
+export async function removeRecoveryCode(): Promise<void> {
+  await removeFactor('recovery');
+}
+
+// ---------------------------------------------------------------------------
+// WebAuthn (passkey) factor
+// ---------------------------------------------------------------------------
+
+export async function enrollWebAuthn(label = 'Passkey'): Promise<void> {
+  const raw = await ensureSqliteDataKeyBytes();
+  let prfSecret: Uint8Array | null = null;
+  try {
+    const enrollment = await createWebAuthnPrfCredential(label);
+    prfSecret = enrollment.prfSecret;
+    const slot = await wrapDataKeyWithWebAuthnSecret(raw, prfSecret, {
+      credentialIdBase64Url: enrollment.credentialIdBase64Url,
+      prfSaltBase64Url: enrollment.prfSaltBase64Url,
+      label: enrollment.label,
+    });
+    await upsertSlot(slot);
+    sessionUnlocked = true;
+  } finally {
+    raw.fill(0);
+    prfSecret?.fill(0);
+  }
+}
+
+export async function unlockWithWebAuthn(): Promise<void> {
+  const slot = findSlot(await readVault(), 'webauthn') as WebAuthnDataKeySlot | undefined;
+  if (!slot) {
+    throw new Error('No passkey is enrolled on this device yet.');
+  }
+  const secret = await evaluateWebAuthnPrf(slot.credentialIdBase64Url, slot.prfSaltBase64Url);
+  try {
+    const raw = await unwrapDataKeyWithWebAuthnSecret(slot, secret);
+    raw.fill(0);
+    sessionUnlocked = true;
+  } finally {
+    secret.fill(0);
+  }
+}
+
+export async function removeWebAuthn(): Promise<void> {
+  await removeFactor('webauthn');
+}
+
+// ---------------------------------------------------------------------------
+// Vault persistence helpers
+// ---------------------------------------------------------------------------
+
+async function readVault(): Promise<DataKeyVaultRecord> {
+  const record = await readEncryptionKeyStoreRecord<DataKeyVaultRecord>(VAULT_RECORD_ID);
+  if (!record || record.magic !== VAULT_MAGIC || record.version !== VAULT_VERSION) {
+    return { magic: VAULT_MAGIC, version: VAULT_VERSION, updatedAt: '', slots: [] };
+  }
+  return record;
+}
+
+async function writeVault(slots: readonly DataKeySlot[]): Promise<void> {
+  if (slots.length === 0) {
+    await deleteEncryptionKeyStoreRecord(VAULT_RECORD_ID);
+    return;
+  }
+  const record: DataKeyVaultRecord = {
+    magic: VAULT_MAGIC,
+    version: VAULT_VERSION,
+    updatedAt: new Date().toISOString(),
+    slots,
+  };
+  await writeEncryptionKeyStoreRecord(VAULT_RECORD_ID, record);
+}
+
+async function upsertSlot(slot: DataKeySlot): Promise<void> {
+  const vault = await readVault();
+  const next = vault.slots.filter((existing) => existing.kind !== slot.kind);
+  next.push(slot);
+  await writeVault(next);
+}
+
+async function removeFactor(kind: WrappingFactorKind): Promise<void> {
+  const vault = await readVault();
+  const next = vault.slots.filter((slot) => slot.kind !== kind);
+  if (next.length !== vault.slots.length) {
+    await writeVault(next);
+  }
+}
+
+function findSlot(vault: DataKeyVaultRecord, kind: WrappingFactorKind): DataKeySlot | undefined {
+  return vault.slots.find((slot) => slot.kind === kind);
+}
+
+export const __sqliteEncryptionVaultForTesting = {
+  vaultRecordId: VAULT_RECORD_ID,
+  readVault,
+};

--- a/apps/web/src/db/webauthn-prf.ts
+++ b/apps/web/src/db/webauthn-prf.ts
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Local WebAuthn PRF helper for at-rest encryption (#2806).
+ *
+ * This is intentionally *separate* from the server-backed passkey sign-in flow
+ * (`src/auth/webauthn.ts`). It creates / evaluates a device-bound credential
+ * purely to derive a stable, high-entropy secret via the WebAuthn `prf`
+ * extension. That secret wraps the SQLite data key — it never leaves the device
+ * and is never sent to a server.
+ *
+ * The PRF secret is reproducible: evaluating the same credential with the same
+ * salt always yields the same bytes, which lets us unwrap the data key later
+ * with a hardware-backed authenticator (Touch ID / Windows Hello / security
+ * key) instead of a passphrase.
+ *
+ * @see https://w3c.github.io/webauthn/#prf-extension
+ */
+
+import { base64UrlToBytes, bytesToBase64Url } from '../lib/security/encryption-at-rest';
+
+const PRF_SALT_BYTES = 32;
+const USER_HANDLE_BYTES = 16;
+const CEREMONY_TIMEOUT_MS = 60_000;
+
+/** Metadata + secret produced when enrolling a WebAuthn wrapping factor. */
+export interface WebAuthnPrfEnrollment {
+  readonly credentialIdBase64Url: string;
+  readonly prfSaltBase64Url: string;
+  readonly prfSecret: Uint8Array;
+  readonly label: string;
+}
+
+interface PrfExtensionResults {
+  readonly prf?: { readonly results?: { readonly first?: ArrayBuffer | Uint8Array } };
+}
+
+/** Feature-detect WebAuthn availability (PRF support is verified at runtime). */
+export function isWebAuthnPrfSupported(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.PublicKeyCredential !== 'undefined' &&
+    typeof navigator !== 'undefined' &&
+    typeof navigator.credentials?.create === 'function' &&
+    typeof navigator.credentials?.get === 'function'
+  );
+}
+
+function relyingPartyId(): string {
+  return typeof window !== 'undefined' && window.location?.hostname
+    ? window.location.hostname
+    : 'localhost';
+}
+
+function readPrfSecret(credential: PublicKeyCredential): Uint8Array {
+  const results = credential.getClientExtensionResults() as PrfExtensionResults;
+  const first = results.prf?.results?.first;
+  if (!first) {
+    throw new Error(
+      'This authenticator did not return a PRF secret. Use a passphrase or recovery code instead.',
+    );
+  }
+  return first instanceof Uint8Array ? new Uint8Array(first) : new Uint8Array(first);
+}
+
+/**
+ * Create a new device-bound credential and derive its PRF secret.
+ *
+ * The returned `prfSecret` must be consumed immediately (to wrap the data key)
+ * and then zeroed by the caller.
+ */
+export async function createWebAuthnPrfCredential(
+  label = 'Passkey',
+): Promise<WebAuthnPrfEnrollment> {
+  if (!isWebAuthnPrfSupported()) {
+    throw new Error('Passkeys are not supported in this browser.');
+  }
+
+  const prfSalt = crypto.getRandomValues(new Uint8Array(PRF_SALT_BYTES));
+  const userHandle = crypto.getRandomValues(new Uint8Array(USER_HANDLE_BYTES));
+  const challenge = crypto.getRandomValues(new Uint8Array(PRF_SALT_BYTES));
+
+  const credential = (await navigator.credentials.create({
+    publicKey: {
+      challenge,
+      rp: { name: 'Finance', id: relyingPartyId() },
+      user: {
+        id: userHandle,
+        name: 'finance-encryption',
+        displayName: 'Finance encryption key',
+      },
+      pubKeyCredParams: [
+        { type: 'public-key', alg: -7 }, // ES256
+        { type: 'public-key', alg: -257 }, // RS256
+      ],
+      timeout: CEREMONY_TIMEOUT_MS,
+      authenticatorSelection: {
+        residentKey: 'required',
+        requireResidentKey: true,
+        userVerification: 'required',
+      },
+      attestation: 'none',
+      extensions: {
+        prf: { eval: { first: toArrayBuffer(prfSalt) } },
+      } as AuthenticationExtensionsClientInputs,
+    },
+  })) as PublicKeyCredential | null;
+
+  if (!credential) {
+    throw new Error('Passkey enrollment was cancelled.');
+  }
+
+  // Some authenticators only surface PRF output on assertion (get), not on
+  // create. Fall back to an immediate evaluation in that case.
+  let prfSecret: Uint8Array;
+  try {
+    prfSecret = readPrfSecret(credential);
+  } catch {
+    prfSecret = await evaluateWebAuthnPrf(
+      bytesToBase64Url(new Uint8Array(credential.rawId)),
+      bytesToBase64Url(prfSalt),
+    );
+  }
+
+  return {
+    credentialIdBase64Url: bytesToBase64Url(new Uint8Array(credential.rawId)),
+    prfSaltBase64Url: bytesToBase64Url(prfSalt),
+    prfSecret,
+    label,
+  };
+}
+
+/**
+ * Re-evaluate the PRF secret for an enrolled credential + salt (for unlock /
+ * rotation). The returned secret must be consumed immediately and then zeroed.
+ */
+export async function evaluateWebAuthnPrf(
+  credentialIdBase64Url: string,
+  prfSaltBase64Url: string,
+): Promise<Uint8Array> {
+  if (!isWebAuthnPrfSupported()) {
+    throw new Error('Passkeys are not supported in this browser.');
+  }
+
+  const challenge = crypto.getRandomValues(new Uint8Array(PRF_SALT_BYTES));
+  const credential = (await navigator.credentials.get({
+    publicKey: {
+      challenge,
+      rpId: relyingPartyId(),
+      timeout: CEREMONY_TIMEOUT_MS,
+      userVerification: 'required',
+      allowCredentials: [
+        {
+          type: 'public-key',
+          id: toArrayBuffer(base64UrlToBytes(credentialIdBase64Url)),
+        },
+      ],
+      extensions: {
+        prf: { eval: { first: toArrayBuffer(base64UrlToBytes(prfSaltBase64Url)) } },
+      } as AuthenticationExtensionsClientInputs,
+    },
+  })) as PublicKeyCredential | null;
+
+  if (!credential) {
+    throw new Error('Passkey verification was cancelled.');
+  }
+
+  return readPrfSecret(credential);
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}

--- a/apps/web/src/hooks/index.ts
+++ b/apps/web/src/hooks/index.ts
@@ -238,3 +238,5 @@ export type {
 } from './useConnectorPermissions';
 export { useMilestoneCheck } from './useMilestoneCheck';
 export type { UseMilestoneCheckResult } from './useMilestoneCheck';
+export { useSqliteEncryption } from './useSqliteEncryption';
+export type { UseSqliteEncryptionResult } from './useSqliteEncryption';

--- a/apps/web/src/hooks/useSqliteEncryption.ts
+++ b/apps/web/src/hooks/useSqliteEncryption.ts
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * React hook for the SQLite at-rest encryption unlock UI (#2806).
+ *
+ * Wraps the data-key vault so settings components never import the repository /
+ * vault directly. All actions re-wrap the *same* data key — they never
+ * regenerate it or change the encrypted snapshot format.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import {
+  isSqliteAtRestEncryptionEnabled,
+  isSqliteAtRestEncryptionSupported,
+  setSqliteAtRestEncryptionEnabled,
+} from '../db/sqlite-at-rest-encryption';
+import {
+  changePassphrase as changePassphraseVault,
+  createRecoveryCode as createRecoveryCodeVault,
+  enrollWebAuthn as enrollWebAuthnVault,
+  getEncryptionFactorStatus,
+  removePassphrase as removePassphraseVault,
+  removeRecoveryCode as removeRecoveryCodeVault,
+  removeWebAuthn as removeWebAuthnVault,
+  setPassphrase as setPassphraseVault,
+  unlockWithPassphrase as unlockWithPassphraseVault,
+  unlockWithRecoveryCode as unlockWithRecoveryCodeVault,
+  unlockWithWebAuthn as unlockWithWebAuthnVault,
+  type EncryptionFactorStatus,
+} from '../db/sqlite-encryption-vault';
+
+/** Shape returned by {@link useSqliteEncryption}. */
+export interface UseSqliteEncryptionResult {
+  /** Web Crypto + IndexedDB available. */
+  readonly supported: boolean;
+  /** Opt-in at-rest encryption flag is on. */
+  readonly enabled: boolean;
+  /** Whether the factor status is still loading. */
+  readonly loading: boolean;
+  /** Current wrapping-factor status, or `null` before the first load. */
+  readonly status: EncryptionFactorStatus | null;
+  /** Re-read the factor status from storage. */
+  readonly refresh: () => Promise<void>;
+  /** Enable or disable at-rest encryption for future writes. */
+  readonly setEncryptionEnabled: (enabled: boolean) => Promise<void>;
+  /** Set (or replace) the passphrase factor. */
+  readonly setPassphrase: (passphrase: string) => Promise<void>;
+  /** Rotate the passphrase in place (verifies the current one). */
+  readonly changePassphrase: (current: string, next: string) => Promise<void>;
+  /** Remove the passphrase factor. */
+  readonly removePassphrase: () => Promise<void>;
+  /** Verify a passphrase can unlock the data key. */
+  readonly unlockWithPassphrase: (passphrase: string) => Promise<void>;
+  /** Generate (or rotate) a recovery code. Returns the plaintext once. */
+  readonly createRecoveryCode: () => Promise<string>;
+  /** Remove the recovery-code factor. */
+  readonly removeRecoveryCode: () => Promise<void>;
+  /** Verify a recovery code can unlock the data key. */
+  readonly unlockWithRecoveryCode: (code: string) => Promise<void>;
+  /** Enroll a passkey (WebAuthn PRF) wrapping factor. */
+  readonly enrollWebAuthn: (label?: string) => Promise<void>;
+  /** Remove the passkey factor. */
+  readonly removeWebAuthn: () => Promise<void>;
+  /** Verify the enrolled passkey can unlock the data key. */
+  readonly unlockWithWebAuthn: () => Promise<void>;
+}
+
+/** Manage at-rest encryption unlock factors. */
+export function useSqliteEncryption(): UseSqliteEncryptionResult {
+  const supported = isSqliteAtRestEncryptionSupported();
+  const [enabled, setEnabled] = useState(() => isSqliteAtRestEncryptionEnabled());
+  const [status, setStatus] = useState<EncryptionFactorStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    if (!supported) {
+      if (mountedRef.current) {
+        setStatus(null);
+        setLoading(false);
+      }
+      return;
+    }
+    try {
+      const next = await getEncryptionFactorStatus();
+      if (mountedRef.current) {
+        setStatus(next);
+      }
+    } finally {
+      if (mountedRef.current) {
+        setLoading(false);
+      }
+    }
+  }, [supported]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const setEncryptionEnabled = useCallback(
+    async (next: boolean) => {
+      setSqliteAtRestEncryptionEnabled(next);
+      setEnabled(next);
+      await refresh();
+    },
+    [refresh],
+  );
+
+  const runThenRefresh = useCallback(
+    <Args extends unknown[], R>(action: (...args: Args) => Promise<R>) =>
+      async (...args: Args): Promise<R> => {
+        const result = await action(...args);
+        await refresh();
+        return result;
+      },
+    [refresh],
+  );
+
+  return {
+    supported,
+    enabled,
+    loading,
+    status,
+    refresh,
+    setEncryptionEnabled,
+    setPassphrase: runThenRefresh(setPassphraseVault),
+    changePassphrase: runThenRefresh(changePassphraseVault),
+    removePassphrase: runThenRefresh(removePassphraseVault),
+    unlockWithPassphrase: unlockWithPassphraseVault,
+    createRecoveryCode: runThenRefresh(createRecoveryCodeVault),
+    removeRecoveryCode: runThenRefresh(removeRecoveryCodeVault),
+    unlockWithRecoveryCode: unlockWithRecoveryCodeVault,
+    enrollWebAuthn: runThenRefresh(enrollWebAuthnVault),
+    removeWebAuthn: runThenRefresh(removeWebAuthnVault),
+    unlockWithWebAuthn: unlockWithWebAuthnVault,
+  };
+}
+
+export default useSqliteEncryption;

--- a/apps/web/src/pages/settings/SettingsSecurityPage.tsx
+++ b/apps/web/src/pages/settings/SettingsSecurityPage.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 
 import { EncryptionDetails } from '../../components/settings/EncryptionDetails';
+import { EncryptionUnlockSettings } from '../../components/settings/EncryptionUnlockSettings';
 
 /**
  * Security & Encryption sub-page — transparent details about local storage,
@@ -13,6 +14,7 @@ export const SettingsSecurityPage: React.FC = () => {
   return (
     <>
       <h2 className="settings-subpage__title">Security &amp; Encryption</h2>
+      <EncryptionUnlockSettings />
       <EncryptionDetails />
     </>
   );


### PR DESCRIPTION
Closes #2806

## Summary
Adds a user-controlled unlock experience for the opt-in SQLite at-rest encryption from #2727. Users can intentionally enable/disable encryption and protect the SQLite **data key** with a passphrase, a WebAuthn (PRF) passkey, and/or a one-time recovery code. The underlying data key is **never regenerated** and the encrypted snapshot format is **never changed** — only the *wrapping* of the data key changes (envelope re-wrap), so existing encrypted databases stay readable.

## Changes
- **`db/data-key-wrapping.ts`** — pure crypto key-slot library (no DOM/IndexedDB deps): wrap/unwrap the raw 32-byte data key with passphrase, recovery code, or WebAuthn-PRF secret; recovery-code generation; `WrongPassphraseError`/`DataKeyUnlockError`.
- **`db/sqlite-encryption-vault.ts`** — IndexedDB vault persisting factor *slots* (`sqlite-data-key-vault:v1`) alongside the untouched device slot; orchestrates set/change/remove/unlock/enroll for each factor.
- **`db/webauthn-prf.ts`** — local (no-server) WebAuthn PRF credential creation + evaluation for the passkey wrapping factor.
- **`db/sqlite-at-rest-encryption.ts`** — additive helpers only: `setSqliteAtRestEncryptionEnabled`, `readDeviceWrappedDataKeyBytes`, `ensureSqliteDataKeyBytes`, key-store record accessors. Existing snapshot encrypt/decrypt + record formats are untouched.
- **`hooks/useSqliteEncryption.ts`** — hooks-only data access (components never import the vault/repo directly).
- **`components/settings/EncryptionUnlockSettings.tsx` + `PassphraseDialog.tsx` + `RecoveryCodeDialog.tsx` + `encryption-unlock.css`** — settings panel and accessible modals, wired into `SettingsSecurityPage`.

## Security notes
- **Envelope re-wrap, never regenerate**: the device-local non-extractable wrapping key slot is retained as the default auto-unlock path (preserves the current boot flow, no lockout/bricking risk). Passphrase/WebAuthn/recovery are *additional* slots that AES-GCM-wrap the **same** raw data key recovered from the device slot. Setting/rotating/removing a factor only adds/replaces/removes a slot.
- The `EncryptedSqliteSnapshotRecord` blob format is never touched — no re-encrypt of the DB, backward compatible, no data-loss risk. A test asserts the snapshot format is unchanged after factors are added.
- Passphrase + recovery derive via PBKDF2-SHA-256 (random per-slot salt stored, 310k iterations, min 12 chars). WebAuthn PRF secret is normalized via SHA-256 to a 32-byte AES-GCM key. Per-slot AAD binding prevents slot/factor confusion.
- **Fails closed**: a wrong passphrase/recovery code surfaces as a friendly `WrongPassphraseError` from an AES-GCM tag failure — no partial decryption, no data-key leakage. Raw key bytes are zeroed after every re-wrap; no extractable data key is ever persisted in plaintext.
- **Recovery copy**: the UI clearly states that if the only wrapping factor is lost the data is unrecoverable, and offers a recovery code as an optional second factor.

### Deferred (follow-up)
Full passphrase-gated boot (removing the device slot + a boot-time unlock prompt) is intentionally **not** included here because it risks bricking startup. This PR keeps the device slot so the app always boots; gating the boot path can be layered on top later.

## Testing
`npx vitest run` (apps/web) — all green:
- `data-key-wrapping.test.ts` — set/unlock/reject-wrong/rotate/switch-modes all preserve the **same** decrypted data key.
- `sqlite-encryption-vault.test.ts` — wrap+unlock, rotate-in-place, recovery-code unlock, snapshot format unchanged (WebAuthn mocked).
- `EncryptionUnlockSettings.test.tsx` / `PassphraseDialog.test.tsx` — set passphrase, wrong-passphrase announcement, too-short inline error, fail-closed.
- Existing `sqlite-at-rest-encryption.test.ts` and `SettingsSecurityPage.test.tsx` still pass.

## Accessibility (WCAG 2.2 AA)
- `role=switch` toggle with `aria-checked`; status conveyed by text + icon, not color alone.
- Modals: focus trap, ESC to close, focus restore, labelled fields, `role=alert` error announcements, `aria-live` status regions.
- Explicit, non-color lockout/recovery copy.