### PR TITLE
fix(ci): repair Windows and Release workflow startup failures (#2888)

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -249,7 +249,7 @@ jobs:
             '',
             "- **Stable download URL:** $stableUrl",
             '- **Versioned asset:** `${{ steps.msi.outputs.name }}`',
-            '- **Signed:** ${{ env.HAS_SIGNING_SECRETS == ''true'' }}',
+            '- **Signed:** ${{ env.HAS_SIGNING_SECRETS == 'true' }}',
             '- **Rolling release page:** ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ env.ROLLING_TAG }}'
           ) -join "`n"
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $body

--- a/.github/workflows/release-platform.yml
+++ b/.github/workflows/release-platform.yml
@@ -108,6 +108,7 @@ jobs:
       dry_run: ${{ steps.meta.outputs.dry_run }}
       publish_release: ${{ steps.meta.outputs.publish_release }}
       store_metadata: ${{ steps.meta.outputs.store_metadata }}
+      matrix: ${{ steps.meta.outputs.matrix }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -162,22 +163,27 @@ jobs:
           echo "publish_release=$PUBLISH_RELEASE" >> "$GITHUB_OUTPUT"
           echo "store_metadata=$STORE_METADATA" >> "$GITHUB_OUTPUT"
 
+          # Build a dynamic job matrix filtered by the requested platform. The
+          # build-platform job cannot reference the matrix context in its if:,
+          # so the selection happens here instead.
+          MATRIX_INCLUDE=""
+          add_platform() {
+            if [ "$PLATFORM_FILTER" = "all" ] || [ "$PLATFORM_FILTER" = "$1" ]; then
+              MATRIX_INCLUDE="${MATRIX_INCLUDE:+$MATRIX_INCLUDE,}{\"platform\":\"$1\",\"runner\":\"$2\"}"
+            fi
+          }
+          add_platform android ubuntu-latest
+          add_platform ios macos-15
+          add_platform web ubuntu-latest
+          add_platform windows windows-latest
+          echo "matrix={\"include\":[$MATRIX_INCLUDE]}" >> "$GITHUB_OUTPUT"
+
   build-platform:
     name: Release ${{ matrix.platform }}
     needs: prepare
-    if: needs.prepare.outputs.platform_filter == 'all' || needs.prepare.outputs.platform_filter == matrix.platform
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - platform: android
-            runner: ubuntu-latest
-          - platform: ios
-            runner: macos-15
-          - platform: web
-            runner: ubuntu-latest
-          - platform: windows
-            runner: windows-latest
+      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 50
     permissions:


### PR DESCRIPTION
## Summary

Repairs two **invalid workflow files** that were failing with a GitHub "workflow file issue" **startup failure** on every push (0 jobs, run name shown as the file path). Both were pre-existing — confirmed across multiple `main` commits before #2886.

## Impact being fixed

- **Windows PR CI has effectively been dead.** `ci-windows.yml` never started, so it never emitted its `Build & Test` job on PRs. The required `Build & Test` status context was being carried by iOS + Android alone (shared context name), meaning **Windows-only changes could merge without the Windows app ever being built.**
- **`release-platform.yml` could not run at all** — a tag push or manual dispatch hit the same startup failure.

## Root cause (confirmed via `actionlint`)

1. **`ci-windows.yml`** — inside a `|` block scalar (a PowerShell script), the summary step used doubled quotes: `${{ env.HAS_SIGNING_SECRETS == ''true'' }}`. Block scalars don't unescape quotes, so GitHub parsed `''true''` as `string · ident · string` → `parser did not reach end of input`. Fixed to single quotes `'true'` (GitHub substitutes the expression before PowerShell sees it, so it stays valid).
2. **`release-platform.yml`** — the `build-platform` job's **job-level `if:`** referenced `matrix.platform`, but the `matrix` context isn't available in `jobs.<id>.if` (only `github`/`needs`/`vars`/`inputs`). Replaced with a **dynamic, platform-filtered matrix** emitted by the `prepare` job and consumed via `strategy.matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}`, dropping the invalid `if:`. Behaviour is preserved: the `platform` dispatch input still selects which platforms build.

## Changes

- `ci-windows.yml` — single-quote the `HAS_SIGNING_SECRETS` expression in the job summary.
- `release-platform.yml` — `prepare` now outputs a filtered `matrix` JSON; `build-platform` consumes it and no longer references `matrix` in a job-level `if:`.

## Issues

Closes #2888

## Testing

- [x] `actionlint` passes on both files (exit 0, no `[expression]` errors)
- [x] Prettier clean
- [ ] Remote CI green + `MERGEABLE`

Part of the CI-hardening follow-up to #2855 / #2886.