### PR TITLE
docs(design): ios Core ML categorization design batch (#2613, #2614, #2615)

### DIFF
--- a/docs/design/ios-categorization-privacy-telemetry.md
+++ b/docs/design/ios-categorization-privacy-telemetry.md
@@ -1,0 +1,363 @@
+# Privacy-Preserving Categorization Telemetry & Tests — Design
+
+> **Status:** Design only (no native build) · **Issue:** [#2615](https://github.com/jrmoulckers/finance/issues/2615) · **Epic:** [#2382](https://github.com/jrmoulckers/finance/issues/2382)
+> **Platforms:** iOS 17+ (SwiftUI) · shared contract in KMP `packages/core`
+> **Privacy posture:** Opt-in, aggregate-only. No merchant content, payee text, amounts, or category labels ever leave the device.
+
+This document specifies the **health metrics**, the **no-merchant-content
+telemetry constraints**, the **unavailable-model fallbacks**, and the
+**deterministic adapter tests** for on-device transaction categorization on
+iOS. It is the privacy and verification backbone for the cluster. It is a
+**design only**: native Swift is gated behind Apple Developer enrollment
+([#1239](https://github.com/jrmoulckers/finance/issues/1239)), but every test
+and metric below is implementable today against a free Personal Team — see
+[Implementation readiness](#implementation-readiness).
+
+Companion docs in this cluster:
+
+- [iOS Core ML categorization adapter](./ios-coreml-categorization-adapter.md) (#2613)
+- [iOS category suggestion review & correction UX](./ios-category-suggestion-review-ux.md) (#2614)
+
+---
+
+## Table of Contents
+
+1. [Goals & non-goals](#goals--non-goals)
+2. [Privacy principles](#privacy-principles)
+3. [What we measure (and what we never do)](#what-we-measure-and-what-we-never-do)
+4. [Telemetry data flow](#telemetry-data-flow)
+5. [Opt-in, consent & user control](#opt-in-consent--user-control)
+6. [Unavailable-model fallbacks](#unavailable-model-fallbacks)
+7. [Logging discipline](#logging-discipline)
+8. [Accessibility of telemetry controls](#accessibility-of-telemetry-controls)
+9. [State matrix: empty, stale, error & disabled](#state-matrix-empty-stale-error--disabled)
+10. [Regulatory alignment (GDPR/CCPA)](#regulatory-alignment-gdprccpa)
+11. [Affected iOS surfaces & shared dependencies](#affected-ios-surfaces--shared-dependencies)
+12. [Smallest test plan](#smallest-test-plan)
+13. [Implementation readiness](#implementation-readiness)
+14. [Open questions](#open-questions)
+
+---
+
+## Goals & non-goals
+
+**Goals**
+
+- Define **aggregate health metrics** that let us judge whether on-device
+  categorization is actually helping — accuracy proxy, coverage, latency,
+  fallback rate — **without ever seeing a single transaction**.
+- Make "no merchant content leaves the device" a **testable invariant**, not
+  a promise.
+- Specify deterministic adapter tests and unavailable-model fallbacks so the
+  feature degrades safely and predictably.
+- Default to the most private option at every fork: this is a financial app.
+
+**Non-goals**
+
+- Inference mechanics — see the [adapter doc](./ios-coreml-categorization-adapter.md).
+- Suggestion UX — see the [review/correction doc](./ios-category-suggestion-review-ux.md).
+- Any server-side analytics schema beyond the content-free counters defined
+  here.
+- Building or shipping Swift (gated by [#1239](https://github.com/jrmoulckers/finance/issues/1239)).
+
+---
+
+## Privacy principles
+
+1. **On-device first.** Inference and metric computation happen on the device.
+2. **Content-free egress.** Only opt-in, pre-aggregated, **numeric** counters
+   may leave the device. Never payee text, amounts, notes, category names,
+   category IDs, account IDs, or model inputs/outputs.
+3. **Data minimization.** Collect the smallest set of counters that answers a
+   real product question. If a metric isn't actionable, it isn't collected.
+4. **Opt-in, revocable.** Telemetry is **off by default** and can be turned
+   off at any time, with immediate effect.
+5. **Unlinkability.** Counters carry no stable user/device identifier beyond
+   what existing app analytics already establish; categorization adds no new
+   identifier and no new processor.
+6. **Fail private.** If anything is ambiguous, emit nothing.
+
+---
+
+## What we measure (and what we never do)
+
+**Allowed (aggregate, numeric, content-free):**
+
+| Metric                        | Type      | Example value   | Why it's safe                               |
+| ----------------------------- | --------- | --------------- | ------------------------------------------- |
+| `suggestion_shown_count`      | counter   | 42              | Volume only; no subject.                    |
+| `suggestion_accepted_count`   | counter   | 31              | Acceptance proxy for accuracy.              |
+| `suggestion_overridden_count` | counter   | 8               | Correction proxy (which category? unknown). |
+| `suggestion_dismissed_count`  | counter   | 3               | Hint rejection rate.                        |
+| `confidence_bucket_histogram` | histogram | {H:20,M:15,L:7} | Calibration only; no labels.                |
+| `fallback_to_rules_count`     | counter   | 4               | Model-availability health.                  |
+| `inference_latency_ms_bucket` | histogram | {<10:30,<50:11} | Performance, bucketed not raw.              |
+| `model_state`                 | enum      | `ready`         | `ready`/`missing`/`incompatible`/`stale`.   |
+| `model_version`               | string    | `1.2.0`         | Build metadata, not user data.              |
+
+**Never collected:**
+
+- Payee / merchant strings, transaction amounts, notes, dates.
+- The suggested or chosen **category name or ID**.
+- Any mapping that could re-identify a merchant or a person.
+- Raw (unbucketed) timing tied to a specific transaction.
+- Free-text of any kind.
+
+The acceptance/override counters are deliberately **categoryless**: we learn
+that 8 suggestions were corrected, never _which_ category or merchant was
+involved. That is enough to track quality without surveilling spending.
+
+---
+
+## Telemetry data flow
+
+```mermaid
+flowchart LR
+    subgraph Device["On device only"]
+        Ev["Categorization events\n(shown / accepted / overridden)"]
+        Agg["Local aggregator\n(counters + histograms)"]
+        Gate{"Telemetry\nopt-in ON?"}
+    end
+    subgraph Egress["Outbound (opt-in only)"]
+        Batch["Content-free counter batch\n(numbers + model_version)"]
+    end
+
+    Ev --> Agg
+    Agg --> Gate
+    Gate -- "no (default)" --> Drop["Discard / keep local only"]
+    Gate -- "yes" --> Batch
+    Batch --> Sink["Existing analytics sink"]
+
+    classDef danger fill:#fff,stroke:#b00,stroke-width:1px;
+```
+
+Notes:
+
+- Events are reduced to counters **before** the opt-in gate; raw events never
+  queue for egress.
+- The aggregator holds only integers/buckets — there is no buffer of
+  per-transaction records to leak.
+- The egress batch reuses the app's existing analytics transport; this feature
+  introduces **no new endpoint and no new processor**.
+
+---
+
+## Opt-in, consent & user control
+
+- **Default off.** Categorization telemetry ships disabled. The user must
+  explicitly enable "Help improve suggestions" in Settings.
+- **Separable.** This toggle is independent from the
+  [suggestions on/off toggle](./ios-category-suggestion-review-ux.md#accept--override--disable-flows):
+  you can use suggestions with zero telemetry.
+- **Revocable with immediate effect.** Turning it off stops aggregation and
+  discards any pending local counters.
+- **Transparent.** A short, plain-language explainer states exactly what is
+  and isn't sent (link to a privacy detail screen), following
+  [content-language-guidelines.md](./content-language-guidelines.md).
+- **No dark patterns.** Enable/disable have equal visual weight; default
+  selection is the private one.
+
+---
+
+## Unavailable-model fallbacks
+
+The model may be missing, incompatible, stale, or throw at runtime. Telemetry
+treats each as a **first-class, content-free health signal**, and the user
+experience always degrades to the deterministic shared rule engine.
+
+```mermaid
+flowchart TD
+    Start["Request suggestion"] --> Check{"Model state?"}
+    Check -- ready --> Run["Run inference"]
+    Check -- missing --> FB["fallback_to_rules_count++\nmodel_state=missing"]
+    Check -- incompatible --> FB2["fallback_to_rules_count++\nmodel_state=incompatible"]
+    Check -- stale --> RunStale["Run, cap confidence = MEDIUM\nmodel_state=stale"]
+    Run -- throws --> Err["fallback_to_rules_count++\nlog code only"]
+    FB --> Rules["Shared rule engine"]
+    FB2 --> Rules
+    Err --> Rules
+    RunStale --> Done["Suggestion"]
+    Run --> Done
+    Rules --> Done
+```
+
+- Every fallback increments `fallback_to_rules_count` and updates
+  `model_state` — both content-free.
+- A runtime error logs a **code/category only** (e.g. `predictionFailed`),
+  never the input that triggered it.
+- The user sees a normal rule-based suggestion (or manual picker); there is no
+  error banner and no crash. See the cluster
+  [state matrices](./ios-coreml-categorization-adapter.md#state-matrix-stale-error-empty--low-confidence).
+
+---
+
+## Logging discipline
+
+Following the project `os.Logger` privacy rules:
+
+- Subsystem `com.finance`, category `categorization`.
+- **Public** fields only: `model_version`, `model_state`, latency bucket,
+  confidence bucket, counter deltas.
+- **Never logged:** payee, amount, note, category name/ID, account ID — these
+  are treated as `.private` by simply never emitting them.
+- No `print()`. No string interpolation of financial values into log lines.
+- A CI guardrail already greps `.swift`/`.kt` for sensitive-data logging
+  patterns; our test suite adds positive assertions (below) that the payee
+  fixture never appears in captured log output.
+
+---
+
+## Accessibility of telemetry controls
+
+The Settings controls (telemetry toggle + explainer) follow
+[accessibility-patterns.md](./accessibility-patterns.md) and
+[cognitive-accessibility.md](./cognitive-accessibility.md):
+
+- **VoiceOver:** the toggle announces name, state, and consequence — e.g.
+  `"Help improve suggestions, off. When on, the app sends anonymous,
+numbers-only quality stats. No transactions are ever shared."`
+- **Dynamic Type:** the explainer uses `String(localized:)` + semantic fonts
+  and reflows at accessibility sizes without truncation.
+- **Plain language:** short sentences; no jargon; reading level appropriate
+  for cognitive-accessibility mode.
+- **Reduce Motion:** no animated illustration on the privacy explainer when
+  Reduce Motion is enabled.
+- **Switch Control / keyboard:** toggle and "Learn more" link are focusable
+  with ≥ 44×44 pt targets and explicit `.accessibilityLabel(_:)`.
+
+---
+
+## State matrix: empty, stale, error & disabled
+
+| State                      | Telemetry behavior                                             | User-facing                         |
+| -------------------------- | -------------------------------------------------------------- | ----------------------------------- |
+| **Disabled (default)**     | Aggregate locally optional; **never** egress.                  | No prompts; suggestions still work. |
+| **Empty**                  | No events → no counters → nothing to send.                     | Nothing.                            |
+| **Stale model**            | `model_state=stale` recorded; suggestions capped at `MEDIUM`.  | No banner.                          |
+| **Missing / incompatible** | `fallback_to_rules_count++`, `model_state` set.                | Rule-based suggestions; no error.   |
+| **Error**                  | Code-only health event; input never logged.                    | No crash, no exposed data.          |
+| **Offline**                | Counters buffer as integers; flush later **only if opted in**. | Identical UX (all on-device).       |
+
+---
+
+## Regulatory alignment (GDPR/CCPA)
+
+- **Data minimization & purpose limitation:** only content-free counters tied
+  to a single purpose (improving suggestion quality) are processed.
+- **Lawful basis / consent:** opt-in, revocable consent; off by default.
+- **No new processor / no new transfer:** reuses the existing analytics
+  transport; categorization adds no cross-border data flow and no merchant
+  content.
+- **Right to access/erasure:** because no personal categorization data leaves
+  the device, there is nothing merchant-specific to export or delete server
+  side; local corrections are erasable via "Forget learned merchants" (see
+  [review/correction doc](./ios-category-suggestion-review-ux.md#correction-persistence--learning)).
+- **Children / sensitive inference:** spending categories can be sensitive;
+  keeping inference and labels on-device avoids creating a sensitive-data
+  processing record off-device.
+
+---
+
+## Affected iOS surfaces & shared dependencies
+
+**iOS surfaces (read-only references; not modified in this design):**
+
+- A new `CategorizationTelemetry` aggregator type in `apps/ios` (counters +
+  buckets, `Sendable`, actor-isolated).
+- A Settings row: "Help improve suggestions" toggle + privacy explainer.
+- Hook points in
+  [`TransactionCreateViewModel.swift`](../../apps/ios/Finance/ViewModels/TransactionCreateViewModel.swift)
+  and the suggestion/review surfaces from
+  [#2614](https://github.com/jrmoulckers/finance/issues/2614) that emit
+  content-free events.
+
+**Shared dependencies (KMP, owned by @kmp-engineer):**
+
+- [`SmartCategorizationEngine.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/categorization/SmartCategorizationEngine.kt)
+  — already exposes `getStats()` (`EngineStats`), a precedent for content-free
+  aggregate diagnostics; the iOS aggregator mirrors that spirit.
+
+---
+
+## Smallest test plan
+
+Deterministic, fixed-seed fixtures with **synthetic** payees. The privacy
+assertions are the highest-priority gate.
+
+**Privacy invariants (must pass before acceptance)**
+
+1. `noMerchantContentInEgress` — serialize a telemetry batch built from a
+   fixture run; assert the payee/category fixture strings are **absent** and
+   the payload contains only numeric counters + `model_version`.
+2. `noPayeeInLogs` — capture `os.Logger` output during inference; assert the
+   payee fixture never appears.
+3. `disabledMeansNoEgress` — with telemetry off, the egress queue is empty
+   after a full suggestion/accept/override cycle.
+4. `optOutDiscardsPendingCounters` — toggling off clears buffered counters.
+5. `noNetworkInCategorizationPath` — a failing URL-protocol stub records
+   **zero** outbound requests during suggestion + correction.
+
+**Aggregation correctness**
+
+6. `countersIncrementExactlyOnce` — one shown/accepted/overridden event yields
+   exactly one increment each.
+7. `confidenceHistogramBuckets` — `{HIGH, MEDIUM, LOW}` events land in the
+   right buckets; no label leaks into the bucket key.
+8. `latencyIsBucketedNotRaw` — recorded latency is a bucket, never a raw
+   per-transaction value.
+
+**Unavailable-model fallbacks (deterministic adapter tests)**
+
+9. `missingModelIncrementsFallback` — `.missing` ⇒ `fallback_to_rules_count++`
+   and rule-based suggestion returned.
+10. `incompatibleModelIncrementsFallback` — label-set hash mismatch ⇒
+    `.incompatible` ⇒ fallback, content-free health event.
+11. `staleModelRecordsStateAndCapsConfidence` — cutoff > 12 months ⇒
+    `model_state=stale`, confidence ≤ `MEDIUM`.
+12. `predictionErrorLogsCodeOnly` — a thrown Core ML error logs a code, not
+    the input, and falls back cleanly.
+
+These share fixtures with the adapter suite in
+[ios-coreml-categorization-adapter.md](./ios-coreml-categorization-adapter.md#smallest-test-plan)
+and the UX suite in
+[ios-category-suggestion-review-ux.md](./ios-category-suggestion-review-ux.md#smallest-test-plan).
+
+---
+
+## Implementation readiness
+
+Split by what a free Apple **Personal Team** can build versus the distribution
+tail gated by Apple Developer Program enrollment
+([#1239](https://github.com/jrmoulckers/finance/issues/1239)). See
+[../ops/human-gated-prerequisites.md](../ops/human-gated-prerequisites.md).
+
+**Buildable now (no paid account, no human-gated signing):**
+
+- Implement the `CategorizationTelemetry` aggregator, the opt-in Settings
+  toggle + explainer, and all event hooks in `apps/ios`.
+- Run the full privacy/aggregation/fallback XCTest suite locally and in CI
+  (`ci-ios`), plus shared `commonTest` (`ci-shared`).
+- The CI sensitive-data-logging guardrail (`ci-lint` / `ci-security`) already
+  scans `.swift`/`.kt`; our positive privacy assertions complement it.
+
+**Distribution tail — gated by [#1239](https://github.com/jrmoulckers/finance/issues/1239) (human-gated):**
+
+- TestFlight/App Store distribution of telemetry-enabled builds.
+- Any future App Group / Keychain access-group entitlements if telemetry is
+  shared across processes (widgets/App Clip) — paid team required.
+- App privacy "nutrition label" updates for store submission (human submits).
+
+No provisioning profiles, certificates, or store submissions are created here.
+
+---
+
+## Open questions
+
+- **Counter retention window:** how long may opted-in local counters buffer
+  before flush/expiry? Proposal: short rolling window, integers only.
+- **Differential privacy:** is added noise on histograms worth it given counts
+  are already merchant-free and categoryless? Likely unnecessary; revisit if
+  buckets ever narrow.
+- **Health surfacing:** expose a local-only "suggestion accuracy" stat to the
+  user (computed on device, never sent)? Could increase trust; out of scope
+  for this pass.

--- a/docs/design/ios-category-suggestion-review-ux.md
+++ b/docs/design/ios-category-suggestion-review-ux.md
@@ -1,0 +1,383 @@
+# iOS Category Suggestion Review & Correction UX — Design
+
+> **Status:** Design only (no native build) · **Issue:** [#2614](https://github.com/jrmoulckers/finance/issues/2614) · **Epic:** [#2382](https://github.com/jrmoulckers/finance/issues/2382)
+> **Platforms:** iOS 17+ (SwiftUI) · shared rules in KMP `packages/core`
+> **Privacy posture:** On-device suggestions. Corrections sync as opaque `payee → categoryId` only.
+
+This document designs how people **see, accept, override, and disable**
+on-device category suggestions on iOS, and how a correction is persisted so
+the system learns without ever sending raw transaction text off the device.
+It is a **design only**: native Swift is gated behind Apple Developer
+enrollment ([#1239](https://github.com/jrmoulckers/finance/issues/1239)); the
+patterns here are implementable today against a free Personal Team — see
+[Implementation readiness](#implementation-readiness).
+
+Companion docs in this cluster:
+
+- [iOS Core ML categorization adapter](./ios-coreml-categorization-adapter.md) (#2613)
+- [Privacy-preserving categorization telemetry & tests](./ios-categorization-privacy-telemetry.md) (#2615)
+
+---
+
+## Table of Contents
+
+1. [Goals & non-goals](#goals--non-goals)
+2. [Where this fits: the KMP boundary](#where-this-fits-the-kmp-boundary)
+3. [Suggestion lifecycle](#suggestion-lifecycle)
+4. [Surfaces & layouts](#surfaces--layouts)
+5. [Confidence display](#confidence-display)
+6. [Accept / override / disable flows](#accept--override--disable-flows)
+7. [Correction persistence & learning](#correction-persistence--learning)
+8. [Accessibility](#accessibility)
+9. [State matrix: empty, loading, stale, error & low-confidence](#state-matrix-empty-loading-stale-error--low-confidence)
+10. [Privacy](#privacy)
+11. [Affected iOS surfaces & shared dependencies](#affected-ios-surfaces--shared-dependencies)
+12. [Smallest test plan](#smallest-test-plan)
+13. [Implementation readiness](#implementation-readiness)
+14. [Open questions](#open-questions)
+
+---
+
+## Goals & non-goals
+
+**Goals**
+
+- Make suggestions **glanceable, honest, and effortless to correct**. A wrong
+  guess must cost one tap to fix and must visibly teach the system.
+- Cover both **imported** transactions (batch review) and **manual** entry
+  (inline suggestion while typing the payee).
+- Express confidence truthfully and accessibly, never overstating a guess.
+- Let users **disable** suggestions entirely, per device, with a clear,
+  reversible setting.
+- Persist corrections through the existing shared learning path so behavior
+  improves across the household's devices.
+
+**Non-goals**
+
+- The inference mechanics — see the [adapter doc](./ios-coreml-categorization-adapter.md).
+- Aggregate health metrics — see the [telemetry doc](./ios-categorization-privacy-telemetry.md).
+- Building or shipping Swift (gated by [#1239](https://github.com/jrmoulckers/finance/issues/1239)).
+
+---
+
+## Where this fits: the KMP boundary
+
+| Concern                                  | Home                     | Notes                                                 |
+| ---------------------------------------- | ------------------------ | ----------------------------------------------------- |
+| Suggestion + confidence contract         | `packages/core`          | `CategorizationSuggestion`, `Confidence`, `Strategy`. |
+| Correction learning (`recordCorrection`) | `packages/core`          | Already exists in `SmartCategorizationEngine`.        |
+| Suggestion preference (on/off)           | `packages/core` + device | Cross-device default; per-device override on iOS.     |
+| SwiftUI screens, sheets, VoiceOver       | `apps/ios`               | Presentation + accessibility only.                    |
+
+The shared engine already exposes correction learning in
+[`SmartCategorizationEngine.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/categorization/SmartCategorizationEngine.kt)
+(`recordCorrection(payee, categoryId)`), and the iOS bridge already calls
+`learnFromHistory(payee:categoryId:)` from
+[`TransactionCreateViewModel.swift`](../../apps/ios/Finance/ViewModels/TransactionCreateViewModel.swift).
+This design adds **review/correction UX** on top of those existing hooks; it
+does not change the shared contract.
+
+---
+
+## Suggestion lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Suggested: model/rules return a category
+    [*] --> NoSuggestion: blank/low signal
+    Suggested --> Accepted: user keeps it (explicit or save)
+    Suggested --> Overridden: user picks a different category
+    Suggested --> Dismissed: user clears the hint
+    NoSuggestion --> ManuallySet: user picks a category
+    Overridden --> Learned: recordCorrection(payee, categoryId)
+    ManuallySet --> Learned: learnFromHistory(payee, categoryId)
+    Accepted --> [*]
+    Learned --> [*]
+    Dismissed --> [*]
+```
+
+A suggestion is always a **proposal, never a commitment**. It is only
+persisted to the transaction when the user accepts (explicitly or by saving),
+and a correction is only learned when the user assigns a different category.
+
+---
+
+## Surfaces & layouts
+
+### 1. Manual entry — inline suggestion
+
+In the transaction create/edit sheet, as the payee field changes, the
+category row shows a non-modal suggestion:
+
+```text
+┌───────────────────────────────────────────────┐
+│ Payee   Blue Bottle Coffee                     │
+│ Category  ◉ Dining   ·  Suggested · Medium  ✕  │  ← chip + dismiss
+│           Tap to change                         │
+└───────────────────────────────────────────────┘
+```
+
+- The suggestion is **pre-selected but reversible**: the picker is one tap
+  away, and the dismiss control (`✕`) clears it without choosing anything.
+- `MEDIUM`/`LOW` suggestions are visually softer (outline chip) than `HIGH`
+  (filled chip) — but always paired with text, never color alone.
+
+### 2. Imported transactions — batch review
+
+After an import, a dedicated review screen groups suggestions so users can
+confirm many at once:
+
+```text
+Review 12 suggested categories
+─────────────────────────────────────────────
+Dining (high)            5 transactions   [Confirm all]
+Groceries (high)         3 transactions   [Confirm all]
+Transport (medium)       2 transactions   [Review]
+Needs your input         2 transactions   [Choose]
+─────────────────────────────────────────────
+[Confirm all high-confidence]      [Skip]
+```
+
+- **High-confidence groups** offer bulk confirm; **medium/low** invite
+  per-row review; **no suggestion** routes to manual choice.
+- Bulk actions are fully undoable from the standard transaction list.
+
+---
+
+## Confidence display
+
+Confidence maps to the shared `Confidence` enum (`HIGH`/`MEDIUM`/`LOW`) from
+the adapter. Display follows the CVD-safe rules in
+[data-visualization.md](./data-visualization.md#2-color-system) — encode by
+**icon + text + position**, never hue alone.
+
+| Confidence | Chip style   | Text label          | Auto-applied?   |
+| ---------- | ------------ | ------------------- | --------------- |
+| `HIGH`     | Filled       | "Suggested"         | Yes             |
+| `MEDIUM`   | Outline      | "Suggested · Maybe" | Yes (easy undo) |
+| `LOW`      | Ghost / hint | "Maybe: Dining?"    | No — hint only  |
+
+Copy is non-judgmental per
+[content-language-guidelines.md](./content-language-guidelines.md): we say
+"We guessed Dining" and "Tap to change," never "You miscategorized this."
+
+---
+
+## Accept / override / disable flows
+
+```mermaid
+flowchart TD
+    A["Suggestion shown"] --> B{User action}
+    B -->|Keep / Save| C["Accept → persist category"]
+    B -->|Pick different| D["Override → recordCorrection"]
+    B -->|Dismiss ✕| E["Clear hint, no learning"]
+    B -->|Turn off suggestions| F["Disable setting"]
+    F --> G["No future auto-suggestions on this device"]
+    D --> H["Future same-payee → corrected category wins"]
+```
+
+**Accept.** Keeping the pre-selected category and saving persists it. No extra
+confirmation tax for the common case.
+
+**Override.** Choosing a different category:
+
+1. Updates the transaction's category.
+2. Calls the shared correction hook (`recordCorrection` /
+   `learnFromHistory`) so the **next** transaction with the same payee is
+   categorized by the user's choice (the engine ranks `USER_CORRECTION`
+   highest).
+3. Emits a content-free "correction" health signal (opt-in only — see
+   [telemetry doc](./ios-categorization-privacy-telemetry.md)).
+
+**Disable.** A Settings toggle — `String(localized: "Suggest categories")` —
+defaults **on** but is one tap to turn off. When off:
+
+- No suggestions are computed or shown anywhere.
+- Existing learned corrections are retained (disabling display ≠ deleting
+  data); a separate "Forget learned merchants" action clears them.
+- The setting is per-device (a privacy-respecting local override) and is
+  stored as a non-sensitive preference, not in Keychain.
+
+---
+
+## Correction persistence & learning
+
+- **What is stored:** an opaque `payee → categoryId` mapping in the shared
+  correction store, exactly as the engine already models it. No amounts,
+  notes, dates, or free text.
+- **Where:** `packages/core` owns the store; it rides the existing sync path
+  so corrections follow the household across devices. iOS does not invent a
+  parallel store.
+- **Precedence:** corrections outrank every other signal, including the
+  on-device model — a user's explicit choice is always honored.
+- **Forgetting:** "Forget learned merchants" clears corrections locally and
+  propagates the deletion through sync, supporting the user's right to
+  erasure (see [Privacy](#privacy)).
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant VM as ViewModel (@MainActor)
+    participant K as KMP engine (packages/core)
+    participant S as Sync (opaque mapping)
+
+    U->>VM: override category (Dining → Groceries)
+    VM->>K: recordCorrection(payee, groceriesId)
+    K->>S: enqueue payee→categoryId (no raw txn text)
+    Note over VM,K: next same-payee suggestion = Groceries (USER_CORRECTION)
+```
+
+---
+
+## Accessibility
+
+Patterns follow [accessibility-patterns.md](./accessibility-patterns.md) and
+[cognitive-accessibility.md](./cognitive-accessibility.md). Specific
+requirements:
+
+- **VoiceOver — suggestion:** the category control announces label,
+  confidence, and the action, e.g. `"Suggested category, Dining, high
+confidence. Double-tap to change."` Confidence is spoken text, not implied
+  by color.
+- **VoiceOver — correction:** after an override, post an
+  `.announcement` (or `AccessibilityNotification.Announcement`) such as
+  `"Category changed to Groceries. We'll remember Blue Bottle Coffee."`
+- **VoiceOver — batch review:** each group is a single element summarizing
+  count + confidence + action ("Dining, high confidence, 5 transactions,
+  Confirm all button").
+- **Dynamic Type:** all chips, labels, and the batch list use
+  `String(localized:)` + semantic fonts; rows grow and wrap at accessibility
+  sizes without truncating the confidence text.
+- **Switch Control / keyboard:** dismiss (`✕`), accept, and override are all
+  focusable, ordered logically, with ≥ 44×44 pt targets.
+- **Reduce Motion:** no celebratory animation on accept; use a static state
+  change.
+- **Accessible names everywhere:** every interactive control has an explicit
+  `.accessibilityLabel(_:)`.
+
+---
+
+## State matrix: empty, loading, stale, error & low-confidence
+
+| State                     | What the user sees                                                                    |
+| ------------------------- | ------------------------------------------------------------------------------------- |
+| **Empty**                 | No payee or no signal → plain category picker, no chip, no error.                     |
+| **Loading**               | Brief neutral placeholder on the category row; typing is never blocked.               |
+| **Low-confidence**        | Ghost "Maybe: …?" hint; nothing auto-applied; one tap to accept or ignore.            |
+| **Stale model**           | Suggestions still appear (capped at `MEDIUM`); no scary banner.                       |
+| **Error / model missing** | Silent fallback to rule-based suggestion or manual choice; no crash, no exposed data. |
+| **Disabled**              | No suggestions anywhere; manual categorization works exactly as before.               |
+| **Offline**               | Identical to online — categorization is fully on-device.                              |
+
+Guiding principle: **a low-confidence or failed guess must never get in the
+way of just picking a category.**
+
+---
+
+## Privacy
+
+- Suggestions are computed on-device; the payee string never leaves the
+  device for inference (see [adapter doc](./ios-coreml-categorization-adapter.md#privacy-boundary-no-remote-data)).
+- Corrections sync only as opaque `payee → categoryId` pairs already covered
+  by existing sync privacy rules — no amounts, notes, or transaction bodies.
+- The suggestions toggle and "Forget learned merchants" give users
+  **control and erasure**, aligning with GDPR/CCPA data-minimization and
+  right-to-delete expectations.
+- No suggestion content is written to logs; only opt-in, aggregate health
+  signals are emitted (see [#2615](https://github.com/jrmoulckers/finance/issues/2615)).
+
+---
+
+## Affected iOS surfaces & shared dependencies
+
+**iOS surfaces (read-only references; not modified in this design):**
+
+- [`TransactionCreateViewModel.swift`](../../apps/ios/Finance/ViewModels/TransactionCreateViewModel.swift)
+  — already has `suggestedCategoryId` + `updateCategorySuggestion()`; this
+  design specifies the surrounding UX.
+- `apps/ios/Finance/Screens/TransactionCreateView.swift`,
+  `TransactionEditView.swift`, `TransactionDetailView.swift` — render the
+  inline suggestion + confidence chip.
+- New (future) `ImportReviewView` + `ImportReviewViewModel` for batch review.
+- `apps/ios/Finance/Components/TransactionRowView.swift` — optional inline
+  "needs category" affordance.
+- A Settings row for the suggestions toggle and "Forget learned merchants."
+
+**Shared dependencies (KMP, owned by @kmp-engineer):**
+
+- [`SmartCategorizationEngine.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/categorization/SmartCategorizationEngine.kt)
+  — `recordCorrection`, `suggest`, `Confidence`.
+- [`Category.kt`](../../packages/models/src/commonMain/kotlin/com/finance/models/Category.kt)
+  — correction target.
+
+---
+
+## Smallest test plan
+
+Deterministic, fixture-based, no real user data.
+
+**iOS view-model (XCTest — buildable now on a free Personal Team)**
+
+1. `acceptKeepsSuggestedCategory` — saving with the pre-selected suggestion
+   persists it unchanged.
+2. `overrideRecordsCorrection` — choosing a different category calls the
+   shared correction hook exactly once with the right `payee → categoryId`.
+3. `dismissDoesNotLearn` — clearing the hint records **no** correction.
+4. `disableSuppressesSuggestions` — with the toggle off, `suggestedCategoryId`
+   stays `nil` for all inputs.
+5. `lowConfidenceIsNotAutoApplied` — a `LOW` suggestion leaves
+   `selectedCategoryId == nil`.
+6. `batchConfirmHighOnly` — "Confirm all high-confidence" applies only `HIGH`
+   rows and leaves others untouched.
+
+**Shared (KMP, `commonTest`)**
+
+7. `correctionOutranksModelAndRules` — after `recordCorrection`, the same
+   payee returns `USER_CORRECTION`.
+8. `forgetMerchantsClearsCorrections` — erasure removes the mapping and the
+   next suggestion no longer reflects it.
+
+**Accessibility & privacy assertions**
+
+9. `suggestionHasAccessibilityLabelWithConfidence` — snapshot the
+   accessibility tree; confidence text is present and not color-encoded.
+10. `correctionPayloadCarriesNoRawText` — the persisted/synced correction
+    contains only `payee` + `categoryId`, asserted field-by-field.
+
+---
+
+## Implementation readiness
+
+Split by what a free Apple **Personal Team** can build versus the distribution
+tail gated by Apple Developer Program enrollment
+([#1239](https://github.com/jrmoulckers/finance/issues/1239)). See
+[../ops/human-gated-prerequisites.md](../ops/human-gated-prerequisites.md).
+
+**Buildable now (no paid account, no human-gated signing):**
+
+- Build the inline suggestion chip, batch `ImportReviewView`, Settings
+  toggle, and "Forget learned merchants" in `apps/ios`.
+- Wire accept/override/dismiss to the existing shared correction hooks.
+- Run all XCTest view-model + accessibility snapshot tests and KMP
+  `commonTest` in CI (`ci-ios`, `ci-shared`).
+
+**Distribution tail — gated by [#1239](https://github.com/jrmoulckers/finance/issues/1239) (human-gated):**
+
+- TestFlight/App Store distribution of builds that include suggestions.
+- Any future widget/App Clip surfacing of suggestions that needs App Group or
+  Keychain access-group entitlements (paid team required).
+
+No provisioning profiles, certificates, or store submissions are created here.
+
+---
+
+## Open questions
+
+- **Batch review entry point:** dedicated screen post-import vs. an inline
+  banner on the transaction list? This doc proposes a dedicated screen for
+  large imports and inline for small ones (threshold TBD).
+- **Correction scope:** household-wide vs. per-user corrections when multiple
+  members share a household? Defer to the shared sync model; UX assumes
+  household-wide with the existing precedence rules.
+- **Undo window:** should bulk-confirm offer a timed undo toast in addition to
+  per-row undo? Leaning yes for imports > 10 rows.

--- a/docs/design/ios-coreml-categorization-adapter.md
+++ b/docs/design/ios-coreml-categorization-adapter.md
@@ -1,0 +1,418 @@
+# iOS Core ML Categorization Adapter — Design
+
+> **Status:** Design only (no native build) · **Issue:** [#2613](https://github.com/jrmoulckers/finance/issues/2613) · **Epic:** [#2382](https://github.com/jrmoulckers/finance/issues/2382)
+> **Platforms:** iOS 17+ (SwiftUI) · shared contract in KMP `packages/core`
+> **Privacy posture:** On-device only. No raw transaction text leaves the device — ever.
+
+This document designs the **iOS-native edge** that turns a transaction's
+merchant text into a category suggestion using Apple's on-device machine
+learning (Core ML + the Natural Language framework), while keeping the
+business contract and rule-based fallback in the shared Kotlin Multiplatform
+(KMP) core. It is a **design only**: no Swift is built or signed here, because
+native delivery is gated behind Apple Developer enrollment
+([#1239](https://github.com/jrmoulckers/finance/issues/1239)). Everything
+described is implementable today against a free Personal Team — see
+[Implementation readiness](#implementation-readiness).
+
+Companion docs in this cluster:
+
+- [iOS category suggestion review & correction UX](./ios-category-suggestion-review-ux.md) (#2614)
+- [Privacy-preserving categorization telemetry & tests](./ios-categorization-privacy-telemetry.md) (#2615)
+
+---
+
+## Table of Contents
+
+1. [Goals & non-goals](#goals--non-goals)
+2. [Where this fits: the KMP boundary](#where-this-fits-the-kmp-boundary)
+3. [Adapter architecture](#adapter-architecture)
+4. [Inference flow](#inference-flow)
+5. [Model packaging & versioning](#model-packaging--versioning)
+6. [Confidence, thresholds & fallback to shared rules](#confidence-thresholds--fallback-to-shared-rules)
+7. [Privacy boundary (no remote data)](#privacy-boundary-no-remote-data)
+8. [Accessibility](#accessibility)
+9. [State matrix: stale, error, empty & low-confidence](#state-matrix-stale-error-empty--low-confidence)
+10. [Affected iOS surfaces & shared dependencies](#affected-ios-surfaces--shared-dependencies)
+11. [Smallest test plan](#smallest-test-plan)
+12. [Implementation readiness](#implementation-readiness)
+13. [Open questions](#open-questions)
+
+---
+
+## Goals & non-goals
+
+**Goals**
+
+- Define a Swift adapter that maps `payee` (merchant text) → a category
+  suggestion with a confidence level, **fully on-device**.
+- Reuse the existing shared categorization contract instead of inventing a
+  parallel one. The shared engine already expresses
+  `CategorizationSuggestion`, `Confidence`, and `CategorizationStrategy` in
+  [`SmartCategorizationEngine.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/categorization/SmartCategorizationEngine.kt).
+- Specify model packaging, versioning, and a deterministic fallback to the
+  shared rule engine when the model is missing, stale, or low-confidence.
+- Keep the design conflict-free with concurrent platform work: this is a
+  **new doc**, no shared code is modified.
+
+**Non-goals**
+
+- Training pipelines, server-side model hosting, or any cloud inference.
+- Implementing Swift code (gated by [#1239](https://github.com/jrmoulckers/finance/issues/1239)).
+- Changing the KMP contract in this PR. Any new shared enum case (e.g. an
+  `ON_DEVICE_MODEL` strategy) is **proposed via ADR** and owned by
+  @kmp-engineer — see [Open questions](#open-questions).
+
+---
+
+## Where this fits: the KMP boundary
+
+The categorization contract is shared and platform-neutral. The Core ML
+adapter is a thin, Apple-specific **strategy provider** that feeds a
+suggestion into the same shape the rest of the app already consumes.
+
+| Concern                               | Home            | Rationale                                         |
+| ------------------------------------- | --------------- | ------------------------------------------------- |
+| Suggestion contract & confidence enum | `packages/core` | One vocabulary for iOS, Android, Web, Windows.    |
+| Rule-based fallback engine            | `packages/core` | Deterministic, testable, already exists.          |
+| User-correction learning store        | `packages/core` | Corrections must sync across devices (see #2614). |
+| Core ML / NaturalLanguage inference   | `apps/ios`      | Apple framework; cannot live in `commonMain`.     |
+| SwiftUI presentation & VoiceOver      | `apps/ios`      | Platform accessibility semantics.                 |
+
+Today the iOS layer already talks to the shared engine through
+`KMPCategorizationEngineProtocol` (used by
+[`TransactionCreateViewModel.swift`](../../apps/ios/Finance/ViewModels/TransactionCreateViewModel.swift)).
+The Core ML adapter slots **in front of** that bridge as an additional,
+higher-recall signal — never replacing user corrections, which always win.
+
+```mermaid
+flowchart LR
+    subgraph iOS["apps/ios — Apple-native edge"]
+        VM["TransactionCreate / Detail\nViewModel (@Observable)"]
+        Adapter["CoreMLCategorizationAdapter\n(Swift, on-device)"]
+        NL["NaturalLanguage\ntokenizer + embedding"]
+        ML["Core ML model\n(MerchantCategory.mlmodelc)"]
+    end
+    subgraph KMP["packages/core — shared contract"]
+        Proto["KMPCategorizationEngineProtocol"]
+        Engine["SmartCategorizationEngine\n(rules + corrections)"]
+        Types["CategorizationSuggestion\nConfidence · Strategy"]
+    end
+
+    VM -->|"payee text\n(never leaves device)"| Adapter
+    Adapter --> NL --> ML
+    ML -->|"label + score"| Adapter
+    Adapter -->|"merge / fallback"| Proto
+    Proto --> Engine
+    Engine --> Types
+    Types -->|"CategorizationSuggestion"| VM
+```
+
+**Boundary rule:** the adapter consumes a `String` payee and produces a value
+that conforms to the shared `CategorizationSuggestion` shape. It does not
+expand the public KMP surface; it only supplies an additional strategy result
+that the shared merge logic ranks against corrections, payee history, keyword
+rules, and amount ranges.
+
+---
+
+## Adapter architecture
+
+The adapter is a `Sendable` value type with a single, narrow async entry
+point. Inference is CPU/Neural-Engine bound and isolated off the main actor;
+only the final `@Observable` state update returns to `@MainActor`.
+
+```swift
+// Conceptual — NOT compiled here (native build gated by #1239).
+struct CoreMLCategorizationAdapter: Sendable {
+    enum ModelState: Sendable {
+        case ready(version: ModelVersion)
+        case missing            // bundle absent → fall back to rules
+        case incompatible       // schema/label-set mismatch → fall back
+    }
+
+    /// Returns a suggestion or nil. Nil means "defer to shared rules".
+    func suggest(payee: String) async -> RawModelSuggestion?
+}
+
+struct RawModelSuggestion: Sendable {
+    let categoryId: String      // mapped from model label → SyncId
+    let score: Double           // 0.0...1.0 softmax probability
+}
+```
+
+Key decisions:
+
+- **Actor isolation:** the Core ML `MLModel` handle is wrapped by an
+  `actor ModelHost` so the non-`Sendable` model is never shared across tasks.
+  No `DispatchQueue` is used; `SWIFT_STRICT_CONCURRENCY = complete` must pass.
+- **Label → category mapping:** the model emits abstract labels (e.g.
+  `groceries`, `dining`, `transport`). A bundled, versioned
+  `LabelCategoryMap` translates labels to the household's `Category.id`
+  ([`Category.kt`](../../packages/models/src/commonMain/kotlin/com/finance/models/Category.kt)).
+  Unknown labels are dropped (return `nil`), never guessed.
+- **Logging:** `os.Logger(subsystem: "com.finance", category: "categorization")`.
+  We log model **version, state, latency, and confidence bucket** — never the
+  payee string or amount. See
+  [privacy telemetry doc](./ios-categorization-privacy-telemetry.md).
+
+---
+
+## Inference flow
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant VM as ViewModel (@MainActor)
+    participant A as CoreMLAdapter
+    participant H as ModelHost (actor)
+    participant K as KMP engine
+
+    U->>VM: edits payee ("BLUE BOTTLE COFFEE")
+    VM->>A: await suggest(payee)
+    A->>A: normalize + tokenize (NaturalLanguage)
+    A->>H: predict(features)
+    alt model ready
+        H-->>A: label="dining", score=0.91
+        A->>A: map label → categoryId, bucket score → Confidence
+    else model missing / incompatible / low score
+        H-->>A: nil
+    end
+    A->>K: merge(modelSuggestion?, payee, amount)
+    K-->>VM: CategorizationSuggestion (best of model + rules + corrections)
+    VM-->>U: pre-selected category + confidence chip (VoiceOver announced)
+```
+
+Normalization (all on-device, deterministic):
+
+1. Trim, fold case, collapse whitespace, strip obvious processor noise
+   (`SQ *`, `TST*`, trailing store numbers) using a bundled regex table.
+2. Tokenize with `NLTokenizer`; optionally embed with the bundled word
+   embedding for OOV robustness.
+3. Predict; take top-1 label + probability.
+4. Bucket probability into the shared `Confidence` enum (next section).
+5. Hand off to the shared merge so **user corrections always override**.
+
+---
+
+## Model packaging & versioning
+
+- **Format:** a compiled `MerchantCategory.mlmodelc` plus a sidecar
+  `model-manifest.json` (semantic `modelVersion`, label set hash,
+  `minOSVersion`, training-data cutoff date). Both ship inside the app bundle
+  — no download at runtime, no remote fetch.
+- **Versioning:** `ModelVersion` is `MAJOR.MINOR.PATCH`.
+  - **MAJOR** = label set changed → requires a new `LabelCategoryMap`; old
+    suggestions are invalidated.
+  - **MINOR** = weights improved, label set stable.
+  - **PATCH** = packaging/metadata only.
+- **Compatibility gate:** at launch the adapter compares the manifest's label
+  set hash to the bundled `LabelCategoryMap` hash. Mismatch ⇒ `ModelState`
+  `.incompatible` ⇒ silent fallback to shared rules (logged as a health
+  event, never user-facing noise).
+- **Staleness:** if `now − trainingCutoff > 12 months`, the model is flagged
+  **stale**. It still runs, but confidence is capped at `MEDIUM` and a health
+  metric is emitted so we can schedule a model refresh in a future app
+  release. Staleness never blocks categorization.
+- **Size budget:** target < 5 MB compiled so the App Clip
+  (`apps/ios/FinanceClip`) can optionally embed a trimmed variant within its
+  15 MB ceiling; the full app has no practical concern.
+
+---
+
+## Confidence, thresholds & fallback to shared rules
+
+The model's softmax score maps to the shared `Confidence` enum so the UI and
+telemetry speak one language across platforms:
+
+| Model score `s`   | Mapped `Confidence` | Behavior                                                 |
+| ----------------- | ------------------- | -------------------------------------------------------- |
+| `s ≥ 0.85`        | `HIGH`              | Pre-select category; show confidence chip.               |
+| `0.60 ≤ s < 0.85` | `MEDIUM`            | Pre-select, but emphasize it is a guess; easy to change. |
+| `0.40 ≤ s < 0.60` | `LOW`               | Offer as a hint only; do **not** auto-apply.             |
+| `s < 0.40`        | — (drop)            | Return `nil`; defer entirely to shared rules.            |
+
+The shared merge then ranks signals (highest wins):
+
+1. **User correction** (`USER_CORRECTION`) — always authoritative.
+2. **On-device model** (proposed `ON_DEVICE_MODEL`) at `HIGH`.
+3. **Payee frequency** (`PAYEE_FREQUENCY`) at `HIGH`.
+4. On-device model at `MEDIUM` vs keyword rules at `HIGH` — tie broken toward
+   the deterministic rule for explainability.
+5. Remaining rule strategies, then amount range.
+
+If the model is `.missing` or `.incompatible`, the adapter returns `nil` for
+**every** transaction and the app behaves exactly like today's rule engine.
+This makes the model a strictly additive, fail-safe enhancement.
+
+---
+
+## Privacy boundary (no remote data)
+
+This is a financial app; we default to the most private option.
+
+- **On-device only.** Inference uses bundled Core ML / NaturalLanguage. There
+  is no network call in the categorization path. The merchant string is read
+  from in-memory transaction state and discarded after prediction.
+- **No raw text off device.** Payee strings, amounts, notes, and predicted
+  categories are never transmitted. Telemetry is aggregate-only (see
+  [#2615](https://github.com/jrmoulckers/finance/issues/2615)).
+- **No payee persistence by the adapter.** The adapter is stateless; learning
+  is owned by the shared correction store, which syncs only opaque
+  `payee → categoryId` mappings already covered by existing sync privacy
+  rules.
+- **Logging discipline.** Per `os.Logger` privacy rules, financial fields are
+  `.private` by redaction (we simply never log them). Only model version,
+  state, latency, and confidence bucket are logged `.public`.
+- **Regulatory alignment.** Because no personal/transaction data leaves the
+  device, GDPR/CCPA exposure for this feature is minimal: there is no new
+  processor, no new cross-border transfer, and the user's
+  [opt-in telemetry](./ios-categorization-privacy-telemetry.md) is the only
+  outbound signal — itself content-free and revocable.
+
+---
+
+## Accessibility
+
+All suggestion surfaces must be fully usable with VoiceOver, Dynamic Type,
+Switch Control, and Reduce Motion. Detailed component patterns live in
+[accessibility-patterns.md](./accessibility-patterns.md) and
+[cognitive-accessibility.md](./cognitive-accessibility.md); the adapter's
+obligations are:
+
+- **VoiceOver:** when a suggestion is applied, the category control announces
+  label + confidence, e.g. `"Suggested category, Dining, medium confidence,
+double-tap to change"`. Confidence is conveyed in **text**, never by color
+  alone.
+- **Dynamic Type:** confidence chips and the suggestion banner use
+  `String(localized:)` text with semantic fonts (`.footnote`, `.body`); no
+  hardcoded sizes; layout reflows to accessibility sizes without truncation.
+- **Reduce Motion:** any "thinking…" affordance during async inference is a
+  static placeholder when Reduce Motion is on (no spinner pulse).
+- **Color independence:** confidence uses a CVD-safe encoding (icon + text +
+  position), per [data-visualization.md](./data-visualization.md#2-color-system).
+- **Non-judgmental copy:** suggestion wording follows
+  [content-language-guidelines.md](./content-language-guidelines.md) — "We
+  guessed Dining" not "You forgot to categorize this."
+
+---
+
+## State matrix: stale, error, empty & low-confidence
+
+| State              | Trigger                                | Adapter behavior                         | User-facing result                                             |
+| ------------------ | -------------------------------------- | ---------------------------------------- | -------------------------------------------------------------- |
+| **Empty**          | Payee blank / too short (< 2 chars)    | Return `nil` immediately                 | No suggestion; manual category picker, no error.               |
+| **Loading**        | Inference in flight                    | Async task pending                       | Category field shows neutral placeholder; never blocks typing. |
+| **Low-confidence** | `0.40 ≤ s < 0.60`                      | Return `LOW`, do not auto-apply          | Dismissible hint ("Maybe: Dining?"); manual choice unchanged.  |
+| **Stale model**    | Training cutoff > 12 months            | Run, cap confidence at `MEDIUM`          | Normal suggestions; health metric emitted; no user banner.     |
+| **Missing model**  | Bundle resource absent                 | `.missing` → `nil` for all               | Identical to today's rule-only behavior.                       |
+| **Incompatible**   | Label-set hash mismatch                | `.incompatible` → `nil` for all          | Rule-only behavior; health event logged.                       |
+| **Error**          | Core ML throws (OOM, corrupt resource) | Catch, log code-only, `.missing` for run | Rule fallback; no crash; no data exposed.                      |
+
+The cardinal rule: **a model problem is never a user problem.** Every failure
+path degrades gracefully to the deterministic shared engine.
+
+---
+
+## Affected iOS surfaces & shared dependencies
+
+**iOS surfaces (read-only references; not modified in this design):**
+
+- [`TransactionCreateViewModel.swift`](../../apps/ios/Finance/ViewModels/TransactionCreateViewModel.swift)
+  — already calls `categorizationEngine.suggest(payee:)`; the adapter becomes
+  an upstream signal here.
+- `apps/ios/Finance/Screens/TransactionCreateView.swift`,
+  `TransactionEditView.swift`, `TransactionDetailView.swift` — render the
+  suggestion + confidence (UX in [#2614](https://github.com/jrmoulckers/finance/issues/2614)).
+- `apps/ios/Finance/Components/TransactionRowView.swift` — optional inline
+  "uncategorized" affordance for batch review.
+- `apps/ios/FinanceClip` — optional trimmed model variant for quick capture.
+
+**Shared dependencies (KMP, owned by @kmp-engineer):**
+
+- [`SmartCategorizationEngine.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/categorization/SmartCategorizationEngine.kt)
+  — merge + confidence enum source of truth.
+- [`CategorizationEngine.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/categorization/CategorizationEngine.kt)
+  — simpler rule path used via the bridge protocol.
+- [`Category.kt`](../../packages/models/src/commonMain/kotlin/com/finance/models/Category.kt)
+  — `Category.id` is the suggestion target.
+
+---
+
+## Smallest test plan
+
+Goal: the smallest deterministic suite that must be green **before**
+implementation is accepted. Fixtures are committed, fixed-seed, and contain no
+real user data.
+
+**Shared (KMP, `commonTest`)**
+
+1. `mergePrefersUserCorrectionOverModel` — given a model `HIGH` + a recorded
+   correction, the correction wins.
+2. `modelSuggestionRanksBetweenCorrectionAndAmountRange` — ordering invariant.
+3. `nilModelSuggestionMatchesRuleOnlyBaseline` — with model `nil`, output is
+   byte-identical to the existing rule engine.
+
+**iOS adapter (XCTest, runs on a free Personal Team — buildable now)**
+
+4. `scoreBucketing` — table test mapping scores `{0.39, 0.40, 0.59, 0.60, 0.84, 0.85}`
+   to `{nil, LOW, LOW, MEDIUM, MEDIUM, HIGH}`.
+5. `payeeNormalizationIsDeterministic` — `"SQ *BLUE BOTTLE #42"` →
+   stable normalized token stream across runs.
+6. `unknownLabelReturnsNil` — a label absent from `LabelCategoryMap` yields
+   `nil`, never a wrong category.
+7. `incompatibleManifestFallsBack` — mismatched label-set hash ⇒ `.incompatible`
+   ⇒ `nil` for all inputs.
+8. `staleModelCapsConfidence` — cutoff > 12 months caps at `MEDIUM`.
+
+**Privacy assertions (shared with [#2615](https://github.com/jrmoulckers/finance/issues/2615))**
+
+9. `noPayeeInLogs` — capture `os.Logger` output for a prediction; assert the
+   payee fixture string never appears.
+10. `noNetworkInCategorizationPath` — adapter under test with a failing URL
+    protocol stub records **zero** outbound requests.
+
+See the full privacy/telemetry suite in
+[ios-categorization-privacy-telemetry.md](./ios-categorization-privacy-telemetry.md#smallest-test-plan).
+
+---
+
+## Implementation readiness
+
+Native implementation is split by what a free Apple **Personal Team** can do
+versus the distribution tail gated by Apple Developer Program enrollment
+([#1239](https://github.com/jrmoulckers/finance/issues/1239)). See the shared
+checklist in
+[../ops/human-gated-prerequisites.md](../ops/human-gated-prerequisites.md).
+
+**Buildable now (no paid account, no human-gated signing):**
+
+- Author `CoreMLCategorizationAdapter`, `ModelHost` actor, normalization,
+  and label mapping in `apps/ios`.
+- Bundle `MerchantCategory.mlmodelc` + manifest; run **on-device inference**
+  on a simulator or a personally-provisioned device (free Personal Team).
+- Run the full XCTest adapter suite and KMP `commonTest` suite locally and in
+  CI (`ci-ios`, `ci-shared`).
+- Propose the shared `ON_DEVICE_MODEL` strategy via ADR to @kmp-engineer.
+
+**Distribution tail — gated by [#1239](https://github.com/jrmoulckers/finance/issues/1239) (human-gated):**
+
+- App Store / TestFlight distribution of the model-bearing build.
+- App Group + Keychain access-group entitlements for sharing a model variant
+  with widgets/App Clip across processes (entitlements need a paid team).
+- Background model-refresh entitlements, if later added.
+
+No provisioning profiles, certificates, or store submissions are created by
+this work. Those remain human-gated.
+
+---
+
+## Open questions
+
+- **ADR for `ON_DEVICE_MODEL`:** add a new `CategorizationStrategy` case vs.
+  reuse `KEYWORD_MATCH` semantics? Owned by @kmp-engineer; this doc assumes a
+  new additive case.
+- **Model provenance:** how is `MerchantCategory.mlmodelc` produced and
+  audited (training data must itself be privacy-clean)? Tracked separately;
+  not in scope for the iOS edge.
+- **App Clip variant:** ship a trimmed model or skip on-device ML in the Clip
+  and rely on rules only? Leaning rules-only to protect the 15 MB budget.


### PR DESCRIPTION
﻿## Summary

Adds three **design-only** docs for the iOS on-device categorization cluster (epic #2382). No native build, no signing, no store actions. All inference is on-device; telemetry is opt-in and content-free (no raw transaction text, amounts, or category labels ever leave the device). The shared categorization contract stays in KMP `packages/core`; the Core ML adapter is the iOS-native edge.

## Changes

- `docs/design/ios-coreml-categorization-adapter.md` (#2613) — Core ML / NaturalLanguage adapter boundary, model packaging/versioning, confidence thresholds, fallback to shared rules, no-remote-data privacy boundary. Mermaid for adapter boundary + inference flow.
- `docs/design/ios-category-suggestion-review-ux.md` (#2614) — suggestion lifecycle, confidence display, accept/override/disable flows, correction persistence, batch import review. VoiceOver + Dynamic Type throughout.
- `docs/design/ios-categorization-privacy-telemetry.md` (#2615) — aggregate health metrics, no-merchant-content constraints, unavailable-model fallbacks, deterministic adapter tests, privacy assertions, GDPR/CCPA alignment.

Each doc includes: ToC, Mermaid diagrams, relative links to existing `docs/design/` and source files, accessibility (VoiceOver/Dynamic Type/Reduce Motion/Switch Control), privacy (on-device only, opt-in telemetry, data minimization), stale/error/empty + low-confidence state matrices, a smallest-tests plan (deterministic fixtures + privacy assertions), and an "Implementation readiness" section linking [`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md) that splits buildable-now (free Personal Team signing; Core ML bundling + on-device inference) from the distribution tail gated by #1239.

## Constraints honored

- New files only — no edits to existing docs, `packages/`, `apps/` code, shared config, or other platforms.
- Prettier `--check` passes on all three files.
- KMP categorization contract kept conceptually in `packages/core`; any new shared strategy proposed via ADR (not implemented here).
- No human-gated operations performed (no provisioning, signing, or store submission).

Closes #2613
Closes #2614
Closes #2615
