### PR TITLE
docs(design): android Schedule C and cash quick-add design batch (#2523, #2525, #2538)

### DIFF
--- a/docs/design/android-cash-quick-entry-deep-links.md
+++ b/docs/design/android-cash-quick-entry-deep-links.md
@@ -1,0 +1,378 @@
+# Android Cash Quick-Entry Deep Links — Design
+
+> **Status:** Design / breakdown · **Issue:** [#2538](https://github.com/jrmoulckers/finance/issues/2538) · **Part of [#2180](https://github.com/jrmoulckers/finance/issues/2180)**
+> **Platform:** Android (Jetpack Compose · Material 3 · Glance) · **minSdk 28 / target 35**
+> **Companion designs:** [Schedule C Quick-Add Sheet](./android-schedule-c-quick-add-sheet.md) · [Quick-Add Defaults & Persistence](./android-quick-add-defaults-persistence.md)
+
+Defines four entry points — **Glance widget, App Shortcut, in-app FAB, and a
+Transactions-screen deep link** — that all land in the **same prefilled
+cash-expense draft**, so a cash-first user can log a small purchase before they
+forget it.
+
+This is a **design + breakdown** document. The deep-link / App-Shortcut / Glance
+plumbing is **implementable now** in debug (`assembleDebug` sideload); only
+**Play Store distribution** is human-gated by
+[#1242](https://github.com/jrmoulckers/finance/issues/1242). See
+[Implementation readiness](#implementation-readiness) and
+[`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md).
+
+---
+
+## Table of Contents
+
+1. [Problem & Goals](#1-problem--goals)
+2. [Entry Points & Single Destination](#2-entry-points--single-destination)
+3. [Architecture Boundary (KMP vs. Compose vs. Android plumbing)](#3-architecture-boundary-kmp-vs-compose-vs-android-plumbing)
+4. [Affected Android Surfaces & Shared Dependencies](#4-affected-android-surfaces--shared-dependencies)
+5. [Deep-Link Contract](#5-deep-link-contract)
+6. [App Shortcut, Widget & FAB Wiring](#6-app-shortcut-widget--fab-wiring)
+7. [Prefilled Cash-Expense Draft](#7-prefilled-cash-expense-draft)
+8. [Offline-First, Empty & Error States](#8-offline-first-empty--error-states)
+9. [Accessibility & Localization (TalkBack, Switch Access, i18n)](#9-accessibility--localization-talkback-switch-access-i18n)
+10. [Test Plan](#10-test-plan)
+11. [Implementation readiness](#implementation-readiness)
+12. [Open Questions](#open-questions)
+
+---
+
+## 1. Problem & Goals
+
+From [#2180](https://github.com/jrmoulckers/finance/issues/2180): _"As a
+cash-first Android user, I need true quick cash entry so small purchases are
+logged before I forget them... Make widget/shortcut actions deep-link directly
+into a prefilled cash expense flow."_
+
+Today the
+[`QuickEntryWidget`](../../apps/android/src/main/kotlin/com/finance/android/widget/QuickEntryWidget.kt)
+just calls `actionStartActivity<MainActivity>()` (lands on the app, not a
+prefilled draft) with **hardcoded English labels**, and the main path is the
+3-step
+[`TransactionCreateScreen`](../../apps/android/src/main/kotlin/com/finance/android/ui/screens/TransactionCreateScreen.kt)
+wizard.
+
+**Goals**
+
+- One canonical **deep link** to a prefilled cash-expense draft.
+- Reach it from **widget, App Shortcut, FAB, and the Transactions screen**.
+- Default to the user's chosen **cash wallet/account** (ties into
+  [#2525 defaults](./android-quick-add-defaults-persistence.md)).
+- **Offline-first**, low-friction, works on budget devices.
+- **Localized** widget/shortcut labels and semantics (Spanish first per #2180).
+
+**Non-goals**
+
+- Implementing the draft sheet itself (covered by the
+  [quick-add sheet design](./android-schedule-c-quick-add-sheet.md)); here we
+  define how to _reach_ a **cash** variant of it.
+- Owning the cash-account selection rule or any finance math (shared/repository).
+
+---
+
+## 2. Entry Points & Single Destination
+
+```mermaid
+flowchart LR
+    W[Glance Quick-Entry Widget] --> DL
+    SC[App Shortcut\n'Add cash expense'] --> DL
+    FAB[Transactions FAB] -->|in-process nav| DEST
+    TX[Transactions screen\nempty-state CTA] -->|in-process nav| DEST
+    DL[Deep link\nhttps://finance.app/quick-add/cash] --> NAV[FinanceNavHost\nnavDeepLink] --> DEST
+    DEST[Cash quick-add draft\nModalBottomSheet, account=cash prefilled]
+```
+
+All four paths converge on **one destination** so behavior, accessibility, and
+tests are defined once. External surfaces (widget, shortcut) use the **deep-link
+URI**; in-app surfaces (FAB, Transactions CTA) use **in-process navigation** to
+the same route.
+
+---
+
+## 3. Architecture Boundary (KMP vs. Compose vs. Android plumbing)
+
+- **Android plumbing** (this doc): the deep-link URI + `navDeepLink`, the App
+  Shortcut, the Glance widget click action, and the FAB — all platform glue that
+  is implementable now in debug.
+- **Compose** renders the prefilled draft (reusing the
+  [quick-add sheet](./android-schedule-c-quick-add-sheet.md), in a "cash"
+  configuration).
+- **KMP** still owns the rules: amount validation, draft creation, and (for cash
+  business expenses) the Schedule C taxonomy in
+  [`ScheduleCDeductionPresets.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/schedulec/ScheduleCDeductionPresets.kt).
+  A plain personal cash expense uses the standard
+  [`Transaction`](../../packages/models/src/commonMain/kotlin/com/finance/models/Transaction.kt)
+  - shared
+    [`TransactionValidator`](../../packages/core/src/commonMain/kotlin/com/finance/core/validation/TransactionValidator.kt).
+
+> **Boundary rule:** the deep link only carries _intent + prefill hints_
+> (mode = cash, optional category/amount). It never carries computed financial
+> results. The draft's deductible/proration math (if a business cash expense) is
+> produced by the shared taxonomy exactly as in the
+> [sheet design](./android-schedule-c-quick-add-sheet.md#6-transaction-draft-contract).
+
+---
+
+## 4. Affected Android Surfaces & Shared Dependencies
+
+| Surface (new/modified)                        | Type            | Role                                                                                                                                                            |
+| --------------------------------------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ui/navigation/FinanceNavHost.kt` (modified)  | Nav graph       | New `Route.QuickAddCash` + `navDeepLink { uriPattern = "$DEEP_LINK_BASE/quick-add/cash..." }`.                                                                  |
+| `AndroidManifest.xml` (modified)              | Manifest        | `<data android:host="finance.app" android:path="/quick-add/cash"/>` in the existing autoVerify VIEW filter; `<meta-data android:name="android.app.shortcuts">`. |
+| `res/xml/shortcuts.xml` (new)                 | Static shortcut | "Add cash expense" App Shortcut → deep-link intent.                                                                                                             |
+| `widget/QuickEntryWidget.kt` (modified)       | Glance widget   | Replace `actionStartActivity<MainActivity>()` with `actionStartActivity` carrying the deep-link URI; localize labels.                                           |
+| `ui/screens/TransactionsScreen.kt` (modified) | Composable      | FAB + empty-state CTA navigate to `Route.QuickAddCash`.                                                                                                         |
+| `ui/quickadd/CashQuickAddArgs.kt` (new)       | Data class      | Parses/validates deep-link args (mode, account hint, category, amount).                                                                                         |
+| `res/values-es/strings.xml` (modified/new)    | Resources       | Spanish strings for widget, shortcut, and sheet labels (#2180 i18n).                                                                                            |
+
+**Shared (KMP) dependencies — read only, no edits:**
+
+- `ScheduleCDeductionPresetTaxonomy` (when the cash expense is a business
+  deduction).
+- `TransactionValidator`, `Transaction`, `Cents`, `Currency`, `SyncId`.
+- `CurrencyFormatter` for display.
+
+**Existing deep-link precedent** (already in
+[`FinanceNavHost.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceNavHost.kt)):
+`navDeepLink { uriPattern = "$DEEP_LINK_BASE/auth/callback" }`,
+`/invite/{code}`, `/transaction/{id}` with base `https://finance.app` and an
+`autoVerify` VIEW intent filter — the new route follows the same pattern.
+
+---
+
+## 5. Deep-Link Contract
+
+**Canonical URI**
+
+```
+https://finance.app/quick-add/cash?account={accountId}&category={categoryId}&amount={cents}&presetId={presetId}
+```
+
+| Query param | Required | Meaning                                                                                                           | Validation                                                                   |
+| ----------- | -------- | ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `account`   | No       | Pre-select this account id (else resolve cash default, see [#2525](./android-quick-add-defaults-persistence.md)). | Re-validated against `AccountRepository`; ignored if missing/archived.       |
+| `category`  | No       | Pre-select category id.                                                                                           | Ignored if unknown.                                                          |
+| `amount`    | No       | Prefill amount in **cents** (`Long`).                                                                             | `> 0` enforced by shared validation _on save_, not on prefill.               |
+| `presetId`  | No       | Schedule C preset (business cash expense).                                                                        | Resolved via `ScheduleCDeductionPresetTaxonomy.findPreset`; ignored if null. |
+
+With **no params**, the link opens the cash draft with the **last-used cash
+account** prefilled and an empty amount — the lowest-friction default.
+
+**`navDeepLink` (in `FinanceNavHost`):**
+
+```kotlin
+data object QuickAddCash : Route(
+    "quick-add/cash?account={account}&category={category}&amount={amount}&presetId={presetId}",
+) {
+    fun createRoute(account: String? = null /* ...optional... */): String = /* build query */ ""
+}
+
+composable(
+    route = Route.QuickAddCash.route,
+    arguments = listOf(
+        navArgument("account") { nullable = true; defaultValue = null },
+        navArgument("category") { nullable = true; defaultValue = null },
+        navArgument("amount") { type = NavType.StringType; nullable = true; defaultValue = null },
+        navArgument("presetId") { nullable = true; defaultValue = null },
+    ),
+    deepLinks = listOf(navDeepLink { uriPattern = "$DEEP_LINK_BASE/quick-add/cash?account={account}&category={category}&amount={amount}&presetId={presetId}" }),
+) { /* CashQuickAdd host renders the sheet */ }
+```
+
+> **Safety:** all params are _hints_. Parsing is defensive (`CashQuickAddArgs`)
+> — bad/unknown values are dropped and the draft falls back to safe defaults; a
+> malformed deep link never crashes or persists garbage. No sensitive data is put
+> in the URI beyond opaque ids (no amounts logged via Timber).
+
+---
+
+## 6. App Shortcut, Widget & FAB Wiring
+
+**App Shortcut (`res/xml/shortcuts.xml`, static):**
+
+```xml
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+  <shortcut
+      android:shortcutId="add_cash_expense"
+      android:enabled="true"
+      android:icon="@drawable/ic_shortcut_cash"
+      android:shortcutShortLabel="@string/shortcut_cash_short"
+      android:shortcutLongLabel="@string/shortcut_cash_long">
+    <intent
+        android:action="android.intent.action.VIEW"
+        android:data="https://finance.app/quick-add/cash" />
+    <categories android:name="android.shortcut.conversation" />
+  </shortcut>
+</shortcuts>
+```
+
+Referenced from the launcher activity via
+`<meta-data android:name="android.app.shortcuts" android:resource="@xml/shortcuts"/>`.
+Labels come from localized string resources (`@string/...`), **not** hardcoded —
+fixing the #2180 i18n gap.
+
+**Glance widget (modify `QuickEntryWidget`):**
+
+- Replace `clickable(actionStartActivity<MainActivity>())` with an action that
+  starts an `Intent(ACTION_VIEW, "https://finance.app/quick-add/cash?...")`
+  (Glance `actionStartActivity(intent)`), so the tile lands directly in the
+  prefilled cash draft instead of the app home.
+- A dedicated **"Cash"** chip defaults to the cash wallet; category chips append
+  `?category=...`.
+- Replace hardcoded `"Quick Add"`, `"Food"`, `"Gas"`, etc. with
+  `context.getString(R.string.widget_...)` for localization, and update each
+  `contentDescription` to use localized strings.
+
+**FAB & Transactions CTA (in-app):**
+
+- `TransactionsScreen` FAB → `navController.navigate(Route.QuickAddCash.createRoute())`
+  (in-process, no URI round-trip).
+- Empty-state CTA ("Log your first cash expense") → same route.
+
+```mermaid
+sequenceDiagram
+    participant L as Launcher / Widget
+    participant A as MainActivity (singleTask)
+    participant N as FinanceNavHost
+    participant H as CashQuickAdd host
+    participant K as KMP rules
+    L->>A: Intent VIEW https://finance.app/quick-add/cash?account=cash-01
+    A->>N: deep link -> Route.QuickAddCash(args)
+    N->>H: open ModalBottomSheet (cash mode, account prefilled)
+    H->>K: createDraft / validate on input
+    K-->>H: draft + validation
+    H-->>A: save -> repository.insert (offline-first) -> dismiss
+```
+
+---
+
+## 7. Prefilled Cash-Expense Draft
+
+The destination reuses the [quick-add sheet](./android-schedule-c-quick-add-sheet.md)
+in a **cash configuration**:
+
+- **Account** defaults to the chosen cash wallet (deep-link `account` hint →
+  else last-used cash account → else household primary cash account → else first
+  account). Account resolution rule lives with
+  [#2525 defaults](./android-quick-add-defaults-persistence.md).
+- **Type** = `EXPENSE`; **amount** prefilled from `amount` cents if present,
+  otherwise empty and focused for immediate entry.
+- **Personal cash expense** → validated by the shared `TransactionValidator`,
+  saved as a standard `Transaction` (no Schedule C tags).
+- **Business cash expense** (a `presetId` was supplied, e.g. from the Schedule C
+  widget chip) → uses the shared taxonomy draft contract exactly as the
+  [sheet design §6](./android-schedule-c-quick-add-sheet.md#6-transaction-draft-contract).
+- **Save** writes through `TransactionRepository.insert` to the local
+  SQLDelight/SQLCipher store immediately (offline-first); `SyncWorker`
+  (WorkManager) reconciles later.
+
+---
+
+## 8. Offline-First, Empty & Error States
+
+| Scenario                                      | Behavior                                                                                                                                                                                                                                   |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Offline (typical for cash-on-the-go)**      | Entire flow works; save persists locally and syncs later. "Saved offline" snackbar with `contentDescription`.                                                                                                                              |
+| **Deep link while app cold-started**          | `MainActivity` (launchMode `singleTask`) routes the link after auth/onboarding gate; the pending route is preserved and opened post-unlock.                                                                                                |
+| **Deep link while locked (biometric)**        | Honor the existing biometric gate via [`BiometricAuthManager`](../../apps/android/src/main/kotlin/com/finance/android/security/BiometricAuthManager.kt); open the draft only after successful auth. Never bypass the lock for a deep link. |
+| **Unknown/malformed params**                  | `CashQuickAddArgs` drops them; draft opens with safe defaults. No crash, no error toast.                                                                                                                                                   |
+| **No cash account configured**                | Sheet prompts "Choose an account" / "Add a cash wallet"; Save disabled with helper text; CTA to account create.                                                                                                                            |
+| **Save failure**                              | Non-dismissing error snackbar + Retry; input preserved; `Timber.e(t, "Cash quick-add save failed")` (no amount/account values logged).                                                                                                     |
+| **No transactions yet (Transactions screen)** | Empty-state illustration + "Log your first cash expense" CTA → `Route.QuickAddCash`.                                                                                                                                                       |
+
+---
+
+## 9. Accessibility & Localization (TalkBack, Switch Access, i18n)
+
+**Accessibility**
+
+- **Widget**: every chip and the widget root carry `contentDescription` (Glance
+  `semantics { contentDescription = ... }`) sourced from **localized** strings,
+  e.g. `getString(R.string.widget_cash_add_cd)`.
+- **App Shortcut** long/short labels are localized resources; the launcher
+  announces them via TalkBack automatically.
+- **FAB**: `contentDescription = stringResource(R.string.fab_quick_add_cash)`
+  ("Add cash expense"); ≥ 56 dp target.
+- **Destination sheet** inherits the
+  [sheet accessibility spec](./android-schedule-c-quick-add-sheet.md#9-accessibility-talkback-switch-access-font-scaling)
+  (heading title, live-region deductible/amount, focus order, ≥ 56 dp targets,
+  200% font scaling).
+- **Switch Access**: FAB and widget chips are single focusable targets with clear
+  labels; the deep link lands focus on the amount field for immediate entry.
+
+**Localization (#2180 — Spanish first)**
+
+- All widget/shortcut/FAB strings move to `res/values/strings.xml` with a
+  `res/values-es/strings.xml` translation; **no hardcoded English** in Compose,
+  Glance, or the manifest-referenced shortcut labels.
+- `contentDescription`s use the same localized resources so TalkBack speaks the
+  user's language.
+- Currency/number formatting goes through shared `CurrencyFormatter` (locale-aware),
+  not manual string building.
+- Verify RTL safety of the widget/sheet layouts (start/end, not left/right).
+
+---
+
+## 10. Test Plan
+
+**Android unit (`apps/android/src/test`, JVM, CI without device):**
+
+- `CashQuickAddArgsTest`
+  - parses all params; drops unknown/malformed values; empty link → safe defaults.
+  - `amount` cents parsed to `Long`; non-numeric ignored.
+  - `presetId` resolves via shared taxonomy; unknown id ignored.
+- `CashQuickAddViewModelTest` (or extension of the quick-add VM tests)
+  - account resolution: deep-link hint → last-used cash → primary cash → first.
+  - personal vs. business (presetId present) draft paths use the correct shared API.
+  - offline insert path saves without network.
+
+**Instrumentation / deep-link (`androidTest`, debug build):**
+
+- `adb shell am start -a android.intent.action.VIEW -d "https://finance.app/quick-add/cash?account=cash-01"`
+  opens the prefilled cash draft (verified via a deep-link instrumentation test,
+  consistent with existing
+  [`NavigationE2ETest`](../../apps/android/src/androidTest/kotlin/com/finance/android/e2e/NavigationE2ETest.kt)).
+- App Shortcut launch opens the same destination.
+- FAB and empty-state CTA navigate to `Route.QuickAddCash`.
+- Cold-start + locked-device deep link respects the biometric gate before opening.
+
+**Localization tests:**
+
+- widget/shortcut/FAB render Spanish strings under `values-es`; no hardcoded
+  English remains (lint check for string literals in Glance/Compose label slots).
+- `contentDescription`s are non-empty and localized.
+
+**Paparazzi snapshots:** widget (English + Spanish), cash draft prefilled state,
+empty-account state, large-font and OLED-dark variants.
+
+---
+
+## Implementation readiness
+
+| Phase                                                                                                                          | Status               | Gate                                                                                                      |
+| ------------------------------------------------------------------------------------------------------------------------------ | -------------------- | --------------------------------------------------------------------------------------------------------- |
+| This design doc                                                                                                                | ✅ Done              | None                                                                                                      |
+| `navDeepLink` route, App Shortcut, Glance widget rewire, FAB/CTA, `values-es`, unit/instrumentation/Paparazzi, `assembleDebug` | 🟢 **Buildable now** | None — debug sideload per [`../ops/human-gated-prerequisites.md` §2](../ops/human-gated-prerequisites.md) |
+| Play Store release + Play **App Shortcuts / deep-link verification on the production listing**                                 | 🔒 **Gated**         | [#1242](https://github.com/jrmoulckers/finance/issues/1242) — keystore + Play Console                     |
+
+The deep-link, App Shortcut, and Glance-widget plumbing is **standard Android
+local code** — fully implementable and testable today with
+`./gradlew :apps:android:assembleDebug` plus `adb`-driven deep-link
+instrumentation; the App Links `autoVerify` filter already exists in the
+manifest. The finance _rules_ live in `packages/core`. **Only Play
+distribution** (release signing, Play Console upload, and the production
+Digital Asset Links / store listing) is human-gated by #1242 — see
+[`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md)
+§§2–3.1. No build, signing, or store action is performed by this design.
+
+---
+
+## Open Questions
+
+1. **App Links autoVerify vs. custom scheme**: reuse the verified
+   `https://finance.app` host (consistent with existing deep links) — production
+   Digital Asset Links verification is part of the #1242 distribution tail, but
+   debug builds work via the same VIEW filter. Confirmed approach: reuse host.
+2. **Shortcut iconography**: needs a `ic_shortcut_cash` vector from
+   `@design-engineer`/icon system ([`icon-system.md`](./icon-system.md)); placeholder
+   until then.
+3. **Additional locales beyond Spanish**: #2180 calls out Spanish; structure the
+   strings so adding more `values-xx` later is trivial.

--- a/docs/design/android-quick-add-defaults-persistence.md
+++ b/docs/design/android-quick-add-defaults-persistence.md
@@ -1,0 +1,340 @@
+# Android Quick-Add Defaults & Preset Persistence — Design
+
+> **Status:** Design / breakdown · **Issue:** [#2525](https://github.com/jrmoulckers/finance/issues/2525) · **Part of [#2141](https://github.com/jrmoulckers/finance/issues/2141)**
+> **Platform:** Android (Jetpack Compose · Material 3) · **minSdk 28 / target 35**
+> **Companion designs:** [Schedule C Quick-Add Sheet](./android-schedule-c-quick-add-sheet.md) · [Cash Quick-Entry Deep Links](./android-cash-quick-entry-deep-links.md)
+
+Defines how the Android quick-add experience remembers the user's **last-used
+account, vehicle, platform, business-use %, and category** so that logging the
+next gig deduction is as close to zero-tap as possible — while keeping every
+deduction _rule_ in shared KMP code.
+
+This is a **design + breakdown** document. The persistence + Compose wiring is
+**buildable now** in debug (`assembleDebug`); only **Play Store distribution** is
+human-gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242). See
+[Implementation readiness](#implementation-readiness) and
+[`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md).
+
+---
+
+## Table of Contents
+
+1. [Problem & Goals](#1-problem--goals)
+2. [What Gets Remembered](#2-what-gets-remembered)
+3. [Architecture Boundary (KMP vs. Compose vs. Storage)](#3-architecture-boundary-kmp-vs-compose-vs-storage)
+4. [Affected Android Surfaces & Shared Dependencies](#4-affected-android-surfaces--shared-dependencies)
+5. [Default-Resolution Rules](#5-default-resolution-rules)
+6. [Storage Design (DataStore — not SharedPreferences for secrets)](#6-storage-design-datastore--not-sharedpreferences-for-secrets)
+7. [Lifecycle: Read, Apply, Persist](#7-lifecycle-read-apply-persist)
+8. [Offline-First, Empty & Error States](#8-offline-first-empty--error-states)
+9. [Accessibility (TalkBack, Switch Access, Font Scaling)](#9-accessibility-talkback-switch-access-font-scaling)
+10. [Test Plan](#10-test-plan)
+11. [Implementation readiness](#implementation-readiness)
+12. [Open Questions](#open-questions)
+
+---
+
+## 1. Problem & Goals
+
+From [#2141](https://github.com/jrmoulckers/finance/issues/2141): _"Keep the
+last-used account / vehicle / platform selected to minimize taps... When I'm
+parked between deliveries, every extra tap is friction."_
+
+The [Schedule C quick-add sheet](./android-schedule-c-quick-add-sheet.md) is
+only "two-tap" if the account, vehicle, platform, and business-use % are already
+filled. This doc defines how those defaults are **resolved, applied, and
+persisted** across sessions and across entry points (FAB, widget, App Shortcut).
+
+**Goals**
+
+- Restore the user's **last-used** selections instantly when the sheet opens.
+- Provide **sensible fallbacks** when no history exists (e.g. preset default
+  business-use %, the household's primary cash account).
+- Keep the **rules** (what a preset's default business-use % _is_, proration,
+  validation) in shared KMP — Android only stores _user preferences_.
+- Make defaults **per-preset where it matters** (a Gas default % differs from a
+  Phone % default).
+
+**Non-goals**
+
+- Storing any secret/credential (those use Keystore/biometric — see boundaries).
+- Owning the Schedule C taxonomy or deductible math (lives in `packages/core`).
+- Cross-device sync of these UI preferences (local-first; revisit if needed).
+
+---
+
+## 2. What Gets Remembered
+
+| Default            | Scope                          | Source of truth for the _value set_                           | Fallback when no history                                       |
+| ------------------ | ------------------------------ | ------------------------------------------------------------- | -------------------------------------------------------------- |
+| **Account**        | Global (last-used overall)     | `AccountRepository` (household accounts)                      | Household primary cash account → first account → none.         |
+| **Vehicle**        | Global, applies to car presets | App-local vehicle list (gig vehicles)                         | Most-recently-used → single vehicle → none.                    |
+| **Platform**       | Global (Uber/Lyft/DoorDash…)   | App-local platform tag list                                   | Last-used → none (optional field).                             |
+| **Business-use %** | **Per-preset**                 | Override value the user last confirmed for _that preset_      | Preset's `defaultBusinessUsePercent` from the shared taxonomy. |
+| **Category**       | Per-preset (derived)           | The preset's `category` (shared); not user-editable per entry | Always the preset's Schedule C category.                       |
+
+**Key distinction:** _Category_ and the _default_ business-use % are **shared
+rules** (read from `ScheduleCDeductionPresetTaxonomy`). What Android persists is
+the user's **last confirmed override** of business-use % and their **last-used
+account/vehicle/platform** — i.e. preferences, not finance logic.
+
+---
+
+## 3. Architecture Boundary (KMP vs. Compose vs. Storage)
+
+```mermaid
+flowchart TD
+    subgraph KMP["packages/core (rules — read only here)"]
+        TAX[ScheduleCDeductionPresetTaxonomy]
+        PRE[preset.defaultBusinessUsePercent\npreset.category\npreset.deductibleByDefault]
+    end
+    subgraph Android["apps/android"]
+        VM[ScheduleCQuickAddViewModel]
+        STORE[QuickAddDefaultsRepository\n(DataStore-backed)]
+        DS[(Preferences DataStore\nlast-used prefs)]
+        ACC[(AccountRepository)]
+    end
+    TAX --> PRE
+    PRE -->|default % if no user override| VM
+    STORE <--> DS
+    STORE -->|last account/vehicle/platform/per-preset %| VM
+    ACC -->|resolve account still exists| VM
+    VM -->|on save: persist last-used| STORE
+```
+
+**Boundary rules:**
+
+- The **default** business-use % for a preset is _always_ read from the shared
+  taxonomy (`preset.defaultBusinessUsePercent`). Android only stores an
+  **override** keyed by preset id, applied _on top of_ the shared default.
+- Category is never persisted as an editable preference — it is the preset's
+  shared `category`.
+- Proration / deductible math stays in `ScheduleCDeductionPresetTaxonomy.createDraft`
+  (see the [sheet design](./android-schedule-c-quick-add-sheet.md#6-transaction-draft-contract)).
+- Account/vehicle/platform are **Android-local UI preferences** with referential
+  re-validation against the repository (a remembered account may have been
+  deleted/archived).
+
+---
+
+## 4. Affected Android Surfaces & Shared Dependencies
+
+| Surface (new/modified)                                 | Type        | Role                                                                                       |
+| ------------------------------------------------------ | ----------- | ------------------------------------------------------------------------------------------ |
+| `data/quickadd/QuickAddDefaultsRepository.kt` (new)    | Repository  | Reads/writes last-used defaults via Preferences DataStore; exposes a `Flow`.               |
+| `data/quickadd/QuickAddDefaults.kt` (new)              | Data class  | Snapshot of resolved defaults (account id, vehicle, platform, per-preset % overrides map). |
+| `ui/quickadd/ScheduleCQuickAddViewModel.kt` (modified) | ViewModel   | Resolves defaults at load; persists last-used on successful save.                          |
+| `ui/quickadd/AccountVehiclePlatformPickers.kt` (new)   | Composables | Small dropdown/segmented pickers for account, vehicle, platform with `contentDescription`. |
+| `di/QuickAddModule.kt` (modified)                      | Koin module | `singleOf(::QuickAddDefaultsRepository)` (+ DataStore provider).                           |
+
+**Shared (KMP) dependencies — read only, no edits:**
+
+- `ScheduleCDeductionPresetTaxonomy` / `ScheduleCDeductionPreset`
+  (`defaultBusinessUsePercent`, `category`, `deductibleByDefault`).
+- `com.finance.models.Account`, `com.finance.models.types.SyncId`.
+- `AccountRepository` (Android data layer) for resolving/validating accounts.
+
+**DI / storage pattern:**
+
+```kotlin
+val quickAddModule = module {
+    single { provideQuickAddDataStore(androidContext()) }   // Preferences DataStore
+    singleOf(::QuickAddDefaultsRepository)
+    viewModelOf(::ScheduleCQuickAddViewModel)
+}
+```
+
+---
+
+## 5. Default-Resolution Rules
+
+When the sheet opens (or a preset is selected), the ViewModel resolves defaults
+in this deterministic order:
+
+```mermaid
+flowchart TD
+    A[Sheet opens] --> B{Stored last-used account exists\nAND still in AccountRepository?}
+    B -->|yes| C[Use stored account]
+    B -->|no| D[Use household primary cash account]
+    D --> E{none?}
+    E -->|yes| F[Use first account, else disable Save]
+    C --> G[Preset selected]
+    D --> G
+    G --> H{User override % stored for this preset id?}
+    H -->|yes| I[Apply stored override %]
+    H -->|no| J[Apply preset.defaultBusinessUsePercent from KMP]
+    I --> K[Vehicle: stored last-used if car preset, else none]
+    J --> K
+    K --> L[Platform: stored last-used, else none]
+```
+
+**Per-preset business-use % override**
+
+- Stored as a `Map<presetId, Int>` of the user's _last confirmed_ override.
+- On preset select: `resolvedPercent = storedOverride[presetId] ?? preset.defaultBusinessUsePercent`.
+- On successful save with an edited %, persist `storedOverride[presetId] = editedPercent`.
+- Reset affordance ("Use suggested 90%") clears the stored override for that
+  preset and falls back to the shared default.
+
+**Account / vehicle / platform**
+
+- Global "last-used" — persisted on each successful save.
+- Vehicle only auto-applies for vehicle-relevant presets (Gas, Tolls/Parking,
+  car & truck, vehicle lease); for non-vehicle presets the vehicle picker is
+  hidden.
+- Platform is optional metadata (added as a transaction tag, e.g.
+  `platform:doordash`); never required to save.
+
+---
+
+## 6. Storage Design (DataStore — not SharedPreferences for secrets)
+
+These are **non-secret UI preferences**, so **Jetpack Preferences DataStore** is
+the store (modern, coroutine/Flow-based, replaces raw SharedPreferences). No
+account numbers, balances, or credentials are stored here — only ids and a
+percentage map.
+
+> **Security boundary:** secrets (biometric keys, tokens) continue to use the
+> Android Keystore via
+> [`BiometricAuthManager`](../../apps/android/src/main/kotlin/com/finance/android/security/BiometricAuthManager.kt)
+> — **never** SharedPreferences/DataStore/plain files. The defaults here are not
+> secrets, but they still must not contain amounts or PII.
+
+**Keys (Preferences DataStore):**
+
+| Key                               | Type    | Example                                | Notes                                                                               |
+| --------------------------------- | ------- | -------------------------------------- | ----------------------------------------------------------------------------------- |
+| `quickadd.last_account_id`        | String  | `acct-cash-01`                         | Re-validated against `AccountRepository` on read.                                   |
+| `quickadd.last_vehicle_id`        | String? | `veh-civic`                            | App-local vehicle id.                                                               |
+| `quickadd.last_platform`          | String? | `doordash`                             | Lowercase tag.                                                                      |
+| `quickadd.business_use_overrides` | String  | JSON `{"schedule-c-car-and-truck":85}` | Serialized `Map<String,Int>`; values clamped 0..100 on write via shared validation. |
+
+**Write discipline**
+
+- Only persist on **successful save** (avoid remembering abandoned/exploratory
+  selections).
+- Before persisting a business-use override, route the value through the shared
+  `validateDraftRequest`/range check so we never store an out-of-range %.
+- Migrations: DataStore schema is additive; unknown keys ignored; corrupt JSON
+  for the overrides map falls back to an empty map (logged via `Timber.w`, no
+  values logged).
+
+---
+
+## 7. Lifecycle: Read, Apply, Persist
+
+```mermaid
+sequenceDiagram
+    participant S as QuickAddSheet
+    participant VM as ViewModel
+    participant DEF as QuickAddDefaultsRepository
+    participant ACC as AccountRepository
+    participant K as ScheduleCDeductionPresetTaxonomy
+
+    S->>VM: onOpen()
+    VM->>DEF: defaults().first()
+    DEF-->>VM: QuickAddDefaults(lastAccountId, vehicle, platform, overrides)
+    VM->>ACC: ensure lastAccountId still exists
+    ACC-->>VM: account or null -> fallback chain (§5)
+    S->>VM: selectPreset(id)
+    VM->>K: findPreset(id).defaultBusinessUsePercent
+    VM->>VM: resolvedPercent = overrides[id] ?? presetDefault
+    Note over VM: render account/vehicle/platform/% pre-filled
+    S->>VM: save()  (after validation passes)
+    VM->>DEF: persistLastUsed(accountId, vehicle, platform, id, editedPercent)
+    DEF-->>VM: ack (DataStore write)
+```
+
+---
+
+## 8. Offline-First, Empty & Error States
+
+| Scenario                            | Behavior                                                                                                                                                                                 |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Offline**                         | DataStore is fully local — defaults resolve and persist with no network. Unaffected by sync state.                                                                                       |
+| **First run (no stored defaults)**  | Fall back per [§5](#5-default-resolution-rules): primary cash account, preset's shared default %, no vehicle/platform. No empty-looking pickers.                                         |
+| **Stored account deleted/archived** | Re-validation fails → silently fall back to the next account in the chain; no error shown, just a sensible default.                                                                      |
+| **No accounts at all**              | Account picker shows "Add an account"; Save disabled with helper text (consistent with the [sheet design](./android-schedule-c-quick-add-sheet.md#8-offline-first-empty--error-states)). |
+| **Corrupt overrides JSON**          | Treated as empty map; preset shared defaults apply. `Timber.w("Resetting quick-add overrides; unreadable")` — no values logged.                                                          |
+| **DataStore write failure**         | Save of the _transaction_ still succeeds (preference persistence is best-effort); failure logged via `Timber.w`, no user-blocking error.                                                 |
+
+---
+
+## 9. Accessibility (TalkBack, Switch Access, Font Scaling)
+
+- **Every picker has a `contentDescription`** stating the current value, e.g.
+  account picker: `"Account, Cash Wallet. Double-tap to change."` Vehicle/platform
+  likewise.
+- **Announce resolved defaults on open** via a polite live region:
+  `"Defaults restored: Cash Wallet, Honda Civic, 90 percent business use."` so a
+  TalkBack user knows what is pre-filled without exploring every field.
+- **Business-use % field** announces both current value and origin:
+  `"Business use 90 percent, suggested default"` vs. `"…, your saved value"`.
+- **Reset affordance** ("Use suggested 90%") has a clear `contentDescription` and
+  announces the change.
+- **Font scaling 200%**: pickers wrap/scroll; the per-preset % control stays
+  reachable; never truncate the value (truncate the label, keep value in
+  `contentDescription`).
+- **Switch Access** focus order: account → vehicle → platform → business-use →
+  (returns to sheet flow). Pickers are single focusable groups.
+
+---
+
+## 10. Test Plan
+
+**Android unit (`apps/android/src/test`, JVM, CI without device):**
+
+- `QuickAddDefaultsRepositoryTest`
+  - round-trips account/vehicle/platform/overrides through a test DataStore.
+  - clamps/rejects out-of-range % on write (delegates to shared range check).
+  - corrupt overrides JSON → empty map, no crash.
+- `ScheduleCQuickAddViewModelTest` (defaults aspects)
+  - resolution order: stored account valid → used; deleted → fallback chain.
+  - `overrides[presetId] ?? preset.defaultBusinessUsePercent` honored
+    (e.g. stored 85 beats Gas's shared 90; absent → 90; Meals → 50; Home office → 25).
+  - successful save persists last-used; abandoned sheet persists nothing.
+  - non-vehicle preset hides vehicle and does not persist a vehicle.
+
+**Compose UI / instrumentation (`androidTest`, debug build):**
+
+- reopening the sheet restores the previously saved account + % (end-to-end with
+  a temp DataStore).
+- "Use suggested" reset returns the field to the shared default.
+
+**Accessibility tests:**
+
+- pickers expose non-empty `contentDescription` with current value.
+- defaults-restored live-region announcement asserted.
+- `fontScale = 2.0` keeps the % value visible.
+
+**Paparazzi snapshots:** default-restored state, override-applied state,
+no-account state, large-font variant.
+
+---
+
+## Implementation readiness
+
+| Phase                                                                                           | Status               | Gate                                                                                                      |
+| ----------------------------------------------------------------------------------------------- | -------------------- | --------------------------------------------------------------------------------------------------------- |
+| This design doc                                                                                 | ✅ Done              | None                                                                                                      |
+| `QuickAddDefaultsRepository` + DataStore + ViewModel wiring, unit/UI/Paparazzi, `assembleDebug` | 🟢 **Buildable now** | None — debug sideload per [`../ops/human-gated-prerequisites.md` §2](../ops/human-gated-prerequisites.md) |
+| Play Store release                                                                              | 🔒 **Gated**         | [#1242](https://github.com/jrmoulckers/finance/issues/1242) — keystore + Play Console                     |
+
+Preferences DataStore, the defaults repository, and the resolution logic are
+all standard local Android code — fully implementable and testable today with
+`./gradlew :apps:android:assembleDebug`. The deduction _rules_ already exist in
+`packages/core`. **Only Play distribution** is human-gated by #1242; see
+[`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md)
+§§2–3.1. No build, signing, or store action is performed by this design.
+
+---
+
+## Open Questions
+
+1. **Per-household scoping**: should last-used defaults be keyed by household id
+   (multi-household users)? Proposed: yes — prefix DataStore keys with the active
+   household id. Low risk to add now.
+2. **Platform list source**: hardcoded gig-platform enum vs. user-managed tags —
+   leaning user-managed tags to avoid a maintenance list; confirm with product.
+3. **Override expiry**: should a stale per-preset % override (e.g. > 1 year old)
+   revert to the shared default? Out of scope for v1; note for later.

--- a/docs/design/android-schedule-c-quick-add-sheet.md
+++ b/docs/design/android-schedule-c-quick-add-sheet.md
@@ -1,0 +1,418 @@
+# Android Schedule C Quick-Add Sheet — Design
+
+> **Status:** Design / breakdown · **Issue:** [#2523](https://github.com/jrmoulckers/finance/issues/2523) · **Part of [#2141](https://github.com/jrmoulckers/finance/issues/2141)**
+> **Platform:** Android (Jetpack Compose · Material 3) · **minSdk 28 / target 35**
+> **Companion designs:** [Quick-Add Defaults & Persistence](./android-quick-add-defaults-persistence.md) · [Cash Quick-Entry Deep Links](./android-cash-quick-entry-deep-links.md)
+
+A one-handed Compose bottom sheet that lets a parked gig worker log a common
+business deduction in two taps, with IRS Schedule C presets, large thumb-reach
+touch targets, and a draft contract backed entirely by shared KMP business rules.
+
+This is a **design + breakdown** document. Native implementation is _unblocked
+for local debug builds_ (`assembleDebug` sideload); only **Play Store
+distribution** is human-gated by
+[#1242](https://github.com/jrmoulckers/finance/issues/1242). See
+[Implementation readiness](#implementation-readiness) and
+[`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md).
+
+---
+
+## Table of Contents
+
+1. [Problem & Goals](#1-problem--goals)
+2. [Architecture Boundary (KMP vs. Compose)](#2-architecture-boundary-kmp-vs-compose)
+3. [Affected Android Surfaces & Shared Dependencies](#3-affected-android-surfaces--shared-dependencies)
+4. [Sheet Anatomy & One-Handed Layout](#4-sheet-anatomy--one-handed-layout)
+5. [Interaction Flow](#5-interaction-flow)
+6. [Transaction-Draft Contract](#6-transaction-draft-contract)
+7. [State Model](#7-state-model)
+8. [Offline-First, Empty & Error States](#8-offline-first-empty--error-states)
+9. [Accessibility (TalkBack, Switch Access, Font Scaling)](#9-accessibility-talkback-switch-access-font-scaling)
+10. [Test Plan](#10-test-plan)
+11. [Implementation readiness](#implementation-readiness)
+12. [Open Questions](#open-questions)
+
+---
+
+## 1. Problem & Goals
+
+From [#2141](https://github.com/jrmoulckers/finance/issues/2141): _"I'm using a
+mid-range Android phone one-handed while parked. I need a thumb-friendly way to
+log common gig expenses without opening a heavy form."_
+
+The current path is the 3-step
+[`TransactionCreateScreen`](../../apps/android/src/main/kotlin/com/finance/android/ui/screens/TransactionCreateScreen.kt)
+wizard (Amount → Category/Account → Confirm), which is too heavy for a quick
+deduction between deliveries.
+
+**Goals**
+
+- **Two-tap capture** for the most common gig deductions (preset → amount → save).
+- **Thumb-reachable** controls anchored to the bottom of a one-handed sheet.
+- **Schedule C alignment**: each preset pre-fills the IRS category, line, default
+  business-use %, and deductible default from the shared taxonomy.
+- **No finance math in Compose** — the sheet renders shared draft state and shows
+  shared validation results.
+
+**Non-goals**
+
+- Replacing the full create/edit wizard (it remains for complex/transfer entries).
+- Mileage tracking (separate workflow) — this sheet logs _expense amounts_, not trips.
+- Owning preset definitions or proration math in the Android layer.
+
+---
+
+## 2. Architecture Boundary (KMP vs. Compose)
+
+All deduction rules, preset definitions, validation, and proration live in the
+shared module
+[`packages/core/.../schedulec/ScheduleCDeductionPresets.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/schedulec/ScheduleCDeductionPresets.kt).
+The Compose sheet is a **pure renderer of shared state** plus a thin Android
+ViewModel that calls into the shared API.
+
+```mermaid
+flowchart TD
+    subgraph Android["apps/android (Compose — render only)"]
+        SHEET[ScheduleCQuickAddSheet\nModalBottomSheet]
+        VM[ScheduleCQuickAddViewModel\nkoinViewModel]
+        REPO[(TransactionRepository\nAccountRepository)]
+    end
+    subgraph KMP["packages/core (shared business rules)"]
+        TAX[ScheduleCDeductionPresetTaxonomy]
+        REQ[ScheduleCDraftRequest]
+        DRAFT[ScheduleCTransactionDraft]
+        VAL[validateDraftRequest / validateDraft]
+    end
+    SHEET -->|amount, override| VM
+    VM -->|createDraft / validate| TAX
+    TAX --> REQ --> DRAFT
+    TAX --> VAL
+    DRAFT -->|render: deductibleAmountCents, irsLine| SHEET
+    VM -->|on save: map draft -> Transaction| REPO
+```
+
+**Boundary rules (do not violate in implementation):**
+
+- The ViewModel never computes proration or deductible amounts — it calls
+  `ScheduleCDeductionPresetTaxonomy.createDraft(presetId, request)`.
+- Validation messages shown in the sheet come from
+  `validateDraftRequest(...)` / `validateDraft(...)`; the Compose layer never
+  re-implements the `amount > 0` or `0..100` business-use checks.
+- The Android layer **maps** the resulting `ScheduleCTransactionDraft` to a
+  [`Transaction`](../../packages/models/src/commonMain/kotlin/com/finance/models/Transaction.kt)
+  at save time (category, amount, tags, memo) — see
+  [§6](#6-transaction-draft-contract).
+- If a new preset or rule is needed, it is added in `packages/*` by
+  `@kmp-engineer`; this design does not implement it here.
+
+---
+
+## 3. Affected Android Surfaces & Shared Dependencies
+
+| Surface (new/modified)                            | Type        | Role                                                                                                                         |
+| ------------------------------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `ui/quickadd/ScheduleCQuickAddSheet.kt` (new)     | Composable  | `ModalBottomSheet` host: preset grid, amount pad, deductible summary, save bar.                                              |
+| `ui/quickadd/ScheduleCPresetChip.kt` (new)        | Composable  | Large preset chip/card (icon + label + IRS line), ≥ 56 dp target.                                                            |
+| `ui/quickadd/ScheduleCQuickAddViewModel.kt` (new) | ViewModel   | Holds UI state; delegates draft creation/validation to shared taxonomy.                                                      |
+| `ui/screens/TransactionsScreen.kt` (modified)     | Composable  | Adds the FAB / entry affordance that launches the sheet (see [deep-links design](./android-cash-quick-entry-deep-links.md)). |
+| `di/QuickAddModule.kt` (new)                      | Koin module | `viewModelOf(::ScheduleCQuickAddViewModel)`; wired in `FinanceApplication`.                                                  |
+
+**Shared (KMP) dependencies — already exist, no edits here:**
+
+- `com.finance.core.schedulec.ScheduleCDeductionPresetTaxonomy` — preset list,
+  `createDraft`, `validateDraftRequest`, `validateDraft`, `findPreset`.
+- `ScheduleCDeductionPreset`, `ScheduleCDraftRequest`, `ScheduleCTransactionDraft`,
+  `ScheduleCValidationIssue`, `ScheduleCExpenseCategory`.
+- `com.finance.models.types.Cents`, `Currency`, `SyncId`.
+- `com.finance.core.currency.CurrencyFormatter` for display formatting.
+- `com.finance.models.Transaction` for the persisted entity.
+
+**Koin pattern** (per repo convention):
+
+```kotlin
+val quickAddModule = module {
+    viewModelOf(::ScheduleCQuickAddViewModel)
+}
+// In the sheet host:
+val vm = koinViewModel<ScheduleCQuickAddViewModel>()
+```
+
+---
+
+## 4. Sheet Anatomy & One-Handed Layout
+
+A Material 3 `ModalBottomSheet`, expandable but usable at a partial height that
+keeps every interactive control in the bottom ~60% of the screen (thumb arc on a
+6.5" device held one-handed).
+
+```
+┌──────────────────────────────────────────┐  ← drag handle (44dp hit area)
+│  ▒▒▒▒▒                                     │
+│  Quick add deduction                       │  ← title (TalkBack heading)
+│  Account: Cash Wallet ▾   Vehicle: Civic ▾ │  ← last-used defaults (#2525)
+│                                            │
+│  ┌──────┐ ┌──────┐ ┌──────┐               │
+│  │ ⛽   │ │ 🅿️   │ │ 📱   │               │  preset grid (2 cols × N rows,
+│  │ Gas  │ │ Toll │ │Phone%│               │  large chips, scrolls vertically)
+│  │ Ln 9 │ │ Ln 9 │ │ Ln25 │               │
+│  └──────┘ └──────┘ └──────┘               │
+│  ┌──────┐ ┌──────┐ ┌──────┐               │
+│  │ 🛡️   │ │ 📦   │ │  …   │               │
+│  │Insur.│ │Suppl.│ │ More │               │
+│  └──────┘ └──────┘ └──────┘               │
+│ ── selected: Gas · Line 9 ─────────────── │
+│  Amount   $ [ 24.50 ]                      │  ← amount field + numeric pad
+│  Business use  [ 90% ]  Deductible ✓       │  ← editable override (default 90%)
+│  Deductible amount:  $22.05                │  ← READ-ONLY, from shared draft
+│                                            │
+│  ┌──────────────────────────────────────┐ │
+│  │            Save deduction             │ │  ← primary, full-width, ≥ 56dp,
+│  └──────────────────────────────────────┘ │     anchored bottom (thumb zone)
+└──────────────────────────────────────────┘
+```
+
+**Layout principles**
+
+- **Touch targets ≥ 56 dp** (preset chips and Save), exceeding the 48 dp minimum
+  in [`accessibility-patterns.md`](./accessibility-patterns.md), because the user
+  may be in a moving-vehicle-adjacent context.
+- **Primary action anchored bottom**, full-width, never requiring a stretch to
+  the top of the screen.
+- **Preset grid scrolls**, not the whole sheet, so the amount/save controls stay
+  pinned and reachable.
+- **Material You dynamic color** via `MaterialTheme`/`dynamicColorScheme`; chips
+  use `primaryContainer`/`onPrimaryContainer` and the selected chip elevates.
+- **No emoji-only meaning** — every chip pairs an icon with a text label and an
+  IRS line caption; the icon is decorative (`contentDescription = null`), the
+  label carries the semantics.
+
+**Preset ordering** for gig drivers (subset surfaced first, full taxonomy behind
+"More"): Gas/Fuel (`schedule-c-car-and-truck`, Line 9), Tolls & Parking (Line 9),
+Phone % (`schedule-c-utilities`, Line 25), Insurance (Line 15), Supplies (Line
+22), Commissions/Platform fees (Line 10). Order is a presentation concern in the
+Android layer; the canonical definitions stay in the shared taxonomy.
+
+---
+
+## 5. Interaction Flow
+
+```mermaid
+sequenceDiagram
+    participant U as User (one-handed)
+    participant S as ScheduleCQuickAddSheet
+    participant VM as ScheduleCQuickAddViewModel
+    participant K as ScheduleCDeductionPresetTaxonomy (KMP)
+    participant R as TransactionRepository
+
+    U->>S: Open sheet (FAB / widget / shortcut)
+    S->>VM: load(defaults)  // last-used account/vehicle/% from #2525
+    VM-->>S: presets + resolved defaults
+    U->>S: Tap "Gas" preset (tap 1)
+    S->>VM: selectPreset("schedule-c-car-and-truck")
+    VM->>K: findPreset(id) -> defaultBusinessUsePercent=90
+    VM-->>S: preset selected, business-use prefilled
+    U->>S: Enter amount $24.50 (tap 2 region)
+    S->>VM: updateAmount("24.50")
+    VM->>K: createDraft(id, ScheduleCDraftRequest(amountCents=2450, override?))
+    K-->>VM: ScheduleCTransactionDraft(deductibleAmountCents=2205, ...)
+    VM-->>S: render deductible summary (read-only)
+    U->>S: Tap "Save deduction"
+    VM->>K: validateDraft(draft)
+    alt issues empty
+        VM->>R: insert(Transaction mapped from draft)  // offline-first
+        VM-->>S: success -> dismiss + snackbar "Saved"
+    else issues present
+        VM-->>S: show field errors (from ScheduleCValidationIssue)
+    end
+```
+
+**Two-tap promise:** with last-used defaults resolved, the minimum path is
+_tap preset → type amount → Save_. Business-use % and deductible are pre-filled
+from the preset and only need touching when the user wants to override.
+
+---
+
+## 6. Transaction-Draft Contract
+
+The shared layer owns the draft; the Android layer owns the **mapping to a
+persisted `Transaction`**. Contract:
+
+**Inputs the sheet provides to KMP**
+
+| Field                          | Source                       | Notes                                       |
+| ------------------------------ | ---------------------------- | ------------------------------------------- |
+| `presetId: String`             | Selected preset chip         | e.g. `schedule-c-car-and-truck`.            |
+| `amountCents: Cents`           | Amount field (parsed)        | Must be `> 0` (shared validation enforces). |
+| `businessUsePercentOverride`   | Editable field (nullable)    | `null` → preset default; else `0..100`.     |
+| `deductibleOverride: Boolean?` | Deductible toggle (nullable) | `null` → preset `deductibleByDefault`.      |
+| `memo: String?`                | Optional note                | Trimmed/normalized by shared `createDraft`. |
+
+**Output from `createDraft(presetId, request)` → `ScheduleCTransactionDraft`**
+
+`presetId`, `category`, `categoryDisplayName`, `irsLine`, `amountCents`,
+`deductible`, `businessUsePercent`, `deductibleAmountCents` (pre-prorated, **read
+only** in UI), `memo`.
+
+**Android mapping `ScheduleCTransactionDraft` → `Transaction` (at save):**
+
+| `Transaction` field | Value                                                                                    |
+| ------------------- | ---------------------------------------------------------------------------------------- |
+| `type`              | `TransactionType.EXPENSE`                                                                |
+| `amount`            | `Cents(-draft.amountCents.amount)` (expense sign, matches wizard convention)             |
+| `accountId`         | Resolved last-used account (see [#2525](./android-quick-add-defaults-persistence.md))    |
+| `categoryId`        | Mapped from `draft.category` to the household category (mapping owned by repository/KMP) |
+| `tags`              | `["schedule-c", draft.irsLine, "business-use:${draft.businessUsePercent}"]`              |
+| `note` / `memo`     | `draft.memo`                                                                             |
+| `currency`          | `Currency.USD` (household currency)                                                      |
+| `status`            | `TransactionStatus.CLEARED`                                                              |
+| `date`              | Today (system zone), matching wizard default                                             |
+
+> **Boundary note:** the deductible **amount** is a derived/reporting value; it is
+> not a separate ledger entry. It is carried via tag/metadata so Schedule C
+> reporting (shared) can reconstruct it. The exact persistence of
+> `deductibleAmountCents` and the category-mapping table are KMP/repository
+> decisions — this doc defines the _contract_, not the storage. Do not invent a
+> new column in the Android layer.
+
+---
+
+## 7. State Model
+
+```kotlin
+// Android-only UI state — no finance math, mirrors shared draft.
+data class ScheduleCQuickAddUiState(
+    val presets: List<ScheduleCDeductionPreset> = emptyList(),
+    val selectedPresetId: String? = null,
+    val amountText: String = "",
+    val businessUsePercentText: String = "",   // prefilled from preset default
+    val deductibleOverride: Boolean? = null,
+    val memo: String = "",
+    val accounts: List<Account> = emptyList(),
+    val selectedAccountId: SyncId? = null,      // last-used default (#2525)
+    val draft: ScheduleCTransactionDraft? = null,  // produced by shared createDraft
+    val fieldErrors: List<ScheduleCValidationIssue> = emptyList(),
+    val isSaving: Boolean = false,
+    val isSaved: Boolean = false,
+    val isOffline: Boolean = false,
+)
+```
+
+- `draft` is recomputed by calling the shared taxonomy whenever amount/preset/
+  override changes; the deductible summary renders `draft.deductibleAmountCents`.
+- `fieldErrors` are the shared `ScheduleCValidationIssue`s mapped to per-field
+  messages — never authored in Compose.
+
+---
+
+## 8. Offline-First, Empty & Error States
+
+| Scenario                        | Behavior                                                                                                                                                                                                                       |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Offline (no network)**        | Full functionality. `TransactionRepository.insert` writes to the local SQLDelight/SQLCipher store; sync happens later via `SyncWorker` (WorkManager). A subtle "Saved offline — will sync" snackbar with `contentDescription`. |
+| **No accounts yet**             | Preset grid still renders; Save is disabled with helper text "Add a cash or bank account to save." CTA deep-links to account create. Announced politely via TalkBack.                                                          |
+| **No amount entered**           | Save disabled; the shared `validateDraftRequest` reports `amountCents` "Amount must be greater than zero" only on attempted save (avoid nagging while typing).                                                                 |
+| **Business-use out of range**   | Inline error from `businessUsePercentOverride` validation ("Business-use percent must be in 0..100"); Save blocked.                                                                                                            |
+| **Save failure (DB/exception)** | Non-dismissing error snackbar with Retry; the sheet stays open with input preserved. Logged via `Timber.e(t, "Quick-add save failed")` — **never** log amount/account values.                                                  |
+| **Preset taxonomy empty**       | Should never happen (static list); defensive empty state shows "Presets unavailable" and routes to the full wizard.                                                                                                            |
+
+**Logging:** use Timber only; never `Log.*`. Never log `amountCents`,
+`deductibleAmountCents`, account names, or balances.
+
+---
+
+## 9. Accessibility (TalkBack, Switch Access, Font Scaling)
+
+Per [`accessibility-patterns.md`](./accessibility-patterns.md) and
+[`cognitive-accessibility.md`](./cognitive-accessibility.md):
+
+- **`contentDescription` on every interactive/informational element.** Preset
+  chip: `"Gas, Schedule C line 9, business use 90 percent. Selects this deduction."`
+  Decorative icons are `null`; the label text carries meaning.
+- **Sheet title is a TalkBack heading** (`semantics { heading() }`); focus moves
+  to the title on open.
+- **Deductible summary is a live region** (`liveRegion = Polite`) so the announced
+  deductible amount updates as the user types the amount (announce the formatted
+  string from `CurrencyFormatter`, e.g. "Deductible amount $22.05").
+- **Logical focus order**: title → defaults → preset grid → amount → business-use
+  → save. Save button reachable by Switch Access scanning early (it is large and
+  late in DOM but grouped).
+- **Touch targets ≥ 56 dp**; spacing ≥ 8 dp to avoid mis-taps one-handed.
+- **Font scaling to 200%**: chips use flexible height + `maxLines` with ellipsis
+  on label but full text in `contentDescription`; the sheet scrolls rather than
+  truncating the amount/save controls. Verify at `fontScale = 2.0`.
+- **State announcements**: selecting a preset announces the new business-use
+  default; save success announces "Deduction saved".
+- **Color independence**: the selected chip is conveyed by elevation + a check
+  glyph + `stateDescription = "Selected"`, not color alone.
+
+---
+
+## 10. Test Plan
+
+**Shared (already covered in KMP; reference only):**
+[`ScheduleCDeductionPresetTaxonomyTest`](../../packages/core/src/commonTest/kotlin/com/finance/core/schedulec/ScheduleCDeductionPresetTaxonomyTest.kt)
+covers `createDraft`, proration, and validation — the Android layer must not
+duplicate these.
+
+**Android unit (`apps/android/src/test`, JVM, runs in CI without a device):**
+
+- `ScheduleCQuickAddViewModelTest`
+  - selecting a preset prefills `businessUsePercentText` from the preset default
+    (Gas → 90, Meals → 50, Home office → 25).
+  - amount change recomputes `draft` via the shared taxonomy; `deductibleAmountCents`
+    matches the shared result (no local math).
+  - `validateDraftRequest` errors surface as `fieldErrors` and block save.
+  - save maps draft → `Transaction` with EXPENSE type, negative amount, schedule-c
+    tags, and the selected account; calls `repository.insert` exactly once.
+  - offline insert path sets `isSaved` without requiring network.
+
+**Compose UI / instrumentation (`androidTest`, debug build):**
+
+- two-tap happy path: open → tap preset → type amount → Save → dismiss.
+- Save disabled when no account / no amount; helper text present.
+- robot pattern consistent with existing
+  [`TransactionRobot`](../../apps/android/src/androidTest/kotlin/com/finance/android/e2e/robot/TransactionRobot.kt).
+
+**Accessibility tests:**
+
+- TalkBack semantics assertions (every chip + save has non-empty
+  `contentDescription`; title is a heading; deductible summary is a live region).
+- `fontScale = 2.0` layout does not clip amount/save.
+- Switch Access focus-order test.
+
+**Paparazzi snapshot tests** (no device, runs in CI):
+
+- collapsed sheet, expanded sheet, preset-selected state, error state, large-font
+  (`fontScale = 1.5`) variant, dark/OLED theme
+  ([`oled-dark-mode.md`](./oled-dark-mode.md)).
+
+---
+
+## Implementation readiness
+
+| Phase                                                                                           | Status               | Gate                                                                                                      |
+| ----------------------------------------------------------------------------------------------- | -------------------- | --------------------------------------------------------------------------------------------------------- |
+| This design doc                                                                                 | ✅ Done              | None                                                                                                      |
+| Compose sheet + ViewModel + Koin wiring, unit/UI/Paparazzi tests, `:apps:android:assembleDebug` | 🟢 **Buildable now** | None — debug sideload per [`../ops/human-gated-prerequisites.md` §2](../ops/human-gated-prerequisites.md) |
+| Play Store release (signed AAB, internal/production tracks)                                     | 🔒 **Gated**         | [#1242](https://github.com/jrmoulckers/finance/issues/1242) — keystore + Play Console                     |
+
+The deduction logic already exists in `packages/core`; the entire sheet is
+renderable and testable today against the shared taxonomy with
+`./gradlew :apps:android:assembleDebug` and unit/instrumentation/Paparazzi
+suites. **Only Play distribution** (release signing, Play Console upload) is
+human-gated by #1242 — see
+[`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md)
+§§2–3.1. No native build, signing, or store action is performed by this design.
+
+---
+
+## Open Questions
+
+1. **Category mapping** `ScheduleCExpenseCategory` → household `Category` row:
+   owned by KMP/repository. Does a mapping table already exist, or does
+   `@kmp-engineer` need to add one? (Tracked separately; does not block the sheet.)
+2. **Deductible-amount persistence**: tag/metadata vs. a dedicated field — KMP
+   decision; this design carries it via tags pending that call.
+3. **Vehicle selector** scope here vs. fully in
+   [#2525](./android-quick-add-defaults-persistence.md) — defaults doc owns the
+   persistence; this sheet only renders the chosen vehicle.


### PR DESCRIPTION
## Summary

Design + breakdown batch for one-handed Android quick-add — Schedule C gig
deduction presets and cash quick-entry. Three related issues delivered as one
merged PR (all design-only; native impl is unblocked for `assembleDebug`
sideload, only Play distribution is gated by #1242).

Part of #2141 (gig Schedule C quick add) and #2180 (cash-first quick entry).

## Changes

Three new design docs under `docs/design/` (no existing files, `packages/`,
shared config, or other platforms touched):

- **`android-schedule-c-quick-add-sheet.md`** (#2523) — one-handed Compose
  `ModalBottomSheet` with gig deduction presets, ≥ 56 dp touch targets, and the
  transaction-draft contract. Maps the shared `ScheduleCTransactionDraft` →
  `Transaction` at save; all deduction/proration/validation stays in
  `packages/core` (Compose renders shared state).
- **`android-quick-add-defaults-persistence.md`** (#2525) — last-used account,
  vehicle, platform, per-preset business-use %, and category default behavior.
  Preferences DataStore for non-secret prefs (secrets stay in Keystore);
  defaults are user preferences layered on top of the shared preset defaults.
- **`android-cash-quick-entry-deep-links.md`** (#2538) — Glance widget, App
  Shortcut, FAB, and Transactions deep links converging on one prefilled
  cash-expense draft route (`navDeepLink`), with Spanish localization for the
  previously hardcoded widget labels.

Each doc covers: affected Android surfaces + shared deps, the KMP↔Compose
boundary, offline-first/empty/error states, TalkBack/Switch Access/font-scaling
accessibility, a test plan (unit + instrumentation + Paparazzi), and an
**Implementation readiness** section distinguishing buildable-now (`assembleDebug`)
from the Play-distribution tail gated by #1242
(`docs/ops/human-gated-prerequisites.md`).

## Testing

- `npx prettier --write` then `--check` on all three files — "All matched files
  use Prettier code style!"
- Grounded against `ScheduleCDeductionPresetTaxonomy`, the transaction-draft
  models, `FinanceNavHost`, `QuickEntryWidget`, `TransactionCreateViewModel`, and
  the human-gated prerequisites runbook. Docs-only change; no code paths altered.

Closes #2523
Closes #2525
Closes #2538
