### PR TITLE
docs(ci): add required-check path-filter guardrail

### DIFF
--- a/.github/instructions/workflows.instructions.md
+++ b/.github/instructions/workflows.instructions.md
@@ -10,7 +10,7 @@ You are working in `.github/workflows/`, owned by `@devops-engineer` for CI/CD, 
 
 - Pin every third-party action by full commit SHA and keep a version comment beside it (for example, `actions/checkout@<sha> # v6.0.3`); never use floating tags like `@v4`.
 - Use least-privilege `permissions:` at the workflow and job level. Start with `contents: read` and add scopes only when a job needs them.
-- Prefer path filters, `concurrency`, timeouts, and caches so checks are fast and deterministic across the monorepo.
+- Prefer `concurrency`, timeouts, and caches so checks are fast and deterministic across the monorepo. Use path scoping to avoid wasted work, but **only via an in-workflow `changes` detector** for required checks — never via trigger-level `on.pull_request.paths` (see "Required checks must not be path-skipped at the trigger level" below).
 - Extract repeated setup/build/smoke-test logic into `workflow_call` reusable workflows named `reusable-*.yml`.
 - Keep required checks blocking and reliable. Informational checks may use `continue-on-error: true`, but must report their status clearly in `$GITHUB_STEP_SUMMARY`.
 - Never echo secrets, tokens, or full environment dumps. Read credentials only from GitHub `secrets`/`vars`, mask derived sensitive values, and avoid writing them to summaries or artifacts.
@@ -21,3 +21,21 @@ You are working in `.github/workflows/`, owned by `@devops-engineer` for CI/CD, 
 - Cache keys must include the relevant lockfiles or Gradle/version-catalog inputs (`package-lock.json`, `gradle/libs.versions.toml`, `build-logic/**`) so stale dependencies do not leak across jobs.
 - Required checks should validate format, lint, type/build, tests, or security gates; release, deploy, and smoke workflows must preserve explicit human approval gates before production-impacting actions.
 - Keep workflow names stable because branch protection and PR status checks depend on them.
+
+## Required checks must not be path-skipped at the trigger level
+
+A status check is **required** when its context name is listed in `main`'s branch protection (today: `ESLint & Prettier`, `Secret Detection`, `CodeQL Analysis (javascript-typescript)`, `CodeQL Analysis (java-kotlin)`, `submit-gradle`, `Build` (web), and `Build & Test` (shared by ci-ios/ci-android/ci-windows)).
+
+**Never add `paths:` or `paths-ignore:` to `on.pull_request` (or `on.push`) for a workflow that emits a required check.** When a PR doesn't match a trigger-level path filter, the workflow does not run at all, so its required context is **never reported** — GitHub then holds the PR in a permanently pending `BLOCKED` state that can only be cleared with `--admin`.
+
+Use the **skip-with-success** pattern instead — scope the work _inside_ the workflow so the required context always reports:
+
+1. A cheap `changes` job that always runs on `pull_request` and uses `dorny/paths-filter` (pinned by SHA) to set a `relevant` output. Guard the filter step with `if: github.event_name == 'pull_request'` so non-PR events fall through.
+2. The real job(s) declare `needs: changes` and
+   `if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.relevant == 'true' }}`.
+
+When the paths are untouched the real job is **skipped**, which branch protection counts as a **pass** for the required context — verified live in this repo (a required check whose only run is `skipped` reaches `CLEAN`/`MERGEABLE` with no `--admin`). On `push` the short-circuit makes the job always run.
+
+Each workflow's own file (e.g. `.github/workflows/ci-web.yml`) must be in its `relevant` filter so that editing the CI definition re-runs that platform's real build on the PR (self-validation).
+
+See `docs/ops/ci-workflow.md` for the full rationale and the canonical detector snippet.

--- a/.github/workflows/ci-android.yml
+++ b/.github/workflows/ci-android.yml
@@ -49,6 +49,12 @@ jobs:
   # Always runs so the required "Build & Test" context is reported on every PR.
   # Detects whether Android/shared-Kotlin paths changed; downstream jobs are
   # skipped (a passing state for required checks) when they did not.
+  #
+  # GUARDRAIL: do NOT add `paths:`/`paths-ignore:` to this workflow's `on:`
+  # triggers. A required check whose workflow is filtered out never reports its
+  # status, leaving PRs stuck in a BLOCKED state. Gate inside the workflow via
+  # this `changes` detector (skip-with-success) instead. See docs/ops/ci-workflow.md
+  # and .github/instructions/workflows.instructions.md.
   changes:
     name: Detect relevant changes
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-ios.yml
+++ b/.github/workflows/ci-ios.yml
@@ -33,6 +33,12 @@ jobs:
   # Always runs so the required "Build & Test" context is reported on every PR.
   # Detects whether iOS-relevant paths changed; the build job is skipped (a
   # passing state for required checks) when they did not.
+  #
+  # GUARDRAIL: do NOT add `paths:`/`paths-ignore:` to this workflow's `on:`
+  # triggers. A required check whose workflow is filtered out never reports its
+  # status, leaving PRs stuck in a BLOCKED state. Gate inside the workflow via
+  # this `changes` detector (skip-with-success) instead. See docs/ops/ci-workflow.md
+  # and .github/instructions/workflows.instructions.md.
   changes:
     name: Detect relevant changes
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -50,6 +50,12 @@ jobs:
   # Always runs so the required "ESLint & Prettier" context is reported on every
   # PR. Detects whether lint-relevant paths changed; the lint jobs are skipped —
   # a passing state for required checks — when they did not.
+  #
+  # GUARDRAIL: do NOT add `paths:`/`paths-ignore:` to this workflow's `on:`
+  # triggers. A required check whose workflow is filtered out never reports its
+  # status, leaving PRs stuck in a BLOCKED state. Gate inside the workflow via
+  # this `changes` detector (skip-with-success) instead. See docs/ops/ci-workflow.md
+  # and .github/instructions/workflows.instructions.md.
   changes:
     name: Detect relevant changes
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -26,6 +26,12 @@ jobs:
   # Always runs so the required "Build" context is reported on every PR.
   # Detects whether web/design-token paths changed; the build job (and its
   # dependents) are skipped — a passing state for required checks — otherwise.
+  #
+  # GUARDRAIL: do NOT add `paths:`/`paths-ignore:` to this workflow's `on:`
+  # triggers. A required check whose workflow is filtered out never reports its
+  # status, leaving PRs stuck in a BLOCKED state. Gate inside the workflow via
+  # this `changes` detector (skip-with-success) instead. See docs/ops/ci-workflow.md
+  # and .github/instructions/workflows.instructions.md.
   changes:
     name: Detect relevant changes
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -35,6 +35,12 @@ jobs:
   # Always runs so the required "Build & Test" context is reported on every PR.
   # Detects whether Windows/shared paths changed; the build job is skipped (a
   # passing state for required checks) when they did not.
+  #
+  # GUARDRAIL: do NOT add `paths:`/`paths-ignore:` to this workflow's `on:`
+  # triggers. A required check whose workflow is filtered out never reports its
+  # status, leaving PRs stuck in a BLOCKED state. Gate inside the workflow via
+  # this `changes` detector (skip-with-success) instead. See docs/ops/ci-workflow.md
+  # and .github/instructions/workflows.instructions.md.
   changes:
     name: Detect relevant changes
     runs-on: ubuntu-latest

--- a/docs/ops/ci-workflow.md
+++ b/docs/ops/ci-workflow.md
@@ -36,6 +36,59 @@ This document describes the continuous integration (CI) workflow for the Finance
 - Conventional commit messages are enforced.
 - PRs must reference issues and pass all status checks.
 
+## Path Filtering & Required Checks
+
+The monorepo scopes expensive platform builds to the code they affect, but **path scoping must never hide a required status check**. A check is _required_ when its context name appears in `main`'s branch protection (e.g. `ESLint & Prettier`, `Build` for web, `Build & Test` for the mobile/desktop platforms, the CodeQL analyses, `Secret Detection`, `submit-gradle`).
+
+### Do not use trigger-level path filters on required checks
+
+Adding `paths:`/`paths-ignore:` under `on.pull_request` (or `on.push`) means the workflow does not run when a PR misses those paths. The required context is then **never reported**, and GitHub leaves the PR stuck in a pending `BLOCKED` state that only `--admin` can override. This is a foot-gun, not an optimization.
+
+### Use the skip-with-success detector instead
+
+Scope the work _inside_ the workflow so the required context always reports a result:
+
+```yaml
+on:
+  pull_request: # NOTE: no `paths:` here — see guardrail below
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  changes:
+    name: Detect relevant changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: dorny/paths-filter@<sha> # v4.0.1, pinned
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            relevant:
+              - 'apps/web/**'
+              - 'packages/design-tokens/**'
+              - '.github/workflows/ci-web.yml' # self-validate: editing CI re-runs the build
+
+  build:
+    name: Build # <- the required context
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.relevant == 'true' }}
+    runs-on: ubuntu-latest
+    steps: ...
+```
+
+Behavior:
+
+- **PR touches relevant paths** → the real job runs and reports a genuine pass/fail.
+- **PR doesn't touch them** → the real job is **skipped**, which branch protection counts as a **pass** (verified live: a required context whose only run is `skipped` reaches `CLEAN`/`MERGEABLE` with no `--admin`).
+- **Push to `main`** → the `github.event_name != 'pull_request'` short-circuit makes the real job always run.
+
+Each workflow includes **its own file** in the `relevant` filter so that editing the CI definition re-runs that platform's real build on the PR (self-validation). The `changes` job in each platform workflow carries an inline `GUARDRAIL` comment restating this rule. See `.github/instructions/workflows.instructions.md` and ADR `docs/architecture/0006-cicd-strategy.md`.
+
 ---
 
 For more details, see the workflow YAML files in `.github/workflows/`.


### PR DESCRIPTION
## Summary

Documents the rule that emerged from the #2855 / #2888 / #2890 fix series so the original failure mode can't be reintroduced: **never put a trigger-level `on.pull_request.paths` filter on a workflow that emits a required status check.** A filtered-out required context is never reported, which leaves PRs stuck in a permanently pending `BLOCKED` state (only clearable with `--admin`).

Docs and comments only — **no workflow behavior changes**.

## Changes

- **`.github/instructions/workflows.instructions.md`** (auto-surfaced to anyone editing `.github/workflows/**`):
  - Refined the ambiguous "Prefer path filters" bullet so it no longer reads as an endorsement of trigger-level filters.
  - Added a new section, "Required checks must not be path-skipped at the trigger level," describing the skip-with-success `changes`-detector pattern and the verified branch-protection behavior.
- **`docs/ops/ci-workflow.md`**: added a "Path Filtering & Required Checks" section with the canonical detector snippet and the live-verified behavior (a skipped required context counts as a pass).
- **Inline `GUARDRAIL` comments** above the `changes:` job in all five platform workflows (`ci-ios`, `ci-android`, `ci-web`, `ci-lint`, `ci-windows`).

## Issues

Closes #2893

## Testing

- [x] actionlint clean (only the pre-existing intentional `if: false` disabled-placeholder warning in `ci-android.yml`)
- [x] `prettier --check` passes on the two docs and all five workflows
- [x] Comments live in the workflow YAML, not inside the `filters: |` block scalar, so paths-filter parsing is unaffected
