### PR TITLE
docs(design): ios iPhone SE compact layouts and grocery card design batch (#2607, #2609, #2610)

### DIFF
--- a/docs/design/ios-grocery-safe-to-spend-card.md
+++ b/docs/design/ios-grocery-safe-to-spend-card.md
@@ -1,0 +1,285 @@
+# Grocery Safe-to-Spend Card (iOS)
+
+> **Status:** Design draft (design-only — no native build in this PR)
+> **Issue:** [#2610](../../issues/2610) · **Parent:** [#2199](../../issues/2199)
+> **Platform:** iOS (SwiftUI) · **Audience:** iOS engineers, design, KMP, QA
+> **Distribution blocker:** [#1239](../../issues/1239) (Apple Developer enrollment — _distribution only_, see [Implementation readiness](#implementation-readiness))
+
+This document specifies a supportive **grocery safe-to-spend** card for the iOS
+Dashboard: a calm, glanceable quick-check that combines the pinned grocery
+budget, the remaining **safe-to-spend** amount, payday/bill context, and a
+**one-tap drill-in** to the full budget.
+
+It is a **design specification only**. No Swift, shared `packages/`, or
+cross-platform code changes here. The safe-to-spend **math stays in KMP
+`packages/core`** (boundary described below — not implemented in this PR). All
+numbers are **design estimates** to confirm on-device.
+
+---
+
+## Table of Contents
+
+- [Intent & tone](#intent--tone)
+- [Where it lives](#where-it-lives)
+- [Anatomy](#anatomy)
+- [Safe-to-spend concept (KMP boundary)](#safe-to-spend-concept-kmp-boundary)
+- [Interaction & drill-in](#interaction--drill-in)
+- [Compact layout & reflow](#compact-layout--reflow)
+- [Accessibility](#accessibility)
+- [Privacy & balance hiding](#privacy--balance-hiding)
+- [Empty, stale & error states](#empty-stale--error-states)
+- [Test plan (smallest viable)](#test-plan-smallest-viable)
+- [Implementation readiness](#implementation-readiness)
+- [Related documents](#related-documents)
+
+---
+
+## Intent & tone
+
+The card answers one anxious, frequent question — _"Can I afford groceries right
+now?"_ — without making the user open a spreadsheet. It is **supportive, not
+punitive**:
+
+- Lead with the **remaining safe-to-spend** figure, framed positively.
+- Add lightweight **context** ("after upcoming bills, until payday Fri") so the
+  number is trustworthy, not mysterious.
+- Never shame. Over-budget is shown as a calm, factual state with a constructive
+  next step — consistent with
+  [content-language-guidelines.md](./content-language-guidelines.md) and
+  [cognitive-accessibility.md](./cognitive-accessibility.md).
+- One clear action: tap to see the full grocery budget.
+
+## Where it lives
+
+A pinned card near the top of the Dashboard, above the existing budget-health
+strip. It does not replace any current section; it is additive.
+
+Read-only references (do **not** edit in this PR):
+
+- [`apps/ios/Finance/Screens/DashboardView.swift`](../../apps/ios/Finance/Screens/DashboardView.swift)
+  — host screen; the card sits in the main `VStack` after `spendingSummaryCard`.
+- [`apps/ios/Finance/ViewModels/DashboardViewModel.swift`](../../apps/ios/Finance/ViewModels/DashboardViewModel.swift)
+  — would expose a read-only, already-computed safe-to-spend value from the
+  bridge (no math in the view model).
+- [`apps/ios/Finance/Models/BudgetItem.swift`](../../apps/ios/Finance/Models/BudgetItem.swift)
+  — the grocery budget's `progress`, `remainingMinorUnits`, `progressColor`.
+- [`apps/ios/Finance/Navigation/DeepLinkHandler.swift`](../../apps/ios/Finance/Navigation/DeepLinkHandler.swift)
+  — `budgetCategory(id:)` route powers the one-tap drill-in.
+
+## Anatomy
+
+```text
+┌───────────────────────────────────────────────┐
+│  🛒  Groceries                      On track ● │  ← title + status chip (text + color)
+│                                                │
+│  Safe to spend                                 │  ← label (secondary)
+│  $128.40                                       │  ← hero amount (large, rounded)
+│  ▓▓▓▓▓▓▓▓░░░░  64% of $200                      │  ← progress ring/bar + budget context
+│                                                │
+│  After 2 upcoming bills · until payday Fri     │  ← context line (caption)
+│                                          ›      │  ← drill-in affordance
+└───────────────────────────────────────────────┘
+```
+
+| Region       | Content                                          | Source                                                |
+| ------------ | ------------------------------------------------ | ----------------------------------------------------- |
+| Title        | Grocery category name + icon                     | `BudgetItem.name` / `IconView`                        |
+| Status chip  | "On track" / "Tight" / "Over" + paired color     | Derived from safe-to-spend state (text **and** color) |
+| Hero amount  | Remaining safe-to-spend (currency, rounded font) | `safeToSpend` from bridge (see boundary)              |
+| Progress     | Ring or bar with "X% of $limit"                  | `BudgetItem.progress` (presentation only)             |
+| Context line | Upcoming-bill count + relative payday            | `safeToSpend` context fields from bridge              |
+| Affordance   | Trailing chevron, whole card tappable            | Drill-in via `budgetCategory(id:)`                    |
+
+## Safe-to-spend concept (KMP boundary)
+
+> **Hard rule:** the safe-to-spend computation is **business logic** and lives in
+> shared **`packages/core`** (with shapes in `packages/models`). iOS only
+> **renders** a value the shared layer already computed and exposed across the
+> Swift Export bridge. This document describes the boundary; it **does not
+> implement** the math, and any change to shared packages requires the normal
+> ADR / `@architect` consultation.
+
+Conceptually, safe-to-spend for groceries is (illustrative — **estimate**, owned
+by `packages/core`, not final):
+
+```text
+safeToSpend = groceryBudgetRemaining
+            − pendingGroceryAuthorizations
+            − knownBillsDueBeforePayday (allocable portion)
+            (clamped at 0 for display; raw sign retained for "over" state)
+```
+
+- **Inputs** (already modeled in shared layer): the grocery `BudgetItem`,
+  pending/cleared transactions, upcoming bills, and the payday/period anchor.
+- **Output contract** (estimate of a new shared bridge surface, e.g. a
+  `SwiftExportAggregatorModule.safeToSpend(...)` returning a small value type):
+  - `amountMinorUnits: Int64` — remaining safe-to-spend (may be negative)
+  - `limitMinorUnits: Int64` — grocery budget limit (for "of $X")
+  - `state` — `onTrack` / `tight` / `over` (drives chip text + color)
+  - `upcomingBillCount: Int32`
+  - `paydayRelativeText` — localized relative date string source
+- **iOS responsibility:** map that value type to SwiftUI; format currency via the
+  existing `SwiftExportFormatterModule`; choose colors/typography; nothing more.
+
+```mermaid
+flowchart LR
+    A[packages/core: safe-to-spend rules] -->|Swift Export bridge| B[DashboardViewModel reads value]
+    B --> C[GrocerySafeToSpendCard renders]
+    C -->|tap| D[DeepLinkHandler budgetCategory id]
+    D --> E[Budgets tab opens grocery budget]
+```
+
+> The bridge method shown is an **estimate** of the contract iOS needs; its final
+> shape is decided by `@kmp-engineer` / `@architect`. iOS must not inline the
+> formula even temporarily.
+
+## Interaction & drill-in
+
+- **Whole card is one tap target.** Tapping routes to the grocery budget detail
+  using the existing `budgetCategory(id:)` deep link, which selects the Budgets
+  tab and opens the matching category
+  ([`DeepLinkHandler`](../../apps/ios/Finance/Navigation/DeepLinkHandler.swift) →
+  `pendingBudgetCategoryId`, consumed by
+  [`BudgetsView`](../../apps/ios/Finance/Screens/BudgetsView.swift)).
+- **No nested controls** that fight the card's tap (chip and progress are
+  decorative); keeps VoiceOver to a single actionable element.
+- **Pinned grocery budget:** the card shows the user's pinned grocery category.
+  The notion of "pinned" is a shared preference (lives with shared budget
+  config, not on iOS); iOS reads it. If none is pinned, see the empty state.
+
+## Compact layout & reflow
+
+The card must follow the SE compact rules in
+[ios-iphone-se-compact-layouts.md](./ios-iphone-se-compact-layouts.md).
+
+| Element      | Standard (XS–XXXL)                                | Accessibility (AX1–AX5)                                  |
+| ------------ | ------------------------------------------------- | -------------------------------------------------------- |
+| Title + chip | One row (title left, chip right)                  | Chip wraps below title at AX2+                           |
+| Hero amount  | `.system(.largeTitle, design: .rounded)` currency | `SizeConstrainedCurrencyText` clamps; never below ~17 pt |
+| Progress     | Ring (compact) **or** full-width bar              | Prefer **bar** at AX sizes (ring labels get cramped)     |
+| Context line | Single caption line                               | Wraps to 2–3 lines; never truncates                      |
+| Affordance   | Trailing chevron                                  | Becomes a full-width "View grocery budget" row at AX3+   |
+
+- Width budget on iPhone SE: ~343 pt of content (375 pt − 2 × 16 pt). Estimate;
+  verify on device.
+- Use `AdaptiveFinanceStack` / `ViewThatFits` (see the compact-layouts doc) so
+  the hero amount and "of $limit" never share a row they cannot fit.
+
+## Accessibility
+
+- **VoiceOver:** the card is **one** combined, actionable element. Suggested
+  reading: _"Groceries, safe to spend $128.40, 64% of $200 used, on track, after
+  2 upcoming bills, until payday Friday. Button. Opens grocery budget."_ Build
+  with `.accessibilityElement(children: .combine)`, an explicit
+  `.accessibilityLabel`, `.accessibilityValue`, `.accessibilityHint`, and the
+  `.isButton` trait.
+- **Dynamic Type up to AX5 at 375 pt:** all text via token Dynamic Type styles
+  ([`FinanceTypography`](../../apps/ios/Finance/Theme/FinanceTypography.swift));
+  currency via `SizeConstrainedCurrencyText` /
+  [`ClampedScaledMetric`](../../apps/ios/Finance/Accessibility/DynamicTypeSupport.swift).
+  No hardcoded sizes.
+- **Reflow:** no truncated amounts at any size; context line wraps, never clips.
+- **Color is never the only signal:** the status uses **text + color** ("Tight",
+  "Over"), so CVD and grayscale users get the state. Progress fill uses the
+  CVD-safe palette from [data-visualization.md](./data-visualization.md).
+- **Reduced Motion:** any progress-fill or value-change animation is replaced by
+  an instant update when `@Environment(\.accessibilityReduceMotion)` is on
+  (see [animation-library.md](./animation-library.md)).
+- **Touch target:** the whole card is ≥ 44 pt tall; the AX3+ explicit drill-in
+  row is a full-width ≥ 44 pt target.
+
+## Privacy & balance hiding
+
+- The card sits behind the app's local auth gate; the amount is sensitive.
+- Honor the same **bucketed/hidden** presentation used for widgets
+  ([`WidgetPrivacyPrompt`](../../apps/ios/Finance/Services/WidgetPrivacyPrompt.swift) /
+  `WidgetPrivacySettings`). When hiding is on, render a masked hero ("•••") and a
+  **state-only** status ("On track") without the exact figure; layout must not
+  shift when toggled.
+- **Lock-screen / widget reachability:** if this card is ever surfaced via a
+  widget or a lock-screen deep link, it must render the **masked** form first,
+  matching the bucketed-by-default widget policy.
+- **Logging:** never log the amount; `os.Logger` amount interpolation stays
+  `privacy: .private`. Only non-sensitive routing/layout facts may be `.public`.
+
+## Empty, stale & error states
+
+| State                 | Presentation                                                                                          |
+| --------------------- | ----------------------------------------------------------------------------------------------------- |
+| **No grocery budget** | Friendly `EmptyStateView`-style prompt: "Pin a grocery budget to see safe-to-spend" + CTA to create   |
+| **No payday set**     | Card still shows safe-to-spend, **omits** the "until payday" clause (no fabricated date)              |
+| **Stale / offline**   | Show value with `OfflineBanner` context and a "Last updated …" relative time; never imply real-time   |
+| **Error**             | Inline, recoverable message with Retry (reuse the Dashboard alert pattern); card collapses gracefully |
+| **Over budget**       | Calm "Over by $X" state with constructive copy + drill-in; color paired with text, no alarm styling   |
+| **Loading**           | Skeleton/placeholder with `accessibilityLabel("Loading")`; no layout jump when the value arrives      |
+
+- States must reflow at AX5 exactly like the happy path (wrap, not truncate).
+- The empty/no-payday states must not invent data; missing context is **omitted**,
+  not faked.
+
+## Test plan (smallest viable)
+
+Shared math is tested in `packages/core`; iOS tests cover **presentation,
+reflow, privacy, and drill-in only**. Full regression matrix lives in
+[ios-iphone-se-ui-regression.md](./ios-iphone-se-ui-regression.md)
+([#2609](../../issues/2609)).
+
+**Shared (`packages/core`) — owned by KMP, referenced here:**
+
+1. Unit tests for the safe-to-spend rule: remaining math, bill/payday
+   allocation, clamping, and `state` thresholds. These run on CI without Apple
+   tooling and are the **source of truth** for correctness.
+
+**Native (`apps/ios`) — smallest set:**
+
+2. **Snapshot tests at 375 × 667 pt** of `GrocerySafeToSpendCard` at
+   `{ .large, .xxxLarge, .accessibility1, .accessibility3, .accessibility5 }`
+   for the **on-track, tight, over, empty, masked** states — assert no clipped
+   currency and correct reflow.
+3. **View-model test** asserting the card maps the bridge value type to display
+   fields correctly and **does no math** (inject a stub
+   `SwiftExportAggregatorModule`; verify pass-through formatting only).
+4. **XCUITest drill-in** extending
+   [`FinanceUITests.swift`](../../apps/ios/Tests/UITests/FinanceUITests.swift):
+   tap the card → assert the Budgets tab opens the grocery category (via the
+   `budgetCategory` deep-link path).
+5. **Privacy test:** snapshot masked vs. visible; assert identical layout frames.
+
+**Acceptance gate:** shared math tests green; card snapshots green at all five
+sizes for every state; drill-in lands on the grocery budget; masked and visible
+layouts match.
+
+## Implementation readiness
+
+Per [`docs/ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md),
+implementation and distribution are **decoupled**. The card (and its shared math)
+are **buildable and testable now**; only store distribution is gated by
+[#1239](../../issues/1239).
+
+| Phase            | Work                                                                                              | Gated by #1239?                                                        |
+| ---------------- | ------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| **Design**       | This document                                                                                     | No                                                                     |
+| **Shared impl**  | Safe-to-spend rule in `packages/core` + tests (KMP, via ADR)                                      | No                                                                     |
+| **iOS impl**     | `GrocerySafeToSpendCard` SwiftUI, view-model wiring, snapshots, XCUITest, simulator + device runs | **No** — simulator needs no signing; device via free **Personal Team** |
+| **Distribution** | Shipping via TestFlight / App Store                                                               | **Yes** — enrollment + signing material + CI secrets                   |
+
+> **Buildable now:** shared math (cross-platform CI), the SwiftUI card on the
+> Simulator, and on-device verification with a **free Apple ID (Personal Team)**.
+>
+> **Needs human action (later):** none for building/testing. Only the eventual
+> store/TestFlight release uses the
+> [§3.2 Apple Developer checklist](../ops/human-gated-prerequisites.md#32-ios-distribution--apple-developer-1239).
+> Agents must **not** perform enrollment, signing, or secret configuration, and
+> must **not** modify shared `packages/` without `@architect` / an ADR.
+
+## Related documents
+
+- [ios-iphone-se-compact-layouts.md](./ios-iphone-se-compact-layouts.md) — compact layout rules ([#2607](../../issues/2607))
+- [ios-iphone-se-ui-regression.md](./ios-iphone-se-ui-regression.md) — regression matrix ([#2609](../../issues/2609))
+- [accessibility-patterns.md](./accessibility-patterns.md) — a11y patterns
+- [cognitive-accessibility.md](./cognitive-accessibility.md) — supportive, low-load design
+- [content-language-guidelines.md](./content-language-guidelines.md) — microcopy & tone
+- [data-visualization.md](./data-visualization.md) — CVD-safe progress/ring palette
+- [responsive-breakpoints.md](./responsive-breakpoints.md) — breakpoint tiers
+- [animation-library.md](./animation-library.md) — motion & Reduce Motion
+- [`docs/ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md) — build vs. distribution gating

--- a/docs/design/ios-iphone-se-compact-layouts.md
+++ b/docs/design/ios-iphone-se-compact-layouts.md
@@ -1,0 +1,309 @@
+# iPhone SE Compact Dashboard & Bills Layouts (iOS)
+
+> **Status:** Design draft (design-only — no native build in this PR)
+> **Issue:** [#2607](../../issues/2607) · **Parent:** [#2190](../../issues/2190)
+> **Platform:** iOS (SwiftUI) · **Audience:** iOS engineers, design, QA
+> **Distribution blocker:** [#1239](../../issues/1239) (Apple Developer enrollment — _distribution only_, see [Implementation readiness](#implementation-readiness))
+
+This document specifies compact-width layout alternatives for the iOS
+**Dashboard** and **Bills** screens so they remain legible, reflow-safe, and
+fully accessible on the smallest supported iPhone — the iPhone SE — across the
+whole Dynamic Type range up to AX5.
+
+It is a **design specification only**. It does not change Swift code, shared
+`packages/`, or any other platform. All numeric thresholds are **design
+estimates** to be confirmed on-device during implementation (no simulator or
+device build is performed here).
+
+---
+
+## Table of Contents
+
+- [Problem statement](#problem-statement)
+- [Reference device & viewport](#reference-device--viewport)
+- [Affected iOS surfaces](#affected-ios-surfaces)
+- [Shared / KMP boundary](#shared--kmp-boundary)
+- [Layout strategy](#layout-strategy)
+  - [Dashboard](#dashboard)
+  - [Bills](#bills)
+- [Reflow decision flow](#reflow-decision-flow)
+- [Accessibility](#accessibility)
+- [Privacy & balance hiding](#privacy--balance-hiding)
+- [Empty, stale & error states](#empty-stale--error-states)
+- [Test plan (smallest viable)](#test-plan-smallest-viable)
+- [Implementation readiness](#implementation-readiness)
+- [Related documents](#related-documents)
+
+---
+
+## Problem statement
+
+Several Dashboard and Bills surfaces use **fixed multi-column rows** built from
+an `HStack` with vertical `Divider`s, plus a fixed **three-column** quick-access
+grid. These were tuned for 390–430 pt-wide devices. On a 375 pt-wide iPhone SE,
+and especially once Dynamic Type reaches the accessibility sizes (AX1–AX5),
+currency values truncate, dividers crush columns, and tap targets collide.
+
+The fixed three-up patterns that need compact alternatives are:
+
+| Surface       | Element                       | Source (read-only reference)                                                                      | Risk on SE                                       |
+| ------------- | ----------------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| Dashboard     | "This Month" summary (3 cols) | [`DashboardView.swift`](../../apps/ios/Finance/Screens/DashboardView.swift) `spendingSummaryCard` | Income / Expenses / Net truncate at AX sizes     |
+| Dashboard     | Quick access grid (3 cols)    | [`DashboardView.swift`](../../apps/ios/Finance/Screens/DashboardView.swift) `quickAccessSection`  | 3 × `GridItem(.flexible())` too narrow at 375 pt |
+| Dashboard     | Budget health strip           | [`DashboardView.swift`](../../apps/ios/Finance/Screens/DashboardView.swift) `budgetHealthSection` | Horizontal scroll OK; label clipping at AX sizes |
+| Bills         | Summary card (3 cols)         | [`BillsListView.swift`](../../apps/ios/Finance/Screens/BillsListView.swift) `summaryCard`         | Due / Monthly Total / Bills crush at AX sizes    |
+| Bills         | Bill row (icon + 2 columns)   | [`BillsListView.swift`](../../apps/ios/Finance/Screens/BillsListView.swift) `billRow`             | Trailing amount + due date overflow              |
+| Budgets (adj) | Overall summary (3 cols)      | [`BudgetsView.swift`](../../apps/ios/Finance/Screens/BudgetsView.swift) `overallSummary`          | Spent / Ring / Budgeted touched by same pattern  |
+
+> The Budgets overall-summary row shares the same three-up idiom and is included
+> for consistency, but the primary scope of [#2607](../../issues/2607) is
+> Dashboard and Bills.
+
+## Reference device & viewport
+
+| Property                  | iPhone SE (2nd / 3rd gen)               | Notes                                                           |
+| ------------------------- | --------------------------------------- | --------------------------------------------------------------- |
+| Display                   | 4.7-inch                                | Smallest device supported at deployment target iOS 17.0         |
+| Logical size (portrait)   | **375 × 667 pt** _(estimate, standard)_ | The compact-width floor we design against                       |
+| Safe content width        | ~343 pt _(estimate)_                    | 375 pt − 2 × 16 pt horizontal padding (`.padding(.horizontal)`) |
+| Scale                     | @2x                                     |                                                                 |
+| Dynamic Type range tested | XS → XXXL → **AX1 → AX5**               | AX5 is the largest accessibility text size                      |
+
+> iPhone SE (1st gen) / iPhone 5s (320 pt) are **not** supported at iOS 17, so
+> **375 pt is the design floor**. Where a layout survives 320 pt cleanly we note
+> it as a bonus, but it is not a target.
+
+## Affected iOS surfaces
+
+Read-only references (do **not** edit in this PR):
+
+- [`apps/ios/Finance/Screens/DashboardView.swift`](../../apps/ios/Finance/Screens/DashboardView.swift)
+- [`apps/ios/Finance/Screens/BillsListView.swift`](../../apps/ios/Finance/Screens/BillsListView.swift)
+- [`apps/ios/Finance/Screens/BudgetsView.swift`](../../apps/ios/Finance/Screens/BudgetsView.swift)
+- [`apps/ios/Finance/Accessibility/DynamicTypeSupport.swift`](../../apps/ios/Finance/Accessibility/DynamicTypeSupport.swift)
+  — already provides `AdaptiveFinanceStack`, `ClampedScaledMetric`, and
+  `SizeConstrainedCurrencyText`, which this spec reuses.
+- [`apps/ios/Finance/Theme/FinanceTypography.swift`](../../apps/ios/Finance/Theme/FinanceTypography.swift)
+  — token-backed Dynamic Type styles. No hardcoded sizes.
+
+## Shared / KMP boundary
+
+This work is **presentation-only**. No business rules change.
+
+- **Stays in `packages/core` / `packages/models`** (do not implement here):
+  monetary aggregation (net worth, monthly income/expenses, budget progress,
+  bill totals). The iOS view models already consume these via the Swift Export
+  aggregator/formatter modules
+  ([`DashboardViewModel`](../../apps/ios/Finance/ViewModels/DashboardViewModel.swift),
+  [`BudgetsViewModel`](../../apps/ios/Finance/ViewModels/BudgetsViewModel.swift)).
+- **Stays in `apps/ios`** (this spec): SwiftUI layout containers, reflow
+  thresholds, accessibility semantics, and currency-label sizing.
+
+No new bridge methods are required for [#2607](../../issues/2607).
+
+## Layout strategy
+
+The strategy is **reflow, not shrink**. We never reduce currency text below the
+readable minimum to force a layout; instead we change the container axis when
+width or Dynamic Type demands it. Three composable techniques:
+
+1. **Axis switch by Dynamic Type** — reuse `AdaptiveFinanceStack`
+   (`@Environment(\.dynamicTypeSize)` → `isAccessibilitySize`) to turn
+   horizontal three-up rows into vertical stacks at AX1+.
+2. **`ViewThatFits`** — let SwiftUI pick the first child that fits the available
+   width, falling back from a 3-up row → 2-up grid → single column.
+3. **Adaptive grid columns** — replace fixed `GridItem(.flexible())` counts with
+   `GridItem(.adaptive(minimum:))` so column count derives from width.
+
+### Dashboard
+
+```text
+Standard (≥ 375 pt, ≤ XXXL)            Accessibility (AX1+)
+┌─────────────────────────────┐       ┌─────────────────────────────┐
+│ Net Worth (hero)            │       │ Net Worth (hero)            │
+├─────────────────────────────┤       ├─────────────────────────────┤
+│ This Month                  │       │ This Month                  │
+│ Income │ Expenses │  Net    │  -->  │ Income                      │
+│        │          │         │       │ Expenses                    │
+│                             │       │ Net                         │
+├─────────────────────────────┤       ├─────────────────────────────┤
+│ Budget Health  → → (scroll) │       │ Budget Health → → (scroll)  │
+├─────────────────────────────┤       ├─────────────────────────────┤
+│ More: [Invest][Bills][Rpts] │  -->  │ More: 2-up, then 1-up at AX3 │
+└─────────────────────────────┘       └─────────────────────────────┘
+```
+
+Recommended rules (design estimates — verify on device):
+
+| Element              | Standard (XS–XXXL)                           | Accessibility (AX1–AX5)                                  |
+| -------------------- | -------------------------------------------- | -------------------------------------------------------- |
+| "This Month" summary | 3-up `HStack` with `Divider`s (current)      | Vertical stack; drop dividers; label-over-value rows     |
+| Quick access "More"  | `GridItem(.adaptive(minimum: 104))` → 3 cols | 2 cols at AX1–AX2; 1 col at AX3–AX5 (full-width rows)    |
+| Budget health strip  | Horizontal scroll (current)                  | Keep scroll; allow label `lineLimit(2)`; widen ring tile |
+| Net worth hero       | `.largeTitle.bold()` currency                | `minimumScaleFactor(0.8)` floor, never below ~17 pt      |
+
+- The "This Month" reflow is the single highest-value change: at AX3+ the three
+  inline `CurrencyLabel`s cannot coexist on one 343 pt row.
+- Quick-access tiles must keep a **44 × 44 pt** minimum tap target (already met
+  by the icon container); when reflowed to one column, render as full-width rows
+  with leading icon + trailing chevron affordance.
+
+### Bills
+
+```text
+Standard summary row                  Accessibility (AX1+)
+┌─────────────────────────────┐       ┌─────────────────────────────┐
+│  Due │ Monthly Total │ Bills │  -->  │ Due:            $X          │
+│      │               │       │       │ Monthly Total:  $Y          │
+│                             │       │ Bills:          N           │
+└─────────────────────────────┘       └─────────────────────────────┘
+```
+
+| Element         | Standard (XS–XXXL)                       | Accessibility (AX1–AX5)                              |
+| --------------- | ---------------------------------------- | ---------------------------------------------------- |
+| Summary card    | 3-up `HStack` with `Divider`s (current)  | Vertical key/value rows; remove dividers             |
+| Bill row        | Icon + name/payee + trailing amount/date | At AX2+, move amount + due date below the name block |
+| Section headers | Color dot + title + count (current)      | Keep; ensure `.isHeader` trait + count stays inline  |
+| Auto-pay badge  | Inline `Label` after payee               | Wraps to its own line at AX sizes                    |
+
+- The bill row's trailing `VStack` (amount over due date) competes with a long
+  payee name on a 343 pt row. At AX2+, prefer a single vertical flow:
+  name → payee/auto-pay → amount → due date.
+- Due-date color (`bill.dueDateColor`) must never be the **only** signal — pair
+  with text ("Overdue", "Due in 3 days") so it survives grayscale / CVD. This
+  matches [accessibility-patterns.md](./accessibility-patterns.md) §Color & Contrast.
+
+## Reflow decision flow
+
+```mermaid
+flowchart TD
+    A[Render summary / grid] --> B{Dynamic Type isAccessibilitySize?}
+    B -->|No| C{ViewThatFits: does 3-up fit width?}
+    C -->|Yes| D[3-up row with dividers]
+    C -->|No| E[2-up grid, no dividers]
+    B -->|Yes| F{Size AX1 or AX2?}
+    F -->|Yes| G[Vertical key/value rows, 2-up quick access]
+    F -->|No AX3 plus| H[Single-column rows, full width]
+```
+
+## Accessibility
+
+All requirements below are **mandatory** and align with
+[accessibility-patterns.md](./accessibility-patterns.md) and
+[cognitive-accessibility.md](./cognitive-accessibility.md).
+
+- **VoiceOver:** existing `.accessibilityElement(children: .combine)` groupings
+  on each card are preserved. When a row reflows to a vertical stack, keep the
+  **combined** element so the value reads as one phrase
+  (e.g. _"This month, expenses, $842"_), not three fragments. Verify reading
+  order top-to-bottom after reflow.
+- **Dynamic Type up to AX5 at 375 pt:** every label uses token Dynamic Type
+  styles from [`FinanceTypography`](../../apps/ios/Finance/Theme/FinanceTypography.swift)
+  / `FinanceTextStyle`. No `.font(.system(size:))` literals. Currency values use
+  `SizeConstrainedCurrencyText` / `ClampedScaledMetric` so they scale but never
+  drop below ~14 pt or overflow.
+- **Reflow:** no horizontal clipping or truncation of monetary values at any
+  size on a 375 pt width. Tables above define the axis switch points. Horizontal
+  scroll is acceptable **only** for the budget-health strip (a browse affordance),
+  never for primary balances.
+- **Reduced Motion:** honor `@Environment(\.accessibilityReduceMotion)`. The
+  layout axis switch must be a **non-animated** swap when Reduce Motion is on
+  (no cross-fade/slide). See [animation-library.md](./animation-library.md).
+- **Touch targets:** maintain ≥ 44 × 44 pt for all interactive tiles/rows after
+  reflow (Apple HIG; see [accessibility-patterns.md](./accessibility-patterns.md)
+  §Touch Target Sizing).
+- **Contrast & CVD:** status colors are paired with text/labels, never used
+  alone. Charts/rings keep the IBM CVD-safe palette
+  ([data-visualization.md](./data-visualization.md)).
+
+## Privacy & balance hiding
+
+- The Dashboard and Bills screens render only after the local auth gate; the
+  hero net-worth value is sensitive. When the app exposes a balance-hiding /
+  bucketed mode (the same concept used for widgets in
+  [`WidgetPrivacyPrompt`](../../apps/ios/Finance/Services/WidgetPrivacyPrompt.swift)),
+  the reflowed currency labels must respect it — masked amounts (e.g. "•••")
+  reflow with the same rules as real values so layout does not "jump" when the
+  user toggles visibility.
+- Never log financial values during layout debugging. Any `os.Logger` use stays
+  `privacy: .private` for amounts (`.public` only for non-sensitive layout
+  metrics like measured width).
+
+## Empty, stale & error states
+
+These reuse existing components; the compact rules apply to them too.
+
+| State       | Dashboard                                                                     | Bills                                                        |
+| ----------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| **Empty**   | `EmptyStateView` for "No Recent Transactions"; summary shows zeros            | `EmptyStateView` "No Bills" with "Add Bill" action           |
+| **Stale**   | `OfflineBanner` pinned above cards when `NetworkMonitor.isConnected == false` | Same offline banner pattern; last-synced amounts shown as-is |
+| **Error**   | Alert with Retry/Dismiss (`viewModel.showError`)                              | Alert with Retry/Dismiss (`viewModel.showError`)             |
+| **Loading** | `ProgressView` centered with `accessibilityLabel("Loading")`                  | `ProgressView` centered with `accessibilityLabel("Loading")` |
+
+- The **offline banner** and **empty state** illustrations must also reflow:
+  at AX sizes the banner text wraps to multiple lines rather than truncating.
+- Stale data should carry a "Last updated …" affordance where available so users
+  understand a balance may be behind real-time (privacy-safe relative time, not
+  an exact balance in the banner).
+
+## Test plan (smallest viable)
+
+Goal: prove reflow correctness at the SE width across the Dynamic Type range
+with the **fewest** new tests. Detailed regression matrix lives in
+[ios-iphone-se-ui-regression.md](./ios-iphone-se-ui-regression.md)
+([#2609](../../issues/2609)); this section names only what gates **this** change.
+
+**Native (apps/ios) — smallest set:**
+
+1. **Snapshot tests at 375 × 667 pt** for `DashboardView` and `BillsListView`
+   at content sizes `{ .large, .xxxLarge, .accessibility1, .accessibility3,
+.accessibility5 }`. Assert no clipped currency labels and correct axis at
+   each size. (Requires a snapshot harness — tracked in the regression doc; do
+   not add the dependency in this design PR.)
+2. **XCUITest reflow assertion** extending
+   [`FinanceUITests.swift`](../../apps/ios/Tests/UITests/FinanceUITests.swift):
+   launch with an AX content-size launch argument, navigate to Dashboard/Bills,
+   assert the summary value elements exist and are hittable (proxy for
+   "not clipped / reachable").
+3. **No new view-model tests** — aggregation is unchanged and already covered by
+   [`DashboardViewModelTests`](../../apps/ios/Tests/DashboardViewModelTests.swift)
+   and `BudgetsViewModelTests`.
+
+**Shared (packages):** none — no business-rule change.
+
+**Acceptance gate:** snapshots green at all five sizes for both screens; no
+truncated monetary text; VoiceOver reads each summary as one combined phrase.
+
+## Implementation readiness
+
+Per [`docs/ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md),
+implementation and distribution are **decoupled**. This layout work is
+**buildable and testable now**; only store distribution is gated by
+[#1239](../../issues/1239).
+
+| Phase              | Work                                                                                  | Gated by #1239?                                                      |
+| ------------------ | ------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| **Design**         | This document                                                                         | No                                                                   |
+| **Implementation** | SwiftUI reflow in Dashboard/Bills, snapshot + XCUITest at SE width, local device runs | **No** — free **Personal Team** signing on a device, plus simulator  |
+| **Distribution**   | TestFlight / App Store build with the new layouts                                     | **Yes** — Apple Developer enrollment + signing material + CI secrets |
+
+> **Buildable now:** all reflow code, simulator snapshots, and on-device
+> verification using a **free Apple ID (Personal Team)** in Xcode (7-day app
+> expiry, max 3 apps/device — fine for layout QA).
+>
+> **Needs human action (later):** nothing in this layout change requires it. Only
+> shipping it through TestFlight/App Store requires the
+> [§3.2 Apple Developer checklist](../ops/human-gated-prerequisites.md#32-ios-distribution--apple-developer-1239).
+> Agents must **not** perform enrollment, signing, or secret configuration.
+
+## Related documents
+
+- [ios-iphone-se-ui-regression.md](./ios-iphone-se-ui-regression.md) — regression matrix ([#2609](../../issues/2609))
+- [ios-grocery-safe-to-spend-card.md](./ios-grocery-safe-to-spend-card.md) — grocery card ([#2610](../../issues/2610))
+- [responsive-breakpoints.md](./responsive-breakpoints.md) — token breakpoint tiers
+- [accessibility-patterns.md](./accessibility-patterns.md) — cross-platform a11y patterns
+- [cognitive-accessibility.md](./cognitive-accessibility.md) — clarity & load
+- [content-language-guidelines.md](./content-language-guidelines.md) — labels & microcopy
+- [data-visualization.md](./data-visualization.md) — CVD-safe chart/ring palette
+- [animation-library.md](./animation-library.md) — motion & Reduce Motion
+- [`docs/ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md) — build vs. distribution gating

--- a/docs/design/ios-iphone-se-ui-regression.md
+++ b/docs/design/ios-iphone-se-ui-regression.md
@@ -1,0 +1,261 @@
+# iPhone SE iOS UI Regression Coverage (iOS)
+
+> **Status:** Design draft (design-only — no native build in this PR)
+> **Issue:** [#2609](../../issues/2609) · **Parent:** [#2190](../../issues/2190)
+> **Platform:** iOS (SwiftUI) · **Audience:** iOS engineers, QA
+> **Distribution blocker:** [#1239](../../issues/1239) (Apple Developer enrollment — _distribution only_, see [Implementation readiness](#implementation-readiness))
+
+This document defines the **regression coverage plan** that protects the
+iPhone SE compact layouts from regressing as features evolve. It enumerates the
+SE-sized destinations to guard, the Dynamic Type sizes to assert, and the
+**smallest** set of native and shared tests required before the layout work in
+[#2607](../../issues/2607) and the grocery card in [#2610](../../issues/2610) are
+accepted.
+
+It is a **test-plan specification only** — it adds no Swift code, no
+dependencies, and touches no other platform. Numbers are **design estimates**
+pending on-device confirmation.
+
+---
+
+## Table of Contents
+
+- [Goal & scope](#goal--scope)
+- [Destinations under coverage](#destinations-under-coverage)
+- [Dynamic Type matrix](#dynamic-type-matrix)
+- [Test pyramid for SE](#test-pyramid-for-se)
+- [Coverage matrix (smallest viable)](#coverage-matrix-smallest-viable)
+- [Snapshot harness approach](#snapshot-harness-approach)
+- [Accessibility assertions](#accessibility-assertions)
+- [Privacy & balance-hiding cases](#privacy--balance-hiding-cases)
+- [Empty, stale & error coverage](#empty-stale--error-coverage)
+- [Shared / KMP boundary](#shared--kmp-boundary)
+- [CI integration](#ci-integration)
+- [Implementation readiness](#implementation-readiness)
+- [Related documents](#related-documents)
+
+---
+
+## Goal & scope
+
+Provide a **repeatable, low-maintenance** safety net that fails fast when a
+change clips currency text, breaks reflow, or drops an accessibility trait on a
+375 pt-wide screen. The plan favors a **small number of high-signal snapshot and
+view-model tests** over an exhaustive XCUITest sweep.
+
+In scope:
+
+- Dashboard, Bills, grocery transaction entry, Budget detail, and the Dynamic
+  Type behavior of each on SE-sized destinations.
+
+Out of scope (covered elsewhere):
+
+- The layout rules themselves — see
+  [ios-iphone-se-compact-layouts.md](./ios-iphone-se-compact-layouts.md).
+- The grocery card visual/interaction spec — see
+  [ios-grocery-safe-to-spend-card.md](./ios-grocery-safe-to-spend-card.md).
+
+## Destinations under coverage
+
+Read-only references (do **not** edit in this PR):
+
+| Destination                  | Primary surface                                                                             | Why it matters on SE                                 |
+| ---------------------------- | ------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| Dashboard                    | [`DashboardView.swift`](../../apps/ios/Finance/Screens/DashboardView.swift)                 | 3-up summary + 3-up quick-access grid reflow         |
+| Bills                        | [`BillsListView.swift`](../../apps/ios/Finance/Screens/BillsListView.swift)                 | 3-up summary card + dense bill rows                  |
+| Grocery transaction entry    | [`TransactionCreateView.swift`](../../apps/ios/Finance/Screens/TransactionCreateView.swift) | Forms must scroll, keyboard avoidance at AX sizes    |
+| Budget detail                | [`BudgetsView.swift`](../../apps/ios/Finance/Screens/BudgetsView.swift) (cards + sheet)     | Ring + amounts + status text on one row              |
+| Grocery safe-to-spend card   | [#2610](../../issues/2610) (planned)                                                        | New Dashboard card; reflow + privacy + drill-in      |
+| Dynamic Type (cross-cutting) | [`DynamicTypeSupport.swift`](../../apps/ios/Finance/Accessibility/DynamicTypeSupport.swift) | Shared scaling primitives that all screens depend on |
+
+## Dynamic Type matrix
+
+We do **not** snapshot all 12 content sizes — that is high cost, low marginal
+signal. We assert at **five representative sizes** that bracket the reflow
+breakpoints from [#2607](../../issues/2607):
+
+| Symbol           | `DynamicTypeSize` | Why this size                                        |
+| ---------------- | ----------------- | ---------------------------------------------------- |
+| Default          | `.large`          | Baseline most users see                              |
+| Largest standard | `.xxxLarge`       | Last non-accessibility size; densest "normal" layout |
+| AX entry         | `.accessibility1` | First size that triggers the axis switch             |
+| AX mid           | `.accessibility3` | Single-column threshold for quick access             |
+| AX max           | `.accessibility5` | Worst case — proves nothing clips or overflows       |
+
+All snapshots fix the **device width at 375 pt** (iPhone SE portrait, _estimate_)
+and let height grow with content.
+
+## Test pyramid for SE
+
+```mermaid
+flowchart TD
+    A[Shared packages/core tests] -->|aggregation, safe-to-spend math| B[iOS view-model tests]
+    B -->|state, formatting, reflow flags| C[SwiftUI snapshot tests at 375 pt × 5 sizes]
+    C -->|visual reflow + clipping| D[A few XCUITest smoke flows]
+    D -->|navigation + hittability| E[Manual on-device pass on real SE]
+```
+
+- **Widest, cheapest layer:** shared math tests in `packages/` (run on CI without
+  Apple tooling).
+- **Next:** iOS view-model unit tests (fast, no UI).
+- **Targeted:** SwiftUI snapshot tests — the core of SE protection.
+- **Thin top:** a handful of XCUITest flows for navigation/hittability.
+- **Manual:** one human pass on a physical SE before release (free Personal Team
+  build).
+
+## Coverage matrix (smallest viable)
+
+| Destination               | View-model unit | Snapshot @375 × 5 sizes | XCUITest smoke | Notes                                                  |
+| ------------------------- | --------------- | ----------------------- | -------------- | ------------------------------------------------------ |
+| Dashboard                 | ✅ (existing)   | ✅ **new**              | ✅ extend      | Summary + quick access reflow are the priority asserts |
+| Bills                     | ✅ (existing)   | ✅ **new**              | ✅ extend      | Summary card + bill row reflow                         |
+| Grocery transaction entry | ✅ (existing)   | ✅ **new** (form)       | ✅ extend      | Assert scrollable form + Save reachable at AX5         |
+| Budget detail             | ✅ (existing)   | ✅ **new**              | optional       | Ring + amounts + status on one row                     |
+| Grocery card ([#2610])    | ⛔ until built  | ✅ **new** when built   | ⛔ until built | Add with the feature; not before                       |
+| Dynamic Type primitives   | ✅ **new** unit | n/a                     | n/a            | `ClampedScaledMetric` clamps at AX5; pure logic test   |
+
+> ✅ existing = covered today by files such as
+> [`DashboardViewModelTests`](../../apps/ios/Tests/DashboardViewModelTests.swift),
+> `BudgetsViewModelTests`, `TransactionCreateViewModelTests`, and the XCUITest
+> suite [`FinanceUITests`](../../apps/ios/Tests/UITests/FinanceUITests.swift).
+> **new** = added with the implementation PR, not this design PR.
+
+### Smallest acceptance set per screen
+
+- **Dashboard:** 5 snapshots + 1 XCUITest (navigate, assert summary values
+  hittable at `.accessibility5`).
+- **Bills:** 5 snapshots + 1 XCUITest (navigate, assert bill row amount + due
+  date present, not clipped).
+- **Grocery entry:** 5 snapshots of the form + 1 XCUITest (open entry, type
+  amount, assert Save button hittable at AX5 above the keyboard).
+- **Budget detail:** 5 snapshots; XCUITest optional (reuses Budgets navigation).
+- **Dynamic Type primitives:** 1 unit test asserting `ClampedScaledMetric`
+  respects min/max bounds.
+
+## Snapshot harness approach
+
+iOS currently has **no snapshot-testing library** wired in (see the Tests
+directory — only XCTest unit + XCUITest). The implementation PR should add a
+single, well-maintained Swift-package snapshot dependency.
+
+- **Constraint:** the framework must be a **Swift Package** (no third-party UI
+  frameworks — SwiftUI + Swift concurrency only). Snapshot testing is a **test
+  dependency**, not a UI framework, so it is permitted; adding it is an
+  implementation decision to record via the normal review, not in this design PR.
+- **Configuration:** snapshots run on a **simulator only** (no signing, no
+  device), so they execute under free tooling and on CI runners that have Xcode.
+- **Fixture data:** drive views with the existing mock repositories
+  ([`MockBillRepository`](../../apps/ios/Finance/Repositories/Mocks/MockBillRepository.swift),
+  `MockBudgetRepository`, `MockTransactionRepository`) so snapshots are
+  deterministic and offline.
+- **Stable rendering:** pin locale to `en_US`, fix the date via injected `Date`,
+  and disable animations so diffs are pixel-stable.
+
+```text
+Snapshot test naming (estimate):
+  test_Dashboard_SE_large
+  test_Dashboard_SE_axLarge1
+  test_Dashboard_SE_axLarge5
+  test_Bills_SE_axLarge3
+  ...
+```
+
+## Accessibility assertions
+
+Each snapshot/UITest pairs with at least one **semantic** assertion (visual
+parity is not enough):
+
+- **VoiceOver grouping:** combined elements (`accessibilityElement(children:
+.combine)`) still read as a single phrase after reflow — assert the
+  `accessibilityLabel`/`accessibilityValue` exists on the grouped element.
+- **Header traits:** section headers keep `.isHeader` (Bills sections, "More",
+  budget detail headers).
+- **Tap targets:** XCUITest asserts interactive elements are `isHittable` at AX5
+  (a practical proxy for the 44 × 44 pt minimum).
+- **No truncation contract:** snapshots are the guard for clipped currency text;
+  reviewers reject any diff showing "…"-truncated amounts.
+- **Reduce Motion:** a smoke test launches with Reduce Motion on and asserts the
+  destination still renders (no motion-dependent content gating).
+
+These mirror [accessibility-patterns.md](./accessibility-patterns.md) and
+[cognitive-accessibility.md](./cognitive-accessibility.md).
+
+## Privacy & balance-hiding cases
+
+Add explicit cases so privacy modes are regression-protected:
+
+- **Masked vs. visible amounts:** snapshot Dashboard/Bills/grocery card in both
+  the "exact" and "bucketed/hidden" presentation (the same concept as
+  [`WidgetPrivacyPrompt`](../../apps/ios/Finance/Services/WidgetPrivacyPrompt.swift)).
+  Assert layout **does not shift** between modes at any Dynamic Type size.
+- **No value leakage in test logs:** tests must not print real amounts; treat
+  fixture amounts as opaque strings in assertions where possible.
+- **Locked-state safety:** any surface reachable from a lock-screen widget
+  deep link must render its masked form first (covered with the grocery card in
+  [#2610](../../issues/2610)).
+
+## Empty, stale & error coverage
+
+For each destination, snapshot the three non-happy states at **at least** the
+default and AX5 sizes:
+
+| State   | What to assert                                                             |
+| ------- | -------------------------------------------------------------------------- |
+| Empty   | `EmptyStateView` renders, CTA reachable, text wraps (not truncates) at AX5 |
+| Stale   | `OfflineBanner` visible, wraps at AX5, primary content still legible       |
+| Error   | Retry/Dismiss alert path reachable (XCUITest), copy not truncated          |
+| Loading | `ProgressView` present with `accessibilityLabel("Loading")`                |
+
+## Shared / KMP boundary
+
+- **`packages/core` / `packages/models` (do not implement here):** the
+  aggregation and safe-to-spend math under test belong to shared logic. Shared
+  unit tests for those rules run on CI **without** Apple tooling and are the
+  base of the pyramid. This plan only **references** them; it does not add them.
+- **`apps/ios` (this plan):** snapshot + XCUITest + view-model tests for
+  presentation and reflow.
+
+The split keeps math regressions catchable on every PR (cross-platform) while UI
+regressions are caught by the iOS-only snapshot layer.
+
+## CI integration
+
+- **Runs where Xcode exists:** snapshot + XCUITest jobs require a macOS runner
+  with Xcode; they need **no signing** (simulator only) and therefore no Apple
+  enrollment.
+- **Shared math** runs on standard Linux CI via the existing `packages/` test
+  tasks.
+- **Failure artifacts:** snapshot jobs upload the failing reference/diff images
+  so reviewers can see exactly what clipped.
+- **Determinism:** fixed locale, fixed clock, animations disabled, fixed device
+  width (375 pt). Flaky snapshots are treated as bugs, not retried away.
+
+## Implementation readiness
+
+Per [`docs/ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md),
+test authoring and execution are **buildable now**; only store distribution is
+gated by [#1239](../../issues/1239).
+
+| Phase              | Work                                                                   | Gated by #1239?                                                             |
+| ------------------ | ---------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| **Design**         | This regression plan                                                   | No                                                                          |
+| **Implementation** | Snapshot harness, snapshot/XCUITest/unit tests, simulator + device run | **No** — simulator needs no signing; device runs use free **Personal Team** |
+| **Distribution**   | Shipping a tested build via TestFlight / App Store                     | **Yes** — enrollment + signing + CI release secrets                         |
+
+> **Buildable now:** the entire test suite runs on the iOS Simulator (no
+> signing) and on a physical SE via free Personal Team signing.
+>
+> **Needs human action (later):** none for testing. Only the eventual
+> store/TestFlight release uses the
+> [§3.2 Apple Developer checklist](../ops/human-gated-prerequisites.md#32-ios-distribution--apple-developer-1239).
+> Agents must **not** perform enrollment, signing, or secret configuration.
+
+## Related documents
+
+- [ios-iphone-se-compact-layouts.md](./ios-iphone-se-compact-layouts.md) — layout spec ([#2607](../../issues/2607))
+- [ios-grocery-safe-to-spend-card.md](./ios-grocery-safe-to-spend-card.md) — grocery card ([#2610](../../issues/2610))
+- [accessibility-patterns.md](./accessibility-patterns.md) — a11y patterns & assertions
+- [cognitive-accessibility.md](./cognitive-accessibility.md) — clarity & load
+- [responsive-breakpoints.md](./responsive-breakpoints.md) — breakpoint tiers
+- [content-language-guidelines.md](./content-language-guidelines.md) — microcopy under test
+- [`docs/ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md) — build vs. distribution gating


### PR DESCRIPTION
## Summary

Adds three **design-only** docs under `docs/design/` for the iOS compact-layout / grocery cluster (parent epics #2190 and #2199). No native build, no signing, no store actions, no code changes — new files only.

The safe-to-spend / budget math is kept conceptually in KMP `packages/core` (boundary described, not implemented). Layouts are grounded in real `apps/ios` SwiftUI surfaces read from the repo; no `apps/` or `packages/` code was modified. All numeric thresholds are labeled **estimates** pending on-device verification.

## Changes

- `docs/design/ios-iphone-se-compact-layouts.md` — compact-width alternatives for the Dashboard "This Month" / quick-access grid and Bills summary cards on iPhone SE (375 pt), with reflow rules across Dynamic Type up to AX5. (#2607)
- `docs/design/ios-iphone-se-ui-regression.md` — SE regression coverage plan: snapshot-at-SE-width + AX-sizes matrix for Dashboard, Bills, grocery entry, Budget detail, and Dynamic Type primitives, plus the smallest native/shared test set. (#2609)
- `docs/design/ios-grocery-safe-to-spend-card.md` — supportive Dashboard grocery safe-to-spend card combining pinned grocery budget, remaining safe spend, payday/bill context, and one-tap drill-in (via existing `budgetCategory` deep link); safe-to-spend math stays in `packages/core`. (#2610)

Each doc is humans-first with a ToC, Mermaid diagrams, relative links, accessibility (VoiceOver, Dynamic Type to AX5 at 4.7" width, reflow, Reduce Motion), privacy/balance-hiding, stale/error/empty states, a smallest-tests plan (snapshot at SE width + AX sizes), and an **Implementation readiness** section linking [`docs/ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md) that splits buildable-now (free Personal Team signing) from the distribution tail gated by #1239.

Verification: `npx prettier --check` passes on all three new files; Mermaid fences avoid `#`-prefixed labels.

Closes #2607
Closes #2609
Closes #2610
