### PR TITLE
docs(design): android voice transaction design batch (#2696, #2697, #2698)

### DIFF
--- a/docs/design/android-voice-app-actions-intent-schema.md
+++ b/docs/design/android-voice-app-actions-intent-schema.md
@@ -1,0 +1,355 @@
+# Android Voice Transaction — App Actions & Intent Schema — Design
+
+> **Status:** Design / breakdown only — native implementation gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+> **Issue:** [#2696](https://github.com/jrmoulckers/finance/issues/2696) · **Part of [#2396](https://github.com/jrmoulckers/finance/issues/2396)** · **Voice-entry epic [#2383](https://github.com/jrmoulckers/finance/issues/2383)**
+> **Platform:** Android (Jetpack Compose · Material 3 · App Actions / Assistant) · **minSdk 28 / target 35**
+> **Audience:** Android engineers, design, QA · **Companion designs:** [Draft Confirmation & Ambiguity Prompts](./android-voice-draft-confirmation.md) · [Privacy, Offline Parsing & Telemetry](./android-voice-privacy-offline-parsing.md)
+
+This document defines the **Android App Actions / Google Assistant entry points,
+the voice transaction intent schema, its parameters, and the deep-link handoff**
+that lands a spoken transaction in a reviewable draft. It exists so a commuter
+(see [#2383](https://github.com/jrmoulckers/finance/issues/2383)) can say
+_"Hey Google, log a 12 dollar coffee at Blue Bottle in Finance"_ and finish
+hands-free — while every spoken value is still parsed, normalized, and scored by
+**shared Kotlin Multiplatform (KMP) logic**, not by Compose.
+
+This is **design only**. The App Actions / `shortcuts.xml` / deep-link plumbing is
+**buildable now** in debug (`assembleDebug` sideload, App Actions Test Tool,
+`adb` deep links); only **Play-validated Assistant distribution** is human-gated
+by [#1242](https://github.com/jrmoulckers/finance/issues/1242) and the Google
+Actions setup tracked under [#2383](https://github.com/jrmoulckers/finance/issues/2383).
+See [Implementation readiness](#10-implementation-readiness) and
+[`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md).
+
+---
+
+## Table of Contents
+
+1. [Problem & goals](#1-problem--goals)
+2. [Invocation surfaces & single destination](#2-invocation-surfaces--single-destination)
+3. [Architecture boundary (KMP vs. Compose vs. App Actions plumbing)](#3-architecture-boundary-kmp-vs-compose-vs-app-actions-plumbing)
+4. [Intent schema & parameters](#4-intent-schema--parameters)
+5. [Invocation phrases, locales & inline inventory](#5-invocation-phrases-locales--inline-inventory)
+6. [Deep-link contract & handoff](#6-deep-link-contract--handoff)
+7. [Offline, empty, error & low-confidence states](#7-offline-empty-error--low-confidence-states)
+8. [Accessibility & localization](#8-accessibility--localization)
+9. [Test plan](#9-test-plan)
+10. [Implementation readiness](#10-implementation-readiness)
+11. [Open questions](#11-open-questions)
+
+---
+
+## 1. Problem & goals
+
+From [#2383](https://github.com/jrmoulckers/finance/issues/2383): _"As an Android
+commuter, I want Google Assistant voice transaction entry, so that I can log
+spending hands-free."_ Today the only fast paths are the
+[`QuickEntryWidget`](../../apps/android/src/main/kotlin/com/finance/android/widget/QuickEntryWidget.kt)
+and the in-app
+[`TransactionCreateScreen`](../../apps/android/src/main/kotlin/com/finance/android/ui/screens/TransactionCreateScreen.kt)
+wizard — neither is hands-free.
+
+**Goals**
+
+- One canonical **voice intent** that captures amount, merchant, category,
+  account, note, and transaction-date.
+- A single **deep-link contract** that hands those values to a draft, reusing the
+  existing navigation graph.
+- **Reuse the shared parser** — [`NaturalLanguageParser`](../../packages/core/src/commonMain/kotlin/com/finance/core/nlp/NaturalLanguageParser.kt)
+  already maps free text to a `TransactionInput` with a `ParseConfidence`; the
+  voice layer feeds it, it does not reimplement parsing in Compose.
+- **Locale-aware** phrasing (Spanish first, consistent with the program's i18n
+  posture in [String Resource Migration Audit](./android-string-resource-migration-audit.md)).
+- A **non-voice fallback** so Assistant is an accelerator, never the only path.
+
+**Non-goals**
+
+- The draft review / confirmation / ambiguity UX — owned by
+  [Draft Confirmation & Ambiguity Prompts](./android-voice-draft-confirmation.md).
+- On-device speech, storage, and telemetry boundaries — owned by
+  [Privacy, Offline Parsing & Telemetry](./android-voice-privacy-offline-parsing.md).
+- Any change to KMP business rules; `NaturalLanguageParser`, `Transaction`, and
+  validation are consumed as-is.
+
+---
+
+## 2. Invocation surfaces & single destination
+
+```mermaid
+flowchart LR
+    A["Assistant voice<br/>'log a 12 dollar coffee in Finance'"] --> CAP
+    SC["App shortcut /<br/>capability tile"] --> CAP
+    CAP["App Actions capability<br/>(shortcuts.xml binding)"] --> DL
+    MAN["In-app mic button<br/>(manual fallback)"] -->|in-process nav| DEST
+    TYPE["Type it instead<br/>(always available)"] -->|in-process nav| DEST
+    DL["Deep link<br/>finance://voice/transaction?..."] --> NAV["FinanceNavHost<br/>navDeepLink"] --> DEST
+    DEST["Voice transaction draft<br/>(review + confirm)"]
+```
+
+All surfaces converge on **one destination** — the voice transaction draft —
+so behavior, accessibility, and tests are defined once. External surfaces
+(Assistant, shortcut) arrive via the **deep-link URI**; in-app surfaces (mic
+button, "type it instead") use **in-process navigation** to the same route. The
+**manual paths are first-class**, satisfying "voice as an alternative input, not
+the sole path."
+
+---
+
+## 3. Architecture boundary (KMP vs. Compose vs. App Actions plumbing)
+
+- **App Actions plumbing** (this doc): the `shortcuts.xml` `<capability>`, the
+  Built-In Intent (BII) / custom-intent binding, the fulfillment deep link, and
+  the `navDeepLink` route in
+  [`FinanceNavHost`](../../apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceNavHost.kt).
+  All platform glue, debug-implementable.
+- **Compose** renders the draft and observes shared state — covered in the
+  [confirmation design](./android-voice-draft-confirmation.md). It owns **no**
+  parsing or finance math.
+- **KMP `packages/core`** owns the rules. The handoff calls
+  [`NaturalLanguageParser.parse(input, referenceDate)`](../../packages/core/src/commonMain/kotlin/com/finance/core/nlp/NaturalLanguageParser.kt),
+  which returns `ParseResult.Success(TransactionInput)` or `ParseResult.Failure`.
+  `TransactionInput` carries `amount: Cents`, `date`, `payee`, `categoryHint`,
+  `type`, `rawInput`, and `confidence: ParseConfidence`. Account resolution and
+  validation reuse the existing
+  [`Transaction`](../../packages/models/src/commonMain/kotlin/com/finance/models/Transaction.kt)
+  and
+  [`TransactionValidator`](../../packages/core/src/commonMain/kotlin/com/finance/core/validation/TransactionValidator.kt).
+
+> **Boundary rule:** the deep link carries only **raw spoken hints** (the
+> utterance fragment and/or the typed parameter strings). It never carries
+> computed results — no resolved `Cents`, no resolved account id, no confidence.
+> Normalization and scoring happen **in KMP after** the handoff, so the same
+> input produces the same draft regardless of entry surface.
+
+---
+
+## 4. Intent schema & parameters
+
+The voice intent maps Assistant/BII parameters to deep-link query parameters to a
+shared `TransactionInput`. Conceptually:
+
+```mermaid
+flowchart TD
+    subgraph Intent["Voice transaction intent (App Action)"]
+        P1["amount (text)"]
+        P2["merchant (text)"]
+        P3["category (inline inventory)"]
+        P4["account (inline inventory)"]
+        P5["note (text)"]
+        P6["transactionDate (text)"]
+    end
+    Intent -->|"fulfillment urlTemplate"| Q["Deep-link query params"]
+    Q -->|"parsed in KMP"| TI["TransactionInput"]
+    TI --> D["Reviewable draft (Compose)"]
+```
+
+| Intent parameter  | Deep-link key | Example spoken value | Maps to (`TransactionInput`)          | Resolved by                                                 |
+| ----------------- | ------------- | -------------------- | ------------------------------------- | ----------------------------------------------------------- |
+| `amount`          | `amount`      | "twelve dollars"     | `amount: Cents`                       | `NaturalLanguageParser` amount extraction → `Cents`         |
+| `merchant`        | `merchant`    | "Blue Bottle"        | `payee: String?`                      | `NaturalLanguageParser` merchant extraction                 |
+| `category`        | `category`    | "coffee"             | `categoryHint: String?`               | Inline inventory synonyms → shared category taxonomy        |
+| `account`         | `account`     | "credit card"        | account selection (resolved in draft) | Inline inventory of the user's accounts; default if omitted |
+| `note`            | `note`        | "with a coworker"    | free-text note on the draft           | Passed through verbatim, length-capped                      |
+| `transactionDate` | `date`        | "yesterday"          | `date: LocalDate`                     | `NaturalLanguageParser` date extraction (relative + ISO)    |
+
+Notes:
+
+- **Only `amount` is effectively required** for a usable draft;
+  `NaturalLanguageParser` returns `ParseResult.Failure` when no amount is found,
+  which the draft surfaces as a missing-field prompt (see the
+  [confirmation design](./android-voice-draft-confirmation.md)).
+- **`type`** (expense vs. income) is inferred by the shared parser from phrasing
+  ("spent", "paid", "received") — it is not a separate spoken parameter.
+- Every parameter is **optional at the intent layer**; missing values become
+  prompts downstream rather than parse errors, so partial utterances still
+  produce a draft.
+
+---
+
+## 5. Invocation phrases, locales & inline inventory
+
+**Capability strategy.** A dedicated finance "log a transaction" Built-In Intent
+does not exist in Google's catalog, so the recommended approach is a **custom App
+Action capability** declared in `res/xml/shortcuts.xml` and bound to dynamic
+shortcuts via `ShortcutManagerCompat`. The capability's `<fulfillment>` uses a
+`urlTemplate` that renders the deep link in [§6](#6-deep-link-contract--handoff).
+A generic-BII path (for example a transfer-style BII) is explicitly **not** used
+because it would misrepresent intent semantics.
+
+**Supported phrases (illustrative, English + Spanish):**
+
+| Locale | Phrase pattern                                       |
+| ------ | ---------------------------------------------------- |
+| en     | "log a {amount} {category} at {merchant} in Finance" |
+| en     | "add an expense in Finance"                          |
+| en     | "I spent {amount} on {category} {date}"              |
+| es     | "registra un gasto de {amount} en {merchant}"        |
+| es     | "anota {amount} de {category} en Finanzas"           |
+
+- **Inline inventory** provides synonym lists for `category` and `account` so
+  Assistant can match spoken aliases ("gas" → "Fuel", "tarjeta" → the user's
+  card) without sending free text to a server. The inventory is generated
+  on-device from the user's categories/accounts.
+- **Fallback deep links** cover discovery: an "Add an expense" app shortcut and an
+  in-app mic button both reach the same destination if Assistant matching fails
+  or the phrase is unrecognized.
+- Phrase strings, shortcut labels, and `<capability>` `shortcutLabel`s are
+  **localized resources** (no hardcoded English), aligned with
+  [String Resource Migration Audit](./android-string-resource-migration-audit.md)
+  and [Content & Language Guidelines](./content-language-guidelines.md).
+
+---
+
+## 6. Deep-link contract & handoff
+
+A single canonical route receives every voice handoff:
+
+```text
+finance://voice/transaction
+  ?amount={amount}
+  &merchant={merchant}
+  &category={category}
+  &account={account}
+  &note={note}
+  &date={date}
+  &source=assistant
+```
+
+An `https://finance.app/voice/add?...` autoVerify variant mirrors it for App
+Links discovery. Contract rules:
+
+- **All keys optional.** A bare `finance://voice/transaction` opens an empty
+  voice-ready draft (mic primed, nothing pre-filled).
+- **`source`** distinguishes `assistant`, `shortcut`, and `manual` for
+  privacy-safe telemetry only (see
+  [Privacy, Offline Parsing & Telemetry](./android-voice-privacy-offline-parsing.md));
+  it never alters financial logic.
+- **No computed values** ever appear in the URI — only raw hints. The route's
+  `VoiceTransactionDraftViewModel` (covered in the confirmation design) calls the
+  shared parser to resolve them.
+- **Validation & sanitization:** a `VoiceIntentArgs` parser trims, length-caps,
+  and URL-decodes each value; oversized or malformed input degrades to a prompt,
+  never a crash.
+
+```mermaid
+flowchart LR
+    A["Assistant fills BII params"] --> B["Fulfillment urlTemplate"]
+    B --> C["navDeepLink in FinanceNavHost"]
+    C --> D["VoiceIntentArgs (validate + sanitize)"]
+    D --> E["NaturalLanguageParser.parse()"]
+    E --> F["TransactionInput + ParseConfidence"]
+    F --> G["Draft (Compose renders shared state)"]
+```
+
+The new route is registered in
+[`FinanceNavHost`](../../apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceNavHost.kt)
+with a `navDeepLink { uriPattern = "..." }`, matching the existing deep-link
+pattern documented in
+[Cash Quick-Entry Deep Links](./android-cash-quick-entry-deep-links.md).
+
+---
+
+## 7. Offline, empty, error & low-confidence states
+
+| State               | Trigger                                | Behavior                                                                                 |
+| ------------------- | -------------------------------------- | ---------------------------------------------------------------------------------------- |
+| Empty / first run   | Bare deep link, no params              | Voice-ready empty draft; mic primed; "Say or type an amount" prompt.                     |
+| Partial fill        | Some params present                    | Pre-fill what arrived; remaining fields become prompts (not errors).                     |
+| No amount           | Parser returns `ParseResult.Failure`   | Draft opens focused on the amount field with an inline hint; nothing is saved.           |
+| Low confidence      | `ParseConfidence.LOW` / `VERY_LOW`     | Fields flagged "Double-check"; assistive tech focuses them first.                        |
+| Ambiguous merchant  | Multiple inventory matches             | Disambiguation handed to the [confirmation flow](./android-voice-draft-confirmation.md). |
+| Assistant offline   | Handoff completes but speech was local | Parsing still runs on-device; draft opens normally (no network needed).                  |
+| Unrecognized phrase | Assistant cannot match the capability  | Falls back to the app shortcut / mic button → same empty draft.                          |
+
+All parsing runs **on-device and offline-first** — the deep-link handoff never
+requires network. No financial values are written to logs (see the
+[privacy design](./android-voice-privacy-offline-parsing.md)).
+
+---
+
+## 8. Accessibility & localization
+
+Targets WCAG 2.2 AA via the shared
+[Accessibility Patterns Library](./accessibility-patterns.md).
+
+- **Voice is an alternative, not a requirement.** The destination always offers a
+  fully keyboard/touch-operable draft; users who cannot or prefer not to speak
+  reach the identical form via the mic button's "type it instead" affordance and
+  the app shortcut.
+- **TalkBack:** the entry button exposes a `contentDescription` ("Add a
+  transaction by voice"); the destination announces it opened and what was
+  pre-filled. Capability/shortcut labels are descriptive, not icon-only.
+- **Switch Access:** every entry affordance is a single-purpose target ≥ 48 dp;
+  no action depends on a long-press or gesture only.
+- **200% font scaling:** the handoff draft (rendered per the confirmation design)
+  reflows rather than truncates; the mic-vs-type choice stacks vertically at large
+  scale.
+- **Localization:** phrases, labels, and prompts are localized resources;
+  spoken-number and date phrasing are locale-aware so "doce dólares" parses like
+  "twelve dollars" (see [Content & Language Guidelines](./content-language-guidelines.md)).
+
+---
+
+## 9. Test plan
+
+| Layer           | Tooling                | Coverage                                                                                                                     |
+| --------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Unit (args)     | JUnit                  | `VoiceIntentArgs` decode/trim/length-cap; malformed/oversized params degrade to empty, never throw; `source` parsing.        |
+| Unit (parse)    | JUnit + fixtures       | Deterministic phrase fixtures → expected `TransactionInput`/`ParseConfidence` (reuses `NaturalLanguageParser` shared tests). |
+| Instrumentation | `androidx.test` + `am` | `adb shell am start -d "finance://voice/transaction?..."` routes to the draft with the right pre-fill across param sets.     |
+| Compose UI      | `compose-ui-test`      | Empty vs. pre-filled draft entry; mic and "type it instead" both reachable; semantics/`contentDescription` assertions.       |
+| Snapshot        | Paparazzi              | Voice entry button + empty/pre-filled handoff at default and 200% font, light/dark + dynamic color.                          |
+
+Shared parsing rules are **not** re-tested here — only the intent-to-args-to-draft
+wiring. A frozen **parse fixture set** (phrase → expected fields) keeps voice and
+typed entry behaviorally identical.
+
+---
+
+## 10. Implementation readiness
+
+This is a design artifact. Work splits into a part buildable today and a tail
+gated by Play / Assistant distribution. See
+[Human-Gated Prerequisites](../ops/human-gated-prerequisites.md) and the
+[Launch Readiness Plan](../ops/launch-readiness-plan.md) for context.
+
+### Buildable now (debug, no human gate)
+
+- `shortcuts.xml` `<capability>`, dynamic-shortcut binding, the fulfillment
+  `urlTemplate`, the `navDeepLink` route, and `VoiceIntentArgs` parsing are pure
+  Android + KMP consumption — runnable via `./gradlew :apps:android:assembleDebug`
+  and sideload.
+- Deep-link routing is verifiable with `adb shell am start -d "finance://..."`.
+- The capability and parameter mapping are verifiable locally with the **App
+  Actions Test Tool** (Android Studio plugin) against a debug build.
+- Unit, instrumentation, Compose, and Paparazzi tests run on CI without signing.
+
+### Play / Assistant-validated distribution tail (gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242))
+
+- Production Assistant invocation requires the app published to a Play track with
+  the capability verified — **human-gated** by Google Play enrollment
+  ([#1242](https://github.com/jrmoulckers/finance/issues/1242)) and the Google
+  Actions Console / App Actions validation setup tracked under
+  [#2383](https://github.com/jrmoulckers/finance/issues/2383).
+- Per [`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md)
+  §2, only this **distribution** tail is gated; the implementation above is not.
+  Agents must not perform enrollment, signing, or secret configuration.
+
+---
+
+## 11. Open questions
+
+- Final custom-capability name and whether a future Google finance BII supersedes
+  it.
+- Whether `account` should resolve at the intent layer (inline inventory only) or
+  always defer to the draft's account picker for safety.
+- Spanish phrase coverage breadth for v1 vs. fast-follow locales.
+- Whether `https` App Links autoVerify is enabled at launch or shortcut-only.
+
+---
+
+**Related:** [Draft Confirmation & Ambiguity Prompts](./android-voice-draft-confirmation.md)
+· [Privacy, Offline Parsing & Telemetry](./android-voice-privacy-offline-parsing.md)
+· [Cash Quick-Entry Deep Links](./android-cash-quick-entry-deep-links.md)
+· [Information Architecture](./information-architecture.md)
+· [User Personas](./personas.md)

--- a/docs/design/android-voice-draft-confirmation.md
+++ b/docs/design/android-voice-draft-confirmation.md
@@ -1,0 +1,338 @@
+# Android Voice Transaction — Draft Confirmation & Ambiguity Prompts — Design
+
+> **Status:** Design / breakdown only — native implementation gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+> **Issue:** [#2697](https://github.com/jrmoulckers/finance/issues/2697) · **Part of [#2396](https://github.com/jrmoulckers/finance/issues/2396)** · **Voice-entry epic [#2383](https://github.com/jrmoulckers/finance/issues/2383)**
+> **Platform:** Android (Jetpack Compose · Material 3) · **minSdk 28 / target 35**
+> **Audience:** Android engineers, design, QA · **Companion designs:** [App Actions & Intent Schema](./android-voice-app-actions-intent-schema.md) · [Privacy, Offline Parsing & Telemetry](./android-voice-privacy-offline-parsing.md)
+
+This document designs the **draft review flow** that a spoken transaction lands
+in: prefilled fields, **missing-field prompts**, **ambiguity disambiguation**,
+correction UX, offline-safe draft state, and the **explicit confirm-before-save**
+gate. It is the human-in-the-loop checkpoint between Assistant and the ledger.
+
+The guiding rule for every screen below: **Compose renders shared state; it does
+not own finance math.** Parsing, confidence scoring, and mapping to a
+`TransactionInput` already live in KMP
+[`NaturalLanguageParser`](../../packages/core/src/commonMain/kotlin/com/finance/core/nlp/NaturalLanguageParser.kt);
+the Android layer observes that draft and presents review and correction
+affordances, then saves through the existing repository.
+
+This is **design only** — the confirmation flow is **buildable now** in debug
+(`assembleDebug` sideload); only Play distribution is human-gated by
+[#1242](https://github.com/jrmoulckers/finance/issues/1242). See
+[Implementation readiness](#11-implementation-readiness) and
+[`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md).
+
+---
+
+## Table of Contents
+
+1. [Goals & non-goals](#1-goals--non-goals)
+2. [The Compose-renders-shared-state boundary](#2-the-compose-renders-shared-state-boundary)
+3. [Voice-to-draft flow](#3-voice-to-draft-flow)
+4. [Composable & ViewModel inventory](#4-composable--viewmodel-inventory)
+5. [State model](#5-state-model)
+6. [Missing-field & ambiguity prompts](#6-missing-field--ambiguity-prompts)
+7. [Correction UX & confirm-before-save](#7-correction-ux--confirm-before-save)
+8. [Offline-safe draft & failed handoff](#8-offline-safe-draft--failed-handoff)
+9. [Empty, error & low-confidence states](#9-empty-error--low-confidence-states)
+10. [Accessibility](#10-accessibility)
+11. [Test plan](#11-test-plan)
+12. [Implementation readiness](#12-implementation-readiness)
+13. [Open questions](#13-open-questions)
+
+---
+
+## 1. Goals & non-goals
+
+From [#2697](https://github.com/jrmoulckers/finance/issues/2697): require explicit
+confirmation before saving any spoken transaction; handle missing or ambiguous
+amount, merchant, account, and category fields; and keep the draft offline-safe
+when the Assistant handoff cannot complete.
+
+**Goals**
+
+- **No silent saves.** A spoken transaction always pauses on a reviewable draft
+  with an explicit **Save** action.
+- **Reuse the existing entry form.** The draft reuses the proven save path in
+  [`TransactionCreateViewModel`](../../apps/android/src/main/kotlin/com/finance/android/ui/viewmodel/TransactionCreateViewModel.kt)
+  and the field patterns of
+  [`TransactionCreateScreen`](../../apps/android/src/main/kotlin/com/finance/android/ui/screens/TransactionCreateScreen.kt)
+  rather than inventing a parallel form.
+- **Resolve missing / ambiguous fields** with clear, low-friction prompts.
+- **Survive a broken handoff** — keep an offline draft if Assistant or navigation
+  fails mid-flow.
+
+**Non-goals**
+
+- The intent schema, capability, and deep-link contract — owned by
+  [App Actions & Intent Schema](./android-voice-app-actions-intent-schema.md).
+- On-device speech, storage, and telemetry boundaries — owned by
+  [Privacy, Offline Parsing & Telemetry](./android-voice-privacy-offline-parsing.md).
+- Any change to KMP business rules; the parser and validator are consumed as-is.
+
+---
+
+## 2. The Compose-renders-shared-state boundary
+
+```mermaid
+flowchart LR
+    DL["Deep link / mic input"] --> VM["VoiceTransactionDraftViewModel"]
+    VM -->|"raw hint / utterance"| P["NaturalLanguageParser.parse()"]
+    P -->|"ParseResult"| VM
+    VM -->|"UI state (StateFlow)"| UI["VoiceDraftConfirmScreen (Compose)"]
+    UI -->|"user edits / confirm"| VM
+    VM -->|"validated Transaction"| R["TransactionRepository (local-first)"]
+```
+
+- The ViewModel calls the **shared parser** and exposes an immutable UI state.
+  Compose only renders that state and forwards user intents back.
+- Confidence and field presence come from `ParseResult.Success(TransactionInput)`
+  (`confidence: ParseConfidence` ∈ `HIGH, MEDIUM, LOW, VERY_LOW`) or
+  `ParseResult.Failure(reason)` — the UI **re-derives nothing financial**.
+- Save maps the reviewed values to a
+  [`Transaction`](../../packages/models/src/commonMain/kotlin/com/finance/models/Transaction.kt)
+  validated by
+  [`TransactionValidator`](../../packages/core/src/commonMain/kotlin/com/finance/core/validation/TransactionValidator.kt),
+  reusing the existing repository insert path.
+
+---
+
+## 3. Voice-to-draft flow
+
+```mermaid
+flowchart TD
+    A["Handoff arrives (params or utterance)"] --> B["Parse in KMP"]
+    B --> C{"Amount found?"}
+    C -->|No| M["Missing-amount prompt"]
+    C -->|Yes| D{"Confidence?"}
+    D -->|"LOW / VERY_LOW"| E["Flag fields: Double-check"]
+    D -->|"HIGH / MEDIUM"| F["Prefilled draft"]
+    M --> F
+    E --> F
+    F --> G{"Ambiguous merchant / category / account?"}
+    G -->|Yes| H["Disambiguation prompt (chips)"]
+    G -->|No| I["Review draft"]
+    H --> I
+    I --> J{"User confirms?"}
+    J -->|"Save"| K["Validate + insert (local-first)"]
+    J -->|"Cancel"| L["Discard or keep as offline draft"]
+    K --> N["Saved confirmation"]
+```
+
+Confirmation is **mandatory**: the flow cannot reach "Saved" (`N`) without the
+user taking the explicit **Save** action at `J`.
+
+---
+
+## 4. Composable & ViewModel inventory
+
+| Component (new/reused)                 | Type       | Role                                                                                      |
+| -------------------------------------- | ---------- | ----------------------------------------------------------------------------------------- |
+| `VoiceDraftConfirmScreen` (new)        | Composable | Hosts the prefilled draft, prompts, and the sticky confirm bar.                           |
+| `VoiceDraftFieldRow` (new)             | Composable | One field row with value, confidence badge, and inline edit.                              |
+| `AmbiguityPromptSheet` (new)           | Composable | `ModalBottomSheet` with candidate chips for ambiguous merchant/category/account.          |
+| `MissingFieldPrompt` (new)             | Composable | Inline required-field prompt (amount/account) with focus + hint.                          |
+| `DraftConfirmBar` (new)                | Composable | Sticky **Save** / **Cancel** bar; Save disabled until required fields valid.              |
+| `VoiceTransactionDraftViewModel` (new) | ViewModel  | Calls shared parser, holds UI state, resolves prompts, performs validated save.           |
+| `TransactionCreateViewModel` (reused)  | ViewModel  | Underlying validated insert path; not duplicated.                                         |
+| Field inputs (reused patterns)         | Composable | Material 3 `OutlinedTextField` with `supportingText`/`isError`, as in transaction create. |
+
+`VoiceTransactionDraftViewModel` is provided via Koin (`viewModelOf(::...)`) and
+obtained in Compose with `koinViewModel<VoiceTransactionDraftViewModel>()`,
+consistent with the app's DI pattern.
+
+---
+
+## 5. State model
+
+```kotlin
+// Illustrative — final shape lives in the Android module, state derived from KMP.
+sealed interface VoiceDraftState {
+    data object Parsing : VoiceDraftState
+    data class Draft(
+        val fields: VoiceDraftFields,           // amount, merchant, category, account, note, date
+        val confidence: ParseConfidence,        // HIGH | MEDIUM | LOW | VERY_LOW
+        val missing: Set<VoiceField>,           // required fields still empty
+        val ambiguities: List<FieldAmbiguity>,  // candidate sets per field
+        val canSave: Boolean,                   // false until required fields valid
+    ) : VoiceDraftState
+    data object Saving : VoiceDraftState
+    data class Saved(val transactionId: SyncId) : VoiceDraftState
+    data class Error(val kind: VoiceDraftError) : VoiceDraftState   // recoverable; draft preserved
+}
+```
+
+- `confidence`, field values, and the `rawInput` survive process death via
+  `SavedStateHandle`, so a half-corrected draft is never lost.
+- `canSave` gates the **Save** action; the UI cannot bypass it.
+- `Error` is always **non-destructive** — the draft is preserved for retry.
+
+---
+
+## 6. Missing-field & ambiguity prompts
+
+Acceptance criterion: handle missing or ambiguous **amount, merchant, account, and
+category**. Confidence comes from `ParseConfidence`; presence and candidate sets
+come from the shared parse + on-device inventory match.
+
+| Field    | Missing behavior                                               | Ambiguous behavior                                                          |
+| -------- | -------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| amount   | Required; **Save** disabled; focus the amount field with hint. | If multiple numbers heard, prompt "Which amount?" with candidate chips.     |
+| account  | Required; default to the user's preferred account, editable.   | Multiple inventory matches → chip picker; never auto-pick silently.         |
+| merchant | Optional; show "Add merchant" affordance.                      | Multiple matches → chip picker ("Blue Bottle" vs. "Blue Bottle Coffee").    |
+| category | Optional; shared parser may infer `categoryHint`.              | Low-confidence hint → "Suggested: Coffee" chip the user accepts or changes. |
+
+- Disambiguation uses Material 3 **filter/assist chips** in an
+  `AmbiguityPromptSheet`; selecting a chip updates the field and re-checks
+  `canSave`.
+- Prompts use plain language per [Cognitive Accessibility](./cognitive-accessibility.md)
+  ("We heard two amounts — tap the right one"), no jargon.
+- Resolving one prompt **never silently changes** another field; totals are never
+  recomputed by the UI.
+
+---
+
+## 7. Correction UX & confirm-before-save
+
+- Every prefilled field is **editable inline** via the same `OutlinedTextField`
+  patterns as
+  [`TransactionCreateScreen`](../../apps/android/src/main/kotlin/com/finance/android/ui/screens/TransactionCreateScreen.kt),
+  with `supportingText` for hints and `isError` for required gaps.
+- Confidence presentation:
+
+  | Band               | Presentation                                                  |
+  | ------------------ | ------------------------------------------------------------- |
+  | `HIGH`             | Filled, no badge; editable on tap.                            |
+  | `MEDIUM`           | Subtle "Double-check" badge.                                  |
+  | `LOW` / `VERY_LOW` | "Double-check" badge; assistive tech focuses the field first. |
+
+- **Confirm-before-save is the core gate.** Saving requires the explicit
+  **Save** action in `DraftConfirmBar`; there is no auto-save timer and no
+  save-on-dismiss. **Cancel** offers "Discard" or "Keep draft" (see §8).
+- On save, the reviewed values map to a `Transaction`, run through
+  `TransactionValidator`, and insert via the existing repository — identical to
+  the manual create path, so voice entries are indistinguishable from typed ones
+  in the ledger.
+
+---
+
+## 8. Offline-safe draft & failed handoff
+
+The flow is fully functional **with no network** — drafting, correction, and save
+run against the local-first repository; sync happens later via the existing
+PowerSync / WorkManager path and is out of scope here.
+
+| Scenario                         | Behavior                                                                                          |
+| -------------------------------- | ------------------------------------------------------------------------------------------------- |
+| Assistant handoff fails mid-flow | If any partial input exists, persist a **local offline draft**; reopenable from the app.          |
+| App killed before confirm        | `SavedStateHandle` restores the in-progress draft on relaunch.                                    |
+| User taps Cancel                 | Offer "Discard" or "Keep draft"; "Keep" stores the offline draft, never a saved transaction.      |
+| Connectivity absent at save      | Save succeeds locally; optional "Saved — will sync later" affordance.                             |
+| Stale offline drafts             | Deferred cleanup uses **WorkManager only** (never AlarmManager/JobScheduler); see privacy design. |
+
+> Offline drafts hold **unconfirmed** input only. They are never treated as saved
+> transactions and never sync as such until the user confirms.
+
+---
+
+## 9. Empty, error & low-confidence states
+
+| State                 | Trigger                            | UX                                                                             |
+| --------------------- | ---------------------------------- | ------------------------------------------------------------------------------ |
+| Empty / voice-ready   | Bare entry, nothing parsed         | "Say or type an amount" with mic primed and a type affordance.                 |
+| Parse failure         | `ParseResult.Failure` (no amount)  | Draft focused on amount with inline hint; nothing saved.                       |
+| Low confidence        | `ParseConfidence.LOW` / `VERY_LOW` | Fields flagged; assistive tech focuses them first; Save still requires review. |
+| Validation error      | Required field empty at Save       | Inline error; assertive live-region announce; focus first invalid field.       |
+| Save/repository error | `insert` throws                    | Non-destructive error card with **Retry**; draft preserved.                    |
+
+No financial values (amounts, merchant, account) are written to Timber; structured
+logs record flow milestones only (see
+[Privacy, Offline Parsing & Telemetry](./android-voice-privacy-offline-parsing.md)).
+
+---
+
+## 10. Accessibility
+
+Targets WCAG 2.2 AA via the shared
+[Accessibility Patterns Library](./accessibility-patterns.md).
+
+- **Voice is an alternative, not the sole path.** The draft is fully operable by
+  touch, keyboard, and switch; the explicit visual confirm step is exactly what
+  lets non-voice and assistive-tech users verify and edit before saving.
+- **TalkBack:** each `VoiceDraftFieldRow` exposes a `contentDescription` combining
+  label, value, and confidence ("Amount, 12 dollars, please double-check").
+  Headings use `semantics { heading() }`. Ambiguity chips announce their candidate
+  and selection state. Save/Cancel announce action and result.
+- **Switch Access:** logical top-to-bottom focus; the sticky `DraftConfirmBar` is
+  reached last; all targets ≥ 48 dp; no gesture-only or long-press-only actions.
+- **200% font scaling:** fields and prompts wrap, never truncate; the confirm bar
+  stacks Save/Cancel vertically at large scale; the ambiguity sheet scrolls.
+- **Live regions:** disambiguation requests, validation errors, and save
+  confirmation use an assertive live region so non-visual users hear outcomes
+  immediately.
+- **Color independence:** confidence and required state use badge text + icon,
+  never color alone.
+
+---
+
+## 11. Test plan
+
+| Layer                | Tooling                | Coverage                                                                                                                                                  |
+| -------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Unit (ViewModel)     | JUnit + coroutine test | Draft seeded from `ParseResult`; **no save without explicit confirm**; `canSave` gating; edits don't mutate shared math.                                  |
+| Unit (state machine) | JUnit                  | `Parsing → Draft → Saving → Saved`; error path preserves draft; `SavedStateHandle` restore; offline "Keep draft" stays unsaved.                           |
+| Unit (prompts)       | JUnit + fixtures       | Deterministic phrase fixtures → expected missing/ambiguity sets for amount/account/merchant/category.                                                     |
+| Compose UI           | `compose-ui-test`      | Save disabled until required fields valid; ambiguity chips resolve fields; confirm-required assertion; semantics/`contentDescription`.                    |
+| Snapshot             | Paparazzi              | `VoiceDraftConfirmScreen` in high-confidence, low-confidence, missing-amount, ambiguity, saving, error — default + 200% font, light/dark + dynamic color. |
+
+A frozen **parse fixture set** keeps confirmation behavior deterministic and in
+lock-step with typed entry. Shared parser rules are covered by `packages/core`
+tests and are **not** re-tested here.
+
+---
+
+## 12. Implementation readiness
+
+This is a design artifact. Work splits into a part buildable today and a tail
+gated by Play distribution. See
+[Human-Gated Prerequisites](../ops/human-gated-prerequisites.md) and the
+[Launch Readiness Plan](../ops/launch-readiness-plan.md) for context.
+
+### Buildable now (debug, no human gate)
+
+- `VoiceDraftConfirmScreen`, `VoiceTransactionDraftViewModel`, the state model,
+  prompts, and the Koin module are pure Compose + KMP consumption — implementable
+  and runnable via `./gradlew :apps:android:assembleDebug` and sideload.
+- Save reuses the existing local `TransactionRepository`; verifiable with unit,
+  Compose, and Paparazzi tests on CI and emulator/sideload.
+- The confirm-before-save gate, ambiguity prompts, and accessibility semantics
+  need no signing or store presence and can be reached via the
+  [deep-link contract](./android-voice-app-actions-intent-schema.md#6-deep-link-contract--handoff)
+  using `adb`.
+
+### Play-distribution tail (gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242))
+
+- End-to-end Assistant invocation into this flow needs the Play-validated
+  capability — **human-gated** by Google Play enrollment
+  ([#1242](https://github.com/jrmoulckers/finance/issues/1242)) and Actions setup
+  under [#2383](https://github.com/jrmoulckers/finance/issues/2383). Per
+  [`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md) §2,
+  only this distribution tail is gated; the draft flow itself is implementable now.
+
+---
+
+## 13. Open questions
+
+- Default account behavior when none is spoken and the user has multiple accounts.
+- Whether "Keep draft" exposes a visible offline-draft inbox or is reopen-only.
+- Maximum number of ambiguity candidates to show before falling back to a picker.
+- Whether biometric re-auth is required before saving above a configurable amount.
+
+---
+
+**Related:** [App Actions & Intent Schema](./android-voice-app-actions-intent-schema.md)
+· [Privacy, Offline Parsing & Telemetry](./android-voice-privacy-offline-parsing.md)
+· [Receipt-to-Expense Draft Flow](./android-receipt-to-expense-draft.md)
+· [UX Design Principles](./ux-principles.md)
+· [Component Library](./component-library.md)

--- a/docs/design/android-voice-privacy-offline-parsing.md
+++ b/docs/design/android-voice-privacy-offline-parsing.md
@@ -1,0 +1,315 @@
+# Android Voice Transaction — Privacy, Offline Parsing & Telemetry Boundaries — Design
+
+> **Status:** Design / breakdown only — native implementation gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+> **Issue:** [#2698](https://github.com/jrmoulckers/finance/issues/2698) · **Part of [#2396](https://github.com/jrmoulckers/finance/issues/2396)** · **Voice-entry epic [#2383](https://github.com/jrmoulckers/finance/issues/2383)**
+> **Platform:** Android (Jetpack Compose · Material 3 · ML Kit on-device) · **minSdk 28 / target 35**
+> **Audience:** Android engineers, design, QA, privacy review · **Companion designs:** [App Actions & Intent Schema](./android-voice-app-actions-intent-schema.md) · [Draft Confirmation & Ambiguity Prompts](./android-voice-draft-confirmation.md)
+
+This document defines the **privacy boundaries, on-device parsing assumptions,
+and telemetry rules** for voice transaction entry. The governing principle for a
+financial app is **default to the most private option**: speech and the spoken
+transaction are processed **on-device**, and **no raw utterance or transaction
+text ever leaves the device**. Telemetry is privacy-preserving — enums, counters,
+and coarse confidence bands only.
+
+The parsing/mapping logic stays in KMP
+[`NaturalLanguageParser`](../../packages/core/src/commonMain/kotlin/com/finance/core/nlp/NaturalLanguageParser.kt);
+Android contributes only the on-device speech surface, encrypted local storage,
+and a redacting telemetry bridge.
+
+This is **design only** — on-device parsing and telemetry redaction are
+**buildable now** in debug (`assembleDebug` sideload); the Play **Data safety**
+declaration and store distribution are human-gated by
+[#1242](https://github.com/jrmoulckers/finance/issues/1242). See
+[Implementation readiness](#11-implementation-readiness) and
+[`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md).
+
+---
+
+## Table of Contents
+
+1. [Goals & privacy principles](#1-goals--privacy-principles)
+2. [Data boundary model](#2-data-boundary-model)
+3. [On-device speech & parsing assumptions](#3-on-device-speech--parsing-assumptions)
+4. [What is and is not stored](#4-what-is-and-is-not-stored)
+5. [Offline draft behavior & local parse failure](#5-offline-draft-behavior--local-parse-failure)
+6. [Telemetry boundaries](#6-telemetry-boundaries)
+7. [Privacy-safe error reporting](#7-privacy-safe-error-reporting)
+8. [Permissions & consent](#8-permissions--consent)
+9. [Accessibility & empty/error states](#9-accessibility--emptyerror-states)
+10. [Test plan](#10-test-plan)
+11. [Implementation readiness](#11-implementation-readiness)
+12. [Open questions](#12-open-questions)
+
+---
+
+## 1. Goals & privacy principles
+
+From [#2698](https://github.com/jrmoulckers/finance/issues/2698): document
+transcription boundaries and what is/is not stored; define offline draft behavior
+and local parse-failure states; and specify telemetry for success, cancellation,
+correction, ambiguity, and privacy-safe error reporting.
+
+**Principles**
+
+- **On-device by default.** Speech recognition and parsing run locally; the
+  network is never required to draft a transaction.
+- **No raw content off device.** Utterances, transcripts, merchant names, notes,
+  amounts, and account identifiers are **never** transmitted as telemetry, crash
+  metadata, or logs.
+- **Data minimization.** Capture the minimum needed to build a draft; discard the
+  transcript as soon as a draft exists.
+- **Explicit consent.** Microphone use is opt-in with a clear rationale and is
+  revocable; voice is an accelerator, never the only way to add a transaction.
+- **Encryption at rest.** Any persisted draft uses the existing SQLCipher-backed
+  store; nothing sensitive lands in SharedPreferences or plain files.
+
+---
+
+## 2. Data boundary model
+
+```mermaid
+flowchart TD
+    subgraph Device["On-device only (never leaves)"]
+        U["Spoken utterance (audio)"] --> S["On-device speech recognition"]
+        S --> T["Transient transcript (in-memory)"]
+        T --> P["NaturalLanguageParser.parse()"]
+        P --> D["Transaction draft (encrypted local store)"]
+    end
+    D -. "privacy-safe events only" .-> TEL["Telemetry: enums, counters, confidence band"]
+    TEL --> SINK["Crash/metrics sink"]
+    U -. "discarded after parse" .-> X["No audio retained"]
+    T -. "discarded after parse" .-> X
+```
+
+- The dashed path to telemetry carries **no raw content** — only categorical
+  signals (see [§6](#6-telemetry-boundaries)).
+- Audio and transcript are **transient and in-memory**; they are discarded once a
+  draft is produced.
+- The only durable artifact is the **encrypted draft / saved transaction**, which
+  stays local-first and syncs through existing channels — outside this design's
+  scope.
+
+---
+
+## 3. On-device speech & parsing assumptions
+
+- **Speech recognition:** prefer Android's on-device recognition
+  (`SpeechRecognizer` with `EXTRA_PREFER_OFFLINE` / on-device intent, or the
+  Assistant-provided transcript when the App Action path is used). The design
+  assumes the **on-device** language pack is available; if only a network
+  recognizer exists, the user is told and offered manual entry (no silent upload).
+- **Entity extraction:** lightweight normalization (numbers, relative dates,
+  merchant spans) can use **ML Kit Entity Extraction**, which runs **on-device**.
+  Its output is fed into the shared parser; ML Kit is a pre-normalizer, not a
+  replacement for KMP logic.
+- **Authoritative parsing in KMP:** the transcript string (or App Action
+  parameters) goes to
+  [`NaturalLanguageParser.parse(input, referenceDate)`](../../packages/core/src/commonMain/kotlin/com/finance/core/nlp/NaturalLanguageParser.kt),
+  returning `ParseResult.Success(TransactionInput)` with `confidence:
+ParseConfidence` ∈ `HIGH, MEDIUM, LOW, VERY_LOW`, or `ParseResult.Failure`. The
+  same input yields the same draft regardless of which speech surface produced the
+  transcript.
+- **No server round-trip** is introduced for parsing. This keeps the feature
+  consistent with the on-device posture of
+  [Receipt-to-Expense Draft Flow](./android-receipt-to-expense-draft.md).
+
+---
+
+## 4. What is and is not stored
+
+| Data                          | Stored?          | Where / lifetime                                                                                             |
+| ----------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------ |
+| Raw audio                     | **No**           | Never persisted; discarded after recognition.                                                                |
+| Transcript text               | **No (durable)** | In-memory only; discarded once the draft is built.                                                           |
+| `rawInput` on the draft       | Transient        | Held in memory / `SavedStateHandle` for the session; not synced as text.                                     |
+| Confirmed transaction         | Yes              | Existing SQLCipher-encrypted local store; syncs via existing channels.                                       |
+| Unconfirmed offline draft     | Yes (encrypted)  | Same encrypted store; cleaned up via WorkManager (see [§5](#5-offline-draft-behavior--local-parse-failure)). |
+| Telemetry events              | Yes (redacted)   | Enums/counters only — **no raw content** (see [§6](#6-telemetry-boundaries)).                                |
+| Microphone-consent preference | Yes              | Encrypted preference; never a secret in plain SharedPreferences.                                             |
+
+> **Rule:** the `rawInput`/transcript may live briefly to support correction and
+> process-death restore, but it is **never** sent off device and **never** written
+> to logs or telemetry.
+
+---
+
+## 5. Offline draft behavior & local parse failure
+
+The feature is **offline-first** — no network is needed to capture, parse, or save.
+
+| State                       | Trigger                                   | Behavior                                                                                  |
+| --------------------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Offline capture             | No connectivity                           | Speech + parse + draft all run locally; save persists locally and syncs later.            |
+| On-device pack missing      | No offline recognition language pack      | Inform the user, offer manual entry; do not silently fall back to a network recognizer.   |
+| Parse failure (no amount)   | `ParseResult.Failure`                     | Open the draft focused on amount with a hint; nothing is saved (see confirmation design). |
+| Low confidence              | `ParseConfidence.LOW` / `VERY_LOW`        | Flag fields for review; never auto-save.                                                  |
+| Handoff incomplete          | Assistant/navigation fails mid-flow       | Persist an encrypted **offline draft**; reopenable later.                                 |
+| Stale offline-draft cleanup | Draft unconfirmed past a retention window | **WorkManager only** deferred cleanup (never AlarmManager/JobScheduler); see boundaries.  |
+
+Unconfirmed drafts are never treated as saved transactions and never sync as such
+until the user explicitly confirms in the
+[draft confirmation flow](./android-voice-draft-confirmation.md).
+
+---
+
+## 6. Telemetry boundaries
+
+Telemetry exists to measure feature health, **not** to reconstruct what a user
+spent. Events flow through the shared
+[`MetricsCollector`](../../packages/core/src/commonMain/kotlin/com/finance/core/monitoring/MetricsCollector.kt)
+abstraction; the Android side is a redacting bridge.
+
+**Allowed events (categorical only):**
+
+| Event                   | Allowed payload                                                         |
+| ----------------------- | ----------------------------------------------------------------------- |
+| `voice_entry_started`   | `source` enum (`assistant` / `shortcut` / `manual`).                    |
+| `voice_parse_result`    | `confidence` band enum; `fieldsPresent` bitmask (presence, not values). |
+| `voice_ambiguity`       | which field type was ambiguous (enum); candidate **count** (integer).   |
+| `voice_correction`      | which field type was corrected (enum); correction **count**.            |
+| `voice_entry_saved`     | boolean success; coarse latency bucket.                                 |
+| `voice_entry_cancelled` | cancel reason enum (`user` / `parse_failure` / `handoff_failed`).       |
+| `voice_error`           | error-kind enum; **no** message text, **no** stack with content.        |
+
+**Never permitted in any event, log, or crash report:**
+
+- Raw utterance or transcript text; merchant names; notes.
+- Amounts or balances (not even rounded), account numbers, or account names.
+- Any free-text field value or `rawInput`.
+
+Additional rules:
+
+- **Presence, not content:** report _that_ a field was filled/corrected, never its
+  value (e.g., `fieldsPresent = {amount, merchant}`).
+- **Sampling & opt-out:** telemetry respects the app's existing analytics
+  consent/opt-out; voice events are never collected when analytics is disabled.
+- **No PII keys:** event names and dimensions are a fixed enum allow-list;
+  free-form dimensions are prohibited.
+
+---
+
+## 7. Privacy-safe error reporting
+
+- Crashes and recoverable errors route through the shared
+  [`CrashReporter`](../../packages/core/src/commonMain/kotlin/com/finance/core/monitoring/CrashReporter.kt),
+  bridged on Android by
+  [`TimberCrashReporter`](../../apps/android/src/main/kotlin/com/finance/android/logging/TimberCrashReporter.kt).
+- **Never** `Log.d()` / `Log.e()` directly — always `Timber`. Voice flow logs
+  record **milestones only** ("voice draft opened", "parse failed",
+  "save succeeded") with **no** field values.
+- Error metadata is restricted to **enums and identifiers** (error kind, `source`,
+  confidence band). Exception messages are mapped to safe codes before reporting;
+  raw transcripts and amounts are **redacted at the boundary**, not relied on to be
+  absent.
+- This mirrors the categorization privacy posture in
+  [iOS Categorization Privacy & Telemetry](./ios-categorization-privacy-telemetry.md)
+  so both platforms make the same guarantees.
+
+---
+
+## 8. Permissions & consent
+
+- **Microphone (`RECORD_AUDIO`)** is requested **just-in-time** with a plain-language
+  rationale ("Used only on your device to turn speech into a transaction draft").
+- Consent is **opt-in and revocable** from settings; revoking it disables voice
+  entry and routes users to manual entry without losing any saved data.
+- **Voice is never the sole path.** Every voice capability has a typed/touch
+  equivalent (mic button "type it instead", app shortcut, manual create), per the
+  [app-actions design](./android-voice-app-actions-intent-schema.md).
+- The consent preference is stored encrypted; it is **never** a secret in plain
+  SharedPreferences or a plain file.
+- A short, accessible **privacy explainer** states what is processed on-device and
+  that nothing is uploaded, surfaced the first time voice entry is used.
+
+---
+
+## 9. Accessibility & empty/error states
+
+Targets WCAG 2.2 AA via the shared
+[Accessibility Patterns Library](./accessibility-patterns.md).
+
+- **Consent & explainer screens** are fully accessible: headings via
+  `semantics { heading() }`, all controls labeled with `contentDescription`,
+  reflow at 200% font, Switch Access targets ≥ 48 dp.
+- **Voice as an alternative:** screen-reader and switch users can complete the
+  entire flow by typing; the mic is an optional accelerator. Permission prompts
+  never block manual entry.
+- **Empty / offline / error states:**
+
+  | State                 | UX                                                                   |
+  | --------------------- | -------------------------------------------------------------------- |
+  | Mic permission denied | Explain impact; offer "Add manually"; never dead-end.                |
+  | No on-device pack     | Inform + offer manual entry; no silent network upload.               |
+  | Parse failure         | Accessible inline hint; assistive tech focuses the amount field.     |
+  | Telemetry/consent off | Feature still works; no events emitted; no user-visible degradation. |
+
+- Status changes (permission result, parse failure) are announced via an
+  assertive live region.
+
+---
+
+## 10. Test plan
+
+| Layer            | Tooling                  | Coverage                                                                                                                              |
+| ---------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Unit (redaction) | JUnit                    | **Telemetry payload contains no raw content** — assert enums/counters only for every event; reject any field value/`rawInput`.        |
+| Unit (parse)     | JUnit + fixtures         | Deterministic transcript fixtures → expected `TransactionInput`/`ParseConfidence` offline; failure path yields `ParseResult.Failure`. |
+| Unit (logging)   | JUnit + Timber test tree | Assert no amount/merchant/account/transcript string ever reaches a log/crash sink (planted test tree captures + scans output).        |
+| Unit (lifecycle) | JUnit                    | Audio/transcript discarded after draft built; offline draft persisted encrypted; WorkManager cleanup enqueued, not AlarmManager.      |
+| Compose UI       | `compose-ui-test`        | Consent/explainer accessible; permission-denied offers manual entry; semantics/`contentDescription` assertions; 200% font reflow.     |
+| Snapshot         | Paparazzi                | Consent explainer, permission-denied, no-pack, parse-failure states at default + 200% font, light/dark + dynamic color.               |
+
+The **privacy assertions** (no raw content in telemetry/logs/crash metadata) are
+first-class, deterministic tests that gate the feature. Shared parser rules are
+covered by `packages/core` tests and are not re-tested here.
+
+---
+
+## 11. Implementation readiness
+
+This is a design artifact. Work splits into a part buildable today and a tail
+gated by Play distribution / Data safety. See
+[Human-Gated Prerequisites](../ops/human-gated-prerequisites.md) and the
+[Launch Readiness Plan](../ops/launch-readiness-plan.md) for context.
+
+### Buildable now (debug, no human gate)
+
+- On-device speech wiring, ML Kit Entity Extraction pre-normalization, the KMP
+  parse call, encrypted offline-draft storage, WorkManager cleanup, and the
+  **redacting telemetry/error bridge** are pure Android + KMP — implementable and
+  runnable via `./gradlew :apps:android:assembleDebug` and sideload.
+- Privacy assertions, redaction unit tests, deterministic offline parse fixtures,
+  and Paparazzi snapshots of consent/error states run on CI without signing.
+
+### Play-distribution tail (gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242))
+
+- The Play **Data safety** form (declaring on-device processing, microphone use,
+  no off-device content) and store distribution are **human-gated** by Google Play
+  enrollment ([#1242](https://github.com/jrmoulckers/finance/issues/1242)); the
+  Assistant validation surface is set up under
+  [#2383](https://github.com/jrmoulckers/finance/issues/2383). Per
+  [`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md) §2,
+  only this distribution tail is gated; the on-device implementation above is not.
+  Agents must not complete enrollment, the Data safety submission, or secret
+  configuration.
+
+---
+
+## 12. Open questions
+
+- Retention window for unconfirmed encrypted offline drafts before WorkManager
+  cleanup.
+- Whether ML Kit Entity Extraction ships in v1 or normalization stays entirely in
+  `NaturalLanguageParser`.
+- Exact latency-bucket boundaries for `voice_entry_saved`.
+- Whether a user-facing "what we collect" voice-entry privacy card links into a
+  broader privacy dashboard.
+
+---
+
+**Related:** [App Actions & Intent Schema](./android-voice-app-actions-intent-schema.md)
+· [Draft Confirmation & Ambiguity Prompts](./android-voice-draft-confirmation.md)
+· [iOS Categorization Privacy & Telemetry](./ios-categorization-privacy-telemetry.md)
+· [Receipt-to-Expense Draft Flow](./android-receipt-to-expense-draft.md)
+· [Accessibility Patterns Library](./accessibility-patterns.md)


### PR DESCRIPTION
## Summary

Design-only documentation for the Android voice-transaction cluster (part of
**#2396**, voice-entry epic **#2383**). Three new docs under `docs/design/`
specify how a spoken transaction becomes a reviewed, confirmed ledger entry while
keeping all parsing/transaction-mapping logic conceptually in KMP
`packages/core` (`NaturalLanguageParser`) and letting Compose render shared state.

No native code, builds, signing, or store actions are included. Each doc splits
the **buildable-now** path (`assembleDebug` sideload; App Actions / deep-link /
intent plumbing debug-implementable) from the **Play-distribution tail gated by
#1242**, linking [`docs/ops/human-gated-prerequisites.md`](../docs/ops/human-gated-prerequisites.md).

## Changes

- **`docs/design/android-voice-app-actions-intent-schema.md`** — App Actions /
  Assistant entry points, the voice intent schema (amount, merchant, category,
  account, note, transaction-date), invocation phrases + inline inventory, and the
  deep-link handoff contract. Includes a Mermaid intent-schema diagram.
- **`docs/design/android-voice-draft-confirmation.md`** — prefilled draft review,
  missing-field and ambiguity prompts, correction UX, explicit confirm-before-save
  gate, and offline-safe draft state. Includes a Mermaid parse/confirm flow.
- **`docs/design/android-voice-privacy-offline-parsing.md`** — on-device speech +
  parsing boundaries, what is/is not stored, privacy-preserving telemetry (enums /
  counters / confidence bands only — no raw utterance or transaction text off
  device), privacy-safe error reporting, and consent/permissions.

Each doc includes a ToC, accessibility (TalkBack, Switch Access, 200% font, voice
as an alternative not the sole path), offline/empty/error + low-confidence /
ambiguity states, a test plan (unit / Compose / Paparazzi, deterministic parse
fixtures, privacy assertions), an Implementation readiness section, and relative
cross-links to existing `docs/design` and `docs/ops` files only. Prettier passes.

Closes #2696
Closes #2697
Closes #2698
