### PR TITLE
docs(design): ios investment data and metrics design batch (#2568, #2570, #2537)

### DIFF
--- a/docs/design/ios-investment-chart-text-alternatives.md
+++ b/docs/design/ios-investment-chart-text-alternatives.md
@@ -1,0 +1,388 @@
+# iOS Investment & Report Chart Text Alternatives
+
+> Design specification that **applies the existing chart text-alternative
+> pattern** to `InvestmentDetailView`, the portfolio performance / projection
+> charts, and the `ReportResultView` charts — adding a spoken summary (date
+> range, extrema, totals, forecast confidence) and a browsable table to each.
+> This doc **reuses**, and does not redefine, the cluster pattern.
+
+**Status:** PROPOSED — design only (native implementation gated, see
+[Implementation readiness](#implementation-readiness))
+**Issue:** [#2537](https://github.com/jrmoulckers/finance/issues/2537) — _Part of
+[#2113](https://github.com/jrmoulckers/finance/issues/2113)_
+**Platform:** iOS (SwiftUI · Swift Charts)
+**Last updated:** 2026-06-22
+**Reused pattern (do not re-specify here):**
+[ios-chart-summaries-data-tables.md](./ios-chart-summaries-data-tables.md) ·
+[ios-chart-voiceover-navigation.md](./ios-chart-voiceover-navigation.md) ·
+[ios-chart-descriptor-adapters.md](./ios-chart-descriptor-adapters.md)
+**Related design docs:** [data-visualization.md](./data-visualization.md) ·
+[accessibility-patterns.md](./accessibility-patterns.md)
+**Sibling investment designs:**
+[ios-investment-data-kmp-design.md](./ios-investment-data-kmp-design.md) ·
+[ios-portfolio-metrics-projections.md](./ios-portfolio-metrics-projections.md)
+
+---
+
+## Table of Contents
+
+1. [Problem & Goal](#1-problem--goal)
+2. [Affected iOS Surfaces](#2-affected-ios-surfaces)
+3. [Shared Dependencies & the iOS / KMP Boundary](#3-shared-dependencies--the-ios--kmp-boundary)
+4. [Applying the Pattern (per surface)](#4-applying-the-pattern-per-surface)
+5. [Summary Content: Date Range, Extrema, Totals, Forecast Confidence](#5-summary-content-date-range-extrema-totals-forecast-confidence)
+6. [Accessibility](#6-accessibility)
+7. [Dynamic Type](#7-dynamic-type)
+8. [Privacy & Balance Hiding](#8-privacy--balance-hiding)
+9. [Empty, Stale & Error States](#9-empty-stale--error-states)
+10. [Test Plan](#10-test-plan)
+11. [Implementation readiness](#implementation-readiness)
+
+---
+
+## 1. Problem & Goal
+
+A VoiceOver-first user with severe central vision loss
+([#2113](https://github.com/jrmoulckers/finance/issues/2113)) experiences an
+unlabelled chart as blank space. Two of this app's chart surfaces are still
+chart-only or chart-plus-generic-label:
+
+- [`InvestmentDetailView.swift`](../../apps/ios/Finance/Screens/InvestmentDetailView.swift)
+  (≈ lines 158–187) renders price history as a `Chart { LineMark … }` whose only
+  accessibility affordance is
+  `.accessibilityLabel("Price history line chart for {symbol}")` — no summary, no
+  data list.
+- [`InvestmentPortfolioView.swift`](../../apps/ios/Finance/Screens/InvestmentPortfolioView.swift)
+  (≈ lines 132–189) exposes the performance line + area chart with only
+  `.accessibilityLabel("Portfolio performance line chart")`. (Its allocation
+  section is already a row list — good; the chart is not.)
+- [`ReportResultView.swift`](../../apps/ios/Finance/Screens/ReportResultView.swift)
+  already ships `reportDataTable` (≈ line 256) — a category / monthly / net-worth
+  row list — but its **charts have no spoken summary**, and the table is a
+  bespoke implementation rather than the shared component.
+
+The reusable solution already exists: the chart-accessibility cluster defines
+`ChartAccessibilityDescriptor`, `ChartSummaryView`, and `ChartDataTable`
+([ios-chart-summaries-data-tables.md](./ios-chart-summaries-data-tables.md)), the
+gesture-free inspection model
+([ios-chart-voiceover-navigation.md](./ios-chart-voiceover-navigation.md)), and
+the `AXChartDescriptor` mapping
+([ios-chart-descriptor-adapters.md](./ios-chart-descriptor-adapters.md)).
+
+**Goal:** **apply** that pattern to the investment and report charts so each gets
+the cluster's standard **summary → chart → table** swipe order, with summaries
+that carry the facts #2537 calls out: **date range, extrema (high/low), totals,
+and forecast confidence text**. This doc specifies the per-surface wiring and the
+investment/report-specific summary content — it does **not** restate the pattern.
+
+**Non-goals:** redefining the summary/table/descriptor components (owned by the
+cluster docs); the projection math (owned by
+[ios-portfolio-metrics-projections.md](./ios-portfolio-metrics-projections.md));
+the underlying data persistence (owned by
+[ios-investment-data-kmp-design.md](./ios-investment-data-kmp-design.md)).
+
+---
+
+## 2. Affected iOS Surfaces
+
+| Surface                                                                                            | Chart today                      | Add summary (facts)                                                 | Add / adopt table                                                        |
+| -------------------------------------------------------------------------------------------------- | -------------------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| [`InvestmentDetailView.swift`](../../apps/ios/Finance/Screens/InvestmentDetailView.swift)          | Price-history line (chart-only)  | First→last value, % change, **high/low**, **date range**            | New `ChartDataTable`: per-date price rows                                |
+| [`InvestmentPortfolioView.swift`](../../apps/ios/Finance/Screens/InvestmentPortfolioView.swift)    | Performance line + area          | Start→end value, **total return**, high/low, date range             | New `ChartDataTable`: per-date value rows                                |
+| Portfolio **projection** chart (from [#2570](https://github.com/jrmoulckers/finance/issues/2570))  | Multi-series scenario line (new) | Horizon, **moderate ending value + range**, **forecast confidence** | New `ChartDataTable`: per-year, per-scenario rows                        |
+| [`ReportResultView.swift`](../../apps/ios/Finance/Screens/ReportResultView.swift) — spending donut | `SectorMark` donut               | Total + **biggest category** + slice count                          | **Adopt** shared `ChartDataTable` (replaces bespoke `categoryDataTable`) |
+| `ReportResultView` — income vs expense bars                                                        | Grouped `BarMark`                | Per-period totals, highest/lowest month, net                        | Adopt shared `ChartDataTable` (from `monthlyDataTable`)                  |
+| `ReportResultView` — net-worth line                                                                | Area + line                      | Start→end, **high/low**, date range                                 | Adopt shared `ChartDataTable` (from `netWorthDataTable`)                 |
+
+> **Reuse, don't fork.** `ReportResultView` already proves the row-list idea; this
+> work **migrates** its three bespoke tables onto the shared `ChartDataTable`
+> component and **adds the missing spoken summary** above each chart — so the app
+> ends with one text-alternative implementation, as the cluster intends
+> ([ios-chart-summaries-data-tables.md §2](./ios-chart-summaries-data-tables.md#2-affected-ios-surfaces)).
+
+---
+
+## 3. Shared Dependencies & the iOS / KMP Boundary
+
+This doc consumes the **same boundary** the cluster already drew — it adds no new
+boundary, only new call sites.
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages/core — platform-neutral (existing/proposed)"]
+        A[Aggregated series + summary facts<br/>total, min, max, first→last delta]
+        B[Projection scenarios + confidence<br/>from #2570]
+    end
+    subgraph BR["apps/ios — Swift Export bridge"]
+        C[SwiftExportFormatterModule<br/>SwiftExportAggregatorModule]
+    end
+    subgraph CLUSTER["apps/ios — reused cluster components"]
+        D[ChartAccessibilityDescriptor]
+        E[ChartSummaryView]
+        F[ChartDataTable]
+    end
+    subgraph SURF["apps/ios — this doc's surfaces"]
+        G[InvestmentDetailView · Portfolio · Projection]
+        H[ReportResultView charts]
+    end
+    A --> C --> D
+    B --> C --> D
+    D --> E
+    D --> F
+    E --> G
+    F --> G
+    E --> H
+    F --> H
+```
+
+| Concern                                                              | Lives in                           | Status                                                                                    |
+| -------------------------------------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------- |
+| `ChartAccessibilityDescriptor`, `ChartSummaryView`, `ChartDataTable` | `apps/ios`                         | **Reused** — defined in the cluster docs, not here                                        |
+| Summary facts (min, max, first→last delta, biggest contributor)      | `packages/core` (proposed via ADR) | **From cluster** — same proposed helper; investment/report just call it                   |
+| Projection scenarios + `ProjectionConfidence`                        | `packages/core` (proposed via ADR) | **From** [ios-portfolio-metrics-projections.md](./ios-portfolio-metrics-projections.md)   |
+| Price/value series + freshness                                       | `packages/core` (proposed via ADR) | **From** [ios-investment-data-kmp-design.md](./ios-investment-data-kmp-design.md)         |
+| Currency → display string                                            | `packages/core` (bridged)          | **Exists** — `SwiftExportFormatterModule.format(amountMinorUnits:currencyCode:showSign:)` |
+| Building descriptors for these specific charts; summary phrasing     | `apps/ios`                         | **This doc**                                                                              |
+
+> **Boundary rule (inherited):** amounts cross as **`Int64` minor units** and are
+> formatted on device; the iOS layer never re-implements currency or return math.
+> See [ios-chart-summaries-data-tables.md §3](./ios-chart-summaries-data-tables.md#3-shared-dependencies--the-ios--kmp-boundary).
+
+> **KMP changes are out of scope for this PR.** The proposed summary-facts and
+> projection helpers are @kmp-engineer / @architect changes via **ADR**
+> ([AGENTS.md](../../AGENTS.md)); this doc only wires existing/planned bridged
+> facts into the reused components.
+
+---
+
+## 4. Applying the Pattern (per surface)
+
+Every surface adopts the cluster's deliberate **summary → chart → table** swipe
+order ([ios-chart-summaries-data-tables.md §4](./ios-chart-summaries-data-tables.md#4-pattern-design)).
+The chart keeps its visual rendering and gains
+`.accessibilityChartDescriptor(…)` from
+[ios-chart-descriptor-adapters.md](./ios-chart-descriptor-adapters.md); the
+gesture-free point inspection comes from
+[ios-chart-voiceover-navigation.md](./ios-chart-voiceover-navigation.md).
+
+### 4.1 `InvestmentDetailView` — price history
+
+```
+[ChartSummaryView]  #1  "AAPL price history. 12 points, Jul 2025 to Jun 2026.
+                         $150.00 rising to $175.00, 16.7 percent. High $182.40,
+                         low $148.10."
+[Chart { LineMark }] #2  (visual; + .accessibilityChartDescriptor)
+[ChartDataTable]    #3  "Jul 2025 … $150.00" · "Aug 2025 … $153.20" · …
+```
+
+- The chart's current `.accessibilityElement(children: .combine)` +
+  single-label is replaced by the three-element pattern; the existing CVD-safe
+  colour and `holdingInfoSection` are unaffected.
+
+### 4.2 `InvestmentPortfolioView` — performance
+
+- Same shape; summary leads with **total return** and **date range**, e.g.
+  "Portfolio performance. 12 months, Jul 2025 to Jun 2026. $35,000 rising to
+  $42,200, total return +20.6 percent. High $43,100, low $34,200." Table rows are
+  per-date portfolio value.
+
+### 4.3 Portfolio **projection** chart (forecast confidence)
+
+- Multi-series (conservative / moderate / optimistic) line; the summary carries
+  the **forecast confidence text** #2537 calls for, sourced from
+  `ProjectionConfidence` ([metrics doc §7](./ios-portfolio-metrics-projections.md#7-confidence-states)):
+  "Projection, 30-year horizon. Moderate estimate $1.20M, range $720K to $2.10M.
+  **Medium confidence — based on limited history. Estimate, not advice.**"
+- Rows: per-year, per-scenario ("2046 · Moderate … $1.20M"). The estimate
+  disclaimer ([metrics doc §8](./ios-portfolio-metrics-projections.md#8-estimate-labelling--assumptions))
+  precedes the summary in swipe order.
+
+### 4.4 `ReportResultView` — donut / bars / net-worth
+
+- The three existing charts (`spendingByCategoryChart`, `incomeVsExpenseChart`,
+  `netWorthChart`) each gain a `ChartSummaryView`; the existing per-mark
+  `.accessibilityLabel`/`.accessibilityValue` stay.
+- `categoryDataTable` / `monthlyDataTable` / `netWorthDataTable` are **refactored
+  onto the shared `ChartDataTable`** so behaviour matches Insights/Analytics. The
+  data and row content are unchanged; only the component is unified.
+
+---
+
+## 5. Summary Content: Date Range, Extrema, Totals, Forecast Confidence
+
+The cluster defines the **grammar**
+([ios-chart-summaries-data-tables.md §5](./ios-chart-summaries-data-tables.md#5-spoken-summary-grammar));
+this section pins the **facts** #2537 names, per chart family on these surfaces.
+
+| Surface / family                | Date range                  | Extrema (high/low)             | Totals / headline              | Forecast confidence                     |
+| ------------------------------- | --------------------------- | ------------------------------ | ------------------------------ | --------------------------------------- |
+| Investment price line           | first→last valuation date   | high & low price + their dates | first→last value + % change    | n/a                                     |
+| Portfolio performance line      | first→last month            | high & low portfolio value     | total return % + end value     | n/a                                     |
+| Projection (scenarios)          | horizon start→end year      | low/high scenario ending value | moderate ending value          | **`ProjectionConfidence` text + range** |
+| Report — spending donut         | report period (`dateRange`) | n/a (share-based)              | total + **biggest category** % | n/a                                     |
+| Report — income vs expense bars | report period               | highest/lowest month           | period income/expense/net      | n/a                                     |
+| Report — net-worth line         | report period               | high & low net worth + dates   | start→end + delta              | n/a                                     |
+
+- **Date range** always uses the existing `dateRange.displayName` (reports) or the
+  series' first/last `Date` (investment), formatted on device.
+- **Extrema** name both the value **and** when it occurred, so "low" is actionable
+  for a non-visual user.
+- **Totals / biggest contributor** reuse the same facts the cluster's bar/donut
+  grammar already specifies.
+- **Forecast confidence** is **text**, derived from the shared
+  `ProjectionConfidence`, and is always accompanied by the estimate disclaimer —
+  never a bare number that implies certainty.
+- All literals use `String(localized:)`; all amounts format through the shared
+  formatter; direction words come from the sign of the shared delta, not colour.
+
+---
+
+## 6. Accessibility
+
+This doc **inherits** the cluster's accessibility contract
+([ios-chart-summaries-data-tables.md §6](./ios-chart-summaries-data-tables.md#6-accessibility))
+and applies it:
+
+- **Swipe order summary → chart → table** on every listed surface; the summary is
+  a single `.accessibilityAddTraits(.isSummaryElement)` element, the table is
+  always in the accessibility tree (never behind a VoiceOver-blocking toggle).
+- The chart retains `.accessibilityChartDescriptor(…)` (audio graph) per
+  [ios-chart-descriptor-adapters.md](./ios-chart-descriptor-adapters.md), and
+  point-by-point inspection follows
+  [ios-chart-voiceover-navigation.md](./ios-chart-voiceover-navigation.md).
+- Per-row labels use `.accessibilityElement(children: .combine)` + label + value,
+  matching the existing `reportDataTable` rows.
+- Section titles keep `.accessibilityAddTraits(.isHeader)` (already the convention
+  in both views).
+- On reload, the new summary sentence is announced politely via
+  `AccessibilityNotification.Announcement`.
+- The projection surface additionally exposes its **estimate disclaimer** and
+  **confidence** as text, ordered before the figures.
+
+---
+
+## 7. Dynamic Type
+
+Inherits [ios-chart-summaries-data-tables.md §7](./ios-chart-summaries-data-tables.md#7-dynamic-type):
+
+- Summary + table text use Dynamic Type styles / the `FinanceTextStyle` ramp —
+  **never** hardcoded point sizes — and the summary **wraps**
+  (`.fixedSize(horizontal: false, vertical: true)`) rather than truncates.
+- Table rows reflow `HStack → VStack` at accessibility sizes; the table shows full
+  values (no `.minimumScaleFactor` clipping). The existing
+  `minimumScaleFactor(0.8)` on the detail metrics grid stays visual-only.
+
+---
+
+## 8. Privacy & Balance Hiding
+
+Inherits [ios-chart-summaries-data-tables.md §8](./ios-chart-summaries-data-tables.md#8-privacy--balance-hiding):
+
+- With balance hiding active, the price/value summaries, the projection figures,
+  and every report amount redact to a placeholder in **both** the visible text and
+  the VoiceOver label, from the same redacted descriptor — no path hides the
+  visual but speaks the number.
+- Non-sensitive facts (point counts, category names, date range, confidence level)
+  may remain.
+- Per [os.Logger guidance](../../AGENTS.md), summary sentences and amounts are
+  `.private` and never logged verbatim.
+
+---
+
+## 9. Empty, Stale & Error States
+
+Inherits the cluster's state matrix
+([ios-chart-summaries-data-tables.md §9](./ios-chart-summaries-data-tables.md#9-empty-stale--error-states))
+and maps it to these surfaces:
+
+| State       | Investment / projection                                                   | Report                                                                 |
+| ----------- | ------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| **Empty**   | Existing "No price history available." becomes the single summary element | Existing `emptyChartPlaceholder` / "No data for this period." retained |
+| **Loading** | Polite "Loading price history…"; skeleton rows `.accessibilityHidden`     | Same                                                                   |
+| **Stale**   | Summary prefix "Showing data as of {asOf}" (from #2568 freshness)         | Report header already shows generated-at; summary echoes it            |
+| **Error**   | Labelled **Retry** (reuses the portfolio view's existing alert path)      | Labelled retry; descriptive rows stay usable                           |
+
+For the **projection** surface, the low-confidence / no-contribution / no-FIRE
+states from
+[ios-portfolio-metrics-projections.md §12](./ios-portfolio-metrics-projections.md#12-empty-stale--error-states)
+flow straight into the summary text (e.g. "Low confidence — add more history").
+No state relies on colour alone; all copy uses `String(localized:)`.
+
+---
+
+## 10. Test Plan
+
+Smallest tests that must pass before implementation is accepted. Native tests run
+on Simulator with **free Personal Team signing** (see
+[Implementation readiness](#implementation-readiness)).
+
+### Shared (KMP) — `packages/core` `commonTest` _(proposed via ADR; not in this PR)_
+
+- Covered by the cluster's `SummaryFactsTest`
+  ([ios-chart-summaries-data-tables.md §10](./ios-chart-summaries-data-tables.md#10-test-plan)):
+  add fixtures for an **investment price series** (extrema + first→last delta) and
+  a **projection scenario set** (moderate value + range + confidence) so the facts
+  these surfaces speak are verified once, platform-neutrally.
+
+### Native (iOS) — XCTest / Swift Testing in `apps/ios/Tests`
+
+- `InvestmentDetailSummaryTests`: the descriptor → sentence mapping yields the
+  expected price-history string incl. date range, high/low (+ dates), and %
+  change; empty and single-point series produce the correct wording.
+- `PortfolioPerformanceSummaryTests`: summary leads with total return + date
+  range; matches the portfolio's computed return.
+- `ProjectionSummaryTests`: the projection summary includes the moderate value,
+  the low→high range, **and** the `ProjectionConfidence` text + estimate
+  disclaimer; suppresses the FIRE range when confidence is Low without a FI number.
+- `ReportChartSummaryTests`: donut (biggest category + total), bars
+  (highest/lowest month + net), and net-worth (start→end + extrema) summaries are
+  correct.
+- `ReportDataTableUnificationTests`: the three report tables render via the shared
+  `ChartDataTable` with the same row count + labels as the current bespoke tables
+  (no regression).
+- `ChartAlternativeOrderTests` (XCUITest): VoiceOver swipe order is
+  summary → chart → table on `InvestmentDetailView`, the portfolio performance
+  chart, the projection chart, and all three report charts.
+- `ChartAlternativePrivacyTests`: with balance hiding on, no raw amount appears in
+  visible text **or** accessibility labels on any listed surface.
+
+---
+
+## Implementation readiness
+
+**Design: ready now. Native code: buildable now, distribution gated.**
+
+Per the
+[Human-Gated Prerequisites runbook](../ops/human-gated-prerequisites.md#2-implementation-vs-distribution--the-decoupling),
+implementation and distribution are decoupled. The "blocked by
+[#1239](https://github.com/jrmoulckers/finance/issues/1239)" note on
+[#2537](https://github.com/jrmoulckers/finance/issues/2537) is a **distribution**
+gate only.
+
+| Phase              | What                                                                                               | Gated by #1239?                         |
+| ------------------ | -------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| **Design**         | This document — per-surface wiring, summary facts, reuse of the cluster components, test plan      | No — deliverable now                    |
+| **Implementation** | Add `ChartSummaryView`/`ChartDataTable` to the listed charts; unify report tables; unit + XCUITest | **No** — free Personal Team signing     |
+| **Distribution**   | TestFlight / App Store build carrying the accessible charts                                        | **Yes** — Apple Developer Program enrol |
+
+- **Buildable now:** wiring the reused components into these charts, the VoiceOver
+  semantics, Dynamic Type behaviour, and the listed tests all run on Simulator /
+  device via free Personal Team signing. No paid entitlements are required.
+- **Gated tail (#1239):** only shipping through TestFlight / the App Store needs
+  the paid Apple Developer enrollment + signing in
+  [human-gated-prerequisites.md §3.2](../ops/human-gated-prerequisites.md#32-ios-distribution--apple-developer-1239).
+  An SME agent must **not** perform enrollment, certificate, or secret steps.
+- **Dependency ordering:** this work lands cleanest **after** the cluster
+  components ([ios-chart-summaries-data-tables.md](./ios-chart-summaries-data-tables.md))
+  exist; the report-table unification and investment-price summary can proceed
+  against the cluster's stub facts, and the projection summary follows
+  [ios-portfolio-metrics-projections.md](./ios-portfolio-metrics-projections.md).
+  The proposed shared summary-facts helper is an @kmp-engineer change via ADR.
+
+_Part of [#2113](https://github.com/jrmoulckers/finance/issues/2113). Reuses the
+chart-accessibility cluster
+([summaries & tables](./ios-chart-summaries-data-tables.md) ·
+[VoiceOver navigation](./ios-chart-voiceover-navigation.md) ·
+[descriptor adapters](./ios-chart-descriptor-adapters.md)); paired with
+[KMP-backed investment data](./ios-investment-data-kmp-design.md) and
+[portfolio metrics & projections](./ios-portfolio-metrics-projections.md)._

--- a/docs/design/ios-investment-data-kmp-design.md
+++ b/docs/design/ios-investment-data-kmp-design.md
@@ -1,0 +1,453 @@
+# iOS KMP-Backed Investment Data (Replacing the Mock)
+
+> Design specification for the **repository / view-model boundary** that replaces
+> `MockInvestmentRepository` with **persisted, synced** portfolio, holding,
+> price, and contribution data — reusing the Swift Export bridge + persistence
+> pattern the rest of the app already uses.
+
+**Status:** PROPOSED — design only (native implementation gated, see
+[Implementation readiness](#implementation-readiness))
+**Issue:** [#2568](https://github.com/jrmoulckers/finance/issues/2568) — _Part of
+[#2118](https://github.com/jrmoulckers/finance/issues/2118)_
+**Platform:** iOS (SwiftUI · Swift Concurrency · Swift Export / KMP)
+**Last updated:** 2026-06-22
+**Related design docs:** [data-model.md](./data-model.md) ·
+[features.md](./features.md) · [accessibility-patterns.md](./accessibility-patterns.md)
+**Sibling designs (this cluster):**
+[ios-portfolio-metrics-projections.md](./ios-portfolio-metrics-projections.md) ·
+[ios-investment-chart-text-alternatives.md](./ios-investment-chart-text-alternatives.md)
+
+---
+
+## Table of Contents
+
+1. [Problem & Goal](#1-problem--goal)
+2. [Affected iOS Surfaces](#2-affected-ios-surfaces)
+3. [Shared Dependencies & the iOS / KMP Boundary](#3-shared-dependencies--the-ios--kmp-boundary)
+4. [The Repository Contract](#4-the-repository-contract)
+5. [Data Model & Persistence](#5-data-model--persistence)
+6. [Sync Expectations](#6-sync-expectations)
+7. [Migration: Mock → Real](#7-migration-mock--real)
+8. [Accessibility](#8-accessibility)
+9. [Dynamic Type](#9-dynamic-type)
+10. [Privacy & Balance Hiding](#10-privacy--balance-hiding)
+11. [Empty, Stale & Error States](#11-empty-stale--error-states)
+12. [Test Plan](#12-test-plan)
+13. [Implementation readiness](#implementation-readiness)
+
+---
+
+## 1. Problem & Goal
+
+An index-fund investor ([#2118](https://github.com/jrmoulckers/finance/issues/2118))
+cannot trust a screen that is mock-backed. Today the investment feature is wired
+to hard-coded sample data:
+
+- [`RepositoryProvider.swift`](../../apps/ios/Finance/Repositories/RepositoryProvider.swift)
+  (≈ lines 94–101) defaults `investments` to `MockInvestmentRepository()`, while
+  every other domain (`accounts`, `transactions`, `budgets`, `goals`,
+  `categories`) already defaults to a `Bridged*Repository` backed by the Swift
+  Export bridge.
+- [`MockInvestmentRepository.swift`](../../apps/ios/Finance/Repositories/Mocks/MockInvestmentRepository.swift)
+  serves fixed holdings (AAPL, MSFT, BND, VNQ, GLD, USDC) and **randomly
+  generated** performance history (`Int64.random(...)` ≈ line 93), and carries an
+  explicit `TODO: Replace MockInvestmentRepository with KMP-backed repository`.
+- [`InvestmentViewModel.swift`](../../apps/ios/Finance/ViewModels/InvestmentViewModel.swift)
+  and the two screens already depend only on the
+  [`InvestmentRepository`](../../apps/ios/Finance/Repositories/InvestmentRepository.swift)
+  protocol, so the swap is a **dependency change, not a UI rewrite**.
+
+**Goal:** define the repository contract, the shared data model + persistence,
+and the sync expectations needed to back the investment feature with **real,
+durable, synced** data — including the **contribution** dimension that
+[ios-portfolio-metrics-projections.md](./ios-portfolio-metrics-projections.md)
+depends on — and the phased migration that flips the default from mock to real
+without changing a single `View` or `ViewModel` call site.
+
+**Non-goals:** brokerage / market-data ingestion (live quotes are a separate,
+provider-gated concern — see [§6](#6-sync-expectations)); the projection and
+text-alternative work (sibling docs). This doc draws the **data boundary** only;
+it does not implement KMP code.
+
+---
+
+## 2. Affected iOS Surfaces
+
+| Surface                                                                                                      | Role                                                 | Change                                                                                                                                     |
+| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| [`RepositoryProvider.swift`](../../apps/ios/Finance/Repositories/RepositoryProvider.swift)                   | DI container                                         | Flip `investments` default `MockInvestmentRepository()` → `BridgedInvestmentRepository()`                                                  |
+| [`InvestmentRepository.swift`](../../apps/ios/Finance/Repositories/InvestmentRepository.swift)               | Data-access protocol                                 | Extend with contribution + freshness accessors (see [§4](#4-the-repository-contract))                                                      |
+| `BridgedInvestmentRepository` (new)                                                                          | Adapter → Swift Export `SwiftExportInvestmentModule` | New, mirrors `BridgedAccountRepository` in [`SwiftExportBridgeProvider.swift`](../../apps/ios/Finance/KMP/SwiftExportBridgeProvider.swift) |
+| [`InvestmentModels.swift`](../../apps/ios/Finance/Models/InvestmentModels.swift)                             | SwiftUI value types                                  | Add `ContributionItem`, `dataAsOf`/freshness, keep money in `Int64` minor units                                                            |
+| [`InvestmentViewModel.swift`](../../apps/ios/Finance/ViewModels/InvestmentViewModel.swift)                   | `@Observable` view model                             | Surface freshness + load contributions; **no math moves here** (stays in KMP)                                                              |
+| [`InvestmentPortfolioView.swift`](../../apps/ios/Finance/Screens/InvestmentPortfolioView.swift)              | List + summary + perf chart                          | Unchanged structurally; gains stale/empty/error fidelity from real data                                                                    |
+| [`InvestmentDetailView.swift`](../../apps/ios/Finance/Screens/InvestmentDetailView.swift)                    | Single-holding detail                                | Unchanged structurally; price history becomes real, not random                                                                             |
+| [`MockInvestmentRepository.swift`](../../apps/ios/Finance/Repositories/Mocks/MockInvestmentRepository.swift) | Preview / test fixture                               | **Retained** for previews/tests; demoted from production default                                                                           |
+
+> **The point of the protocol:** because `InvestmentRepository` is already the
+> only thing the view models import, "replace the mock" is one DI edit plus the
+> bridge adapter. The mock stays as the preview/test double, exactly like
+> `MockAccountRepository` does today.
+
+---
+
+## 3. Shared Dependencies & the iOS / KMP Boundary
+
+Business rules (portfolio math, allocation, contribution accounting) are
+platform-neutral and already partly exist in
+[`InvestmentEngine.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/investment/InvestmentEngine.kt).
+Apple-specific concerns (SwiftUI, Keychain, VoiceOver) stay in `apps/ios`.
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages/core · packages/models — platform-neutral"]
+        A[Portfolio / Holding / AssetClass<br/>InvestmentEngine.kt]
+        B[Contribution model<br/>+ price/quote history<br/>proposed]
+        C[InvestmentRepository<br/>SQLDelight-backed · proposed]
+    end
+    subgraph SYNC["packages/sync — CRDT / delta sync"]
+        D[SyncableInvestmentRepository<br/>proposed · mirrors SyncableAccountRepository]
+    end
+    subgraph BR["apps/ios — Swift Export bridge"]
+        E[SwiftExportInvestmentModule<br/>proposed · mirrors SwiftExportAccountModule]
+        F[BridgedInvestmentRepository]
+    end
+    subgraph IOS["apps/ios — SwiftUI"]
+        G[InvestmentViewModel @Observable]
+        H[Portfolio / Detail views]
+    end
+    A --> C --> E
+    B --> C
+    C --> D
+    E --> F --> G --> H
+```
+
+| Concern                                                              | Lives in                            | Status                                                                                                                                             |
+| -------------------------------------------------------------------- | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Portfolio`, `Holding`, `AssetClass`, summary/return/allocation math | `packages/core`                     | **Exists** — [`InvestmentEngine.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/investment/InvestmentEngine.kt)                    |
+| `Contribution` model (deposits/buys by date & amount)                | `packages/core` / `packages/models` | **Proposed via ADR** — needed by [metrics doc](./ios-portfolio-metrics-projections.md)                                                             |
+| Price / quote history persistence (vs. today's random series)        | `packages/core`                     | **Proposed via ADR** — replaces `getPerformanceHistory` randomness                                                                                 |
+| `InvestmentRepository` (SQLDelight read/write, soft-delete)          | `packages/core` (`packages/db`)     | **Proposed via ADR** — mirrors existing account/transaction repos                                                                                  |
+| Sync (delta apply, `observeUnsyncedCount`)                           | `packages/sync`                     | **Proposed via ADR** — mirrors [`SyncableRepository`](../../packages/sync/src/commonMain/kotlin/com/finance/sync/repository/SyncableRepository.kt) |
+| Encrypted on-device store (SQLCipher, Keychain-held key)             | `apps/ios`                          | **Exists** — `LiveSwiftExportBridge` + `PersistentDataStore`                                                                                       |
+| `SwiftExportInvestmentModule` + `BridgedInvestmentRepository`        | `apps/ios`                          | **This doc** (new, mirrors account module/adapter)                                                                                                 |
+| Currency → display string (`Int64` minor units → locale string)      | `packages/core` (bridged)           | **Exists** — `SwiftExportFormatterModule.format(amountMinorUnits:currencyCode:showSign:)`                                                          |
+
+> **Boundary rule:** money crosses the bridge as **`Int64` minor units**
+> (`Cents` in KMP). The iOS layer never re-implements return, gain/loss, or
+> allocation math — those already live in `InvestmentEngine` and stay there.
+> Kotlin → Swift type mapping is the standard one (`Long` → `Int64`, `List` →
+> `Array`, sealed/enum → enum).
+
+> **KMP changes are out of scope for this PR.** Every "proposed" row above is an
+> @kmp-engineer / @architect change introduced via ADR per
+> [AGENTS.md](../../AGENTS.md). This design names the contracts; it does not edit
+> `packages/`.
+
+---
+
+## 4. The Repository Contract
+
+### 4.1 Today
+
+[`InvestmentRepository`](../../apps/ios/Finance/Repositories/InvestmentRepository.swift)
+is already `Sendable` and fully `async throws`:
+
+```swift
+protocol InvestmentRepository: Sendable {
+    func getPortfolios() async throws -> [PortfolioItem]
+    func getPortfolio(id: String) async throws -> PortfolioItem?
+    func getHoldings(portfolioId: String) async throws -> [HoldingItem]
+    func getHolding(id: String) async throws -> HoldingItem?
+    func getPerformanceHistory(portfolioId: String, months: Int) async throws -> [PerformanceDataPoint]
+    func deleteAllInvestments() async throws    // GDPR "Delete Everything"
+}
+```
+
+The shape is correct; what is missing is (a) real data behind it, (b)
+contributions, and (c) a way to tell the UI **how fresh** the data is.
+
+### 4.2 Target
+
+Extend the protocol additively (defaulted, so existing call sites stay valid):
+
+```swift
+protocol InvestmentRepository: Sendable {
+    // existing six methods, unchanged signatures …
+
+    /// Cash contributions (deposits / buys) for a portfolio, ascending by date.
+    /// Required by the contribution-aware metrics in #2570.
+    func getContributions(portfolioId: String) async throws -> [ContributionItem]
+
+    /// Real price/quote history for a single holding (replaces random series).
+    func getPriceHistory(holdingId: String, months: Int) async throws -> [PerformanceDataPoint]
+
+    /// Freshness signal: when the underlying snapshot was last synced/valued.
+    func dataFreshness(portfolioId: String) async throws -> DataFreshness
+}
+
+struct DataFreshness: Sendable, Hashable {
+    let asOf: Date          // valuation timestamp
+    let isStale: Bool       // older than the freshness budget (e.g. > 24h)
+    let source: Source      // .synced, .localOnly, .placeholder
+    enum Source: Sendable { case synced, localOnly, placeholder }
+}
+```
+
+Contract rules:
+
+- **Idempotent reads, no surprises:** repositories return whatever is persisted;
+  they never fabricate data. The random walk in the mock is exactly the behaviour
+  we are removing.
+- **Soft delete:** the shared `Portfolio` already carries `deletedAt`; reads
+  exclude soft-deleted rows. `deleteAllInvestments()` maps to the existing
+  "Delete Everything" GDPR flow (same as `deleteAllAccounts()`), routed through
+  the Swift Export sync module so the deletion propagates.
+- **Currency:** all amounts remain `Int64` minor units; `currencyCode` per
+  portfolio/holding is preserved end-to-end.
+- **Errors** surface as thrown Swift errors; the bridge wraps KMP failures
+  (`KMPRepositoryError.bridgeCallFailed`) exactly like the existing
+  `KMP*Repository` types so the view model's existing `catch` keeps working.
+
+---
+
+## 5. Data Model & Persistence
+
+### 5.1 Entities
+
+| Entity       | Shared source of truth                                            | iOS value type                                                          | Notes                                                               |
+| ------------ | ----------------------------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Portfolio    | `Portfolio` (`InvestmentEngine.kt`)                               | [`PortfolioItem`](../../apps/ios/Finance/Models/InvestmentModels.swift) | Adds `ownerId`/`householdId` for sync scoping (already in KMP type) |
+| Holding      | `Holding` (`InvestmentEngine.kt`)                                 | `HoldingItem`                                                           | `quantity`, `costBasis`, `currentValue`, `previousClose`            |
+| Price point  | **proposed** `PriceQuote(holdingId, date, valueCents)`            | `PerformanceDataPoint`                                                  | Replaces `Int64.random(...)`; one row per valuation date            |
+| Contribution | **proposed** `Contribution(portfolioId, date, amountCents, kind)` | **new** `ContributionItem`                                              | `kind ∈ {deposit, dividendReinvest, withdrawal}`; drives #2570      |
+| Allocation   | derived (`InvestmentEngine.assetAllocation`)                      | `AllocationSlice`                                                       | Computed, never stored                                              |
+
+`ContributionItem` (new iOS value type, mirrors a proposed KMP `Contribution`):
+
+```swift
+struct ContributionItem: Identifiable, Hashable, Sendable {
+    let id: String
+    let portfolioId: String
+    let date: Date
+    let amountMinorUnits: Int64       // positive = in, negative = withdrawal
+    let kind: Kind
+    let currencyCode: String
+    enum Kind: String, Sendable { case deposit, dividendReinvest, withdrawal }
+}
+```
+
+### 5.2 Persistence
+
+- **Store:** the same encrypted on-device database every other domain uses —
+  `LiveSwiftExportBridge` over `PersistentDataStore` (SQLCipher), with the
+  database key held in the **Keychain**
+  (`kSecAttrAccessibleWhenUnlockedThisDeviceOnly`). No investment data lands in
+  `UserDefaults`.
+- **Tables:** `portfolio`, `holding`, `price_quote`, `contribution`, following
+  the existing SQLDelight schema conventions in `packages/db` (sync columns:
+  `updatedAt`, `deletedAt`, `syncVersion`).
+- **Widgets / App Group:** if a portfolio-value widget is later added, only a
+  **redacted, already-formatted** summary string crosses into the App Group;
+  raw rows and keys never leave the app sandbox (consistent with the balance
+  widget pattern).
+
+---
+
+## 6. Sync Expectations
+
+- **Mechanism:** investments sync through the same delta pipeline as accounts.
+  A proposed `SyncableInvestmentRepository` implements the existing
+  [`SyncableRepository`](../../packages/sync/src/commonMain/kotlin/com/finance/sync/repository/SyncableRepository.kt)
+  contract (`tableName`, `applySyncChange`, `toRowData`,
+  `observeUnsyncedCount`), mirroring `SyncableAccountRepository`.
+- **Scope:** rows are scoped by `ownerId` / `householdId` (already on the
+  `Portfolio` type) so a household can share a portfolio view under existing
+  sharing rules.
+- **Offline-first:** reads always come from the local encrypted store; sync
+  reconciles in the background. The UI's `DataFreshness.asOf` tells the user when
+  the snapshot was valued, and `isStale` drives the stale banner
+  ([§11](#11-empty-stale--error-states)).
+- **Valuation vs. market data — explicit boundary:** this design syncs
+  **user-entered / persisted valuations and contributions**. Live brokerage
+  quotes and near-real-time market data are a **separate, provider-credential-
+  gated** concern (see the market-data entry in
+  [human-gated-prerequisites.md §3.5](../ops/human-gated-prerequisites.md#35-windows-market-data--provider-credentials-2702));
+  until a provider is wired, `currentValue` / `previousClose` come from the last
+  synced valuation, and the UI labels the as-of time rather than implying a live
+  price.
+- **Conflict resolution:** last-writer-wins per row at the field granularity the
+  shared sync engine already provides; contributions are append-only (a corrected
+  contribution is a new row + soft-deleted old row), which keeps the
+  money-weighted return history auditable.
+
+---
+
+## 7. Migration: Mock → Real
+
+A phased switch so the app is never broken and previews keep working.
+
+```mermaid
+flowchart LR
+    P0[Phase 0<br/>today: Mock default] --> P1[Phase 1<br/>SwiftExportInvestmentModule<br/>+ BridgedInvestmentRepository]
+    P1 --> P2[Phase 2<br/>flip RepositoryProvider default]
+    P2 --> P3[Phase 3<br/>contributions + real price history]
+    P3 --> P4[Phase 4<br/>enable sync + freshness]
+```
+
+| Phase | Change                                                                                                                                   | Risk control                                                                                       |
+| ----- | ---------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| **1** | Add `SwiftExportInvestmentModule` to the bridge protocol + a `BridgedInvestmentRepository` adapter (mirrors `BridgedAccountRepository`). | Default still `MockInvestmentRepository`; nothing changes for users until Phase 2.                 |
+| **2** | Flip the `RepositoryProvider` default to `BridgedInvestmentRepository()`. Stub bridge returns seeded data; live bridge reads the store.  | One-line DI change; mock stays for `#Preview` + tests. Reversible by reverting the default.        |
+| **3** | Replace `getPerformanceHistory` randomness with persisted `PriceQuote` rows; add `getContributions`.                                     | Empty-history portfolios render the existing "No price history" empty state — no random fallback.  |
+| **4** | Wire `SyncableInvestmentRepository` + `dataFreshness`; surface stale/synced states.                                                      | Sync failures degrade to `localOnly`; the UI still shows last-known valuation with an as-of label. |
+
+- **No call-site churn:** because the view models depend on the protocol, Phases
+  1–4 touch DI + the adapter only. `InvestmentPortfolioView` /
+  `InvestmentDetailView` / `InvestmentViewModel` need **no** structural edits.
+- **Stub parity:** when the `FinanceSync` XCFramework is absent (e.g. building on
+  Windows CI), the bridge falls back to `PersistentDataStore`/stub exactly as it
+  does for accounts today, so the iOS target still builds and tests green.
+- **Mock retained on purpose:** `MockInvestmentRepository` keeps SwiftUI previews
+  deterministic and is the injected double in unit tests.
+
+---
+
+## 8. Accessibility
+
+This is a data/boundary design, but the data it introduces directly feeds
+accessible UI, so the contract carries a11y obligations:
+
+- **Freshness is announced, not coloured.** `DataFreshness.isStale` / `.source`
+  produce a **text** label ("Updated 2 days ago", "Offline — last synced…"), so a
+  VoiceOver user learns staleness without relying on a colour badge
+  ([accessibility-patterns.md](./accessibility-patterns.md)).
+- **Real data → honest VoiceOver values.** The existing per-row
+  `.accessibilityLabel`/`.accessibilityValue` on holdings and the portfolio
+  summary now read **true** returns and values instead of mock numbers.
+- **Contributions are first-class text.** Contribution rows expose
+  `.accessibilityElement(children: .combine)` with label (date + kind) and value
+  (formatted amount), matching the existing holding-row convention.
+- The chart text-alternative obligations for these surfaces are specified
+  separately in
+  [ios-investment-chart-text-alternatives.md](./ios-investment-chart-text-alternatives.md).
+
+---
+
+## 9. Dynamic Type
+
+- All new labels (freshness caption, contribution rows) use Dynamic Type system
+  styles / the `FinanceTextStyle` ramp — **never** hardcoded point sizes.
+- Real data can be larger than the mock's tidy values (e.g. seven-figure
+  balances); currency labels keep `.minimumScaleFactor` only on dense visual rows
+  and **wrap** rather than truncate in detail/summary text at the largest
+  accessibility sizes.
+- Contribution and holding rows adopt the adaptive stack convention so a
+  label + amount row reflows `HStack → VStack` at accessibility sizes.
+
+---
+
+## 10. Privacy & Balance Hiding
+
+- **Keychain-only secrets.** The SQLCipher key and any sync tokens live in the
+  Keychain (`…WhenUnlockedThisDeviceOnly`); no investment value, key, or token is
+  written to `UserDefaults`.
+- **Balance hiding.** When privacy mode is active, the view model redacts every
+  monetary field (portfolio total, holding value, gain/loss, contribution amount)
+  to a placeholder in **both** the visible text **and** the VoiceOver string,
+  derived from the same redacted model — there is no path that hides the number
+  visually but speaks it.
+- **Logging.** Per [os.Logger guidance](../../AGENTS.md), amounts, symbols+
+  quantities, and balances are `.private`; only non-sensitive lifecycle events
+  (`"investment sync started"`, error `.localizedDescription` marked `.public`)
+  are logged. The existing `InvestmentViewModel` logger already follows this.
+- **Deletion.** `deleteAllInvestments()` participates in the GDPR
+  "Delete Everything" path and tombstones rows through sync so a wiped device
+  does not resurrect data on next sync.
+
+---
+
+## 11. Empty, Stale & Error States
+
+| State                  | Trigger                                | Behaviour                                                                                                                                  |
+| ---------------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Empty (no data)**    | No portfolios persisted                | Existing `EmptyStateView` ("No Investments — Add investment accounts…") in `InvestmentPortfolioView`; single focusable element.            |
+| **Empty (no history)** | Portfolio exists, no `PriceQuote` rows | Existing "No price history available." caption (no random fallback); summary states "no history yet".                                      |
+| **Stale**              | `DataFreshness.isStale == true`        | Banner/caption "Showing data as of {asOf}"; numbers still render; staleness announced in text, reuses offline signal.                      |
+| **Local-only**         | `source == .localOnly` (sync offline)  | "Offline — last synced {asOf}"; reuses the app's `OfflineBanner` pattern.                                                                  |
+| **Error**              | Repository throws                      | Existing alert in `InvestmentPortfolioView` with **Retry** + **Dismiss**; non-judgemental copy per [ux-principles.md](./ux-principles.md). |
+
+All states use `String(localized:)`; none rely on colour alone.
+
+---
+
+## 12. Test Plan
+
+Smallest tests that must pass before implementation is accepted. Native tests run
+on Simulator with **free Personal Team signing** — no paid enrollment (see
+[Implementation readiness](#implementation-readiness)).
+
+### Shared (KMP) — `packages/core` / `packages/sync` `commonTest` _(proposed via ADR; not in this PR)_
+
+- `InvestmentRepositoryTest`: round-trip persist → read for portfolios, holdings,
+  price quotes, contributions; soft-deleted rows are excluded.
+- `ContributionTest`: deposit / dividend-reinvest / withdrawal kinds sum and
+  order correctly (ascending by date), incl. empty and single-entry cases.
+- `SyncableInvestmentRepositoryTest`: `toRowData` ⇄ `applySyncChange` round-trips
+  a portfolio + holding; `observeUnsyncedCount` reflects pending writes;
+  last-writer-wins on a conflicting valuation.
+- Extend `InvestmentEngineTest` only if new derived helpers are added (existing
+  summary/return/allocation tests already cover the math).
+
+### Native (iOS) — XCTest / Swift Testing in `apps/ios/Tests`
+
+- `BridgedInvestmentRepositoryTests`: the adapter forwards each protocol method to
+  the `SwiftExportInvestmentModule` and surfaces thrown errors unchanged (mirror
+  `SwiftExportWireUpTests`).
+- `RepositoryProviderTests`: the production default is `BridgedInvestmentRepository`
+  after the flip; previews/tests can still inject `MockInvestmentRepository`.
+- `InvestmentViewModelTests`: with a stub repository, `loadPortfolios()` populates
+  portfolios/allocation/history; a thrown error sets `errorMessage` and empties
+  the list; `DataFreshness.isStale` drives a stale flag (no UI regression).
+- `InvestmentFreshnessTests`: `.synced` / `.localOnly` / `.placeholder` produce
+  the expected **text** label (asserted as accessibility string, not colour).
+- `InvestmentPrivacyRedactionTests`: with balance-hiding on, neither visible text
+  nor accessibility label exposes a raw amount on portfolio, holding, or
+  contribution rows.
+
+---
+
+## Implementation readiness
+
+**Design: ready now. Native code: buildable now, distribution gated.**
+
+Per the
+[Human-Gated Prerequisites runbook](../ops/human-gated-prerequisites.md#2-implementation-vs-distribution--the-decoupling),
+implementation and distribution are decoupled. The "blocked by
+[#1239](https://github.com/jrmoulckers/finance/issues/1239)" note on
+[#2568](https://github.com/jrmoulckers/finance/issues/2568) is a **distribution**
+gate only.
+
+| Phase              | What                                                                                           | Gated by #1239?                         |
+| ------------------ | ---------------------------------------------------------------------------------------------- | --------------------------------------- |
+| **Design**         | This document — contract, model, persistence, sync, migration, test plan                       | No — deliverable now                    |
+| **Implementation** | `SwiftExportInvestmentModule`, `BridgedInvestmentRepository`, DI flip, view-model + unit tests | **No** — free Personal Team signing     |
+| **Distribution**   | TestFlight / App Store build carrying real investment data                                     | **Yes** — Apple Developer Program enrol |
+
+- **Buildable now:** the bridge adapter, DI flip, freshness plumbing, and all
+  listed iOS tests run on Simulator / device via free Personal Team signing. No
+  paid entitlements are required.
+- **Gated tail (#1239):** only shipping through TestFlight / the App Store needs
+  the paid Apple Developer enrollment + signing material in
+  [human-gated-prerequisites.md §3.2](../ops/human-gated-prerequisites.md#32-ios-distribution--apple-developer-1239).
+  An SME agent must **not** perform enrollment, certificate, or secret steps.
+- **Shared-logic tail:** the `Contribution` model, `PriceQuote` persistence, the
+  SQLDelight-backed `InvestmentRepository`, and `SyncableInvestmentRepository` are
+  @kmp-engineer / @architect changes via **ADR**. Until they land, the iOS bridge
+  can persist via `PersistentDataStore` against the proposed schema and the mock
+  remains the preview/test double — so iOS work is unblocked in parallel.
+
+_Part of [#2118](https://github.com/jrmoulckers/finance/issues/2118). Sibling
+designs:
+[contribution-aware metrics & projections](./ios-portfolio-metrics-projections.md)
+· [investment chart text alternatives](./ios-investment-chart-text-alternatives.md)._

--- a/docs/design/ios-portfolio-metrics-projections.md
+++ b/docs/design/ios-portfolio-metrics-projections.md
@@ -1,0 +1,433 @@
+# iOS Contribution-Aware Portfolio Metrics & Projections
+
+> Design specification for **market-return-vs-contribution** metrics,
+> **compound-growth scenarios**, **FIRE-linked projection summaries**, and the
+> **confidence states** that make those numbers honest — tuned for the passive
+> index-fund investor.
+
+**Status:** PROPOSED — design only (native implementation gated, see
+[Implementation readiness](#implementation-readiness))
+**Issue:** [#2570](https://github.com/jrmoulckers/finance/issues/2570) — _Part of
+[#2118](https://github.com/jrmoulckers/finance/issues/2118)_
+**Platform:** iOS (SwiftUI · Swift Charts · Swift Concurrency)
+**Last updated:** 2026-06-22
+**Related design docs:** [data-visualization.md](./data-visualization.md) ·
+[accessibility-patterns.md](./accessibility-patterns.md) ·
+[ux-principles.md](./ux-principles.md) ·
+[cognitive-accessibility.md](./cognitive-accessibility.md)
+**Depends on:**
+[ios-investment-data-kmp-design.md](./ios-investment-data-kmp-design.md)
+(contribution + price data)
+**Sibling design:**
+[ios-investment-chart-text-alternatives.md](./ios-investment-chart-text-alternatives.md)
+(text alternative for the projection chart)
+
+---
+
+## Table of Contents
+
+1. [Problem & Goal](#1-problem--goal)
+2. [Affected iOS Surfaces](#2-affected-ios-surfaces)
+3. [Shared Dependencies & the iOS / KMP Boundary](#3-shared-dependencies--the-ios--kmp-boundary)
+4. [Metric 1 — Market Return vs Contributions](#4-metric-1--market-return-vs-contributions)
+5. [Metric 2 — Compound-Growth Scenarios](#5-metric-2--compound-growth-scenarios)
+6. [Metric 3 — FIRE-Linked Projection Summary](#6-metric-3--fire-linked-projection-summary)
+7. [Confidence States](#7-confidence-states)
+8. [Estimate Labelling & Assumptions](#8-estimate-labelling--assumptions)
+9. [Accessibility](#9-accessibility)
+10. [Dynamic Type](#10-dynamic-type)
+11. [Privacy & Balance Hiding](#11-privacy--balance-hiding)
+12. [Empty, Stale & Error States](#12-empty-stale--error-states)
+13. [Test Plan](#13-test-plan)
+14. [Implementation readiness](#implementation-readiness)
+
+---
+
+## 1. Problem & Goal
+
+The persona ([#2118](https://github.com/jrmoulckers/finance/issues/2118)) invests
+almost exclusively in broad index funds (VTI, VXUS, BND) and wants to connect
+**today's balance + contributions** to a **long-term FI timeline** — without
+hype. Today the investment screens are purely descriptive:
+
+- [`InvestmentPortfolioView.swift`](../../apps/ios/Finance/Screens/InvestmentPortfolioView.swift)
+  shows current value, total gain/loss, return %, allocation, and a historical
+  performance line — but **no contribution context** and **no forward view**.
+- [`InvestmentEngine.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/investment/InvestmentEngine.kt)
+  computes `portfolioReturnPercent` as a simple `(value − cost) / cost` figure,
+  which **conflates market gains with money you added** — misleading for someone
+  who dollar-cost-averages monthly.
+
+**Goal:** specify three platform-neutral metric families and their iOS
+presentation:
+
+1. **Market return vs contributions** — separate "money I added" from "money the
+   market made".
+2. **Compound-growth scenarios** — simple, clearly-labelled projections from
+   current balance + monthly contribution at a small set of assumed real return
+   rates.
+3. **FIRE-linked projection summary** — translate those scenarios into "years to
+   your FI number", reusing the household's FIRE target.
+
+…all wrapped in **confidence states** so a thin data history never masquerades as
+precision.
+
+**Non-goals:** the data persistence that feeds these metrics (owned by
+[ios-investment-data-kmp-design.md](./ios-investment-data-kmp-design.md)); the
+chart's text alternative (owned by the
+[sibling doc](./ios-investment-chart-text-alternatives.md)); tax-, fee-, or
+sequence-of-returns modelling (explicitly out of scope — see
+[§8](#8-estimate-labelling--assumptions)).
+
+---
+
+## 2. Affected iOS Surfaces
+
+| Surface                                                                                         | Change                                                                                                  |
+| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| [`InvestmentPortfolioView.swift`](../../apps/ios/Finance/Screens/InvestmentPortfolioView.swift) | New **Contributions vs Market** card; new **Projection** section (scenario chart + summary)             |
+| [`InvestmentDetailView.swift`](../../apps/ios/Finance/Screens/InvestmentDetailView.swift)       | Per-holding contribution split in the metrics grid (where contribution data exists)                     |
+| [`InvestmentViewModel.swift`](../../apps/ios/Finance/ViewModels/InvestmentViewModel.swift)      | Expose bridged metric/projection structs (`@Observable`); **no math added here** — it calls the bridge  |
+| `PortfolioProjectionCard` (new SwiftUI view)                                                    | Renders scenarios + FIRE summary + confidence chip; consumes the descriptor in the text-alternative doc |
+| [`InvestmentModels.swift`](../../apps/ios/Finance/Models/InvestmentModels.swift)                | Add `ContributionBreakdown`, `ProjectionScenario`, `FireProjectionSummary`, `ProjectionConfidence`      |
+
+> **Math stays shared.** Every figure below is computed in `packages/core` and
+> bridged as already-rounded values; the view models hold the result, format it
+> via `SwiftExportFormatterModule`, and lay it out. No projection arithmetic runs
+> in Swift.
+
+---
+
+## 3. Shared Dependencies & the iOS / KMP Boundary
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages/core — platform-neutral math (proposed via ADR)"]
+        A[Contributions + valuations<br/>from #2568 data layer]
+        B[ContributionBreakdown<br/>market return vs contributions]
+        C[Compound-growth projector<br/>scenarios at assumed real rates]
+        D[FIRE link<br/>years-to-target vs FI number]
+        E[ProjectionConfidence<br/>mirrors PredictionConfidence]
+    end
+    subgraph BR["apps/ios — Swift Export bridge"]
+        F[SwiftExportInvestmentModule<br/>metrics + projection accessors]
+    end
+    subgraph IOS["apps/ios — SwiftUI"]
+        G[InvestmentViewModel @Observable]
+        H[ContributionsCard · PortfolioProjectionCard]
+    end
+    A --> B --> F
+    A --> C --> F
+    C --> D --> F
+    B --> E
+    C --> E
+    F --> G --> H
+```
+
+| Concern                                                             | Lives in                        | Status                                                                                                                                                                                                            |
+| ------------------------------------------------------------------- | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Contributions + valuations source data                              | `packages/core` (+ persistence) | **From** [ios-investment-data-kmp-design.md](./ios-investment-data-kmp-design.md)                                                                                                                                 |
+| Market-return-vs-contribution math (money-weighted + simple deltas) | `packages/core`                 | **Proposed via ADR** — extends `InvestmentEngine`                                                                                                                                                                 |
+| Compound-growth projection (future value of annuity + lump sum)     | `packages/core`                 | **Proposed via ADR** — pure function, deterministic, unit-tested                                                                                                                                                  |
+| FIRE target (FI number, years-to-target)                            | `packages/core`                 | **Proposed via ADR** — reuses household FIRE inputs / savings logic ([`SavingsEngine.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/savings/SavingsEngine.kt))                                   |
+| Confidence model                                                    | `packages/core`                 | **Proposed via ADR** — mirror of `PredictionConfidence { LOW, MEDIUM, HIGH }` in [`BalancePredictionEngine.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/prediction/BalancePredictionEngine.kt) |
+| Currency formatting (`Int64` → locale string)                       | `packages/core` (bridged)       | **Exists** — `SwiftExportFormatterModule.format(...)`                                                                                                                                                             |
+| SwiftUI cards, VoiceOver semantics, Dynamic Type                    | `apps/ios`                      | **This doc**                                                                                                                                                                                                      |
+
+> **Boundary rule:** amounts cross as **`Int64` minor units**; rates and
+> percentages cross as `Double`; projection horizons as `Int` years/months. The
+> projector is a **pure, deterministic function of (balance, monthlyContribution,
+> realRate, years)** so it is trivially testable in `commonTest` and identical
+> across platforms.
+
+> **KMP changes are out of scope for this PR.** Every "proposed" row is an
+> @kmp-engineer / @architect change via **ADR** per [AGENTS.md](../../AGENTS.md).
+> This doc names the contracts and the iOS presentation; it does not edit
+> `packages/`.
+
+---
+
+## 4. Metric 1 — Market Return vs Contributions
+
+**Why:** `(value − cost) / cost` rewards someone for simply adding cash. The
+persona needs to see how much of their growth is **the market** vs **their own
+deposits**.
+
+Bridged result type (iOS mirror of a proposed KMP `ContributionBreakdown`):
+
+```swift
+struct ContributionBreakdown: Sendable, Hashable {
+    let totalContributedMinorUnits: Int64   // sum of deposits − withdrawals
+    let currentValueMinorUnits: Int64
+    let marketGainMinorUnits: Int64         // currentValue − totalContributed
+    let simpleReturnPercent: Double?        // (value − cost)/cost  (existing)
+    let moneyWeightedReturnPercent: Double? // time-aware return on contributions
+    let currencyCode: String
+}
+```
+
+- **Decomposition shown to the user:** "You've put in **$48,000**. The market
+  added **$11,200**. Total **$59,200**." A simple two-segment bar (contributions
+  vs market gain) makes the split glanceable; the
+  [text-alternative doc](./ios-investment-chart-text-alternatives.md) gives it a
+  spoken summary + rows.
+- **Money-weighted return** (a time-aware IRR-style figure on the contribution
+  schedule) is the honest "how did my investing do" number and is computed in
+  KMP; the existing simple return stays available and clearly labelled as
+  "Total return (incl. contributions)".
+- **Withdrawals** reduce `totalContributed`; the breakdown stays correct for
+  someone drawing down.
+- All three numbers are **derived in `packages/core`**; iOS only formats.
+
+---
+
+## 5. Metric 2 — Compound-Growth Scenarios
+
+A small, opinionated set of **clearly-labelled estimates** — never a single
+false-precision number.
+
+```swift
+struct ProjectionScenario: Identifiable, Sendable, Hashable {
+    let id: String                  // "conservative" | "moderate" | "optimistic"
+    let label: String               // String(localized:)
+    let realRatePercent: Double     // assumed annualised REAL return
+    let endingBalanceMinorUnits: Int64
+    let points: [PerformanceDataPoint]  // year-by-year, for the projection chart
+}
+```
+
+- **Inputs:** current balance + average monthly contribution (from #2568
+  contribution history; if no contribution history, contribution defaults to 0
+  and the UI says so) + a horizon (default to the FIRE timeline, with a
+  picker: 10 / 20 / 30 years).
+- **Scenarios:** three fixed **real** (inflation-adjusted) rates — e.g.
+  **conservative 3%**, **moderate 5%**, **optimistic 7%** — chosen to bracket a
+  broadly diversified index portfolio. Rates are constants in shared code, not
+  user-tuned magic, and every scenario is captioned with its rate.
+- **Math:** future value of current balance (lump sum) **plus** future value of a
+  monthly contribution annuity, compounded monthly, in **real** terms so the
+  number is in today's dollars. Deterministic; no Monte Carlo in v1.
+- **Presentation:** a single Swift Charts line chart with three series
+  (one per scenario) using the CVD-safe `ChartColorPalette`, plus a compact
+  "In {years} years: **{moderate}** (range {conservative}–{optimistic})" caption.
+  The chart's non-visual equivalent is specified in the
+  [text-alternative doc](./ios-investment-chart-text-alternatives.md).
+
+---
+
+## 6. Metric 3 — FIRE-Linked Projection Summary
+
+Translate the scenarios into the question the persona actually asks: **"when?"**
+
+```swift
+struct FireProjectionSummary: Sendable, Hashable {
+    let fiNumberMinorUnits: Int64        // FI target (e.g. annualExpenses × 25)
+    let currentBalanceMinorUnits: Int64
+    let progressFraction: Double         // current / fiNumber, clamped 0…1
+    let yearsToTargetModerate: Double?   // nil if not reachable in horizon
+    let yearsRangeLow: Double?           // optimistic-rate years
+    let yearsRangeHigh: Double?          // conservative-rate years
+    let confidence: ProjectionConfidence
+}
+```
+
+- **FI number** comes from the household's FIRE inputs (annual expenses × the
+  configured safe-withdrawal multiple, default 25× ≈ the 4% rule). This reuses
+  shared savings/FIRE logic
+  ([`SavingsEngine.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/savings/SavingsEngine.kt))
+  rather than re-deriving it; if a dedicated FIRE engine lands, this summary
+  binds to it.
+- **Years-to-target** is reported as a **range** ("about **18–26 years**, ~22 at
+  a moderate 5% real return"), never a single hero number, and is `nil` /
+  "beyond {horizon}" when the target isn't reachable in the chosen horizon.
+- **Progress** is shown as a labelled `ProgressView` ("**31%** of your FI number")
+  with a text value for VoiceOver — colour is never the only cue.
+- If FIRE inputs are missing, the summary degrades to a prompt ("Set your annual
+  expenses to see your FI timeline") instead of guessing.
+
+---
+
+## 7. Confidence States
+
+Projections are only as trustworthy as their inputs. Mirror the existing
+`PredictionConfidence { LOW, MEDIUM, HIGH }` enum from
+[`BalancePredictionEngine.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/prediction/BalancePredictionEngine.kt)
+so the app speaks one confidence language.
+
+```swift
+enum ProjectionConfidence: Sendable { case low, medium, high }
+```
+
+| Confidence | Trigger (computed in KMP)                                                           | UI treatment                                                                                              |
+| ---------- | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| **High**   | ≥ 24 months of contribution history **and** ≥ 12 valuations **and** FIRE inputs set | Full scenarios + FIRE range; chip "High confidence"                                                       |
+| **Medium** | ≥ 6 months history, some gaps, FIRE inputs set                                      | Scenarios shown; range widened; chip "Medium — based on limited history"                                  |
+| **Low**    | < 6 months history **or** no contribution data **or** no FIRE inputs                | Scenarios shown as "rough estimate"; FIRE range suppressed if no FI number; chip "Low — add more history" |
+
+- Confidence is **text + icon**, never colour alone; the chip's
+  `.accessibilityValue` states the level and the reason.
+- Lower confidence **widens** the displayed range and softens copy
+  ("rough estimate") rather than hiding the feature — transparency over silence.
+- Confidence is derived in shared code from data availability, so iOS and any
+  future platform agree.
+
+---
+
+## 8. Estimate Labelling & Assumptions
+
+**Projections are estimates, and the UI says so — prominently and in text.**
+
+- Every projection surface carries a persistent, VoiceOver-readable disclaimer:
+  **"Estimate. Not financial advice. Markets vary and past performance doesn't
+  guarantee future results."** (`String(localized:)`).
+- **Stated assumptions** (shown in an expandable "How this is calculated" /
+  `DisclosureGroup`, always reachable by VoiceOver):
+  - Returns are **real (inflation-adjusted)**, so amounts are in **today's
+    dollars**.
+  - Assumed real rates are **fixed constants** (3% / 5% / 7%), **not** a forecast
+    of any specific fund.
+  - Contributions are assumed **constant** at the recent monthly average and
+    invested monthly.
+  - **Excluded:** taxes, fees/expense ratios, sequence-of-returns risk, currency
+    effects, and one-off events. v1 is deterministic compounding, **not** a
+    probabilistic simulation.
+- Per [ux-principles.md](./ux-principles.md) and
+  [cognitive-accessibility.md](./cognitive-accessibility.md), copy is plain,
+  non-hype, and avoids implying certainty ("could grow to", not "will be").
+- Numbers are **rounded** for display (no false precision); the rounding happens
+  in shared code so all platforms match.
+
+---
+
+## 9. Accessibility
+
+- **Every metric is text-first.** The contributions split, each scenario's
+  ending balance, the FIRE range, and the confidence level are all real text with
+  `.accessibilityLabel` / `.accessibilityValue` — a VoiceOver user gets the full
+  story without the charts. The projection **chart's** spoken summary + data
+  table are specified in
+  [ios-investment-chart-text-alternatives.md](./ios-investment-chart-text-alternatives.md).
+- **Confidence and progress never rely on colour** — chip text + SF Symbol, and a
+  spoken progress value ("31 percent of your FI number").
+- **Disclaimer is in the accessibility tree**, not a visual-only footnote, and is
+  swipe-reachable before the numbers it qualifies.
+- **Direction words** ("market added", "market lost") come from the sign of the
+  shared delta, not from red/green.
+- Reduce Motion: the scenario chart's draw-in animation respects the
+  `accessibilityReduceMotion` environment value.
+
+---
+
+## 10. Dynamic Type
+
+- All metric labels, scenario captions, the FIRE range, and the disclaimer use
+  Dynamic Type system styles / the `FinanceTextStyle` ramp — **never** hardcoded
+  point sizes — and **wrap** (`.fixedSize(horizontal: false, vertical: true)`)
+  rather than truncate at the largest accessibility sizes.
+- The contributions-vs-market bar and scenario captions reflow `HStack → VStack`
+  via the adaptive-stack convention at accessibility sizes.
+- Multi-figure rows (range "$x–$y") keep `.minimumScaleFactor` only on dense
+  visual chips, never on the primary numbers in the summary text.
+
+---
+
+## 11. Privacy & Balance Hiding
+
+- When balance hiding is active, **every** projected amount, the FI number, the
+  contributions split, and the ending balances redact to a placeholder in **both**
+  the visible text **and** the VoiceOver string, from the same redacted model.
+  Non-sensitive values (years-to-target, confidence level, progress %) may remain.
+- Per [os.Logger guidance](../../AGENTS.md), projected balances, contributions,
+  and the FI number are `.private`; only confidence level and lifecycle events are
+  loggable. Projections are **derived** on device from already-local data — no
+  new secret is introduced, and nothing is sent to a third party.
+- No projection inputs/outputs are written to `UserDefaults`; any future widget
+  receives only a pre-redacted, formatted string via the App Group.
+
+---
+
+## 12. Empty, Stale & Error States
+
+| State                | Trigger                                 | Behaviour                                                                                                     |
+| -------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| **Empty**            | No holdings / no balance                | Projection section hidden; reuse `EmptyStateView` ("Add investments to see projections").                     |
+| **No contributions** | Holdings exist, no contribution history | Scenarios use balance-only growth; caption "Add contributions for a personalised projection"; confidence Low. |
+| **No FIRE inputs**   | No annual-expenses / FI number          | FIRE summary replaced by a prompt ("Set annual expenses for your FI timeline"); scenarios still shown.        |
+| **Stale**            | Underlying valuation stale (from #2568) | "Based on data as of {asOf}" prefix on the projection summary; numbers still render; staleness announced.     |
+| **Error**            | Bridge/metric computation throws        | Projection section shows a labelled **Retry**; the descriptive cards (value, allocation) stay usable.         |
+
+All copy uses `String(localized:)`; no state relies on colour alone; error copy
+is non-judgemental per [ux-principles.md](./ux-principles.md).
+
+---
+
+## 13. Test Plan
+
+Smallest tests that must pass before implementation is accepted. Native tests run
+on Simulator with **free Personal Team signing** (see
+[Implementation readiness](#implementation-readiness)).
+
+### Shared (KMP) — `packages/core` `commonTest` _(proposed via ADR; not in this PR)_
+
+- `ContributionBreakdownTest`: given a contribution schedule + current value,
+  `totalContributed`, `marketGain`, and `moneyWeightedReturnPercent` are correct;
+  covers withdrawals, zero contributions, and a loss (market gain negative).
+- `CompoundGrowthProjectorTest`: future value of (lump sum + monthly annuity) at
+  3/5/7% real matches closed-form expectations within rounding; horizon 0 returns
+  the current balance; negative contribution (drawdown) decreases the balance.
+- `FireProjectionTest`: years-to-target is monotonic in rate (optimistic ≤
+  moderate ≤ conservative years); unreachable-in-horizon yields `nil`; missing FI
+  number yields the prompt state.
+- `ProjectionConfidenceTest`: history length × FIRE-inputs presence map to
+  Low/Medium/High exactly per the [§7](#7-confidence-states) thresholds.
+
+### Native (iOS) — XCTest / Swift Testing in `apps/ios/Tests`
+
+- `InvestmentViewModelProjectionTests`: with a stub bridge, the view model exposes
+  the bridged breakdown/scenarios/FIRE summary unchanged and **performs no math**.
+- `ProjectionCardA11yTests`: the disclaimer is a focusable element ordered before
+  the numbers; confidence chip's `.accessibilityValue` states level + reason.
+- `ProjectionPrivacyRedactionTests`: with balance hiding on, no projected amount
+  or FI number appears in visible text **or** accessibility labels.
+- `ProjectionDynamicTypeTests` (snapshot/XCUITest): at the largest accessibility
+  size the scenario caption and FIRE range wrap and remain fully readable.
+- `ProjectionStateTests`: empty / no-contributions / no-FIRE / stale / error each
+  expose exactly one labelled focusable element (or labelled retry) and the
+  estimate disclaimer where projections are shown.
+
+---
+
+## Implementation readiness
+
+**Design: ready now. Native code: buildable now, distribution gated.**
+
+Per the
+[Human-Gated Prerequisites runbook](../ops/human-gated-prerequisites.md#2-implementation-vs-distribution--the-decoupling),
+implementation and distribution are decoupled. The "blocked by
+[#1239](https://github.com/jrmoulckers/finance/issues/1239)" note on
+[#2570](https://github.com/jrmoulckers/finance/issues/2570) is a **distribution**
+gate only.
+
+| Phase              | What                                                                                              | Gated by #1239?                         |
+| ------------------ | ------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| **Design**         | This document — metrics, scenarios, FIRE link, confidence, assumptions, test plan                 | No — deliverable now                    |
+| **Implementation** | `ContributionsCard`, `PortfolioProjectionCard`, view-model wiring, unit + a11y tests on Simulator | **No** — free Personal Team signing     |
+| **Distribution**   | TestFlight / App Store build carrying projections                                                 | **Yes** — Apple Developer Program enrol |
+
+- **Buildable now:** all cards, the projection chart, VoiceOver semantics,
+  Dynamic Type behaviour, and the listed iOS tests run on Simulator / device via
+  free Personal Team signing. No paid entitlements are required.
+- **Gated tail (#1239):** only shipping through TestFlight / the App Store needs
+  the paid Apple Developer enrollment + signing in
+  [human-gated-prerequisites.md §3.2](../ops/human-gated-prerequisites.md#32-ios-distribution--apple-developer-1239).
+  An SME agent must **not** perform enrollment, certificate, or secret steps.
+- **Shared-logic tail:** the contribution-breakdown, compound-growth projector,
+  FIRE link, and confidence model are @kmp-engineer / @architect changes via
+  **ADR**, and they depend on the contribution/price data from
+  [ios-investment-data-kmp-design.md](./ios-investment-data-kmp-design.md). Until
+  those land, the iOS cards can bind to the stub bridge with seeded scenarios so
+  the SwiftUI + a11y work proceeds in parallel.
+
+_Part of [#2118](https://github.com/jrmoulckers/finance/issues/2118). Depends on
+[KMP-backed investment data](./ios-investment-data-kmp-design.md); paired with
+[investment chart text alternatives](./ios-investment-chart-text-alternatives.md)._


### PR DESCRIPTION
## Summary

Design-only batch (three new docs, no code/build changes) covering the iOS
investment experience for the index-fund persona. All work is the **design**
phase per the implementation-vs-distribution decoupling in
[`docs/ops/human-gated-prerequisites.md`](../blob/main/docs/ops/human-gated-prerequisites.md);
native implementation is buildable now via free Personal Team signing, only the
distribution tail is gated by #1239.

Closes #2568
Closes #2570
Closes #2537

## Changes

Three new docs under `docs/design/` (distinct paths; no existing files,
`packages/`, shared config, or other platforms touched):

1. **`ios-investment-data-kmp-design.md`** (#2568, _Part of #2118_) — the
   repository / view-model boundary to replace `MockInvestmentRepository` with
   persisted/synced portfolio, holding, price, and **contribution** data. Details
   the `InvestmentRepository` contract (current + target), the SQLCipher/Keychain
   persistence + `SyncableRepository` sync expectations, and a phased
   **mock → real** migration (`SwiftExportInvestmentModule` +
   `BridgedInvestmentRepository`, then flip the `RepositoryProvider` default) that
   touches DI only — no view/view-model rewrite.

2. **`ios-portfolio-metrics-projections.md`** (#2570, _Part of #2118_) —
   market-return-vs-contribution metrics, compound-growth scenarios,
   FIRE-linked projection summaries, and confidence states (mirroring the
   existing `PredictionConfidence`). Projections are clearly labelled **estimates
   with stated assumptions** (real returns, fixed rates, constant contributions;
   taxes/fees/sequence-of-returns excluded).

3. **`ios-investment-chart-text-alternatives.md`** (#2537, _Part of #2113_) —
   applies the **existing** chart text-alternative cluster
   (`ios-chart-summaries-data-tables.md`, `ios-chart-voiceover-navigation.md`,
   `ios-chart-descriptor-adapters.md`) to `InvestmentDetailView`, the portfolio
   performance/projection charts, and the `ReportResultView` charts — adding
   spoken summaries (date range, extrema, totals, forecast-confidence text) and
   unifying the report tables onto the shared `ChartDataTable`. Reuses, does not
   redefine, the pattern.

Each doc grounds in the actual iOS code (`MockInvestmentRepository`,
`InvestmentRepository`, `InvestmentViewModel`, `InvestmentPortfolioView`,
`InvestmentDetailView`, `ReportResultView`) and shared models
(`InvestmentEngine.kt`), and covers affected iOS surfaces, the iOS/KMP boundary,
accessibility (VoiceOver, Dynamic Type), privacy (balance hiding, Keychain),
empty/stale/error states, a smallest-tests plan, and an **Implementation
readiness** section linking `../ops/human-gated-prerequisites.md`.

## Testing

- `npx prettier --check` on all three files — passes ("All matched files use
  Prettier code style!").
- Cross-linked paths (sibling design docs, `apps/ios` source, `packages/core` +
  `packages/sync` source, `docs/ops/human-gated-prerequisites.md`) verified to
  exist.
- Docs-only change: no native build, signing, or app submission performed.
