### PR TITLE
docs(design): android receipt capture design batch (#2547, #2549, #2563)

### DIFF
--- a/docs/design/android-cameraX-receipt-capture.md
+++ b/docs/design/android-cameraX-receipt-capture.md
@@ -1,0 +1,290 @@
+# Android CameraX Receipt Capture & Fallback — Design
+
+> **Status:** Design / breakdown only — native implementation gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+> **Issue:** [#2563](https://github.com/jrmoulckers/finance/issues/2563) · **Part of:** [#2388](https://github.com/jrmoulckers/finance/issues/2388)
+> **Platform:** Android (Jetpack Compose + Material 3) · **Audience:** Android engineers, design, QA
+
+This document designs **production-grade receipt capture** on Android using
+**CameraX**, with permission rationale, gallery and manual-entry fallbacks,
+crop/retake, and clear **no-upload** privacy copy. It is the capture front-end for
+the [receipt-to-expense draft flow](./android-receipt-to-expense-draft.md); the
+captured image is handed to on-device OCR and never leaves the device.
+
+It replaces the prototype capture in
+[`ReceiptOcrScreen`](../../apps/android/src/main/kotlin/com/finance/android/ui/screens/ReceiptOcrScreen.kt),
+which uses `ActivityResultContracts.TakePicturePreview()` (a low-resolution
+thumbnail) — insufficient for reliable OCR. CameraX gives full-resolution capture,
+tap-to-focus, and a controllable preview surface.
+
+As everywhere in the receipt cluster, **Compose renders shared state**. Capture
+produces a `Bitmap`/URI for the existing on-device
+[`AndroidMlKitReceiptOcrAdapter`](../../apps/android/src/main/kotlin/com/finance/android/receipt/AndroidMlKitReceiptOcrAdapter.kt);
+all parsing and finance math stay in KMP `packages/core`.
+
+---
+
+## Table of Contents
+
+1. [Goals & non-goals](#1-goals--non-goals)
+2. [Capture architecture](#2-capture-architecture)
+3. [Camera permission rationale](#3-camera-permission-rationale)
+4. [Fallback: gallery & manual entry](#4-fallback-gallery--manual-entry)
+5. [Crop & retake](#5-crop--retake)
+6. [No-upload privacy copy](#6-no-upload-privacy-copy)
+7. [Offline-first, empty, and error states](#7-offline-first-empty-and-error-states)
+8. [Accessibility](#8-accessibility)
+9. [Test plan](#9-test-plan)
+10. [Implementation readiness](#10-implementation-readiness)
+11. [Cross-links](#11-cross-links)
+
+---
+
+## 1. Goals & non-goals
+
+### Goals
+
+- Add a **CameraX capture flow** that produces a full-resolution image for OCR
+  (acceptance criterion from [#2388](https://github.com/jrmoulckers/finance/issues/2388):
+  "Add a camera capture flow that produces a reviewable transaction draft").
+- Show a **clear permission rationale** before/at the camera request, and a
+  graceful path when permission is denied.
+- Provide **gallery** and **manual-entry** fallbacks when ML Kit or camera
+  permission is unavailable (criterion: "Document fallback/manual entry when ML Kit
+  or camera permissions are unavailable").
+- Offer **crop and retake** before committing to OCR.
+- Reassure with **no-upload** privacy copy at the point of capture.
+
+### Non-goals
+
+- OCR field parsing, draft assembly, and save — see [Android Receipt-to-Expense Draft Flow](./android-receipt-to-expense-draft.md) ([#2547](https://github.com/jrmoulckers/finance/issues/2547)).
+- Attachment persistence and COGS mapping — see [Android Receipt Attachments & COGS Mapping](./android-receipt-attachments-cogs.md) ([#2549](https://github.com/jrmoulckers/finance/issues/2549)).
+- Any change to KMP packages or to other platforms.
+
+---
+
+## 2. Capture architecture
+
+CameraX is composed inside Compose; the preview is hosted in an `AndroidView`
+wrapping a `PreviewView`, which is the standard, supported Compose↔CameraX bridge
+(this is **not** an XML layout — it is a single interop node, allowed for
+framework surfaces like camera previews).
+
+| Component                 | Type          | Responsibility                                                             |
+| ------------------------- | ------------- | -------------------------------------------------------------------------- |
+| `ReceiptCaptureScreen`    | `@Composable` | Hosts preview, shutter, gallery/manual entry points, and privacy banner.   |
+| `CameraPreview`           | `@Composable` | `AndroidView(PreviewView)` bound to a CameraX `Preview` + `ImageCapture`.  |
+| `CaptureControls`         | `@Composable` | Shutter, flash toggle, gallery shortcut, cancel.                           |
+| `CropRetakeScreen`        | `@Composable` | Review the still: crop overlay, **Retake**, **Use photo**.                 |
+| `ReceiptCaptureViewModel` | `ViewModel`   | Owns capture/permission state; emits the image to the OCR adapter.         |
+| CameraX use cases         | (CameraX)     | `Preview` + `ImageCapture` bound to lifecycle via `ProcessCameraProvider`. |
+
+```mermaid
+flowchart TD
+    Start["Enter ReceiptCaptureScreen"] --> Perm{"Camera permission?"}
+    Perm -->|"Granted"| Live["CameraX live preview"]
+    Perm -->|"Not yet"| Rationale["Show rationale -> request"]
+    Perm -->|"Denied permanently"| Fallback["Gallery / Manual entry"]
+    Rationale --> Live
+    Live -->|"Shutter"| Still["ImageCapture still (full-res)"]
+    Still --> Crop["Crop & retake"]
+    Crop -->|"Use photo"| OCR["On-device OCR adapter"]
+    Crop -->|"Retake"| Live
+    Fallback -->|"Pick image"| OCR
+    Fallback -->|"Manual"| Draft["Manual draft entry (#2547)"]
+    OCR --> Draft
+```
+
+- Capture is bound to the Composable lifecycle; the camera is released on
+  `onStop`/dispose to avoid leaks and battery drain.
+- The shutter writes a full-resolution still (compressed) and passes it to the
+  existing `AndroidMlKitReceiptOcrAdapter.extract(bitmap)` — the OCR boundary is
+  unchanged.
+- DI: `koinViewModel<ReceiptCaptureViewModel>()`; registered additively in the
+  receipt Koin module.
+
+---
+
+## 3. Camera permission rationale
+
+Permission is requested with rationale, not cold. The flow distinguishes
+first-ask, "show rationale", and "permanently denied".
+
+```mermaid
+stateDiagram-v2
+    [*] --> CheckPermission
+    CheckPermission --> Granted: already granted
+    CheckPermission --> FirstAsk: never asked
+    CheckPermission --> Rationale: shouldShowRationale
+    CheckPermission --> Blocked: permanently denied
+    FirstAsk --> Granted: user allows
+    FirstAsk --> Rationale: user denies once
+    Rationale --> Granted: user allows
+    Rationale --> Blocked: user denies again
+    Blocked --> Fallback: offer gallery / manual / Settings
+    Granted --> [*]
+    Fallback --> [*]
+```
+
+- Rationale copy explains **why** the camera is needed and reaffirms **no upload**
+  (see §6) in plain language per [Content & Language Guidelines](./content-language-guidelines.md).
+- "Permanently denied" never dead-ends: the user is offered **Choose from
+  gallery**, **Enter manually**, and a deep link to **App settings**.
+- Permission state is held in the ViewModel and survives configuration changes; the
+  request uses `ActivityResultContracts.RequestPermission()`.
+
+---
+
+## 4. Fallback: gallery & manual entry
+
+Fallback is a first-class path, not an error.
+
+| Condition                      | Fallback offered                                                                                                       |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| Camera permission denied       | **Choose from gallery** (`GetContent("image/*")`) + **Enter manually**.                                                |
+| No camera hardware             | Gallery + manual; camera controls hidden.                                                                              |
+| ML Kit unavailable / OCR fails | **Enter manually** (jump straight to the draft form from [#2547](https://github.com/jrmoulckers/finance/issues/2547)). |
+| Low-quality / unreadable image | Retake (camera) or re-pick (gallery), plus manual entry.                                                               |
+
+- The gallery path reuses the existing `GetContent` contract already present in
+  [`ReceiptOcrScreen`](../../apps/android/src/main/kotlin/com/finance/android/ui/screens/ReceiptOcrScreen.kt).
+- Manual entry hands off directly to the
+  [receipt-to-expense draft flow](./android-receipt-to-expense-draft.md) with an
+  empty draft, so the user can always create the expense regardless of camera/OCR
+  availability.
+- Fallbacks are surfaced **before** failure where possible (for example, a
+  permanent "Enter manually" affordance always visible on the capture screen).
+
+---
+
+## 5. Crop & retake
+
+After the shutter, the user reviews the still before OCR runs:
+
+- **Crop overlay** with draggable handles to isolate the receipt and drop
+  background clutter, improving OCR accuracy. Crop math is local image geometry, not
+  finance math.
+- **Retake** returns to the live preview without losing the camera session.
+- **Use photo** commits the cropped bitmap to
+  `AndroidMlKitReceiptOcrAdapter.extract(...)`.
+- Rotation is corrected from EXIF/sensor orientation before OCR.
+- The cropped result is what flows downstream; the attachment opt-in in
+  [#2549](https://github.com/jrmoulckers/finance/issues/2549) stores the cropped
+  image (only if the user opts in).
+
+---
+
+## 6. No-upload privacy copy
+
+Privacy is stated **at the moment of capture**, not buried in settings:
+
+- A persistent banner on the capture and crop screens: **"Receipts are scanned on
+  this device. The photo and its text are never uploaded."** This mirrors the
+  existing on-screen assurance in `ReceiptOcrScreen`.
+- The permission rationale repeats the no-upload promise so the user grants camera
+  access with full context.
+- Copy is reviewed against [Content & Language Guidelines](./content-language-guidelines.md)
+  and kept plain per [Cognitive Accessibility Mode](./cognitive-accessibility.md).
+- Engineering guardrail: capture, crop, and OCR have **no network calls**; ML Kit
+  Text Recognition runs on-device. This is asserted in tests (§9).
+
+---
+
+## 7. Offline-first, empty, and error states
+
+Capture is inherently offline; no connectivity is required at any step.
+
+| State                  | Trigger                     | UX                                                                                                                             |
+| ---------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| First entry            | Screen opened               | Live preview (if permitted) + visible gallery/manual affordances.                                                              |
+| Permission not granted | No camera permission        | Rationale (§3); never a blank black screen.                                                                                    |
+| No camera hardware     | `FEATURE_CAMERA_ANY` absent | Hide camera UI; lead with gallery + manual.                                                                                    |
+| Capture failure        | `ImageCapture` error        | Inline error + **Try again**; offer gallery/manual.                                                                            |
+| Unreadable image       | OCR returns unusable result | Route to crop/retake or manual; reuse the unusable-scan path from [#2547](https://github.com/jrmoulckers/finance/issues/2547). |
+| ML Kit unavailable     | Recognition module missing  | Skip OCR; go straight to manual draft entry.                                                                                   |
+
+No image bytes, OCR text, or financial values are written to Timber. Capture logs
+record only non-sensitive lifecycle events ("camera bound", "capture succeeded",
+"permission denied") via `Timber.d`/`Timber.w` — never `Log.*` directly and never
+sensitive data.
+
+---
+
+## 8. Accessibility
+
+Camera UIs are notoriously hard for assistive tech; this design treats
+accessibility as a requirement, per the
+[Accessibility Patterns Library](./accessibility-patterns.md). Target WCAG 2.2 AA.
+
+- **TalkBack:** The shutter, flash, gallery, and cancel controls each have a clear
+  `contentDescription` ("Capture receipt photo"). The live preview is labelled and
+  announces guidance ("Point the camera at a receipt, then double-tap to capture").
+  The no-upload banner is announced on screen entry.
+- **Switch Access:** All controls are ≥ 48 dp and reachable without relying on the
+  preview surface; the shutter is operable via a single switch action. Crop handles
+  expose discrete nudge actions so cropping does not require a drag gesture.
+- **200% font scaling:** Controls and banner text scale and wrap; the preview area
+  shrinks gracefully but controls remain fully visible (no clipped shutter).
+- **Non-visual capture:** Because framing a receipt is visual, the gallery and
+  **manual entry** fallbacks are always available as fully accessible alternatives —
+  a blind user can still create the expense end-to-end.
+- **Color independence & contrast:** Controls use icon + label with sufficient
+  contrast over the preview (scrim behind controls).
+
+Every interactive Composable here carries a `contentDescription`.
+
+---
+
+## 9. Test plan
+
+| Layer                | Tooling                   | Coverage                                                                                                                                             |
+| -------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Unit (ViewModel)     | JUnit + coroutine test    | Permission state machine (first-ask → rationale → blocked → fallback); capture-to-OCR handoff; manual fallback path.                                 |
+| Unit (no-network)    | JUnit                     | Assert capture/crop/OCR perform no network I/O (fake injected; verify zero calls).                                                                   |
+| Compose UI           | `compose-ui-test`         | Rationale shown before request; denied → gallery/manual visible; crop **Retake**/**Use photo**; semantics + `contentDescription`; font-scale `2.0f`. |
+| Snapshot             | Paparazzi                 | `ReceiptCaptureScreen` (permission-needed, denied/blocked, no-camera), `CropRetakeScreen` — default + 200% font, light/dark + dynamic color.         |
+| Instrumented (later) | `androidx.test` + CameraX | Real `PreviewView` binding + `ImageCapture` on emulator/sideload (debug build) for the live preview path.                                            |
+
+CameraX preview binding is verified on-device with a **debug** build; no signing is
+required. Shared OCR parsing is covered by existing `packages/core` tests.
+
+---
+
+## 10. Implementation readiness
+
+This is a design artifact. CameraX and permission plumbing are **fully
+debug-implementable today**. See [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md)
+and the [Launch Readiness Plan](../ops/launch-readiness-plan.md) for gating.
+
+### Buildable now (debug, no human gate)
+
+- **All** CameraX capture, `PreviewView` interop, the permission rationale state
+  machine, crop/retake, gallery + manual fallbacks, and no-upload copy are pure
+  Compose + AndroidX — runnable via `./gradlew :apps:android:assembleDebug` and
+  sideload to a device/emulator.
+- Permission flows, fallbacks, and accessibility semantics need no signing, no
+  store presence, and no production keystore.
+- The capture → OCR handoff reuses the existing on-device adapter; unit, Compose,
+  Paparazzi, and emulator instrumentation all run in CI/debug.
+
+### Play-distribution tail (gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242))
+
+- Production signing keystore + Google Play Console onboarding.
+- Play **Data safety** / privacy declarations reflecting on-device-only camera and
+  OCR (no image upload), camera-permission justification, internal-testing-track
+  upload, and staged rollout.
+- Anything requiring a release-signed AAB (not `assembleDebug`).
+
+The entire capture experience can be built, sideloaded, and tested in debug now;
+only its production distribution is gated.
+
+---
+
+## 11. Cross-links
+
+- Sibling: [Android Receipt-to-Expense Draft Flow](./android-receipt-to-expense-draft.md) — [#2547](https://github.com/jrmoulckers/finance/issues/2547)
+- Sibling: [Android Receipt Attachments & COGS Mapping](./android-receipt-attachments-cogs.md) — [#2549](https://github.com/jrmoulckers/finance/issues/2549)
+- [Android Architecture](../architecture/android-architecture.md)
+- [Accessibility Patterns Library](./accessibility-patterns.md) · [Cognitive Accessibility Mode](./cognitive-accessibility.md)
+- [Component Library](./component-library.md) · [UX Design Principles](./ux-principles.md) · [Content & Language Guidelines](./content-language-guidelines.md)
+- [Information Architecture](./information-architecture.md) · [User Personas](./personas.md)
+- Ops: [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md) · [Launch Readiness Plan](../ops/launch-readiness-plan.md)

--- a/docs/design/android-receipt-attachments-cogs.md
+++ b/docs/design/android-receipt-attachments-cogs.md
@@ -1,0 +1,299 @@
+# Android Receipt Attachments & COGS Mapping — Design
+
+> **Status:** Design / breakdown only — native implementation gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+> **Issue:** [#2549](https://github.com/jrmoulckers/finance/issues/2549) · **Part of:** [#2183](https://github.com/jrmoulckers/finance/issues/2183)
+> **Platform:** Android (Jetpack Compose + Material 3) · **Audience:** Android engineers, design, QA
+
+This document designs two opt-in capabilities layered on top of the
+[receipt-to-expense draft flow](./android-receipt-to-expense-draft.md):
+
+1. **Opt-in receipt photo attachment** tied to the saved transaction, stored
+   on-device with **no upload**.
+2. **Line-item accept/reject** and **COGS / inventory / supplies** category
+   mapping for itemized receipts, so a food-truck owner can later do margin math.
+
+As with all receipt work, **Compose renders shared state**. The COGS
+classification, attachment metadata model, and confidence scoring already exist
+in KMP `packages/core`
+([`ReceiptCogsExtensions.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/receipt/cogs/ReceiptCogsExtensions.kt)).
+Android collects the opt-in, stores bytes locally, and presents the mapping — it
+does not classify or score on the JVM side.
+
+---
+
+## Table of Contents
+
+1. [Goals & non-goals](#1-goals--non-goals)
+2. [Shared COGS & attachment contracts](#2-shared-cogs--attachment-contracts)
+3. [Opt-in attachment model & on-device storage](#3-opt-in-attachment-model--on-device-storage)
+4. [Line-item accept/reject UX](#4-line-item-acceptreject-ux)
+5. [COGS / inventory / supplies mapping](#5-cogs--inventory--supplies-mapping)
+6. [Flows](#6-flows)
+7. [Offline-first, empty, and error states](#7-offline-first-empty-and-error-states)
+8. [Accessibility](#8-accessibility)
+9. [Test plan](#9-test-plan)
+10. [Implementation readiness](#10-implementation-readiness)
+11. [Cross-links](#11-cross-links)
+
+---
+
+## 1. Goals & non-goals
+
+### Goals
+
+- Persist the **receipt image as an attachment** linked to the transaction, only
+  after **explicit opt-in** (acceptance criterion from
+  [#2388](https://github.com/jrmoulckers/finance/issues/2388): "Store receipt
+  images only after explicit user opt-in").
+- Let the user **accept or reject each extracted line item**.
+- Map accepted items to business categories — **COGS**, **inventory**, or
+  **supplies** — using the shared classifier, with user override.
+- Keep all storage **encrypted, on-device, and offline** until the user later
+  syncs through the existing sync path.
+
+### Non-goals
+
+- Capture and OCR — see [Android CameraX Receipt Capture & Fallback](./android-cameraX-receipt-capture.md) ([#2563](https://github.com/jrmoulckers/finance/issues/2563)).
+- The base draft + correction + save flow — see [Android Receipt-to-Expense Draft Flow](./android-receipt-to-expense-draft.md) ([#2547](https://github.com/jrmoulckers/finance/issues/2547)).
+- Defining the **persisted** transaction-attachment table. The Android app today
+  has no transaction-level attachment model in
+  [`packages/models`](../../packages/models/src/commonMain/kotlin/com/finance/models/Transaction.kt);
+  that schema is a KMP-owned follow-up (see §3). This doc designs the Android UX
+  and the platform storage adapter around the shared metadata contract.
+
+---
+
+## 2. Shared COGS & attachment contracts
+
+These types already exist in `packages/core` and are the source of truth. Compose
+binds to them; it does not duplicate the rules.
+
+| Shared type / function                                                           | Role                                                                             |
+| -------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `ReceiptCogsCategory` (`COST_OF_GOODS_SOLD`, `INVENTORY`, `SUPPLIES`, `UNKNOWN`) | The business categories rendered as mapping options.                             |
+| `ReceiptCogsCategoryIds`                                                         | Maps each COGS category to an optional app category ID for the saved draft.      |
+| `ReceiptLineItemCategorySuggestion`                                              | Per-line description, cents, suggested category, matched keywords, confidence.   |
+| `ReceiptCategorySuggestion`                                                      | Overall deterministic category + reason + matched amount.                        |
+| `ReceiptCogsAnalysis`                                                            | Bundles draft, per-line suggestions, tax/payment hints, confidence, attachments. |
+| `ReceiptAttachmentMetadata`                                                      | Platform-neutral file metadata (filename, MIME type, size, checksum).            |
+| `ExtractedReceiptText.analyzeCogsReceipt(…)` / `.toCogsTransactionDraft(…)`      | Extension entry points the ViewModel calls.                                      |
+| `ReceiptCogsExtensions.suggestLineItemCategories(…)` / `analyzeReceipt(…)`       | Deterministic classification + scoring.                                          |
+
+All of the above are defined in
+[`ReceiptCogsExtensions.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/receipt/cogs/ReceiptCogsExtensions.kt).
+The Android ViewModel calls `analyzeCogsReceipt()` and exposes the resulting
+`ReceiptCogsAnalysis` as immutable UI state — no category math on the Android side.
+
+---
+
+## 3. Opt-in attachment model & on-device storage
+
+### Opt-in is mandatory and explicit
+
+- The receipt image is **not** stored unless the user toggles **"Attach receipt
+  photo to this expense."** Default is **off**.
+- The opt-in copy states plainly that the image stays on the device and is
+  encrypted — see [Content & Language Guidelines](./content-language-guidelines.md).
+- Declining attachment never blocks saving the expense; it only omits the image.
+
+### Storage adapter (Android-owned)
+
+- Bytes are written to **app-internal encrypted storage** (the same SQLCipher /
+  encrypted-at-rest posture the app uses for its database — see
+  [Android Architecture](../architecture/android-architecture.md)). Never to
+  shared/public media, `SharedPreferences`, or plain files.
+- The Android adapter computes `ReceiptAttachmentMetadata` (filename, MIME type,
+  `sizeBytes`, `checksum`) and hands the metadata to the shared draft via
+  `ReceiptTransactionDraft.attachments`. **Bytes and checksums are supplied by the
+  platform adapter; the shared layer only carries the metadata.**
+- Images are downscaled/compressed on-device before storage to bound size; the
+  original is never uploaded.
+
+### KMP follow-up (not implemented here)
+
+The persisted transaction↔attachment relationship (a new table/column and DAO)
+belongs in KMP `packages/*` and is owned by the KMP engineer. This document
+defines the **Android UX, opt-in gate, and encrypted local storage adapter** that
+consume the shared `ReceiptAttachmentMetadata` contract; it deliberately does not
+add the shared persistence schema. The dependency is called out so the work can be
+sequenced.
+
+```mermaid
+flowchart TD
+    Toggle["Opt-in toggle (default OFF)"] -->|"ON"| Store["Encrypted on-device store (app-internal)"]
+    Toggle -->|"OFF"| Skip["No image persisted"]
+    Store --> Meta["ReceiptAttachmentMetadata (filename, mime, size, checksum)"]
+    Meta --> Draft["ReceiptTransactionDraft.attachments (packages/core)"]
+    Skip --> Draft
+    Draft --> Save["TransactionRepository.insert()"]
+```
+
+---
+
+## 4. Line-item accept/reject UX
+
+The base draft screen already lists line items with accept checkboxes (see the
+existing pattern in
+[`ReceiptOcrScreen`](../../apps/android/src/main/kotlin/com/finance/android/ui/screens/ReceiptOcrScreen.kt)).
+This design formalizes it:
+
+| Element                   | Behaviour                                                                                      |
+| ------------------------- | ---------------------------------------------------------------------------------------------- |
+| Per-line accept toggle    | Material 3 `Checkbox`/`Switch`; default **accepted** for items above the confidence threshold. |
+| Line description + amount | Description and shared-formatted cents; never editable into financial math by the UI.          |
+| Suggested category chip   | Shows `ReceiptLineItemCategorySuggestion.category`; tapping opens the mapping sheet (§5).      |
+| Bulk actions              | "Accept all" / "Reject all" for fast entry from the truck.                                     |
+| Running summary           | Count + total of accepted items, formatted from shared cents.                                  |
+
+- Accept/reject only filters which items flow into the draft; it does not change
+  any amount. The accepted set is plain UI state.
+- Rejected items are visually de-emphasized but remain reachable by assistive tech
+  so a mistaken reject is recoverable.
+
+---
+
+## 5. COGS / inventory / supplies mapping
+
+For each accepted line item (and for the overall draft category), the user can
+keep the shared suggestion or override it:
+
+| Suggestion source                            | Default                               | Override                                                                  |
+| -------------------------------------------- | ------------------------------------- | ------------------------------------------------------------------------- |
+| `ReceiptLineItemCategorySuggestion.category` | Pre-selected chip per line            | Single-select among COGS / Inventory / Supplies / Unknown.                |
+| `ReceiptCategorySuggestion` (overall)        | Header chip + plain-language `reason` | Override applies to the draft's category ID via `ReceiptCogsCategoryIds`. |
+
+- The mapping sheet presents the four `ReceiptCogsCategory` values with their
+  `displayName` ("Cost of Goods Sold", "Inventory", "Supplies", "Unknown").
+- The "**ingredients → inventory/COGS**" follow-up from
+  [#2183](https://github.com/jrmoulckers/finance/issues/2183) is surfaced as a
+  one-tap suggestion when the overall suggestion is `INVENTORY` or
+  `COST_OF_GOODS_SOLD`; the actual category-to-ID resolution uses the shared
+  `ReceiptCogsCategoryIds.idFor(category)`.
+- Confidence/`reason` text is shown so the user understands the suggestion,
+  following [Cognitive Accessibility Mode](./cognitive-accessibility.md). The UI
+  never recomputes the suggestion — overrides simply replace the selected value.
+
+---
+
+## 6. Flows
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant VM as ReceiptCogsViewModel
+    participant Core as packages/core
+    participant Store as Encrypted store (Android)
+    participant Repo as TransactionRepository
+
+    VM->>Core: receipt.analyzeCogsReceipt(categoryIds)
+    Core-->>VM: ReceiptCogsAnalysis (suggestions + confidence)
+    VM-->>User: Line items with accept toggles + category chips
+    User->>VM: Reject some items / override a category
+    User->>VM: Toggle "Attach receipt photo" ON
+    VM->>Store: persist compressed image (encrypted)
+    Store-->>VM: ReceiptAttachmentMetadata
+    User->>VM: Save expense
+    VM->>Core: build draft with accepted items + attachments
+    Core-->>VM: ReceiptTransactionDraft
+    VM->>Repo: insert(Transaction)
+    Repo-->>User: Saved with linked receipt + COGS mapping
+```
+
+---
+
+## 7. Offline-first, empty, and error states
+
+Everything here works offline; attachment bytes live locally until the existing
+sync path uploads them later (out of scope).
+
+| State                 | Trigger                                          | UX                                                                                |
+| --------------------- | ------------------------------------------------ | --------------------------------------------------------------------------------- |
+| No line items         | Receipt parsed to total only                     | Hide the itemized section; still allow attachment + single-category draft.        |
+| All items rejected    | User rejects everything                          | Keep the header total; warn that no items map to COGS; saving still allowed.      |
+| Attachment opt-in off | Default                                          | No storage performed; expense saves without an image.                             |
+| Storage failure       | Disk full / write error                          | Non-blocking error card with **Retry**; expense can still save without the image. |
+| Ambiguous category    | `AMBIGUOUS_CATEGORY` flag from shared confidence | Surface as a "Choose a category" prompt; do not auto-commit `UNKNOWN`.            |
+| Offline               | No connectivity                                  | No blocking; "Saved locally — receipt will sync later" affordance.                |
+
+Sensitive financial values (amounts, totals, line items) are **never** logged via
+Timber. Attachment logs record only non-sensitive events ("attachment stored",
+size band) — never the image contents or the merchant total.
+
+---
+
+## 8. Accessibility
+
+Follows the shared [Accessibility Patterns Library](./accessibility-patterns.md);
+target WCAG 2.2 AA.
+
+- **TalkBack:** Each line item row announces description, amount, accept state, and
+  mapped category as one coherent label ("Buns, 6 dollars, accepted, mapped to
+  Cost of Goods Sold"). The attachment toggle announces its on/off state and the
+  privacy consequence.
+- **Switch Access:** Accept toggles, category chips, and the attachment switch are
+  ≥ 48 dp, single-purpose, and ordered logically. "Accept all"/"Reject all" give a
+  fast scan-free path.
+- **200% font scaling:** Rows reflow to multi-line; category chips wrap; amounts
+  never truncate. The mapping sheet scrolls rather than clipping options.
+- **Color independence:** Accepted/rejected and category are conveyed by text +
+  icon, not color alone.
+- **Live regions:** Bulk accept/reject and attachment success/failure announce via
+  a polite live region.
+
+Every interactive Composable defined here has a `contentDescription`.
+
+---
+
+## 9. Test plan
+
+| Layer                  | Tooling                | Coverage                                                                                                                                                                |
+| ---------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Unit (ViewModel)       | JUnit + coroutine test | `analyzeCogsReceipt` results mapped to state; accept/reject filters items only; override replaces shared suggestion without recomputation; opt-in OFF persists nothing. |
+| Unit (storage adapter) | JUnit (Robolectric)    | Image written to encrypted internal storage; correct `ReceiptAttachmentMetadata`; storage failure does not block save.                                                  |
+| Compose UI             | `compose-ui-test`      | Accept/reject toggles; category mapping sheet selection; attachment toggle gates storage; semantics assertions; font-scale `2.0f`.                                      |
+| Snapshot               | Paparazzi              | Line-item list (mixed accepted/rejected), mapping sheet, attachment opt-in on/off — default + 200% font, light/dark + dynamic color.                                    |
+
+Shared COGS classification, confidence scoring, and tax/payment extraction are
+covered by existing `packages/core` tests and are not re-tested here.
+
+---
+
+## 10. Implementation readiness
+
+This is a design artifact. See [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md)
+and the [Launch Readiness Plan](../ops/launch-readiness-plan.md) for gating.
+
+### Buildable now (debug, no human gate)
+
+- Line-item accept/reject UI, the COGS mapping sheet, and the attachment opt-in
+  toggle are pure Compose + KMP consumption — runnable via
+  `./gradlew :apps:android:assembleDebug` and sideload.
+- The encrypted on-device storage adapter reuses the app's existing
+  encryption-at-rest posture and is unit-testable (Robolectric) without signing.
+- All COGS/attachment rendering binds to existing `packages/core` contracts.
+
+### Cross-team dependency (additive, not store-gated)
+
+- The **persisted** transaction↔attachment schema/DAO is a KMP `packages/*`
+  follow-up owned by the KMP engineer (see §3). It is not blocked by
+  [#1242](https://github.com/jrmoulckers/finance/issues/1242); it is simply
+  out of Android's file ownership and must be sequenced.
+
+### Play-distribution tail (gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242))
+
+- Production signing keystore + Google Play Console onboarding.
+- Privacy declarations covering on-device image storage, internal-testing-track
+  upload, and staged rollout.
+- Anything requiring a release-signed AAB (not `assembleDebug`).
+
+---
+
+## 11. Cross-links
+
+- Sibling: [Android Receipt-to-Expense Draft Flow](./android-receipt-to-expense-draft.md) — [#2547](https://github.com/jrmoulckers/finance/issues/2547)
+- Sibling: [Android CameraX Receipt Capture & Fallback](./android-cameraX-receipt-capture.md) — [#2563](https://github.com/jrmoulckers/finance/issues/2563)
+- [Android Architecture](../architecture/android-architecture.md)
+- [Accessibility Patterns Library](./accessibility-patterns.md) · [Cognitive Accessibility Mode](./cognitive-accessibility.md)
+- [Component Library](./component-library.md) · [UX Design Principles](./ux-principles.md) · [Content & Language Guidelines](./content-language-guidelines.md)
+- [Data Model](./data-model.md) · [Information Architecture](./information-architecture.md) · [User Personas](./personas.md)
+- Ops: [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md) · [Launch Readiness Plan](../ops/launch-readiness-plan.md)

--- a/docs/design/android-receipt-to-expense-draft.md
+++ b/docs/design/android-receipt-to-expense-draft.md
@@ -1,0 +1,338 @@
+# Android Receipt-to-Expense Draft Flow — Design
+
+> **Status:** Design / breakdown only — native implementation gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+> **Issue:** [#2547](https://github.com/jrmoulckers/finance/issues/2547) · **Part of:** [#2183](https://github.com/jrmoulckers/finance/issues/2183)
+> **Platform:** Android (Jetpack Compose + Material 3) · **Audience:** Android engineers, design, QA
+
+This document designs the Jetpack Compose flow that turns **on-device receipt
+OCR output** into a **reviewable, correctable expense draft** that the user can
+save as a real transaction. It is a design/breakdown only — it does not add
+native code while production signing and Play distribution remain blocked by
+[#1242](https://github.com/jrmoulckers/finance/issues/1242).
+
+The guiding rule for every screen below: **Compose renders shared state; it does
+not own finance math.** Receipt parsing, category suggestion, confidence
+scoring, and draft assembly already live in Kotlin Multiplatform (KMP)
+`packages/core`. The Android layer only collects an image, observes the shared
+analysis as state, and presents correction affordances.
+
+---
+
+## Table of Contents
+
+1. [Goals & non-goals](#1-goals--non-goals)
+2. [Personas & jobs to be done](#2-personas--jobs-to-be-done)
+3. [The Compose-renders-shared-state boundary](#3-the-compose-renders-shared-state-boundary)
+4. [End-to-end flow](#4-end-to-end-flow)
+5. [Composable & ViewModel inventory](#5-composable--viewmodel-inventory)
+6. [State management](#6-state-management)
+7. [Low-confidence field correction UX](#7-low-confidence-field-correction-ux)
+8. [Offline-first, empty, and error states](#8-offline-first-empty-and-error-states)
+9. [Accessibility](#9-accessibility)
+10. [Test plan](#10-test-plan)
+11. [Implementation readiness](#11-implementation-readiness)
+12. [Cross-links](#12-cross-links)
+
+---
+
+## 1. Goals & non-goals
+
+### Goals
+
+- Take the output of on-device OCR (already produced by
+  [`AndroidMlKitReceiptOcrAdapter`](../../apps/android/src/main/kotlin/com/finance/android/receipt/AndroidMlKitReceiptOcrAdapter.kt))
+  and present a **draft expense** with merchant, date, total, tax hint, and
+  payment hint pre-filled.
+- Let the user **correct low-confidence fields** before saving.
+- Provide an explicit **Save** action that creates a real
+  [`Transaction`](../../packages/models/src/commonMain/kotlin/com/finance/models/Transaction.kt)
+  via the existing repository, reusing the proven save path in
+  [`TransactionCreateViewModel`](../../apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/TransactionCreateViewModel.kt).
+- Keep everything **on-device and offline-first** — no receipt text or image
+  leaves the device during drafting.
+
+### Non-goals
+
+- OCR capture and the camera/gallery surface — designed separately in
+  [Android CameraX Receipt Capture & Fallback](./android-cameraX-receipt-capture.md)
+  ([#2563](https://github.com/jrmoulckers/finance/issues/2563)).
+- Attachment persistence and COGS / inventory / supplies mapping — designed in
+  [Android Receipt Attachments & COGS Mapping](./android-receipt-attachments-cogs.md)
+  ([#2549](https://github.com/jrmoulckers/finance/issues/2549)).
+- Any change to KMP business rules. The parser, draft builder, and confidence
+  model in `packages/core` are consumed as-is.
+
+---
+
+## 2. Personas & jobs to be done
+
+The driving persona from [#2183](https://github.com/jrmoulckers/finance/issues/2183)
+is a **food-truck owner** entering expenses from the truck with limited time and
+messy hands. See [User Personas & MVP Scope](./personas.md) for the broader
+persona set.
+
+Jobs this flow must satisfy:
+
+- "Scan a receipt and **save the extracted total as an expense** in one flow."
+- "**Fix what the scan got wrong** without retyping everything."
+- "Trust that nothing was uploaded while I review."
+
+Each job maps to a section: save (§4–§6), correction (§7), privacy (§8).
+
+---
+
+## 3. The Compose-renders-shared-state boundary
+
+All finance/business logic stays in KMP `packages/core`. The Android layer is a
+thin renderer. The contract types and functions below already exist and are the
+single source of truth:
+
+| Shared type / function                                                    | Source                                                                                                                         | Role in this flow                                            |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
+| `ExtractedReceiptText`, `ExtractedReceiptLineItem`, `parseReceiptText(…)` | [`ReceiptTextParser.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/dataimport/ReceiptTextParser.kt)           | Normalises raw OCR text into merchant/date/total/line items. |
+| `ReceiptCogsExtensions.buildTransactionDraft(…)`                          | [`ReceiptCogsExtensions.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/receipt/cogs/ReceiptCogsExtensions.kt) | Assembles a `ReceiptTransactionDraft` from parsed output.    |
+| `ReceiptTransactionDraft`                                                 | `ReceiptCogsExtensions.kt`                                                                                                     | Category, amount (cents), tax, payment method, attachments.  |
+| `ReceiptConfidence` / `ReceiptConfidenceBand` / `ReceiptConfidenceFlag`   | `ReceiptCogsExtensions.kt`                                                                                                     | Decides which fields are auto-filled vs. flagged for review. |
+
+**Boundary rules**
+
+- The ViewModel calls shared functions and exposes their results as immutable UI
+  state. It never re-implements totals, tax math, or category rules in Kotlin/JVM
+  code.
+- All money is integer **cents** (`Cents`) across the boundary. Compose only
+  formats for display via the shared `CurrencyFormatter`.
+- Confidence drives presentation only: a `LOW`/`UNUSABLE` band changes which
+  fields are highlighted, never the underlying values.
+
+```mermaid
+flowchart LR
+    subgraph KMP["KMP packages/core (shared, no UI)"]
+        Parser["parseReceiptText()"]
+        Draft["ReceiptCogsExtensions.buildTransactionDraft()"]
+        Conf["scoreConfidence() -> ReceiptConfidence"]
+    end
+    subgraph Android["apps/android (Compose, renders only)"]
+        VM["ReceiptDraftViewModel"]
+        UI["ReceiptDraftScreen"]
+        Repo["TransactionRepository.insert()"]
+    end
+    OCR["On-device OCR text"] --> Parser
+    Parser --> Draft
+    Parser --> Conf
+    Draft --> VM
+    Conf --> VM
+    VM --> UI
+    UI -->|"Save"| VM
+    VM --> Repo
+```
+
+---
+
+## 4. End-to-end flow
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Cap as Capture (see #2563)
+    participant OCR as ML Kit adapter
+    participant VM as ReceiptDraftViewModel
+    participant Core as packages/core
+    participant Repo as TransactionRepository
+
+    User->>Cap: Provide receipt image
+    Cap->>OCR: Bitmap
+    OCR->>Core: parseReceiptText(rawText)
+    Core-->>OCR: ExtractedReceiptText
+    OCR->>VM: ExtractedReceiptText
+    VM->>Core: buildTransactionDraft(receipt)
+    Core-->>VM: ReceiptTransactionDraft + ReceiptConfidence
+    VM-->>User: Draft pre-filled, low-confidence fields flagged
+    User->>VM: Correct merchant / total / date / category
+    User->>VM: Save
+    VM->>Repo: insert(Transaction)
+    Repo-->>VM: Saved
+    VM-->>User: Confirmation + deep link to transaction
+```
+
+The draft screen is reached from the capture surface ([#2563](https://github.com/jrmoulckers/finance/issues/2563))
+and, on save, hands off to the existing transaction detail destination wired in
+[`FinanceNavHost`](../../apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceNavHost.kt).
+
+---
+
+## 5. Composable & ViewModel inventory
+
+| Composable / class      | Type          | Responsibility                                                                |
+| ----------------------- | ------------- | ----------------------------------------------------------------------------- |
+| `ReceiptDraftScreen`    | `@Composable` | Top-level screen; observes `ReceiptDraftUiState`; hosts sections below.       |
+| `DraftHeaderSection`    | `@Composable` | Merchant + date + total summary card with confidence badge.                   |
+| `DraftFieldRow`         | `@Composable` | One correctable field (label, value, confidence flag, edit affordance).       |
+| `DraftConfidenceBanner` | `@Composable` | Explains why review is needed when band is `MEDIUM`/`LOW`/`UNUSABLE`.         |
+| `DraftSaveBar`          | `@Composable` | Sticky bottom bar with **Save expense** and **Discard** actions.              |
+| `ReceiptDraftViewModel` | `ViewModel`   | Calls shared `buildTransactionDraft`; holds correction edits; saves via repo. |
+
+- The screen is obtained with `koinViewModel<ReceiptDraftViewModel>()`; the
+  ViewModel is registered with `viewModelOf(::ReceiptDraftViewModel)` in the
+  receipt Koin module (new module, additive, no edits to shared DI).
+- Save reuses the validated mapping in
+  [`TransactionCreateViewModel.save()`](../../apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/TransactionCreateViewModel.kt)
+  — same `Transaction` construction, `householdId`, and `TransactionRepository`
+  contract — so drafted expenses are indistinguishable from manually entered ones.
+- Every interactive and informational Composable carries a `contentDescription`
+  (see §9). Reuse shared building blocks from the
+  [Component Library](./component-library.md).
+
+---
+
+## 6. State management
+
+A single immutable `ReceiptDraftUiState` is exposed as a `StateFlow` and
+collected with `collectAsStateWithLifecycle()`.
+
+```text
+ReceiptDraftUiState(
+    status: Loading | Ready | Saving | Saved | Error,
+    draft: ReceiptTransactionDraft?,      // from packages/core
+    confidence: ReceiptConfidence?,       // from packages/core
+    editableMerchant: String,
+    editableTotalText: String,            // formatted; parsed back to Cents on save
+    editableDate: LocalDate,
+    fieldFlags: Set<ReceiptConfidenceFlag>,
+    validationErrors: List<String>,
+)
+```
+
+- The ViewModel seeds editable fields from the shared draft, then tracks user
+  edits locally. **It re-derives nothing financial** — it only echoes the user's
+  corrected values into the `Transaction` at save time.
+- `status` is a sealed hierarchy so Compose can exhaustively render each branch
+  (mirrors the existing `ReceiptOcrUiState` pattern in
+  [`ReceiptOcrScreen`](../../apps/android/src/main/kotlin/com/finance/android/ui/screens/ReceiptOcrScreen.kt)).
+- Process death: editable fields and the source `rawText` survive via
+  `SavedStateHandle`, so a corrected draft is not lost if the system reclaims the
+  process.
+
+---
+
+## 7. Low-confidence field correction UX
+
+Acceptance criterion from [#2388](https://github.com/jrmoulckers/finance/issues/2388):
+"Provide correction UI for low-confidence fields." Confidence is computed in
+`packages/core` (`scoreConfidence` → `ReceiptConfidence`), and the band/flag map
+to presentation:
+
+| Band / flag                          | Presentation                                                             |
+| ------------------------------------ | ------------------------------------------------------------------------ |
+| `HIGH`                               | Field shown filled, no badge; editable on tap.                           |
+| `MEDIUM`                             | Subtle "Double-check" badge; field focusable first by assistive tech.    |
+| `LOW` / `UNUSABLE`                   | Field rendered empty with inline hint; flagged in the confidence banner. |
+| `MISSING_TOTAL` / `MISSING_MERCHANT` | Required-field error state; **Save** disabled until provided.            |
+| `TAX_DETECTED` / `PAYMENT_DETECTED`  | Read-only hints surfaced as helper text, not editable values.            |
+
+- Corrections use Material 3 `OutlinedTextField` with `supportingText` for hints
+  and `isError` for required gaps — consistent with
+  [UX Design Principles](./ux-principles.md) and
+  [Content & Language Guidelines](./content-language-guidelines.md).
+- Plain-language helper copy follows the
+  [Cognitive Accessibility Mode](./cognitive-accessibility.md) guidance: short
+  sentences, no jargon ("We could not read the total — please type it").
+- Edits never silently mutate other fields. Totals are not recomputed by the UI.
+
+---
+
+## 8. Offline-first, empty, and error states
+
+The flow is fully functional **with no network**. Drafting, correction, and save
+all run against the local repository; sync happens later through the existing
+PowerSync/WorkManager path and is out of scope here.
+
+| State                   | Trigger                                          | UX                                                                                                                      |
+| ----------------------- | ------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| Empty / first run       | Screen entered with no parsed draft              | Friendly empty card: "Scan or pick a receipt to start a draft."                                                         |
+| Unusable scan           | `band == UNUSABLE`, `merchant`/`total` both null | Offer **Enter manually** (manual path from [#2563](https://github.com/jrmoulckers/finance/issues/2563)) and **Retake**. |
+| Partial extraction      | Some fields null                                 | Pre-fill what exists; flag the rest (see §7).                                                                           |
+| Save validation error   | `MISSING_TOTAL` etc. at save                     | Inline errors; announce via assertive live region; focus first invalid field.                                           |
+| Repository/save failure | `insert` throws                                  | Non-destructive error card with **Retry**; draft preserved.                                                             |
+| Offline                 | No connectivity                                  | No blocking; optional "Saved locally — will sync later" affordance.                                                     |
+
+No financial data (amounts, merchant totals, account numbers) is ever written to
+Timber. Structured logs use `Timber.d`/`Timber.w` for flow milestones only
+(for example "draft built", "save succeeded") with no sensitive values.
+
+---
+
+## 9. Accessibility
+
+This flow targets WCAG 2.2 AA and follows the shared
+[Accessibility Patterns Library](./accessibility-patterns.md).
+
+- **TalkBack:** Every field row exposes a `contentDescription` combining label,
+  value, and confidence ("Total, 24 dollars 80 cents, please double-check").
+  Headings use `semantics { heading() }`. Save/Discard announce their action and
+  result.
+- **Switch Access:** Logical focus order top-to-bottom; the sticky `DraftSaveBar`
+  is reachable last and its actions are large, single-purpose targets (≥ 48 dp).
+  No action depends on a gesture or long-press only.
+- **200% font scaling:** All layouts use `sp` text and wrap rather than truncate.
+  The save bar collapses Save/Discard into a vertical stack at large scale; the
+  summary card grows in height, never clipping the total.
+- **Live regions:** Validation errors and save confirmation use an assertive live
+  region so non-visual users hear the outcome immediately.
+- **Color independence:** Confidence is conveyed by badge text + icon, never color
+  alone, satisfying contrast guidance in the patterns library.
+
+---
+
+## 10. Test plan
+
+| Layer                | Tooling                | Coverage                                                                                                                                                                                             |
+| -------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Unit (ViewModel)     | JUnit + coroutine test | Draft seeding from shared output; edits do not mutate shared math; save maps to a valid `Transaction`; validation gates on `MISSING_TOTAL`/`MISSING_MERCHANT`.                                       |
+| Unit (state machine) | JUnit                  | `Loading → Ready → Saving → Saved` transitions; error path preserves the draft; process-death restore from `SavedStateHandle`.                                                                       |
+| Compose UI           | `compose-ui-test`      | Low-confidence field shows correction UI; Save disabled until required fields present; error card exposes **Retry**; semantics/`contentDescription` assertions; font-scale `2.0f` layout assertions. |
+| Snapshot             | Paparazzi              | `ReceiptDraftScreen` in: high-confidence, low-confidence, unusable, saving, error — at default and 200% font scale, light/dark and dynamic-color themes.                                             |
+
+Shared business rules (`parseReceiptText`, `buildTransactionDraft`,
+`scoreConfidence`) are covered by existing `packages/core` tests and are **not**
+re-tested here — only the Android rendering and save wiring are.
+
+---
+
+## 11. Implementation readiness
+
+This is a design artifact. Implementation splits into a part that is fully
+buildable today and a tail that is gated by Play onboarding.
+
+See [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md) and the
+[Launch Readiness Plan](../ops/launch-readiness-plan.md) for the gating context.
+
+### Buildable now (debug, no human gate)
+
+- The `ReceiptDraftScreen`, `ReceiptDraftViewModel`, state model, and Koin module
+  are pure Compose + KMP consumption — fully implementable and runnable via
+  `./gradlew :apps:android:assembleDebug` and sideload.
+- Save wiring reuses the existing local `TransactionRepository`; verifiable with
+  unit, Compose, and Paparazzi tests on CI and emulator/sideload.
+- Correction UX, confidence presentation, and accessibility semantics need no
+  signing or store presence.
+
+### Play-distribution tail (gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242))
+
+- Production signing keystore + Google Play Console onboarding.
+- Internal-testing-track upload, privacy declarations, and staged rollout.
+- Anything requiring a release-signed AAB (not `assembleDebug`).
+
+No part of this draft flow itself is blocked from being built and tested in debug;
+only its production distribution is.
+
+---
+
+## 12. Cross-links
+
+- Sibling: [Android CameraX Receipt Capture & Fallback](./android-cameraX-receipt-capture.md) — [#2563](https://github.com/jrmoulckers/finance/issues/2563)
+- Sibling: [Android Receipt Attachments & COGS Mapping](./android-receipt-attachments-cogs.md) — [#2549](https://github.com/jrmoulckers/finance/issues/2549)
+- [Android Architecture](../architecture/android-architecture.md)
+- [Accessibility Patterns Library](./accessibility-patterns.md) · [Cognitive Accessibility Mode](./cognitive-accessibility.md)
+- [Component Library](./component-library.md) · [UX Design Principles](./ux-principles.md) · [Content & Language Guidelines](./content-language-guidelines.md)
+- [Data Model](./data-model.md) · [Information Architecture](./information-architecture.md) · [User Personas](./personas.md)
+- Ops: [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md) · [Launch Readiness Plan](../ops/launch-readiness-plan.md)


### PR DESCRIPTION
## Summary

Adds three **design-only** docs for the Android receipt-capture cluster. No native
code, no signing, no store actions — design/breakdown only while native Android
implementation remains gated by #1242.

Each doc follows the docs instructions: humans-first, table of contents, Mermaid
flows, relative links, accessibility (TalkBack, Switch Access, 200% font scaling),
offline-first / empty / error states, a unit + Compose + Paparazzi test plan, and an
"Implementation readiness" section that splits buildable-now (`assembleDebug`
sideload; CameraX/permission plumbing all debug-implementable) from the
Play-distribution tail gated by #1242.

The docs hold the line on the architecture boundary: **Compose renders shared KMP
state; finance/business math stays in `packages/core`** (consumed as-is, not
re-implemented).

## Changes

- `docs/design/android-receipt-to-expense-draft.md` — OCR output → correctable
  expense draft → save (Part of #2183).
- `docs/design/android-receipt-attachments-cogs.md` — opt-in receipt attachment,
  line-item accept/reject, COGS/inventory/supplies mapping (Part of #2183).
- `docs/design/android-cameraX-receipt-capture.md` — production CameraX capture,
  permission rationale, gallery/manual fallback, crop/retake, no-upload privacy copy
  (Part of #2388).

New files only. No existing files, `packages/`, `apps/` code, shared config, other
platforms, or other docs were touched.

## Validation

- `npx prettier --check` passes on all three new files.

Closes #2547
Closes #2549
Closes #2563
