### PR TITLE
docs(design): android shared goals and debt payoff design batch (#2649, #2650, #2656)

### DIFF
--- a/docs/design/android-house-downpayment-planner.md
+++ b/docs/design/android-house-downpayment-planner.md
@@ -1,0 +1,391 @@
+# Android House Down-Payment Milestones & Catch-Up Planner
+
+> **Status:** PROPOSED — Pending human review
+> **Issue:** [#2650](https://github.com/jrmoulckers/finance/issues/2650) · Part of [#2147](https://github.com/jrmoulckers/finance/issues/2147)
+> **Platform:** Android (Jetpack Compose, Material 3)
+> **Last Updated:** 2026-06-22
+> **Design only:** Native implementation remains blocked by [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+
+---
+
+## Table of Contents
+
+1. [Purpose](#purpose)
+2. [Persona and Why This Matters](#persona-and-why-this-matters)
+3. [Goals and Non-Goals](#goals-and-non-goals)
+4. [Scope Boundaries With Sibling Work](#scope-boundaries-with-sibling-work)
+5. [Projection Math Lives in KMP](#projection-math-lives-in-kmp)
+6. [Milestone Cards](#milestone-cards)
+7. [Per-Partner Monthly Targets](#per-partner-monthly-targets)
+8. [Behind / On-Track / Ahead and Catch-Up](#behind--on-track--ahead-and-catch-up)
+9. [Plain-Language Copy](#plain-language-copy)
+10. [Accessibility Considerations](#accessibility-considerations)
+11. [Offline, Empty, Error, and Milestone States](#offline-empty-error-and-milestone-states)
+12. [Test Plan](#test-plan)
+13. [Implementation Readiness](#implementation-readiness)
+14. [References](#references)
+
+---
+
+## Purpose
+
+Buying a first home is one big number split into a few scary sub-numbers: the
+**down payment**, the **closing costs**, and an **emergency buffer** to avoid
+moving in house-poor. This document designs the Android Compose surfaces that
+break that into legible **milestone cards**, show a **suggested monthly target
+per partner** using shared projections, and — crucially — handle **behind/ahead
+catch-up** with non-shaming copy for uneven incomes or missed months.
+
+It is **design and breakdown only** while
+[#1242](https://github.com/jrmoulckers/finance/issues/1242) gates Google Play
+distribution. No Kotlin is written here, and no finance math is implemented in
+Compose — the projection logic is a **shared KMP concern** that should reuse the
+same engine as teen goal planning, with the web savings/projection engines as the
+parity reference.
+
+---
+
+## Persona and Why This Matters
+
+The persona ([#2147](https://github.com/jrmoulckers/finance/issues/2147)): a
+couple saving together for a home, often with **two different incomes** and
+**different months of higher and lower cash flow**. They benefit from a single
+confident sentence per milestone — "Down payment: $18k of $40k, about Sep 2027 at
+your current pace" — and from catch-up guidance that feels like a teammate, not a
+scold. This intersects with [Persona 3 (household / couples)](personas.md) and
+the plain-language goal framing in
+[android-teen-goal-projections.md](android-teen-goal-projections.md).
+
+> **Important framing:** every date, monthly target, and "catch-up" number is an
+> **estimate**, visibly labelled as such, and never a promise or a mortgage-readiness
+> determination. This surface plans the household's _own_ savings goal; it is not
+> lending advice.
+
+---
+
+## Goals and Non-Goals
+
+**Goals**
+
+- Define **milestone cards** for down payment, closing costs, and emergency buffer,
+  each with progress, a projected date, and a pace state.
+- Show a **suggested monthly target per partner** derived from shared projections,
+  honoring uneven incomes without prescribing a split in Compose.
+- Provide **behind / on-track / ahead** messaging with **non-shaming catch-up copy**
+  for missed or uneven contributions.
+- Reuse the **same projection engine as teen goal planning** so the household and
+  teen surfaces agree on math and never duplicate rules.
+- Respect partner privacy: per-partner targets are shown only as the shared
+  visibility policy permits.
+
+**Non-Goals**
+
+- Implementing or editing the projection/target math (lives in KMP `packages/core`;
+  the web engines are the parity reference — see
+  [Projection Math Lives in KMP](#projection-math-lives-in-kmp)).
+- Per-partner contribution attribution and history — owned by
+  [android-shared-goal-contributors.md](android-shared-goal-contributors.md).
+- The visibility/RBAC policy itself — owned by
+  [android-household-privacy-dashboard.md](android-household-privacy-dashboard.md).
+- Mortgage pre-qualification, affordability lending decisions, or rate quotes.
+- Editing KMP `packages/*`, web, or any non-Android platform.
+
+---
+
+## Scope Boundaries With Sibling Work
+
+```mermaid
+flowchart TD
+    THIS[Issue 2650: House down-payment planner<br/>THIS DOC: milestone cards + catch-up]
+    CONTRIB[Issue 2649: Shared goal contributors<br/>per-partner attribution + history]
+    TEEN[Issue 2661: Teen goal projections<br/>shared projection engine consumer]
+    PRIV[Issue 2640: Household privacy dashboard<br/>visibility policy]
+    KMP[KMP packages-core<br/>shared projection + target rules]
+
+    THIS -->|renders shared projections| KMP
+    TEEN -->|renders same projection engine| KMP
+    THIS -->|attribution handled by| CONTRIB
+    THIS -->|per-partner targets honor| PRIV
+```
+
+This doc owns the **home-purchase milestone and catch-up** experience. Who
+contributed what is the contributors doc; what each partner may see is the privacy
+dashboard. The **projection engine is shared with teen goal planning** — both
+consume the same KMP outputs.
+
+---
+
+## Projection Math Lives in KMP
+
+Monthly targets, projected completion dates, and catch-up amounts are **business
+logic** and must be shared, not duplicated in Compose. The web references already
+exist as
+[`goal-projection-engine.ts`](../../apps/web/src/lib/savings/goal-projection-engine.ts)
+and [`savings-goals.ts`](../../apps/web/src/lib/planning/savings-goals.ts), which
+produce monthly targets, a `state` of `behind | on-track | ahead | complete`, and a
+catch-up figure. The Android client consumes an **equivalent shared model from KMP
+`packages/core`** — the same engine that powers teen goal planning — so all goal
+surfaces agree.
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages-core (shared - do NOT edit here)"]
+        ENGINE[Projection rules<br/>monthly + per-partner targets<br/>projected date + pace state<br/>catch-up amount]
+        FMT[Number / currency / date formatting]
+    end
+    subgraph Web["apps-web (parity reference)"]
+        WENG[goal-projection-engine.ts<br/>savings-goals.ts]
+    end
+    subgraph Android["apps-android (this work)"]
+        VM[DownPaymentViewModel<br/>maps shared summary to milestone UI state]
+        UI[Compose milestone cards + catch-up]
+    end
+    WENG -.parity.-> ENGINE
+    VM --> ENGINE
+    VM --> FMT
+    UI --> VM
+```
+
+> This document **describes** the boundary. It does **not** implement KMP changes —
+> `packages/core` is owned by @kmp-engineer and the web engines by @web-engineer.
+> Compose is a pure renderer of shared state. The existing
+> [`Goal`](../../packages/models/src/commonMain/kotlin/com/finance/models/Goal.kt)
+> model already carries `targetAmount`, `currentAmount`, and `targetDate`; a home
+> purchase is modelled as a small set of these goals (down payment, closing costs,
+> buffer) sharing a household. The per-partner split is **never** computed in
+> Compose.
+
+---
+
+## Milestone Cards
+
+Each milestone is a Material 3 card rendering shared state — a header, progress, a
+projected date, and a pace chip. The three home-purchase milestones:
+
+| Milestone            | What it funds                                   | Typical framing                            |
+| -------------------- | ----------------------------------------------- | ------------------------------------------ |
+| **Down payment**     | The deposit toward purchase price               | Usually the largest, leads the stack       |
+| **Closing costs**    | Fees, taxes, and one-time purchase costs        | A meaningful add-on, often underestimated  |
+| **Emergency buffer** | Post-move cash cushion to avoid house-poor risk | Protects against moving in with $0 reserve |
+
+```mermaid
+flowchart TD
+    STACK[Home purchase plan] --> DP[Down payment card]
+    STACK --> CC[Closing costs card]
+    STACK --> EB[Emergency buffer card]
+    DP --> PROG[Progress + projected date]
+    DP --> CHIP[Pace chip: behind / on-track / ahead]
+    DP --> TARGET[Suggested monthly target]
+    STACK --> ROLLUP[Combined home-readiness rollup]
+```
+
+- Cards render in a sensible default order (down payment first) and roll up into a
+  combined "home-readiness" estimate.
+- Progress and pace visuals follow [data-visualization.md](data-visualization.md)
+  and [chart-component-specs.md](chart-component-specs.md); they never rely on color
+  alone. Cards reuse [component-library.md](component-library.md).
+- A card with **no target amount yet** prompts the household to set one rather than
+  showing a misleading $0-of-$0 state.
+
+---
+
+## Per-Partner Monthly Targets
+
+The card shows a **suggested monthly target** and, when permitted, a per-partner
+breakdown. The split is produced by the shared engine, which can weight by income
+or stated preference; Compose only renders the result.
+
+- **Default:** the household monthly target ("Save about $900/month to reach your
+  down payment by Sep 2027").
+- **Per-partner (permitted):** "Alex about $520 · Sam about $380" — shown only when
+  the shared visibility policy allows per-partner figures; otherwise the surface
+  shows the household target alone.
+- **Uneven incomes are normal:** the per-partner suggestion is framed as a starting
+  point the couple can adjust, never as an obligation, and never compares partners
+  unfavorably.
+- The remaining-paychecks / pay-cadence input is a **shared input**, not a Compose
+  computation; when cadence is unknown, show a monthly target only.
+
+> Per-partner targets are **estimates** and respect the same partner privacy
+> boundaries as the contributors surface; if a partner has not consented to
+> per-partner visibility, only the household target appears.
+
+---
+
+## Behind / On-Track / Ahead and Catch-Up
+
+Catch-up is where tone matters most. Pace states map directly from the shared
+engine `state`:
+
+```mermaid
+stateDiagram-v2
+    [*] --> OnTrack
+    OnTrack --> Behind: balance below plan
+    OnTrack --> Ahead: balance above plan
+    Behind --> OnTrack: caught up
+    Ahead --> OnTrack: pace normalized
+    OnTrack --> Complete: milestone funded
+    Behind --> Complete: milestone funded
+    Ahead --> Complete: milestone funded
+    Complete --> [*]
+```
+
+- **Behind** shows a **catch-up monthly number** ("a little behind — about
+  $1,050/month keeps Sep 2027 on the table") and an alternative ("or keep $900/month
+  and aim for Nov 2027"). It never says the household failed.
+- **Ahead** is honest and encouraging ("you're ahead — you could be ready sooner").
+- **Missed a month / uneven income:** copy normalizes it ("Some months are tighter —
+  that's okay. Here's how to get back on plan"), reusing the catch-up patterns from
+  [android-teen-goal-projections.md](android-teen-goal-projections.md).
+- **Complete:** a clear win state per milestone, rolling into the combined readiness
+  estimate with no nagging.
+
+---
+
+## Plain-Language Copy
+
+Copy is part of the product here. Every string below is a placeholder for a
+localized, resource-backed string and follows
+[content-language-guidelines.md](content-language-guidelines.md).
+
+| Context              | Plain-language copy (example)                                  |
+| -------------------- | -------------------------------------------------------------- |
+| Milestone progress   | "Down payment: $18k of $40k saved"                             |
+| Monthly target       | "Save about $900/month to reach this by Sep 2027"              |
+| Per-partner target   | "Alex about $520 · Sam about $380 (estimate)"                  |
+| On track             | "On track for Sep 2027"                                        |
+| Ahead                | "You're ahead — you could be ready sooner"                     |
+| Behind (catch-up)    | "A little behind — about $1,050/month keeps Sep 2027 in reach" |
+| Missed-month framing | "Some months are tighter. Here's how to get back on plan."     |
+| No target yet        | "Set your down-payment target to see a monthly plan"           |
+| Milestone complete   | "Down payment funded. Nice work, both of you."                 |
+
+**Copy rules**
+
+- Lead with the **milestone and the plan**, not with blame for a shortfall.
+- Catch-up is **a new number plus an alternative date**, never a verdict.
+- Always pair estimates with "about"/"around" or an explicit estimate label.
+- Never imply lending readiness, approval odds, or that this is financial advice.
+
+---
+
+## Accessibility Considerations
+
+- **TalkBack:** each milestone card exposes one cohesive `contentDescription`
+  ("Down payment, $18,000 of $40,000 saved, on track for about September 2027,
+  suggested $900 a month"). The pace chip and the catch-up action each carry their
+  own label. Per-partner targets, when shown, are announced as estimates.
+- **Switch Access:** the "adjust target," "set monthly amount," and catch-up
+  affordances are reachable and operable with touch targets ≥ 48dp.
+- **Font scaling:** milestone headers, currency, dates, and the monthly target stay
+  readable and unclipped at **200%** font scale; no fixed-height containers around
+  amounts.
+- **Non-color cues:** behind / on-track / ahead use text and an icon, never color
+  alone, per [data-visualization.md](data-visualization.md).
+- **Plain language / cognitive load:** one plan per card, most important number
+  first, aligned with [cognitive-accessibility.md](cognitive-accessibility.md).
+- See [accessibility-patterns.md](accessibility-patterns.md) for the underlying
+  screen-reader, focus, and touch-target patterns.
+
+---
+
+## Offline, Empty, Error, and Milestone States
+
+- **Offline:** milestone projections are computed from already-synced goal data, so
+  the cards render fully **offline** using the last-known shared summary; show data
+  freshness rather than blocking the plan.
+- **Empty (no home plan):** show a friendly setup state ("Plan your home purchase —
+  start with a down-payment target") instead of blank cards.
+- **Empty (target without a date):** show the monthly target as soon as an amount
+  exists, and prompt "Add a target date to see your finish date."
+- **Milestone states:** first contribution, quarter, halfway, almost there, and
+  funded are derived from the shared milestone percent; Compose only chooses the
+  label and the celebratory affordance.
+- **Error:** if the shared summary cannot be produced, fail safe to raw progress
+  ("$18k of $40k saved") with a quiet "Plan unavailable right now" — never a stack
+  trace, never a blank screen.
+
+---
+
+## Test Plan
+
+| Layer              | Tooling                         | What it verifies                                                                                                         |
+| ------------------ | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Unit               | JUnit                           | ViewModel maps shared summary → milestone UI state for behind / on-track / ahead / complete.                             |
+| Unit (math parity) | JUnit                           | Per-partner and household monthly targets read from the shared engine, not recomputed.                                   |
+| Unit (safety)      | JUnit                           | No Timber call logs balances, target amounts, projected dates, or per-partner figures.                                   |
+| Compose UI         | `createComposeRule` + semantics | Milestone cards, pace chip, monthly target, and catch-up resolve `contentDescription`.                                   |
+| Compose UI         | `createComposeRule`             | Behind state surfaces a catch-up number and an alternative-date option.                                                  |
+| Snapshot           | Paparazzi                       | Down-payment / closing / buffer cards in behind / on-track / ahead / complete + empty + no-date at {1x, 2x}, light/dark. |
+| Pseudolocalization | `en-XA` / `ar-XB`               | Copy expansion and RTL mirroring for the milestone and catch-up sentences.                                               |
+| Accessibility      | Espresso/Accessibility checks   | TalkBack order, Switch Access reachability, touch targets ≥ 48dp.                                                        |
+
+---
+
+## Implementation Readiness
+
+This is a design artifact. Execution splits into a **buildable-now** tier and a
+**Play-distribution tail** gated by
+[#1242](https://github.com/jrmoulckers/finance/issues/1242). See
+[../ops/human-gated-prerequisites.md](../ops/human-gated-prerequisites.md) and
+[../ops/launch-readiness-plan.md](../ops/launch-readiness-plan.md).
+
+**Buildable now — `assembleDebug` + sideload (no human gate):**
+
+- Build the milestone cards, monthly-target and per-partner rendering, and catch-up
+  states as Compose surfaces rendering a shared projection summary (mock/in-memory
+  data while KMP wiring lands).
+- Verify pace/milestone states, catch-up copy, accessibility, and
+  pseudolocale/expansion snapshots on a debug build / emulator.
+- All of this runs on an emulator with **no signing, store credentials, or
+  human-gated operations**.
+
+**Play-distribution tail — human-gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242):**
+
+- Production signing + Play Console listing.
+- Any store-level data-safety declaration touching shared/household financial data.
+- Staged rollout / internal testing track.
+
+The shared projection engine (reused with teen goal planning) is delivered by KMP
+`packages/core`; the web savings/projection engines are the parity reference;
+Compose stays render-only.
+
+---
+
+## References
+
+**Design docs**
+
+- [android-teen-goal-projections.md](android-teen-goal-projections.md) — shared projection engine consumer + catch-up tone (#2661)
+- [android-shared-goal-contributors.md](android-shared-goal-contributors.md) — per-partner attribution + history (#2649)
+- [android-household-privacy-dashboard.md](android-household-privacy-dashboard.md) — visibility policy & aggregates (#2640)
+- [android-goal-projection-widget.md](android-goal-projection-widget.md) — home-screen widget states (#2663)
+- [content-language-guidelines.md](content-language-guidelines.md) — non-judgmental, plain copy
+- [cognitive-accessibility.md](cognitive-accessibility.md) — plain-language and load reduction
+- [accessibility-patterns.md](accessibility-patterns.md) — screen reader, focus, touch targets
+- [data-visualization.md](data-visualization.md) — progress visuals, non-color cues
+- [chart-component-specs.md](chart-component-specs.md) — progress ring/bar specs
+- [component-library.md](component-library.md) — card and list components
+- [information-architecture.md](information-architecture.md) — surface and navigation map
+- [ux-principles.md](ux-principles.md) — product UX principles
+- [personas.md](personas.md) — household / couples persona
+
+**Ops**
+
+- [../ops/human-gated-prerequisites.md](../ops/human-gated-prerequisites.md) — buildable-now vs. gated split
+- [../ops/launch-readiness-plan.md](../ops/launch-readiness-plan.md) — launch checklist
+
+**Android / web / KMP (read-only boundary)**
+
+- [`goal-projection-engine.ts`](../../apps/web/src/lib/savings/goal-projection-engine.ts) — web parity reference, shared with teen planning (owned by @web-engineer)
+- [`savings-goals.ts`](../../apps/web/src/lib/planning/savings-goals.ts) — savings planning rules
+- [`GoalProjection.tsx`](../../apps/web/src/components/savings/GoalProjection.tsx) — web projection UI parity
+- [`GoalsScreen.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/screens/GoalsScreen.kt) — host surface
+- [`Goal.kt`](../../packages/models/src/commonMain/kotlin/com/finance/models/Goal.kt) — shared goal model (owned by @kmp-engineer)
+- [`Household.kt`](../../packages/models/src/commonMain/kotlin/com/finance/models/Household.kt) — household model
+
+**Issues**
+
+- [#2650](https://github.com/jrmoulckers/finance/issues/2650) — this issue
+- [#2147](https://github.com/jrmoulckers/finance/issues/2147) — parent (shared goals cluster)
+- [#1242](https://github.com/jrmoulckers/finance/issues/1242) — Play Console + keystore (gate)

--- a/docs/design/android-joint-debt-payoff-planner.md
+++ b/docs/design/android-joint-debt-payoff-planner.md
@@ -1,0 +1,403 @@
+# Android Joint Debt Payoff Planner Shell & Debt Ownership Flow
+
+> **Status:** PROPOSED — Pending human review
+> **Issue:** [#2656](https://github.com/jrmoulckers/finance/issues/2656) · Part of [#2153](https://github.com/jrmoulckers/finance/issues/2153)
+> **Platform:** Android (Jetpack Compose, Material 3)
+> **Last Updated:** 2026-06-22
+> **Design only:** Native implementation remains blocked by [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+
+---
+
+## Table of Contents
+
+1. [Purpose](#purpose)
+2. [Persona and Why This Matters](#persona-and-why-this-matters)
+3. [Goals and Non-Goals](#goals-and-non-goals)
+4. [Scope Boundaries With Sibling Work](#scope-boundaries-with-sibling-work)
+5. [Payoff Math Lives in KMP](#payoff-math-lives-in-kmp)
+6. [Planner Shell and Entry Points](#planner-shell-and-entry-points)
+7. [Debt Inventory and Ownership Classification](#debt-inventory-and-ownership-classification)
+8. [Personal / Shared / Jointly-Funded States](#personal--shared--jointly-funded-states)
+9. [Plain-Language Copy](#plain-language-copy)
+10. [Accessibility Considerations](#accessibility-considerations)
+11. [Offline, Empty, and Error States](#offline-empty-and-error-states)
+12. [Test Plan](#test-plan)
+13. [Implementation Readiness](#implementation-readiness)
+14. [References](#references)
+
+---
+
+## Purpose
+
+Debt is sensitive, and shared debt doubly so. A couple needs to **see their
+liabilities in one place**, label each one as **personal, shared, or
+jointly-funded**, decide **who contributes** to paying it off, and do all of that
+without exposing a partner's private debt they never agreed to share. This
+document designs the Android Compose **debt payoff planner shell** and the **debt
+ownership flow**: entry points, the debt inventory, ownership classification, and
+the personal vs. jointly-funded states — using the web `DebtPage` payoff planner as
+the parity reference.
+
+It is **design and breakdown only** while
+[#1242](https://github.com/jrmoulckers/finance/issues/1242) gates Google Play
+distribution. No Kotlin is written here, and no payoff math is implemented in
+Compose — that logic is a **shared KMP concern**, with the web debt engines as the
+parity reference.
+
+---
+
+## Persona and Why This Matters
+
+The persona ([#2153](https://github.com/jrmoulckers/finance/issues/2153)): a
+household managing a mix of **personal** debts (one partner's student loan, a
+pre-relationship card) and **shared** debts (a joint card, a co-signed loan), some
+of which both partners **fund jointly** even when only one "owns" them. They need
+a clear, non-judgmental inventory and explicit, consent-driven ownership labels —
+not an interface that outs someone's private balance. This intersects with
+[Persona 3 (household / couples)](personas.md), the privacy foundation in
+[android-household-privacy-dashboard.md](android-household-privacy-dashboard.md),
+and debt education in
+[android-credit-building-education.md](android-credit-building-education.md).
+
+> **Important framing:** payoff dates, interest-saved figures, and method
+> comparisons (avalanche vs. snowball) are **estimates**, visibly labelled as such.
+> This surface plans the household's _own_ payoff; it is not debt counseling,
+> consolidation advice, or a credit decision.
+
+---
+
+## Goals and Non-Goals
+
+**Goals**
+
+- Define the **payoff planner shell**: entry points, top-level structure, and how
+  the debt inventory and planner outputs fit together.
+- Define Compose screens for a **debt inventory**, **ownership labels**, and
+  **partner contribution choices**.
+- Document how liabilities map to **personal / shared / jointly-funded** debt, as a
+  rendering of shared classification — not Compose-side logic.
+- Provide **empty-state guidance** and **privacy copy** for sensitive debts so a
+  partner's private liability is never exposed without consent.
+- Keep parity with the web `DebtPage` payoff-planner behavior.
+
+**Non-Goals**
+
+- Implementing or editing payoff math — avalanche/snowball ordering, payoff dates,
+  interest projections (lives in KMP `packages/core`; the web debt engines are the
+  parity reference — see [Payoff Math Lives in KMP](#payoff-math-lives-in-kmp)).
+- The full payoff-strategy comparison UI and amortization detail — this issue is the
+  **shell and ownership flow**; deeper planner surfaces are downstream siblings.
+- The household visibility/RBAC policy itself — owned by
+  [android-household-privacy-dashboard.md](android-household-privacy-dashboard.md).
+- Credit-building education content — owned by
+  [android-credit-building-education.md](android-credit-building-education.md) and
+  [android-secured-card-tracking.md](android-secured-card-tracking.md).
+- Editing KMP `packages/*`, web, or any non-Android platform.
+
+---
+
+## Scope Boundaries With Sibling Work
+
+```mermaid
+flowchart TD
+    THIS[Issue 2656: Joint debt payoff shell + ownership<br/>THIS DOC: inventory, ownership, planner shell]
+    PRIV[Issue 2640: Household privacy dashboard<br/>visibility policy for sensitive debts]
+    EDU[Credit-building education<br/>learning content, not planning]
+    SECURED[Secured card tracking<br/>credit-building accounts]
+    KMP[KMP packages-core<br/>shared payoff + classification rules]
+
+    THIS -->|renders shared payoff + ownership state| KMP
+    THIS -->|hides sensitive debts per| PRIV
+    THIS -->|links out to| EDU
+    THIS -->|distinct from| SECURED
+```
+
+This doc owns the **shell, inventory, and ownership flow**. What each partner is
+allowed to see about a sensitive debt is the privacy dashboard; the actual payoff
+arithmetic is shared KMP. Education and secured-card tracking are separate
+surfaces this shell can link to.
+
+---
+
+## Payoff Math Lives in KMP
+
+Payoff ordering, projected payoff dates, and interest-saved comparisons are
+**business logic** and must be shared, not duplicated in Compose. The web
+references already exist —
+[`debt-payoff-engine.ts`](../../apps/web/src/lib/debt-payoff-engine.ts),
+[`debt-types.ts`](../../apps/web/src/lib/debt-types.ts), and
+[`debt-progress-rings.ts`](../../apps/web/src/lib/debt/debt-progress-rings.ts) —
+and drive the web [`DebtPage.tsx`](../../apps/web/src/pages/DebtPage.tsx). The
+Android client consumes an **equivalent shared model from KMP `packages/core`** so
+both platforms agree on every payoff number and every ownership classification.
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages-core (shared - do NOT edit here)"]
+        ENGINE[Payoff rules<br/>avalanche / snowball order<br/>payoff date + interest estimate]
+        CLASS[Ownership classification<br/>personal / shared / jointly-funded]
+        FMT[Number / currency / date formatting]
+    end
+    subgraph Web["apps-web (parity reference)"]
+        WENG[debt-payoff-engine.ts<br/>debt-types.ts]
+        WPAGE[DebtPage.tsx]
+    end
+    subgraph Android["apps-android (this work)"]
+        VM[DebtPlannerViewModel<br/>maps shared summary to UI state]
+        UI[Compose planner shell + inventory + ownership]
+    end
+    WENG -.parity.-> ENGINE
+    WPAGE -.parity.-> UI
+    VM --> ENGINE
+    VM --> CLASS
+    VM --> FMT
+    UI --> VM
+```
+
+> This document **describes** the boundary. It does **not** implement KMP changes —
+> `packages/core` is owned by @kmp-engineer and the web engines by @web-engineer.
+> Compose is a pure renderer of shared state. The existing
+> [`Liability`](../../packages/models/src/commonMain/kotlin/com/finance/models/Liability.kt)
+> model already carries `householdId`, `ownerId`, `type`, `remainingBalance`,
+> `originalAmount`, and `status`, with
+> [`LiabilityInstallment`](../../packages/models/src/commonMain/kotlin/com/finance/models/LiabilityInstallment.kt)
+> for schedules — those are the inputs a shared classification and payoff model
+> needs. Ownership and split logic are **never** baked into UI-only code.
+
+---
+
+## Planner Shell and Entry Points
+
+The shell is the top-level container that hosts the inventory and surfaces the
+shared payoff summary. It is a new Compose screen reachable from planning and
+dashboard entry points; it does not replace existing screens.
+
+```mermaid
+flowchart TD
+    PLAN[Planning / dashboard entry point] --> SHELL[Debt payoff planner shell]
+    SHELL --> SUMMARY[Household payoff summary<br/>estimate-labelled]
+    SHELL --> INVENTORY[Debt inventory list]
+    INVENTORY --> ITEM[Debt item: balance, type, ownership label]
+    ITEM --> OWNERSHIP[Ownership flow: personal / shared / jointly-funded]
+    OWNERSHIP --> CONTRIB[Partner contribution choice]
+    SHELL --> EDU[Link: credit-building education]
+```
+
+- The shell shows a **household payoff summary** (estimate-labelled) only over the
+  debts the viewer is permitted to see; private debts are excluded from both the
+  list and the totals.
+- Entry points reuse the existing planning surfaces (for example
+  [`PlanningScreen`](../../apps/android/src/main/kotlin/com/finance/android/ui/screens/PlanningScreen.kt))
+  and follow [information-architecture.md](information-architecture.md) for
+  placement and navigation.
+- Cards, lists, and chips reuse [component-library.md](component-library.md);
+  progress rings follow [chart-component-specs.md](chart-component-specs.md).
+
+---
+
+## Debt Inventory and Ownership Classification
+
+The inventory is a list of liabilities, each rendered with its balance, type, and
+an ownership label produced by the shared classifier.
+
+| Liability type (`LiabilityType`) | Example                     | Notes                                  |
+| -------------------------------- | --------------------------- | -------------------------------------- |
+| `LOAN`                           | Student loan, auto loan     | May be personal or co-signed/shared    |
+| `CREDIT_LINE`                    | Credit card, line of credit | Often the joint-vs-personal decision   |
+| `BNPL`                           | Buy-now-pay-later plan      | Installment schedule from shared model |
+| `OTHER`                          | Anything not above          | Falls back to generic copy             |
+
+```mermaid
+stateDiagram-v2
+    [*] --> Unclassified
+    Unclassified --> Personal: owned by one partner, funded by them
+    Unclassified --> Shared: both partners own / co-signed
+    Unclassified --> JointlyFunded: one owner, both contribute
+    Personal --> Shared: reclassified by consent
+    Personal --> JointlyFunded: partner opts to contribute
+    JointlyFunded --> Personal: contribution withdrawn
+    Shared --> JointlyFunded: ownership adjusted
+```
+
+- The **ownership label** is read from the shared classifier; Compose renders it and
+  offers a consent-driven way to change it. The transition is persisted through the
+  shared layer, not decided in Compose.
+- A reclassification that exposes a debt to a partner requires **explicit consent**
+  and follows the privacy model in
+  [android-household-privacy-dashboard.md](android-household-privacy-dashboard.md).
+
+---
+
+## Personal / Shared / Jointly-Funded States
+
+| State              | Who owns it         | Who funds payoff         | Visibility default                               |
+| ------------------ | ------------------- | ------------------------ | ------------------------------------------------ |
+| **Personal**       | One partner         | The owner                | Private to the owner unless they choose to share |
+| **Shared**         | Both partners       | Both, per agreement      | Visible to both                                  |
+| **Jointly-funded** | One partner (owner) | Both partners contribute | Owner controls how much detail the partner sees  |
+
+- **Personal & private:** appears only for the owner. The partner's planner totals
+  simply do not include it; there is no placeholder hinting it exists.
+- **Shared:** both partners see the debt and the planner attributes payoff progress
+  to the household.
+- **Jointly-funded:** the owner keeps ownership but the partner contributes; the
+  **partner contribution choice** (a percentage, a fixed amount, or "as we go") is a
+  shared input the surface renders, never a Compose computation.
+- All payoff figures and method comparisons shown in these states are **estimates**,
+  explicitly labelled.
+
+---
+
+## Plain-Language Copy
+
+Copy is part of the product here, and tone is critical for debt. Every string below
+is a placeholder for a localized, resource-backed string and follows
+[content-language-guidelines.md](content-language-guidelines.md).
+
+| Context                     | Plain-language copy (example)                                    |
+| --------------------------- | ---------------------------------------------------------------- |
+| Household payoff summary    | "About $14,200 left across your shared debts (estimate)"         |
+| Personal label              | "Personal — only you can see this"                               |
+| Shared label                | "Shared — you and your partner"                                  |
+| Jointly-funded label        | "Yours, funded together"                                         |
+| Reclassify consent prompt   | "Share this debt with your partner? They'll see its balance."    |
+| Partner contribution        | "How would you like to split paying this off?"                   |
+| Empty inventory             | "No debts tracked yet. Add one to plan a payoff — at your pace." |
+| Sensitive-debt privacy note | "Private debts stay private. Your partner won't see these."      |
+
+**Copy rules**
+
+- **Non-judgmental and non-shaming:** debt is normal; the surface helps plan, it
+  never lectures or ranks partners.
+- **Consent before exposure:** any action that reveals a debt to a partner says so
+  plainly before it happens.
+- Always pair payoff dates and interest-saved figures with "about"/"around" or an
+  explicit estimate label.
+- Never frame this as advice, consolidation, or a credit recommendation.
+
+---
+
+## Accessibility Considerations
+
+- **TalkBack:** each debt item exposes one cohesive `contentDescription` ("Auto
+  loan, about $8,400 remaining, shared, on track to be paid off around March 2028,
+  estimate"). Ownership labels and the contribution-choice control each carry their
+  own label. Private debts are never announced on a partner's device.
+- **Switch Access:** add-debt, reclassify, and contribution-choice affordances are
+  reachable and operable with touch targets ≥ 48dp.
+- **Font scaling:** balances, ownership labels, and payoff estimates stay readable
+  and unclipped at **200%** font scale; no fixed-height rows around amounts.
+- **Non-color cues:** ownership state and payoff progress use text, icon, and shape,
+  never color alone, per [data-visualization.md](data-visualization.md).
+- **Plain language / cognitive load:** one debt per row, clear ownership label,
+  estimate-first honesty, aligned with
+  [cognitive-accessibility.md](cognitive-accessibility.md).
+- See [accessibility-patterns.md](accessibility-patterns.md) for the underlying
+  screen-reader, focus, and touch-target patterns.
+
+---
+
+## Offline, Empty, and Error States
+
+- **Offline:** the inventory and payoff summary render from already-synced
+  liabilities, so the shell works fully **offline** using the last-known shared
+  summary; show data freshness rather than blocking. Edits queue and sync later.
+- **Empty (no debts):** show a supportive empty state ("No debts tracked yet. Add
+  one to plan a payoff — at your pace.") rather than a blank screen; never imply the
+  user _should_ have debt.
+- **Empty (partner has private debts):** the viewer simply sees only their permitted
+  set; the surface never hints that hidden debts exist.
+- **Conflict:** if both partners edit a shared debt or its ownership offline, defer
+  to the shared `ConflictStrategy.resolverFor()` outcome and show a quiet "updated
+  from your partner's device" note; Compose never invents a merge.
+- **Error:** if the shared payoff summary cannot be produced, fail safe to raw
+  balances per debt with a quiet "Payoff estimate unavailable right now" — never a
+  stack trace, never a blank screen.
+
+---
+
+## Test Plan
+
+| Layer              | Tooling                         | What it verifies                                                                                   |
+| ------------------ | ------------------------------- | -------------------------------------------------------------------------------------------------- |
+| Unit               | JUnit                           | ViewModel maps shared summary → UI state for personal / shared / jointly-funded.                   |
+| Unit (privacy)     | JUnit                           | A partner's private debt never appears in the other partner's list or totals.                      |
+| Unit (safety)      | JUnit                           | No Timber call logs balances, providers, payoff dates, or ownership of sensitive debts.            |
+| Compose UI         | `createComposeRule` + semantics | Inventory rows, ownership labels, summary, and contribution control resolve `contentDescription`.  |
+| Compose UI         | `createComposeRule`             | Reclassify flow requires explicit consent before exposing a debt to a partner.                     |
+| Snapshot           | Paparazzi                       | Inventory + ownership states (personal / shared / jointly-funded) + empty at {1x, 2x}, light/dark. |
+| Pseudolocalization | `en-XA` / `ar-XB`               | Copy expansion and RTL mirroring for labels and consent prompts.                                   |
+| Accessibility      | Espresso/Accessibility checks   | TalkBack order, Switch Access reachability, touch targets ≥ 48dp.                                  |
+
+---
+
+## Implementation Readiness
+
+This is a design artifact. Execution splits into a **buildable-now** tier and a
+**Play-distribution tail** gated by
+[#1242](https://github.com/jrmoulckers/finance/issues/1242). See
+[../ops/human-gated-prerequisites.md](../ops/human-gated-prerequisites.md) and
+[../ops/launch-readiness-plan.md](../ops/launch-readiness-plan.md).
+
+**Buildable now — `assembleDebug` + sideload (no human gate):**
+
+- Build the planner shell, debt inventory, ownership flow, and partner-contribution
+  control as Compose surfaces rendering a shared payoff + classification summary
+  (mock/in-memory data while KMP wiring lands).
+- Verify ownership states, consent-driven reclassification, sensitive-debt privacy,
+  accessibility, and pseudolocale/expansion snapshots on a debug build / emulator.
+- All of this runs on an emulator with **no signing, store credentials, or
+  human-gated operations**.
+
+**Play-distribution tail — human-gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242):**
+
+- Production signing + Play Console listing.
+- Any store-level data-safety declaration touching sensitive debt / household
+  financial data.
+- Staged rollout / internal testing track.
+
+The shared payoff and classification model is delivered by KMP `packages/core` (the
+web `DebtPage` and debt engines are the parity reference); Compose stays
+render-only.
+
+---
+
+## References
+
+**Design docs**
+
+- [android-household-privacy-dashboard.md](android-household-privacy-dashboard.md) — visibility policy for sensitive debts (#2640)
+- [android-credit-building-education.md](android-credit-building-education.md) — debt/credit education content
+- [android-secured-card-tracking.md](android-secured-card-tracking.md) — credit-building accounts
+- [android-shared-goal-contributors.md](android-shared-goal-contributors.md) — sibling household contribution flow (#2649)
+- [content-language-guidelines.md](content-language-guidelines.md) — non-judgmental, plain copy
+- [cognitive-accessibility.md](cognitive-accessibility.md) — plain-language and load reduction
+- [accessibility-patterns.md](accessibility-patterns.md) — screen reader, focus, touch targets
+- [data-visualization.md](data-visualization.md) — progress visuals, non-color cues
+- [chart-component-specs.md](chart-component-specs.md) — progress ring/bar specs
+- [component-library.md](component-library.md) — list, chip, and card components
+- [information-architecture.md](information-architecture.md) — surface and navigation map
+- [ux-principles.md](ux-principles.md) — product UX principles
+- [personas.md](personas.md) — household / couples persona
+
+**Ops**
+
+- [../ops/human-gated-prerequisites.md](../ops/human-gated-prerequisites.md) — buildable-now vs. gated split
+- [../ops/launch-readiness-plan.md](../ops/launch-readiness-plan.md) — launch checklist
+
+**Android / web / KMP (read-only boundary)**
+
+- [`DebtPage.tsx`](../../apps/web/src/pages/DebtPage.tsx) — web payoff-planner parity reference (owned by @web-engineer)
+- [`debt-payoff-engine.ts`](../../apps/web/src/lib/debt-payoff-engine.ts) — payoff math parity
+- [`debt-types.ts`](../../apps/web/src/lib/debt-types.ts) — debt classification types
+- [`debt-progress-rings.ts`](../../apps/web/src/lib/debt/debt-progress-rings.ts) — payoff progress visuals parity
+- [`PlanningScreen.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/screens/PlanningScreen.kt) — candidate entry-point host
+- [`Liability.kt`](../../packages/models/src/commonMain/kotlin/com/finance/models/Liability.kt) — shared liability model (owned by @kmp-engineer)
+- [`LiabilityInstallment.kt`](../../packages/models/src/commonMain/kotlin/com/finance/models/LiabilityInstallment.kt) — installment schedule model
+- [`DataPartitioning.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/household/DataPartitioning.kt) — shared visibility/partition rules
+
+**Issues**
+
+- [#2656](https://github.com/jrmoulckers/finance/issues/2656) — this issue
+- [#2153](https://github.com/jrmoulckers/finance/issues/2153) — parent (joint debt cluster)
+- [#1242](https://github.com/jrmoulckers/finance/issues/1242) — Play Console + keystore (gate)

--- a/docs/design/android-shared-goal-contributors.md
+++ b/docs/design/android-shared-goal-contributors.md
@@ -1,0 +1,419 @@
+# Android Shared Goal Contributors & Contribution History
+
+> **Status:** PROPOSED — Pending human review
+> **Issue:** [#2649](https://github.com/jrmoulckers/finance/issues/2649) · Part of [#2147](https://github.com/jrmoulckers/finance/issues/2147)
+> **Platform:** Android (Jetpack Compose, Material 3)
+> **Last Updated:** 2026-06-22
+> **Design only:** Native implementation remains blocked by [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+
+---
+
+## Table of Contents
+
+1. [Purpose](#purpose)
+2. [Persona and Why This Matters](#persona-and-why-this-matters)
+3. [Goals and Non-Goals](#goals-and-non-goals)
+4. [Scope Boundaries With Sibling Work](#scope-boundaries-with-sibling-work)
+5. [Contribution Math Lives in KMP](#contribution-math-lives-in-kmp)
+6. [Privacy: Exact Amount vs. Summarized Effort](#privacy-exact-amount-vs-summarized-effort)
+7. [Compose Surfaces](#compose-surfaces)
+8. [Add / Edit Contribution UX](#add--edit-contribution-ux)
+9. [Contribution History and Filtering](#contribution-history-and-filtering)
+10. [Plain-Language Copy](#plain-language-copy)
+11. [Accessibility Considerations](#accessibility-considerations)
+12. [Offline, Empty, and Error States](#offline-empty-and-error-states)
+13. [Test Plan](#test-plan)
+14. [Implementation Readiness](#implementation-readiness)
+15. [References](#references)
+
+---
+
+## Purpose
+
+When two partners save toward the same goal — a vacation, a shared emergency
+buffer, a new couch — each person wants to see **household progress** _and_ a
+fair, honest picture of **who has put in what**, without that turning into
+surveillance. This document designs the Android Compose surfaces for **shared
+goal contributors** and **contribution history**: household total progress,
+per-partner contribution progress, an add/edit contribution flow, history
+filtering, and the privacy controls that decide whether a contribution shows as
+an **exact amount** or as **summarized effort**.
+
+It is **design and breakdown only** while
+[#1242](https://github.com/jrmoulckers/finance/issues/1242) gates Google Play
+distribution. No Kotlin is written here, and no split/contribution business rules
+are implemented in Compose — that logic is a **shared KMP concern**, with the web
+`shared-goal-contributions` engine as the parity reference.
+
+---
+
+## Persona and Why This Matters
+
+The persona ([#2147](https://github.com/jrmoulckers/finance/issues/2147)): a
+couple or household sharing financial goals under a "yours, mine, ours" model.
+They want to feel like a team, not auditors. The product's job is to celebrate
+**household momentum** first, surface **per-partner contribution** in a way each
+person has consented to, and never weaponize the numbers. This intersects with
+[Persona 3 (household / couples)](personas.md) and the privacy foundation in
+[android-household-privacy-dashboard.md](android-household-privacy-dashboard.md).
+
+> **Important framing:** progress figures, projected completion dates, and any
+> "fair share" suggestion are **estimates**, visibly labelled as such. They
+> describe the household's own goal; they are never financial advice or a verdict
+> on a partner.
+
+---
+
+## Goals and Non-Goals
+
+**Goals**
+
+- Render **household total progress** and **per-partner contribution progress**
+  for a shared goal, as a pure renderer of shared state.
+- Define an **add / edit contribution** flow that attributes a contribution to a
+  contributor without baking split math into Compose.
+- Provide **contribution history** with filtering (by contributor, by date
+  range, by amount bucket) and clear empty/loading states.
+- Make the **visibility choice** — exact contribution amounts vs. summarized
+  effort — first-class, per-partner, and respected on both partners' devices.
+- Keep parity with the web shared-goal-contribution surface so both platforms
+  agree on totals, attribution, and rounding.
+
+**Non-Goals**
+
+- Implementing or editing the contribution/split math (lives in KMP
+  `packages/core`; the web engine is the parity reference — see
+  [Contribution Math Lives in KMP](#contribution-math-lives-in-kmp)).
+- Defining the household privacy/RBAC model itself — owned by
+  [android-household-privacy-dashboard.md](android-household-privacy-dashboard.md)
+  and the shared partition layer; this doc **consumes** those rules.
+- The save-$X projection surfaces and home-screen widget — owned by
+  [android-teen-goal-projections.md](android-teen-goal-projections.md) and
+  [android-goal-projection-widget.md](android-goal-projection-widget.md).
+- Editing KMP `packages/*`, web, or any non-Android platform.
+
+---
+
+## Scope Boundaries With Sibling Work
+
+```mermaid
+flowchart TD
+    THIS[Issue 2649: Shared goal contributors<br/>THIS DOC: contributors + history Compose surfaces]
+    PRIV[Issue 2640: Household privacy dashboard<br/>visibility policy + aggregates]
+    PROJ[Issue 2661: Teen/goal projections<br/>save-X projection surfaces]
+    WIDGET[Issue 2663: Goal projection widget<br/>Glance home-screen states]
+    KMP[KMP packages-core<br/>shared contribution + split rules]
+
+    THIS -->|renders shared contribution state| KMP
+    THIS -->|honors visibility policy from| PRIV
+    THIS -->|same goal, different surface| PROJ
+    THIS -->|same totals, smaller surface| WIDGET
+```
+
+This doc owns the **in-app contributor breakdown and history** for a shared goal.
+The privacy dashboard owns _what each partner is allowed to see_; this surface
+**asks** that policy and renders accordingly. Projection and widget docs render
+the same goal totals on other surfaces.
+
+---
+
+## Contribution Math Lives in KMP
+
+Attribution, per-partner totals, and any "fair share" suggestion are **business
+logic** and must be shared, not duplicated in Compose. The web reference already
+exists as
+[`shared-goal-contributions.ts`](../../apps/web/src/lib/savings/shared-goal-contributions.ts)
+and [`goal-contributions.ts`](../../apps/web/src/lib/household/goal-contributions.ts),
+which derive per-contributor totals, household progress, and a visibility-aware
+summary. The Android client consumes an **equivalent shared model from KMP
+`packages/core`** so both platforms agree on every number.
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages-core (shared - do NOT edit here)"]
+        ENGINE[Contribution rules<br/>per-partner totals<br/>household progress<br/>visibility-aware summary]
+        FMT[Number / currency / date formatting]
+    end
+    subgraph Web["apps-web (parity reference)"]
+        WENG[shared-goal-contributions.ts<br/>goal-contributions.ts]
+    end
+    subgraph Android["apps-android (this work)"]
+        VM[SharedGoalViewModel<br/>maps shared summary to UI state]
+        UI[Compose contributor + history surfaces]
+    end
+    WENG -.parity.-> ENGINE
+    VM --> ENGINE
+    VM --> FMT
+    UI --> VM
+```
+
+> This document **describes** the boundary. It does **not** implement KMP changes
+> — `packages/core` is owned by @kmp-engineer and the web engine by @web-engineer.
+> Compose is a pure renderer of shared state. The existing
+> [`Goal`](../../packages/models/src/commonMain/kotlin/com/finance/models/Goal.kt)
+> model already carries `householdId`, `ownerId`, and `currentAmount`; those are
+> the baseline inputs a shared contribution model needs. Per the issue, **do not
+> bake split logic into UI-only code** — Compose renders the shared summary, it
+> does not compute it.
+
+---
+
+## Privacy: Exact Amount vs. Summarized Effort
+
+The acceptance criteria require documenting **visibility choices for exact
+contribution amounts vs. summarized effort**. Each partner controls how their own
+contributions appear to the other; the rendering is decided by the shared
+visibility policy, not by Compose.
+
+| Visibility mode       | What the partner sees                                   | When to default to it                           |
+| --------------------- | ------------------------------------------------------- | ----------------------------------------------- |
+| **Exact amounts**     | "Alex contributed $120 on Jun 3"                        | Both partners opted into full transparency      |
+| **Summarized effort** | "Alex contributed — about a third of this month"        | One partner prefers privacy on exact figures    |
+| **Household only**    | Only the combined total shows; no per-partner breakdown | Either partner has not consented to attribution |
+
+**Privacy rules**
+
+- The **stricter** of the two partners' choices wins for any given pair — consent
+  is mutual, never assumed (consistent with
+  [android-household-privacy-dashboard.md](android-household-privacy-dashboard.md)).
+- A summarized view shows **relative effort** (share of the period, a coarse
+  bucket, or a progress proportion), never a recoverable exact figure.
+- The viewer always sees **their own** contributions in full; the policy only
+  governs what they see of the _other_ partner.
+- Compose never decides visibility locally — it renders the
+  `visibility`-tagged summary returned by the shared layer. If the policy says
+  "household only," the per-partner rows are simply absent from the model.
+
+---
+
+## Compose Surfaces
+
+Three Compose surfaces, all pure renderers of shared state, slotting into the
+existing
+[`GoalsScreen`](../../apps/android/src/main/kotlin/com/finance/android/ui/screens/GoalsScreen.kt)
+and the goal-detail flow:
+
+1. **Household progress header** — the combined total ("$1,840 of $3,000 saved")
+   and a progress indicator for the whole goal.
+2. **Contributors panel** — a row per contributor showing that partner's progress
+   _as permitted by the visibility policy_ (exact, summarized, or hidden).
+3. **Contribution history list** — a chronological, filterable list of
+   contributions with attribution rendered per the same policy.
+
+```mermaid
+flowchart TD
+    DETAIL[Shared goal detail] --> HEADER[Household progress header]
+    DETAIL --> PANEL[Contributors panel]
+    DETAIL --> HISTORY[Contribution history list]
+    PANEL --> ROW[Per-partner row: exact / summarized / hidden]
+    PANEL --> ADD[Add contribution]
+    HISTORY --> FILTER[Filter: contributor / date / amount bucket]
+    ROW --> EDIT[Edit / remove own contribution]
+```
+
+Progress visuals follow [data-visualization.md](data-visualization.md) and the
+progress/ring guidance in [chart-component-specs.md](chart-component-specs.md);
+they never rely on color alone (see [Accessibility](#accessibility-considerations)).
+Layout and list components reuse [component-library.md](component-library.md).
+
+---
+
+## Add / Edit Contribution UX
+
+A contribution records that a contributor moved money toward the goal. The flow is
+a Material 3 bottom sheet launched from the contributors panel or goal detail.
+
+- **Add:** amount, contributor (defaults to the current user; choosing another
+  partner is only offered when the shared layer permits attribution), optional
+  date and note. The sheet shows a live "new household total" preview that is read
+  back from the shared summary, not computed in Compose.
+- **Edit / remove:** a partner can edit or remove **their own** contributions.
+  Editing another partner's contribution is gated by the shared permission model,
+  never by a Compose-side check alone.
+- **Validation** (positive amount, valid date, contributor membership) is surfaced
+  inline, but the authoritative rule set lives in the shared layer; Compose mirrors
+  its result.
+- **Confirmation:** removing a contribution asks for confirmation and explains the
+  effect ("This lowers the household total by $120"), reusing the non-destructive
+  patterns in [content-language-guidelines.md](content-language-guidelines.md).
+
+> The "new household total" preview is an **estimate** until the contribution is
+> persisted and synced; label it as a preview, not a committed balance.
+
+---
+
+## Contribution History and Filtering
+
+The history list answers "where did our progress come from?" without becoming a
+ledger to police a partner.
+
+| Filter        | Options                                         | Notes                                                       |
+| ------------- | ----------------------------------------------- | ----------------------------------------------------------- |
+| Contributor   | All · This partner · Other partner(s)           | "Other partner" rows respect the visibility policy          |
+| Date range    | This month · Last 3 months · This year · Custom | Custom uses the shared date formatting                      |
+| Amount bucket | Any · Small · Medium · Large (coarse buckets)   | Buckets, not exact thresholds, support summarized-effort UX |
+
+- When visibility is **summarized** or **household only**, history rows for the
+  other partner collapse to effort language ("Alex contributed — about a third of
+  June") rather than exact lines.
+- Filtering operates on the **shared, already-permission-filtered** dataset — the
+  client never reconstructs hidden amounts from totals.
+- The list is paged and renders the most recent contributions first; older entries
+  load on demand to keep the surface responsive.
+
+---
+
+## Plain-Language Copy
+
+Copy is part of the product here. Every string below is a placeholder for a
+localized, resource-backed string and follows
+[content-language-guidelines.md](content-language-guidelines.md).
+
+| Context                | Plain-language copy (example)                          |
+| ---------------------- | ------------------------------------------------------ |
+| Household progress     | "$1,840 of $3,000 saved together"                      |
+| Exact contributor row  | "Alex contributed $120"                                |
+| Summarized contributor | "Alex contributed — about a third this month"          |
+| Household-only mode    | "Per-partner breakdown is private for this goal"       |
+| Add success            | "Added. You're $120 closer together"                   |
+| Empty history          | "No contributions yet — add the first one"             |
+| Behind-but-encouraging | "A bit behind plan — every contribution still adds up" |
+
+**Copy rules**
+
+- Lead with **shared progress and teamwork**, not with comparison between partners.
+- Never frame one partner's smaller contribution as a deficiency; uneven incomes
+  are normal (see the catch-up tone in
+  [android-house-downpayment-planner.md](android-house-downpayment-planner.md)).
+- Pair any projected total or "fair share" hint with "about"/"around" or an
+  explicit estimate label.
+
+---
+
+## Accessibility Considerations
+
+- **TalkBack:** the household progress header exposes one cohesive
+  `contentDescription` ("Saved $1,840 of $3,000 together, 61 percent"). Each
+  contributor row carries its own label reflecting the visibility mode ("Alex
+  contributed about a third this month"), and never leaks an exact figure that the
+  policy hides. The add-contribution sheet announces the live total preview as an
+  estimate.
+- **Switch Access:** the add button, per-row edit affordances, and every filter
+  control are reachable and operable with touch targets ≥ 48dp.
+- **Font scaling:** contributor rows, currency, and history entries stay readable
+  and unclipped at **200%** font scale; no fixed-height rows around amounts.
+- **Non-color cues:** progress and contributor share are conveyed with text and
+  shape, never color alone, per [data-visualization.md](data-visualization.md).
+- **Plain language / cognitive load:** one number per row, teamwork-first framing,
+  aligned with [cognitive-accessibility.md](cognitive-accessibility.md).
+- See [accessibility-patterns.md](accessibility-patterns.md) for the underlying
+  screen-reader, focus, and touch-target patterns.
+
+---
+
+## Offline, Empty, and Error States
+
+- **Offline:** contributor totals and history render from already-synced data, so
+  the surface works fully **offline** using the last-known shared summary. New
+  contributions queue and sync later; the header shows the data's freshness rather
+  than blocking.
+- **Empty (no contributions):** show a friendly empty state inviting the first
+  contribution ("Start your shared progress — add the first contribution"), not a
+  blank panel.
+- **Empty (household-only privacy):** the contributors panel cleanly states that
+  the per-partner breakdown is private for this goal, instead of showing blank
+  rows.
+- **Conflict:** if two partners edit overlapping contributions offline, defer to
+  the shared `ConflictStrategy.resolverFor()` outcome and show a quiet "updated
+  from your partner's device" note; Compose never invents a merge.
+- **Error:** if the shared summary cannot be produced, fail safe to the raw
+  household total ("$1,840 of $3,000 saved") with a quiet "Breakdown unavailable
+  right now" — never a stack trace, never a blank screen.
+
+---
+
+## Test Plan
+
+| Layer              | Tooling                         | What it verifies                                                                                     |
+| ------------------ | ------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| Unit               | JUnit                           | ViewModel maps shared summary → UI state for exact / summarized / household-only modes.              |
+| Unit (privacy)     | JUnit                           | Hidden amounts are never reconstructable from totals; stricter partner choice wins.                  |
+| Unit (safety)      | JUnit                           | No Timber call logs contributor names, amounts, or goal balances.                                    |
+| Compose UI         | `createComposeRule` + semantics | Header, contributor rows, add sheet, and filters resolve `contentDescription`.                       |
+| Compose UI         | `createComposeRule`             | Add/edit contribution updates the previewed household total; remove confirms first.                  |
+| Snapshot           | Paparazzi                       | Contributors panel + history in exact / summarized / household-only + empty at {1x, 2x}, light/dark. |
+| Pseudolocalization | `en-XA` / `ar-XB`               | Copy expansion and RTL mirroring for progress and contributor rows.                                  |
+| Accessibility      | Espresso/Accessibility checks   | TalkBack order, Switch Access reachability, touch targets ≥ 48dp.                                    |
+
+---
+
+## Implementation Readiness
+
+This is a design artifact. Execution splits into a **buildable-now** tier and a
+**Play-distribution tail** gated by
+[#1242](https://github.com/jrmoulckers/finance/issues/1242). See
+[../ops/human-gated-prerequisites.md](../ops/human-gated-prerequisites.md) and
+[../ops/launch-readiness-plan.md](../ops/launch-readiness-plan.md).
+
+**Buildable now — `assembleDebug` + sideload (no human gate):**
+
+- Build the household progress header, contributors panel, add/edit sheet, and
+  filterable history as Compose surfaces rendering a shared contribution summary
+  (mock/in-memory data while KMP wiring lands).
+- Verify exact / summarized / household-only visibility rendering, accessibility,
+  and pseudolocale/expansion snapshots on a debug build / emulator.
+- All of this runs on an emulator with **no signing, store credentials, or
+  human-gated operations**.
+
+**Play-distribution tail — human-gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242):**
+
+- Production signing + Play Console listing.
+- Any store-level data-safety declaration touching shared/household financial data.
+- Staged rollout / internal testing track.
+
+The shared contribution model is delivered by KMP `packages/core` (the web
+`shared-goal-contributions` engine is the parity reference); Compose stays
+render-only.
+
+---
+
+## References
+
+**Design docs**
+
+- [android-household-privacy-dashboard.md](android-household-privacy-dashboard.md) — visibility policy & aggregates (#2640)
+- [android-teen-goal-projections.md](android-teen-goal-projections.md) — save-$X projection surfaces (#2661)
+- [android-goal-projection-widget.md](android-goal-projection-widget.md) — home-screen widget states (#2663)
+- [android-house-downpayment-planner.md](android-house-downpayment-planner.md) — sibling shared-goal planner (#2650)
+- [content-language-guidelines.md](content-language-guidelines.md) — non-judgmental, plain copy
+- [cognitive-accessibility.md](cognitive-accessibility.md) — plain-language and load reduction
+- [accessibility-patterns.md](accessibility-patterns.md) — screen reader, focus, touch targets
+- [data-visualization.md](data-visualization.md) — progress visuals, non-color cues
+- [chart-component-specs.md](chart-component-specs.md) — progress ring/bar specs
+- [component-library.md](component-library.md) — list, sheet, and card components
+- [information-architecture.md](information-architecture.md) — surface and navigation map
+- [ux-principles.md](ux-principles.md) — product UX principles
+- [personas.md](personas.md) — household / couples persona
+
+**Ops**
+
+- [../ops/human-gated-prerequisites.md](../ops/human-gated-prerequisites.md) — buildable-now vs. gated split
+- [../ops/launch-readiness-plan.md](../ops/launch-readiness-plan.md) — launch checklist
+
+**Android / web / KMP (read-only boundary)**
+
+- [`shared-goal-contributions.ts`](../../apps/web/src/lib/savings/shared-goal-contributions.ts) — web parity reference (owned by @web-engineer)
+- [`goal-contributions.ts`](../../apps/web/src/lib/household/goal-contributions.ts) — household contribution rules
+- [`GoalContributionDialog.tsx`](../../apps/web/src/components/goals/GoalContributionDialog.tsx) — web add/edit parity
+- [`GoalDetailPage.tsx`](../../apps/web/src/pages/GoalDetailPage.tsx) — web goal detail parity
+- [`GoalsScreen.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/screens/GoalsScreen.kt) — host surface
+- [`Goal.kt`](../../packages/models/src/commonMain/kotlin/com/finance/models/Goal.kt) — shared goal model (owned by @kmp-engineer)
+- [`Household.kt`](../../packages/models/src/commonMain/kotlin/com/finance/models/Household.kt) — household model
+- [`HouseholdMember.kt`](../../packages/models/src/commonMain/kotlin/com/finance/models/HouseholdMember.kt) — member/contributor model
+- [`DataPartitioning.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/household/DataPartitioning.kt) — shared visibility/partition rules
+
+**Issues**
+
+- [#2649](https://github.com/jrmoulckers/finance/issues/2649) — this issue
+- [#2147](https://github.com/jrmoulckers/finance/issues/2147) — parent (shared goals cluster)
+- [#1242](https://github.com/jrmoulckers/finance/issues/1242) — Play Console + keystore (gate)


### PR DESCRIPTION
## Summary

Adds three **design-only** Android docs for the shared-goals / debt cluster. No
native builds, no signing, no store actions — these specify Compose surfaces,
states, accessibility, and the KMP boundary so implementation can proceed up to
the distribution line. Native delivery stays gated by #1242; each doc splits a
buildable-now (`assembleDebug` sideload) tier from the Play-distribution tail.

All goal/milestone/debt-payoff math stays conceptually in KMP `packages/core`;
Compose is described as a pure renderer of shared state. Projections are labelled
as estimates, and shared/household surfaces respect partner privacy boundaries.

## Changes

- **`docs/design/android-shared-goal-contributors.md`** (#2649) — household total
  and per-partner contribution progress, add/edit contribution UX, contribution
  history + filtering, and exact-amount vs. summarized-effort visibility controls.
- **`docs/design/android-house-downpayment-planner.md`** (#2650) — milestone cards
  for down payment / closing costs / emergency buffer, per-partner monthly targets
  from shared projections (reusing the teen goal-planning engine), and non-shaming
  behind/ahead catch-up states.
- **`docs/design/android-joint-debt-payoff-planner.md`** (#2656) — payoff planner
  shell and entry points, debt inventory, ownership classification, personal /
  shared / jointly-funded states, and privacy copy for sensitive debts (web
  `DebtPage` as the parity reference).

Each doc includes a ToC, Mermaid diagrams, relative cross-links to existing
`docs/design/` and `docs/ops/` files, accessibility coverage (TalkBack, Switch
Access, 200% font), offline/empty/error + milestone states, a unit/Compose/
Paparazzi test plan, and an Implementation Readiness section linking
`../ops/human-gated-prerequisites.md`.

New files only — no existing files, `packages/`, app code, or shared config touched.

Closes #2649
Closes #2650
Closes #2656
