### PR TITLE
docs(design): ios App Intents and Siri query design batch (#2617, #2618, #2619)

### DIFF
--- a/docs/design/ios-app-intents-siri-query.md
+++ b/docs/design/ios-app-intents-siri-query.md
@@ -1,0 +1,326 @@
+# iOS App Intents and Siri Finance Query Design
+
+> Design specification for the iOS **voice and typed finance-query surface** —
+> App Intents, Siri, Shortcuts, and Spotlight entry points that answer questions
+> like _"What's my balance?"_ or _"How much did I spend on groceries this
+> month?"_ **entirely on-device**, by delegating all query parsing and
+> aggregation to shared KMP business logic.
+
+**Status:** PROPOSED — design only (native implementation gated, see
+[Implementation readiness](#implementation-readiness))
+**Issue:** [#2617](https://github.com/jrmoulckers/finance/issues/2617) — _Part of
+[#2386](https://github.com/jrmoulckers/finance/issues/2386)_
+**Platform:** iOS 17+ (SwiftUI · App Intents · SiriKit) · watchOS 10+ (companion)
+**Last updated:** 2026-06-22
+**Related design docs:**
+[information-architecture.md](./information-architecture.md) ·
+[ux-principles.md](./ux-principles.md) ·
+[accessibility-patterns.md](./accessibility-patterns.md) ·
+[content-language-guidelines.md](./content-language-guidelines.md) ·
+[data-model.md](./data-model.md)
+**Sibling docs (this cluster):**
+[ios-local-query-planner-clarification.md](./ios-local-query-planner-clarification.md) ·
+[ios-nl-query-fixtures.md](./ios-nl-query-fixtures.md)
+
+---
+
+## Table of Contents
+
+1. [Problem and Goal](#1-problem-and-goal)
+2. [Affected iOS Surfaces](#2-affected-ios-surfaces)
+3. [Shared Dependencies and the KMP Boundary](#3-shared-dependencies-and-the-kmp-boundary)
+4. [Supported Local Intents](#4-supported-local-intents)
+5. [Entry Points: Voice and Typed](#5-entry-points-voice-and-typed)
+6. [Intent Resolution Flow](#6-intent-resolution-flow)
+7. [Sensitive-Result Confirmation Rules](#7-sensitive-result-confirmation-rules)
+8. [Accessibility](#8-accessibility)
+9. [Privacy and Data Minimization](#9-privacy-and-data-minimization)
+10. [Empty, Stale, Error, and Low-Confidence States](#10-empty-stale-error-and-low-confidence-states)
+11. [Test Plan](#11-test-plan)
+12. [Implementation readiness](#implementation-readiness)
+
+---
+
+## 1. Problem and Goal
+
+People want quick answers to small money questions without opening the app and
+navigating. The goal is a **hands-free and hands-on** query surface that:
+
+- Answers a constrained set of finance questions ("balance", "spending by
+  category / merchant / account / date range") from Siri, Shortcuts, Spotlight,
+  and a typed in-app field.
+- Runs **100% on-device** — no phrase, transcript, or financial figure is ever
+  sent to a cloud NLP service.
+- Treats **voice as one of several equal entry points**, never the only path:
+  every voice action has a typed and a VoiceOver-navigable equivalent.
+- Reuses one shared parser and aggregator (KMP `packages/core`) so iOS, and
+  later Android, return identical answers for identical questions.
+
+Non-goals: free-form conversational AI, multi-step transactional actions
+(transfers, payments), and any natural-language _generation_ beyond a small set
+of templated response strings.
+
+## 2. Affected iOS Surfaces
+
+| Surface             | Role                                                                   | New / changed                        |
+| ------------------- | ---------------------------------------------------------------------- | ------------------------------------ |
+| App Intents bundle  | `AppIntent` types (balance, spending) + `AppShortcutsProvider` phrases | New `Finance/Intents/`               |
+| Siri / voice        | Spoken invocation and `IntentDialog` spoken response                   | New, via App Intents                 |
+| Shortcuts app       | User-composable actions and parameters                                 | New, via App Intents                 |
+| Spotlight           | Typed query suggestions surfaced as App Shortcuts                      | New, via App Intents                 |
+| In-app query field  | SwiftUI typed-entry view that calls the same planner directly          | New `Finance/Query/QueryEntryView`   |
+| Result presentation | SwiftUI snippet view (`IntentSnippetView`) + in-app result view        | New `Finance/Query/QueryResultView`  |
+| Biometric gate      | `LAContext` + Keychain for sensitive-result reveal                     | Reuses existing `KeychainService`    |
+| watchOS companion   | Read-only spoken/short result relay (no parsing on watch)              | New `FinanceWatch/Query` (follow-up) |
+
+No existing screen is replaced; this is an additive surface that links back into
+existing destinations defined in
+[information-architecture.md](./information-architecture.md).
+
+## 3. Shared Dependencies and the KMP Boundary
+
+The hard rule for this cluster: **iOS owns the Apple-framework surface; KMP owns
+the meaning of a query and the math.** The iOS layer never parses a sentence or
+sums a transaction itself.
+
+```mermaid
+flowchart LR
+  subgraph Native["iOS native (apps/ios)"]
+    A["Siri, Shortcuts, Spotlight"]
+    B["App Intents bundle"]
+    C["Typed QueryEntryView (SwiftUI)"]
+    D["IntentSnippetView and QueryResultView"]
+    E["Biometric gate (LAContext, Keychain)"]
+  end
+
+  subgraph Shared["KMP shared (packages/core, packages/models)"]
+    P["QueryPlanner (text to FinanceQuery)"]
+    Q["QueryExecutor (FinanceQuery to QueryResult)"]
+    R["Clarification model"]
+    M["Models: Account, Transaction, Category"]
+  end
+
+  A --> B
+  C --> P
+  B --> P
+  P -->|"parsed"| Q
+  P -->|"ambiguous or low confidence"| R
+  Q --> D
+  R --> D
+  Q --> M
+  E -. "gates reveal" .-> D
+```
+
+- **KMP (`packages/core`, `packages/models`)** — owns `QueryPlanner`,
+  `FinanceQuery`, `QueryExecutor`, `QueryResult`, and `Clarification`. This is
+  where category/merchant/account/date-range parsing and aggregation live (see
+  [ios-local-query-planner-clarification.md](./ios-local-query-planner-clarification.md)).
+  Shared models follow [data-model.md](./data-model.md).
+- **iOS native (`apps/ios`)** — owns `AppIntent` conformances, the
+  `AppShortcutsProvider` phrase catalog, `IntentDialog`, SwiftUI snippet and
+  result views, VoiceOver semantics, Dynamic Type layout, and the biometric
+  gate. It translates KMP types across the Swift Export bridge and renders them.
+- **Type mapping** across the bridge follows the standard contract
+  (`Int` → `Int32`, `String` → `String`, `List` → `Array`, Kotlin `sealed` →
+  Swift `enum`). `Clarification` is a sealed type → Swift enum the UI switches
+  over exhaustively.
+
+> Any change to `QueryPlanner` / `FinanceQuery` shape is a **KMP change** and
+> must be proposed to @kmp-engineer / @architect via ADR — this doc does not
+> implement it.
+
+## 4. Supported Local Intents
+
+The v1 catalog is intentionally small and fully enumerable (each maps to one
+`AppIntent` and one or more `AppShortcutPhrase`s):
+
+| Intent                | Example phrases                                          | Shape returned                         |
+| --------------------- | -------------------------------------------------------- | -------------------------------------- |
+| `BalanceQueryIntent`  | "What's my balance?", "Balance on Checking"              | One account or net balance (sensitive) |
+| `SpendingQueryIntent` | "How much did I spend on groceries this month?"          | Sum over a category / merchant / range |
+| `SpendingByDimension` | "Spending by category last week", "Top merchants in May" | A small ranked list                    |
+| `BudgetQueryIntent`   | "How much is left in my dining budget?"                  | Remaining-budget figure (sensitive)    |
+
+All phrases are declared with `String(localized:)` so Siri vocabulary and
+Shortcuts titles localize. Parameters (account, category, date range) are
+resolved by the **KMP planner**, not by hand-written Swift parsing.
+
+## 5. Entry Points: Voice and Typed
+
+Voice is an _alternative_, never the sole path. Every supported question is
+reachable four ways, all funneling into the same KMP `QueryPlanner`:
+
+1. **Voice (Siri)** — spoken phrase → App Intent → planner. Spoken `IntentDialog`
+   response, optionally with a visual snippet.
+2. **Shortcuts (tap / automation)** — same App Intent, parameters pre-filled.
+3. **Spotlight (typed)** — typed query surfaces an App Shortcut.
+4. **In-app typed field** — `QueryEntryView` calls the planner directly; useful
+   when speech is unavailable, in a quiet space, or for users who do not use
+   voice. This is the **canonical fallback** and must always be present.
+
+Speech recognition availability (`SFSpeechRecognizer` authorization, dictation
+toggles) **must not** change which answers are reachable — only _how_ they are
+entered. Fixtures in
+[ios-nl-query-fixtures.md](./ios-nl-query-fixtures.md) exercise the planner with
+text only, so the test suite is independent of speech availability.
+
+## 6. Intent Resolution Flow
+
+```mermaid
+flowchart TD
+  S["Entry: spoken or typed phrase"] --> N{"Speech path?"}
+  N -->|"spoken"| T["On-device transcription (SFSpeechRecognizer)"]
+  N -->|"typed"| U["Raw text"]
+  T --> U
+  U --> P["KMP QueryPlanner.parse"]
+  P --> C{"Result type"}
+  C -->|"FinanceQuery confident"| X["KMP QueryExecutor.run"]
+  C -->|"Clarification needed"| K["Render clarification prompt"]
+  C -->|"Unsupported or low confidence"| L["Graceful decline, suggest typed entry"]
+  X --> SN{"Sensitive result?"}
+  SN -->|"yes"| B["Biometric gate via LAContext"]
+  SN -->|"no"| R["Render result"]
+  B -->|"success"| R
+  B -->|"fail or cancel"| H["Withhold figure, offer open-in-app"]
+  K --> P
+```
+
+- On-device transcription uses `SFSpeechRecognizer` configured with
+  `requiresOnDeviceRecognition = true`; if on-device recognition is
+  unavailable, the surface falls back to **typed entry** rather than a network
+  request.
+- The clarification loop is bounded (see
+  [planner doc §clarification](./ios-local-query-planner-clarification.md)); it
+  is not an open-ended conversation.
+
+## 7. Sensitive-Result Confirmation Rules
+
+Balances, remaining-budget figures, and account-level totals are **sensitive**.
+Spending aggregates phrased as a single number tied to an account are also
+sensitive.
+
+- **Reveal gate:** sensitive figures returned via Siri/Shortcuts require a
+  successful `LAContext` evaluation (Face ID / Touch ID, falling back to device
+  passcode) when the device is locked or when "Hide on Lock Screen" is enabled.
+  Access control uses `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`.
+- **Spoken responses** never voice a sensitive figure on a locked device. The
+  spoken `IntentDialog` instead says a non-sensitive prompt (e.g. _"Unlock
+  Finance to hear your balance"_) — copy per
+  [content-language-guidelines.md](./content-language-guidelines.md).
+- **Snippet redaction:** before a successful gate, the snippet shows a masked
+  placeholder (•••) with a "Tap to reveal in app" affordance.
+- **No biometric bypass** for convenience — this is a hard boundary.
+
+## 8. Accessibility
+
+- **VoiceOver:** every interactive element in `QueryEntryView`,
+  `QueryResultView`, and clarification prompts has an `.accessibilityLabel()`
+  and, where the value is the point of the screen, an `.accessibilityValue()`.
+  Result rows reuse the labeling grammar from
+  [ios-transaction-row-voiceover-labels.md](./ios-transaction-row-voiceover-labels.md)
+  and chart results reuse
+  [ios-chart-voiceover-navigation.md](./ios-chart-voiceover-navigation.md).
+- **Voice as alternative, not sole path:** because some VoiceOver and Switch
+  Control users do not use Siri voice input, the typed `QueryEntryView` is the
+  guaranteed-present equivalent; no answer is voice-only.
+- **Announcements:** result availability posts an
+  `AccessibilityNotification.Announcement` so the answer is spoken once rendered,
+  even when focus has not moved.
+- **Dynamic Type:** all strings use text styles (no hardcoded sizes); result and
+  clarification layouts reflow and never truncate the figure. Tested at
+  `accessibility5`.
+- **Reduce Motion:** result transitions honor `accessibilityReduceMotion`.
+- Cognitive-load guidance follows
+  [cognitive-accessibility.md](./cognitive-accessibility.md): one question, one
+  clear answer, plain-language prompts.
+
+## 9. Privacy and Data Minimization
+
+- **On-device only:** parsing, aggregation, and (where available) transcription
+  run locally. No phrase, transcript, account name, or amount leaves the device.
+  There is **no cloud NLP**.
+- **Data minimization:** an App Intent receives only the fields it needs; the
+  snippet/dialog carries the single answer, not the underlying transaction set.
+- **Logging:** structured `os.Logger` only; financial values are `.private` and
+  never interpolated as `.public`. Phrases are not logged verbatim.
+- **Donations:** intent donation metadata excludes amounts and account
+  identifiers; only the abstract intent type is donated to the system.
+- **GDPR / CCPA:** because no personal financial data is transmitted or shared
+  with a processor, this surface introduces **no new data-sharing**. On-device
+  caches honor the app's existing data-deletion path; deleting the account
+  clears any donated shortcuts and cached results. No new consent surface is
+  required, but the privacy nutrition label must continue to declare "Data Not
+  Collected" for this feature.
+
+## 10. Empty, Stale, Error, and Low-Confidence States
+
+| State              | Trigger                                      | Behavior                                                                 |
+| ------------------ | -------------------------------------------- | ------------------------------------------------------------------------ |
+| Empty result       | Valid query, no matching transactions        | "No spending found for …" + typed-entry affordance; never an error toast |
+| Stale data         | Local store older than freshness window      | Show answer with a "as of <time>" qualifier; offer refresh in app        |
+| Parse error        | Planner throws / bridge failure              | Decline gracefully, log non-sensitively, suggest typed entry             |
+| Ambiguous          | Multiple entity candidates (see planner doc) | Clarification prompt with ≤3 candidates                                  |
+| Low confidence     | Below auto-execute threshold                 | Offer best guess as a confirmable suggestion, do not auto-answer         |
+| Unsupported intent | Phrase outside the v1 catalog                | "I can answer balance and spending questions" + examples                 |
+| Locked / sensitive | Sensitive figure on locked device            | Masked + biometric gate (§7)                                             |
+
+All copy is templated and localized; no state dead-ends — each offers a next
+step (typed entry, open in app, or rephrase).
+
+## 11. Test Plan
+
+Smallest meaningful set before implementation is accepted. The deterministic NL
+fixtures in [ios-nl-query-fixtures.md](./ios-nl-query-fixtures.md) are the
+**anchor**: native and shared tests both consume the same fixture corpus.
+
+**Shared (KMP, `packages/core`) — runs on JVM, no device:**
+
+1. `QueryPlannerTest` — each fixture phrase parses to the expected `FinanceQuery`
+   or `Clarification` (golden comparison).
+2. `QueryExecutorTest` — each `FinanceQuery` over a seeded, fixed-clock dataset
+   yields the expected `QueryResult`.
+
+**Native (iOS, Simulator — free signing):**
+
+3. `IntentResolutionTests` (XCTest) — each `AppIntent` maps a phrase to the
+   planner call and renders the expected snippet/dialog for one fixture per
+   intent.
+4. `SensitiveGateTests` — sensitive results are masked until a stubbed
+   `LAContext` succeeds; spoken response withholds figures when locked.
+5. `QueryAccessibilityUITests` (XCUITest) — VoiceOver labels/values present,
+   Dynamic Type at `accessibility5` does not truncate the figure, typed-entry
+   path reaches every answer with speech disabled.
+
+CI: shared tests in `ci-shared.yml`, native tests in `ci-ios.yml` (Simulator).
+No device farm or signing required for any of the above.
+
+## Implementation readiness
+
+**Design: ready now. Native code: buildable now, distribution gated.**
+
+Per the
+[Human-Gated Prerequisites runbook](../ops/human-gated-prerequisites.md#2-implementation-vs-distribution--the-decoupling),
+implementation and distribution are decoupled. The "blocked by
+[#1239](https://github.com/jrmoulckers/finance/issues/1239)" note on
+[#2617](https://github.com/jrmoulckers/finance/issues/2617) is a **distribution**
+gate only.
+
+| Phase              | What                                                                      | Gated by #1239?                     |
+| ------------------ | ------------------------------------------------------------------------- | ----------------------------------- |
+| **Design**         | This document, intent catalog, resolution flow, confirmation rules, tests | No — deliverable now                |
+| **Implementation** | App Intents, `AppShortcutsProvider`, snippet/dialog views, planner bridge | **No** — free Personal Team signing |
+| **Distribution**   | TestFlight / App Store build carrying the Siri surface                    | **Yes** — Apple Developer Program   |
+
+- **Buildable now:** `AppIntent`, `AppShortcutsProvider`, `IntentDialog`,
+  `SFSpeechRecognizer` on-device recognition, `LAContext`, and SwiftUI snippet
+  views are all standard iOS 17 APIs with no paid entitlement; they run on
+  Simulator and on a device via free Personal Team signing.
+- **Gated tail (#1239):** only store/TestFlight distribution needs the paid
+  enrollment + signing material in
+  [human-gated-prerequisites.md §3.2](../ops/human-gated-prerequisites.md#32-ios-distribution--apple-developer-1239).
+  An SME agent must **not** perform enrollment, certificate, or secret steps.
+
+_Part of [#2386](https://github.com/jrmoulckers/finance/issues/2386). Sibling
+designs:
+[local query planner and clarification](./ios-local-query-planner-clarification.md)
+· [deterministic NL fixtures](./ios-nl-query-fixtures.md)._

--- a/docs/design/ios-local-query-planner-clarification.md
+++ b/docs/design/ios-local-query-planner-clarification.md
@@ -1,0 +1,297 @@
+# Constrained Local Finance Query Planner and Clarification UX
+
+> Design specification for the **shared, on-device query planner** that turns a
+> short finance phrase into a structured, bounded `FinanceQuery` over category,
+> merchant, account, and date-range dimensions — and for the **clarification
+> UX** iOS shows when a phrase is ambiguous or low-confidence. The planner is
+> deliberately _constrained_: it recognizes a small grammar, never invents
+> answers, and asks rather than guesses.
+
+**Status:** PROPOSED — design only (native implementation gated, see
+[Implementation readiness](#implementation-readiness))
+**Issue:** [#2618](https://github.com/jrmoulckers/finance/issues/2618) — _Part of
+[#2386](https://github.com/jrmoulckers/finance/issues/2386)_
+**Platform:** Shared KMP (`packages/core`) + iOS 17 presentation (`apps/ios`)
+**Last updated:** 2026-06-22
+**Related design docs:**
+[data-model.md](./data-model.md) ·
+[ux-principles.md](./ux-principles.md) ·
+[cognitive-accessibility.md](./cognitive-accessibility.md) ·
+[content-language-guidelines.md](./content-language-guidelines.md) ·
+[accessibility-patterns.md](./accessibility-patterns.md)
+**Sibling docs (this cluster):**
+[ios-app-intents-siri-query.md](./ios-app-intents-siri-query.md) ·
+[ios-nl-query-fixtures.md](./ios-nl-query-fixtures.md)
+
+---
+
+## Table of Contents
+
+1. [Problem and Goal](#1-problem-and-goal)
+2. [Affected iOS Surfaces](#2-affected-ios-surfaces)
+3. [Shared Dependencies and the KMP Boundary](#3-shared-dependencies-and-the-kmp-boundary)
+4. [Query Grammar and Supported Dimensions](#4-query-grammar-and-supported-dimensions)
+5. [Planner Pipeline](#5-planner-pipeline)
+6. [Confidence Scoring and Thresholds](#6-confidence-scoring-and-thresholds)
+7. [Clarification UX](#7-clarification-ux)
+8. [Accessibility](#8-accessibility)
+9. [Privacy and Data Minimization](#9-privacy-and-data-minimization)
+10. [Empty, Stale, Error, and Low-Confidence States](#10-empty-stale-error-and-low-confidence-states)
+11. [Test Plan](#11-test-plan)
+12. [Implementation readiness](#implementation-readiness)
+
+---
+
+## 1. Problem and Goal
+
+The [Siri/App Intents surface](./ios-app-intents-siri-query.md) needs a single,
+predictable component that converts a short phrase into something the app can
+execute. We want a planner that is:
+
+- **Constrained** — recognizes a finite grammar of dimensions
+  (category, merchant, account, date range) and a small set of aggregations
+  (balance, sum, ranked list, count). It is not an open-ended assistant.
+- **Deterministic** — the same phrase, dataset, locale, and clock always yield
+  the same `FinanceQuery` (so it can be pinned by golden fixtures, see
+  [ios-nl-query-fixtures.md](./ios-nl-query-fixtures.md)).
+- **Honest** — when a phrase is ambiguous or weakly matched, it returns a
+  `Clarification` instead of guessing. Asking is cheaper than a wrong number.
+- **Shared** — implemented once in KMP `packages/core` so every platform parses
+  identically; iOS only renders the prompts and results.
+
+## 2. Affected iOS Surfaces
+
+| Surface                       | Role                                                         |
+| ----------------------------- | ------------------------------------------------------------ |
+| `QueryEntryView` (SwiftUI)    | Typed entry; submits raw text to the KMP planner             |
+| `ClarificationView` (SwiftUI) | Renders a `Clarification` as a bounded disambiguation prompt |
+| App Intents `IntentDialog`    | Spoken/visual clarification when invoked via Siri            |
+| `QueryResultView` (SwiftUI)   | Renders the executed `QueryResult`                           |
+| `@Observable QueryViewModel`  | Holds entry text, planner state, clarification turns, result |
+
+The view model is `@Observable` (Observation framework), not `ObservableObject`.
+All planner calls are `async` and update `@MainActor` UI state.
+
+## 3. Shared Dependencies and the KMP Boundary
+
+```mermaid
+flowchart LR
+  subgraph Native["iOS native (apps/ios)"]
+    V["QueryEntryView"]
+    VM["QueryViewModel (Observable)"]
+    CV["ClarificationView"]
+    RV["QueryResultView"]
+  end
+
+  subgraph Shared["KMP (packages/core, packages/models)"]
+    PL["QueryPlanner"]
+    NM["Normalizer (lowercase, locale, synonyms)"]
+    ER["EntityResolver (category, merchant, account)"]
+    DR["DateRangeResolver"]
+    QB["QuerySpec builder, confidence"]
+    EX["QueryExecutor"]
+    CL["Clarification (sealed)"]
+  end
+
+  V --> VM --> PL
+  PL --> NM --> ER --> DR --> QB
+  QB -->|"confident"| EX --> RV
+  QB -->|"ambiguous or low"| CL --> CV
+  CV -->|"user picks candidate"| VM
+```
+
+- **KMP owns** `QueryPlanner`, `Normalizer`, `EntityResolver`,
+  `DateRangeResolver`, the `FinanceQuery` (a.k.a. `QuerySpec`) builder,
+  `QueryExecutor`, and the `Clarification` sealed hierarchy. Entity resolution
+  reads `Account` / `Category` / `Transaction` per
+  [data-model.md](./data-model.md).
+- **iOS owns** only presentation: text input, rendering `Clarification`
+  candidates, capturing the chosen candidate, and rendering `QueryResult`.
+- **Bridge mapping:** `Clarification` (Kotlin `sealed`) → Swift `enum` the UI
+  switches over exhaustively; `FinanceQuery` fields map by the standard contract
+  (`Int` → `Int32`, `String` → `String`, `List` → `Array`).
+
+> Grammar/threshold changes are **KMP changes**: propose via ADR to
+> @kmp-engineer / @architect. This doc specifies behavior, not Kotlin code.
+
+## 4. Query Grammar and Supported Dimensions
+
+A `FinanceQuery` is a small, closed struct. v1 dimensions:
+
+| Dimension   | Examples (input)                             | Resolution source                          |
+| ----------- | -------------------------------------------- | ------------------------------------------ |
+| Aggregation | "balance", "how much", "top", "how many"     | Verb/keyword → `Aggregation` enum          |
+| Category    | "groceries", "dining", "transport"           | `Category` names + curated synonym table   |
+| Merchant    | "at Trader Joe's", "Amazon"                  | Distinct merchant strings in `Transaction` |
+| Account     | "Checking", "my Visa", "savings"             | `Account` names + type aliases             |
+| Date range  | "this month", "last week", "in May", "today" | `DateRangeResolver` (locale + clock)       |
+
+Rules:
+
+- **At most one** value per dimension in v1; multiple values of the same
+  dimension ("groceries and dining") trigger clarification rather than a guess.
+- **Synonyms** are a curated, localized table (`String(localized:)` keys on the
+  iOS side for any display text; matching itself is in KMP). No fuzzy ML
+  matching — matching is normalized exact + a bounded edit-distance for typos.
+- **Unbounded date** defaults to a sensible window (current month) only when the
+  aggregation requires one and none is stated; this default is surfaced in the
+  answer ("this month") so it is never silent.
+
+## 5. Planner Pipeline
+
+```mermaid
+flowchart TD
+  A["Raw phrase"] --> B["Normalize (lowercase, strip filler, locale tokens)"]
+  B --> C["Detect aggregation keyword"]
+  C --> D["Resolve entities (category, merchant, account)"]
+  D --> E["Resolve date range"]
+  E --> F["Score confidence per dimension and overall"]
+  F --> G{"Overall band"}
+  G -->|"high"| H["Emit FinanceQuery"]
+  G -->|"medium"| I["Emit Clarification (confirm or choose)"]
+  G -->|"low"| J["Emit Clarification (unsupported, suggest examples)"]
+  D -->|"multiple candidates"| I
+```
+
+Each stage is pure and side-effect-free over its inputs (text + a snapshot of
+entity names + a fixed clock), which is what makes the planner fixture-testable.
+
+## 6. Confidence Scoring and Thresholds
+
+Confidence is a bounded `Double` in `0.0...1.0`, combining per-dimension match
+quality (exact = high, synonym = medium, edit-distance = lower) and coverage
+(did we find an aggregation and at least one filter?).
+
+| Band   | Range       | Behavior                                                  |
+| ------ | ----------- | --------------------------------------------------------- |
+| High   | ≥ 0.85      | Auto-build `FinanceQuery` and execute                     |
+| Medium | 0.50 – 0.85 | Build best-guess but **confirm** ("Did you mean dining?") |
+| Low    | < 0.50      | Decline; return `Clarification.unsupported` with examples |
+
+Thresholds are constants in KMP and are pinned by fixtures so behavior cannot
+drift silently. They are not user-configurable in v1.
+
+## 7. Clarification UX
+
+A `Clarification` is one of a small sealed set; iOS renders each as a bounded,
+non-conversational prompt:
+
+| `Clarification` case | When                               | iOS rendering                                            |
+| -------------------- | ---------------------------------- | -------------------------------------------------------- |
+| `.chooseEntity`      | 2–3 candidates for one dimension   | List of ≤3 tappable candidates + "None of these"         |
+| `.confirmGuess`      | Single medium-confidence guess     | "Did you mean <X>?" Yes / No (rephrase)                  |
+| `.missingDimension`  | Aggregation found, no filter/range | Prompt for the missing piece with example chips          |
+| `.unsupported`       | Low confidence / outside catalog   | "I can answer balance and spending questions" + examples |
+
+UX rules (aligned with [cognitive-accessibility.md](./cognitive-accessibility.md)
+and [ux-principles.md](./ux-principles.md)):
+
+- **Bounded turns:** at most **two** clarification turns, then the surface offers
+  typed entry / open-in-app and stops. No infinite loops.
+- **Always show ≤3 candidates** to limit cognitive load; if more match, narrow
+  by recency rather than listing all.
+- **Plain, non-judgmental language** per
+  [content-language-guidelines.md](./content-language-guidelines.md); never blame
+  the user ("I didn't catch that", not "Invalid query").
+- **Escape hatch always present:** "None of these" / "Type it instead" on every
+  prompt — so voice is never a trap.
+
+## 8. Accessibility
+
+- **VoiceOver:** each candidate in `ClarificationView` is its own element with a
+  descriptive `.accessibilityLabel()` (e.g. _"Dining category, choose"_); the
+  prompt is announced via `AccessibilityNotification.Announcement` when it
+  appears. Patterns from [accessibility-patterns.md](./accessibility-patterns.md).
+- **Voice as alternative, not sole path:** clarification is fully operable by
+  tap and by VoiceOver — a user who cannot or will not speak resolves ambiguity
+  the same way. The "Type it instead" affordance is mandatory.
+- **Dynamic Type:** candidate rows and prompts use text styles and reflow to
+  multi-line at large sizes; chips wrap, never truncate. Verified at
+  `accessibility5`.
+- **Focus order:** prompt → candidates → escape hatch, a logical reading order;
+  focus moves to the prompt when it appears.
+- **Switch Control / keyboard:** all candidates are focusable controls with ≥44pt
+  targets.
+
+## 9. Privacy and Data Minimization
+
+- **On-device only:** normalization, entity resolution, scoring, and execution
+  all run locally. Phrases and candidates never leave the device; there is no
+  cloud NLP.
+- **Data minimization:** the planner reads only entity _names_ and the minimal
+  transaction fields needed to aggregate; raw phrases are not persisted.
+- **No verbatim logging:** `os.Logger` records the abstract path (band, case
+  taken) but never the phrase, candidate names, or amounts (`.private`).
+- **GDPR / CCPA:** introduces no new data collection or sharing — all processing
+  is local and ephemeral. Clearing app data clears any cached synonym/entity
+  snapshots; no new consent surface is required.
+
+## 10. Empty, Stale, Error, and Low-Confidence States
+
+| State          | Trigger                                     | Behavior                                                      |
+| -------------- | ------------------------------------------- | ------------------------------------------------------------- |
+| Empty          | Valid `FinanceQuery`, zero matches          | "No spending found for <filter> <range>" + adjust/typed entry |
+| Stale          | Entity snapshot older than freshness window | Resolve against last-known; qualify result "as of <time>"     |
+| Error          | Resolver/executor failure or bridge error   | `Clarification.unsupported` fallback + non-sensitive log      |
+| Ambiguous      | Multiple candidates for a dimension         | `.chooseEntity` (≤3)                                          |
+| Low confidence | Overall < 0.50                              | `.unsupported` with examples; no auto-execute                 |
+| Over-specified | Two values for one dimension                | `.chooseEntity` to pick one (v1 single-value rule)            |
+
+Every state resolves to a next action; none dead-ends.
+
+## 11. Test Plan
+
+Smallest set, fixture-anchored on
+[ios-nl-query-fixtures.md](./ios-nl-query-fixtures.md):
+
+**Shared (KMP, `packages/core`) — JVM, no device:**
+
+1. `NormalizerTest` — filler stripping, locale tokens, synonym mapping are
+   deterministic for each fixture.
+2. `EntityResolverTest` — exact / synonym / typo (edit-distance) cases resolve
+   to expected candidates; over-specified input yields multiple candidates.
+3. `DateRangeResolverTest` — "this month", "last week", "in May", "today" resolve
+   to exact ranges under a **fixed clock**.
+4. `QueryPlannerTest` — full phrase → expected `FinanceQuery` **or** expected
+   `Clarification` case (golden).
+5. `ConfidenceThresholdTest` — boundary phrases land in the expected band.
+
+**Native (iOS, Simulator — free signing):**
+
+6. `ClarificationViewTests` (XCTest/snapshot) — each `Clarification` case renders
+   the correct controls, ≤3 candidates, and an escape hatch.
+7. `ClarificationA11yUITests` (XCUITest) — VoiceOver labels/announcement,
+   Dynamic Type at `accessibility5`, two-turn bound enforced, "Type it instead"
+   reachable without speech.
+
+CI: shared in `ci-shared.yml`, native in `ci-ios.yml` (Simulator). No signing.
+
+## Implementation readiness
+
+**Design: ready now. Native code: buildable now, distribution gated.**
+
+Per the
+[Human-Gated Prerequisites runbook](../ops/human-gated-prerequisites.md#2-implementation-vs-distribution--the-decoupling),
+implementation and distribution are decoupled. The "blocked by
+[#1239](https://github.com/jrmoulckers/finance/issues/1239)" note on
+[#2618](https://github.com/jrmoulckers/finance/issues/2618) is a **distribution**
+gate only.
+
+| Phase              | What                                                                  | Gated by #1239?                     |
+| ------------------ | --------------------------------------------------------------------- | ----------------------------------- |
+| **Design**         | This document, grammar, pipeline, thresholds, clarification UX, tests | No — deliverable now                |
+| **Implementation** | KMP planner/executor/clarification + SwiftUI prompt and result views  | **No** — free Personal Team signing |
+| **Distribution**   | TestFlight / App Store build carrying the planner-backed surface      | **Yes** — Apple Developer Program   |
+
+- **Buildable now:** the KMP planner builds and unit-tests on the JVM with no
+  Apple account; the SwiftUI `ClarificationView` / `QueryResultView` and the
+  `@Observable` view model run on Simulator and on-device via free Personal Team
+  signing.
+- **Gated tail (#1239):** only store/TestFlight distribution needs the paid
+  enrollment + signing material in
+  [human-gated-prerequisites.md §3.2](../ops/human-gated-prerequisites.md#32-ios-distribution--apple-developer-1239).
+  An SME agent must **not** perform enrollment, certificate, or secret steps.
+
+_Part of [#2386](https://github.com/jrmoulckers/finance/issues/2386). Sibling
+designs: [App Intents and Siri surface](./ios-app-intents-siri-query.md) ·
+[deterministic NL fixtures](./ios-nl-query-fixtures.md)._

--- a/docs/design/ios-nl-query-fixtures.md
+++ b/docs/design/ios-nl-query-fixtures.md
@@ -1,0 +1,303 @@
+# Deterministic iOS Natural-Language Query Fixtures
+
+> Design specification for a **deterministic, speech-independent fixture corpus**
+> that pins the behavior of the on-device finance query planner and its three
+> output variants — typed result, spoken (Siri) response, and VoiceOver output.
+> The fixtures are the shared contract that lets KMP and iOS tests agree on
+> exactly what each phrase should produce, with no reliance on a microphone,
+> network, or wall-clock time.
+
+**Status:** PROPOSED — design only (native implementation gated, see
+[Implementation readiness](#implementation-readiness))
+**Issue:** [#2619](https://github.com/jrmoulckers/finance/issues/2619) — _Part of
+[#2386](https://github.com/jrmoulckers/finance/issues/2386)_
+**Platform:** Shared KMP test resources (`packages/core`) + iOS test consumers
+(`apps/ios`)
+**Last updated:** 2026-06-22
+**Related design docs:**
+[data-model.md](./data-model.md) ·
+[content-language-guidelines.md](./content-language-guidelines.md) ·
+[accessibility-patterns.md](./accessibility-patterns.md) ·
+[cognitive-accessibility.md](./cognitive-accessibility.md)
+**Sibling docs (this cluster):**
+[ios-app-intents-siri-query.md](./ios-app-intents-siri-query.md) ·
+[ios-local-query-planner-clarification.md](./ios-local-query-planner-clarification.md)
+
+---
+
+## Table of Contents
+
+1. [Problem and Goal](#1-problem-and-goal)
+2. [Affected iOS Surfaces and Consumers](#2-affected-ios-surfaces-and-consumers)
+3. [Shared Dependencies and the KMP Boundary](#3-shared-dependencies-and-the-kmp-boundary)
+4. [Fixture Schema](#4-fixture-schema)
+5. [Determinism Rules](#5-determinism-rules)
+6. [Fixture Categories](#6-fixture-categories)
+7. [Result Variants: Typed, Spoken, VoiceOver](#7-result-variants-typed-spoken-voiceover)
+8. [Accessibility Fixtures](#8-accessibility-fixtures)
+9. [Privacy and Synthetic Data](#9-privacy-and-synthetic-data)
+10. [Empty, Stale, Error, and Low-Confidence Fixtures](#10-empty-stale-error-and-low-confidence-fixtures)
+11. [Test Plan](#11-test-plan)
+12. [Implementation readiness](#implementation-readiness)
+
+---
+
+## 1. Problem and Goal
+
+The [planner](./ios-local-query-planner-clarification.md) and the
+[Siri surface](./ios-app-intents-siri-query.md) only stay trustworthy if their
+behavior is pinned. Speech recognition is non-deterministic and unavailable in
+CI, so tests must never depend on it. The goal is a **single fixture corpus**
+that:
+
+- Maps each input **phrase (text)** to its expected parse and outputs — so the
+  same corpus drives both KMP planner tests and iOS rendering tests.
+- Is **fully deterministic**: fixed clock, fixed locale set, seeded synthetic
+  dataset, no randomness, no network, no microphone.
+- Covers all three **output variants** (typed, spoken, VoiceOver) plus every
+  edge state (empty / error / ambiguous / low-confidence / clarification).
+- Acts as the **regression anchor**: a planner or copy change that alters any
+  expected value must update a fixture, making behavior changes reviewable.
+
+## 2. Affected iOS Surfaces and Consumers
+
+| Consumer                                 | Uses the fixtures for                                             |
+| ---------------------------------------- | ----------------------------------------------------------------- |
+| KMP `QueryPlannerTest` (`packages/core`) | phrase → `FinanceQuery` / `Clarification` golden assertions       |
+| KMP `QueryExecutorTest`                  | `FinanceQuery` over seeded data → `QueryResult` golden assertions |
+| iOS `IntentResolutionTests`              | per-intent rendering of one fixture's snippet + spoken dialog     |
+| iOS `QueryViewSnapshotTests`             | typed `QueryResultView` / `ClarificationView` snapshots           |
+| iOS `QueryAccessibilityUITests`          | expected VoiceOver label/value/announcement strings per fixture   |
+
+Speech is **out of scope** for fixtures: transcription is assumed already done;
+the input is always text.
+
+## 3. Shared Dependencies and the KMP Boundary
+
+```mermaid
+flowchart LR
+  subgraph Resources["Shared fixtures (packages/core test resources)"]
+    FX["nl-query-fixtures (structured data)"]
+    DS["seed-dataset (synthetic accounts, transactions)"]
+    CK["fixed clock, locale list"]
+  end
+
+  subgraph Shared["KMP tests (packages/core)"]
+    PT["QueryPlannerTest"]
+    ET["QueryExecutorTest"]
+  end
+
+  subgraph Native["iOS tests (apps/ios)"]
+    IR["IntentResolutionTests"]
+    SN["QueryViewSnapshotTests"]
+    AX["QueryAccessibilityUITests"]
+  end
+
+  FX --> PT
+  FX --> ET
+  DS --> ET
+  CK --> PT
+  CK --> ET
+  FX --> IR
+  FX --> SN
+  FX --> AX
+```
+
+- **KMP owns** the canonical fixture format, the seed dataset, the fixed clock,
+  and the planner/executor that the fixtures assert against. Fixtures live with
+  the shared tests so there is one source of truth. Synthetic data follows the
+  [data-model.md](./data-model.md) shapes.
+- **iOS owns** how it reads the shared fixture corpus into XCTest/XCUITest and
+  asserts on rendered typed/spoken/VoiceOver output. iOS does **not** maintain a
+  divergent copy of the phrases.
+- **Bridge note:** the corpus is plain structured data (language-neutral), so it
+  crosses to Swift without bespoke type mapping; only the expected `Aggregation`
+  / `Clarification` enum tags must stay in sync with the KMP sealed types.
+
+> Adding/altering the fixture _format_ touches shared test resources — coordinate
+> with @kmp-engineer via ADR. Adding new _rows_ in the agreed format is routine.
+
+## 4. Fixture Schema
+
+Each fixture is one record. Conceptual shape (serialized as language-neutral
+structured data, e.g. one object per case):
+
+| Field               | Meaning                                                               |
+| ------------------- | --------------------------------------------------------------------- |
+| `id`                | Stable identifier (e.g. `spend.groceries.thisMonth`)                  |
+| `locale`            | BCP-47 tag the phrase is written for (e.g. `en-US`, `en-GB`)          |
+| `phrase`            | The input text (already transcribed; never audio)                     |
+| `expectedKind`      | `query` \| `clarification` \| `unsupported`                           |
+| `expectedQuery`     | For `query`: aggregation + resolved category/merchant/account/range   |
+| `expectedClarify`   | For `clarification`: case + ordered candidate ids                     |
+| `expectedResult`    | For `query`: the `QueryResult` over the seed dataset                  |
+| `expectedTyped`     | Rendered typed answer string (template-resolved)                      |
+| `expectedSpoken`    | Spoken `IntentDialog` string (may differ from typed; redaction-aware) |
+| `expectedVoiceOver` | VoiceOver label/value/announcement string                             |
+| `confidenceBand`    | Expected `high` \| `medium` \| `low`                                  |
+| `tags`              | Category labels for filtering (see §6)                                |
+
+Strings that are user-facing reference the same localized keys defined for the
+UI (`String(localized:)`), so a copy change updates both the app and the fixture
+expectation in one place — consistent with
+[content-language-guidelines.md](./content-language-guidelines.md).
+
+## 5. Determinism Rules
+
+Non-negotiable for every fixture run:
+
+- **Fixed clock:** a single pinned "now" (e.g. `2026-05-15T12:00:00Z`) so
+  "this month", "last week", "today" resolve to byte-stable ranges. No
+  `Date()` / `Clock.System` in tested paths.
+- **Fixed locale set:** fixtures declare their `locale`; tests run each fixture
+  under its declared locale only. No reliance on the host locale.
+- **Seeded synthetic dataset:** a small, committed set of accounts,
+  transactions, categories, and merchants with fixed ids/amounts/dates. No
+  randomness, no generated faker data at run time.
+- **No I/O:** no network, no microphone, no file access beyond reading the
+  committed corpus. Speech is assumed complete; input is text.
+- **Stable ordering:** ranked lists and candidate lists have a defined,
+  deterministic tiebreak (amount desc, then name asc) so golden comparisons are
+  exact.
+- **Currency/number formatting** is pinned to the fixture locale so
+  `expectedTyped` / `expectedSpoken` are exact.
+
+## 6. Fixture Categories
+
+The corpus is tagged so suites can select subsets:
+
+| Tag             | Purpose                                                         | Example phrase                              |
+| --------------- | --------------------------------------------------------------- | ------------------------------------------- |
+| `happy.balance` | Confident balance queries                                       | "What's my balance?"                        |
+| `happy.spend`   | Confident category/merchant/range spend sums                    | "How much did I spend on groceries in May?" |
+| `happy.rank`    | Top-N ranked lists                                              | "Top merchants this month"                  |
+| `ambiguous`     | 2–3 candidate entities → `.chooseEntity`                        | "How much on transport?" (two categories)   |
+| `confirm`       | Single medium-confidence guess → `.confirmGuess`                | "Spending on dinning" (typo)                |
+| `missing`       | Aggregation but no filter/range → `.missingDimension`           | "How much did I spend?"                     |
+| `unsupported`   | Outside the v1 catalog → `.unsupported`                         | "Transfer 50 to savings"                    |
+| `empty`         | Valid query, zero matches                                       | "Spending on travel last week" (none)       |
+| `locale`        | Same intent across `en-US` / `en-GB` date and currency variance | "in May", "£" vs "$"                        |
+| `sensitive`     | Triggers redaction on a locked device                           | "Balance on Checking"                       |
+
+Every `ambiguous` / `confirm` / `missing` / `unsupported` / `empty` fixture is
+paired with the expected next-step copy so the clarification UX is pinned too.
+
+## 7. Result Variants: Typed, Spoken, VoiceOver
+
+A single fixture pins **three** outputs because the surface presents the answer
+three ways and they legitimately differ:
+
+| Variant       | Source field        | Notes                                                                |
+| ------------- | ------------------- | -------------------------------------------------------------------- |
+| Typed         | `expectedTyped`     | What `QueryResultView` shows on screen; full figure when unlocked    |
+| Spoken (Siri) | `expectedSpoken`    | `IntentDialog`; may omit/round a figure and redacts when locked      |
+| VoiceOver     | `expectedVoiceOver` | Label/value/announcement; spells out currency and ranges for clarity |
+
+Rules:
+
+- **Spoken ≠ typed by design:** spoken responses are shorter and redaction-aware
+  (see [Siri surface §7](./ios-app-intents-siri-query.md)); the fixture records
+  both so neither drifts.
+- **VoiceOver strings are explicit:** currency is read in full ("twelve dollars
+  and forty cents", per locale) and ranges are read unambiguously
+  ("May first to May thirty-first").
+- A fixture with `confidenceBand = low` has no `expectedResult`; only
+  `expectedClarify` and the three variants of the decline copy.
+
+## 8. Accessibility Fixtures
+
+- **Every fixture carries `expectedVoiceOver`** so VoiceOver output is a tested
+  contract, not an afterthought — labels/values follow
+  [accessibility-patterns.md](./accessibility-patterns.md).
+- **Speech-independent by construction:** because input is text, the suite runs
+  identically whether or not Siri/dictation is available — voice is an entry
+  method, never a test dependency.
+- **Dynamic Type fixtures:** snapshot fixtures include an `accessibility5`
+  variant assertion that the figure is not truncated and the layout reflows.
+- **Plain-language assertions:** clarification fixtures assert non-judgmental
+  copy per [cognitive-accessibility.md](./cognitive-accessibility.md) (e.g. the
+  decline string must not contain blaming language).
+
+## 9. Privacy and Synthetic Data
+
+- **Synthetic only:** the seed dataset is invented — no real accounts, balances,
+  merchants, or amounts. Safe to commit and review.
+- **On-device parity:** fixtures exercise only the on-device path; there is no
+  fixture that asserts a network call, because none exists.
+- **No secrets:** the corpus contains no tokens, keys, or credentials; it is
+  ordinary test data and never touches Keychain.
+- **GDPR / CCPA:** synthetic fixtures hold no personal data, so they create no
+  subject-rights or retention obligations; they document the privacy posture
+  (on-device, data-minimized) rather than weaken it.
+
+## 10. Empty, Stale, Error, and Low-Confidence Fixtures
+
+| State          | Fixture tag(s)      | Pinned expectation                                                 |
+| -------------- | ------------------- | ------------------------------------------------------------------ |
+| Empty          | `empty`             | `expectedResult` = zero; `expectedTyped/Spoken/VoiceOver` = "none" |
+| Stale          | `happy.*` + `stale` | result carries an "as of <fixed time>" qualifier string            |
+| Error          | `error`             | bridge/executor failure path → `unsupported` decline copy          |
+| Ambiguous      | `ambiguous`         | `.chooseEntity` with ordered candidate ids (≤3)                    |
+| Confirm        | `confirm`           | `.confirmGuess` with the single guessed entity id                  |
+| Low confidence | `unsupported`       | `confidenceBand = low`, no result, decline copy in all 3 variants  |
+
+Each edge fixture asserts the **next-step affordance** copy as well, so the
+no-dead-end rule from the sibling docs is regression-protected.
+
+## 11. Test Plan
+
+The fixtures _are_ the test plan's backbone; this section names the smallest
+suites that consume them.
+
+**Shared (KMP, `packages/core`) — JVM, no device:**
+
+1. `FixtureLoaderTest` — corpus parses, ids are unique, every fixture has the
+   fields its `expectedKind` requires.
+2. `QueryPlannerTest` — for each fixture, `phrase` → `expectedKind` and the
+   matching `expectedQuery` / `expectedClarify` (golden).
+3. `QueryExecutorTest` — for each `query` fixture, `expectedResult` over the seed
+   dataset under the fixed clock.
+
+**Native (iOS, Simulator — free signing):**
+
+4. `IntentResolutionTests` — one fixture per intent renders `expectedSpoken`
+   and the snippet matching `expectedTyped`.
+5. `QueryViewSnapshotTests` — `expectedTyped` and clarification rendering match
+   reference snapshots, including the `accessibility5` variant.
+6. `QueryAccessibilityUITests` — VoiceOver output equals `expectedVoiceOver`;
+   the suite runs with speech disabled to prove independence.
+
+A planner/copy change that alters any expected value must update the
+corresponding fixture in the same PR — making behavior changes explicit and
+reviewable. CI: shared in `ci-shared.yml`, native in `ci-ios.yml` (Simulator);
+no signing or device farm required.
+
+## Implementation readiness
+
+**Design: ready now. Native code: buildable now, distribution gated.**
+
+Per the
+[Human-Gated Prerequisites runbook](../ops/human-gated-prerequisites.md#2-implementation-vs-distribution--the-decoupling),
+implementation and distribution are decoupled. The "blocked by
+[#1239](https://github.com/jrmoulckers/finance/issues/1239)" note on
+[#2619](https://github.com/jrmoulckers/finance/issues/2619) is a **distribution**
+gate only.
+
+| Phase              | What                                                                   | Gated by #1239?                     |
+| ------------------ | ---------------------------------------------------------------------- | ----------------------------------- |
+| **Design**         | This document, fixture schema, determinism rules, categories, variants | No — deliverable now                |
+| **Implementation** | Committed corpus + KMP golden tests + iOS XCTest/XCUITest consumers    | **No** — free Personal Team signing |
+| **Distribution**   | TestFlight / App Store build carrying the fixture-backed feature       | **Yes** — Apple Developer Program   |
+
+- **Buildable now:** the fixture corpus is plain data; KMP golden tests run on
+  the JVM with no Apple account; iOS XCTest/XCUITest consumers run on Simulator
+  and on-device via free Personal Team signing. None of it needs speech, network,
+  or paid entitlements.
+- **Gated tail (#1239):** only store/TestFlight distribution needs the paid
+  enrollment + signing material in
+  [human-gated-prerequisites.md §3.2](../ops/human-gated-prerequisites.md#32-ios-distribution--apple-developer-1239).
+  An SME agent must **not** perform enrollment, certificate, or secret steps.
+
+_Part of [#2386](https://github.com/jrmoulckers/finance/issues/2386). Sibling
+designs: [App Intents and Siri surface](./ios-app-intents-siri-query.md) ·
+[local query planner and clarification](./ios-local-query-planner-clarification.md)._


### PR DESCRIPTION
# Summary

Adds three **design-only** documents under `docs/design/` for the iOS App Intents
/ Siri on-device finance-query cluster. No app, package, or shared-config code is
touched — new files only. All query parsing/aggregation logic stays conceptually
in KMP `packages/core`; the iOS docs describe only the native App Intents / Siri
surface and the native↔KMP boundary. All processing is on-device (no cloud NLP);
financial data never leaves the device.

# Changes

- `docs/design/ios-app-intents-siri-query.md` (#2617) — voice/typed entry points,
  supported local intents, App Intents/Siri capability needs, and sensitive-result
  confirmation (biometric) rules.
- `docs/design/ios-local-query-planner-clarification.md` (#2618) — constrained
  shared planner for category/merchant/account/date-range queries, confidence
  bands, and the bounded clarification UX for ambiguous/low-confidence phrases.
- `docs/design/ios-nl-query-fixtures.md` (#2619) — deterministic, speech-independent
  NL fixture corpus pinning typed/spoken/VoiceOver result variants and every edge
  state; anchors the smallest-tests plan shared across the cluster.

Each doc includes a ToC, Mermaid diagrams (intent/planner flow + native↔KMP
boundary), accessibility (VoiceOver, Dynamic Type, voice as an alternative not the
sole path), privacy (on-device only, data minimization, GDPR/CCPA), empty/stale/
error/ambiguous/low-confidence + clarification states, a smallest-tests plan, and
an "Implementation readiness" section linking
`docs/ops/human-gated-prerequisites.md` that splits buildable-now work (free
Personal Team signing; App Intents fully implementable) from the distribution tail
gated by #1239. Cross-links reference only existing `docs/design/` files. Prettier
`--check` passes on all three files.

Closes #2617
Closes #2618
Closes #2619
