### PR TITLE
docs(design): ios transaction quick-capture design batch (#2599, #2608, #2603)

### DIFF
--- a/docs/design/ios-compact-transaction-stepper.md
+++ b/docs/design/ios-compact-transaction-stepper.md
@@ -1,0 +1,316 @@
+# Compact Transaction-Create Stepper — iOS
+
+> Design specification for how the multi-step `Type → Details → Review`
+> transaction-create flow adapts on **small screens** (iPhone SE, 320–375pt
+> width) and at **large Dynamic Type / accessibility sizes**. It defines a
+> collapsing step indicator, content-priority rules for the Details step, and a
+> strict invariant: the visual collapse must **never** change the VoiceOver,
+> Switch Control, or validation semantics of the underlying flow.
+
+**Status:** Design (implementation-ready) · pre-implementation
+**Issue:** [#2608](https://github.com/jrmoulckers/finance/issues/2608) — Compact transaction-create stepper and entry flow for iOS
+**Part of:** [#2190](https://github.com/jrmoulckers/finance/issues/2190)
+**Platforms:** iOS · iPadOS · macOS (SwiftUI)
+**WCAG target:** 2.2 Level AA — SC 1.4.4 Resize Text, SC 1.4.10 Reflow, SC 1.3.1 Info & Relationships, SC 2.5.5 Target Size
+**Related:** [responsive-breakpoints.md](./responsive-breakpoints.md) · [accessibility-patterns.md](./accessibility-patterns.md) · [cognitive-accessibility.md](./cognitive-accessibility.md) · [ios-one-thumb-quick-add.md](./ios-one-thumb-quick-add.md) · [ios-wallet-adjacent-capture-inbox.md](./ios-wallet-adjacent-capture-inbox.md) · [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md)
+
+---
+
+## Table of Contents
+
+1. [Problem & Goals](#1-problem--goals)
+2. [Adaptation Triggers](#2-adaptation-triggers)
+3. [Step Indicator: Full → Compact → Minimal](#3-step-indicator-full--compact--minimal)
+4. [Content Priorities on the Details Step](#4-content-priorities-on-the-details-step)
+5. [Affected iOS Surfaces](#5-affected-ios-surfaces)
+6. [Shared Dependencies & the Validation Boundary](#6-shared-dependencies--the-validation-boundary)
+7. [Accessibility, Dynamic Type & Reachability](#7-accessibility-dynamic-type--reachability)
+8. [Privacy](#8-privacy)
+9. [Stale, Error & Empty States](#9-stale-error--empty-states)
+10. [Test Plan](#10-test-plan)
+11. [Implementation Readiness](#11-implementation-readiness)
+12. [Open Questions](#12-open-questions)
+
+---
+
+## 1. Problem & Goals
+
+`apps/ios/Finance/Screens/TransactionCreateView.swift` renders a three-step
+wizard with a horizontal step indicator (`stepIndicator`): three labeled dots
+(`Type`, `Details`, `Review`) joined by connector lines, each in an
+`.frame(maxWidth: .infinity)` column. This layout is fine on a 390pt+ screen at
+default text size, but it breaks down in two directions:
+
+- **Small width (iPhone SE, 320–375pt).** Three equal columns with `.caption2`
+  labels plus connectors leave very little room; the Details `Form` then stacks
+  Amount keypad + Payee + Account + Category + Status + BNPL + Tags + Mood +
+  Date + Note, forcing heavy scrolling before the user reaches the `Next`
+  button.
+- **Large Dynamic Type (AX1–AX5).** The fixed 12pt dots and `.caption2` labels
+  don't scale with text; meanwhile the labels themselves grow and **truncate or
+  collide** with the connector lines, and the Details form's section density
+  becomes overwhelming.
+
+**Goals**
+
+1. **A step indicator that degrades gracefully** from full (dots + labels +
+   connectors) to compact (progress bar + "Step 2 of 3 · Details") to minimal
+   (current step label only), chosen by available width and text size.
+2. **Content priority** on the dense Details step: always show amount + the
+   required fields; progressively disclose the optional ones.
+3. **Semantic invariance.** Whatever the visual form, assistive technology and
+   the shared validator see the same three-step model with the same gating.
+
+**Non-goals.** This design does not add or remove steps, does not change which
+fields are required (that is shared validation), and does not redesign the
+express one-thumb path (see [ios-one-thumb-quick-add.md](./ios-one-thumb-quick-add.md)).
+It governs how the **existing** wizard reflows.
+
+---
+
+## 2. Adaptation Triggers
+
+Selection is driven by SwiftUI environment values, not device model checks:
+
+| Input                 | API                                         | Used for                                    |
+| --------------------- | ------------------------------------------- | ------------------------------------------- |
+| Available width       | `GeometryReader` / `ViewThatFits`           | Full vs. compact indicator; chip wrapping   |
+| Text size             | `@Environment(\.dynamicTypeSize)`           | Collapse to compact at `>= .accessibility1` |
+| Horizontal size class | `@Environment(\.horizontalSizeClass)`       | Regular (iPad/Mac) keeps full indicator     |
+| Reduce Motion         | `@Environment(\.accessibilityReduceMotion)` | Cross-fade vs. animate step transitions     |
+
+**Primary rule:** prefer `ViewThatFits` to let the layout pick the richest
+indicator that fits the current width _and_ text size, with an explicit
+Dynamic-Type override so accessibility sizes force the compact form even when
+width alone would allow the full one. Avoid hardcoded screen-width breakpoints;
+align thresholds with [responsive-breakpoints.md](./responsive-breakpoints.md).
+
+---
+
+## 3. Step Indicator: Full → Compact → Minimal
+
+Three presentations of the **same** `TransactionCreateViewModel.Step` model:
+
+### Full (default — regular width, ≤ `.xxLarge`)
+
+The existing design: three dots, per-step labels, connector lines, checkmark on
+completed steps. Unchanged.
+
+### Compact (narrow width OR `>= .accessibility1`)
+
+- A single full-width **segmented progress bar** (3 segments; filled up to and
+  including the current step).
+- One line of text beneath: **"Step 2 of 3 · Details"** using `.subheadline`,
+  wrapping (never truncating) the step title.
+- No per-step labels, no checkmark glyph clutter — completion is conveyed by the
+  filled segments and the "2 of 3" count.
+
+### Minimal (extreme: very narrow AND `>= .accessibility3`)
+
+- Drop the segmented bar to a thin determinate `ProgressView(value:)`.
+- Keep only **"Step 2 of 3 · Details"** as the heading, styled as a section
+  header so it remains a VoiceOver heading and a Dynamic-Type anchor.
+
+```mermaid
+flowchart LR
+    A["Full
+    dots + labels + connectors"] -->|narrow OR AX1| B["Compact
+    segmented bar + 'Step 2 of 3 · Details'"]
+    B -->|very narrow AND AX3| C["Minimal
+    thin progress + heading text"]
+```
+
+**Invariant (all three):** the indicator is one combined accessibility element
+whose label is **"Step 2 of 3, Details, current step"** and whose value tracks
+progress — identical to today's
+`accessibilityLabel("Step \(n): \(title)")` + `accessibilityValue("Current
+step")`. The visual collapse changes pixels only; VoiceOver output is constant.
+
+---
+
+## 4. Content Priorities on the Details Step
+
+The Details `Form` is the densest screen. Define a priority order and disclose
+by priority when space/text-size is constrained:
+
+| Priority      | Fields                                     | Behavior when compact                                                  |
+| ------------- | ------------------------------------------ | ---------------------------------------------------------------------- |
+| **P0 always** | Amount (keypad), Account                   | Always visible, top of form; these back the shared required-field gate |
+| **P1 high**   | Payee, Category                            | Visible; Category shows the engine suggestion inline                   |
+| **P2 medium** | Date, Status                               | Visible but below P1                                                   |
+| **P3 low**    | Tags, Note                                 | Collapsed into a **"More details"** `DisclosureGroup`, expanded off    |
+| **P4 niche**  | BNPL liability, Mood tag (feature-flagged) | Inside "More details"; Mood only when `moodTagsEnabled`                |
+
+Rules:
+
+- On small width / large type, P3–P4 start **collapsed** so the user reaches the
+  `Next`/`Save` button with minimal scrolling; on regular width they may stay
+  expanded.
+- The amount keypad's 3-column `LazyVGrid` keys grow with Dynamic Type while
+  keeping ≥ 44×44pt targets; if width is too small for three comfortable
+  columns, key spacing tightens before key size drops below the minimum target.
+- "More details" remembers its expanded/collapsed state within the session so a
+  power user isn't forced to re-open it on every step return.
+- The Review step is unaffected in field set but uses the same compact indicator;
+  long summaries wrap rather than truncate.
+
+---
+
+## 5. Affected iOS Surfaces
+
+| Surface                                                        | Change                                                                                             |
+| -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `apps/ios/Finance/Screens/TransactionCreateView.swift`         | `stepIndicator` becomes adaptive (Full/Compact/Minimal via `ViewThatFits` + env); P3–P4 disclosure |
+| **New** `apps/ios/Finance/Components/StepIndicator.swift`      | Extracted, reusable adaptive indicator with the fixed accessibility contract                       |
+| `apps/ios/Finance/ViewModels/TransactionCreateViewModel.swift` | No rule change; may expose a `progress` convenience (`currentStep / stepCount`)                    |
+| `apps/ios/Finance/Screens/QuickAddView.swift` (from #2599)     | Reuses `StepIndicator` when the express sheet expands to full form                                 |
+| `apps/ios/Tests/TransactionCreateViewModelTests.swift`         | Add `canAdvance`/progress assertions per step                                                      |
+| **New** `apps/ios/Tests/StepIndicatorSnapshotTests.swift`      | Snapshot the three presentations across size classes / Dynamic Type                                |
+
+---
+
+## 6. Shared Dependencies & the Validation Boundary
+
+- **Step count, order, and labels are pure iOS presentation.** The
+  `TransactionCreateViewModel.Step` enum (`type/details/review`) is a SwiftUI
+  wizard construct and stays in `apps/ios`. Collapsing the indicator is a layout
+  decision with no shared counterpart.
+- **What is required at each step comes from shared rules.** `canAdvance` and the
+  final save gate defer to `TransactionValidator`
+  (`packages/core/src/.../validation/TransactionValidator.kt`) via
+  `KMPTransactionValidatorProtocol`: the Details step's "Amount + Account
+  required" mirrors `ZeroAmount` / `AccountNotFound`, and Category remains
+  optional because the shared model permits a null category. Content-priority
+  P0/P1 buckets are chosen to match those shared requirements, so the visual
+  collapse never hides a field the validator requires without surfacing it.
+- **No `packages/` change is needed.** If future work wanted the step model
+  itself to be shared/driven by KMP (e.g. cross-platform wizard config), that is
+  an ADR to `@kmp-engineer` — explicitly out of scope. Boundary: **rules in KMP,
+  reflow in SwiftUI.**
+
+---
+
+## 7. Accessibility, Dynamic Type & Reachability
+
+- **Dynamic Type is the headline requirement.** No hardcoded sizes for indicator
+  labels or step text; the current 12pt dots / `.caption2` labels are replaced
+  by scalable styles (`.subheadline`, section-header for minimal). The indicator
+  must remain legible and uncollided from `.xSmall` through `.accessibility5` —
+  this is the core acceptance bar for #2608.
+- **Reflow (SC 1.4.10).** Content reflows without horizontal scrolling at 200%
+  text; the connector-line layout that overflows today is exactly what the
+  compact/minimal forms fix.
+- **Stable VoiceOver semantics.** As stated in §3, the combined accessibility
+  element and its label/value are identical across all three visual forms;
+  collapsing must not drop the "Step N of 3" information (SC 1.3.1).
+- **Switch Control / focus order.** Focus order is indicator (heading) → step
+  content (top to bottom by priority) → bottom bar (`Back`/`Next`/`Save`). The
+  "More details" disclosure is focusable and announces expanded/collapsed.
+- **Reachability.** The `Back`/`Next`/`Save` bottom bar already sits in the thumb
+  zone; the compact indicator frees vertical space so required fields are closer
+  to it, reducing one-handed scrolling on small phones.
+- **Reduce Motion.** Step transitions and indicator fills cross-fade instead of
+  sliding/animating when Reduce Motion is on.
+
+---
+
+## 8. Privacy
+
+- The step indicator and reflow logic handle **no financial values** — they
+  arrange chrome, not data. The amount appears only within the Details/Review
+  content, governed by the same `.private` logging policy as the rest of the
+  flow.
+- No new persistence is introduced; "More details" expansion state is transient
+  session UI state, not stored, and certainly never written to the Keychain or
+  synced.
+- No screenshots, analytics, or logs should capture the rendered amount as part
+  of layout instrumentation; any layout telemetry stays structural (which form
+  was chosen), never value-bearing.
+
+---
+
+## 9. Stale, Error & Empty States
+
+- **Validation error while collapsed.** When a step can't advance, the inline
+  error must name the offending step/field even though per-step labels are
+  hidden — e.g. "Step 2 (Details): enter an amount". The error text is the
+  message returned by `TransactionValidator`, surfaced near the bottom bar where
+  the user's attention (and thumb) already is.
+- **Empty pickers.** If accounts/categories haven't loaded, the P0 Account
+  picker shows the existing "Select Account" prompt and `Next` stays disabled —
+  unchanged behavior, just within the compact layout.
+- **Stale layout.** Rotating, entering Split View/Stage Manager, or changing the
+  system text size mid-flow must re-evaluate the trigger and swap presentation
+  without losing field state — the indicator is derived state, the field values
+  live in the view model.
+- **Review step with sparse data.** Optional fields omitted from the summary
+  (already the behavior) simply don't render; the compact indicator still reads
+  "Step 3 of 3 · Review".
+
+---
+
+## 10. Test Plan
+
+### 10.1 Shared (Kotlin · `packages/core` · `commonTest`)
+
+- `TransactionValidatorTest`: amount + account required, category optional —
+  confirms the requirement set the P0/P1 content priorities are built around
+  (so a collapsed layout can't hide a truly required field).
+
+### 10.2 Native (Swift · iOS Simulator · XCTest)
+
+- `StepIndicatorSnapshotTests` (new): render Full / Compact / Minimal across
+  - widths: iPhone SE (375pt) and a Pro Max,
+  - Dynamic Type: `.large`, `.accessibility1`, `.accessibility5`,
+  - light + OLED dark,
+    asserting no truncation/collision and that the correct form is chosen.
+- `StepIndicatorAccessibilityTests` (new): assert the combined element's
+  `accessibilityLabel` is "Step N of 3, <Title>, current step" **identically**
+  in all three visual forms.
+- `TransactionCreateViewModelTests` (extend
+  `apps/ios/Tests/TransactionCreateViewModelTests.swift`): `canAdvance` is
+  `false` on Details until amount + account set; `progress` equals
+  `currentStep+1 / stepCount`.
+- A Details-step snapshot at `.accessibility3` asserting P3–P4 ("More details")
+  start collapsed and `Next` is reachable with minimal scrolling.
+
+### 10.3 Manual / QA gate (every UI PR)
+
+- iPhone SE at AX5: walk Type → Details → Review; verify indicator is legible,
+  uncollided, and required fields reach the bottom bar without long scrolls.
+- VoiceOver: confirm "Step 2 of 3, Details" is announced in every visual form.
+- Rotate / resize mid-flow: field state preserved, presentation re-chosen.
+
+---
+
+## 11. Implementation Readiness
+
+### ✅ Buildable now — no enrollment required
+
+The adaptive `StepIndicator`, the Details content-priority disclosure, and all
+snapshot/accessibility/view-model tests are pure SwiftUI + existing shared
+validation reached through `KMPBridge`. They build and run today on device or
+simulator under **free Personal Team signing**. There are no new entitlements,
+no networking, and no `packages/` changes — this is among the most
+straightforwardly implementable items in the cluster.
+
+### 🔒 Distribution tail — gated by [#1239](https://github.com/jrmoulckers/finance/issues/1239) (human action)
+
+Only TestFlight/App Store distribution, release signing, and CI release
+workflows are human-gated by Apple Developer Program enrollment, per
+[Human-Gated Prerequisites](../ops/human-gated-prerequisites.md) §2.
+Implementation and local verification are **not** blocked. No provisioning,
+certificates, or secrets are created here.
+
+---
+
+## 12. Open Questions
+
+1. Should the Full→Compact threshold be derived purely from `ViewThatFits`, or
+   pinned to a named breakpoint in
+   [responsive-breakpoints.md](./responsive-breakpoints.md) for cross-surface
+   consistency? Proposal: `ViewThatFits` with a Dynamic-Type override floor.
+2. Should "More details" expansion state persist across sessions (UserDefaults)
+   rather than per-session? Leaning per-session to avoid surprising defaults.
+3. Is the Minimal tier ever reached in practice, or does Compact + reflow cover
+   AX5 on the smallest supported device? Validate with the SE/AX5 snapshot.

--- a/docs/design/ios-one-thumb-quick-add.md
+++ b/docs/design/ios-one-thumb-quick-add.md
@@ -1,0 +1,406 @@
+# One-Thumb Quick-Add Transaction Entry — iOS
+
+> Design specification for a fast, one-handed "quick-add" transaction entry on
+> the **Transactions** tab: a thumb-reachable capture affordance, a
+> bottom-anchored sheet that opens straight to the amount keypad, remembered
+> defaults (account, type, category), optional payee skipping, and a low-effort
+> save confirmation with undo. The goal is _amount → save_ in a single thumb
+> arc, without sacrificing accessibility, privacy, or the shared validation
+> contract.
+
+**Status:** Design (implementation-ready) · pre-implementation
+**Issue:** [#2599](https://github.com/jrmoulckers/finance/issues/2599) — In-app one-thumb quick-add entry design for iOS
+**Part of:** [#2167](https://github.com/jrmoulckers/finance/issues/2167)
+**Platforms:** iOS · iPadOS · macOS (SwiftUI) — with hooks for App Clip and Lock Screen widget quick entry
+**WCAG target:** 2.2 Level AA — SC 2.5.5 Target Size, SC 2.5.1 Pointer Gestures, SC 1.4.4 Resize Text
+**Related:** [accessibility-patterns.md](./accessibility-patterns.md) · [cognitive-accessibility.md](./cognitive-accessibility.md) · [ux-principles.md](./ux-principles.md) · [responsive-breakpoints.md](./responsive-breakpoints.md) · [ios-compact-transaction-stepper.md](./ios-compact-transaction-stepper.md) · [ios-wallet-adjacent-capture-inbox.md](./ios-wallet-adjacent-capture-inbox.md) · [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md)
+
+---
+
+## Table of Contents
+
+1. [Problem & Goals](#1-problem--goals)
+2. [The One-Thumb Flow](#2-the-one-thumb-flow)
+3. [Transactions Tab Affordance](#3-transactions-tab-affordance)
+4. [The Quick-Add Bottom Sheet](#4-the-quick-add-bottom-sheet)
+5. [Remembered Defaults & Optional Payee](#5-remembered-defaults--optional-payee)
+6. [Save Confirmation & Undo](#6-save-confirmation--undo)
+7. [Affected iOS Surfaces](#7-affected-ios-surfaces)
+8. [Shared Dependencies & the Validation Boundary](#8-shared-dependencies--the-validation-boundary)
+9. [Accessibility, Dynamic Type & Reachability](#9-accessibility-dynamic-type--reachability)
+10. [Privacy](#10-privacy)
+11. [Stale, Error & Empty States](#11-stale-error--empty-states)
+12. [Test Plan](#12-test-plan)
+13. [Implementation Readiness](#13-implementation-readiness)
+14. [Open Questions](#14-open-questions)
+
+---
+
+## 1. Problem & Goals
+
+Today the only way to add a transaction from the **Transactions** tab is the
+`Add transaction` menu anchored in the **top-trailing toolbar** of
+`apps/ios/Finance/Screens/TransactionsView.swift`. On a 6.1"+ phone held in one
+hand, that target sits outside the comfortable thumb arc, and the resulting
+`TransactionCreateView` is a three-step `Type → Details → Review` wizard
+(`apps/ios/Finance/Screens/TransactionCreateView.swift`) that requires several
+deliberate taps before a value is even entered. For the dominant use case —
+"I just spent $4.50 on coffee, log it before I forget" — this is too much
+ceremony.
+
+The infrastructure for fast entry already exists but is fragmented:
+
+- A Venmo-style cents-first digit pad lives in `TransactionCreateViewModel`
+  (`amountCents`, `appendAmountDigit`, `formattedAmount`).
+- `applyQuickEntry(action:)` can pre-seed payee/category for a named shortcut
+  (`lunch`, `coffee`, `groceries`, `gas`).
+- The Lock Screen `QuickEntryWidget` and `DeepLinkHandler` already route into a
+  biometric-gated create sheet.
+- The App Clip `QuickTransactionView` already proves a single-screen
+  amount-first capture pattern.
+
+**Goals**
+
+1. **One thumb, one screen, two seconds.** Put a capture affordance in the
+   bottom thumb arc and open straight to the amount keypad.
+2. **Remember the boring parts.** Default the account, type, and category to the
+   user's recent behavior so only the amount changes between captures.
+3. **Make payee optional.** Allow save without a payee, deriving a sensible
+   label from the category (mirroring `AddExpenseIntent`'s
+   `resolvedPayee = payee ?? category.categoryName`).
+4. **Confirm without blocking.** A haptic + inline confirmation with **Undo**,
+   not a modal that interrupts the next capture.
+
+**Non-goals.** This design does not replace the full `Type → Details → Review`
+wizard (kept for complex entries — transfers, BNPL, tags, mood) and does not
+change shared business rules. It is an _express lane_ that composes the same
+view model and the same KMP validator.
+
+---
+
+## 2. The One-Thumb Flow
+
+```mermaid
+flowchart TD
+    A[Transactions tab] -->|tap bottom Quick Add| B[Quick-Add sheet
+    opens at .medium detent
+    amount keypad focused]
+    B -->|type digits| C[Amount shows Venmo-style]
+    C -->|defaults already filled| D{Need to change
+    account / category / payee?}
+    D -->|no| E[Save]
+    D -->|yes, tap chip| F[Inline pickers / payee field]
+    F --> E
+    E -->|success haptic| G[Inline confirmation toast + Undo]
+    G -->|auto-dismiss 4s| A
+    G -->|Undo| H[Soft-delete draft, reopen sheet]
+    E -->|need full options| I[Expand → full Type/Details/Review wizard]
+```
+
+Every primary control in the flow (keypad, default chips, Save, Undo) sits in
+the lower half of the screen. "Expand to full form" is the documented escape
+hatch to the existing wizard and to the compact-stepper behavior specified in
+[ios-compact-transaction-stepper.md](./ios-compact-transaction-stepper.md).
+
+---
+
+## 3. Transactions Tab Affordance
+
+**Decision: a bottom-trailing floating capture button**, layered above the list
+within `TransactionsView`, in addition to (not replacing) the existing toolbar
+menu.
+
+- **Placement.** Bottom-trailing, inset 16pt from the trailing and bottom safe
+  areas, so it rests inside the right-hand thumb arc for the majority of users
+  while staying clear of the home indicator and the tab bar. A left-handed
+  accommodation is covered in §9.
+- **Form.** A 56×56pt circular button using the shared `IconView(.add)` token
+  (consistent with the toolbar `add` icon already used in `TransactionsView`),
+  with a subtle shadow and `.fill` material background so it reads on both light
+  and OLED dark backgrounds.
+- **Single tap** opens the Quick-Add sheet (§4). **Long-press / context menu**
+  exposes the named shortcuts already modeled by `QuickEntryShortcut`
+  (`Log coffee`, `Log lunch`, `Log groceries`, `Log gas`) and a "Full form…"
+  item that opens the existing wizard.
+- **Coexistence.** The top-trailing `Add transaction` menu stays for
+  discoverability, pointer/keyboard users, and the `Quick Add (NLP)` entry into
+  `NlpInputView`. The floating button is purely a reachability addition.
+- **iPad / Mac.** On regular width the floating button is suppressed in favor of
+  the toolbar affordance and a keyboard shortcut (`⌘N`), because thumb
+  reachability is not the constraint there.
+
+The button must not obscure the last row of the list; the `List` gains a
+bottom content inset equal to the button height + inset so pull-to-refresh and
+the final transaction stay tappable.
+
+---
+
+## 4. The Quick-Add Bottom Sheet
+
+A dedicated `QuickAddView` presented with `.sheet`, distinct from
+`TransactionCreateView` but driven by the **same** `TransactionCreateViewModel`
+seeded into a new "quick" mode (so validation, persistence, and the
+categorization engine are shared, not duplicated).
+
+- **Detents.** `.presentationDetents([.medium, .large])` with
+  `.presentationDragIndicator(.visible)`. It opens at `.medium`; dragging to
+  `.large` reveals the optional fields. `.presentationBackgroundInteraction` is
+  disabled so the list underneath cannot steal focus.
+- **Layout, top to bottom (essentials only at `.medium`):**
+  1. **Amount display** — large monospaced-digit currency, reusing
+     `formattedAmount` + the currency symbol logic already in
+     `TransactionCreateView`.
+  2. **Default chips row** — Account · Category · Type, each a tappable chip
+     pre-filled from remembered defaults (§5). Tapping a chip reveals an inline
+     `Menu`/`Picker`, never a full push navigation.
+  3. **Venmo-style digit pad** — the existing 3-column `LazyVGrid` keypad
+     (`1–9`, `0`, `⌫`) bound to `appendAmountDigit` / `removeLastAmountDigit`,
+     anchored at the bottom so all keys are thumb-reachable.
+  4. **Save** — full-width `borderedProminent` button pinned to the bottom,
+     above the home indicator.
+- **Optional payee** is a single collapsed field directly under the chips;
+  empty is allowed (§5).
+- **Expand affordance.** Dragging to `.large` (or a "More options" disclosure)
+  surfaces date, note, status, tags, BNPL, and mood — the same `Form` sections
+  as the wizard's Details step — without navigating away.
+- **Keypad ≠ system keyboard.** The cents-first pad means no decimal point and
+  no system keyboard for the amount, keeping the whole interaction in the thumb
+  zone. The payee field still uses the system keyboard when tapped.
+
+---
+
+## 5. Remembered Defaults & Optional Payee
+
+**Remembered defaults** make repeat capture near-instant:
+
+| Default              | Source of "remembered" value                                                                 | Storage                                                  |
+| -------------------- | -------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| Transaction **type** | Last saved type, falling back to `.expense`                                                  | `UserDefaults` (App Group) — non-sensitive preference    |
+| **Account**          | Most-recently-used account id; else the first account from `AccountRepository.getAccounts()` | `UserDefaults` (App Group) — id only, not balances       |
+| **Category**         | `CategorizationEngine.suggest(payee:)` once a payee is typed; else last-used category id     | Suggestion is shared (KMP); last-used id in UserDefaults |
+| **Currency**         | Account's currency, else `USD`                                                               | Derived, not stored separately                           |
+
+Rules:
+
+- Remembered values are **preferences, not secrets** — account/category **ids**
+  and an enum, never amounts, payees, balances, or tokens. They therefore live
+  in App Group `UserDefaults` (shared with the widget/clip), **never** the
+  Keychain (the Keychain remains reserved for credentials per project policy).
+- Defaults are applied at sheet construction so the user lands on a fully valid
+  draft that needs only an amount.
+- Editing a default chip updates the remembered value for next time.
+
+**Optional payee skipping:**
+
+- The current iOS form over-constrains entry: `canAdvance` for the Details step
+  requires `!payee.isEmpty`. The **shared** contract is more permissive —
+  `KMPTransaction.payee` is nullable and `TransactionValidator` does not require
+  a payee. Quick-Add aligns the iOS rule with the shared rule.
+- When payee is empty on save, derive a display label from the chosen category
+  (e.g. "Dining Out") exactly as `AddExpenseIntent` already does, so the saved
+  record is never blank in the list. This derivation is an **iOS presentation
+  concern** and stays in the view model.
+- Save remains gated on the genuinely required fields: `amountCents > 0` and a
+  selected account — both already enforced by `TransactionValidator`
+  (`ZeroAmount`, `AccountNotFound`).
+
+---
+
+## 6. Save Confirmation & Undo
+
+Confirmation must reassure without blocking the next capture.
+
+- **On success:** fire `HapticManager.shared.transactionSaved()` (already wired
+  in the wizard), dismiss the sheet, and present a **non-modal inline
+  confirmation** anchored at the bottom of the Transactions tab: a checkmark +
+  "Saved" + an **Undo** action, auto-dismissing after ~4 seconds.
+- **Undo** soft-deletes the just-saved transaction through
+  `TransactionRepository` and reopens the Quick-Add sheet pre-filled with the
+  prior values, so a misfire costs one tap to recover.
+- **On validation failure:** fire `HapticManager.shared.validationWarning()` and
+  show the message **inline within the sheet** (not the wizard's separate
+  `.alert`), keeping the user in the keypad context.
+- The confirmation deliberately avoids announcing the **amount** in a persistent
+  on-screen banner (see §10) — it confirms _that_ a save happened, while
+  VoiceOver users get the amount through the focused element, not a broadcast.
+
+---
+
+## 7. Affected iOS Surfaces
+
+| Surface                                                        | Change                                                                                            |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `apps/ios/Finance/Screens/TransactionsView.swift`              | Add bottom-trailing floating capture button (compact width only), bottom content inset, new sheet |
+| `apps/ios/Finance/Screens/TransactionCreateView.swift`         | Extract shared step components; add an "Expand to full form" entry path from Quick-Add            |
+| **New** `apps/ios/Finance/Screens/QuickAddView.swift`          | Bottom-sheet express entry: amount, default chips, keypad, optional payee, Save                   |
+| `apps/ios/Finance/ViewModels/TransactionCreateViewModel.swift` | Add quick mode, remembered-defaults load/persist, payee-derivation, `canSaveQuick` gate           |
+| `apps/ios/Finance/Components/` (Haptics, IconView, chips)      | Reuse existing `HapticManager`, `IconView`, tag/chip components                                   |
+| `apps/ios/FinanceWidget/QuickEntryWidget.swift`                | No change to the widget; Quick-Add becomes the destination for its deep link                      |
+| `apps/ios/FinanceClip/QuickTransactionView.swift`              | Aligns conceptually; no code change — the clip remains the reduced standalone capture             |
+| `apps/ios/Tests/TransactionCreateViewModelTests.swift`         | Extend for quick mode, defaults, optional payee, undo                                             |
+
+---
+
+## 8. Shared Dependencies & the Validation Boundary
+
+The boundary is deliberate and **unchanged** by this design:
+
+- **Shared (Kotlin, `packages/core` / `packages/models`) owns the rules.**
+  - `packages/core/src/.../validation/TransactionValidator.kt` is the single
+    source of truth for what makes a transaction savable (non-zero amount,
+    existing account, optional category, future-date bounds). Quick-Add calls it
+    through `KMPTransactionValidatorProtocol` exactly as the wizard does.
+  - `packages/core/src/.../categorization/CategorizationEngine.kt` provides
+    `suggest(payee:)` and `learnFromHistory(payee:categoryId:)` — the source of
+    the remembered/suggested category.
+  - `packages/models/.../models/Transaction.kt` defines the draft shape; payee
+    nullability there is what _permits_ optional-payee entry.
+- **iOS owns presentation only:** sheet layout, detents, the floating affordance,
+  thumb-reachability, default-chip UI, payee-from-category display derivation,
+  haptics, and the confirmation/undo UX.
+
+This design requires **no change to `packages/`**. If a future iteration wants
+"remembered defaults" computed from shared history (rather than an iOS-local
+preference), that would be a shared-logic change proposed to `@kmp-engineer` via
+ADR — out of scope here. The boundary stays: **rules in KMP, pixels in SwiftUI.**
+
+---
+
+## 9. Accessibility, Dynamic Type & Reachability
+
+- **VoiceOver.** Every interactive element gets an explicit label/hint following
+  the patterns already in `TransactionCreateView`:
+  - Floating button: `accessibilityLabel("Quick add transaction")`,
+    `accessibilityHint("Opens the quick entry sheet")`.
+  - Each keypad key keeps its existing per-digit label and `⌫` "Delete" label.
+  - Default chips combine into `"Account: Checking, double-tap to change"`.
+  - The confirmation exposes an Undo action via `.accessibilityAction`.
+- **One-handed reachability beyond placement.** The bottom-trailing position
+  helps right thumbs; we additionally:
+  - Respect the system **Reachability** gesture (no custom interception).
+  - Keep _all_ required controls within the `.medium` detent so a user never has
+    to stretch to the top of the screen to complete a save.
+  - Offer a setting (or honor layout direction) so the button mirrors to
+    bottom-_leading_ for left-handed/RTL users.
+- **Dynamic Type.** No hardcoded font sizes for text; amount uses
+  `.monospacedDigit()` title styles that scale. At accessibility sizes the
+  keypad keys grow and the chips wrap (defer detailed thresholds to
+  [ios-compact-transaction-stepper.md](./ios-compact-transaction-stepper.md)).
+  Tap targets stay ≥ 44×44pt.
+- **Reduce Motion.** The sheet present/expand and the confirmation toast use
+  the system sheet transition; when Reduce Motion is on, the toast cross-fades
+  instead of sliding, and Undo does not animate the reopen.
+- **Switch Control / keyboard.** Focus order is amount → chips → payee → Save;
+  `⌘N` opens Quick-Add and `Return` saves when the draft is valid.
+
+---
+
+## 10. Privacy
+
+- **No secrets outside the Keychain.** Remembered defaults are non-sensitive
+  ids/enums in App Group `UserDefaults`; nothing in this flow writes tokens,
+  credentials, or balances to `UserDefaults`.
+- **Financial values are `.private`.** Per project logging policy, the amount,
+  payee, and any balance are `.private` in `os.Logger`; only coarse events
+  ("quick add opened", "quick add saved") are logged, never the value.
+- **Lock Screen & widget path stays biometric-gated.** Quick-Add reached via the
+  Lock Screen `QuickEntryWidget` / `DeepLinkHandler` continues through the
+  existing `BiometricAuthManager` gate before any amount field is shown — the
+  widget itself never renders money.
+- **Confirmation restraint.** The success toast confirms the action without
+  persistently displaying the amount on screen, reducing shoulder-surfing risk
+  while still being fully available to VoiceOver on the focused element.
+
+---
+
+## 11. Stale, Error & Empty States
+
+- **Empty — no accounts yet.** If `AccountRepository.getAccounts()` returns
+  empty, Quick-Add cannot satisfy the shared `AccountNotFound` rule. Show an
+  inline empty state ("Add an account to start logging") with a button to the
+  account-creation flow, rather than presenting a dead keypad.
+- **Empty — no categories.** Category is optional per shared rules; the chip
+  shows "Uncategorized" and save still succeeds.
+- **Stale defaults.** If a remembered account/category id no longer exists
+  (deleted/merged), silently fall back to the first available account / clear the
+  category, and refresh the remembered value — never block on a stale id.
+- **Save error (offline / repository failure).** The app is local-first;
+  persistence is optimistic. If `createTransaction` throws, show the message
+  inline in the sheet with **Retry**, keep the keypad state intact, and do not
+  fire the success haptic.
+- **Validation error.** Surfaced inline (not a blocking alert) with the message
+  returned by `TransactionValidator`, so the user can correct without losing the
+  amount.
+
+---
+
+## 12. Test Plan
+
+Smallest meaningful tests first; UI snapshot tests gate every visual PR.
+
+### 12.1 Shared (Kotlin · `packages/core` · `commonTest`)
+
+- `TransactionValidatorTest`: a transaction with **null/empty payee** but valid
+  amount + account is **valid** (proves optional-payee is a shared guarantee,
+  not just an iOS choice).
+- `TransactionValidatorTest`: zero amount → `ZeroAmount`; missing account →
+  `AccountNotFound` (the two gates Quick-Add relies on).
+- `CategorizationEngineTest`: `suggest(payee:)` returns the learned category
+  after `learnFromHistory`, validating the default-category source.
+
+### 12.2 Native (Swift · iOS Simulator · XCTest)
+
+- `TransactionCreateViewModelTests` (extend existing
+  `apps/ios/Tests/TransactionCreateViewModelTests.swift`):
+  - Quick mode seeds remembered type/account/category from preferences.
+  - `appendAmountDigit` / `removeLastAmountDigit` produce the expected
+    `amountCents` and `formattedAmount` (cents-first behavior).
+  - Save with empty payee derives the category-based label and succeeds.
+  - `canSaveQuick` is false with zero amount or no account, true otherwise.
+  - Undo path soft-deletes and restores prior field values.
+- A `QuickAddView` snapshot test at default and AX3 Dynamic Type, light + OLED
+  dark, verifying keypad + Save remain within the `.medium` detent.
+- Accessibility test asserting the floating button and keypad keys expose
+  non-empty labels (mirrors existing `accessibilityIdentifier` usage).
+
+### 12.3 Manual / QA gate (every UI PR)
+
+- iPhone SE (smallest) and a Pro Max: confirm Save + keypad are thumb-reachable
+  one-handed; left-handed mirror works.
+- VoiceOver walkthrough: open → enter amount → save → Undo.
+- Reduce Motion on: confirmation cross-fades, no slide.
+
+---
+
+## 13. Implementation Readiness
+
+### ✅ Buildable now — no enrollment required
+
+The entire Quick-Add flow — `QuickAddView`, view-model quick mode, remembered
+defaults, optional-payee derivation, confirmation/undo, and all unit/UI tests —
+builds and runs today on a device or simulator using **free Personal Team
+signing** (Xcode + a free Apple ID). It depends only on already-shipping shared
+logic (`TransactionValidator`, `CategorizationEngine`) reached through the
+existing `KMPBridge`, plus existing iOS components (`HapticManager`, `IconView`,
+the Venmo-style keypad). No paid entitlements are required: the App Group used
+for remembered defaults already backs the widget/clip.
+
+### 🔒 Distribution tail — gated by [#1239](https://github.com/jrmoulckers/finance/issues/1239) (human action)
+
+Only the **distribution** step is human-gated: TestFlight/App Store builds,
+release signing, and CI release workflows require Apple Developer Program
+enrollment and signing secrets. Per
+[Human-Gated Prerequisites](../ops/human-gated-prerequisites.md) §2, feature
+implementation is decoupled from distribution and is **not** blocked. No
+provisioning, certificates, or secrets are created as part of this work.
+
+---
+
+## 14. Open Questions
+
+1. Should "remembered defaults" eventually move to shared history scoring (KMP)
+   so they sync across devices? If so, that is an ADR to `@kmp-engineer`.
+2. Left-handed mirroring: explicit setting vs. inferred from interaction
+   heatmap vs. RTL-only? Default proposal is an explicit accessibility setting.
+3. Undo window length (4s) and whether it should pause while VoiceOver focus is
+   on the toast — likely yes, to avoid timing out assistive users.

--- a/docs/design/ios-wallet-adjacent-capture-inbox.md
+++ b/docs/design/ios-wallet-adjacent-capture-inbox.md
@@ -1,0 +1,377 @@
+# Wallet-Adjacent Capture & Review Inbox — iOS
+
+> Design specification for the **best-available** "Apple Pay–adjacent" capture
+> experience on iOS. **iOS does not expose raw Apple Pay / Wallet transaction
+> data to third-party apps** — there is no public API for arbitrary card
+> transactions, and we will not attempt to use private ones. This design instead
+> builds capture from **connected-account activity** (bank/card feeds via the
+> sync backend) and **user-initiated manual capture**, surfacing candidates in a
+> **review inbox** with explicit **confidence states** and **privacy-preserving
+> prefill** (masked merchant/amount/date, never PAN or full card data).
+
+**Status:** Design (implementation-ready) · pre-implementation
+**Issue:** [#2603](https://github.com/jrmoulckers/finance/issues/2603) — Wallet-adjacent iOS transaction capture and review inbox design
+**Part of:** [#2171](https://github.com/jrmoulckers/finance/issues/2171)
+**Platforms:** iOS · iPadOS · macOS (SwiftUI); notifications/share-extension hooks
+**WCAG target:** 2.2 Level AA — SC 1.4.1 Use of Color, SC 1.3.1 Info & Relationships, SC 2.5.5 Target Size
+**Related:** [accessibility-patterns.md](./accessibility-patterns.md) · [ios-noncolor-financial-state-cues.md](./ios-noncolor-financial-state-cues.md) · [cognitive-accessibility.md](./cognitive-accessibility.md) · [ios-one-thumb-quick-add.md](./ios-one-thumb-quick-add.md) · [data-model.md](./data-model.md) · [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md)
+
+---
+
+## Table of Contents
+
+1. [Problem & the Apple Pay Reality](#1-problem--the-apple-pay-reality)
+2. [Capture Sources (What We Can Actually Use)](#2-capture-sources-what-we-can-actually-use)
+3. [The Review Inbox](#3-the-review-inbox)
+4. [Confidence States](#4-confidence-states)
+5. [Privacy-Preserving Prefill](#5-privacy-preserving-prefill)
+6. [Affected iOS Surfaces](#6-affected-ios-surfaces)
+7. [Shared Dependencies & the Capture Boundary](#7-shared-dependencies--the-capture-boundary)
+8. [Accessibility, Dynamic Type & Reachability](#8-accessibility-dynamic-type--reachability)
+9. [Privacy & Security](#9-privacy--security)
+10. [Stale, Error & Empty States](#10-stale-error--empty-states)
+11. [Test Plan](#11-test-plan)
+12. [Implementation Readiness](#12-implementation-readiness)
+13. [Open Questions](#13-open-questions)
+
+---
+
+## 1. Problem & the Apple Pay Reality
+
+Users expect "the app sees what I tapped to pay." On iOS that expectation cannot
+be met directly, and it is important the design says so plainly:
+
+- **No third-party access to Apple Pay/Wallet transactions.** PassKit
+  (`PKPassLibrary`, `PKPaymentPass`) only exposes passes the app itself
+  provisioned and the payment sheet for charges the app itself initiates as a
+  merchant. There is **no public API** that returns the user's general Apple Pay
+  purchase history, the merchant of a tap-to-pay, or the card's transaction
+  feed.
+- **No private APIs.** We will not call undocumented Wallet/PassKit internals or
+  scrape system UI. Doing so is an App Store rejection and a privacy violation,
+  and is explicitly out of scope.
+- **No PAN, ever.** The full card number / Primary Account Number is never
+  available to the app and must never be requested, stored, logged, or
+  reconstructed. The system only ever exposes a device-specific masked suffix
+  for passes the app provisioned — not arbitrary cards.
+
+**Therefore the "wallet-adjacent" experience is, by necessity, built from
+sources we _can_ legitimately use** (§2), feeding a **review inbox** (§3) where
+the user confirms machine-suggested drafts. The word "adjacent" is literal: we
+sit beside Apple Pay with the best legitimate signal, not inside it.
+
+**Goals**
+
+1. Turn connected-account activity and user-initiated captures into **draft**
+   transactions, never silently-committed ones.
+2. Give users a single **inbox** to review, accept, edit, or dismiss candidates
+   with one thumb.
+3. Communicate **confidence** honestly and accessibly (non-color).
+4. Prefill only **masked, minimal** fields; keep raw card data out of the app
+   entirely.
+
+---
+
+## 2. Capture Sources (What We Can Actually Use)
+
+| Source                               | Mechanism (legitimate)                                                                                   | Produces                                   |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| **Connected-account activity**       | Bank/card aggregation through the existing sync backend (`packages/sync`) → normalized transaction feed  | High/medium-confidence draft candidates    |
+| **Receipt / document scan**          | User-initiated `VisionKit` `DataScannerViewController` / `VNRecognizeTextRequest` on a receipt photo     | Medium/low-confidence drafts (amount/date) |
+| **Share-sheet & pasteboard import**  | User shares an order email/SMS/receipt to the app, or pastes text; on-device parsing                     | Medium/low-confidence drafts               |
+| **App Clip / widget quick captures** | Existing `ClipTransaction` pending queue (App Group) and Lock Screen quick entry awaiting reconciliation | User-authored drafts to merge/dedup        |
+| **Manual quick-add**                 | The one-thumb flow ([ios-one-thumb-quick-add.md](./ios-one-thumb-quick-add.md))                          | User-authored, high confidence             |
+
+All sources are **user-initiated or user-authorized** (an account connection is
+an explicit consent). None reads Apple Pay state. Each yields a **candidate
+draft**, never a committed transaction — the inbox is the commit gate.
+
+---
+
+## 3. The Review Inbox
+
+A new **Review Inbox** surface (a list reached from the Transactions tab and/or
+a badge on it), modeled closely on the existing date-grouped
+`TransactionsView` so interaction patterns transfer:
+
+- **List of candidate drafts**, grouped by confidence then date. Each row shows
+  masked merchant, amount, date, the suggested category (from
+  `CategorizationEngine`), source, and a **confidence badge** (§4).
+- **One-thumb actions via swipe** (mirroring `TransactionsView` swipe actions):
+  - Trailing swipe → **Dismiss** (won't ask again for this candidate).
+  - Leading swipe → **Accept** (commits the draft as a real transaction).
+  - Tap → opens a **review sheet** prefilled with the masked fields for edit
+    before accept.
+- **Batch accept** for a run of high-confidence candidates ("Accept all
+  high-confidence"), with a single undo.
+- **Merge/dedup.** When a candidate matches an existing manual entry or a queued
+  `ClipTransaction` (same amount window + date + merchant), the row offers
+  **Merge** instead of creating a duplicate.
+- **Empty inbox** is the success state, not a dead end (§10).
+
+```mermaid
+flowchart TD
+    S1[Connected account feed] --> Q[Candidate draft queue]
+    S2[Receipt / share / paste] --> Q
+    S3[Clip / widget pending] --> Q
+    Q --> SCORE[Shared: dedup + confidence scoring + validate]
+    SCORE --> INBOX[Review Inbox]
+    INBOX -->|Accept / Merge| COMMIT[Commit via TransactionRepository]
+    INBOX -->|Edit| SHEET[Review sheet, masked prefill] --> COMMIT
+    INBOX -->|Dismiss| DROP[Suppress candidate]
+```
+
+---
+
+## 4. Confidence States
+
+Confidence is computed by **shared logic** (§7) and rendered honestly. Three
+tiers drive both the badge and the default action — and, per
+[ios-noncolor-financial-state-cues.md](./ios-noncolor-financial-state-cues.md),
+confidence is **never color-only**:
+
+| Tier       | Meaning                                          | Badge (text + symbol + shape)                                | Default UX                                     |
+| ---------- | ------------------------------------------------ | ------------------------------------------------------------ | ---------------------------------------------- |
+| **High**   | Strong field match, recognized merchant, deduped | "High" · `checkmark.seal` · filled capsule                   | One-tap **Accept**; eligible for batch         |
+| **Medium** | Plausible but ambiguous category/merchant/amount | "Review" · `questionmark.circle` · tinted capsule            | Opens prefilled **review sheet** before commit |
+| **Low**    | Sparse/uncertain (e.g. OCR of a blurry receipt)  | "Needs info" · `exclamationmark.triangle` · outlined capsule | Manual completion required; cannot batch       |
+
+Rules:
+
+- The badge always pairs a **word + SF Symbol + shape**, so color-vision-
+  deficient users and grayscale screenshots still convey the tier.
+- Confidence is advisory; the user can always downgrade their trust by editing.
+  Accepting never bypasses `TransactionValidator`.
+- Low-confidence candidates never auto-fill a risky field (e.g. category) as if
+  certain — they show the suggestion as a clearly optional hint.
+
+---
+
+## 5. Privacy-Preserving Prefill
+
+Prefill carries the **minimum** needed to review, and only in masked form:
+
+- **Allowed fields:** amount (minor units), date, normalized merchant/payee
+  string, a **masked** account reference (e.g. "Card ···· 4242" — last-4 only,
+  for connected accounts the user already linked), suggested category, source
+  label.
+- **Forbidden fields:** full PAN, CVV, expiry, cardholder name from the card,
+  raw track data, Apple Pay device account numbers — none of these are available
+  and none are ever requested or persisted.
+- **Masking is done before the data reaches the view.** The "···· 4242" string
+  is a display token, not a stored number; the model carries an opaque account
+  id, and only the last-4 (already non-sensitive and user-visible on their own
+  statements) is shown.
+- **On-device parsing.** Receipt OCR and share/paste parsing run on-device
+  (`VisionKit` / `NaturalLanguage`); raw document text is held only long enough
+  to extract amount/date/merchant, then discarded — not uploaded for parsing.
+- **No prefill without consent.** Connected-account candidates exist only because
+  the user linked an account; manual-capture candidates exist only because the
+  user shared/scanned/pasted. There is no background harvesting.
+
+---
+
+## 6. Affected iOS Surfaces
+
+| Surface                                                          | Change                                                                                    |
+| ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| **New** `apps/ios/Finance/Screens/ReviewInboxView.swift`         | Candidate list, confidence badges, swipe Accept/Dismiss/Merge, batch accept               |
+| **New** `apps/ios/Finance/Screens/CandidateReviewSheet.swift`    | Masked-prefill review/edit sheet built on the Details field set                           |
+| **New** `apps/ios/Finance/ViewModels/ReviewInboxViewModel.swift` | `@Observable` VM: load candidates, accept/merge/dismiss, batch, undo                      |
+| `apps/ios/Finance/Screens/TransactionsView.swift`                | Entry point + unread-count badge to the inbox                                             |
+| **New** `apps/ios/Finance/Components/ConfidenceBadge.swift`      | Non-color badge (word + symbol + shape) reusing `ios-noncolor` cue vocabulary             |
+| `apps/ios/Finance/Intents/` & share extension (future)           | A Share Extension target to receive receipts/order emails (separate target; design-noted) |
+| `apps/ios/Shared/SharedTransactionModel.swift`                   | Reuse the App Group `ClipTransaction` pending queue as one candidate source (merge/dedup) |
+| **New** `apps/ios/Tests/ReviewInboxViewModelTests.swift`         | Accept/merge/dismiss/batch/undo and masking assertions                                    |
+
+The Share Extension and any push notification ("3 transactions to review") are
+called out as **future targets**: they are designed for here but their
+entitlements live in the gated tail (§12).
+
+---
+
+## 7. Shared Dependencies & the Capture Boundary
+
+This is the most boundary-sensitive of the cluster. The split:
+
+- **Shared (Kotlin, `packages/core` / `packages/models`) owns the rules and the
+  intelligence:**
+  - **Candidate generation & normalization** from the connected-account feed
+    belongs to the sync/aggregation layer (`packages/sync`) and shared models
+    (`packages/models/.../models/Transaction.kt`), so every platform reviews the
+    same drafts.
+  - **Dedup / merge matching** (amount window + date + merchant similarity) is a
+    platform-neutral algorithm and should live in `packages/core` so iOS,
+    Android, web, and Windows behave identically.
+  - **Confidence scoring** is likewise shared business logic in `packages/core`.
+  - **Validation** of any accepted draft stays in
+    `packages/core/.../validation/TransactionValidator.kt` (via
+    `KMPTransactionValidatorProtocol`); **category suggestion** stays in
+    `CategorizationEngine`.
+- **iOS owns presentation and platform capture mechanics only:**
+  - The inbox UI, swipe actions, confidence **badge rendering**, the review
+    sheet, accessibility, and notifications.
+  - **On-device capture plumbing** that is inherently Apple: `VisionKit` receipt
+    scanning, the Share Extension, pasteboard handling — these produce raw
+    extracted text/fields that are handed to shared logic for scoring/dedup.
+
+> **Boundary note (do not implement here):** the dedup-matching, confidence-
+> scoring, and any new "candidate draft" model are **shared** concerns. If they
+> don't already exist in `packages/`, introducing them is a change for
+> `@kmp-engineer` via ADR — this document specifies the iOS-side contract and
+> the data it expects, not the Kotlin implementation. iOS must not fork these
+> rules locally. Boundary: **scoring/dedup/validation in KMP, capture mechanics
+> and review UI in SwiftUI.**
+
+---
+
+## 8. Accessibility, Dynamic Type & Reachability
+
+- **Confidence badges are non-color** (word + SF Symbol + shape), so VoiceOver
+  reads "High confidence", "Needs review", "Needs info", and grayscale users see
+  the tier. This directly reuses
+  [ios-noncolor-financial-state-cues.md](./ios-noncolor-financial-state-cues.md).
+- **VoiceOver row labels** combine into "Masked merchant, amount, date, suggested
+  category, <confidence> confidence" with a hint "Swipe up for Accept, Dismiss,
+  Merge", mirroring `TransactionsView`'s accessibility composition.
+- **One-thumb review.** Accept/Dismiss live on swipe (thumb-reachable) and the
+  batch-accept button is bottom-anchored; the review sheet uses the same
+  bottom-anchored Save as the quick-add sheet.
+- **Dynamic Type.** All badge/row text scales; badges wrap word + symbol rather
+  than truncating; targets stay ≥ 44×44pt.
+- **Switch Control / keyboard.** Each row exposes Accept/Dismiss/Merge as
+  `.accessibilityAction`s so non-swipe users get the same actions; focus order
+  is badge → fields → actions.
+- **Reduce Motion.** Accept/merge/dismiss collapse rows with a cross-fade instead
+  of a slide; batch accept doesn't cascade-animate.
+
+---
+
+## 9. Privacy & Security
+
+- **Apple Pay/Wallet data is never read** (restated from §1) — design correctness
+  depends on this being explicit so no one "optimizes" toward private APIs.
+- **No PAN/card data** is stored, logged, or transmitted; only user-visible
+  last-4 display tokens and opaque account ids exist on device.
+- **Secrets stay in the Keychain.** Connected-account session/refresh tokens (to
+  the extent any reach the device) live in the Keychain with
+  `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`, never `UserDefaults`. The
+  App Group pending-candidate queue holds only masked, non-secret draft fields.
+- **`.private` logging.** Amounts, merchants, and account references are
+  `.private` in `os.Logger`; only structural events ("inbox loaded: 4
+  candidates", "candidate accepted") are `.public`.
+- **On-device parsing only;** raw receipt/email text is transient and discarded
+  after field extraction, never uploaded for the purpose of parsing.
+- **Biometric gate.** Opening the inbox honors the existing app-lock /
+  `BiometricAuthManager` policy before masked financial details are shown, just
+  like the rest of the app.
+
+---
+
+## 10. Stale, Error & Empty States
+
+- **Empty inbox (the good state).** Show a positive empty state ("You're all
+  caught up — no transactions to review") using `ContentUnavailableView`, with a
+  secondary action to connect an account or scan a receipt — not a dead screen.
+- **No connected accounts.** If aggregation isn't set up, the inbox explains that
+  connected-account capture is unavailable and points to manual capture
+  (scan/share/quick-add) so the feature still has value offline.
+- **Stale feed.** Show "Last updated <relative time>"; if the feed is older than
+  a threshold or sync failed, badge the inbox as stale and offer **Refresh**
+  rather than presenting possibly-outdated candidates as fresh.
+- **Sync/parse error.** Partial failures keep already-fetched candidates and show
+  an inline, dismissible error with Retry; OCR/parse failure on a single capture
+  marks that candidate **Low** with "couldn't read amount", never silently
+  dropping it.
+- **Conflict on accept.** If a candidate fails `TransactionValidator` at accept
+  time (e.g. its account was deleted), the review sheet opens with the offending
+  field flagged instead of committing an invalid record.
+- **Duplicate detected.** When dedup finds a match, the row defaults to **Merge**
+  and explains why, preventing double-counting.
+
+---
+
+## 11. Test Plan
+
+### 11.1 Shared (Kotlin · `packages/core` · `commonTest`)
+
+- **Dedup/matching test:** two near-identical candidates (same amount, date
+  within N minutes, similar merchant) are matched; dissimilar ones are not.
+- **Confidence-scoring test:** known field combinations map to High/Medium/Low
+  deterministically.
+- **`TransactionValidatorTest`:** an accepted candidate with a deleted account →
+  `AccountNotFound`; a valid one passes — proving accept can't bypass rules.
+- **Masking unit (wherever normalization lives):** output never contains more
+  than last-4; full PAN-like inputs are rejected/redacted.
+
+### 11.2 Native (Swift · iOS Simulator · XCTest)
+
+- `ReviewInboxViewModelTests` (new):
+  - Loads candidates and sorts by confidence then date.
+  - Accept commits via a mock `TransactionRepository`; Dismiss suppresses;
+    Merge calls the merge path, not a second create.
+  - Batch accept commits only High-confidence rows; single undo restores them.
+  - Prefill exposes **only** masked fields (assert no field longer than last-4
+    for the account token; assert no PAN-shaped strings).
+- `ConfidenceBadge` snapshot/accessibility test: each tier renders word + symbol
+  - shape and reads correctly in grayscale and to VoiceOver.
+- `CandidateReviewSheet` snapshot at default and AX3 Dynamic Type.
+
+### 11.3 Manual / QA gate (every UI PR)
+
+- Grayscale + Increase Contrast: confidence tiers remain distinguishable.
+- VoiceOver: swipe-action equivalents reachable; batch accept announced.
+- Empty inbox, no-connected-accounts, and stale-feed states each render their
+  intended copy and recovery action.
+
+---
+
+## 12. Implementation Readiness
+
+### ✅ Buildable now — no enrollment required
+
+The inbox UI, confidence badges, review sheet, view models, the masking/prefill
+display layer, and all native tests build and run today under **free Personal
+Team signing**, driven by **mock candidate sources** and the existing shared
+`TransactionValidator` / `CategorizationEngine` via `KMPBridge`. The App Group
+`ClipTransaction` queue already exists as one real candidate source for local
+verification. Receipt scanning via `VisionKit` and on-device parsing are
+free-framework capabilities usable without enrollment. None of this requires
+`packages/` changes to demonstrate the iOS contract against mocks.
+
+### 🔒 Distribution & capability tail — gated by [#1239](https://github.com/jrmoulckers/finance/issues/1239) (human action)
+
+Human-gated per [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md)
+§2 — implementation is **not** blocked, only the following tail:
+
+- TestFlight/App Store distribution, release signing, CI release workflows
+  (Apple Developer Program enrollment + signing secrets).
+- **Push notifications** ("transactions to review") require the Push
+  Notifications capability — a paid entitlement, so the notification path is
+  designed here but ships behind the gate.
+- A **Share Extension** target is buildable locally but is distributed with the
+  app under the same enrollment gate.
+
+> **Separate (non-Apple) dependency:** _live_ connected-account aggregation needs
+> the bank/market data provider credentials tracked outside this issue; until
+> then the inbox runs against the local `ClipTransaction` queue and fixtures.
+> That provider setup is its own human-gated task and is **not** created here.
+
+No provisioning, certificates, secrets, or account registrations are performed as
+part of this design.
+
+---
+
+## 13. Open Questions
+
+1. Where exactly should the dedup-matching and confidence-scoring models live —
+   `packages/core` vs. `packages/sync` — and what is the candidate-draft schema?
+   This is an ADR conversation with `@kmp-engineer`/`@architect`.
+2. Should the inbox be a top-level tab, a Transactions-tab section, or a
+   notification-driven sheet? Proposal: a Transactions-tab entry with a badge,
+   promotable later.
+3. Retention policy for dismissed candidates and extracted receipt text —
+   proposal: dismissed candidates suppressed by stable hash, raw text never
+   retained past extraction.
+4. How aggressively should batch-accept trust "High"? Proposal: conservative —
+   only deduped, recognized-merchant candidates qualify.


### PR DESCRIPTION
# Summary

Design-only batch delivering three related iOS transaction quick-capture/entry design docs as one merged PR. No native build, signing, or distribution work — implementation is unblocked per the implementation-vs-distribution decoupling in [`docs/ops/human-gated-prerequisites.md`](docs/ops/human-gated-prerequisites.md) (only the distribution tail is gated by #1239).

Closes #2599
Closes #2608
Closes #2603

Part of #2167 · Part of #2190 · Part of #2171

# Changes

Three new, distinct design docs under `docs/design/` (no existing files, `packages/`, shared config, or other platforms touched):

- **`docs/design/ios-one-thumb-quick-add.md`** (#2599, Part of #2167) — Transactions-tab thumb-reachable capture affordance, bottom-sheet express entry opening on the Venmo-style keypad, remembered defaults (account/type/category as non-secret App Group prefs), optional payee skipping aligned to the shared validator, and a non-blocking save confirmation with Undo.
- **`docs/design/ios-compact-transaction-stepper.md`** (#2608, Part of #2190) — Full → Compact → Minimal step-indicator behavior driven by `ViewThatFits` + Dynamic Type, content-priority disclosure for the dense Details step on iPhone SE and AX text sizes, with a strict invariant that visual collapse never changes VoiceOver/validation semantics.
- **`docs/design/ios-wallet-adjacent-capture-inbox.md`** (#2603, Part of #2171) — Best-available "Apple Pay–adjacent" capture. **Explicit:** iOS does **not** expose raw Apple Pay/Wallet transaction data and no private APIs are used; design is built on connected-account activity + user-initiated manual capture, a review inbox with non-color confidence states, and privacy-preserving prefill (masked merchant/amount/date/last-4, never PAN).

Each doc identifies affected `apps/ios` surfaces and the shared `packages/core` (`TransactionValidator`, `CategorizationEngine`) / `packages/models` boundary (described, not implemented); covers accessibility (VoiceOver, one-handed reachability, Switch Control), Dynamic Type, privacy, and stale/error/empty states; names the smallest native/shared tests; and includes an Implementation Readiness section (buildable now via free Personal Team signing vs. distribution tail gated by #1239).

# Testing

- `npx prettier --write` then `npx prettier --check` on all three docs — **all pass** ("All matched files use Prettier code style!").
- Docs ground their designs in existing code: `TransactionsView`, `TransactionCreateView`/`ViewModel` (3-step wizard + cents-first keypad), `QuickEntryWidget`, App Clip `QuickTransactionView`, `AddExpenseIntent`, and the shared `TransactionValidator`/`CategorizationEngine`.
- Design-only PR: no application code changed; no native build or signing performed.
