### PR TITLE
docs(design): android gig economy design batch (#2512, #2514, #2516)

### DIFF
--- a/docs/design/android-gig-payout-reconciliation.md
+++ b/docs/design/android-gig-payout-reconciliation.md
@@ -1,0 +1,235 @@
+# Android Gig Payout Reconciliation by Platform — Design
+
+> **Status:** PROPOSED — Pending human review
+> **Issue:** [#2514](https://github.com/jrmoulckers/finance/issues/2514) — _Part of [#2133](https://github.com/jrmoulckers/finance/issues/2133)_
+> **Platform:** Android / Wear OS (Jetpack Compose, Material 3)
+> **Last Updated:** 2026-06-22
+> **Owner:** @android-engineer
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Goals and Non-Goals](#goals-and-non-goals)
+3. [Affected Android Surfaces](#affected-android-surfaces)
+4. [Shared Dependencies (KMP)](#shared-dependencies-kmp)
+5. [Architecture and Math Boundary](#architecture-and-math-boundary)
+6. [Dashboard Layout](#dashboard-layout)
+7. [Period Selection (Today / Week / Month)](#period-selection-today--week--month)
+8. [Linking to Filtered Transactions](#linking-to-filtered-transactions)
+9. [Offline-First Behavior](#offline-first-behavior)
+10. [Screen States](#screen-states)
+11. [Accessibility (TalkBack)](#accessibility-talkback)
+12. [Test Plan](#test-plan)
+13. [Implementation Readiness](#implementation-readiness)
+14. [Open Questions](#open-questions)
+
+---
+
+## Overview
+
+A gig worker wants to answer one question quickly: **"Did the money I expected actually show up?"**
+This design covers an Android **Platform Earnings dashboard** that compares **expected payouts** against
+**received deposits** per gig platform for **today, this week, and this month**, and links each row to the
+filtered transaction list that backs the number.
+
+It builds directly on the
+[platform mapping design](./android-gig-platform-mapping.md) (which produces the matches) and reuses the
+shared reconciliation engine — Compose renders the result and never computes variance itself.
+
+## Goals and Non-Goals
+
+**Goals**
+
+- Show per-platform **Expected vs. Received vs. Variance** for Today / Week / Month.
+- Classify each platform row as **Matched / Partial / Missing / Overpaid** using shared logic.
+- Surface **unexpected deposits** (received with no expected payout).
+- Deep-link every figure to the corresponding filtered transactions for trust and drill-down.
+
+**Non-Goals**
+
+- No new reconciliation math in Android — all of it lives in `packages/*`.
+- No direct platform API ingestion of "expected" amounts; expected payouts come from the shared model
+  (user-entered schedule or imported expectations) — out of scope here.
+- No Play Store distribution; design-only while distribution is gated by
+  [#1242](https://github.com/jrmoulckers/finance/issues/1242).
+
+## Affected Android Surfaces
+
+| Surface                         | Path                                                                                                                                                    | Change                                                          |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| **New** — Reconciliation screen | `apps/android/.../ui/screens/gig/GigPayoutReconciliationScreen.kt`                                                                                      | Dashboard with period tabs + platform rows                      |
+| **New** — Reconciliation VM     | `apps/android/.../ui/viewmodel/gig/GigPayoutReconciliationViewModel.kt`                                                                                 | Builds inputs, calls KMP `reconcile`, exposes `StateFlow`       |
+| **New** — Summary cards         | `apps/android/.../ui/components/gig/ReconciliationSummaryCard.kt`                                                                                       | Expected/Received/Variance totals card                          |
+| **New** — Platform row          | `apps/android/.../ui/components/gig/PlatformReconciliationRow.kt`                                                                                       | Per-platform status row with variance + status pill             |
+| Period selector                 | reuse `DateRangePreset` from [`SearchFilterState.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/components/search/SearchFilterState.kt) | `TODAY` / `THIS_WEEK` / `THIS_MONTH`                            |
+| Transactions screen             | [`apps/android/.../ui/screens/TransactionsScreen.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/screens/TransactionsScreen.kt)          | Accept pre-applied platform + date filter from a deep link      |
+| DI wiring                       | [`apps/android/.../di/AppModule.kt`](../../apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt)                                            | `viewModelOf(::GigPayoutReconciliationViewModel)`               |
+| Navigation                      | [`apps/android/.../ui/navigation/FinanceNavHost.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceNavHost.kt)            | Route `gig/reconciliation` + deep link to filtered transactions |
+
+## Shared Dependencies (KMP)
+
+All reconciliation logic is already implemented in
+[`packages/core/.../gig/payout/GigPayoutCalculator.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/gig/payout/GigPayoutCalculator.kt):
+
+| KMP symbol                                            | Role on Android                                                                                                              |
+| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `GigPayoutCalculator.receivedPayoutsFromTransactions` | Turns matched income transactions into `ReceivedGigPayout`s for the period                                                   |
+| `ExpectedGigPayout`                                   | Expected amount + date + platform + tolerance (source: shared expectations model)                                            |
+| `GigPayoutCalculator.reconcile`                       | Date-bounded, single-use matching → `GigPayoutReconciliation`                                                                |
+| `GigPayoutReconciliation`                             | Totals + per-item results + `unexpectedReceived`; exposes `matchedItems` / `partialItems` / `missingItems` / `overpaidItems` |
+| `GigPayoutReconciliationItem`                         | Per-expected result: `status`, `received`, `receivedAmount`, `variance`                                                      |
+| `GigPayoutReconciliationStatus`                       | `MATCHED` / `PARTIAL` / `MISSING` / `OVERPAID` — drives the status pill                                                      |
+| `UnexpectedGigPayout`                                 | Deposits with `NO_EXPECTED_PAYOUT` — surfaced as a dedicated section                                                         |
+| `GigPlatformMapping` / `matchPlatform`                | Reused from the mapping feature to attribute received deposits                                                               |
+
+Amounts are integer `Cents`; formatting is locale-aware in the presentation layer only.
+
+## Architecture and Math Boundary
+
+**Rule:** the ViewModel assembles inputs (transactions, mappings, expected payouts, period bounds) and
+calls `GigPayoutCalculator.reconcile`. Compose renders the returned `GigPayoutReconciliation`. No
+variance, tolerance, or matching arithmetic happens in Android code.
+
+```mermaid
+flowchart TD
+    subgraph KMP["packages/* (shared Kotlin — owns the math)"]
+        RX[receivedPayoutsFromTransactions]
+        RC[reconcile]
+        EXP[ExpectedGigPayout source]
+        REPO[(Transaction + Mapping repos\nSQLDelight + SQLCipher)]
+    end
+    subgraph Android["apps/android (Compose — renders state only)"]
+        VM[GigPayoutReconciliationViewModel]
+        UI[GigPayoutReconciliationScreen\nSummary card + platform rows]
+    end
+    REPO --> VM
+    EXP --> VM
+    VM -->|"transactions+mappings+period"| RX
+    RX -->|received payouts| VM
+    VM -->|"reconcile(expected, received, tolerance)"| RC
+    RC -->|GigPayoutReconciliation| VM
+    VM -->|StateFlow<UiState>| UI
+    UI -->|tap row / total| VM
+    VM -->|deep link: platform + date filter| UI
+```
+
+## Dashboard Layout
+
+```mermaid
+flowchart TB
+    Tabs["Period tabs: Today · Week · Month"]
+    Totals["Summary card: Expected · Received · Variance"]
+    List["Per-platform rows (status pill + variance)"]
+    Unexpected["Unexpected deposits section"]
+    Empty["Empty / loading / error states"]
+    Tabs --> Totals --> List --> Unexpected --> Empty
+```
+
+- **Summary card (`ReconciliationSummaryCard`):** big totals for `totalExpected`, `totalReceived`, and
+  computed `variance = received − expected` with a directional, non-judgmental label
+  (e.g., "On track", "Short by $X", "Extra $X"). Color is paired with text/icon (never color alone).
+- **Platform rows (`PlatformReconciliationRow`):** platform name, expected, received, variance, and a
+  **status pill** mapped from `GigPayoutReconciliationStatus`:
+  - `MATCHED` → "Matched" (success)
+  - `PARTIAL` → "Partial" (caution)
+  - `MISSING` → "Not received yet" (neutral/alert)
+  - `OVERPAID` → "Over expected" (info)
+- **Unexpected deposits:** a separate list of `unexpectedReceived` (e.g., a bonus or referral) so users
+  can map them via the [mapping feature](./android-gig-platform-mapping.md) or recognize an error.
+
+## Period Selection (Today / Week / Month)
+
+- Reuse `DateRangePreset.TODAY / THIS_WEEK / THIS_MONTH` so behavior matches the existing transaction
+  filters exactly (ISO week, current calendar month). The selected preset defines the `from`/`to`
+  bounds passed to `receivedPayoutsFromTransactions` and the expected-payout window.
+- A small "as of" timestamp clarifies that Today reflects deposits that have actually posted; pending
+  deposits are excluded by the shared eligibility rules (non-void, non-deleted income).
+
+## Linking to Filtered Transactions
+
+Every figure is a **trust anchor** — tapping it must show the exact transactions behind it.
+
+- Tapping a platform's **Received** value (or row) deep-links to
+  [`TransactionsScreen`](../../apps/android/src/main/kotlin/com/finance/android/ui/screens/TransactionsScreen.kt)
+  with the platform filter + the active date preset pre-applied (same `SearchFilterState` contract used
+  by the [mapping design](./android-gig-platform-mapping.md#platform-filter-chip-transactions)).
+- Tapping an **unexpected deposit** opens the single
+  [`TransactionDetailScreen`](../../apps/android/src/main/kotlin/com/finance/android/ui/screens/TransactionDetailScreen.kt).
+- Navigation passes platform id(s) + date preset as route arguments via
+  [`FinanceNavHost`](../../apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceNavHost.kt);
+  the Transactions VM resolves matching through KMP, not local string logic.
+
+## Offline-First Behavior
+
+- **Load:** read transactions, mappings, and expected payouts from the local encrypted SQLDelight store
+  first and reconcile in-memory; the dashboard is fully usable offline.
+- **Refresh:** pull-to-refresh re-reads local state and reconciles; a background
+  [`SyncWorker`](../../apps/android/src/main/kotlin/com/finance/android/sync/SyncWorker.kt) (WorkManager)
+  brings in new deposits when connectivity returns, then the dashboard recomputes reactively.
+- **Staleness:** show a "Last synced …" line; reconciliation is always against the latest **local** data,
+  so figures are deterministic offline.
+- **No writes** are required by this read-only dashboard except deep-link navigation state, so there is no
+  conflict surface here; conflicts are handled upstream by the mapping/transaction features.
+
+## Screen States
+
+| State                           | Trigger                             | Compose treatment                                                                                     |
+| ------------------------------- | ----------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| **Loading**                     | Initial reconcile                   | Skeleton summary card + 3 row placeholders; `contentDescription = "Loading payout reconciliation"`    |
+| **Empty (no expected payouts)** | No `ExpectedGigPayout` for period   | Explainer + CTA "Add expected payouts" / link to mapping; show received-only totals                   |
+| **Empty (no income)**           | No matched deposits in period       | "No platform deposits yet for {period}"                                                               |
+| **Populated**                   | Reconciliation present              | Summary + rows + unexpected section                                                                   |
+| **All matched**                 | every item `MATCHED`, no unexpected | Positive confirmation banner ("Everything reconciled")                                                |
+| **Error**                       | Repository/sync failure             | Non-blocking `Snackbar` + **Retry**; show last good snapshot if available; `Timber.e` without amounts |
+| **Offline**                     | No connectivity                     | Banner "Offline — showing last synced data"; dashboard remains interactive                            |
+
+## Accessibility (TalkBack)
+
+Follows [`accessibility-patterns.md`](./accessibility-patterns.md),
+[`data-visualization.md`](./data-visualization.md), and
+[`cognitive-accessibility.md`](./cognitive-accessibility.md).
+
+- Each platform row exposes a single composed announcement:
+  "DoorDash, expected 120 dollars, received 96 dollars, short by 24 dollars, status partial".
+- Status is conveyed by **text + icon + color**, never color alone (color-blind safe).
+- Summary totals are a labeled group; the variance reads with direction ("short" / "extra" / "on track").
+- Tappable figures are exposed as buttons with role + action hint ("double-tap to view transactions").
+- Period tabs are a tab list with selected-state announced; content reflows at 200% font scale.
+- Amounts use locale-aware currency formatting with full words for screen readers where helpful.
+
+## Test Plan
+
+| Layer                                      | Coverage                                                                                                                                                                                               |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **KMP (existing, referenced)**             | `GigPayoutCalculatorTest` covers reconcile/matching tolerance/date bounds; Android does not duplicate math tests                                                                                       |
+| **ViewModel unit (`assembleDebug` path)**  | Period bounds map to correct `from`/`to`; received-payout assembly; mapping of `GigPayoutReconciliation` → UI rows; status pill mapping; unexpected-deposit surfacing; error → retry; offline snapshot |
+| **Compose UI (androidTest / Robolectric)** | Period tab switch recomputes; tapping Received deep-links with correct platform + date args; empty/all-matched/error states render expected semantics                                                  |
+| **Paparazzi snapshots**                    | Dashboard for each period; each status (`MATCHED`/`PARTIAL`/`MISSING`/`OVERPAID`); unexpected section; empty + error; light/dark + dynamic color; 1x and 2x font scale                                 |
+| **Accessibility checks**                   | Row announcement composition; tappable-figure roles; non-color status encoding; large-font reflow                                                                                                      |
+
+## Implementation Readiness
+
+This is a **design deliverable**; it ships as documentation only.
+
+**Buildable now (no enrollment required), per
+[`human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md) §2:**
+
+- Implement the dashboard, `GigPayoutReconciliationViewModel`, deep-link wiring, and Koin module.
+- Verify with `./gradlew :apps:android:assembleDebug`, JVM unit tests, and Paparazzi snapshots. The
+  reconciliation engine already exists in `packages/core`.
+
+**Distribution tail (gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242)):**
+
+- Release signing and Play Store upload remain **human-gated**; see
+  [`human-gated-prerequisites.md` §3.1](../ops/human-gated-prerequisites.md#31-android-distribution--google-play-1242).
+- No part of this dashboard requires the distribution tail to build or test locally.
+
+## Open Questions
+
+- Where do `ExpectedGigPayout` records originate on mobile — user-entered schedule, imported, or inferred?
+  (Owned by `packages/*`; Android consumes whatever the shared source provides.)
+- Default `dateToleranceDays` / `defaultToleranceCents` for mobile reconcile calls? (Recommend a small
+  date tolerance to absorb weekend posting delays; confirm with @kmp-engineer.)
+- Should the dashboard offer a Wear OS Tile/Complication for "today's expected vs received"? (Follow-up.)

--- a/docs/design/android-gig-platform-mapping.md
+++ b/docs/design/android-gig-platform-mapping.md
@@ -1,0 +1,276 @@
+# Android Gig-Platform Mapping and Filters — Design
+
+> **Status:** PROPOSED — Pending human review
+> **Issue:** [#2512](https://github.com/jrmoulckers/finance/issues/2512) — _Part of [#2133](https://github.com/jrmoulckers/finance/issues/2133)_
+> **Platform:** Android / Wear OS (Jetpack Compose, Material 3)
+> **Last Updated:** 2026-06-22
+> **Owner:** @android-engineer
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Goals and Non-Goals](#goals-and-non-goals)
+3. [Affected Android Surfaces](#affected-android-surfaces)
+4. [Shared Dependencies (KMP)](#shared-dependencies-kmp)
+5. [Architecture and Math Boundary](#architecture-and-math-boundary)
+6. [User Flows](#user-flows)
+7. [Compose Surface Specs](#compose-surface-specs)
+8. [Override Precedence](#override-precedence)
+9. [Offline-First Behavior](#offline-first-behavior)
+10. [Screen States](#screen-states)
+11. [Accessibility (TalkBack)](#accessibility-talkback)
+12. [Test Plan](#test-plan)
+13. [Implementation Readiness](#implementation-readiness)
+14. [Open Questions](#open-questions)
+
+---
+
+## Overview
+
+Gig workers earn from several platforms (Uber, Lyft, DoorDash, Instacart, Upwork…) whose deposits
+land in their bank feed under inconsistent payee names, descriptions, and account labels. This design
+covers the **Android Compose settings surface and the transaction-filter entry points** that let a
+user map those raw signals to a canonical gig platform, so that downstream features
+([payout reconciliation](./android-gig-payout-reconciliation.md) and
+[take-home summary](./android-gig-take-home-summary.md)) can attribute income correctly.
+
+The design introduces:
+
+- A **Gig Platforms settings screen** to review, edit, and add platform mappings (payee / description /
+  account patterns).
+- **Platform chips** as a new filter dimension wired into the existing transaction filter row.
+- **Override precedence** rules so a user's explicit per-transaction choice always wins over an
+  automatic pattern match.
+- **Offline-first** load/save/sync expectations consistent with the rest of the app.
+
+All matching and scoring math already exists in shared Kotlin Multiplatform (KMP) code — Compose only
+renders shared state and forwards user intent.
+
+## Goals and Non-Goals
+
+**Goals**
+
+- Let users map payees, descriptions, and deposit-account names to canonical gig platforms.
+- Surface a **Platform** filter chip on the Transactions screen consistent with existing chips.
+- Allow a per-transaction manual override that is durable and sync-safe.
+- Work fully offline; reflect sync status without blocking edits.
+
+**Non-Goals**
+
+- No OAuth / direct platform API integrations (out of scope; see
+  [`human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md)).
+- No new finance math in the Android layer — all attribution logic stays in `packages/*`.
+- No Play Store distribution work; this issue is design-only while distribution is gated by
+  [#1242](https://github.com/jrmoulckers/finance/issues/1242).
+
+## Affected Android Surfaces
+
+| Surface                          | Path                                                                                                                                                             | Change                                                             |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| Transactions screen              | [`apps/android/.../ui/screens/TransactionsScreen.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/screens/TransactionsScreen.kt)                   | Add a **Platform** filter chip + bottom-sheet selector             |
+| Filter chip row                  | [`apps/android/.../ui/components/search/FilterChipRow.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/components/search/FilterChipRow.kt)         | New `onPlatformClick` chip slot with badge count                   |
+| Filter state                     | [`apps/android/.../ui/components/search/SearchFilterState.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/components/search/SearchFilterState.kt) | New `GigPlatformFilter(selectedPlatformIds: Set<String>)`          |
+| Transactions VM                  | [`apps/android/.../ui/viewmodel/TransactionsViewModel.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/TransactionsViewModel.kt)         | Extend `TransactionFilter` with platform; delegate matching to KMP |
+| Transaction detail               | [`apps/android/.../ui/screens/TransactionDetailScreen.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/screens/TransactionDetailScreen.kt)         | "Gig platform" row with override action                            |
+| **New** — Gig Platforms settings | `apps/android/.../ui/screens/gig/GigPlatformMappingScreen.kt`                                                                                                    | Mapping list + add/edit editor                                     |
+| **New** — Mapping VM             | `apps/android/.../ui/viewmodel/gig/GigPlatformMappingViewModel.kt`                                                                                               | Holds mappings, save/sync, validation                              |
+| **New** — Platform chips         | `apps/android/.../ui/components/gig/GigPlatformChips.kt`                                                                                                         | Reusable Material 3 chip row of platforms                          |
+| DI wiring                        | [`apps/android/.../di/AppModule.kt`](../../apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt)                                                     | `viewModelOf(::GigPlatformMappingViewModel)` + repository binding  |
+| Navigation                       | [`apps/android/.../ui/navigation/FinanceNavHost.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceNavHost.kt)                     | Route `settings/gig-platforms`                                     |
+
+## Shared Dependencies (KMP)
+
+All matching and grouping logic lives in
+[`packages/core/.../gig/payout/GigPayoutCalculator.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/gig/payout/GigPayoutCalculator.kt):
+
+| KMP symbol                                                       | Role on Android                                                                                             |
+| ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `GigPlatformMapping`                                             | The serializable mapping record (payee / description / account pattern lists) edited by the settings screen |
+| `GigPlatformDefaults.mappings`                                   | Seed list (Uber, Lyft, DoorDash, Instacart, Grubhub, Shipt, Upwork, Fiverr) shown on first run              |
+| `GigPayoutMatchInput`                                            | Built from a `Transaction` (payee, note, account name) for evaluation                                       |
+| `GigPlatformMatcher.match` / `GigPayoutCalculator.matchPlatform` | Deterministic, weighted, case-insensitive matcher — **the only attribution authority**                      |
+| `GigPlatformMatch`                                               | Result (platformId, name, score, matched fields/patterns) used for chips + "why matched" detail             |
+| `GigPayoutCalculator.groupIncomeByPlatform`                      | Groups income for the filtered list; powers the Platform chip counts                                        |
+
+The mapping records are persisted via the existing repository/sync stack (`packages/sync`, SQLDelight
+
+- SQLCipher Android driver). No new persistence format is introduced by Android.
+
+## Architecture and Math Boundary
+
+**Rule:** Compose renders shared state; it never owns finance/attribution math. The ViewModel adapts
+repository flows into immutable UI state and calls KMP for every matching decision.
+
+```mermaid
+flowchart TD
+    subgraph KMP["packages/* (shared Kotlin — owns the math)"]
+        M[GigPlatformMapping records]
+        Calc[GigPlatformMatcher / GigPayoutCalculator]
+        Repo[(Mapping + Transaction repos\nSQLDelight + SQLCipher)]
+    end
+    subgraph Android["apps/android (Compose — renders state only)"]
+        VM[GigPlatformMappingViewModel\n+ TransactionsViewModel]
+        UI[GigPlatformMappingScreen\nFilterChipRow + GigPlatformChips]
+    end
+    Repo --> VM
+    M --> Calc
+    VM -->|"match(input, mappings)"| Calc
+    Calc -->|GigPlatformMatch| VM
+    VM -->|StateFlow<UiState>| UI
+    UI -->|user intent: edit / select / override| VM
+    VM -->|save mapping / override| Repo
+```
+
+**What the Android layer must NOT do:** re-implement normalization, scoring, weighting, or tie-breaking.
+If a behavior is missing (e.g., a new tie-break rule), it is filed against the KMP package, not patched
+in Compose.
+
+## User Flows
+
+```mermaid
+sequenceDiagram
+    participant U as User (TalkBack on/off)
+    participant S as GigPlatformMappingScreen
+    participant VM as GigPlatformMappingViewModel
+    participant K as GigPayoutCalculator (KMP)
+    participant R as Mapping Repository
+
+    U->>S: Open Settings → Gig Platforms
+    S->>VM: load()
+    VM->>R: observeMappings(householdId)
+    R-->>VM: mappings (or GigPlatformDefaults on first run)
+    VM-->>S: UiState(mappings, syncStatus)
+    U->>S: Add pattern "DASHERDIRECT" → DoorDash
+    S->>VM: upsertPattern(...)
+    VM->>K: validate + matchPreview(samplePayees)
+    K-->>VM: GigPlatformMatch previews
+    VM->>R: save(mapping)  %% optimistic, offline-safe
+    R-->>VM: queued for sync
+    VM-->>S: UiState(updated, "Saved · will sync")
+```
+
+## Compose Surface Specs
+
+### Gig Platforms settings screen
+
+- **Top app bar:** title "Gig platforms", back navigation, overflow → "Reset to defaults".
+- **List:** one `Card` per platform showing display name, platform icon/initial, and chips summarizing
+  pattern counts ("3 payee · 2 description · 1 account"). Tapping a card opens the editor.
+- **Editor (bottom sheet or detail):** three labeled sections — Payee patterns, Description patterns,
+  Account patterns — each an editable chip group with add/remove. A **live preview** row shows which
+  sample payees would now match, computed by calling `GigPayoutCalculator.matchPlatform`.
+- **Add platform** FAB → name + at least one pattern (mirrors `GigPlatformMapping` `init` validation:
+  non-blank id/name, ≥1 non-blank pattern).
+- **Empty seed:** first run pre-populates from `GigPlatformDefaults.mappings` (read-only until edited).
+
+### Platform filter chip (Transactions)
+
+- New `FilterChip` in the existing `FilterChipRow`, icon `Icons.Default.LocalShipping` (or platform
+  glyph), badge count = number of selected platforms, consistent with the existing badge pattern.
+- Tapping opens a multi-select bottom sheet listing all mapped platforms plus an **"Unmatched"** pseudo
+  row (maps to `GigPayoutCalculator.UNMATCHED_PLATFORM_NAME`).
+- Selection updates `SearchFilterState`; the VM filters transactions by evaluating each transaction's
+  `GigPayoutMatchInput` against current mappings via KMP — never by string comparison in Compose.
+
+### Transaction detail — platform row
+
+- Shows the matched platform name + a subtle "Auto" or "Manual" tag.
+- "Change platform" opens the same platform chip selector; choosing one writes a **manual override**
+  (see below). A "Clear override" action reverts to automatic matching.
+
+## Override Precedence
+
+Attribution resolves in this strict order (highest wins):
+
+1. **Per-transaction manual override** — an explicit `platformId` the user set on a transaction. Stored
+   on the transaction record (custom field / tag) and synced; survives mapping edits.
+2. **Highest-scoring automatic match** — `GigPlatformMatcher.match` result over current mappings
+   (payee weight > description > account, with exact-match bonus and length tiebreak).
+3. **Unmatched bucket** — no override and no pattern hit ⇒ grouped under "Unmatched".
+
+```mermaid
+flowchart LR
+    A{Manual override set?} -->|Yes| O[Use override platformId]
+    A -->|No| B{Any pattern match?}
+    B -->|Yes| C[Use highest-scoring GigPlatformMatch]
+    B -->|No| U[Unmatched]
+```
+
+The override is data the user owns; Compose presents the precedence outcome that KMP computes and the
+repository stores. The UI must clearly distinguish **Auto** vs **Manual** so the user understands why a
+transaction is attributed a given way.
+
+## Offline-First Behavior
+
+- **Load:** read mappings + transactions from the local encrypted SQLDelight store first; render
+  immediately. Network/sync is never on the critical path.
+- **Save:** writes are **optimistic** — update local state, mark the row "pending sync", and enqueue via
+  the existing sync stack ([`SyncWorker`](../../apps/android/src/main/kotlin/com/finance/android/sync/SyncWorker.kt),
+  WorkManager). No `AlarmManager`/`JobScheduler`.
+- **Conflict:** mapping/override merges defer to the shared conflict strategy
+  (`SyncStatusViewModel` → `ConflictStrategy.resolverFor()`); the UI shows a non-blocking
+  "Resolved from another device" note when a remote change wins.
+- **Status surfacing:** a small inline indicator (`Synced` / `Pending` / `Offline`) reuses existing sync
+  status styling; edits remain fully available offline.
+
+## Screen States
+
+| State                     | Trigger                           | Compose treatment                                                                                                  |
+| ------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| **Loading**               | Initial read                      | Skeleton cards; `contentDescription = "Loading gig platforms"`                                                     |
+| **Empty (no mappings)**   | Fresh install before seed         | Friendly empty state + "Use suggested platforms" CTA that loads `GigPlatformDefaults`                              |
+| **Populated**             | Mappings present                  | Card list + filter chips                                                                                           |
+| **Saving / Pending sync** | After edit, offline or syncing    | Inline "Saving…" / "Pending sync" affordance; controls stay enabled                                                |
+| **Error (save/sync)**     | Repository or sync failure        | Non-blocking `Snackbar` with **Retry**; never lose the user's local edit; log via `Timber.e` (no financial values) |
+| **No results (filter)**   | Platform filter excludes all rows | "No transactions for selected platforms" + "Clear platform filter"                                                 |
+
+## Accessibility (TalkBack)
+
+Follows [`accessibility-patterns.md`](./accessibility-patterns.md) and
+[`cognitive-accessibility.md`](./cognitive-accessibility.md).
+
+- Every chip, card, and icon-button has a meaningful `contentDescription` (e.g., a selected DoorDash
+  chip announces "DoorDash, selected, platform filter").
+- Pattern chips announce their field group: "Payee pattern, DASHERDIRECT, double-tap to remove".
+- The Auto/Manual tag is exposed as text, not color alone (color-blind safe); pair color with a label.
+- Live-region announcement on save: "Mapping saved, will sync when online".
+- Touch targets ≥ 48 dp; content reflows and remains usable at 200% font scale.
+- Selector bottom sheets are reachable by Switch Access; focus order is logical (header → options →
+  apply/clear).
+
+## Test Plan
+
+| Layer                                      | Coverage                                                                                                                                                                                                                          |
+| ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **KMP (existing, referenced)**             | `GigPayoutCalculatorTest` already covers matching/grouping; Android relies on it and does **not** duplicate math tests                                                                                                            |
+| **ViewModel unit (`assembleDebug` path)**  | `GigPlatformMappingViewModel`: load/seed defaults, upsert/remove pattern, validation errors, optimistic save, error → retry; `TransactionsViewModel`: platform filter applied, "Unmatched" handling, override precedence ordering |
+| **Compose UI (androidTest / Robolectric)** | Chip selection toggles state; add/remove pattern updates preview; empty/error/no-results states render expected `contentDescription`s                                                                                             |
+| **Paparazzi snapshots**                    | `GigPlatformMappingScreen` (loading, empty-seed, populated, error), Platform filter sheet, detail platform row (Auto vs Manual), light/dark + dynamic color, 1x and 2x font scale                                                 |
+| **Accessibility checks**                   | `contentDescription` presence assertions; TalkBack focus-order manual pass; large-font reflow snapshot                                                                                                                            |
+
+## Implementation Readiness
+
+This is a **design deliverable**; it ships as documentation only.
+
+**Buildable now (no enrollment required), per
+[`human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md) §2:**
+
+- Implement Compose screens, `GigPlatformMappingViewModel`, filter wiring, and Koin modules.
+- Verify with `./gradlew :apps:android:assembleDebug` (sideload), JVM unit tests, and Paparazzi
+  snapshots. All shared math is already present in `packages/core`.
+
+**Distribution tail (gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242)):**
+
+- Release signing, Play Store track upload, and any production push/entitlement work remain
+  **human-gated**. See [`human-gated-prerequisites.md` §3.1](../ops/human-gated-prerequisites.md#31-android-distribution--google-play-1242).
+- Nothing in this feature requires the distribution tail to be implemented or tested locally.
+
+## Open Questions
+
+- Should manual overrides live as a transaction tag, a custom field, or a dedicated column? (Decide with
+  @kmp-engineer; affects sync schema and is owned by `packages/*`.)
+- Do we expose per-platform color theming, or keep platform identity to icon + label for color-blind
+  safety? (Recommend label-first.)
+- Should "Reset to defaults" merge with or replace user edits? (Recommend additive merge with confirm.)

--- a/docs/design/android-gig-take-home-summary.md
+++ b/docs/design/android-gig-take-home-summary.md
@@ -1,0 +1,239 @@
+# Android Gig Take-Home Summary Cards — Design
+
+> **Status:** PROPOSED — Pending human review
+> **Issue:** [#2516](https://github.com/jrmoulckers/finance/issues/2516) — _Part of [#2135](https://github.com/jrmoulckers/finance/issues/2135)_
+> **Platform:** Android / Wear OS (Jetpack Compose, Material 3)
+> **Last Updated:** 2026-06-22
+> **Owner:** @android-engineer
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Goals and Non-Goals](#goals-and-non-goals)
+3. [Affected Android Surfaces](#affected-android-surfaces)
+4. [Shared Dependencies (KMP)](#shared-dependencies-kmp)
+5. [Architecture and Math Boundary](#architecture-and-math-boundary)
+6. [Card Anatomy](#card-anatomy)
+7. [Day / Week / Shift Scopes](#day--week--shift-scopes)
+8. [Platform and Shift Filters](#platform-and-shift-filters)
+9. [Offline-First Behavior](#offline-first-behavior)
+10. [Screen States](#screen-states)
+11. [Accessibility (TalkBack)](#accessibility-talkback)
+12. [Test Plan](#test-plan)
+13. [Implementation Readiness](#implementation-readiness)
+14. [Open Questions](#open-questions)
+
+---
+
+## Overview
+
+Gross pay is not what a gig worker keeps. After fuel, mileage, other operating costs, and a self-employment
+tax reserve, the **take-home** number is what matters. This design covers Android **Compose summary cards**
+that break a period into **Gross → Operating cost → Tax reserve → Take-home**, scoped by **day**, **week**,
+or **shift**, and filterable by **platform** and **shift**.
+
+The breakdown math is already implemented in shared Kotlin Multiplatform (KMP) — Compose renders the
+shared `GigTakeHomeResult` and forwards filter intent only.
+
+## Goals and Non-Goals
+
+**Goals**
+
+- Render the four-line waterfall (gross, operating cost, tax reserve, take-home) per scope.
+- Support **day / week / shift** scopes and **platform + shift** filtering.
+- Use the shared `GigTakeHomeCalculator` so figures match every other client exactly.
+- Be glanceable, non-judgmental, fully offline, and TalkBack-complete.
+
+**Non-Goals**
+
+- No tax/expense math in Android — all of it lives in `packages/*`.
+- No tax advice or filing; this is an estimate/reserve aid only.
+- No Play Store distribution; design-only while distribution is gated by
+  [#1242](https://github.com/jrmoulckers/finance/issues/1242).
+
+## Affected Android Surfaces
+
+| Surface                    | Path                                                                                                                                                    | Change                                                              |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| **New** — Take-home screen | `apps/android/.../ui/screens/gig/GigTakeHomeScreen.kt`                                                                                                  | Scope tabs + filter chips + card list                               |
+| **New** — Take-home VM     | `apps/android/.../ui/viewmodel/gig/GigTakeHomeViewModel.kt`                                                                                             | Builds `GigTakeHomeInput`, calls KMP, exposes `StateFlow`           |
+| **New** — Take-home card   | `apps/android/.../ui/components/gig/TakeHomeCard.kt`                                                                                                    | Gross → cost → reserve → take-home waterfall card                   |
+| **New** — Shift filter     | `apps/android/.../ui/components/gig/ShiftFilterChips.kt`                                                                                                | Shift selection chips                                               |
+| Platform chips             | reuse `GigPlatformChips.kt` from [mapping design](./android-gig-platform-mapping.md)                                                                    | Platform multi-select                                               |
+| Period scope               | reuse `DateRangePreset` from [`SearchFilterState.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/components/search/SearchFilterState.kt) | `TODAY` (day) / `THIS_WEEK` (week); shift = custom intra-day window |
+| DI wiring                  | [`apps/android/.../di/AppModule.kt`](../../apps/android/src/main/kotlin/com/finance/android/di/AppModule.kt)                                            | `viewModelOf(::GigTakeHomeViewModel)`                               |
+| Navigation                 | [`apps/android/.../ui/navigation/FinanceNavHost.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceNavHost.kt)            | Route `gig/take-home`                                               |
+| Glance widget (follow-up)  | `apps/android/.../widget/TakeHomeWidget.kt`                                                                                                             | Home-screen "today's take-home" summary                             |
+
+## Shared Dependencies (KMP)
+
+The take-home breakdown is implemented in
+[`packages/core/.../tax/TaxCalculators.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/tax/TaxCalculators.kt):
+
+| KMP symbol                                                                                                                                                | Role on Android                                                                                                                                                    |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `GigTakeHomeInput`                                                                                                                                        | Inputs: `grossIncomeCents`, `businessExpenseCents`, `mileageDeductions`, `reserveRate`, `wagesCents`, `isMarriedFilingSeparately`                                  |
+| `GigTakeHomeCalculator.calculate`                                                                                                                         | Returns the full breakdown — **the only authority** for take-home math                                                                                             |
+| `GigTakeHomeResult`                                                                                                                                       | `grossIncomeCents`, `businessExpenseCents`, `mileageDeductionCents`, `netSelfEmploymentIncomeCents`, `estimatedTaxReserveCents`, `estimatedSETax`, `takeHomeCents` |
+| `TaxReserveCalculator`                                                                                                                                    | Default reserve rate `0.28` (suggested band `0.25`–`0.30`); used for reserve estimate                                                                              |
+| `VehicleCostCalculator` ([vehicle/VehicleCostCalculator.kt](../../packages/core/src/commonMain/kotlin/com/finance/core/vehicle/VehicleCostCalculator.kt)) | Operating cost aggregation / cost-per-mile inputs                                                                                                                  |
+| `MileageDeductionCalculator` / `TripDeduction`                                                                                                            | Mileage deduction component of operating cost                                                                                                                      |
+| `GigPayoutCalculator.groupIncomeByPlatform`                                                                                                               | Source of per-platform gross income for the period/filters                                                                                                         |
+
+Amounts are integer `Cents`; the UI applies locale-aware currency formatting only at render time.
+
+## Architecture and Math Boundary
+
+**Rule:** the ViewModel gathers period/platform/shift-scoped transactions and costs, assembles a
+`GigTakeHomeInput`, and calls `GigTakeHomeCalculator.calculate`. Compose renders the returned
+`GigTakeHomeResult`. **No** gross/cost/reserve/take-home arithmetic occurs in Android code.
+
+```mermaid
+flowchart TD
+    subgraph KMP["packages/* (shared Kotlin — owns the math)"]
+        GROUP[groupIncomeByPlatform]
+        VEH[VehicleCostCalculator]
+        TH[GigTakeHomeCalculator.calculate]
+        REPO[(Transaction + cost repos\nSQLDelight + SQLCipher)]
+    end
+    subgraph Android["apps/android (Compose — renders state only)"]
+        VM[GigTakeHomeViewModel]
+        UI[GigTakeHomeScreen\nTakeHomeCard per scope]
+    end
+    REPO --> VM
+    VM -->|period + platform + shift filters| GROUP
+    GROUP -->|gross per platform| VM
+    VM -->|operating cost inputs| VEH
+    VEH -->|business expense / mileage| VM
+    VM -->|"GigTakeHomeInput"| TH
+    TH -->|GigTakeHomeResult| VM
+    VM -->|StateFlow<UiState>| UI
+    UI -->|scope / platform / shift intent| VM
+```
+
+## Card Anatomy
+
+`TakeHomeCard` renders a four-line **waterfall** plus a headline take-home figure:
+
+```mermaid
+flowchart TB
+    G["Gross income"] --> C["− Operating cost (expenses + mileage)"]
+    C --> R["− Tax reserve (≈ 28%)"]
+    R --> T["= Take-home"]
+```
+
+- **Headline:** `takeHomeCents`, large, with the scope label ("Today", "This week", "Evening shift").
+- **Breakdown rows:** Gross (`grossIncomeCents`), Operating cost (`businessExpenseCents` +
+  `mileageDeductionCents`), Tax reserve (`estimatedTaxReserveCents`), Take-home (`takeHomeCents`).
+- **Reserve note:** a short, factual caption ("Set aside ~28% for self-employment tax") with a link to a
+  deeper [take-home / tax reserve explainer]; never alarmist.
+- **Net SE income** (`netSelfEmploymentIncomeCents`) and `estimatedSETax` available in an expandable
+  "How this is calculated" disclosure for transparency.
+- **Color is paired with text/icons** (color-blind safe); take-home is emphasized via type scale, not
+  color alone.
+
+## Day / Week / Shift Scopes
+
+| Scope     | Window                                                | Bounds source                                                    |
+| --------- | ----------------------------------------------------- | ---------------------------------------------------------------- |
+| **Day**   | A single calendar day (default today)                 | `DateRangePreset.TODAY` (or a picked day)                        |
+| **Week**  | Current ISO week                                      | `DateRangePreset.THIS_WEEK`                                      |
+| **Shift** | A user-defined intra-day or cross-midnight work block | Custom start/end timestamps (a shift may span two calendar days) |
+
+- Scope is a Material 3 tab/segmented control; switching scope re-queries transactions and recomputes via
+  KMP. The selected scope drives the `from`/`to` (and time window for shift) used to gather gross income
+  and costs before building `GigTakeHomeInput`.
+- **Shift** is the finest grain: it bounds by timestamp, so a 6 pm–2 am shift correctly aggregates across
+  midnight. Shift definitions are shared data; Android only selects and displays them.
+
+## Platform and Shift Filters
+
+- **Platform filter:** reuse the platform chips from the
+  [mapping design](./android-gig-platform-mapping.md#platform-filter-chip-transactions). Selecting Uber +
+  DoorDash restricts gross income (via `groupIncomeByPlatform`) and proportional costs to those platforms.
+- **Shift filter:** `ShiftFilterChips` lets the user pick one or more named shifts (e.g., "Morning",
+  "Evening"). Combined with the Day/Week scope, this answers "what did my evening shifts net this week?".
+- Filters compose: scope × platform × shift. All filtering of the underlying transaction set is delegated
+  to shared selection logic; Compose passes the chosen ids/bounds, never recomputes membership.
+
+## Offline-First Behavior
+
+- **Load:** read transactions + cost inputs from the local encrypted SQLDelight store and compute the
+  breakdown in-memory; the screen is fully usable offline.
+- **Recompute:** changing scope/platform/shift recomputes locally and instantly — no network dependency.
+- **Sync:** new deposits/expenses arrive via the background
+  [`SyncWorker`](../../apps/android/src/main/kotlin/com/finance/android/sync/SyncWorker.kt) (WorkManager);
+  cards recompute reactively when local data updates.
+- **Read-mostly:** this screen primarily reads. If the user edits the reserve rate or a shift definition,
+  the write is **optimistic** and queued for sync, with conflicts deferred to the shared
+  `ConflictStrategy.resolverFor()` path; the UI shows a non-blocking "Pending sync" affordance.
+- **Staleness:** a "Last synced …" line clarifies that figures reflect the latest **local** data.
+
+## Screen States
+
+| State                     | Trigger                                      | Compose treatment                                                                            |
+| ------------------------- | -------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| **Loading**               | Initial compute                              | Skeleton card; `contentDescription = "Loading take-home summary"`                            |
+| **Empty (no income)**     | No matched income in scope                   | "No earnings recorded for {scope}" + link to add a transaction                               |
+| **Empty (filtered out)**  | Platform/shift filter excludes all           | "No earnings for the selected platforms/shifts" + "Clear filters"                            |
+| **Populated**             | `GigTakeHomeResult` present                  | Headline + waterfall + disclosure                                                            |
+| **Zero take-home**        | Costs + reserve ≥ gross (result clamps to 0) | Show $0 take-home with neutral explainer (result never goes negative)                        |
+| **Saving / Pending sync** | Reserve-rate or shift edit                   | Inline "Pending sync"; controls stay enabled                                                 |
+| **Error**                 | Repository/sync failure                      | Non-blocking `Snackbar` + **Retry**; last good snapshot retained; `Timber.e` without amounts |
+| **Offline**               | No connectivity                              | Banner "Offline — showing last synced data"; screen remains interactive                      |
+
+## Accessibility (TalkBack)
+
+Follows [`accessibility-patterns.md`](./accessibility-patterns.md),
+[`data-visualization.md`](./data-visualization.md),
+[`cognitive-accessibility.md`](./cognitive-accessibility.md), and
+[`content-language-guidelines.md`](./content-language-guidelines.md).
+
+- Each card composes one clear announcement:
+  "Today: gross 180 dollars, operating cost 40 dollars, tax reserve 39 dollars, take-home 101 dollars".
+- The waterfall rows read in order; the take-home headline is emphasized via heading semantics, not color.
+- Reserve caption uses plain, non-judgmental language (no shame/alarm); the band is described as a
+  guideline, not a demand.
+- Scope tabs and filter chips announce selected state; all touch targets ≥ 48 dp; layout reflows at 200%
+  font scale without truncation.
+- The "How this is calculated" disclosure is keyboard/Switch-Access reachable and announces expand/collapse.
+
+## Test Plan
+
+| Layer                                      | Coverage                                                                                                                                                                                                                            |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **KMP (existing, referenced)**             | `TaxCalculatorsTest` (incl. `GigTakeHomeCalculator`) and `VehicleCostCalculatorTest` own the math; Android does not duplicate them                                                                                                  |
+| **ViewModel unit (`assembleDebug` path)**  | Scope → bounds (day/week/shift incl. cross-midnight); platform/shift filter composition; `GigTakeHomeInput` assembly; mapping `GigTakeHomeResult` → card state; zero-clamp case; reserve-rate edit (optimistic save); error → retry |
+| **Compose UI (androidTest / Robolectric)** | Scope/filter changes recompute; disclosure expand/collapse; empty/zero/error states render expected semantics                                                                                                                       |
+| **Paparazzi snapshots**                    | Card for day/week/shift; populated, zero take-home, empty, error; with/without disclosure; light/dark + dynamic color; 1x and 2x font scale                                                                                         |
+| **Accessibility checks**                   | Composed card announcement; heading semantics on take-home; non-color encoding; large-font reflow                                                                                                                                   |
+
+## Implementation Readiness
+
+This is a **design deliverable**; it ships as documentation only.
+
+**Buildable now (no enrollment required), per
+[`human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md) §2:**
+
+- Implement the screen, `GigTakeHomeViewModel`, filter chips, and Koin module.
+- Verify with `./gradlew :apps:android:assembleDebug`, JVM unit tests, and Paparazzi snapshots.
+  `GigTakeHomeCalculator`, `TaxReserveCalculator`, and `VehicleCostCalculator` already exist in
+  `packages/core`.
+
+**Distribution tail (gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242)):**
+
+- Release signing, Play Store upload, and any Glance-widget production rollout remain **human-gated**; see
+  [`human-gated-prerequisites.md` §3.1](../ops/human-gated-prerequisites.md#31-android-distribution--google-play-1242).
+- Nothing here requires the distribution tail to build or test locally.
+
+## Open Questions
+
+- How are **operating costs** attributed to a shift/platform — direct expense transactions, allocated
+  vehicle cost-per-mile, or both? (Owned by `packages/*`; Android consumes the shared allocation.)
+- Where do **shift definitions** live and how are they edited? (Shared model; confirm with @kmp-engineer.)
+- Should the reserve rate be per-user adjustable here, or read-only from settings? (Recommend read-only on
+  this screen with a deep link to the tax-reserve setting.)
+- Wear OS Tile/Complication and Glance widget for "today's take-home" — scope as follow-ups under
+  [#2135](https://github.com/jrmoulckers/finance/issues/2135).


### PR DESCRIPTION
## Summary

Design deliverables (docs-only) for three related Android gig-economy issues, batched into one PR. Each
doc grounds its design in the existing KMP shared logic (`packages/core` — `GigPayoutCalculator`,
`GigTakeHomeCalculator`, `TaxReserveCalculator`, `VehicleCostCalculator`) and the existing Android filter
infrastructure, keeping **all finance math in `packages/*`** while Compose renders shared state.

Per [`docs/ops/human-gated-prerequisites.md`](docs/ops/human-gated-prerequisites.md) §2, native Android
implementation is **unblocked** — the `#1242` gate applies only to the _distribution_ tail (release
signing / Play Store). These designs are buildable now via `assembleDebug` + unit + Paparazzi.

## Changes

- **`docs/design/android-gig-platform-mapping.md`** (#2512, _Part of #2133_) — Compose settings +
  transaction-filter entry points for mapping payees/descriptions/accounts to gig platforms; platform
  chips, override precedence, offline-first sync.
- **`docs/design/android-gig-payout-reconciliation.md`** (#2514, _Part of #2133_) — platform earnings
  dashboard comparing expected payouts vs received deposits for today/week/month, deep-linking to
  filtered transactions.
- **`docs/design/android-gig-take-home-summary.md`** (#2516, _Part of #2135_) — day/week/shift Compose
  cards for gross → operating cost → tax reserve → take-home, with platform + shift filters.

Each doc identifies affected Android surfaces + shared dependencies, describes the KMP math boundary
(without implementing it), covers offline-first load/save/error + empty + accessibility (TalkBack)
states, includes a test plan, and an "Implementation readiness" section (buildable-now vs. distribution
tail gated by #1242).

## Testing

- `npx prettier --check` passes for all three files.
- Markdown only — no app code changed; no `packages/`, shared config, or other platforms touched.
- Mermaid diagrams render in GitHub; relative links point to real source paths and sibling docs.

Closes #2512
Closes #2514
Closes #2516
