### PR TITLE
docs(design): ios chart accessibility design batch (#2534, #2540, #2542)

### DIFF
--- a/docs/design/ios-chart-descriptor-adapters.md
+++ b/docs/design/ios-chart-descriptor-adapters.md
@@ -1,0 +1,367 @@
+# iOS Chart Descriptor Adapters for Swift Charts
+
+> Design specification for **view-model descriptors** that map shared chart
+> series into Swift Charts accessibility descriptors (`AXChartDescriptor` /
+> audio graph) and the adjacent non-gesture controls that drive selection.
+
+**Status:** PROPOSED — design only (native implementation gated, see
+[Implementation readiness](#implementation-readiness))
+**Issue:** [#2542](https://github.com/jrmoulckers/finance/issues/2542) — _Part of
+[#2115](https://github.com/jrmoulckers/finance/issues/2115)_
+**Platform:** iOS (SwiftUI · Swift Charts · Accessibility)
+**Last updated:** 2026-06-22
+**Related design docs:** [data-visualization.md](./data-visualization.md) ·
+[chart-component-specs.md](./chart-component-specs.md) ·
+[accessibility-patterns.md](./accessibility-patterns.md)
+**Sibling docs (this cluster):**
+[ios-chart-summaries-data-tables.md](./ios-chart-summaries-data-tables.md) ·
+[ios-chart-voiceover-navigation.md](./ios-chart-voiceover-navigation.md)
+
+---
+
+## Table of Contents
+
+1. [Problem & Goal](#1-problem--goal)
+2. [Affected iOS Surfaces](#2-affected-ios-surfaces)
+3. [Shared Dependencies & the iOS / KMP Boundary](#3-shared-dependencies--the-ios--kmp-boundary)
+4. [The Descriptor Model](#4-the-descriptor-model)
+5. [Mapping to `AXChartDescriptor`](#5-mapping-to-axchartdescriptor)
+6. [Adjacent Non-Gesture Controls](#6-adjacent-non-gesture-controls)
+7. [Accessibility](#7-accessibility)
+8. [Dynamic Type](#8-dynamic-type)
+9. [Privacy & Balance Hiding](#9-privacy--balance-hiding)
+10. [Empty, Stale & Error States](#10-empty-stale--error-states)
+11. [Test Plan](#11-test-plan)
+12. [Implementation readiness](#implementation-readiness)
+
+---
+
+## 1. Problem & Goal
+
+The summaries/tables doc and the navigation doc both need the **same answer** to
+"what are the points, axes, and series of this chart, as accessible facts?".
+Today every chart re-derives that ad hoc and none of them feed Swift Charts'
+built-in audio-graph support:
+
+- The charts assign per-mark `.accessibilityLabel` / `.accessibilityValue` (e.g.
+  [`SpendingChart.swift`](../../apps/ios/Finance/Charts/SpendingChart.swift)
+  ≈ lines 47–50,
+  [`TrendChart.swift`](../../apps/ios/Finance/Charts/TrendChart.swift)
+  ≈ lines 64–67) but stop there.
+- None of them implement `AXChartDescriptorRepresentable` /
+  `.accessibilityChartDescriptor(…)`, so VoiceOver's **"Play Audio Graph" /
+  "Describe Chart"** rotor actions are unavailable
+  ([#2115](https://github.com/jrmoulckers/finance/issues/2115)).
+- Each chart owns its own selection state (`selectedDate`, `selectedAngle`),
+  derived independently from the data, so the summary, the table, the audio
+  graph, and the selection control can drift.
+
+**Goal:** define one reusable, testable **`ChartAccessibilityDescriptor`**
+view-model type that:
+
+1. Is built once from the shared, platform-neutral series data.
+2. Adapts into a Swift Charts **`AXChartDescriptor`** (axes, series, data points)
+   to power the audio graph.
+3. Feeds the **spoken summary + table** ([ios-chart-summaries-data-tables.md](./ios-chart-summaries-data-tables.md)).
+4. Feeds the **adjustable/stepper/rotor selection**
+   ([ios-chart-voiceover-navigation.md](./ios-chart-voiceover-navigation.md)) and
+   the **adjacent non-gesture controls** described here.
+
+This descriptor is the **single source of truth** that makes the whole cluster
+consistent.
+
+---
+
+## 2. Affected iOS Surfaces
+
+| Surface                                                                                      | Series shape                                                                     | Descriptor produced                                   |
+| -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| [`SpendingChart.swift`](../../apps/ios/Finance/Charts/SpendingChart.swift)                   | `[CategorySpending]` (category, amount)                                          | 1 categorical axis × 1 numeric axis, 1 series         |
+| [`CategoryBreakdownChart.swift`](../../apps/ios/Finance/Charts/CategoryBreakdownChart.swift) | `[CategorySlice]` (category, amount, %)                                          | Categorical × numeric (value + derived %), 1 series   |
+| [`TrendChart.swift`](../../apps/ios/Finance/Charts/TrendChart.swift)                         | `[TrendDataPoint]` (date, value, series)                                         | Temporal × numeric, **N series**                      |
+| [`PredictionChart.swift`](../../apps/ios/Finance/Charts/PredictionChart.swift)               | history `[TrendDataPoint]` + `[TrendPrediction]` (predicted, lower, upper, conf) | Temporal × numeric, history + predicted series + band |
+| [`InsightsView.swift`](../../apps/ios/Finance/Screens/InsightsView.swift)                    | `[SpendingBreakdown]`, `[MonthlyAmount]`                                         | Categorical and temporal descriptors                  |
+| [`AnalyticsView.swift`](../../apps/ios/Finance/Screens/AnalyticsView.swift)                  | `[CategoryTrend]`, `[TrendPrediction]`                                           | Temporal × numeric, multi-series                      |
+| [`InvestmentDetailView.swift`](../../apps/ios/Finance/Screens/InvestmentDetailView.swift)    | price history (date, value)                                                      | Temporal × numeric, 1 series                          |
+
+All consume the same `ChartColorPalette`
+([`ChartColorPalette.swift`](../../apps/ios/Finance/Charts/ChartColorPalette.swift))
+— the descriptor carries **identity by name**, not colour, so the audio graph and
+the table are colour-independent.
+
+---
+
+## 3. Shared Dependencies & the iOS / KMP Boundary
+
+The descriptor is **iOS-owned** (it speaks Apple's `AXChartDescriptor` and
+SwiftUI types), but its **inputs are platform-neutral**. This is the explicit
+boundary the issue calls for: shared series data in
+`packages/core` / `packages/models`; Apple accessibility semantics in `apps/ios`.
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages/core · packages/models (platform-neutral)"]
+        S[Series & points<br/>amounts: Int64 minor units<br/>dates, labels, confidence]
+    end
+    subgraph BRIDGE["apps/ios — Swift Export bridge"]
+        B[SwiftExportAggregatorModule<br/>SwiftExportFormatterModule<br/>Kotlin→Swift type mapping]
+    end
+    subgraph DESC["apps/ios — descriptor adapter (this doc)"]
+        D[ChartAccessibilityDescriptor]
+    end
+    subgraph OUT["apps/ios — consumers"]
+        AX[AXChartDescriptor<br/>audio graph]
+        SUM[Summary + Table]
+        SEL[Adjustable / Stepper / Rotor]
+    end
+    S --> B --> D
+    D --> AX
+    D --> SUM
+    D --> SEL
+```
+
+| Concern                                                                       | Lives in                            | Notes                                                                                                                                                                 |
+| ----------------------------------------------------------------------------- | ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Series & point data (dates, labels, amounts in minor units, confidence)       | `packages/core` / `packages/models` | Already vended through `SwiftExportAggregatorModule` / `SwiftExportFormatterModule` ([`SwiftExportBridge.swift`](../../apps/ios/Finance/KMP/SwiftExportBridge.swift)) |
+| Kotlin → Swift type mapping (`Int`→`Int32`, `List`→`Array`, sealed→enum)      | Bridge boundary                     | Per Swift Export conventions; **no KMP types leak past the bridge**                                                                                                   |
+| `ChartAccessibilityDescriptor` struct + adapter to `AXChartDescriptor`        | `apps/ios`                          | This document                                                                                                                                                         |
+| Audio-graph axes/series/points (`AXNumericDataAxisDescriptor`, `AXDataPoint`) | `apps/ios`                          | Apple framework, iOS 17+                                                                                                                                              |
+| Adjacent non-gesture controls (series toggle, point stepper)                  | `apps/ios`                          | Shares `selectedIndex` with [ios-chart-voiceover-navigation.md](./ios-chart-voiceover-navigation.md)                                                                  |
+
+> **Boundary rule:** the descriptor **reads** shared aggregates; it never adds
+> business math. Currency strings come from the shared formatter so the audio
+> graph's spoken axis labels are locale-correct. Amounts cross as `Int64` minor
+> units and are converted to `Double` only at the `AXDataPoint` boundary (Swift
+> Charts axes are `Double`), consistent with
+> [data-visualization.md §6.1](./data-visualization.md#61-cents-to-dollars-conversion).
+
+> **No `packages/` edits in this PR.** If the shared layer should expose a
+> ready-made "chart series DTO", that is proposed to @kmp-engineer via ADR
+> ([AGENTS.md](../../AGENTS.md)); this design names the contract only.
+
+---
+
+## 4. The Descriptor Model
+
+A value type (Sendable) the view model builds once per data load:
+
+```
+ChartAccessibilityDescriptor            // conceptual shape — not an implementation
+├─ title: String                        // localized
+├─ kind: .bar | .donut | .line | .prediction
+├─ xAxis: AxisDescriptor                // categorical OR temporal
+│    ├─ title: String
+│    └─ values: [labelled categories]  OR  [date range + ticks]
+├─ yAxis: NumericAxisDescriptor
+│    ├─ title: String
+│    ├─ range: (minMinorUnits, maxMinorUnits)
+│    └─ format: (Int64) -> String       // delegates to shared formatter
+├─ series: [SeriesDescriptor]
+│    ├─ name: String                     // identity, NOT colour
+│    ├─ points: [PointDescriptor]
+│    │    ├─ x: category | date
+│    │    ├─ valueMinorUnits: Int64
+│    │    ├─ lowerMinorUnits / upperMinorUnits: Int64?   // prediction band
+│    │    └─ confidencePercent: Double?                  // prediction
+│    └─ isForecast: Bool
+└─ summaryFacts: SummaryFacts            // total, min, max, delta, top — see doc #2534
+```
+
+- **One descriptor per chart**, built from the bridged aggregates.
+- Carries `Int64` minor units end-to-end; formatting is deferred to the shared
+  formatter (`yAxis.format`) so every consumer renders identical strings.
+- `summaryFacts` is the same structure consumed by
+  [ios-chart-summaries-data-tables.md](./ios-chart-summaries-data-tables.md);
+  `series[*].points` is the same ordering consumed by the selection navigation in
+  [ios-chart-voiceover-navigation.md](./ios-chart-voiceover-navigation.md).
+
+---
+
+## 5. Mapping to `AXChartDescriptor`
+
+The adapter conforms the chart container to `AXChartDescriptorRepresentable` and
+returns an `AXChartDescriptor`, attached via `.accessibilityChartDescriptor(self)`.
+This is what powers VoiceOver's **audio graph** ("Play Audio Graph" / "Describe
+Chart" rotor actions).
+
+| `ChartAccessibilityDescriptor` | Swift Charts accessibility type                                                            |
+| ------------------------------ | ------------------------------------------------------------------------------------------ |
+| `xAxis` (temporal)             | `AXNumericDataAxisDescriptor` (date as time-interval) + tick labels                        |
+| `xAxis` (categorical)          | `AXCategoricalDataAxisDescriptor` (ordered category names)                                 |
+| `yAxis` (numeric, currency)    | `AXNumericDataAxisDescriptor` with `valueDescriptionProvider` calling the shared formatter |
+| `series[i]`                    | `AXDataSeriesDescriptor(name:isContinuous:dataPoints:)`                                    |
+| `series[i].points[j]`          | `AXDataPoint(x:y:additionalValues:label:)`                                                 |
+| `confidencePercent` / band     | `AXDataPoint.additionalValues` (spoken as "range … , N% confidence")                       |
+| `summaryFacts`                 | `AXChartDescriptor.summary` string                                                         |
+
+**Mapping rules**
+
+- **Axis labels are spoken via the shared formatter** — the
+  `valueDescriptionProvider` converts the `Double` axis value back through
+  `SwiftExportFormatterModule.format(amountMinorUnits:…)` so the audio graph says
+  "$12,500", not "12500.0".
+- **Continuity:** line/prediction series set `isContinuous: true`; bar/donut set
+  `isContinuous: false` (discrete categories).
+- **Donut → 1-D:** a donut maps to a single categorical series whose `y` is the
+  slice value and whose `additionalValues` carry the percentage.
+- **Prediction band:** the predicted series adds `lower`/`upper` as
+  `additionalValues`; the historical and predicted series are **named distinctly**
+  ("Spending", "Forecast") so the audio graph separates them.
+- The audio graph is **complementary** to — not a replacement for — the summary,
+  table, and adjustable selection. A user can play the graph, read the table, and
+  step the selection, all backed by the one descriptor.
+
+> Mirrors the four web strategies in
+> [accessibility-patterns.md §7.2](./accessibility-patterns.md#72-chart-accessibility)
+> (CVD palette, container description, per-point labels, keyboard/AT navigation) —
+> the descriptor is the iOS analogue of `buildChartDescription()` plus the
+> per-`Cell` labels, unified.
+
+---
+
+## 6. Adjacent Non-Gesture Controls
+
+The descriptor also drives the **visible controls** that make a chart inspectable
+without a drag gesture (the partner of the adjustable action in
+[ios-chart-voiceover-navigation.md §4](./ios-chart-voiceover-navigation.md#4-interaction-design)):
+
+| Control                | Bound to                           | Purpose                                                                        |
+| ---------------------- | ---------------------------------- | ------------------------------------------------------------------------------ |
+| Series toggle / Picker | `series[*].name`                   | Choose the active series on multi-series charts (Trend)                        |
+| Point `Stepper`        | `selectedIndex` into active series | Move the selection point-by-point (keyboard / Switch Control)                  |
+| "Show data table"      | `summaryFacts` + `series.points`   | Reveal the row alternative ([doc #2534](./ios-chart-summaries-data-tables.md)) |
+
+- These controls and the VoiceOver adjustable action **share one `selectedIndex`**
+  held by the view model, so highlight, spoken value, audio graph cursor, and
+  stepper never disagree.
+- Controls are standard SwiftUI (`Picker`, `Stepper`), so they inherit keyboard,
+  Switch Control, Full Keyboard Access, and pointer support for free, at ≥ 44×44 pt.
+
+---
+
+## 7. Accessibility
+
+| Requirement                  | Implementation                                                                                                    |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| Audio graph                  | `.accessibilityChartDescriptor(self)` returning the mapped `AXChartDescriptor`                                    |
+| Axis labels spoken correctly | `valueDescriptionProvider` → shared formatter (locale-correct currency, "negative"/"expense")                     |
+| Per-point detail             | `AXDataPoint.label` + `additionalValues` (range, confidence)                                                      |
+| Chart summary                | `AXChartDescriptor.summary` = `summaryFacts` sentence (same as [doc #2534](./ios-chart-summaries-data-tables.md)) |
+| Selection without drag       | Shared `selectedIndex` → adjustable action + stepper ([doc #2540](./ios-chart-voiceover-navigation.md))           |
+| Colour independence          | Series identity by name; descriptor never encodes colour                                                          |
+| CVD-safe palette             | Visual layer still uses [`ChartColorPalette`](../../apps/ios/Finance/Charts/ChartColorPalette.swift)              |
+
+---
+
+## 8. Dynamic Type
+
+- The descriptor is data, not layout, so it is inherently size-independent; the
+  **adjacent controls** it drives follow the `FinanceTextStyle` ramp /
+  `.financeFont()` and `@ScaledMetric`
+  ([accessibility-patterns.md §9.2](./accessibility-patterns.md#92-ios-swiftui)).
+- Series pickers and point steppers reflow via `AdaptiveFinanceStack` at
+  accessibility text sizes so control labels never clip.
+- Audio-graph spoken output is unaffected by Dynamic Type, but the visible
+  selected-value caption fed by the descriptor wraps and never truncates.
+
+---
+
+## 9. Privacy & Balance Hiding
+
+- The descriptor is built from the **already-redacted** model when balance-hiding
+  is active: `valueMinorUnits` and the formatter output resolve to "Hidden", so
+  the audio graph, summary, table, and selection all speak the same redaction.
+- Because there is exactly one descriptor, there is **no path** where the visual
+  is hidden but the audio graph leaks the amount — the redaction is applied once,
+  upstream of all consumers.
+- Non-monetary facts (series names, dates, counts, confidence %) may remain;
+  every `Int64` amount honours the redaction flag.
+- Amounts are `.private` in `os.Logger`; the descriptor is never logged with raw
+  values.
+
+---
+
+## 10. Empty, Stale & Error States
+
+| State       | Descriptor                                 | `AXChartDescriptor`                              | Controls          |
+| ----------- | ------------------------------------------ | ------------------------------------------------ | ----------------- |
+| **Empty**   | `series == []`, `summaryFacts` = "no data" | Not attached; chart replaced by `EmptyStateView` | Hidden            |
+| **Loading** | `nil` (not yet built)                      | Not attached; labelled `ProgressView`            | Disabled          |
+| **Stale**   | Built from cached data + `asOf` timestamp  | `summary` includes "as of {time}"                | Enabled           |
+| **Error**   | `nil`; error model instead                 | Not attached; labelled "Retry" button            | Replaced by Retry |
+
+- Stale state reads the sync/offline signal (`SwiftExportSyncModule`,
+  `OfflineBanner`) and stamps `asOf` into the descriptor so the audio-graph summary
+  states the data age.
+- Consistent with [data-visualization.md §7](./data-visualization.md#7-empty-loading--error-states)
+  and the companion state tables in
+  [doc #2534 §9](./ios-chart-summaries-data-tables.md#9-empty-stale--error-states)
+  and [doc #2540 §9](./ios-chart-voiceover-navigation.md#9-empty-stale--error-states).
+
+---
+
+## 11. Test Plan
+
+Smallest tests required before acceptance. Native tests run on Simulator with
+**free Personal Team signing** (see [Implementation readiness](#implementation-readiness)).
+
+### Native (iOS) — XCTest / Swift Testing in `apps/ios/Tests`
+
+- `ChartDescriptorBuilderTests`: building a descriptor from each fixture
+  (`[CategorySpending]`, `[TrendDataPoint]` multi-series, history + `[TrendPrediction]`)
+  yields the expected axis kinds, series count, ordered points, and `summaryFacts`.
+- `AXChartDescriptorMappingTests`: the adapter produces an `AXChartDescriptor`
+  with the correct axis descriptor types (numeric vs. categorical), `isContinuous`
+  per kind, one `AXDataSeriesDescriptor` per series, and `AXDataPoint` counts equal
+  to point counts; prediction `additionalValues` include lower/upper/confidence.
+- `AXAxisLabelFormatTests`: `valueDescriptionProvider` round-trips a `Double` axis
+  value back to the shared formatter's currency string for `en-US`, `de-DE`, `JPY`.
+- `ChartDescriptorPrivacyTests`: with balance-hiding on, the descriptor's formatted
+  values and the mapped `AXDataPoint` labels contain no raw amount.
+- `ChartDescriptorStateTests`: empty/loading/error produce no attached descriptor
+  and the documented fallback; stale stamps `asOf` into the summary.
+- Extend `WidgetRenderingTests` / `AnalyticsViewModelTests` to assert the view
+  model exposes a non-nil descriptor for populated data.
+
+### Shared (KMP) — `packages/core` `commonTest` _(only if the series DTO is adopted; ADR-gated)_
+
+- `ChartSeriesDtoTest`: if a shared chart-series DTO is introduced, verify
+  aggregation → DTO mapping for category, trend, and prediction shapes. Until the
+  ADR lands, the iOS adapter builds the descriptor from existing bridged aggregates
+  and this test is N/A.
+
+---
+
+## Implementation readiness
+
+**Design: ready now. Native code: buildable now, distribution gated.**
+
+Per the
+[Human-Gated Prerequisites runbook](../ops/human-gated-prerequisites.md#2-implementation-vs-distribution--the-decoupling),
+implementation and distribution are decoupled. The "blocked by
+[#1239](https://github.com/jrmoulckers/finance/issues/1239)" note on
+[#2542](https://github.com/jrmoulckers/finance/issues/2542) is a **distribution**
+gate only.
+
+| Phase              | What                                                                                      | Gated by #1239?                         |
+| ------------------ | ----------------------------------------------------------------------------------------- | --------------------------------------- |
+| **Design**         | This document, the descriptor model, the `AXChartDescriptor` mapping, the test plan       | No — deliverable now                    |
+| **Implementation** | `ChartAccessibilityDescriptor`, `AXChartDescriptorRepresentable` adapter, controls, tests | **No** — free Personal Team signing     |
+| **Distribution**   | TestFlight / App Store build carrying the feature                                         | **Yes** — Apple Developer Program enrol |
+
+- **Buildable now:** `AXChartDescriptor`, `AXNumericDataAxisDescriptor`,
+  `AXCategoricalDataAxisDescriptor`, `AXDataSeriesDescriptor`, `AXDataPoint`, and
+  `.accessibilityChartDescriptor(…)` are standard iOS 17 accessibility APIs with no
+  paid entitlement; the descriptor and its tests run on Simulator and on a device
+  via free Personal Team signing.
+- **Gated tail (#1239):** only store/TestFlight distribution needs the paid
+  enrollment + signing material in
+  [human-gated-prerequisites.md §3.2](../ops/human-gated-prerequisites.md#32-ios-distribution--apple-developer-1239).
+  An SME agent must **not** perform enrollment, certificate, or secret steps.
+- **Shared-logic tail:** a shared chart-series DTO in `packages/` is optional and
+  ADR-gated (@kmp-engineer); the descriptor is fully implementable today from the
+  already-bridged aggregates.
+
+_Part of [#2115](https://github.com/jrmoulckers/finance/issues/2115). Sibling
+designs: [summaries & data tables](./ios-chart-summaries-data-tables.md) ·
+[VoiceOver navigation](./ios-chart-voiceover-navigation.md)._

--- a/docs/design/ios-chart-summaries-data-tables.md
+++ b/docs/design/ios-chart-summaries-data-tables.md
@@ -1,0 +1,373 @@
+# iOS Chart Summaries & Data-Table Alternatives
+
+> Design specification for a **reusable spoken-summary + table/list alternative**
+> pattern that pairs every financial chart on iOS with an equivalent text
+> representation, kept in the same VoiceOver swipe order as the chart.
+
+**Status:** PROPOSED — design only (native implementation gated, see
+[Implementation readiness](#implementation-readiness))
+**Issue:** [#2534](https://github.com/jrmoulckers/finance/issues/2534) — _Part of
+[#2113](https://github.com/jrmoulckers/finance/issues/2113)_
+**Platform:** iOS (SwiftUI · Swift Charts)
+**Last updated:** 2026-06-22
+**Related design docs:** [data-visualization.md](./data-visualization.md) ·
+[chart-component-specs.md](./chart-component-specs.md) ·
+[accessibility-patterns.md](./accessibility-patterns.md)
+**Sibling docs (this cluster):**
+[ios-chart-voiceover-navigation.md](./ios-chart-voiceover-navigation.md) ·
+[ios-chart-descriptor-adapters.md](./ios-chart-descriptor-adapters.md)
+
+---
+
+## Table of Contents
+
+1. [Problem & Goal](#1-problem--goal)
+2. [Affected iOS Surfaces](#2-affected-ios-surfaces)
+3. [Shared Dependencies & the iOS / KMP Boundary](#3-shared-dependencies--the-ios--kmp-boundary)
+4. [Pattern Design](#4-pattern-design)
+5. [Spoken Summary Grammar](#5-spoken-summary-grammar)
+6. [Accessibility](#6-accessibility)
+7. [Dynamic Type](#7-dynamic-type)
+8. [Privacy & Balance Hiding](#8-privacy--balance-hiding)
+9. [Empty, Stale & Error States](#9-empty-stale--error-states)
+10. [Test Plan](#10-test-plan)
+11. [Implementation readiness](#implementation-readiness)
+
+---
+
+## 1. Problem & Goal
+
+A VoiceOver-first user with severe central vision loss
+([#2113](https://github.com/jrmoulckers/finance/issues/2113)) cannot perceive a
+chart at all — for them an unlabelled `Chart { … }` is blank space. Today, the
+iOS charts stop at a single generic container label:
+
+- [`InsightsView.swift`](../../apps/ios/Finance/Screens/InsightsView.swift)
+  (≈ lines 158–180) renders the spending breakdown donut with only
+  `accessibilityLabel("Spending breakdown chart")` + a generic hint.
+- [`TrendChart.swift`](../../apps/ios/Finance/Charts/TrendChart.swift)
+  (≈ lines 135–139) and
+  [`PredictionChart.swift`](../../apps/ios/Finance/Charts/PredictionChart.swift)
+  (≈ lines 122–126) stop at a chart label; there is no adjacent data list or
+  numeric summary.
+- [`InvestmentDetailView.swift`](../../apps/ios/Finance/Screens/InvestmentDetailView.swift)
+  (≈ lines 158–187) exposes price history as a chart-only visualization.
+
+The app already proves a reusable text-alternative pattern exists:
+[`ReportResultView.swift`](../../apps/ios/Finance/Screens/ReportResultView.swift)
+ships a `reportDataTable` (≈ line 256) that renders category / monthly / net-worth
+results as an accessible row list. **This document generalises that proven
+pattern into a single reusable component set** so every chart surface gets:
+
+1. A **spoken summary** — one focusable element stating the headline facts
+   (date range, total, biggest contributor, highest/lowest point, forecast
+   range) _before_ the chart in swipe order.
+2. A **browsable table/list alternative** — every underlying data point as an
+   accessible row, in the same swipe order as the chart, never hidden behind a
+   visual-only "View as table" toggle for VoiceOver users.
+
+This is the **text-alternative** half of the chart-accessibility cluster. The
+**point-by-point inspection** half (rotor / stepper / adjustable actions) lives
+in [ios-chart-voiceover-navigation.md](./ios-chart-voiceover-navigation.md), and
+the **audio-graph descriptor** mapping lives in
+[ios-chart-descriptor-adapters.md](./ios-chart-descriptor-adapters.md). All three
+read the same view-model descriptor (see [§3](#3-shared-dependencies--the-ios--kmp-boundary)).
+
+---
+
+## 2. Affected iOS Surfaces
+
+| Surface                                                                                      | Chart today                            | Summary needed                                                  | Table/list needed                          |
+| -------------------------------------------------------------------------------------------- | -------------------------------------- | --------------------------------------------------------------- | ------------------------------------------ |
+| [`InsightsView.swift`](../../apps/ios/Finance/Screens/InsightsView.swift)                    | Category donut + monthly-spending bars | Total + biggest category + period; trend direction + peak month | Per-category rows; per-month rows          |
+| [`AnalyticsView.swift`](../../apps/ios/Finance/Screens/AnalyticsView.swift)                  | Trend, prediction, top-category charts | Avg/projected spend, savings rate, forecast range, top movers   | Category-trend rows; prediction rows       |
+| [`TrendChart.swift`](../../apps/ios/Finance/Charts/TrendChart.swift)                         | Multi-series line                      | Series count, range min→max per series, start vs. end delta     | Per-date, per-series rows                  |
+| [`PredictionChart.swift`](../../apps/ios/Finance/Charts/PredictionChart.swift)               | History line + confidence band         | Forecast value + confidence interval + confidence %             | Historical rows + predicted rows w/ bounds |
+| [`CategoryBreakdownChart.swift`](../../apps/ios/Finance/Charts/CategoryBreakdownChart.swift) | Donut (`chartAngleSelection`)          | Total + top slice + slice count                                 | Per-slice rows (amount + %)                |
+| [`SpendingChart.swift`](../../apps/ios/Finance/Charts/SpendingChart.swift)                   | Category bar                           | Total + highest/lowest category                                 | Per-category rows                          |
+| [`InvestmentDetailView.swift`](../../apps/ios/Finance/Screens/InvestmentDetailView.swift)    | Price-history line (chart-only)        | First→last value, % change, high/low                            | Per-date price rows                        |
+
+> **Reuse, don't fork:** `reportDataTable` in
+> [`ReportResultView.swift`](../../apps/ios/Finance/Screens/ReportResultView.swift)
+> stays as-is and adopts the shared `ChartDataTable` component once extracted, so
+> there is a single text-alternative implementation across the app.
+
+---
+
+## 3. Shared Dependencies & the iOS / KMP Boundary
+
+The summary _content_ (which numbers matter) is platform-neutral business logic;
+the summary _presentation_ (VoiceOver semantics, SwiftUI layout, Dynamic Type) is
+Apple-specific. The cluster draws one boundary, shared by all three docs:
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages/core · packages/models — platform-neutral"]
+        A[Aggregated series data<br/>amounts in minor units Int64]
+        B[Summary facts<br/>total, min, max, delta,<br/>biggest contributor, range]
+    end
+    subgraph BR["apps/ios — Swift Export bridge"]
+        C[SwiftExportAggregatorModule<br/>SwiftExportFormatterModule]
+    end
+    subgraph IOS["apps/ios — SwiftUI"]
+        D[ChartAccessibilityDescriptor<br/>view-model struct]
+        E[ChartSummaryView<br/>spoken summary]
+        F[ChartDataTable<br/>row list alternative]
+    end
+    A --> C --> D
+    B --> C --> D
+    D --> E
+    D --> F
+```
+
+| Concern                                                                         | Lives in                            | Notes                                                                                                                                |
+| ------------------------------------------------------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| Series aggregation (spending-by-category, totals, savings rate, cash flow)      | `packages/core`                     | Already bridged via `SwiftExportAggregatorModule` in [`SwiftExportBridge.swift`](../../apps/ios/Finance/KMP/SwiftExportBridge.swift) |
+| Summary facts (min, max, first/last delta, biggest contributor, forecast range) | `packages/core` (proposed addition) | Platform-neutral, unit-testable in `commonTest`; **proposed via ADR**, not implemented here                                          |
+| Currency → display string (minor units → locale string, signed)                 | `packages/core`                     | `SwiftExportFormatterModule.format(amountMinorUnits:currencyCode:showSign:)`                                                         |
+| `ChartAccessibilityDescriptor` view-model struct                                | `apps/ios`                          | Owned by [ios-chart-descriptor-adapters.md](./ios-chart-descriptor-adapters.md)                                                      |
+| `ChartSummaryView`, `ChartDataTable` SwiftUI views + VoiceOver semantics        | `apps/ios`                          | This document                                                                                                                        |
+| Audio-graph `AXChartDescriptor`                                                 | `apps/ios`                          | [ios-chart-descriptor-adapters.md](./ios-chart-descriptor-adapters.md)                                                               |
+
+> **Boundary rule:** amounts cross the bridge as **`Int64` minor units**; the
+> iOS layer never re-implements currency math. Per
+> [data-visualization.md §6.1](./data-visualization.md#61-cents-to-dollars-conversion),
+> chart marks may consume major-unit `Double`, but summaries and tables format
+> through the shared formatter to stay locale-correct.
+
+> **KMP changes are out of scope for this PR.** Any new `commonMain` summary
+> helper is proposed to @kmp-engineer via ADR per
+> [AGENTS.md](../../AGENTS.md); this design names the contract, it does not edit
+> `packages/`.
+
+---
+
+## 4. Pattern Design
+
+Two reusable SwiftUI views, both driven by the shared
+`ChartAccessibilityDescriptor` (defined in
+[ios-chart-descriptor-adapters.md](./ios-chart-descriptor-adapters.md)). Swipe
+order is deliberate: **summary → chart → table**, so a VoiceOver user hears the
+headline, can skip the visual, and still reach every data point.
+
+```
+┌──────────────────────────────────────────────┐
+│ [ChartSummaryView]   ← 1 element, swipe order #1
+│   "Spending by category. 6 categories,        │
+│    total $1,855 this month. Largest: Food,    │
+│    $520, 28 percent."                         │
+├──────────────────────────────────────────────┤
+│ [Chart { … }]        ← visual, swipe order #2  │
+│   .accessibilityChartDescriptor(…) (audio graph)│
+├──────────────────────────────────────────────┤
+│ [ChartDataTable]     ← swipe order #3          │
+│   Food …………… $520 · 28%                        │
+│   Transport …… $310 · 17%                       │
+│   …                                            │
+└──────────────────────────────────────────────┘
+```
+
+### 4.1 `ChartSummaryView`
+
+- A single `Text` exposed as one accessibility element with
+  `.accessibilityAddTraits(.isSummaryElement)` so VoiceOver can read it first via
+  the "Summary" hint and the rotor.
+- Visible by default (sighted low-vision + Dynamic Type users benefit too), but
+  collapses gracefully — it is plain wrapping text, never truncated.
+- Content comes from the descriptor's `summarySentence` (see [§5](#5-spoken-summary-grammar)).
+
+### 4.2 `ChartDataTable`
+
+- Generalises the existing `reportDataTable` row pattern from
+  [`ReportResultView.swift`](../../apps/ios/Finance/Screens/ReportResultView.swift):
+  each row is `.accessibilityElement(children: .combine)` with a
+  `.accessibilityLabel` (name) + `.accessibilityValue` (formatted amount + %).
+- Renders as a `Grid` / row stack — **not** hidden behind a visual toggle. The
+  table is always in the accessibility tree; sighted users may collapse it behind
+  a `DisclosureGroup` ("Show data table") but VoiceOver users reach it by swipe
+  regardless (the disclosure defaults open under VoiceOver).
+- For time-series charts the rows are date-ordered; for breakdowns they are
+  value-descending to match the visual legend.
+
+### 4.3 Row content per chart family
+
+| Chart family         | Row label              | Row value                                  |
+| -------------------- | ---------------------- | ------------------------------------------ |
+| Category bar / donut | Category name          | "$520, 28 percent"                         |
+| Trend line (multi)   | "Mar 2026 · Net Worth" | "$12,500"                                  |
+| Prediction           | "Aug 2026 (predicted)" | "$3,900, range $3,400 to $4,200, 90% conf" |
+| Investment price     | "Mar 3"                | "$184.20"                                  |
+
+---
+
+## 5. Spoken Summary Grammar
+
+The summary is **one sentence built from platform-neutral facts**, formatted on
+device for locale. Patterns mirror `buildChartDescription()` documented in
+[data-visualization.md §5.2](./data-visualization.md#52-text-descriptions) so the
+web and iOS phrasings stay consistent.
+
+| Chart type     | Sentence template                                                                                                                   |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Bar / category | `"{title}. {n} categories, total {total} {period}. Largest: {topName}, {topAmount}, {topPct} percent."`                             |
+| Donut          | `"{title}. {n} categories totalling {total}. Largest slice {topName} at {topPct} percent."`                                         |
+| Line (single)  | `"{title}. {n} points from {firstDate} to {lastDate}. {first} rising/falling to {last}, {deltaPct} percent change."`                |
+| Line (multi)   | `"{title}. {m} series over {n} points. {seriesName}: {min} to {max}. …"`                                                            |
+| Prediction     | `"{title}. {histN} months history, {predN} months forecast. Next: {predAmount}, range {low} to {high}, {conf} percent confidence."` |
+
+**Rules**
+
+- All amounts go through `SwiftExportFormatterModule.format(…)` — never hardcode
+  `$` or separators (see
+  [accessibility-patterns.md §7.1](./accessibility-patterns.md#71-currency-formatting-for-screen-readers)).
+- Direction words ("rising", "falling") come from the sign of the platform-neutral
+  delta, not from colour — colour is never the sole signal
+  ([data-visualization.md §2.4](./data-visualization.md#24-never-color-alone)).
+- Negative amounts say "negative" / "expense", never rely on a minus glyph.
+- The sentence is locale-formatted but **not** translated ad hoc — every literal
+  uses `String(localized:)`.
+
+---
+
+## 6. Accessibility
+
+| Requirement              | Implementation                                                                                                             |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| Spoken summary           | `ChartSummaryView` as a single element with `.accessibilityAddTraits(.isSummaryElement)`, swipe-order #1                   |
+| Text alternative present | `ChartDataTable` always in the accessibility tree, swipe-order #3, same data as chart                                      |
+| Audio graph              | Chart keeps `.accessibilityChartDescriptor(…)` from [ios-chart-descriptor-adapters.md](./ios-chart-descriptor-adapters.md) |
+| Per-row labels           | `.accessibilityElement(children: .combine)` + label (name) + value (amount, %)                                             |
+| Headings                 | Section titles use `.accessibilityAddTraits(.isHeader)` (already the convention in the affected views)                     |
+| Data-update announcement | On reload, post `AccessibilityNotification.Announcement` with the new summary sentence (polite)                            |
+| Colour independence      | Legend swatches stay `.accessibilityHidden(true)`; identity comes from the row label text                                  |
+| CVD-safe palette         | Unchanged — [`ChartColorPalette`](../../apps/ios/Finance/Charts/ChartColorPalette.swift)                                   |
+
+The point-by-point selection announcements (date/value/series on selection change)
+are specified in
+[ios-chart-voiceover-navigation.md §Announcements](./ios-chart-voiceover-navigation.md);
+this doc only covers the **static** summary + table.
+
+---
+
+## 7. Dynamic Type
+
+- Summary and table text use the `FinanceTextStyle` ramp + `.financeFont()` /
+  Dynamic Type system styles described in
+  [accessibility-patterns.md §9.2](./accessibility-patterns.md#92-ios-swiftui) —
+  **never** hardcoded point sizes.
+- The summary sentence **wraps** (`.fixedSize(horizontal: false, vertical: true)`),
+  never truncates, at the largest accessibility text size.
+- Table rows adopt `AdaptiveFinanceStack` so a label + amount + percentage row
+  reflows from `HStack` to `VStack` at accessibility sizes instead of clipping.
+- Percentages and amounts use `.minimumScaleFactor` only on the visual chart
+  legend, never on the table (the table must show full values).
+
+---
+
+## 8. Privacy & Balance Hiding
+
+Financial summaries are sensitive: a spoken total leaks the same data a hidden
+on-screen balance protects.
+
+- When the app's **balance-hiding / privacy mode** is active, `ChartSummaryView`
+  and `ChartDataTable` redact amounts to a placeholder ("Hidden") in **both** the
+  visible text **and** the VoiceOver label — the accessibility string is derived
+  from the same redacted model, never from the raw amount.
+- The redaction decision is made in the view model that builds the descriptor, so
+  the chart, summary, and table are always consistent (no path that hides the
+  visual but speaks the number).
+- Per [os.Logger guidance](../../AGENTS.md) and
+  [accessibility-patterns.md §7.1](./accessibility-patterns.md#71-currency-formatting-for-screen-readers),
+  amounts are treated as `.private` in logs; summaries are never logged verbatim.
+- Counts and category names that are not themselves sensitive may remain ("6
+  categories"), but every monetary figure follows the redaction flag.
+
+---
+
+## 9. Empty, Stale & Error States
+
+These mirror the chart states in
+[data-visualization.md §7](./data-visualization.md#7-empty-loading--error-states)
+and the existing `EmptyStateView` usage in `InsightsView` / `AnalyticsView`.
+
+| State       | Summary text                                                | Table                                              | A11y behaviour                                                |
+| ----------- | ----------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------- |
+| **Empty**   | "No data yet. Add transactions to see this {chartType}."    | Hidden; replaced by the same empty message         | Single focusable element; matches `EmptyStateView`            |
+| **Loading** | "Loading {chartType}…" (announced once, polite)             | Skeleton rows, marked `.accessibilityHidden(true)` | No spinner-only state — `ProgressView` has a label            |
+| **Stale**   | Prefix: "Showing data as of {timestamp}. " + normal summary | Rendered normally with a "last updated" caption    | Stale badge announced as part of the summary, not colour-only |
+| **Error**   | "Couldn't load {chartType}. {reason}."                      | Hidden; retry control exposed as a button          | Error is a labelled `Button("Retry")`, focus moves to it      |
+
+- **Stale** reuses the offline/last-synced signal already surfaced by
+  `OfflineBanner` and the sync module
+  ([`SwiftExportBridge.swift`](../../apps/ios/Finance/KMP/SwiftExportBridge.swift)
+  `SwiftExportSyncModule`); the summary states the as-of time so a VoiceOver user
+  knows the numbers may lag.
+- **Error** copy is non-judgemental per
+  [UX Principles](./ux-principles.md) and never blames the user.
+
+---
+
+## 10. Test Plan
+
+Smallest tests that must pass before implementation is accepted. Native UI tests
+run on Simulator with **free Personal Team signing** — no paid enrollment
+(see [Implementation readiness](#implementation-readiness)).
+
+### Shared (KMP) — `packages/core` `commonTest` _(proposed via ADR; not in this PR)_
+
+- `SummaryFactsTest`: given a fixed series, `total`, `min`, `max`,
+  `biggestContributor`, and `firstToLastDelta` are computed correctly, including
+  empty, single-point, all-zero, and negative-amount cases.
+- `SummaryFactsTest.locale`: formatter produces locale-correct strings for
+  `en-US`, `de-DE`, and a zero-decimal currency (e.g. `JPY`).
+
+### Native (iOS) — XCTest / Swift Testing in `apps/ios/Tests`
+
+- `ChartSummaryViewTests`: the descriptor → sentence mapping yields the expected
+  string per chart family (bar, donut, line, prediction), including the
+  negative-amount ("expense") and zero-data wording.
+- `ChartDataTableTests`: row count equals data-point count; each row's
+  `accessibilityLabel`/`accessibilityValue` contains name + formatted amount.
+- `ChartAccessibilityOrderTests` (XCUITest): VoiceOver swipe order is
+  summary → chart → table on Insights and Analytics.
+- `ChartPrivacyRedactionTests`: with balance-hiding on, neither the visible text
+  nor the accessibility label contains a raw amount.
+- `ChartStateTests`: empty / loading / stale / error each expose exactly one
+  labelled focusable element (or labelled retry button) and no unlabelled chart.
+- Extend `InsightsViewModelTests` / `AnalyticsViewModelTests` to assert the
+  view model emits a populated `ChartAccessibilityDescriptor` for non-empty data.
+
+---
+
+## Implementation readiness
+
+**Design: ready now. Native code: buildable now, distribution gated.**
+
+Per the
+[Human-Gated Prerequisites runbook](../ops/human-gated-prerequisites.md#2-implementation-vs-distribution--the-decoupling),
+implementation and distribution are decoupled. The "blocked by
+[#1239](https://github.com/jrmoulckers/finance/issues/1239)" note on
+[#2534](https://github.com/jrmoulckers/finance/issues/2534) is a **distribution**
+gate only.
+
+| Phase              | What                                                                                  | Gated by #1239?                         |
+| ------------------ | ------------------------------------------------------------------------------------- | --------------------------------------- |
+| **Design**         | This document, the summary grammar, the boundary, the test plan                       | No — deliverable now                    |
+| **Implementation** | `ChartSummaryView`, `ChartDataTable`, descriptor wiring, unit + XCUITest on Simulator | **No** — free Personal Team signing     |
+| **Distribution**   | TestFlight / App Store build carrying the feature                                     | **Yes** — Apple Developer Program enrol |
+
+- **Buildable now:** all SwiftUI views, VoiceOver semantics, Dynamic Type
+  behaviour, and the listed tests run on Simulator / a device via free Personal
+  Team signing. No paid entitlements are required (no push, no Associated
+  Domains).
+- **Gated tail (#1239):** only shipping this through TestFlight / the App Store
+  needs the paid Apple Developer enrollment and signing material described in
+  [human-gated-prerequisites.md §3.2](../ops/human-gated-prerequisites.md#32-ios-distribution--apple-developer-1239).
+  An SME agent must **not** perform enrollment, certificate, or secret steps.
+- **Shared-logic tail:** the proposed `commonMain` summary helper is an
+  @kmp-engineer change via ADR; until then the iOS layer can compute summary facts
+  locally from already-bridged aggregates, then migrate.
+
+_Part of [#2113](https://github.com/jrmoulckers/finance/issues/2113). Sibling
+designs: [VoiceOver navigation](./ios-chart-voiceover-navigation.md) ·
+[descriptor adapters](./ios-chart-descriptor-adapters.md)._

--- a/docs/design/ios-chart-voiceover-navigation.md
+++ b/docs/design/ios-chart-voiceover-navigation.md
@@ -1,0 +1,346 @@
+# iOS Chart VoiceOver Navigation (No-Drag Inspection)
+
+> Design specification for inspecting iOS financial charts **point-by-point
+> without touch-drag gestures** — using adjustable actions, a rotor/stepper
+> fallback, and spoken announcements for date / value / series selection.
+
+**Status:** PROPOSED — design only (native implementation gated, see
+[Implementation readiness](#implementation-readiness))
+**Issue:** [#2540](https://github.com/jrmoulckers/finance/issues/2540) — _Part of
+[#2115](https://github.com/jrmoulckers/finance/issues/2115)_
+**Platform:** iOS (SwiftUI · Swift Charts)
+**Last updated:** 2026-06-22
+**Related design docs:** [data-visualization.md](./data-visualization.md) ·
+[chart-component-specs.md](./chart-component-specs.md) ·
+[accessibility-patterns.md](./accessibility-patterns.md)
+**Sibling docs (this cluster):**
+[ios-chart-summaries-data-tables.md](./ios-chart-summaries-data-tables.md) ·
+[ios-chart-descriptor-adapters.md](./ios-chart-descriptor-adapters.md)
+
+---
+
+## Table of Contents
+
+1. [Problem & Goal](#1-problem--goal)
+2. [Affected iOS Surfaces](#2-affected-ios-surfaces)
+3. [Shared Dependencies & the iOS / KMP Boundary](#3-shared-dependencies--the-ios--kmp-boundary)
+4. [Interaction Design](#4-interaction-design)
+5. [Announcements](#5-announcements)
+6. [Accessibility](#6-accessibility)
+7. [Dynamic Type](#7-dynamic-type)
+8. [Privacy & Balance Hiding](#8-privacy--balance-hiding)
+9. [Empty, Stale & Error States](#9-empty-stale--error-states)
+10. [Test Plan](#10-test-plan)
+11. [Implementation readiness](#implementation-readiness)
+
+---
+
+## 1. Problem & Goal
+
+Today, the only way to inspect a value on the trend and prediction charts is a
+**transparent overlay with a custom `DragGesture`**:
+
+- [`TrendChart.swift`](../../apps/ios/Finance/Charts/TrendChart.swift)
+  (≈ lines 115–133) adds a clear `Rectangle` overlay and a
+  `DragGesture(minimumDistance: 0)` to map the touch X position to a date.
+- [`PredictionChart.swift`](../../apps/ios/Finance/Charts/PredictionChart.swift)
+  (≈ lines 102–121) uses the same drag-only interaction for forecast inspection.
+- [`CategoryBreakdownChart.swift`](../../apps/ios/Finance/Charts/CategoryBreakdownChart.swift)
+  drives selection through `.chartAngleSelection`, which is likewise a pointer
+  gesture.
+
+There is **no** `accessibilityAdjustableAction`, `accessibilityAction`,
+`accessibilityRotor`, or chart-descriptor-driven selection on these charts
+([#2115](https://github.com/jrmoulckers/finance/issues/2115)). When VoiceOver is
+on, the drag overlay is unreachable — a VoiceOver user can hear the static
+summary ([ios-chart-summaries-data-tables.md](./ios-chart-summaries-data-tables.md))
+but cannot move to "the August point" and ask "what's the forecast there?".
+
+**Goal:** give VoiceOver users a standard, gesture-free way to move the selection
+point-by-point through chart data and hear the selected date, value, and
+series/forecast-confidence on every change — without removing the existing
+drag affordance for sighted pointer users.
+
+This is the **navigation** half of the chart-accessibility cluster. The
+**text alternative** is in
+[ios-chart-summaries-data-tables.md](./ios-chart-summaries-data-tables.md); the
+**audio-graph descriptor** mapping (the other VoiceOver gesture, "Play Audio
+Graph") is in
+[ios-chart-descriptor-adapters.md](./ios-chart-descriptor-adapters.md). All three
+read the same `ChartAccessibilityDescriptor`.
+
+---
+
+## 2. Affected iOS Surfaces
+
+| Surface                                                                                      | Current inspection             | Add                                                           |
+| -------------------------------------------------------------------------------------------- | ------------------------------ | ------------------------------------------------------------- |
+| [`TrendChart.swift`](../../apps/ios/Finance/Charts/TrendChart.swift)                         | Drag overlay → `selectedDate`  | Adjustable action stepping date; per-series read on selection |
+| [`PredictionChart.swift`](../../apps/ios/Finance/Charts/PredictionChart.swift)               | Drag overlay → `selectedDate`  | Adjustable action; announce value + confidence interval       |
+| [`CategoryBreakdownChart.swift`](../../apps/ios/Finance/Charts/CategoryBreakdownChart.swift) | `chartAngleSelection`          | Adjustable action stepping slices; announce slice + %         |
+| [`InsightsView.swift`](../../apps/ios/Finance/Screens/InsightsView.swift)                    | Inline donut + bars, no select | Inherit pattern via shared modifier                           |
+| [`AnalyticsView.swift`](../../apps/ios/Finance/Screens/AnalyticsView.swift)                  | Inline charts                  | Inherit pattern via shared modifier                           |
+| [`InvestmentDetailView.swift`](../../apps/ios/Finance/Screens/InvestmentDetailView.swift)    | Price-history line, no select  | Adjustable action stepping dates; announce price              |
+
+The drag overlay stays for pointer users; the new behaviour is **additive** and
+activates under VoiceOver.
+
+---
+
+## 3. Shared Dependencies & the iOS / KMP Boundary
+
+Selection navigation is **pure presentation/interaction** — it has no business
+rules of its own. It reads the **same view-model descriptor** the other two docs
+use, so there is one source of "what is point _i_".
+
+```mermaid
+flowchart LR
+    A[ChartAccessibilityDescriptor<br/>ordered points + per-point facts<br/>amounts in minor units] --> B[SelectionIndex<br/>view-model state]
+    B --> C[accessibilityAdjustableAction<br/>increment / decrement]
+    B --> D[accessibilityRotor<br/>jump to peaks / months]
+    B --> E[Announcement<br/>date · value · series/conf]
+    C --> B
+    D --> B
+```
+
+| Concern                                                              | Lives in                                               | Notes                                                                                                           |
+| -------------------------------------------------------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| Ordered points + per-point facts (date, value, series, bounds, conf) | `apps/ios` VM, sourced from `packages/core` aggregates | Built by the descriptor adapter — see [ios-chart-descriptor-adapters.md](./ios-chart-descriptor-adapters.md)    |
+| Currency formatting of the announced value                           | `packages/core`                                        | `SwiftExportFormatterModule` in [`SwiftExportBridge.swift`](../../apps/ios/Finance/KMP/SwiftExportBridge.swift) |
+| Selection index + increment/decrement logic                          | `apps/ios`                                             | Trivial bounds-checked index; no shared logic needed                                                            |
+| Adjustable action, rotor, announcement wiring                        | `apps/ios`                                             | This document                                                                                                   |
+
+> **Boundary rule:** this layer adds **no** new platform-neutral logic. It
+> consumes already-bridged aggregates and the shared formatter. No `packages/`
+> edits; any future shared helper is an @kmp-engineer ADR.
+
+---
+
+## 4. Interaction Design
+
+Three complementary, gesture-free mechanisms, in priority order.
+
+### 4.1 Adjustable action (primary)
+
+Each chart container becomes a single **adjustable** accessibility element:
+
+- `.accessibilityElement(children: .contain)` on the chart (already present) plus
+  `.accessibilityAddTraits(.allowsDirectInteraction)` is **avoided** — instead the
+  container exposes `.accessibilityAdjustableAction { direction in … }`.
+- VoiceOver users swipe **up/down** (the standard "adjustable" gesture) to move
+  the selection `.increment` / `.decrement` by one data point.
+- `.accessibilityValue` reflects the current selection so VoiceOver reads it after
+  each adjustment (see [§5](#5-announcements)).
+- This is the same gesture users already know from sliders/steppers — no custom
+  training, no drag.
+
+```
+Chart (adjustable element)
+  swipe up   → selectedIndex += 1  → announce point
+  swipe down → selectedIndex -= 1  → announce point
+  value      → "Mar 2026, Net Worth $12,500"
+```
+
+### 4.2 Rotor (secondary, for "jump to")
+
+A custom `.accessibilityRotor` lets users jump to meaningful points without
+stepping through every one:
+
+| Rotor entry       | Jumps to                                               |
+| ----------------- | ------------------------------------------------------ |
+| "Highest"         | Max-value point (per visible series)                   |
+| "Lowest"          | Min-value point                                        |
+| "Latest"          | Most recent point                                      |
+| "Forecast"        | First predicted point (PredictionChart)                |
+| Per-month entries | Each month/slice by name (`AccessibilityRotorContent`) |
+
+The rotor is built from the descriptor's ordered points, so it stays in sync with
+the data and the table.
+
+### 4.3 Stepper fallback (tertiary, always-visible control)
+
+An **adjacent, non-gesture** `Stepper`/segmented control sits beside the chart for
+users who are not on VoiceOver but cannot drag (motor, Switch Control, external
+keyboard):
+
+- A SwiftUI `Stepper("Selected point", onIncrement:onDecrement:)` or
+  `Picker` of point labels, bound to the same `selectedIndex`.
+- Fully keyboard- and Switch-Control-operable; 44×44 pt minimum target
+  ([accessibility-patterns.md §8](./accessibility-patterns.md#8-touch-target-sizing)).
+- This control is the visible twin of the adjustable action — the
+  **adjacent non-gesture control** the descriptor-adapter doc also references.
+
+> The adjacent control and the adjustable action are bound to **one**
+> `selectedIndex` so the chart highlight, the spoken value, and the stepper never
+> disagree.
+
+### 4.4 Multi-series handling
+
+For `TrendChart` with >1 series, the adjustable action steps **dates**, and a
+secondary rotor (or the series control from
+[ios-chart-descriptor-adapters.md](./ios-chart-descriptor-adapters.md)) switches
+the **active series**. The announcement always names the series so the user never
+loses context.
+
+---
+
+## 5. Announcements
+
+On every selection change, VoiceOver must speak the **date, value, and
+series/forecast confidence**. Two mechanisms, chosen by source of change:
+
+1. **Adjustable action** → update `.accessibilityValue`; VoiceOver reads it
+   automatically (no manual post needed). This is the preferred path.
+2. **Stepper / rotor / programmatic jump** → post
+   `AccessibilityNotification.Announcement(text)` (polite) since the value change
+   originates outside the adjustable gesture.
+
+### Announcement grammar
+
+| Chart          | Spoken value template                                                           |
+| -------------- | ------------------------------------------------------------------------------- |
+| Trend (single) | `"{date}, {value}"` → "March 2026, $12,500"                                     |
+| Trend (multi)  | `"{date}, {series}, {value}"` → "March 2026, Net Worth, $12,500"                |
+| Prediction     | `"{date}, predicted {value}, range {low} to {high}, {conf} percent confidence"` |
+| Category donut | `"{category}, {value}, {pct} percent"` → "Food, $520, 28 percent"               |
+| Investment     | `"{date}, {value}"` → "March 3, $184.20"                                        |
+
+**Rules**
+
+- Values format through `SwiftExportFormatterModule.format(…)` — locale-correct,
+  signed; negatives say "negative"/"expense"
+  ([accessibility-patterns.md §7.1](./accessibility-patterns.md#71-currency-formatting-for-screen-readers)).
+- Announcements are **polite**, never assertive, so they don't interrupt the
+  user mid-gesture.
+- Confidence is spoken as a percentage word ("90 percent confidence"), never a
+  bare number or colour.
+- Edges: at the first/last point an `.decrement`/`.increment` past the end is a
+  no-op that re-announces the current point (no silent dead-end).
+
+---
+
+## 6. Accessibility
+
+| Requirement                      | Implementation                                                                                                  |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Gesture-free inspection          | `.accessibilityAdjustableAction` (swipe up/down) on the chart element                                           |
+| "Jump to" navigation             | `.accessibilityRotor` for highest/lowest/latest/forecast/per-month                                              |
+| Non-VoiceOver fallback           | Adjacent `Stepper`/`Picker` bound to the same `selectedIndex`, keyboard + Switch Control operable               |
+| Selection announced              | `.accessibilityValue` (adjustable path) or `AccessibilityNotification.Announcement` (programmatic path)         |
+| Audio graph (complementary)      | `.accessibilityChartDescriptor(…)` — see [ios-chart-descriptor-adapters.md](./ios-chart-descriptor-adapters.md) |
+| Text alternative (complementary) | Summary + table — see [ios-chart-summaries-data-tables.md](./ios-chart-summaries-data-tables.md)                |
+| Reduce Motion                    | Selection highlight transition skipped when `accessibilityReduceMotion` is on (charts already read it)          |
+| Hit targets                      | Stepper/segment controls ≥ 44×44 pt                                                                             |
+| Colour independence              | Selected point identity is spoken text, not just the highlight ring                                             |
+
+The drag overlay remains for pointer users but is marked
+`.accessibilityHidden(true)` (as the `RuleMark` already is in `TrendChart`), so it
+never competes with the adjustable element.
+
+---
+
+## 7. Dynamic Type
+
+- The adjacent stepper/picker labels use the `FinanceTextStyle` ramp /
+  `.financeFont()` and `@ScaledMetric` control sizing
+  ([accessibility-patterns.md §9.2](./accessibility-patterns.md#92-ios-swiftui)) —
+  no hardcoded sizes.
+- At accessibility text sizes the stepper row reflows via `AdaptiveFinanceStack`
+  (HStack → VStack) so the label and the ± controls don't clip.
+- Spoken announcements are size-independent, but the **visible** selected-value
+  caption (if shown) wraps and never truncates.
+
+---
+
+## 8. Privacy & Balance Hiding
+
+- When **balance-hiding / privacy mode** is on, the spoken `.accessibilityValue`
+  and any announcement redact the amount ("Hidden") — derived from the same
+  redacted descriptor used by the summary/table, so a hidden balance is never
+  spoken.
+- The selection date, series name, and confidence (non-monetary) may still be
+  announced; only monetary figures follow the redaction flag.
+- Amounts stay `.private` in `os.Logger`; selection changes are not logged with
+  values.
+- Rotor entries like "Highest"/"Lowest" still navigate, but the announced value is
+  redacted — position is not itself sensitive, the amount is.
+
+---
+
+## 9. Empty, Stale & Error States
+
+| State       | Adjustable action        | Stepper / rotor                     | Announcement                                                            |
+| ----------- | ------------------------ | ----------------------------------- | ----------------------------------------------------------------------- |
+| **Empty**   | Disabled (no points)     | Hidden                              | None; the empty summary element is focusable                            |
+| **Loading** | Disabled                 | Disabled                            | "Loading…" once (polite), via `ProgressView`                            |
+| **Stale**   | Enabled on cached points | Enabled                             | Selection value prefixed/suffixed "(as of {time})" once per chart focus |
+| **Error**   | Disabled                 | Replaced by labelled "Retry" button | Error announced; focus moves to Retry                                   |
+
+- Stale data reuses the sync/offline signal (`SwiftExportSyncModule`,
+  `OfflineBanner`); the user is told the inspected numbers may lag.
+- These mirror [data-visualization.md §7](./data-visualization.md#7-empty-loading--error-states)
+  and the companion states in
+  [ios-chart-summaries-data-tables.md §9](./ios-chart-summaries-data-tables.md#9-empty-stale--error-states).
+
+---
+
+## 10. Test Plan
+
+Smallest tests required before acceptance. Native UI tests run on Simulator with
+**free Personal Team signing** (see [Implementation readiness](#implementation-readiness)).
+
+### Native (iOS) — XCTest / Swift Testing in `apps/ios/Tests`
+
+- `ChartSelectionViewModelTests`: `increment`/`decrement` move `selectedIndex`
+  within bounds; past-end is a no-op that re-targets the same point; multi-series
+  series-switch keeps the date.
+- `ChartAdjustableValueTests`: for each chart family the computed
+  `accessibilityValue` matches the announcement grammar (single, multi, prediction
+  with confidence, donut with %).
+- `ChartRotorTests`: "Highest"/"Lowest"/"Latest"/"Forecast" resolve to the correct
+  indices for a fixed dataset, including ties.
+- `ChartNoDragInspectionUITests` (XCUITest, VoiceOver-style traversal): the chart
+  is reachable and adjustable **without** issuing a drag; swipe-up/down changes the
+  announced value; the adjacent stepper changes the same selection.
+- `ChartSelectionPrivacyTests`: with balance-hiding on, the adjustable value and
+  announcements contain no raw amount.
+- `ChartSelectionStateTests`: empty/loading/error disable the adjustable action and
+  expose the correct fallback (no value, or labelled Retry).
+
+### Shared (KMP) — none new
+
+Navigation adds no platform-neutral logic; it relies on the already-tested
+aggregator/formatter modules. (Any future shared "peaks" helper would be an
+@kmp-engineer ADR with its own `commonTest`.)
+
+---
+
+## Implementation readiness
+
+**Design: ready now. Native code: buildable now, distribution gated.**
+
+Per the
+[Human-Gated Prerequisites runbook](../ops/human-gated-prerequisites.md#2-implementation-vs-distribution--the-decoupling),
+implementation and distribution are decoupled. The "blocked by
+[#1239](https://github.com/jrmoulckers/finance/issues/1239)" note on
+[#2540](https://github.com/jrmoulckers/finance/issues/2540) is a **distribution**
+gate only.
+
+| Phase              | What                                                                             | Gated by #1239?                         |
+| ------------------ | -------------------------------------------------------------------------------- | --------------------------------------- |
+| **Design**         | This document, interaction model, announcement grammar, test plan                | No — deliverable now                    |
+| **Implementation** | Adjustable action, rotor, adjacent stepper, announcements, XCUITest on Simulator | **No** — free Personal Team signing     |
+| **Distribution**   | TestFlight / App Store build carrying the feature                                | **Yes** — Apple Developer Program enrol |
+
+- **Buildable now:** `accessibilityAdjustableAction`, `accessibilityRotor`,
+  `AccessibilityNotification.Announcement`, and the adjacent stepper are all
+  standard SwiftUI iOS 17 APIs with no paid entitlement; they run on Simulator and
+  on a device via free Personal Team signing.
+- **Gated tail (#1239):** only store/TestFlight distribution needs the paid
+  enrollment + signing material in
+  [human-gated-prerequisites.md §3.2](../ops/human-gated-prerequisites.md#32-ios-distribution--apple-developer-1239).
+  An SME agent must **not** perform enrollment, certificate, or secret steps.
+
+_Part of [#2115](https://github.com/jrmoulckers/finance/issues/2115). Sibling
+designs: [summaries & data tables](./ios-chart-summaries-data-tables.md) ·
+[descriptor adapters](./ios-chart-descriptor-adapters.md)._


### PR DESCRIPTION
## Summary

Adds **three cohesive iOS design docs** for the chart-accessibility cluster
(_part of #2113 / #2115_). Design deliverables only — no native build/signing.
Native implementation is unblocked (buildable now via free Personal Team
signing); only the App Store distribution tail is gated by #1239, per
[`docs/ops/human-gated-prerequisites.md`](docs/ops/human-gated-prerequisites.md).

Closes #2534
Closes #2540
Closes #2542

## Changes

- `docs/design/ios-chart-summaries-data-tables.md` (**#2534**) — reusable
  spoken-summary + table/list alternative pattern for Insights, Analytics,
  TrendChart, PredictionChart, and category breakdown. Generalises the existing
  `reportDataTable` pattern; defines summary grammar and swipe order
  (summary → chart → table).
- `docs/design/ios-chart-voiceover-navigation.md` (**#2540**) — gesture-free
  inspection via `accessibilityAdjustableAction`, a rotor "jump to" set, and an
  adjacent stepper fallback; announcement grammar for date/value/series and
  forecast confidence. Replaces the drag-only overlay for VoiceOver users.
- `docs/design/ios-chart-descriptor-adapters.md` (**#2542**) — a single
  `ChartAccessibilityDescriptor` view-model that maps shared series →
  `AXChartDescriptor` (audio graph) and drives the adjacent non-gesture controls,
  keeping summary, table, audio graph, and selection consistent.

All three cross-link each other and ground in existing
[`data-visualization.md`](docs/design/data-visualization.md),
[`chart-component-specs.md`](docs/design/chart-component-specs.md),
[`accessibility-patterns.md`](docs/design/accessibility-patterns.md), and the
`apps/ios/Finance/Charts` + `Screens` chart code. Each doc covers the iOS/KMP
boundary (platform-neutral series data in `packages/core`/`packages/models`;
Swift Charts + a11y semantics in `apps/ios`), VoiceOver + audio graph, Dynamic
Type, privacy/balance-hiding, empty/stale/error states, a smallest-tests plan,
and an Implementation-readiness section.

## Testing

- `npx prettier --write` then `--check` on all three docs — **all pass**.
- Docs-only change; no code, no `packages/`, no shared config, no other
  platforms touched. No native build or signing performed (none required for
  design deliverables).

## Boundaries / human-gated

- No KMP/`packages/` edits — shared-logic additions are noted as ADR proposals
  to @kmp-engineer.
- No provisioning, signing, secrets, or App Store actions. The #1239 gate
  applies only to distribution, which is out of scope here.
