### PR TITLE
docs(design): android gig tax-reserve and mileage design batch (#2517, #2518, #2519)

### DIFF
--- a/docs/design/android-gig-tax-reserve-settings.md
+++ b/docs/design/android-gig-tax-reserve-settings.md
@@ -1,0 +1,328 @@
+# Android — Gig Tax-Reserve Settings & Onboarding Flow
+
+> **Status:** DRAFT — design only (pending human review)
+> **Owner:** @android-engineer
+> **Issue:** [#2517](https://github.com/jrmoulckers/finance/issues/2517) · **Part of** [#2135](https://github.com/jrmoulckers/finance/issues/2135)
+> **Platform:** Android phone + tablet (Jetpack Compose, Material 3)
+> **Last Updated:** 2026-06-22
+
+This document specifies the **design** for the Android settings and onboarding flow that lets a
+self-employed / gig worker configure their tax-reserve percentages, understand estimate
+disclaimers, and opt in to weekly reserve reminders. It is **design + breakdown only** — no native
+implementation ships while the Android _distribution_ tail is gated by
+[#1242](https://github.com/jrmoulckers/finance/issues/1242) (see
+[Implementation Readiness](#implementation-readiness)).
+
+---
+
+## Table of Contents
+
+- [1. Goals & Non-Goals](#1-goals--non-goals)
+- [2. KMP / Compose Boundary](#2-kmp--compose-boundary)
+- [3. Affected Android Surfaces](#3-affected-android-surfaces)
+- [4. Shared Dependencies](#4-shared-dependencies)
+- [5. Onboarding Flow](#5-onboarding-flow)
+- [6. Settings Surface](#6-settings-surface)
+- [7. Estimate Disclaimers](#7-estimate-disclaimers)
+- [8. Weekly Reserve Reminders](#8-weekly-reserve-reminders)
+- [9. State Model (Offline / Empty / Error)](#9-state-model-offline--empty--error)
+- [10. Accessibility (TalkBack & Font Scaling)](#10-accessibility-talkback--font-scaling)
+- [11. Test Plan](#11-test-plan)
+- [12. Implementation Readiness](#12-implementation-readiness)
+
+---
+
+## 1. Goals & Non-Goals
+
+### Goals
+
+- Let a gig worker set an overall tax-reserve **rate**, or break it down into federal / state /
+  self-employment components, during onboarding and later in Settings.
+- Render the **recommended reserve range** (25%–30%, default 28%) sourced from shared KMP constants,
+  so guidance stays consistent across platforms.
+- Surface clear, repeated **"this is an estimate, not tax advice"** disclaimers wherever a dollar
+  figure or percentage is shown.
+- Let the user **opt in** to a weekly local reminder to move money into their tax-reserve bucket.
+- Work **fully offline** — all rates persist locally and never require network or backend auth.
+
+### Non-Goals
+
+- Computing the reserve math in Compose (owned by KMP — see [§2](#2-kmp--compose-boundary)).
+- Filing, paying, or transmitting estimated taxes to any tax authority.
+- Multi-jurisdiction / multi-state tax tables (out of scope; tracked separately under #2135).
+- Wear OS surfacing of reserve settings (a possible follow-up, not part of this issue).
+
+---
+
+## 2. KMP / Compose Boundary
+
+**All finance math stays in KMP `packages/*`.** Compose renders shared state and forwards user
+intents; it never recomputes tax figures. This mirrors the
+[Data Model](./data-model.md) rule that money is integer cents and computed in shared code.
+
+| Concern                                         | Owner   | Symbol / location                                                                                                                              |
+| ----------------------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Default & suggested reserve rates               | KMP     | `TaxReserveCalculator.DEFAULT_TAX_RESERVE_RATE` (`0.28`), `MIN_SUGGESTED_TAX_RESERVE_RATE` (`0.25`), `MAX_SUGGESTED_TAX_RESERVE_RATE` (`0.30`) |
+| Rate breakdown (federal/state/SE)               | KMP     | `TaxReserveSettings`, `TaxReserveRateBreakdown`                                                                                                |
+| Recommended reserve from net income             | KMP     | `TaxReserveCalculator.calculateRecommendedTaxReserveCents(...)`                                                                                |
+| Quarter summary, due dates, shortfall           | KMP     | `TaxReserveCalculator.buildTaxReserveSummary(...)` → `TaxReserveSummary`                                                                       |
+| Estimated take-home preview                     | KMP     | `GigTakeHomeCalculator.calculate(...)` → `GigTakeHomeResult`                                                                                   |
+| Rate clamping / validation (`0.0..1.0`)         | KMP     | `normalizeRate(...)` inside the calculator                                                                                                     |
+| Compose screens, ViewModels, persistence wiring | Android | `apps/android/...` (this doc)                                                                                                                  |
+
+Source of truth:
+[`packages/core/src/commonMain/kotlin/com/finance/core/tax/TaxCalculators.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/tax/TaxCalculators.kt).
+
+> **Rule:** the Android layer must never hard-code `0.28`, the `25–30%` band, or any percentage math.
+> It reads these from the shared calculator so the iOS/web/Windows clients stay consistent. The
+> ViewModel holds a `TaxReserveSettings` instance and asks the calculator for derived values.
+
+```mermaid
+flowchart LR
+    A[TaxReserveSettingsScreen<br/>Compose] -->|intent: rate change| B[TaxReserveSettingsViewModel]
+    B -->|TaxReserveSettings| C[TaxReserveCalculator<br/>KMP packages/core]
+    C -->|recommended cents,<br/>summary, take-home| B
+    B -->|TaxReserveUiState| A
+    B --> D[EncryptedSharedPreferences<br/>local persistence]
+    B --> E[ReserveReminderScheduler<br/>WorkManager]
+```
+
+---
+
+## 3. Affected Android Surfaces
+
+All new Compose; **no XML layouts**. New files live under
+`apps/android/src/main/kotlin/com/finance/android/`.
+
+| Surface            | New file (proposed)                                                                               | Role                                                              |
+| ------------------ | ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| Onboarding step    | `ui/onboarding/TaxReserveOnboardingStep.kt`                                                       | Optional "Set aside for taxes" step in the onboarding pager       |
+| Settings screen    | `ui/screens/settings/TaxReserveSettingsScreen.kt`                                                 | Full rate editor + disclaimers + reminder toggle                  |
+| Settings entry row | _edit-adjacent_ `ui/screens/SettingsScreen.kt` (new section composable only)                      | "Tax reserve" row that navigates to the screen                    |
+| ViewModel          | `ui/screens/settings/TaxReserveSettingsViewModel.kt`                                              | Holds `TaxReserveUiState`, calls KMP calculator                   |
+| Reminder worker    | `sync/ReserveReminderWorker.kt`                                                                   | Weekly `CoroutineWorker` posting the reserve nudge                |
+| Reminder scheduler | `sync/ReserveReminderScheduler.kt`                                                                | Enqueues / cancels the periodic work                              |
+| Koin wiring        | `di/AppModule.kt` (append only)                                                                   | `viewModelOf(::TaxReserveSettingsViewModel)` + scheduler `single` |
+| Navigation         | `ui/navigation/FinanceNavHost.kt` (route add)                                                     | `taxReserveSettings` destination                                  |
+| Preview / snapshot | `ui/screens/settings/TaxReserveSettingsPreview.kt`, `test/.../snapshot/TaxReserveSnapshotTest.kt` | Compose Preview + Paparazzi                                       |
+
+> The existing [`SettingsScreen.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/screens/SettingsScreen.kt)
+> already composes many `@Suppress("TooManyFunctions")` sections; we add one **Tax reserve** section
+> composable and a nav action rather than rewriting the screen. The dedicated editor lives on its own
+> route to keep the rate-breakdown UI focused.
+
+---
+
+## 4. Shared Dependencies
+
+| Dependency                                                                           | Use                                                                   |
+| ------------------------------------------------------------------------------------ | --------------------------------------------------------------------- |
+| `com.finance.core.tax.TaxReserveCalculator`                                          | Default/suggested rates, recommended reserve, quarter summary         |
+| `com.finance.core.tax.TaxReserveSettings` / `TaxReserveRateBreakdown`                | The persisted/edited model                                            |
+| `com.finance.core.tax.TaxReserveSummary` / `TaxReserveSummaryInput`                  | "What you'd owe this quarter" preview                                 |
+| `com.finance.core.tax.GigTakeHomeCalculator`                                         | Optional take-home preview using the chosen rate                      |
+| `com.finance.models.types.Cents`                                                     | Integer-cent money type (never floats)                                |
+| Koin `koin-compose-viewmodel`                                                        | `koinViewModel<TaxReserveSettingsViewModel>()`                        |
+| `androidx.security.crypto.EncryptedSharedPreferences` (via `EncryptedPrefsProvider`) | Local persistence of `TaxReserveSettings` (no secrets in plain prefs) |
+| WorkManager (`androidx.work`)                                                        | Weekly reserve reminder — **never** `AlarmManager`/`JobScheduler`     |
+| Timber                                                                               | Structured logging — **never** log rates, amounts, or income          |
+
+Persistence note: the rate (a percentage, not a secret) is stored in the existing encrypted
+`finance_settings` store reached through
+[`EncryptedPrefsProvider`](../../apps/android/src/main/kotlin/com/finance/android/security/EncryptedPrefsProvider.kt),
+matching how `SettingsViewModel` already persists preferences. The reserve **bucket balance** is
+derived from account data, not stored here.
+
+---
+
+## 5. Onboarding Flow
+
+An **optional, skippable** step added to the onboarding pager
+([`OnboardingNavigation.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/onboarding/OnboardingNavigation.kt)).
+It only appears when the user self-identifies as self-employed / gig (existing onboarding profile
+question); otherwise it is bypassed so non-gig users are not burdened.
+
+```mermaid
+flowchart TD
+    Start([Onboarding pager]) --> Q{Gig / self-employed?}
+    Q -->|No| Skip[Skip tax-reserve step]
+    Q -->|Yes| Intro[Intro: why set aside for taxes]
+    Intro --> Mode{Simple or detailed?}
+    Mode -->|Simple| Slider[Single rate slider<br/>default 28%, band 25–30% highlighted]
+    Mode -->|Detailed| Breakdown[Federal + State + SE inputs<br/>sum shown live]
+    Slider --> Preview[Live take-home preview + disclaimer]
+    Breakdown --> Preview
+    Preview --> Remind{Enable weekly reminder?}
+    Remind --> Save[Persist TaxReserveSettings]
+    Save --> Done([Continue onboarding])
+    Skip --> Done
+```
+
+Behaviour:
+
+- **Simple mode** is default: one slider/stepper bound to `TaxReserveSettings.rate`. The
+  recommended `25%–30%` band (from the KMP `MIN/MAX_SUGGESTED` constants) is visually highlighted,
+  and `28%` is the pre-selected default.
+- **Detailed mode** exposes federal / state / self-employment fields mapping to
+  `TaxReserveRateBreakdown`. The live sum is computed by the KMP calculator and shown as the
+  effective rate; Compose only displays it.
+- The step is **fully skippable** and re-enterable later from Settings — never a hard gate.
+- Defaults are applied even if skipped, so the rest of the app has a valid `TaxReserveSettings`.
+
+---
+
+## 6. Settings Surface
+
+The dedicated `TaxReserveSettingsScreen` (Material 3, `Scaffold` + `LargeTopAppBar`) contains:
+
+1. **Rate editor card** — Simple/Detailed toggle (same components as onboarding, reused).
+   - Simple: `Slider` (or `+`/`−` stepper for precise 1% control) with the suggested band marked.
+   - Detailed: three labelled `OutlinedTextField`s (federal/state/SE) with `%` suffix; live effective
+     rate from KMP.
+2. **Preview card** — "At a 28% reserve, on \$1,000 of net gig income you'd set aside \$280." Numbers
+   come from `TaxReserveCalculator.calculateRecommendedTaxReserveCents(...)` / `GigTakeHomeCalculator`.
+   Marked clearly as an example.
+3. **This quarter card** (when income data exists) — `TaxReserveSummary` fields: recommended reserve,
+   amount already reserved, shortfall, next quarterly due date + `daysUntilDue`, and the
+   `dueDateStatus` chip (`FUTURE` / `DUE_SOON` / `DUE_TODAY`).
+4. **Reminders card** — weekly reminder `Switch` + day/time preference (see [§8](#8-weekly-reserve-reminders)).
+5. **Disclaimer footer** — persistent (see [§7](#7-estimate-disclaimers)).
+
+Material 3 / Material You: inherit `MaterialTheme` dynamic color from the app; status uses
+semantic color roles (e.g. `error`/`tertiary`) and **never color alone** to convey shortfall — pair
+with text + icon.
+
+---
+
+## 7. Estimate Disclaimers
+
+Tax math is an **estimate, not advice**. Disclaimers appear at three densities:
+
+| Placement                                 | Copy intent                                                                                                    |
+| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Onboarding intro                          | "This sets aside a portion of gig income as an estimate. It isn't tax advice — check with a tax professional." |
+| Inline under every dollar/percent preview | Short: "Estimate only." linking to the full text.                                                              |
+| Persistent settings footer                | Full disclaimer + "Rates are guidance based on common self-employment ranges."                                 |
+| Reminder notification body                | "Estimated reserve — not tax advice." (no amounts on lock screen)                                              |
+
+Implementation notes:
+
+- Disclaimer copy lives in Android string resources (localizable) — **not** in KMP, since it is
+  UI/legal copy, not math. Align wording with
+  [`content-language-guidelines.md`](./content-language-guidelines.md).
+- The inline "Estimate only" affordance is a `TextButton`/link that expands the full text in a
+  `ModalBottomSheet`, keeping primary screens uncluttered.
+- Disclaimers are **always visible** when a figure is shown — never gated behind a dismiss.
+
+---
+
+## 8. Weekly Reserve Reminders
+
+Opt-in, **local-only**, privacy-preserving nudges to move money into the tax bucket.
+
+- Scheduled with **WorkManager** (`PeriodicWorkRequestBuilder<ReserveReminderWorker>(7, DAYS)`),
+  following the exact pattern of
+  [`BillReminderWorker`](../../apps/android/src/main/kotlin/com/finance/android/sync/BillReminderWorker.kt):
+  `CoroutineWorker` + `KoinComponent`, `enqueueUniquePeriodicWork(..., ExistingPeriodicWorkPolicy.KEEP)`,
+  linear backoff. **Never** `AlarmManager`/`JobScheduler`.
+- Reuses the existing notifications stack (`NotificationPreferences`, `NotificationContentBuilder`,
+  `NotificationDispatcher`, a new `NotificationType.TAX_RESERVE_REMINDER` channel). The toggle writes
+  through `NotificationScheduler` so enabling/cancelling work stays centralized.
+- **Privacy:** notification uses generic copy ("Time to set aside for taxes this week") with
+  `VISIBILITY_PRIVATE`; **no amounts, balances, or income** on the lock screen (matches
+  `BillReminderWorker` and the project rule against logging/displaying sensitive financial data).
+- Tapping the notification deep-links to `TaxReserveSettingsScreen` via `FinanceNavHost`.
+- Day-of-week + time are user preferences persisted with the rate; default Sunday evening.
+- POST_NOTIFICATIONS runtime permission (API 33+) is requested only when the user first enables the
+  reminder; declining disables the toggle gracefully with an explanatory caption.
+
+---
+
+## 9. State Model (Offline / Empty / Error)
+
+`TaxReserveUiState` is a sealed/immutable state exposed as `StateFlow` from the ViewModel.
+
+| State                    | Trigger                             | Compose rendering                                                                                                                              |
+| ------------------------ | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Loading**              | Reading persisted settings          | Skeleton/`CircularProgressIndicator` with `contentDescription = "Loading tax reserve settings"`                                                |
+| **Ready (with income)**  | Settings + income data present      | Full editor + "this quarter" `TaxReserveSummary` card                                                                                          |
+| **Ready (empty income)** | Settings present, no gig income yet | Editor + preview using an **illustrative example**; "this quarter" card shows an empty-state ("Log gig income to see your quarterly estimate") |
+| **Offline**              | No connectivity                     | **No functional change** — everything is local-first; an unobtrusive caption notes figures are computed on-device                              |
+| **Error (persistence)**  | Encrypted-prefs read/write failure  | Inline error card + retry; falls back to in-memory defaults so the user is never blocked; logged via `Timber.e` **without** values             |
+| **Permission denied**    | POST_NOTIFICATIONS declined         | Reminder toggle reverts to off with caption + "Open settings" action                                                                           |
+
+**Offline-first guarantee:** this feature has **no backend dependency**. Rates and reminder
+preferences persist locally and compute via KMP; sync (when present) only propagates the stored
+`TaxReserveSettings`, never the math. This is the source of the "buildable now" claim in
+[§12](#12-implementation-readiness).
+
+---
+
+## 10. Accessibility (TalkBack & Font Scaling)
+
+Follows [`accessibility-patterns.md`](./accessibility-patterns.md) and the project rule that **every
+interactive/informational Composable carries a `contentDescription`** (or merged semantics).
+
+- **Headings:** section titles use `Modifier.semantics { heading() }` for TalkBack rotor navigation.
+- **Rate slider:** exposes `stateDescription` as a percentage (e.g. "28 percent") and uses
+  `progressBarRangeInfo` so TalkBack announces value + range; provide a stepper alternative for users
+  who can't drag (Switch Access / large-target needs).
+- **Detailed fields:** each `OutlinedTextField` has a programmatic label, `%` semantics, and
+  `keyboardType = Number`; error states announced via `error` semantics.
+- **Preview & summary numbers:** merged into a single readable phrase, e.g.
+  "Estimated reserve, 280 dollars on 1,000 dollars of net income. Estimate only." Status chips
+  include text, not color alone (e.g. "Due soon, in 9 days").
+- **Disclaimer:** reachable in reading order immediately after any figure; the "Estimate only" link
+  has a descriptive `contentDescription` ("Read full tax estimate disclaimer").
+- **Reminder toggle:** `Switch` with `stateDescription` ("On"/"Off") and a `contentDescription`
+  describing the action ("Weekly tax reserve reminder").
+- **Font scaling:** layouts use `sp` text + wrap/scrollable columns; verified at **200%** font scale
+  and large display size with no truncation or overlap (Compose `verticalScroll`).
+- **Touch targets:** ≥ 48 dp; stepper buttons spaced for Switch Access scanning.
+- **Contrast:** semantic Material 3 roles meet WCAG AA in light, dark, and OLED themes.
+
+---
+
+## 11. Test Plan
+
+| Layer                    | Tool                                                      | Coverage                                                                                                                             |
+| ------------------------ | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| KMP boundary (reference) | existing `TaxCalculatorsTest` in `packages/core`          | Confirms math is shared; Android tests do **not** re-assert tax math                                                                 |
+| ViewModel                | JUnit + coroutines/Turbine                                | Rate edit → state update; clamp out-of-range input via KMP; simple↔detailed sum; persistence read/write; error fallback to defaults  |
+| Reminder scheduling      | Robolectric + `WorkManagerTestInitHelper`                 | Enqueue on enable, cancel on disable, `KEEP` policy idempotency, permission-denied path                                              |
+| Compose UI               | Compose UI test (`createComposeRule`)                     | Slider/stepper interaction, detailed-mode validation errors, disclaimer expansion, empty-income state                                |
+| Accessibility            | Compose semantics assertions + Accessibility Scanner pass | `contentDescription` presence, heading semantics, slider range info, 200% font scale snapshot                                        |
+| Snapshot                 | **Paparazzi**                                             | `TaxReserveSettingsScreen` in light/dark/OLED, empty vs. with-income, 200% font scale, RTL                                           |
+| Edge cases               | unit + UI                                                 | 0% and 100% rate, federal+state+SE summing > 100% (clamped by KMP), no income, persistence failure, declined notification permission |
+
+> Per project conventions, **money/percent math assertions belong to the KMP suite**; Android tests
+> assert wiring, rendering, accessibility, and state transitions only.
+
+---
+
+## 12. Implementation Readiness
+
+This issue is **design + breakdown only**. Per the
+[Human-Gated Prerequisites runbook](../ops/human-gated-prerequisites.md), the
+"blocked by #1242" status applies **only to the distribution tail**, not to feature implementation.
+
+| Phase                                                           | Status                                                                  | Notes                                                                                             |
+| --------------------------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| **Design** (this doc)                                           | ✅ Deliverable now                                                      | No external accounts/secrets needed                                                               |
+| **Implementation** (Compose, ViewModel, WorkManager, Koin)      | ✅ Buildable now                                                        | Verifiable via `./gradlew :apps:android:assembleDebug` + sideload; all deps are local + KMP       |
+| **Local tests** (unit / Compose / Paparazzi)                    | ✅ Runnable now                                                         | No enrollment required                                                                            |
+| **Distribution** (Play Store, release signing, FCM-backed push) | 🔒 Gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242) | Needs Google Play enrollment, release keystore, and CI secrets — **human-gated**, see the runbook |
+
+**Buildable-now scope:** everything above ships and runs on a debug build. Local notifications use
+the on-device `NotificationManager` (no FCM), so the reminder works without any paid entitlement.
+
+**Distribution tail (human action required):** Play Store release, app signing, and any
+server-pushed reserve nudge (vs. local WorkManager notification) depend on #1242 prerequisites listed
+in [§3.1 of the runbook](../ops/human-gated-prerequisites.md#31-android-distribution--google-play-1242).
+No AI agent performs those steps.
+
+---
+
+_Part of [#2135](https://github.com/jrmoulckers/finance/issues/2135). Companion designs:
+[Shift mileage flow](./android-shift-mileage-flow.md) ·
+[Mileage presets & IRS export](./android-mileage-presets-irs-export.md)._

--- a/docs/design/android-mileage-presets-irs-export.md
+++ b/docs/design/android-mileage-presets-irs-export.md
@@ -1,0 +1,331 @@
+# Android — Mileage Presets, Platform Attachment & IRS Export/Audit Trail
+
+> **Status:** DRAFT — design only (pending human review)
+> **Owner:** @android-engineer
+> **Issue:** [#2519](https://github.com/jrmoulckers/finance/issues/2519) · **Part of** [#2137](https://github.com/jrmoulckers/finance/issues/2137)
+> **Platform:** Android phone + tablet, Compose + Material 3
+> **Last Updated:** 2026-06-22
+
+This document specifies the **design** for reusable route/hotspot **presets**, **gig-platform
+attachment**, free-text **notes**, and the **export / audit trail** needed to substantiate mileage
+deductions for the **IRS**. It is **design + breakdown only** — implementation is unblocked, but the
+_distribution_ tail is gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242) (see
+[Implementation Readiness](#implementation-readiness)).
+
+---
+
+## Table of Contents
+
+- [1. Goals & Non-Goals](#1-goals--non-goals)
+- [2. KMP / Compose Boundary](#2-kmp--compose-boundary)
+- [3. Affected Android Surfaces](#3-affected-android-surfaces)
+- [4. Shared Dependencies](#4-shared-dependencies)
+- [5. Route / Hotspot Presets](#5-route--hotspot-presets)
+- [6. Platform Attachment](#6-platform-attachment)
+- [7. Notes](#7-notes)
+- [8. IRS Export & Audit Trail](#8-irs-export--audit-trail)
+- [9. State Model (Offline / Empty / Error)](#9-state-model-offline--empty--error)
+- [10. Accessibility (TalkBack & Font Scaling)](#10-accessibility-talkback--font-scaling)
+- [11. Test Plan](#11-test-plan)
+- [12. Implementation Readiness](#12-implementation-readiness)
+
+---
+
+## 1. Goals & Non-Goals
+
+### Goals
+
+- Let a gig worker save **route presets** (start/end, default miles, purpose, business-use %) and
+  **hotspot** presets for frequent trips, then log a trip in one tap.
+- **Attach a gig platform** (Uber, Lyft, DoorDash, …) to presets, trips, and shifts using the shared
+  platform model.
+- Capture **notes** per preset/trip/shift for substantiation context.
+- Produce an **IRS-ready export** (annual summary + per-trip detail) and maintain an **audit trail**
+  (source, timestamps, external IDs) so deductions are defensible.
+
+### Non-Goals
+
+- The running start/pause/end flow — see [Shift mileage flow](./android-shift-mileage-flow.md) (#2518).
+- Tax-reserve percentages — see [Gig tax-reserve settings](./android-gig-tax-reserve-settings.md) (#2517).
+- Live GPS route capture (future; v1 presets are user-defined).
+- Automated platform API import of trips (a future audit `source`; the model already reserves
+  `PLATFORM_IMPORT`, but no integration ships here).
+- Generating official IRS forms; we export a substantiation report, **not** a filed return.
+
+---
+
+## 2. KMP / Compose Boundary
+
+Preset modelling, deduction math, and summary generation are **owned by KMP `packages/core`**.
+Compose manages CRUD UI, file/share plumbing, and rendering of shared results.
+
+| Concern                                     | Owner   | Symbol / location                                                                                                  |
+| ------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------ |
+| Route preset model + validation             | KMP     | `RoutePreset` (`com.finance.core.mileage`)                                                                         |
+| Platform attachment model                   | KMP     | `GigPlatformLink`; defaults in `GigPlatformDefaults`                                                               |
+| Trip from preset                            | KMP     | `MileageCalculator.createTripEntryFromPreset(...)`                                                                 |
+| Trip deduction & validation                 | KMP     | `MileageCalculator.calculateTripDeduction(...)`, `validateTripEntry(...)`                                          |
+| Annual / shift summaries                    | KMP     | `MileageCalculator.generateAnnualMileageSummary(...)` → `AnnualMileageSummary`; `summarizeShift(...)`              |
+| Audit metadata & source                     | KMP     | `MileageAuditMetadata`, `MileageAuditSource` (`MANUAL`, `PLATFORM_IMPORT`, `CALENDAR`, `ODOMETER`, `ROUTE_PRESET`) |
+| IRS rates (cents/mile by year)              | KMP     | `MileageCalculator.getMileageRate(...)` (2024: 67¢ business; 2025: 70¢)                                            |
+| Compose CRUD, export formatting, file/share | Android | `apps/android/...` (this doc)                                                                                      |
+
+Source of truth:
+[`MileageModels.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/mileage/MileageModels.kt)
+and
+[`MileageCalculator.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/mileage/MileageCalculator.kt).
+
+> **Rule:** Android does not compute deductible miles, apply business-use %, or pick the IRS rate.
+> It collects fields, calls KMP to build `MileageTripEntry` / `AnnualMileageSummary`, then renders
+> and serializes the returned values. Export formatting (CSV/PDF text) is Android UI work, but the
+> **numbers come from KMP**.
+
+```mermaid
+flowchart LR
+    A[Presets / Trips Compose] -->|RoutePreset + override| B[MileagePresetsViewModel]
+    B -->|createTripEntryFromPreset| C[MileageCalculator KMP]
+    C -->|MileageTripEntry| B
+    B -->|generateAnnualMileageSummary| C
+    C -->|AnnualMileageSummary| B
+    B -->|export rows| D[Export formatter<br/>CSV / PDF]
+    B --> E[(SQLDelight presets + trips + audit)]
+```
+
+---
+
+## 3. Affected Android Surfaces
+
+All new Compose; **no XML**. Files under `apps/android/src/main/kotlin/com/finance/android/`.
+
+| Surface            | New file (proposed)                                                          | Role                                            |
+| ------------------ | ---------------------------------------------------------------------------- | ----------------------------------------------- |
+| Presets list       | `ui/screens/mileage/RoutePresetsScreen.kt`                                   | Manage saved routes/hotspots                    |
+| Preset editor      | `ui/screens/mileage/RoutePresetEditScreen.kt`                                | Create/edit a `RoutePreset`                     |
+| Trip log           | `ui/screens/mileage/MileageTripListScreen.kt`                                | View/filter logged trips                        |
+| Trip editor        | `ui/screens/mileage/MileageTripEditScreen.kt`                                | Manual trip incl. platform + notes              |
+| Platform picker    | `ui/screens/mileage/PlatformPickerSheet.kt`                                  | Choose a `GigPlatformLink`                      |
+| Export screen      | `ui/screens/mileage/MileageExportScreen.kt`                                  | Year picker, format, share intent               |
+| ViewModel(s)       | `ui/screens/mileage/MileagePresetsViewModel.kt`, `MileageExportViewModel.kt` | Hold UI state, call KMP                         |
+| Export formatter   | `data/mileage/MileageExportFormatter.kt`                                     | CSV/PDF rows from KMP summaries                 |
+| Audit store        | `data/mileage/MileageAuditStore.kt`                                          | Persist `MileageAuditMetadata` with each record |
+| Koin wiring        | `di/AppModule.kt` (append)                                                   | `viewModelOf(...)`, formatter/store `single`s   |
+| Navigation         | `ui/navigation/FinanceNavHost.kt`                                            | `routePresets`, `mileageExport` routes          |
+| Preview / snapshot | `.../mileage/*Preview.kt`, `test/.../snapshot/MileageExportSnapshotTest.kt`  | Preview + Paparazzi                             |
+
+Export sharing reuses the existing export plumbing pattern from
+[`DataExportManager`](../../apps/android/src/main/kotlin/com/finance/android/ui/viewmodel) (CSV/PDF
+via Android `FileProvider` + share `Intent`).
+
+---
+
+## 4. Shared Dependencies
+
+| Dependency                                                                                     | Use                                                                     |
+| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `com.finance.core.mileage.RoutePreset`                                                         | Saved route/hotspot template + validation                               |
+| `com.finance.core.mileage.MileageCalculator`                                                   | `createTripEntryFromPreset`, deductions, `generateAnnualMileageSummary` |
+| `com.finance.core.mileage.MileageTripEntry` / `MileagePurposeSummary` / `AnnualMileageSummary` | Trip + summary models for the audit/export                              |
+| `com.finance.core.mileage.GigPlatformLink` / `GigPlatformDefaults`                             | Platform attachment + seed list                                         |
+| `com.finance.core.mileage.MileageAuditMetadata` / `MileageAuditSource`                         | Audit trail provenance                                                  |
+| `com.finance.core.gig.payout.GigPlatformDefaults`                                              | Uber/Lyft/DoorDash/Instacart/Grubhub/Shipt/Upwork/Fiverr defaults       |
+| SQLDelight (+ SQLCipher)                                                                       | Encrypted local storage of presets, trips, audit metadata               |
+| Android `FileProvider` + share `Intent`                                                        | Export delivery (CSV/PDF)                                               |
+| Koin `koin-compose-viewmodel`                                                                  | `koinViewModel<...>()`                                                  |
+| Timber                                                                                         | Logging — **never** notes, locations, miles, or platform account IDs    |
+
+---
+
+## 5. Route / Hotspot Presets
+
+A `RoutePreset` (KMP) captures: `name`, `startLocation`, `endLocation`, optional `defaultMiles`,
+`defaultPurpose` (default `BUSINESS`), `defaultBusinessUsePercent` (0–100, default 100), optional
+`platform`, and `notes`. KMP `init` blocks enforce non-blank fields and valid ranges; Android shows
+those validation messages.
+
+- **Hotspot** presets are a UX flavor of the same model — a named location pair (e.g. "Home →
+  Airport queue") for frequent gig staging trips.
+- **Log from preset:** one tap calls `MileageCalculator.createTripEntryFromPreset(...)`, optionally
+  with a `milesOverride` and date; the audit `source` is set to `ROUTE_PRESET`.
+- **CRUD** lives in `RoutePresetsScreen` (list, with swipe/overflow edit/delete) + `RoutePresetEditScreen`.
+- Presets sync offline-first via the standard sync queue (client-generated IDs).
+
+```mermaid
+flowchart TD
+    L[RoutePresetsScreen] -->|+ New| E[RoutePresetEditScreen]
+    E -->|valid RoutePreset| L
+    L -->|tap 'Log trip'| O{Override miles/date?}
+    O -->|No| K[createTripEntryFromPreset]
+    O -->|Yes| K2[createTripEntryFromPreset + milesOverride]
+    K --> T[MileageTripEntry · source=ROUTE_PRESET]
+    K2 --> T
+    T --> DB[(SQLDelight trips + audit)]
+```
+
+---
+
+## 6. Platform Attachment
+
+Trips, presets, and shifts can carry a `GigPlatformLink` (`platformId`, `displayName`, optional
+`accountId`).
+
+- The `PlatformPickerSheet` is seeded from `GigPlatformDefaults` (Uber, Lyft, DoorDash, Instacart,
+  Grubhub, Shipt, Upwork, Fiverr) and allows a custom platform.
+- Attaching a platform sets `MileageAuditMetadata.platform` for substantiation and enables
+  **per-platform** filtering/grouping in the trip log and export.
+- `accountId` (e.g. a driver handle) is **optional** and treated as low-sensitivity metadata — it is
+  **never logged via Timber** and is excluded from lock-screen/notification content.
+- Platform attachment is consistent with the shared gig-payout matching model (same platform IDs),
+  so mileage and income can later be correlated in shared code without Android duplicating logic.
+
+---
+
+## 7. Notes
+
+- Free-text `notes` exist on `RoutePreset`, `MileageTripEntry`, and `WorkShiftSession` (all KMP
+  models). Notes provide IRS substantiation context (e.g. "client meeting", "surge in downtown").
+- The Compose editor trims and length-limits notes (UI concern); the KMP model stores the string.
+- Notes are **sensitive free text** — they may contain client/personal info, so they:
+  - are stored only in the **encrypted** SQLDelight DB,
+  - are **never** written to Timber logs,
+  - are excluded from notifications and Glance widgets.
+- Notes are included in the IRS export detail rows (the user is exporting their own substantiation).
+
+---
+
+## 8. IRS Export & Audit Trail
+
+### Audit trail
+
+Every mileage record carries `MileageAuditMetadata`:
+
+- `source` — `MANUAL`, `ROUTE_PRESET`, `ODOMETER`, `CALENDAR`, or `PLATFORM_IMPORT` (future).
+- `platform` — the attached `GigPlatformLink`, if any.
+- `externalTripId` / `externalShiftId` / `supportReference` — correlation IDs.
+- `createdAt` / `updatedAt` / `importedAt` — timestamps (KMP enforces `updatedAt >= createdAt`).
+
+The Android `MileageAuditStore` writes/updates this metadata on every create/edit so the provenance
+chain is complete and tamper-evident-by-timestamp. The audit trail is **read-only in the export**.
+
+### Export
+
+The export is built from KMP `generateAnnualMileageSummary(trips, year)` →
+`AnnualMileageSummary`, which provides per-purpose totals (`MileagePurposeSummary`: total deductible
+miles, IRS `rateCentsPerMile`, `deductionCents`) plus annual totals. Android formats, it does not
+compute.
+
+| Export part       | Content                                                                                         | Source                                      |
+| ----------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------- |
+| **Header**        | Tax year, generated date, applied IRS rates per purpose                                         | `AnnualMileageSummary` + `getMileageRate`   |
+| **Summary table** | Per purpose: deductible miles × rate = deduction                                                | `MileagePurposeSummary`                     |
+| **Detail rows**   | Per trip: date, start, end, miles, purpose, business-use %, platform, notes, source, timestamps | `MileageTripEntry` + `MileageAuditMetadata` |
+| **Disclaimer**    | "Estimate for substantiation; not tax advice or a filed return."                                | Android string resource                     |
+
+- **Formats:** CSV (spreadsheet-friendly, primary) and a printable **PDF** report. Money rendered
+  from integer cents (never floats).
+- **Delivery:** Android `FileProvider` + share `Intent` (email, Drive, print). No backend upload
+  required; export is fully **offline**.
+- **Determinism:** given the same trips, the export is byte-stable (sorted by date then id) so a user
+  can re-generate identical substantiation.
+
+```mermaid
+flowchart LR
+    Y[Year picker] --> VM[MileageExportViewModel]
+    VM -->|generateAnnualMileageSummary| KMP[MileageCalculator]
+    KMP -->|AnnualMileageSummary| VM
+    VM --> F[MileageExportFormatter<br/>CSV / PDF]
+    F --> SH[FileProvider + share Intent]
+```
+
+---
+
+## 9. State Model (Offline / Empty / Error)
+
+`StateFlow`-backed UI state per screen (presets, trips, export).
+
+| State                    | Trigger                                     | Compose rendering                                                                              |
+| ------------------------ | ------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| **Loading**              | Reading presets/trips                       | Skeleton + `contentDescription`                                                                |
+| **Empty (presets)**      | No presets yet                              | Illustration + "Create your first route preset" CTA                                            |
+| **Empty (trips/export)** | No trips for the year                       | "No trips logged for {year}" empty state; export disabled with explanation                     |
+| **Ready**                | Data present                                | Lists / editor / export preview                                                                |
+| **Offline**              | No connectivity                             | **No functional change** — CRUD + export are local; "Saved on device" caption                  |
+| **Validation error**     | Blank name, end < start odometer, miles ≤ 0 | KMP messages inline on the field                                                               |
+| **Export error**         | File write / share failure                  | Non-destructive error + retry; partial file cleaned up; `Timber.e` **without** notes/locations |
+| **Permission**           | (PDF print/share)                           | Standard share sheet; no special runtime permission needed for `FileProvider`                  |
+
+**Offline-first guarantee:** presets, trips, audit metadata, and export all function with **zero
+network**. Sync only mirrors stored records. This is why the feature is "buildable now" in
+[§12](#12-implementation-readiness).
+
+---
+
+## 10. Accessibility (TalkBack & Font Scaling)
+
+Per [`accessibility-patterns.md`](./accessibility-patterns.md) and the **`contentDescription` on every
+interactive/informational Composable** rule.
+
+- **Preset list items:** merged semantics read name + route + platform, e.g. "Home to Airport, 12.4
+  miles, business, Uber. Double-tap to log a trip." Edit/delete affordances individually labelled.
+- **Editor fields:** programmatic labels for name, start, end, miles, business-use %, purpose,
+  platform; validation errors via `error` semantics and announced.
+- **Platform picker:** each option labelled with platform name; selection state via
+  `stateDescription`; custom-platform entry clearly labelled.
+- **Export screen:** year picker announces selection; format toggle labelled; the "Export" button
+  describes the result ("Export {year} mileage as CSV"); disabled empty-state button explains why.
+- **Summary/preview numbers:** read as phrases — "Business: 1,240 deductible miles at 67 cents, 830
+  dollars 80 cents deduction." Status/purpose conveyed with text, not color alone.
+- **Notes field:** labelled, with a character-count `stateDescription`; reachable in reading order.
+- **Font scaling:** verified at **200%**; tables/rows reflow (wrap or horizontal scroll) without
+  truncation; export preview remains legible.
+- **Touch targets** ≥ 48 dp; list actions spaced for Switch Access scanning.
+- **Contrast:** AA across light/dark/OLED.
+
+---
+
+## 11. Test Plan
+
+| Layer                    | Tool                                               | Coverage                                                                                                                                 |
+| ------------------------ | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| KMP boundary (reference) | existing `MileageCalculatorTest` (`packages/core`) | Preset→trip, deduction, annual summary validated in shared code; Android does **not** re-assert math                                     |
+| Presets CRUD             | JUnit + Compose UI                                 | Create/edit/delete; KMP validation surfaced; log-from-preset with/without override                                                       |
+| Platform attachment      | JUnit + UI                                         | Defaults seeded; custom platform; audit `platform` set; filtering by platform                                                            |
+| Notes                    | unit + UI                                          | Trim/limit; stored; **excluded** from logs/notifications/widgets                                                                         |
+| Audit trail              | unit                                               | `source` set correctly per entry path; timestamps monotonic (`updatedAt >= createdAt`)                                                   |
+| Export formatter         | JUnit (golden files)                               | CSV/PDF byte-stable; cents rendered correctly; totals equal `AnnualMileageSummary`; empty-year handling                                  |
+| Export delivery          | instrumented                                       | `FileProvider` URI + share `Intent`; offline export succeeds                                                                             |
+| ViewModel                | JUnit + Turbine                                    | State emissions; KMP calls; error/empty/offline paths                                                                                    |
+| Accessibility            | semantics + Accessibility Scanner                  | `contentDescription`, merged item semantics, 200% font scale                                                                             |
+| Snapshot                 | **Paparazzi**                                      | Presets list (empty + populated), editor, export preview — light/dark/OLED, 200% font, RTL                                               |
+| Edge cases               | unit + UI                                          | Preset with no `defaultMiles` (requires override), miles ≤ 0, end < start odometer, year with no trips, very long notes, custom platform |
+
+> Deduction and summary math assertions live in the **KMP suite**; Android tests cover CRUD,
+> attachment, audit provenance, export formatting/stability, rendering, and accessibility.
+
+---
+
+## 12. Implementation Readiness
+
+**Design + breakdown only** for this issue. Per the
+[Human-Gated Prerequisites runbook](../ops/human-gated-prerequisites.md), "blocked by #1242" gates
+**only distribution**, not implementation.
+
+| Phase                                                                                            | Status                                                                  | Notes                                                                    |
+| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| **Design** (this doc)                                                                            | ✅ Deliverable now                                                      | No accounts/secrets needed                                               |
+| **Implementation** (Compose CRUD, KMP calls, SQLDelight, export formatter, `FileProvider` share) | ✅ Buildable now                                                        | `./gradlew :apps:android:assembleDebug` + sideload; all deps local + KMP |
+| **Local tests** (unit / Compose / golden-file / Paparazzi)                                       | ✅ Runnable now                                                         | No enrollment                                                            |
+| **Distribution** (Play Store, release signing)                                                   | 🔒 Gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242) | Google Play enrollment, keystore, CI secrets — **human-gated**           |
+
+**Buildable-now scope:** presets CRUD, platform attachment, notes, audit trail, and CSV/PDF export
+(shared via `FileProvider`) all run on a debug build entirely on-device — no paid entitlement.
+
+**Distribution tail (human action required):** Play Store release and signing depend on the #1242
+prerequisites in
+[§3.1 of the runbook](../ops/human-gated-prerequisites.md#31-android-distribution--google-play-1242).
+No AI agent performs those steps.
+
+---
+
+_Part of [#2137](https://github.com/jrmoulckers/finance/issues/2137). Companion designs:
+[Shift mileage flow](./android-shift-mileage-flow.md) ·
+[Gig tax-reserve settings](./android-gig-tax-reserve-settings.md)._

--- a/docs/design/android-shift-mileage-flow.md
+++ b/docs/design/android-shift-mileage-flow.md
@@ -1,0 +1,367 @@
+# Android — One-Handed Shift Mileage Flow (Start / Pause / End)
+
+> **Status:** DRAFT — design only (pending human review)
+> **Owner:** @android-engineer
+> **Issue:** [#2518](https://github.com/jrmoulckers/finance/issues/2518) · **Part of** [#2137](https://github.com/jrmoulckers/finance/issues/2137)
+> **Platform:** Android phone (one-handed, on-the-go), Compose + Material 3
+> **Last Updated:** 2026-06-22
+
+This document specifies the **design** for a one-handed Jetpack Compose shift-mileage flow: a gig
+worker starts, pauses, resumes, and ends a work shift while tracking mileage, entirely operable with
+a thumb. It defines the **state machine**, offline persistence expectations, and shortcut entry
+points. It is **design + breakdown only** — native implementation is unblocked, but the
+_distribution_ tail stays gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+(see [Implementation Readiness](#implementation-readiness)).
+
+---
+
+## Table of Contents
+
+- [1. Goals & Non-Goals](#1-goals--non-goals)
+- [2. KMP / Compose Boundary](#2-kmp--compose-boundary)
+- [3. Affected Android Surfaces](#3-affected-android-surfaces)
+- [4. Shared Dependencies](#4-shared-dependencies)
+- [5. Shift State Machine](#5-shift-state-machine)
+- [6. One-Handed Compose Layout](#6-one-handed-compose-layout)
+- [7. Offline Persistence Expectations](#7-offline-persistence-expectations)
+- [8. Shortcut Entry Points](#8-shortcut-entry-points)
+- [9. State Model (Offline / Empty / Error)](#9-state-model-offline--empty--error)
+- [10. Accessibility (TalkBack & Font Scaling)](#10-accessibility-talkback--font-scaling)
+- [11. Test Plan](#11-test-plan)
+- [12. Implementation Readiness](#12-implementation-readiness)
+
+---
+
+## 1. Goals & Non-Goals
+
+### Goals
+
+- Let a driver **start a shift** in one tap and reach the running controls with a thumb.
+- Support **pause / resume** (e.g. a break) without ending the shift, and a clear **end** that
+  produces a `WorkShiftSession` plus its mileage trips.
+- Capture mileage either by **odometer start/end** or a **direct miles** entry, deferring all math
+  to KMP.
+- **Survive process death, app kill, and offline** — a running shift is durable.
+- Provide fast **shortcut entry points** (app shortcut, Quick Settings-style widget tile, deep link)
+  to start/resume.
+
+### Non-Goals
+
+- GPS / live-tracking of distance (battery + privacy heavy; future work, not this issue). Mileage is
+  user-entered (odometer or miles) for v1.
+- IRS export / audit trail and route presets — covered by the companion doc
+  [Mileage presets & IRS export](./android-mileage-presets-irs-export.md) (#2519).
+- The tax-reserve settings flow — see [Gig tax-reserve settings](./android-gig-tax-reserve-settings.md) (#2517).
+- Wear OS shift control surface — a desirable follow-up (DataLayer to phone), explicitly out of scope
+  here; no `apps/wear` module exists yet.
+
+---
+
+## 2. KMP / Compose Boundary
+
+Mileage and deduction math live in **KMP `packages/core`**; Compose only renders shared state and
+collects raw inputs (odometer readings, miles, timestamps, platform).
+
+| Concern                                           | Owner   | Symbol / location                                                                                |
+| ------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------ |
+| Shift session model                               | KMP     | `WorkShiftSession` (`com.finance.core.mileage`)                                                  |
+| Trip entry model                                  | KMP     | `MileageTripEntry`, `MileageDistanceInput`                                                       |
+| Miles from odometer vs. direct                    | KMP     | `MileageCalculator.calculateTripMiles(...)`                                                      |
+| Trip + shift deduction totals                     | KMP     | `MileageCalculator.calculateTripDeduction(...)`, `summarizeShift(...)` → `ShiftDeductionSummary` |
+| IRS rate by year/purpose                          | KMP     | `MileageCalculator.getMileageRate(...)` (2024: 67¢ business; 2025: 70¢)                          |
+| Audit metadata                                    | KMP     | `MileageAuditMetadata`, `MileageAuditSource`                                                     |
+| Compose UI, state machine, persistence, shortcuts | Android | `apps/android/...` (this doc)                                                                    |
+
+Source of truth:
+[`packages/core/.../mileage/MileageCalculator.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/mileage/MileageCalculator.kt)
+and
+[`MileageModels.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/mileage/MileageModels.kt).
+
+> **Rule:** the UI never multiplies miles × rate, never rounds miles, and never derives miles from
+> odometer arithmetic itself. It calls `MileageCalculator`. The IRS cents-per-mile values
+> (67¢/70¢ …) are **owned by KMP** and must never be duplicated in Android code.
+
+```mermaid
+flowchart LR
+    A[ShiftMileageScreen<br/>Compose] -->|odometer / miles / pause| B[ShiftMileageViewModel]
+    B -->|MileageDistanceInput| C[MileageCalculator.calculateTripMiles]
+    C --> B
+    B -->|WorkShiftSession + trips| D[MileageCalculator.summarizeShift]
+    D -->|ShiftDeductionSummary| B
+    B -->|ShiftUiState| A
+    B --> E[(Durable store:<br/>SQLDelight + DataStore active-shift)]
+```
+
+---
+
+## 3. Affected Android Surfaces
+
+All new Compose; **no XML**. Files under `apps/android/src/main/kotlin/com/finance/android/`.
+
+| Surface                       | New file (proposed)                                                                   | Role                                                   |
+| ----------------------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| Shift screen                  | `ui/screens/mileage/ShiftMileageScreen.kt`                                            | One-handed running-shift UI                            |
+| Start sheet                   | `ui/screens/mileage/ShiftStartSheet.kt`                                               | Quick start (platform, starting odometer)              |
+| End sheet                     | `ui/screens/mileage/ShiftEndSheet.kt`                                                 | Capture ending odometer/miles + confirm                |
+| ViewModel                     | `ui/screens/mileage/ShiftMileageViewModel.kt`                                         | Owns `ShiftUiState`, drives the state machine          |
+| Active-shift store            | `data/mileage/ActiveShiftStore.kt`                                                    | Durable in-progress shift (survives kill)              |
+| Foreground service (optional) | `mileage/ShiftTimerService.kt`                                                        | Keeps elapsed-time notification while running          |
+| Shortcuts                     | `mileage/ShiftShortcuts.kt`                                                           | Dynamic `ShortcutInfoCompat` for start/resume          |
+| Glance tile                   | `widget/ShiftQuickStartWidget.kt`                                                     | Home-screen start/stop tile (Glance)                   |
+| Koin wiring                   | `di/AppModule.kt` (append)                                                            | `viewModelOf(::ShiftMileageViewModel)`, store `single` |
+| Navigation                    | `ui/navigation/FinanceNavHost.kt`                                                     | `shiftMileage` route + deep link                       |
+| Preview / snapshot            | `.../mileage/ShiftMileagePreview.kt`, `test/.../snapshot/ShiftMileageSnapshotTest.kt` | Preview + Paparazzi                                    |
+
+Reuses the existing Glance widget patterns in
+[`apps/android/.../widget/`](../../apps/android/src/main/kotlin/com/finance/android/widget) (e.g.
+`QuickEntryWidget`, `WidgetUpdater`, `WidgetPrivacyFormatter`).
+
+---
+
+## 4. Shared Dependencies
+
+| Dependency                                                             | Use                                                             |
+| ---------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `com.finance.core.mileage.MileageCalculator`                           | Miles, trip & shift deductions, validation, `taxYearFor`        |
+| `com.finance.core.mileage.WorkShiftSession` / `MileageTripEntry`       | Persisted shift + trips                                         |
+| `com.finance.core.mileage.MileageDistanceInput`                        | Odometer/miles raw input → KMP                                  |
+| `com.finance.core.mileage.MileageAuditMetadata` / `MileageAuditSource` | `ODOMETER` / `MANUAL` provenance                                |
+| `com.finance.core.mileage.GigPlatformLink`                             | Attach Uber/Lyft/DoorDash to the shift                          |
+| WorkManager                                                            | Flush/finalize closed shifts to sync queue                      |
+| SQLDelight (+ SQLCipher)                                               | Durable storage of closed shifts/trips                          |
+| Jetpack DataStore                                                      | The single **active** in-progress shift snapshot                |
+| Koin `koin-compose-viewmodel`                                          | `koinViewModel<ShiftMileageViewModel>()`                        |
+| Timber                                                                 | Logging — **never** odometer values, earnings, or location text |
+
+---
+
+## 5. Shift State Machine
+
+The shift is a finite state machine owned by `ShiftMileageViewModel` and mirrored to durable storage
+on every transition.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Starting: tap Start
+    Starting --> Running: starting odometer captured
+    Starting --> Idle: cancel
+    Running --> Paused: tap Pause (break)
+    Paused --> Running: tap Resume
+    Running --> Ending: tap End
+    Paused --> Ending: tap End
+    Ending --> Saving: ending odometer / miles confirmed
+    Saving --> Summary: WorkShiftSession + trips persisted
+    Saving --> Running: validation error (re-open)
+    Summary --> Idle: dismiss
+    Running --> Recovering: process death
+    Paused --> Recovering: process death
+    Recovering --> Running: restore active shift
+    Recovering --> Paused: restore paused shift
+```
+
+| State        | Meaning                                                            | Durable?                    |
+| ------------ | ------------------------------------------------------------------ | --------------------------- |
+| `Idle`       | No active shift                                                    | n/a                         |
+| `Starting`   | Collecting platform + starting odometer                            | snapshot written on confirm |
+| `Running`    | Shift active, clock ticking                                        | yes — DataStore snapshot    |
+| `Paused`     | Break; elapsed paused-time accumulated                             | yes                         |
+| `Ending`     | Collecting ending odometer/miles                                   | yes (still recoverable)     |
+| `Saving`     | Building `WorkShiftSession` via KMP, persisting to SQLDelight      | transient                   |
+| `Summary`    | Shows `ShiftDeductionSummary` (miles, deductible miles, deduction) | persisted closed shift      |
+| `Recovering` | App relaunched with an unfinished shift                            | restores to prior state     |
+
+Rules:
+
+- **Pause accounting:** the ViewModel tracks active vs. paused elapsed time; the persisted
+  `WorkShiftSession` keeps `startedAt`/`endedAt` (KMP requires `endedAt >= startedAt`). Pause is a UI
+  concept layered on top; total miles come from odometer/miles, not the clock.
+- **Validation** is delegated: ending odometer `>= starting odometer` and miles finiteness are
+  enforced by `MileageCalculator` / model `init` blocks; the ViewModel surfaces those messages.
+- **Single active shift** invariant: starting a second shift while one runs prompts to end/resume the
+  current one.
+
+---
+
+## 6. One-Handed Compose Layout
+
+Designed for thumb reach on a phone held in one hand, in motion-adjacent contexts (stopped/parked).
+
+- **Primary actions anchored to the bottom** within the thumb arc: a single large `Start` FAB-style
+  button when idle; `Pause`/`Resume` + `End` as bottom buttons when running. Top of the screen is
+  read-only status (elapsed time, platform, running miles estimate).
+- **Large touch targets:** primary buttons ≥ 64 dp tall, full-width or wide, generous spacing so they
+  can't be mis-tapped; secondary actions kept out of the bottom hot zone.
+- **Minimal text entry while running:** odometer/miles entry uses a numeric keypad sheet
+  (`ModalBottomSheet`) that rises into the thumb zone; supports a "same as last trip" quick fill.
+- **Single decision per screen:** start, then run, then end — no multi-field forms mid-shift.
+- **Confirmation, not accidental loss:** `End` shows a bottom sheet to confirm; destructive cancel is
+  guarded.
+- **Material 3 / Material You:** dynamic color; the running state uses a distinct, high-contrast
+  container (e.g. `primaryContainer`) so it's glanceable; status conveyed with text + icon, never
+  color alone.
+- **Optional foreground notification** (`ShiftTimerService`) shows elapsed time and a stop action so
+  the worker doesn't have to keep the app open; uses `VISIBILITY_PRIVATE`, no earnings shown.
+
+```mermaid
+flowchart TB
+    subgraph Screen[Running shift — thumb zone at bottom]
+        S[Status: 01:24 elapsed · Uber · ~18.0 mi] --- C[Pause | End buttons, bottom]
+    end
+```
+
+---
+
+## 7. Offline Persistence Expectations
+
+The shift flow is **offline-first and durable** — it must never lose a running shift.
+
+- **Active shift** is written to **Jetpack DataStore** on every state transition (start, pause,
+  resume, odometer edit). This is the single source of truth for `Recovering` after process death or
+  app kill.
+- **Closed shifts + trips** are committed to the encrypted **SQLDelight** store (SQLCipher), then
+  enqueued for background sync via **WorkManager** when connectivity returns. No network is required
+  to start, run, or end a shift.
+- **Crash / kill recovery:** on launch, if a non-`Idle` snapshot exists, the app routes into
+  `Recovering` and restores the prior state; elapsed-time is recomputed from stored `startedAt` and
+  accumulated pause duration.
+- **No data loss on offline end:** ending a shift offline persists locally and shows the
+  `ShiftDeductionSummary` immediately (computed by KMP on-device); sync happens later.
+- **Idempotent sync:** closed shifts carry client-generated IDs (per the offline-first ID rule in the
+  [Data Model](./data-model.md)) so re-sync is safe.
+
+```mermaid
+sequenceDiagram
+    participant UI as ShiftMileageScreen
+    participant VM as ShiftMileageViewModel
+    participant DS as DataStore (active)
+    participant DB as SQLDelight (closed)
+    participant WM as WorkManager
+    UI->>VM: Start / Pause / odometer edit
+    VM->>DS: persist active snapshot (every transition)
+    UI->>VM: End + confirm
+    VM->>DB: write WorkShiftSession + trips (KMP-built)
+    VM->>DS: clear active snapshot
+    VM->>WM: enqueue sync (deferred, offline-safe)
+```
+
+---
+
+## 8. Shortcut Entry Points
+
+Fast ways to start/resume without navigating the app:
+
+| Entry point                                 | Mechanism                                              | Behaviour                                                         |
+| ------------------------------------------- | ------------------------------------------------------ | ----------------------------------------------------------------- |
+| **App shortcut** (long-press launcher icon) | Dynamic `ShortcutInfoCompat` (`ShortcutManagerCompat`) | "Start shift" when idle; "Resume shift" when one is active/paused |
+| **Home-screen tile**                        | **Glance** widget (`ShiftQuickStartWidget`)            | Toggle start/stop + elapsed time; reuses `WidgetUpdater`          |
+| **Deep link**                               | `finance://shift` route in `FinanceNavHost`            | Used by shortcut, widget, and the foreground notification         |
+| **Notification action**                     | `ShiftTimerService` foreground notification            | Pause / End directly from the shade                               |
+
+Notes:
+
+- Shortcuts are **dynamic** and updated on each state transition (e.g. label flips to "Resume").
+- All entry points converge on the same `shiftMileage` destination + ViewModel, so state stays
+  consistent regardless of how the user arrived.
+- The Glance tile follows the existing widget privacy pattern
+  ([`WidgetPrivacyFormatter`](../../apps/android/src/main/kotlin/com/finance/android/widget/WidgetPrivacyFormatter.kt)):
+  shows elapsed time + miles, **no earnings**.
+- A Wear OS complication/tile for one-tap start is a noted **future** entry point (DataLayer to
+  phone), not implemented here.
+
+---
+
+## 9. State Model (Offline / Empty / Error)
+
+`ShiftUiState` exposed as `StateFlow`; mirrors the state machine plus transient UI concerns.
+
+| State                           | Trigger                       | Compose rendering                                                                            |
+| ------------------------------- | ----------------------------- | -------------------------------------------------------------------------------------------- |
+| **Empty / Idle**                | No active shift, no history   | Large `Start shift` CTA + brief explainer                                                    |
+| **Empty / Idle (with history)** | Past shifts exist             | `Start` CTA + recent shifts summary list                                                     |
+| **Running / Paused**            | Active shift                  | Status + thumb-zone controls; paused shows a "Paused" banner                                 |
+| **Saving**                      | Ending                        | Inline progress on the End sheet; buttons disabled                                           |
+| **Summary**                     | Shift closed                  | `ShiftDeductionSummary` card (miles, deductible miles, deduction cents)                      |
+| **Offline**                     | No connectivity               | **No functional change**; subtle "Saved on device, will sync" caption                        |
+| **Recovering**                  | Unfinished shift on launch    | "Resume your shift?" prompt restoring prior state                                            |
+| **Error (validation)**          | Ending odometer < start, etc. | KMP validation message inline on the End sheet; stay in `Ending`                             |
+| **Error (persistence)**         | DataStore/DB write failure    | Non-destructive error + retry; active snapshot kept in memory; `Timber.e` **without** values |
+
+**Offline-first guarantee:** start/run/pause/end all work with **zero network**. Sync only mirrors
+already-persisted shifts. This underpins the "buildable now" claim in
+[§12](#12-implementation-readiness).
+
+---
+
+## 10. Accessibility (TalkBack & Font Scaling)
+
+Per [`accessibility-patterns.md`](./accessibility-patterns.md) and the **`contentDescription` on every
+interactive/informational Composable** rule.
+
+- **Primary buttons:** explicit `contentDescription` describing action + current state — e.g. "Start
+  shift", "Pause shift, currently running", "End shift". State changes announced via
+  `stateDescription`.
+- **Elapsed time:** announced as a readable phrase ("1 hour 24 minutes elapsed"), updated via a live
+  region only at meaningful intervals to avoid TalkBack chatter (not every second).
+- **Running miles estimate:** merged semantics, "Approximately 18.0 miles so far. Estimate."
+- **Odometer/miles entry:** numeric fields labelled programmatically; validation errors surfaced with
+  `error` semantics and announced.
+- **One-handed = reachable, also operable by Switch Access:** the linear, single-decision flow maps
+  cleanly to sequential scanning; targets ≥ 48 dp (primary ≥ 64 dp).
+- **Recovering prompt:** focus moves to the "Resume your shift?" dialog on launch; clearly labelled
+  Resume/Discard actions.
+- **Font scaling:** verified at **200%**; status + controls reflow without truncation; bottom buttons
+  remain fully visible (scrollable content above the fixed action bar).
+- **Contrast & no-color-only:** running/paused states distinguished by text + icon + container, not
+  hue alone; AA contrast across light/dark/OLED.
+- **Foreground notification** is fully described for TalkBack with actionable Pause/End buttons.
+
+---
+
+## 11. Test Plan
+
+| Layer                    | Tool                                               | Coverage                                                                                                                    |
+| ------------------------ | -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| KMP boundary (reference) | existing `MileageCalculatorTest` (`packages/core`) | Miles/odometer/deduction math validated in shared code; Android does **not** re-assert it                                   |
+| State machine            | JUnit                                              | Every transition incl. pause/resume, end, cancel, single-active invariant, validation re-entry                              |
+| Recovery                 | Robolectric / instrumented                         | Kill during Running/Paused/Ending → correct `Recovering` restore; elapsed-time recomputed                                   |
+| Persistence              | DataStore + SQLDelight tests                       | Active snapshot written each transition; closed shift committed; offline end persists                                       |
+| ViewModel                | JUnit + Turbine                                    | `ShiftUiState` emissions; KMP calls for miles + `summarizeShift`                                                            |
+| WorkManager              | `WorkManagerTestInitHelper`                        | Sync enqueued after close; idempotent re-sync                                                                               |
+| Compose UI               | `createComposeRule`                                | Thumb-zone controls, end-confirm sheet, numeric entry, summary render                                                       |
+| Shortcuts/Widget         | instrumented + Glance test                         | Dynamic shortcut label flips; deep link resolves; tile start/stop                                                           |
+| Accessibility            | semantics assertions + Accessibility Scanner       | `contentDescription`, state announcements, 200% font scale                                                                  |
+| Snapshot                 | **Paparazzi**                                      | Idle / Running / Paused / Summary in light/dark/OLED + 200% font + RTL                                                      |
+| Edge cases               | unit + UI                                          | Equal start/end odometer (zero miles), missing ending reading, second-start-while-running, persistence failure, offline end |
+
+> Mileage/deduction math assertions live in the **KMP suite**; Android tests cover the state machine,
+> recovery, persistence, rendering, shortcuts, and accessibility.
+
+---
+
+## 12. Implementation Readiness
+
+**Design + breakdown only** for this issue. Per the
+[Human-Gated Prerequisites runbook](../ops/human-gated-prerequisites.md), "blocked by #1242" gates
+**only distribution**, not implementation.
+
+| Phase                                                                                             | Status                                                                  | Notes                                                                    |
+| ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| **Design** (this doc)                                                                             | ✅ Deliverable now                                                      | No accounts/secrets needed                                               |
+| **Implementation** (Compose, state machine, DataStore/SQLDelight, WorkManager, shortcuts, Glance) | ✅ Buildable now                                                        | `./gradlew :apps:android:assembleDebug` + sideload; all deps local + KMP |
+| **Local tests** (unit / Robolectric / Compose / Paparazzi)                                        | ✅ Runnable now                                                         | No enrollment                                                            |
+| **Distribution** (Play Store, release signing)                                                    | 🔒 Gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242) | Google Play enrollment, keystore, CI secrets — **human-gated**           |
+
+**Buildable-now scope:** the full start/pause/end flow, durable recovery, shortcuts, foreground
+notification, and Glance tile all run on a debug build with on-device storage — no paid entitlement.
+
+**Distribution tail (human action required):** Play Store release and signing depend on the #1242
+prerequisites in
+[§3.1 of the runbook](../ops/human-gated-prerequisites.md#31-android-distribution--google-play-1242).
+No AI agent performs those steps.
+
+---
+
+_Part of [#2137](https://github.com/jrmoulckers/finance/issues/2137). Companion designs:
+[Mileage presets & IRS export](./android-mileage-presets-irs-export.md) ·
+[Gig tax-reserve settings](./android-gig-tax-reserve-settings.md)._


### PR DESCRIPTION
## Summary

Design-only deliverables for the Android **gig tax-reserve + shift-mileage** work, batched as one PR.
Three new `docs/design/*.md` documents specify the Android (Jetpack Compose / Material 3) surfaces,
shared KMP boundary, state models, accessibility, and test plans for:

- **#2517** — gig tax-reserve settings & onboarding (rates, estimate disclaimers, weekly reminders) — _part of #2135_
- **#2518** — one-handed shift-mileage flow + state machine, offline persistence, shortcuts — _part of #2137_
- **#2519** — route/hotspot presets, platform attachment, notes, IRS export & audit trail — _part of #2137_

No native code, builds, or signing — implementation stays unblocked up to the distribution boundary;
only the _distribution_ tail is gated by #1242 per
[`docs/ops/human-gated-prerequisites.md`](../blob/main/docs/ops/human-gated-prerequisites.md).

## Changes

- `docs/design/android-gig-tax-reserve-settings.md` (#2517)
- `docs/design/android-shift-mileage-flow.md` (#2518)
- `docs/design/android-mileage-presets-irs-export.md` (#2519)

Each doc covers: affected Android surfaces + shared deps; the **KMP/Compose boundary** (all tax-reserve
% and IRS-rate mileage math stays in `packages/core` — `TaxReserveCalculator`, `GigTakeHomeCalculator`,
`MileageCalculator`, `RoutePreset`, `MileageAuditMetadata`; Compose only renders shared state);
offline-first / empty / error states; **TalkBack & font-scaling** accessibility; a test plan
(unit / Compose / Paparazzi); and an **Implementation Readiness** section distinguishing buildable-now
(`assembleDebug` sideload) from the distribution tail gated by #1242.

## Testing

- `npx prettier --check` on all three docs — ✅ all pass.
- Verified every relative link target (runbook, sibling design docs, KMP sources, Android reference
  files) exists, and the `#1242` runbook anchor matches.
- Grounded designs against the real shared models (`TaxCalculators.kt`, `MileageCalculator.kt`,
  `MileageModels.kt`, `VehicleCostCalculator.kt`, `GigPayoutCalculator.kt`) and Android patterns
  (`AppModule.kt`, `BillReminderWorker.kt`, Glance widgets, `EncryptedPrefsProvider`).

Docs-only change — no application code or shared/config files touched.

Closes #2517
Closes #2518
Closes #2519
