### PR TITLE
docs(design): android credit-building and ITIN onboarding design batch (#2530, #2531, #2532)

### DIFF
--- a/docs/design/android-credit-building-education.md
+++ b/docs/design/android-credit-building-education.md
@@ -1,0 +1,369 @@
+# Android Credit-Building Education Path
+
+> **Status:** PROPOSED — Pending human review
+> **Issue:** [#2530](https://github.com/jrmoulckers/finance/issues/2530) · Part of [#2174](https://github.com/jrmoulckers/finance/issues/2174)
+> **Platform:** Android (Compose education modules, learning paths)
+> **Last Updated:** 2026-06-22
+> **Design only:** Native implementation remains blocked by [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+
+---
+
+## Table of Contents
+
+1. [Purpose](#purpose)
+2. [Persona and Why This Matters](#persona-and-why-this-matters)
+3. [Goals and Non-Goals](#goals-and-non-goals)
+4. [Scope Boundaries With Sibling Work](#scope-boundaries-with-sibling-work)
+5. [Education Modules](#education-modules)
+6. [Learning Path Structure](#learning-path-structure)
+7. [Content Model and KMP Boundary](#content-model-and-kmp-boundary)
+8. [Estimates, Sensitivity, and Tone](#estimates-sensitivity-and-tone)
+9. [Localization and Text Expansion](#localization-and-text-expansion)
+10. [Accessibility Considerations](#accessibility-considerations)
+11. [Offline, Empty, and Error States](#offline-empty-and-error-states)
+12. [Test Plan](#test-plan)
+13. [Implementation Readiness](#implementation-readiness)
+14. [References](#references)
+
+---
+
+## Purpose
+
+A newcomer building credit from zero rarely arrives knowing what a FICO score is,
+why a credit card kept at 90% utilization quietly hurts them, what a credit report
+contains, or that a flurry of applications creates hard inquiries. The existing
+Android learning surface ([`LearningPathContent.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/learning/LearningPathContent.kt),
+rendered by [`LearningPathsScreen.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/learning/LearningPathsScreen.kt))
+covers general budgeting, debt, and investing — it has **no credit-building path**.
+
+This document designs a **plain-language credit-building learning path** — five
+Compose education modules (FICO, utilization, credit reports, inquiries, and safe
+beginner guidance), authored in English/Spanish and rendered from shared state. It
+is **design and breakdown only** while [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+gates store distribution. It teaches; it never gives credit, legal, or financial
+advice, and it never owns finance math.
+
+---
+
+## Persona and Why This Matters
+
+The persona ([#2174](https://github.com/jrmoulckers/finance/issues/2174)): someone
+new to US credit — perhaps a recent immigrant, a young adult, or anyone with a thin
+or nonexistent credit file — who wants to build credit safely without falling into
+fee traps or debt. They benefit from short, jargon-free explanations more than from
+dashboards full of numbers. This intersects with [Persona 4: Casey](personas.md)
+(plain-language, low cognitive load) and the broader newcomer cluster designed in
+[android-newcomer-us-finance-education.md](android-newcomer-us-finance-education.md).
+
+> **Important framing:** this is **financial _education_**, not credit, legal, or
+> financial _advice_. Every module says so, links to authoritative primary sources
+> (e.g. CFPB, AnnualCreditReport.gov), labels any number as an illustrative
+> _estimate_, and never prescribes an action ("apply for X", "do Y"). See
+> [Estimates, Sensitivity, and Tone](#estimates-sensitivity-and-tone).
+
+---
+
+## Goals and Non-Goals
+
+**Goals**
+
+- A dedicated **credit-building learning path** with five beginner modules: FICO
+  basics, utilization, credit reports, hard/soft inquiries, and safe beginner
+  guidance.
+- Plain language, translatable copy, and an **English/Spanish** content shape that
+  feeds [#2528](android-spanish-education-formatting.md) directly.
+- Reuse the existing `LearningPath` / `LearningModule` / `QuizQuestion` scaffolding
+  rather than inventing a parallel UI.
+- Clear cross-links to the **secured-card tracking** surface
+  ([android-secured-card-tracking.md](android-secured-card-tracking.md)) so a
+  learner who understands utilization can see it reflected on their own card.
+
+**Non-Goals**
+
+- Pulling, scoring, or estimating the user's _real_ credit score (no bureau
+  integration, no score simulation in this work — illustrative examples only).
+- Tax, legal, immigration, or credit _advice_ of any kind.
+- Editing KMP `packages/*` or any non-Android platform.
+- Learning-progress persistence mechanics (owned by
+  [android-learning-progress-persistence.md](android-learning-progress-persistence.md)),
+  string-extraction mechanics (owned by
+  [android-string-resource-migration-audit.md](android-string-resource-migration-audit.md)),
+  and Spanish copy review (owned by
+  [android-spanish-education-formatting.md](android-spanish-education-formatting.md)).
+
+---
+
+## Scope Boundaries With Sibling Work
+
+```mermaid
+flowchart TD
+    THIS[Issue 2530: Credit-building education<br/>THIS DOC: 5 modules + path]
+    CARD[Issue 2531: Secured-card tracking<br/>account surface + checklist]
+    NEW[Issue 2535: Newcomer US basics<br/>W-2 / 1099 / 401k]
+    PROG[Issue 2667: Learning progress<br/>persistence layer]
+    SPAN[Issue 2528: Spanish formatting]
+    STR[Issue 2527: String extraction]
+
+    THIS -->|utilization concept<br/>shown on a real card| CARD
+    THIS -->|sits beside, not inside| NEW
+    THIS -->|reuses, does not own| PROG
+    THIS -->|content shape feeds| SPAN
+    THIS -->|strings resource-backed| STR
+```
+
+This doc owns **only** the credit-building education content and its learning-path
+surface. Where a concept (utilization) has a concrete in-app expression, it
+**cross-links** to the secured-card surface rather than duplicating it.
+
+---
+
+## Education Modules
+
+Each module is short, plain-language, and structured like existing learning modules
+(title, body, key takeaways, optional non-gating quiz) so it slots into the current
+[`LearningPath` / `LearningModule`](../../apps/android/src/main/kotlin/com/finance/android/ui/learning/LearningPathContent.kt)
+model. Glossary terms reuse [`FinancialConceptContent.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/education/FinancialConceptContent.kt).
+
+| Module              | One-line scope                                                       | Key takeaway focus                                                          |
+| ------------------- | -------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| FICO basics         | What a credit score is, roughly what moves it, and what it is _for_. | Payment history + amounts owed matter most; range is a band, not a verdict. |
+| Utilization         | What "using a percentage of your limit" means and why lower helps.   | Keeping balances low relative to the limit generally helps over time.       |
+| Credit reports      | What a credit report is, who issues it, and how to read one.         | You can get reports for free; checking your own does not hurt your score.   |
+| Inquiries           | Hard vs. soft inquiries and why many applications at once can hurt.  | Checking your own (soft) is safe; many hard pulls cluster as risk.          |
+| Safe beginner guide | Low-risk habits for building credit from zero, fee-trap awareness.   | Pay on time, keep balances low, avoid fee traps; building takes time.       |
+
+```mermaid
+flowchart TD
+    HUB[Credit-Building Basics<br/>learning path]
+    HUB --> M1[FICO basics]
+    HUB --> M2[Utilization]
+    HUB --> M3[Credit reports]
+    HUB --> M4[Inquiries]
+    HUB --> M5[Safe beginner guide]
+    M2 --> XREF[Cross-link: see utilization<br/>on your secured card<br/>Issue 2531]
+    M5 --> XREF2[Cross-link: graduation checklist<br/>Issue 2531]
+```
+
+**Content rules**
+
+- Define every acronym on first use (FICO, APR, utilization); assume no prior
+  knowledge.
+- All amounts and any score figure are **illustrative and obviously fictional**,
+  visibly labelled as an _estimate / example_ — never the user's real number.
+- Every module ends with "this is general education, not financial or credit
+  advice" plus a link to an authoritative primary source (CFPB,
+  AnnualCreditReport.gov) instead of an in-app instruction to act.
+- The optional quiz (reusing `QuizQuestion`) reinforces understanding and **never
+  gates** progression or unlocks features.
+
+---
+
+## Learning Path Structure
+
+The credit-building path is a new `LearningPath` entry alongside the existing
+budgeting/investing/debt paths. It does not change path ordering logic or the
+in-memory model — it adds content.
+
+```mermaid
+flowchart LR
+    LIST[Learning paths list] --> PATH[Credit-Building Basics]
+    PATH --> MOD[Module detail<br/>title - body - takeaways]
+    MOD --> QUIZ{Optional quiz?}
+    QUIZ -->|skip| NEXT[Next module]
+    QUIZ -->|answer| FEEDBACK[Non-judgmental feedback]
+    FEEDBACK --> NEXT
+    MOD --> SRC[Authoritative source link<br/>opens in browser]
+```
+
+- Progress (completed modules, resume pointer, quiz scores) is **read from** the
+  persistence layer in [android-learning-progress-persistence.md](android-learning-progress-persistence.md);
+  this doc does not re-design persistence.
+- The path renders through the existing
+  [`LearningPathViewModel`](../../apps/android/src/main/kotlin/com/finance/android/ui/learning/LearningPathViewModel.kt)
+  state; Compose stays a pure renderer.
+
+---
+
+## Content Model and KMP Boundary
+
+Education content is _content_, but **any reusable business rule (e.g. a utilization
+ratio, a score-band lookup, an illustrative example calculation) stays in KMP
+`packages/core`**. Compose renders shared state; it never computes credit math
+locally.
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages/core (shared - do NOT edit here)"]
+        RULES[Credit concepts / utilization<br/>illustrative-example rules]
+        FMT[NumberFormatting + StringProvider]
+    end
+    subgraph Android["apps/android (this work)"]
+        CONTENT[Credit module content records<br/>FICO / utilization / reports / inquiries / safe]
+        UI[Compose learning module UI]
+    end
+    UI --> CONTENT
+    UI --> FMT
+    CONTENT --> RULES
+```
+
+**Content storage decision (to confirm in implementation):**
+
+- Short labels/titles → Android string resources (localizable via
+  [#2527](android-string-resource-migration-audit.md) /
+  [#2528](android-spanish-education-formatting.md)).
+- Long-form module bodies → structured content records (as today's
+  `LearningModule`) whose **text fields remain resource-backed or
+  translation-managed**, so Spanish coverage is achievable. Long prose as raw
+  Kotlin literals is disallowed.
+- Any numeric example that touches a ratio or band defers to shared KMP rules and
+  [`NumberFormatting`](../../packages/core/src/commonMain/kotlin/com/finance/core/i18n/NumberFormatting.kt) /
+  [`StringProvider`](../../packages/core/src/commonMain/kotlin/com/finance/core/i18n/StringProvider.kt);
+  the module never re-implements finance math.
+
+> This document **describes** the boundary. It does not implement KMP changes —
+> `packages/core` is owned by @kmp-engineer.
+
+---
+
+## Estimates, Sensitivity, and Tone
+
+This content is high-trust. Non-negotiables:
+
+- **No advice framing, ever.** Every module is labelled financial _education_, not
+  financial/credit/legal advice, and links to a primary source rather than telling
+  the user to take an action.
+- **Label every estimate.** Any score or dollar figure is an illustrative
+  _example_, visibly marked as such, never represented as the user's real score or
+  a prediction of it. No score "simulator".
+- **Never log sensitive data.** Per the observability guardrails, do not log any
+  real or example score, balance, or limit through Timber; calls must omit them.
+- **Inclusive, non-judgmental tone** per
+  [content-language-guidelines.md](content-language-guidelines.md): building credit
+  from zero is normal, not a failing; avoid shame or pressure language.
+- **No dark patterns.** No urgency, no "apply now" nudges, no affiliate framing.
+
+---
+
+## Localization and Text Expansion
+
+- All module text is **resource-backed and translatable**, feeding Spanish coverage
+  ([#2528](android-spanish-education-formatting.md)). US credit terms (FICO, hard
+  inquiry) often lack a short Spanish equivalent, so expect **25–30%+ expansion**;
+  design module cards and takeaway chips to wrap, never clip.
+- Keep proper nouns/acronyms (FICO, APR) as-is across languages but localize the
+  surrounding explanation.
+- Validate layouts under the `en-XA` pseudolocale and at `2.0x` font scale; verify
+  RTL safety with `ar-XB`.
+
+---
+
+## Accessibility Considerations
+
+- **TalkBack:** every module card, quiz option, source link, and cross-link carries
+  a meaningful `contentDescription`; reading order follows module structure
+  (title → body → takeaways → quiz → source). Estimate labels are spoken ("example
+  score, not your real score").
+- **Switch Access:** quiz controls, links, and the path list are reachable and
+  operable with adequate (≥ 48dp) touch targets.
+- **Font scaling:** all education prose stays readable and unclipped at **200%**
+  font scale; no fixed-height text containers.
+- **Plain language / cognitive load:** one concept per screen, short sentences,
+  glossary cross-links — aligned with
+  [cognitive-accessibility.md](cognitive-accessibility.md).
+- **Non-color cues:** any "good/caution" framing of an example utilization uses
+  text/icon, not color alone.
+- See [accessibility-patterns.md](accessibility-patterns.md) for the underlying
+  patterns.
+
+---
+
+## Offline, Empty, and Error States
+
+- **Offline:** credit-building content is static and must be **fully available
+  offline** — bundle it with the app, do not fetch at read time. A learner on a
+  budget device with intermittent data must still learn. Authoritative source links
+  open the browser only when tapped, with a graceful "no connection" message.
+- **Empty:** if the path renders before content loads (or a future locale lacks a
+  module), show a helpful empty state ("more guides coming") rather than a blank
+  screen.
+- **Error:** if a source link cannot open, fail safe with a non-judgmental message
+  and the plain URL to copy; never block the learner from continuing the module.
+
+---
+
+## Test Plan
+
+| Layer              | Tooling                         | What it verifies                                                                 |
+| ------------------ | ------------------------------- | -------------------------------------------------------------------------------- |
+| Unit               | JUnit                           | Each of the five modules has title/body/takeaways; path registers in the list.   |
+| Unit (safety)      | JUnit                           | Every module carries an "education, not advice" disclaimer + a source link.      |
+| Compose UI         | `createComposeRule` + semantics | Module text, quiz options, and `contentDescription` resolve from resources.      |
+| Snapshot           | Paparazzi                       | FICO/utilization/reports/inquiries/safe cards at `{en, en-XA, es}` × `{1x, 2x}`. |
+| Pseudolocalization | `en-XA` / `ar-XB`               | Expansion + mirroring for long credit prose.                                     |
+| Accessibility      | Espresso/Accessibility checks   | TalkBack order, Switch Access reachability, touch targets ≥ 48dp.                |
+| Behavior           | Espresso                        | Quiz never gates progression; estimate labels are present and announced.         |
+
+---
+
+## Implementation Readiness
+
+This is a design artifact. Execution splits into a **buildable-now** tier and a
+**Play-distribution tail** gated by
+[#1242](https://github.com/jrmoulckers/finance/issues/1242). See
+[../ops/human-gated-prerequisites.md](../ops/human-gated-prerequisites.md) and
+[../ops/launch-readiness-plan.md](../ops/launch-readiness-plan.md).
+
+**Buildable now — `assembleDebug` + sideload (no human gate):**
+
+- Author the five credit-building modules as resource-backed content records and
+  register the new learning path.
+- Wire any illustrative example to shared KMP rules / formatting (render-only).
+- Verify offline availability, accessibility, and pseudolocale/expansion snapshots
+  on a debug build / emulator.
+
+**Play-distribution tail — human-gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242):**
+
+- Production signing + Play Console listing.
+- Any store-level content declaration referencing educational/financial content.
+- Staged rollout / internal testing track.
+
+Everything in the buildable-now tier runs on an emulator with **no signing, store
+credentials, or human-gated operations**. Spanish rendering is delivered through
+[#2528](android-spanish-education-formatting.md).
+
+---
+
+## References
+
+**Design docs**
+
+- [android-secured-card-tracking.md](android-secured-card-tracking.md) — secured-card surface + checklist (#2531)
+- [android-newcomer-us-finance-education.md](android-newcomer-us-finance-education.md) — sibling newcomer education (#2535)
+- [android-itin-onboarding-profile.md](android-itin-onboarding-profile.md) — onboarding profile capture (#2532)
+- [android-learning-progress-persistence.md](android-learning-progress-persistence.md) — progress persistence (#2667)
+- [android-string-resource-migration-audit.md](android-string-resource-migration-audit.md) — string extraction + lint (#2527)
+- [android-spanish-education-formatting.md](android-spanish-education-formatting.md) — Spanish coverage (#2528)
+- [content-language-guidelines.md](content-language-guidelines.md) — non-judgmental, inclusive copy
+- [accessibility-patterns.md](accessibility-patterns.md) — screen reader, focus, touch targets
+- [cognitive-accessibility.md](cognitive-accessibility.md) — plain-language and load reduction
+- [information-architecture.md](information-architecture.md) — surface and navigation map
+- [ux-principles.md](ux-principles.md) — product UX principles
+- [personas.md](personas.md) — Persona 4 (Casey)
+
+**Ops**
+
+- [../ops/human-gated-prerequisites.md](../ops/human-gated-prerequisites.md) — buildable-now vs. gated split
+- [../ops/launch-readiness-plan.md](../ops/launch-readiness-plan.md) — launch checklist
+
+**Android / KMP (read-only boundary)**
+
+- [`LearningPathContent.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/learning/LearningPathContent.kt) — existing module model
+- [`LearningPathViewModel.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/learning/LearningPathViewModel.kt) — existing path state
+- [`FinancialConceptContent.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/education/FinancialConceptContent.kt) — existing glossary content
+- [`NumberFormatting.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/i18n/NumberFormatting.kt) — shared formatting (owned by @kmp-engineer)
+
+**Issues**
+
+- [#2530](https://github.com/jrmoulckers/finance/issues/2530) — this issue
+- [#2174](https://github.com/jrmoulckers/finance/issues/2174) — parent (credit education + secured-card support)
+- [#1242](https://github.com/jrmoulckers/finance/issues/1242) — Play Console + keystore (gate)

--- a/docs/design/android-itin-onboarding-profile.md
+++ b/docs/design/android-itin-onboarding-profile.md
@@ -1,0 +1,381 @@
+# Android ITIN-Aware Onboarding Profile
+
+> **Status:** PROPOSED — Pending human review
+> **Issue:** [#2532](https://github.com/jrmoulckers/finance/issues/2532) · Part of [#2178](https://github.com/jrmoulckers/finance/issues/2178)
+> **Platform:** Android (Compose onboarding + profile/settings)
+> **Last Updated:** 2026-06-22
+> **Design only:** Native implementation remains blocked by [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+
+---
+
+## Table of Contents
+
+1. [Purpose](#purpose)
+2. [Persona and Why This Matters](#persona-and-why-this-matters)
+3. [Goals and Non-Goals](#goals-and-non-goals)
+4. [Scope Boundaries With Sibling Work](#scope-boundaries-with-sibling-work)
+5. [Profile Questions](#profile-questions)
+6. [Onboarding Flow](#onboarding-flow)
+7. [Privacy Copy and Data Handling](#privacy-copy-and-data-handling)
+8. [Content Model and KMP Boundary](#content-model-and-kmp-boundary)
+9. [Sensitivity and Tone](#sensitivity-and-tone)
+10. [Localization and Text Expansion](#localization-and-text-expansion)
+11. [Accessibility Considerations](#accessibility-considerations)
+12. [Offline, Empty, and Error States](#offline-empty-and-error-states)
+13. [Test Plan](#test-plan)
+14. [Implementation Readiness](#implementation-readiness)
+15. [References](#references)
+
+---
+
+## Purpose
+
+A new immigrant without an SSN yet is silently excluded by onboarding that assumes
+a salaried, SSN-holding US worker. The current Android onboarding
+([`OnboardingScreen.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/onboarding/OnboardingScreen.kt),
+[`OnboardingViewModel.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/onboarding/OnboardingViewModel.kt),
+[`OnboardingNavigation.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/onboarding/OnboardingNavigation.kt))
+captures none of the identity or income context that would let the app tailor
+education without assuming one path.
+
+This document designs **optional onboarding/profile questions** — tax-ID type
+(SSN / ITIN / none / prefer not to say), income type (W-2 / 1099 / hourly /
+seasonal / mixed), and language — plus the **privacy copy** that makes them feel
+safe. It is the **profile-capture surface**; the education _content_ it tailors is
+designed in [android-newcomer-us-finance-education.md](android-newcomer-us-finance-education.md).
+It is **design and breakdown only** while
+[#1242](https://github.com/jrmoulckers/finance/issues/1242) gates store
+distribution.
+
+> **Critical privacy rule:** we **never** capture or store the actual SSN/ITIN
+> _number_. We store at most an optional, coarse _category_ used to tailor
+> education. This is education only — no tax, legal, or immigration advice claims.
+
+---
+
+## Persona and Why This Matters
+
+The persona ([#2178](https://github.com/jrmoulckers/finance/issues/2178)): a new
+immigrant who may not have an SSN yet, may use an ITIN, works mixed W-2 / 1099 /
+hourly / seasonal jobs, and is meeting US finance basics for the first time. Even a
+simple, optional acknowledgement of ITIN and mixed-income realities makes the app
+feel welcoming instead of exclusionary. This intersects with
+[Persona 4: Casey](personas.md) on plain language and reduced cognitive load, and
+relies on inclusive copy from
+[content-language-guidelines.md](content-language-guidelines.md).
+
+> **Framing:** this is **financial _education_** profiling to tailor content, not
+> tax, legal, or immigration _advice_, and not identity verification. No choice
+> unlocks, restricts, or gates any feature.
+
+---
+
+## Goals and Non-Goals
+
+**Goals**
+
+- **Optional, skippable** onboarding questions for tax-ID category, income type,
+  and preferred language — never blocking account creation.
+- Capture at most a **coarse category** (e.g. `SSN | ITIN | None/not yet | Prefer
+not to say`), **never the identifier itself**.
+- Use answers only to **tailor education and budgeting tips**; "none/not yet" and
+  "prefer not to say" are first-class, fully-supported paths.
+- Make every question **editable later** in profile/settings, with privacy copy
+  that explains exactly what is and is not stored.
+
+**Non-Goals**
+
+- Storing, validating, or transmitting a real SSN/ITIN number, or any KYC/identity
+  verification.
+- Gating, unlocking, or restricting any feature based on an answer.
+- Tax, legal, immigration, or financial _advice_ of any kind.
+- Authoring the **education content** these answers tailor — that is owned by
+  [android-newcomer-us-finance-education.md](android-newcomer-us-finance-education.md);
+  this doc owns the **capture surface and privacy copy**.
+- Editing KMP `packages/*` or any non-Android platform.
+
+---
+
+## Scope Boundaries With Sibling Work
+
+```mermaid
+flowchart TD
+    THIS[Issue 2532: ITIN-aware onboarding profile<br/>THIS DOC: capture + privacy copy]
+    NEW[Issue 2535: Newcomer US education<br/>W-2 / 1099 / 401k content]
+    SPAN[Issue 2528: Spanish formatting]
+    STR[Issue 2527: String extraction]
+
+    THIS -->|stores coarse category| TAILOR[Tailoring signal]
+    TAILOR -->|drives| NEW
+    NEW -->|reads category, owns content| TAILOR
+    THIS -->|copy resource-backed| SPAN
+    THIS -->|strings extracted| STR
+```
+
+The existing newcomer-education doc sketched an ITIN-aware onboarding _flow_ to
+illustrate its content; **this doc is the authoritative design of the capture
+surface, the coarse data model, the editing surface, and the privacy copy**. The
+two are explicitly complementary, not duplicative.
+
+---
+
+## Profile Questions
+
+All questions are optional, have a "prefer not to say" path, and default to
+identity-neutral copy.
+
+| Question           | Options (coarse category only)                                                                 | Used to tailor                            |
+| ------------------ | ---------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| Tax-ID type        | `SSN` · `ITIN` · `None / not yet` · `Prefer not to say`                                        | ITIN-aware tips; reassurance if none      |
+| Income type        | `Hourly` · `Salaried` · `Contract (1099)` · `W-2` · `Mixed` · `Seasonal` · `Prefer not to say` | Mixed-income budgeting + relevant modules |
+| Preferred language | `English` · `Español` · (system default)                                                       | UI + education language                   |
+
+- Tax-ID type stores **only the category**, never a number. There is **no numeric
+  field** for SSN/ITIN anywhere in the schema, UI, or serialization.
+- Income type may allow multiple selections (real lives are "mixed"); the result is
+  still a set of categories.
+- Preferred language hooks into the existing localization stack; it is a hint, not
+  a hard switch that hides system settings.
+
+---
+
+## Onboarding Flow
+
+```mermaid
+flowchart LR
+    START[Start onboarding] --> SKIPALL{Skip all?<br/>always available}
+    SKIPALL -->|skip| DONE[Continue to app]
+    SKIPALL -->|continue| ID{Tax-ID type?<br/>optional}
+    ID -->|SSN| INC
+    ID -->|ITIN| ITINTIP[Note: ITIN-aware tips available]
+    ID -->|None / not yet| NONETIP[Reassure: the app works without one]
+    ID -->|Prefer not to say| INC
+    ITINTIP --> INC
+    NONETIP --> INC
+    INC{Income type?<br/>optional} -->|Hourly/Seasonal/Contract/Mixed| MIX[Flag mixed-income tips]
+    INC -->|Salaried/W-2| LANG
+    INC -->|Prefer not to say| LANG
+    MIX --> LANG
+    LANG{Preferred language?<br/>optional} --> DONE
+```
+
+- **Every step is skippable** and the whole block can be skipped at once; skipping
+  is a first-class outcome, not a nag.
+- Answers **tailor** downstream education (additive tips); they never unlock or
+  restrict features.
+- Default copy is **identity-neutral**; tailored tips are additive overlays, so a
+  user who skips sees a complete, non-broken experience.
+- The same questions are reachable later from profile/settings with identical
+  options and privacy copy.
+
+---
+
+## Privacy Copy and Data Handling
+
+This surface lives or dies on trust. Privacy copy is part of the design, not an
+afterthought.
+
+- **Plain-language "what we store" panel** shown before/at the tax-ID question:
+  "We never ask for or store your SSN or ITIN number. We only remember the _type_
+  you choose, on this device, to show more relevant tips. You can change or clear
+  it anytime."
+- **Coarse category only.** Stored value is one of a small enum; there is no field
+  capable of holding a 9-digit identifier.
+- **Local, kept out of logs and analytics.** The category is an app-local
+  preference; it must never appear in Timber logs, crash reports, or analytics
+  events (the implementation honors the repo's never-log-sensitive-data rule).
+- **Clearable.** A single control in settings resets all profile answers to
+  "unspecified".
+- **No advice claims.** Copy explicitly says this tailors _education_, and is not
+  tax, legal, or immigration advice.
+
+```mermaid
+flowchart LR
+    UI[Onboarding/profile answer] --> CAT[Coarse category enum<br/>SSN / ITIN / None / Unspecified]
+    CAT --> PREF[App-local preference store]
+    PREF -. never .-> LOGS[Timber / analytics / crash]
+    PREF --> TAILOR[Tailoring signal only]
+```
+
+---
+
+## Content Model and KMP Boundary
+
+The captured category is **data for tailoring**; any reusable rule that maps a
+category to tips (or smooths mixed income) lives in **KMP `packages/core`**. Compose
+renders shared state; it never owns the mapping or any finance math.
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages/core (shared - do NOT edit here)"]
+        MAP[Category to tailoring rules]
+        SMOOTH[Mixed-income budgeting rules]
+        STRP[StringProvider]
+    end
+    subgraph Android["apps/android (this work)"]
+        ONB[Onboarding question UI]
+        PROF[Profile/settings edit UI]
+        STORE[App-local coarse-category preference]
+    end
+    ONB --> STORE
+    PROF --> STORE
+    STORE --> MAP
+    ONB --> STRP
+    PROF --> STRP
+    MAP --> SMOOTH
+```
+
+- Labels/options/privacy copy → Android string resources (localizable via
+  [#2527](android-string-resource-migration-audit.md) /
+  [#2528](android-spanish-education-formatting.md)).
+- The category→tips mapping and any income-smoothing math live in shared KMP rules;
+  the Android UI reads the result via
+  [`StringProvider`](../../packages/core/src/commonMain/kotlin/com/finance/core/i18n/StringProvider.kt)
+  and renders it.
+
+> This document **describes** the boundary. It does not implement KMP changes —
+> `packages/core` is owned by @kmp-engineer.
+
+---
+
+## Sensitivity and Tone
+
+- **Never store the identifier.** At most an optional, coarse category; no numeric
+  SSN/ITIN field exists anywhere.
+- **Never log sensitive data.** Category and income answers must be omitted from
+  Timber, analytics, and crash reporting.
+- **Inclusive, non-judgmental tone** per
+  [content-language-guidelines.md](content-language-guidelines.md): ITIN, "none/not
+  yet", and mixed/seasonal income are normal, not exceptional or lesser.
+- **No advice framing.** Tailoring is education only; link to authoritative primary
+  sources rather than instructing the user.
+- **Skippable and reversible** end to end.
+
+---
+
+## Localization and Text Expansion
+
+- All question labels, options, and privacy copy are **resource-backed and
+  translatable**, feeding Spanish coverage
+  ([#2528](android-spanish-education-formatting.md)). US terms (W-2, 1099, ITIN)
+  often lack short Spanish equivalents; expect **25–30%+ expansion** — design
+  option chips and the privacy panel to wrap, never clip or truncate.
+- Keep acronyms (SSN, ITIN, W-2, 1099) as-is across languages; localize the
+  surrounding explanation.
+- Validate under `en-XA` and at `2.0x` font scale; verify RTL with `ar-XB`.
+
+---
+
+## Accessibility Considerations
+
+- **TalkBack:** every question, option, the skip control, and the privacy panel
+  carry a meaningful `contentDescription`; reading order is question → options →
+  privacy note → skip/continue. The "we never store your number" guarantee is part
+  of the spoken description on the tax-ID question.
+- **Switch Access:** all options, skip, continue, and the settings reset control are
+  reachable and operable with adequate (≥ 48dp) touch targets.
+- **Font scaling:** all onboarding and privacy copy stay readable and unclipped at
+  **200%** font scale; no fixed-height containers; chips reflow.
+- **Plain language / cognitive load:** one question per screen, short sentences,
+  aligned with [cognitive-accessibility.md](cognitive-accessibility.md).
+- **Non-color cues:** selected/unselected options indicated by text/shape, not
+  color alone.
+- See [accessibility-patterns.md](accessibility-patterns.md) for the underlying
+  patterns.
+
+---
+
+## Offline, Empty, and Error States
+
+- **Offline:** onboarding and profile editing are **fully available offline** — no
+  question requires a network call. A newcomer on intermittent data completes setup
+  without friction.
+- **Empty / skipped:** if the user skips everything, the app shows a complete,
+  identity-neutral experience with **no broken or empty tailored sections**;
+  tailored tips are purely additive.
+- **Error:** if an answer fails to persist, **fail safe** — never block onboarding
+  or continuing; retry silently and surface a calm, non-judgmental message. Never
+  re-prompt for an answer the user chose to skip.
+
+---
+
+## Test Plan
+
+| Layer              | Tooling                         | What it verifies                                                                  |
+| ------------------ | ------------------------------- | --------------------------------------------------------------------------------- |
+| Unit               | JUnit                           | All questions optional; skip path produces a valid, complete profile state.       |
+| Unit (privacy)     | JUnit                           | Only the coarse category persists; **no identifier field exists or serializes**.  |
+| Unit (mapping)     | JUnit                           | Category → tailoring signal is read from shared rules, not computed in the UI.    |
+| Compose UI         | `createComposeRule` + semantics | Question/option/privacy text + `contentDescription` resolve from resources.       |
+| Snapshot           | Paparazzi                       | Onboarding questions + privacy panel at `{en, en-XA, es}` × `{1x, 2x}`.           |
+| Pseudolocalization | `en-XA` / `ar-XB`               | Expansion + mirroring for privacy copy and option chips.                          |
+| Accessibility      | Espresso/Accessibility checks   | TalkBack order, Switch Access reachability, touch targets ≥ 48dp, non-color cues. |
+| Behavior           | Espresso                        | Every question skippable + editable later; settings reset clears all answers.     |
+
+---
+
+## Implementation Readiness
+
+This is a design artifact. Execution splits into a **buildable-now** tier and a
+**Play-distribution tail** gated by
+[#1242](https://github.com/jrmoulckers/finance/issues/1242). See
+[../ops/human-gated-prerequisites.md](../ops/human-gated-prerequisites.md) and
+[../ops/launch-readiness-plan.md](../ops/launch-readiness-plan.md).
+
+**Buildable now — `assembleDebug` + sideload (no human gate):**
+
+- Add optional onboarding/profile questions (coarse category only, **never** the
+  identifier) and the privacy panel.
+- Persist answers as app-local preferences; wire the tailoring signal to shared KMP
+  rules (render-only).
+- Verify skip/edit/reset behavior, offline availability, accessibility, and
+  pseudolocale/expansion snapshots on a debug build / emulator.
+
+**Play-distribution tail — human-gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242):**
+
+- Production signing + Play Console listing.
+- Store **Data Safety** declaration reflecting that only an optional coarse category
+  (never an SSN/ITIN number) is stored locally.
+- Staged rollout / internal testing track.
+
+Everything in the buildable-now tier runs on an emulator with **no signing, store
+credentials, or human-gated operations**. Spanish rendering is delivered through
+[#2528](android-spanish-education-formatting.md); the education content these answers
+tailor is delivered through
+[android-newcomer-us-finance-education.md](android-newcomer-us-finance-education.md).
+
+---
+
+## References
+
+**Design docs**
+
+- [android-newcomer-us-finance-education.md](android-newcomer-us-finance-education.md) — education content tailored by this profile (#2535)
+- [android-credit-building-education.md](android-credit-building-education.md) — credit-building education path (#2530)
+- [android-secured-card-tracking.md](android-secured-card-tracking.md) — secured-card surface (#2531)
+- [android-string-resource-migration-audit.md](android-string-resource-migration-audit.md) — string extraction + lint (#2527)
+- [android-spanish-education-formatting.md](android-spanish-education-formatting.md) — Spanish coverage (#2528)
+- [content-language-guidelines.md](content-language-guidelines.md) — non-judgmental, inclusive copy
+- [accessibility-patterns.md](accessibility-patterns.md) — screen reader, focus, touch targets
+- [cognitive-accessibility.md](cognitive-accessibility.md) — plain-language and load reduction
+- [information-architecture.md](information-architecture.md) — onboarding/surface map
+- [ux-principles.md](ux-principles.md) — product UX principles
+- [personas.md](personas.md) — Persona 4 (Casey)
+
+**Ops**
+
+- [../ops/human-gated-prerequisites.md](../ops/human-gated-prerequisites.md) — buildable-now vs. gated split
+- [../ops/launch-readiness-plan.md](../ops/launch-readiness-plan.md) — launch checklist
+
+**Android / KMP (read-only boundary)**
+
+- [`OnboardingScreen.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/onboarding/OnboardingScreen.kt) — existing onboarding surface
+- [`OnboardingViewModel.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/onboarding/OnboardingViewModel.kt) — existing onboarding state
+- [`OnboardingNavigation.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/onboarding/OnboardingNavigation.kt) — onboarding navigation
+- [`StringProvider.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/i18n/StringProvider.kt) — shared string provider (owned by @kmp-engineer)
+
+**Issues**
+
+- [#2532](https://github.com/jrmoulckers/finance/issues/2532) — this issue
+- [#2178](https://github.com/jrmoulckers/finance/issues/2178) — parent (ITIN-aware onboarding + US basics)
+- [#1242](https://github.com/jrmoulckers/finance/issues/1242) — Play Console + keystore (gate)

--- a/docs/design/android-secured-card-tracking.md
+++ b/docs/design/android-secured-card-tracking.md
@@ -1,0 +1,399 @@
+# Android Secured-Card Tracking and Checklist
+
+> **Status:** PROPOSED — Pending human review
+> **Issue:** [#2531](https://github.com/jrmoulckers/finance/issues/2531) · Part of [#2174](https://github.com/jrmoulckers/finance/issues/2174)
+> **Platform:** Android (Compose account surfaces, checklist)
+> **Last Updated:** 2026-06-22
+> **Design only:** Native implementation remains blocked by [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+
+---
+
+## Table of Contents
+
+1. [Purpose](#purpose)
+2. [Persona and Why This Matters](#persona-and-why-this-matters)
+3. [Goals and Non-Goals](#goals-and-non-goals)
+4. [Scope Boundaries With Sibling Work](#scope-boundaries-with-sibling-work)
+5. [Secured-Card Account Metadata](#secured-card-account-metadata)
+6. [Deposit and Limit Display](#deposit-and-limit-display)
+7. [Utilization Goals](#utilization-goals)
+8. [Graduation Checklist](#graduation-checklist)
+9. [Content Model and KMP Boundary](#content-model-and-kmp-boundary)
+10. [Estimates, Sensitivity, and Tone](#estimates-sensitivity-and-tone)
+11. [Localization and Text Expansion](#localization-and-text-expansion)
+12. [Accessibility Considerations](#accessibility-considerations)
+13. [Offline, Empty, and Error States](#offline-empty-and-error-states)
+14. [Test Plan](#test-plan)
+15. [Implementation Readiness](#implementation-readiness)
+16. [References](#references)
+
+---
+
+## Purpose
+
+A secured credit card is the most common first rung for someone building credit
+from zero: the user puts down a refundable deposit that usually equals the credit
+limit, uses the card responsibly, and eventually "graduates" to an unsecured card
+or gets the deposit back. The app today models generic accounts
+([`AccountsScreen.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/screens/AccountsScreen.kt),
+[`AccountRepository.kt`](../../apps/android/src/main/kotlin/com/finance/android/data/repository/AccountRepository.kt))
+but has **no concept of a secured card** — no deposit, no limit relationship, no
+utilization goal, and no graduation milestones.
+
+This document designs the Compose surfaces for **secured-card tracking**: optional
+account metadata (deposit, limit, secured flag), a clear deposit/limit display, a
+utilization goal, and a **graduation checklist**. It is **design and breakdown
+only** while [#1242](https://github.com/jrmoulckers/finance/issues/1242) gates store
+distribution. It tracks and explains; it never gives credit advice and never owns
+finance math — utilization and goal rules live in KMP `packages/core`.
+
+---
+
+## Persona and Why This Matters
+
+The persona ([#2174](https://github.com/jrmoulckers/finance/issues/2174)): a
+newcomer to US credit using a secured card as their on-ramp. They want to _see_
+that keeping the balance low matters, and to know **what milestones lead to
+graduation** — without scary jargon, fee traps, or shame. This pairs directly with
+the credit-building education path
+([android-credit-building-education.md](android-credit-building-education.md)): the
+utilization module explains the concept, and this surface shows it on the user's
+own card. It also aligns with [Persona 4: Casey](personas.md) on plain language and
+low cognitive load.
+
+> **Important framing:** this is **tracking + financial _education_**, not credit,
+> legal, or financial _advice_. Utilization figures and "graduation readiness" are
+> labelled **estimates / general guidance**, never a guarantee that an issuer will
+> upgrade the card. See [Estimates, Sensitivity, and Tone](#estimates-sensitivity-and-tone).
+
+---
+
+## Goals and Non-Goals
+
+**Goals**
+
+- Optional **secured-card metadata** on an account: a `secured` flag, refundable
+  **deposit** amount, and **credit limit** (often equal to the deposit).
+- A clear **deposit/limit display** that explains the deposit↔limit relationship in
+  plain language.
+- A **utilization goal** the user can set (e.g. "keep usage under a target
+  percentage"), rendered from shared state with progress framed as an estimate.
+- A **graduation checklist** of educational, non-binding milestones (on-time
+  payments, low utilization, account age) with progress and clear "this is general
+  guidance" copy.
+
+**Non-Goals**
+
+- Connecting to a real card issuer, reading a real limit/balance from a bureau, or
+  predicting an actual graduation/upgrade decision.
+- Computing utilization or goal/checklist progress in Compose — those rules live in
+  KMP `packages/core`; the UI renders the result.
+- Tax, legal, immigration, or credit _advice_ of any kind.
+- Editing KMP `packages/*`, the shared account schema, or any non-Android platform.
+- The credit _concept_ explainers themselves (owned by
+  [android-credit-building-education.md](android-credit-building-education.md)).
+
+---
+
+## Scope Boundaries With Sibling Work
+
+```mermaid
+flowchart TD
+    THIS[Issue 2531: Secured-card tracking<br/>THIS DOC: metadata + checklist]
+    EDU[Issue 2530: Credit-building education<br/>utilization concept]
+    PROG[Issue 2667: Learning progress<br/>persistence patterns]
+    SPAN[Issue 2528: Spanish formatting]
+    STR[Issue 2527: String extraction]
+
+    EDU -->|concept explained here| THIS
+    THIS -->|shows concept on real card| EDU
+    THIS -->|reuses offline-first patterns| PROG
+    THIS -->|copy is resource-backed| SPAN
+    THIS -->|strings extracted| STR
+```
+
+This doc owns **only** the secured-card account surface and the graduation
+checklist UI. The "what is utilization" teaching lives in the credit-building
+education path; this surface links to it.
+
+---
+
+## Secured-Card Account Metadata
+
+Secured-card fields are **optional, additive metadata** layered onto an account.
+They never change how non-secured accounts behave.
+
+| Field             | Type (conceptual)     | Notes                                                         |
+| ----------------- | --------------------- | ------------------------------------------------------------- |
+| `isSecured`       | boolean (optional)    | Marks the account as a secured card; default off.             |
+| `depositAmount`   | money (optional)      | Refundable security deposit; rendered via shared formatting.  |
+| `creditLimit`     | money (optional)      | The card's limit; often equals the deposit.                   |
+| `utilizationGoal` | percentage (optional) | User-set target (e.g. "under 30%"); a goal, not a prediction. |
+| `openedDate`      | date (optional)       | Used to surface account-age milestone context.                |
+
+```mermaid
+flowchart LR
+    EDIT[Account create/edit] --> TOGGLE{Secured card?}
+    TOGGLE -->|no| PLAIN[Standard account fields]
+    TOGGLE -->|yes| SEC[Reveal: deposit, limit,<br/>utilization goal]
+    SEC --> SAVE[Persist as optional metadata]
+    SAVE --> CARD[Secured-card detail surface]
+```
+
+- The secured fields appear only when the user marks the account secured; they are
+  editable later from the same surfaces
+  ([`AccountEditScreen.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/screens/AccountEditScreen.kt)
+  is the read-only boundary reference).
+- The **shared account schema is owned by @kmp-engineer**; this doc only describes
+  the Android-side rendering and the metadata it expects to read from shared state.
+
+---
+
+## Deposit and Limit Display
+
+Newcomers are frequently confused that the deposit _is_ (usually) the limit. The
+display makes the relationship explicit and reassuring.
+
+- Show deposit and limit side by side with a one-line plain-language explainer:
+  "Your deposit is refundable and usually sets your credit limit."
+- All monetary values render through shared formatting
+  ([`MoneyOperations.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/money/MoneyOperations.kt),
+  [`NumberFormatting.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/i18n/NumberFormatting.kt)) —
+  never formatted ad hoc in Compose.
+- If deposit and limit differ, show both without judgment; do not imply one is
+  "wrong".
+
+---
+
+## Utilization Goals
+
+Utilization = balance ÷ limit. The **calculation lives in KMP `packages/core`**;
+Compose renders the shared result and the user's chosen goal.
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages/core (shared - do NOT edit here)"]
+        UTIL[Utilization ratio rule]
+        GOALCHK[Goal-progress rule]
+    end
+    subgraph Android["apps/android (this work)"]
+        GOALUI[Utilization goal UI<br/>set target + show progress]
+    end
+    GOALUI -->|reads ratio + status| UTIL
+    GOALUI -->|reads progress| GOALCHK
+```
+
+- The user sets a target (default suggestion framed as **general guidance**, e.g.
+  "many people aim to keep usage low"); the UI never claims a specific number
+  guarantees a score change.
+- Progress is shown with a labelled **estimate** ("estimated utilization") plus a
+  non-color cue (text/icon), and links to the utilization education module in
+  [android-credit-building-education.md](android-credit-building-education.md).
+
+---
+
+## Graduation Checklist
+
+The checklist is a set of **educational, non-binding milestones** that commonly
+precede graduating from a secured to an unsecured card. It tracks habits; it does
+**not** predict or promise an issuer's decision.
+
+| Milestone (illustrative)       | What it tracks                                       | Framing                                  |
+| ------------------------------ | ---------------------------------------------------- | ---------------------------------------- |
+| On-time payments               | A streak of payments made on time.                   | "Helps build history" — general guidance |
+| Low utilization held           | Utilization kept under the user's goal over time.    | Estimate, links to utilization module    |
+| Account age                    | How long the card has been open.                     | Context only, from `openedDate`          |
+| No new hard inquiries (recent) | Whether the user reports no recent new applications. | Self-reported, educational               |
+
+```mermaid
+flowchart TD
+    CHK[Graduation checklist]
+    CHK --> A[On-time payments]
+    CHK --> B[Low utilization held]
+    CHK --> C[Account age]
+    CHK --> D[No recent hard inquiries]
+    A & B & C & D --> STATE[Progress summary<br/>'general guidance, not a guarantee']
+    STATE --> LEARN[Link: safe beginner guide<br/>Issue 2530]
+```
+
+- Checklist progress is computed from **shared rules in KMP `packages/core`**; the
+  Compose checklist renders booleans/progress it is given.
+- Every checklist surface repeats the **"this is general guidance, not a guarantee
+  of graduation or credit advice"** disclaimer.
+- Completing the checklist celebrates the _habits_, not a promised outcome.
+
+---
+
+## Content Model and KMP Boundary
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages/core (shared - do NOT edit here)"]
+        SCHEMA[Account schema +<br/>secured-card fields]
+        RULES[Utilization + checklist rules]
+        FMT[MoneyOperations + NumberFormatting]
+    end
+    subgraph Android["apps/android (this work)"]
+        META[Secured-card metadata UI]
+        DISP[Deposit/limit display]
+        GOAL[Utilization goal UI]
+        LIST[Graduation checklist UI]
+    end
+    META --> SCHEMA
+    DISP --> FMT
+    GOAL --> RULES
+    LIST --> RULES
+```
+
+- **All finance math and eligibility-style logic stay in KMP `packages/core`.**
+  Compose renders shared state — it never computes utilization, goal progress, or
+  checklist completion locally.
+- Labels/titles → Android string resources (localizable via
+  [#2527](android-string-resource-migration-audit.md) /
+  [#2528](android-spanish-education-formatting.md)).
+- Monetary and percentage values → shared formatting only.
+
+> This document **describes** the boundary. It does not implement KMP or schema
+> changes — `packages/core` is owned by @kmp-engineer.
+
+---
+
+## Estimates, Sensitivity, and Tone
+
+- **No advice framing.** Utilization status and graduation readiness are labelled
+  **estimates / general guidance**, never financial or credit advice, and never a
+  promise an issuer will upgrade the card.
+- **Never log sensitive data.** Deposit, limit, balance, and utilization values are
+  sensitive financial data; do not log them through Timber — calls must omit them.
+- **Inclusive, non-judgmental tone** per
+  [content-language-guidelines.md](content-language-guidelines.md): a secured card
+  is a normal, smart on-ramp, not a sign of failure; avoid shame language.
+- **No dark patterns / fee-trap awareness.** No urgency, no "spend to graduate
+  faster" nudges; the safe beginner guidance in #2530 warns about fee traps.
+
+---
+
+## Localization and Text Expansion
+
+- All labels, explainers, and checklist copy are **resource-backed and
+  translatable**, feeding Spanish coverage
+  ([#2528](android-spanish-education-formatting.md)). Expect **25–30%+ expansion**
+  on terms like "refundable security deposit" and "credit utilization"; design
+  cards and checklist rows to wrap, never clip.
+- Currency and percentage rendering follows shared locale-aware formatting.
+- Validate under `en-XA` and at `2.0x` font scale; verify RTL with `ar-XB`.
+
+---
+
+## Accessibility Considerations
+
+- **TalkBack:** every metadata field, the deposit/limit pair, the utilization goal
+  control, and each checklist row carry a meaningful `contentDescription`. The
+  deposit/limit relationship is announced as a sentence, not two bare numbers.
+  Estimate labels are spoken ("estimated utilization").
+- **Switch Access:** the secured toggle, goal control, and checklist items are
+  reachable and operable with adequate (≥ 48dp) touch targets.
+- **Font scaling:** deposit/limit, goal, and checklist text stay readable and
+  unclipped at **200%** font scale; no fixed-height containers.
+- **Non-color cues:** utilization "good/caution" and checklist done/not-done use
+  text + icon, never color alone.
+- **Plain language / cognitive load:** one idea per row, aligned with
+  [cognitive-accessibility.md](cognitive-accessibility.md).
+- See [accessibility-patterns.md](accessibility-patterns.md) for the underlying
+  patterns.
+
+---
+
+## Offline, Empty, and Error States
+
+- **Offline:** secured-card metadata and the checklist are **local-first** — the
+  user can view and edit deposit/limit/goal and see checklist progress fully
+  offline. Nothing in this surface requires a network call.
+- **Empty:** before the user marks an account secured (or sets a goal), show a
+  helpful empty state explaining what a secured card is and inviting setup —
+  never a blank panel. A checklist with no milestones yet shows "track your
+  progress here".
+- **Error:** if metadata fails to persist, **fail safe** — never block account
+  editing; retry silently and surface a calm, non-judgmental message. Never show a
+  graduation outcome as if it were guaranteed.
+
+---
+
+## Test Plan
+
+| Layer              | Tooling                         | What it verifies                                                                       |
+| ------------------ | ------------------------------- | -------------------------------------------------------------------------------------- |
+| Unit               | JUnit                           | Secured fields are optional/additive; non-secured accounts are unaffected.             |
+| Unit (boundary)    | JUnit                           | UI reads utilization/checklist results from shared state; no local finance math.       |
+| Compose UI         | `createComposeRule` + semantics | Deposit/limit, goal, and checklist text + `contentDescription` resolve from resources. |
+| Snapshot           | Paparazzi                       | Secured-card detail + checklist at `{en, en-XA, es}` × `{1x, 2x}`, empty + populated.  |
+| Pseudolocalization | `en-XA` / `ar-XB`               | Expansion + mirroring for deposit/limit/checklist copy.                                |
+| Accessibility      | Espresso/Accessibility checks   | TalkBack order, Switch Access reachability, touch targets ≥ 48dp, non-color cues.      |
+| Behavior           | Espresso                        | Estimate/guidance disclaimers present; no "guaranteed graduation" claims; fail-safe.   |
+
+---
+
+## Implementation Readiness
+
+This is a design artifact. Execution splits into a **buildable-now** tier and a
+**Play-distribution tail** gated by
+[#1242](https://github.com/jrmoulckers/finance/issues/1242). See
+[../ops/human-gated-prerequisites.md](../ops/human-gated-prerequisites.md) and
+[../ops/launch-readiness-plan.md](../ops/launch-readiness-plan.md).
+
+**Buildable now — `assembleDebug` + sideload (no human gate):**
+
+- Render optional secured-card metadata, deposit/limit display, utilization goal,
+  and graduation checklist from shared state (mock/stub repository as needed).
+- Wire utilization and checklist progress to shared KMP rules (render-only).
+- Verify offline editing, accessibility, and pseudolocale/expansion snapshots on a
+  debug build / emulator.
+
+**Play-distribution tail — human-gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242):**
+
+- Production signing + Play Console listing.
+- Any store-level data-safety declaration referencing the optional financial
+  metadata.
+- Staged rollout / internal testing track.
+
+Everything in the buildable-now tier runs on an emulator with **no signing, store
+credentials, or human-gated operations**. The shared account-schema additions are
+coordinated with @kmp-engineer and are not implemented in this Android-only doc.
+
+---
+
+## References
+
+**Design docs**
+
+- [android-credit-building-education.md](android-credit-building-education.md) — credit concepts incl. utilization (#2530)
+- [android-newcomer-us-finance-education.md](android-newcomer-us-finance-education.md) — sibling newcomer education (#2535)
+- [android-itin-onboarding-profile.md](android-itin-onboarding-profile.md) — onboarding profile capture (#2532)
+- [android-learning-progress-persistence.md](android-learning-progress-persistence.md) — offline-first persistence patterns (#2667)
+- [android-string-resource-migration-audit.md](android-string-resource-migration-audit.md) — string extraction + lint (#2527)
+- [android-spanish-education-formatting.md](android-spanish-education-formatting.md) — Spanish coverage (#2528)
+- [content-language-guidelines.md](content-language-guidelines.md) — non-judgmental, inclusive copy
+- [accessibility-patterns.md](accessibility-patterns.md) — screen reader, focus, touch targets
+- [cognitive-accessibility.md](cognitive-accessibility.md) — plain-language and load reduction
+- [component-library.md](component-library.md) — card/list/checklist component patterns
+- [data-model.md](data-model.md) — data-model conventions
+- [personas.md](personas.md) — Persona 4 (Casey)
+
+**Ops**
+
+- [../ops/human-gated-prerequisites.md](../ops/human-gated-prerequisites.md) — buildable-now vs. gated split
+- [../ops/launch-readiness-plan.md](../ops/launch-readiness-plan.md) — launch checklist
+
+**Android / KMP (read-only boundary)**
+
+- [`AccountsScreen.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/screens/AccountsScreen.kt) — existing accounts surface
+- [`AccountEditScreen.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/screens/AccountEditScreen.kt) — existing account edit surface
+- [`AccountRepository.kt`](../../apps/android/src/main/kotlin/com/finance/android/data/repository/AccountRepository.kt) — existing account repository
+- [`MoneyOperations.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/money/MoneyOperations.kt) — shared money math (owned by @kmp-engineer)
+- [`NumberFormatting.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/i18n/NumberFormatting.kt) — shared formatting (owned by @kmp-engineer)
+
+**Issues**
+
+- [#2531](https://github.com/jrmoulckers/finance/issues/2531) — this issue
+- [#2174](https://github.com/jrmoulckers/finance/issues/2174) — parent (credit education + secured-card support)
+- [#1242](https://github.com/jrmoulckers/finance/issues/1242) — Play Console + keystore (gate)


### PR DESCRIPTION
## Summary

Adds three **design-only** documents under `docs/design/` for the Android
credit-building / newcomer cluster. These are documentation artifacts — no native
build, signing, or store actions. Finance/eligibility logic stays conceptually in
KMP `packages/core`; the docs describe the Compose-renders-shared-state boundary
without implementing it. All credit/ITIN content is framed as **education only**
(no advice claims; estimates are labelled).

Closes #2530
Closes #2531
Closes #2532

## Changes

- `docs/design/android-credit-building-education.md` — **#2530** (part of #2174):
  Compose credit-building learning path with five plain-language modules (FICO,
  utilization, credit reports, inquiries, safe beginner guidance), English/Spanish
  content shape, and the KMP content boundary.
- `docs/design/android-secured-card-tracking.md` — **#2531** (part of #2174):
  optional secured-card account metadata, deposit/limit display, utilization goal,
  and an educational graduation checklist — utilization/checklist rules read from
  shared KMP state.
- `docs/design/android-itin-onboarding-profile.md` — **#2532** (part of #2178):
  optional onboarding/profile questions (SSN/ITIN/none, W-2/1099/hourly/seasonal
  income, language) with privacy copy. Captures only a coarse category — **never**
  the SSN/ITIN number — and gates no features.

## Conventions

Each doc follows `docs.instructions.md`: humans-first prose, table of contents,
Mermaid diagrams, relative links to existing `docs/` files, accessibility (TalkBack,
Switch Access, 200% font scaling), offline/empty/error states, a test plan
(unit / Compose / Paparazzi), and an **Implementation readiness** section linking
[`docs/ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md) that
splits buildable-now (`assembleDebug` sideload) work from the Play-distribution tail
gated by #1242.

## Verification

- `npx prettier --check` passes on all three new files.
- All relative links resolve to existing files; all internal ToC anchors resolve.
- New files only — no existing files, `packages/`, `apps/` code, shared config, or
  other platforms touched.
