### PR TITLE
docs(design): android couples and wedding planning design batch (#2645, #2647, #2652)

### DIFF
--- a/docs/design/android-couples-money-checkin.md
+++ b/docs/design/android-couples-money-checkin.md
@@ -1,0 +1,397 @@
+# Android Couples Money Check-In Flow & Prompt Experience — Design
+
+> **Status:** DESIGN — Implementation-ready (native build/test unblocked; store distribution gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242))
+> **Issue:** [#2652](https://github.com/jrmoulckers/finance/issues/2652) — _Part of [#2150](https://github.com/jrmoulckers/finance/issues/2150)_ (couples collaboration)
+> **Platform:** Android (Jetpack Compose · Material 3)
+> **Last Updated:** 2026-06-22
+
+This document specifies the **opt-in couples money check-in**: a supportive,
+weekly or monthly Compose ritual with discussion prompts and a collaborative
+tone. It covers **setup, session, recap, and skip/reschedule** states and the
+**prompt library** (fun-money boundaries, joint account structure, wedding spend,
+and upcoming shared expenses).
+
+This is a **ritual, not a surveillance dashboard.** It opens conversation; it does
+not rank, audit, or expose either partner's private data. Any figure shown is a
+**privacy-safe shared summary** sourced from `packages/core`, and copy is written
+to be **collaborative and never accusatory**.
+
+---
+
+## Table of Contents
+
+1. [Goals & Non-Goals](#1-goals--non-goals)
+2. [Architecture Boundary (Compose ↔ KMP)](#2-architecture-boundary-compose--kmp)
+3. [Grounding in Existing Code](#3-grounding-in-existing-code)
+4. [Flow Overview](#4-flow-overview)
+5. [Setup State](#5-setup-state)
+6. [Session State](#6-session-state)
+7. [Recap State](#7-recap-state)
+8. [Skip & Reschedule States](#8-skip--reschedule-states)
+9. [Prompt Library & Collaborative Tone](#9-prompt-library--collaborative-tone)
+10. [Scheduling (WorkManager) & Privacy](#10-scheduling-workmanager--privacy)
+11. [Composable & ViewModel Structure](#11-composable--viewmodel-structure)
+12. [Accessibility (TalkBack, Switch Access, Font Scaling)](#12-accessibility-talkback-switch-access-font-scaling)
+13. [Offline, Empty & Error States](#13-offline-empty--error-states)
+14. [Test Plan](#14-test-plan)
+15. [Implementation Readiness](#15-implementation-readiness)
+16. [Open Questions](#16-open-questions)
+
+---
+
+## 1. Goals & Non-Goals
+
+### Goals
+
+- Offer an **opt-in** weekly/monthly check-in both partners agree to — never
+  imposed, always escapable.
+- Guide a short **session** with **discussion prompts** that open conversation
+  about fun-money boundaries, joint account structure, wedding spend, and
+  upcoming shared expenses.
+- Provide **setup, session, recap, and skip/reschedule** states with a warm,
+  collaborative tone.
+- Show only **privacy-safe shared summaries** (aggregates the couple already
+  chose to share) — never raw transactions or a partner's private balances.
+- Write **accessibility copy that avoids accusatory language** and works fully
+  with **TalkBack, Switch Access, and 200% font scaling**.
+
+### Non-Goals
+
+- **Not a surveillance dashboard.** No spend ranking, no "who overspent," no
+  drill-down into a partner's private line items.
+- **No money math in Compose.** Any summary shown is computed in `packages/core`
+  and respects the household privacy boundary (see §2–§3).
+- **No new shared rules here.** Where prompt content references shared figures
+  (e.g., wedding spend), it consumes existing shared summaries; missing summaries
+  are an @kmp-engineer follow-up under #2150, not a Compose workaround.
+- **No notifications via AlarmManager/JobScheduler.** Reminders use WorkManager
+  - the existing push path (§10).
+- **No store distribution work** (gated by #1242 — see §15).
+
+---
+
+## 2. Architecture Boundary (Compose ↔ KMP)
+
+The check-in is a **conversation surface** with a thin data tail. Prompt content
+and session structure live in the Android layer; **any money summary it
+references is shared, privacy-safe state from `packages/core`.**
+
+```mermaid
+flowchart LR
+    subgraph Android [apps/android · Compose]
+        UI[MoneyCheckInScreen]
+        VM[MoneyCheckInViewModel]
+        WM[CheckInReminderWorker - WorkManager]
+    end
+    subgraph Shared [packages/core · KMP - source of truth]
+        AGG[Privacy-safe shared summaries]
+        DP[DataPartitioning + RbacPermissions]
+        SE[SavingsEngine - optional suggestions]
+    end
+    UI --> VM
+    VM -->|immutable UiState| AGG
+    AGG --> DP
+    VM --> SE
+    WM --> VM
+```
+
+- The ViewModel exposes **one immutable `StateFlow<MoneyCheckInUiState>`**.
+- **Summaries are pre-bucketed shared aggregates** filtered through
+  `DataPartitioning` — the check-in cannot request a partner's private detail.
+- **Prompt copy is local string resources** (no business logic); only the
+  optional figure attached to a prompt comes from shared code.
+
+---
+
+## 3. Grounding in Existing Code
+
+| Concern                    | Source of truth (do **not** reimplement in Compose)                                                                                                                                                                           | Today's state                              |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| Partner partition & roles  | [`DataPartitioning`](../../packages/core/src/commonMain/kotlin/com/finance/core/household/DataPartitioning.kt) + [`RbacPermissions`](../../packages/core/src/commonMain/kotlin/com/finance/core/household/RbacPermissions.kt) | Exists: `filterVisible`, role gates        |
+| Privacy-safe masking       | Privacy foundation per [android-household-privacy-dashboard.md](./android-household-privacy-dashboard.md)                                                                                                                     | Exists: bucketed / percent summaries       |
+| Joint vs personal accounts | [`Household`](../../packages/models/src/commonMain/kotlin/com/finance/models/Household.kt) + [`HouseholdMember`](../../packages/models/src/commonMain/kotlin/com/finance/models/HouseholdMember.kt)                           | Exists: household scoping                  |
+| Wedding spend summary      | Wedding workspace shell — [android-wedding-workspace-shell.md](./android-wedding-workspace-shell.md)                                                                                                                          | Designed under #2645 (summary reused here) |
+| Upcoming shared expenses   | [`BillReminderEngine`](../../packages/core/src/commonMain/kotlin/com/finance/core/recurring/BillReminderEngine.kt)                                                                                                            | Exists: next-N due bucketing               |
+| Optional savings nudge     | [`SavingsEngine`](../../packages/core/src/commonMain/kotlin/com/finance/core/savings/SavingsEngine.kt)                                                                                                                        | Exists: suggestion generation              |
+| Reminder scheduling        | WorkManager (Android) — see [SyncWorker pattern]                                                                                                                                                                              | Exists: WorkManager is the app's scheduler |
+
+> The check-in **reuses** these summaries; it does not compute new financial
+> figures. Wedding spend, joint structure, and upcoming expenses are all shown as
+> shared, privacy-safe summaries.
+
+---
+
+## 4. Flow Overview
+
+```mermaid
+stateDiagram-v2
+    [*] --> Setup
+    Setup --> Scheduled: both opt in
+    Scheduled --> Session: start check-in
+    Scheduled --> Skip: not now
+    Skip --> Scheduled: reschedule
+    Session --> Recap: finish
+    Recap --> Scheduled: next check-in set
+    Recap --> [*]
+```
+
+- The check-in is reachable from the Planning hub and from a gentle reminder
+  notification (§10).
+- Either partner can **skip or reschedule** at any point; skipping is friction-
+  free and never framed as a failure.
+
+---
+
+## 5. Setup State
+
+First run is a **mutual opt-in**, not a unilateral toggle.
+
+- **Invite to ritual:** one partner proposes a cadence (**weekly** or
+  **monthly**) and a default day/time; the other **accepts** before reminders
+  start. Until both accept, no reminders are scheduled.
+- **What we'll talk about:** a preview of prompt themes (fun-money, joint
+  accounts, wedding, upcoming expenses) so consent is informed.
+- **Privacy note up front:** plain copy stating the check-in shows **only shared
+  summaries**, never a partner's private transactions — sets the supportive tone.
+- **Tone preview:** an example prompt is shown so partners see the collaborative
+  framing before committing.
+
+> Setup copy follows [content-language-guidelines.md](./content-language-guidelines.md)
+> and [cognitive-accessibility.md](./cognitive-accessibility.md): short, warm,
+> one decision per step.
+
+---
+
+## 6. Session State
+
+A session is a **short, paced sequence of prompt cards** — think 5–8 minutes, not
+an audit.
+
+- **One prompt per card**, advanced at the couple's pace; a progress indicator
+  shows "Prompt 2 of 5."
+- **Optional shared figure:** a prompt may attach a **privacy-safe summary**
+  (e.g., "Wedding spend so far: a rounded range") pulled from shared code — shown
+  as context for conversation, **not a scorecard**.
+- **No inputs required:** prompts invite discussion, not data entry. An optional
+  "Jot a shared note" field can capture an agreement the couple wants to keep.
+- **Pause / leave anytime:** leaving mid-session saves progress and routes to a
+  gentle skip state (§8) — never a "you abandoned it" message.
+- **Equal footing:** copy addresses "you two" / "as a team," never singling out a
+  partner.
+
+---
+
+## 7. Recap State
+
+The recap **closes the loop warmly** and sets up the next ritual.
+
+- **Highlights, not metrics:** a short summary of themes discussed and any
+  **shared notes/agreements** the couple chose to save — no spending verdicts.
+- **Optional next step:** at most one gentle, **opt-in** suggestion sourced from
+  `SavingsEngine` (e.g., "Want to set a fun-money amount together?"), clearly
+  skippable.
+- **Next check-in:** confirms the next scheduled date and offers to change
+  cadence.
+- **Gratitude tone:** closing copy thanks both partners for showing up — framing
+  the ritual as a positive habit.
+
+---
+
+## 8. Skip & Reschedule States
+
+Skipping is **first-class and judgment-free**.
+
+| Action                | Behavior                                                                            |
+| --------------------- | ----------------------------------------------------------------------------------- |
+| **Not now**           | Dismisses the session; offers a one-tap reschedule (e.g., "Tomorrow," "Next week"). |
+| **Reschedule**        | Picks a new date/time; reminder re-queues via WorkManager (§10).                    |
+| **Pause ritual**      | Stops reminders entirely until the couple opts back in; no nagging.                 |
+| **Leave mid-session** | Saves progress; returns to a calm "Pick up later?" state — never a failure label.   |
+
+- Copy for every skip path is **supportive** ("Life's busy — we'll check in
+  later") and avoids guilt or streak-shaming.
+- Reschedule respects both partners: a change one proposes is reflected for both
+  but doesn't expose either's calendar detail.
+
+---
+
+## 9. Prompt Library & Collaborative Tone
+
+Prompts are **local string resources** grouped by theme. Every prompt is phrased
+as a **shared, open question** — collaborative, curious, never accusatory.
+
+| Theme                        | Example prompt (collaborative framing)                                            |
+| ---------------------------- | --------------------------------------------------------------------------------- |
+| **Fun-money boundaries**     | "What's a personal-spending amount that feels fair to both of us this month?"     |
+| **Joint account structure**  | "Is our split of joint vs personal still working for both of us?"                 |
+| **Wedding spend**            | "How are we feeling about wedding spending so far — anything to adjust together?" |
+| **Upcoming shared expenses** | "What's coming up that we'd like to plan for as a team?"                          |
+
+**Tone rules (enforced in copy review and tests):**
+
+- Use **"we" / "us" / "together"**; avoid "you spent," "you went over," "your
+  fault," or any second-person blame.
+- Frame numbers as **shared context**, never as a verdict on one partner.
+- Prefer **questions over statements**; invite, don't instruct.
+- No streaks, scores, or guilt mechanics — this is a ritual, not a leaderboard.
+- Cross-check against [content-language-guidelines.md](./content-language-guidelines.md)
+  and [ux-principles.md](./ux-principles.md) (supportive, non-judgmental finance
+  voice).
+
+---
+
+## 10. Scheduling (WorkManager) & Privacy
+
+- **Reminders use WorkManager**, never AlarmManager/JobScheduler. A
+  `CheckInReminderWorker` enqueues the next gentle reminder after setup/recap and
+  on reschedule.
+- **Push:** if a reminder surfaces as a notification, it carries **no financial
+  data** — just "Time for your money check-in?" Tapping deep-links into the flow.
+- **Both-opt-in gating:** reminders only schedule once both partners accepted in
+  setup; pausing cancels the worker.
+- **Privacy boundary:** the worker and notification never read or render private
+  partner data; any summary is fetched in-session through the shared
+  privacy-safe path. No secrets or balances in `SharedPreferences` — sensitive
+  values stay in the encrypted store; auth-gated surfaces use the existing
+  biometric/Keystore path.
+
+---
+
+## 11. Composable & ViewModel Structure
+
+| Composable             | Responsibility                                                         |
+| ---------------------- | ---------------------------------------------------------------------- |
+| `MoneyCheckInScreen`   | Host scaffold routing setup / session / recap / skip; live-region host |
+| `CheckInSetupScreen`   | Mutual opt-in, cadence picker, privacy note (§5)                       |
+| `CheckInSessionScreen` | Paced prompt-card pager with progress + optional shared note (§6)      |
+| `PromptCard`           | Single prompt with optional privacy-safe summary chip                  |
+| `CheckInRecapScreen`   | Highlights, optional opt-in suggestion, next-check-in (§7)             |
+| `SkipRescheduleSheet`  | Not-now / reschedule / pause options (§8)                              |
+| `SharedSummaryChip`    | Privacy-safe bucketed/percent context with non-accusatory semantics    |
+
+- **ViewModel:** `MoneyCheckInViewModel` (Koin `viewModelOf`, resolved via
+  `koinViewModel()`), exposing one immutable `StateFlow<MoneyCheckInUiState>`;
+  any shared figure is read through the privacy-safe path.
+- **Koin wiring (additions only):** `viewModelOf(::MoneyCheckInViewModel)`.
+- **Logging:** Timber only; **never log prompt responses, shared notes, or any
+  financial summary** — log lifecycle as enum/boolean (e.g.
+  `Timber.d("check-in state -> %s", state.name)`); never `Log.*`.
+- **Theming:** Material 3 + dynamic color; warm semantic tokens, no hard-coded
+  hex.
+
+---
+
+## 12. Accessibility (TalkBack, Switch Access, Font Scaling)
+
+Per [accessibility-patterns.md](./accessibility-patterns.md). Copy is written to
+be **non-accusatory** for assistive-tech users too — the `contentDescription`
+carries the same warm, collaborative framing as the visible text.
+
+| Surface             | Visible UI                 | TalkBack `contentDescription`                                                  |
+| ------------------- | -------------------------- | ------------------------------------------------------------------------------ |
+| Setup opt-in        | "Start a money ritual"     | "Set up a money check-in together. Both of you choose the day and how often."  |
+| Cadence picker      | "Weekly / Monthly"         | "Choose how often to check in. Weekly or monthly."                             |
+| Prompt card         | prompt text                | "Discussion prompt 2 of 5. {prompt}. There's no right answer."                 |
+| Shared summary chip | "Wedding: a rounded range" | "Wedding spending so far, shown as a rounded range for privacy. Context only." |
+| Skip                | "Not now"                  | "Skip this check-in. We can pick a new time. No problem."                      |
+| Reschedule          | "Next week"                | "Reschedule the check-in for next week."                                       |
+| Recap               | "Thanks for checking in"   | "Check-in complete. Thanks for taking time together. Next one is scheduled."   |
+
+- **Headings:** each state's title uses `semantics { heading() }`.
+- **No accusatory copy:** assistive-tech strings avoid "you spent / you went
+  over"; a string-resource lint/test guards against blame phrasing.
+- **Switch Access:** logical order title → prompt → advance → skip; targets
+  ≥ 48dp; the pager is operable without gestures.
+- **200% font scaling:** prompt cards reflow and never truncate prompt text;
+  verified via Compose preview + Paparazzi at large-font configs.
+- **Live region:** advancing a prompt announces "Prompt 3 of 5"; finishing
+  announces the recap politely.
+- **No color-only signaling:** state and summary cues pair icon + text with color.
+
+---
+
+## 13. Offline, Empty & Error States
+
+- **Offline:** the ritual runs fully offline — prompts are local resources; any
+  shared summary uses cached privacy-safe state with a "may be a few minutes old"
+  note. Shared notes save locally and sync via WorkManager.
+- **Empty (not set up):** setup invitation (§5); no reminders until both opt in.
+- **Empty (no shared summaries available):** prompts still run as pure discussion
+  — the optional summary chip is simply omitted, never a blank/error.
+- **Solo (no partner yet):** the ritual explains it's designed for two and offers
+  to invite a partner; it does not present a one-sided "audit."
+- **Error (summary fetch):** the prompt degrades gracefully to discussion-only
+  with a quiet "couldn't load context" note; no stack traces, no sensitive data.
+- **Reminder delivery offline:** WorkManager retries with backoff; a missed
+  reminder never double-fires.
+
+---
+
+## 14. Test Plan
+
+- **Unit (ViewModel):** state machine transitions Setup → Scheduled → Session →
+  Recap and every skip/reschedule/pause path; reminders only schedule after
+  mutual opt-in; pause cancels the worker.
+- **Copy / tone tests:** a string-resource test asserts prompt and accessibility
+  copy contain no blame phrases ("you spent," "you went over," "your fault," etc.)
+  — enforcing the collaborative, non-accusatory rule (§9, §12).
+- **Privacy parity:** assert any in-session figure is a privacy-safe summary from
+  the shared path (`DataPartitioning.filterVisible`), never a raw partner amount;
+  a semantics test asserts no exact private amount renders in a prompt card.
+- **Compose UI / semantics:** assert `contentDescription` on every prompt card,
+  chip, skip, and reschedule control; assert the pager is Switch-Access operable.
+- **Paparazzi snapshots:** setup, session (with and without summary chip), recap,
+  and skip sheet — at default and 200% font scale, light/dark + dynamic color.
+- **Accessibility:** TalkBack walkthrough per §12; Switch Access order;
+  touch-target and contrast checks.
+- **Scheduling:** WorkManager reminder enqueues/cancels correctly across setup,
+  reschedule, and pause; offline retry/backoff verified.
+
+---
+
+## 15. Implementation Readiness
+
+Per [`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md)
+§2 (Implementation vs. Distribution), this feature is **decoupled**: design and
+native implementation are buildable and testable now; only store distribution
+waits on #1242.
+
+### ✅ Buildable now (debug / free signing — no enrollment, no secrets)
+
+- This design doc and all shared-summary consumption decisions.
+- All Compose UI, `MoneyCheckInViewModel`, the `CheckInReminderWorker`, and Koin
+  wiring.
+- Unit tests, copy/tone tests, Compose semantics/UI tests, and Paparazzi
+  snapshots.
+- Local verification via `./gradlew :apps:android:assembleDebug` + sideload, per
+  [`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md)
+  §2 "Free local build/test paths."
+- Any required **shared** summary is a `packages/core` change (owned by
+  @kmp-engineer) — also unblocked; not store-gated.
+
+### 🔒 Distribution tail — gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+
+- Release signing with the production keystore.
+- Google Play Console upload / release-track promotion.
+- The signed-AAB release workflow and its CI secrets.
+- Push notification delivery configuration for production reminders.
+
+These are **human-gated** and out of scope for SME agents — see the
+[Human-Gated Prerequisites Runbook](../ops/human-gated-prerequisites.md) §3.1.
+Until then the ritual is fully exercisable via debug sideload (reminders fire
+locally through WorkManager).
+
+---
+
+## 16. Open Questions
+
+1. **Cadence defaults** — should the suggested default be weekly or monthly for
+   couples planning a wedding (higher activity), and who can change it?
+2. **Shared notes storage** — are check-in notes a shared household record (synced
+   via the existing pipeline), and what scope masks them from a future viewer?
+3. **Prompt personalization** — should the prompt set adapt when a wedding
+   workspace exists (surface more wedding prompts), driven by a shared flag rather
+   than a Compose heuristic?
+4. **Suggestion source** — confirm `SavingsEngine` is the right (single, opt-in)
+   nudge source for the recap, or whether a couples-specific suggestion is a
+   shared follow-up under #2150.

--- a/docs/design/android-wedding-actuals-cashflow.md
+++ b/docs/design/android-wedding-actuals-cashflow.md
@@ -1,0 +1,369 @@
+# Android Wedding Actuals, Guest-Count Estimates & Cash-Flow Views — Design
+
+> **Status:** DESIGN — Implementation-ready (native build/test unblocked; store distribution gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242))
+> **Issue:** [#2647](https://github.com/jrmoulckers/finance/issues/2647) — _Part of [#2145](https://github.com/jrmoulckers/finance/issues/2145)_ (couples / life-event planning)
+> **Platform:** Android (Jetpack Compose · Material 3)
+> **Last Updated:** 2026-06-22
+
+This document specifies the Android **analytics views** for the Wedding
+Workspace: **budgeted-vs-actual**, **per-guest estimate rows**, **remaining
+wedding spend with the next due date**, and links to **shared goals and
+household cash-flow planning**. These views build on the workspace shell and
+vendor tracker in
+[Android Shared Wedding Workspace Shell](./android-wedding-workspace-shell.md)
+([#2645](https://github.com/jrmoulckers/finance/issues/2645)).
+
+Every total, estimate, and date bucket here is **computed in `packages/core`**
+and rendered by Compose. **Estimates and projections are explicitly labeled** so
+a couple never mistakes a guest-count projection for a committed amount, and all
+partner-visible values respect the household privacy boundary.
+
+---
+
+## Table of Contents
+
+1. [Goals & Non-Goals](#1-goals--non-goals)
+2. [Architecture Boundary (Compose ↔ KMP)](#2-architecture-boundary-compose--kmp)
+3. [Grounding in Existing Code](#3-grounding-in-existing-code)
+4. [Budgeted-vs-Actual View](#4-budgeted-vs-actual-view)
+5. [Per-Guest Estimate Rows](#5-per-guest-estimate-rows)
+6. [Remaining Spend & Next Due Date](#6-remaining-spend--next-due-date)
+7. [Links to Shared Goals & Household Cash Flow](#7-links-to-shared-goals--household-cash-flow)
+8. [Partner Privacy in Analytics](#8-partner-privacy-in-analytics)
+9. [Composable & ViewModel Structure](#9-composable--viewmodel-structure)
+10. [Accessibility (TalkBack, Switch Access, Font Scaling)](#10-accessibility-talkback-switch-access-font-scaling)
+11. [Offline, Empty & Error States](#11-offline-empty--error-states)
+12. [Test Plan](#12-test-plan)
+13. [Implementation Readiness](#13-implementation-readiness)
+14. [Open Questions](#14-open-questions)
+
+---
+
+## 1. Goals & Non-Goals
+
+### Goals
+
+- Show **budgeted-vs-actual** per vendor category so the couple sees where they
+  are over or under plan.
+- Provide **guest-count-sensitive estimate rows** for **catering, rentals, and
+  invitations** — values that scale with headcount, always labeled "Estimate."
+- Surface **remaining wedding spend** and the **next due date** as a single
+  glanceable summary.
+- **Link to shared goals** (the wedding savings `Goal`) and **household
+  cash-flow planning** so the wedding sits in the couple's overall money picture.
+- Keep every view legible to **TalkBack, Switch Access, and 200% font scaling**,
+  with text alternatives for any chart.
+
+### Non-Goals
+
+- **No money math in Compose.** Totals, per-guest multiplications, remaining
+  spend, date bucketing, and cash-flow projections are computed in
+  `packages/core` (see §2–§3). Compose renders and formats only.
+- **No new shared planner rules here.** When shared planner rules don't yet
+  exist, this doc labels the dependency; it does not implement the rules
+  (owned by @kmp-engineer under #2145).
+- **No vendor CRUD here.** Vendor entry/states live in the shell doc (#2645).
+- **No check-in ritual here.** See
+  [Android Couples Money Check-In](./android-couples-money-checkin.md) (#2652).
+- **No store distribution work** (gated by #1242 — see §13).
+
+---
+
+## 2. Architecture Boundary (Compose ↔ KMP)
+
+These analytics are **derived views over shared state**. Compose subscribes to a
+single immutable UI state; the shared layer does the arithmetic and the
+projection.
+
+```mermaid
+flowchart LR
+    subgraph Android [apps/android · Compose]
+        UI[WeddingAnalyticsScreen]
+        VM[WeddingAnalyticsViewModel]
+    end
+    subgraph Shared [packages/core · KMP - source of truth]
+        AG[FinancialAggregator - budgeted vs actual]
+        GE[Guest-count estimator - proposed]
+        CF[OperatingCashForecastEngine - cash flow]
+        DP[DataPartitioning - partner scope]
+    end
+    UI --> VM
+    VM -->|immutable UiState| AG
+    VM --> GE
+    VM --> CF
+    VM --> DP
+```
+
+- **Per-guest estimate = headcount × per-unit estimate**, computed in shared code
+  (the proposed guest-count estimator), never multiplied in Compose.
+- **Cash-flow projection** reuses the existing
+  [`OperatingCashForecastEngine`](../../packages/core/src/commonMain/kotlin/com/finance/core/forecast/OperatingCashForecast.kt)
+  so the wedding's upcoming due dates fold into the household's projected
+  balances — the same engine the
+  [operating cash calendar](./android-operating-cash-calendar.md) renders.
+- **Projection confidence** (the engine already models a confidence enum) is
+  surfaced as a label, never hidden.
+
+---
+
+## 3. Grounding in Existing Code
+
+| Concern                 | Source of truth (do **not** reimplement in Compose)                                                                                                                                                           | Today's state                                      |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| Budgeted vs actual      | [`FinancialAggregator`](../../packages/core/src/commonMain/kotlin/com/finance/core/aggregation/FinancialAggregator.kt) + [`Budget`](../../packages/models/src/commonMain/kotlin/com/finance/models/Budget.kt) | Exists: spend-by-category, totals vs budget amount |
+| Cash-flow projection    | [`OperatingCashForecastEngine`](../../packages/core/src/commonMain/kotlin/com/finance/core/forecast/OperatingCashForecast.kt)                                                                                 | Exists: horizon snapshots, threshold breaches      |
+| Next due date / buckets | [`BillReminderEngine`](../../packages/core/src/commonMain/kotlin/com/finance/core/recurring/BillReminderEngine.kt)                                                                                            | Exists: `scheduleNextN`, monthly calendar          |
+| Wedding savings goal    | [`Goal`](../../packages/models/src/commonMain/kotlin/com/finance/models/Goal.kt)                                                                                                                              | Exists: target/current/`progress`                  |
+| Savings suggestions     | [`SavingsEngine`](../../packages/core/src/commonMain/kotlin/com/finance/core/savings/SavingsEngine.kt)                                                                                                        | Exists: suggestion generation (optional surface)   |
+| Partner scope           | [`DataPartitioning`](../../packages/core/src/commonMain/kotlin/com/finance/core/household/DataPartitioning.kt)                                                                                                | Exists: `filterVisible`, `partition`               |
+| Guest-count estimator   | **Proposed** thin `packages/core` addition (headcount × per-unit)                                                                                                                                             | Not yet — @kmp-engineer follow-up under #2145      |
+
+> The **guest-count estimator** and any wedding-specific planner rules are a
+> small shared addition. Until they land, Compose renders the actuals it can
+> derive from existing engines and shows the estimate rows in an empty/seed
+> state.
+
+---
+
+## 4. Budgeted-vs-Actual View
+
+A per-category list comparing the couple's **budgeted** amount to **actual**
+spend (deposits + paid installments), driven by `FinancialAggregator` and the
+shared `Budget` rows.
+
+| Column   | Meaning                                              | Source                |
+| -------- | ---------------------------------------------------- | --------------------- |
+| Category | Venue / Catering / Photography / …                   | Vendor category       |
+| Budgeted | Planned amount for the category                      | `Budget` (shared)     |
+| Actual   | Paid so far                                          | `FinancialAggregator` |
+| Variance | Actual − budgeted (over/under) — **computed shared** | `FinancialAggregator` |
+| Progress | Actual ÷ budgeted, shown as a bar + text             | Shared ratio          |
+
+- **Over/under** is conveyed by text + icon + a non-color bar fill — never color
+  alone (see [data-visualization.md](./data-visualization.md)).
+- Each bar has a **text alternative** (e.g., "Catering: 80% of budget used").
+- A **header total** shows the wedding's overall budgeted vs actual; both are
+  shared figures, formatted by Compose.
+
+---
+
+## 5. Per-Guest Estimate Rows
+
+Some costs scale with the guest count. These rows are **estimates** and are
+labeled as such everywhere they appear.
+
+```mermaid
+flowchart TD
+    GC[Guest count - couple's input] --> EST[Guest-count estimator - packages/core]
+    PU[Per-guest unit estimates] --> EST
+    EST --> CAT[Catering estimate]
+    EST --> REN[Rentals estimate]
+    EST --> INV[Invitations estimate]
+```
+
+| Estimate row | Scales with        | Example label                           |
+| ------------ | ------------------ | --------------------------------------- |
+| Catering     | Guests × per-plate | "Catering — estimate for 120 guests"    |
+| Rentals      | Guests × per-seat  | "Rentals — estimate for 120 guests"     |
+| Invitations  | Guests × per-card  | "Invitations — estimate for 120 guests" |
+
+- **Headcount is a couple's input** (a stepper / field). Changing it re-runs the
+  **shared estimator** and the UI re-renders; Compose performs no multiplication.
+- Every value carries an **"Estimate" badge** and a `contentDescription` that
+  says "estimated," distinct from committed/actual amounts (§4).
+- A **range affordance** (e.g., "100–140 guests") can show low/high estimates if
+  the shared estimator returns a band; the band is labeled, not implied.
+- Editing a per-unit estimate is a shared-model value; the row updates from
+  shared output.
+
+---
+
+## 6. Remaining Spend & Next Due Date
+
+A compact summary card answers _"how much is left, and what's next?"_
+
+- **Remaining wedding spend** = estimated total − actual paid, **computed in
+  `packages/core`** and labeled as including estimates where guest-count rows
+  contribute.
+- **Next due date** = the soonest unpaid installment across all vendors, from the
+  shared due-date bucket (`BillReminderEngine`). Shown as "Next: {vendor} due
+  {date}."
+- **Countdown context:** an optional "X days away" line, derived from the shared
+  bucket against the platform clock (not computed in Compose).
+- **Empty / paid:** if nothing is due, the card reads _"All caught up — no
+  payments due."_
+
+---
+
+## 7. Links to Shared Goals & Household Cash Flow
+
+The wedding is one part of the couple's finances; these views link out rather
+than duplicating those surfaces.
+
+- **Shared goal link:** a row shows the linked **wedding savings `Goal`** with
+  its shared `progress` (e.g., "Wedding fund — 62% funded"), deep-linking to the
+  existing goal surface. Progress is the shared `Goal.progress`, not recomputed.
+  See [android-goal-projection-widget.md](./android-goal-projection-widget.md)
+  for the projection pattern reused here.
+- **Household cash-flow link:** a row summarizes how upcoming wedding due dates
+  affect the household's **projected balance**, using
+  [`OperatingCashForecastEngine`](../../packages/core/src/commonMain/kotlin/com/finance/core/forecast/OperatingCashForecast.kt)
+  output, and deep-links to the
+  [operating cash calendar](./android-operating-cash-calendar.md). Any **threshold
+  breach** (projected shortfall) is surfaced as a labeled projection warning.
+- These links keep the wedding views thin — they **reference** shared
+  goal/cash-flow state instead of forking it.
+
+---
+
+## 8. Partner Privacy in Analytics
+
+Analytics aggregate money, so they must honor the same partner boundary as the
+shell (see
+[android-household-privacy-dashboard.md](./android-household-privacy-dashboard.md)).
+
+- **Aggregates respect scope:** budgeted-vs-actual and remaining-spend totals are
+  computed over the **partner-visible set** via `DataPartitioning.filterVisible`
+  — a partner never sees a total that includes amounts they aren't allowed to
+  see.
+- **Summary-only partners** see **bucketed ranges / percent** for goal and
+  cash-flow links, not exact figures.
+- **No private leakage in projections:** a Compose semantics test asserts a
+  partner-view projection never renders an exact amount the owner kept private.
+
+---
+
+## 9. Composable & ViewModel Structure
+
+| Composable               | Responsibility                                                 |
+| ------------------------ | -------------------------------------------------------------- |
+| `WeddingAnalyticsScreen` | Scaffold, summary card, sectioned analytics, live-region host  |
+| `BudgetVsActualSection`  | Per-category list with text-alternative progress bars (§4)     |
+| `GuestEstimateSection`   | Headcount stepper + estimate rows with "Estimate" badges (§5)  |
+| `RemainingSpendCard`     | Remaining spend + next due date summary (§6)                   |
+| `SharedGoalLinkRow`      | Wedding savings goal progress + deep link (§7)                 |
+| `CashFlowLinkRow`        | Household projection summary + deep link + breach warning (§7) |
+| `EstimateBadge`          | Reusable "Estimate" / "Projection" label with semantics        |
+
+- **ViewModel:** `WeddingAnalyticsViewModel` (Koin `viewModelOf`, resolved via
+  `koinViewModel()`), exposing one immutable `StateFlow<WeddingAnalyticsUiState>`
+  and delegating all arithmetic/projection to shared engines.
+- **Koin wiring (additions only):** `viewModelOf(::WeddingAnalyticsViewModel)`.
+- **Logging:** Timber only; **never log amounts, balances, or guest counts as
+  money** — log structural events as enum/boolean (e.g.
+  `Timber.d("analytics section expanded: %s", section.name)`); never `Log.*`.
+- **Charts:** any chart uses Material 3 tokens and ships a **text alternative /
+  data table** per [data-visualization.md](./data-visualization.md).
+
+---
+
+## 10. Accessibility (TalkBack, Switch Access, Font Scaling)
+
+Per [accessibility-patterns.md](./accessibility-patterns.md). All copy below is
+the `contentDescription` / `semantics` string.
+
+| Surface              | Visible UI              | TalkBack `contentDescription`                                                       |
+| -------------------- | ----------------------- | ----------------------------------------------------------------------------------- |
+| Budget-vs-actual row | "80% used"              | "Catering, 80 percent of budget used. Actual under budget."                         |
+| Over-budget row      | ⚠ "Over"                | "Venue, over budget. Actual exceeds the planned amount."                            |
+| Guest estimate row   | "Estimate · 120 guests" | "Catering, estimated for 120 guests. This is a projection, not a committed amount." |
+| Headcount stepper    | "120"                   | "Guest count, 120. Adjust to update estimates."                                     |
+| Remaining spend      | "$8,400 left"           | "Estimated remaining wedding spend, eight thousand four hundred dollars."           |
+| Next due             | "Next: Venue Jul 3"     | "Next payment, Venue, due July 3rd."                                                |
+| Cash-flow breach     | ⚠ "Tight in August"     | "Projected shortfall in August. This is a projection based on current plans."       |
+
+- **Headings:** each analytics section uses `semantics { heading() }`.
+- **Estimate vs actual:** the word "estimated"/"projection" is in the
+  `contentDescription` for every estimate, so non-visual users get the same
+  caveat sighted users see in the badge.
+- **Switch Access:** logical order summary → budget-vs-actual → estimates →
+  links; targets ≥ 48dp.
+- **200% font scaling:** rows and bars reflow; numbers never truncate — verified
+  via Compose preview + Paparazzi at large-font configs.
+- **No color-only signaling:** over/under and breach states pair icon + text with
+  color (WCAG 1.4.1).
+- **Live region:** changing headcount announces _"Estimates updated for {n}
+  guests."_
+
+---
+
+## 11. Offline, Empty & Error States
+
+- **Offline:** analytics read from the encrypted local store and recompute from
+  cached shared state; an offline chip announces _"Offline — figures may be a few
+  minutes old."_ Projections show their last-synced basis.
+- **Empty (no vendors/amounts):** budget-vs-actual shows "Add vendor amounts to
+  compare against budget"; estimate rows prompt for a guest count; remaining-spend
+  card invites entering a first amount.
+- **Empty (no guest count):** estimate rows show a single "Set guest count to
+  estimate catering, rentals, and invitations" prompt.
+- **Empty (no goal / no cash-flow data):** link rows offer to create a wedding
+  savings goal or open the cash calendar rather than showing a blank.
+- **Error (load/compute):** skeleton → retry row with an announced live-region
+  message; no raw stack traces; no sensitive data in messages.
+
+---
+
+## 12. Test Plan
+
+- **Unit (ViewModel):** budget-vs-actual variance mapping (over / under / on);
+  estimate rows reflect shared estimator output for changing headcount (UI does
+  no multiplication); remaining spend and next-due taken verbatim from shared
+  code; cash-flow breach surfaces when the engine reports one.
+- **Shared-rule parity:** golden test that rendered totals, per-guest estimates,
+  remaining spend, and projection labels equal the shared engines' output for the
+  same fixtures the web/shared suites use.
+- **Compose UI / semantics:** assert every estimate carries an "estimated/
+  projection" `contentDescription`; assert charts expose a text alternative;
+  assert partner-view aggregates never render a private exact amount.
+- **Paparazzi snapshots:** budget-vs-actual (over/under), estimate rows at two
+  headcounts, remaining-spend card, and link rows — at default and 200% font
+  scale, light/dark + dynamic color.
+- **Accessibility:** TalkBack walkthrough per §10; Switch Access order;
+  touch-target and contrast checks.
+- **Offline:** cached projections render with a stale-basis label; reconnect
+  recomputes without flicker or double-counting.
+
+---
+
+## 13. Implementation Readiness
+
+Per [`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md)
+§2 (Implementation vs. Distribution), this feature is **decoupled**: design and
+native implementation are buildable and testable now; only store distribution
+waits on #1242.
+
+### ✅ Buildable now (debug / free signing — no enrollment, no secrets)
+
+- This design doc and all shared-API consumption decisions.
+- All Compose UI, `WeddingAnalyticsViewModel`, and Koin wiring.
+- Unit tests, Compose semantics/UI tests, and Paparazzi snapshots.
+- Local verification via `./gradlew :apps:android:assembleDebug` + sideload, per
+  [`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md)
+  §2 "Free local build/test paths."
+- The **proposed guest-count estimator / planner rules** are a `packages/core`
+  change (owned by @kmp-engineer) — also unblocked; not store-gated.
+
+### 🔒 Distribution tail — gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+
+- Release signing with the production keystore.
+- Google Play Console upload / release-track promotion.
+- The signed-AAB release workflow and its CI secrets.
+
+These are **human-gated** and out of scope for SME agents — see the
+[Human-Gated Prerequisites Runbook](../ops/human-gated-prerequisites.md) §3.1.
+Until then the feature is fully exercisable via debug sideload.
+
+---
+
+## 14. Open Questions
+
+1. **Estimator band** — does the guest-count estimator return a single value or a
+   low/high band? The UI supports a labeled band if provided.
+2. **Budget source** — do wedding categories reuse the standard `Budget` rows, or
+   a wedding-scoped budget set? Either way Compose reads shared `Budget` data.
+3. **Cash-flow horizon** — what forecast horizon should the household cash-flow
+   link summarize for the wedding (to next due date, to wedding date)? A shared
+   default tracked under #2145.
+4. **Actual definition** — does "actual" count only paid installments, or also
+   committed-but-unpaid contracts? A shared rule, not a Compose choice.

--- a/docs/design/android-wedding-workspace-shell.md
+++ b/docs/design/android-wedding-workspace-shell.md
@@ -1,0 +1,407 @@
+# Android Shared Wedding Workspace Shell & Vendor Tracker — Design
+
+> **Status:** DESIGN — Implementation-ready (native build/test unblocked; store distribution gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242))
+> **Issue:** [#2645](https://github.com/jrmoulckers/finance/issues/2645) — _Part of [#2145](https://github.com/jrmoulckers/finance/issues/2145)_ (couples / life-event planning)
+> **Platform:** Android (Jetpack Compose · Material 3)
+> **Last Updated:** 2026-06-22
+
+This document specifies the **Wedding Workspace shell** and the **vendor /
+deposit tracker** for Android: a Jetpack Compose surface that a couple opens from
+**Planning**, seeds from a wedding **template**, and uses to track vendors,
+deposits, installment due dates, and balance states. It is the Android design
+counterpart to the existing web life-event wedding concept and **renders
+shared planner state computed in `packages/core`** — the Compose layer draws the
+workspace, it does not own the money math or the partner-visibility policy.
+
+Every shared figure here is a **projection / tracked actual**, not advice, and
+every partner-visible value flows through the household privacy boundary so an
+**invited partner sees what the workspace owner chose to share, in a read-only
+mode** by default.
+
+---
+
+## Table of Contents
+
+1. [Goals & Non-Goals](#1-goals--non-goals)
+2. [Architecture Boundary (Compose ↔ KMP)](#2-architecture-boundary-compose--kmp)
+3. [Grounding in Existing Code](#3-grounding-in-existing-code)
+4. [Navigation: Planning → Wedding Workspace](#4-navigation-planning--wedding-workspace)
+5. [Template Onboarding](#5-template-onboarding)
+6. [Vendor & Deposit Tracker](#6-vendor--deposit-tracker)
+7. [Vendor States: Empty, Overdue, Paid, Partially Paid](#7-vendor-states-empty-overdue-paid-partially-paid)
+8. [Partner Privacy & Read-Only States](#8-partner-privacy--read-only-states)
+9. [Composable & ViewModel Structure](#9-composable--viewmodel-structure)
+10. [Accessibility (TalkBack, Switch Access, Font Scaling)](#10-accessibility-talkback-switch-access-font-scaling)
+11. [Offline, Empty & Error States](#11-offline-empty--error-states)
+12. [Test Plan](#12-test-plan)
+13. [Implementation Readiness](#13-implementation-readiness)
+14. [Open Questions](#14-open-questions)
+
+---
+
+## 1. Goals & Non-Goals
+
+### Goals
+
+- Give a couple a single **Wedding Workspace** reachable from Planning, seeded
+  from a reusable **template** (catering, venue, photography, attire, rentals,
+  invitations, etc.).
+- Track each **vendor**: deposit paid, remaining balance, installment due dates,
+  and a clear **state** (empty / overdue / paid / partially paid).
+- Let an **invited partner** view the workspace **read-only** by default and
+  contribute only where the owner has granted edit, honoring the household
+  privacy boundary.
+- Reuse the existing web wedding life-event product behavior and **shared models
+  / engines** instead of duplicating business rules in Compose.
+- Make every state and amount legible to **TalkBack, Switch Access, and 200%
+  font scaling**, with non-color status cues.
+
+### Non-Goals
+
+- **No new money math in Compose.** Totals, remaining balances, due-date
+  bucketing, and projections come from `packages/core` (see §2–§3). A gap in
+  shared rules is a `packages/` task owned by @kmp-engineer, not a Compose
+  workaround.
+- **No actuals / cash-flow analytics here.** Budgeted-vs-actual, per-guest
+  estimates, and remaining-cash views are designed in the sibling doc
+  [Android Wedding Actuals & Cash-Flow Views](./android-wedding-actuals-cashflow.md)
+  ([#2647](https://github.com/jrmoulckers/finance/issues/2647)).
+- **No check-in ritual here.** The couples money check-in is
+  [Android Couples Money Check-In](./android-couples-money-checkin.md)
+  ([#2652](https://github.com/jrmoulckers/finance/issues/2652)).
+- **No store distribution work.** Release signing, Play Console upload, and the
+  release CI workflow stay gated by #1242 (see §13).
+- **No XML layouts, AlarmManager/JobScheduler, or secrets in SharedPreferences.**
+
+---
+
+## 2. Architecture Boundary (Compose ↔ KMP)
+
+The workspace is a **thin renderer of shared state**. The Compose layer owns
+layout, navigation, accessibility, and input affordances; the **shared layer in
+`packages/core` owns every monetary value, due-date bucket, and the
+partner-visibility decision**.
+
+```mermaid
+flowchart LR
+    subgraph Android [apps/android · Compose]
+        UI[WeddingWorkspaceScreen + VendorTracker]
+        VM[WeddingWorkspaceViewModel]
+    end
+    subgraph Shared [packages/core · KMP - source of truth]
+        PL[Wedding planner aggregate - proposed]
+        FA[FinancialAggregator]
+        BR[BillReminderEngine - due dates]
+        DP[DataPartitioning + RbacPermissions]
+    end
+    DB[(SQLDelight - SQLCipher)]
+    UI --> VM
+    VM -->|reads immutable UiState| PL
+    PL --> FA
+    PL --> BR
+    PL --> DP
+    PL --> DB
+```
+
+- The ViewModel exposes **one immutable `StateFlow<WeddingWorkspaceUiState>`**;
+  the screen collects it with `koinViewModel()`.
+- **All amounts are `Cents`/`Money` from shared code.** Compose never adds,
+  subtracts, or rounds money. It formats locale-aware strings for display only.
+- The **proposed shared "wedding planner aggregate"** (a thin `packages/core`
+  addition owned by @kmp-engineer) composes existing engines; this Android doc
+  consumes it and does not define it. Until it lands, the workspace renders an
+  empty/seed state.
+
+---
+
+## 3. Grounding in Existing Code
+
+The workspace composes capabilities that already exist in the shared layer or are
+a small, well-scoped addition to it.
+
+| Concern                       | Source of truth (do **not** reimplement in Compose)                                                                                                                                                                           | Today's state                                      |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| Vendor totals / remaining     | [`FinancialAggregator`](../../packages/core/src/commonMain/kotlin/com/finance/core/aggregation/FinancialAggregator.kt)                                                                                                        | Exists: totals, net cash flow, spend by category   |
+| Installment / due-date bucket | [`BillReminderEngine`](../../packages/core/src/commonMain/kotlin/com/finance/core/recurring/BillReminderEngine.kt)                                                                                                            | Exists: `scheduleNextN`, `generateMonthlyCalendar` |
+| Installment record analog     | [`LiabilityInstallment`](../../packages/models/src/commonMain/kotlin/com/finance/models/LiabilityInstallment.kt)                                                                                                              | Exists: due date + amount + paid model to mirror   |
+| Goal linkage (wedding fund)   | [`Goal`](../../packages/models/src/commonMain/kotlin/com/finance/models/Goal.kt)                                                                                                                                              | Exists: target/current/progress, `householdId`     |
+| Partner partition & roles     | [`DataPartitioning`](../../packages/core/src/commonMain/kotlin/com/finance/core/household/DataPartitioning.kt) + [`RbacPermissions`](../../packages/core/src/commonMain/kotlin/com/finance/core/household/RbacPermissions.kt) | Exists: `filterVisible`, `partition`, role gates   |
+| Web parity reference          | Web life-event wedding concept (reuse copy/semantics, do not fork)                                                                                                                                                            | Exists: product reference per #2645 notes          |
+| Wedding planner aggregate     | **Proposed** thin `packages/core` addition that composes the rows above                                                                                                                                                       | Not yet — @kmp-engineer follow-up under #2145      |
+
+> **Models** ([`Goal`](../../packages/models/src/commonMain/kotlin/com/finance/models/Goal.kt),
+> [`Budget`](../../packages/models/src/commonMain/kotlin/com/finance/models/Budget.kt))
+> already carry `householdId`/`ownerId`, so partner scoping is consistent with
+> the rest of the app. The vendor/deposit records the workspace reads are a
+> shared-model addition (owned by @kmp-engineer); Compose renders whatever the
+> shared layer exposes.
+
+---
+
+## 4. Navigation: Planning → Wedding Workspace
+
+The workspace is a destination under Planning, not a new top-level tab — it
+follows the app's existing information architecture (see
+[information-architecture.md](./information-architecture.md)).
+
+```mermaid
+flowchart TD
+    P[Planning hub] --> LE[Life events]
+    LE --> WT{Wedding workspace exists?}
+    WT -->|No| ON[Template onboarding]
+    WT -->|Yes| WS[Wedding workspace shell]
+    ON --> WS
+    WS --> VT[Vendor tracker]
+    WS --> AC[Actuals and cash flow - Issue 2647]
+    WS --> CI[Money check-in - Issue 2652]
+```
+
+- Entry point: a **"Plan a wedding"** card in the Planning life-events list.
+- The route is registered in the existing nav graph (`FinanceNavHost`), reusing
+  Planning's back stack — no parallel navigation tree.
+- Deep link `finance://planning/wedding` opens the workspace (or onboarding if
+  none exists), so notifications and the check-in flow can route into it.
+
+---
+
+## 5. Template Onboarding
+
+First open with no workspace shows a **template picker** that seeds a starter set
+of vendor categories. The template is **product copy + category seeds only** —
+amounts and dates stay empty until the couple enters them.
+
+- **Template choices:** _Classic_, _Intimate_, _Destination_, _Build my own_.
+  Each pre-creates vendor placeholders (e.g., Venue, Catering, Photography,
+  Attire, Flowers, Music, Rentals, Invitations).
+- **Couple basics (optional):** target date, who's invited as a partner, and an
+  optional link to a **wedding savings `Goal`** so progress is visible.
+- Seeding writes **placeholder vendor rows with zero amounts**; the couple fills
+  in deposits and balances later. No projection is shown until at least one
+  vendor has an amount.
+- A **"Skip template"** path lands directly on an empty tracker with an
+  add-vendor affordance.
+
+> Onboarding copy follows [content-language-guidelines.md](./content-language-guidelines.md)
+> and [cognitive-accessibility.md](./cognitive-accessibility.md): plain,
+> supportive, no jargon, one decision per step.
+
+---
+
+## 6. Vendor & Deposit Tracker
+
+The tracker is the workspace's core surface: a scrollable list of **vendor
+cards**, each summarizing the deposit, remaining balance, and next due date.
+
+| Field           | Meaning                                                  | Source                       |
+| --------------- | -------------------------------------------------------- | ---------------------------- |
+| Vendor name     | Free text (e.g., "Riverside Venue")                      | User input (shared model)    |
+| Category        | Venue / Catering / Photography / …                       | Template seed or user        |
+| Estimated total | What the couple expects to owe — **labeled "Estimate"**  | User input                   |
+| Deposit paid    | Amount already paid                                      | User input → shared total    |
+| Remaining       | Estimated total − paid — **computed in `packages/core`** | `FinancialAggregator`        |
+| Installments    | Optional schedule of due dates + amounts                 | `BillReminderEngine` buckets |
+| Next due date   | Soonest unpaid installment                               | Shared due-date bucket       |
+| State           | Empty / Overdue / Paid / Partially paid (§7)             | Derived in shared layer      |
+
+- **Data entry UX:** a bottom sheet (`VendorEditSheet`) with Material 3 fields;
+  amount entry uses the app's shared money input. Adding an installment opens an
+  inline date + amount row.
+- **Remaining balance is never computed in Compose.** The ViewModel reads the
+  shared `remaining` value; the card formats it.
+- **Quick actions:** mark a deposit paid, add an installment, or attach the
+  vendor to the wedding savings `Goal`.
+
+---
+
+## 7. Vendor States: Empty, Overdue, Paid, Partially Paid
+
+Each vendor card renders exactly one **state**, derived in the shared layer and
+surfaced with text + icon (never color alone — see
+[data-visualization.md](./data-visualization.md) on non-color cues).
+
+```mermaid
+stateDiagram-v2
+    [*] --> Empty
+    Empty --> PartiallyPaid: deposit recorded
+    PartiallyPaid --> Paid: balance cleared
+    PartiallyPaid --> Overdue: installment past due
+    Overdue --> PartiallyPaid: catch-up payment
+    Overdue --> Paid: balance cleared
+    Paid --> [*]
+```
+
+| State              | Visible cue                | Meaning                                               |
+| ------------------ | -------------------------- | ----------------------------------------------------- |
+| **Empty**          | "No amount yet" + outline  | Placeholder vendor, no estimate or deposit entered    |
+| **Partially paid** | "Deposit paid" + half ring | Some paid, balance remaining, no past-due installment |
+| **Overdue**        | ⚠ "Past due" + bold        | An installment due date has passed and is unpaid      |
+| **Paid**           | ✓ "Paid in full"           | Remaining balance is zero                             |
+
+- **Overdue** is determined by the shared due-date bucket against the device
+  clock passed in from the platform — Compose does not compute "past due."
+- Status order in the list: Overdue first, then Partially paid, then Empty, then
+  Paid (a shared-sorted list; UI honors it).
+
+---
+
+## 8. Partner Privacy & Read-Only States
+
+A wedding is a **shared life event**, but the workspace still respects the
+household privacy boundary defined in
+[android-household-privacy-dashboard.md](./android-household-privacy-dashboard.md).
+
+- **Owner vs invited partner:** the workspace owner can edit; an **invited
+  partner is read-only by default**. Edit grants come from `RbacPermissions`
+  (e.g., a `PARTNER` role with edit vs a `VIEWER`), never from a Compose flag.
+- **Read-only rendering:** when the viewer lacks edit, the edit sheet, quick
+  actions, and add-vendor FAB are **absent (not just disabled)**, and a banner
+  announces _"You're viewing {owner}'s wedding workspace."_
+- **Privacy-safe summaries:** if a vendor or the linked savings goal is shared as
+  a summary, the partner sees a **bucketed range / percent**, not exact amounts —
+  reusing the same masking the privacy dashboard documents.
+- **No leakage:** a Compose semantics test asserts no exact amount string appears
+  in a partner-view node when the shared policy says "summary only."
+
+---
+
+## 9. Composable & ViewModel Structure
+
+All UI is Jetpack Compose + Material 3 with dynamic color (Material You); no XML.
+
+| Composable               | Responsibility                                                        |
+| ------------------------ | --------------------------------------------------------------------- |
+| `WeddingWorkspaceScreen` | Scaffold, header summary, vendor list, FAB, snackbar/live-region host |
+| `TemplatePickerScreen`   | One-decision-per-step onboarding (§5)                                 |
+| `VendorCard`             | Per-vendor summary: estimate, deposit, remaining, next due, state     |
+| `VendorStateChip`        | Empty / Overdue / Paid / Partially-paid chip with merged semantics    |
+| `VendorEditSheet`        | Material 3 bottom sheet for entry (owner / edit-granted only)         |
+| `InstallmentRow`         | Inline due-date + amount row                                          |
+| `PartnerReadOnlyBanner`  | "Viewing {owner}'s workspace" notice for invited partners             |
+
+- **ViewModel:** `WeddingWorkspaceViewModel` (Koin `viewModelOf`, resolved via
+  `koinViewModel()`), exposing one immutable `StateFlow<WeddingWorkspaceUiState>`
+  and delegating every monetary/visibility decision to shared code.
+- **Koin wiring (additions only):** `viewModelOf(::WeddingWorkspaceViewModel)` —
+  reuses the existing household id provider, repositories, and aggregator.
+- **Logging:** Timber only. **Never log vendor names, amounts, or balances** —
+  log state transitions as enum names (e.g.
+  `Timber.d("vendor state -> %s", state.name)`), never `Log.*`.
+- **Theming:** Material 3 semantic tokens; no hard-coded hex.
+
+---
+
+## 10. Accessibility (TalkBack, Switch Access, Font Scaling)
+
+All copy below is the `contentDescription` / `semantics` string per
+[accessibility-patterns.md](./accessibility-patterns.md). `{owner}` /
+`{partner}` resolve to display names; amounts come from the locale-aware
+formatter.
+
+| Surface               | Visible UI       | TalkBack `contentDescription`                                              |
+| --------------------- | ---------------- | -------------------------------------------------------------------------- |
+| Vendor card (partial) | "Deposit paid"   | "{vendor}, partially paid. Deposit recorded, estimated balance remaining." |
+| Vendor card (overdue) | ⚠ "Past due"     | "{vendor}, payment past due. An installment due date has passed."          |
+| Vendor card (paid)    | ✓ "Paid in full" | "{vendor}, paid in full."                                                  |
+| Vendor card (empty)   | "No amount yet"  | "{vendor}, no amount entered yet. Double tap to add an estimate."          |
+| Next due date         | "Due Jul 3"      | "Next installment due July 3rd, estimated."                                |
+| Partner read-only     | banner           | "You're viewing {owner}'s wedding workspace. Editing is off for you."      |
+| Add vendor FAB        | "+" FAB          | "Add a wedding vendor."                                                    |
+
+- **Headings:** workspace section headers use `semantics { heading() }`.
+- **No double-announcement:** when the state chip already says "Overdue," the
+  amount node does not repeat it within the same focusable group.
+- **Switch Access:** logical focus order Overdue → Partial → Empty → Paid,
+  matching the shared sort; all targets ≥ 48dp.
+- **200% font scaling:** vendor cards reflow (wrap, never truncate amounts);
+  verified in Compose preview + Paparazzi at large-font configs.
+- **Live region:** marking a deposit paid announces _"{vendor} marked paid"_ via
+  a polite live region.
+- **Non-color cues:** every state pairs an icon + text with its color (WCAG
+  1.4.1).
+
+---
+
+## 11. Offline, Empty & Error States
+
+- **Offline:** the workspace is **offline-first** — vendor data reads from the
+  encrypted local SQLDelight store; edits queue and sync via WorkManager. An
+  offline chip announces _"Offline — changes will sync later."_
+- **Empty (no workspace):** template picker (§5).
+- **Empty (workspace, no vendors):** an illustration + "Add your first vendor"
+  with a single primary action; no projection shown.
+- **Empty (placeholders only):** vendors exist but no amounts → cards in the
+  Empty state; the header summary reads _"Add amounts to see your wedding
+  total."_
+- **Error (load):** skeleton cards → retry row with an announced live-region
+  message; no raw stack traces, no sensitive data in the message.
+- **Stale partner view:** if a partner's cached view is older than the owner's
+  last sync, a subtle "Last updated …" line sets expectations.
+
+---
+
+## 12. Test Plan
+
+- **Unit (ViewModel):** state mapping from shared planner output — Empty /
+  Partial / Overdue / Paid; sort order (Overdue first); partner read-only when
+  `RbacPermissions` denies edit; remaining balance taken verbatim from shared
+  code (no Compose-side arithmetic).
+- **Shared-rule parity:** a golden test asserts the rendered vendor states and
+  remaining balances equal the shared aggregate's output for the same fixtures
+  the web suite uses — proves the UI didn't fork business rules.
+- **Compose UI / semantics:** assert `contentDescription` on every card, chip,
+  amount, and the FAB; assert the edit sheet/FAB are **absent** for read-only
+  partners; assert no exact amount leaks into a summary-only partner node.
+- **Paparazzi snapshots:** each vendor state, plus owner vs partner read-only,
+  at default and 200% font scale, light/dark + dynamic color.
+- **Accessibility:** TalkBack walkthrough script per §10; Switch Access focus
+  order; touch-target and contrast checks.
+- **Offline:** edits made offline persist locally and reconcile on reconnect
+  (WorkManager sync), with no duplicate vendor rows.
+
+---
+
+## 13. Implementation Readiness
+
+Per [`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md)
+§2 (Implementation vs. Distribution), this feature is **decoupled**: design and
+native implementation are buildable and testable now; only store distribution
+waits on #1242.
+
+### ✅ Buildable now (debug / free signing — no enrollment, no secrets)
+
+- This design doc and all shared-API consumption decisions.
+- All Compose UI, `WeddingWorkspaceViewModel`, and Koin wiring.
+- Unit tests, Compose semantics/UI tests, and Paparazzi snapshots.
+- Local verification via `./gradlew :apps:android:assembleDebug` + sideload
+  ("Install unknown apps"), per
+  [`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md)
+  §2 "Free local build/test paths."
+- The **proposed wedding planner aggregate** is a `packages/core` change (owned
+  by @kmp-engineer) — also unblocked; not store-gated.
+
+### 🔒 Distribution tail — gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+
+- Release signing with the production keystore.
+- Google Play Console upload / release-track promotion.
+- The signed-AAB release workflow and its CI secrets.
+
+These are **human-gated** ($25 enrollment, identity verification, keystore
+generation, GitHub secret config) and out of scope for SME agents — see the
+[Human-Gated Prerequisites Runbook](../ops/human-gated-prerequisites.md) §3.1.
+Until then the feature is fully exercisable via debug sideload.
+
+---
+
+## 14. Open Questions
+
+1. **Vendor model location** — does the shared layer add a dedicated
+   `WeddingVendor` record, or reuse a generic life-event line item with an
+   installment child (mirroring `LiabilityInstallment`)? Compose renders either.
+2. **Wedding planner aggregate shape** — confirm the proposed `packages/core`
+   aggregate exposes pre-derived state + sort so all platforms render identical
+   vendor states.
+3. **Partner edit grants** — should "Ours" wedding workspaces default partners to
+   edit, or stay read-only until explicitly granted via `RbacPermissions`?
+4. **Goal linkage** — when a vendor is attached to a wedding savings `Goal`, do
+   deposits decrement the goal target view, or stay independent? Likely a shared
+   decision tracked under #2145.


### PR DESCRIPTION
## Summary

Design-docs-only batch for the Android couples / wedding planning cluster. Three
new docs under `docs/design/` specify the Compose surfaces while keeping all
finance/estimate/cash-flow math conceptually in KMP `packages/core` (the docs
describe the Compose-renders-shared-state boundary; nothing is implemented).
Shared/household data respects the privacy boundary between partners, and all
projections/estimates are explicitly labeled.

No native builds, signing, or store actions. New files only — no existing file,
package, app code, shared config, or other-platform doc is touched.

## Changes

- **`docs/design/android-wedding-workspace-shell.md`** (#2645) — Wedding
  workspace entry from Planning, template onboarding, vendor/deposit tracker,
  installment due dates, and empty / overdue / paid / partially-paid states, with
  read-only states for invited partners.
- **`docs/design/android-wedding-actuals-cashflow.md`** (#2647) — Budgeted-vs-
  actual, guest-count-sensitive estimate rows (catering / rentals / invitations),
  remaining spend + next due date, and links to shared goals and household
  cash-flow planning.
- **`docs/design/android-couples-money-checkin.md`** (#2652) — Opt-in weekly/
  monthly couples money check-in: setup, session, recap, and skip/reschedule
  states; prompt library (fun-money boundaries, joint account structure, wedding
  spend, upcoming shared expenses); collaborative, non-accusatory tone.

Each doc follows `docs/instructions/docs.instructions.md`: humans-first, ToC,
Mermaid diagrams, relative links to existing docs/source, accessibility
(TalkBack, Switch Access, 200% font), offline/empty/error states, a test plan
(unit / Compose / Paparazzi), and an "Implementation readiness" section linking
`../ops/human-gated-prerequisites.md` that splits buildable-now (`assembleDebug`
sideload) from the Play-distribution tail gated by #1242.

## Verification

- `npx prettier --check` passes on all three new files.
- All cross-linked design docs and `packages/` source paths verified to exist.
- No `#`-prefixed labels inside Mermaid fences.

Closes #2645
Closes #2647
Closes #2652
