### PR TITLE
docs(design): android i18n and newcomer education design batch (#2527, #2528, #2535)

### DIFF
--- a/docs/design/android-newcomer-us-finance-education.md
+++ b/docs/design/android-newcomer-us-finance-education.md
@@ -1,0 +1,353 @@
+# Android Newcomer US Finance Education
+
+> **Status:** PROPOSED — Pending human review
+> **Issue:** [#2535](https://github.com/jrmoulckers/finance/issues/2535) · Part of [#2178](https://github.com/jrmoulckers/finance/issues/2178)
+> **Platform:** Android (Compose education modules, onboarding)
+> **Last Updated:** 2026-06-22
+> **Design only:** Native implementation remains blocked by [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+
+---
+
+## Table of Contents
+
+1. [Purpose](#purpose)
+2. [Persona and Why This Matters](#persona-and-why-this-matters)
+3. [Goals and Non-Goals](#goals-and-non-goals)
+4. [Education Modules](#education-modules)
+5. [ITIN-Aware Onboarding](#itin-aware-onboarding)
+6. [Content Model and KMP Boundary](#content-model-and-kmp-boundary)
+7. [Mixed-Income Budgeting](#mixed-income-budgeting)
+8. [Sensitivity, Privacy, and Tone](#sensitivity-privacy-and-tone)
+9. [Localization and Text Expansion](#localization-and-text-expansion)
+10. [Accessibility Considerations](#accessibility-considerations)
+11. [Offline, Empty, and Error States](#offline-empty-and-error-states)
+12. [Test Plan](#test-plan)
+13. [Implementation Readiness](#implementation-readiness)
+14. [References](#references)
+
+---
+
+## Purpose
+
+Newcomers to the US financial system frequently lack the assumed background the
+app silently relies on. A repo scan found **no SSN, ITIN, W-2, 1099, or 401(k)
+educational content**; the existing learning paths in
+[`LearningPathContent.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/learning/LearningPathContent.kt)
+cover general budgeting/investing/debt, and a sample `401(k)` account name exists
+in `SampleData.kt` with no explainer. The onboarding flow is generic and never
+captures whether income is hourly, contract, W-2, or 1099, or whether the user
+has an SSN, an ITIN, or neither.
+
+This document designs **plain-language education modules** (W-2, 1099,
+withholding, 401(k), mixed-income budgeting) and **ITIN-aware onboarding** so the
+app does not assume a salaried, SSN-holding US worker. It is design and breakdown
+only while [#1242](https://github.com/jrmoulckers/finance/issues/1242) gates store
+distribution.
+
+---
+
+## Persona and Why This Matters
+
+The persona ([#2178](https://github.com/jrmoulckers/finance/issues/2178)): a new
+immigrant who may not have an SSN yet, uses an ITIN, works mixed W-2 / 1099 jobs,
+and is encountering 401(k) for the first time. If the app assumes one identity
+path, it quietly excludes many immigrant users. Even simple acknowledgement of
+ITIN and mixed-income realities makes the app feel welcoming and useful. This
+intersects with [Persona 4: Casey](personas.md) on plain-language and
+cognitive-load reduction (see [cognitive-accessibility.md](cognitive-accessibility.md)).
+
+> **Important framing:** this is **financial _education_**, not tax, legal, or
+> immigration _advice_. Every module must say so, link to authoritative primary
+> sources, and avoid prescribing actions. See
+> [Sensitivity, Privacy, and Tone](#sensitivity-privacy-and-tone).
+
+---
+
+## Goals and Non-Goals
+
+**Goals**
+
+- Beginner explainers for **W-2, 1099, withholding, and 401(k)**, written in
+  plain language and translatable.
+- Optional, **non-blocking** onboarding choices: SSN / ITIN / none / prefer not
+  to say; and income type: hourly / salaried / contract / mixed / seasonal.
+- **Mixed-income budgeting** tips for hourly/seasonal/contract earners.
+- Reuse the existing learning-path UI scaffolding rather than inventing a new one.
+
+**Non-Goals**
+
+- Tax filing, tax calculation, or immigration guidance of any kind.
+- Collecting or storing the actual SSN/ITIN _number_ (see privacy section — we
+  store at most a coarse, optional _category_, never the identifier).
+- Editing KMP `packages/*` or non-Android platforms.
+- The general string-migration mechanics (owned by
+  [#2527](android-string-resource-migration-audit.md)) and Spanish copy review
+  (owned by [#2528](android-spanish-education-formatting.md)).
+
+---
+
+## Education Modules
+
+Each module is short, plain-language, and structured like existing learning
+modules (title, body, key takeaways, optional quiz) so it slots into the current
+[`LearningPath`/`LearningModule`](../../apps/android/src/main/kotlin/com/finance/android/ui/learning/LearningPathContent.kt)
+model.
+
+| Module       | One-line scope                                                | Key takeaways focus                                |
+| ------------ | ------------------------------------------------------------- | -------------------------------------------------- |
+| W-2          | What a W-2 is and when/why you get one as an employee.        | Employer reports wages + taxes withheld.           |
+| 1099         | What a 1099 means for contract/gig income.                    | No automatic withholding; you may owe at tax time. |
+| Withholding  | Why money is taken out of a paycheck before you see it.       | Withholding ≠ your final tax; it's a prepayment.   |
+| 401(k)       | What an employer retirement plan is and what "match" means.   | Pre-tax contributions; matching is "free" money.   |
+| Mixed income | Budgeting when income is hourly/seasonal/contract and varies. | Budget from a baseline; smooth irregular income.   |
+
+```mermaid
+flowchart TD
+    HUB[Newcomer US Basics\nlearning path] --> M1[W-2]
+    HUB --> M2[1099]
+    HUB --> M3[Withholding]
+    HUB --> M4[401k]
+    HUB --> M5[Mixed-income budgeting]
+    M1 & M2 & M3 --> XREF[Cross-link: 'how this shows up\nin your transactions']
+    M4 --> SAMPLE[Links the 401k sample account\nto a real explainer]
+```
+
+**Content rules**
+
+- Define the acronym on first use; never assume prior knowledge.
+- Use concrete, low-stakes examples; keep amounts illustrative and obviously
+  fictional (no real or sensitive financial data).
+- Every module ends with "this is general education, not tax advice" and a link
+  to an authoritative source (e.g. IRS) rather than an in-app instruction to act.
+- A short, optional quiz reinforces understanding (reusing the existing
+  `QuizQuestion` model), never gates progress.
+
+---
+
+## ITIN-Aware Onboarding
+
+Onboarding gains **optional** profile questions. They are skippable, editable
+later in settings, and never block account creation.
+
+```mermaid
+flowchart LR
+    START[Start onboarding] --> ID{Tax ID type?\noptional}
+    ID -->|SSN| NEXT
+    ID -->|ITIN| ITINTIP[Show: ITIN-aware tips\n+ link to ITIN basics]
+    ID -->|None / not yet| NONETIP[Reassure: app works without one]
+    ID -->|Prefer not to say| NEXT
+    ITINTIP --> NEXT
+    NONETIP --> NEXT
+    NEXT{Income type?\noptional} -->|Hourly / Seasonal / Contract / Mixed| MIX[Surface mixed-income budgeting]
+    NEXT -->|Salaried| DONE[Continue]
+    MIX --> DONE
+```
+
+- **Choices:** Tax ID = `SSN | ITIN | None/not yet | Prefer not to say`. Income =
+  `Hourly | Salaried | Contract | Mixed | Seasonal | Prefer not to say`.
+- The choice **tailors education and budgeting tips**; it does not unlock or
+  restrict features. "None/not yet" and "Prefer not to say" are first-class paths.
+- Avoid any flow that assumes a standard salaried, SSN-holding worker. Default
+  copy is identity-neutral; tailored tips are additive.
+
+---
+
+## Content Model and KMP Boundary
+
+Education content is _content_, but the app's **finance math and any reusable
+business rules stay in KMP `packages/core`**. Compose renders shared state; it
+does not compute withholding, contributions, or budgets locally.
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages/core (shared · do NOT edit here)"]
+        RULES[Budgeting / income-smoothing rules]
+        I18N[i18n StringProvider + NumberFormatting]
+    end
+    subgraph Android["apps/android (this work)"]
+        CONTENT[Education content records\nW-2 / 1099 / 401k / mixed]
+        UI[Compose learning module UI]
+        ONB[ITIN-aware onboarding UI]
+    end
+    UI --> CONTENT
+    UI --> I18N
+    ONB --> RULES
+    ONB --> I18N
+```
+
+**Content storage decision (to confirm in implementation):**
+
+- Short labels/titles → Android string resources (localizable via
+  [#2527](android-string-resource-migration-audit.md) /
+  [#2528](android-spanish-education-formatting.md)).
+- Long-form module bodies → structured content records (as today's
+  `LearningModule` does) whose **text fields are still resource-backed or
+  translation-managed**, so Spanish coverage is achievable. Long prose as raw
+  Kotlin literals is explicitly disallowed (that is the very anti-pattern
+  [#2166](https://github.com/jrmoulckers/finance/issues/2166) flags).
+- Any numeric example that touches budgeting logic defers to shared KMP rules /
+  [`NumberFormatting`](../../packages/core/src/commonMain/kotlin/com/finance/core/i18n/NumberFormatting.kt);
+  the module never re-implements finance math.
+
+> This document **describes** the boundary. It does not implement KMP changes —
+> `packages/core` is owned by @kmp-engineer.
+
+---
+
+## Mixed-Income Budgeting
+
+For hourly/seasonal/contract earners, the standard "fixed monthly salary"
+assumption breaks. The module (and tailored tips) teach:
+
+- **Budget from a baseline:** plan against a conservative low month, not the best
+  month.
+- **Smooth the peaks:** route surplus from high months into a buffer for lean
+  months.
+- **Set aside for taxes on 1099 income:** because nothing is withheld
+  automatically — framed as education, with a link to authoritative guidance, not
+  a calculated number.
+- **Irregular-income goals:** percentage-of-income contributions rather than
+  fixed amounts.
+
+The underlying smoothing/budget logic, if any is computed, lives in KMP shared
+rules; the Android module renders explanations and the shared state.
+
+---
+
+## Sensitivity, Privacy, and Tone
+
+This content area is high-trust and high-stakes. Non-negotiables:
+
+- **No advice framing.** Every module is labeled financial _education_, not tax,
+  legal, or immigration advice, and links to primary sources (IRS, etc.).
+- **Never store the identifier.** We store at most an optional, coarse _category_
+  (`SSN | ITIN | None | Unspecified`) used to tailor content — **never** the
+  actual SSN/ITIN number. This category is an app-local preference, kept out of
+  logs and analytics.
+- **Never log sensitive data.** Per the observability guardrails, do not log
+  SSN/ITIN/income values; Timber calls must omit them. (The repo's CI sensitive-
+  data check scans code, not docs; the rule still binds the implementation.)
+- **Inclusive, non-judgmental tone** per
+  [content-language-guidelines.md](content-language-guidelines.md): acknowledge
+  ITIN and mixed-income realities as normal, not exceptional.
+- **Skippable and reversible.** All onboarding identity/income questions are
+  optional and editable later.
+
+---
+
+## Localization and Text Expansion
+
+- All module text and onboarding copy are **resource-backed and translatable**,
+  feeding directly into Spanish coverage
+  ([#2528](android-spanish-education-formatting.md)). US tax terms (W-2, 1099)
+  often have no short Spanish equivalent, so expect **25–30%+ expansion**; design
+  modules and onboarding cards to wrap, not clip.
+- Keep acronyms (W-2, 1099, 401(k), ITIN) as-is across languages but localize the
+  surrounding explanation.
+- Validate layouts under the `en-XA` pseudolocale and at `2.0x` font scale.
+
+---
+
+## Accessibility Considerations
+
+- **TalkBack:** every module card, quiz option, and onboarding choice carries a
+  meaningful `contentDescription`; reading order follows the module structure
+  (title → body → takeaways → quiz).
+- **Plain language / cognitive load:** short sentences, one concept per screen,
+  glossary cross-links — aligned with
+  [cognitive-accessibility.md](cognitive-accessibility.md).
+- **Font scaling:** education prose must remain readable and unclipped at 200%
+  font scale; no fixed-height text containers.
+- **Switch Access:** quiz and onboarding controls are reachable and operable via
+  Switch Access with adequate (≥ 48dp) targets.
+- **RTL readiness:** resource-backed text + start/end modifiers keep the modules
+  RTL-safe for future locales; `ar-XB` pseudolocale exercises mirroring.
+- See [accessibility-patterns.md](accessibility-patterns.md) for the underlying
+  patterns.
+
+---
+
+## Offline, Empty, and Error States
+
+- **Offline:** education content is static and must be **fully available
+  offline** — bundle it with the app rather than fetching at read time. A
+  newcomer on a budget device with intermittent data must still learn.
+- **Empty:** if a tailored path has no modules yet for a chosen profile, show a
+  helpful empty state ("more guides coming") rather than a blank screen.
+- **Error:** if onboarding choices fail to persist, fail safe — never block the
+  user from continuing; retry silently and surface a non-judgmental message.
+
+---
+
+## Test Plan
+
+| Layer              | Tooling                         | What it verifies                                                                        |
+| ------------------ | ------------------------------- | --------------------------------------------------------------------------------------- |
+| Unit               | JUnit                           | Each module has title/body/takeaways; profile→tailoring mapping is correct.             |
+| Unit (privacy)     | JUnit                           | Only the coarse category is persisted; no identifier field exists/serializes.           |
+| Compose UI         | `createComposeRule` + semantics | Module + onboarding text and `contentDescription` resolve from resources.               |
+| Snapshot           | Paparazzi                       | W-2/1099/withholding/401(k)/mixed cards + onboarding at `{en, en-XA, es}` × `{1x, 2x}`. |
+| Pseudolocalization | `en-XA` / `ar-XB`               | Expansion + mirroring for long education prose.                                         |
+| Accessibility      | Espresso/Accessibility checks   | TalkBack order, Switch Access reachability, touch targets ≥ 48dp.                       |
+| Behavior           | Espresso                        | All identity/income questions are skippable and editable later.                         |
+
+---
+
+## Implementation Readiness
+
+This is a design artifact. Execution splits into a **buildable-now** tier and a
+**Play-distribution tail** gated by
+[#1242](https://github.com/jrmoulckers/finance/issues/1242). See
+[../ops/human-gated-prerequisites.md](../ops/human-gated-prerequisites.md) and
+[../ops/launch-readiness-plan.md](../ops/launch-readiness-plan.md).
+
+**Buildable now — `assembleDebug` + sideload (no human gate):**
+
+- Author the five education modules as resource-backed content records.
+- Add optional ITIN-aware onboarding choices (category only, never the identifier).
+- Wire tailored tips and the mixed-income budgeting module to shared rules.
+- Verify offline availability, accessibility, and pseudolocale/expansion
+  snapshots on a debug build / emulator.
+
+**Play-distribution tail — human-gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242):**
+
+- Production signing + Play Console listing.
+- Any store-level data-safety / content declarations referencing the optional
+  profile category.
+- Staged rollout / internal testing track.
+
+Everything in the buildable-now tier runs on an emulator with no signing, store
+credentials, or human-gated operations. Spanish rendering of these modules is
+delivered through [#2528](android-spanish-education-formatting.md).
+
+---
+
+## References
+
+**Design docs**
+
+- [android-string-resource-migration-audit.md](android-string-resource-migration-audit.md) — string extraction + lint (#2527)
+- [android-spanish-education-formatting.md](android-spanish-education-formatting.md) — Spanish coverage (#2528)
+- [content-language-guidelines.md](content-language-guidelines.md) — non-judgmental, inclusive copy
+- [accessibility-patterns.md](accessibility-patterns.md) — screen reader, focus, touch targets
+- [cognitive-accessibility.md](cognitive-accessibility.md) — plain-language and load reduction
+- [information-architecture.md](information-architecture.md) — surface and navigation map
+- [ux-principles.md](ux-principles.md) — product UX principles
+- [personas.md](personas.md) — Persona 4 (Casey), accessibility-first
+
+**Ops**
+
+- [../ops/human-gated-prerequisites.md](../ops/human-gated-prerequisites.md) — buildable-now vs. gated split
+- [../ops/launch-readiness-plan.md](../ops/launch-readiness-plan.md) — launch checklist
+
+**Android / KMP (read-only boundary)**
+
+- [`LearningPathContent.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/learning/LearningPathContent.kt) — existing module model
+- [`FinancialConceptContent.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/education/FinancialConceptContent.kt) — existing glossary content
+- [`NumberFormatting.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/i18n/NumberFormatting.kt) — shared formatting (owned by @kmp-engineer)
+
+**Issues**
+
+- [#2535](https://github.com/jrmoulckers/finance/issues/2535) — this issue
+- [#2178](https://github.com/jrmoulckers/finance/issues/2178) — parent (ITIN-aware onboarding + US basics)
+- [#1242](https://github.com/jrmoulckers/finance/issues/1242) — Play Console + keystore (gate)

--- a/docs/design/android-spanish-education-formatting.md
+++ b/docs/design/android-spanish-education-formatting.md
@@ -1,0 +1,367 @@
+# Android Spanish Education and Formatting Coverage
+
+> **Status:** PROPOSED — Pending human review
+> **Issue:** [#2528](https://github.com/jrmoulckers/finance/issues/2528) · Part of [#2166](https://github.com/jrmoulckers/finance/issues/2166)
+> **Platform:** Android (Compose, Glance widgets, receipt OCR, settings)
+> **Last Updated:** 2026-06-22
+> **Design only:** Native implementation remains blocked by [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+
+---
+
+## Table of Contents
+
+1. [Purpose](#purpose)
+2. [Persona and Why This Matters](#persona-and-why-this-matters)
+3. [Goals and Non-Goals](#goals-and-non-goals)
+4. [Coverage Map](#coverage-map)
+5. [Architecture Boundary: Formatting Lives in KMP](#architecture-boundary-formatting-lives-in-kmp)
+6. [Locale-Aware Formatting](#locale-aware-formatting)
+7. [Translation Workflow](#translation-workflow)
+8. [Text Expansion Considerations](#text-expansion-considerations)
+9. [Accessibility Considerations](#accessibility-considerations)
+10. [Offline, Empty, and Error States](#offline-empty-and-error-states)
+11. [Receipt OCR and Settings Specifics](#receipt-ocr-and-settings-specifics)
+12. [Test Plan](#test-plan)
+13. [Implementation Readiness](#implementation-readiness)
+14. [References](#references)
+
+---
+
+## Purpose
+
+Spanish resources already exist in
+[`values-es/strings.xml`](../../apps/android/src/main/res/values-es/strings.xml),
+but they rarely reach the screen because the UI is hardcoded in English (see the
+[string-resource migration audit](android-string-resource-migration-audit.md),
+#2527). This document designs **complete Spanish coverage** across the surfaces a
+Spanish-preferred user actually touches — finance education, onboarding, widgets,
+receipt OCR, settings — and the **locale-aware formatting** that must accompany
+the words.
+
+The guiding rule from [#2166](https://github.com/jrmoulckers/finance/issues/2166):
+**a screen that switches between Spanish and English mid-flow is a bug.** Coverage
+is measured end-to-end per user journey, not per string.
+
+---
+
+## Persona and Why This Matters
+
+The driving persona ([#2166](https://github.com/jrmoulckers/finance/issues/2166)):
+a 35-year-old who moved from Mexico two years ago, uses a budget Samsung Galaxy
+A14, and prefers Spanish for financial terms. Financial terminology is already
+stressful; mixing languages mid-flow erodes trust and increases mistakes. This
+aligns with [Persona 4: Casey](personas.md) on the accessibility-first axis —
+clarity and predictability reduce cognitive load (see
+[cognitive-accessibility.md](cognitive-accessibility.md)).
+
+---
+
+## Goals and Non-Goals
+
+**Goals**
+
+- Define Spanish coverage targets per journey: transaction entry, sync, education
+  / glossary, onboarding, widgets, receipt OCR, and settings.
+- Specify **locale-aware formatting** (currency, numbers, dates, percentages)
+  that is correct for `es` / `es-MX` users.
+- Define a translation workflow and a "no mixed-language journey" acceptance bar.
+- Respect the architecture boundary: **formatting and terminology rules live in
+  KMP `packages/core`**; Android renders the results.
+
+**Non-Goals**
+
+- The string-extraction mechanics and lint gate (owned by
+  [#2527](android-string-resource-migration-audit.md)).
+- Newcomer-specific US finance modules (owned by
+  [#2535](android-newcomer-us-finance-education.md)); this doc covers their
+  Spanish rendering, not their authoring.
+- Editing KMP `packages/*` or any non-Android platform.
+- Play Store listing localization (gated by
+  [#1242](https://github.com/jrmoulckers/finance/issues/1242)).
+
+---
+
+## Coverage Map
+
+Coverage is tracked per surface and per journey. A surface is "covered" only when
+every visible string **and** every `contentDescription` resolve from Spanish
+resources at the active locale.
+
+| Surface              | Spanish copy                    | Locale-aware formatting           | Owner of formatting logic  |
+| -------------------- | ------------------------------- | --------------------------------- | -------------------------- |
+| Onboarding           | `strings.xml`                   | Dates, currency previews          | KMP `packages/core`        |
+| Transaction entry    | `strings.xml`                   | Amount input, currency symbol     | KMP `NumberFormatting`     |
+| Sync status          | `strings.xml`                   | Relative timestamps               | KMP + Android `Context`    |
+| Education / glossary | `strings.xml` / content records | Inline amounts in examples        | KMP                        |
+| Glance widgets       | `strings.xml`                   | Balance + budget %                | KMP `NumberFormatting`     |
+| Receipt OCR          | `strings.xml`                   | Parsed amount/date normalization  | KMP (parse) + Android (UI) |
+| Settings             | `strings.xml`                   | Language picker, regional formats | Android + KMP              |
+
+```mermaid
+flowchart TD
+    J[User journey in Spanish] --> S1[Onboarding]
+    J --> S2[Transaction entry]
+    J --> S3[Sync status]
+    J --> S4[Education / glossary]
+    J --> S5[Glance widget]
+    J --> S6[Receipt OCR]
+    J --> S7[Settings]
+    S1 & S2 & S3 & S4 & S5 & S6 & S7 --> G{Every string + a11y\nresolves in es?}
+    G -->|yes| OK[Journey covered]
+    G -->|no| BUG[Mixed-language = bug]
+```
+
+---
+
+## Architecture Boundary: Formatting Lives in KMP
+
+Currency, number, and percentage formatting are **business rules**, not UI
+concerns. They live in KMP `packages/core` and are shared across platforms so
+that "$1,234.56" vs. "1.234,56 $" is decided once, consistently.
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages/core (shared · do NOT edit here)"]
+        NF[NumberFormatting\nformatCents / formatPercent]
+        SP[StringProvider\nfallback chain]
+        LOC[Locale es / es-MX]
+    end
+    subgraph Android["apps/android (this work)"]
+        VM[ViewModel renders shared state]
+        UI[Compose / Glance]
+        RES[values-es/strings.xml]
+    end
+    VM --> NF
+    VM --> SP
+    SP --> LOC
+    UI --> RES
+    VM --> UI
+```
+
+- Composables call into the shared layer for any amount/date/percent rendering;
+  they never re-implement formatting locally.
+- The KMP [`NumberFormatting`](../../packages/core/src/commonMain/kotlin/com/finance/core/i18n/NumberFormatting.kt)
+  baseline already knows `MXN → "MX$"`. Platform apps **may** delegate to
+  `java.text.NumberFormat`/`android.icu` for full locale fidelity (grouping
+  separators, decimal commas), but the _decision of which formatter and which
+  locale_ remains shared state, not a Compose detail.
+- The KMP [`Locale`](../../packages/core/src/commonMain/kotlin/com/finance/core/i18n/Locale.kt)
+  type already models `es` and `es-MX`; Android maps the user's per-app language
+  selection onto it.
+
+> This document **describes** the boundary. It does not implement KMP changes —
+> `packages/core` is owned by @kmp-engineer.
+
+---
+
+## Locale-Aware Formatting
+
+Words alone are not "Spanish coverage." A Spanish user expects regionally correct
+formatting. The following must be verified per locale:
+
+| Element    | `en-US`        | `es-MX` (example)          | Notes                                                         |
+| ---------- | -------------- | -------------------------- | ------------------------------------------------------------- |
+| Currency   | `$1,234.56`    | `$1,234.56` (MXN as `MX$`) | Symbol + grouping/decimal separators are locale-driven.       |
+| Percentage | `75.5%`        | `75,5 %`                   | Some `es` locales use a comma decimal and a space before `%`. |
+| Date       | `Jun 22, 2026` | `22 jun 2026`              | Day-first ordering; month abbreviations localized.            |
+| Large nums | `1,000,000`    | `1.000.000`                | Grouping separator differs; never hardcode `,`.               |
+| Relative   | `2 hours ago`  | `hace 2 horas`             | Sync timestamps must localize, not just translate the noun.   |
+
+Rules:
+
+- **Never** build amount strings via interpolation in Compose
+  (`"$" + value`). Route through the shared formatter so separators and symbol
+  placement follow the locale.
+- **Decimal-comma locales** must round-trip in the **transaction amount input**:
+  parsing "1.234,56" must yield the same `Cents` as "1234.56". The parse rule is
+  shared (KMP), the keyboard/IME affordance is Android.
+- **Receipt OCR** normalizes parsed amounts/dates to the canonical `Cents`/ISO
+  representation in the shared layer before display, so a receipt scanned in any
+  format renders consistently in the user's locale.
+
+---
+
+## Translation Workflow
+
+```mermaid
+flowchart LR
+    EN[values/strings.xml\nEnglish source of truth] --> EXTRACT[New keys from #2527 migration]
+    EXTRACT --> TODO[values-es: key marked pending]
+    TODO --> TRANS[Translate + review\nnative Spanish reviewer]
+    TRANS --> PSEUDO[en-XA pseudolocale\nlayout check]
+    PSEUDO --> SNAP[Paparazzi es snapshot]
+    SNAP --> DONE[Journey marked covered]
+```
+
+- English `values/strings.xml` is the **source of truth**; every key added by the
+  [#2527](android-string-resource-migration-audit.md) migration appears in
+  `values-es` as `pending` until translated.
+- Translations are reviewed by a native Spanish speaker for **financial-term
+  accuracy** (e.g. "saldo," "presupuesto," "movimiento") and for the
+  non-judgmental tone in [content-language-guidelines.md](content-language-guidelines.md).
+- A **missing-translation report** (diff of `values` vs. `values-es` keys) runs
+  in CI; any key present in English but missing/`pending` in Spanish fails the
+  coverage check for that journey.
+- The KMP fallback chain
+  ([`StringProvider`](../../packages/core/src/commonMain/kotlin/com/finance/core/i18n/StringProvider.kt))
+  means a missing key degrades to English rather than crashing — useful in dev,
+  but **not acceptable as a shipped state** for an in-scope journey.
+
+---
+
+## Text Expansion Considerations
+
+Spanish copy runs **~25–30% longer than English** (occasionally more for
+finance phrases that lack a short Spanish equivalent). Every Spanish surface must
+be validated for expansion:
+
+- Snapshot each covered screen in `es` **and** `en-XA` (the pseudolocale pads and
+  accents text to simulate expansion) at `1.0x` and `2.0x` font scale.
+- Buttons, chips, and tab labels are the most fragile — design for two-line wrap
+  or icon+label fallbacks rather than truncation.
+- Glance widgets have tight, fixed real estate; prioritize abbreviation rules
+  (shared in KMP) over clipping, and expose the full value to TalkBack.
+- This 25–30% budget is shared with the
+  [migration audit](android-string-resource-migration-audit.md#text-expansion-and-layout-resilience).
+
+---
+
+## Accessibility Considerations
+
+- **TalkBack in Spanish:** `contentDescription` strings must be translated too —
+  an English description on a Spanish screen is a coverage bug. Use `a11y_*`
+  keys (matching existing `values-es` conventions like
+  `a11y_add_new_transaction`).
+- **Pronunciation:** ensure TalkBack reads amounts and dates using the localized
+  formatted string, not a raw numeric literal, so currency and separators are
+  spoken naturally in Spanish.
+- **Font scaling:** Spanish + 2.0x font scale is the worst-case layout; it must
+  not clip. Combine the expansion and font-scale axes in snapshots.
+- **RTL readiness:** Spanish is LTR, but routing everything through resources and
+  start/end modifiers keeps the pipeline RTL-safe for future locales; `ar-XB`
+  pseudolocale exercises mirroring in CI.
+- Follow [accessibility-patterns.md](accessibility-patterns.md) for focus order,
+  touch targets (≥ 48dp), and screen-reader semantics.
+
+---
+
+## Offline, Empty, and Error States
+
+- **Offline:** the offline/sync banner is high-frequency for users on budget
+  devices and intermittent data; it must be fully Spanish, including relative
+  timestamps ("hace 2 horas").
+- **Empty:** empty states (no transactions, no accounts, no budgets) often ship
+  last; here they are explicitly in scope, with translated illustration
+  `contentDescription`s.
+- **Error:** validation and failure copy must be Spanish and follow "inform, then
+  offer an action." Map shared error concepts to the KMP
+  [`Strings.ERROR_*`](../../packages/core/src/commonMain/kotlin/com/finance/core/i18n/Strings.kt)
+  vocabulary so phrasing stays consistent across platforms.
+- **Receipt OCR failure:** "couldn't read this receipt" and the manual-entry
+  fallback must be Spanish, with the parsed-but-uncertain fields clearly marked.
+
+---
+
+## Receipt OCR and Settings Specifics
+
+**Receipt OCR**
+
+- OCR text recognition runs on-device; the _parsing_ of amounts/dates into
+  canonical `Cents`/ISO form is shared (KMP). The **review UI** (confirm amount,
+  category, date) is Android and must be fully Spanish.
+- Decimal-comma and day-first receipts must parse correctly; surface low-
+  confidence fields for user confirmation rather than guessing silently.
+
+**Settings**
+
+- A **per-app language** control (Android 13+ per-app languages;
+  `LocaleManager`/`AppCompatDelegate`) lets the user choose Spanish without
+  changing the whole device — critical for the "don't force me back into English"
+  requirement.
+- Regional format preferences (currency display, first day of week) read from the
+  shared locale and render via the shared formatter.
+- The language picker itself and its `contentDescription`s are localized.
+
+---
+
+## Test Plan
+
+| Layer              | Tooling                           | What it verifies                                                                 |
+| ------------------ | --------------------------------- | -------------------------------------------------------------------------------- |
+| Unit (formatting)  | JUnit (Android) over shared API   | `es-MX` currency/percent/date format correctly; decimal-comma parse round-trips. |
+| Unit (coverage)    | Keys diff `values` vs `values-es` | No English-only keys remain for an in-scope journey.                             |
+| Compose UI         | `createComposeRule` + semantics   | Visible text + `contentDescription` resolve in `es`, not English.                |
+| Snapshot           | Paparazzi                         | `es` and `en-XA` render without clipping at 1x/2x font for each journey.         |
+| Pseudolocalization | `en-XA` / `ar-XB`                 | Expansion + mirroring exercised without waiting on real translations.            |
+| End-to-end journey | Espresso (es locale)              | A full journey (onboard → add txn → view widget) shows zero English.             |
+
+**Coverage acceptance bar:** a journey passes only when the journey-level E2E and
+the key-diff both show **zero English leakage**. Per-string translation is
+necessary but not sufficient.
+
+---
+
+## Implementation Readiness
+
+This is a design artifact. Execution splits into a **buildable-now** tier and a
+**Play-distribution tail** gated by
+[#1242](https://github.com/jrmoulckers/finance/issues/1242). See
+[../ops/human-gated-prerequisites.md](../ops/human-gated-prerequisites.md) and
+[../ops/launch-readiness-plan.md](../ops/launch-readiness-plan.md).
+
+**Buildable now — `assembleDebug` + sideload (no human gate):**
+
+- Spanish translation of all extracted keys (depends on
+  [#2527](android-string-resource-migration-audit.md) extraction).
+- Locale-aware formatting wired through the shared layer and verified on a debug
+  build / emulator set to `es-MX`.
+- Per-app language picker in settings, testable without the Play Store.
+- Pseudolocale (`en-XA`) expansion snapshots and the `values`/`values-es`
+  key-diff coverage check.
+
+**Play-distribution tail — human-gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242):**
+
+- Spanish Play Store listing (title, description, screenshots) and store-level
+  language declarations.
+- Signing + internal testing track for the localized build.
+
+Everything in the buildable-now tier is exercisable today on an emulator with the
+device or per-app language set to Spanish — no signing, store credentials, or
+human-gated operations.
+
+---
+
+## References
+
+**Design docs**
+
+- [android-string-resource-migration-audit.md](android-string-resource-migration-audit.md) — string extraction + lint (#2527)
+- [android-newcomer-us-finance-education.md](android-newcomer-us-finance-education.md) — newcomer modules (#2535)
+- [content-language-guidelines.md](content-language-guidelines.md) — non-judgmental copy
+- [accessibility-patterns.md](accessibility-patterns.md) — screen reader, focus, touch targets
+- [cognitive-accessibility.md](cognitive-accessibility.md) — plain-language and load reduction
+- [information-architecture.md](information-architecture.md) — surface and navigation map
+- [ux-principles.md](ux-principles.md) — product UX principles
+- [personas.md](personas.md) — Persona 4 (Casey), accessibility-first
+
+**Ops**
+
+- [../ops/human-gated-prerequisites.md](../ops/human-gated-prerequisites.md) — buildable-now vs. gated split
+- [../ops/launch-readiness-plan.md](../ops/launch-readiness-plan.md) — launch checklist
+
+**KMP i18n (read-only boundary — owned by @kmp-engineer)**
+
+- [`StringProvider.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/i18n/StringProvider.kt)
+- [`NumberFormatting.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/i18n/NumberFormatting.kt)
+- [`Locale.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/i18n/Locale.kt)
+- [`Strings.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/i18n/Strings.kt)
+
+**Android resources**
+
+- [`values-es/strings.xml`](../../apps/android/src/main/res/values-es/strings.xml) — existing Spanish bundle
+
+**Issues**
+
+- [#2528](https://github.com/jrmoulckers/finance/issues/2528) — this issue
+- [#2166](https://github.com/jrmoulckers/finance/issues/2166) — parent (Spanish-preferred localization)
+- [#1242](https://github.com/jrmoulckers/finance/issues/1242) — Play Console + keystore (gate)

--- a/docs/design/android-string-resource-migration-audit.md
+++ b/docs/design/android-string-resource-migration-audit.md
@@ -1,0 +1,382 @@
+# Android Compose String-Resource Migration Audit
+
+> **Status:** PROPOSED — Pending human review
+> **Issue:** [#2527](https://github.com/jrmoulckers/finance/issues/2527) · Part of [#2166](https://github.com/jrmoulckers/finance/issues/2166)
+> **Platform:** Android (Jetpack Compose, Glance widgets, notifications)
+> **Last Updated:** 2026-06-22
+> **Design only:** Native implementation remains blocked by [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+
+---
+
+## Table of Contents
+
+1. [Purpose](#purpose)
+2. [Problem Statement](#problem-statement)
+3. [Goals and Non-Goals](#goals-and-non-goals)
+4. [Architecture Boundary: KMP vs. Android Resources](#architecture-boundary-kmp-vs-android-resources)
+5. [Audit Inventory](#audit-inventory)
+6. [Migration Strategy](#migration-strategy)
+7. [Lint Gates](#lint-gates)
+8. [Accessibility Considerations](#accessibility-considerations)
+9. [Text Expansion and Layout Resilience](#text-expansion-and-layout-resilience)
+10. [Offline, Empty, and Error States](#offline-empty-and-error-states)
+11. [Test Plan](#test-plan)
+12. [Implementation Readiness](#implementation-readiness)
+13. [References](#references)
+
+---
+
+## Purpose
+
+The Android client currently renders user-facing copy as hardcoded Kotlin string
+literals inside Composables, Glance widgets, and notification builders. A grep
+across `apps/android/src/main/kotlin` finds **no `stringResource(...)` usage at
+all**, which means localized resources (including the existing
+[`values-es/strings.xml`](../../apps/android/src/main/res/values-es/strings.xml))
+never reach the screen.
+
+This document is the **migration audit and plan**: it inventories the hardcoded
+surfaces, defines the target architecture, and specifies lint gates that prevent
+regressions. It is a design and breakdown artifact only — no native code is
+written here while [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+(Play Console + signing) gates store distribution.
+
+This work unblocks [#2528 (Spanish coverage)](android-spanish-education-formatting.md)
+and [#2535 (newcomer education)](android-newcomer-us-finance-education.md): both
+depend on a string-resource pipeline existing first.
+
+---
+
+## Problem Statement
+
+| Symptom                          | Evidence                                                                           | Impact                                                             |
+| -------------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| Hardcoded English in Composables | `TransactionCreateScreen.kt`, `CurrencyConversionScreen.kt`, `SyncStatusScreen.kt` | Spanish users see mixed-language screens; trust drops.             |
+| Hardcoded education content      | `FinancialConceptContent.kt`, `LearningPathContent.kt`                             | Glossary and learning paths are English-only and untranslatable.   |
+| No `stringResource()` usage      | Repo-wide grep returns zero hits                                                   | Translations in `values-es/strings.xml` are never displayed.       |
+| No lint gate                     | No Compose/Glance hardcoded-string detector configured                             | New literals slip in continuously; the backlog grows every sprint. |
+
+The product principle is explicit: **mixed-language screens are bugs, not
+acceptable fallback behavior** (see [#2166](https://github.com/jrmoulckers/finance/issues/2166)).
+
+---
+
+## Goals and Non-Goals
+
+**Goals**
+
+- Produce a complete inventory of hardcoded user-facing text on Android.
+- Define a phased migration to Android string resources + the KMP i18n layer.
+- Specify a lint gate (Android Lint `HardcodedText` + a Compose-aware custom
+  rule) so the zero-`stringResource` regression cannot recur.
+- Preserve the **separation of concerns**: finance math and terminology rules
+  live in KMP `packages/core`; Compose only renders shared state.
+
+**Non-Goals**
+
+- Translating strings (owned by [#2528](android-spanish-education-formatting.md)).
+- Authoring new education modules (owned by [#2535](android-newcomer-us-finance-education.md)).
+- Editing KMP `packages/*` or any platform other than Android.
+- Shipping to Google Play (blocked by [#1242](https://github.com/jrmoulckers/finance/issues/1242)).
+
+---
+
+## Architecture Boundary: KMP vs. Android Resources
+
+Two complementary localization systems coexist. The audit must route each string
+to the correct layer rather than collapsing them.
+
+```mermaid
+flowchart TD
+    subgraph KMP["packages/core · i18n (shared, do NOT edit here)"]
+        SP[StringProvider]
+        SB[StringBundle / StringKey]
+        NF[NumberFormatting]
+        ES[EnglishStrings fallback]
+    end
+    subgraph Android["apps/android (this work)"]
+        RES[res/values*/strings.xml]
+        SR["stringResource(R.string.*)"]
+        VM[ViewModel: shared state]
+        UI[Composable / Glance / Notification]
+    end
+    VM -->|domain terms, formatting rules| SP
+    SP --> SB
+    SP --> NF
+    SP --> ES
+    UI -->|chrome, labels, a11y descriptions| SR
+    SR --> RES
+    VM --> UI
+```
+
+**Routing rule of thumb:**
+
+- **Android `strings.xml`** owns UI chrome, button labels, screen titles,
+  `contentDescription` text, notification titles/bodies, and Glance widget
+  labels — anything the platform localizes by resource qualifier
+  (`values-es`, `values-night`, etc.).
+- **KMP `packages/core` i18n** owns _domain terminology and formatting rules_:
+  budget status vocabulary, currency/number formatting
+  ([`NumberFormatting`](../../packages/core/src/commonMain/kotlin/com/finance/core/i18n/NumberFormatting.kt)),
+  and the cross-platform fallback chain
+  ([`StringProvider`](../../packages/core/src/commonMain/kotlin/com/finance/core/i18n/StringProvider.kt)).
+  Composables render the resulting strings; they never compute amounts or invent
+  financial vocabulary locally.
+
+> The KMP `StringProvider` fallback chain is _exact locale → language-only →
+> default (English) → key-as-is_. The Android resource resolver does the same by
+> qualifier. We deliberately **do not implement** changes in `packages/core`
+> here — this doc only describes the boundary so the migration respects it.
+
+---
+
+## Audit Inventory
+
+The following surfaces were identified from [#2166](https://github.com/jrmoulckers/finance/issues/2166)
+and a repository scan. Each entry will become a tracked migration task. Line
+numbers are indicative anchors; the implementation PR will re-verify against HEAD.
+
+| Surface             | File                                                                                                                                    | Examples of hardcoded text             | Target         |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- | -------------- |
+| Transaction entry   | [`TransactionCreateScreen.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/screens/TransactionCreateScreen.kt)            | Field labels, validation copy, buttons | `strings.xml`  |
+| Currency conversion | [`CurrencyConversionScreen.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/screens/currency/CurrencyConversionScreen.kt) | Titles, helper text, action labels     | `strings.xml`  |
+| Sync status         | [`SyncStatusScreen.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/sync/SyncStatusScreen.kt)                             | Status messages, retry copy            | `strings.xml`  |
+| Education tooltips  | [`FinancialConceptContent.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/education/FinancialConceptContent.kt)          | Concept titles + descriptions          | `strings.xml`† |
+| Learning paths      | [`LearningPathContent.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/learning/LearningPathContent.kt)                   | Module titles, body copy, quiz options | `strings.xml`† |
+| Glance widgets      | `apps/android/.../widget/*`                                                                                                             | Balance/budget summary labels          | `strings.xml`  |
+| Notifications       | `apps/android/.../notifications/*`                                                                                                      | Channel names, titles, bodies          | `strings.xml`  |
+| Shared fallback     | [`EnglishStrings.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/i18n/EnglishStrings.kt) (KMP, read-only here)          | Domain term defaults                   | KMP (no edit)  |
+
+† Education content is long-form. See
+[android-spanish-education-formatting.md](android-spanish-education-formatting.md)
+and [android-newcomer-us-finance-education.md](android-newcomer-us-finance-education.md)
+for the content-modeling decision (resource strings vs. structured content
+records). This audit only records that the text must become localizable; it does
+not pick the storage format for prose modules.
+
+**Audit deliverable:** a machine-checkable manifest (CSV or JSON under
+`apps/android/`) listing each literal, its file/line, proposed resource key, and
+migration status (`pending` / `migrated` / `keep-as-literal`). "Keep-as-literal"
+is reserved for non-user-facing strings (test tags, log tags, analytics event
+names) and must carry a justification comment.
+
+### Resource key naming
+
+Follow the existing `values-es/strings.xml` conventions:
+
+- `screen_element` for visible copy (e.g. `transaction_create_amount_label`).
+- `a11y_*` for `contentDescription` and TalkBack-only labels
+  (e.g. `a11y_add_new_transaction`).
+- Reuse domain vocabulary keys already modeled in the KMP
+  [`Strings`](../../packages/core/src/commonMain/kotlin/com/finance/core/i18n/Strings.kt)
+  registry where a 1:1 concept exists, to avoid drift between platforms.
+
+---
+
+## Migration Strategy
+
+A phased rollout keeps each PR small, reviewable, and independently testable.
+
+```mermaid
+flowchart LR
+    P0[Phase 0\nAudit manifest\n+ lint gate] --> P1[Phase 1\nHigh-traffic screens\nTxn / Sync / Currency]
+    P1 --> P2[Phase 2\nWidgets +\nNotifications]
+    P2 --> P3[Phase 3\nEducation content\nglossary + paths]
+    P3 --> P4[Phase 4\nPseudolocale CI\n+ snapshot baseline]
+```
+
+- **Phase 0 — Baseline.** Land the audit manifest and the lint gate _in warning
+  mode_ so the current backlog is visible without breaking the build. Establish
+  Paparazzi snapshot baselines for the target screens in English.
+- **Phase 1 — High-traffic screens.** Migrate transaction entry, sync status,
+  and currency conversion. These are the screens most cited in
+  [#2166](https://github.com/jrmoulckers/finance/issues/2166).
+- **Phase 2 — Widgets and notifications.** Glance widgets and notification
+  builders also resolve resources via a `Context`; migrate their labels and
+  channel names.
+- **Phase 3 — Education content.** Coordinate with
+  [#2535](android-newcomer-us-finance-education.md) on the storage format before
+  migrating long-form modules.
+- **Phase 4 — Enforce.** Flip the lint gate to error, add the `en-XA`/`ar-XB`
+  pseudolocale CI job, and freeze the snapshot baseline.
+
+Each migrated string follows the same mechanical recipe:
+
+1. Add the key/value to `values/strings.xml` (English source of truth).
+2. Replace the literal with `stringResource(R.string.<key>)` in Compose (or
+   `context.getString(...)` in Glance/notification code).
+3. Move any `contentDescription` literal to an `a11y_*` resource key.
+4. Add the key to `values-es/strings.xml` as `pending` (the actual Spanish copy
+   is owned by [#2528](android-spanish-education-formatting.md)).
+
+---
+
+## Lint Gates
+
+The regression that produced "zero `stringResource` usage" must be made
+impossible to reintroduce silently.
+
+- **Android Lint `HardcodedText`** — enabled at `error` severity for the
+  `:apps:android` module once Phase 1 lands. Catches literal `text = "…"` in
+  XML-adjacent contexts.
+- **Custom Compose detector** — Android Lint's built-in `HardcodedText` does not
+  see Compose `Text("literal")`. A lightweight custom lint rule (or a
+  Detekt/ktlint rule) flags string literals passed to `Text(`,
+  `contentDescription =`, and notification/Glance builders, with an allowlist
+  for non-user-facing tags.
+- **CI wiring.** The gate runs in the existing Android CI lane
+  ([`ci-android.yml`](../../.github/workflows/ci-android.yml), owned by
+  @devops-engineer — referenced, not edited). Severity escalates from `warning`
+  (Phase 0) to `error` (Phase 4).
+
+> **Boundary note:** workflow files are owned by @devops-engineer. This doc
+> _specifies_ the gate; the actual `.github/workflows/` change is requested via
+> that owner.
+
+---
+
+## Accessibility Considerations
+
+Localization and accessibility are inseparable: a migrated string is only
+"done" when its accessibility metadata is migrated too.
+
+- **TalkBack:** every interactive or informational Composable keeps a
+  `contentDescription`, and that description must come from an `a11y_*` resource
+  key — never a hardcoded literal. Decorative elements use `null` explicitly.
+- **Font scaling:** all migrated text uses `sp` units and must survive 200% font
+  scale (Android `fontScale = 2.0`) without truncation or clipping. Avoid fixed
+  heights on text containers.
+- **RTL readiness:** although Spanish is LTR, routing all copy through resources
+  is the prerequisite for future RTL locales (e.g. Arabic). Use
+  start/end (not left/right) modifiers and `supportsRtl="true"` so the pipeline
+  is RTL-safe before any RTL language ships. The `ar-XB` pseudolocale exercises
+  this in CI.
+- **Reading level:** keep migrated copy plain-language per
+  [content-language-guidelines.md](content-language-guidelines.md) and the
+  cognitive-accessibility guidance in
+  [cognitive-accessibility.md](cognitive-accessibility.md).
+
+See [accessibility-patterns.md](accessibility-patterns.md) for the
+cross-platform screen-reader and touch-target patterns this migration must honor.
+
+---
+
+## Text Expansion and Layout Resilience
+
+Migrating to resources exposes layouts to translated lengths. **Spanish strings
+run roughly 25–30% longer than English** (German and French longer still).
+Layouts that "fit" hardcoded English will overflow once real translations load.
+
+- Design and snapshot every migrated screen against a **+30% length** assumption.
+- Prefer flexible/wrapping layouts; never assume a label fits on one line.
+- The `en-XA` pseudolocale (which pads and accents text) is the automated
+  expansion check; treat clipping under `en-XA` as a layout bug.
+- Truncation, when unavoidable, must be `TextOverflow.Ellipsis` with the full
+  text exposed to TalkBack via `contentDescription`.
+
+This expansion budget is shared with
+[android-spanish-education-formatting.md](android-spanish-education-formatting.md),
+which owns the actual Spanish copy.
+
+---
+
+## Offline, Empty, and Error States
+
+These states are frequently the _last_ to be localized and the _first_ a
+newcomer hits. They are in scope for the audit:
+
+- **Offline:** sync-status and "you're offline" banners must be resource-backed;
+  no English "Offline" leaking through while the rest of the screen is Spanish.
+- **Empty:** empty-state copy (no transactions, no budgets, no accounts) is
+  user-facing and must migrate, with an `a11y_*` description for the illustration.
+- **Error:** validation and failure copy (invalid amount, sync failed, network
+  error) maps to the KMP error vocabulary
+  ([`Strings.ERROR_*`](../../packages/core/src/commonMain/kotlin/com/finance/core/i18n/Strings.kt))
+  where a shared concept exists, and to `strings.xml` for Android-specific phrasing.
+  Error copy follows the "inform, then offer an action" rule from
+  [content-language-guidelines.md](content-language-guidelines.md).
+
+---
+
+## Test Plan
+
+| Layer              | Tooling                         | What it verifies                                                                     |
+| ------------------ | ------------------------------- | ------------------------------------------------------------------------------------ |
+| Unit               | JUnit + Robolectric             | Resource keys resolve; no `MissingResourceException`; `a11y_*` keys exist.           |
+| Compose UI         | `createComposeRule` + semantics | Visible text and `contentDescription` come from resources, not literals.             |
+| Lint               | Android Lint / Detekt rule      | Hardcoded `Text("…")` / `contentDescription = "…"` fails the build (Phase 4).        |
+| Snapshot           | Paparazzi                       | English baseline + `en-XA` (expansion) + `es` render without clipping at 1x/2x font. |
+| Pseudolocalization | `en-XA`, `ar-XB` resConfigs     | Expansion + RTL mirroring exercised in CI without waiting on real translations.      |
+| Accessibility      | Espresso/Accessibility checks   | TalkBack focus order intact; touch targets ≥ 48dp; contrast unaffected.              |
+
+**Snapshot matrix (key screens):** transaction entry, sync status, currency
+conversion, one Glance widget, one notification, one education module — each at
+`{en, en-XA, es}` × `{1.0x, 2.0x}` font scale.
+
+**Pseudolocalization** is the cornerstone: it lets us validate expansion and
+mirroring _in the debug build, today_, before any Play distribution or external
+translation vendor is involved.
+
+---
+
+## Implementation Readiness
+
+This is a design artifact. Execution splits cleanly into a **buildable-now** tier
+and a **Play-distribution tail** gated by
+[#1242](https://github.com/jrmoulckers/finance/issues/1242). See
+[../ops/human-gated-prerequisites.md](../ops/human-gated-prerequisites.md) for
+the canonical gate list and
+[../ops/launch-readiness-plan.md](../ops/launch-readiness-plan.md) for
+launch sequencing.
+
+**Buildable now — debug-only, `assembleDebug` + sideload (no human gate):**
+
+- Audit manifest of hardcoded literals.
+- String-resource extraction and `stringResource()` plumbing.
+- Locale-switch plumbing (per-app language / `LocaleManager`) verifiable on a
+  debug build or emulator.
+- Pseudolocale (`en-XA`, `ar-XB`) resConfigs and CI snapshot baselines.
+- Lint gate in warning mode, then error mode.
+
+**Play-distribution tail — human-gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242):**
+
+- Production signing keystore and Play Console app listing.
+- Per-locale Play Store listing metadata and store-level language declarations.
+- Staged rollout / internal testing track for localized builds.
+
+Nothing in the buildable-now tier requires signing, store credentials, or any
+human-gated operation; all of it is exercisable via `assembleDebug` and a
+sideloaded APK on an emulator or test device.
+
+---
+
+## References
+
+**Design docs**
+
+- [android-spanish-education-formatting.md](android-spanish-education-formatting.md) — Spanish coverage (#2528)
+- [android-newcomer-us-finance-education.md](android-newcomer-us-finance-education.md) — newcomer education (#2535)
+- [accessibility-patterns.md](accessibility-patterns.md) — screen reader, focus, touch targets
+- [cognitive-accessibility.md](cognitive-accessibility.md) — plain-language and load reduction
+- [content-language-guidelines.md](content-language-guidelines.md) — non-judgmental copy standard
+- [information-architecture.md](information-architecture.md) — navigation and surface map
+- [ux-principles.md](ux-principles.md) — product UX principles
+- [personas.md](personas.md) — including Persona 4 (Casey, accessibility-first)
+
+**Ops**
+
+- [../ops/human-gated-prerequisites.md](../ops/human-gated-prerequisites.md) — buildable-now vs. gated split
+- [../ops/launch-readiness-plan.md](../ops/launch-readiness-plan.md) — launch checklist
+
+**KMP i18n (read-only boundary — owned by @kmp-engineer)**
+
+- [`StringProvider.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/i18n/StringProvider.kt)
+- [`Strings.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/i18n/Strings.kt)
+- [`NumberFormatting.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/i18n/NumberFormatting.kt)
+- [`EnglishStrings.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/i18n/EnglishStrings.kt)
+
+**Issues**
+
+- [#2527](https://github.com/jrmoulckers/finance/issues/2527) — this issue
+- [#2166](https://github.com/jrmoulckers/finance/issues/2166) — parent (Spanish-preferred localization)
+- [#1242](https://github.com/jrmoulckers/finance/issues/1242) — Play Console + keystore (gate)


### PR DESCRIPTION
﻿## Summary

Adds three **design-only** docs (no native builds, no signing, no store actions) for the Android i18n / newcomer-education cluster under `docs/design/`. All native Android implementation remains blocked by #1242; these docs plan the work and split a buildable-now (`assembleDebug` sideload) tier from the Play-distribution tail.

Closes #2527
Closes #2528
Closes #2535

## Changes

- `docs/design/android-string-resource-migration-audit.md` (#2527) — audit of hardcoded Compose/Glance/notification text, phased migration, and Android Lint + Compose-aware lint gates. Part of #2166.
- `docs/design/android-spanish-education-formatting.md` (#2528) — Spanish coverage across onboarding, transactions, sync, education, widgets, receipt OCR, settings, plus locale-aware currency/number/date formatting. Part of #2166.
- `docs/design/android-newcomer-us-finance-education.md` (#2535) — plain-language W-2 / 1099 / withholding / 401(k) / mixed-income modules and ITIN-aware optional onboarding. Part of #2178.

## Notes

- New files only; no existing files, `packages/`, `apps/` code, shared config, or other platforms were touched.
- Terminology and formatting logic are kept conceptually in KMP `packages/core` (boundary described, not implemented).
- Each doc includes a ToC, Mermaid diagrams, accessibility notes (TalkBack, font scaling, RTL-readiness), text-expansion budget (Spanish ~25–30% longer), offline/empty/error states, a unit/Compose/Paparazzi/pseudo-localization test plan, and an Implementation readiness section linking `../ops/human-gated-prerequisites.md` and `../ops/launch-readiness-plan.md`.
- `npx prettier --check` passes on all three new files.
