### PR TITLE
docs(design): ios accessibility design batch (#2544, #2546, #2548)

### DIFF
--- a/docs/design/ios-dynamic-type-reflow-audit.md
+++ b/docs/design/ios-dynamic-type-reflow-audit.md
@@ -1,0 +1,272 @@
+# Dynamic Type Reflow Audit — Core iOS Finance Surfaces — Design
+
+> **Status:** PROPOSED — pending human review
+> **Issue:** [#2548](https://github.com/jrmoulckers/finance/issues/2548) · Part of [#2119](https://github.com/jrmoulckers/finance/issues/2119)
+> **Platform:** iOS / iPadOS (SwiftUI) · Deployment target iOS 17.0
+> **Labels:** `platform:ios` · `accessibility` · `priority:high` · `effort:m`
+> **Author:** iOS engineer (design only — no native build performed)
+
+This document audits where core finance surfaces clip, shrink, or truncate text
+at large Dynamic Type sizes and specifies how to replace one-line
+truncation / `minimumScaleFactor` patterns with **wrapping** and
+**accessibility-size vertical stacks**. It is design-only; the distribution tail
+is gated by Apple Developer enrollment
+([#1239](https://github.com/jrmoulckers/finance/issues/1239)).
+
+---
+
+## Table of Contents
+
+1. [Why this matters](#1-why-this-matters)
+2. [The anti-pattern](#2-the-anti-pattern)
+3. [Dynamic Type sizes and the AX threshold](#3-dynamic-type-sizes-and-the-ax-threshold)
+4. [Reflow strategy toolkit](#4-reflow-strategy-toolkit)
+5. [Surface-by-surface audit](#5-surface-by-surface-audit)
+6. [Transaction row reflow (worked example)](#6-transaction-row-reflow-worked-example)
+7. [Charts, legends, and axis labels](#7-charts-legends-and-axis-labels)
+8. [Redundant non-color cues and contrast](#8-redundant-non-color-cues-and-contrast)
+9. [Privacy — balance hiding under reflow](#9-privacy--balance-hiding-under-reflow)
+10. [Stale, error, and empty states](#10-stale-error-and-empty-states)
+11. [Shared dependencies and the KMP boundary](#11-shared-dependencies-and-the-kmp-boundary)
+12. [Smallest tests plan](#12-smallest-tests-plan)
+13. [Implementation readiness](#13-implementation-readiness)
+14. [References](#14-references)
+
+## 1. Why this matters
+
+Money has to stay readable at every text size. A user who sets Larger Text to
+AX5 (`accessibilityExtraExtraExtraLarge`) needs the _whole_ amount, payee, and
+category — not "$1,2…" or a font shrunk below legibility. Truncating or
+auto-shrinking financial figures is both an accessibility failure (WCAG 1.4.4
+Resize Text, 1.4.10 Reflow) and a correctness hazard: a clipped balance can be
+misread.
+
+## 2. The anti-pattern
+
+The recurring pattern across the codebase is "force one line, then shrink":
+
+```swift
+Text(value)
+    .font(.title3)
+    .lineLimit(1)            // refuse to wrap
+    .minimumScaleFactor(0.7) // shrink up to 30% instead
+```
+
+At AX sizes this either clips (when shrink hits its floor) or renders amounts
+markedly smaller than surrounding text — defeating the user's size preference.
+The fix is to **let text wrap** and, at accessibility sizes, **stack
+horizontally-paired labels vertically** so each gets the full width.
+
+Confirmed occurrences (non-exhaustive) found by scanning
+`apps/ios/Finance/Screens` and `Components` for `minimumScaleFactor` /
+`lineLimit(1)`:
+
+| File                                                                                            | Where                                                          |
+| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| [`AnalyticsView.swift`](../../apps/ios/Finance/Screens/AnalyticsView.swift)                     | metric card value (`lineLimit(1)` + `minimumScaleFactor(0.7)`) |
+| [`InvestmentDetailView.swift`](../../apps/ios/Finance/Screens/InvestmentDetailView.swift)       | metric values                                                  |
+| [`InvestmentPortfolioView.swift`](../../apps/ios/Finance/Screens/InvestmentPortfolioView.swift) | holding row text                                               |
+| [`TransactionRowView.swift`](../../apps/ios/Finance/Components/TransactionRowView.swift)        | payee / category `lineLimit(1)`                                |
+| [`TransactionsView.swift`](../../apps/ios/Finance/Screens/TransactionsView.swift)               | inline row payee / category                                    |
+| [`DashboardView.swift`](../../apps/ios/Finance/Screens/DashboardView.swift)                     | recent-row payee, summary columns                              |
+| [`InsightsView.swift`](../../apps/ios/Finance/Screens/InsightsView.swift)                       | insight text                                                   |
+| [`ProgressRing.swift`](../../apps/ios/Finance/Components/ProgressRing.swift)                    | centered percentage                                            |
+| [`NlpInputView.swift`](../../apps/ios/Finance/Screens/NlpInputView.swift)                       | parsed field text                                              |
+
+## 3. Dynamic Type sizes and the AX threshold
+
+```mermaid
+flowchart LR
+    XS["xSmall"] --> S --> M --> L["Large (default)"] --> XL --> XXL --> XXXL
+    XXXL --> AX1["AX1"] --> AX2 --> AX3 --> AX4 --> AX5["AX5"]
+    style AX1 fill:#0E8A16,color:#fff
+    style AX5 fill:#0E8A16,color:#fff
+```
+
+The five **accessibility** sizes (AX1–AX5) are the design pivot. SwiftUI exposes
+this via `@Environment(\.dynamicTypeSize)` and `dynamicTypeSize.isAccessibilitySize`.
+The repo already ships the right primitive — `AdaptiveFinanceStack` in
+[`DynamicTypeSupport.swift`](../../apps/ios/Finance/Accessibility/DynamicTypeSupport.swift)
+switches `HStack → VStack` at accessibility sizes — but it is **not yet adopted
+by any screen**. This audit is largely "adopt the primitives we already have".
+
+## 4. Reflow strategy toolkit
+
+| Tool                                                  | Use it for                                                         | Replaces                        |
+| ----------------------------------------------------- | ------------------------------------------------------------------ | ------------------------------- |
+| `AdaptiveFinanceStack`                                | label↔value pairs that should stack vertically at AX               | rigid `HStack` rows             |
+| `ViewThatFits`                                        | "horizontal if it fits, else vertical" without a manual size check | `minimumScaleFactor`            |
+| Remove `lineLimit(1)` / allow wrapping                | payee, category, insight text                                      | one-line truncation             |
+| `SizeConstrainedCurrencyText` + `ClampedScaledMetric` | prominent amounts that must scale but never below a floor          | `minimumScaleFactor(0.7)`       |
+| `@ScaledMetric`                                       | icon sizes, padding, tap targets that must grow with text          | hardcoded point dimensions      |
+| `allowsTightening(true)` (sparingly)                  | a single short label where a 1–2% squeeze avoids a wrap            | aggressive `minimumScaleFactor` |
+
+Rules of thumb:
+
+1. **Amounts may shrink to a readable floor, never clip.** Use
+   `SizeConstrainedCurrencyText` (already in the repo) which clamps via
+   `ClampedScaledMetric(min:max:)` instead of an open-ended 0.7 factor.
+2. **Text labels wrap, they do not truncate.** Drop `lineLimit(1)` on payee,
+   category, insight, and legend text; give them the full width by stacking.
+3. **Pairs stack at AX.** Any `label — value` row (summary columns, metric
+   cards, holding rows) becomes vertical at `isAccessibilitySize`.
+
+## 5. Surface-by-surface audit
+
+| Surface                       | Symptom at AX3–AX5                                | Reflow fix                                                                                        |
+| ----------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| Transactions list rows        | payee + amount collide; amount squeezed right     | `AdaptiveFinanceStack`: payee/category over amount; wrap payee; amount uses size-constrained text |
+| Dashboard recent rows         | same collision; "See All" header crowds title     | adopt the consolidated `TransactionRowView`; wrap header, stack at AX                             |
+| Dashboard summary columns     | 3-column `HStack` (Income/Expenses/Net) overflows | switch to vertical list of label/value pairs at AX; drop fixed `Divider` heights                  |
+| Dashboard net-worth card      | `largeTitle` amount can clip on narrow devices    | `SizeConstrainedCurrencyText`; allow two lines; keep `combine` label                              |
+| Analytics metric cards        | `lineLimit(1)` + `minimumScaleFactor(0.7)` clips  | remove forced single line; stack icon/title/value; size-constrained value                         |
+| Analytics chart legends       | legend chips truncate / wrap mid-word             | use `FlowLayout` (already in repo) so chips wrap as units; never truncate a series name           |
+| Investment portfolio holdings | symbol + name + value cram into one row           | stack at AX; wrap the security name                                                               |
+| Investment detail metrics     | metric grid shrinks numbers                       | same metric-card fix; remove `minimumScaleFactor`                                                 |
+| Insights cards                | insight sentence truncates to one line            | allow multi-line wrapping; no `lineLimit(1)`                                                      |
+| Progress ring percentage      | centered number overflows the ring                | move the precise value to an adjacent wrapping label at AX; ring shows coarse fill only           |
+
+Existing repo assets that make these cheap: `AdaptiveFinanceStack`,
+`SizeConstrainedCurrencyText`, `ClampedScaledMetric`, `DynamicTypeMetrics`
+([`DynamicTypeSupport.swift`](../../apps/ios/Finance/Accessibility/DynamicTypeSupport.swift)),
+and [`FlowLayout`](../../apps/ios/Finance/Components/FlowLayout.swift) for legends/chips.
+
+## 6. Transaction row reflow (worked example)
+
+```mermaid
+flowchart TD
+    subgraph Default["Default – Large"]
+      direction LR
+      I1["icon"] --- T1["payee / category"] --- A1["$4.50"]
+    end
+    subgraph AX["AX3–AX5"]
+      direction TB
+      I2["icon + payee (wraps)"]
+      C2["category · account (wraps)"]
+      A2["Expense $4.50 (size-constrained)"]
+      I2 --> C2 --> A2
+    end
+```
+
+```swift
+// Conceptual — horizontal by default, vertical at accessibility sizes.
+AdaptiveFinanceStack {
+    IconView(transaction.type.iconToken, size: iconSize)   // @ScaledMetric icon
+        .accessibilityHidden(true)
+    VStack(alignment: .leading) {
+        Text(transaction.payee)                            // no lineLimit(1) → wraps
+        Text("\(transaction.category) · \(transaction.accountName)")
+            .font(.caption).foregroundStyle(.secondary)    // wraps
+    }
+    SizeConstrainedCurrencyText(amount: formatted)         // clamps, never clips
+}
+// One combined label/value per row stays intact — see #2544.
+```
+
+The **accessibility label is unchanged by reflow** (the #2544 contract): the
+spoken content must be identical at Large and at AX5. Layout changes; meaning
+does not.
+
+## 7. Charts, legends, and axis labels
+
+[`AnalyticsView`](../../apps/ios/Finance/Screens/AnalyticsView.swift) and
+[`InvestmentPortfolioView`](../../apps/ios/Finance/Screens/InvestmentPortfolioView.swift)
+use Swift Charts with the CVD-safe palette. At large sizes:
+
+- **Legends** must wrap as whole chips (`FlowLayout`); a series name is never
+  truncated. Provide an `.accessibilityLabel` per legend entry pairing the
+  series name with its color-independent role.
+- **Axis labels** should thin out (fewer ticks) rather than overlap; prefer
+  abbreviated, locale-aware number formatting on the axis while the
+  `AccessibilityChartDescriptor` / per-mark `.accessibilityLabel` carries the
+  full value for VoiceOver.
+- The **chart itself** keeps a summary `.accessibilityLabel` (already present,
+  e.g. "Portfolio performance line chart") and exposes data points via Audio
+  Graphs where practical.
+
+## 8. Redundant non-color cues and contrast
+
+Reflow must not remove non-color cues. When chips/legends wrap, keep the textual
+label next to each swatch; when amounts move below payee, keep the `+`/`−` sign
+and the income/expense icon. Verify the reflowed layouts under Increase
+Contrast, Smart Invert, and Bold Text. This aligns with
+[Accessibility Patterns §5 Color & Contrast](./accessibility-patterns.md#5-color--contrast)
+and the larger-target guidance in
+[Cognitive Accessibility Mode](./cognitive-accessibility.md#7-touch-target-requirements).
+
+## 9. Privacy — balance hiding under reflow
+
+If amounts are hidden (privacy mode or `.privacySensitive()` redaction), the
+reflowed layout must reserve space for the redaction placeholder so the row does
+not visually "jump" when balances are revealed, and the placeholder must wrap /
+size identically. The VoiceOver redaction rule from
+[#2544 §9](./ios-transaction-row-voiceover-labels.md#9-privacy--balance-hiding)
+still applies: hidden on screen ⇒ "Amount hidden" to VoiceOver. Reflow never
+re-exposes a hidden figure.
+
+## 10. Stale, error, and empty states
+
+| State         | Reflow consideration                                                                                                                                                 |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Empty         | [`EmptyStateView`](../../apps/ios/Finance/Components/EmptyStateView.swift) title/message must wrap and remain centered at AX; CTA button grows with `@ScaledMetric`. |
+| Error         | [`ErrorStateView`](../../apps/ios/Finance/Components/ErrorStateView.swift) message wraps; Retry button stays full-width and tappable (≥44pt scaled).                 |
+| Stale/offline | [`OfflineBanner`](../../apps/ios/Finance/Components/OfflineBanner.swift) text wraps to two lines rather than truncating at AX.                                       |
+| Loading       | `ProgressView` label unaffected; ensure surrounding skeleton respects size.                                                                                          |
+
+## 11. Shared dependencies and the KMP boundary
+
+- All reflow work is **SwiftUI layout** in `apps/ios` — no `packages/` change.
+- Amount/locale formatting comes from
+  [`CurrencyLabel`](../../apps/ios/Finance/Components/CurrencyLabel.swift) (apps/ios),
+  fed by `TransactionItem` mapped from `packages/models` via the
+  [Swift Export bridge](../../apps/ios/Finance/KMP/SwiftExportBridge.swift). The
+  numeric/currency rules stay shared; the _presentation_ stays native.
+- Any shared-package change goes through an ADR with `@architect`.
+
+## 12. Smallest tests plan
+
+- **Snapshot at AX sizes (primary):** render each audited surface at Large and
+  AX5 via `app.launchEnvironment["UIPreferredContentSizeCategory"]`; assert no
+  clipping and that label↔value pairs are stacked. Pairs with the snapshot layer
+  in [#2546 §6](./ios-transaction-accessibility-regression.md#6-layer-3--snapshot-at-ax-text-sizes).
+- **XCUITest accessibility audit:** `app.performAccessibilityAudit()` reports a
+  `.textClipped` / `.dynamicType` issue when text truncates — run for
+  Transactions, Dashboard, Analytics, Investments at AX5.
+- **Unit:** assert `ClampedScaledMetric` floors/ceilings and that
+  `AdaptiveFinanceStack` chooses `VStack` when `isAccessibilitySize` is true
+  (inject the trait via environment in a hosting controller).
+- **Preview coverage:** add `.dynamicTypeSize(.accessibility5)` previews for each
+  reflowed view so regressions are visible in Xcode previews.
+
+The smallest acceptance gate: the four primary surfaces pass
+`performAccessibilityAudit()` at AX5 with zero text-clipping issues.
+
+## 13. Implementation readiness
+
+See [`docs/ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md).
+
+**Buildable now (no human gate):**
+
+- All reflow refactors and their snapshot/audit tests are implementable today on
+  the iOS Simulator and a personal device using **free Personal Team** signing.
+  No paid enrollment is needed to change layouts, adopt the existing Dynamic Type
+  primitives, or run accessibility audits at AX sizes.
+
+**Gated by [#1239](https://github.com/jrmoulckers/finance/issues/1239):**
+
+- TestFlight / App Store distribution of the reflowed build, and any
+  physical-device test matrix run under a paid team. The layout work itself
+  needs none of these.
+
+No human-gated operation is required to implement or verify this audit.
+
+## 14. References
+
+- Sibling designs: [transaction-row VoiceOver labels (#2544)](./ios-transaction-row-voiceover-labels.md) ·
+  [accessibility regression coverage (#2546)](./ios-transaction-accessibility-regression.md)
+- Repo primitives: [`DynamicTypeSupport.swift`](../../apps/ios/Finance/Accessibility/DynamicTypeSupport.swift) ·
+  [`FlowLayout.swift`](../../apps/ios/Finance/Components/FlowLayout.swift)
+- [Accessibility Patterns Library](./accessibility-patterns.md) — §5 Color & Contrast, §8 Touch Target Sizing
+- [Cognitive Accessibility Mode](./cognitive-accessibility.md) — typography & spacing changes
+- [Responsive Breakpoints](./responsive-breakpoints.md) — cross-platform reflow philosophy
+- Apple HIG — Typography, Dynamic Type · WCAG 2.2 — 1.4.4 Resize Text, 1.4.10 Reflow

--- a/docs/design/ios-transaction-accessibility-regression.md
+++ b/docs/design/ios-transaction-accessibility-regression.md
@@ -1,0 +1,275 @@
+# iOS Transaction Accessibility Regression Coverage — Design
+
+> **Status:** PROPOSED — pending human review
+> **Issue:** [#2546](https://github.com/jrmoulckers/finance/issues/2546) · Part of [#2117](https://github.com/jrmoulckers/finance/issues/2117)
+> **Platform:** iOS / iPadOS (SwiftUI) · Deployment target iOS 17.0
+> **Labels:** `platform:ios` · `accessibility` · `priority:medium` · `effort:s`
+> **Author:** iOS engineer (design only — no native build performed)
+
+This document defines the **smallest durable test suite** that prevents the
+transaction-row VoiceOver regressions described in
+[#2544](./ios-transaction-row-voiceover-labels.md) and the Dynamic Type reflow
+regressions in [#2548](./ios-dynamic-type-reflow-audit.md) from recurring. It
+is design-only; the distribution tail is gated by Apple Developer enrollment
+([#1239](https://github.com/jrmoulckers/finance/issues/1239)).
+
+---
+
+## Table of Contents
+
+1. [Goal and non-goals](#1-goal-and-non-goals)
+2. [What regressed and why tests missed it](#2-what-regressed-and-why-tests-missed-it)
+3. [Test pyramid for accessibility](#3-test-pyramid-for-accessibility)
+4. [Layer 1 — unit tests (label composition)](#4-layer-1--unit-tests-label-composition)
+5. [Layer 2 — XCUITest accessibility audits](#5-layer-2--xcuitest-accessibility-audits)
+6. [Layer 3 — snapshot at AX text sizes](#6-layer-3--snapshot-at-ax-text-sizes)
+7. [Coverage matrix](#7-coverage-matrix)
+8. [Privacy, stale, error, and empty-state cases](#8-privacy-stale-error-and-empty-state-cases)
+9. [Test data and fixtures](#9-test-data-and-fixtures)
+10. [CI integration](#10-ci-integration)
+11. [Shared dependencies and the KMP boundary](#11-shared-dependencies-and-the-kmp-boundary)
+12. [Implementation readiness](#12-implementation-readiness)
+13. [References](#13-references)
+
+## 1. Goal and non-goals
+
+**Goal:** lock the accessibility contract of a transaction row — label, value,
+trait, focus-stop count, rotor headings, swipe-action parity, redaction, and
+reflow — so a future refactor that drops the amount (exactly the #2544 bug)
+fails CI loudly.
+
+**Non-goals:** re-testing SwiftUI itself, pixel-perfect visual snapshots,
+or duplicating business-rule tests that belong in `packages/`.
+
+## 2. What regressed and why tests missed it
+
+The amount and status disappeared from the row announcement because an explicit
+`.accessibilityLabel` on a `.combine` element overrode the merged children (see
+[#2544 §3](./ios-transaction-row-voiceover-labels.md#3-root-cause)). The existing
+suite never caught it because:
+
+- The current tests under [`apps/ios/Tests`](../../apps/ios/Tests) are
+  **view-model** tests ([`TransactionsViewModelTests`](../../apps/ios/Tests/TransactionsViewModelTests.swift),
+  [`DashboardViewModelTests`](../../apps/ios/Tests/DashboardViewModelTests.swift)) — they assert
+  data, never the **accessibility tree**.
+- The one UI suite
+  ([`apps/ios/Tests/UITests/FinanceUITests.swift`](../../apps/ios/Tests/UITests/FinanceUITests.swift))
+  checks navigation and `staticTexts`, never a row's `.label`/`.value`.
+- The label string is **embedded inside the view body**, so there is no pure
+  function a unit test can call.
+
+The fix is therefore structural (extract a pure composer — see
+[#2544 §12](./ios-transaction-row-voiceover-labels.md#12-proposed-implementation))
+**and** test-shaped, as below.
+
+## 3. Test pyramid for accessibility
+
+```mermaid
+flowchart TD
+    A["Layer 1 — Unit (XCTest)\nlabel/value composer · pure · milliseconds"] --> B
+    B["Layer 2 — XCUITest accessibility audit\nperformAccessibilityAudit + label assertions"] --> C
+    C["Layer 3 — Snapshot at AX1–AX5\nreflow + focus-stop hierarchy"]
+    style A fill:#0E8A16,color:#fff
+    style B fill:#1f883d,color:#fff
+    style C fill:#155f2b,color:#fff
+```
+
+Bias toward Layer 1 (cheapest, runs without a host app or device) and add the
+minimum Layer 2/3 needed to cover what unit tests cannot see.
+
+## 4. Layer 1 — unit tests (label composition)
+
+New file: `apps/ios/Tests/TransactionAccessibilityTests.swift`. These call the
+pure composer extracted in #2544 — no `XCUIApplication`, no simulator UI.
+
+```swift
+import XCTest
+@testable import Finance
+
+final class TransactionAccessibilityTests: XCTestCase {
+    func testExpenseRowAnnouncesSignedAmount() {
+        let t = TransactionItem.fixture(payee: "Blue Bottle", amountMinorUnits: -450,
+                                        category: "Coffee", accountName: "Checking")
+        let label = transactionRowLabel(t, balancesHidden: false)
+        XCTAssertTrue(label.contains("Blue Bottle"))
+        XCTAssertTrue(label.contains("Expense of"))   // amount NOT dropped
+        XCTAssertTrue(label.contains("Coffee"))
+        XCTAssertTrue(label.contains("Checking"))
+    }
+
+    func testPendingAndRecurringSurfaceInValue() {
+        let t = TransactionItem.fixture(status: .pending, isRecurring: true)
+        XCTAssertEqual(transactionRowValue(t), "Pending, Recurring")
+    }
+
+    func testClearedNonRecurringHasNoValue() {
+        XCTAssertNil(transactionRowValue(.fixture(status: .cleared, isRecurring: false)))
+    }
+
+    func testBalancesHiddenRedactsAmount() {
+        let label = transactionRowLabel(.fixture(amountMinorUnits: -450), balancesHidden: true)
+        XCTAssertTrue(label.contains("Amount hidden"))
+        XCTAssertFalse(label.contains("4.50"))        // never leak the figure
+    }
+
+    func testIncomeUsesIncomePhrasing() {
+        let label = transactionRowLabel(.fixture(amountMinorUnits: 250_000, type: .income),
+                                        balancesHidden: false)
+        XCTAssertTrue(label.contains("Income of"))
+    }
+}
+```
+
+These five tests alone would have failed against the buggy code, because the
+composer would not have contained "Expense of …".
+
+## 5. Layer 2 — XCUITest accessibility audits
+
+Extend `FinanceUITests` (or a new `AccessibilityUITests.swift`) with the iOS 17+
+automated audit plus targeted assertions the audit cannot make:
+
+```swift
+func testTransactionsScreenPassesAccessibilityAudit() throws {
+    launchAppSkippingOnboarding()
+    navigateToTab("Transactions", expectedNavTitle: "Transactions")
+    // Catches: missing labels, clipped text at large sizes, low contrast,
+    // elements not reachable by VoiceOver, hit-region/trait problems.
+    try app.performAccessibilityAudit()
+}
+
+func testDashboardRecentRowAnnouncesAmount() throws {
+    launchAppSkippingOnboarding()
+    let row = app.buttons.matching(NSPredicate(format: "label CONTAINS %@", "Blue Bottle")).firstMatch
+    XCTAssertTrue(row.waitForExistence(timeout: defaultTimeout))
+    XCTAssertTrue(row.label.contains("Expense of") || row.label.contains("Income of"))
+}
+
+func testRowExposesEditAndDeleteAsCustomActions() throws {
+    // Switch Control / VoiceOver users reach swipe actions via the Actions rotor;
+    // assert the custom actions exist without performing a physical swipe.
+    // (Asserted through the accessibility audit + element action availability.)
+}
+```
+
+Notes:
+
+- `performAccessibilityAudit()` (XCUITest, iOS 17) is the backstop for "every
+  interactive element has a label" and "text is not clipped at the current
+  size"; run it for Transactions, Dashboard, and (for #2548) Analytics and
+  Investments.
+- Use `--uitesting` launch argument (already wired) plus a deterministic
+  seed so the same fixture transactions appear every run.
+
+## 6. Layer 3 — snapshot at AX text sizes
+
+Snapshot the **accessibility hierarchy** (not just pixels) of a single row at
+the default size and at the five accessibility sizes (AX1–AX5) to lock:
+
+1. focus-stop **count** (one row = one stop),
+2. label/value text,
+3. reflow from horizontal to vertical (ties to
+   [#2548](./ios-dynamic-type-reflow-audit.md)).
+
+Drive the size with the launch environment so no third-party snapshot library
+is required:
+
+```swift
+app.launchEnvironment["UIPreferredContentSizeCategory"] = "UICTContentSizeCategoryAccessibilityExtraExtraExtraLarge" // AX5
+```
+
+If a snapshot library is later approved, prefer the system-native
+`XCTAttachment` of the element tree over image diffs to avoid brittleness. No
+third-party UI framework is introduced (per platform boundary).
+
+## 7. Coverage matrix
+
+| Case                                   | L1 unit | L2 audit | L3 snapshot |
+| -------------------------------------- | :-----: | :------: | :---------: |
+| Expense announces signed amount        |   ✅    |    ✅    |      —      |
+| Income announces signed amount         |   ✅    |    ✅    |      —      |
+| Transfer announces neutral amount      |   ✅    |    —     |      —      |
+| Pending surfaces in value              |   ✅    |    ✅    |      —      |
+| Recurring surfaces in value            |   ✅    |    —     |      —      |
+| Cleared/non-recurring → no value       |   ✅    |    —     |      —      |
+| Multi-tag rows                         |   ✅    |    —     |      —      |
+| Date present in row (not just header)  |   ✅    |    ✅    |      —      |
+| One focus stop per row                 |    —    |    ✅    |     ✅      |
+| Section header is a heading (rotor)    |    —    |    ✅    |      —      |
+| Swipe actions reachable via rotor      |    —    |    ✅    |      —      |
+| Balances hidden → amount redacted      |   ✅    |    ✅    |      —      |
+| AX5 reflow keeps amount + label intact |    —    |    ✅    |     ✅      |
+| Empty / search-empty state             |    —    |    ✅    |      —      |
+| Error alert focus + labeled buttons    |    —    |    ✅    |      —      |
+
+## 8. Privacy, stale, error, and empty-state cases
+
+- **Privacy:** the `testBalancesHiddenRedactsAmount` unit test plus an audit run
+  with the hide-balances launch flag set; assert no spoken amount leaks.
+- **Stale / offline:** drive `--offline` (or mocked `NetworkMonitor`) so
+  [`OfflineBanner`](../../apps/ios/Finance/Components/OfflineBanner.swift)
+  appears; assert it is announced and the list still passes the audit.
+- **Error:** force the repository mock to throw; assert the error alert receives
+  focus and Retry/Dismiss are labeled buttons.
+- **Empty:** assert `EmptyStateView` title is a heading and the CTA is a labeled
+  button; assert no phantom row elements exist in the accessibility tree.
+
+## 9. Test data and fixtures
+
+- Add a `TransactionItem.fixture(...)` factory in
+  [`apps/ios/Tests/TestHelpers.swift`](../../apps/ios/Tests/TestHelpers.swift) with
+  sensible defaults so each test overrides only the field under test.
+- Reuse the existing mock repositories
+  ([`apps/ios/Finance/Repositories/Mocks`](../../apps/ios/Finance/Repositories/Mocks)) for
+  deterministic UI runs; seed a fixed set including one pending, one recurring,
+  one income, one transfer, and one multi-tag transaction.
+- Keep fixtures free of real PII; amounts are synthetic.
+
+## 10. CI integration
+
+- Unit tests (Layer 1) run in the existing iOS unit job in
+  [`.github/workflows/ci-ios.yml`](../../.github/workflows/ci-ios.yml) — fast,
+  no device.
+- XCUITest audits (Layer 2/3) run on a simulator runner; gate them behind the
+  same job that already builds the app so no new required check is added without
+  a green baseline first.
+- The accessibility audit assertion is **blocking** once green: a dropped label
+  fails the build, which is the entire point of #2546.
+
+## 11. Shared dependencies and the KMP boundary
+
+- The composer under test lives in `apps/ios` (Apple accessibility semantics) —
+  so do its tests. Nothing here touches `packages/`.
+- Business-rule correctness (what _pending_ means, sign of an amount) is tested
+  in `packages/core` / `packages/models` and is **not** re-tested here; these
+  tests assert only the **presentation/announcement** contract.
+- Any need to change a shared package is an ADR with `@architect`, not a direct
+  edit.
+
+## 12. Implementation readiness
+
+See [`docs/ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md).
+
+**Buildable now (no human gate):**
+
+- Every layer here runs with **free Personal Team** signing or no signing at
+  all: Layer 1 unit tests need no Apple account; Layer 2/3 run on the iOS
+  Simulator. `performAccessibilityAudit()` is available on the iOS 17 SDK used
+  by CI. All of #2546 is implementable and verifiable today.
+
+**Gated by [#1239](https://github.com/jrmoulckers/finance/issues/1239):**
+
+- Running these tests on a **physical** device under a paid team, and shipping
+  the verified build to TestFlight / App Store. The tests themselves do not
+  require enrollment.
+
+No human-gated operation is required to implement or run this suite.
+
+## 13. References
+
+- Sibling designs: [transaction-row VoiceOver labels (#2544)](./ios-transaction-row-voiceover-labels.md) ·
+  [Dynamic Type reflow audit (#2548)](./ios-dynamic-type-reflow-audit.md)
+- [Accessibility Patterns Library](./accessibility-patterns.md) — §3 Screen Reader Support
+- [Cognitive Accessibility Mode](./cognitive-accessibility.md) — testing checklist precedent
+- Existing tests: [`apps/ios/Tests`](../../apps/ios/Tests) ·
+  [`apps/ios/Tests/UITests/FinanceUITests.swift`](../../apps/ios/Tests/UITests/FinanceUITests.swift)
+- Apple — XCTest `performAccessibilityAudit()`, Dynamic Type, VoiceOver

--- a/docs/design/ios-transaction-row-voiceover-labels.md
+++ b/docs/design/ios-transaction-row-voiceover-labels.md
@@ -1,0 +1,314 @@
+# iOS Transaction Row VoiceOver Labels — Design
+
+> **Status:** PROPOSED — pending human review
+> **Issue:** [#2544](https://github.com/jrmoulckers/finance/issues/2544) · Part of [#2117](https://github.com/jrmoulckers/finance/issues/2117)
+> **Platform:** iOS / iPadOS (SwiftUI) · Deployment target iOS 17.0
+> **Labels:** `platform:ios` · `accessibility` · `priority:high` · `effort:s`
+> **Author:** iOS engineer (design only — no native build performed)
+
+This document specifies how a single transaction row should be announced by
+VoiceOver as **one focus stop** that carries payee, signed amount, category,
+account, date, and status (pending / recurring). It is a design-only
+deliverable: native Swift/SwiftUI changes are tracked separately and the
+distribution tail is gated by Apple Developer enrollment
+([#1239](https://github.com/jrmoulckers/finance/issues/1239)).
+
+---
+
+## Table of Contents
+
+1. [Problem statement](#1-problem-statement)
+2. [Affected iOS surfaces](#2-affected-ios-surfaces)
+3. [Root cause](#3-root-cause)
+4. [Focus-stop model (current vs proposed)](#4-focus-stop-model-current-vs-proposed)
+5. [VoiceOver label / value / trait composition](#5-voiceover-label--value--trait-composition)
+6. [Rotor and date-section context](#6-rotor-and-date-section-context)
+7. [Redundant non-color cues](#7-redundant-non-color-cues)
+8. [Dynamic Type interplay](#8-dynamic-type-interplay)
+9. [Privacy — balance hiding](#9-privacy--balance-hiding)
+10. [Stale, error, and empty states](#10-stale-error-and-empty-states)
+11. [Shared dependencies and the KMP boundary](#11-shared-dependencies-and-the-kmp-boundary)
+12. [Proposed implementation](#12-proposed-implementation)
+13. [Smallest tests plan](#13-smallest-tests-plan)
+14. [Implementation readiness](#14-implementation-readiness)
+15. [References](#15-references)
+
+---
+
+## 1. Problem statement
+
+A transaction row contains four to six pieces of meaning: **who** (payee),
+**how much** (signed amount), **what** (category), **where** (account),
+**when** (date), and **state** (pending / recurring). Sighted users absorb all
+of this in a single glance. A VoiceOver user must receive the same information
+in a single focus stop, in a deliberate reading order, without losing the
+amount or the status.
+
+Today the amount and status are silently dropped from the announcement on every
+transaction surface (see [§3](#3-root-cause)), and the date lives only in the
+date-section header — a separate focus stop a user may not have visited. The
+goal of #2544 is to standardise one correct, localized, privacy-aware label
+across all transaction rows.
+
+## 2. Affected iOS surfaces
+
+| Surface                  | File                                                                                                                 | Row builder                     | Currently announced             | Missing                              |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------- | ------------------------------- | ------------------------------- | ------------------------------------ |
+| Reusable row component   | [`apps/ios/Finance/Components/TransactionRowView.swift`](../../apps/ios/Finance/Components/TransactionRowView.swift) | `accessibilityLabelText`        | payee, category, account, tags  | amount, date, **pending**, recurring |
+| Transactions list        | [`apps/ios/Finance/Screens/TransactionsView.swift`](../../apps/ios/Finance/Screens/TransactionsView.swift)           | `transactionAccessibilityLabel` | payee, category, account, tags  | amount, date, pending, recurring     |
+| Dashboard recent rows    | [`apps/ios/Finance/Screens/DashboardView.swift`](../../apps/ios/Finance/Screens/DashboardView.swift)                 | `transactionRow` inline         | payee, category                 | amount, date, status, account        |
+| Swipe actions (edit/del) | [`apps/ios/Finance/Screens/TransactionsView.swift`](../../apps/ios/Finance/Screens/TransactionsView.swift)           | `.swipeActions` buttons         | "Edit transaction" / "Delete …" | which transaction; custom-action map |
+
+Supporting components referenced by every row:
+
+- [`CurrencyLabel`](../../apps/ios/Finance/Components/CurrencyLabel.swift) — already produces a
+  sign-aware spoken description (`"Income of $X"` / `"Expense of $X"`), but that
+  description is discarded when the parent overrides the combined label.
+- [`TransactionItem`](../../apps/ios/Finance/Models/TransactionItem.swift) — the model carrying
+  `amountMinorUnits`, `currencyCode`, `date`, `status`, `isRecurring`, `tags`.
+
+> **Note:** three independent row builders exist with three different label
+> strings. Consolidating on the reusable `TransactionRowView` (see
+> [§12](#12-proposed-implementation)) removes the divergence at its source.
+
+## 3. Root cause
+
+Every row uses `.accessibilityElement(children: .combine)` **and then** sets an
+explicit `.accessibilityLabel(...)`. An explicit label on a combined element
+**replaces** the auto-merged child labels — so the amount rendered by
+`CurrencyLabel` and the "Pending" / "Recurring" badges never reach VoiceOver.
+
+```swift
+// TransactionRowView.swift (today)
+HStack { /* icon, payee, pending badge, recurring icon, CurrencyLabel */ }
+    .accessibilityElement(children: .combine)          // would merge children…
+    .accessibilityLabel(accessibilityLabelText)        // …but this OVERRIDES the merge
+
+private var accessibilityLabelText: String {
+    // payee, category, accountName, tags — no amount, no date, no status
+}
+```
+
+The fix is not "remove the explicit label" (the auto-merge order is
+unpredictable and reads the orange "Pending" capsule and decorative icon in
+visual order). The fix is to **compose one deterministic label/value/trait set
+by hand** that includes every meaningful field, and to mark decorative views
+`.accessibilityHidden(true)` so they never leak into the merge.
+
+## 4. Focus-stop model (current vs proposed)
+
+```mermaid
+flowchart TD
+    subgraph Current["Current — meaning is split / lost"]
+      H1["Section header: 'June 21, 2026' (heading)"]
+      R1["Row: 'Blue Bottle, Coffee, Checking'\n(amount + pending + recurring DROPPED)"]
+      H1 --> R1
+    end
+
+    subgraph Proposed["Proposed — one complete focus stop"]
+      H2["Section header: 'June 21, 2026' (heading, rotor)"]
+      R2["Row label: 'Blue Bottle, Expense of $4.50, Coffee, Checking, June 21'\nValue: 'Pending, Recurring'\nTrait: Button · Hint: 'Tap to view details…'"]
+      H2 --> R2
+    end
+```
+
+## 5. VoiceOver label / value / trait composition
+
+A row is a **button** (it pushes a detail / edit screen). Compose the focus
+stop as follows. All strings use `String(localized:)`; the order below is the
+spoken order.
+
+| Element        | Source                                                    | Spoken order | Rule                                                                                            |
+| -------------- | --------------------------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------- |
+| **Label**      | payee → amount → category → account → date                | 1            | Identity first, money second; join with `", "`. Amount uses `CurrencyLabel` spoken description. |
+| **Value**      | status descriptors (`Pending`, `Recurring`)               | 2            | Omit when the row is the default `cleared` / non-recurring — silence reduces verbosity.         |
+| **Trait**      | `.isButton`                                               | 3            | Tells VoiceOver an activation is available; do not add `.isStaticText`.                         |
+| **Hint**       | "Tap to view details. Swipe to edit or delete."           | 4            | Honour Settings → VoiceOver → "Speak hints"; never put critical info only in the hint.          |
+| **Decorative** | type icon, color swatch, divider, inline tag chips visual | hidden       | `.accessibilityHidden(true)` so the merge cannot read them in visual order.                     |
+
+### Canonical composition (pseudocode)
+
+```swift
+// Pure, testable — see §13. Lives in apps/ios (Apple a11y semantics).
+func transactionRowLabel(_ t: TransactionItem, balancesHidden: Bool) -> String {
+    let amount = balancesHidden
+        ? String(localized: "Amount hidden")
+        : CurrencyLabel.spokenDescription(t.amountMinorUnits, t.currencyCode) // "Expense of $4.50"
+    var parts = [t.payee, amount, t.category]
+    if !t.accountName.isEmpty { parts.append(t.accountName) }
+    parts.append(t.date.formatted(.dateTime.month().day())) // "June 21"
+    return parts.joined(separator: ", ")
+}
+
+func transactionRowValue(_ t: TransactionItem) -> String? {
+    var s: [String] = []
+    if t.status == .pending { s.append(String(localized: "Pending")) }
+    if t.isRecurring { s.append(String(localized: "Recurring")) }
+    return s.isEmpty ? nil : s.joined(separator: ", ")
+}
+```
+
+### Worked examples
+
+| Transaction                                               | Label (spoken)                                             | Value                |
+| --------------------------------------------------------- | ---------------------------------------------------------- | -------------------- |
+| Blue Bottle, −$4.50, Coffee, Checking, pending, recurring | "Blue Bottle, Expense of $4.50, Coffee, Checking, June 21" | "Pending, Recurring" |
+| Payroll, +$2,500.00, Income, Checking, cleared            | "Payroll, Income of $2,500.00, Income, Checking, June 20"  | _(none)_             |
+| Transfer, $300.00, Transfer, Savings, cleared             | "Transfer, $300.00, Transfer, Savings, June 19"            | _(none)_             |
+
+## 6. Rotor and date-section context
+
+- The date-section header (`Text(group.date, style: .date)`) **stays** a
+  VoiceOver **heading** (`.accessibilityAddTraits(.isHeader)`) so the **Headings
+  rotor** lets users jump between days. Each row additionally repeats the short
+  date so a user who lands mid-list still gets the "when" without back-tracking.
+- Add an **Actions rotor** entry for the swipe actions via
+  `.accessibilityAction(named:)` so "Edit" and "Delete" are reachable without
+  performing a physical swipe (swipe gestures are hard for Switch Control and
+  some motor profiles):
+
+  ```swift
+  .accessibilityAction(named: Text("Edit transaction")) { edit(t) }
+  .accessibilityAction(named: Text("Delete transaction")) { confirmDelete(t.id) }
+  ```
+
+- Swipe-action buttons must name the **subject** ("Delete transaction") and the
+  destructive one keeps `role: .destructive` so the trait is announced.
+
+## 7. Redundant non-color cues
+
+Financial direction and status must never depend on color alone (WCAG 1.4.1):
+
+| Signal    | Color (visual)      | Redundant non-color cue (required)                                      |
+| --------- | ------------------- | ----------------------------------------------------------------------- |
+| Income    | green               | leading `+`/down-left arrow icon **and** spoken "Income of …"           |
+| Expense   | red                 | leading `−`/up-right arrow icon **and** spoken "Expense of …"           |
+| Transfer  | blue                | transfer arrow icon **and** spoken "Transfer"                           |
+| Pending   | orange capsule      | the **word** "Pending" in the capsule **and** in the VoiceOver value    |
+| Recurring | secondary-tint icon | the **word** "Recurring" in the VoiceOver value (icon stays decorative) |
+
+The amount color in `CurrencyLabel` is therefore a _reinforcement_, not the
+sole carrier of meaning. Verify against Increase Contrast and Smart Invert.
+
+## 8. Dynamic Type interplay
+
+This work composes the **string**; the **layout** that must wrap that string at
+accessibility sizes (AX1–AX5) is covered by the Dynamic Type reflow audit
+([#2548](./ios-dynamic-type-reflow-audit.md)). Two contracts connect them:
+
+1. The composed label is identical regardless of type size — VoiceOver content
+   must not change when the row reflows from horizontal to vertical.
+2. The amount must remain a **separate visual element** (so it can move below
+   payee at AX sizes) while still feeding the single combined label.
+
+## 9. Privacy — balance hiding
+
+When a future "Hide balances" privacy mode (or `.privacySensitive()` redaction
+while the app is backgrounded / in the app switcher) hides amounts on screen,
+the **accessibility label and value must also redact the amount** — otherwise
+VoiceOver leaks exactly the figure the user asked to hide.
+
+- Thread a `balancesHidden` flag into the label composer; substitute
+  `String(localized: "Amount hidden")` for the spoken amount.
+- Never place the real amount in `accessibilityValue` "for convenience".
+- The redaction state itself is not sensitive; announcing "Amount hidden" is
+  expected and reassuring.
+
+See [Financial Data Accessibility](./accessibility-patterns.md#7-financial-data-accessibility)
+for the cross-platform rule and the widget-side precedent in
+[`WidgetPrivacyPrompt`](../../apps/ios/Finance/Services/WidgetPrivacyPrompt.swift).
+
+## 10. Stale, error, and empty states
+
+| State           | Surface                                                                    | VoiceOver behaviour                                                                                |
+| --------------- | -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| Loading         | `ProgressView` with `.accessibilityLabel("Loading")`                       | Already labeled; keep as a single focus stop, no row labels yet.                                   |
+| Empty           | [`EmptyStateView`](../../apps/ios/Finance/Components/EmptyStateView.swift) | Title is a heading; CTA "Add Transaction" is a labeled button. No phantom rows announced.          |
+| Search-empty    | `ContentUnavailableView.search(text:)`                                     | System component is already accessible; verify the query echoes in the announcement.               |
+| Error           | `.alert("Error", …)` with Retry / Dismiss                                  | VoiceOver focus moves to the alert; both buttons labeled; message is the spoken body.              |
+| Stale / offline | [`OfflineBanner`](../../apps/ios/Finance/Components/OfflineBanner.swift)   | Announce as a live region (`.accessibilityAddTraits(.updatesFrequently)`) when connectivity flips. |
+
+Per-row staleness (e.g. a transaction edited locally but not yet synced) is not
+currently surfaced; if added later, expose it in the row **value** ("Not
+synced"), never via color only.
+
+## 11. Shared dependencies and the KMP boundary
+
+```mermaid
+flowchart LR
+    Core["packages/core\n(status, recurrence rules)"] --> Bridge["SwiftExportBridge\n(apps/ios/Finance/KMP)"]
+    Models["packages/models\n(transaction shape)"] --> Bridge
+    Bridge --> Item["TransactionItem\n(apps/ios)"]
+    Item --> Label["Row label composer\n(apps/ios — Apple a11y semantics)"]
+    Curr["CurrencyLabel.spokenDescription\n(apps/ios)"] --> Label
+```
+
+- **Stays in `packages/`** (no change required for #2544): what _pending_ /
+  _recurring_ mean, sign of an amount, currency minor-unit math.
+- **Stays in `apps/ios`** (this work): label/value/trait composition, spoken
+  ordering, localization, redaction, rotor and swipe-action semantics.
+
+No shared-package edits are needed; if a future need arises, it goes through an
+ADR per the KMP boundary, not a direct `packages/` change.
+
+## 12. Proposed implementation
+
+1. **Consolidate** the three row builders onto the reusable
+   `TransactionRowView`; delete the inline copies in `TransactionsView` and
+   `DashboardView` (Dashboard passes a "compact" flag if it wants fewer visible
+   fields, but the _label_ stays complete).
+2. **Extract** `transactionRowLabel(_:balancesHidden:)` and
+   `transactionRowValue(_:)` as pure functions (file-private or a small
+   `TransactionAccessibility` enum) so they are unit-testable without a host app.
+3. **Mark decorative** views hidden: type icon, color circle, divider, inline
+   tag visuals → `.accessibilityHidden(true)`.
+4. **Apply** `.accessibilityElement(children: .ignore)` + explicit
+   `.accessibilityLabel` + `.accessibilityValue` + `.accessibilityAddTraits(.isButton)`
+   - `.accessibilityHint` + `.accessibilityAction(named:)` for swipe parity.
+5. **Keep the section header** a heading for the rotor.
+6. **Localize** every fragment; verify pseudo-localized and RTL ordering.
+
+## 13. Smallest tests plan
+
+The detailed regression suite is owned by
+[#2546](./ios-transaction-accessibility-regression.md). The minimum to accept
+**this** change:
+
+- **Unit (XCTest, no host app):** assert `transactionRowLabel`/`Value` output
+  for income, expense, transfer, pending, recurring, multi-tag, empty-account,
+  and `balancesHidden == true` cases. Pure functions → fast and deterministic.
+- **UI (XCUITest):** `app.performAccessibilityAudit()` on the Transactions and
+  Dashboard screens (iOS 17+) — zero issues. Assert a row element's
+  `.label`/`.value` contains the amount and "Pending".
+- **Snapshot (optional):** accessibility-hierarchy snapshot at default size to
+  lock the focus-stop order.
+
+## 14. Implementation readiness
+
+See [`docs/ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md)
+for the authoritative split.
+
+**Buildable now (no human gate):**
+
+- All VoiceOver label/value/trait/rotor/swipe-action work in this document is
+  implementable and testable today on the iOS Simulator and on a personal
+  device using a **free Personal Team** signing certificate (no paid enrollment
+  required to build, run, and run XCUITest accessibility audits).
+- Unit and UI accessibility tests run in CI without any Apple account.
+
+**Gated by [#1239](https://github.com/jrmoulckers/finance/issues/1239) (Apple Developer enrollment):**
+
+- TestFlight / App Store distribution of the build containing these labels.
+- Any capability that needs a paid-team entitlement (push, App Groups across a
+  signed distribution build, etc.). The a11y work itself needs none of these.
+
+No human-gated operation is required to _implement or verify_ this design.
+
+## 15. References
+
+- Sibling designs: [accessibility regression coverage (#2546)](./ios-transaction-accessibility-regression.md) ·
+  [Dynamic Type reflow audit (#2548)](./ios-dynamic-type-reflow-audit.md)
+- [Accessibility Patterns Library](./accessibility-patterns.md) — §3 Screen Reader Support, §7 Financial Data Accessibility
+- [Cognitive Accessibility Mode](./cognitive-accessibility.md) — content and simplification guidance
+- Apple HIG — VoiceOver, Accessibility, Dynamic Type
+- WCAG 2.2 — 1.3.1 Info & Relationships, 1.4.1 Use of Color, 4.1.2 Name/Role/Value


### PR DESCRIPTION
## Summary

Design-only batch (no native build, no signing, no store actions) adding three
new docs under `docs/design/` for the iOS accessibility cluster. Each doc is
grounded in the real `apps/ios` transaction/dashboard/analytics/investment
surfaces and follows `docs.instructions.md`: humans-first, ToC, Mermaid
diagrams, relative links, deep accessibility detail, privacy (balance hiding),
stale/error/empty states, a smallest-tests plan, and an Implementation
readiness section that splits buildable-now work (free Personal Team signing)
from the distribution tail gated by #1239.

## Changes

- **`docs/design/ios-transaction-row-voiceover-labels.md`** (#2544) — root-causes
  the dropped amount/status announcement (explicit `.accessibilityLabel` over a
  `.combine` element) across `TransactionRowView`, `TransactionsView`,
  `DashboardView` recent rows, and swipe actions; specifies a single-focus-stop
  label/value/trait composition, rotor + date-section context, redundant
  non-color cues, and redaction-aware labels.
- **`docs/design/ios-transaction-accessibility-regression.md`** (#2546) — defines
  the smallest durable suite: pure-function unit tests for label composition,
  `performAccessibilityAudit()` XCUITest coverage, and accessibility-hierarchy
  snapshots at AX sizes, with a coverage matrix and CI integration.
- **`docs/design/ios-dynamic-type-reflow-audit.md`** (#2548) — audits
  one-line/`minimumScaleFactor` truncation across transactions, dashboard cards,
  analytics, legends, and investment metrics; specifies wrapping +
  accessibility-size vertical stacks using the repo's existing
  `AdaptiveFinanceStack` / `SizeConstrainedCurrencyText` / `FlowLayout`
  primitives.

## Notes

- New files only; no existing files, `packages/`, `apps/` code, shared config,
  or other docs were modified.
- `npx prettier --check` passes on all three files.
- Cross-links existing a11y references (`accessibility-patterns.md`,
  `cognitive-accessibility.md`) and `../ops/human-gated-prerequisites.md`.

Closes #2544
Closes #2546
Closes #2548
