### PR TITLE
docs(design): android teen goal projection and beginner-mode design batch (#2661, #2663, #2675)

### DIFF
--- a/docs/design/android-goal-projection-widget.md
+++ b/docs/design/android-goal-projection-widget.md
@@ -1,0 +1,371 @@
+# Android Goal Projection Widget & Milestone States
+
+> **Status:** PROPOSED — Pending human review
+> **Issue:** [#2663](https://github.com/jrmoulckers/finance/issues/2663) · Part of [#2207](https://github.com/jrmoulckers/finance/issues/2207)
+> **Platform:** Android (Glance home-screen widget, WorkManager)
+> **Last Updated:** 2026-06-22
+> **Design only:** Native implementation remains blocked by [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+
+---
+
+## Table of Contents
+
+1. [Purpose](#purpose)
+2. [Goals and Non-Goals](#goals-and-non-goals)
+3. [Scope Boundaries With Sibling Work](#scope-boundaries-with-sibling-work)
+4. [Widget Data Contract](#widget-data-contract)
+5. [Shared Projection Boundary](#shared-projection-boundary)
+6. [Milestone and Pace States](#milestone-and-pace-states)
+7. [Widget States](#widget-states)
+8. [Refresh: WorkManager and Glance](#refresh-workmanager-and-glance)
+9. [Privacy-Safe Lock-Screen Copy](#privacy-safe-lock-screen-copy)
+10. [Estimates, Sensitivity, and Tone](#estimates-sensitivity-and-tone)
+11. [Accessibility Considerations](#accessibility-considerations)
+12. [Offline, Empty, and Error States](#offline-empty-and-error-states)
+13. [Test Plan](#test-plan)
+14. [Implementation Readiness](#implementation-readiness)
+15. [References](#references)
+
+---
+
+## Purpose
+
+The home-screen Goal Progress widget today renders **placeholder data** — the
+existing [`GoalProgressWidget`](../../apps/android/src/main/kotlin/com/finance/android/widget/GoalProgressWidget.kt)
+ships a `"No goals yet"` stub with a `TODO` to read real data. This document defines
+the **real data contract** the widget should consume — top goal, projected date,
+weekly target, and milestone state — and specifies every widget state (no-goal,
+offline, stale, behind-pace) plus refresh and privacy expectations.
+
+It is **design and breakdown only** while [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+gates Google Play distribution. The widget **consumes** shared projection outputs; it
+**never** recalculates finance formulas in Glance UI.
+
+---
+
+## Goals and Non-Goals
+
+**Goals**
+
+- Define a **widget data contract** carrying top goal, projected completion date,
+  weekly target, and milestone state.
+- Specify the **no-goal, offline, stale-data, and behind-pace** widget states.
+- Document **WorkManager / Glance refresh** expectations.
+- Specify **privacy-safe** copy for at-a-glance / lock-screen contexts.
+
+**Non-Goals**
+
+- The in-app, full-screen projection experience — owned by
+  [android-teen-goal-projections.md](android-teen-goal-projections.md).
+- Implementing or editing the projection math (lives in KMP `packages/core`; the web
+  `goal-projection-engine` is the parity reference).
+- Beginner-mode preference plumbing and jargon mapping — owned by
+  [android-teen-beginner-mode.md](android-teen-beginner-mode.md).
+- Editing KMP `packages/*`, web, or any non-Android platform.
+
+---
+
+## Scope Boundaries With Sibling Work
+
+```mermaid
+flowchart TD
+    THIS[Issue 2663: Goal projection widget<br/>THIS DOC: Glance data contract + states]
+    INAPP[Issue 2661: In-app projections<br/>full-screen Compose surfaces]
+    MODE[Issue 2675: Beginner mode<br/>plain-language copy]
+    KMP[KMP packages-core<br/>shared projection rules]
+
+    THIS -->|renders shared outputs| KMP
+    INAPP -->|renders same shared outputs| KMP
+    THIS -->|same plan, compact surface| INAPP
+    THIS -->|copy adapts under| MODE
+```
+
+The widget shows the **same plan** as the in-app card, in a glanceable surface. It
+owns the **data contract**, the **state matrix**, and **refresh + privacy** for the
+widget — nothing about the math.
+
+---
+
+## Widget Data Contract
+
+The contract is a small, **pre-formatted, render-ready** snapshot. The widget must
+not see raw balances or do arithmetic — it receives strings and an enum, mirroring
+how the existing `WidgetGoalData` is already pre-formatted before it reaches Glance.
+
+| Field             | Type        | Notes                                                       |
+| ----------------- | ----------- | ----------------------------------------------------------- |
+| `goalName`        | String      | Top (most advanced) active goal name.                       |
+| `projectedDate`   | String?     | Pre-formatted estimate, e.g. "Aug 2027"; null when unknown. |
+| `weeklyTarget`    | String?     | Pre-formatted, e.g. "$25/wk"; privacy-masked per mode.      |
+| `milestone`       | Enum        | first / quarter / halfway / almost / done.                  |
+| `pace`            | Enum        | behind / on-pace / ahead / complete.                        |
+| `progressPercent` | Int (0–100) | For the text/bar progress indicator.                        |
+| `totalGoals`      | Int         | "N active goals" footer.                                    |
+| `dataFreshness`   | Enum        | fresh / stale / offline.                                    |
+| `lastUpdated`     | String      | Human-readable, e.g. "Updated 2h ago".                      |
+
+```mermaid
+flowchart LR
+    REPO[Goal repository<br/>synced data] --> SUM[Shared projection summary]
+    SUM --> MAP[Widget mapper<br/>format + privacy mask]
+    MAP --> CONTRACT[WidgetGoalProjectionData<br/>pre-formatted snapshot]
+    CONTRACT --> GLANCE[Glance widget UI]
+```
+
+> The contract carries **already-localized, already-masked strings**, so Glance does
+> no formatting or math. The mapper applies [`WidgetPrivacyFormatter`](../../apps/android/src/main/kotlin/com/finance/android/widget/WidgetPrivacyFormatter.kt)
+> before the data reaches the widget.
+
+---
+
+## Shared Projection Boundary
+
+The widget consumes the **same shared projection summary** as the in-app surfaces.
+The web [`goal-projection-engine.ts`](../../apps/web/src/lib/savings/goal-projection-engine.ts)
+is the parity reference (`weeklyTargetCents`, `milestonePercent`,
+`behind | on-track | ahead | complete`). The equivalent shared model lives in KMP
+`packages/core`; Glance never recomputes it.
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages-core (shared - do NOT edit here)"]
+        ENGINE[Projection rules<br/>weekly target + milestone + pace]
+    end
+    subgraph Android["apps-android (this work)"]
+        MAP[Widget mapper<br/>format + privacy]
+        WIDGET[GoalProgressWidget - Glance]
+    end
+    ENGINE --> MAP --> WIDGET
+```
+
+> This document **describes** the boundary; it does **not** implement KMP changes.
+> `packages/core` is owned by @kmp-engineer; the web engine by @web-engineer.
+
+---
+
+## Milestone and Pace States
+
+Milestone and pace are **provided** by the shared summary; the widget only chooses a
+compact label/icon.
+
+| Milestone enum | Shared % | Compact widget label |
+| -------------- | -------- | -------------------- |
+| `first`        | > 0%     | "Started"            |
+| `quarter`      | ≥ 25%    | "25%"                |
+| `halfway`      | ≥ 50%    | "Halfway"            |
+| `almost`       | ≥ 75%    | "Almost there"       |
+| `done`         | 100%     | "Reached"            |
+
+```mermaid
+stateDiagram-v2
+    [*] --> OnPace
+    OnPace --> Behind: below expected
+    OnPace --> Ahead: above expected
+    Behind --> OnPace: caught up
+    Ahead --> OnPace: normalized
+    OnPace --> Complete: target reached
+    Behind --> Complete: target reached
+    Ahead --> Complete: target reached
+    Complete --> [*]
+```
+
+The behind-pace state never uses a "failure" framing — it shows the catch-up weekly
+target in compact form (e.g. "$35/wk to stay on track") and a non-color icon.
+
+---
+
+## Widget States
+
+```mermaid
+flowchart TD
+    START[Widget render] --> Q1{Any active goal?}
+    Q1 -->|no| NOGOAL[No-goal state]
+    Q1 -->|yes| Q2{Data fresh?}
+    Q2 -->|offline| OFFLINE[Offline state]
+    Q2 -->|stale| STALE[Stale-data state]
+    Q2 -->|fresh| Q3{Pace}
+    Q3 -->|behind| BEHIND[Behind-pace state]
+    Q3 -->|on-pace / ahead| OK[On-pace / ahead state]
+    Q3 -->|complete| DONE[Complete state]
+```
+
+| State         | What it shows                                                         |
+| ------------- | --------------------------------------------------------------------- |
+| No-goal       | Friendly prompt: "Pick something to save for" + tap-to-open.          |
+| On-pace/ahead | Goal name, "$X/wk", projected date estimate, milestone, on-pace icon. |
+| Behind-pace   | Same, with catch-up "$X/wk to stay on track" + neutral catch-up icon. |
+| Complete      | "Goal reached" celebratory state; no nagging.                         |
+| Stale-data    | Last-known plan + "Updated Nh ago" + subtle stale indicator.          |
+| Offline       | Last-known plan + "Offline — showing last saved" indicator.           |
+
+Every state remains tappable to open the app at the relevant goal
+([`MainActivity`](../../apps/android/src/main/kotlin/com/finance/android/widget/GoalProgressWidget.kt)
+deep-link target), matching the existing widget's `actionStartActivity` behavior.
+
+---
+
+## Refresh: WorkManager and Glance
+
+- **Trigger after sync.** The existing [`SyncWorker`](../../apps/android/src/main/kotlin/com/finance/android/sync/SyncWorker.kt)
+  already calls [`WidgetUpdater.refreshAll`](../../apps/android/src/main/kotlin/com/finance/android/widget/WidgetUpdater.kt)
+  after a successful sync, which calls `GoalProgressWidget().updateAll(context)`.
+  Real projection data flows on that existing path — no new scheduler.
+- **WorkManager only.** Periodic refresh uses **WorkManager** (never AlarmManager /
+  JobScheduler), with constraints and backoff tuned for battery; the widget reflects
+  whatever the last sync produced.
+- **Glance redraw.** On data change, the mapper produces a fresh contract snapshot
+  and `updateAll` redraws; Glance does no work beyond layout.
+- **Freshness, not spinners.** Widgets cannot show a live loading spinner, so the
+  contract carries a `dataFreshness` enum and a `lastUpdated` string the widget
+  renders as honest "Updated Nh ago" / "Offline" copy.
+
+```mermaid
+sequenceDiagram
+    participant WM as WorkManager
+    participant SW as SyncWorker
+    participant WU as WidgetUpdater
+    participant GW as GoalProgressWidget
+    WM->>SW: scheduled sync
+    SW->>SW: sync goals (shared summary refreshed)
+    SW->>WU: refreshAll(context)
+    WU->>GW: updateAll(context)
+    GW->>GW: render latest contract snapshot
+```
+
+---
+
+## Privacy-Safe Lock-Screen Copy
+
+Widgets can appear on the lock screen and in screenshots, so the widget must be
+**safe to show to a shoulder-surfer** by default — especially for a minor.
+
+- **Default to masked.** Reuse [`WidgetPrivacyFormatter`](../../apps/android/src/main/kotlin/com/finance/android/widget/WidgetPrivacyFormatter.kt)
+  (`Visible / Bucketed / Percent / Dots`). The widget's default mode hides exact
+  amounts; "progress only" (percent + milestone) is the safest lock-screen framing.
+- **No raw balances in glanceable text.** Show "Halfway to your car" or "$X/wk"
+  bucketed/masked, not "$6,700 of $10,000," unless the user opts into visible amounts.
+- **Goal name is optional.** Offer an option to hide the goal name (show "Your goal")
+  for users who do not want it on a lock screen.
+- **Never log.** Do not log goal names, amounts, targets, or projected dates via
+  Timber from the widget or its mapper.
+
+---
+
+## Estimates, Sensitivity, and Tone
+
+- **Label estimates.** Projected dates and targets are estimates; the widget shows
+  "est." / "about" framing in the compact copy and never a guaranteed date.
+- **Non-judgmental.** Behind-pace is catch-up, not failure, per
+  [content-language-guidelines.md](content-language-guidelines.md).
+- **Privacy-first for minors.** Masked by default; no analytics on goal contents.
+- **No dark patterns.** No urgency, no pressure, no upsell in the widget.
+
+---
+
+## Accessibility Considerations
+
+- **TalkBack:** the widget exposes one cohesive `contentDescription` summarizing the
+  plan ("Car goal, halfway there, save about $25 a week, estimated August 2027,
+  on pace; tap to open"), matching the existing widget's `semantics` approach but
+  fed by real, privacy-masked data.
+- **Switch Access:** the whole widget is a single actionable target (open app) with a
+  ≥ 48dp touch area.
+- **Font scaling:** Glance text honors system font scale; the layout must stay legible
+  and avoid clipping the plan line at large scales (prefer fewer, prioritized lines).
+- **Plain language / cognitive load:** the widget shows **one** plan and **one**
+  milestone — never a dense dashboard — aligned with [cognitive-accessibility.md](cognitive-accessibility.md).
+- **Non-color cues:** pace is conveyed with icon + text, never color alone, per
+  [data-visualization.md](data-visualization.md).
+- See [accessibility-patterns.md](accessibility-patterns.md) for the underlying patterns.
+
+---
+
+## Offline, Empty, and Error States
+
+- **Offline:** render the **last-known** contract snapshot with an "Offline — showing
+  last saved" indicator; never blank, never an error card.
+- **Empty (no goal):** show the no-goal prompt inviting goal creation.
+- **Stale:** when the last sync is old, keep the plan but surface "Updated Nh ago" so
+  the saver knows it may have moved.
+- **Error:** if a contract snapshot cannot be produced, fall back to the safest
+  framing (progress-only / milestone) with "Plan unavailable right now"; never crash
+  the widget host, never show a stack trace.
+
+---
+
+## Test Plan
+
+| Layer             | Tooling                         | What it verifies                                                                  |
+| ----------------- | ------------------------------- | --------------------------------------------------------------------------------- |
+| Unit              | JUnit                           | Mapper builds the contract from a shared summary for every milestone/pace combo.  |
+| Unit (privacy)    | JUnit                           | Masking modes produce no raw amounts by default; no Timber logs goal data.        |
+| Unit (states)     | JUnit                           | no-goal / offline / stale / behind-pace resolve to the correct state.             |
+| Compose/Glance UI | `createComposeRule` + semantics | Each state renders expected text + `contentDescription`.                          |
+| Snapshot          | Paparazzi                       | no-goal, on-pace, behind-pace, complete, stale, offline at `{1x, 2x}` light/dark. |
+| Refresh           | WorkManager test / instrumented | `SyncWorker` → `WidgetUpdater.refreshAll` redraws with new data.                  |
+| Accessibility     | Espresso/Accessibility checks   | Single actionable target, ≥ 48dp, TalkBack summary correct.                       |
+
+---
+
+## Implementation Readiness
+
+This is a design artifact. Execution splits into a **buildable-now** tier and a
+**Play-distribution tail** gated by
+[#1242](https://github.com/jrmoulckers/finance/issues/1242). See
+[../ops/human-gated-prerequisites.md](../ops/human-gated-prerequisites.md) and
+[../ops/launch-readiness-plan.md](../ops/launch-readiness-plan.md).
+
+**Buildable now — `assembleDebug` + sideload (no human gate):**
+
+- The **Glance widget plumbing is debug-implementable today**: define the data
+  contract, build the mapper (with privacy masking), wire the state matrix, and
+  render every state from mock/last-known data.
+- Reuse the existing `SyncWorker` → `WidgetUpdater.refreshAll` → `updateAll` path; no
+  new scheduling API.
+- Verify states, privacy masking, refresh, accessibility, and snapshots on a debug
+  build / emulator — **no signing, store credentials, or human-gated operations**.
+
+**Play-distribution tail — human-gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242):**
+
+- Production signing + Play Console listing.
+- Data-safety declaration covering widget surfaces and minors' data.
+- Staged rollout / internal testing track.
+
+The shared projection model is delivered by KMP `packages/core`; the widget renders it.
+
+---
+
+## References
+
+**Design docs**
+
+- [android-teen-goal-projections.md](android-teen-goal-projections.md) — in-app projection surfaces (#2661)
+- [android-teen-beginner-mode.md](android-teen-beginner-mode.md) — beginner mode + plain language (#2675)
+- [content-language-guidelines.md](content-language-guidelines.md) — non-judgmental, plain copy
+- [cognitive-accessibility.md](cognitive-accessibility.md) — plain-language and load reduction
+- [accessibility-patterns.md](accessibility-patterns.md) — screen reader, focus, touch targets
+- [data-visualization.md](data-visualization.md) — progress visuals, non-color cues
+- [chart-component-specs.md](chart-component-specs.md) — progress ring/bar specs
+- [information-architecture.md](information-architecture.md) — surface and navigation map
+- [ux-principles.md](ux-principles.md) — product UX principles
+- [personas.md](personas.md) — Persona 4 (Casey)
+
+**Ops**
+
+- [../ops/human-gated-prerequisites.md](../ops/human-gated-prerequisites.md) — buildable-now vs. gated split
+- [../ops/launch-readiness-plan.md](../ops/launch-readiness-plan.md) — launch checklist
+
+**Android / web / KMP (read-only boundary)**
+
+- [`GoalProgressWidget.kt`](../../apps/android/src/main/kotlin/com/finance/android/widget/GoalProgressWidget.kt) — existing widget (placeholder data)
+- [`WidgetPrivacyFormatter.kt`](../../apps/android/src/main/kotlin/com/finance/android/widget/WidgetPrivacyFormatter.kt) — masking modes
+- [`WidgetUpdater.kt`](../../apps/android/src/main/kotlin/com/finance/android/widget/WidgetUpdater.kt) — refresh entry point
+- [`SyncWorker.kt`](../../apps/android/src/main/kotlin/com/finance/android/sync/SyncWorker.kt) — WorkManager sync entry point
+- [`goal-projection-engine.ts`](../../apps/web/src/lib/savings/goal-projection-engine.ts) — web parity reference (owned by @web-engineer)
+- [`Goal.kt`](../../packages/models/src/commonMain/kotlin/com/finance/models/Goal.kt) — shared goal model (owned by @kmp-engineer)
+
+**Issues**
+
+- [#2663](https://github.com/jrmoulckers/finance/issues/2663) — this issue
+- [#2207](https://github.com/jrmoulckers/finance/issues/2207) — parent (teen goal cluster)
+- [#1242](https://github.com/jrmoulckers/finance/issues/1242) — Play Console + keystore (gate)

--- a/docs/design/android-teen-beginner-mode.md
+++ b/docs/design/android-teen-beginner-mode.md
@@ -1,0 +1,332 @@
+# Android Teen Beginner Mode & Plain-Language Surfaces
+
+> **Status:** PROPOSED — Pending human review
+> **Issue:** [#2675](https://github.com/jrmoulckers/finance/issues/2675) · Part of [#2209](https://github.com/jrmoulckers/finance/issues/2209)
+> **Platform:** Android (Jetpack Compose, preference-driven)
+> **Last Updated:** 2026-06-22
+> **Design only:** Native implementation remains blocked by [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+
+---
+
+## Table of Contents
+
+1. [Purpose](#purpose)
+2. [Persona and Why This Matters](#persona-and-why-this-matters)
+3. [Goals and Non-Goals](#goals-and-non-goals)
+4. [Scope Boundaries With Sibling Work](#scope-boundaries-with-sibling-work)
+5. [The Beginner-Mode Preference](#the-beginner-mode-preference)
+6. [Entry Points](#entry-points)
+7. [Copy Transformations](#copy-transformations)
+8. [Cognitive Accessibility Patterns](#cognitive-accessibility-patterns)
+9. [Estimates, Privacy, and Tone](#estimates-privacy-and-tone)
+10. [Accessibility Considerations](#accessibility-considerations)
+11. [Offline, Empty, and Error States](#offline-empty-and-error-states)
+12. [Test Plan](#test-plan)
+13. [Implementation Readiness](#implementation-readiness)
+14. [References](#references)
+
+---
+
+## Purpose
+
+A teen or first-time saver opening the app meets words like "budget variance,"
+"net worth," and "allocation" — vocabulary that signals "this app isn't for me."
+This document designs a **preference-driven beginner mode**: a single toggle that
+swaps finance jargon for plain, teen-first language (needs / wants / saving for
+later), simplifies categories, and applies cognitive-accessibility patterns across
+key surfaces.
+
+It is **design and breakdown only** while [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+gates Google Play distribution. It reuses the existing
+[`ExpertiseTier`](../../apps/android/src/main/kotlin/com/finance/android/ui/expertise/ExpertiseTier.kt)
+concept and the cognitive-accessibility design rather than inventing a parallel
+system, and writes **no Kotlin** here.
+
+---
+
+## Persona and Why This Matters
+
+The persona ([#2209](https://github.com/jrmoulckers/finance/issues/2209)): a teen or
+absolute beginner who is capable and motivated but not yet fluent in finance terms.
+Jargon is a barrier to entry, not a feature. This persona maps closely to
+[Persona 4: Casey](personas.md) (plain language, low cognitive load) and the existing
+`ExpertiseTier.BEGINNER`, which already promises "simplified views with helpful
+guidance."
+
+> Beginner mode is a **presentation preference**, not a different data model. The same
+> goals, budgets, and transactions are shown — just named and framed in plain
+> language. No finance math changes.
+
+---
+
+## Goals and Non-Goals
+
+**Goals**
+
+- Define a **beginner-mode preference**: where it lives, how it is set, how surfaces
+  read it reactively.
+- Define **onboarding and settings entry points** for turning beginner mode on.
+- Specify **copy transformations** from finance jargon (budgets, goals, learning) to
+  plain language (needs / wants / saving for later).
+- Apply **cognitive-accessibility patterns** to teen-first surfaces.
+
+**Non-Goals**
+
+- Goal projection surfaces and copy — owned by
+  [android-teen-goal-projections.md](android-teen-goal-projections.md).
+- Widget rendering — owned by [android-goal-projection-widget.md](android-goal-projection-widget.md).
+- Changing any finance calculation, category model, or data schema (KMP `packages/*`).
+- Editing KMP `packages/*`, web, or any non-Android platform.
+
+---
+
+## Scope Boundaries With Sibling Work
+
+```mermaid
+flowchart TD
+    THIS[Issue 2675: Beginner mode<br/>THIS DOC: preference + plain language]
+    PROJ[Issue 2661: Goal projections<br/>copy adapts under beginner mode]
+    WIDGET[Issue 2663: Goal widget<br/>copy adapts under beginner mode]
+    TIER[ExpertiseTier - existing<br/>BEGINNER tier + feature config]
+
+    THIS -->|builds on| TIER
+    PROJ -->|reads| THIS
+    WIDGET -->|reads| THIS
+```
+
+This doc owns the **preference** and the **plain-language layer**. Sibling surfaces
+read the preference to decide which copy to show; they do not define the preference
+themselves.
+
+---
+
+## The Beginner-Mode Preference
+
+Beginner mode reuses the existing tier infrastructure rather than adding a competing
+flag. The app already has
+[`ExpertiseTierManager`](../../apps/android/src/main/kotlin/com/finance/android/ui/expertise/ExpertiseTierManager.kt),
+which persists the selected tier and exposes it as a reactive `StateFlow` for Compose.
+`ExpertiseTier.BEGINNER` already drives
+[`TierFeatureConfig`](../../apps/android/src/main/kotlin/com/finance/android/ui/expertise/ExpertiseTier.kt)
+(`showSimplifiedLabels = true`, `showGuidedWorkflows = true`, fewer categories).
+
+```mermaid
+flowchart LR
+    PREF[Beginner-mode preference<br/>maps to ExpertiseTier.BEGINNER]
+    MGR[ExpertiseTierManager<br/>StateFlow of current tier]
+    CFG[TierFeatureConfig<br/>simplified labels + guidance]
+    UI[Compose surfaces<br/>choose plain-language copy]
+
+    PREF --> MGR --> CFG --> UI
+```
+
+- **Storage:** the tier flag is a **non-sensitive UI preference**; it persists via the
+  existing preference-backed `ExpertiseTierManager` `StateFlow`. (Secrets never go in
+  SharedPreferences — but a display-mode flag is not a secret.)
+- **Reactive:** surfaces observe the tier flow; flipping the toggle updates copy
+  immediately without a restart.
+- **Independent of accessibility mode:** beginner mode and
+  [cognitive-accessibility.md](cognitive-accessibility.md) mode can be combined; they
+  are orthogonal toggles.
+
+---
+
+## Entry Points
+
+```mermaid
+flowchart TD
+    OB[Onboarding] -->|"New to this? Use simple words"| SET1[Beginner mode ON]
+    SETTINGS[Settings - Display / Experience] --> TOGGLE{Beginner mode}
+    TOGGLE -->|on| SIMPLE[Plain-language surfaces]
+    TOGGLE -->|off| STD[Standard labels]
+    EXP[Existing ExpertiseTier screen] --> TOGGLE
+```
+
+- **Onboarding:** during onboarding
+  ([`OnboardingScreen`](../../apps/android/src/main/kotlin/com/finance/android/ui/onboarding/OnboardingScreen.kt)),
+  offer a friendly, opt-in choice ("New to money apps? We'll use simple words") that
+  maps to the beginner tier — never assumed, never a dark pattern.
+- **Settings:** a discoverable toggle in the experience/display settings, co-located
+  with the existing
+  [`ExpertiseTierScreen`](../../apps/android/src/main/kotlin/com/finance/android/ui/expertise/ExpertiseTierScreen.kt)
+  so beginner mode is just the friendly name for the BEGINNER tier.
+- **Reversible anywhere:** the saver can turn it on or off at any time with no data
+  loss and no penalty.
+
+---
+
+## Copy Transformations
+
+Beginner mode swaps presentation strings only; the underlying records are unchanged.
+All copy is resource-backed and follows
+[content-language-guidelines.md](content-language-guidelines.md).
+
+| Standard term        | Plain-language (beginner mode) |
+| -------------------- | ------------------------------ |
+| Budget               | Spending plan                  |
+| Budget category      | What I spend on                |
+| Needs                | Stuff I have to pay for        |
+| Wants                | Stuff I choose to buy          |
+| Goal / target amount | What I'm saving for            |
+| Savings goal         | Saving for later               |
+| Net worth            | What I have                    |
+| Allocation           | How it's split                 |
+| Variance / over      | A little more than planned     |
+| Transaction          | Money in / money out           |
+| Projection           | Estimate of what's next        |
+
+**Copy rules**
+
+- One idea per label; avoid compound finance terms.
+- Frame "needs / wants / saving for later" as the simplified category trio rather than
+  formal budgeting buckets.
+- Never shame: "a little more than planned" instead of "over budget."
+- Estimates stay labelled as estimates even in plain language ("an estimate, not a
+  promise").
+- Plain language must not become **inaccurate** language — simpler words, same truth.
+
+---
+
+## Cognitive Accessibility Patterns
+
+Beginner mode adopts the patterns in
+[cognitive-accessibility.md](cognitive-accessibility.md) on teen-first surfaces:
+
+- **One primary action per screen**; defer secondary options behind "More."
+- **Fewer categories at once** (the BEGINNER `maxBudgetCategories` already caps this).
+- **Short sentences, concrete nouns, no acronyms** without an inline plain definition.
+- **Guided workflows** (BEGINNER `showGuidedWorkflows = true`) for first-time tasks.
+- **Generous touch targets and spacing**; calm, low-novelty visuals.
+- **Progressive disclosure**: advanced metrics are hidden, not removed, and reachable
+  when the saver is ready.
+
+```mermaid
+flowchart LR
+    A[Surface under beginner mode] --> B[Plain labels]
+    A --> C[One primary action]
+    A --> D[Fewer items + progressive disclosure]
+    A --> E[Inline plain definitions for any term]
+```
+
+---
+
+## Estimates, Privacy, and Tone
+
+- **Label every estimate.** Plain-language framing never drops the estimate label;
+  projections remain "an estimate, not a promise."
+- **Privacy-first for minors.** Beginner mode is a display preference only — it must
+  not enable extra data collection or analytics on what a minor is saving for. Never
+  log goal names, amounts, or category contents via Timber.
+- **Encouraging, non-judgmental tone** per
+  [content-language-guidelines.md](content-language-guidelines.md).
+- **No dark patterns.** The onboarding prompt is a neutral, opt-in choice — no
+  pressure, no pre-checked manipulation, fully reversible.
+
+---
+
+## Accessibility Considerations
+
+- **TalkBack:** the beginner-mode toggle has a clear `contentDescription` and announces
+  its on/off state and effect ("Beginner mode, on: uses simple words"). Surfaces that
+  re-label in plain language keep correct, updated descriptions.
+- **Switch Access:** the toggle and all re-labelled controls are reachable and operable
+  with touch targets ≥ 48dp.
+- **Font scaling:** plain-language labels (often longer) stay unclipped at **200%**
+  font scale; no fixed-height chips or single-line truncation of category names.
+- **Plain language / cognitive load:** this entire mode _is_ a cognitive-accessibility
+  feature — see [cognitive-accessibility.md](cognitive-accessibility.md).
+- **Non-color cues:** any "needs vs. wants vs. saving" distinction uses text/icon, not
+  color alone, per [data-visualization.md](data-visualization.md).
+- See [accessibility-patterns.md](accessibility-patterns.md) for the underlying patterns.
+
+---
+
+## Offline, Empty, and Error States
+
+- **Offline:** beginner mode is a local preference and **must work fully offline** —
+  the toggle and all re-labelled copy are available without a network.
+- **Empty:** empty states get the friendliest plain-language framing ("Nothing here
+  yet — let's add your first thing to save for").
+- **Error (preference read/write):** if the preference cannot be read, **default to
+  standard labels** (the safe, accurate baseline) rather than a broken half-state; if
+  it cannot be written, surface a quiet "Couldn't save that setting" and keep the
+  in-memory choice for the session.
+- **Toggle race:** flipping the toggle quickly must settle on the last value with no
+  flicker between vocabularies mid-screen.
+
+---
+
+## Test Plan
+
+| Layer              | Tooling                         | What it verifies                                                                       |
+| ------------------ | ------------------------------- | -------------------------------------------------------------------------------------- |
+| Unit               | JUnit                           | Beginner preference maps to `ExpertiseTier.BEGINNER` + simplified `TierFeatureConfig`. |
+| Unit (copy)        | JUnit                           | Each standard term has a plain-language string; no plain string changes a number.      |
+| Unit (privacy)     | JUnit                           | Toggling mode triggers no extra data collection; no Timber logs goal/category data.    |
+| Compose UI         | `createComposeRule` + semantics | Toggle announces state; surfaces swap labels reactively from the tier flow.            |
+| Snapshot           | Paparazzi                       | Key surfaces in standard vs. beginner copy at `{1x, 2x}`, light/dark.                  |
+| Pseudolocalization | `en-XA` / `ar-XB`               | Longer plain-language labels expand/mirror without clipping.                           |
+| Accessibility      | Espresso/Accessibility checks   | TalkBack toggle label, Switch Access reachability, touch targets ≥ 48dp.               |
+
+---
+
+## Implementation Readiness
+
+This is a design artifact. Execution splits into a **buildable-now** tier and a
+**Play-distribution tail** gated by
+[#1242](https://github.com/jrmoulckers/finance/issues/1242). See
+[../ops/human-gated-prerequisites.md](../ops/human-gated-prerequisites.md) and
+[../ops/launch-readiness-plan.md](../ops/launch-readiness-plan.md).
+
+**Buildable now — `assembleDebug` + sideload (no human gate):**
+
+- Wire the beginner-mode preference onto the existing `ExpertiseTierManager` tier flow
+  and add the onboarding + settings entry points.
+- Author resource-backed plain-language strings and apply them reactively on key
+  surfaces.
+- Verify copy transformations, cognitive-accessibility patterns, accessibility, and
+  pseudolocale/expansion snapshots on a debug build / emulator — **no signing, store
+  credentials, or human-gated operations**.
+
+**Play-distribution tail — human-gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242):**
+
+- Production signing + Play Console listing.
+- Content-rating / data-safety declarations that reference a teen/beginner experience.
+- Staged rollout / internal testing track.
+
+No finance math or schema changes are involved — beginner mode is a presentation layer
+over existing shared data.
+
+---
+
+## References
+
+**Design docs**
+
+- [android-teen-goal-projections.md](android-teen-goal-projections.md) — goal projection surfaces (#2661)
+- [android-goal-projection-widget.md](android-goal-projection-widget.md) — home-screen widget states (#2663)
+- [cognitive-accessibility.md](cognitive-accessibility.md) — plain-language and load reduction
+- [content-language-guidelines.md](content-language-guidelines.md) — non-judgmental, plain copy
+- [accessibility-patterns.md](accessibility-patterns.md) — screen reader, focus, touch targets
+- [data-visualization.md](data-visualization.md) — non-color cues
+- [information-architecture.md](information-architecture.md) — surface and navigation map
+- [ux-principles.md](ux-principles.md) — product UX principles
+- [personas.md](personas.md) — Persona 4 (Casey)
+
+**Ops**
+
+- [../ops/human-gated-prerequisites.md](../ops/human-gated-prerequisites.md) — buildable-now vs. gated split
+- [../ops/launch-readiness-plan.md](../ops/launch-readiness-plan.md) — launch checklist
+
+**Android (read-only boundary)**
+
+- [`ExpertiseTier.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/expertise/ExpertiseTier.kt) — tier enum + `TierFeatureConfig`
+- [`ExpertiseTierManager.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/expertise/ExpertiseTierManager.kt) — reactive tier preference
+- [`ExpertiseTierScreen.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/expertise/ExpertiseTierScreen.kt) — existing tier settings surface
+- [`OnboardingScreen.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/onboarding/OnboardingScreen.kt) — onboarding entry point
+
+**Issues**
+
+- [#2675](https://github.com/jrmoulckers/finance/issues/2675) — this issue
+- [#2209](https://github.com/jrmoulckers/finance/issues/2209) — parent (beginner/teen mode cluster)
+- [#1242](https://github.com/jrmoulckers/finance/issues/1242) — Play Console + keystore (gate)

--- a/docs/design/android-teen-goal-projections.md
+++ b/docs/design/android-teen-goal-projections.md
@@ -1,0 +1,373 @@
+# Android Teen Goal Projections & Save-X-Per-Week UI
+
+> **Status:** PROPOSED — Pending human review
+> **Issue:** [#2661](https://github.com/jrmoulckers/finance/issues/2661) · Part of [#2207](https://github.com/jrmoulckers/finance/issues/2207)
+> **Platform:** Android (Jetpack Compose, Material 3)
+> **Last Updated:** 2026-06-22
+> **Design only:** Native implementation remains blocked by [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+
+---
+
+## Table of Contents
+
+1. [Purpose](#purpose)
+2. [Persona and Why This Matters](#persona-and-why-this-matters)
+3. [Goals and Non-Goals](#goals-and-non-goals)
+4. [Scope Boundaries With Sibling Work](#scope-boundaries-with-sibling-work)
+5. [Projection Math Lives in KMP](#projection-math-lives-in-kmp)
+6. [Plain-Language Copy](#plain-language-copy)
+7. [Compose Surfaces](#compose-surfaces)
+8. [Milestone and Pace States](#milestone-and-pace-states)
+9. [Paycheck-Based Targets](#paycheck-based-targets)
+10. [Estimates, Sensitivity, and Tone](#estimates-sensitivity-and-tone)
+11. [Accessibility Considerations](#accessibility-considerations)
+12. [Offline, Empty, and Error States](#offline-empty-and-error-states)
+13. [Test Plan](#test-plan)
+14. [Implementation Readiness](#implementation-readiness)
+15. [References](#references)
+
+---
+
+## Purpose
+
+A teen saving for a first car, a phone, or a concert ticket does not think in
+"savings rate" or "time-to-goal velocity." They think: _"How much do I put aside
+each week, and when do I get the thing?"_ This document designs the Compose
+surfaces that answer exactly those two questions for the **top goals** on Android,
+using teen-friendly, plain-language copy and clearly labelled **estimates**.
+
+It is **design and breakdown only** while [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+gates Google Play distribution. No Kotlin is written here, and no finance math is
+implemented in Compose — the projection logic is a **shared KMP concern**, with the
+web `goal-projection-engine` as the parity reference.
+
+---
+
+## Persona and Why This Matters
+
+The persona ([#2207](https://github.com/jrmoulckers/finance/issues/2207)): a teen or
+beginner saver who is motivated by a concrete _thing_ and a concrete _date_, not by
+abstract financial dashboards. They benefit from a single, confident sentence —
+"Save $25/week to get your car by Aug 2027" — far more than from a chart full of
+projections. This intersects with [Persona 4: Casey](personas.md) (plain language,
+low cognitive load) and the broader beginner-mode work in
+[android-teen-beginner-mode.md](android-teen-beginner-mode.md).
+
+> **Important framing:** every date and dollar figure on these surfaces is an
+> **estimate**, visibly labelled as such, and never a promise. See
+> [Estimates, Sensitivity, and Tone](#estimates-sensitivity-and-tone).
+
+---
+
+## Goals and Non-Goals
+
+**Goals**
+
+- Show **save-$X/week** and a **projected completion date** for each top goal.
+- Offer a **paycheck-based target** option alongside the weekly target.
+- Provide **behind / on-pace / ahead** messaging in encouraging, non-judgmental copy.
+- Define **milestone checkpoints** (first deposit, quarter, halfway, almost there,
+  done) and the catch-up language used when a saver falls behind.
+- Keep parity with the web `GoalProjection` surface so the two platforms agree.
+
+**Non-Goals**
+
+- Implementing or editing the projection math (lives in KMP `packages/core`; the web
+  engine is the parity reference — see [Projection Math Lives in KMP](#projection-math-lives-in-kmp)).
+- The home-screen Glance widget rendering of these outputs — owned by
+  [android-goal-projection-widget.md](android-goal-projection-widget.md).
+- Beginner-mode preference plumbing and jargon-to-plain copy mapping — owned by
+  [android-teen-beginner-mode.md](android-teen-beginner-mode.md).
+- Editing KMP `packages/*`, web, or any non-Android platform.
+
+---
+
+## Scope Boundaries With Sibling Work
+
+```mermaid
+flowchart TD
+    THIS[Issue 2661: Teen goal projections<br/>THIS DOC: in-app Compose surfaces]
+    WIDGET[Issue 2663: Goal projection widget<br/>Glance home-screen states]
+    MODE[Issue 2675: Beginner mode<br/>preference + plain language]
+    KMP[KMP packages-core<br/>shared projection rules]
+
+    THIS -->|renders shared outputs| KMP
+    WIDGET -->|renders same shared outputs| KMP
+    THIS -->|copy adapts under| MODE
+    THIS -->|same numbers, smaller surface| WIDGET
+```
+
+This doc owns the **in-app, full-screen Compose** projection experience. The compact
+home-screen rendering is the widget doc; the preference that flips copy into
+plain-language teen mode is the beginner-mode doc. All three consume the **same**
+shared projection outputs.
+
+---
+
+## Projection Math Lives in KMP
+
+The projection calculation is **business logic** and must be shared, not duplicated
+in Compose. The web reference already exists as
+[`goal-projection-engine.ts`](../../apps/web/src/lib/savings/goal-projection-engine.ts),
+which produces a summary of `weeklyTargetCents`, `paycheckTargetCents`,
+`milestonePercent`, a `state` of `behind | on-track | ahead | complete`, and a
+`messageToken`. The Android client should consume an **equivalent shared model from
+KMP `packages/core`** so both platforms agree on every number and every state.
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages-core (shared - do NOT edit here)"]
+        ENGINE[Goal projection rules<br/>weekly + paycheck targets<br/>milestone percent + pace state]
+        FMT[Number / currency / date formatting]
+    end
+    subgraph Web["apps-web (parity reference)"]
+        WENG[goal-projection-engine.ts]
+    end
+    subgraph Android["apps-android (this work)"]
+        VM[GoalsViewModel<br/>maps shared summary to UI state]
+        UI[Compose projection surfaces]
+    end
+    WENG -.parity.-> ENGINE
+    VM --> ENGINE
+    VM --> FMT
+    UI --> VM
+```
+
+> This document **describes** the boundary. It does **not** implement KMP changes —
+> `packages/core` is owned by @kmp-engineer, and the web engine is owned by
+> @web-engineer. Compose is a pure renderer of shared state. The current
+> [`Goal`](../../packages/models/src/commonMain/kotlin/com/finance/models/Goal.kt)
+> model already carries `targetAmount`, `currentAmount`, and `targetDate`, which are
+> the inputs a shared projection needs.
+
+---
+
+## Plain-Language Copy
+
+Copy is the product here. Every string below is a placeholder for a localized,
+resource-backed string and follows [content-language-guidelines.md](content-language-guidelines.md).
+
+| Context             | Plain-language copy (example)                            |
+| ------------------- | -------------------------------------------------------- |
+| Primary target line | "Save $25/week to get your car by Aug 2027"              |
+| Paycheck target     | "That's about $50 from each paycheck"                    |
+| On pace             | "Nice — you're on track for Aug 2027"                    |
+| Ahead               | "You're ahead! You could reach this sooner"              |
+| Behind (catch-up)   | "A little behind — save $35/week to still make Aug 2027" |
+| No date yet         | "Add a target date to see your weekly plan"              |
+| Complete            | "Goal reached. You did it!"                              |
+
+**Copy rules**
+
+- Lead with the **action and the reward** ("Save $X/week to get your car").
+- Behind messaging is **catch-up, never shame**: it offers a new weekly number, not
+  a verdict.
+- Always pair an estimate with the word "about," "around," or an explicit
+  "Estimate" label so the number never reads as a guarantee.
+- Reuse non-judgmental goal-progress patterns from
+  [content-language-guidelines.md](content-language-guidelines.md).
+
+---
+
+## Compose Surfaces
+
+Two Compose surfaces, both pure renderers of shared state, slotting into the
+existing [`GoalsScreen`](../../apps/android/src/main/kotlin/com/finance/android/ui/screens/GoalsScreen.kt):
+
+1. **Goal projection card** (in the goals list / goal detail): the primary
+   save-$X/week line, projected date, a milestone progress indicator, and the pace
+   chip.
+2. **Target-mode toggle**: lets the saver switch between a **weekly** and a
+   **per-paycheck** target without changing any underlying number — it only reframes
+   the same remaining amount.
+
+```mermaid
+flowchart TD
+    LIST[Goals list] --> CARD[Goal projection card]
+    CARD --> LINE[Save X per week line + projected date]
+    CARD --> RING[Milestone progress indicator]
+    CARD --> CHIP[Pace chip: behind / on pace / ahead]
+    CARD --> TOGGLE{Target mode}
+    TOGGLE -->|weekly| WK[Show weekly target]
+    TOGGLE -->|paycheck| PC[Show per-paycheck target]
+```
+
+Progress and pace visuals follow [data-visualization.md](data-visualization.md) and
+the progress/ring guidance in [chart-component-specs.md](chart-component-specs.md);
+they never rely on color alone (see [Accessibility](#accessibility-considerations)).
+
+---
+
+## Milestone and Pace States
+
+Milestone checkpoints give a teen a sense of momentum between "0" and "done." They
+are derived from the shared `milestonePercent`; Compose only chooses a label.
+
+| Milestone     | Trigger (shared %) | Teen-friendly label          |
+| ------------- | ------------------ | ---------------------------- |
+| First deposit | > 0%               | "You started — nice!"        |
+| Quarter       | ≥ 25%              | "A quarter of the way there" |
+| Halfway       | ≥ 50%              | "Halfway! Keep going"        |
+| Almost there  | ≥ 75%              | "So close now"               |
+| Done          | 100%               | "Goal reached. You did it!"  |
+
+Pace states map directly from the shared engine `state`:
+
+```mermaid
+stateDiagram-v2
+    [*] --> OnPace
+    OnPace --> Behind: balance below expected
+    OnPace --> Ahead: balance above expected
+    Behind --> OnPace: caught up
+    Ahead --> OnPace: pace normalized
+    OnPace --> Complete: reached target
+    Behind --> Complete: reached target
+    Ahead --> Complete: reached target
+    Complete --> [*]
+```
+
+- **Behind** shows the **catch-up** weekly number, never a red "failure" framing.
+- **Ahead** is celebratory but honest ("you could reach this sooner").
+- **Complete** is a clear win state with no further nagging.
+
+---
+
+## Paycheck-Based Targets
+
+Many teens are paid per shift or per paycheck rather than weekly, so a per-paycheck
+target is often more actionable. The shared engine already exposes a
+`paycheckTargetCents` derived from a paychecks-remaining input; Compose renders it as
+"about $X from each paycheck." The number of remaining paychecks is a **shared input**
+(pay cadence), not something Compose computes. When pay cadence is unknown, hide the
+paycheck option rather than guessing, and keep the weekly target as the default.
+
+---
+
+## Estimates, Sensitivity, and Tone
+
+This is a minor-facing, money-adjacent surface. Non-negotiables:
+
+- **Label every estimate.** Dates and weekly/paycheck amounts are projections, shown
+  with "about/around" or an explicit "Estimate" label — never a promise.
+- **No advice framing.** This shows a plan to hit the saver's _own_ goal; it never
+  recommends financial products or actions.
+- **Encouraging, non-judgmental tone** per
+  [content-language-guidelines.md](content-language-guidelines.md): falling behind is
+  normal and recoverable; the surface offers a next step, not a scolding.
+- **Privacy-first for minors.** Never log goal names, balances, target amounts, or
+  projected dates through Timber — calls must omit them. No analytics on a minor's
+  goal contents.
+- **No dark patterns.** No urgency countdowns, no "you'll fail" pressure, no upsell.
+
+---
+
+## Accessibility Considerations
+
+- **TalkBack:** the projection card exposes one cohesive `contentDescription` that
+  reads the plain-language plan first ("Save about $25 a week to reach your car goal,
+  estimated August 2027, you're on pace"), then the milestone. The pace chip and the
+  target-mode toggle each carry their own label.
+- **Switch Access:** the target-mode toggle and any "see details" affordance are
+  reachable and operable with touch targets ≥ 48dp.
+- **Font scaling:** the save-$X/week line and projected date stay readable and
+  unclipped at **200%** font scale; no fixed-height containers around currency or
+  date text.
+- **Plain language / cognitive load:** one plan per card, short sentences, the most
+  important number first — aligned with [cognitive-accessibility.md](cognitive-accessibility.md).
+- **Non-color cues:** behind / on-pace / ahead are conveyed with text and an icon,
+  never color alone, per [data-visualization.md](data-visualization.md).
+- See [accessibility-patterns.md](accessibility-patterns.md) for the underlying
+  screen-reader, focus, and touch-target patterns.
+
+---
+
+## Offline, Empty, and Error States
+
+- **Offline:** projections are computed from already-synced goal data, so the card
+  must render fully **offline** using the last-known shared summary. Show the
+  freshness of the underlying data rather than blocking the plan.
+- **Empty (no goal):** show a friendly empty state inviting the saver to create a
+  goal ("Pick something to save for and we'll show your weekly plan"), not a blank
+  card.
+- **Empty (no target date):** show the weekly plan as soon as an amount exists, and
+  prompt "Add a target date to see your finish date" rather than a silent gap.
+- **Error:** if the shared summary cannot be produced (e.g. malformed inputs), fail
+  safe to the raw progress ("$X of $Y saved") with a quiet "Plan unavailable right
+  now" message — never a stack trace, never a blank screen.
+
+---
+
+## Test Plan
+
+| Layer              | Tooling                         | What it verifies                                                                   |
+| ------------------ | ------------------------------- | ---------------------------------------------------------------------------------- |
+| Unit               | JUnit                           | ViewModel maps shared summary → UI state for behind/on-track/ahead/complete.       |
+| Unit (safety)      | JUnit                           | Every projected number renders with an estimate label; no Timber logs goal data.   |
+| Compose UI         | `createComposeRule` + semantics | Save-$X/week line, pace chip, milestone, and toggle resolve `contentDescription`.  |
+| Compose UI         | `createComposeRule`             | Target-mode toggle swaps weekly ↔ paycheck without changing remaining amount.      |
+| Snapshot           | Paparazzi                       | Card in behind/on-pace/ahead/complete + no-date + empty at `{1x, 2x}`, light/dark. |
+| Pseudolocalization | `en-XA` / `ar-XB`               | Copy expansion and mirroring for the plan sentence.                                |
+| Accessibility      | Espresso/Accessibility checks   | TalkBack order, Switch Access reachability, touch targets ≥ 48dp.                  |
+
+---
+
+## Implementation Readiness
+
+This is a design artifact. Execution splits into a **buildable-now** tier and a
+**Play-distribution tail** gated by
+[#1242](https://github.com/jrmoulckers/finance/issues/1242). See
+[../ops/human-gated-prerequisites.md](../ops/human-gated-prerequisites.md) and
+[../ops/launch-readiness-plan.md](../ops/launch-readiness-plan.md).
+
+**Buildable now — `assembleDebug` + sideload (no human gate):**
+
+- Build the projection card and target-mode toggle as Compose surfaces that render a
+  shared projection summary (mock/in-memory data while KMP wiring lands).
+- Verify milestone/pace states, plain-language copy, accessibility, and
+  pseudolocale/expansion snapshots on a debug build / emulator.
+- All of this runs on an emulator with **no signing, store credentials, or
+  human-gated operations**.
+
+**Play-distribution tail — human-gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242):**
+
+- Production signing + Play Console listing.
+- Any store-level content/data-safety declaration touching minors' financial data.
+- Staged rollout / internal testing track.
+
+The shared projection model is delivered by KMP `packages/core` (the web
+`goal-projection-engine` is the parity reference); Compose stays render-only.
+
+---
+
+## References
+
+**Design docs**
+
+- [android-goal-projection-widget.md](android-goal-projection-widget.md) — home-screen widget states (#2663)
+- [android-teen-beginner-mode.md](android-teen-beginner-mode.md) — beginner mode + plain language (#2675)
+- [content-language-guidelines.md](content-language-guidelines.md) — non-judgmental, plain copy
+- [cognitive-accessibility.md](cognitive-accessibility.md) — plain-language and load reduction
+- [accessibility-patterns.md](accessibility-patterns.md) — screen reader, focus, touch targets
+- [data-visualization.md](data-visualization.md) — progress visuals, non-color cues
+- [chart-component-specs.md](chart-component-specs.md) — progress ring/bar specs
+- [information-architecture.md](information-architecture.md) — surface and navigation map
+- [ux-principles.md](ux-principles.md) — product UX principles
+- [personas.md](personas.md) — Persona 4 (Casey)
+
+**Ops**
+
+- [../ops/human-gated-prerequisites.md](../ops/human-gated-prerequisites.md) — buildable-now vs. gated split
+- [../ops/launch-readiness-plan.md](../ops/launch-readiness-plan.md) — launch checklist
+
+**Android / web / KMP (read-only boundary)**
+
+- [`goal-projection-engine.ts`](../../apps/web/src/lib/savings/goal-projection-engine.ts) — web parity reference (owned by @web-engineer)
+- [`GoalProjection.tsx`](../../apps/web/src/components/savings/GoalProjection.tsx) — web projection UI parity
+- [`GoalsScreen.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/screens/GoalsScreen.kt) — host surface
+- [`Goal.kt`](../../packages/models/src/commonMain/kotlin/com/finance/models/Goal.kt) — shared goal model (owned by @kmp-engineer)
+
+**Issues**
+
+- [#2661](https://github.com/jrmoulckers/finance/issues/2661) — this issue
+- [#2207](https://github.com/jrmoulckers/finance/issues/2207) — parent (teen goal cluster)
+- [#1242](https://github.com/jrmoulckers/finance/issues/1242) — Play Console + keystore (gate)


### PR DESCRIPTION
## Summary

Adds three **design-only** docs for the Android teen-finance cluster (parent
[#2207](https://github.com/jrmoulckers/finance/issues/2207) /
[#2209](https://github.com/jrmoulckers/finance/issues/2209)). New files only — no
code, no shared config, no other platforms touched. Native implementation stays
gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242).

All three keep goal-projection math **conceptually in KMP `packages/core`** (boundary
described, not implemented; the web `goal-projection-engine` is the parity reference),
label every projection as an **estimate**, use teen-appropriate plain language, and are
**privacy-first for minors**.

## Changes

- `docs/design/android-teen-goal-projections.md` — in-app Compose save-$X/week and
  per-paycheck targets, projected completion dates, milestone checkpoints, and
  non-judgmental catch-up language.
- `docs/design/android-goal-projection-widget.md` — Glance widget data contract
  (top goal, projected date, weekly target, milestone state) plus no-goal / offline /
  stale-data / behind-pace states, WorkManager + Glance refresh, and privacy-safe
  lock-screen copy.
- `docs/design/android-teen-beginner-mode.md` — preference-driven beginner mode built
  on the existing `ExpertiseTier`, onboarding/settings entry points, jargon →
  plain-language copy transformations, and cognitive-accessibility patterns.

Each doc includes a ToC, Mermaid diagrams, accessibility coverage (TalkBack, Switch
Access, 200% font, plain-language/cognitive), offline/empty/error + milestone states,
a unit/Compose/Paparazzi test plan, and an "Implementation readiness" section linking
[`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md) that
splits buildable-now (`assembleDebug` sideload; Glance widget plumbing is
debug-implementable) from the Play-distribution tail gated by #1242. Cross-links point
only to existing `docs/design/` and `docs/ops/` files (paths verified). Prettier
`--check` passes on all three.

Closes #2661
Closes #2663
Closes #2675
