### PR TITLE
docs(design): ios low-noise minimalist design batch (#2572, #2577, #2580)

### DIFF
--- a/docs/design/ios-fire-minimalist-preset.md
+++ b/docs/design/ios-fire-minimalist-preset.md
@@ -1,0 +1,381 @@
+# iOS FIRE Minimalist Preset (Dashboard & Navigation)
+
+> Design specification for a **named, opt-in "FIRE minimalist" preset** that re-tunes the
+> iOS dashboard and navigation around the four numbers a financial-independence-minded user
+> actually watches — **savings rate, net worth, investments, and FI progress** — with
+> **safe defaults**, a **clear reset to Standard**, and **estimates labelled as estimates,
+> not advice**.
+
+**Status:** PROPOSED — design only (native implementation gated, see
+[Implementation readiness](#12-implementation-readiness))
+**Issue:** [#2580](https://github.com/jrmoulckers/finance/issues/2580) — _Part of
+[#2122](https://github.com/jrmoulckers/finance/issues/2122)_
+**Platform:** iOS / iPadOS (SwiftUI · Swift Concurrency, iOS 17+)
+**Owner:** @ios-engineer
+**Last updated:** 2026-06-22
+**Related design docs:** [ux-principles.md](./ux-principles.md) ·
+[information-architecture.md](./information-architecture.md) ·
+[cognitive-accessibility.md](./cognitive-accessibility.md) ·
+[accessibility-patterns.md](./accessibility-patterns.md) ·
+[content-language-guidelines.md](./content-language-guidelines.md) ·
+[data-visualization.md](./data-visualization.md)
+**Builds on:**
+[ios-module-visibility-preferences.md](./ios-module-visibility-preferences.md) (the
+preference store this preset writes through)
+**Consumes (FI/FIRE math, already designed):**
+[ios-fi-calculator-flow.md](./ios-fi-calculator-flow.md) ·
+[ios-fire-results-goal-integration.md](./ios-fire-results-goal-integration.md) ·
+[ios-portfolio-metrics-projections.md](./ios-portfolio-metrics-projections.md)
+
+---
+
+## Table of Contents
+
+1. [Problem & Goal](#1-problem--goal)
+2. [Affected iOS Surfaces](#2-affected-ios-surfaces)
+3. [What the Preset Does](#3-what-the-preset-does)
+4. [Preset Model & the iOS / KMP Boundary](#4-preset-model--the-ios--kmp-boundary)
+5. [Applying & Reverting the Preset](#5-applying--reverting-the-preset)
+6. [Projections-as-Estimates Safety](#6-projections-as-estimates-safety)
+7. [Accessibility](#7-accessibility)
+8. [Dynamic Type](#8-dynamic-type)
+9. [Privacy & Balance Hiding](#9-privacy--balance-hiding)
+10. [Empty, Stale & Error States](#10-empty-stale--error-states)
+11. [Test Plan](#11-test-plan)
+12. [Implementation readiness](#12-implementation-readiness)
+13. [Open Questions](#13-open-questions)
+
+---
+
+## 1. Problem & Goal
+
+A FIRE-minded user does not want the full general-purpose surface; they want a calm
+dashboard that answers "**am I getting closer to financial independence?**". Today's
+[`DashboardView.swift`](../../apps/ios/Finance/Screens/DashboardView.swift) leads with net
+worth and monthly spending and offers a broad "More" grid; the FI numbers are designed in
+[ios-fi-calculator-flow.md](./ios-fi-calculator-flow.md) /
+[ios-fire-results-goal-integration.md](./ios-fire-results-goal-integration.md), and the
+module-hiding mechanism is designed in
+[ios-module-visibility-preferences.md](./ios-module-visibility-preferences.md). What is
+missing is a **one-tap way to compose those into a coherent minimalist mode**.
+
+**Goal:** specify a **"FIRE minimalist" preset** — a named bundle of
+visibility + emphasis defaults applied through the
+[module-visibility store (#2577)](./ios-module-visibility-preferences.md) — that:
+
+1. Foregrounds **savings rate, net worth, investments, and FI progress**, and quietens
+   modules that aren't part of the FI loop.
+2. Applies via **safe, non-destructive defaults** (hides nothing irreversibly, deletes
+   nothing) and offers a **clear "Reset to Standard"** path at any time.
+3. Treats every forward-looking number (FI progress, projected FI date, savings-rate trend)
+   as a **clearly-labelled estimate, never advice** — reusing the safety patterns already
+   established for FIRE results.
+
+**Non-goals:** new FIRE math (it is consumed, not invented — see
+[ios-portfolio-metrics-projections.md](./ios-portfolio-metrics-projections.md)), a separate
+"FIRE app mode" with its own navigation stack, and any new shared schema beyond the preset
+definition.
+
+---
+
+## 2. Affected iOS Surfaces
+
+All under `apps/ios/` (owned by @ios-engineer).
+
+| Surface                                                                                  | Change                                                                                                              |
+| ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `Screens/PresetPickerView.swift` **(new)**                                               | Choose a dashboard preset: **Standard** (default) · **FIRE minimalist**; shows what each changes before applying.   |
+| `Models/DashboardPreset.swift` **(new)**                                                 | iOS view-model of the shared preset: id, display name, the visibility map + emphasis it applies.                    |
+| `ViewModels/DashboardViewModel.swift` _(modify)_ / `ModuleVisibilityViewModel` _(reuse)_ | Apply a preset by writing the visibility store (#2577) and exposing a "FI summary" emphasis flag.                   |
+| `Components/FIProgressCard.swift` **(new)**                                              | Calm FI-progress card (FI %, savings rate, "~years to FI (est.)") reusing `ProgressRing` + `CurrencyLabel`.         |
+| [`Screens/DashboardView.swift`](../../apps/ios/Finance/Screens/DashboardView.swift)      | **Modify:** when the FIRE preset is active, order/emphasise net worth → savings rate → FI progress → investments.   |
+| [`Screens/SettingsView.swift`](../../apps/ios/Finance/Screens/SettingsView.swift)        | **Modify (light):** add a "Dashboard preset" row → `PresetPickerView`.                                              |
+| `Resources/*.lproj/Localizable.strings`                                                  | **Modify:** preset names/descriptions, FI card copy, estimate/disclaimer, reset confirmation. No hardcoded strings. |
+
+The preset **does not** introduce a parallel navigation system — it composes existing
+surfaces and the visibility store, keeping a single source of truth.
+
+---
+
+## 3. What the Preset Does
+
+The **FIRE minimalist** preset is a declarative bundle (data, not code paths):
+
+**Foregrounds (shown + emphasised, in this order):**
+
+1. **Net worth** — the existing hero card stays at the top.
+2. **Savings rate** — a calm percentage with a short trend, framed as an estimate.
+3. **FI progress** — `FIProgressCard`: FI % toward the FI number + "~N years to FI (est.)",
+   consuming the FIRE metrics designed in
+   [ios-fire-results-goal-integration.md](./ios-fire-results-goal-integration.md).
+4. **Investments** — quick access to the portfolio / allocation
+   ([ios-low-noise-etf-allocation.md](./ios-low-noise-etf-allocation.md)).
+
+**Quietens (hidden by default under this preset, reversibly):**
+
+- Bills, Reports, and mood tags quick actions on the dashboard; the recent-transactions card
+  is demoted (kept, but below FI progress) rather than removed — spending still matters to a
+  savings rate.
+
+**Keeps (never hidden):** the core tabs (Dashboard / Accounts / Transactions), Settings, and
+the net-worth hero — the same invariants as
+[#2577 §3](./ios-module-visibility-preferences.md). The preset can only toggle modules that
+the catalog says are hideable; it can never violate those invariants.
+
+This realises [ux-principles.md §1 "Clarity Over Completeness"](./ux-principles.md): one
+hero number, the FI loop front-and-centre, density kept under the 5–7 item limit.
+
+---
+
+## 4. Preset Model & the iOS / KMP Boundary
+
+A preset is **data** (a named set of visibility + emphasis defaults) plus **math it
+consumes** (savings rate, FI %, years-to-FI). Both belong in KMP; iOS applies and renders.
+
+```mermaid
+flowchart LR
+    subgraph shared["packages/core + packages/models (KMP — port via ADR, NOT this PR)"]
+        P["DashboardPreset catalog<br/>(Standard, FIRE minimalist)<br/>= visibility map + emphasis"]
+        M["SavingsRate / FIRE metrics<br/>(savingsRate%, fiPercent, yearsToFI, FI date)"]
+    end
+    subgraph bridge["packages/sync (Swift Export — ADR if missing)"]
+        P --> Cp["DashboardPresetDTO"]
+        M --> Cm["FIREMetricsDTO / SavingsRateDTO"]
+    end
+    subgraph ios["apps/ios (this PR — @ios-engineer)"]
+        Cp --> A["Apply preset → ModuleVisibilityStore (#2577)"]
+        A --> D["DashboardView ordering + emphasis"]
+        Cm --> F["FIProgressCard (estimates only)"]
+    end
+```
+
+**Responsibilities**
+
+| Concern                                                                 | Layer                                 |
+| ----------------------------------------------------------------------- | ------------------------------------- |
+| Preset catalog (which modules each preset shows/hides + emphasis order) | `packages/core` / `packages/models`   |
+| Savings-rate and all FIRE numbers (FI %, years-to-FI, FI date)          | `packages/core` (shared math)         |
+| Type mapping (ids `String`, %/`Double`, `Cents`→`Int64`, date→`Date`)   | Swift Export bridge (`packages/sync`) |
+| Applying a preset by **writing the visibility store (#2577)**           | iOS                                   |
+| Dashboard ordering/emphasis, FI card layout, estimate copy, reset UX    | iOS                                   |
+| VoiceOver explanations, Dynamic Type, privacy, Reduce Motion            | iOS                                   |
+
+- **iOS composes, it does not compute.** The preset is a shared definition; iOS applies it by
+  writing the same visibility flags from
+  [#2577](./ios-module-visibility-preferences.md), so there is **one** visibility source of
+  truth and no divergent logic. FI/savings numbers arrive as DTOs (already designed in
+  [ios-portfolio-metrics-projections.md](./ios-portfolio-metrics-projections.md)).
+- **No new shared schema beyond the preset definition.** The preset reuses the module catalog
+  from #2577 and the FIRE engine from #2556/#2558; landing the preset catalog in
+  `packages/models` is **@kmp-engineer via ADR**. iOS binds `StubSwiftExportBridge` (preset
+  fixture + `fireMetrics` stub) so the surface is buildable now.
+
+---
+
+## 5. Applying & Reverting the Preset
+
+- **Preview before apply.** `PresetPickerView` shows a plain-language summary of exactly what
+  the FIRE preset will show/hide/emphasise **before** the user commits — no silent surprises.
+- **Apply = write visibility flags.** Selecting "FIRE minimalist" writes the preset's map
+  through the [#2577 store](./ios-module-visibility-preferences.md); the dashboard re-renders
+  on next pass (no app restart) via the `@Observable` view model.
+- **Non-destructive, always.** Applying or switching presets **never deletes data**; hidden
+  modules keep their data and reappear on revert (framed "Hidden", per
+  [content-language-guidelines.md](./content-language-guidelines.md)).
+- **Clear reset path.** A prominent **"Reset to Standard"** restores the default
+  (all-visible) preset; it is reversible work, not destruction, and is reachable from both
+  `PresetPickerView` and the #2577 module screen.
+- **Post-apply, still customisable.** After applying the FIRE preset a user can still
+  individually toggle any module in the #2577 screen; the preset is a starting point, not a
+  lock. Manual edits "detune" the preset to a "FIRE minimalist (modified)" label so the user
+  knows they've diverged.
+
+---
+
+## 6. Projections-as-Estimates Safety
+
+Because this preset **foregrounds forward-looking numbers**, the not-advice discipline from
+[ios-fire-results-goal-integration.md §6](./ios-fire-results-goal-integration.md) and
+[ios-portfolio-metrics-projections.md §8](./ios-portfolio-metrics-projections.md) is
+mandatory here:
+
+- **Every derived/forward number is labelled an estimate** at the point of display: FI
+  progress is "~{n}% (est.)" where modelled, years-to-FI is "~N years (est.)", the FI date is
+  "around {Month Year}", savings-rate trend is "(est.)". Only the user's own
+  entered/aggregated balances appear without "est.".
+- **Persistent, selectable disclaimer** on the FI card: _"These are estimates based on your
+  assumptions, not financial advice. Real returns vary and aren't guaranteed."_ Present in the
+  VoiceOver reading order.
+- **Assumptions stay co-present.** The FI card links to the FIRE inputs
+  ([ios-fi-calculator-flow.md](./ios-fi-calculator-flow.md)) so no FI figure is shown without
+  a path to the assumptions that produced it.
+- **No promissory or shaming language.** "with these assumptions, you'd reach…", never "you
+  will retire at…"; savings rate is reported, never graded — non-judgemental framing per
+  [ux-principles.md §3](./ux-principles.md).
+
+---
+
+## 7. Accessibility
+
+Per [accessibility-patterns.md](./accessibility-patterns.md) and
+[cognitive-accessibility.md](./cognitive-accessibility.md):
+
+- **Explanatory, combined labels.** `FIProgressCard` is
+  `.accessibilityElement(children: .combine)` →
+  _"FI progress, about 34 percent, estimated. Savings rate about 41 percent this year,
+  estimated. Around 11 years to financial independence with your current assumptions."_ —
+  explanation, not a bare number.
+- **Preset picker is clear to VoiceOver.** Each preset row has a label + a hint summarising
+  what it changes ("Shows savings rate, net worth, investments, and FI progress; hides bills
+  and reports. Reversible."). The selected preset is announced.
+- **Reset is explained:** _"Reset to Standard. Shows all modules again. Does not delete any
+  data."_
+- **Switch Control / Full Keyboard Access:** preset rows, the FI card's links, and the reset
+  button are real focusable controls; nothing is gesture-only.
+- **Estimate words are spoken** — "estimated", "around", "not guaranteed" are part of the
+  label text, never visual-only.
+
+---
+
+## 8. Dynamic Type
+
+- **No hardcoded font sizes** — card titles `.headline`, figures reuse `CurrencyLabel`,
+  explainers `.footnote`/`.secondary`, disclaimer `.caption`. All scale AX1–AX5.
+- **Reflow over truncation.** Under the FIRE preset the dashboard remains a single scrolling
+  column; at `accessibility1`+ the FI card's metric pair stacks vertically and the
+  explainer/disclaimer wrap fully. Verified at AX5 in [§11](#11-test-plan).
+- **Explainers never truncate** — they are the teaching content.
+
+---
+
+## 9. Privacy & Balance Hiding
+
+- **Preset choice is non-sensitive UI state** — stored through the #2577 App-Group store,
+  **never Keychain**. It contains no balances or PII.
+- **Balance hiding parity.** On the FI card, **monetary figures** (net worth, FI number) are
+  masked ("•••••") when balance-hiding is active; **percentages, the savings rate, and
+  explainer text remain visible** (they reveal no balance) — consistent with
+  [ios-fire-results-goal-integration.md §9](./ios-fire-results-goal-integration.md). Masked
+  amounts read "hidden" to VoiceOver.
+- **App-switcher redaction** is inherited (no exemption).
+- **Logging is privacy-aware.** Log only `.public` events via `os.Logger` — "preset applied:
+  fire-minimalist", "preset reset" — never an amount or rate value. Never `print()`.
+
+---
+
+## 10. Empty, Stale & Error States
+
+| State           | Trigger                                           | Presentation                                                                                                                                        |
+| --------------- | ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **No FI input** | FIRE assumptions not yet entered                  | FI card shows a prompt ("Set up FI to see your progress") linking to the FIRE inputs — **no fabricated FI %**. Preset still applies.                |
+| **Loading**     | Metrics not yet derived                           | FI card skeleton with title + explainer visible; static under Reduce Motion. `.accessibilityLabel("Calculating your FI estimate")`.                 |
+| **Stale**       | Derived from cached/offline aggregates            | Card renders + "based on data as of {relative time}"; show [`OfflineBanner`](../../apps/ios/Finance/Components/OfflineBanner.swift) offline.        |
+| **Error**       | Preset apply or metric derivation fails           | Apply failure → fall back to **Standard** (fail safe, never hide content); metric failure → section-scoped `ErrorStateView` + Retry; log `.public`. |
+| **Modified**    | User hand-edits modules after applying the preset | Label becomes "FIRE minimalist (modified)"; "Reset to Standard" remains available. No data change.                                                  |
+
+- **Fail safe = Standard.** Any preset-apply error resolves to the full, all-visible Standard
+  preset; a preset can never strand a user in a broken minimal view.
+- **Stale is first-class, not an error** (local-first) — old figures with an "as of" stamp are
+  correct.
+- **Empty is a prompt** — the FI card points to the one missing input rather than showing a
+  guessed number.
+
+---
+
+## 11. Test Plan — Smallest Tests First
+
+### 11.1 Shared (KMP) — verify/port parity, not re-implemented here
+
+- `DashboardPresetTest` (KMP, **@kmp-engineer via ADR**): the FIRE preset's visibility map
+  shows exactly {net worth, savings rate, FI progress, investments} foregrounded and quietens
+  bills/reports/mood; it **respects the #2577 non-hideable invariants** (never hides core
+  tabs/Settings/net-worth hero); Standard = all visible.
+- Savings-rate and FIRE-metric parity are already covered by the #2556/#2570 KMP suites
+  (reused, not duplicated).
+
+### 11.2 Bridge
+
+- `SwiftExportBridgeTests`: `DashboardPresetDTO` round-trips id + map + emphasis order;
+  `FIREMetricsDTO` / savings-rate DTO map as in
+  [ios-portfolio-metrics-projections.md](./ios-portfolio-metrics-projections.md).
+
+### 11.3 iOS unit (XCTest, `apps/ios/Tests/`)
+
+1. **`PresetApplyTests`** — applying "FIRE minimalist" writes the expected flags to the
+   #2577 store (spy) and never violates invariants; "Reset to Standard" restores all-visible;
+   an apply error falls back to Standard.
+2. **`FIProgressCardTests`** — maps FI %/savings rate/years from DTOs; **no FI input → prompt,
+   not a number**; estimate words present; masked (privacy) labels contain no amount.
+3. **`PresetModifiedStateTests`** — a manual module toggle after applying flips the label to
+   "(modified)" and keeps reset available.
+
+### 11.4 iOS UI / a11y (`apps/ios/Tests/UITests/`)
+
+4. **`FIREPresetUITests`** — selecting the preset reorders the dashboard (net worth → savings
+   rate → FI progress → investments) and hides bills/reports; **VoiceOver** reads the FI
+   card's explanation (not number-only) and the disclaimer; **Dynamic Type** at AX5 stacks the
+   FI metrics untruncated; **Privacy** masks amounts but not percentages; **Reduce Motion**
+   applies the preset without animated reshuffle; **Reset** returns to Standard.
+
+### 11.5 Gate
+
+`node tools/agent-scripts/pre-push-check.js --fix` (lint + strict concurrency) plus the
+suites above. `SWIFT_STRICT_CONCURRENCY = complete`: preset/metric DTOs `Sendable`, store an
+`actor`, UI state `@MainActor`.
+
+---
+
+## 12. Implementation readiness
+
+Per the [Human-Gated Prerequisites runbook](../ops/human-gated-prerequisites.md) (§2),
+Apple Developer enrollment
+[#1239](https://github.com/jrmoulckers/finance/issues/1239) gates **distribution only** —
+not implementation. This design and its iOS code are **buildable and testable now**.
+
+### Buildable now (no enrollment, no secrets)
+
+- ✅ **This design doc** — fully unblocked.
+- ✅ `PresetPickerView`, `DashboardPreset`, `FIProgressCard`, and the `DashboardView`
+  ordering/emphasis — SwiftUI + `@Observable`, reusing `ProgressRing` / `CurrencyLabel` /
+  `EmptyStateView` / `ErrorStateView` / `OfflineBanner` and the
+  [#2577 visibility store](./ios-module-visibility-preferences.md).
+- ✅ All unit + UI/a11y tests in [§11](#11-test-plan) in the iOS Simulator.
+- ✅ On-device verification via **free Personal Team signing** (free Apple ID) — see
+  [ios-setup.md](../guides/ios-setup.md).
+- ✅ Against `StubSwiftExportBridge` (preset fixture + `fireMetrics`/savings stub), the entire
+  preset surface is developable **before** the Kotlin ports land.
+
+### Distribution tail — gated by #1239 (human, not this PR)
+
+- 🔒 App Store / TestFlight builds, release signing, and CI release secrets are
+  **human-gated** (runbook
+  [§3.2](../ops/human-gated-prerequisites.md#32-ios-distribution--apple-developer-1239)) and
+  out of scope here.
+
+### Dependency note (process gate, not human-gated)
+
+The **preset catalog** belongs in `packages/models` (reusing the #2577 module catalog) and
+the **savings-rate / FIRE math** in `packages/core`, re-exported via `packages/sync` —
+**@kmp-engineer via ADR**, not this iOS PR. Until then iOS binds the stub bridge. This preset
+**depends on** [#2577](./ios-module-visibility-preferences.md) (the visibility store) and the
+FIRE engine from #2556/#2558.
+
+### Needs Human Action
+
+- None for design **or** iOS implementation up to the distribution boundary. Only
+  TestFlight/App Store shipping is human-gated ([#1239](https://github.com/jrmoulckers/finance/issues/1239)).
+
+---
+
+## 13. Open Questions
+
+1. **Preset count for v1:** ship just Standard + FIRE minimalist (proposed), or seed a third
+   (e.g. "Budget-focused") to validate the preset abstraction?
+2. **Emphasis vs. reorder:** does the FIRE preset literally reorder dashboard sections, or
+   only emphasise (size/weight) while keeping order? (Proposed: a small, fixed reorder.)
+3. **"Modified" persistence:** should a modified preset be saved as a user preset, or just
+   labelled until reset? (Proposed: labelled-until-reset for v1.)
+4. **Savings-rate window:** trailing 12 months vs. year-to-date vs. user-selectable as the FI
+   card's default? (Defer to the FIRE inputs design.)
+5. **Onboarding hook:** offer the FIRE preset during onboarding for users who self-identify as
+   FI-focused, or keep it Settings-only in v1? (Proposed: Settings-only first.)

--- a/docs/design/ios-low-noise-etf-allocation.md
+++ b/docs/design/ios-low-noise-etf-allocation.md
@@ -1,0 +1,363 @@
+# iOS Low-Noise ETF Allocation Views
+
+> Design specification for **ETF-level rollups**, **calm allocation summaries**, and
+> **chart + text-alternative parity** tuned for the passive index-fund investor who
+> wants "am I still diversified the way I intended?" answered at a glance — without
+> ticker noise, day-trader colour, or false precision.
+
+**Status:** PROPOSED — design only (native implementation gated, see
+[Implementation readiness](#12-implementation-readiness))
+**Issue:** [#2572](https://github.com/jrmoulckers/finance/issues/2572) — _Part of
+[#2118](https://github.com/jrmoulckers/finance/issues/2118)_
+**Platform:** iOS / iPadOS (SwiftUI · Swift Charts · Swift Concurrency, iOS 17+)
+**Owner:** @ios-engineer
+**Last updated:** 2026-06-22
+**Related design docs:** [data-visualization.md](./data-visualization.md) ·
+[chart-component-specs.md](./chart-component-specs.md) ·
+[accessibility-patterns.md](./accessibility-patterns.md) ·
+[cognitive-accessibility.md](./cognitive-accessibility.md) ·
+[ux-principles.md](./ux-principles.md) ·
+[content-language-guidelines.md](./content-language-guidelines.md)
+**Sibling design docs:**
+[ios-investment-chart-text-alternatives.md](./ios-investment-chart-text-alternatives.md) ·
+[ios-chart-summaries-data-tables.md](./ios-chart-summaries-data-tables.md) ·
+[ios-noncolor-financial-state-cues.md](./ios-noncolor-financial-state-cues.md) ·
+[ios-portfolio-metrics-projections.md](./ios-portfolio-metrics-projections.md)
+**Depends on (shared data):**
+[ios-investment-data-kmp-design.md](./ios-investment-data-kmp-design.md)
+
+---
+
+## Table of Contents
+
+1. [Problem & Goal](#1-problem--goal)
+2. [Affected iOS Surfaces](#2-affected-ios-surfaces)
+3. [Shared Dependencies & the iOS / KMP Boundary](#3-shared-dependencies--the-ios--kmp-boundary)
+4. [The Low-Noise Allocation Surface](#4-the-low-noise-allocation-surface)
+5. [Chart & Text-Alternative Parity](#5-chart--text-alternative-parity)
+6. [Accuracy & Estimate Labelling](#6-accuracy--estimate-labelling)
+7. [Accessibility](#7-accessibility)
+8. [Dynamic Type](#8-dynamic-type)
+9. [Privacy & Balance Hiding](#9-privacy--balance-hiding)
+10. [Empty, Stale & Error States](#10-empty-stale--error-states)
+11. [Test Plan](#11-test-plan)
+12. [Implementation readiness](#12-implementation-readiness)
+13. [Open Questions](#13-open-questions)
+
+---
+
+## 1. Problem & Goal
+
+The persona of [#2118](https://github.com/jrmoulckers/finance/issues/2118) holds a
+handful of broad ETFs (e.g. VTI, VXUS, BND) and checks in **rarely and calmly**.
+Today, [`InvestmentPortfolioView.swift`](../../apps/ios/Finance/Screens/InvestmentPortfolioView.swift)
+already renders an asset-class allocation list (using `AssetClassUI` from
+[`InvestmentModels.swift`](../../apps/ios/Finance/Models/InvestmentModels.swift)) and a
+holdings list, but it is **holding-centric**: each row is one position, and there is no
+**fund-level rollup** ("how much is in VTI vs everything else?") nor a **calm summary**
+of whether the mix still matches the investor's intent.
+
+**Goal:** specify a **low-noise allocation surface** that:
+
+1. **Rolls holdings up to ETFs/funds**, then to **asset classes** (look-through),
+   collapsing the long tail into an explicit **"Other"** bucket so the screen never
+   shows more than ~5–7 items — the density limit from
+   [ux-principles.md §1](./ux-principles.md).
+2. Shows an optional, **non-judgemental drift readout** — _actual vs. the investor's
+   target mix_ — framed as information, never as "you are doing it wrong".
+3. Provides a **chart and an equivalent text/table alternative** so the meaning is
+   identical for VoiceOver, Dynamic Type, and reduced-motion users.
+
+**Non-goals:** trade execution, rebalancing actions/orders, real-time quotes, advice or
+recommendations, and any new shared schema (look-through math is described, not
+implemented, and lands in `packages/core` via ADR).
+
+---
+
+## 2. Affected iOS Surfaces
+
+All under `apps/ios/` (owned by @ios-engineer).
+
+| Surface                                                                                                 | Change                                                                                                              |
+| ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| [`Screens/InvestmentPortfolioView.swift`](../../apps/ios/Finance/Screens/InvestmentPortfolioView.swift) | **Modify (light):** replace the flat allocation list with the new low-noise section; keep summary/perf/holdings.    |
+| `Screens/AllocationDetailView.swift` **(new)**                                                          | "Details on demand" screen: full breakdown, target-vs-actual table, the chart's data table, and "as of" provenance. |
+| `Components/AllocationDonut.swift` **(new)**                                                            | Calm donut/ring chart (Swift Charts) with center label, top-N + "Other", CVD-safe palette, reduced-motion static.   |
+| `Components/AllocationRow.swift` **(new)**                                                              | One rollup row: label + percent + thin bar + non-colour drift glyph; combined VoiceOver label.                      |
+| [`ViewModels/InvestmentViewModel.swift`](../../apps/ios/Finance/ViewModels/InvestmentViewModel.swift)   | **Modify:** expose `rollups`, `otherBucket`, and `driftStates` derived from shared DTOs (render-only, no math).     |
+| [`Models/InvestmentModels.swift`](../../apps/ios/Finance/Models/InvestmentModels.swift)                 | **Modify:** add UI rollup view-types (`AllocationRollupUI`) mirroring shared DTOs; reuse `AssetClassUI` palette.    |
+| `Resources/*.lproj/Localizable.strings`                                                                 | **Modify:** new localized strings (titles, "Other", drift copy, estimate/disclaimer, masks). No hardcoded strings.  |
+
+Existing building blocks reused as-is:
+[`CurrencyLabel`](../../apps/ios/Finance/Components/CurrencyLabel.swift),
+[`EmptyStateView`](../../apps/ios/Finance/Components/EmptyStateView.swift),
+[`ErrorStateView`](../../apps/ios/Finance/Components/ErrorStateView.swift),
+[`OfflineBanner`](../../apps/ios/Finance/Components/OfflineBanner.swift),
+[`ProgressRing`](../../apps/ios/Finance/Components/ProgressRing.swift), and the
+`ChartColorPalette` already used by the portfolio chart.
+
+---
+
+## 3. Shared Dependencies & the iOS / KMP Boundary
+
+Per the repo rule, **allocation math is platform-neutral and lives in KMP**; iOS only
+renders. This design **describes** the boundary and does **not** implement shared code.
+
+```mermaid
+flowchart LR
+    subgraph shared["packages/core + packages/models (KMP — port via ADR, NOT this PR)"]
+        A["Holdings (symbol, units, value, classification)"] --> B["AllocationRollupEngine"]
+        B --> C["fundRollups: by ticker/fund<br/>assetClassRollups: look-through<br/>otherBucket: long tail<br/>drift = actual − target"]
+    end
+    subgraph bridge["packages/sync (Swift Export — ADR if missing)"]
+        C --> D["AllocationRollupDTO[]<br/>(label, percent: Double,<br/>valueMinorUnits: Int64,<br/>driftPercent: Double?, asOf: Instant)"]
+    end
+    subgraph ios["apps/ios (this PR — @ios-engineer)"]
+        D --> E["InvestmentViewModel: rollups + otherBucket + driftStates"]
+        E --> F["AllocationDonut / AllocationRow / AllocationDetailView"]
+    end
+```
+
+**Responsibilities**
+
+| Concern                                                                            | Layer                                 |
+| ---------------------------------------------------------------------------------- | ------------------------------------- |
+| Roll holdings → funds → asset classes (look-through), long-tail "Other" threshold  | `packages/core` (shared)              |
+| Target mix storage and `drift = actual − target`                                   | `packages/core` / `packages/models`   |
+| Type mapping (`Cents`→`Int64`, %→`Double`, `Instant`→`Date`)                       | Swift Export bridge (`packages/sync`) |
+| Donut/ring layout, palette, top-N selection, "Other" grouping for display          | iOS                                   |
+| Drift glyph + non-colour cue, estimate copy, VoiceOver text, Dynamic Type, privacy | iOS                                   |
+
+- **iOS renders, it does not compute.** Percentages, the "Other" bucket contents, and
+  drift values arrive as DTOs; iOS chooses how many slices to show before grouping, but
+  never re-derives the numbers.
+- **No shared schema change here.** Target-mix persistence and look-through are described
+  for `@kmp-engineer` to land via ADR; the canonical reference data shape is documented
+  in [ios-investment-data-kmp-design.md](./ios-investment-data-kmp-design.md). Until then
+  iOS binds to the existing `StubSwiftExportBridge` so the surface is buildable now.
+
+---
+
+## 4. The Low-Noise Allocation Surface
+
+Two-level disclosure (simple → details on demand), per
+[information-architecture.md](./information-architecture.md):
+
+**Level 1 — the calm summary (in `InvestmentPortfolioView`):**
+
+- A **donut/ring** with a **center label** = "N funds" or the largest slice's name, and
+  **top 5 slices + "Other"** beneath it as `AllocationRow`s (label · percent · thin bar).
+- A single **"In line with your plan"** / **"Drifting from your plan"** status line when a
+  target mix exists — plain language, never red-on-failure. If no target is set, the drift
+  line is simply absent (no nagging).
+- A **"View allocation details"** row → `AllocationDetailView`.
+
+**Level 2 — `AllocationDetailView` (details on demand):**
+
+- The **full rollup** (every fund + every asset class), the **target-vs-actual table**
+  (Holding/Class · Target % · Actual % · Drift), and the **chart's data table** (§5).
+- An **"as of {relative time}"** provenance line and the estimate/disclaimer block (§6).
+
+Defaults are deliberately quiet: **whole-percent figures** by default, no flashing,
+no per-second updates, no green/red profit framing — allocation is about _shape_, not
+_score_. This matches the "one hero number per screen, density is the enemy" guidance of
+[ux-principles.md](./ux-principles.md).
+
+---
+
+## 5. Chart & Text-Alternative Parity
+
+The donut is **decorative-plus**: every fact it conveys must be available without it,
+mirroring [ios-investment-chart-text-alternatives.md](./ios-investment-chart-text-alternatives.md)
+and [ios-chart-summaries-data-tables.md](./ios-chart-summaries-data-tables.md).
+
+- **Colour is never the only encoding.** Each slice/row carries an **SF Symbol + text
+  label + percent**; the palette is the existing **CVD-safe `ChartColorPalette`**
+  (IBM-derived) from [data-visualization.md §2](./data-visualization.md). Drift direction
+  uses a **glyph** (`arrow.up`/`arrow.down`/`checkmark`) + text, per
+  [ios-noncolor-financial-state-cues.md](./ios-noncolor-financial-state-cues.md) — not hue.
+- **The donut is one combined accessibility element** with a summary label (§7); the
+  **`AllocationRow` list IS the per-slice text alternative**, so VoiceOver users navigate
+  the same data the chart shows.
+- **A data table** (`Target % · Actual % · Drift`) lives in `AllocationDetailView` for
+  exact figures, sortable, fully VoiceOver-navigable.
+- **Reduce Motion:** the donut renders in its final state with **no sweep/spin animation**;
+  it uses `.drawingGroup()` like the existing performance chart but gates any transition on
+  `@Environment(\.accessibilityReduceMotion)`, per [animation-library.md](./animation-library.md).
+- **Contrast:** labels and figures meet **≥ 4.5:1** in light, dark
+  ([oled-dark-mode.md](./oled-dark-mode.md)), and high-contrast modes.
+
+---
+
+## 6. Accuracy & Estimate Labelling
+
+Allocation views can quietly imply precision they don't have; this surface is explicit:
+
+- **Percentages are derived, mark provenance, not promises.** Show **"as of {relative
+  time}"** wherever a percentage or drift appears; when values are stale/offline, say so
+  (§10) rather than implying live accuracy.
+- **Drift is information, not a verdict.** Copy is "3% above your bond target", never
+  "you failed to rebalance" — non-judgemental framing per
+  [content-language-guidelines.md](./content-language-guidelines.md) and
+  [ux-principles.md §3](./ux-principles.md).
+- **No advice, no actions.** The surface never says "you should buy/sell"; there are no
+  order buttons. A persistent, selectable caption reads: _"Allocation percentages are
+  estimates based on your latest holdings data, not financial advice."_
+- **Look-through is labelled.** Where a fund is decomposed into asset classes via shared
+  reference data, the detail view notes "based on fund composition data" so the investor
+  knows the class split is **modelled**, not a direct holding.
+
+---
+
+## 7. Accessibility
+
+Patterns follow [accessibility-patterns.md](./accessibility-patterns.md) and the existing
+allocation rows in `InvestmentPortfolioView`.
+
+- **Combined, meaningful labels.** Each `AllocationRow` is
+  `.accessibilityElement(children: .combine)` →
+  _"US Total Market, 62 percent of portfolio, 2 percent above target."_ The donut exposes a
+  single summary value: _"Allocation: 5 holdings shown, largest US Total Market at 62
+  percent, remainder grouped as Other."_
+- **Headers & order.** "Allocation" is `.accessibilityAddTraits(.isHeader)`; reading order
+  is summary → rows → "View details", matching visual order.
+- **Switch Control / Full Keyboard Access / VoiceOver rotor.** The "View allocation
+  details" row, each rollup row, and table cells are **real focusable controls** with
+  labels and hints; nothing is gesture-only. Detail-view chart navigation follows
+  [ios-chart-voiceover-navigation.md](./ios-chart-voiceover-navigation.md).
+- **Estimate words are spoken.** "estimate", "as of", "above/below target" are part of the
+  label text, so the not-advice framing is never visual-only.
+
+---
+
+## 8. Dynamic Type
+
+- **No hardcoded font sizes.** Row labels `.subheadline`, percentages reuse `.subheadline`
+  / `CurrencyLabel`, captions `.caption`. All scale through AX1–AX5.
+- **Reflow over truncation.** At `accessibility1`+ the donut shrinks and the rows stack as
+  full-width label-over-value; the target-vs-actual **table becomes a stacked list** rather
+  than a horizontally-scrolling grid. Verified at AX5 in [§11](#11-test-plan).
+- **"Other" stays meaningful at large sizes** — its row always shows count and combined
+  percent so collapsing the tail never hides scale.
+
+---
+
+## 9. Privacy & Balance Hiding
+
+- **Percentages are not balances.** When balance-hiding is active, **monetary values**
+  (per-slice dollar amounts in the detail view) are masked ("•••••"); **percentages, drift,
+  and labels remain visible** because they reveal no balance — consistent with
+  [ios-portfolio-metrics-projections.md §11](./ios-portfolio-metrics-projections.md).
+- **Accessibility parity:** masked amounts read as "hidden" to VoiceOver; never speak a
+  hidden balance. App-switcher snapshot redaction is inherited (no exemption).
+- **Logging is privacy-aware.** Holdings, tickers, and amounts are `.private` and never
+  logged. Log only `.public` events via `os.Logger` — "allocation viewed",
+  "allocation details opened" — counts/flags, never a holding or amount. Never `print()`.
+
+---
+
+## 10. Empty, Stale & Error States
+
+| State         | Trigger                              | Presentation                                                                                                                                          |
+| ------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Loading**   | Rollups not yet derived              | Donut + rows show skeletons with titles visible; static under Reduce Motion. `.accessibilityLabel("Loading allocation")`.                             |
+| **Empty**     | No investment holdings               | Reuse `EmptyStateView` ("Add investment accounts to see your allocation") — same as today's portfolio empty state. No fabricated slices.              |
+| **No target** | Holdings exist, no target mix set    | Show actual allocation only; **omit** the drift line; offer a calm "Set a target mix" affordance (optional, never required).                          |
+| **Stale**     | Derived from cached/offline holdings | Render with an "as of {relative time}" caption; show [`OfflineBanner`](../../apps/ios/Finance/Components/OfflineBanner.swift) when offline.           |
+| **Error**     | Rollup/bridge failure                | Section-scoped [`ErrorStateView`](../../apps/ios/Finance/Components/ErrorStateView.swift) + Retry; summary/perf/holdings stay usable. Logs `.public`. |
+
+- **Stale is first-class, not an error** (local-first) — old percentages with an "as of"
+  stamp are correct, not broken.
+- **Errors are section-scoped** — a failed rollup never blanks the whole investments screen.
+- **Empty is a prompt, not a blank** — it points to the one missing thing (an account).
+
+---
+
+## 11. Test Plan — Smallest Tests First
+
+### 11.1 Shared (KMP) — verify/port parity, not re-implemented here
+
+- `AllocationRollupEngineTest` (KMP, **@kmp-engineer via ADR**): fund rollup sums to 100%,
+  long tail collapses into "Other" at the threshold, look-through class split is correct,
+  `drift = actual − target` (incl. no-target → null), and empty holdings → empty result.
+
+### 11.2 Bridge
+
+- `SwiftExportBridgeTests`: `AllocationRollupDTO` round-trips `label`, `percent`,
+  `valueMinorUnits` (Int64), optional `driftPercent`, and `asOf`; ordering is stable.
+
+### 11.3 iOS unit (XCTest, `apps/ios/Tests/`)
+
+1. **`AllocationViewModelTests`** — DTOs → `rollups` map 1:1; top-N + "Other" grouping is
+   correct and `Other.percent` equals the sum of the tail; `driftStates` classify
+   above/at/below target; no-target hides the drift line.
+2. **`AllocationRowA11yTests`** — combined labels include label + percent + drift words;
+   masked (privacy) labels contain no amount; drift uses glyph + text (no colour-only).
+
+### 11.4 iOS UI / a11y (`apps/ios/Tests/UITests/`)
+
+3. **`AllocationUITests`** — donut + rows render; "View allocation details" reaches the
+   table; **VoiceOver** reads the summary then per-slice rows; **Dynamic Type** at AX5
+   reflows (table → stacked list, untruncated); **Privacy** masks amounts but not
+   percentages; **Reduce Motion** renders the donut with no sweep animation.
+
+### 11.5 Gate
+
+`node tools/agent-scripts/pre-push-check.js --fix` (lint + strict concurrency) plus the
+suites above. `SWIFT_STRICT_CONCURRENCY = complete`: DTOs/rollup view-types `Sendable`, UI
+state `@MainActor`.
+
+---
+
+## 12. Implementation readiness
+
+Per the [Human-Gated Prerequisites runbook](../ops/human-gated-prerequisites.md) (§2),
+Apple Developer enrollment
+[#1239](https://github.com/jrmoulckers/finance/issues/1239) gates **distribution only** —
+not implementation. This design and its iOS code are **buildable and testable now**.
+
+### Buildable now (no enrollment, no secrets)
+
+- ✅ **This design doc** — fully unblocked.
+- ✅ `AllocationDonut`, `AllocationRow`, `AllocationDetailView`, and the
+  `InvestmentViewModel`/`InvestmentModels` additions — SwiftUI + `@Observable` + Swift
+  concurrency, reusing `CurrencyLabel` / `EmptyStateView` / `ErrorStateView` /
+  `OfflineBanner` / `ChartColorPalette`.
+- ✅ All unit + UI/a11y tests in [§11](#11-test-plan) in the iOS Simulator.
+- ✅ On-device verification via **free Personal Team signing** (free Apple ID): 7-day
+  expiry, ≤ 3 apps/device, no TestFlight/push — sufficient to verify this surface. See
+  [ios-setup.md](../guides/ios-setup.md).
+- ✅ Against the `StubSwiftExportBridge` allocation fixtures, the entire surface is
+  developable **before** the Kotlin rollup engine lands.
+
+### Distribution tail — gated by #1239 (human, not this PR)
+
+- 🔒 App Store / TestFlight builds, release signing, App Store Connect API key, and CI
+  release secrets are **human-gated** (runbook
+  [§3.2](../ops/human-gated-prerequisites.md#32-ios-distribution--apple-developer-1239))
+  and out of scope here.
+
+### Dependency note (process gate, not human-gated)
+
+The `AllocationRollupEngine`, look-through reference data, and target-mix persistence must
+land in `packages/core` / `packages/models` and be re-exported via `packages/sync` —
+**@kmp-engineer via ADR**, not this iOS PR. Until then the surface binds to the stub bridge.
+
+### Needs Human Action
+
+- None for design **or** iOS implementation up to the distribution boundary. Only
+  TestFlight/App Store shipping is human-gated ([#1239](https://github.com/jrmoulckers/finance/issues/1239)).
+
+---
+
+## 13. Open Questions
+
+1. **"Other" threshold:** group below a fixed percent (e.g. < 5%) vs. always show top-5 +
+   Other? (Proposed: top-5 + Other, capped at the 5–7 density limit.)
+2. **Target mix source:** user-entered per asset class vs. per fund vs. a chosen model
+   portfolio template? (Affects the `packages/models` shape — ADR.)
+3. **Look-through depth:** classify at fund level only, or decompose multi-asset funds into
+   underlying classes in v1? (Proposed: asset-class look-through, clearly labelled as
+   modelled.)
+4. **Donut vs. stacked bar** as the default Level-1 visual for low-noise users? (Defer to a
+   quick a11y/legibility comparison at AX sizes.)

--- a/docs/design/ios-module-visibility-preferences.md
+++ b/docs/design/ios-module-visibility-preferences.md
@@ -1,0 +1,367 @@
+# iOS Module Visibility Preferences (Low-Noise Mode)
+
+> Design specification for **persisted, opt-in preferences** that let a user hide tabs,
+> dashboard cards, quick actions, and optional modules (bills, reports, mood tags, and
+> similar) — so the app can be quietened to a low-noise surface that shows only what each
+> person actually uses, with **safe defaults** and a **one-tap reset**.
+
+**Status:** PROPOSED — design only (native implementation gated, see
+[Implementation readiness](#11-implementation-readiness))
+**Issue:** [#2577](https://github.com/jrmoulckers/finance/issues/2577) — _Part of
+[#2122](https://github.com/jrmoulckers/finance/issues/2122)_
+**Platform:** iOS / iPadOS (SwiftUI · Swift Concurrency, iOS 17+)
+**Owner:** @ios-engineer
+**Last updated:** 2026-06-22
+**Related design docs:** [information-architecture.md](./information-architecture.md) ·
+[ux-principles.md](./ux-principles.md) ·
+[cognitive-accessibility.md](./cognitive-accessibility.md) ·
+[accessibility-patterns.md](./accessibility-patterns.md) ·
+[content-language-guidelines.md](./content-language-guidelines.md)
+**Sibling design docs:**
+[ios-fire-minimalist-preset.md](./ios-fire-minimalist-preset.md) (a named preset built on
+this preference store)
+
+---
+
+## Table of Contents
+
+1. [Problem & Goal](#1-problem--goal)
+2. [Affected iOS Surfaces](#2-affected-ios-surfaces)
+3. [The Module Catalog & Safe Invariants](#3-the-module-catalog--safe-invariants)
+4. [Preference Model, Persistence & the iOS / KMP Boundary](#4-preference-model-persistence--the-ios--kmp-boundary)
+5. [The Preferences UI](#5-the-preferences-ui)
+6. [Applying Visibility Across Surfaces](#6-applying-visibility-across-surfaces)
+7. [Accessibility](#7-accessibility)
+8. [Dynamic Type](#8-dynamic-type)
+9. [Privacy](#9-privacy)
+10. [Empty, Stale, Error & Reset States](#10-empty-stale-error--reset-states)
+11. [Test Plan](#11-test-plan)
+12. [Implementation readiness](#12-implementation-readiness)
+13. [Open Questions](#13-open-questions)
+
+---
+
+## 1. Problem & Goal
+
+The app surfaces many optional modules. The root
+[`MainTabView.swift`](../../apps/ios/Finance/Navigation/MainTabView.swift) has five tabs
+(Dashboard, Accounts, Transactions, Budgets, Goals); the
+[`DashboardView.swift`](../../apps/ios/Finance/Screens/DashboardView.swift) stacks a
+net-worth card, a monthly spending summary, budget-health rings, a "More" quick-access
+grid (Investments / Bills / Reports), and recent transactions; and
+[`SettingsView.swift`](../../apps/ios/Finance/Screens/SettingsView.swift) exposes many
+feature sections. Not every user wants every module — for some, mood tags, reports, or
+bills are noise that competes with the numbers they care about.
+
+**Goal:** specify a **module-visibility preference store** and the UI to manage it, so a
+user can hide optional modules and the relevant surfaces (tabs, dashboard cards, quick
+actions) **honour those choices on next render**, with:
+
+1. A **catalog of toggleable modules** with **safe defaults** (everything visible) and
+   **non-hideable invariants** (you can never hide your way into a broken app).
+2. **Durable, private, local persistence** that also reaches **widgets and the watch** via
+   the existing App Group.
+3. A **clear, non-destructive reset** ("Reset to defaults") and a calm, discoverable
+   Settings surface — the foundation the [FIRE minimalist preset](./ios-fire-minimalist-preset.md)
+   ([#2580](https://github.com/jrmoulckers/finance/issues/2580)) builds on.
+
+**Non-goals:** deleting data (hiding ≠ deleting), reordering modules (tracked separately),
+per-household/shared preferences, and any new shared backend schema.
+
+---
+
+## 2. Affected iOS Surfaces
+
+All under `apps/ios/` (owned by @ios-engineer).
+
+| Surface                                                                                                                                                                        | Change                                                                                                             |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| `Screens/ModuleVisibilitySettingsView.swift` **(new)**                                                                                                                         | The preferences screen: grouped toggles per module + "Reset to defaults".                                          |
+| `ViewModels/ModuleVisibilityViewModel.swift` **(new)**                                                                                                                         | `@Observable` VM wrapping the preference store; exposes per-module `isVisible` bindings + reset.                   |
+| `Models/ModulePreferences.swift` **(new)**                                                                                                                                     | iOS view-model of the shared catalog/defaults; `ModuleID` enum + `ModuleVisibility` map (mirrors shared contract). |
+| `Services/ModuleVisibilityStore.swift` **(new)**                                                                                                                               | Persistence actor over the App Group `UserDefaults`; publishes changes; writes mirror for widgets/watch.           |
+| [`Navigation/MainTabView.swift`](../../apps/ios/Finance/Navigation/MainTabView.swift)                                                                                          | **Modify:** filter optional tabs through visibility (core tabs are invariant — see §3).                            |
+| [`Screens/DashboardView.swift`](../../apps/ios/Finance/Screens/DashboardView.swift)                                                                                            | **Modify:** gate optional cards/quick-access entries on visibility; keep the hero net-worth card always.           |
+| [`Screens/SettingsView.swift`](../../apps/ios/Finance/Screens/SettingsView.swift)                                                                                              | **Modify (light):** add a "Low-Noise / Modules" row linking to the new settings screen.                            |
+| [`Services/WidgetDataWriter.swift`](../../apps/ios/Finance/Services/WidgetDataWriter.swift) / [`WatchDataSender.swift`](../../apps/ios/Finance/Services/WatchDataSender.swift) | **Modify (light):** include visibility flags so widgets/complications can respect hidden modules.                  |
+| `Resources/*.lproj/Localizable.strings`                                                                                                                                        | **Modify:** localized module names, descriptions, reset copy, confirmations. No hardcoded strings.                 |
+
+This follows the existing `@AppStorage`-backed preferences pattern already used by
+[`AppearanceSettingsView.swift`](../../apps/ios/Finance/Screens/AppearanceSettingsView.swift)
+(`IconPackPreference.key`).
+
+---
+
+## 3. The Module Catalog & Safe Invariants
+
+The **catalog** (which modules exist and may be hidden) is the platform-neutral part and
+is described here for the shared layer; iOS renders and persists choices.
+
+**Toggleable modules (proposed v1):**
+
+| Module                        | Default | Surface affected                            |
+| ----------------------------- | ------- | ------------------------------------------- |
+| Budgets tab                   | Visible | `MainTabView` tab                           |
+| Goals tab                     | Visible | `MainTabView` tab                           |
+| Investments quick action      | Visible | Dashboard "More" grid                       |
+| Bills quick action / module   | Visible | Dashboard "More" grid + Bills screens       |
+| Reports quick action / module | Visible | Dashboard "More" grid + Reports screens     |
+| Net-worth card                | Visible | Dashboard hero card _(see invariant below)_ |
+| Spending summary card         | Visible | Dashboard card                              |
+| Budget-health strip           | Visible | Dashboard card                              |
+| Recent transactions card      | Visible | Dashboard card                              |
+| Mood / mood-tag entry         | Visible | Transaction entry + tags                    |
+
+**Non-hideable invariants (safe defaults — the app can never be bricked by hiding):**
+
+- **At least the Dashboard, Accounts, and Transactions tabs always remain** — the user can
+  never hide all navigation. These are **not** in the toggleable catalog.
+- **Settings is always reachable** (so visibility can always be changed back).
+- **A user cannot hide every dashboard card.** If all optional cards are hidden, the
+  Dashboard still shows the **net-worth hero** (or, if that too is hidden, a calm "Your
+  dashboard is minimised — adjust in Settings" prompt that links back).
+- **Hiding never deletes data.** Hidden modules retain their data; re-showing restores the
+  full view. This is framed per [content-language-guidelines.md](./content-language-guidelines.md):
+  "Hidden" not "Removed".
+
+These invariants are validated by shared tests (§11.1) so every platform agrees on what is
+hideable, keeping iOS/Android/Web/Windows consistent.
+
+---
+
+## 4. Preference Model, Persistence & the iOS / KMP Boundary
+
+```mermaid
+flowchart LR
+    subgraph shared["packages/core + packages/models (KMP — port via ADR, NOT this PR)"]
+        A["ModuleCatalog (IDs, defaults, invariants)"] --> B["ModuleVisibility rules<br/>(can-hide? resolve effective visibility)"]
+    end
+    subgraph bridge["packages/sync (Swift Export — ADR if missing)"]
+        B --> C["ModuleVisibilityDTO<br/>(moduleId: String, isVisible: Bool)"]
+    end
+    subgraph ios["apps/ios (this PR — @ios-engineer)"]
+        C --> D["ModuleVisibilityStore (actor, App Group UserDefaults)"]
+        D --> E["ModuleVisibilityViewModel (@Observable)"]
+        E --> F["MainTabView / DashboardView / SettingsView"]
+        D --> G["WidgetDataWriter / WatchDataSender (App Group)"]
+    end
+```
+
+**Responsibilities**
+
+| Concern                                                             | Layer                                 |
+| ------------------------------------------------------------------- | ------------------------------------- |
+| The module catalog, defaults, and non-hideable invariants           | `packages/core` / `packages/models`   |
+| "Is this module allowed to be hidden? resolve effective visibility" | `packages/core` (rules)               |
+| Type mapping (`String` id, `Bool`)                                  | Swift Export bridge (`packages/sync`) |
+| **Local persistence**, change publishing, App-Group mirroring       | iOS (`ModuleVisibilityStore`)         |
+| Settings UI, tab/card gating, accessibility, Dynamic Type, reset UX | iOS                                   |
+
+**Persistence (iOS-owned):**
+
+- Stored in the **App Group** `UserDefaults(suiteName: "group.com.finance.app")` (the same
+  suite already used by [`WidgetDataWriter`](../../apps/ios/Finance/Services/WidgetDataWriter.swift)
+  and the watch), so widgets and complications read the same flags. **Not Keychain** —
+  these are **non-sensitive UI preferences**, not secrets. (Keychain remains reserved for
+  tokens/keys per the security rules; see [§9](#9-privacy).)
+- `ModuleVisibilityStore` is an **`actor`** to serialise reads/writes;
+  cross-boundary types are `Sendable`; UI state updates are `@MainActor`. No `DispatchQueue`.
+- **iOS does not invent the catalog.** The list of hideable modules and the invariants come
+  from the shared contract; iOS binds the existing `StubSwiftExportBridge` until the Kotlin
+  port lands, so the screen is buildable now.
+
+---
+
+## 5. The Preferences UI
+
+`ModuleVisibilitySettingsView` is a standard SwiftUI `Form`, mirroring the structure of
+[`AppearanceSettingsView`](../../apps/ios/Finance/Screens/AppearanceSettingsView.swift) and
+the grouped sections in [`SettingsView`](../../apps/ios/Finance/Screens/SettingsView.swift):
+
+- **Grouped sections** ("Tabs", "Dashboard cards", "Quick actions", "Other modules"), each
+  a `Section` of `Toggle`s — one per module, with a short footer explaining what hiding does
+  ("Hidden modules keep their data; you can show them again anytime.").
+- A trailing **"Reset to defaults"** button (`role: .destructive`-styled but **non-data
+  destructive**) with a confirmation that clarifies it only restores visibility, never data.
+- **Non-hideable items are not shown as broken toggles** — they're simply absent from the
+  catalog, so the user never sees a disabled/forbidden control.
+- Calm, non-judgemental copy throughout per
+  [content-language-guidelines.md](./content-language-guidelines.md) — "Show / Hide", never
+  "Enable real features / Disable".
+
+Discoverability: a single **"Low-Noise / Modules"** `NavigationLink` is added to
+`SettingsView`'s general/appearance area (one row, no new top-level surface).
+
+---
+
+## 6. Applying Visibility Across Surfaces
+
+- **Tabs (`MainTabView`):** the `Tab` enum keeps core tabs always; optional tabs (Budgets,
+  Goals) are included only when `isVisible(.budgets)` / `isVisible(.goals)`. Because tabs
+  are built from `Tab.allCases`, gating is a single `filter`. Deep links to a hidden tab
+  still resolve (the destination remains in the navigation graph) so functionality is never
+  lost — only chrome is quietened.
+- **Dashboard cards (`DashboardView`):** each optional section (`spendingSummaryCard`,
+  `budgetHealthSection`, `quickAccessSection` entries, `recentTransactionsSection`) is wrapped
+  in `if viewModel.isVisible(.x)`. The **net-worth hero stays** unless explicitly hidden,
+  and the all-hidden invariant (§3) provides the minimised prompt.
+- **Quick actions:** the "More" grid renders only visible entries; an empty grid hides its
+  header entirely (no empty "More" label).
+- **Widgets/watch:** flags are mirrored through the App Group so a hidden module's widget can
+  show a neutral "Hidden in app" placeholder rather than stale data.
+- **Live updates:** the `@Observable` VM observes the store; toggling a preference updates
+  the affected surface on next render without an app restart.
+
+---
+
+## 7. Accessibility
+
+Per [accessibility-patterns.md](./accessibility-patterns.md) and
+[cognitive-accessibility.md](./cognitive-accessibility.md) (reducing noise is itself a
+cognitive-accessibility win):
+
+- **Every toggle is labelled and hinted.** `Toggle` rows have
+  `.accessibilityLabel(moduleName)` and `.accessibilityHint("Hides {module} from your
+dashboard")`; state is announced as on/off by VoiceOver natively. Each carries a stable
+  `.accessibilityIdentifier("module_toggle_<id>")`.
+- **Reset is explained.** The reset control reads _"Reset module visibility to defaults.
+  Shows all modules again. Does not delete any data."_
+- **Section headers** use `.accessibilityAddTraits(.isHeader)`; reading order matches visual
+  order.
+- **Switch Control / Full Keyboard Access:** all toggles, the reset button, and the Settings
+  entry row are real focusable controls; nothing is gesture-only.
+- **No surprise.** Hiding a module never silently removes an accessibility-relied-upon
+  control elsewhere without the user's explicit action in this screen.
+
+---
+
+## 8. Dynamic Type
+
+- **No hardcoded font sizes** — `Form`/`Section`/`Toggle` and `.footnote` footers scale
+  through AX1–AX5 by default.
+- **Toggle rows wrap, never truncate** module names/descriptions at large sizes; the toggle
+  control stays right-aligned and reachable.
+- Verified at AX5 in [§11](#11-test-plan).
+
+---
+
+## 9. Privacy
+
+- **Preferences are non-sensitive UI state**, stored in App-Group `UserDefaults` — **never
+  Keychain** (Keychain is reserved for secrets per the security rules). They contain no
+  balances, no PII, only module on/off flags.
+- **Logging is privacy-aware.** Log only `.public` events via `os.Logger` — "module hidden",
+  "module shown", "visibility reset" — by module id, never any financial value. Never
+  `print()`.
+- **No new sync surface.** v1 preferences are local + App Group only; a future "sync my
+  preferences" capability would be a separate shared-schema decision via ADR, not assumed
+  here.
+
+---
+
+## 10. Empty, Stale, Error & Reset States
+
+| State            | Trigger                                  | Presentation                                                                                                                  |
+| ---------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| **First run**    | No stored preferences yet                | Catalog renders with **all toggles on** (safe default); no error, no empty screen.                                            |
+| **All hidden**   | User hides every optional dashboard card | Dashboard shows the net-worth hero (or the "Your dashboard is minimised — adjust in Settings" prompt), per the §3 invariant.  |
+| **Stale/widget** | Widget reads cached flags                | Widget honours last-known visibility; a hidden module's widget shows a neutral "Hidden in app" placeholder, never stale data. |
+| **Store error**  | App-Group read/write fails               | Fall back to **defaults (all visible)** — fail safe, never hide content on error; log `.public` error; surface stays usable.  |
+| **Reset**        | "Reset to defaults" confirmed            | All modules return to visible; a brief, non-judgemental confirmation; **no data is touched**.                                 |
+
+- **Fail safe = show, not hide.** Any persistence failure resolves to "visible" so a bug can
+  never make a user's data unreachable.
+- **Reset is reversible work, not destruction** — it only rewrites flags.
+
+---
+
+## 11. Test Plan — Smallest Tests First
+
+### 11.1 Shared (KMP) — verify/port parity, not re-implemented here
+
+- `ModuleVisibilityRulesTest` (KMP, **@kmp-engineer via ADR**): the catalog lists exactly
+  the hideable modules; non-hideable invariants (Dashboard/Accounts/Transactions tabs,
+  Settings reachable, "not all dashboard cards hideable") hold; default resolves to all
+  visible; effective-visibility resolution is deterministic.
+
+### 11.2 Bridge
+
+- `SwiftExportBridgeTests`: `ModuleVisibilityDTO` round-trips `moduleId` + `isVisible`;
+  unknown ids are ignored (forward-compatible).
+
+### 11.3 iOS unit (XCTest, `apps/ios/Tests/`)
+
+1. **`ModuleVisibilityStoreTests`** — writes/reads round-trip through the App-Group suite;
+   first-run returns all-visible; a corrupt/missing value falls back to defaults; the actor
+   serialises concurrent writes.
+2. **`ModuleVisibilityViewModelTests`** — toggling updates the published map; "Reset"
+   restores defaults; invariant modules never appear in the toggle list.
+3. **`DashboardVisibilityTests`** (pure where possible) — given a visibility map, the
+   computed list of dashboard sections matches expectation; the all-hidden case still
+   yields the net-worth hero / minimised prompt.
+
+### 11.4 iOS UI / a11y (`apps/ios/Tests/UITests/`)
+
+4. **`ModuleVisibilityUITests`** — toggling "Reports" off removes it from the dashboard
+   "More" grid and (if applicable) its tab; **VoiceOver** announces each toggle's
+   label/state and the reset hint; **Dynamic Type** at AX5 wraps rows untruncated; **Reset**
+   restores all modules; data for a hidden module is intact when re-shown.
+
+### 11.5 Gate
+
+`node tools/agent-scripts/pre-push-check.js --fix` (lint + strict concurrency) plus the
+suites above. `SWIFT_STRICT_CONCURRENCY = complete`: store is an `actor`, DTOs `Sendable`,
+UI state `@MainActor`.
+
+---
+
+## 12. Implementation readiness
+
+Per the [Human-Gated Prerequisites runbook](../ops/human-gated-prerequisites.md) (§2),
+Apple Developer enrollment
+[#1239](https://github.com/jrmoulckers/finance/issues/1239) gates **distribution only** —
+not implementation. This design and its iOS code are **buildable and testable now**.
+
+### Buildable now (no enrollment, no secrets)
+
+- ✅ **This design doc** — fully unblocked.
+- ✅ `ModuleVisibilitySettingsView`, `ModuleVisibilityViewModel`, `ModuleVisibilityStore`,
+  and the `MainTabView` / `DashboardView` / `SettingsView` gating — SwiftUI + `@Observable`
+  - an `actor` store over App-Group `UserDefaults`, reusing the existing `AppearanceSettings`
+    preference pattern.
+- ✅ All unit + UI/a11y tests in [§11](#11-test-plan) in the iOS Simulator.
+- ✅ On-device verification via **free Personal Team signing** (free Apple ID) — see
+  [ios-setup.md](../guides/ios-setup.md). App-Group entitlements work under a Personal Team
+  for local testing.
+- ✅ Against the `StubSwiftExportBridge` catalog fixture, the settings + gating are
+  developable **before** the Kotlin rules port lands.
+
+### Distribution tail — gated by #1239 (human, not this PR)
+
+- 🔒 App Store / TestFlight builds, release signing, and CI release secrets are
+  **human-gated** (runbook
+  [§3.2](../ops/human-gated-prerequisites.md#32-ios-distribution--apple-developer-1239)) and
+  out of scope here.
+
+### Dependency note (process gate, not human-gated)
+
+The module catalog, defaults, and invariants belong in `packages/core` / `packages/models`
+re-exported via `packages/sync` — **@kmp-engineer via ADR**, not this iOS PR. Until then iOS
+binds the stub bridge. The App-Group identifier `group.com.finance.app` already exists.
+
+### Needs Human Action
+
+- None for design **or** iOS implementation up to the distribution boundary. Only
+  TestFlight/App Store shipping is human-gated ([#1239](https://github.com/jrmoulckers/finance/issues/1239)).
+
+---
+
+## 13. Open Questions
+
+1. **Reorder vs. hide:** v1 is hide-only; module **reordering** is deferred. Confirm split.
+2. **Per-device vs. synced preferences:** local + App Group in v1; a synced option would be a
+   separate shared-schema ADR.
+3. **Mood-tag granularity:** hide the mood-tag entry only, or the whole tagging affordance?
+4. **Tab minimum:** is a 3-tab floor (Dashboard/Accounts/Transactions) the right invariant,
+   or should Accounts also be optional for a pure budgeting user? (Proposed: keep the
+   3-tab floor.)


### PR DESCRIPTION
## Summary

Design docs only (no native builds, no signing, no store actions) for the iOS low-noise / minimalist cluster. Three new, distinct files under `docs/design/`, each grounding the design in real `apps/ios` surfaces while keeping allocation/savings/FIRE math conceptually in KMP `packages/core` (boundary described, not implemented).

## Changes

- `docs/design/ios-low-noise-etf-allocation.md` — ETF-level rollups, calm allocation summary, and chart + text-alternative parity for passive investors (#2572, part of #2118).
- `docs/design/ios-module-visibility-preferences.md` — persisted, opt-in preferences to hide tabs, dashboard cards, quick actions, and optional modules, with safe invariants and a reset path (#2577, part of #2122).
- `docs/design/ios-fire-minimalist-preset.md` — a named "FIRE minimalist" preset for the dashboard/navigation (savings rate, net worth, investments, FI progress) built on the #2577 visibility store, with projections labelled as estimates (#2580, part of #2122).

Each doc covers: ToC, Mermaid native↔KMP boundary, affected iOS surfaces, accessibility (VoiceOver, Dynamic Type, Switch Control, Reduce Motion), privacy / balance-hiding, stale/empty/error states, a smallest-tests-first plan, and an **Implementation readiness** section linking [`docs/ops/human-gated-prerequisites.md`](docs/ops/human-gated-prerequisites.md) that splits buildable-now (free Personal Team signing) from the distribution tail gated by #1239.

## Validation

- `npx prettier --check` passes on all three new files.
- New files only — no existing files, `packages/`, `apps/` code, shared config, or other platforms touched.

Closes #2572
Closes #2577
Closes #2580
