### PR TITLE
ci(workflows): make platform CI self-validating on own-file edits

### DIFF
--- a/.github/workflows/ci-android.yml
+++ b/.github/workflows/ci-android.yml
@@ -72,6 +72,7 @@ jobs:
               - 'config/detekt/**'
               - '**/*.kt'
               - '**/*.kts'
+              - '.github/workflows/ci-android.yml'
 
   detekt:
     name: detekt Analysis

--- a/.github/workflows/ci-ios.yml
+++ b/.github/workflows/ci-ios.yml
@@ -52,6 +52,7 @@ jobs:
               - 'gradle/**'
               - '*.gradle.kts'
               - 'gradle.properties'
+              - '.github/workflows/ci-ios.yml'
 
   build:
     name: Build & Test

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -83,6 +83,7 @@ jobs:
               - 'apps/**'
               - 'packages/**'
               - 'services/**'
+              - '.github/workflows/ci-lint.yml'
 
   eslint-prettier:
     name: ESLint & Prettier

--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -41,6 +41,7 @@ jobs:
             relevant:
               - 'apps/web/**'
               - 'packages/design-tokens/**'
+              - '.github/workflows/ci-web.yml'
 
   build:
     name: Build


### PR DESCRIPTION
## Summary

Makes the platform CI workflows self-validating: editing a workflow's own definition file on a PR now re-runs that platform's real build/lint job, instead of skipping-with-success.

Today the `changes` detector (dorny/paths-filter) gates each platform's real job, but a workflow's **own file** isn't in its `relevant` filter — so a PR that edits `ci-web.yml` (or ios/android/lint) skips the very job it changed. `ci-windows.yml` already self-validates (its own file was added to its filter in #2855); this brings the other four in line.

## Changes

- `ci-ios.yml` -> add `.github/workflows/ci-ios.yml` to the `relevant` filter
- `ci-android.yml` -> add `.github/workflows/ci-android.yml`
- `ci-web.yml` -> add `.github/workflows/ci-web.yml`
- `ci-lint.yml` -> add `.github/workflows/ci-lint.yml` (explicit, even though the broad `**/*.yml` glob already covered it — keeps the self-validation guarantee robust if that glob is ever narrowed, and makes intent greppable across all five workflows)

No behavioral change for code PRs that don't touch CI config. `.github/actions/**` was intentionally **not** added — no such directory exists and the platform workflows don't consume composite/reusable actions, so it would be dead config.

## Self-validation

This PR edits `ci-ios.yml`, `ci-android.yml`, `ci-web.yml`, and `ci-lint.yml`, so with this change each of those platforms' real jobs run on this very PR — demonstrating the fix end-to-end.

## Issues

Closes #2890

## Testing

- [x] actionlint clean (only the pre-existing intentional `if: false` disabled-placeholder warning in `ci-android.yml`, unrelated to this change)
- [x] `prettier --check` passes on all four files
