### PR TITLE
docs(design): android business-personal split and scenario planner design batch (#2543, #2545, #2557)

### DIFF
--- a/docs/design/android-business-personal-reporting-filters.md
+++ b/docs/design/android-business-personal-reporting-filters.md
@@ -1,0 +1,397 @@
+# Android Business / Personal Reporting Filters — Design
+
+> **Status:** PROPOSED — Pending human review
+> **Issue:** #2545 · **Part of** #2182
+> **Platform:** Android (Jetpack Compose · Material 3)
+> **Priority:** P1 · **Effort:** M (3–5 days)
+> **Last Updated:** 2026-06-22
+
+This document specifies the Android design for a **business / personal lens** that
+filters the dashboard, analytics, and report builder into **Combined**,
+**Business-only**, and **Personal-only** views, backed by the shared split logic.
+It covers the Compose surfaces, the boundary between Compose UI and the shared
+Kotlin Multiplatform (KMP) finance engine, offline/empty/error states,
+accessibility, a test plan, and implementation readiness.
+
+> **User story (#2182):** _"As a small business owner, I want to filter my
+> dashboard, analytics, and report builder by business, personal, or split, and see
+> a combined view and a business-only view side by side, so I can answer 'how is the
+> truck doing?' separately from 'how is my household doing?'"_
+
+This design **consumes** the classification produced by the sibling
+[Business / Personal / Split Tagging UX](./android-business-personal-split-tagging.md)
+(#2543) and renders aggregates the shared engine computes.
+
+---
+
+## Table of Contents
+
+1. [Goals & Non-Goals](#1-goals--non-goals)
+2. [Architecture Boundary (Compose ↔ KMP)](#2-architecture-boundary-compose--kmp)
+3. [Affected Android Surfaces](#3-affected-android-surfaces)
+4. [Shared Dependencies](#4-shared-dependencies)
+5. [Filter Model & Lens Behavior](#5-filter-model--lens-behavior)
+6. [Side-by-Side Combined vs. Business View](#6-side-by-side-combined-vs-business-view)
+7. [UI States: Loading, Empty, Error, Offline](#7-ui-states-loading-empty-error-offline)
+8. [Accessibility (TalkBack, Switch Access, Font Scaling)](#8-accessibility-talkback-switch-access-font-scaling)
+9. [Test Plan](#9-test-plan)
+10. [Implementation Readiness](#10-implementation-readiness)
+11. [Open Questions](#11-open-questions)
+
+---
+
+## 1. Goals & Non-Goals
+
+**Goals**
+
+- Add a persistent **business/personal lens** to the dashboard, analytics, and
+  report builder with three positions: **Combined**, **Business**, **Personal**.
+- For **Split** transactions, attribute only the **business portion** to the
+  Business lens and only the **personal portion** to the Personal lens — the engine
+  computes the portions; the filter never double-counts.
+- Offer a **side-by-side** Combined vs. Business comparison so the operator can read
+  household and truck health together.
+- Keep the chosen lens **persisted** per surface (the operator's last choice sticks).
+- Work fully **offline-first** against the local encrypted store; never block on
+  network.
+- Be fully operable with **TalkBack**, **Switch Access**, and large font scaling.
+
+**Non-Goals**
+
+- No finance math in Compose. Filtering, business-portion attribution, and totals
+  stay in KMP (see [§2](#2-architecture-boundary-compose--kmp)).
+- No classification UI here — that is the sibling
+  [Tagging UX](./android-business-personal-split-tagging.md) (#2543).
+- No P&L template work — the food-truck P&L is
+  [its own design](./android-foodtruck-pnl-report.md) (#2551); this issue only adds
+  the business/personal **lens** to existing report surfaces.
+- No CSV/PDF export changes in this issue.
+- No native release/signing work — distribution is gated (see
+  [§10](#10-implementation-readiness)).
+
+---
+
+## 2. Architecture Boundary (Compose ↔ KMP)
+
+**The rule:** Compose renders pre-filtered, pre-aggregated state. It does **not**
+filter by classification, sum business vs. personal portions, or split amounts. All
+of that is owned by the shared engine.
+
+The shared engine already exists:
+[`packages/core/.../expensesplit/ExpenseSplitEngine.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/expensesplit/ExpenseSplitEngine.kt)
+with models in
+[`ExpenseSplitModels.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/expensesplit/ExpenseSplitModels.kt).
+Relevant API:
+
+- `ExpenseSplitEngine.businessExpenses(classified)` /
+  `personalExpenses(classified)` — partition a classified list by lens. Note the
+  engine treats `BUSINESS` **and** `SPLIT` as having a business side; `PERSONAL` is
+  the personal side.
+- `ExpenseSplitEngine.businessPortion(amountCents, expenseType, splitRatio)` /
+  `personalPortion(...)` — the portion attributed to each lens for a split.
+- `ExpenseSplitEngine.generateBusinessExpenseReport(classified, start, end)` →
+  `BusinessExpenseReport(totalBusinessCents, totalDeductibleCents,
+totalSplitBusinessPortionCents, categoryBreakdown, ...)`.
+- `ExpenseSplitEngine.quarterlyBusinessSummary(classified, year)` for period
+  roll-ups.
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages/core (shared, all platforms)"]
+        F[ExpenseSplitEngine.business/personalExpenses]
+        A[generateBusinessExpenseReport<br/>quarterlyBusinessSummary]
+        M[BusinessExpenseReport<br/>cents + categoryBreakdown]
+        F --> M
+        A --> M
+    end
+    subgraph Android["apps/android (Compose)"]
+        REPO[(Repositories:<br/>Transaction / Category)]
+        VM[BusinessReportFilterViewModel<br/>maps report -> UI state]
+        UI[Compose: lens control,<br/>dashboard / analytics / report cards]
+    end
+    REPO --> VM
+    VM --> F
+    VM --> A
+    M --> VM
+    VM --> UI
+    UI -->|intent: lens| VM
+```
+
+**Mapping responsibilities**
+
+| Concern                                          | Owner                                                  |
+| ------------------------------------------------ | ------------------------------------------------------ |
+| Partition classified transactions by lens        | KMP `ExpenseSplitEngine.business/personalExpenses`     |
+| Business/personal portion of each split          | KMP `ExpenseSplitEngine.business/personalPortion`      |
+| Totals, deductible totals, category breakdown    | KMP `ExpenseSplitEngine.generateBusinessExpenseReport` |
+| Quarterly business roll-ups                      | KMP `ExpenseSplitEngine.quarterlyBusinessSummary`      |
+| Cents → currency string, percent display         | Android (presentation only, shared currency formatter) |
+| Lens selection, persistence, side-by-side layout | Android (UI state, not math)                           |
+| Reading classified transactions from local store | Android repositories (offline-first)                   |
+
+> If a number must be **computed or filtered**, it belongs in KMP. If it must be
+> **formatted, selected, or laid out**, it belongs in Compose. The Android client
+> passes `ClassifiedExpense` lists from local data to the engine; it never
+> re-implements partitioning or attribution.
+
+---
+
+## 3. Affected Android Surfaces
+
+All paths under `apps/android/src/main/kotlin/com/finance/android/`.
+
+**New**
+
+- `ui/business/report/BusinessLensControl.kt` — the reusable lens selector: a
+  Material 3 `SegmentedButton` (**Combined | Business | Personal**) with a
+  side-by-side toggle.
+- `ui/business/report/BusinessReportFilterViewModel.kt` — `koinViewModel`, collects
+  classified-transaction flows, calls `ExpenseSplitEngine`, exposes a single
+  `StateFlow<BusinessReportUiState>` keyed by the active lens.
+- `ui/business/report/BusinessReportUiState.kt` — sealed UI state
+  (`Loading`, `Empty`, `Error`, `Ready`) + display models (formatted strings + raw
+  cents for semantics) for each lens.
+- `ui/business/report/SideBySideComparison.kt` — a two-column (or stacked, on narrow
+  widths) Combined-vs-Business comparison block.
+
+**Modified (within `apps/android/` only)**
+
+- Dashboard, analytics, and report-builder composables — host `BusinessLensControl`
+  at the top and read the lens-scoped totals (entry point only; no math added).
+- `ui/navigation/FinanceNavHost.kt` — carry the lens as a typed nav argument /
+  saved state so it persists across navigation (follows the existing `Route`
+  pattern).
+
+**Reused (no edits required)**
+
+- Existing chart/card composables — reference for Material 3 card + Canvas chart
+  patterns and `semantics { heading() }` usage; charts re-render with lens-scoped
+  data.
+- `logging/TimberCrashReporter.kt` — structured logging (never log amounts).
+
+---
+
+## 4. Shared Dependencies
+
+| Dependency                                                                                     | Location                                               | Use                                                   |
+| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------ | ----------------------------------------------------- |
+| `ExpenseSplitEngine`, `BusinessExpenseReport`, `QuarterlyBusinessSummary`, `ClassifiedExpense` | `packages/core/.../expensesplit/ExpenseSplitEngine.kt` | Lens partitioning, attribution, period roll-ups       |
+| `ExpenseType`, `SplitRatio`, `SplitAmounts`                                                    | `packages/core/.../expensesplit/ExpenseSplitModels.kt` | Classification + split portion inputs                 |
+| `Cents` / money formatting                                                                     | `packages/core/.../money`, `.../multicurrency`         | Integer-cents money + display formatting              |
+| Transaction / Category repositories                                                            | `apps/android/.../data/repository/`                    | Offline-first source of classified transactions       |
+| Koin modules                                                                                   | `apps/android/.../di/`                                 | `viewModelOf(::BusinessReportFilterViewModel)` wiring |
+| Timber                                                                                         | `apps/android/.../logging/TimberCrashReporter.kt`      | Structured logging (never `Log.*`, never log amounts) |
+
+> **Boundary note:** `apps/android` consumes `packages/core` as a direct Kotlin
+> dependency (no bridging layer). Edits in this issue stay inside `apps/android/`;
+> the engine in `packages/` is consumed as-is.
+
+---
+
+## 5. Filter Model & Lens Behavior
+
+The lens has three positions backed by the engine's partitioning:
+
+| Lens         | What it shows                                                                    | Engine call                                      |
+| ------------ | -------------------------------------------------------------------------------- | ------------------------------------------------ |
+| **Combined** | Everything, full transaction amounts (household + truck together)                | No partition — full classified list              |
+| **Business** | Business side only: `BUSINESS` full amount + the **business portion** of `SPLIT` | `businessExpenses(...)` + `businessPortion(...)` |
+| **Personal** | Personal side only: `PERSONAL` full amount + the **personal portion** of `SPLIT` | `personalExpenses(...)` + `personalPortion(...)` |
+
+Key behaviors:
+
+- **Split attribution, never double-count:** under the Business lens a 70/30 split
+  contributes only its business portion; under Personal, only its personal portion.
+  The two lenses partition the same total — the engine guarantees the portions sum
+  back exactly (remainder cent → personal).
+- **Deductible emphasis:** the Business lens can surface `totalDeductibleCents` and
+  `totalSplitBusinessPortionCents` from `BusinessExpenseReport` as secondary lines.
+- **Lens persistence:** the active lens is saved per surface (dashboard / analytics /
+  report builder) so reopening keeps the operator's last choice.
+- **Period interaction:** the existing period/range controls remain; the lens is an
+  orthogonal dimension layered on top. Quarterly roll-ups use
+  `quarterlyBusinessSummary`.
+
+**Formatting rules (presentation only):**
+
+- Currency via the shared formatter (household default currency, integer cents).
+- Empty lens (e.g. Business lens with no business activity) renders `—` totals with
+  an explanatory empty state, never `0` masquerading as data.
+
+---
+
+## 6. Side-by-Side Combined vs. Business View
+
+The **side-by-side** toggle answers the user's explicit request to read
+"how is the truck doing?" next to "how is my household doing?".
+
+- **Wide layout (≥ medium width / unfolded):** two columns — **Combined** (left)
+  and **Business** (right) — each a compact summary card (net, top categories,
+  trend). Personal can be derived as Combined − Business but is rendered as its own
+  column only when the operator selects it (avoids a cramped three-column layout).
+- **Narrow layout (phones):** the two summaries stack vertically with clear section
+  headers; the lens control collapses to a single segmented row.
+- Each side reads its **own** engine-computed totals; the UI never subtracts one card
+  from another to fake a lens (that subtraction, if needed, is an engine concern).
+
+Responsive behavior follows the breakpoints in
+[`responsive-breakpoints.md`](./responsive-breakpoints.md); information grouping
+follows [`information-architecture.md`](./information-architecture.md).
+
+```mermaid
+flowchart TB
+    LENS[BusinessLensControl] --> MODE{Side-by-side?}
+    MODE -->|No| SINGLE[Single lens summary<br/>Combined / Business / Personal]
+    MODE -->|Yes, wide| TWO[Two columns:<br/>Combined + Business]
+    MODE -->|Yes, narrow| STACK[Stacked summaries<br/>with section headers]
+```
+
+---
+
+## 7. UI States: Loading, Empty, Error, Offline
+
+`BusinessReportUiState` is a sealed interface; each surface renders exactly one
+branch per lens.
+
+- **Loading** — skeleton placeholders for summary cards/charts; TalkBack announces
+  "Loading business and personal report".
+- **Empty (lens)** — the active lens has no activity in range (e.g. Business lens
+  before any business classification): show "No business activity for this period"
+  with a CTA to classify (links conceptually to the
+  [Tagging UX](./android-business-personal-split-tagging.md)); render totals as `—`.
+- **Empty (all)** — no transactions in range at all: a neutral empty state shared
+  with the existing dashboard.
+- **Error** — repository/aggregation failure. Show a retry affordance; log via
+  `Timber.e(t, "Business report filter failed")` **without** any amounts, merchant
+  names, or account data.
+- **Offline** — the default, not an error. Reports compute from the local
+  SQLCipher-encrypted store; show a subtle "Showing local data" affordance only if a
+  sync is pending, never a blocking spinner.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Loading
+    Loading --> Ready: report computed for lens
+    Loading --> Empty: no activity in lens
+    Loading --> Error: repo/aggregation failure
+    Ready --> Ready: change lens / period
+    Error --> Loading: retry
+    Ready --> Empty: lens/range with no activity
+```
+
+---
+
+## 8. Accessibility (TalkBack, Switch Access, Font Scaling)
+
+Mandatory — every interactive and informational Composable carries a
+`contentDescription`, consistent with
+[`accessibility-patterns.md`](./accessibility-patterns.md) §7 (Financial Data
+Accessibility), §8 (Touch Target Sizing), and §9.3 (Android / Compose).
+
+- **Lens control:** the `SegmentedButton` exposes `selected` semantics so TalkBack
+  reads "Business, selected" / "Combined, not selected". The side-by-side toggle
+  announces its on/off state.
+- **Summary values:** each total is a single merged semantics node combining label +
+  value + lens, e.g. _"Business net, 4,260 dollars"_ and _"Personal net, 1,180
+  dollars"_. Use `Modifier.semantics(mergeDescendants = true)`; spell out "dollars"
+  and "percent".
+- **Headings:** lens section titles and each side-by-side column header use
+  `semantics { heading() }` so TalkBack users can jump between Combined and Business.
+- **Side-by-side reading order:** focus order is Combined column → Business column on
+  wide layouts and top → bottom on narrow layouts, so the comparison reads logically.
+- **Charts:** lens-scoped charts carry text alternatives / data-table fallbacks per
+  accessibility-patterns §7.2 (never color-only); the lens name is part of the chart
+  description.
+- **Empty `—` totals** read "not available, no business activity this period".
+- **Switch Access:** lens change, side-by-side toggle, and period change are all
+  reachable by sequential scanning; no action is swipe-only.
+- **Font scaling:** layout uses `sp` text and reflows to **200%**; side-by-side
+  columns collapse to a stacked layout when width is constrained, with no truncation
+  of money values.
+- **Touch targets:** all segments/toggles/chips ≥ 48×48 dp (accessibility-patterns
+  §8).
+- **Color & contrast:** lens states and profit/loss emphasis are conveyed by label +
+  sign, not hue alone (WCAG 1.4.1); emphasis meets ≥ 4.5:1.
+
+---
+
+## 9. Test Plan
+
+**Shared engine (already covered in `packages/`; not edited here)** — referenced for
+traceability: partitioning, business/personal portion attribution, report totals,
+and quarterly roll-ups are unit-tested in the `expensesplit` package
+(`ExpenseSplitEngineTest`). The Android work depends on, but does not re-test, that
+math.
+
+**Android unit tests** (`apps/android/src/test/...`)
+
+- `BusinessReportFilterViewModelTest` — each lens maps to the correct engine call;
+  the Business lens includes the **business portion** of splits and the Personal lens
+  the **personal portion** (asserts the ViewModel does **no** arithmetic and that
+  business + personal portions reconcile to Combined); empty lens yields the `—`
+  state; error on repository failure; lens persists across recomputes.
+- `BusinessReportFormattingTest` — cents→currency and percent display only, including
+  the `—` placeholder for empty lenses.
+
+**Compose UI tests** (`apps/android/src/androidTest/...`)
+
+- `BusinessLensControlTest` — switching Combined/Business/Personal updates the
+  summary; side-by-side toggle shows two columns on wide and stacks on narrow.
+- `SideBySideComparisonTest` — Combined and Business columns render their own
+  engine-computed totals; focus order is correct.
+- **Accessibility assertions** — every interactive node has a non-empty content
+  description; totals merge into single semantics nodes; heading semantics present;
+  verified with `onNodeWithContentDescription` and the Compose a11y test APIs.
+
+**Snapshot tests (Paparazzi)** (`apps/android/src/test/.../ui/snapshot/`)
+
+- `BusinessReportFilterSnapshotTest` — Combined, Business, Personal, side-by-side
+  (wide), stacked (narrow), empty-lens, light/dark, and large-font (1.5×/2.0×)
+  variants. Mirrors the existing `DashboardSnapshotTest` approach.
+
+**Manual QA**
+
+- Airplane mode: all three lenses and side-by-side render from local data.
+- Switch lens and confirm a known split contributes its business portion to Business
+  and its personal portion to Personal (sums reconcile to Combined).
+- TalkBack swipe-through reads lens control → Combined → Business in logical order.
+- Largest system font: side-by-side collapses cleanly with no truncated totals.
+
+---
+
+## 10. Implementation Readiness
+
+This is a **design deliverable**; the feature is implementable now up to the
+distribution boundary. Per
+[`docs/ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md) §2,
+the "blocked by #1242" reference on #2545 is a **distribution** gate only.
+
+**Buildable now (no enrollment, SME-completable):**
+
+- Lens control, side-by-side comparison, ViewModel, Koin wiring, navigation/state
+  persistence, and all tests above.
+- Local verification via `./gradlew :apps:android:assembleDebug` and sideload, plus
+  `:apps:android:testDebugUnitTest` / Paparazzi `verifyPaparazziDebug`.
+- The shared `ExpenseSplitEngine` already exists — no `packages/` changes. (Depends on
+  the #2543 classification being persisted; the filter reads whatever is stored.)
+
+**Distribution tail (human-gated by #1242):**
+
+- Google Play release signing, AAB upload, and release-track promotion.
+- See
+  [Android distribution checklist](../ops/human-gated-prerequisites.md#31-android-distribution--google-play-1242).
+  Nothing in this design requires a store build to validate.
+
+---
+
+## 11. Open Questions
+
+1. **Three-up layout** — should very wide / unfolded layouts offer Combined +
+   Business + Personal as three columns, or keep Personal as a separate selection?
+   Proposed: two-column max for legibility; revisit on large-screen telemetry.
+2. **Income vs. expense lens** — the engine's report focuses on business expenses;
+   should the Business lens also attribute business **income**? Proposed: yes via the
+   existing transaction kind, but confirm income classification source with #2543.
+3. **Default lens** — should the dashboard default to Combined or remember the last
+   lens per surface? Proposed: remember per surface, defaulting to Combined on first
+   run.

--- a/docs/design/android-business-personal-split-tagging.md
+++ b/docs/design/android-business-personal-split-tagging.md
@@ -1,0 +1,423 @@
+# Android Business / Personal / Split Tagging UX — Design
+
+> **Status:** PROPOSED — Pending human review
+> **Issue:** #2543 · **Part of** #2182
+> **Platform:** Android (Jetpack Compose · Material 3)
+> **Priority:** P1 · **Effort:** M (3–5 days)
+> **Last Updated:** 2026-06-22
+
+This document specifies the Android design for classifying transactions,
+accounts, and categories as **business**, **personal**, or **split**, plus the
+**ambiguous cleanup** flow for transactions that have not yet been classified.
+It covers the Compose surfaces to build, the boundary between Compose UI and the
+shared Kotlin Multiplatform (KMP) finance engine, offline/empty/error states,
+accessibility, a test plan, and implementation readiness.
+
+> **User story (#2182):** _"As a small business owner, I want to tag accounts,
+> categories, budgets, and transactions as business, personal, or split, so I can
+> use one app without losing separation."_ When the food-truck owner buys propane,
+> groceries, and commissary supplies on the same card, they need **fast separation
+> at entry time** and a way to **flag ambiguous transactions for later cleanup**.
+
+---
+
+## Table of Contents
+
+1. [Goals & Non-Goals](#1-goals--non-goals)
+2. [Architecture Boundary (Compose ↔ KMP)](#2-architecture-boundary-compose--kmp)
+3. [Affected Android Surfaces](#3-affected-android-surfaces)
+4. [Shared Dependencies](#4-shared-dependencies)
+5. [Tagging UX Layout](#5-tagging-ux-layout)
+6. [Split Editor & Validation](#6-split-editor--validation)
+7. [Ambiguous Cleanup Flow](#7-ambiguous-cleanup-flow)
+8. [UI States: Loading, Empty, Error, Offline](#8-ui-states-loading-empty-error-offline)
+9. [Accessibility (TalkBack, Switch Access, Font Scaling)](#9-accessibility-talkback-switch-access-font-scaling)
+10. [Test Plan](#10-test-plan)
+11. [Implementation Readiness](#11-implementation-readiness)
+12. [Open Questions](#12-open-questions)
+
+---
+
+## 1. Goals & Non-Goals
+
+**Goals**
+
+- Let an operator classify a transaction as **Business**, **Personal**, or
+  **Split** in one tap from the transaction detail and quick-entry surfaces.
+- Provide a **split editor** for the business/personal percentage with a live
+  preview of the business and personal currency portions.
+- Surface **smart defaults** (category- and merchant-inferred) so most expenses are
+  pre-classified, with manual override always available.
+- Provide an **ambiguous cleanup** queue listing transactions that still need
+  classification, so the operator can clear the backlog quickly.
+- Carry a **business/personal default** on accounts and categories so new
+  transactions inherit a sensible starting classification.
+- Work fully **offline-first** against the local encrypted store; never block on
+  network.
+- Be fully operable with **TalkBack**, **Switch Access**, and large font scaling.
+
+**Non-Goals**
+
+- No finance math in Compose. Split portions, rounding, deductible amounts, and
+  validation all stay in KMP (see [§2](#2-architecture-boundary-compose--kmp)).
+- No dashboard/report filtering here — that is the sibling design
+  [Business / Personal Reporting Filters](./android-business-personal-reporting-filters.md)
+  (#2545); this issue produces the classification the filters consume.
+- No tax-form export in this issue (Schedule C draft entry is covered by
+  [Schedule C Quick-Add Sheet](./android-schedule-c-quick-add-sheet.md)).
+- No native release/signing work — distribution is gated (see
+  [§11](#11-implementation-readiness)).
+
+---
+
+## 2. Architecture Boundary (Compose ↔ KMP)
+
+**The rule:** Compose renders shared, pre-computed state and collects user intent.
+It does **not** compute split portions, round cents, validate ratios, or decide
+deductibility. All of that is owned by the shared engine.
+
+The shared engine already exists:
+[`packages/core/.../expensesplit/ExpenseSplitEngine.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/expensesplit/ExpenseSplitEngine.kt)
+with models in
+[`ExpenseSplitModels.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/expensesplit/ExpenseSplitModels.kt)
+and inference rules in
+[`BusinessExpenseRules.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/expensesplit/BusinessExpenseRules.kt).
+Relevant API:
+
+- `ExpenseType` — `BUSINESS`, `PERSONAL`, `SPLIT`.
+- `SplitRatio(businessPercent, personalPercent)` — whole-number percents that must
+  sum to 100.
+- `ExpenseSplitEngine.splitAmounts(totalCents, expenseType, splitRatio)` →
+  `SplitAmounts(totalCents, businessCents, personalCents, remainderAssignedTo)`.
+  Split uses **banker's rounding** on the business portion and assigns any
+  remainder cent to **personal**, so portions always sum exactly to the total.
+- `ExpenseSplitEngine.validateSplitRatio(...)` and `validateClassification(...)`
+  return an `ExpenseSplitValidationResult` that **keeps all errors** (no fail-fast)
+  for inline display.
+- `BusinessExpenseRules.inferExpenseCategory(...)` / `getBusinessExpenseDefaults(...)`
+  derive a suggested category + deductible percent from payee/note/tags.
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages/core (shared, all platforms)"]
+        E[ExpenseSplitEngine.splitAmounts / validate]
+        R[BusinessExpenseRules.infer / defaults]
+        M[SplitAmounts / ExpenseType<br/>ClassifiedExpense + validation]
+        E --> M
+        R --> M
+    end
+    subgraph Android["apps/android (Compose)"]
+        REPO[(Repositories:<br/>Transaction / Account / Category)]
+        VM[BusinessTaggingViewModel<br/>maps engine output -> UI state]
+        UI[Compose: classification chips,<br/>split editor, cleanup queue]
+    end
+    REPO --> VM
+    VM --> E
+    VM --> R
+    M --> VM
+    VM --> UI
+    UI -->|intent: type / ratio| VM
+```
+
+**Mapping responsibilities**
+
+| Concern                                                | Owner                                                  |
+| ------------------------------------------------------ | ------------------------------------------------------ |
+| Business/personal split portions (banker's rounding)   | KMP `ExpenseSplitEngine.splitAmounts`                  |
+| Remainder-cent assignment (→ personal)                 | KMP `ExpenseSplitEngine`                               |
+| Ratio + classification validation (all errors)         | KMP `ExpenseSplitEngine.validate*`                     |
+| Category/merchant inference & deductible defaults      | KMP `BusinessExpenseRules`                             |
+| Cents → currency string, percent display               | Android (presentation only, shared currency formatter) |
+| Chip selection, sheet state, undo, cleanup queue order | Android (UI state, not math)                           |
+| Reading/writing classification on local store          | Android repositories (offline-first)                   |
+
+> If a number must be **computed or validated**, it belongs in KMP. If it must be
+> **formatted, selected, or styled**, it belongs in Compose. The Android client
+> constructs `ExpenseSplitTransaction` / `SplitRatio` from local data and passes
+> them to the engine; it never re-implements the split math.
+
+---
+
+## 3. Affected Android Surfaces
+
+All paths under `apps/android/src/main/kotlin/com/finance/android/`.
+
+**New**
+
+- `ui/business/tagging/BusinessTaggingControls.kt` — the reusable classification
+  control: a Material 3 `SegmentedButton` row (**Business | Personal | Split**)
+  plus an inline split summary. Embeddable in transaction detail and quick-entry.
+- `ui/business/tagging/SplitEditorSheet.kt` — a Material 3 `ModalBottomSheet` with a
+  percentage `Slider` + stepper, live business/personal currency preview, and
+  inline validation messages.
+- `ui/business/tagging/AmbiguousCleanupScreen.kt` — `Scaffold` + `LazyColumn` queue
+  of unclassified transactions with one-tap classify and swipe affordances.
+- `ui/business/tagging/BusinessTaggingViewModel.kt` — `koinViewModel`, collects
+  repository flows, calls `ExpenseSplitEngine` / `BusinessExpenseRules`, exposes a
+  single `StateFlow<BusinessTaggingUiState>`.
+- `ui/business/tagging/BusinessTaggingUiState.kt` — sealed UI state
+  (`Loading`, `Empty`, `Error`, `Ready`) + display models (already-formatted
+  strings + raw cents for semantics).
+
+**Modified (within `apps/android/` only)**
+
+- `ui/navigation/FinanceNavHost.kt` — add a `Route.AmbiguousCleanup` destination and
+  wire entry from the existing transaction list overflow / insights. (Follows the
+  existing `Route` sealed-class pattern.)
+- Transaction detail and quick-entry composables — host `BusinessTaggingControls`
+  (entry point only; no math added).
+
+**Reused (no edits required)**
+
+- Account/Category settings composables — reference for surfacing a
+  business/personal **default** selector (the default seeds new transactions).
+- `logging/TimberCrashReporter.kt` — structured logging (never log amounts).
+
+---
+
+## 4. Shared Dependencies
+
+| Dependency                                                                               | Location                                                 | Use                                                   |
+| ---------------------------------------------------------------------------------------- | -------------------------------------------------------- | ----------------------------------------------------- |
+| `ExpenseSplitEngine`, `SplitAmounts`, `ExpenseType`, `SplitRatio`, `ClassifiedExpense`   | `packages/core/.../expensesplit/ExpenseSplitEngine.kt`   | Split portions, classification, validation            |
+| `BusinessExpenseRules`, `ExpenseCategory`, `ExpenseCategoryOption`, `BusinessExpenseTag` | `packages/core/.../expensesplit/BusinessExpenseRules.kt` | Category inference + deductible defaults              |
+| `Cents` / money formatting                                                               | `packages/core/.../money`, `.../multicurrency`           | Integer-cents money + display formatting              |
+| Transaction / Account / Category repositories                                            | `apps/android/.../data/repository/`                      | Offline-first source + persistence of classification  |
+| Koin modules                                                                             | `apps/android/.../di/`                                   | `viewModelOf(::BusinessTaggingViewModel)` wiring      |
+| Timber                                                                                   | `apps/android/.../logging/TimberCrashReporter.kt`        | Structured logging (never `Log.*`, never log amounts) |
+
+> **Boundary note:** `apps/android` consumes `packages/core` as a direct Kotlin
+> dependency (no bridging layer). Edits in this issue stay inside `apps/android/`;
+> the engine and rules in `packages/` are consumed as-is.
+
+---
+
+## 5. Tagging UX Layout
+
+`BusinessTaggingControls` is a compact, embeddable block:
+
+1. **Classification segmented control** — Material 3 `SegmentedButton`:
+   **Business | Personal | Split**. Maps directly to
+   `ExpenseType.BUSINESS / PERSONAL / SPLIT`. The initial selection comes from the
+   account/category default or `BusinessExpenseRules` inference, never guessed in UI.
+2. **Inline split summary** (visible only when `SPLIT` is selected) — reads the
+   `SplitAmounts` returned by the engine, e.g. _"Business $42.00 · Personal $18.00
+   (70/30)"_. Tapping opens the [Split Editor](#6-split-editor--validation).
+3. **Deductible hint** (optional) — when the engine flags a likely deductible
+   business category, show a quiet assist chip ("Likely deductible: Meals 50%")
+   sourced from `BusinessExpenseRules`; this is informational, not a calculation.
+
+**Formatting rules (presentation only):**
+
+- Currency via the shared formatter (household default currency, integer cents).
+- Percentages render the whole-number `businessPercent` / `personalPercent`.
+- A split that has not been edited shows the inherited default ratio; the engine
+  is still the source of the portion math.
+
+---
+
+## 6. Split Editor & Validation
+
+`SplitEditorSheet` (Material 3 `ModalBottomSheet`):
+
+- **Percentage control** — a `Slider` (0–100, business side) with a paired numeric
+  stepper. The personal percent is always `100 − business`, mirroring the engine's
+  invariant; the UI never lets the two drift out of sum.
+- **Live preview** — on every change the ViewModel calls
+  `ExpenseSplitEngine.splitAmounts(...)` and renders `businessCents` /
+  `personalCents`. Because the engine assigns the remainder cent to personal, the
+  preview always sums to the transaction total — the UI shows exactly what will be
+  saved.
+- **Inline validation** — `validateSplitRatio` / `validateClassification` return a
+  list of human-readable errors (e.g. _"Split ratio must sum to 100"_,
+  _"Personal expenses cannot be deductible"_). The sheet renders all of them and
+  disables **Save** until `isValid`.
+- **Quick presets** — chips for common ratios (50/50, 70/30, 80/20, 100/0). Each
+  preset just sets a `SplitRatio`; the engine recomputes portions.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Personal
+    Personal --> Business: tap Business
+    Business --> Personal: tap Personal
+    Business --> SplitEditing: tap Split
+    Personal --> SplitEditing: tap Split
+    SplitEditing --> SplitValid: ratio sums to 100
+    SplitEditing --> SplitInvalid: ratio invalid (Save disabled)
+    SplitInvalid --> SplitEditing: adjust
+    SplitValid --> [*]: Save
+```
+
+---
+
+## 7. Ambiguous Cleanup Flow
+
+The **ambiguous cleanup** queue (`AmbiguousCleanupScreen`) lists transactions whose
+classification is still unresolved — for example a card used for both groceries at
+home and commissary supplies. "Ambiguous" is defined by repository state (no stored
+`ExpenseType`, or an explicit `needs-review` flag), **not** by UI heuristics; the
+engine's inference only supplies a _suggested_ classification.
+
+Per row:
+
+- Merchant, amount, date, and the **suggested** classification from
+  `BusinessExpenseRules.getBusinessExpenseDefaults(...)` shown as a dismissible
+  assist chip.
+- **One-tap accept** applies the suggestion; **Business / Personal / Split** chips
+  override it; **Split** opens the editor.
+- An **Undo** snackbar follows each classification so a mis-tap is reversible
+  without leaving the queue.
+
+Clearing the queue is the core "later cleanup" job; the count is surfaced as a
+badge on the entry point so the operator knows how much business cleanup remains.
+
+---
+
+## 8. UI States: Loading, Empty, Error, Offline
+
+`BusinessTaggingUiState` is a sealed interface; each surface renders exactly one
+branch.
+
+- **Loading** — skeleton placeholders for the controls / queue rows; TalkBack
+  announces "Loading business and personal classification".
+- **Empty (cleanup queue)** — no unclassified transactions: a positive empty state
+  ("All caught up — every transaction is classified") rather than an error.
+- **Empty (no business activity)** — account/category has no transactions yet: show
+  the controls with the inherited default and a hint to classify on first entry.
+- **Error** — repository/validation failure. Show a retry affordance; log via
+  `Timber.e(t, "Business classification failed")` **without** any amounts, merchant
+  names, or account data.
+- **Offline** — the default, not an error. Classification reads and writes the local
+  SQLCipher-encrypted store; show a subtle "Saved locally, will sync" affordance only
+  if a sync is pending, never a blocking spinner.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Loading
+    Loading --> Ready: data loaded
+    Loading --> Empty: nothing to classify
+    Loading --> Error: repo/validation failure
+    Ready --> Ready: classify / edit split
+    Error --> Loading: retry
+    Ready --> Empty: queue cleared
+```
+
+---
+
+## 9. Accessibility (TalkBack, Switch Access, Font Scaling)
+
+Mandatory — every interactive and informational Composable carries a
+`contentDescription`, consistent with
+[`accessibility-patterns.md`](./accessibility-patterns.md) §7 (Financial Data
+Accessibility), §8 (Touch Target Sizing), and §9.3 (Android / Compose).
+
+- **Classification control:** the `SegmentedButton` exposes `selected` semantics so
+  TalkBack reads "Business, selected" / "Split, not selected". Each segment is a
+  labelled button, not an icon-only target.
+- **Split summary & preview:** the inline summary is a single merged semantics node
+  combining label + portions, e.g. _"Split: business 42 dollars, personal 18
+  dollars, 70 to 30"_. Use `Modifier.semantics(mergeDescendants = true)`. Spell out
+  "dollars" and "percent" — never read raw glyphs.
+- **Split editor slider:** the `Slider` sets `stateDescription` to the current
+  percentage ("Business 70 percent") and supports Switch Access increment/decrement;
+  the numeric stepper provides an alternative to dragging for motor accessibility.
+- **Validation errors:** announced via a `LiveRegion` (assertive) so they are read
+  immediately when Save is blocked; each error is also visually adjacent to the
+  control.
+- **Cleanup rows:** each row merges into one node ("Commissary Supply, 60 dollars,
+  June 18, suggested Business"); swipe/Undo actions are exposed as custom
+  accessibility actions, not gesture-only.
+- **Switch Access:** all actions (classify, open editor, accept suggestion, undo)
+  are reachable by sequential scanning; no action depends on a swipe gesture alone.
+- **Font scaling:** layout uses `sp` text and reflows to **200%** with no truncation;
+  the split summary stacks label/portions vertically when width is constrained.
+- **Touch targets:** all chips/segments/stepper buttons ≥ 48×48 dp
+  (accessibility-patterns §8).
+- **Color & contrast:** business/personal/split states are distinguished by \*\*label
+  - icon\*\*, not hue alone (WCAG 1.4.1); emphasis meets ≥ 4.5:1.
+
+---
+
+## 10. Test Plan
+
+**Shared engine (already covered in `packages/`; not edited here)** — referenced for
+traceability: split portions, banker's rounding, remainder-to-personal, and ratio/
+classification validation are unit-tested in the `expensesplit` package
+(`ExpenseSplitEngineTest`). The Android work depends on, but does not re-test, that
+math.
+
+**Android unit tests** (`apps/android/src/test/...`)
+
+- `BusinessTaggingViewModelTest` — selecting Business/Personal/Split maps straight to
+  `ExpenseType`; the split preview reflects the engine's `SplitAmounts` (asserts the
+  ViewModel does **no** arithmetic, including remainder-cent placement); invalid
+  ratios surface the engine's error list and keep Save disabled; suggestion accept
+  applies `BusinessExpenseRules` defaults.
+- `BusinessTaggingFormattingTest` — cents→currency and percent display only (e.g.
+  `4200 → "$42.00"`, `70 → "70%"`), including the inherited-default rendering.
+
+**Compose UI tests** (`apps/android/src/androidTest/...`)
+
+- `BusinessTaggingControlsTest` — segmented control switches type; split summary
+  appears only for `SPLIT`; opening the editor and saving persists the ratio.
+- `SplitEditorSheetTest` — slider/stepper stay in sum; Save disabled on invalid;
+  presets set the expected ratio.
+- `AmbiguousCleanupScreenTest` — queue lists unclassified rows; one-tap accept and
+  override update state; Undo restores prior state; empty state renders.
+- **Accessibility assertions** — every interactive node has a non-empty content
+  description; rows/summaries merge into single semantics nodes; slider exposes a
+  state description; verified with `onNodeWithContentDescription` and the Compose
+  a11y test APIs.
+
+**Snapshot tests (Paparazzi)** (`apps/android/src/test/.../ui/snapshot/`)
+
+- `BusinessTaggingSnapshotTest` — controls (Business / Personal / Split), split
+  editor (valid + invalid), cleanup queue (populated + empty), light/dark, and
+  large-font (1.5×/2.0×) variants. Mirrors the existing snapshot-test approach.
+
+**Manual QA**
+
+- Airplane mode: classify and edit splits; values persist and sync flag appears.
+- TalkBack swipe-through reads control → summary → editor in logical order.
+- Switch Access: classify a transaction and edit a split using scanning only.
+- Largest system font: no truncated money values in summary or queue rows.
+
+---
+
+## 11. Implementation Readiness
+
+This is a **design deliverable**; the feature is implementable now up to the
+distribution boundary. Per
+[`docs/ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md) §2,
+the "blocked by #1242" reference on #2543 is a **distribution** gate only.
+
+**Buildable now (no enrollment, SME-completable):**
+
+- Compose controls, split editor, cleanup screen, ViewModel, Koin wiring,
+  navigation, and all tests above.
+- Local verification via `./gradlew :apps:android:assembleDebug` and sideload, plus
+  `:apps:android:testDebugUnitTest` / Paparazzi `verifyPaparazziDebug`.
+- The shared `ExpenseSplitEngine` and `BusinessExpenseRules` already exist — no
+  `packages/` changes.
+
+**Distribution tail (human-gated by #1242):**
+
+- Google Play release signing, AAB upload, and release-track promotion.
+- See
+  [Android distribution checklist](../ops/human-gated-prerequisites.md#31-android-distribution--google-play-1242).
+  Nothing in this design requires a store build to validate.
+
+---
+
+## 12. Open Questions
+
+1. **Default inheritance order** — when both account and category carry a
+   business/personal default, which wins? Proposed: category default overrides
+   account default; merchant inference only fills when neither is set.
+2. **Ambiguity definition** — should "ambiguous" include transactions whose stored
+   classification disagrees with current inference (a re-review prompt), or only
+   never-classified ones? Proposed: start with never-classified; add a soft
+   "re-review" signal later.
+3. **Bulk classify** — is multi-select bulk classification in scope for the cleanup
+   queue, or a fast-follow? Proposed: ship single-row first, add bulk once the queue
+   pattern is validated.

--- a/docs/design/android-business-scenario-planner.md
+++ b/docs/design/android-business-scenario-planner.md
@@ -1,0 +1,453 @@
+# Android Business Scenario Planner & Alerts — Design
+
+> **Status:** PROPOSED — Pending human review
+> **Issue:** #2557 · **Part of** #2185
+> **Platform:** Android (Jetpack Compose · Material 3)
+> **Priority:** P1 · **Effort:** L (1–2 weeks)
+> **Last Updated:** 2026-06-22
+
+This document specifies the Android design for a **what-if scenario planner** that
+models one-off expenses/revenue against recurring obligations, plus **local
+low-balance and payroll-risk alerts**. It answers the operator's recurring
+question — _"If I buy $900 of ingredients today, am I still safe for payroll
+Friday?"_ — and warns before a projected balance goes negative. It covers the
+Compose surfaces, the boundary between Compose UI and the shared Kotlin
+Multiplatform (KMP) finance engine, offline/empty/error states, accessibility, a
+test plan, and implementation readiness.
+
+> **User story (#2185):** _"As a small business owner, I want to model payroll, tax
+> estimates, commissary rent, and one-off expenses against expected inflows, and be
+> warned when projected balances go negative before a future date, so I avoid timing
+> mistakes instead of explaining them after the fact."_
+
+This design **extends** the read-only
+[Operating Cash Calendar](./android-operating-cash-calendar.md) (#2555, also part of
+#2185) with **interactive what-if scenarios** and **local alerts**; both render the
+same shared forecast engine's output.
+
+---
+
+## Table of Contents
+
+1. [Goals & Non-Goals](#1-goals--non-goals)
+2. [Architecture Boundary (Compose ↔ KMP)](#2-architecture-boundary-compose--kmp)
+3. [Affected Android Surfaces](#3-affected-android-surfaces)
+4. [Shared Dependencies](#4-shared-dependencies)
+5. [Scenario Planner UX](#5-scenario-planner-ux)
+6. [Local Alerts: Low-Balance & Payroll-Risk](#6-local-alerts-low-balance--payroll-risk)
+7. [UI States: Loading, Empty, Error, Offline](#7-ui-states-loading-empty-error-offline)
+8. [Accessibility (TalkBack, Switch Access, Font Scaling)](#8-accessibility-talkback-switch-access-font-scaling)
+9. [Test Plan](#9-test-plan)
+10. [Implementation Readiness](#10-implementation-readiness)
+11. [Open Questions](#11-open-questions)
+
+---
+
+## 1. Goals & Non-Goals
+
+**Goals**
+
+- Let an operator add **one-off what-if entries** (an expense like "$900 ingredients
+  today" or revenue like "$2k catering deposit Friday") and instantly see the
+  re-projected balance and whether any **threshold is breached**.
+- Compare a **baseline** forecast (recurring commitments only) against a **scenario**
+  forecast (baseline + what-ifs) so the operator sees the delta.
+- Detect and surface **low-balance** and **payroll-risk** alerts: the first date a
+  projected balance falls below zero or a buffer, and specifically whether an
+  upcoming **payroll** commitment is covered.
+- Evaluate alerts **locally** and re-check them in the background with **WorkManager**,
+  posting an on-device notification when a breach is newly detected.
+- Label all forward-looking numbers as **estimates / projections**, never as
+  guaranteed balances.
+- Work fully **offline-first**; the forecast is deterministic and local.
+- Be fully operable with **TalkBack**, **Switch Access**, and large font scaling.
+
+**Non-Goals**
+
+- No forecast math in Compose — expansion of recurring commitments, day-by-day
+  balances, confidence bands, and breach detection live in the shared engine
+  ([§2](#2-architecture-boundary-compose--kmp)).
+- No remote push (FCM/Supabase) delivery in this issue — alerts are **local**;
+  server push is distribution-adjacent and out of scope here.
+- No bank-connection / live-balance ingestion — starting balance and commitments
+  come from existing local data and user entries.
+- No `AlarmManager` / `JobScheduler` — background re-checks use **WorkManager** only.
+- No native release/signing work — distribution is gated (see
+  [§10](#10-implementation-readiness)).
+
+---
+
+## 2. Architecture Boundary (Compose ↔ KMP)
+
+**The rule:** Compose collects what-if intent and renders a pre-computed forecast. It
+never expands recurring schedules, sums balances, computes confidence bands, or
+decides when a threshold is breached. The shared engine owns all of it.
+
+The shared engine already exists:
+[`packages/core/.../forecast/OperatingCashForecast.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/forecast/OperatingCashForecast.kt).
+`OperatingCashForecastEngine.forecast(input)` consumes an
+`OperatingCashForecastInput` and returns an `OperatingCashForecastResult`. Relevant
+API:
+
+- `OneOffForecastEntry(id, description, amount, direction, kind, date)` — the what-if
+  input; `kind` defaults to `ForecastCashFlowKind.SCENARIO`.
+- `RecurringForecastCommitment(...)` — payroll/tax/bill commitments with cadence;
+  `ForecastCashFlowKind.PAYROLL` marks payroll for risk evaluation.
+- `ForecastBalanceThreshold` (e.g. `ForecastBalanceThreshold.ZERO`) — the floor used
+  to detect a breach; the engine returns the **first** breach date per threshold.
+- `OperatingCashForecastResult` exposes `balancePoints` (per-day), `horizonSnapshots`
+  (7/30/90-day with `lowBalance`/`highBalance` confidence bands), `occurrences`, and
+  `thresholdBreaches` (`ForecastThresholdBreach(thresholdId, date, projectedBalance)`).
+
+The scenario is just **two engine calls**: a baseline `forecast(...)` and a scenario
+`forecast(...)` whose input adds the operator's `oneOffEntries`. The UI diffs the two
+results for display; it does not recompute balances.
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages/core (shared, all platforms)"]
+        E[OperatingCashForecastEngine.forecast]
+        M[OperatingCashForecastResult<br/>balancePoints / horizonSnapshots<br/>thresholdBreaches]
+        E --> M
+    end
+    subgraph Android["apps/android (Compose + WorkManager)"]
+        REPO[(Repositories:<br/>balance / recurring commitments)]
+        VM[ScenarioPlannerViewModel<br/>baseline + scenario inputs]
+        UI[Compose: what-if editor,<br/>projection chart, alert banner]
+        W[ScenarioAlertWorker<br/>periodic re-check]
+        N[Local notification<br/>on new breach]
+    end
+    REPO --> VM
+    VM -->|baseline input| E
+    VM -->|scenario input + one-offs| E
+    M --> VM
+    VM --> UI
+    UI -->|intent: add what-if| VM
+    REPO --> W
+    W --> E
+    M --> W
+    W --> N
+```
+
+**Mapping responsibilities**
+
+| Concern                                                     | Owner                                                   |
+| ----------------------------------------------------------- | ------------------------------------------------------- |
+| Expanding recurring commitments to dated occurrences        | KMP `OperatingCashForecastEngine`                       |
+| Day-by-day balance projection + horizon roll-ups            | KMP `OperatingCashForecastEngine`                       |
+| Confidence bands (low/high) and z-score math                | KMP `OperatingCashForecastEngine`                       |
+| First threshold breach detection (low-balance / payroll)    | KMP `OperatingCashForecastEngine` (`thresholdBreaches`) |
+| Building baseline vs. scenario inputs from local data       | Android ViewModel (assembles inputs, no math)           |
+| Cents → currency string, date formatting, "estimate" labels | Android (presentation only, shared currency formatter)  |
+| Scheduling background re-checks                             | Android **WorkManager** (`ScenarioAlertWorker`)         |
+| Posting the local notification                              | Android `NotificationManager` (on-device only)          |
+
+> If a number must be **computed or projected**, it belongs in KMP. If it must be
+> **formatted, scheduled, or rendered**, it belongs in Compose / platform services.
+> Every projected value is labeled an **estimate** in the UI.
+
+---
+
+## 3. Affected Android Surfaces
+
+All paths under `apps/android/src/main/kotlin/com/finance/android/`.
+
+**New**
+
+- `ui/business/scenario/ScenarioPlannerScreen.kt` — `Scaffold` + `LazyColumn`:
+  what-if editor, baseline-vs-scenario projection, horizon outlook, and the alert
+  banner.
+- `ui/business/scenario/WhatIfEntrySheet.kt` — Material 3 `ModalBottomSheet` to add a
+  one-off entry (amount, inflow/outflow, date, optional kind), mapped to
+  `OneOffForecastEntry`.
+- `ui/business/scenario/ScenarioPlannerViewModel.kt` — `koinViewModel`, builds the
+  baseline and scenario `OperatingCashForecastInput`, calls the engine twice, and
+  exposes a single `StateFlow<ScenarioPlannerUiState>`.
+- `ui/business/scenario/ScenarioPlannerUiState.kt` — sealed UI state
+  (`Loading`, `Empty`, `Error`, `Ready`) + display models (formatted strings + raw
+  cents/dates for semantics), including a `payrollSafe: Boolean` flag derived from
+  the engine's breaches vs. payroll occurrences.
+- `sync/work/ScenarioAlertWorker.kt` — a `CoroutineWorker` (WorkManager) that
+  re-runs the forecast on a periodic cadence and posts a local notification when a
+  **new** breach is detected.
+- `notifications/ScenarioAlertNotifier.kt` — wraps `NotificationManager` channel
+  creation + posting (on-device only; no FCM).
+
+**Modified (within `apps/android/` only)**
+
+- `ui/navigation/FinanceNavHost.kt` — add a `Route.ScenarioPlanner` destination and
+  wire entry from the operating cash calendar and insights (follows the existing
+  `Route` sealed-class pattern; deep link from the alert notification).
+- Koin DI module — `viewModelOf(::ScenarioPlannerViewModel)` and worker/notifier
+  wiring (mirrors the existing `SyncModule` / `SyncWorker` registration pattern).
+
+**Reused (no edits required)**
+
+- [Operating Cash Calendar](./android-operating-cash-calendar.md) composables —
+  reference for rendering `balancePoints` / `horizonSnapshots` and risk indicators.
+- `sync/SyncWorker.kt` — reference for the WorkManager registration pattern.
+- `logging/TimberCrashReporter.kt` — structured logging (never log amounts).
+
+---
+
+## 4. Shared Dependencies
+
+| Dependency                                                                                                  | Location                                              | Use                                                        |
+| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- | ---------------------------------------------------------- |
+| `OperatingCashForecastEngine`, `OperatingCashForecastInput`, `OperatingCashForecastResult`                  | `packages/core/.../forecast/OperatingCashForecast.kt` | Baseline + scenario projection, breaches, confidence bands |
+| `OneOffForecastEntry`, `RecurringForecastCommitment`, `ForecastBalanceThreshold`, `ForecastThresholdBreach` | `packages/core/.../forecast/OperatingCashForecast.kt` | What-if entries, commitments, thresholds, breaches         |
+| `ForecastCashFlowKind` (`PAYROLL`, `TAX`, `BILL`, `SCENARIO`), `ForecastConfidence`                         | `packages/core/.../forecast/OperatingCashForecast.kt` | Classifying payroll risk + confidence presets              |
+| `Cents` / money formatting                                                                                  | `packages/core/.../money`, `.../multicurrency`        | Integer-cents money + display formatting                   |
+| Balance / recurring-commitment repositories                                                                 | `apps/android/.../data/repository/`                   | Offline-first source for starting balance + commitments    |
+| WorkManager                                                                                                 | `apps/android/.../sync/` (pattern)                    | Background periodic alert re-check                         |
+| Koin modules                                                                                                | `apps/android/.../di/`                                | `viewModelOf(::ScenarioPlannerViewModel)` + worker wiring  |
+| Timber                                                                                                      | `apps/android/.../logging/TimberCrashReporter.kt`     | Structured logging (never `Log.*`, never log amounts)      |
+
+> **Boundary note:** `apps/android` consumes `packages/core` as a direct Kotlin
+> dependency (no bridging layer). Edits in this issue stay inside `apps/android/`;
+> the forecast engine in `packages/` is consumed as-is.
+
+---
+
+## 5. Scenario Planner UX
+
+`ScenarioPlannerScreen`, top to bottom:
+
+1. **Top app bar** — title "Scenario planner", back navigation, overflow (horizon
+   range, confidence preset). Confidence maps to `ForecastConfidence` LOW/MEDIUM/HIGH.
+2. **Headline answer card** — the operator's core question, phrased plainly:
+   _"Payroll Friday: **Safe** (estimated $1,240 cushion)"_ or _"**At risk** — short
+   by an estimated $310 on Jun 27"_. The verdict is derived from the engine's
+   `thresholdBreaches` and the payroll `occurrences`; the cushion is straight from a
+   `balancePoint` / `horizonSnapshot`. Always labeled **estimate**.
+3. **What-if list** — the operator's added `OneOffForecastEntry` items, each with
+   amount, direction, and date; swipe-to-remove and an **Add what-if** button opening
+   `WhatIfEntrySheet`.
+4. **Baseline vs. scenario projection** — a line/area chart of `balancePoints` for
+   both the baseline and scenario results, with the **first breach** marked. The
+   delta ("$900 today moves your Friday low to …") is computed by diffing the two
+   engine results, not by the UI summing anything.
+5. **Horizon outlook** — 7/30/90-day `horizonSnapshots` with `expectedBalance` and
+   the low/high confidence band, each labeled as an estimated range.
+
+**Add-what-if flow** (`WhatIfEntrySheet`):
+
+- Amount (integer cents via the shared money input), **Inflow/Outflow** toggle, date
+  picker, and an optional kind (defaults to `SCENARIO`). On confirm, the ViewModel
+  appends an `OneOffForecastEntry` and re-runs the scenario `forecast(...)`.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Baseline
+    Baseline --> Scenario: add what-if entry
+    Scenario --> Scenario: add / remove what-if
+    Scenario --> Baseline: clear all what-ifs
+    Scenario --> Breach: threshold breached in horizon
+    Baseline --> Breach: baseline already breaches
+    Breach --> Scenario: adjust what-ifs to recover
+```
+
+**Formatting rules (presentation only):**
+
+- Currency via the shared formatter (household default currency, integer cents).
+- Every projected figure carries an **"estimate"** / **"projected"** qualifier in the
+  visible label and the TalkBack description.
+- Breach dates render in the user's locale date format; "no breach in horizon" renders
+  as an explicit positive state, never a blank.
+
+---
+
+## 6. Local Alerts: Low-Balance & Payroll-Risk
+
+Alerts are **derived from the engine**, evaluated **locally**, and re-checked in the
+background — no server, no remote push in this issue.
+
+- **Low-balance alert:** the engine's first `ForecastThresholdBreach` against
+  `ForecastBalanceThreshold.ZERO` (or an operator-set buffer) — "Projected to go
+  negative on Jun 27 (estimated −$310)".
+- **Payroll-risk alert:** the planner adds a payroll-specific check — is the balance
+  on/just-before the next `ForecastCashFlowKind.PAYROLL` occurrence ≥ the payroll
+  amount? This reuses `balancePoints` + `occurrences`; the threshold can be modeled as
+  a payroll-sized `ForecastBalanceThreshold` so detection stays in the engine.
+- **Background re-check (`ScenarioAlertWorker`):** a periodic WorkManager job
+  re-builds the baseline input from local data, runs `forecast(...)`, and compares the
+  earliest breach date against the last notified state. On a **new or earlier** breach
+  it posts a local notification deep-linking into `ScenarioPlannerScreen`. The worker
+  honors battery/Doze constraints via WorkManager `Constraints`; it **never** uses
+  `AlarmManager`/`JobScheduler`.
+- **De-duplication:** the worker stores the last-notified breach key (threshold id +
+  date) so the operator is not re-notified for an unchanged risk.
+- **No sensitive logging:** the worker and notifier log only outcomes
+  (`Timber.i("scenario alert posted")`) — never amounts, balances, or breach values.
+
+```mermaid
+flowchart TB
+    SCHED[WorkManager periodic] --> WORKER[ScenarioAlertWorker]
+    WORKER --> ENG[OperatingCashForecastEngine.forecast]
+    ENG --> BR{New / earlier breach?}
+    BR -->|No| END[No-op, reschedule]
+    BR -->|Yes| NOTIFY[Post local notification]
+    NOTIFY --> DEEP[Deep link -> ScenarioPlannerScreen]
+```
+
+> The notification copy states the **estimated** breach date and a single clear
+> action ("Review scenario"); it deliberately omits exact amounts from the
+> notification surface for privacy on a lock screen.
+
+---
+
+## 7. UI States: Loading, Empty, Error, Offline
+
+`ScenarioPlannerUiState` is a sealed interface; the screen renders exactly one branch.
+
+- **Loading** — skeleton placeholders for the headline card and chart; TalkBack
+  announces "Loading scenario planner".
+- **Empty** — no recurring commitments and no balance to project from: an onboarding
+  empty state ("Add payroll, taxes, or bills to forecast your cash") with a CTA;
+  what-ifs are disabled until there is a baseline.
+- **Baseline-only** — commitments exist but the operator has added no what-ifs: show
+  the baseline projection and alerts; the scenario equals the baseline.
+- **Error** — repository/forecast failure. Show a retry affordance; log via
+  `Timber.e(t, "Scenario forecast failed")` **without** any amounts, balances, or
+  account data.
+- **Offline** — the default, not an error. The forecast is deterministic and computes
+  from the local SQLCipher-encrypted store; no spinner, no network dependency. The
+  background worker also runs fully offline.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Loading
+    Loading --> Empty: no commitments / balance
+    Loading --> Ready: forecast computed
+    Loading --> Error: repo/forecast failure
+    Ready --> Ready: add / remove what-if
+    Error --> Loading: retry
+    Ready --> Empty: all inputs cleared
+```
+
+---
+
+## 8. Accessibility (TalkBack, Switch Access, Font Scaling)
+
+Mandatory — every interactive and informational Composable carries a
+`contentDescription`, consistent with
+[`accessibility-patterns.md`](./accessibility-patterns.md) §7 (Financial Data
+Accessibility), §8 (Touch Target Sizing), and §9.3 (Android / Compose).
+
+- **Headline verdict:** a single merged semantics node spelling out the estimate, e.g.
+  _"Payroll Friday, estimated safe, cushion 1,240 dollars"_ or _"At risk, estimated
+  short by 310 dollars on June 27"_. Use `Modifier.semantics(mergeDescendants = true)`;
+  spell out "dollars" and always include "estimated".
+- **Headings:** the headline, projection, horizon outlook, and what-if list titles use
+  `semantics { heading() }` so TalkBack users can jump by section.
+- **Projection chart:** carries a text-alternative / data-table fallback per
+  accessibility-patterns §7.2 — describing the baseline line, the scenario line, and
+  the breach point in words (never color-only). Breach is conveyed by label + marker,
+  not hue alone (WCAG 1.4.1).
+- **What-if entries:** each row merges into one node ("Ingredients, outflow 900
+  dollars, June 22"); remove is exposed as a custom accessibility action, not
+  swipe-only.
+- **Add-what-if sheet:** amount/date/direction controls are labelled fields with error
+  association; the Inflow/Outflow toggle announces its state.
+- **Alert notification:** uses a clear, non-truncated title + body and a single
+  action; the channel name is descriptive ("Cash-flow alerts").
+- **Switch Access:** add/remove what-if, change horizon, open the alert, and dismiss
+  are all reachable by sequential scanning; no swipe-only actions.
+- **Font scaling:** layout uses `sp` text and reflows to **200%**; the headline card and
+  horizon rows stack vertically with no truncation of money values.
+- **Touch targets:** all controls ≥ 48×48 dp (accessibility-patterns §8).
+
+---
+
+## 9. Test Plan
+
+**Shared engine (already covered in `packages/`; not edited here)** — referenced for
+traceability: recurring expansion, day-by-day balances, confidence bands, and
+threshold-breach detection are unit-tested in the `forecast` package
+(`OperatingCashForecastEngineTest`). The Android work depends on, but does not
+re-test, that math.
+
+**Android unit tests** (`apps/android/src/test/...`)
+
+- `ScenarioPlannerViewModelTest` — adding a what-if appends an `OneOffForecastEntry`
+  and the scenario result differs from baseline exactly by the engine's output
+  (asserts the ViewModel does **no** arithmetic); the `payrollSafe` verdict is derived
+  from the engine's breaches vs. payroll occurrences; empty/baseline-only/error states
+  map correctly.
+- `ScenarioFormattingTest` — cents→currency, date formatting, and the mandatory
+  "estimate"/"projected" qualifier on every projected value.
+- `ScenarioAlertWorkerTest` — given a fixture forecast with a breach, the worker
+  decides to notify; given an unchanged breach key, it de-duplicates (no notify); it
+  logs no amounts.
+
+**Compose UI tests** (`apps/android/src/androidTest/...`)
+
+- `ScenarioPlannerScreenTest` — add/remove what-if updates the projection and headline;
+  a breach marker appears when the scenario crosses zero; baseline-only and empty
+  states render their CTAs.
+- `WhatIfEntrySheetTest` — amount/date/direction inputs build the expected entry;
+  invalid input blocks confirm.
+- **Accessibility assertions** — every interactive node has a non-empty content
+  description; the headline and rows merge into single semantics nodes; chart text
+  alternative present; heading semantics present; verified with
+  `onNodeWithContentDescription` and the Compose a11y test APIs.
+
+**Snapshot tests (Paparazzi)** (`apps/android/src/test/.../ui/snapshot/`)
+
+- `ScenarioPlannerSnapshotTest` — Ready (payroll safe), Ready (at risk / breach),
+  baseline-only, Empty, light/dark, and large-font (1.5×/2.0×) variants. Mirrors the
+  existing snapshot-test approach.
+
+**Manual QA**
+
+- Airplane mode: add a what-if and confirm the projection and alert recompute from
+  local data; the background worker runs offline.
+- TalkBack swipe-through reads headline verdict → what-ifs → projection in logical
+  order, always announcing "estimated".
+- Switch Access: add and remove a what-if and open the alert using scanning only.
+- Largest system font: headline and horizon rows reflow with no truncated money values.
+
+---
+
+## 10. Implementation Readiness
+
+This is a **design deliverable**; the feature is implementable now up to the
+distribution boundary. Per
+[`docs/ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md) §2,
+the "blocked by #1242" reference on #2557 is a **distribution** gate only. Note the
+**local** alert path needs no server enrollment; only remote push would be gated, and
+remote push is explicitly out of scope here.
+
+**Buildable now (no enrollment, SME-completable):**
+
+- Scenario screen, what-if sheet, ViewModel, the WorkManager `ScenarioAlertWorker`,
+  the local notifier, Koin wiring, navigation, and all tests above.
+- Local verification via `./gradlew :apps:android:assembleDebug` and sideload, plus
+  `:apps:android:testDebugUnitTest` / Paparazzi `verifyPaparazziDebug`. Local
+  notifications post on a sideloaded debug build with no Play services.
+- The shared `OperatingCashForecastEngine` already exists — no `packages/` changes.
+
+**Distribution tail (human-gated by #1242):**
+
+- Google Play release signing, AAB upload, and release-track promotion.
+- See
+  [Android distribution checklist](../ops/human-gated-prerequisites.md#31-android-distribution--google-play-1242).
+  Nothing in this design requires a store build to validate; remote/FCM push (if added
+  later) is a separate, distribution-adjacent effort.
+
+---
+
+## 11. Open Questions
+
+1. **Re-check cadence** — how often should `ScenarioAlertWorker` re-forecast? Proposed:
+   daily, plus an immediate re-check after the operator edits commitments, balancing
+   freshness against battery.
+2. **Buffer default** — should the low-balance threshold default to zero or a
+   configurable safety buffer (e.g. one payroll run)? Proposed: zero by default with an
+   optional buffer the engine treats as the threshold amount.
+3. **Saved scenarios** — should the operator be able to name and save multiple scenarios
+   for later, or is a single live scenario enough for v1? Proposed: single live scenario
+   first; add saved scenarios as a fast-follow if requested.
+4. **Notification permission** — on Android 13+ the app must request
+   `POST_NOTIFICATIONS`; confirm the in-app priming UX so alerts are not silently
+   dropped (the rationale prompt is itself accessible and non-blocking).


### PR DESCRIPTION
## Summary

Adds three **Android (Jetpack Compose · Material 3) design docs** for the business/personal cluster of the food-truck/small-business persona. Design + breakdown only — no native build, signing, or store actions. All finance/reporting/scenario math stays in the shared KMP `packages/core`; Compose renders pre-computed shared state and projections are labeled as estimates.

Closes #2543
Closes #2545
Closes #2557

## Changes

New files only (no existing files, code, shared config, or other docs touched):

- `docs/design/android-business-personal-split-tagging.md` — #2543 (Part of #2182): business/personal/split classification controls, split editor + validation, and the ambiguous-cleanup queue. Boundary: `ExpenseSplitEngine` / `BusinessExpenseRules` own split portions, banker's rounding, and validation.
- `docs/design/android-business-personal-reporting-filters.md` — #2545 (Part of #2182): Combined / Business-only / Personal-only lens for dashboard, analytics, and report builder, plus a side-by-side comparison. Boundary: `ExpenseSplitEngine` owns partitioning, business-portion attribution, and report roll-ups (never double-counts splits).
- `docs/design/android-business-scenario-planner.md` — #2557 (Part of #2185): what-if expense/revenue scenarios and local low-balance / payroll-risk alerts re-checked via WorkManager (no AlarmManager/JobScheduler, no remote push). Boundary: `OperatingCashForecastEngine` owns projection, confidence bands, and threshold-breach detection; projections labeled as estimates.

## Conventions

Each doc follows `.github/instructions/docs.instructions.md`: humans-first, ToC, Mermaid diagrams, relative links to existing docs only, accessibility (TalkBack, Switch Access, 200% font scaling), offline/empty/error states, a unit/Compose/Paparazzi test plan, and an **Implementation readiness** section that links `../ops/human-gated-prerequisites.md` and splits buildable-now (`assembleDebug` sideload) from the Play-distribution tail gated by #1242.

`npx prettier --check` passes on all three files.
