### PR TITLE
docs(design): ios notification center and alert design batch (#2595, #2597, #2621)

### DIFF
--- a/docs/design/ios-finance-alert-rules-deeplinks.md
+++ b/docs/design/ios-finance-alert-rules-deeplinks.md
@@ -1,0 +1,382 @@
+# Actionable iOS Finance Alerts — Rules & Deep-Link Design
+
+> A design for **actionable** local notifications: the budget-threshold, bill,
+> goal, and transaction-review alert families, the `UNNotificationCategory`
+> actions attached to each, and the deep links that land the user on the _exact_
+> context — the over-budget category, the due bill, the reached goal, the
+> transaction needing review — in one tap.
+
+**Status:** PROPOSED — design only (native implementation buildable now; store distribution gated)
+**Issue:** [#2597](https://github.com/jrmoulckers/finance/issues/2597) — Part of [#2163](https://github.com/jrmoulckers/finance/issues/2163)
+**Platform:** iOS / iPadOS (SwiftUI, `UserNotifications`, iOS 17+)
+**Owner:** @ios-engineer
+**Related:** [ios-notification-center-navigation.md](./ios-notification-center-navigation.md) · [ios-smart-notification-timing.md](./ios-smart-notification-timing.md) · [content-language-guidelines.md](./content-language-guidelines.md) · [accessibility-patterns.md](./accessibility-patterns.md) · [ios-noncolor-financial-state-cues.md](./ios-noncolor-financial-state-cues.md) · [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md)
+
+---
+
+## Table of Contents
+
+1. [Goal & Scope](#1-goal--scope)
+2. [Current State](#2-current-state)
+3. [Alert Families & Rules](#3-alert-families--rules)
+4. [Actionable Categories & Actions](#4-actionable-categories--actions)
+5. [Deep-Link Routing](#5-deep-link-routing)
+6. [End-to-End Flow](#6-end-to-end-flow)
+7. [Privacy & Balance Hiding in Previews](#7-privacy--balance-hiding-in-previews)
+8. [Empty, Stale & Error States](#8-empty-stale--error-states)
+9. [Accessibility](#9-accessibility)
+10. [Native ↔ KMP Boundary](#10-native--kmp-boundary)
+11. [Affected Surfaces & Shared Dependencies](#11-affected-surfaces--shared-dependencies)
+12. [Test Plan (Smallest Tests First)](#12-test-plan-smallest-tests-first)
+13. [Implementation Readiness](#13-implementation-readiness)
+14. [Open Questions](#14-open-questions)
+
+---
+
+## 1. Goal & Scope
+
+A finance alert that says "your Groceries budget needs attention" but drops the
+user on a generic Home screen wastes the moment of intent. This design specifies
+**actionable** local notifications: each alert family carries the right
+`UNNotificationAction`s and a deep link that opens the precise context, so the
+user can act (review, snooze, mark paid) without hunting.
+
+**In scope:**
+
+- The four alert families — **budget threshold**, **bill**, **goal milestone**,
+  **transaction review** — and the rule inputs that produce them.
+- The `UNNotificationCategory` + `UNNotificationAction` set per family.
+- The deep-link routes (additive to the existing `AppDeepLink`) and the
+  notification-response → navigation handoff.
+- Privacy of the delivered preview, accessibility, and failure handling.
+
+**Out of scope:**
+
+- The summary surface / IA — see
+  [ios-notification-center-navigation.md](./ios-notification-center-navigation.md).
+- _When_ each alert fires — see
+  [ios-smart-notification-timing.md](./ios-smart-notification-timing.md).
+- The rule **arithmetic** (budget utilization, due-date math), which is shared
+  KMP work ([§10](#10-native--kmp-boundary)).
+
+---
+
+## 2. Current State
+
+Grounded in the repository:
+
+- [`NotificationSchedulerService`](../../apps/ios/Finance/Services/NotificationSchedulerService.swift)
+  already sets `content.categoryIdentifier` from
+  `NotificationType.categoryIdentifier` (`finance.<rawValue>`) and a
+  `threadIdentifier`, but registers **no** `UNNotificationCategory`/actions and
+  attaches **no** deep link — so notifications are currently inert taps.
+- [`SmartAlert`](../../apps/ios/Finance/Models/NotificationModels.swift) already
+  carries an optional `actionURL: String?` — the hook this design fills in.
+- [`DeepLinkHandler`](../../apps/ios/Finance/Navigation/DeepLinkHandler.swift)
+  is a mature `@Observable` router with an `AppDeepLink` enum, custom-scheme
+  (`finance://`) + Universal Link parsing, per-tab routing, and consume/clear
+  semantics. It already handles `account`, `transaction`, `budgetCategory`,
+  `quickEntry`, and `clipExpense`.
+- [`FinanceWidgetDeepLinks`](../../apps/ios/Shared/WidgetPrivacy.swift) shows the
+  established pattern: **deep links carry identifiers only, never money.**
+- The app wires `.onOpenURL { deepLinkHandler.handle(url) }` in
+  [`FinanceApp`](../../apps/ios/Finance/FinanceApp.swift).
+
+**Conclusion:** the router, the URL convention, and the `actionURL` slot all
+exist. This design adds the **categories/actions**, the **new routes**, and the
+**`UNUserNotificationCenterDelegate` handoff** — reusing the router verbatim.
+
+---
+
+## 3. Alert Families & Rules
+
+Each family is produced by a shared rule (KMP) and rendered/scheduled natively.
+The _rule inputs_ below describe intent; the exact thresholds are owned by
+`packages/core`.
+
+| Family                 | `NotificationType` | Fires when (rule, shared)                                      | Lands on (deep link)       |
+| ---------------------- | ------------------ | -------------------------------------------------------------- | -------------------------- |
+| **Budget threshold**   | `.budgetAlert`     | Category utilization crosses 75% / 90% / 100% of period budget | The budget category detail |
+| **Bill reminder**      | `.billReminder`    | `dueDate − offsetDays` reached for a confirmed recurring rule  | The bill detail            |
+| **Goal milestone**     | `.goalMilestone`   | Goal progress crosses 50% / 75% / 100%                         | The goal detail            |
+| **Transaction review** | `.unusualSpending` | A transaction is uncategorized / large / flagged for review    | The transaction detail     |
+
+- Thresholds mirror what
+  [`generateSmartAlerts`](../../apps/ios/Finance/Services/NotificationSchedulerService.swift)
+  encodes today (budget 75/90/100, goal 50/75/100), and the bill offset mirrors
+  KMP [`BillReminder.offsetDays`](../../packages/core/src/commonMain/kotlin/com/finance/core/recurring/BillReminder.kt).
+- Copy for every family follows
+  [content-language-guidelines.md](./content-language-guidelines.md#bills-and-recurring-payments):
+  non-judgmental, action-first, no shaming.
+
+---
+
+## 4. Actionable Categories & Actions
+
+Register one `UNNotificationCategory` per family at launch, with a small,
+predictable action set. Actions are **identifiers only** — they trigger an
+in-app deep link or a background mutation; they never embed money.
+
+| Category (`categoryIdentifier`) | Actions                                               | Notes                                           |
+| ------------------------------- | ----------------------------------------------------- | ----------------------------------------------- |
+| `finance.budgetAlert`           | **Review** (foreground) · **Snooze** (background)     | Review → budget category deep link              |
+| `finance.billReminder`          | **Mark paid** (background) · **View** (foreground)    | Mark paid records via repository; View → bill   |
+| `finance.goalMilestone`         | **View** (foreground)                                 | Celebration; minimal actions                    |
+| `finance.unusualSpending`       | **Review** (foreground) · **Looks fine** (background) | Review → transaction; dismiss confirms expected |
+
+Rules for actions:
+
+- **Default tap** (no action chosen) always deep-links to the family's context.
+- **Foreground actions** (`.foreground` option) open the app and route via the
+  deep-link handler. **Background actions** mutate via a repository call inside
+  the scheduler actor and then refresh — no UI thrash.
+- **Destructive/auth:** any action that changes money state (e.g. "Mark paid")
+  uses `.authenticationRequired` so it respects the device lock; we never bypass
+  biometric/lock for convenience.
+- Actions register once via `center.setNotificationCategories(...)`; titles use
+  `String(localized:)`.
+
+---
+
+## 5. Deep-Link Routing
+
+Extend the existing `AppDeepLink`/`DeepLinkHandler` **additively** with the
+four destinations. The `budgetCategory` and `transaction` routes already exist;
+the bill and goal routes are new. All identifiers are percent-encoded exactly as
+[`FinanceWidgetDeepLinks`](../../apps/ios/Shared/WidgetPrivacy.swift) does.
+
+```swift
+// Additive cases proposed for AppDeepLink (implemented in a follow-up PR,
+// in apps/ios — not modified by this design doc).
+case bill(id: String)            // finance://bill/{id}
+case goal(id: String)            // finance://goal/{id}
+// Reused as-is:
+//   budgetCategory(id:)  finance://budget/category/{id}
+//   transaction(id:)     finance://transaction/{id}
+```
+
+| Family             | URL (custom scheme)              | Universal Link                             | Tab                  |
+| ------------------ | -------------------------------- | ------------------------------------------ | -------------------- |
+| Budget threshold   | `finance://budget/category/{id}` | `https://finance.app/budget/category/{id}` | Budgets              |
+| Bill reminder      | `finance://bill/{id}`            | `https://finance.app/bill/{id}`            | Transactions / Bills |
+| Goal milestone     | `finance://goal/{id}`            | `https://finance.app/goal/{id}`            | Goals                |
+| Transaction review | `finance://transaction/{id}`     | `https://finance.app/transaction/{id}`     | Transactions         |
+
+Routing rules:
+
+- The scheduler stamps each `UNNotificationRequest` `userInfo` with its deep-link
+  URL string (identifier only) and the alert `id` for dedup.
+- A `UNUserNotificationCenterDelegate` reads `response.notification.request`,
+  resolves the action, and calls `deepLinkHandler.handle(url)` — the **same**
+  entry point used by `.onOpenURL`, so notification taps and in-app taps converge.
+- Unknown/legacy payloads fall through to `AppDeepLink.unknown`, which the
+  handler already logs and ignores safely.
+
+---
+
+## 6. End-to-End Flow
+
+```mermaid
+sequenceDiagram
+    participant Core as KMP core (rules)
+    participant Sched as NotificationSchedulerService (actor)
+    participant UNC as UNUserNotificationCenter
+    participant Del as NotificationCenterDelegate
+    participant DLH as DeepLinkHandler
+    participant UI as SwiftUI destination
+
+    Core->>Sched: Alert candidates + context id (no money)
+    Sched->>UNC: add(request) with category + userInfo url
+    Note over UNC: Delivered locally (no remote server)
+    UNC-->>Del: didReceive response (tap or action)
+    Del->>DLH: handle(url) / background mutation
+    DLH->>UI: select tab + push detail (exact context)
+```
+
+The path is entirely **local**: rules compute candidates, the actor schedules a
+local notification, iOS delivers it on-device, and the delegate routes the
+response through the existing handler. No remote push service is involved.
+
+---
+
+## 7. Privacy & Balance Hiding in Previews
+
+The delivered notification preview is visible on a **locked** screen, so it is
+the most privacy-sensitive surface in this design.
+
+- **No sensitive amounts in previews by default.** Bodies use amount-free,
+  context-first copy — "Groceries is over budget", "Rent is due in 3 days",
+  "You reached your Emergency Fund goal" — per
+  [content-language-guidelines.md](./content-language-guidelines.md#account-balance-notifications).
+- **Deep links carry identifiers only, never money**, matching the
+  [`FinanceWidgetDeepLinks`](../../apps/ios/Shared/WidgetPrivacy.swift) rule;
+  `userInfo` holds an opaque id and a URL string, not a balance.
+- If a user opts into showing detail, in-app screens (post-unlock) may reveal
+  numbers via [`WidgetMoneyFormatter`](../../apps/ios/Shared/WidgetPrivacy.swift)
+  masking modes — never the locked-screen preview.
+- **Logging:** `os.Logger` records the family/`categoryIdentifier`
+  (`privacy: .public`) and routes ids with `.private`, mirroring the existing
+  `DeepLinkHandler` logging — never amounts or payees.
+
+---
+
+## 8. Empty, Stale & Error States
+
+| Condition   | Behavior                                                                                                                                                                                                                                 |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Empty**   | No candidates → nothing is scheduled; this is a normal, silent state, not an error.                                                                                                                                                      |
+| **Stale**   | If the underlying entity changed after scheduling (budget edited, bill paid), the delegate re-validates on tap and, if the context is gone, routes to the parent list with a gentle "this no longer applies" note instead of a dead end. |
+| **Offline** | Scheduling and delivery are fully local, so alerts work offline. A "Mark paid" mutation queues in the offline-first repository and reconciles on sync.                                                                                   |
+| **Error**   | A failed `center.add(...)` is logged (`.public` reason) and surfaced only in the settings flow, never as a user-facing crash. A failed background action keeps the notification actionable for retry.                                    |
+
+---
+
+## 9. Accessibility
+
+- **VoiceOver:** notification actions are labeled by the system from their
+  `title`; we provide clear `String(localized:)` titles ("Review", "Mark paid").
+  In-app destinations reuse their screens' existing VoiceOver labels.
+- **Color independence:** priority/urgency in any in-app representation pairs
+  color with text + glyph, per
+  [accessibility-patterns.md](./accessibility-patterns.md#53-never-convey-information-by-color-alone)
+  and [ios-noncolor-financial-state-cues.md](./ios-noncolor-financial-state-cues.md).
+- **Dynamic Type:** any in-app action sheet/confirmation uses semantic fonts and
+  reflows at accessibility sizes
+  ([accessibility-patterns.md](./accessibility-patterns.md#92-ios-swiftui)).
+- **Reduce Motion:** the deep-link landing avoids decorative transitions and
+  honors [Reduced Motion](./accessibility-patterns.md#61-reduced-motion-support).
+- **Touch targets:** confirmation controls meet 44×44 pt
+  ([accessibility-patterns.md](./accessibility-patterns.md#8-touch-target-sizing)).
+- **Plain language & error recovery:** copy and the "no longer applies" fallback
+  follow [cognitive-accessibility.md](./cognitive-accessibility.md#error-prevention--recovery).
+
+---
+
+## 10. Native ↔ KMP Boundary
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages/core + packages/models (shared — DO NOT implement here)"]
+        K1["BudgetCalculator: utilization, isOverBudget"]
+        K2["BillReminderEngine: scheduleNotifications (pure, deterministic)"]
+        K3["Goal progress + review-flag rules"]
+    end
+    subgraph Bridge["Swift Export bridge (apps/ios/Finance/KMP)"]
+        B1["Typed alert candidates (context id, family, no money)"]
+    end
+    subgraph iOS["apps/ios (native — this design)"]
+        N1["NotificationSchedulerService: categories + actions"]
+        N2["NotificationCenterDelegate: response -> handle(url)"]
+        N3["DeepLinkHandler: AppDeepLink routing"]
+        N4["SwiftUI destinations"]
+    end
+    K1 --> B1
+    K2 --> B1
+    K3 --> B1
+    B1 --> N1 --> N2 --> N3 --> N4
+```
+
+- **Rule evaluation is shared.** Budget utilization lives in
+  [`BudgetCalculator`](../../packages/core/src/commonMain/kotlin/com/finance/core/budget/BudgetCalculator.kt);
+  bill scheduling lives in
+  [`BillReminderEngine`](../../packages/core/src/commonMain/kotlin/com/finance/core/recurring/BillReminderEngine.kt),
+  whose own docs state it is "pure and deterministic… Platform notification
+  scheduling (actual OS-level alarms) is the caller's responsibility." That is
+  exactly this boundary.
+- **iOS owns** category/action registration, the
+  `UNUserNotificationCenterDelegate`, the additive `AppDeepLink` cases, and the
+  SwiftUI destinations. No shared package is edited by this design; consolidating
+  iOS-native `generateSmartAlerts` into shared rules is proposed to
+  @kmp-engineer via ADR.
+
+---
+
+## 11. Affected Surfaces & Shared Dependencies
+
+**New (this design, implemented in follow-up iOS PRs):**
+
+- `apps/ios/Finance/Services/NotificationCategories.swift` — category/action
+  registration.
+- `apps/ios/Finance/Services/NotificationCenterDelegate.swift` —
+  `UNUserNotificationCenterDelegate` response handling.
+- Additive `AppDeepLink.bill` / `.goal` cases + parsing in `DeepLinkHandler`.
+
+**Touched (additively):**
+
+- `NotificationSchedulerService.scheduleNotification` stamps `userInfo` with the
+  deep-link URL and registers categories.
+- `FinanceApp` sets the notification-center delegate at launch.
+
+**Reused unchanged:** `DeepLinkHandler` routing, `AppDeepLink.transaction` /
+`.budgetCategory`, `FinanceWidgetDeepLinks` URL convention, `WidgetMoneyFormatter`.
+
+**Shared dependency:** `BudgetCalculator`, `BillReminderEngine`, goal/review
+rules in KMP `packages/core` via the Swift Export bridge ([§10](#10-native--kmp-boundary)).
+
+---
+
+## 12. Test Plan (Smallest Tests First)
+
+1. **Category registration (Swift unit):** assert exactly one category per family
+   with the expected action identifiers and options (`.foreground`,
+   `.authenticationRequired` on money-mutating actions).
+2. **Deep-link parsing (Swift unit):** extend the existing
+   [`DeepLinkHandlerTests`](../../apps/ios/Tests/DeepLinkHandlerTests.swift)
+   pattern — assert `finance://bill/{id}` and `finance://goal/{id}` parse to the
+   new cases and route to the correct tab; malformed → `.unknown`.
+3. **Response handoff (Swift unit):** given a stub `UNNotificationResponse` with
+   a `userInfo` URL, assert the delegate calls `handle(url)` and the handler sets
+   the expected pending id + tab.
+4. **Privacy (Swift unit):** assert generated bodies for each family contain no
+   currency substring by default, and `userInfo` contains an id + URL but no
+   amount key.
+5. **Action mapping (Swift unit):** for each action identifier, assert it maps to
+   the intended outcome (foreground deep link vs background mutation), using a
+   fake repository to verify "Mark paid" records once.
+6. **Stale context (Swift unit):** with a deleted/edited entity and a **fixed
+   reference `Date`**, assert the delegate falls back to the parent list.
+7. **Shared (KMP, owned by @kmp-engineer):** `BudgetCalculator` thresholds and
+   `BillReminderEngine.scheduleNotifications` are tested in `packages/core`.
+
+---
+
+## 13. Implementation Readiness
+
+See [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md).
+
+**Buildable now (no paid enrollment) — free Personal Team signing:**
+
+- `UNNotificationCategory`/`UNNotificationAction` registration, the
+  `UNUserNotificationCenterDelegate`, local scheduling, and the deep-link handoff
+  all run on a device under a **free Apple ID** (Personal Team). Local
+  notifications need **no** paid entitlement, and the custom `finance://` scheme
+  works without Associated Domains.
+- Every test in [§12](#12-test-plan-smallest-tests-first) runs without
+  enrollment. (Universal Link verification via Associated Domains is the only
+  piece that benefits from a real team — the custom scheme covers local testing.)
+
+**Distribution tail — gated by [#1239](https://github.com/jrmoulckers/finance/issues/1239):**
+
+- App Store / TestFlight distribution **and** verified Associated-Domains
+  Universal Links require the paid program. The custom-scheme path is fully
+  testable now; only the `https://finance.app/...` verification is gated.
+- On the implementation PR, add a `## Needs Human Action` note pointing at
+  [§3.2 of the prerequisites runbook](../ops/human-gated-prerequisites.md#32-ios-distribution--apple-developer-1239)
+  for the Universal-Link + distribution criteria only.
+
+---
+
+## 14. Open Questions
+
+1. **"Mark paid" semantics:** does a bill reminder's background action record a
+   transaction immediately, or open a confirm sheet? Default: confirm sheet
+   (foreground) when `.authenticationRequired` is needed; silent record only for
+   already-unlocked sessions.
+2. **Bill tab home:** do bills route to the Transactions tab's bill detail or a
+   dedicated Bills surface? Resolve with the IA in
+   [ios-notification-center-navigation.md](./ios-notification-center-navigation.md).
+3. **Snooze granularity:** fixed (e.g. "tomorrow morning") or user-chosen? The
+   timing of a snooze is owned by
+   [ios-smart-notification-timing.md](./ios-smart-notification-timing.md).
+4. **Shared candidate model:** confirm with @kmp-engineer the exact Swift Export
+   shape of an "alert candidate" so iOS never re-derives money.

--- a/docs/design/ios-notification-center-navigation.md
+++ b/docs/design/ios-notification-center-navigation.md
@@ -1,0 +1,365 @@
+# iOS Notification Center — Navigation & Summary Design
+
+> A design for the **alert center**: the Settings entry point, the at-a-glance
+> active-alert summary, the permission and quiet-hours states, and the
+> information architecture that turns today's buried notification toggles into a
+> coherent surface. Native scheduling stays in iOS; the rules that decide _what_
+> is worth surfacing stay shared.
+
+**Status:** PROPOSED — design only (native implementation buildable now; store distribution gated)
+**Issue:** [#2595](https://github.com/jrmoulckers/finance/issues/2595) — Part of [#2163](https://github.com/jrmoulckers/finance/issues/2163)
+**Platform:** iOS / iPadOS (SwiftUI, `@Observable`, iOS 17+)
+**Owner:** @ios-engineer
+**Related:** [ios-finance-alert-rules-deeplinks.md](./ios-finance-alert-rules-deeplinks.md) · [ios-smart-notification-timing.md](./ios-smart-notification-timing.md) · [information-architecture.md](./information-architecture.md) · [accessibility-patterns.md](./accessibility-patterns.md) · [content-language-guidelines.md](./content-language-guidelines.md) · [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md)
+
+---
+
+## Table of Contents
+
+1. [Goal & Scope](#1-goal--scope)
+2. [Current State](#2-current-state)
+3. [Information Architecture](#3-information-architecture)
+4. [Navigation Model](#4-navigation-model)
+5. [Active-Alert Summary](#5-active-alert-summary)
+6. [Permission States](#6-permission-states)
+7. [Quiet Hours](#7-quiet-hours)
+8. [Empty, Stale & Error States](#8-empty-stale--error-states)
+9. [Privacy & Balance Hiding](#9-privacy--balance-hiding)
+10. [Accessibility](#10-accessibility)
+11. [Native ↔ KMP Boundary](#11-native--kmp-boundary)
+12. [Affected Surfaces & Shared Dependencies](#12-affected-surfaces--shared-dependencies)
+13. [Test Plan (Smallest Tests First)](#13-test-plan-smallest-tests-first)
+14. [Implementation Readiness](#14-implementation-readiness)
+15. [Open Questions](#15-open-questions)
+
+---
+
+## 1. Goal & Scope
+
+Today a user who wants to understand "what is the app telling me, and what will
+it tell me next?" has to open **Settings → Notifications** and read a flat list
+of toggles. There is no single place that answers _what is active right now_,
+_did I grant permission_, and _when am I muted_. This design specifies a
+**Notification (Alert) Center**: a humans-first summary surface plus the
+information architecture and navigation around it.
+
+**In scope:**
+
+- The Settings **entry point** and the route into a dedicated alert center.
+- An **active-alert summary** built from the existing `SmartAlert` model.
+- A clear **permission state** model (not-determined / authorized / denied /
+  provisional) with a recovery path to system Settings.
+- A **quiet-hours** summary and its place in the IA (the timing _policy_ lives
+  in [ios-smart-notification-timing.md](./ios-smart-notification-timing.md)).
+- Empty / stale / error states, privacy in previews, and accessibility.
+
+**Out of scope:**
+
+- The _actionable_ notification categories and deep-link destinations — see
+  [ios-finance-alert-rules-deeplinks.md](./ios-finance-alert-rules-deeplinks.md).
+- The on-device _timing_ heuristics — see
+  [ios-smart-notification-timing.md](./ios-smart-notification-timing.md).
+- The alert-rule **math** itself, which is shared KMP work ([§11](#11-native--kmp-boundary)).
+
+---
+
+## 2. Current State
+
+Grounded in the repository as it stands:
+
+- [`NotificationSettingsView`](../../apps/ios/Finance/Screens/NotificationSettingsView.swift)
+  is a flat `List` with three sections — a permission section, a per-type
+  toggle section (`Alert Types`), and a conditional `Smart Alerts` section.
+- [`NotificationSettingsViewModel`](../../apps/ios/Finance/ViewModels/NotificationSettingsViewModel.swift)
+  is `@Observable`, owns `schedules`, `smartAlerts`, `permissionGranted`, and
+  `permissionStatus`, and already loads alerts via the scheduler.
+- [`NotificationSchedulerService`](../../apps/ios/Finance/Services/NotificationSchedulerService.swift)
+  is an `actor` that wraps `UNUserNotificationCenter` (permission, scheduling,
+  cancellation) and generates `SmartAlert`s on-device.
+- [`NotificationModels`](../../apps/ios/Finance/Models/NotificationModels.swift)
+  defines `NotificationType`, `NotificationSchedule`, `SmartAlert`, and
+  `AlertPriority` — the vocabulary this center renders.
+- There is **no** dedicated summary surface and **no** quiet-hours concept yet.
+
+**Conclusion:** the data and the scheduler exist; this design supplies the
+missing _surface_ and _structure_, reusing the models unchanged.
+
+---
+
+## 3. Information Architecture
+
+The center is a hub reached from Settings, not a sixth tab. It groups four
+concerns that are currently flattened: _status_, _what's active_, _what types_,
+and _when muted_.
+
+```mermaid
+flowchart TD
+    SET["Settings (root)"] --> NC["Notifications (Alert Center hub)"]
+    NC --> SUM["Active Alerts summary"]
+    NC --> PERM["Permission status + recovery"]
+    NC --> TYPES["Alert Types (per-type toggles)"]
+    NC --> QH["Quiet Hours"]
+    SUM --> DL["Tap an alert -> deep link to its context"]
+    TYPES --> DETAIL["Per-type detail: frequency, time, threshold"]
+```
+
+The hub keeps the existing `Alert Types` list intact (it already works) and adds
+two siblings — a **summary** at the top and **Quiet Hours** below — plus a
+hardened **permission** block. This mirrors the cross-platform
+[information-architecture.md](./information-architecture.md) principle of one
+predictable home per concern.
+
+---
+
+## 4. Navigation Model
+
+The center uses a `NavigationStack` driven by a type-safe route enum so that a
+notification tap (from the alert-rules design) and an in-app tap converge on the
+same destinations.
+
+```swift
+// New, additive — does not modify existing files in this design.
+enum NotificationRoute: Hashable, Sendable {
+    case alertTypes
+    case typeDetail(NotificationType)
+    case quietHours
+    case permission
+}
+```
+
+- The hub is pushed from `SettingsView`'s existing Notifications row; it owns a
+  `NavigationPath` and renders destinations via `.navigationDestination(for:)`.
+- The **summary rows** do not navigate within the center — they emit the same
+  `AppDeepLink` values defined in
+  [ios-finance-alert-rules-deeplinks.md](./ios-finance-alert-rules-deeplinks.md),
+  so tapping a "Groceries over budget" summary lands on the budget, identical to
+  tapping the system notification.
+- All view models stay `@Observable`; no `ObservableObject`. State updates that
+  touch UI run on `@MainActor`; `UNUserNotificationCenter` access stays inside
+  the `NotificationSchedulerService` actor.
+
+---
+
+## 5. Active-Alert Summary
+
+The summary answers "what is the app flagging right now?" using the existing
+`SmartAlert` array, already sorted by `AlertPriority`.
+
+- **Header** shows a count ("3 active") and is announced as a single VoiceOver
+  element, matching the current `smartAlertsSection` header pattern.
+- **Rows** show title, a one-line body, and a priority chip. Priority must
+  **not** be conveyed by color alone (see
+  [§10](#10-accessibility)); the chip carries its text label
+  (`Urgent` / `High` / `Normal` / `Low`) and a non-color glyph.
+- **Tone** follows
+  [content-language-guidelines.md](./content-language-guidelines.md#notification-and-push-alert-guidelines):
+  no shaming language, action-oriented, plain.
+- The summary is a **projection** of repository data through the scheduler; it
+  holds no money of its own and stores nothing new.
+
+---
+
+## 6. Permission States
+
+Authorization is a first-class state, not a single boolean. The center renders
+each `UNAuthorizationStatus` distinctly and always offers a forward path.
+
+| Status                       | What the user sees                                       | Primary action                            |
+| ---------------------------- | -------------------------------------------------------- | ----------------------------------------- |
+| `.notDetermined`             | Value explainer + **Enable** button                      | Request authorization                     |
+| `.authorized` / `.ephemeral` | "Notifications on" confirmation                          | None (manage types below)                 |
+| `.provisional`               | "Delivering quietly" note + **Promote** affordance       | Request full authorization                |
+| `.denied`                    | Calm explainer that the choice lives in **iOS Settings** | Deep link to `UIApplication.openSettings` |
+
+- The request path reuses
+  [`requestPermission()`](../../apps/ios/Finance/ViewModels/NotificationSettingsViewModel.swift);
+  on grant, default schedules apply exactly as today.
+- The denied state never nags. It states the fact once and provides the system
+  Settings link — convenience, never coercion.
+- Status is re-read on `.task` and on `scenePhase` return-to-foreground, because
+  the user may have changed it in iOS Settings while away.
+
+---
+
+## 7. Quiet Hours
+
+Quiet hours is the user-facing control surface; the _policy_ that consumes it
+(and the Focus-aware fallbacks) is specified in
+[ios-smart-notification-timing.md](./ios-smart-notification-timing.md).
+
+- A simple **start/end time** pair plus an on/off toggle, persisted in
+  `UserDefaults` (a preference, **not** a secret — secrets stay in Keychain).
+- The summary line reads, e.g., "Muted 10:00 PM – 7:00 AM". During quiet hours
+  the center shows a small "Quiet hours active" banner so a missing alert is
+  explained, never mysterious.
+- Quiet hours shifts _delivery time_ only; it never suppresses an alert's
+  existence in the in-app summary, so nothing is silently lost.
+
+---
+
+## 8. Empty, Stale & Error States
+
+| Condition   | Behavior                                                                                                                                                                                                 |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Empty**   | No active alerts → a reassuring empty state ("You're all caught up"), not a blank section. The `Alert Types` list still renders so the user can configure.                                               |
+| **Stale**   | Alerts carry the moment they were generated; past a threshold the summary shows "Updated {relative}" so a stale list is labeled, not trusted blindly.                                                    |
+| **Offline** | Generation runs against the **local** repositories, so the summary is always available offline; a small "Offline — based on local data" note sets expectations.                                          |
+| **Error**   | A generation failure surfaces the existing inline error alert and keeps the previously rendered list (a known-good list beats a blank one). Logged via `os.Logger`, `.public` keys only — never amounts. |
+
+---
+
+## 9. Privacy & Balance Hiding
+
+- **No sensitive amounts in notification previews by default.** Summary _rows_
+  inside the app may show detail because the device is unlocked and the user
+  opened the screen, but the **delivered notification** body that mirrors a
+  summary item must default to amount-free copy (e.g. "Groceries is over budget"
+  not "Groceries is $84 over"). This follows
+  [content-language-guidelines.md](./content-language-guidelines.md#account-balance-notifications).
+- Where a number genuinely helps in-app, route it through the existing
+  [`WidgetMoneyFormatter`](../../apps/ios/Shared/WidgetPrivacy.swift) masking
+  modes (Bucketed by default) rather than printing raw currency, so the same
+  privacy posture used by widgets applies here.
+- **Logging:** only the `RefreshReason`/type counts are logged `.public`; payee,
+  amount, and balance are never logged, matching the repo `os.Logger` convention.
+
+---
+
+## 10. Accessibility
+
+- **VoiceOver:** every row is a single combined element with a label (title), a
+  value (priority + body), and a hint, mirroring today's `smartAlertRow`. The
+  summary header keeps `.isHeader`. The permission button keeps an explicit
+  label + hint.
+- **Dynamic Type:** all text uses semantic fonts (`.body`, `.caption`,
+  `.subheadline`) — never hardcoded sizes — and rows reflow vertically at the
+  largest accessibility sizes instead of truncating, per
+  [accessibility-patterns.md](./accessibility-patterns.md#92-ios-swiftui).
+- **Color independence:** priority chips pair color with text and a glyph so
+  meaning survives without color, per
+  [accessibility-patterns.md](./accessibility-patterns.md#53-never-convey-information-by-color-alone)
+  and [ios-noncolor-financial-state-cues.md](./ios-noncolor-financial-state-cues.md).
+- **Reduce Motion:** the center is a static list; any expand/collapse honors
+  [Reduced Motion](./accessibility-patterns.md#61-reduced-motion-support) with a
+  cross-fade fallback.
+- **Touch targets:** all controls meet the 44×44 pt minimum
+  ([accessibility-patterns.md](./accessibility-patterns.md#8-touch-target-sizing)).
+- **Plain language:** copy follows
+  [cognitive-accessibility.md](./cognitive-accessibility.md#plain-language-guidelines).
+
+---
+
+## 11. Native ↔ KMP Boundary
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages/core + packages/models (shared — DO NOT implement here)"]
+        K1["Alert rule evaluation: budget / bill / goal status"]
+        K2["What is worth surfacing + priority ordering"]
+    end
+    subgraph Bridge["Swift Export bridge (apps/ios/Finance/KMP)"]
+        B1["Typed alert/summary models"]
+    end
+    subgraph iOS["apps/ios (native — this design)"]
+        N1["NotificationSettingsViewModel"]
+        N2["Alert Center surface + NavigationStack"]
+        N3["NotificationSchedulerService (UNUserNotificationCenter)"]
+        N4["Quiet-hours preference (UserDefaults)"]
+    end
+    K1 --> K2 --> B1 --> N1
+    N1 --> N2
+    N1 --> N3
+    N4 --> N3
+```
+
+- The **decision** of what counts as an alert and how alerts are ranked is a
+  platform-neutral business rule and belongs in KMP `packages/core` /
+  `packages/models`. Today `generateSmartAlerts` lives natively; consolidating
+  that logic into shared code (so Android/Web agree) is proposed to
+  @kmp-engineer via ADR — **not** implemented in this iOS work.
+- **iOS owns** the surface, the `NavigationStack`/route enum, accessibility
+  semantics, quiet-hours preference storage, and all `UNUserNotificationCenter`
+  scheduling. No shared package is modified by this design.
+
+---
+
+## 12. Affected Surfaces & Shared Dependencies
+
+**New (this design):**
+
+- `apps/ios/Finance/Screens/NotificationCenterView.swift` — the hub + summary.
+- `apps/ios/Finance/Navigation/NotificationRoute.swift` — the route enum.
+- A quiet-hours preference type (iOS-local).
+
+**Touched (additively, in implementation PRs — not in this doc):**
+
+- The Settings Notifications row pushes the new hub.
+- `NotificationSettingsViewModel` gains a summary projection + quiet-hours
+  read/write (no model changes).
+
+**Reused unchanged:** `NotificationModels`, `NotificationSchedulerService`,
+`WidgetMoneyFormatter` (privacy masking), `DeepLinkHandler` (for summary taps).
+
+**Shared dependency:** alert-rule evaluation in KMP `packages/core` via the
+Swift Export bridge ([§11](#11-native--kmp-boundary)).
+
+---
+
+## 13. Test Plan (Smallest Tests First)
+
+1. **Permission state mapping (Swift unit):** for each `UNAuthorizationStatus`,
+   assert the view model exposes the expected banner state and primary action —
+   using a stub scheduler that returns a fixed status (no system prompt).
+2. **Summary projection (Swift unit):** feed a fixed `[SmartAlert]` and assert
+   ordering (priority-descending) and count match; assert empty input yields the
+   empty-state flag.
+3. **Quiet-hours formatting (Swift unit):** given a start/end pair, assert the
+   summary string and the "active now" boolean against a **fixed reference
+   `Date`** (deterministic — inject the clock, never read wall time).
+4. **Privacy default (Swift unit):** assert the notification-mirroring copy for a
+   summary item contains no currency substring by default.
+5. **Stale labeling (Swift unit):** with an old generation timestamp and a fixed
+   clock, assert the "Updated {relative}" caption appears past threshold.
+6. **Navigation (XCUITest, smallest):** Settings → Notifications shows the hub;
+   tapping `Alert Types` pushes the existing list; tapping a summary row routes
+   to the deep-link destination.
+7. **Shared (KMP, owned by @kmp-engineer):** alert-evaluation correctness is
+   tested in `packages/core`, not iOS.
+
+---
+
+## 14. Implementation Readiness
+
+See [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md).
+
+**Buildable now (no paid enrollment) — free Personal Team signing:**
+
+- The whole surface — `NavigationStack`, the summary, permission requests,
+  quiet-hours preferences, and local scheduling — runs on a device under a
+  **free Apple ID** (Personal Team). `UNUserNotificationCenter` authorization and
+  local-notification scheduling require **no** paid entitlement.
+- Every test in [§13](#13-test-plan-smallest-tests-first) runs without
+  enrollment.
+
+**Distribution tail — gated by [#1239](https://github.com/jrmoulckers/finance/issues/1239):**
+
+- Only App Store / TestFlight distribution of the app is gated. The center
+  itself uses no paid capability.
+- On the implementation PR, add a `## Needs Human Action` note pointing at
+  [§3.2 of the prerequisites runbook](../ops/human-gated-prerequisites.md#32-ios-distribution--apple-developer-1239)
+  for the distribution criterion only.
+
+---
+
+## 15. Open Questions
+
+1. **Summary entry beyond Settings:** should the Dashboard show a compact
+   "active alerts" affordance that deep-links into the center, or is Settings the
+   only home? Default: Settings-only for v1 to avoid IA sprawl.
+2. **Provisional authorization:** do we opt into `.provisional` (quiet delivery
+   without a prompt) for first-run, then promote? Tracked with the timing design.
+3. **Quiet-hours storage location:** plain `UserDefaults` vs the App Group suite
+   (so a future widget can reflect "muted")? Default: standard defaults until a
+   widget needs it.
+4. **Shared alert model:** confirm with @kmp-engineer whether `SmartAlert`
+   moves to `packages/models` (cross-platform parity) or stays iOS-native.

--- a/docs/design/ios-smart-notification-timing.md
+++ b/docs/design/ios-smart-notification-timing.md
@@ -1,0 +1,386 @@
+# Local Smart Notification Timing Policy — iOS
+
+> A privacy-preserving policy for **when** finance reminders fire. Bill reminders,
+> budget nudges, and review prompts should arrive when a user is likely to act —
+> computed **entirely on-device** from local interaction history, bounded by
+> quiet hours, and respectful of Focus. No server decides timing; no sensitive
+> amount leaves the device.
+
+**Status:** PROPOSED — design only (native implementation buildable now; store distribution gated)
+**Issue:** [#2621](https://github.com/jrmoulckers/finance/issues/2621) — Part of [#2391](https://github.com/jrmoulckers/finance/issues/2391)
+**Platform:** iOS / iPadOS (SwiftUI, `UserNotifications`, iOS 17+)
+**Owner:** @ios-engineer
+**Related:** [ios-notification-center-navigation.md](./ios-notification-center-navigation.md) · [ios-finance-alert-rules-deeplinks.md](./ios-finance-alert-rules-deeplinks.md) · [content-language-guidelines.md](./content-language-guidelines.md) · [accessibility-patterns.md](./accessibility-patterns.md) · [cognitive-accessibility.md](./cognitive-accessibility.md) · [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md)
+
+---
+
+## Table of Contents
+
+1. [Goal & Scope](#1-goal--scope)
+2. [Current State](#2-current-state)
+3. [Timing Policy Model](#3-timing-policy-model)
+4. [Local Interaction History](#4-local-interaction-history)
+5. [Quiet Hours & Focus-Aware Fallbacks](#5-quiet-hours--focus-aware-fallbacks)
+6. [Rate Limiting & Coalescing](#6-rate-limiting--coalescing)
+7. [Scheduling Flow](#7-scheduling-flow)
+8. [Privacy & Balance Hiding](#8-privacy--balance-hiding)
+9. [Empty, Stale & Error States](#9-empty-stale--error-states)
+10. [Accessibility](#10-accessibility)
+11. [Native ↔ KMP Boundary](#11-native--kmp-boundary)
+12. [Affected Surfaces & Shared Dependencies](#12-affected-surfaces--shared-dependencies)
+13. [Test Plan (Smallest Tests First)](#13-test-plan-smallest-tests-first)
+14. [Implementation Readiness](#14-implementation-readiness)
+15. [Open Questions](#15-open-questions)
+
+---
+
+## 1. Goal & Scope
+
+A reminder that arrives at 3 AM, or three reminders in five minutes, trains the
+user to ignore the app. The parent story ([#2391](https://github.com/jrmoulckers/finance/issues/2391))
+asks for "smart push-notification timing." Because this product uses **local
+notifications only** (no remote push server), we deliver that intent as an
+**on-device timing policy**: a deterministic function that, given a candidate
+alert and the user's local signals, chooses a delivery time the user is likely
+to act on — then schedules it with `UNCalendarNotificationTrigger`.
+
+**In scope:**
+
+- A timing model for the three reminder kinds — **bill reminders**, **budget
+  nudges**, **review prompts** — expressed as pure inputs/outputs.
+- A privacy-preserving **local interaction history** (engagement signals) that
+  never leaves the device.
+- **Quiet hours** and **Focus-aware fallbacks** (interruption level, relevance).
+- Rate limiting / coalescing so the app stays welcome.
+
+**Out of scope:**
+
+- The notification _content_, categories, and deep links — see
+  [ios-finance-alert-rules-deeplinks.md](./ios-finance-alert-rules-deeplinks.md).
+- The settings surface that exposes quiet hours — see
+  [ios-notification-center-navigation.md](./ios-notification-center-navigation.md).
+- Remote/server-side timing — explicitly excluded; everything is local.
+
+---
+
+## 2. Current State
+
+Grounded in the repository:
+
+- [`NotificationSchedulerService`](../../apps/ios/Finance/Services/NotificationSchedulerService.swift)
+  schedules with a `UNCalendarNotificationTrigger` from a fixed
+  `scheduledHour`/`scheduledMinute` on `NotificationSchedule` — a **static** time
+  with no awareness of when the user actually engages.
+- [`NotificationSchedule`](../../apps/ios/Finance/Models/NotificationModels.swift)
+  already carries `scheduledHour`, `scheduledMinute`, and `frequency`, so the
+  data shape needed for a chosen time exists; only the _choice_ is missing.
+- KMP [`BillReminderEngine`](../../packages/core/src/commonMain/kotlin/com/finance/core/recurring/BillReminderEngine.kt)
+  already computes deterministic `ScheduledNotification`s
+  (`notificationDate` = `dueDate − offsetDays`, plus a `reminderTime`) and
+  documents that OS-level scheduling is the caller's job — the perfect seam for a
+  timing _refinement_ step.
+- There is **no** interaction-history store and **no** quiet-hours/Focus logic
+  yet.
+
+**Conclusion:** the scheduler and the deterministic due-date math exist; this
+design adds the **time-of-day selection policy**, the **local signal store**, and
+the **quiet-hours/Focus** guardrails.
+
+---
+
+## 3. Timing Policy Model
+
+The policy is a **pure function** of explicit inputs, so it is testable with
+fixtures and identical to reason about on any platform:
+
+```text
+chooseDeliveryTime(
+    candidate,           // family + earliest-eligible date (from rules)
+    history,             // local engagement summary (buckets, not events)
+    quietHours,          // user start/end
+    constraints          // max-per-day, min-spacing, locale calendar
+) -> DeliveryDecision    // concrete date+time OR "suppress" + reason
+```
+
+Per-family defaults, refined by history:
+
+| Kind              | Default window                | Refinement signal                                 |
+| ----------------- | ----------------------------- | ------------------------------------------------- |
+| **Bill reminder** | Morning of `dueDate − offset` | Shift toward the hour the user most opens the app |
+| **Budget nudge**  | Early evening (review time)   | Shift toward the user's typical "review" hour     |
+| **Review prompt** | Within a day of the event     | Bias to a recently-active hour, never overnight   |
+
+Properties the model must hold:
+
+- **Deterministic:** same inputs → same output (no wall-clock reads inside; the
+  clock is injected). This makes the [§13](#13-test-plan-smallest-tests-first)
+  fixtures exact.
+- **Bounded:** the output is always inside an allowed window and outside quiet
+  hours; if no slot fits, it returns a **suppress** decision with a reason rather
+  than firing at a bad time.
+- **Explainable:** every decision carries a reason code surfaced (in plain
+  language) in the alert center's "why this time" affordance.
+
+---
+
+## 4. Local Interaction History
+
+To choose a good hour we need to know when the user tends to engage — without
+profiling them off-device.
+
+- **What we store:** coarse, on-device **engagement buckets** only — e.g. counts
+  of app-open and notification-open events per hour-of-day and per weekday. No
+  per-event timestamps, no amounts, no payees, no locations.
+- **Where:** local storage on the device (standard `UserDefaults`/local store —
+  a **preference**, not a secret; secrets stay in Keychain). Nothing syncs to a
+  server; this is consistent with the "all local notifications, timing computed
+  on-device" constraint.
+- **How it informs timing:** the policy reads the bucket histogram to find a
+  likely-active hour, falling back to the per-family default when history is thin
+  (cold start). A small **decay** keeps recent behavior weighted over stale.
+- **User control & transparency:** a single toggle ("Use my activity to time
+  reminders") defaults to on but is fully reversible; turning it off reverts to
+  static per-family defaults. This mirrors the consent posture in
+  [content-language-guidelines.md](./content-language-guidelines.md#notification-and-push-alert-guidelines).
+
+---
+
+## 5. Quiet Hours & Focus-Aware Fallbacks
+
+Timing must defer to the user's stated and system-level boundaries.
+
+- **Quiet hours (user-set):** the policy never schedules inside the quiet window
+  (from [ios-notification-center-navigation.md](./ios-notification-center-navigation.md)).
+  A slot that would land inside is moved to the next eligible edge (e.g. just
+  after the quiet window ends), never silently dropped.
+- **Focus / Do Not Disturb (system):** we do not read the user's Focus state
+  (private); instead we cooperate with the system using
+  `UNNotificationInterruptionLevel`:
+  - `.passive` for low-value budget nudges (won't break Focus),
+  - `.active` (default) for normal reminders,
+  - `.timeSensitive` **only** for genuinely time-critical bills (e.g. due today)
+    and only if the user has allowed Time Sensitive notifications.
+- **Relevance:** set `relevanceScore` so the most actionable alert sorts to the
+  top of a stacked Notification Center, improving the odds the user acts on the
+  right one.
+- **Fallback ladder:** if Time Sensitive is disallowed, a due-today bill degrades
+  gracefully to `.active` at the best in-window hour rather than escalating.
+
+---
+
+## 6. Rate Limiting & Coalescing
+
+A welcome app is a quiet app.
+
+- **Max per day:** a hard cap (default small, e.g. 2–3) across all families; once
+  spent, lower-priority candidates roll to the next day.
+- **Min spacing:** enforce a minimum gap between any two delivered reminders so
+  they never cluster.
+- **Coalescing:** multiple budget nudges on the same day collapse into one "a few
+  budgets need a look" reminder rather than several pings (content owned by the
+  alert-rules design; the _decision to coalesce_ is timing policy).
+- **Priority wins ties:** when the cap forces a choice, higher `AlertPriority`
+  (from [`NotificationModels`](../../apps/ios/Finance/Models/NotificationModels.swift))
+  is delivered first; the rest defer, never drop silently — they reappear next
+  eligible day.
+
+---
+
+## 7. Scheduling Flow
+
+```mermaid
+flowchart TD
+    C["Alert candidate (family + earliest date, from KMP rules)"] --> P["TimingPolicy.chooseDeliveryTime (pure)"]
+    H["Local engagement buckets (on-device)"] --> P
+    Q["Quiet hours (user pref)"] --> P
+    R["Rate-limit + min-spacing constraints"] --> P
+    P --> D{Decision}
+    D -->|"Deliver at T"| S["Scheduler: UNCalendarNotificationTrigger at T"]
+    D -->|"Suppress (reason)"| X["Defer to next eligible day + record reason"]
+    S --> UNC["UNUserNotificationCenter (local delivery)"]
+    UNC --> ENG["User opens / ignores"]
+    ENG --> H
+```
+
+The loop is closed and entirely on-device: delivery outcomes update the local
+engagement buckets, which sharpen the next decision — no telemetry leaves the
+phone.
+
+---
+
+## 8. Privacy & Balance Hiding
+
+- **Computed on-device, stays on-device.** Timing inputs are coarse engagement
+  buckets, never financial values; nothing about timing is sent anywhere.
+- **No sensitive amounts in previews by default.** The delivered body follows
+  the amount-free default from
+  [ios-finance-alert-rules-deeplinks.md](./ios-finance-alert-rules-deeplinks.md)
+  and [content-language-guidelines.md](./content-language-guidelines.md#account-balance-notifications);
+  timing never introduces a number into a preview.
+- **Buckets are not secrets but are still minimized.** They are coarse
+  (hour-of-day counts), stored locally, and clearable from settings; turning off
+  the activity toggle deletes them.
+- **Logging:** `os.Logger` records only the chosen hour bucket and a reason code
+  (`privacy: .public`); it never logs the candidate's amount, payee, or the raw
+  history, matching the repo convention.
+
+---
+
+## 9. Empty, Stale & Error States
+
+| Condition         | Behavior                                                                                                                                                           |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Cold start**    | No history yet → use the per-family default window; the policy degrades to today's static behavior, so the feature is never worse than now.                        |
+| **Stale history** | Decay down-weights old buckets; if all data is stale, defaults take over. A user returning after a long absence is treated like cold start.                        |
+| **Suppressed**    | A candidate with no valid in-window slot returns a **suppress** decision with a reason; it is deferred and explained in the center, never silently lost.           |
+| **Offline**       | Timing needs no network; it runs fully offline. Local delivery is unaffected.                                                                                      |
+| **Error**         | A scheduling failure is logged (`.public` reason) and the candidate retries next cycle; a corrupt history store resets to empty (cold start) rather than crashing. |
+
+---
+
+## 10. Accessibility
+
+- **Predictability over surprise:** smart timing must never feel random. The
+  alert center exposes a plain-language "why this time" reason, supporting the
+  consistent-navigation and plain-language guidance in
+  [cognitive-accessibility.md](./cognitive-accessibility.md#consistent-navigation-patterns).
+- **VoiceOver:** the quiet-hours and activity-toggle controls (in the center)
+  carry labels, values, and hints; the "why this time" detail is a readable text
+  element, not an icon-only cue.
+- **Dynamic Type:** all timing-related copy uses semantic fonts and reflows at
+  accessibility sizes
+  ([accessibility-patterns.md](./accessibility-patterns.md#92-ios-swiftui)).
+- **Reduce Motion:** timing has no animation of its own; any settings transitions
+  honor [Reduced Motion](./accessibility-patterns.md#61-reduced-motion-support).
+- **No color-only meaning:** any "active/snoozed/suppressed" status pairs color
+  with text, per
+  [accessibility-patterns.md](./accessibility-patterns.md#53-never-convey-information-by-color-alone).
+- **Time Sensitive respects the user:** escalation only when the user has allowed
+  it — the policy never assumes urgency on the user's behalf.
+
+---
+
+## 11. Native ↔ KMP Boundary
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages/core + packages/models (shared — DO NOT implement here)"]
+        K1["BillReminderEngine: earliest-eligible date (pure)"]
+        K2["Timing policy math: window selection from buckets (shareable, pure)"]
+    end
+    subgraph Bridge["Swift Export bridge (apps/ios/Finance/KMP)"]
+        B1["DeliveryDecision (date+time or suppress+reason)"]
+    end
+    subgraph iOS["apps/ios (native — this design)"]
+        N1["Engagement buckets (local store)"]
+        N2["Quiet-hours pref + Focus cooperation (interruptionLevel)"]
+        N3["NotificationSchedulerService: UNCalendarNotificationTrigger"]
+    end
+    K1 --> K2 --> B1 --> N3
+    N1 --> B1
+    N2 --> N3
+```
+
+- **The timing math is shareable and pure**, so it should live in KMP
+  `packages/core` next to
+  [`BillReminderEngine`](../../packages/core/src/commonMain/kotlin/com/finance/core/recurring/BillReminderEngine.kt)
+  (Android/Web get the same fairness). Introducing or extending that shared
+  policy is proposed to @kmp-engineer via ADR — **not** implemented in this iOS
+  work.
+- **iOS owns** the local engagement-bucket store, reading quiet-hours
+  preferences, Focus cooperation via `UNNotificationInterruptionLevel` /
+  `relevanceScore`, and the `UNCalendarNotificationTrigger` scheduling. No shared
+  package is modified by this design.
+
+---
+
+## 12. Affected Surfaces & Shared Dependencies
+
+**New (this design, implemented in follow-up iOS PRs):**
+
+- `apps/ios/Finance/Services/EngagementHistoryStore.swift` — on-device buckets.
+- `apps/ios/Finance/Services/NotificationTimingPolicy.swift` — the iOS adapter
+  that calls the shared decision and applies interruption level / relevance.
+
+**Touched (additively):**
+
+- `NotificationSchedulerService.scheduleNotification` consumes a
+  `DeliveryDecision` (chosen time + interruption level) instead of a fixed hour.
+- The alert center gains the "Use my activity" toggle and a "why this time"
+  reason (UI owned by [ios-notification-center-navigation.md](./ios-notification-center-navigation.md)).
+
+**Reused unchanged:** `NotificationSchedule` time fields, `AlertPriority`,
+`UNCalendarNotificationTrigger` plumbing.
+
+**Shared dependency:** `BillReminderEngine` + (proposed) shared timing math in
+KMP `packages/core` via the Swift Export bridge ([§11](#11-native--kmp-boundary)).
+
+---
+
+## 13. Test Plan (Smallest Tests First)
+
+Determinism is the whole point, so every test uses **fixed fixtures and an
+injected clock** — no wall-clock reads.
+
+1. **Window selection (Swift/KMP unit):** given a bucket histogram and per-family
+   default, assert the chosen hour is the expected likely-active hour; with empty
+   history assert the default.
+2. **Quiet-hours guard (Swift unit):** a candidate whose ideal hour is inside
+   quiet hours moves to the next eligible edge; assert exact time against a
+   **fixed reference `Date`**.
+3. **Suppress decision (Swift unit):** when no in-window slot exists, assert a
+   `suppress` decision with the expected reason and a next-day deferral.
+4. **Rate limit (Swift unit):** with the daily cap reached, assert lower-priority
+   candidates defer and the highest `AlertPriority` is delivered first.
+5. **Min spacing (Swift unit):** two candidates closer than the gap → the second
+   shifts; assert the resulting spacing.
+6. **Interruption level (Swift unit):** a due-today bill maps to `.timeSensitive`
+   only when allowed, else degrades to `.active`; budget nudge → `.passive`.
+7. **History privacy (Swift unit):** assert the store holds only coarse buckets
+   (no amounts/payees) and that the activity-off path clears it.
+8. **Determinism (Swift/KMP unit):** identical inputs → identical
+   `DeliveryDecision` across repeated runs (golden fixture).
+9. **Shared (KMP, owned by @kmp-engineer):** if the policy math lands in
+   `packages/core`, its window-selection and boundary cases are tested there.
+
+---
+
+## 14. Implementation Readiness
+
+See [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md).
+
+**Buildable now (no paid enrollment) — free Personal Team signing:**
+
+- The engagement-bucket store, the timing policy, quiet-hours guards, interruption
+  levels, relevance scoring, and `UNCalendarNotificationTrigger` scheduling all
+  run on a device under a **free Apple ID** (Personal Team). Local notifications
+  and Time Sensitive interruption levels need **no** paid entitlement for local
+  testing.
+- Every test in [§13](#13-test-plan-smallest-tests-first) — pure-function timing
+  with fixtures — runs without any device or enrollment.
+
+**Distribution tail — gated by [#1239](https://github.com/jrmoulckers/finance/issues/1239):**
+
+- Only App Store / TestFlight distribution is gated. The timing policy uses no
+  paid capability; the `Time Sensitive` notification _entitlement string_ is a
+  capability available under free signing for local runs.
+- On the implementation PR, add a `## Needs Human Action` note pointing at
+  [§3.2 of the prerequisites runbook](../ops/human-gated-prerequisites.md#32-ios-distribution--apple-developer-1239)
+  for the distribution criterion only.
+
+---
+
+## 15. Open Questions
+
+1. **Where the math lives:** confirm with @kmp-engineer whether window-selection
+   moves to `packages/core` (cross-platform fairness) or stays an iOS adapter for
+   v1, with an ADR to follow.
+2. **Bucket granularity:** hour-of-day only, or hour × weekday? Default:
+   hour-of-day for v1 (smaller, less identifying), upgrade if accuracy is poor.
+3. **Daily cap default:** is 2–3 right for finance reminders, or should bills be
+   exempt from the cap (always deliver)? Likely: due-today bills bypass the cap.
+4. **Cold-start window defaults:** validate the per-family default hours
+   (morning bills, evening budget review) against
+   [content-language-guidelines.md](./content-language-guidelines.md#notification-and-push-alert-guidelines).
+5. **Decay rate:** how fast should old engagement buckets fade so the policy
+   adapts without over-reacting to a single unusual day?


### PR DESCRIPTION
﻿## Summary

Adds three **design-only** documents (no native build, no signing, no store actions) for the iOS notification cluster, grounded in the existing `NotificationSchedulerService`, `NotificationModels`, `DeepLinkHandler`, and KMP `BillReminderEngine` / `BudgetCalculator`. All notifications are **local** (no remote push), timing is computed **on-device**, and previews are **privacy-preserving** (no sensitive amounts by default).

## Changes

- `docs/design/ios-notification-center-navigation.md` (#2595) — Settings entry point, active-alert summary, permission states, quiet hours, and alert-center IA + type-safe navigation.
- `docs/design/ios-finance-alert-rules-deeplinks.md` (#2597) — budget/bill/goal/transaction-review alert families, `UNNotificationCategory` actions, and deep links to exact context (additive to `AppDeepLink`).
- `docs/design/ios-smart-notification-timing.md` (#2621) — on-device, privacy-preserving timing policy using local engagement buckets, quiet hours, and Focus-aware `interruptionLevel` fallbacks.

Each doc follows `docs.instructions.md`: humans-first, ToC, Mermaid (native↔KMP boundary + scheduling/deep-link flow), relative links, accessibility (VoiceOver, Dynamic Type, Reduce Motion), stale/error/empty states, deterministic smallest-tests plan, and an Implementation readiness section splitting buildable-now (free Personal Team signing; local notifications fully implementable) from the distribution tail gated by #1239.

Boundary preserved: alert-rule evaluation/timing math stays conceptually in KMP `packages/core`; iOS owns `UNUserNotificationCenter` scheduling and deep-links. No existing files, `packages/`, `apps/` code, or other docs were modified — new files only.

Closes #2595
Closes #2597
Closes #2621
