### PR TITLE
docs(design): ios FI/FIRE and net-worth projection design batch (#2556, #2558, #2564)

### DIFF
--- a/docs/design/ios-fi-calculator-flow.md
+++ b/docs/design/ios-fi-calculator-flow.md
@@ -1,0 +1,580 @@
+# iOS Financial-Independence (FI/FIRE) Calculator — Flow & Surface Design
+
+> Native SwiftUI flow for a Financial-Independence / Retire-Early (FIRE)
+> calculator on iPhone and iPad: sensible **default assumptions**, a progressive
+> **Advanced** disclosure for the levers that matter, live **sensitivity
+> controls** (safe-withdrawal rate and expected return), and explicit
+> **validation states** — feeding the results + goal-integration surface
+> designed in
+> [ios-fire-results-goal-integration.md](./ios-fire-results-goal-integration.md).
+
+**Status:** PROPOSED — design only (implementation gated where noted)
+**Issue:** [#2556](https://github.com/jrmoulckers/finance/issues/2556) — Part of [#2114](https://github.com/jrmoulckers/finance/issues/2114)
+**Platform:** iOS / iPadOS (SwiftUI, iOS 17+)
+**Owner:** @ios-engineer
+**Related design:** [ios-fire-results-goal-integration.md](./ios-fire-results-goal-integration.md) · [ios-net-worth-projection-overlay.md](./ios-net-worth-projection-overlay.md) · [ios-net-worth-trend-chart.md](./ios-net-worth-trend-chart.md) · [data-visualization.md](./data-visualization.md) · [accessibility-patterns.md](./accessibility-patterns.md) · [content-language-guidelines.md](./content-language-guidelines.md) · [ux-principles.md](./ux-principles.md) · [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md)
+
+---
+
+## Table of Contents
+
+1. [Goal & Scope](#1-goal--scope)
+2. [Placement & Navigation](#2-placement--navigation)
+3. [Inputs & Default Assumptions](#3-inputs--default-assumptions)
+4. [Advanced Section (Progressive Disclosure)](#4-advanced-section-progressive-disclosure)
+5. [Sensitivity Controls (SWR & Expected Return)](#5-sensitivity-controls-swr--expected-return)
+6. [Validation States](#6-validation-states)
+7. [Financial-Advice Safety: Estimates, Assumptions, Disclaimers](#7-financial-advice-safety-estimates-assumptions-disclaimers)
+8. [Accessibility](#8-accessibility)
+9. [Dynamic Type](#9-dynamic-type)
+10. [Privacy: Balance Hiding](#10-privacy-balance-hiding)
+11. [States: Empty, Loading, Stale & Error](#11-states-empty-loading-stale--error)
+12. [Affected Surfaces & Shared Dependencies](#12-affected-surfaces--shared-dependencies)
+13. [Native ↔ Shared Boundary](#13-native--shared-boundary)
+14. [Test Plan](#14-test-plan)
+15. [Implementation Readiness](#15-implementation-readiness)
+16. [Open Questions](#16-open-questions)
+
+---
+
+## 1. Goal & Scope
+
+Answer a single motivating question — **"How close am I to financial
+independence, and what changes the answer?"** — with a calm, single-screen
+SwiftUI flow that works for a first-time user (sensible defaults, one number to
+enter) _and_ a power user (every assumption is editable and its effect is
+visible immediately).
+
+This document covers the **input/flow half** of the FIRE feature. The numeric
+**outputs** (FI number, years-to-FI, Coast FI, projected FI date, SWR
+sensitivity) and their **goal-linking summary cards** live in the companion
+[ios-fire-results-goal-integration.md](./ios-fire-results-goal-integration.md);
+the **net-worth projection overlay** that visualizes the contribution-paced path
+toward those targets lives in
+[ios-net-worth-projection-overlay.md](./ios-net-worth-projection-overlay.md).
+The three are intentionally separable surfaces around one shared computation.
+
+**In scope (this design):**
+
+- A `FICalculatorView` SwiftUI screen with a form of FIRE inputs.
+- A small set of **default assumptions** so the screen is useful with the
+  fewest possible taps.
+- An **Advanced** disclosure group for the less-common levers (expected return,
+  ages, income) so the default surface stays uncluttered.
+- Live **sensitivity controls** (safe-withdrawal-rate and expected-return
+  sliders/steppers) that re-derive results without leaving the screen.
+- **Validation** for every field with inline, non-blocking error states.
+- Empty / loading / **stale** / error states and a privacy (balance-hiding)
+  mode.
+
+**Out of scope (deliberately deferred):**
+
+- The results presentation and goal cards — see
+  [ios-fire-results-goal-integration.md](./ios-fire-results-goal-integration.md).
+- The projection chart overlay — see
+  [ios-net-worth-projection-overlay.md](./ios-net-worth-projection-overlay.md).
+- Monte-Carlo / sequence-of-returns simulation, tax modeling, Social Security,
+  and healthcare bridges (the web reference has scaffolding for these under
+  `apps/web/src/lib/investment/`; they are follow-on issues under #2114, not part
+  of the v1 deterministic calculator).
+- watchOS, widgets, and App Clip variants.
+
+> **Why a single screen, not a wizard:** per
+> [ux-principles](./ux-principles.md) (_"respect the user's time; progressive
+> disclosure over multi-step gates"_) the common case is one field (annual
+> expenses) on top of prefilled defaults. A multi-step wizard would add friction
+> for a calculation users want to re-run and tweak repeatedly.
+
+---
+
+## 2. Placement & Navigation
+
+- **Entry point:** a "Financial Independence" row in the existing
+  [`InsightsView`](../../apps/ios/Finance/Screens/InsightsView.swift) (planning
+  section) and a deep link from the FIRE results cards. It is a pushed
+  destination on a `NavigationStack`, not a new tab — consistent with the
+  list-first information architecture used by
+  [`AnalyticsView`](../../apps/ios/Finance/Screens/AnalyticsView.swift) and
+  [`HealthScoreView`](../../apps/ios/Finance/Screens/HealthScoreView.swift).
+- **Type-safe routing:** add an `FICalculator` case to the app's
+  `NavigationPath` route enum so the screen is reachable from Insights and from
+  the results surface without untyped string routes.
+- **Prefill on open:** current portfolio (investable net worth) and an annual
+  expense estimate are **prefilled from already-computed aggregates** (the same
+  Swift Export aggregator the dashboard uses), so a returning user sees a
+  meaningful result immediately and only edits what they want to change.
+- **Results handoff:** the screen owns the inputs; tapping "See results" (or
+  scrolling to the inline results section) renders the cards from
+  [ios-fire-results-goal-integration.md](./ios-fire-results-goal-integration.md).
+  v1 keeps inputs and results on **one scrollable screen** (form on top, result
+  cards below) so sensitivity changes are visible without navigation.
+
+```
+┌──────────────────────────────────────────────┐
+│  ‹ Insights        Financial Independence      │  ← nav title
+│                                                │
+│  Annual spending                     $42,000 › │  ← the one field most edit
+│  Current investments                $310,000 › │  ← prefilled from aggregates
+│                                                │
+│  Safe withdrawal rate          4.0%  ◉────────│  ← sensitivity slider
+│  Expected real return          5.0%  ────◉────│  ← sensitivity slider
+│                                                │
+│  ▸ Advanced (ages, income, savings)            │  ← DisclosureGroup, collapsed
+│                                                │
+│  ┌── Estimate ──────────────────────────────┐ │
+│  │ FI number      $1,050,000                 │ │  ← results (doc #2558)
+│  │ Years to FI    ~12 years (est.)           │ │
+│  └───────────────────────────────────────────┘ │
+│  These are estimates based on your assumptions.│  ← disclaimer (always visible)
+└──────────────────────────────────────────────┘
+```
+
+---
+
+## 3. Inputs & Default Assumptions
+
+The calculator binds to the shared `FIREInput` contract (see
+[§13](#13-native--shared-boundary)). Fields, defaults, and rationale:
+
+| Field                     | Control                     | Default                                 | Rationale / source                                                              |
+| ------------------------- | --------------------------- | --------------------------------------- | ------------------------------------------------------------------------------- |
+| **Annual spending**       | Currency `TextField`        | Derived from trailing-12-month expenses | The single most-important input; prefilled from aggregates, always editable.    |
+| **Current investments**   | Currency `TextField`        | Investable net worth from aggregator    | Prefilled; user can override (e.g., exclude home equity).                       |
+| **Safe withdrawal rate**  | `Slider` + stepper (§5)     | **4.0%**                                | The "4% rule" baseline; the default the whole field is anchored on.             |
+| **Expected real return**  | `Slider` + stepper (§5)     | **5.0%** (real, inflation-adjusted)     | Conservative long-run real equity/bond blend; clearly labeled "real".           |
+| **Annual savings**        | Currency `TextField` (adv.) | Derived from trailing income − expenses | Drives years-to-FI; prefilled, editable in Advanced.                            |
+| **Annual income**         | Currency `TextField` (adv.) | Derived from trailing income            | Used only for the savings-rate readout; optional.                               |
+| **Current age**           | Stepper / `Picker` (adv.)   | Empty (optional)                        | Needed for Coast FI; if blank, Coast FI is shown as "Add your age to see this". |
+| **Target retirement age** | Stepper / `Picker` (adv.)   | 65 (used only when current age is set)  | Coast FI horizon; never assumed without an explicit current age.                |
+
+**Default-assumption rules**
+
+- **Defaults are labeled, not hidden.** Every default value is visible in its
+  control (the SWR slider reads "4.0%", not a blank), so the user always knows
+  what assumption produced the estimate. This is a financial-advice-safety
+  requirement, not just polish (see [§7](#7-financial-advice-safety-estimates-assumptions-disclaimers)).
+- **Defaults are conservative and documented.** 4% SWR and 5% real return are
+  the conventional FIRE-community baselines; a one-line "Why these defaults?"
+  info row (a `.popover`/`.sheet` with plain-language explanations and the
+  not-advice disclaimer) explains them without cluttering the form.
+- **Currency & locale come from the shared formatter**, never hardcoded — the
+  same module the dashboard and [`CurrencyLabel`](../../apps/ios/Finance/Components/CurrencyLabel.swift)
+  use — so symbols, grouping, and minor units are correct per locale. All
+  amounts are integer **minor units** (`Int64`) across the bridge, matching
+  [`GoalItem`](../../apps/ios/Finance/Models/GoalItem.swift)'s `…MinorUnits`
+  convention.
+- **Reset to defaults** is always one tap away (toolbar overflow → "Reset
+  assumptions"), so experimentation is reversible.
+
+---
+
+## 4. Advanced Section (Progressive Disclosure)
+
+The less-common levers live in a `DisclosureGroup` labeled **"Advanced (ages,
+income, savings)"**, collapsed by default.
+
+- **Contents:** annual savings, annual income, current age, target retirement
+  age, and a per-field "Why this matters" hint.
+- **Expansion persists** via `@AppStorage` (`fiCalculator.advancedExpanded`) — a
+  non-secret UI preference, so `UserDefaults` is appropriate (no financial data
+  is persisted there; only the open/closed flag).
+- **No recompute penalty:** changing Advanced fields re-derives results from the
+  same already-bound input struct; there is no separate "apply" step.
+- **Coast FI gating:** Coast FI (in the results surface) is only meaningful with
+  a current age + target retirement age. When those are blank, the Advanced
+  section shows an inline prompt ("Add your age to estimate Coast FI") rather
+  than fabricating an age — never silently assume a personal attribute.
+- **Accessibility:** the `DisclosureGroup` header is a real button with
+  `.accessibilityHint("Shows additional assumptions")` and an
+  `.accessibilityValue` of "expanded"/"collapsed"; expanding moves VoiceOver
+  focus to the first revealed field.
+
+---
+
+## 5. Sensitivity Controls (SWR & Expected Return)
+
+Two assumptions dominate the result and are surfaced **on the main form** (not
+buried in Advanced) as live sensitivity controls:
+
+| Control                  | Range     | Step | Default | Notes                                                                  |
+| ------------------------ | --------- | ---- | ------- | ---------------------------------------------------------------------- |
+| **Safe withdrawal rate** | 2.5%–6.0% | 0.1% | 4.0%    | Lower = larger FI number (more conservative).                          |
+| **Expected real return** | 0%–10%    | 0.5% | 5.0%    | Higher = fewer years to FI; clearly labeled **real** (post-inflation). |
+
+**Behavioral rules**
+
+- **Live, debounced recompute.** Each control is a `Slider` paired with a
+  `Stepper` and a numeric readout. Dragging recomputes on a short debounce
+  (~150 ms) so the result cards and the projection overlay update smoothly
+  without thrashing the bridge (compute is cheap and deterministic — see
+  [§13](#13-native--shared-boundary)).
+- **Bounded inputs prevent nonsense.** The ranges above are enforced by the
+  control so the user cannot enter a 0% or 50% withdrawal rate; the math's own
+  guards (e.g., `withdrawalRate <= 0 → FI number 0`) remain a backstop.
+- **Sensitivity is the point.** A small caption under each slider states the
+  directional effect in plain language ("A lower withdrawal rate means a bigger
+  target and a safer plan"), reinforcing that the output is assumption-driven.
+  The dedicated **SWR sensitivity strip** (4.0% / 3.5% / 3.0% side-by-side) is
+  rendered in the results surface — see
+  [ios-fire-results-goal-integration.md §SWR sensitivity](./ios-fire-results-goal-integration.md).
+- **Reduce Motion.** Result figures crossfade on change; when
+  `accessibilityReduceMotion` is on, values swap instantly (no number-rolling
+  animation), consistent with
+  [data-visualization §8](./data-visualization.md).
+- **Touch targets.** Sliders and steppers meet the 44×44 pt minimum; the stepper
+  gives a precise, VoiceOver-friendly alternative to dragging.
+
+---
+
+## 6. Validation States
+
+Validation is **inline, non-blocking, and plain-language** — the screen never
+hard-errors; it guides. Logic lives in the `@Observable` view model as derived
+state.
+
+| Field / condition                               | State       | Presentation                                                                                                        |
+| ----------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------- |
+| Annual spending empty                           | **Prompt**  | Result section shows an empty state ("Enter your annual spending to see your FI number"); not an error.             |
+| Annual spending ≤ 0 or non-numeric              | **Invalid** | Inline caption "Enter an amount greater than zero"; field tinted with a warning, results suppressed for that field. |
+| Current investments < 0                         | **Invalid** | "Investments can't be negative."                                                                                    |
+| Target retirement age ≤ current age             | **Invalid** | "Retirement age must be after your current age." Coast FI suppressed until fixed.                                   |
+| SWR / return outside slider range               | **Clamped** | Control prevents it; no error needed (defensive only).                                                              |
+| Savings = 0 **and** return = 0 (FI unreachable) | **Warning** | Years-to-FI reads "Not reachable with these assumptions" (the math returns `maxYears`); non-judgmental, factual.    |
+| All required inputs valid                       | **Valid**   | Results + projection render; disclaimer remains visible.                                                            |
+
+**Rules**
+
+- **Validation messages are guidance, not scolding** — phrased per
+  [content-language-guidelines](./content-language-guidelines.md) (factual,
+  non-judgmental, no exclamation/blame). "Not reachable with these assumptions"
+  is framed as information about the _assumptions_, never about the person.
+- **Errors are field-scoped.** One invalid field suppresses only the results it
+  affects; the rest of the screen stays usable (mirrors the card-scoped error
+  philosophy in [ios-net-worth-trend-chart.md §8](./ios-net-worth-trend-chart.md)).
+- **VoiceOver parity.** An invalid field exposes its message via
+  `.accessibilityValue`/`.accessibilityHint` (e.g., "Invalid. Enter an amount
+  greater than zero") so the guidance is not visual-only; focus is **not** stolen
+  on every keystroke (announce on commit / focus loss to avoid VoiceOver spam).
+
+---
+
+## 7. Financial-Advice Safety: Estimates, Assumptions, Disclaimers
+
+This is a planning calculator, **not financial advice**, and the design must make
+that unmistakable.
+
+- **Always-visible disclaimer.** A persistent footer below the results reads:
+  _"These are estimates based on the assumptions above, not financial advice.
+  Real returns vary and are not guaranteed."_ It is real text (Dynamic Type,
+  selectable), not an image, and is included in the VoiceOver reading order.
+- **Every output is labeled an estimate.** Derived numbers carry an "est." or
+  "estimated" qualifier (e.g., "~12 years (est.)"), and projected dates use
+  "around"/"by about" phrasing — never a falsely precise single date. The
+  results-surface copy in
+  [ios-fire-results-goal-integration.md §Estimate labeling](./ios-fire-results-goal-integration.md)
+  owns the per-card wording; this screen guarantees the disclaimer is present
+  wherever inputs are edited.
+- **Assumptions travel with the result.** Because the SWR and return are on the
+  same screen as the output, the user can never see an FI number without seeing
+  the assumptions that produced it. A "Why these defaults?" info affordance
+  explains each in plain language.
+- **No guarantees, no targets framed as promises.** Copy avoids "you will retire
+  at…"; it uses "with these assumptions, you'd reach your target around…".
+- **Deterministic, transparent math.** v1 uses the deterministic shared
+  functions (no hidden Monte-Carlo), so the relationship between inputs and
+  outputs is explainable; future probabilistic modeling is a separate, clearly
+  labeled feature.
+
+---
+
+## 8. Accessibility
+
+Per [accessibility-patterns](./accessibility-patterns.md) and the app's existing
+VoiceOver conventions (see
+[`ConfidenceIndicatorView`](../../apps/ios/Finance/Components/ConfidenceIndicatorView.swift)
+and [`PredictionChart`](../../apps/ios/Finance/Charts/PredictionChart.swift)):
+
+- **Every control is labeled.** Currency fields, sliders, steppers, and the
+  Advanced disclosure each have a `String(localized:)` `.accessibilityLabel`,
+  a `.accessibilityValue` reflecting the current value (e.g., the SWR slider
+  reads "4.0 percent"), and a `.accessibilityHint` for directional effect.
+- **Sliders use adjustable semantics.** The SWR/return sliders are inherently
+  `.adjustable` to VoiceOver (swipe up/down to change), and the paired stepper
+  gives a discrete, predictable alternative for users who find continuous
+  sliders hard to target — a non-gesture path to the same value.
+- **Plain-language explanations of estimates.** The disclaimer, the "Why these
+  defaults?" content, and per-field hints are all spoken; VoiceOver users hear
+  _why_ a number is an estimate, not just the number (a core requirement of this
+  batch).
+- **Switch Control / Full Keyboard Access.** Every field, slider, stepper, and
+  disclosure is a real focusable control with a label; no value is reachable only
+  by drag.
+- **Contrast.** Warning tints, captions, and result text meet ≥ 4.5:1 in light,
+  dark, and high-contrast themes; validation never relies on color alone — it is
+  always accompanied by an icon + text (per
+  [data-visualization §2.4 "Never Color Alone"](./data-visualization.md)).
+- **Focus management.** Expanding Advanced or revealing a validation message moves
+  or announces focus deliberately; results updates use
+  `.accessibilityRespondsToUserInteraction` so live recomputation is discoverable
+  but not interruptive.
+
+---
+
+## 9. Dynamic Type
+
+- **No hardcoded font sizes.** Field labels use `.body`, the result figures reuse
+  `CurrencyLabel` (already Dynamic-Type aware), slider readouts use `.callout`,
+  captions/disclaimer use `.footnote`/`.caption`. All scale through AX1–AX5.
+- **Layout reflow at large sizes.** Two-column rows (label + value) collapse to
+  stacked label-over-value at `accessibility1`+ via
+  `@Environment(\.dynamicTypeSize)` and `ViewThatFits`, so nothing truncates. The
+  SWR/return controls stack their readout above the slider at large sizes.
+- **Disclaimer never clips.** The financial-advice disclaimer wraps to as many
+  lines as needed; it is verified visible (not truncated) at AX5 in
+  [§14](#14-test-plan).
+
+---
+
+## 10. Privacy: Balance Hiding
+
+The screen honors the app-wide balance-hiding / privacy mode (the same posture as
+[`PrivacySettingsView`](../../apps/ios/Finance/Screens/PrivacySettingsView.swift)
+and the net-worth surfaces):
+
+- When privacy mode is active, **prefilled and entered amounts** (current
+  investments, savings, income, FI number, result figures) are masked
+  ("•••••"); the **assumption controls** (SWR %, return %, ages) remain visible
+  because they reveal no balance.
+- **Accessibility parity:** masked figures are also masked to VoiceOver ("hidden")
+  — never speak an amount that is visually hidden.
+- **Privacy-screen on backgrounding:** the screen participates in the existing
+  app-switcher snapshot redaction; no special exemption.
+- **Logging:** per the `os.Logger` rules, amounts are `.private` and never
+  logged. Log only non-sensitive events ("FI calculator opened", "assumptions
+  reset", "SWR changed") at `.public` — counts and which control changed, never
+  a value. This matches the logging discipline in
+  [`GoalsViewModel`](../../apps/ios/Finance/ViewModels/GoalsViewModel.swift).
+
+---
+
+## 11. States: Empty, Loading, Stale & Error
+
+| State       | Trigger                                        | Presentation                                                                                                                                                               |
+| ----------- | ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Loading** | Prefill aggregates not yet resolved            | Form renders with skeleton placeholders in prefilled fields; assumption controls are usable immediately. Respects Reduce Motion (static placeholder).                      |
+| **Empty**   | No spending data to prefill (new user)         | Fields blank with prompts; results section shows `EmptyStateView` ("Enter your spending to estimate your FI number"). No fabricated defaults for personal amounts.         |
+| **Stale**   | Prefill derived from a cached/offline snapshot | Render prefilled values + a subtle "Based on data as of {relative time}" caption; reuse [`OfflineBanner`](../../apps/ios/Finance/Components/OfflineBanner.swift) offline.  |
+| **Error**   | Prefill aggregate load fails                   | Inline, non-modal: fields fall back to blank/editable + a compact "Couldn't load your latest figures — enter them manually" with Retry. The calculator stays fully usable. |
+
+Design rationale:
+
+- **A failed prefill is never a dead end.** The calculator works entirely on
+  manually entered values; a prefill failure degrades to manual entry, it does
+  not block the feature (mirrors the card-scoped, non-fatal error pattern in
+  [ios-net-worth-trend-chart.md §8](./ios-net-worth-trend-chart.md)).
+- **Stale is informational, not alarming.** The app is local-first; showing
+  slightly old prefill with an "as of" stamp is correct.
+- **Empty prompts, never assumes.** The screen will not invent a spending figure;
+  it asks. Only impersonal assumptions (SWR, return) have defaults.
+
+---
+
+## 12. Affected Surfaces & Shared Dependencies
+
+### 12.1 iOS surfaces (all in `apps/ios/`, owned by @ios-engineer)
+
+| Surface                                                        | Change                                                                                               |
+| -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `Finance/Screens/FICalculatorView.swift` **(new)**             | The form: inputs, defaults, Advanced disclosure, sensitivity controls, validation, disclaimer.       |
+| `Finance/ViewModels/FICalculatorViewModel.swift` **(new)**     | `@Observable` VM: holds `FIREInput`, derives results via the bridge, owns validation + states.       |
+| `Finance/Models/FIREInputUI.swift` **(new)**                   | Swift-native input/value types (minor-unit `Int64`, percentages) mapped to/from the bridge contract. |
+| `Finance/Screens/InsightsView.swift` **(modify)**              | Add a "Financial Independence" entry row + `NavigationPath` route.                                   |
+| `Finance/KMP/SwiftExportBridge.swift` + protocols **(modify)** | Expose an `fireMetrics(input:)` bridge call (see [§13](#13-native--shared-boundary)).                |
+| `Finance/KMP/StubSwiftExportBridge.swift` **(modify)**         | Stub `fireMetrics` for previews/tests, so the UI is independently developable.                       |
+| `Finance/Resources/*.lproj/Localizable.strings` **(modify)**   | New localized strings (field labels, defaults rationale, validation, disclaimer, masks).             |
+
+### 12.2 Shared dependencies (KMP — **not edited by this design**)
+
+- **FIRE math** — `calculateFINumber`, `calculateFIPercent`, `calculateCoastFI`,
+  `calculateSavingsRate`, `calculateYearsToFI`, and the aggregate
+  `calculateFIREMetrics(input)` currently exist as a **canonical TypeScript
+  reference** in
+  [`apps/web/src/lib/investment/fire-calculator.ts`](../../apps/web/src/lib/investment/fire-calculator.ts)
+  with tests in `fire-calculator.test.ts`. Their **platform-neutral home is
+  `packages/core`** (alongside the existing analytics models such as
+  [`NetWorthSnapshot`](../../packages/core/src/commonMain/kotlin/com/finance/core/analytics/NetWorthSnapshot.kt)),
+  re-exported via the FinanceSync Swift Export bridge.
+- **Money/locale formatting** — the shared currency formatter module already used
+  by the dashboard / `CurrencyLabel`.
+
+> **The shared FIRE engine is not yet in `packages/core` (KMP).** Porting it from
+> the web reference — preserving parity with `fire-calculator.test.ts` — is a
+> `packages/` change **owned by @kmp-engineer and proposed via ADR** (per
+> ownership rules); iOS must not implement the math or edit `packages/`. The iOS
+> surface binds to a Swift-native `FIPlanningBridge` protocol with a stub, so this
+> screen is fully buildable/testable before the Kotlin port lands (see
+> [§13](#13-native--shared-boundary) and [§15](#15-implementation-readiness)).
+
+---
+
+## 13. Native ↔ Shared Boundary
+
+ViewModels talk to a Swift-native bridge **protocol**, never to KMP types
+directly — the same pattern as `DashboardViewModel` and the trend-chart design.
+
+```mermaid
+flowchart LR
+    subgraph shared["packages/core (KMP — platform-neutral; port via ADR, NOT this PR)"]
+        A["FireCalculator.calculateFIREMetrics(input)"] --> B["FIREMetrics<br/>(Cents, percentages, yearsToFI, projectedFIDate)"]
+    end
+    subgraph bridge["packages/sync (Swift Export — ADR if missing)"]
+        B --> C["SwiftExportFireModule.fireMetrics(input)<br/>→ FIREMetricsDTO (Int64 minor units, Double %)"]
+    end
+    subgraph ios["apps/ios (this PR — @ios-engineer)"]
+        C --> D["FICalculatorViewModel<br/>holds FIREInput, validates, debounces"]
+        D --> E["FICalculatorView (form + sliders + Advanced + disclaimer)"]
+        D --> F["Results cards + projection overlay (docs #2558 / #2564)"]
+    end
+```
+
+**Responsibilities**
+
+| Concern                                                              | Layer                         |
+| -------------------------------------------------------------------- | ----------------------------- |
+| FI number, FI %, Coast FI, savings rate, years-to-FI, projected date | `packages/core` (shared)      |
+| Compound-growth / growing-annuity iteration, SWR math                | `packages/core` (shared)      |
+| Type mapping (`Cents`→`Int64`, percentage→`Double`, date→`Date`)     | Swift Export bridge           |
+| Input collection, defaults, prefill from aggregates                  | iOS (`FICalculatorViewModel`) |
+| **Validation** + clamping + debounce                                 | iOS                           |
+| Estimate labeling, disclaimer copy, "Why these defaults?"            | iOS (a11y/content semantics)  |
+| Sensitivity slider UX, Reduce Motion, Dynamic Type                   | iOS                           |
+
+- **iOS does not re-implement the math.** It assembles a validated `FIREInput`
+  and renders the returned metrics. If iOS finds itself computing FI numbers, the
+  boundary has been crossed.
+- **Determinism enables instant sensitivity.** Because `calculateFIREMetrics` is
+  pure and cheap, sliders can recompute live with a tiny debounce and no bridge
+  round-trip concerns (the call is synchronous-fast; still invoked off the main
+  actor with results applied on `@MainActor`).
+- **Parity guard.** The shared port must match the web reference's documented
+  behaviors (e.g., `withdrawalRate ≤ 0 → FI number 0`, unreachable →
+  `maxYears`), so the iOS validation copy in [§6](#6-validation-states) aligns
+  with the math's guards rather than duplicating them.
+
+---
+
+## 14. Test Plan
+
+Smallest set that must pass before implementation is accepted. Names are
+illustrative targets in existing locations.
+
+### 14.1 Shared (KMP) — verify/port parity, not re-implement here
+
+- The ported `FireCalculatorTest` (KMP) must mirror the web
+  `fire-calculator.test.ts` cases: FI number at 4% = expenses × 25; FI % including
+  over-100%; Coast FI discounting; savings rate; years-to-FI iteration including
+  the **unreachable → maxYears** and **already-FI → 0** edges; projected-FI-date
+  derivation. Adding/porting these is **@kmp-engineer via ADR**, not this PR.
+
+### 14.2 Bridge
+
+- `SwiftExportBridgeTests`: `fireMetrics(input:)` maps `Cents → Int64` minor
+  units and percentages → `Double` correctly, round-trips a zero/edge input, and
+  returns the same fields the UI binds.
+
+### 14.3 iOS unit (XCTest, `apps/ios/Tests/`)
+
+1. **`FICalculatorViewModelTests`**
+   - Prefill: aggregates populate spending/investments; failure → blank +
+     `.error` (manual-entry fallback), not a crash (spy bridge).
+   - Validation: spending ≤ 0 → invalid + results suppressed; retirement age ≤
+     current age → Coast FI suppressed; savings = 0 & return = 0 → "not reachable"
+     state.
+   - Sensitivity: changing SWR/return re-derives metrics; debounce coalesces rapid
+     changes (assert recompute call count on a spy bridge).
+   - Defaults: SWR 4.0% / return 5.0% applied on first open; "Reset assumptions"
+     restores them.
+2. **`FIREInputMappingTests`** (pure, no UI)
+   - UI input ↔ bridge DTO mapping is lossless for minor units and percentages;
+     clamping keeps SWR/return within range.
+
+### 14.4 iOS UI / a11y (`apps/ios/Tests/UITests/`)
+
+3. **`FICalculatorUITests`**
+   - The screen shows `fi_calculator_form`; editing spending updates the result
+     section; the disclaimer is present.
+   - **VoiceOver:** SWR slider exposes an adjustable value ("4.0 percent") and a
+     directional hint; the disclaimer is in the reading order.
+   - **Dynamic Type:** at AX5 no label/disclaimer is truncated and sliders remain
+     operable (reflowed).
+   - **Privacy mode:** balance-hiding masks amounts and result figures but leaves
+     assumption percentages visible.
+   - **Reduce Motion:** result figures swap without animation.
+
+### 14.5 Gate
+
+`node tools/agent-scripts/pre-push-check.js --fix` (lint + strict-concurrency)
+plus the suites above. `SWIFT_STRICT_CONCURRENCY = complete` must pass: the bridge
+DTO and input types are `Sendable`; UI state is `@MainActor`.
+
+---
+
+## 15. Implementation Readiness
+
+Per the [Human-Gated Prerequisites runbook](../ops/human-gated-prerequisites.md)
+(§2, _Implementation vs. Distribution decoupling_), the Apple Developer enrollment
+blocker [#1239](https://github.com/jrmoulckers/finance/issues/1239) gates
+**distribution only** — not implementation. This design and its implementation are
+**buildable and testable now**.
+
+### Buildable now (no enrollment, no secrets)
+
+- ✅ **This design doc** — fully unblocked, no Apple account required.
+- ✅ The `FICalculatorView`, `@Observable` view model, sensitivity sliders,
+  Advanced disclosure, validation, and disclaimer — all SwiftUI + Swift
+  concurrency.
+- ✅ All unit + UI/a11y tests in [§14](#14-test-plan), run in the iOS Simulator.
+- ✅ On-device verification via **free Personal Team signing** (a free Apple ID in
+  Xcode): 7-day app expiry, max 3 apps/device, no TestFlight/push — all acceptable
+  for verifying this feature.
+- ✅ Against the `StubSwiftExportBridge` `fireMetrics`, the entire screen is
+  developable and testable **before** the Kotlin port lands.
+
+### Distribution tail — gated by #1239 (human, not this PR)
+
+- 🔒 App Store / TestFlight builds, release signing, and CI release
+  (`release-ios.yml`) require Apple Developer Program enrollment ($99/yr), signing
+  material, an App Store Connect API key, and GitHub secrets. These are
+  **human-gated** (runbook §3.2) and **out of scope** here.
+
+### Dependency note (process gate, not human-gated)
+
+The shared **FIRE engine must be ported to `packages/core`** from the web
+reference (parity with `fire-calculator.test.ts`) and **re-exported** through the
+`packages/sync` Swift Export bridge. That is a `packages/` change **owned by
+@kmp-engineer and proposed via ADR** — not implemented in this iOS PR. Until it
+lands, the UI builds against the stub bridge, so the iOS surface is independently
+developable; only the live numbers depend on the shared port.
+
+### Needs Human Action
+
+- None for design **or** iOS implementation up to the distribution boundary. The
+  only human-gated step is shipping to TestFlight/App Store, tracked by
+  [#1239](https://github.com/jrmoulckers/finance/issues/1239); see
+  [runbook §3.2](../ops/human-gated-prerequisites.md#32-ios-distribution--apple-developer-1239).
+
+---
+
+## 16. Open Questions
+
+1. **Shared engine location:** new `packages/core/.../planning/FireCalculator.kt`
+   vs. extending the existing `analytics` package? (ADR decision with
+   @kmp-engineer.)
+2. **Real vs. nominal return:** default to **real** (proposed, simpler — no
+   separate inflation input) vs. nominal + an inflation field in Advanced?
+3. **Inline vs. pushed results:** v1 keeps inputs + results on one scroll
+   (proposed) — confirm vs. a separate results screen on small devices.
+4. **Prefill source for "investable" net worth:** total net worth vs. excluding
+   illiquid assets (home equity) by default? (Affects FI realism.)
+5. **Sensitivity ranges:** are SWR 2.5–6.0% and return 0–10% the right bounds, or
+   should they be configurable/locale-aware?

--- a/docs/design/ios-fire-results-goal-integration.md
+++ b/docs/design/ios-fire-results-goal-integration.md
@@ -1,0 +1,516 @@
+# iOS FIRE Results & Goal Integration — Surface Design
+
+> Native SwiftUI presentation of Financial-Independence results — **FI number**,
+> **years-to-FI**, **Coast FI**, **SWR sensitivity**, and a **projected FI
+> date** — as a set of summary cards with plain-language, VoiceOver-friendly
+> explanations, plus a path to **link FI as a goal** alongside the existing Goals
+> feature. Consumes the inputs from
+> [ios-fi-calculator-flow.md](./ios-fi-calculator-flow.md) and shares the
+> projection visual with
+> [ios-net-worth-projection-overlay.md](./ios-net-worth-projection-overlay.md).
+
+**Status:** PROPOSED — design only (implementation gated where noted)
+**Issue:** [#2558](https://github.com/jrmoulckers/finance/issues/2558) — Part of [#2114](https://github.com/jrmoulckers/finance/issues/2114)
+**Platform:** iOS / iPadOS (SwiftUI, iOS 17+)
+**Owner:** @ios-engineer
+**Related design:** [ios-fi-calculator-flow.md](./ios-fi-calculator-flow.md) · [ios-net-worth-projection-overlay.md](./ios-net-worth-projection-overlay.md) · [ios-net-worth-trend-chart.md](./ios-net-worth-trend-chart.md) · [data-visualization.md](./data-visualization.md) · [accessibility-patterns.md](./accessibility-patterns.md) · [content-language-guidelines.md](./content-language-guidelines.md) · [ux-principles.md](./ux-principles.md) · [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md)
+
+---
+
+## Table of Contents
+
+1. [Goal & Scope](#1-goal--scope)
+2. [The Result Cards](#2-the-result-cards)
+3. [SWR Sensitivity Strip](#3-swr-sensitivity-strip)
+4. [Projected FI Date](#4-projected-fi-date)
+5. [Goal-Linking Integration](#5-goal-linking-integration)
+6. [Financial-Advice Safety: Estimate Labeling & Disclaimers](#6-financial-advice-safety-estimate-labeling--disclaimers)
+7. [Accessibility — VoiceOver-Friendly Explanations](#7-accessibility--voiceover-friendly-explanations)
+8. [Dynamic Type](#8-dynamic-type)
+9. [Privacy: Balance Hiding](#9-privacy-balance-hiding)
+10. [States: Empty, Loading, Stale & Error](#10-states-empty-loading-stale--error)
+11. [Affected Surfaces & Shared Dependencies](#11-affected-surfaces--shared-dependencies)
+12. [Native ↔ Shared Boundary](#12-native--shared-boundary)
+13. [Test Plan](#13-test-plan)
+14. [Implementation Readiness](#14-implementation-readiness)
+15. [Open Questions](#15-open-questions)
+
+---
+
+## 1. Goal & Scope
+
+Turn the FIRE inputs into an **at-a-glance, understandable answer**: "Here's your
+number, here's roughly when you'd reach it, and here's what changes it." Each
+metric is a calm summary card whose VoiceOver description **explains the metric in
+plain language**, not just reads a figure — a core requirement of this batch.
+
+This document is the **results half** of the FIRE feature; the **input/flow half**
+(defaults, Advanced disclosure, sensitivity sliders, validation) is
+[ios-fi-calculator-flow.md](./ios-fi-calculator-flow.md), and the **chart that
+visualizes the path** to these targets is
+[ios-net-worth-projection-overlay.md](./ios-net-worth-projection-overlay.md). All
+three consume one shared, deterministic computation.
+
+**In scope (this design):**
+
+- Summary cards for **FI number**, **FI progress (%)**, **years-to-FI**, **Coast
+  FI** (with reached/not-reached state), and **current passive income**.
+- An **SWR sensitivity strip** showing the FI number at 4.0% / 3.5% / 3.0% so the
+  user sees how conservative assumptions enlarge the target.
+- A **projected FI date** card framed as an estimate ("around {month year}").
+- **Goal-linking**: create/track an FI (or Coast-FI) target as a first-class goal
+  using the existing Goals surface, with a clear summary on both sides.
+- VoiceOver explanations, Dynamic Type, privacy, and empty/loading/stale/error
+  states.
+
+**Out of scope (deliberately deferred):**
+
+- Input collection and validation — see
+  [ios-fi-calculator-flow.md](./ios-fi-calculator-flow.md).
+- The projection line/area chart — see
+  [ios-net-worth-projection-overlay.md](./ios-net-worth-projection-overlay.md).
+- Editing the underlying Goals model, schema, or repository contract (owned by
+  the Goals feature / shared packages); this design **reuses** them.
+- Monte-Carlo confidence bands, tax/withdrawal sequencing, and Social Security
+  (follow-on under #2114).
+
+> **Why cards, not a dense dashboard:** per
+> [data-visualization](./data-visualization.md) (_"Clarity Over Completeness"_)
+> and [ux-principles](./ux-principles.md), each FIRE concept gets its own card
+> with a one-line explanation, so a user new to FIRE can learn the vocabulary
+> while reading their own numbers.
+
+---
+
+## 2. The Result Cards
+
+Cards render below the inputs on the same scroll (per the flow design) and update
+live as the sensitivity sliders move. Each is a reusable `FIResultCard` with a
+title, a primary figure, a one-line plain-language explainer, and a combined
+VoiceOver label.
+
+| Card               | Primary figure                         | Plain-language explainer (visible + spoken)                                                         | Source field (`FIREMetrics`) |
+| ------------------ | -------------------------------------- | --------------------------------------------------------------------------------------------------- | ---------------------------- |
+| **FI number**      | e.g. `$1,050,000`                      | "The amount that could cover your spending at your withdrawal rate."                                | `fiNumberCents`              |
+| **FI progress**    | e.g. `30%` + `ProgressRing`            | "How far your investments have come toward your FI number."                                         | `fiPercent`                  |
+| **Years to FI**    | e.g. `~12 years (est.)`                | "About how long at your current saving and assumed returns." Shows "Not reachable…" when unbounded. | `yearsToFI`                  |
+| **Coast FI**       | e.g. `Reached` / `$420,000 needed now` | "Enough invested now to coast to retirement with no more contributions." Gated on age.              | `coastFICents`, `isCoastFI`  |
+| **Passive income** | e.g. `$12,400 / yr (est.)`             | "What your investments could generate now at your withdrawal rate."                                 | `currentPassiveIncomeCents`  |
+
+**Rules**
+
+- **One concept per card.** No card combines two metrics; the explainer line is
+  always present (it is the teaching surface), styled `.footnote`/`.secondary`.
+- **Progress uses an existing component.** FI progress reuses
+  [`ProgressRing`](../../apps/ios/Finance/Components/ProgressRing.swift) (already
+  Dynamic-Type + VoiceOver aware), with over-100% handled gracefully ("FI
+  reached" when `fiPercent ≥ 100`).
+- **Direction is never color-only.** Where a card uses a semantic tint (e.g.,
+  Coast FI reached = green), it is always paired with a glyph + text ("✓
+  Reached"), per
+  [data-visualization §2.4 "Never Color Alone"](./data-visualization.md). Declines
+  / shortfalls use amber, never red, per the non-judgmental rule.
+- **Live updates.** Cards bind to the `@Observable` view model; when the SWR or
+  return slider changes (flow design §5), figures crossfade (instant under Reduce
+  Motion).
+- **No fabricated precision.** Years-to-FI is "~N years (est.)"; Coast-FI without
+  an age shows a prompt ("Add your age in Advanced to estimate Coast FI"), never a
+  guessed number.
+
+```
+┌──────────────────┐  ┌──────────────────┐
+│ FI number        │  │ FI progress      │
+│ $1,050,000       │  │   ◍ 30%          │
+│ Covers spending  │  │ Toward your FI   │
+│ at 4.0% (est.)   │  │ number           │
+└──────────────────┘  └──────────────────┘
+┌──────────────────┐  ┌──────────────────┐
+│ Years to FI      │  │ Coast FI         │
+│ ~12 years (est.) │  │ ✓ Reached        │
+│ At current saving│  │ No more needed   │
+└──────────────────┘  └──────────────────┘
+These are estimates based on your assumptions — not financial advice.
+```
+
+---
+
+## 3. SWR Sensitivity Strip
+
+A horizontal strip beneath the FI-number card makes the single biggest assumption
+**legible**: the FI number at three withdrawal rates.
+
+| Column   | Withdrawal rate | Figure                  | Note                                      |
+| -------- | --------------- | ----------------------- | ----------------------------------------- |
+| **4.0%** | baseline        | FI number at 4%         | The conventional baseline (highlighted).  |
+| **3.5%** | more cautious   | FI number at 3.5%       | Larger target.                            |
+| **3.0%** | most cautious   | FI number at 3% (≈ ×33) | Largest target; for sequence-risk-averse. |
+
+- **Purpose:** show that "your number" is a function of an assumption, reinforcing
+  the financial-advice-safety stance ([§6](#6-financial-advice-safety-estimate-labeling--disclaimers)).
+  The three figures come from the **same shared `calculateFINumber`** evaluated at
+  three rates — iOS does not invent the math, it requests/derives from the shared
+  result set (see [§12](#12-native--shared-boundary)).
+- **Reflects the live SWR.** Whichever rate the slider is on is highlighted; the
+  other two are reference points. Tapping a column sets the slider to that rate
+  (a convenient shortcut, not a separate state).
+- **Accessibility:** the strip is one container with a combined label —
+  _"Your FI number ranges from {3% value} at a 3 percent withdrawal rate to
+  {4% value} at 4 percent. Lower rates mean a larger, safer target."_ — so the
+  relationship, not just three numbers, is spoken. Each column is also
+  individually focusable.
+- **Dynamic Type / reflow:** at large sizes the three columns stack vertically
+  (label-over-value) via `ViewThatFits`; the strip never truncates a currency
+  figure.
+
+---
+
+## 4. Projected FI Date
+
+A dedicated card converts years-to-FI into a human date, **explicitly hedged**.
+
+- **Copy:** "Estimated FI date: **around {Month Year}**", with a `.footnote`
+  qualifier "based on your current saving and a {return}% assumed real return —
+  actual timing will vary." Derived from `projectedFIDate`/`yearsToFI` in the
+  shared metrics.
+- **Never a hard date.** Uses "around"/"by about" framing — never "you will be FI
+  on March 2038". When years-to-FI is unbounded (the math returns `maxYears`), the
+  card reads "Not reachable with these assumptions — try increasing savings or
+  adjusting the return" (factual, non-judgmental).
+- **Relationship to the projection chart.** This card is the textual summary; the
+  visual path to the date is the
+  [net-worth projection overlay](./ios-net-worth-projection-overlay.md). Tapping
+  the card scrolls to / opens that overlay with the FI target line shown.
+- **Accessibility:** VoiceOver reads the full hedged sentence (estimate + the
+  assumption that produced it), satisfying the "explain the projection" rule.
+
+---
+
+## 5. Goal-Linking Integration
+
+FI is, fundamentally, a savings goal — so the design **links it into the existing
+Goals feature** rather than building a parallel tracker.
+
+### 5.1 Create / link an FI goal
+
+- A "Track this as a goal" button on the FI-number card (and Coast-FI card) opens
+  the existing
+  [`GoalCreateView`](../../apps/ios/Finance/Screens/GoalCreateView.swift)
+  **prefilled**: name "Financial Independence", `targetMinorUnits` = FI number,
+  `currentMinorUnits` = current investable portfolio, an `infinity`/`target` icon,
+  and (if the user set ages) the projected FI date as the goal `targetDate`.
+- The goal is created through the **existing `GoalRepository`** contract — no
+  schema change. It appears in
+  [`GoalsView`](../../apps/ios/Finance/Screens/GoalsView.swift) like any other
+  goal, with the same progress ring and status.
+- A **Coast-FI** variant can be linked separately (target = Coast-FI amount), so a
+  user can track both "fully FI" and the nearer "Coast FI" milestone.
+
+### 5.2 Two-way summary
+
+- **On the FIRE surface:** if an FI goal already exists, the FI-number card shows
+  a small "Linked goal" chip with current progress, deep-linking to the goal
+  detail. Re-running the calculator with new assumptions offers "Update linked
+  goal target?" (explicit, never silent), since the FI number is assumption-driven.
+- **On the Goals surface:** the linked goal is an ordinary
+  [`GoalItem`](../../apps/ios/Finance/Models/GoalItem.swift); the FIRE-specific
+  explanation ("This target is your FI number at a {rate}% withdrawal rate, an
+  estimate") is carried in the goal `notes`, so the assumption travels with the
+  goal and the not-advice framing is preserved wherever the goal is viewed.
+
+### 5.3 Boundaries
+
+- This design **reuses** the Goals model/repository as-is; it does **not** modify
+  `GoalItem`, `GoalRepository`, or the shared goal schema. If a first-class
+  "goal kind = FI" field were ever wanted (vs. encoding via name/notes), that is a
+  shared-package change via ADR with @kmp-engineer — out of scope here.
+- Linking is **opt-in**. The calculator is fully usable without ever creating a
+  goal; goal-linking is an offered convenience, not a gate.
+
+---
+
+## 6. Financial-Advice Safety: Estimate Labeling & Disclaimers
+
+Mirrors and reinforces
+[ios-fi-calculator-flow.md §7](./ios-fi-calculator-flow.md); the results surface
+is where most numbers appear, so labeling is strictest here.
+
+- **Every derived number is labeled an estimate** at the point of display:
+  years-to-FI is "~N years (est.)", the FI date is "around {Month Year}", passive
+  income is "(est.)". Only the user's own entered/aggregated balances are shown
+  without "est.".
+- **Persistent disclaimer** below the cards: _"These are estimates based on the
+  assumptions above, not financial advice. Real returns vary and are not
+  guaranteed."_ Real, selectable text; in the VoiceOver reading order.
+- **Assumptions are always co-present.** The SWR sensitivity strip and the
+  return/SWR readouts ensure no FI number is ever shown without the assumptions
+  that produced it.
+- **No promissory language.** Copy uses "with these assumptions, you'd reach…",
+  never "you will retire at…". The "Not reachable" state is framed as information
+  about the _assumptions_, never the person, per
+  [content-language-guidelines](./content-language-guidelines.md).
+- **Goal notes carry the caveat.** A linked FI goal records the rate/assumption in
+  its notes so the estimate framing survives outside this screen.
+
+---
+
+## 7. Accessibility — VoiceOver-Friendly Explanations
+
+The defining a11y requirement of this surface: **VoiceOver users hear an
+explanation of each metric, not just a number.** Patterns follow
+[accessibility-patterns](./accessibility-patterns.md),
+[`ConfidenceIndicatorView`](../../apps/ios/Finance/Components/ConfidenceIndicatorView.swift),
+and [`ProgressRing`](../../apps/ios/Finance/Components/ProgressRing.swift).
+
+- **Combined, explanatory labels.** Each `FIResultCard` is
+  `.accessibilityElement(children: .combine)` with a label that includes the
+  explainer, e.g.:
+  - FI number → _"FI number, one million fifty thousand dollars. The amount that
+    could cover your spending at a 4 percent withdrawal rate. This is an
+    estimate."_
+  - Years to FI → _"Years to financial independence, about 12 years, estimated,
+    based on your current saving and a 5 percent assumed real return."_
+  - Coast FI (reached) → _"Coast FI, reached. You have enough invested to coast to
+    retirement with no further contributions, based on your assumptions."_
+- **Progress semantics.** The FI-progress ring exposes `.accessibilityValue` as a
+  percentage and a hint ("30 percent of your FI number"); over-100% reads "FI
+  reached".
+- **Sensitivity strip** speaks the _range and relationship_, not three bare
+  numbers ([§3](#3-swr-sensitivity-strip)).
+- **Estimate words are spoken.** "estimated", "around", "not guaranteed" are part
+  of the label text, so the financial-advice framing is never visual-only.
+- **Switch Control / Full Keyboard Access.** Cards, the "Track as goal" button,
+  sensitivity columns, and the linked-goal chip are all real focusable controls
+  with labels and hints; nothing is reachable only by gesture.
+- **Contrast & color.** All figures/explainers meet ≥ 4.5:1 across light, dark,
+  and high-contrast; reached/not-reached never relies on color alone (glyph +
+  text).
+
+---
+
+## 8. Dynamic Type
+
+- **No hardcoded font sizes.** Card titles `.headline`, figures reuse
+  `CurrencyLabel`, explainers `.footnote`/`.secondary`, disclaimer `.caption`.
+  All scale through AX1–AX5.
+- **Grid reflow.** The two-up card grid (`LazyVGrid`) collapses to a single
+  column at `accessibility1`+ via `@Environment(\.dynamicTypeSize)`; the SWR strip
+  stacks (§3). Verified at AX5 in [§13](#13-test-plan).
+- **Explainers wrap, never truncate** — they are the teaching content and must
+  remain fully readable at the largest sizes.
+
+---
+
+## 9. Privacy: Balance Hiding
+
+- When balance-hiding is active, **monetary figures** (FI number, passive income,
+  sensitivity-strip amounts, linked-goal progress amount) are masked ("•••••");
+  **percentages and the explainer text** remain visible (they reveal no balance).
+  Years-to-FI and the FI date are not balances and remain visible.
+- **Accessibility parity:** masked amounts are masked to VoiceOver too ("hidden")
+  — never speak a hidden balance; the explainer still reads.
+- **App-switcher redaction:** participates in the existing privacy-screen snapshot
+  behavior; no exemption.
+- **Logging:** amounts are `.private` and never logged. Log only `.public`
+  events — "FIRE results viewed", "FI goal linked" — counts/flags, never an
+  amount (same discipline as
+  [`GoalsViewModel`](../../apps/ios/Finance/ViewModels/GoalsViewModel.swift)).
+
+---
+
+## 10. States: Empty, Loading, Stale & Error
+
+| State       | Trigger                                                    | Presentation                                                                                                                                                          |
+| ----------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Loading** | Metrics not yet derived (first compute / awaiting prefill) | Cards show skeleton figures with titles + explainers visible; respects Reduce Motion (static placeholder). `.accessibilityLabel("Calculating your FI estimate")`.     |
+| **Empty**   | Required input missing (e.g., no spending)                 | Cards replaced by an `EmptyStateView`: "Enter your spending to see your FI estimate", deep-linking back to the inputs. No fabricated numbers.                         |
+| **Stale**   | Derived from cached/offline aggregates                     | Cards render + a subtle "Based on data as of {relative time}" caption; reuse [`OfflineBanner`](../../apps/ios/Finance/Components/OfflineBanner.swift) when offline.   |
+| **Error**   | Metric derivation fails (bridge error)                     | Inline, non-modal `ErrorStateView` scoped to the results section + Retry; inputs and the rest of the screen stay usable. Logs `error.localizedDescription` `.public`. |
+
+- **Stale is first-class, not an error** — local-first; old inputs with an "as of"
+  stamp are correct (consistent with
+  [ios-net-worth-trend-chart.md §8](./ios-net-worth-trend-chart.md)).
+- **Errors are section-scoped** — a failed compute never hides the inputs or the
+  rest of the screen; the user can adjust assumptions and retry.
+- **Empty is a prompt, not a blank** — it points back to the one missing input.
+
+---
+
+## 11. Affected Surfaces & Shared Dependencies
+
+### 11.1 iOS surfaces (all in `apps/ios/`, owned by @ios-engineer)
+
+| Surface                                                       | Change                                                                                                           |
+| ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `Finance/Screens/FIResultsSection.swift` **(new)**            | The results cards container (FI number, progress, years, Coast FI, passive income) + disclaimer.                 |
+| `Finance/Components/FIResultCard.swift` **(new)**             | Reusable card: title + figure + explainer + combined a11y label.                                                 |
+| `Finance/Components/SWRSensitivityStrip.swift` **(new)**      | The 4.0/3.5/3.0% strip with combined a11y description.                                                           |
+| `Finance/ViewModels/FICalculatorViewModel.swift` **(modify)** | Extend the flow VM (shared with #2556) to expose derived `FIREMetrics`, sensitivity set, and linked-goal status. |
+| `Finance/Screens/GoalCreateView.swift` **(modify)**           | Accept a prefill seed (name/target/current/icon/notes/date) for the "Track as goal" path.                        |
+| `Finance/Screens/GoalsView.swift` **(modify, light)**         | Show the FI goal like any other goal (no schema change); optional "Linked from FI" affordance.                   |
+| `Finance/Resources/*.lproj/Localizable.strings` **(modify)**  | New localized strings (card titles, explainers, disclaimer, sensitivity, goal-link copy, masks).                 |
+
+### 11.2 Shared dependencies (KMP — **not edited by this design**)
+
+- **FIRE math / `FIREMetrics`** — `fiNumberCents`, `fiPercent`, `coastFICents`,
+  `isCoastFI`, `yearsToFI`, `projectedFIDate`, `currentPassiveIncomeCents`,
+  `savingsRatePercent`. Canonical TypeScript reference today in
+  [`apps/web/src/lib/investment/fire-calculator.ts`](../../apps/web/src/lib/investment/fire-calculator.ts);
+  **target home `packages/core`**, re-exported via the Swift Export bridge (see
+  [ios-fi-calculator-flow.md §12](./ios-fi-calculator-flow.md)).
+- **Goals model/repository** — `GoalItem` / `GoalRepository` (existing); reused,
+  not modified.
+- **Money/locale formatting** — the shared currency formatter module.
+
+> **Same dependency posture as the flow design:** the shared FIRE engine is **not
+> yet in `packages/core`**; porting it from the web reference (parity with
+> `fire-calculator.test.ts`) is **@kmp-engineer via ADR**. iOS binds to the
+> Swift-native `FIPlanningBridge` stub so these cards are buildable/testable now.
+
+---
+
+## 12. Native ↔ Shared Boundary
+
+```mermaid
+flowchart LR
+    subgraph shared["packages/core (KMP — port via ADR, NOT this PR)"]
+        A["FireCalculator.calculateFIREMetrics(input)"] --> B["FIREMetrics<br/>(FI number, %, Coast FI, yearsToFI, FI date, passive income)"]
+    end
+    subgraph bridge["packages/sync (Swift Export — ADR if missing)"]
+        B --> C["FIREMetricsDTO (Int64 minor units, Double %, Date)"]
+    end
+    subgraph ios["apps/ios (this PR — @ios-engineer)"]
+        C --> D["FICalculatorViewModel<br/>exposes metrics + sensitivity set + linked-goal status"]
+        D --> E["FIResultCard / SWRSensitivityStrip / FI-date card"]
+        D --> F["GoalCreateView prefill → GoalRepository (existing)"]
+    end
+```
+
+**Responsibilities**
+
+| Concern                                                      | Layer                              |
+| ------------------------------------------------------------ | ---------------------------------- |
+| All FIRE numbers (FI, %, Coast FI, years, FI date, passive)  | `packages/core` (shared)           |
+| FI number at 3.0/3.5/4.0% (sensitivity set)                  | `packages/core` (re-evaluate math) |
+| Type mapping (`Cents`→`Int64`, %→`Double`, date→`Date`)      | Swift Export bridge                |
+| Card layout, explainer copy, estimate labeling, disclaimer   | iOS                                |
+| Goal prefill + linking via existing `GoalRepository`         | iOS (reuses shared contract)       |
+| VoiceOver explanations, Dynamic Type, privacy, Reduce Motion | iOS                                |
+
+- **iOS renders, it does not compute.** The sensitivity strip's three figures come
+  from the shared math evaluated at three rates (a small DTO list), not from an
+  iOS-side formula.
+- **Goal-linking crosses no new boundary.** It reuses the existing `GoalRepository`
+  exactly as the Goals feature does; the FI specifics live in name/notes, so no
+  shared schema change is required for v1.
+
+---
+
+## 13. Test Plan
+
+### 13.1 Shared (KMP) — verify/port parity, not re-implement here
+
+- The ported `FireCalculatorTest` (KMP) covers FI number / % / Coast FI /
+  years-to-FI / projected date / passive income parity with the web
+  `fire-calculator.test.ts`, including over-100% progress, unreachable →
+  `maxYears`, already-FI → 0. **@kmp-engineer via ADR**, not this PR.
+
+### 13.2 Bridge
+
+- `SwiftExportBridgeTests`: `FIREMetricsDTO` round-trips all fields; the
+  sensitivity set (FI number at 3.0/3.5/4.0%) maps correctly and is monotonic
+  (lower rate → larger FI number).
+
+### 13.3 iOS unit (XCTest, `apps/ios/Tests/`)
+
+1. **`FIResultsViewModelTests`**
+   - Card values map from `FIREMetrics`; `fiPercent ≥ 100` → "FI reached"; missing
+     age → Coast-FI prompt (not a number); `yearsToFI == maxYears` → "Not
+     reachable" copy.
+   - Sensitivity set has three rates, highlighted column tracks the live SWR, and
+     tapping a column updates the SWR.
+   - Linked-goal status: detects an existing FI goal; "Update target?" offered (not
+     auto-applied) when assumptions change.
+2. **`FIGoalLinkTests`**
+   - "Track as goal" builds a `GoalItem` prefill with correct target/current/notes
+     (assumption recorded) and calls the existing repository (spy) — no schema
+     mutation.
+3. **`FIResultCardA11yTests`** (pure where possible)
+   - Combined VoiceOver labels include the explainer + estimate wording; masked
+     (privacy) labels contain no amount.
+
+### 13.4 iOS UI / a11y (`apps/ios/Tests/UITests/`)
+
+4. **`FIResultsUITests`**
+   - `fi_results_section` shows all cards; the disclaimer is present; "Track as
+     goal" reaches `GoalCreateView` prefilled.
+   - **VoiceOver:** each card exposes an explanatory (not number-only) label; the
+     sensitivity strip speaks the range/relationship.
+   - **Dynamic Type:** at AX5 the grid is single-column, explainers/disclaimer
+     untruncated, strip stacked.
+   - **Privacy mode:** amounts masked, percentages/explainers visible.
+   - **Reduce Motion:** figures swap without animation when assumptions change.
+
+### 13.5 Gate
+
+`node tools/agent-scripts/pre-push-check.js --fix` (lint + strict-concurrency)
+plus the suites above. `SWIFT_STRICT_CONCURRENCY = complete`: DTOs `Sendable`, UI
+state `@MainActor`.
+
+---
+
+## 14. Implementation Readiness
+
+Per the [Human-Gated Prerequisites runbook](../ops/human-gated-prerequisites.md)
+(§2), Apple Developer enrollment
+[#1239](https://github.com/jrmoulckers/finance/issues/1239) gates **distribution
+only** — not implementation. This design and its implementation are **buildable
+and testable now**.
+
+### Buildable now (no enrollment, no secrets)
+
+- ✅ **This design doc** — fully unblocked.
+- ✅ The result cards, sensitivity strip, FI-date card, and goal-linking UI — all
+  SwiftUI + `@Observable` + Swift concurrency, reusing existing `ProgressRing` /
+  `CurrencyLabel` / `GoalCreateView`.
+- ✅ All unit + UI/a11y tests in [§13](#13-test-plan) in the iOS Simulator.
+- ✅ On-device verification via **free Personal Team signing** (free Apple ID):
+  7-day expiry, ≤ 3 apps/device, no TestFlight/push — fine for verifying this
+  feature.
+- ✅ Against the `StubSwiftExportBridge` `fireMetrics`, the entire results surface
+  is developable **before** the Kotlin port lands.
+
+### Distribution tail — gated by #1239 (human, not this PR)
+
+- 🔒 App Store / TestFlight builds, release signing, App Store Connect API key,
+  and CI release secrets are **human-gated** (runbook §3.2) and out of scope.
+
+### Dependency note (process gate, not human-gated)
+
+The shared FIRE engine must be ported to `packages/core` and re-exported via the
+`packages/sync` Swift Export bridge — **@kmp-engineer via ADR**, not this iOS PR
+(shared with the flow design). Until then, cards bind to the stub bridge. The
+Goals model/repository are reused unchanged; a first-class "FI goal kind" (if ever
+desired) would be a separate ADR.
+
+### Needs Human Action
+
+- None for design **or** iOS implementation up to the distribution boundary. Only
+  TestFlight/App Store shipping is human-gated, tracked by
+  [#1239](https://github.com/jrmoulckers/finance/issues/1239); see
+  [runbook §3.2](../ops/human-gated-prerequisites.md#32-ios-distribution--apple-developer-1239).
+
+---
+
+## 15. Open Questions
+
+1. **Goal kind encoding:** v1 encodes "this is an FI goal" via name/notes
+   (proposed, no schema change) vs. a first-class `goalKind` field (ADR with
+   @kmp-engineer). Confirm.
+2. **Coast-FI as a separate goal:** offer linking Coast FI and full FI as two
+   goals (proposed) vs. a single goal with a milestone?
+3. **Sensitivity rates:** fixed 4.0/3.5/3.0% (proposed) vs. user-selectable
+   comparison rates?
+4. **"Update linked goal" UX:** prompt on every assumption change vs. only on
+   explicit "recalculate"? (Avoid nagging; favor explicit.)
+5. **Passive-income card:** include in v1 (proposed) or defer to reduce card count
+   for first-time users?

--- a/docs/design/ios-net-worth-projection-overlay.md
+++ b/docs/design/ios-net-worth-projection-overlay.md
@@ -1,0 +1,547 @@
+# iOS Net-Worth Projection Overlay — Surface Design
+
+> A forward-looking, **contribution-paced projection** overlay that extends the
+> existing net-worth trend chart into the future on iPhone and iPad: a dashed
+> projection line + soft band, explicit **confidence copy** ("projection, not a
+> prediction"), tap/scrub **point inspection**, and full **non-gesture
+> alternatives** so every future value is reachable without a trackpad or drag.
+> Visualizes the path toward the FI targets from
+> [ios-fire-results-goal-integration.md](./ios-fire-results-goal-integration.md).
+
+**Status:** PROPOSED — design only (implementation gated where noted)
+**Issue:** [#2564](https://github.com/jrmoulckers/finance/issues/2564) — Part of [#2116](https://github.com/jrmoulckers/finance/issues/2116)
+**Platform:** iOS / iPadOS (SwiftUI, iOS 17+)
+**Owner:** @ios-engineer
+**Related design:** [ios-net-worth-trend-chart.md](./ios-net-worth-trend-chart.md) · [ios-fi-calculator-flow.md](./ios-fi-calculator-flow.md) · [ios-fire-results-goal-integration.md](./ios-fire-results-goal-integration.md) · [data-visualization.md](./data-visualization.md) · [chart-component-specs.md](./chart-component-specs.md) · [accessibility-patterns.md](./accessibility-patterns.md) · [content-language-guidelines.md](./content-language-guidelines.md) · [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md)
+
+---
+
+## Table of Contents
+
+1. [Goal & Scope](#1-goal--scope)
+2. [Placement: Extending the Trend Chart](#2-placement-extending-the-trend-chart)
+3. [The Contribution-Paced Projection](#3-the-contribution-paced-projection)
+4. [Confidence Copy & Financial-Advice Safety](#4-confidence-copy--financial-advice-safety)
+5. [Point Inspection (Scrub) & Non-Gesture Alternatives](#5-point-inspection-scrub--non-gesture-alternatives)
+6. [Accessibility — VoiceOver for Future Values](#6-accessibility--voiceover-for-future-values)
+7. [Dynamic Type](#7-dynamic-type)
+8. [Privacy: Balance Hiding](#8-privacy-balance-hiding)
+9. [States: Empty, Loading, Stale & Error](#9-states-empty-loading-stale--error)
+10. [Affected Surfaces & Shared Dependencies](#10-affected-surfaces--shared-dependencies)
+11. [Native ↔ Shared Boundary](#11-native--shared-boundary)
+12. [Test Plan](#12-test-plan)
+13. [Implementation Readiness](#13-implementation-readiness)
+14. [Open Questions](#14-open-questions)
+
+---
+
+## 1. Goal & Scope
+
+Answer **"If I keep saving like this, where could my net worth be?"** by extending
+the historical net-worth line into the future with a clearly-differentiated,
+clearly-labeled **projection** — and to show the path toward the
+[FI number / projected FI date](./ios-fire-results-goal-integration.md) instead of
+leaving those as abstract figures.
+
+This overlay **builds on, and does not replace,** the historical
+[net-worth trend chart](./ios-net-worth-trend-chart.md): same card, same range
+controls, same accessibility scaffolding — extended forward. It reuses the
+confidence-band visual language already established by
+[`PredictionChart`](../../apps/ios/Finance/Charts/PredictionChart.swift).
+
+**In scope (this design):**
+
+- A **projection overlay** on the existing `NetWorthTrendChart`: a dashed future
+  line + a soft "range" band, paced by the user's **monthly contribution** and an
+  assumed growth rate.
+- A horizon control (e.g., **1Y / 5Y / 10Y / to FI**) for how far ahead to
+  project.
+- **Confidence copy** that frames the overlay as an assumption-driven projection,
+  not a prediction, with an always-visible disclaimer.
+- **Point inspection**: tap/scrub a future month to read its projected value, with
+  full **non-gesture** alternatives (stepper, "View as table", VoiceOver
+  per-point).
+- Optional **FI-target rule line** + projected FI date marker, linking the
+  projection to the FIRE results.
+- Privacy, Dynamic Type, and empty/loading/stale/error states.
+
+**Out of scope (deliberately deferred):**
+
+- The historical series, range controls, decimation, and the base chart — owned by
+  [ios-net-worth-trend-chart.md](./ios-net-worth-trend-chart.md); this design
+  **extends** it.
+- Monte-Carlo / probabilistic fan charts and sequence-of-returns risk (the "band"
+  here is a simple assumption range, **not** a statistical confidence interval —
+  see [§3](#3-the-contribution-paced-projection)). Probabilistic modeling is a
+  labeled follow-on under #2116.
+- watchOS, widgets, and App Clip variants.
+
+> **Why an overlay, not a new screen:** the projection is most meaningful sitting
+> directly on the history it extends, so the eye reads "where I've been → where
+> this pace leads." Per [data-visualization](./data-visualization.md), the future
+> is _detail on demand_ layered onto the existing card, not a separate
+> destination.
+
+---
+
+## 2. Placement: Extending the Trend Chart
+
+- The overlay is a **mode of the existing `NetWorthTrendCard`** (dashboard +
+  accounts), enabled by a "Show projection" toggle / segment, not a new card. When
+  off, the card is exactly the historical trend from
+  [ios-net-worth-trend-chart.md](./ios-net-worth-trend-chart.md).
+- It also appears **inline in the FIRE calculator flow**, beneath the result cards
+  ([ios-fire-results-goal-integration.md §4](./ios-fire-results-goal-integration.md)),
+  where the projection's contribution + growth come from the FIRE inputs and the
+  **FI-target rule line** is shown by default.
+- A **vertical "today" divider** separates solid history (left) from the dashed
+  projection (right), so past vs. future is unmistakable even before reading any
+  label.
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  Net Worth — Projection (estimate)                         │
+│  $48,250 today  →  ~$612,000 in 10 yrs (est.)              │
+│                                       ┌╌╌ band ╌╌╌╌╌╌╌╮    │
+│                              ╭╌╌╌╌╌╌╌╌┤ projection    │    │  ← dashed + band
+│   solid history     ╭───────╯         └╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╯    │
+│  ───────────────────╯        ┊today                        │  ← "today" divider
+│  2019      2022      2025     ┊  2030      2035            │
+│  [1Y] [5Y] [10Y] [to FI]      Contribution $1,500/mo ›     │  ← horizon + pace
+│  Projection assumes $1,500/mo and 5% growth — not advice.  │  ← confidence copy
+└──────────────────────────────────────────────────────────┘
+```
+
+- Reuses the base card's **range controls** for the _historical_ window and adds a
+  separate **horizon control** for the _future_ window, so the two axes of "how
+  far back" and "how far forward" are independent and clearly labeled.
+
+---
+
+## 3. The Contribution-Paced Projection
+
+The projection is **deterministic and transparent**: starting from today's net
+worth, each month adds the user's contribution and a simple growth increment —
+the shared `projectNetWorth` model.
+
+### 3.1 Model (shared)
+
+Mirrors the canonical reference
+[`projectNetWorth`](../../apps/web/src/lib/investment/net-worth-projection.ts):
+
+```
+netWorth(0)      = current net worth
+growth(m)        = max(0, netWorth(m-1)) × (annualGrowth% / 100 / 12)
+netWorth(m)      = netWorth(m-1) + monthlyContribution + growth(m)
+```
+
+- **Contribution-paced:** the line's slope is driven primarily by the user's
+  **monthly contribution** (savings), with compounding layered on — so the user
+  sees the lever they actually control. The contribution defaults to the
+  trailing income − expenses figure (same source as the FIRE inputs) and is
+  editable inline ("Contribution $1,500/mo ›").
+- **Growth assumption:** the same assumed **real return** used by the FIRE
+  calculator (default 5%), surfaced and editable; changing it re-paces the line
+  live (debounced), consistent with the sensitivity controls in
+  [ios-fi-calculator-flow.md §5](./ios-fi-calculator-flow.md).
+- **Output:** an array of `NetWorthForecastPoint`-equivalent values
+  (`month`, `netWorthCents`, `contributionCents`, `projectedGrowthCents`) so each
+  inspected point can attribute how much came from contributions vs. growth.
+
+### 3.2 Visual language (reusing `PredictionChart` conventions)
+
+| Element             | Treatment                                                                                                                  |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| **History line**    | Solid `ChartColorPalette.blue`, `.monotone` — unchanged from the trend chart.                                              |
+| **Projection line** | **Dashed** line (`StrokeStyle(dash: [6, 4])`) in `ChartColorPalette.purple`, matching `PredictionChart`'s prediction line. |
+| **Range band**      | Soft `AreaMark` (purple, ~0.15 opacity) between an optimistic/conservative pace — **decorative**, `.accessibilityHidden`.  |
+| **Today divider**   | A `RuleMark` at today, labeled "Today" for VoiceOver.                                                                      |
+| **FI-target line**  | Optional horizontal `RuleMark` at the FI number, labeled "FI target {amount}"; intersection marks the projected FI date.   |
+
+- **The band is an assumption range, not statistics.** It is drawn from a
+  conservative vs. optimistic growth pace (e.g., return ± a fixed spread), and the
+  copy says so. It is explicitly **not** a Monte-Carlo confidence interval; we do
+  not imply statistical probability (see [§4](#4-confidence-copy--financial-advice-safety)).
+- **Dashed + band + divider** give three independent, non-color signals that the
+  right side is the future, satisfying "never rely on color alone".
+- **Reduce Motion:** the projection draws in instantly (no sweep animation) when
+  `accessibilityReduceMotion` is set; horizon changes crossfade or swap instantly
+  per the setting, consistent with
+  [data-visualization §8](./data-visualization.md).
+
+---
+
+## 4. Confidence Copy & Financial-Advice Safety
+
+Projecting the future is the highest-risk surface for over-promising, so the copy
+is deliberate and always present.
+
+- **Always-visible confidence line** under the chart: _"Projection assumes
+  ${contribution}/mo and {growth}% annual growth. This is an estimate, not a
+  prediction or financial advice — real results will differ."_ Real, selectable
+  text; in the VoiceOver reading order.
+- **"Projection," never "prediction."** Headlines and labels use "projected",
+  "estimated", "could be", "at this pace" — never "will be". The headline figure
+  reads "~$612,000 in 10 years (est.)", never a bare future number.
+- **Assumptions are co-present and editable.** The contribution and growth are on
+  the card; the user can never see the future line without seeing what produced
+  it, and adjusting them is the intended interaction.
+- **The band is labeled an assumption range**, not a probability. Its inspection
+  copy says "range reflects more/less optimistic growth assumptions", explicitly
+  disclaiming statistical confidence — distinct from the spending-forecast
+  confidence interval in `PredictionChart` (which is a different, bounded
+  short-horizon model).
+- **Non-judgmental framing.** If contributions are low or the FI target is far
+  out, copy stays factual ("at this pace, your FI target is beyond the {N}-year
+  horizon") per [content-language-guidelines](./content-language-guidelines.md) —
+  never implying the user is doing something wrong.
+- **Long-horizon humility.** For 10Y/"to FI" horizons a one-line note reminds that
+  longer projections are less certain; we cap the default horizon and require an
+  explicit tap to extend further out.
+
+---
+
+## 5. Point Inspection (Scrub) & Non-Gesture Alternatives
+
+Users must be able to read **any future month's projected value** — and crucially,
+**without** a drag gesture.
+
+### 5.1 Pointer scrubbing (sugar, not the only path)
+
+- Tap/drag reuses the `chartOverlay` + `RuleMark` scrub pattern from
+  [`PredictionChart`](../../apps/ios/Finance/Charts/PredictionChart.swift) and
+  `TrendChart`: a rule + single `PointMark` + a callout showing the month, the
+  projected value, and the contribution-vs-growth split for that point.
+- Scrubbing is **pointer-only convenience**; every value it reveals is reachable
+  by the non-gesture paths below.
+
+### 5.2 Non-gesture alternatives (first-class, required)
+
+| Alternative                | Behavior                                                                                                                                                                                                            |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Horizon stepper**        | A discrete stepper / segmented control ("1Y · 5Y · 10Y · to FI") moves the inspected point and the headline to that horizon — no drag needed.                                                                       |
+| **"Inspect month" picker** | A `Picker`/stepper to select a specific future month; the callout updates and is announced. Fully operable via Switch Control / keyboard.                                                                           |
+| **"View as table"**        | A disclosure reveals a `Grid`/`List` of `Month → Projected net worth (contribution / growth)` rows — the same contract as the trend chart and `ReportResultView`. Non-gestural access to **every** projected value. |
+| **VoiceOver per-point**    | `AXChartDescriptor` exposes each projected month (see [§6](#6-accessibility--voiceover-for-future-values)).                                                                                                         |
+
+- **Parity guarantee:** any value obtainable by scrubbing is obtainable by the
+  table, the picker, and VoiceOver — no future value is gesture-locked. This
+  satisfies the issue's "non-gesture alternatives for future net-worth values"
+  requirement and the
+  [chart-component-specs](./chart-component-specs.md) "Data table alternative on
+  every chart" contract.
+- **Touch targets** for the stepper/picker/toggle meet 44×44 pt.
+
+---
+
+## 6. Accessibility — VoiceOver for Future Values
+
+Projections must be **fully understandable without sight**, and the spoken output
+must make clear these are estimates. Follows
+[accessibility-patterns](./accessibility-patterns.md), the trend chart's a11y
+contract, and `PredictionChart`'s audio-graph support.
+
+### 6.1 Container / audio-graph summary
+
+The chart container exposes a generated, data-bearing, **estimate-framed**
+description built from the full projection series, e.g.:
+
+> _"Net worth projection. Today about $48,250. At a pace of $1,500 per month and
+> 5 percent assumed annual growth, projected to about $612,000 in 10 years. This
+> is an estimate, not a prediction. Your FI target of about $1,050,000 is reached
+> around 2038."_
+
+- Built by a pure `NetWorthProjectionDescription` helper (testable without a view)
+  taking the forecast points + assumptions + currency, returning a localized
+  string. Numbers use the shared currency formatter (no hardcoded symbols).
+
+### 6.2 Per-point navigation (`AXChartDescriptor`)
+
+- Adopt Swift Charts' `AXChartDescriptor` so VoiceOver users swipe through each
+  projected month and hear, e.g., _"March 2030, projected, fifty-eight thousand
+  dollars."_ The word **"projected"** is part of each value so future points are
+  never confused with historical actuals.
+- History points and projection points are **distinct data series** in the
+  descriptor (e.g., "Net worth" vs. "Projected net worth"), and the Audio Graph
+  rotor sonifies both, with the projection clearly named.
+- Decorative marks (band, divider, scrub rule) are `.accessibilityHidden(true)`;
+  only the lines/points carry data.
+
+### 6.3 Other a11y requirements
+
+- **Horizon & contribution controls:** real focusable controls with
+  `.accessibilityLabel` + `.accessibilityValue` (e.g., horizon "10 years",
+  contribution "$1,500 per month") and hints describing effect.
+- **Confidence copy is spoken**: the "estimate, not a prediction" disclaimer is in
+  the reading order — the projection's uncertainty is never visual-only.
+- **Switch Control / Full Keyboard Access:** the toggle, horizon stepper, inspect
+  picker, "View as table", and contribution/growth editors are all reachable and
+  operable without gestures.
+- **Contrast:** the dashed purple projection line meets ≥ 3:1 as a UI stroke; all
+  captions/headline/disclaimer meet ≥ 4.5:1 across light, dark, and high-contrast
+  ([data-visualization §2.5](./data-visualization.md)).
+
+---
+
+## 7. Dynamic Type
+
+- **No hardcoded font sizes.** Headline reuses `CurrencyLabel`; the confidence copy
+  uses `.footnote`/`.caption`; axis annotations `.caption2`; the horizon control
+  labels scale. All scale through AX1–AX5.
+- **Layout reflow.** At `accessibility1`+ the horizon control wraps or becomes a
+  scrollable segment row (never truncates "to FI"); the contribution editor moves
+  to its own row via `ViewThatFits`. The "View as table" rows wrap value + split.
+- **Confidence copy never clips** — it wraps to as many lines as needed and is
+  verified visible at AX5 in [§12](#12-test-plan). Chart height is fixed (card),
+  but surrounding text grows the card vertically.
+
+---
+
+## 8. Privacy: Balance Hiding
+
+- When balance-hiding is active, the **headline future figure, today's figure,
+  callout values, table values, FI-target amount, and the audio-graph text** are
+  masked ("•••••"). The **projection shape** may remain (it reveals no absolute
+  amount) — default: keep the silhouette, mask all numbers — with the same
+  optional "blur the line" setting offered by the trend chart.
+- **The contribution and growth assumptions** (e.g., "$1,500/mo", "5%") are
+  treated as balances for masking purposes where they reveal cash position; the
+  growth **percentage** may remain. Default: mask the dollar contribution, keep the
+  percentage. (Confirm with privacy owners — [§14](#14-open-questions).)
+- **Accessibility parity:** masked numbers are masked in the VoiceOver description
+  and `AXChartDescriptor` too ("Net worth hidden") — never speak a hidden balance.
+  "View as table" shows the same mask.
+- **App-switcher redaction:** participates in the existing privacy-screen snapshot
+  behavior.
+- **Logging:** never log series or projected values. Per `os.Logger` rules,
+  balances are `.private`; log only `.public` events ("projection shown,
+  horizon=10Y, points=120") — counts/horizons, never an amount.
+
+---
+
+## 9. States: Empty, Loading, Stale & Error
+
+| State       | Trigger                                                       | Presentation                                                                                                                                                              |
+| ----------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Loading** | History or projection inputs not yet resolved                 | History renders if ready; projection area shows a shimmer (static under Reduce Motion). `.accessibilityLabel("Calculating projection")`.                                  |
+| **Empty**   | No current net worth / no contribution basis (brand-new user) | Projection hidden; show a prompt "Add accounts and a monthly contribution to see a projection." The historical card (if any) still shows. No fabricated contribution.     |
+| **Stale**   | Starting point derived from a cached/offline snapshot         | Project from the cached "today" + a caption "Projection from data as of {relative time}"; reuse [`OfflineBanner`](../../apps/ios/Finance/Components/OfflineBanner.swift). |
+| **Error**   | Projection computation/load fails                             | Inline, card-scoped "Couldn't build projection" + Retry; history and the rest of the surface stay usable. Logs `error.localizedDescription` `.public` only.               |
+
+- **Empty asks, never assumes a contribution.** The projection requires a savings
+  pace; if none is known, the surface prompts for it rather than inventing one
+  (financial-advice safety).
+- **Stale is informational** (local-first), consistent with
+  [ios-net-worth-trend-chart.md §8](./ios-net-worth-trend-chart.md).
+- **Errors are card-scoped** — a failed projection never hides the historical
+  trend or the rest of the dashboard/FIRE screen.
+
+---
+
+## 10. Affected Surfaces & Shared Dependencies
+
+### 10.1 iOS surfaces (all in `apps/ios/`, owned by @ios-engineer)
+
+| Surface                                                          | Change                                                                                                                           |
+| ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `Finance/Charts/NetWorthProjectionOverlay.swift` **(new)**       | The dashed projection line + band + today divider + FI-target rule + scrub callout, layered on `NetWorthTrendChart`.             |
+| `Finance/ViewModels/NetWorthProjectionViewModel.swift` **(new)** | `@Observable` VM: holds contribution/growth/horizon, derives forecast points via the bridge, owns inspection + states.           |
+| `Finance/Charts/NetWorthProjectionDescription.swift` **(new)**   | Pure helper building the estimate-framed audio-graph text + `AXChartDescriptor` (history + projection series).                   |
+| `Finance/Charts/NetWorthTrendCard.swift` **(modify)**            | Add a "Show projection" toggle + horizon/contribution controls + "View as table" for future rows (extends the trend-chart card). |
+| `Finance/Screens/FIResultsSection.swift` **(modify)**            | Embed the overlay beneath the FIRE result cards with the FI-target line on (links to #2558).                                     |
+| `Finance/KMP/SwiftExportBridge.swift` + protocols **(modify)**   | Expose `projectNetWorth(...)` returning Swift-native forecast points (see [§11](#11-native--shared-boundary)).                   |
+| `Finance/KMP/StubSwiftExportBridge.swift` **(modify)**           | Stub `projectNetWorth` for previews/tests.                                                                                       |
+| `Finance/Resources/*.lproj/Localizable.strings` **(modify)**     | New localized strings (headline, horizon labels, confidence copy, table headers, masks).                                         |
+
+### 10.2 Shared dependencies (KMP — **not edited by this design**)
+
+- **Historical series** — `ReportGenerator.netWorthOverTime(...)` and
+  [`NetWorthSnapshot`](../../packages/core/src/commonMain/kotlin/com/finance/core/analytics/NetWorthSnapshot.kt)
+  **already exist** in `packages/core` (consumed by the trend chart) and provide
+  the starting point + history.
+- **Projection math** — `projectNetWorth(starting, monthlyContribution, growth,
+months, startMonth)` (contribution + compounding), canonical TypeScript
+  reference today in
+  [`apps/web/src/lib/investment/net-worth-projection.ts`](../../apps/web/src/lib/investment/net-worth-projection.ts).
+  Its **platform-neutral home is `packages/core`**, re-exported via the Swift
+  Export bridge.
+- **Money/locale formatting** — the shared currency formatter module.
+
+> **The forward `projectNetWorth` model is not yet in `packages/core` (KMP)** (the
+> historical `netWorthOverTime` is). Porting it from the web reference (parity with
+> `net-worth-projection.test.ts`) and re-exporting via `packages/sync` is a
+> `packages/` change **owned by @kmp-engineer and proposed via ADR** — iOS must
+> not implement the math or edit `packages/`. The overlay binds to a Swift-native
+> `NetWorthProjectionBridge` stub, so it is buildable/testable now (see
+> [§11](#11-native--shared-boundary), [§13](#13-implementation-readiness)).
+
+---
+
+## 11. Native ↔ Shared Boundary
+
+```mermaid
+flowchart LR
+    subgraph shared["packages/core (KMP — netWorthOverTime exists; projectNetWorth port via ADR)"]
+        A["ReportGenerator.netWorthOverTime()"] --> B["history: List&lt;NetWorthSnapshot&gt;"]
+        H["NetWorthProjection.projectNetWorth(start, contribution, growth, months)"] --> I["forecast: List&lt;NetWorthForecastPoint&gt;"]
+    end
+    subgraph bridge["packages/sync (Swift Export — ADR for projectNetWorth)"]
+        B --> C["[NetWorthTrendPoint] (Int64, Date)"]
+        I --> J["[NetWorthForecastPoint] (Int64 value/contribution/growth, Date)"]
+    end
+    subgraph ios["apps/ios (this PR — @ios-engineer)"]
+        C --> D["NetWorthProjectionViewModel"]
+        J --> D
+        D --> E["NetWorthProjectionOverlay (dashed line + band + divider + scrub)"]
+        D --> F["AXChartDescriptor + audio-graph text + 'View as table'"]
+    end
+```
+
+**Responsibilities**
+
+| Concern                                                               | Layer                                 |
+| --------------------------------------------------------------------- | ------------------------------------- |
+| Historical net-worth series + starting "today" value                  | `packages/core` (exists)              |
+| Contribution-paced compounding projection (`projectNetWorth`)         | `packages/core` (port via ADR)        |
+| Optimistic/conservative band pace (return ± spread)                   | `packages/core` (two projection runs) |
+| Type mapping (`Cents`→`Int64`, `LocalDate`/month→`Date`)              | Swift Export bridge                   |
+| Horizon windowing, contribution/growth editing, debounce              | iOS (`NetWorthProjectionViewModel`)   |
+| Dashed/band/divider visuals, scrub, Reduce Motion, Dynamic Type       | iOS                                   |
+| Estimate-framed audio-graph text + `AXChartDescriptor` + table        | iOS (a11y semantics)                  |
+| Confidence copy, "projection not prediction", non-judgmental phrasing | iOS (content semantics)               |
+
+- **iOS does not compute the projection.** It supplies starting value,
+  contribution, growth, and horizon, and renders the returned forecast points. The
+  band is two shared runs (conservative/optimistic), not an iOS-side formula.
+- **Shared approximation caveat carried verbatim.** The historical series'
+  back-cast approximation (documented for the trend chart) and the projection's
+  simple-growth assumption are **shared behavior**, surfaced honestly in the
+  confidence copy — iOS must not "correct" them locally.
+
+---
+
+## 12. Test Plan
+
+### 12.1 Shared (KMP) — verify/port parity, not re-implement here
+
+- Ported `NetWorthProjectionTest` (KMP) mirrors the web
+  `net-worth-projection.test.ts`: monotonic growth with positive contribution;
+  `max(0, …)` growth guard (no growth on negative net worth); correct
+  month stepping and contribution/growth attribution per point; zero-growth →
+  pure contribution accumulation. **@kmp-engineer via ADR**, not this PR.
+- `netWorthOverTime` history coverage already exists (per the trend-chart design)
+  — verify, don't duplicate.
+
+### 12.2 Bridge
+
+- `SwiftExportBridgeTests`: `projectNetWorth` maps `Cents → Int64` value /
+  contribution / growth and month → `Date`; returns oldest-first; round-trips a
+  zero-horizon (empty) request.
+
+### 12.3 iOS unit (XCTest, `apps/ios/Tests/`)
+
+1. **`NetWorthProjectionViewModelTests`**
+   - Horizon: 1Y/5Y/10Y produce the correct point counts; "to FI" extends until the
+     FI target is crossed (or caps at the max horizon with a "beyond horizon"
+     flag); changing horizon performs no extra bridge call beyond the needed window
+     (spy bridge).
+   - Inspection: selecting a month (via picker, **not** drag) yields the right
+     projected value + contribution/growth split.
+   - States: no contribution basis → `.empty`; bridge throw → `.error`; cached
+     start → `.stale` with an "as of" timestamp.
+   - Live re-pacing: changing contribution/growth re-derives the forecast
+     (debounced; assert coalesced call count).
+2. **`NetWorthProjectionDescriptionTests`** (pure, no UI)
+   - Description includes today, horizon value, the **estimate/"not a prediction"**
+     framing, and (when present) the FI target + projected FI date; declines/low
+     pace phrased non-judgmentally; **privacy mode → masked** with no amounts.
+   - `AXChartDescriptor` exposes both series; projection points are labeled
+     "projected".
+
+### 12.4 iOS UI / a11y (`apps/ios/Tests/UITests/`)
+
+3. **`NetWorthProjectionUITests`**
+   - Toggling "Show projection" reveals the dashed line, band, and today divider;
+     the confidence copy is present.
+   - **Non-gesture:** the horizon stepper and "Inspect month" picker change the
+     read-out value **without any drag**; "View as table" lists every projected
+     month.
+   - **VoiceOver:** the container label is estimate-framed; per-point values say
+     "projected"; the disclaimer is in the reading order.
+   - **Dynamic Type:** at AX5 the confidence copy and "to FI" label are
+     untruncated and controls remain operable (reflowed).
+   - **Privacy mode:** headline, callouts, table, and FI-target amounts masked;
+     percentages handled per [§8](#8-privacy-balance-hiding).
+   - **Reduce Motion:** projection appears without sweep; horizon change does not
+     animate.
+
+### 12.5 Gate
+
+`node tools/agent-scripts/pre-push-check.js --fix` (lint + strict-concurrency)
+plus the suites above. `SWIFT_STRICT_CONCURRENCY = complete`: forecast DTOs
+`Sendable`, UI state `@MainActor`.
+
+---
+
+## 13. Implementation Readiness
+
+Per the [Human-Gated Prerequisites runbook](../ops/human-gated-prerequisites.md)
+(§2, _Implementation vs. Distribution decoupling_), the Apple Developer enrollment
+blocker [#1239](https://github.com/jrmoulckers/finance/issues/1239) gates
+**distribution only** — not implementation. This design and its implementation are
+**buildable and testable now**.
+
+### Buildable now (no enrollment, no secrets)
+
+- ✅ **This design doc** — fully unblocked.
+- ✅ The projection overlay, `@Observable` view model, dashed/band/divider Swift
+  Charts visuals, scrub + non-gesture inspection, `AXChartDescriptor`,
+  estimate-framed audio-graph text, and "View as table" — all SwiftUI + Swift
+  concurrency, reusing `PredictionChart` conventions and the existing trend-chart
+  scaffolding.
+- ✅ All unit + UI/a11y tests in [§12](#12-test-plan) in the iOS Simulator.
+- ✅ On-device verification via **free Personal Team signing** (free Apple ID):
+  7-day expiry, ≤ 3 apps/device, no TestFlight/push — fine for verifying this
+  feature.
+- ✅ Against the `StubSwiftExportBridge` `projectNetWorth`, the entire overlay is
+  developable **before** the Kotlin port lands; the historical
+  `netWorthOverTime` it extends already exists in `packages/core`.
+
+### Distribution tail — gated by #1239 (human, not this PR)
+
+- 🔒 App Store / TestFlight builds, release signing, App Store Connect API key,
+  and CI release secrets are **human-gated** (runbook §3.2) and out of scope.
+
+### Dependency note (process gate, not human-gated)
+
+The forward **`projectNetWorth` model must be ported to `packages/core`** from the
+web reference (parity with `net-worth-projection.test.ts`) and **re-exported** via
+the `packages/sync` Swift Export bridge — **@kmp-engineer via ADR**, not this iOS
+PR. The historical series it extends already exists. Until the forward port lands,
+the overlay binds to the stub bridge, so the iOS surface is independently
+developable; only the live projected numbers depend on the shared port.
+
+### Needs Human Action
+
+- None for design **or** iOS implementation up to the distribution boundary. Only
+  TestFlight/App Store shipping is human-gated, tracked by
+  [#1239](https://github.com/jrmoulckers/finance/issues/1239); see
+  [runbook §3.2](../ops/human-gated-prerequisites.md#32-ios-distribution--apple-developer-1239).
+
+---
+
+## 14. Open Questions
+
+1. **Bridge surface:** does `packages/sync` re-export only `netWorthOverTime`, or
+   should the ADR add `projectNetWorth` alongside it (proposed)? Affects whether
+   iOS consumes the shared call or temporarily derives a simple projection locally
+   behind the same protocol.
+2. **Band semantics:** fixed conservative/optimistic spread around the growth rate
+   (proposed) vs. omit the band entirely for v1 to avoid any "confidence interval"
+   misread? Confirm with design/privacy.
+3. **"To FI" horizon cap:** hard-cap at, e.g., 40 years with a "beyond horizon"
+   note (proposed) vs. show the raw crossing even if far out.
+4. **Contribution masking default:** mask the dollar contribution but keep the
+   growth percentage (proposed) — confirm with privacy owners.
+5. **Default visibility:** projection **off** by default on the dashboard card
+   (proposed, history-first) and **on** in the FIRE flow — confirm.


### PR DESCRIPTION
## Summary

Design-only batch (no native build/signing) delivering the iOS
**financial-independence (FI/FIRE)** and **net-worth projection** design across
three related, cross-linked surfaces. These are the iOS counterparts to the
existing web FIRE/projection logic and extend the new
`ios-net-worth-trend-chart.md` design.

Native SwiftUI implementation is **unblocked**: per
[`docs/ops/human-gated-prerequisites.md`](docs/ops/human-gated-prerequisites.md)
(§2, implementation-vs-distribution decoupling), the Apple Developer enrollment
blocker #1239 gates **distribution only**. Everything here is buildable/testable
now via free Personal Team signing.

Closes #2556
Closes #2558
Closes #2564

Part of #2114 · Part of #2116

## Changes

Three new docs under `docs/design/` (no existing files, `packages/`, shared
config, or other platforms touched):

- **`ios-fi-calculator-flow.md`** (#2556) — SwiftUI FI/FIRE calculator screen:
  default assumptions, Advanced progressive disclosure, live SWR/expected-return
  sensitivity controls, and inline non-blocking validation states.
- **`ios-fire-results-goal-integration.md`** (#2558) — result cards for FI
  number, years-to-FI, Coast FI, SWR sensitivity strip, and projected FI date,
  with plain-language VoiceOver explanations and opt-in linking of FI as a goal
  via the existing Goals model/repository.
- **`ios-net-worth-projection-overlay.md`** (#2564) — contribution-paced
  projection overlay on the trend chart: dashed line + assumption band + "today"
  divider, "projection not prediction" confidence copy, point inspection, and
  first-class non-gesture alternatives (horizon stepper, inspect-month picker,
  "View as table", VoiceOver per-point).

Each doc covers: affected iOS surfaces + the native↔shared boundary (FI / SWR /
Coast-FI / compound-growth and `projectNetWorth` math belongs in `packages/core`
via @kmp-engineer ADR — described, not implemented); accessibility with VoiceOver
explanations of estimates; Dynamic Type; privacy/balance-hiding; empty / loading
/ stale / error states; financial-advice safety (everything labeled an estimate
with co-present assumptions + persistent disclaimers); a smallest-tests plan; and
an Implementation Readiness split (buildable now via free Personal Team signing
vs. the distribution tail gated by #1239).

Grounded in existing code: `apps/ios` `TrendChart` / `PredictionChart` /
`ConfidenceIndicatorView` / `ProgressRing` / `GoalItem` / `GoalsViewModel` /
`GoalCreateView`, `packages/core` `NetWorthSnapshot` + `ReportGenerator.netWorthOverTime`,
and the canonical web reference math in `apps/web/src/lib/investment/`.

## Testing

- `npx prettier --check` passes for all three docs.
- Docs-only change — no code, no native build, no signing. Test plans inside each
  doc enumerate the smallest shared (KMP, via @kmp-engineer ADR), bridge, iOS
  unit, and iOS UI/a11y tests for the eventual implementation.
