### PR TITLE
fix(ci): harden GitHub Actions script-injection sinks (#2897)

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -103,6 +103,7 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           PR_NUM="${{ github.event.pull_request.number || github.event.inputs.pr_number }}"
 
@@ -128,7 +129,7 @@ jobs:
             --archive=tgz \
             --meta pr="${PR_NUM}" \
             --meta commit="${{ github.sha }}" \
-            --meta branch="${{ github.head_ref }}" \
+            --meta branch="$HEAD_REF" \
             apps/web/dist >"$DEPLOY_LOG" 2>&1; then
             echo "::error::Vercel preview deploy failed:"
             cat "$DEPLOY_LOG"
@@ -190,6 +191,8 @@ jobs:
 
       - name: Create or update PR comment
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         with:
           script: |
             const prNumber = ${{ github.event.pull_request.number || github.event.inputs.pr_number }};
@@ -204,7 +207,7 @@ jobs:
               `|---|---|`,
               `| **URL** | [${url}](${url}) |`,
               `| **Commit** | \`${sha}\` |`,
-              `| **Branch** | \`${{ github.head_ref }}\` |`,
+              `| **Branch** | \`${process.env.HEAD_REF}\` |`,
               `| **Status** | ✅ Deployed |`,
               '',
               '---',

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -362,9 +362,9 @@ jobs:
 
       - name: Check if this is a release commit
         id: check
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
-          COMMIT_MSG="${{ github.event.head_commit.message }}"
-
           if echo "$COMMIT_MSG" | grep -qP 'chore\(release\):\s*v[\d.]+'; then
             VERSION=$(echo "$COMMIT_MSG" | grep -oP 'v[\d]+\.[\d]+\.[\d]+[^\s]*' | head -1)
             echo "is_release=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Hardens three GitHub Actions **script-injection sinks** flagged by actionlint. Each interpolated an attacker-controllable `${{ ... }}` context directly into a `run:`/`github-script` body, where GitHub substitutes it into the script source *before* execution — so a crafted value runs as code on the runner (CWE-94).

## Changes

- `deploy-preview.yml` — `github.head_ref` in the Vercel deploy `run:` block now passed via `env: HEAD_REF` and referenced as `"$HEAD_REF"`.
- `deploy-preview.yml` — `github.head_ref` in the PR-comment `github-script` block now passed via step `env:` and referenced as `process.env.HEAD_REF`.
- `release-train.yml` — `github.event.head_commit.message` now passed via `env: COMMIT_MSG` instead of an inline shell assignment.

## Why it matters

`deploy-preview.yml` runs on `pull_request` (fork PRs get no secrets), but **same-repo branch PRs do** receive secrets and the injected line runs *after* the `VERCEL_TOKEN` gate. `release-train.yml` runs on `push` with release/publish privileges. The `env:` indirection keeps the value as inert data, not executable script text. No behavior change.

## Validation

- `actionlint` — exit 0, no script-injection findings
- `prettier --check` — clean

## Issues

Closes #2897

## Testing

- [x] actionlint passes
- [x] Prettier formatting clean
- [ ] Preview deploy + release detection unchanged (logic identical; only the value source moved to `env:`)
