### PR TITLE
docs(design): ios widget and savings-rate design batch (#2583, #2585, #2589)

### DIFF
--- a/docs/design/ios-savings-rate-dashboard-card.md
+++ b/docs/design/ios-savings-rate-dashboard-card.md
@@ -1,0 +1,355 @@
+# Promote Savings-Rate Card to the iOS Dashboard
+
+> The dashboard already _computes_ savings rate but never shows it. This design
+> promotes it to a first-class, low-noise card — a headline percentage, a
+> non-color trend badge versus last month, compact copy, and a single tap target
+> into the deeper view — without adding clutter to the existing Dashboard.
+
+**Status:** PROPOSED — design only (native implementation buildable now; store distribution gated)
+**Issue:** [#2589](https://github.com/jrmoulckers/finance/issues/2589) — Part of [#2162](https://github.com/jrmoulckers/finance/issues/2162)
+**Platform:** iOS / iPadOS (SwiftUI, iOS 17+)
+**Owner:** @ios-engineer
+**Related:** [ios-net-worth-trend-chart.md](./ios-net-worth-trend-chart.md) · [ios-noncolor-financial-state-cues.md](./ios-noncolor-financial-state-cues.md) · [accessibility-patterns.md](./accessibility-patterns.md) · [data-visualization.md](./data-visualization.md) · [content-language-guidelines.md](./content-language-guidelines.md) · [information-architecture.md](./information-architecture.md) · [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md)
+
+---
+
+## Table of Contents
+
+1. [Goal & Scope](#1-goal--scope)
+2. [Current State](#2-current-state)
+3. [Placement & Card Hierarchy](#3-placement--card-hierarchy)
+4. [Trend Badge (vs Last Month)](#4-trend-badge-vs-last-month)
+5. [Compact Copy](#5-compact-copy)
+6. [Tap Target & Navigation](#6-tap-target--navigation)
+7. [Accessibility](#7-accessibility)
+8. [Privacy & Balance Hiding](#8-privacy--balance-hiding)
+9. [States: Empty, Loading, Stale, Error & Edge Cases](#9-states-empty-loading-stale-error--edge-cases)
+10. [Native ↔ KMP Boundary](#10-native--kmp-boundary)
+11. [Affected Surfaces & Shared Dependencies](#11-affected-surfaces--shared-dependencies)
+12. [Test Plan (Smallest Tests First)](#12-test-plan-smallest-tests-first)
+13. [Implementation Readiness](#13-implementation-readiness)
+14. [Open Questions](#14-open-questions)
+
+---
+
+## 1. Goal & Scope
+
+Savings rate — the share of income you keep — is the single most motivating
+number for the budgeting personas, yet the
+[`DashboardView`](../../apps/ios/Finance/Screens/DashboardView.swift) renders net
+worth, a monthly income/expense summary, budget rings, quick access, and recent
+transactions, but **not** savings rate, even though
+[`DashboardViewModel`](../../apps/ios/Finance/ViewModels/DashboardViewModel.swift)
+already calculates it. This design closes that gap.
+
+**In scope:**
+
+- A `SavingsRateCard` SwiftUI surface placed in the existing Dashboard scroll
+  stack with a clear visual hierarchy.
+- A **trend badge** comparing this month to last month, using a non-color cue
+  (arrow + sign) per the iOS state-cue guidance.
+- **Compact copy**, a **44 pt tap target** into the existing detail surface, and
+  full accessibility / privacy / state coverage.
+
+**Out of scope:**
+
+- A full savings-rate _history chart_ — the card deep-links into the existing
+  analytics/insights surface; the trend over time is a follow-on under #2162.
+- Changing the **calculation** — savings-rate math stays in KMP `packages/core`
+  via the bridge ([§10](#10-native--kmp-boundary)).
+- New tabs or navigation destinations — the goal is "first-class **without**
+  adding noise," so the card slots into the existing Dashboard, no new IA
+  (see [information-architecture.md](./information-architecture.md)).
+
+> **Why a card, not a screen:** consistent with
+> [ios-net-worth-trend-chart.md](./ios-net-worth-trend-chart.md), the headline
+> figure belongs inline on the Dashboard next to the income/expense summary that
+> explains it; detail-on-demand lives one tap away.
+
+---
+
+## 2. Current State
+
+- [`DashboardViewModel`](../../apps/ios/Finance/ViewModels/DashboardViewModel.swift)
+  exposes `savingsRate: Double` (a 0–100 percentage) plus `monthlyIncome` and
+  `monthlyExpenses`, all recomputed in `recomputeAggregations()` via the bridge
+  `aggregator.savingsRate(...)`. **The value exists but is never rendered.**
+- The view model computes for the **current month** window only; a
+  **previous-month** value is needed for the trend badge ([§4](#4-trend-badge-vs-last-month)).
+- The Dashboard's cards use a consistent style: `.regularMaterial` background,
+  `RoundedRectangle(cornerRadius: 16)`, `CurrencyLabel`, and
+  `.accessibilityElement(children: .combine)` — the new card matches this.
+- `savingsRate` is a percentage, so it is computed and formatted **without**
+  the privacy `CurrencyLabel` path — relevant to [§8](#8-privacy--balance-hiding).
+
+---
+
+## 3. Placement & Card Hierarchy
+
+Insert `SavingsRateCard` **directly under** the existing `spendingSummaryCard`
+(which shows Income / Expenses / Net), because savings rate is the natural
+synthesis of those two numbers:
+
+```text
+ScrollView
+  ├─ OfflineBanner (conditional)
+  ├─ netWorthCard
+  ├─ spendingSummaryCard        ← Income / Expenses / Net
+  ├─ SavingsRateCard            ← NEW (this design)
+  ├─ budgetHealthSection
+  ├─ quickAccessSection
+  └─ recentTransactionsSection
+```
+
+Visual hierarchy inside the card (top → bottom, leading-aligned):
+
+1. **Eyebrow label:** "Savings Rate" — `.subheadline`, `.secondary`,
+   `.isHeader` trait.
+2. **Headline:** the percentage — large, rounded, `.monospacedDigit()`
+   (e.g. `.system(.largeTitle, design: .rounded, weight: .bold)`), with the
+   **trend badge** trailing on the same baseline.
+3. **Caption:** one compact, plain-language line ([§5](#5-compact-copy)).
+
+The card is a `NavigationLink` (single tap target) styled to match the other
+material cards; it adds exactly one row to the stack — no nested controls, no
+chart — honoring "without adding noise."
+
+---
+
+## 4. Trend Badge (vs Last Month)
+
+The badge answers "is this getting better?" at a glance.
+
+- **Delta in percentage points:** `current − previous` savings rate, rendered as
+  `+4 pts` / `−3 pts` / `even`. Points (not "%") avoids the percent-of-a-percent
+  ambiguity.
+- **Non-color cue first:** an SF Symbol (`arrow.up.right` / `arrow.down.right` /
+  `arrow.right`) **plus** an explicit sign — color is secondary, per
+  [ios-noncolor-financial-state-cues.md](./ios-noncolor-financial-state-cues.md)
+  and [data-visualization §2.4](./data-visualization.md#24-never-color-alone).
+- **Semantics:** higher savings rate is positive (use `statusPositive`); lower is
+  cautionary (`statusWarning`/`statusNegative`). Crucially, the **direction is
+  carried by the arrow and sign**, not by hue alone.
+- **Requires a previous-month value:** add `previousSavingsRate` to the view
+  model, computed via the same bridge call over the **prior** month window. This
+  is presentation wiring; the arithmetic stays in KMP core ([§10](#10-native--kmp-boundary)).
+
+The badge reflows below the headline under large Dynamic Type rather than
+truncating (see [§7](#7-accessibility)).
+
+---
+
+## 5. Compact Copy
+
+All `String(localized:)` with translator comments, plain and non-judgmental per
+the [content language guidelines](./content-language-guidelines.md):
+
+| Element            | Copy (en)                                    | Notes                                      |
+| ------------------ | -------------------------------------------- | ------------------------------------------ |
+| Eyebrow            | "Savings Rate"                               | Card title                                 |
+| Headline           | "{n}%"                                       | Integer percent; `NumberFormatter` percent |
+| Badge (up)         | "+{d} pts vs last month"                     | `d` = absolute point delta                 |
+| Badge (down)       | "−{d} pts vs last month"                     | Minus sign, not hyphen                     |
+| Badge (flat)       | "Even with last month"                       |                                            |
+| Caption (positive) | "You're keeping {n}% of income."             | Reinforces meaning, no praise/shame        |
+| Caption (zero/neg) | "Spending matched or passed income."         | Neutral framing for ≤ 0 savings rate       |
+| Empty              | "Add transactions to see your savings rate." |                                            |
+
+Copy stays to one caption line; numbers are locale-formatted.
+
+---
+
+## 6. Tap Target & Navigation
+
+- The entire card is **one** `NavigationLink` (≥ 44 pt height by construction —
+  the material card padding already exceeds it), routing to the existing
+  detail surface — **[`InsightsView`](../../apps/ios/Finance/Screens/InsightsView.swift)**
+  (or `AnalyticsView`) — reusing the pattern from the Dashboard's existing
+  `quickAccessSection` `NavigationLink`s. No new screen is introduced.
+- `.accessibilityHint` describes the destination ("Opens savings insights"); the
+  link has a clear `.accessibilityLabel` + `.accessibilityValue` ([§7](#7-accessibility)).
+- Pull-to-refresh and `.task { loadDashboard() }` already drive the value; the
+  card needs no independent loading path.
+
+---
+
+## 7. Accessibility
+
+Per the [accessibility patterns library](./accessibility-patterns.md):
+
+- **VoiceOver:** the card is one combined element.
+  - `.accessibilityLabel`: "Savings rate"
+  - `.accessibilityValue`: "{n} percent, up {d} points versus last month"
+    (direction spoken as words, never relying on the arrow glyph or color).
+  - `.accessibilityHint`: "Opens savings insights".
+  - Decorative arrow symbol is `.accessibilityHidden(true)` since its meaning is
+    already in the spoken value.
+- **Dynamic Type:** no hardcoded sizes — semantic fonts only; the headline uses
+  `.minimumScaleFactor` only as a last resort, and the trend badge **wraps to a
+  second line** at large accessibility sizes instead of clipping (validate
+  against [ios-dynamic-type-reflow-audit.md](./ios-dynamic-type-reflow-audit.md)).
+- **Reduce Motion:** if a count-up or badge animation is ever added, gate it on
+  `accessibilityReduceMotion` and fall back to an instant value
+  ([accessibility-patterns §6.1](./accessibility-patterns.md#61-reduced-motion-support)).
+- **Never color alone:** trend direction is conveyed by arrow + sign + words, so
+  the card is fully legible to color-blind users and in grayscale
+  ([data-visualization §2.4](./data-visualization.md#24-never-color-alone)).
+- **Contrast:** reuse the CVD-safe status palette from the widget/app tokens,
+  meeting WCAG AA in light/dark ([data-visualization §2.1](./data-visualization.md#21-cvd-safe-palette)).
+
+---
+
+## 8. Privacy & Balance Hiding
+
+Savings rate is a **percentage**, not a balance, so it is inherently
+privacy-friendlier than dollar figures — but the design still respects the app's
+balance-hiding posture:
+
+- The **percentage and the trend badge remain visible** even when amount-hiding
+  is active: a percent reveals no absolute balance, mirroring how the widget
+  `.percent` masking mode ([`WidgetMoneyFormatter`](../../apps/ios/Shared/WidgetPrivacy.swift))
+  is the privacy-safe representation.
+- Any **absolute amounts** that might appear in the caption (none in the default
+  copy) must route through the existing privacy-aware formatting; the default
+  copy deliberately avoids dollar amounts so the card needs no unmasking.
+- When the deeper [`InsightsView`](../../apps/ios/Finance/Screens/InsightsView.swift)
+  shows underlying income/expense figures, those follow the app's existing
+  masking — out of scope here, but the tap target must not leak amounts in its
+  accessibility value (it speaks the percent only).
+
+> Rule of thumb: **percentages pass; dollars get masked.** The savings-rate card
+> is percent-first by design, so it stays informative under balance hiding.
+
+---
+
+## 9. States: Empty, Loading, Stale, Error & Edge Cases
+
+| State           | Trigger                                                 | Rendering                                                                                                                  |
+| --------------- | ------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| **Loading**     | `isLoading && accounts.isEmpty`                         | Inherits the Dashboard's existing `ProgressView`; the card simply isn't built yet                                          |
+| **Empty**       | No transactions in the current month                    | "Add transactions to see your savings rate." with a neutral icon; no badge                                                 |
+| **Zero income** | `monthlyIncome == 0` (rate undefined; bridge returns 0) | Show "—" headline + empty-style caption, not a misleading "0%"                                                             |
+| **Negative**    | Expenses ≥ income (rate ≤ 0)                            | Render the actual value (e.g. "0%") with the neutral "Spending matched or passed income." caption; trend badge still valid |
+| **Stale**       | Data older than the app's refresh (offline)             | Render last-known value; the Dashboard's `OfflineBanner` already signals connectivity                                      |
+| **Error**       | `loadDashboard()` sets `errorMessage`                   | The Dashboard's existing error `alert` handles it; the card shows last-known or hides until retry                          |
+
+The card must **distinguish "0% saved" from "no data"** — the zero-income case
+renders "—", never a falsely precise "0%".
+
+---
+
+## 10. Native ↔ KMP Boundary
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages/core + packages/models (KMP — DO NOT implement here)"]
+        K1["savingsRate(transactions, from, to)"]
+        K2[Income / spending aggregation]
+    end
+    subgraph Bridge["Swift Export bridge (apps/ios/Finance/KMP)"]
+        B1[SwiftExportAggregatorModule]
+    end
+    subgraph iOS["apps/ios (native — this design)"]
+        V1[DashboardViewModel<br/>savingsRate + previousSavingsRate]
+        V2[SavingsRateCard<br/>format + trend badge + a11y]
+    end
+    K1 --> B1
+    K2 --> B1
+    B1 --> V1 --> V2
+```
+
+- The **savings-rate formula** (and the income/spending it derives from) lives in
+  KMP `packages/core`, already surfaced through
+  [`SwiftExportAggregatorModule.savingsRate`](../../apps/ios/Finance/KMP/SwiftExportBridge.swift).
+  The card and view model **call** it for the current and prior month windows;
+  they do not reimplement the math.
+- The only new view-model value, `previousSavingsRate`, is computed by invoking
+  the **same** bridge method over the previous-month date range — wiring, not new
+  arithmetic.
+- iOS owns layout, the trend-badge presentation, formatting, accessibility, and
+  privacy rendering only.
+
+---
+
+## 11. Affected Surfaces & Shared Dependencies
+
+**New (this design):**
+
+- `apps/ios/Finance/Components/SavingsRateCard.swift` (or an inline `private var`
+  in `DashboardView`, matching the existing card style).
+
+**Touched:**
+
+- [`DashboardView`](../../apps/ios/Finance/Screens/DashboardView.swift) — add the
+  card to the scroll stack between `spendingSummaryCard` and `budgetHealthSection`.
+- [`DashboardViewModel`](../../apps/ios/Finance/ViewModels/DashboardViewModel.swift)
+  — add `previousSavingsRate` (and a `savingsRateTrend` convenience) computed via
+  the bridge over the prior month.
+
+**Reused unchanged:**
+
+- The bridge `SwiftExportAggregatorModule`, the existing
+  [`InsightsView`](../../apps/ios/Finance/Screens/InsightsView.swift) navigation
+  target, the status color tokens, and the Dashboard's error/refresh plumbing.
+
+**Shared dependency:** KMP `packages/core` savings-rate aggregation
+([§10](#10-native--kmp-boundary)).
+
+---
+
+## 12. Test Plan (Smallest Tests First)
+
+1. **Trend computation (Swift unit):** given `savingsRate` and
+   `previousSavingsRate`, assert the badge delta + direction (`up` / `down` /
+   `even`), including the equal case → "Even with last month".
+2. **Zero-income guard (Swift unit):** `monthlyIncome == 0` ⇒ headline "—" and the
+   empty-style caption, **not** "0%".
+3. **Negative savings (Swift unit):** expenses ≥ income ⇒ value renders with the
+   neutral caption; trend still computed.
+4. **VoiceOver value (XCUITest, smallest):** assert the card's combined
+   `accessibilityValue` speaks the percent and direction in words and exposes no
+   dollar amount.
+5. **Dynamic Type reflow (snapshot):** render at default and `.accessibility5`;
+   assert the trend badge wraps and nothing clips.
+6. **Privacy (Swift unit/snapshot):** with amount-hiding on, assert the percent
+   and badge remain visible and no masked dollar value leaks into the card.
+7. **Empty state (snapshot):** no current-month transactions ⇒ empty copy, no badge.
+8. **Shared (KMP, owned by @kmp-engineer):** savings-rate correctness (including
+   rounding and the income = 0 boundary) is tested in `packages/core`, not iOS.
+
+---
+
+## 13. Implementation Readiness
+
+See [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md).
+
+**Buildable now (no paid enrollment) — free Personal Team signing:**
+
+- This is **pure SwiftUI** on an existing screen with an existing bridge value —
+  no entitlements, App Groups, push, or Associated Domains. It builds and runs on
+  a device under a **free Apple ID** (Personal Team) and in the simulator with no
+  Apple Developer Program membership.
+- All tests in [§12](#12-test-plan-smallest-tests-first) run locally without
+  enrollment.
+
+**Distribution tail — gated by [#1239](https://github.com/jrmoulckers/finance/issues/1239):**
+
+- Only App Store / TestFlight distribution of the build is gated; the feature
+  itself has **no** distribution-dependent capability. Add a `## Needs Human
+Action` note on the PR pointing at
+  [§3.2 of the prerequisites runbook](../ops/human-gated-prerequisites.md#32-ios-distribution--apple-developer-1239)
+  for the distribution criterion only.
+
+---
+
+## 14. Open Questions
+
+1. **Deep-link target:** `InsightsView` vs `AnalyticsView` vs `HealthScoreView` —
+   confirm which best hosts "savings over time" so the tap is satisfying.
+2. **Point vs percent delta:** confirm "pts" is clearer than "%" for the trend
+   badge with the target personas (copy review with @content/design).
+3. **Window definition:** does "last month" mean calendar month or trailing 30
+   days? Must match the KMP-core window used by `savingsRate` to keep the badge
+   honest.
+4. **Threshold framing:** should the caption flag a target savings rate (e.g.
+   20%) once goals exist (#2162), or stay descriptive for now? Default: descriptive.

--- a/docs/design/ios-today-spend-funmoney-widget.md
+++ b/docs/design/ios-today-spend-funmoney-widget.md
@@ -1,0 +1,398 @@
+# Today Spend & Fun Money — WidgetKit Surface Design
+
+> A small/medium home-screen widget that answers two everyday questions at a
+> glance — **"How much have I spent today?"** and **"How much fun money is
+> left?"** — reading only from the App Group cache, never the network, and
+> respecting the same privacy masking as the existing Balance and Budget widgets.
+
+**Status:** PROPOSED — design only (native implementation buildable now; store distribution gated)
+**Issue:** [#2583](https://github.com/jrmoulckers/finance/issues/2583) — Part of [#2159](https://github.com/jrmoulckers/finance/issues/2159)
+**Platform:** iOS / iPadOS (WidgetKit + SwiftUI, iOS 17+)
+**Owner:** @ios-engineer
+**Related:** [ios-widget-freshness-pipeline.md](./ios-widget-freshness-pipeline.md) · [ios-savings-rate-dashboard-card.md](./ios-savings-rate-dashboard-card.md) · [data-visualization.md](./data-visualization.md) · [accessibility-patterns.md](./accessibility-patterns.md) · [ios-noncolor-financial-state-cues.md](./ios-noncolor-financial-state-cues.md) · [content-language-guidelines.md](./content-language-guidelines.md) · [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md)
+
+---
+
+## Table of Contents
+
+1. [Goal & Scope](#1-goal--scope)
+2. [Widget Families & Layout](#2-widget-families--layout)
+3. [Timeline Payloads & App Group Cache](#3-timeline-payloads--app-group-cache)
+4. [Timeline Refresh Flow](#4-timeline-refresh-flow)
+5. [Copy & Localization](#5-copy--localization)
+6. [Privacy & Balance Hiding](#6-privacy--balance-hiding)
+7. [Accessibility](#7-accessibility)
+8. [States: Empty, Stale, Error & Placeholder](#8-states-empty-stale-error--placeholder)
+9. [Native ↔ KMP Boundary](#9-native--kmp-boundary)
+10. [Affected Surfaces & Shared Dependencies](#10-affected-surfaces--shared-dependencies)
+11. [Test Plan (Smallest Tests First)](#11-test-plan-smallest-tests-first)
+12. [Implementation Readiness](#12-implementation-readiness)
+13. [Open Questions](#13-open-questions)
+
+---
+
+## 1. Goal & Scope
+
+Today's spend and discretionary ("fun money") headroom are the two numbers a
+budget-conscious user wants between opening the app — exactly the
+glanceable, zero-interaction job WidgetKit is built for. This design adds a
+**new `TodaySpendWidget`** to the existing
+[`FinanceWidgetBundle`](../../apps/ios/FinanceWidget/FinanceWidgetBundle.swift),
+alongside the shipped `BalanceWidget`, `BudgetProgressWidget`,
+`RecentTransactionsWidget`, and `QuickEntryWidget`.
+
+**In scope (this design):**
+
+- `systemSmall` and `systemMedium` widget entries for **today spend** and
+  **fun-money status**.
+- Codable **timeline payloads** and the App Group cache keys that feed them.
+- **Privacy masking** reusing the canonical
+  [`WidgetMoneyFormatter` / `WidgetMaskingMode`](../../apps/ios/Shared/WidgetPrivacy.swift).
+- **Copy** (all `String(localized:)`), empty / stale / error / placeholder
+  states, and full **VoiceOver / Dynamic Type / Reduce Motion** behavior.
+- The **timeline refresh contract** this widget needs from the app
+  (the write side is specified in [ios-widget-freshness-pipeline.md](./ios-widget-freshness-pipeline.md)).
+
+**Out of scope (deliberately deferred):**
+
+- Lock Screen `accessory*` families and watchOS complications (follow-on under
+  #2159 — the data model below is forward-compatible with them).
+- Interactive App Intents inside the widget (e.g. "log a coffee"); tap routes to
+  the app via a deep link only.
+- The **business math** for today spend and discretionary headroom — that lives
+  in KMP `packages/core` (see [§9](#9-native--kmp-boundary)). This document
+  specifies the _surface_ and the _bridge contract_, not the calculation.
+
+> **Why cache-only:** like every shipped widget, the timeline provider reads the
+> App Group cache and **never** performs network or database I/O — an empty
+> cache renders an empty state (mirroring
+> [`WidgetDataProvider.readBudgets`](../../apps/ios/FinanceWidget/WidgetDataProvider.swift)).
+
+---
+
+## 2. Widget Families & Layout
+
+| Family         | Today Spend                                                                  | Fun Money                                                              |
+| -------------- | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `systemSmall`  | Headline "spent today" amount + count of transactions + "vs typical" caption | Circular `Gauge` of discretionary used + remaining label               |
+| `systemMedium` | Left: today spend headline + sparkline-free caption; Right: fun-money gauge  | Combined: both metrics side by side with a single tap target each side |
+
+Layout rules (consistent with
+[`BudgetProgressWidget`](../../apps/ios/FinanceWidget/BudgetProgressWidget.swift)):
+
+- Use `Gauge(.accessoryCircular)` for fun-money progress; tint via
+  [`FinanceWidgetColors`](../../apps/ios/FinanceWidget/FinanceWidgetDesignTokens.swift)
+  status palette (`statusPositive` / `statusWarning` / `statusNegative`).
+- Money uses `.monospacedDigit()` with `.minimumScaleFactor(0.6)` and
+  `lineLimit(1)` so values never truncate under large Dynamic Type.
+- `.containerBackground(.fill.tertiary, for: .widget)` and
+  `.contentMarginsDisabled()` to match the shipped widgets.
+- The whole widget is a single `Link` to a deep link (identifiers only, never
+  money — see [§6](#6-privacy--balance-hiding)); medium splits into two `Link`s.
+
+Proposed deep links (extend
+[`FinanceWidgetDeepLinks`](../../apps/ios/Shared/WidgetPrivacy.swift) — identifiers only):
+
+- Today spend → `finance://spending/today`
+- Fun money → `finance://budget/discretionary`
+
+---
+
+## 3. Timeline Payloads & App Group Cache
+
+Two new Codable, `Sendable` payloads are written to the shared App Group
+(`group.com.finance.app`, via
+[`SharedConstants.sharedDefaults`](../../apps/ios/Shared/SharedConstants.swift))
+and read by the timeline provider. They carry **integer minor units only** plus
+an `updatedAt` stamp for staleness — exactly the convention used by
+`WidgetBalanceData` / `WidgetBudgetData` in
+[`WidgetDataWriter`](../../apps/ios/Finance/Services/WidgetDataWriter.swift).
+
+```text
+WidgetDaySpendData
+  spentTodayMinorUnits: Int64       // sum of today's expense transactions (positive)
+  typicalDayMinorUnits: Int64       // trailing average for "vs typical" caption (0 if unknown)
+  transactionCount: Int32
+  currencyCode: String
+  updatedAt: Date
+
+WidgetFunMoneyData
+  remainingMinorUnits: Int64        // discretionary headroom (may be negative)
+  limitMinorUnits: Int64            // discretionary envelope for the period
+  spentMinorUnits: Int64
+  periodEnd: Date                   // when the envelope resets (e.g. month end)
+  currencyCode: String
+  updatedAt: Date
+```
+
+Proposed cache keys (namespaced like the existing `widget.balance` /
+`widget.budgets`):
+
+| Key                 | Producer (app side)                          | Consumer (widget side)                |
+| ------------------- | -------------------------------------------- | ------------------------------------- |
+| `widget.todaySpend` | `WidgetDataWriter.writeTodaySpend(_:)` (new) | `WidgetDataProvider.readTodaySpend()` |
+| `widget.funMoney`   | `WidgetDataWriter.writeFunMoney(_:)` (new)   | `WidgetDataProvider.readFunMoney()`   |
+
+> The **producer** call sites and invalidation are owned by
+> [ios-widget-freshness-pipeline.md](./ios-widget-freshness-pipeline.md). This
+> doc only defines the payload shape and read path so the two designs compose.
+
+`derived` view-model values (computed in the widget, no money stored): masking
+mode via `WidgetDataProvider.maskingMode(for: "TodaySpendWidget")`,
+`funMoneyProgress = spent / limit` clamped to `0...1`, and a `status` enum
+(`onTrack` / `watch` / `over`) derived from progress thresholds (75% / 100%).
+
+---
+
+## 4. Timeline Refresh Flow
+
+The widget reload contract has two triggers: **data writes** from the app
+(push) and a **scheduled midnight rollover** (pull) so "Today" resets even if
+the app never opens.
+
+```mermaid
+flowchart TD
+    subgraph App["Finance app (host process)"]
+        A[Transaction saved / import / sync done] --> B[WidgetRefreshCoordinator]
+        B --> C[Bridge recompute<br/>today spend + fun money]
+        C --> D[WidgetDataWriter.writeTodaySpend / writeFunMoney]
+        D --> E[App Group cache:<br/>widget.todaySpend / widget.funMoney]
+        D --> F["WidgetCenter.reloadTimelines(ofKind: TodaySpendWidget)"]
+    end
+    subgraph Widget["TodaySpendWidget (extension process)"]
+        F --> G[TimelineProvider.getTimeline]
+        E --> G
+        G --> H{Cache present?}
+        H -->|yes & fresh| I[Render today spend + fun money]
+        H -->|yes & stale| J[Render with 'Updated …' note]
+        H -->|missing| K[Empty state]
+        G --> L["Schedule next reload .after(nextLocalMidnight)"]
+    end
+```
+
+Policy details:
+
+- **Reload kind:** target `ofKind: "TodaySpendWidget"` (not
+  `reloadAllTimelines`) to stay well under WidgetKit's daily reload budget.
+- **Scheduled rollover:** the timeline returns a single entry with
+  `policy: .after(nextLocalMidnight)` computed via `Calendar.current` so the
+  "Today" window flips at the user's local midnight. (Balance uses a 30-minute
+  `.after`; today spend is event-driven plus a daily boundary.)
+- **No network:** the provider only reads the cache; freshness is the host
+  app's responsibility ([ios-widget-freshness-pipeline.md](./ios-widget-freshness-pipeline.md)).
+
+---
+
+## 5. Copy & Localization
+
+All strings use `String(localized:)` with a `comment:` for translators, per the
+[content language guidelines](./content-language-guidelines.md). No hardcoded
+currency — formatting flows through `WidgetMoneyFormatter`.
+
+| Element                 | Copy (en)            | Notes                                                 |
+| ----------------------- | -------------------- | ----------------------------------------------------- |
+| Today header            | "Today"              | Reuses `WidgetDateFormatter` "Today" string           |
+| Today spend label       | "Spent today"        |                                                       |
+| Today vs typical (low)  | "Below your usual"   | Only when `typicalDayMinorUnits > 0`                  |
+| Today vs typical (high) | "Above your usual"   | Non-color cue pairs with `arrow.up` symbol            |
+| Fun money header        | "Fun money"          | Discretionary envelope                                |
+| Fun money remaining     | "{amount} left"      | `amount` masked per mode                              |
+| Fun money over          | "Over by {amount}"   | `status == .over`                                     |
+| Empty                   | "No cached spending" | + "Open Finance to sync." (matches budget empty copy) |
+| Stale                   | "Updated {relative}" | e.g. "Updated 3 h ago"                                |
+
+Tone: plain, non-judgmental ("Above your usual", not "You overspent") per the
+content guidelines. Numbers stay locale-formatted by `NumberFormatter`.
+
+---
+
+## 6. Privacy & Balance Hiding
+
+Widgets can be visible on a locked device, so this surface inherits the existing
+privacy model verbatim:
+
+- **Default masking is `.bucketed`** via
+  [`WidgetPrivacySettings.defaultMode`](../../apps/ios/Shared/WidgetPrivacy.swift);
+  the first time exact amounts could appear, the app raises the existing
+  first-add consent prompt
+  ([`WidgetPrivacyPrompt`](../../apps/ios/Finance/Services/WidgetPrivacyPrompt.swift))
+  before any precise figure is shown.
+- All money renders through
+  `WidgetCurrencyFormatter.format(…, mode:)` so `.bucketed`, `.percent`, and
+  `.dots` modes are honored. **Fun-money is ideal for `.percent`** — the gauge
+  and "% used" carry the meaning without revealing dollars.
+- **Deep links never carry money** — only identifiers
+  (`finance://spending/today`), matching the existing
+  `FinanceWidgetDeepLinks` contract ("They contain identifiers only, never money").
+- VoiceOver values are produced by `formatForVoiceOver(…, mode:)`, which keeps
+  masking consistent between the visual and spoken representations.
+
+---
+
+## 7. Accessibility
+
+Follows the [accessibility patterns library](./accessibility-patterns.md) and
+the iOS [non-color financial state cues](./ios-noncolor-financial-state-cues.md)
+guidance.
+
+- **VoiceOver:** each metric is one `.accessibilityElement(children: .combine)`
+  with an `.accessibilityLabel` (what) and `.accessibilityValue` (the masked
+  amount/percent). Example — Today: label "Spent today", value
+  "{masked amount}, {count} transactions, above your usual". Decorative SF
+  Symbols use `.accessibilityHidden(true)`; the gauge gets an explicit
+  `.accessibilityLabel`/`.accessibilityValue` ("{n} percent of fun money used").
+- **Dynamic Type:** no hardcoded point sizes — `.font(.system(.title2, …))`,
+  `.minimumScaleFactor(0.6)`, `lineLimit(1)` for money; captions may wrap. The
+  medium layout reflows to keep both metrics legible at the largest accessibility
+  sizes (see [ios-dynamic-type-reflow-audit.md](./ios-dynamic-type-reflow-audit.md)).
+- **Reduce Motion:** widgets do not animate timeline transitions, but the gauge
+  must not imply motion; render a static fill. No count-up animation.
+- **Never color alone:** over-budget is signaled by an SF Symbol (e.g.
+  `exclamationmark.triangle`) and text ("Over by …"), not red fill only —
+  consistent with [data-visualization §2.4](./data-visualization.md#24-never-color-alone)
+  and the budget widget's color + percent pairing.
+- **Contrast:** the CVD-safe status palette in `FinanceWidgetColors` already
+  meets contrast in light/dark; verify against
+  [data-visualization §2.1](./data-visualization.md#21-cvd-safe-palette).
+
+---
+
+## 8. States: Empty, Stale, Error & Placeholder
+
+| State           | Trigger                                            | Rendering                                                                          |
+| --------------- | -------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| **Placeholder** | `context.isPreview` / gallery                      | Static sample (e.g. "$24 spent today", 60% fun money) like widget previews         |
+| **Empty**       | No cache or decode returns nil                     | Icon + "No cached spending" + "Open Finance to sync." (no stale figure)            |
+| **Stale**       | `now - updatedAt` exceeds a threshold (e.g. > 6 h) | Render last values + caption "Updated {relative}" so the user isn't misled         |
+| **Error**       | Decode/encode failure                              | Fall back to empty state; host logs via `os.Logger` (`privacy: .public` keys only) |
+| **Over-budget** | `funMoney.status == .over`                         | Symbol + "Over by {amount}" + `statusNegative` tint                                |
+
+Staleness is computed from the payload's `updatedAt`; the freshness pipeline
+keeps it current, but the widget must **degrade gracefully** when the app hasn't
+refreshed (e.g. low-power mode throttling reloads).
+
+---
+
+## 9. Native ↔ KMP Boundary
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages/core + packages/models (KMP — DO NOT implement here)"]
+        K1[Money / minor-unit math]
+        K2["todaySpend(transactions, day)"]
+        K3["discretionaryRemaining(...)"]
+    end
+    subgraph Bridge["Swift Export bridge (apps/ios/Finance/KMP)"]
+        B1[SwiftExportAggregatorModule]
+    end
+    subgraph iOS["apps/ios (native — this design)"]
+        N1[WidgetRefreshCoordinator]
+        N2[WidgetDataWriter payloads]
+        N3[TodaySpendWidget view + formatting]
+    end
+    K1 --> B1
+    K2 --> B1
+    K3 --> B1
+    B1 --> N1 --> N2 --> N3
+```
+
+- The **calculation** of today's spend window and the discretionary envelope is
+  platform-neutral and belongs in KMP `packages/core` (alongside the existing
+  `totalSpending` / `savingsRate` aggregations exposed through
+  [`SwiftExportAggregatorModule`](../../apps/ios/Finance/KMP/SwiftExportBridge.swift)).
+- Two new shared methods are implied — a day-windowed spend and a discretionary
+  headroom — which should be **proposed to @kmp-engineer via an ADR**, not added
+  in this iOS work. Until they exist, the coordinator can compose them from the
+  current `totalSpending` plus a discretionary-category filter as a temporary
+  Swift-side adapter, clearly marked for migration.
+- iOS owns **only** WidgetKit plumbing, SwiftUI layout, masking/formatting, and
+  accessibility semantics — never the arithmetic.
+
+---
+
+## 10. Affected Surfaces & Shared Dependencies
+
+**New (this design):**
+
+- `apps/ios/FinanceWidget/TodaySpendWidget.swift` — widget + `TimelineProvider` + views.
+- `WidgetDaySpendData` / `WidgetFunMoneyData` payloads + read helpers in
+  `WidgetDataProvider`.
+
+**Touched by the companion freshness design (not here):**
+
+- [`WidgetDataWriter`](../../apps/ios/Finance/Services/WidgetDataWriter.swift) —
+  `writeTodaySpend` / `writeFunMoney` + `reloadTimelines(ofKind: "TodaySpendWidget")`.
+- [`FinanceWidgetBundle`](../../apps/ios/FinanceWidget/FinanceWidgetBundle.swift) —
+  register the new widget.
+
+**Reused unchanged:**
+
+- [`WidgetPrivacy.swift`](../../apps/ios/Shared/WidgetPrivacy.swift) (masking,
+  formatter, deep links), `FinanceWidgetDesignTokens` (palette/spacing),
+  `SharedConstants` (App Group), `WidgetPrivacyPrompt` (consent).
+
+**Shared dependency:** KMP `packages/core` day-spend / discretionary math
+(see [§9](#9-native--kmp-boundary)) — ADR required before native code lands.
+
+---
+
+## 11. Test Plan (Smallest Tests First)
+
+Smallest, fastest tests that must pass before implementation is accepted:
+
+1. **Payload round-trip (Swift unit):** encode/decode `WidgetDaySpendData` and
+   `WidgetFunMoneyData` via the App Group `UserDefaults` keys; assert minor
+   units and `updatedAt` survive ISO-8601.
+2. **Masking parity (Swift unit):** `WidgetCurrencyFormatter` under `.visible` /
+   `.bucketed` / `.percent` / `.dots` for representative amounts (incl. negative
+   fun money) — assert the spoken (`formatForVoiceOver`) and visual strings agree.
+3. **Status thresholds (Swift unit):** `funMoneyProgress` → `status`
+   (`onTrack` < 0.75 ≤ `watch` < 1.0 ≤ `over`), including the over-by case.
+4. **Timeline policy (Swift unit):** `getTimeline` returns `.after(nextLocalMidnight)`
+   and a present-cache entry; missing cache yields the empty entry.
+5. **State snapshots (SwiftUI preview/snapshot):** placeholder, empty, stale, and
+   over-budget renders at default and `.accessibility3` Dynamic Type.
+6. **VoiceOver labels (XCUITest, smallest):** assert `accessibilityLabel` /
+   `accessibilityValue` strings exist and are non-empty for both metrics.
+7. **Shared (KMP, owned by @kmp-engineer):** unit tests for the day-spend and
+   discretionary-headroom functions live in `packages/core` test sources, not iOS.
+
+---
+
+## 12. Implementation Readiness
+
+See [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md) for the full
+implementation-vs-distribution decoupling.
+
+**Buildable now (no paid enrollment) — free Personal Team signing:**
+
+- The entire WidgetKit surface, App Group timeline plumbing, masking, and
+  accessibility can be built and run on a device with a **free Apple ID**
+  (Personal Team), exactly as the shipped widgets are. App Groups work under
+  Personal Team signing for local verification.
+- All unit/snapshot/XCUITests in [§11](#11-test-plan-smallest-tests-first) run
+  locally without enrollment.
+
+**Distribution tail — gated by [#1239](https://github.com/jrmoulckers/finance/issues/1239):**
+
+- App Store / TestFlight distribution of the widget, and any **paid
+  entitlements** (push, Associated Domains for universal links) require Apple
+  Developer Program enrollment. Universal-link deep linking in production needs
+  Associated Domains; the in-app `finance://` scheme works under free signing.
+- Leave a `## Needs Human Action` note on the implementing PR pointing at
+  [§3.2 of the prerequisites runbook](../ops/human-gated-prerequisites.md#32-ios-distribution--apple-developer-1239)
+  only for the distribution criteria — not the feature work.
+
+---
+
+## 13. Open Questions
+
+1. **Discretionary definition:** is "fun money" a dedicated envelope/goal or a
+   filtered set of categories? Resolution drives the KMP method signature
+   (ADR with @kmp-engineer).
+2. **"Typical day" baseline:** trailing 30-day mean vs same-weekday mean — a
+   KMP-core concern; the widget only renders the result.
+3. **Stale threshold:** is 6 h the right cutoff, or should it follow the app's
+   sync cadence? Coordinate with [ios-widget-freshness-pipeline.md](./ios-widget-freshness-pipeline.md).
+4. **Accessory families:** confirm Lock Screen / watch variants are a separate
+   issue under #2159 so the payload can stay forward-compatible.

--- a/docs/design/ios-widget-freshness-pipeline.md
+++ b/docs/design/ios-widget-freshness-pipeline.md
@@ -1,0 +1,376 @@
+# iOS Widget Freshness Pipeline — Transaction Save & Sync
+
+> A design for **when and how** the App Group widget cache is rebuilt and
+> WidgetKit timelines are reloaded — so balance, budget, recent-transaction, and
+> the new today-spend / fun-money widgets reflect a transaction the moment it is
+> saved, imported, or synced, without thrashing WidgetKit's reload budget.
+
+**Status:** PROPOSED — design only (native implementation buildable now; store distribution gated)
+**Issue:** [#2585](https://github.com/jrmoulckers/finance/issues/2585) — Part of [#2159](https://github.com/jrmoulckers/finance/issues/2159)
+**Platform:** iOS / iPadOS (Swift concurrency + WidgetKit, iOS 17+)
+**Owner:** @ios-engineer
+**Related:** [ios-today-spend-funmoney-widget.md](./ios-today-spend-funmoney-widget.md) · [ios-savings-rate-dashboard-card.md](./ios-savings-rate-dashboard-card.md) · [accessibility-patterns.md](./accessibility-patterns.md) · [data-visualization.md](./data-visualization.md) · [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md)
+
+---
+
+## Table of Contents
+
+1. [Goal & Scope](#1-goal--scope)
+2. [Current State](#2-current-state)
+3. [Architecture: WidgetRefreshCoordinator](#3-architecture-widgetrefreshcoordinator)
+4. [Invalidation Flow](#4-invalidation-flow)
+5. [Call Sites](#5-call-sites)
+6. [Coalescing & Reload Budget](#6-coalescing--reload-budget)
+7. [States: Empty, Stale, Offline & Error](#7-states-empty-stale-offline--error)
+8. [Privacy & Logging](#8-privacy--logging)
+9. [Accessibility Implications](#9-accessibility-implications)
+10. [Native ↔ KMP Boundary](#10-native--kmp-boundary)
+11. [Affected Surfaces & Shared Dependencies](#11-affected-surfaces--shared-dependencies)
+12. [Test Plan (Smallest Tests First)](#12-test-plan-smallest-tests-first)
+13. [Implementation Readiness](#13-implementation-readiness)
+14. [Open Questions](#14-open-questions)
+
+---
+
+## 1. Goal & Scope
+
+A widget is only as trustworthy as its freshest number. Today the
+[`WidgetDataWriter`](../../apps/ios/Finance/Services/WidgetDataWriter.swift)
+actor can _write_ the App Group cache and reload a timeline, but **nothing
+calls it** on the data-mutating paths — so a user who logs a coffee sees a stale
+balance widget until something else happens to trigger a write.
+
+This design specifies the **freshness pipeline**: a single coordinator, the
+exact **call sites** that invoke it (transaction save, import, sync completion,
+app lifecycle, budget edits), the **cache-invalidation** rules, and the
+**coalescing** that keeps reloads within WidgetKit's daily budget.
+
+**In scope:**
+
+- A `WidgetRefreshCoordinator` that recomputes every widget payload from the
+  repositories + Swift Export aggregator and writes the App Group cache.
+- The triggers/call sites and a debounce/coalescing policy.
+- Empty / stale / offline / error behavior at the **data** layer (the visual
+  states live in each widget's design).
+- The `widget.todaySpend` / `widget.funMoney` keys from
+  [ios-today-spend-funmoney-widget.md](./ios-today-spend-funmoney-widget.md).
+
+**Out of scope:**
+
+- Widget _visual_ design (owned per-widget) and the today-spend payload shape
+  (defined in the companion doc).
+- The aggregation **math** itself — sourced from KMP `packages/core` via the
+  bridge ([§10](#10-native--kmp-boundary)).
+- Background _network_ sync scheduling internals (PowerSync owns that); this doc
+  only hooks the **completion** event.
+
+---
+
+## 2. Current State
+
+Grounded in the repository as it stands:
+
+- [`WidgetDataWriter`](../../apps/ios/Finance/Services/WidgetDataWriter.swift) is
+  an `actor` with `writeBalance`, `writeTransactions`, `writeBudgets`, each of
+  which encodes to `SharedConstants.sharedDefaults` and calls
+  `WidgetCenter.shared.reloadTimelines(ofKind:)`. **It has no callers** outside
+  its own file (verified by search).
+- [`WidgetDataProvider`](../../apps/ios/FinanceWidget/WidgetDataProvider.swift)
+  reads those keys cache-only and renders empty states when absent.
+- The only timeline reloads that fire today are from
+  [`WidgetPrivacyPrompt`](../../apps/ios/Finance/Services/WidgetPrivacyPrompt.swift)
+  (after a masking choice) and the watchOS app — **not** from data mutations.
+- [`DashboardViewModel`](../../apps/ios/Finance/ViewModels/DashboardViewModel.swift)
+  already recomputes balances, monthly income/expense, and savings rate via the
+  bridge aggregator — the same inputs the widget cache needs.
+- [`TransactionCreateViewModel.save()`](../../apps/ios/Finance/ViewModels/TransactionCreateViewModel.swift)
+  persists via `TransactionRepository` and returns success — the natural hook
+  for a post-save refresh.
+- [`PowerSyncManager`](../../apps/ios/Finance/Services/PowerSyncManager.swift)
+  exposes `observeSyncStatus()` and transitions to `.connected` after
+  `syncNow()` / `processOfflineQueue()` — the natural hook for a post-sync
+  refresh.
+
+**Conclusion:** the write primitive exists; this design supplies the missing
+_orchestration_ and _invalidation_.
+
+---
+
+## 3. Architecture: WidgetRefreshCoordinator
+
+Introduce a small `actor WidgetRefreshCoordinator` (Sendable, `SWIFT_STRICT_CONCURRENCY = complete`)
+that owns the rebuild-and-reload cycle. It does **not** duplicate math — it asks
+the repositories and the bridge aggregator, then hands plain payloads to
+`WidgetDataWriter`.
+
+```text
+actor WidgetRefreshCoordinator {
+  static let shared
+  // Dependencies injected: AccountRepository, TransactionRepository,
+  // BudgetRepository, SwiftExportAggregatorModule, WidgetDataWriter
+
+  func refresh(reason: RefreshReason) async   // coalesced entry point
+}
+
+enum RefreshReason: String, Sendable {         // for os.Logger (.public)
+  case transactionSaved, transactionDeleted, importCompleted,
+       syncCompleted, budgetChanged, appBackgrounded, manual
+}
+```
+
+Responsibilities:
+
+1. **Fetch** the same inputs the dashboard uses (accounts, recent transactions,
+   budgets) from the repositories.
+2. **Compute** payloads via the bridge: balance/trend, top budgets + rollup,
+   recent transactions, and (per the companion doc) today spend + fun money.
+3. **Write** each payload through `WidgetDataWriter`, which already reloads the
+   matching timeline kind.
+4. **Coalesce** rapid successive calls ([§6](#6-coalescing--reload-budget)).
+
+Keeping this in an actor guarantees serialized writes to the shared
+`UserDefaults` and a single in-flight rebuild, avoiding interleaved partial
+caches.
+
+---
+
+## 4. Invalidation Flow
+
+```mermaid
+flowchart TD
+    subgraph Triggers
+        T1[Transaction save / edit / delete]
+        T2[CSV / receipt import completes]
+        T3[Budget created / edited]
+        T4["PowerSync .connected (sync done)"]
+        T5[scenePhase → background]
+    end
+    T1 --> CO[WidgetRefreshCoordinator.refresh]
+    T2 --> CO
+    T3 --> CO
+    T4 --> CO
+    T5 --> CO
+    CO --> DB{Coalesce<br/>in-flight?}
+    DB -->|yes| MERGE[Drop / merge into pending]
+    DB -->|no| FETCH[Fetch accounts / txns / budgets]
+    FETCH --> AGG["Bridge aggregator<br/>(KMP core math)"]
+    AGG --> PAY[Build payloads]
+    PAY --> WRITE[WidgetDataWriter.write*]
+    WRITE --> CACHE[App Group UserDefaults]
+    WRITE --> RELOAD["WidgetCenter.reloadTimelines(ofKind:)"]
+    RELOAD --> WID[Widgets re-render from cache]
+```
+
+Invalidation is **write-through**: every refresh rewrites the full set of keys
+(or the affected subset) and reloads only the matching kinds. There is no
+partial/dirty-flag cache to get out of sync — the cache is always a projection
+of current repository state at `updatedAt`.
+
+---
+
+## 5. Call Sites
+
+| #   | Call site                                                                                                         | Trigger                  | Reload kinds                                         |
+| --- | ----------------------------------------------------------------------------------------------------------------- | ------------------------ | ---------------------------------------------------- |
+| 1   | [`TransactionCreateViewModel.save()`](../../apps/ios/Finance/ViewModels/TransactionCreateViewModel.swift) success | create / update          | balance, transactions, budgets, todaySpend, funMoney |
+| 2   | Transaction delete (edit/detail VM)                                                                               | delete                   | same as above                                        |
+| 3   | Import completion (CSV / receipt scan)                                                                            | batch insert done        | all                                                  |
+| 4   | [`PowerSyncManager.observeSyncStatus()`](../../apps/ios/Finance/Services/PowerSyncManager.swift) → `.connected`   | remote pull/push applied | all                                                  |
+| 5   | Budget create/edit (`BudgetCreateViewModel`)                                                                      | budget mutation          | budgets, funMoney                                    |
+| 6   | App `scenePhase` → `.background`                                                                                  | leaving foreground       | all (one final coalesced refresh)                    |
+
+Wiring rules:
+
+- View models call `await WidgetRefreshCoordinator.shared.refresh(reason:)`
+  **after** the repository write succeeds (so the cache reflects committed
+  state), not before. Failures do **not** refresh (avoids writing a half-applied
+  cache).
+- The sync hook subscribes once at app start to `observeSyncStatus()` and calls
+  `refresh(reason: .syncCompleted)` on each transition into `.connected` (and on
+  a successful `syncNow()` result), letting remote changes land in widgets.
+- The `scenePhase` hook ensures the cache is current before the app is
+  suspended, the most common moment a user then glances at a widget.
+
+---
+
+## 6. Coalescing & Reload Budget
+
+WidgetKit budgets timeline reloads (roughly dozens per widget per day); bulk
+imports or a sync that touches many rows must **not** issue one reload per row.
+
+- **Single in-flight rebuild:** the actor holds an `isRefreshing` flag; calls
+  arriving during a rebuild set a `pendingReason` rather than starting a second
+  pass. When the current pass finishes, exactly one follow-up runs if a request
+  arrived meanwhile.
+- **Debounce window:** coalesce bursts within a short window (e.g. 1–2 s) so a
+  multi-step save (transaction + tags + categorization learn) yields one reload.
+- **Per-kind targeting:** always `reloadTimelines(ofKind:)`, never
+  `reloadAllTimelines()` from the host app, so unaffected widgets keep their
+  budget. (The watch app's `reloadAllTimelines()` stays watch-scoped.)
+- **Import path:** import calls `refresh(reason: .importCompleted)` **once** at
+  the end of the batch, not per inserted row.
+
+> These are policy, not premature optimization: WidgetKit silently drops reloads
+> once the budget is spent, which would otherwise present as "my widget is
+> stale" bugs.
+
+---
+
+## 7. States: Empty, Stale, Offline & Error
+
+| Condition   | Coordinator behavior                                                                                                                                                                                                |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Empty**   | When repositories return no data, write **empty** payloads (e.g. `[]`, zeroed balance) so widgets show their _empty_ state — never leave a stale non-empty cache behind.                                            |
+| **Stale**   | Every payload carries `updatedAt`; widgets render an "Updated {relative}" note past a threshold (see companion docs). The coordinator's job is simply to keep `updatedAt` current.                                  |
+| **Offline** | Saves still write locally (offline-first), so the coordinator refreshes from the **local** repository immediately; the later `.syncCompleted` hook reconciles when connectivity returns. No spinner, no failure.    |
+| **Error**   | Encode failure is logged (`os.Logger`, `.public` keys only) and the prior cache is left intact — a known-good stale value beats a blank one. Repository read failure aborts the refresh without clearing the cache. |
+
+---
+
+## 8. Privacy & Logging
+
+- The cache stores **integer minor units** and identifiers only — the same shape
+  `WidgetDataWriter` already persists. Masking is applied at _render_ time by
+  `WidgetMoneyFormatter`, never at write time, so the privacy mode can change
+  without rewriting the cache.
+- **No financial values in logs.** Following the repo's `os.Logger` convention,
+  log only the `RefreshReason` (`privacy: .public`) and counts — never payee,
+  amount, or balance. Mirror the existing
+  [`DashboardViewModel`](../../apps/ios/Finance/ViewModels/DashboardViewModel.swift)
+  logging (`error.localizedDescription, privacy: .public`).
+- App Group access uses `SharedConstants.appGroupIdentifier`; no secrets are
+  written to the App Group — tokens remain in the Keychain, never in widget
+  storage.
+
+---
+
+## 9. Accessibility Implications
+
+This pipeline has no UI of its own, but it underpins the accessibility of every
+widget it feeds:
+
+- The "Updated {relative}" stale caption that VoiceOver reads is only accurate
+  if the coordinator keeps `updatedAt` fresh — so freshness is an accessibility
+  concern, not just a visual one.
+- By guaranteeing the cache reflects committed state, it prevents VoiceOver from
+  announcing an amount that no longer matches the app — a correctness/trust issue
+  for non-visual users.
+- No animation or motion is introduced, so [Reduce Motion](./accessibility-patterns.md#61-reduced-motion-support)
+  is unaffected; widgets render statically from the cache.
+
+---
+
+## 10. Native ↔ KMP Boundary
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages/core + packages/models (KMP — DO NOT implement here)"]
+        K1[Aggregations: balance, spend, savings, discretionary]
+    end
+    subgraph Bridge["Swift Export bridge (apps/ios/Finance/KMP)"]
+        B1[SwiftExportAggregatorModule]
+    end
+    subgraph iOS["apps/ios (native — this design)"]
+        N1[Repositories] --> N2[WidgetRefreshCoordinator]
+        B1 --> N2
+        N2 --> N3[WidgetDataWriter]
+        N3 --> N4[App Group cache + reloadTimelines]
+    end
+    K1 --> B1
+```
+
+- All **arithmetic** (totals, savings rate, today spend, discretionary headroom)
+  comes from KMP `packages/core` through the existing
+  [`SwiftExportAggregatorModule`](../../apps/ios/Finance/KMP/SwiftExportBridge.swift).
+  The coordinator **composes** these results into payloads; it does not compute
+  money itself.
+- The coordinator, `WidgetDataWriter`, App Group plumbing, coalescing, and reload
+  scheduling are **iOS-only** concerns.
+- Any _new_ shared aggregation (e.g. day-windowed spend) is proposed to
+  @kmp-engineer via ADR — not added in this iOS work.
+
+---
+
+## 11. Affected Surfaces & Shared Dependencies
+
+**New (this design):**
+
+- `apps/ios/Finance/Services/WidgetRefreshCoordinator.swift` — the orchestrator.
+
+**Touched (call-site wiring):**
+
+- `TransactionCreateViewModel`, the transaction edit/detail delete path,
+  `BudgetCreateViewModel`, the import flow, and the app's `scenePhase`/sync-status
+  subscription — each gains a single `await … refresh(reason:)` call.
+- [`WidgetDataWriter`](../../apps/ios/Finance/Services/WidgetDataWriter.swift) —
+  gains `writeTodaySpend` / `writeFunMoney` (defined in the companion doc).
+
+**Reused unchanged:**
+
+- [`WidgetDataProvider`](../../apps/ios/FinanceWidget/WidgetDataProvider.swift),
+  `SharedConstants`, `WidgetPrivacy.swift`, `PowerSyncManager.observeSyncStatus()`.
+
+**Shared dependency:** KMP `packages/core` aggregations via the Swift Export
+bridge ([§10](#10-native--kmp-boundary)).
+
+---
+
+## 12. Test Plan (Smallest Tests First)
+
+1. **Coalescing (Swift unit):** fire N rapid `refresh()` calls; assert exactly
+   one rebuild runs and at most one follow-up — using a fake `WidgetDataWriter`
+   that counts `reloadTimelines` invocations.
+2. **Write-through on save (Swift unit):** stub repositories + bridge; after
+   `refresh(reason: .transactionSaved)`, assert the App Group keys decode to the
+   expected payloads (balance, budgets, transactions) with a current `updatedAt`.
+3. **Empty projection (Swift unit):** with empty repositories, assert the cache
+   is written as empty (`[]` / zeroed) — not left stale.
+4. **Failure does not clobber (Swift unit):** a repository read error leaves the
+   previously cached values intact and logs the reason.
+5. **Sync hook (Swift unit):** feed a fake `observeSyncStatus()` stream that
+   yields `.connected`; assert `refresh(reason: .syncCompleted)` runs once per
+   transition.
+6. **Per-kind targeting (Swift unit):** assert the writer reloads only the kinds
+   whose payloads changed (no `reloadAllTimelines` from the host).
+7. **Lifecycle (XCUITest, smallest):** background the app after a save; relaunch
+   and assert the cache timestamp advanced (integration smoke).
+8. **Shared (KMP, owned by @kmp-engineer):** aggregation correctness is tested in
+   `packages/core`, not iOS.
+
+---
+
+## 13. Implementation Readiness
+
+See [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md).
+
+**Buildable now (no paid enrollment) — free Personal Team signing:**
+
+- App Groups, `UserDefaults(suiteName:)`, `WidgetCenter.reloadTimelines`, actor
+  concurrency, and all the call-site wiring run on a device under a **free Apple
+  ID** (Personal Team). No paid entitlement is required to verify the freshness
+  loop end to end locally.
+- Every test in [§12](#12-test-plan-smallest-tests-first) runs without enrollment.
+
+**Distribution tail — gated by [#1239](https://github.com/jrmoulckers/finance/issues/1239):**
+
+- Only App Store / TestFlight distribution of the app+widget bundle is gated.
+  The pipeline itself uses no paid entitlement (Background App Refresh and
+  WidgetKit reloads work under free signing for local testing).
+- Add a `## Needs Human Action` note on the PR pointing at
+  [§3.2 of the prerequisites runbook](../ops/human-gated-prerequisites.md#32-ios-distribution--apple-developer-1239)
+  for the distribution criterion only.
+
+---
+
+## 14. Open Questions
+
+1. **Debounce window:** confirm 1–2 s is right for the busiest path (bulk import)
+   vs perceived latency on a single save.
+2. **Delete path location:** does delete live in `TransactionEditViewModel`,
+   `TransactionsViewModel`, or both? Wire the coordinator wherever the repository
+   delete is awaited.
+3. **Sync granularity:** should a `.connected` transition with zero applied
+   changes still refresh? Default: yes, it's cheap after coalescing, but could be
+   gated on `changesApplied > 0` from `KMPSyncResult`.
+4. **BGTask refresh:** should a periodic `BGAppRefreshTask` also call the
+   coordinator for users who rarely open the app? Tracked separately under #2159.


### PR DESCRIPTION
## Summary

Three **new, design-only** docs under `docs/design/` for the iOS widget / savings
cluster (part of #2159 and #2162). No app, package, or shared config code is
touched — new files only. All platform-neutral spend/savings-rate math is kept
conceptually in KMP `packages/core` (boundary described, not implemented); the
WidgetKit / App Group timeline plumbing is buildable now under free Personal Team
signing, with the distribution tail gated by #1239.

Each doc follows `docs.instructions.md`: humans-first, a table of contents,
Mermaid diagrams (including the native ↔ KMP boundary and a timeline / cache
refresh flow), relative links to real `apps/ios` surfaces and existing
`docs/design` files, accessibility (VoiceOver, Dynamic Type, Reduce Motion),
privacy / balance-hiding, empty / stale / error states, a smallest-tests plan,
and an **Implementation readiness** section linking
[`../ops/human-gated-prerequisites.md`](docs/ops/human-gated-prerequisites.md)
that splits buildable-now from the #1239-gated distribution tail.

## Changes

- `docs/design/ios-today-spend-funmoney-widget.md` — Today Spend & Fun Money
  WidgetKit surface: small/medium families, App Group timeline payloads + cache
  keys, midnight-rollover refresh policy, privacy masking, copy, accessibility,
  and states.
- `docs/design/ios-widget-freshness-pipeline.md` — `WidgetRefreshCoordinator`,
  the transaction-save / import / sync-completion call sites, App Group cache
  invalidation, and reload-budget coalescing that wires the existing (but
  uncalled) `WidgetDataWriter`.
- `docs/design/ios-savings-rate-dashboard-card.md` — promotes the already-computed
  savings rate to a first-class Dashboard card: hierarchy, non-color trend badge,
  compact copy, 44 pt tap target, privacy (percent-first), and edge cases.

## Verification

- `npx prettier --check` passes on all three new files.
- Cross-links verified against existing `docs/design/` and `docs/ops/` files and
  real `apps/ios` source paths.

Closes #2583
Closes #2585
Closes #2589
