### PR TITLE
ci(workflows): make required checks skip-with-success on untouched paths (#2855)

### DIFF
--- a/.github/workflows/ci-android.yml
+++ b/.github/workflows/ci-android.yml
@@ -22,17 +22,6 @@ on:
       - '**/*.kts'
   pull_request:
     branches: [main]
-    paths:
-      - 'apps/android/**'
-      - 'packages/**'
-      - 'build-logic/**'
-      - 'gradle/**'
-      - '*.gradle.kts'
-      - 'gradle.properties'
-      - 'settings.gradle*'
-      - 'config/detekt/**'
-      - '**/*.kt'
-      - '**/*.kts'
 
 concurrency:
   group: ci-android-${{ github.ref }}
@@ -57,8 +46,37 @@ env:
   TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
 jobs:
+  # Always runs so the required "Build & Test" context is reported on every PR.
+  # Detects whether Android/shared-Kotlin paths changed; downstream jobs are
+  # skipped (a passing state for required checks) when they did not.
+  changes:
+    name: Detect relevant changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            relevant:
+              - 'apps/android/**'
+              - 'packages/**'
+              - 'build-logic/**'
+              - 'gradle/**'
+              - '*.gradle.kts'
+              - 'gradle.properties'
+              - 'settings.gradle*'
+              - 'config/detekt/**'
+              - '**/*.kt'
+              - '**/*.kts'
+
   detekt:
     name: detekt Analysis
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.relevant == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -151,6 +169,8 @@ jobs:
 
   build-and-test:
     name: Build & Test
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.relevant == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.github/workflows/ci-ios.yml
+++ b/.github/workflows/ci-ios.yml
@@ -18,13 +18,6 @@ on:
       - 'gradle.properties'
   pull_request:
     branches: [main]
-    paths:
-      - 'apps/ios/**'
-      - 'packages/**'
-      - 'build-logic/**'
-      - 'gradle/**'
-      - '*.gradle.kts'
-      - 'gradle.properties'
   workflow_dispatch:
 
 concurrency:
@@ -37,8 +30,33 @@ permissions:
   pull-requests: write
 
 jobs:
+  # Always runs so the required "Build & Test" context is reported on every PR.
+  # Detects whether iOS-relevant paths changed; the build job is skipped (a
+  # passing state for required checks) when they did not.
+  changes:
+    name: Detect relevant changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            relevant:
+              - 'apps/ios/**'
+              - 'packages/**'
+              - 'build-logic/**'
+              - 'gradle/**'
+              - '*.gradle.kts'
+              - 'gradle.properties'
+
   build:
     name: Build & Test
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.relevant == 'true' }}
     runs-on: macos-15
     timeout-minutes: 30
 

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -33,27 +33,6 @@ on:
   pull_request:
     branches: [main]
     types: [opened, edited, synchronize, reopened]
-    paths:
-      - '**/*.ts'
-      - '**/*.tsx'
-      - '**/*.js'
-      - '**/*.jsx'
-      - '**/*.mjs'
-      - '**/*.cjs'
-      - '**/*.json'
-      - '**/*.css'
-      - '**/*.html'
-      - '**/*.yaml'
-      - '**/*.yml'
-      - '.eslintrc*'
-      - 'eslint.config.*'
-      - '.prettierrc*'
-      - '.prettierignore'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'apps/**'
-      - 'packages/**'
-      - 'services/**'
 
 concurrency:
   group: ci-lint-${{ github.ref }}
@@ -68,8 +47,47 @@ env:
   TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
 jobs:
+  # Always runs so the required "ESLint & Prettier" context is reported on every
+  # PR. Detects whether lint-relevant paths changed; the lint jobs are skipped —
+  # a passing state for required checks — when they did not.
+  changes:
+    name: Detect relevant changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            relevant:
+              - '**/*.ts'
+              - '**/*.tsx'
+              - '**/*.js'
+              - '**/*.jsx'
+              - '**/*.mjs'
+              - '**/*.cjs'
+              - '**/*.json'
+              - '**/*.css'
+              - '**/*.html'
+              - '**/*.yaml'
+              - '**/*.yml'
+              - '.eslintrc*'
+              - 'eslint.config.*'
+              - '.prettierrc*'
+              - '.prettierignore'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'apps/**'
+              - 'packages/**'
+              - 'services/**'
+
   eslint-prettier:
     name: ESLint & Prettier
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.relevant == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -100,7 +118,8 @@ jobs:
 
   pr-title:
     name: Semantic PR Title
-    if: github.event_name == 'pull_request'
+    needs: changes
+    if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.relevant == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -123,6 +142,8 @@ jobs:
 
   observability-guardrails:
     name: Observability Guardrails
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.relevant == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -9,7 +9,6 @@ on:
     paths: ['apps/web/**', 'packages/design-tokens/**']
   pull_request:
     branches: [main]
-    paths: ['apps/web/**', 'packages/design-tokens/**']
 
 concurrency:
   group: web-ci-${{ github.event.pull_request.number || github.ref }}
@@ -17,14 +16,36 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
 jobs:
+  # Always runs so the required "Build" context is reported on every PR.
+  # Detects whether web/design-token paths changed; the build job (and its
+  # dependents) are skipped — a passing state for required checks — otherwise.
+  changes:
+    name: Detect relevant changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            relevant:
+              - 'apps/web/**'
+              - 'packages/design-tokens/**'
+
   build:
     name: Build
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.relevant == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -164,8 +185,8 @@ jobs:
 
   e2e-pr-report:
     name: Merge PR E2E Report
-    if: ${{ always() && github.event_name == 'pull_request' && !cancelled() }}
-    needs: e2e-pr-smoke
+    if: ${{ always() && github.event_name == 'pull_request' && needs.changes.outputs.relevant == 'true' && !cancelled() }}
+    needs: [changes, e2e-pr-smoke]
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -20,13 +20,6 @@ on:
       - '.github/workflows/ci-windows.yml'
   pull_request:
     branches: [main]
-    paths:
-      - 'apps/windows/**'
-      - 'packages/**'
-      - 'build-logic/**'
-      - 'gradle/**'
-      - '*.gradle.kts'
-      - 'gradle.properties'
   workflow_dispatch:
 
 concurrency:
@@ -39,8 +32,34 @@ permissions:
   pull-requests: write
 
 jobs:
+  # Always runs so the required "Build & Test" context is reported on every PR.
+  # Detects whether Windows/shared paths changed; the build job is skipped (a
+  # passing state for required checks) when they did not.
+  changes:
+    name: Detect relevant changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            relevant:
+              - 'apps/windows/**'
+              - 'packages/**'
+              - 'build-logic/**'
+              - 'gradle/**'
+              - '*.gradle.kts'
+              - 'gradle.properties'
+              - '.github/workflows/ci-windows.yml'
+
   build:
     name: Build & Test
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.relevant == 'true' }}
     runs-on: windows-latest
     timeout-minutes: 30
 


### PR DESCRIPTION
## Summary

Fixes the structural `BLOCKED` merge state that forced `--admin` on web/docs/single-platform PRs (root cause tracked in #2855).

Branch protection on `main` requires several status check contexts (`ESLint & Prettier`, `Build`, `Build & Test`) that were emitted by **trigger-level path-filtered** workflows. When a PR didn't touch a given path, the whole workflow never ran, so the required context was **never reported** — leaving it stuck as `Expected` and the PR permanently `BLOCKED`.

This keeps every required check a **hard gate**, but makes it report **success when the relevant code path wasn't touched** (the skip-with-success pattern already proven in-repo by `ci-security.yml`'s `codeql-java-kotlin` job).

## Approach

For each affected workflow:

- Removed the trigger-level `pull_request: paths:` filter so the workflow **always runs on PRs**.
- Added a cheap always-running `changes` job (`dorny/paths-filter`, already pinned in-repo) that sets a `relevant` output.
- Gated each real job with `needs: changes` + `if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.relevant == 'true' }}`.

On an untouched-path PR the real job is **skipped** — which GitHub treats as a **pass** for a required context — instead of never reporting. `push`/main CI and all deploy/release flows keep their original `push: paths:` filters and are unaffected.

## Changes

- `ci-lint.yml` — gate `eslint-prettier` (required `ESLint & Prettier`), `pr-title` (PR-only + relevant), `observability-guardrails`.
- `ci-web.yml` — gate `build` (required `Build`); add `pull-requests: read` for the detector; also gate `e2e-pr-report` so it no longer fires a noisy run on non-web PRs.
- `ci-ios.yml`, `ci-android.yml`, `ci-windows.yml` — gate the `Build & Test` jobs (and Android `detekt`). `ci-windows.yml`'s filter includes `.github/workflows/ci-windows.yml`.

## This PR is its own verification

Because it touches only `.github/workflows/**`:

- `ESLint & Prettier` → runs **real** (lint filter matches `**/*.yml`) and must pass.
- `Build & Test` (windows) → runs **real** (windows filter matches this workflow file).
- `Build & Test` (ios/android) → **skipped**.
- `Build` (web) → its only check run is **skipped** — the pure litmus test for "skipped required check = pass".

If this PR reaches `MERGEABLE` without `--admin`, the pattern is confirmed for the whole fleet. **No branch-protection settings change is required** — context names are unchanged.

## Issues

Closes #2855

## Testing

- [x] Prettier clean on all 5 workflows (`prettier --check`)
- [x] YAML parses (validated via Prettier's parser)
- [ ] Remote CI green + PR `MERGEABLE` without `--admin` (the live experiment)