### PR TITLE
docs(design): android food-truck reporting design batch (#2551, #2553, #2555)

### DIFF
--- a/docs/design/android-foodtruck-category-margin-cards.md
+++ b/docs/design/android-foodtruck-category-margin-cards.md
@@ -1,0 +1,325 @@
+# Android Food-Truck Category Defaults & Margin Cards — Design
+
+> **Status:** PROPOSED — Pending human review
+> **Issue:** #2553 · **Part of** #2184
+> **Platform:** Android (Jetpack Compose · Material 3)
+> **Priority:** P1 · **Effort:** L (1–2 weeks)
+> **Last Updated:** 2026-06-22
+
+This document specifies the Android design for **(a)** small-business/food-truck
+**category defaults** that pre-classify income and expenses into the P&L buckets,
+and **(b)** **margin summary cards** that surface gross/net margin and food-cost
+at a glance. It complements the P&L report template
+([`android-foodtruck-pnl-report.md`](./android-foodtruck-pnl-report.md), #2551) by
+defining how raw activity becomes the categorized inputs that report aggregates.
+
+> **User story (#2184):** _"As a food-truck owner, I want sensible default
+> categories and quick margin cards so I can see whether each week is healthy
+> without building a spreadsheet."_
+
+---
+
+## Table of Contents
+
+1. [Goals & Non-Goals](#1-goals--non-goals)
+2. [Architecture Boundary (Compose ↔ KMP)](#2-architecture-boundary-compose--kmp)
+3. [Affected Android Surfaces](#3-affected-android-surfaces)
+4. [Shared Dependencies](#4-shared-dependencies)
+5. [Category Defaults](#5-category-defaults)
+6. [Margin Summary Cards](#6-margin-summary-cards)
+7. [UI States: Loading, Empty, Error, Offline](#7-ui-states-loading-empty-error-offline)
+8. [Accessibility (TalkBack)](#8-accessibility-talkback)
+9. [Test Plan](#9-test-plan)
+10. [Implementation Readiness](#10-implementation-readiness)
+11. [Open Questions](#11-open-questions)
+
+---
+
+## 1. Goals & Non-Goals
+
+**Goals**
+
+- Provide a curated set of **default categories** for food-truck operators that
+  map cleanly onto the four P&L buckets — **Revenue, COGS, Labor, Overhead** — and
+  carry IRS Schedule C alignment for later tax workflows.
+- Present **margin summary cards** (Gross Margin, Net Margin, Food-Cost %, Net
+  Profit) that an operator can scan in seconds, reusing the same shared engine
+  output as the full P&L report.
+- Make categorizing a transaction a one-tap action from sensible defaults.
+- Be fully **offline-first** and **TalkBack**-accessible.
+
+**Non-Goals**
+
+- No new finance math in Compose — margins/ratios come from the shared engine
+  (see [§2](#2-architecture-boundary-compose--kmp)).
+- No automatic ML categorization in this issue (defaults + manual selection only;
+  ML categorization tracked separately).
+- No editing of the canonical Schedule C taxonomy from Android — presets are
+  read-only shared data; user overrides are per-transaction.
+
+---
+
+## 2. Architecture Boundary (Compose ↔ KMP)
+
+**The rule:** the **list of default categories**, their **P&L bucket mapping**,
+their **Schedule C alignment**, and all **margin math** live in KMP. Compose
+renders the presets and the computed margins; it owns only layout, labels, and
+selection state.
+
+Two shared sources already exist:
+
+- **Category defaults / tax taxonomy:**
+  [`packages/core/.../schedulec/ScheduleCDeductionPresets.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/schedulec/ScheduleCDeductionPresets.kt)
+  — `ScheduleCDeductionPresetTaxonomy.presets` with `displayName`, `irsLine`,
+  `description`, `examples`, and `defaultBusinessUsePercent`.
+- **Margins:**
+  [`packages/core/.../pnl/SmallBusinessPnlEngine.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/pnl/SmallBusinessPnlEngine.kt)
+  — `PnlSummary.grossMarginBasisPoints`, `netMarginBasisPoints`,
+  `foodCostBasisPoints` (basis points, `10_000 = 100.00%`).
+
+The **food-truck default mapping** (which preset/category belongs to Revenue vs.
+COGS vs. Labor vs. Overhead) is a reusable business rule and therefore belongs in
+KMP. If a `FoodTruckCategoryDefaults` provider does not yet exist in
+`packages/core`, it must be added **by the KMP engineer** (out of scope for this
+Android issue); Android consumes it read-only. Android must **not** hard-code the
+mapping in Compose.
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages/core (shared)"]
+        P[ScheduleC presets +<br/>FoodTruck bucket mapping]
+        E[SmallBusinessPnlEngine -> PnlSummary<br/>margins in basis points]
+    end
+    subgraph Android["apps/android (Compose)"]
+        VM[FoodTruckCategoryViewModel /<br/>margin card state]
+        PICK[CategoryDefaultsPicker]
+        CARDS[MarginSummaryCards]
+    end
+    P --> VM --> PICK
+    E --> VM --> CARDS
+```
+
+| Concern                                                         | Owner                                                             |
+| --------------------------------------------------------------- | ----------------------------------------------------------------- |
+| Default category list, display names, examples, Schedule C line | KMP `ScheduleCDeductionPresetTaxonomy`                            |
+| Mapping default categories → Revenue/COGS/Labor/Overhead bucket | KMP (`FoodTruckCategoryDefaults`, shared)                         |
+| Gross/net margin, food-cost ratio                               | KMP `SmallBusinessPnlEngine`                                      |
+| Selection state, chip/grid layout, labels                       | Android (presentation)                                            |
+| Color/threshold treatment of "healthy vs. thin" margin          | Android (semantic styling; thresholds sourced from shared config) |
+| Reading/writing the chosen category on a transaction            | Android repository (offline-first)                                |
+
+---
+
+## 3. Affected Android Surfaces
+
+All paths under `apps/android/src/main/kotlin/com/finance/android/`.
+
+**New**
+
+- `ui/screens/report/foodtruck/components/MarginSummaryCards.kt` — a row/grid of
+  Material 3 cards: **Gross Margin**, **Net Margin**, **Food-Cost %**, **Net
+  Profit**. Pure presentation of `PnlSummary`.
+- `ui/categorization/foodtruck/CategoryDefaultsPicker.kt` — a Compose picker
+  showing the food-truck default categories grouped by P&L bucket, each with its
+  Schedule C subtitle and examples.
+- `ui/categorization/foodtruck/FoodTruckCategoryViewModel.kt` — `koinViewModel`;
+  exposes the shared defaults and the current margin summary as one
+  `StateFlow<FoodTruckCategoryUiState>`.
+
+**Modified**
+
+- `ui/components/CategoryPicker.kt` — add an optional "Food-truck defaults" tab/
+  section that renders `CategoryDefaultsPicker` (entry point only; no mapping
+  logic added in Compose).
+- `ui/screens/report/foodtruck/PnlReportScreen.kt` (from #2551) — embed
+  `MarginSummaryCards` above the statement card so the report and the summary
+  cards share one source of truth.
+- `ui/navigation/FinanceNavHost.kt` — no new top-level route required; cards live
+  inside the P&L surface and the picker is reached from transaction entry.
+
+**Reused (reference)**
+
+- `ui/insights/InsightsScreen.kt` — Material 3 card + `semantics { heading() }`
+  patterns.
+- `ui/screens/report/ReportBuilderScreen.kt` — `FilterChip`/`SegmentedButton`
+  patterns for the bucket grouping.
+
+---
+
+## 4. Shared Dependencies
+
+| Dependency                                                                                 | Location                                                   | Use                                                |
+| ------------------------------------------------------------------------------------------ | ---------------------------------------------------------- | -------------------------------------------------- |
+| `ScheduleCDeductionPresetTaxonomy`, `ScheduleCDeductionPreset`, `ScheduleCExpenseCategory` | `packages/core/.../schedulec/ScheduleCDeductionPresets.kt` | Default category metadata + tax alignment          |
+| `FoodTruckCategoryDefaults` (bucket mapping)                                               | `packages/core` (shared; added by KMP eng if absent)       | Maps defaults → P&L buckets                        |
+| `SmallBusinessPnlEngine`, `PnlSummary`                                                     | `packages/core/.../pnl/SmallBusinessPnlEngine.kt`          | Margin/food-cost basis points                      |
+| `Cents` / money formatting                                                                 | `packages/core/.../money`, `.../multicurrency`             | Display formatting                                 |
+| Category & Transaction repositories                                                        | `apps/android/.../data/repository/`                        | Offline-first persistence                          |
+| Koin modules                                                                               | `apps/android/.../di/`                                     | `viewModelOf(::FoodTruckCategoryViewModel)`        |
+| Timber                                                                                     | `apps/android/.../logging/`                                | Logging (no amounts/category-level financial data) |
+
+> **Boundary note:** Android consumes `packages/core` directly. All edits in this
+> issue stay within `apps/android/`. Any new shared mapping is owned by the KMP
+> engineer; this design only describes how Android reads it.
+
+---
+
+## 5. Category Defaults
+
+Default categories are grouped by P&L bucket. The labels/Schedule C lines come
+from `ScheduleCDeductionPresetTaxonomy`; the bucket assignment comes from the
+shared `FoodTruckCategoryDefaults`. Representative starter set:
+
+| P&L bucket   | Default category                                                                                                  | Schedule C line (shared)                   |
+| ------------ | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| **Revenue**  | Truck sales, Catering, Event/festival sales                                                                       | — (income)                                 |
+| **COGS**     | Food & ingredients, Beverages, Packaging/supplies                                                                 | Line 22 (Supplies) / COGS Part III         |
+| **Labor**    | Crew wages, Contract labor                                                                                        | Line 26 (Wages) / Line 11 (Contract labor) |
+| **Overhead** | Commissary/booth rent, Fuel & vehicle, Permits & licenses, Insurance, Repairs & maintenance, Card-processing fees | Lines 20b, 9, 23, 15, 21, 10               |
+
+**Picker behavior**
+
+- Defaults render as Material 3 cards/chips grouped under bucket headers; each
+  shows the category name, a one-line description, and up to three `examples`
+  (from the shared preset) to disambiguate.
+- Selecting a default writes the chosen category onto the transaction via the
+  repository (offline-first). The default `defaultBusinessUsePercent` is carried
+  through for later Schedule C use but is **not** edited here.
+- An operator can still pick any existing category; defaults are a fast path, not
+  a restriction.
+- The set is **read-only shared data** — Android never mutates the taxonomy.
+
+---
+
+## 6. Margin Summary Cards
+
+A compact, scannable summary computed entirely from one `PnlSummary` for the
+selected period (same engine call as the P&L report — never a second, divergent
+computation).
+
+| Card             | Source field             | Display                          |
+| ---------------- | ------------------------ | -------------------------------- |
+| **Gross Margin** | `grossMarginBasisPoints` | `xx.x%` (Gross Profit ÷ Revenue) |
+| **Net Margin**   | `netMarginBasisPoints`   | `xx.x%` (Net Profit ÷ Revenue)   |
+| **Food-Cost %**  | `foodCostBasisPoints`    | `xx.x%` (COGS ÷ Revenue)         |
+| **Net Profit**   | `netProfitCents`         | currency, sign-aware             |
+
+**Health styling (presentation only):** cards may apply a healthy / watch / thin
+emphasis (e.g., food-cost in a typical 28–35% target band reads "healthy", above
+reads "watch"). The **thresholds are sourced from shared config**, not hard-coded
+math; Compose only maps a shared band value to a color + label. Color never
+carries meaning alone — a text label ("Healthy", "Watch", "Thin") and an icon
+accompany it.
+
+**Zero-revenue:** ratio cards render `—` with the TalkBack label "not available,
+no revenue this period"; the Net Profit card still renders (costs can exist with
+no revenue).
+
+---
+
+## 7. UI States: Loading, Empty, Error, Offline
+
+- **Loading** — shimmer placeholders for cards and picker; announces "Loading
+  margins".
+- **Empty** — no activity in range → cards show `—`; picker still shows the full
+  default set so the operator can start categorizing.
+- **Zero-revenue** — ratio cards `—`, Net Profit populated, inline hint "Add
+  revenue to see margins".
+- **Error** — repository/shared-data load failure → retry affordance; `Timber.e`
+  without amounts.
+- **Offline** — default mode; cards and defaults compute/read from the local
+  encrypted store with no network dependency.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Loading
+    Loading --> Ready
+    Loading --> Empty: no activity
+    Loading --> Error
+    Ready --> Ready: period / category change
+    Error --> Loading: retry
+```
+
+---
+
+## 8. Accessibility (TalkBack)
+
+Per [`docs/design/accessibility-patterns.md`](./accessibility-patterns.md) §5
+(Color & Contrast) and §7 (Financial Data):
+
+- Each margin card is a **single merged semantics node**:
+  _"Gross Margin, 62.0 percent, healthy"_ — label, value, and health band read
+  together. Use `Modifier.semantics(mergeDescendants = true)`.
+- Health band is conveyed by **label + icon**, never color alone (WCAG 1.4.1).
+- `—` ratio reads "not available, no revenue this period".
+- Card group has a `heading()` ("Margin summary"); cards are reachable in a
+  logical left-to-right, top-to-bottom order.
+- Category defaults: each option exposes `contentDescription` combining bucket +
+  name + Schedule C line, e.g. _"Overhead, Commissary rent, Schedule C line 20b"_;
+  selected state announced ("selected").
+- Touch targets ≥ 48×48 dp; cards/chips reflow under large font scaling without
+  truncating the percentage or currency value.
+- Contrast ≥ 4.5:1 for all card text and band emphasis.
+
+---
+
+## 9. Test Plan
+
+**Android unit tests** (`apps/android/src/test/...`)
+
+- `FoodTruckCategoryViewModelTest` — exposes shared defaults unchanged; maps a
+  fixture `PnlSummary` to card display models; Empty/zero-revenue → `—`; Error on
+  load failure; never computes a ratio itself (passes engine basis points through).
+- `MarginCardFormattingTest` — bps→`xx.x%` and cents→currency, including `—`
+  placeholder and sign-aware Net Profit.
+
+**Compose UI tests** (`apps/android/src/androidTest/...`)
+
+- `MarginSummaryCardsTest` — renders four cards; zero-revenue shows `—`; health
+  band label present; every card has a non-empty merged content description.
+- `CategoryDefaultsPickerTest` — defaults grouped by bucket; selection writes back;
+  Schedule C subtitle shown; all options have content descriptions.
+
+**Snapshot tests (Paparazzi)**
+
+- `MarginSummaryCardsSnapshotTest` — healthy / watch / thin / zero-revenue, light
+  - dark, large font (1.5×/2.0×).
+
+**Manual QA**
+
+- Airplane mode: cards + defaults render from local data.
+- TalkBack: cards read as single nodes with health band; picker order logical.
+- Largest font: no truncated percentages.
+
+---
+
+## 10. Implementation Readiness
+
+This is a **design deliverable**; implementation is unblocked up to distribution.
+Per [`docs/ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md)
+§2, "blocked by #1242" is a **distribution** gate only.
+
+**Buildable now (SME-completable):**
+
+- Compose cards/picker, ViewModel, Koin wiring, and all tests.
+- Local verification: `./gradlew :apps:android:assembleDebug`,
+  `:apps:android:testDebugUnitTest`, Paparazzi `verifyPaparazziDebug`, sideload.
+- Shared `ScheduleCDeductionPresetTaxonomy` and `SmallBusinessPnlEngine` already
+  exist. The only shared addition (food-truck bucket **mapping**) is owned by the
+  KMP engineer and does not require any store enrollment.
+
+**Distribution tail (human-gated by #1242):**
+
+- Google Play signing/upload only — see
+  [Android distribution checklist](../ops/human-gated-prerequisites.md#31-android-distribution--google-play-1242).
+
+---
+
+## 11. Open Questions
+
+1. **Food-cost target band** — confirm the healthy/watch/thin thresholds (e.g.
+   28–35% food cost) and whether they vary by cuisine; these belong in shared
+   config, not Compose.
+2. **Card-processing fees** — Overhead vs. COGS placement (also flagged in #2551).
+3. **Default set ownership** — confirm the canonical food-truck default list lives
+   in `packages/core` (`FoodTruckCategoryDefaults`) so iOS/Web/Windows reuse it.

--- a/docs/design/android-foodtruck-pnl-report.md
+++ b/docs/design/android-foodtruck-pnl-report.md
@@ -1,0 +1,341 @@
+# Android Food-Truck P&L Report Template — Design
+
+> **Status:** PROPOSED — Pending human review
+> **Issue:** #2551 · **Part of** #2184
+> **Platform:** Android (Jetpack Compose · Material 3)
+> **Priority:** P1 · **Effort:** L (1–2 weeks)
+> **Last Updated:** 2026-06-22
+
+This document specifies the Android design for a weekly/monthly profit-and-loss
+(P&L) report tailored to small-business and food-truck operators. It covers the
+surfaces to build, the boundary between Compose UI and the shared Kotlin
+Multiplatform (KMP) finance engine, offline/empty/error states, accessibility,
+a test plan, and implementation readiness.
+
+> **User story (#2184):** _"As a food-truck owner, I want a weekly/monthly P&L
+> with COGS, labor, and margin breakdowns so I know whether the truck is making
+> money."_
+
+---
+
+## Table of Contents
+
+1. [Goals & Non-Goals](#1-goals--non-goals)
+2. [Architecture Boundary (Compose ↔ KMP)](#2-architecture-boundary-compose--kmp)
+3. [Affected Android Surfaces](#3-affected-android-surfaces)
+4. [Shared Dependencies](#4-shared-dependencies)
+5. [Report Template Layout](#5-report-template-layout)
+6. [UI States: Loading, Empty, Error, Offline](#6-ui-states-loading-empty-error-offline)
+7. [Accessibility (TalkBack)](#7-accessibility-talkback)
+8. [Test Plan](#8-test-plan)
+9. [Implementation Readiness](#9-implementation-readiness)
+10. [Open Questions](#10-open-questions)
+
+---
+
+## 1. Goals & Non-Goals
+
+**Goals**
+
+- Render a **weekly** and **monthly** P&L report with the canonical small-business
+  lines: **Revenue → COGS → Gross Profit → Labor → Overhead → Net Profit**, plus
+  **Gross Margin** and **Net Margin** percentages.
+- Let an operator switch the grouping (weekly/monthly) and the period range, and
+  drill into a single period to see its contributing line items.
+- Work fully **offline-first** against the local encrypted store; never block on
+  network.
+- Be fully operable with **TalkBack**, **Switch Access**, and large font scaling.
+
+**Non-Goals**
+
+- No finance math in Compose. All aggregation, margin, and rounding logic stays
+  in KMP (see [§2](#2-architecture-boundary-compose--kmp)).
+- No PDF/CSV export in this issue (the existing `ReportBuilder` export path is
+  reused later; out of scope here).
+- No multi-currency consolidation; reports render in the household default
+  currency, mirroring `docs/design/data-model.md` money rules.
+- No native release/signing work — distribution is gated (see [§9](#9-implementation-readiness)).
+
+---
+
+## 2. Architecture Boundary (Compose ↔ KMP)
+
+**The rule:** Compose renders shared, pre-computed state. It does **not** sum
+cents, compute margins, divide ratios, or pick period boundaries. All of that is
+owned by the shared engine.
+
+The shared engine already exists:
+[`packages/core/.../pnl/SmallBusinessPnlEngine.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/pnl/SmallBusinessPnlEngine.kt).
+It exposes `SmallBusinessPnlEngine.aggregate(...)` returning a `PnlReport` with:
+
+- `summary: PnlSummary` and `periods: List<PnlPeriodReport>`.
+- `PnlSummary` fields are integer cents (`revenueCents`, `cogsCents`,
+  `laborCents`, `overheadCents`, `grossProfitCents`, `operatingExpenseCents`,
+  `netProfitCents`) plus **basis-point** ratios (`grossMarginBasisPoints`,
+  `netMarginBasisPoints`, `foodCostBasisPoints`) where `10_000 = 100.00%`.
+- Weekly periods start Monday; monthly periods are calendar months (engine-owned).
+- Zero-revenue periods return a `ZERO_REVENUE_RATIO_BASIS_POINTS` sentinel rather
+  than dividing by zero — the UI maps this to a `—` placeholder, never `NaN`.
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages/core (shared, all platforms)"]
+        E[SmallBusinessPnlEngine.aggregate]
+        M[PnlReport / PnlSummary<br/>cents + basis points]
+        E --> M
+    end
+    subgraph Android["apps/android (Compose)"]
+        R[(Repositories:<br/>Transaction / Category)]
+        VM[FoodTruckPnlViewModel<br/>maps PnlReport -> UI state]
+        UI[Compose: PnlReportScreen<br/>formats cents + bps for display]
+    end
+    R --> VM
+    VM --> E
+    M --> VM
+    VM --> UI
+```
+
+**Mapping responsibilities**
+
+| Concern                                               | Owner                                                      |
+| ----------------------------------------------------- | ---------------------------------------------------------- |
+| Summing revenue/COGS/labor/overhead, overflow-checked | KMP `SmallBusinessPnlEngine`                               |
+| Gross/net margin, food-cost ratio (basis points)      | KMP `SmallBusinessPnlEngine`                               |
+| Weekly (Mon–Sun) / monthly period bucketing           | KMP `SmallBusinessPnlEngine.periodFor`                     |
+| Cents → currency string, bps → `xx.x%`                | Android (presentation only, via shared currency formatter) |
+| Color/sign/treatment of negative net profit           | Android (semantic, not math)                               |
+| Reading transactions/categories from local store      | Android repositories (offline-first)                       |
+
+> If a number must be **computed**, it belongs in KMP. If it must be
+> **formatted or styled**, it belongs in Compose. Currency/percent string
+> formatting reuses the shared formatter in `packages/core/.../money` /
+> `multicurrency` so all platforms render identically.
+
+---
+
+## 3. Affected Android Surfaces
+
+All paths under `apps/android/src/main/kotlin/com/finance/android/`.
+
+**New**
+
+- `ui/screens/report/foodtruck/PnlReportScreen.kt` — the P&L report screen
+  (Scaffold + `LazyColumn`). Grouping toggle (Weekly/Monthly), period selector,
+  summary header, line-item rows, per-period drill-in.
+- `ui/screens/report/foodtruck/PnlReportViewModel.kt` — `koinViewModel`, collects
+  repository flows, calls `SmallBusinessPnlEngine.aggregate`, exposes a single
+  `StateFlow<PnlReportUiState>`.
+- `ui/screens/report/foodtruck/PnlReportUiState.kt` — sealed UI state
+  (`Loading`, `Empty`, `Error`, `Ready`) + display models (already-formatted
+  strings + raw values for semantics).
+- `ui/screens/report/foodtruck/components/PnlLineRow.kt`,
+  `PnlMarginHeader.kt`, `PnlPeriodCard.kt` — reusable Compose pieces.
+
+**Modified**
+
+- `ui/navigation/FinanceNavHost.kt` — add a `Route.FoodTruckPnl` destination and
+  wire navigation from the existing **Report Builder** entry point. (Follows the
+  existing `Route` sealed-class pattern, e.g. `ReportBuilder`, `Insights`.)
+- `ui/screens/report/ReportBuilderScreen.kt` — add a "Food-truck P&L" template
+  card that deep-links into the new screen (entry point only; no math added).
+
+**Reused (no edits required)**
+
+- `ui/insights/InsightsScreen.kt` — reference for Material 3 card + Canvas chart
+  patterns and `semantics { heading() }` usage.
+- `widget/BudgetSummaryWidget.kt` — reference for a future Glance P&L summary
+  (out of scope here, noted for continuity).
+
+---
+
+## 4. Shared Dependencies
+
+| Dependency                                                                                                       | Location                                          | Use                                                   |
+| ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- | ----------------------------------------------------- |
+| `SmallBusinessPnlEngine`, `PnlReport`, `PnlSummary`, `PnlPeriodReport`, `PnlPeriodGrouping`, `PnlLineItem(Type)` | `packages/core/.../pnl/SmallBusinessPnlEngine.kt` | All P&L aggregation, margins, period bucketing        |
+| `Cents` / money formatting                                                                                       | `packages/core/.../money`, `.../multicurrency`    | Integer-cents money + display formatting              |
+| Transaction & Category repositories                                                                              | `apps/android/.../data/repository/`               | Offline-first source for line items                   |
+| Koin modules                                                                                                     | `apps/android/.../di/`                            | `viewModelOf(::PnlReportViewModel)` wiring            |
+| Timber                                                                                                           | `apps/android/.../logging/TimberCrashReporter.kt` | Structured logging (never `Log.*`, never log amounts) |
+
+> **Boundary note:** `apps/android` consumes `packages/core` as a direct Kotlin
+> dependency (no bridging layer). The Android client only constructs
+> `PnlLineItem`/`PnlInputs` from local data and passes them to the engine; it
+> never re-implements the aggregation. Edits in this issue stay inside
+> `apps/android/`; the engine in `packages/` is consumed as-is.
+
+---
+
+## 5. Report Template Layout
+
+Vertical scroll (`LazyColumn`), top to bottom:
+
+1. **Top app bar** — title "Food-Truck P&L", back navigation, overflow (period
+   range, future export).
+2. **Grouping toggle** — Material 3 `SegmentedButton`: **Weekly | Monthly**.
+   Maps directly to `PnlPeriodGrouping.WEEKLY` / `MONTHLY`.
+3. **Period selector** — chip row / dropdown listing the available periods from
+   `PnlReport.periods` (engine-provided, Monday-start weeks or calendar months).
+4. **Margin header card** (`PnlMarginHeader`) — emphasizes the two headline
+   ratios: **Gross Margin** and **Net Margin**, plus **Net Profit** in currency.
+   Color/sign treatment is presentational; the values come straight from
+   `PnlSummary`.
+5. **P&L statement card** — ordered `PnlLineRow`s:
+
+   | Row                       | Source field             | Notes                          |
+   | ------------------------- | ------------------------ | ------------------------------ |
+   | Revenue                   | `revenueCents`           | —                              |
+   | Cost of Goods Sold (COGS) | `cogsCents`              | Subtracted                     |
+   | **Gross Profit**          | `grossProfitCents`       | Subtotal, emphasized           |
+   | Food Cost %               | `foodCostBasisPoints`    | COGS ÷ revenue, secondary line |
+   | Labor                     | `laborCents`             | —                              |
+   | Overhead                  | `overheadCents`          | —                              |
+   | Operating Expenses        | `operatingExpenseCents`  | Labor + overhead subtotal      |
+   | **Net Profit**            | `netProfitCents`         | Bottom line, emphasized        |
+   | Gross Margin %            | `grossMarginBasisPoints` | —                              |
+   | Net Margin %              | `netMarginBasisPoints`   | —                              |
+
+6. **Per-period breakdown** — a `PnlPeriodCard` per `PnlPeriodReport`, each
+   showing that period's mini-summary; tapping expands to the contributing
+   `lineItemIds` (drill-in resolves IDs back to transactions via the repository).
+
+**Formatting rules (presentation only):**
+
+- Currency via the shared formatter (household default currency, integer cents).
+- Percentages: `basisPoints / 100.0` → one decimal place, e.g. `2_540 → 25.4%`.
+- Zero-revenue period: render margins/food-cost as `—` with the TalkBack label
+  "not available, no revenue this period".
+
+---
+
+## 6. UI States: Loading, Empty, Error, Offline
+
+`PnlReportUiState` is a sealed interface; the screen renders exactly one branch.
+
+- **Loading** — skeleton placeholders for the margin header and statement card;
+  TalkBack announces "Loading profit and loss report".
+- **Empty** — no transactions in range (or no revenue and no costs). Show an
+  illustrative empty state: "No business activity yet for this period" + a CTA to
+  add income/expense. `PnlSummary.lineItemCount == 0` drives this.
+- **Partial / zero-revenue** — costs exist but `hasRevenue == false`. Render the
+  statement with currency rows populated and ratio rows as `—`; surface an inline
+  note "Add revenue to see margins".
+- **Error** — repository/aggregation failure. Show a retry affordance; log via
+  `Timber.e(t, "P&L aggregation failed")` **without** any amounts or account data.
+- **Offline** — this is the default, not an error. Reports compute from the local
+  SQLCipher-encrypted store; show a subtle "Showing local data" affordance only if
+  a sync is pending, never a blocking spinner.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Loading
+    Loading --> Empty: lineItemCount == 0
+    Loading --> Ready: report computed
+    Loading --> Error: repo/aggregation failure
+    Ready --> Ready: grouping / period change
+    Error --> Loading: retry
+    Ready --> Empty: range with no activity
+```
+
+---
+
+## 7. Accessibility (TalkBack)
+
+Mandatory — every interactive and informational Composable carries a
+`contentDescription`, consistent with
+[`docs/design/accessibility-patterns.md`](./accessibility-patterns.md) §7
+(Financial Data Accessibility).
+
+- **Headings:** margin header and statement card titles use
+  `semantics { heading() }` so TalkBack users can jump by heading.
+- **Money & ratios:** each `PnlLineRow` exposes a single merged semantics node
+  combining label + value, e.g. _"Gross Profit, 1,240 dollars"_ and _"Net Margin,
+  18.2 percent"_. Use `Modifier.semantics(mergeDescendants = true)` so the row
+  reads as one node, not three fragments. Spell out "percent" and the currency —
+  never read raw glyphs.
+- **Negative net profit** announces sign explicitly: _"Net Profit, negative 320
+  dollars"_ (do not rely on color alone — WCAG 1.4.1).
+- **Grouping toggle** is a labelled `SegmentedButton`; selected state is conveyed
+  via `selected` semantics ("Weekly, selected").
+- **Period selector** chips read "Week of June 9, selected" / "June 2026".
+- **Zero-revenue ratios** read "not available, no revenue this period".
+- **Font scaling:** layout uses `sp` text and wraps/reflows to 200% scale with no
+  truncation of money values; statement rows stack label/value vertically when the
+  available width is constrained.
+- **Touch targets:** all toggles/chips ≥ 48×48 dp (accessibility-patterns §8).
+- **Color & contrast:** profit/loss emphasis meets ≥ 4.5:1; sign + label carry the
+  meaning independently of hue.
+
+---
+
+## 8. Test Plan
+
+**Shared engine (already covered in `packages/`; not edited here)** — referenced
+for traceability: weekly/monthly bucketing, margin basis points, zero-revenue
+sentinel, and overflow checks are unit-tested in the `pnl` package. The Android
+work depends on, but does not re-test, that math.
+
+**Android unit tests** (`apps/android/src/test/...`)
+
+- `PnlReportViewModelTest` — maps a fixture `PnlReport` to `Ready`; verifies
+  Empty when `lineItemCount == 0`; Error on repository failure; recomputes on
+  grouping/period change; never performs arithmetic itself (asserts it passes the
+  engine's values straight through, including the zero-revenue `—` mapping).
+- `PnlReportFormattingTest` — cents→currency and bps→percent formatting only
+  (e.g. `2_540 → "25.4%"`, `-32000 → "-$320.00"`), including the `—` placeholder.
+
+**Compose UI tests** (`apps/android/src/androidTest/...`)
+
+- `PnlReportScreenTest` — grouping toggle switches Weekly/Monthly; period
+  selection updates the statement; drill-in expands a period card; empty/error
+  states render their CTAs.
+- **Accessibility assertions** — every interactive node has a non-empty
+  content description; statement rows merge into single semantics nodes; heading
+  semantics present; verified with `onNodeWithContentDescription` and the
+  Compose a11y test APIs.
+
+**Snapshot tests (Paparazzi)** (`apps/android/src/test/.../ui/snapshot/`)
+
+- `PnlReportSnapshotTest` — Ready (profit), Ready (loss), Empty, zero-revenue,
+  light/dark, and large-font (1.5×/2.0×) variants. Mirrors the existing
+  `DashboardSnapshotTest`/`BudgetsSnapshotTest` approach.
+
+**Manual QA**
+
+- Airplane mode: full report renders from local data.
+- TalkBack swipe-through reads headings → margins → statement in logical order.
+- Font size set to largest system setting: no truncated money values.
+
+---
+
+## 9. Implementation Readiness
+
+This is a **design deliverable**; the feature is implementable now up to the
+distribution boundary. Per
+[`docs/ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md) §2,
+the "blocked by #1242" reference on #2551 is a **distribution** gate only.
+
+**Buildable now (no enrollment, SME-completable):**
+
+- Compose screens, ViewModel, Koin wiring, navigation, and all tests above.
+- Local verification via `./gradlew :apps:android:assembleDebug` and sideload, plus
+  `:apps:android:testDebugUnitTest` / Paparazzi `verifyPaparazziDebug`.
+- The shared `SmallBusinessPnlEngine` already exists — no `packages/` changes.
+
+**Distribution tail (human-gated by #1242):**
+
+- Google Play release signing, AAB upload, and release-track promotion.
+- See [Android distribution checklist](../ops/human-gated-prerequisites.md#31-android-distribution--google-play-1242).
+  Nothing in this design requires a store build to validate.
+
+---
+
+## 10. Open Questions
+
+1. **Period range default** — last 4 weeks vs. current month? Proposed: default to
+   the current month for Monthly and trailing 8 weeks for Weekly.
+2. **Tips & fees mapping** — confirm whether card-processing fees land in Overhead
+   vs. COGS for food trucks (engine treats them as line-item type; mapping is a
+   data/categorization concern, see #2553).
+3. **Owner draws** — out of P&L (a distribution, not an expense); confirm they are
+   excluded from the four P&L line types upstream.

--- a/docs/design/android-operating-cash-calendar.md
+++ b/docs/design/android-operating-cash-calendar.md
@@ -1,0 +1,335 @@
+# Android Operating Cash Calendar — Design
+
+> **Status:** PROPOSED — Pending human review
+> **Issue:** #2555 · **Part of** #2185
+> **Platform:** Android (Jetpack Compose · Material 3)
+> **Priority:** P1 · **Effort:** L (1–2 weeks)
+> **Last Updated:** 2026-06-22
+
+This document specifies the Android design for an **operating cash calendar** that
+projects whether a small-business/food-truck operator can cover **payroll**,
+**taxes**, and **bills** before revenue lands. It renders daily and weekly
+projected balances with **risk indicators** for upcoming shortfalls.
+
+> **User story (#2185):** _"As a food-truck owner, I want to forecast whether I can
+> cover payroll, taxes, and truck bills before revenue lands, so I don't get caught
+> short."_
+
+---
+
+## Table of Contents
+
+1. [Goals & Non-Goals](#1-goals--non-goals)
+2. [Architecture Boundary (Compose ↔ KMP)](#2-architecture-boundary-compose--kmp)
+3. [Affected Android Surfaces](#3-affected-android-surfaces)
+4. [Shared Dependencies](#4-shared-dependencies)
+5. [Calendar Layout & Risk Indicators](#5-calendar-layout--risk-indicators)
+6. [UI States: Loading, Empty, Error, Offline](#6-ui-states-loading-empty-error-offline)
+7. [Accessibility (TalkBack)](#7-accessibility-talkback)
+8. [Test Plan](#8-test-plan)
+9. [Implementation Readiness](#9-implementation-readiness)
+10. [Open Questions](#10-open-questions)
+
+---
+
+## 1. Goals & Non-Goals
+
+**Goals**
+
+- Show a forward-looking **cash calendar** with **daily projected balances** and a
+  **weekly roll-up**, driven by recurring payroll/tax/bill commitments and one-off
+  what-ifs.
+- Highlight **risk indicators**: the first day a projected balance breaches a floor
+  (e.g. goes negative or below a buffer), and per-horizon (7/30/90-day) outlooks
+  with low/high confidence bands.
+- Let an operator tap a day to see the commitments due that day.
+- Work fully **offline-first**; the forecast is deterministic and local.
+- Be fully operable with **TalkBack** and large font scaling.
+
+**Non-Goals**
+
+- No forecast math in Compose — projection, expansion of recurring commitments,
+  confidence bands, and breach detection live in the shared engine
+  ([§2](#2-architecture-boundary-compose--kmp)).
+- No bank-connection / live-balance ingestion in this issue (starting balance and
+  commitments come from existing local data and user entries).
+- No push notifications for breaches in this issue (reminders are a follow-up; FCM/
+  push delivery is also distribution-adjacent).
+
+---
+
+## 2. Architecture Boundary (Compose ↔ KMP)
+
+**The rule:** Compose renders a pre-computed forecast. It never expands recurring
+schedules, sums balances day-by-day, computes confidence bands, or decides when a
+threshold is breached. The shared engine owns all of it.
+
+The shared engine already exists:
+[`packages/core/.../forecast/OperatingCashForecast.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/forecast/OperatingCashForecast.kt).
+`OperatingCashForecastEngine.forecast(input)` consumes an
+`OperatingCashForecastInput` (starting balance, horizons, recurring commitments,
+one-off entries, thresholds, baseline daily net + deviation, confidence) and
+returns an `OperatingCashForecastResult` with:
+
+- `balancePoints: List<ForecastBalancePoint>` — per-day `date`, `startingBalance`,
+  `committedInflow`, `committedOutflow`, `baselineNet`, `endingBalance`, and the
+  `occurrences` due that day. **This is the daily calendar data.**
+- `horizonSnapshots: List<ForecastHorizonSnapshot>` — per horizon (7/30/90)
+  `expectedBalance`, `lowBalance`, `highBalance`, committed in/out, confidence.
+- `thresholdBreaches: List<ForecastThresholdBreach>` — first date each floor is
+  breached + the projected balance. **This drives the risk indicators.**
+- Commitments carry a `ForecastCashFlowKind` (`PAYROLL`, `TAX`, `BILL`, …) so the
+  UI can group/icon them without inventing categories.
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages/core (shared)"]
+        IN[OperatingCashForecastInput]
+        ENG[OperatingCashForecastEngine.forecast]
+        OUT[balancePoints / horizonSnapshots /<br/>thresholdBreaches]
+        IN --> ENG --> OUT
+    end
+    subgraph Android["apps/android (Compose)"]
+        REPO[(Accounts / recurring<br/>commitments / bills)]
+        VM[CashCalendarViewModel<br/>builds input, maps result]
+        UI[CashCalendarScreen<br/>renders days + risk chips]
+    end
+    REPO --> VM --> IN
+    OUT --> VM --> UI
+```
+
+| Concern                                                             | Owner                                    |
+| ------------------------------------------------------------------- | ---------------------------------------- |
+| Expanding recurring payroll/tax/bill schedules to dated occurrences | KMP `OperatingCashForecastEngine`        |
+| Day-by-day running balance, weekly roll-up                          | KMP (`balancePoints`)                    |
+| Confidence bands (low/high) per horizon                             | KMP (`horizonSnapshots`, z-score math)   |
+| First-breach detection vs. thresholds (risk)                        | KMP (`thresholdBreaches`)                |
+| Calendar grid layout, day cells, color of risk state                | Android (presentation)                   |
+| Cents → currency, date → label                                      | Android (presentation, shared formatter) |
+| Reading balances/commitments, persisting what-ifs                   | Android repositories (offline-first)     |
+
+> Android's only "logic" is **building the input** (collecting starting balance +
+> commitments + thresholds from local data) and **mapping the output** to display
+> models. If it computes a balance or a band, it is in the wrong layer. All edits
+> stay in `apps/android/`; the engine is consumed as-is.
+
+---
+
+## 3. Affected Android Surfaces
+
+All paths under `apps/android/src/main/kotlin/com/finance/android/`.
+
+**New**
+
+- `ui/screens/planning/cashcalendar/CashCalendarScreen.kt` — the calendar surface:
+  month grid + weekly roll-up + horizon outlook header + a selected-day detail
+  sheet.
+- `ui/screens/planning/cashcalendar/CashCalendarViewModel.kt` — `koinViewModel`;
+  assembles `OperatingCashForecastInput` from repositories, calls
+  `OperatingCashForecastEngine.forecast`, exposes
+  `StateFlow<CashCalendarUiState>`.
+- `ui/screens/planning/cashcalendar/CashCalendarUiState.kt` — sealed state +
+  display models (day cell model with formatted balance, risk level, occurrence
+  count).
+- `ui/screens/planning/cashcalendar/components/DayCell.kt`,
+  `WeeklyRollupRow.kt`, `HorizonOutlookHeader.kt`, `RiskBanner.kt`,
+  `DayDetailSheet.kt`.
+
+**Modified**
+
+- `ui/navigation/FinanceNavHost.kt` — add `Route.CashCalendar` and link it from the
+  existing **Planning** destination (follows the `Route` sealed-class pattern; the
+  app already has a `Planning` route).
+- `ui/screens/planning/` host — add an entry card "Operating cash calendar".
+
+**Reused (reference)**
+
+- `widget/BudgetSummaryWidget.kt` — Glance pattern for a future "days until cash
+  crunch" home-screen widget (noted; out of scope here).
+- `ui/insights/InsightsScreen.kt` — Material 3 card + `Canvas` patterns for an
+  optional balance sparkline.
+
+---
+
+## 4. Shared Dependencies
+
+| Dependency                                                                                                                                                                                                                     | Location                                              | Use                                                     |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------- | ------------------------------------------------------- |
+| `OperatingCashForecastEngine`, `OperatingCashForecastInput/Result`, `ForecastBalancePoint`, `ForecastHorizonSnapshot`, `ForecastThresholdBreach`, `RecurringForecastCommitment`, `OneOffForecastEntry`, `ForecastCashFlowKind` | `packages/core/.../forecast/OperatingCashForecast.kt` | All projection, banding, and breach math                |
+| `Cents` / money formatting                                                                                                                                                                                                     | `packages/core/.../money`, `.../multicurrency`        | Display formatting                                      |
+| Account / recurring / bill repositories                                                                                                                                                                                        | `apps/android/.../data/repository/`                   | Offline-first source of balance + commitments           |
+| Koin modules                                                                                                                                                                                                                   | `apps/android/.../di/`                                | `viewModelOf(::CashCalendarViewModel)`                  |
+| WorkManager (existing `SyncWorker`)                                                                                                                                                                                            | `apps/android/.../sync/`                              | Background refresh of source data only (never the math) |
+| Timber                                                                                                                                                                                                                         | `apps/android/.../logging/`                           | Logging without balances/amounts                        |
+
+> **Boundary note:** Android consumes `packages/core` directly (no bridging). All
+> edits in this issue stay within `apps/android/`. The forecast engine already
+> exists — **no `packages/` changes are required** for this feature.
+
+---
+
+## 5. Calendar Layout & Risk Indicators
+
+**Top to bottom:**
+
+1. **Top app bar** — "Operating Cash Calendar", back nav, overflow (edit
+   commitments, add what-if).
+2. **Horizon outlook header** (`HorizonOutlookHeader`) — three compact tiles for
+   **7 / 30 / 90 days** from `horizonSnapshots`: `expectedBalance` with a
+   `lowBalance–highBalance` band and a confidence tag. These come straight from the
+   engine; no recomputation.
+3. **Risk banner** (`RiskBanner`) — if `thresholdBreaches` is non-empty, a
+   prominent banner: _"Projected to fall below $0 on Fri, Jul 3"_ using the first
+   breach (earliest date). Severity escalates if the breach is within 7 days.
+4. **Month grid** — `DayCell` per `ForecastBalancePoint`:
+   - Date number + the day's **projected ending balance** (compact).
+   - A small **risk dot / band**: neutral (comfortably above floor), **watch**
+     (within buffer), **risk** (at/below a threshold on or after this day).
+   - A marker when `occurrences` is non-empty (payroll/tax/bill due that day),
+     icon-coded by `ForecastCashFlowKind`.
+5. **Weekly roll-up** (`WeeklyRollupRow`) — per ISO week: net committed in/out and
+   the week-end projected balance, summarized from the daily `balancePoints`.
+6. **Selected-day detail sheet** (`DayDetailSheet`) — tap a day to see its
+   `occurrences` (description, kind, amount, direction) and the starting/ending
+   balance for that day.
+
+**Risk-level mapping (presentation only):** a day's risk level is derived from the
+engine's `endingBalance` vs. the `ForecastBalanceThreshold` floor and the
+`thresholdBreaches` list — Compose maps a shared comparison result to a color +
+label; it does not compute the band. The default floor is
+`ForecastBalanceThreshold.ZERO` (overdraft); an optional buffer threshold can be
+added by the operator and is passed into the engine input.
+
+**Formatting:** balances via the shared currency formatter; dates via the shared
+date formatter; bands shown as "low–high".
+
+---
+
+## 6. UI States: Loading, Empty, Error, Offline
+
+- **Loading** — skeleton grid + outlook tiles; announces "Calculating cash
+  forecast".
+- **Empty** — no commitments and a flat baseline → render the grid with the
+  starting balance carried forward and an inline hint "Add payroll, taxes, or bills
+  to forecast risk". (`balancePoints` still exist; just no occurrences/breaches.)
+- **Error** — repository/input-assembly failure → retry; `Timber.e(t, "Cash
+forecast failed")` **without** balances or amounts.
+- **Offline** — default mode. The forecast is deterministic and computed locally
+  from the encrypted store; no network is required. If source data is stale, show a
+  subtle "Updated <time> ago" affordance — never a blocking spinner.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Loading
+    Loading --> Ready: forecast computed
+    Loading --> Empty: no commitments
+    Loading --> Error
+    Ready --> Ready: add what-if / change threshold
+    Error --> Loading: retry
+```
+
+---
+
+## 7. Accessibility (TalkBack)
+
+Per [`docs/design/accessibility-patterns.md`](./accessibility-patterns.md) §7
+(Financial Data) and §5 (Color & Contrast):
+
+- **Risk never relies on color alone** (WCAG 1.4.1). Each `DayCell` exposes a
+  merged semantics node combining date, projected balance, risk **label**, and
+  whether commitments are due, e.g. _"July 3, projected balance negative 120
+  dollars, at risk, payroll due"_. Use `Modifier.semantics(mergeDescendants =
+true)`.
+- **Risk banner** is announced assertively on first appearance via a live region
+  ("Projected to fall below zero dollars on Friday, July 3") and is a `heading()`.
+- **Horizon tiles** read as single nodes: _"30 day outlook, expected 1,250 dollars,
+  range 900 to 1,600 dollars, medium confidence"_; "dollars"/"percent" spelled out,
+  negatives announced as "negative".
+- **Calendar traversal:** the month grid uses a logical reading order (week by
+  week); each day is individually focusable; the selected-day sheet receives focus
+  on open and restores focus on dismiss (accessibility-patterns §1, focus
+  management).
+- **Touch targets** ≥ 48×48 dp for day cells and controls; grid reflows and day
+  balances remain readable at 200% font scale (consider a list fallback for very
+  large fonts so balances are not truncated).
+- **Contrast** ≥ 4.5:1 for balances, risk labels, and band text.
+
+---
+
+## 8. Test Plan
+
+**Shared engine (already covered in `packages/`; not edited here)** — referenced
+for traceability: recurring expansion, daily balance roll-forward, confidence
+bands, and first-breach detection are unit-tested in the `forecast` package. The
+Android work depends on, but does not re-test, that math.
+
+**Android unit tests** (`apps/android/src/test/...`)
+
+- `CashCalendarViewModelTest` — builds a correct `OperatingCashForecastInput` from
+  fixture repositories; maps a fixture `OperatingCashForecastResult` to day cells,
+  weekly roll-ups, horizon tiles, and a risk banner; Empty when no commitments;
+  Error on failure. Asserts it passes engine balances/breaches through **without**
+  arithmetic.
+- `CashCalendarFormattingTest` — cents→currency (sign-aware), date→label, and
+  band "low–high" rendering only.
+- `RiskLevelMappingTest` — given engine `endingBalance` + threshold + breaches,
+  the mapping to neutral/watch/risk labels is correct (comparison only, no band
+  math).
+
+**Compose UI tests** (`apps/android/src/androidTest/...`)
+
+- `CashCalendarScreenTest` — risk banner shows when a breach exists and hides when
+  not; tapping a day opens the detail sheet with that day's occurrences; horizon
+  tiles render; Empty/Error states render their CTAs.
+- **Accessibility assertions** — every day cell and tile has a non-empty merged
+  content description; risk banner is a heading and announces; focus moves to the
+  sheet on open and back on close.
+
+**Snapshot tests (Paparazzi)**
+
+- `CashCalendarSnapshotTest` — healthy month, month with a breach (risk banner),
+  empty, light/dark, large font (1.5×/2.0×).
+
+**Manual QA**
+
+- Airplane mode: full forecast renders from local data.
+- TalkBack: day cells read date + balance + risk + due commitments; risk banner
+  announced; sheet focus handling correct.
+- Largest font: balances not truncated (list fallback engages if needed).
+
+---
+
+## 9. Implementation Readiness
+
+This is a **design deliverable**; the feature is implementable now up to the
+distribution boundary. Per
+[`docs/ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md) §2,
+the "blocked by #1242" reference on #2555 is a **distribution** gate only.
+
+**Buildable now (SME-completable):**
+
+- Compose calendar/sheet, ViewModel, Koin wiring, navigation, and all tests above.
+- Local verification: `./gradlew :apps:android:assembleDebug`,
+  `:apps:android:testDebugUnitTest`, Paparazzi `verifyPaparazziDebug`, and sideload.
+- The shared `OperatingCashForecastEngine` already exists — **no `packages/`
+  changes** required.
+
+**Distribution tail (human-gated by #1242):**
+
+- Google Play release signing + upload only.
+- A future **breach reminder** would use FCM/push, which is distribution-adjacent
+  (paid entitlement) — explicitly out of scope here. See
+  [Android distribution checklist](../ops/human-gated-prerequisites.md#31-android-distribution--google-play-1242).
+
+---
+
+## 10. Open Questions
+
+1. **Default buffer threshold** — ship with overdraft-only (`ZERO`) or a small
+   default safety buffer? Proposed: overdraft-only by default, operator-configurable
+   buffer passed into the engine input.
+2. **Horizon set** — keep the engine default `7/30/90` for the outlook header, or
+   offer a "next payday" horizon? Proposed: start with `7/30/90`.
+3. **Baseline daily net** — whether to seed `baselineDailyNet`/`dailyNetDeviation`
+   from historical averages (a shared concern) or leave at zero until enough data
+   exists. Proposed: zero until the shared layer provides a baseline.


### PR DESCRIPTION
## Summary

Design docs (design/breakdown only) for three related small-business/food-truck Android reporting surfaces. No native build, signing, or distribution work — implementation is unblocked up to the Google Play distribution boundary, which remains human-gated by #1242 (see `docs/ops/human-gated-prerequisites.md`).

Each doc grounds the design in the **already-existing shared KMP engines** and is explicit about the Compose ↔ KMP boundary: Compose renders shared, pre-computed state; all finance math (P&L aggregation, margins, projected balances, breach detection) stays in `packages/core`.

Closes #2551
Closes #2553
Closes #2555

## Changes

- **`docs/design/android-foodtruck-pnl-report.md`** (#2551, _Part of_ #2184) — weekly/monthly P&L report template: Revenue → COGS → Gross Profit → Labor → Overhead → Net Profit, with gross/net margin and food-cost %. Backed by `SmallBusinessPnlEngine` (`packages/core/.../pnl`).
- **`docs/design/android-foodtruck-category-margin-cards.md`** (#2553, _Part of_ #2184) — small-business/food-truck category defaults (mapped to P&L buckets + Schedule C lines) and at-a-glance margin summary cards. Backed by `ScheduleCDeductionPresetTaxonomy` (`packages/core/.../schedulec`) and `SmallBusinessPnlEngine`.
- **`docs/design/android-operating-cash-calendar.md`** (#2555, _Part of_ #2185) — payroll/tax/bill operating cash calendar with daily/weekly projected balances and risk indicators. Backed by `OperatingCashForecastEngine` (`packages/core/.../forecast`).

Each doc identifies affected Android surfaces + shared dependencies, the Compose↔KMP boundary, offline-first/empty/error states, TalkBack accessibility, a test plan (unit / Compose UI / Paparazzi), and an Implementation Readiness section (buildable now via `assembleDebug`; distribution tail gated by #1242).

## Testing

- `npx prettier --check` passes on all three files.
- Docs-only change — no code, no native build. Shared engines referenced already exist in `packages/core`; no `packages/` edits.
