### PR TITLE
docs(design): ios accessibility cues and low-noise migration design batch (#2550, #2554, #2581)

### DIFF
--- a/docs/design/ios-dynamic-type-layout-tests.md
+++ b/docs/design/ios-dynamic-type-layout-tests.md
@@ -1,0 +1,387 @@
+# Accessibility-Size Layout Tests for iOS Dynamic Type — Design
+
+> **Status:** PROPOSED — design only (no native build performed)
+> **Issue:** [#2550](https://github.com/jrmoulckers/finance/issues/2550) · Part of [#2119](https://github.com/jrmoulckers/finance/issues/2119)
+> **Platform:** iOS / iPadOS (SwiftUI) · Deployment target iOS 17.0
+> **Owner:** @ios-engineer
+> **Last updated:** 2026-06-22
+
+This document specifies the **automated test harness** that proves core finance
+surfaces stay readable and uncut at the largest Dynamic Type (accessibility)
+sizes — and catches regressions when they don't. It is the test counterpart to
+the layout work in the
+[Dynamic Type Reflow Audit](./ios-dynamic-type-reflow-audit.md): that doc says
+_what_ to reflow; this doc says _how we prove it stays reflowed_. It is
+design-only — the distribution tail is gated by Apple Developer enrollment
+([#1239](https://github.com/jrmoulckers/finance/issues/1239)); local build and
+test need no paid account.
+
+---
+
+## Table of Contents
+
+1. [Why this matters](#1-why-this-matters)
+2. [Scope — surfaces under test](#2-scope--surfaces-under-test)
+3. [The AX1–AX5 size matrix](#3-the-ax1ax5-size-matrix)
+4. [What "passing" means (assertions)](#4-what-passing-means-assertions)
+5. [Test layers](#5-test-layers)
+6. [Snapshot harness at AX sizes](#6-snapshot-harness-at-ax-sizes)
+7. [XCTest accessibility audits](#7-xctest-accessibility-audits)
+8. [Unit tests for the Dynamic Type primitives](#8-unit-tests-for-the-dynamic-type-primitives)
+9. [Privacy, balance hiding, and redaction under reflow](#9-privacy-balance-hiding-and-redaction-under-reflow)
+10. [Stale, error, and empty states](#10-stale-error-and-empty-states)
+11. [Shared dependencies and the KMP boundary](#11-shared-dependencies-and-the-kmp-boundary)
+12. [Smallest tests plan](#12-smallest-tests-plan)
+13. [CI integration](#13-ci-integration)
+14. [Implementation readiness](#14-implementation-readiness)
+15. [References](#15-references)
+
+---
+
+## 1. Why this matters
+
+A user who raises Larger Text to AX5
+(`accessibilityExtraExtraExtraLarge`) must still see the **whole** amount, payee,
+category, and chart summary — not "$1,2…" or a number shrunk below legibility.
+Clipping or auto-shrinking financial figures is both an accessibility failure
+(WCAG 2.2 — 1.4.4 Resize Text, 1.4.10 Reflow) and a correctness hazard: a
+truncated balance can be misread.
+
+The reflow fixes themselves are specified in
+[ios-dynamic-type-reflow-audit.md](./ios-dynamic-type-reflow-audit.md). The gap
+this doc closes is **durable, automated coverage**: today nothing fails CI when a
+new `lineLimit(1)` or hardcoded font sneaks back in. This design adds an
+AX-size snapshot matrix plus accessibility audits so a regression is caught
+before merge, not by a user at AX5.
+
+---
+
+## 2. Scope — surfaces under test
+
+The five surface clusters named in [#2550](https://github.com/jrmoulckers/finance/issues/2550),
+mapped to real files in `apps/ios/`:
+
+| Cluster                  | Primary view(s)                                                                                                                                                                                                                                                            | Why it is risk-prone at AX                        |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| **Dashboard**            | [`DashboardView.swift`](../../apps/ios/Finance/Screens/DashboardView.swift)                                                                                                                                                                                                | net-worth hero, 3-column summary, recent rows     |
+| **Transactions**         | [`TransactionsView.swift`](../../apps/ios/Finance/Screens/TransactionsView.swift) · [`TransactionRowView.swift`](../../apps/ios/Finance/Components/TransactionRowView.swift) · [`TransactionDetailView.swift`](../../apps/ios/Finance/Screens/TransactionDetailView.swift) | payee/category/amount collision in one row        |
+| **Analytics / Insights** | [`AnalyticsView.swift`](../../apps/ios/Finance/Screens/AnalyticsView.swift) · [`InsightsView.swift`](../../apps/ios/Finance/Screens/InsightsView.swift)                                                                                                                    | metric cards (`lineLimit(1)`), chart legends/axes |
+| **Reports**              | [`ReportBuilderView.swift`](../../apps/ios/Finance/Screens/ReportBuilderView.swift) · [`ReportResultView.swift`](../../apps/ios/Finance/Screens/ReportResultView.swift)                                                                                                    | grouped numeric tables, summary totals            |
+| **Investment detail**    | [`InvestmentDetailView.swift`](../../apps/ios/Finance/Screens/InvestmentDetailView.swift) · [`InvestmentPortfolioView.swift`](../../apps/ios/Finance/Screens/InvestmentPortfolioView.swift)                                                                                | metric grid, holding rows, performance chart      |
+
+Supporting components exercised through these surfaces — and therefore covered
+transitively — include
+[`CurrencyLabel.swift`](../../apps/ios/Finance/Components/CurrencyLabel.swift),
+[`ProgressRing.swift`](../../apps/ios/Finance/Components/ProgressRing.swift),
+[`BudgetProgressChart.swift`](../../apps/ios/Finance/Charts/BudgetProgressChart.swift),
+[`EmptyStateView.swift`](../../apps/ios/Finance/Components/EmptyStateView.swift),
+[`ErrorStateView.swift`](../../apps/ios/Finance/Components/ErrorStateView.swift),
+and [`OfflineBanner.swift`](../../apps/ios/Finance/Components/OfflineBanner.swift).
+
+---
+
+## 3. The AX1–AX5 size matrix
+
+SwiftUI exposes the size via `@Environment(\.dynamicTypeSize)` and the
+`dynamicTypeSize.isAccessibilitySize` flag. Tests drive the size either by
+injecting `.dynamicTypeSize(_:)` into a hosting view (unit/snapshot) or via the
+launch environment for UI tests:
+
+```swift
+app.launchEnvironment["UIPreferredContentSizeCategory"] =
+    "UICTContentSizeCategoryAccessibilityExtraExtraExtraLarge" // AX5
+```
+
+```mermaid
+flowchart LR
+    XS["xSmall"] --> M["Medium"] --> L["Large (default)"] --> XXXL["xxxLarge"]
+    XXXL --> AX1["AX1"] --> AX2["AX2"] --> AX3["AX3"] --> AX4["AX4"] --> AX5["AX5"]
+    style L fill:#1F6FEB,color:#fff
+    style AX1 fill:#0E8A16,color:#fff
+    style AX3 fill:#0E8A16,color:#fff
+    style AX5 fill:#0E8A16,color:#fff
+```
+
+The **size sampling strategy** keeps the suite fast while covering the failure
+boundary:
+
+| Tier           | Sizes run              | Where                                   | Rationale                                                      |
+| -------------- | ---------------------- | --------------------------------------- | -------------------------------------------------------------- |
+| **Boundary**   | `Large`, `AX5`         | every surface, every PR (required gate) | the default and the worst case catch ~all clipping regressions |
+| **Pivot**      | `xxxLarge`, `AX1`      | every surface, every PR                 | `AX1` is where `HStack → VStack` reflow first triggers         |
+| **Full sweep** | `AX1`–`AX5` (all five) | nightly / label `run-full-a11y`         | confirms monotonic behaviour across the accessibility band     |
+
+`AX1` and `AX5` are the two non-negotiable assertions: `AX1` is the reflow
+trip-point (`isAccessibilitySize` becomes true) and `AX5` is the maximum stress.
+
+---
+
+## 4. What "passing" means (assertions)
+
+A surface **passes** at a given size when all of the following hold:
+
+1. **No clipping / truncation of financial figures.** No amount renders with a
+   trailing ellipsis or is cut by its container. Text labels (payee, category,
+   insight, legend, security name) **wrap**; they do not truncate.
+2. **Pairs are stacked at AX.** Any `label ↔ value` row (summary columns, metric
+   cards, holding rows) is laid out vertically once `isAccessibilitySize` is
+   true — verified through the
+   [`AdaptiveFinanceStack`](../../apps/ios/Finance/Accessibility/DynamicTypeSupport.swift)
+   primitive choosing `VStack`.
+3. **Amounts shrink to a readable floor, never below.**
+   [`SizeConstrainedCurrencyText`](../../apps/ios/Finance/Accessibility/DynamicTypeSupport.swift)
+   clamps via `ClampedScaledMetric(min:max:)` rather than an open-ended
+   `minimumScaleFactor`.
+4. **Tap targets stay ≥ 44 pt** (scaled) per
+   [accessibility-patterns.md §8](./accessibility-patterns.md#8-touch-target-sizing).
+5. **The accessibility tree is unchanged by reflow.** The spoken label/value for
+   a row is identical at `Large` and `AX5` — layout changes, meaning does not
+   (the [#2544 contract](./ios-transaction-row-voiceover-labels.md#5-voiceover-label--value--trait-composition)).
+6. **`performAccessibilityAudit()` reports zero issues** of type `.textClipped`
+   / `.dynamicType` (see [§7](#7-xctest-accessibility-audits)).
+
+---
+
+## 5. Test layers
+
+Three layers, cheapest first — mirroring the pyramid in
+[ios-transaction-accessibility-regression.md §3](./ios-transaction-accessibility-regression.md#3-test-pyramid-for-accessibility):
+
+```mermaid
+flowchart TD
+    U["Layer 1 — unit / hosting<br/>primitive behaviour at injected sizes"] --> S["Layer 2 — snapshot<br/>render each surface at Large + AX1 + AX5"]
+    S --> A["Layer 3 — XCUITest audit<br/>performAccessibilityAudit() at AX5"]
+    style U fill:#0E8A16,color:#fff
+    style S fill:#1F6FEB,color:#fff
+    style A fill:#8250DF,color:#fff
+```
+
+- **Layer 1 (most tests):** pure/hosting tests of the Dynamic Type primitives —
+  fast, deterministic, no rendering of full screens ([§8](#8-unit-tests-for-the-dynamic-type-primitives)).
+- **Layer 2 (the core gate):** deterministic snapshots of each surface at a fixed
+  device size × the size tiers ([§6](#6-snapshot-harness-at-ax-sizes)).
+- **Layer 3 (semantic safety net):** running-app audits that flag clipped text
+  and missing semantics the snapshot eye might miss ([§7](#7-xctest-accessibility-audits)).
+
+---
+
+## 6. Snapshot harness at AX sizes
+
+Snapshots are the primary regression gate. Each surface is rendered from a
+**fixed fixture view model** (no network, no clock dependency) into a hosting
+controller, at a fixed device width, across the size tiers.
+
+```swift
+// Conceptual — render a surface deterministically at a chosen size.
+@MainActor
+func snapshot(_ view: some View, size: DynamicTypeSize, device: SnapshotDevice) -> UIImage {
+    let host = UIHostingController(
+        rootView: view
+            .environment(\.dynamicTypeSize, size)
+            .frame(width: device.width)
+    )
+    return host.renderImage() // deterministic; no animations
+}
+
+func testDashboardReflowAcrossSizes() {
+    let vm = DashboardViewModel.fixture(.populated) // stable fixture
+    for size in [.large, .accessibility1, .accessibility5] {
+        assertSnapshot(of: DashboardView(viewModel: vm), size: size, device: .iPhoneSE) // narrowest
+        assertSnapshot(of: DashboardView(viewModel: vm), size: size, device: .iPhone15Pro)
+    }
+}
+```
+
+Harness rules:
+
+- **Determinism first.** Fixtures are frozen — fixed amounts, fixed dates, fixed
+  category names, a fixed currency (`USD`) plus one long-name locale case
+  (e.g. a German payee) to exercise wrapping. No live data, no `Date()`.
+- **Narrowest device is mandatory.** iPhone SE (compact width) is the hardest
+  reflow case; every surface snapshots there at `AX5`.
+- **Tolerance is near-zero** for layout pixels but allows sub-pixel
+  antialiasing; reference images live beside the tests and are reviewed on diff.
+- **One image per (surface × size × device)** keeps failures legible — a diff
+  points to exactly which combination regressed.
+- **Previews mirror the snapshots.** Each reflowed view ships a
+  `.dynamicTypeSize(.accessibility5)` Xcode preview so authors see the worst case
+  while editing.
+
+> Snapshot tests need no paid signing — they run on the iOS Simulator. Where the
+> team prefers not to vendor reference images, the same fixtures feed the Layer 3
+> audit (which asserts _behaviour_, not pixels) as the required gate, with
+> snapshots as an advisory check.
+
+---
+
+## 7. XCTest accessibility audits
+
+`XCUIApplication.performAccessibilityAudit()` (Xcode 15+, iOS 17) is the
+semantic safety net. It surfaces `.textClipped`, `.dynamicType`,
+`.contrast`, `.hitRegion`, and `.elementDetection` issues automatically.
+
+```swift
+func testTransactionsNoClippingAtAX5() throws {
+    let app = XCUIApplication()
+    app.launchEnvironment["UIPreferredContentSizeCategory"] =
+        "UICTContentSizeCategoryAccessibilityExtraExtraExtraLarge"
+    app.launchEnvironment["FINANCE_FIXTURE"] = "transactions.populated"
+    app.launch()
+    app.tabBars.buttons["tab_transactions"].tap()
+
+    try app.performAccessibilityAudit(for: [.textClipped, .dynamicType, .hitRegion]) { issue in
+        // Allow nothing for text clipping on money surfaces.
+        return false // do not suppress — every reported issue fails the test
+    }
+}
+```
+
+- Run the audit for **Dashboard, Transactions, Analytics, Insights, Reports,
+  Investment detail** at `AX5` (the boundary tier).
+- The audit complements snapshots: snapshots catch _visual_ reflow, the audit
+  catches _semantic_ clipping and sub-minimum hit regions a static image can hide.
+- Audits reuse the same fixtures as the snapshots via `launchEnvironment`, so the
+  two layers test the same frozen data.
+
+---
+
+## 8. Unit tests for the Dynamic Type primitives
+
+The primitives that make reflow cheap already exist in
+[`DynamicTypeSupport.swift`](../../apps/ios/Finance/Accessibility/DynamicTypeSupport.swift).
+Lock their behaviour with fast, pure tests so the snapshot layer can trust them:
+
+1. **`ClampedScaledMetricTests`** — the wrapped value never drops below `min`
+   nor exceeds `max` across `xSmall → AX5`; the base value is returned at
+   `Large`.
+2. **`AdaptiveFinanceStackTests`** — host the view with an injected
+   `dynamicTypeSize`; assert it chooses `VStack` when `isAccessibilitySize`
+   (`AX1`–`AX5`) and `HStack` otherwise (`xSmall`–`xxxLarge`). The `AX1` boundary
+   is the critical assertion.
+3. **`SizeConstrainedCurrencyTextTests`** — the rendered font size is clamped at
+   the `min: 14, max: 52` bounds; the amount string is never altered (only its
+   size), and its `.accessibilityLabel` equals the formatted amount.
+4. **`FinanceTextStyleTests`** — every `FinanceTextStyle` resolves to a
+   Dynamic-Type-aware `Font.TextStyle` (no `.system(size:)` literal escapes the
+   enum).
+
+These are the **smallest** tests and the first to run; a primitive regression
+fails here before any screen is rendered.
+
+---
+
+## 9. Privacy, balance hiding, and redaction under reflow
+
+Layout tests must not weaken the privacy contract:
+
+- **Redaction placeholders reflow identically.** When amounts are hidden
+  (privacy mode / `.privacySensitive()`), the snapshot at `AX5` must show the
+  redaction placeholder occupying the **same reflowed slot** the real amount
+  would — no layout "jump" on reveal. A dedicated fixture
+  (`dashboard.privacyHidden`) snapshots the hidden state at `Large` and `AX5`.
+- **Hidden on screen ⇒ "Amount hidden" to VoiceOver.** The audit asserts that a
+  redacted figure is never re-exposed by reflow, upholding
+  [#2544 §9](./ios-transaction-row-voiceover-labels.md#9-privacy--balance-hiding).
+- **No financial values in test logs.** Snapshot/audit failures report the
+  surface, size, and device — never a balance. Test logging stays `.public`
+  metadata only, consistent with the `os.Logger` privacy rules.
+
+---
+
+## 10. Stale, error, and empty states
+
+Each surface has non-happy states that also reflow and must be covered:
+
+| State         | Fixture     | Assertion at AX5                                                                                                                    |
+| ------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Empty         | `*.empty`   | [`EmptyStateView`](../../apps/ios/Finance/Components/EmptyStateView.swift) title/message wrap, centered; CTA grows and stays ≥44pt. |
+| Error         | `*.error`   | [`ErrorStateView`](../../apps/ios/Finance/Components/ErrorStateView.swift) message wraps; Retry stays full-width, tappable.         |
+| Stale/offline | `*.offline` | [`OfflineBanner`](../../apps/ios/Finance/Components/OfflineBanner.swift) text wraps to two lines, not truncated.                    |
+| Loading       | `*.loading` | skeleton/`ProgressView` respects size; no fixed-height row clips its label.                                                         |
+
+Empty/error/offline fixtures snapshot at `Large` and `AX5` for at least the
+Dashboard and Transactions surfaces (the most-seen non-happy paths).
+
+---
+
+## 11. Shared dependencies and the KMP boundary
+
+- **All layout and test code is `apps/ios`-only.** No `packages/` change is
+  required or proposed; this is presentation-layer testing.
+- **Fixtures map from shared models.** Test view models hydrate from
+  `TransactionItem` / portfolio / report types that mirror `packages/models`
+  via the [Swift Export bridge](../../apps/ios/Finance/KMP/SwiftExportBridge.swift);
+  tests use the in-repo `Stub`/`Mock` repositories
+  ([`Repositories/Mocks`](../../apps/ios/Finance/Repositories/Mocks/)) so no
+  network or live KMP runtime is needed.
+- **Numeric/currency formatting stays shared**; only the _presentation_ is under
+  test here. Any shared-package change would go through an ADR with `@architect`.
+
+---
+
+## 12. Smallest tests plan
+
+The minimum acceptance gate, in dependency order:
+
+1. **Unit (Layer 1):** `ClampedScaledMetricTests`, `AdaptiveFinanceStackTests`
+   (the `AX1` boundary), `SizeConstrainedCurrencyTextTests` — fast, pure.
+2. **Audit (Layer 3):** `performAccessibilityAudit(for: [.textClipped,
+.dynamicType])` at `AX5` on the four highest-traffic surfaces — Dashboard,
+   Transactions, Analytics, Investment detail — **zero** reported issues.
+3. **Snapshot (Layer 2):** Dashboard + Transactions at `Large` and `AX5` on
+   iPhone SE (narrowest) — the two surfaces most prone to row collision.
+
+Reports and Insights join the snapshot/audit set in the same PR but the gate is
+green once (1)–(3) pass. The full `AX1`–`AX5` sweep runs nightly.
+
+---
+
+## 13. CI integration
+
+- Wire the unit + audit suites into the existing iOS test job invoked by
+  `node tools/agent-scripts/pre-push-check.js --fix`; they run on the Simulator
+  with `SWIFT_STRICT_CONCURRENCY = complete`.
+- The **required** PR gate is the boundary tier (`Large` + `AX5`) audits plus the
+  primitive unit tests — fast enough for every push.
+- The **full sweep** (`AX1`–`AX5`, multi-device snapshots) runs on a nightly
+  schedule and on PRs carrying a `run-full-a11y` label, keeping per-PR time low.
+- A failing snapshot/audit blocks merge; reference-image updates are an explicit,
+  reviewed diff (never auto-accepted).
+
+---
+
+## 14. Implementation readiness
+
+See [`docs/ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md)
+(§2 — implementation vs. distribution decoupling).
+
+**Buildable now (no human gate):**
+
+- The entire test harness — primitive unit tests, AX-size snapshots, and
+  `performAccessibilityAudit()` runs — is implementable today on the iOS
+  Simulator and a personal device using **free Personal Team** signing. No paid
+  enrollment is needed to write or run accessibility tests.
+
+**Gated by [#1239](https://github.com/jrmoulckers/finance/issues/1239):**
+
+- Only a **paid physical-device test matrix** under a distribution team, and
+  TestFlight/App Store delivery of the verified build, sit behind enrollment. The
+  test design and its local execution need none of these.
+
+No human-gated operation is required to implement or verify this test plan.
+
+---
+
+## 15. References
+
+- Companion design: [Dynamic Type Reflow Audit (#2548)](./ios-dynamic-type-reflow-audit.md)
+  — the layout changes these tests defend.
+- Sibling coverage: [Transaction Accessibility Regression (#2546)](./ios-transaction-accessibility-regression.md)
+  · [Transaction Row VoiceOver Labels (#2544)](./ios-transaction-row-voiceover-labels.md)
+- Related: [Semantic Non-Color Financial State Cues (#2552)](./ios-noncolor-financial-state-cues.md)
+  · [Apply Redundant Financial State Cues (#2554)](./ios-redundant-financial-state-cues.md)
+- Repo primitives: [`DynamicTypeSupport.swift`](../../apps/ios/Finance/Accessibility/DynamicTypeSupport.swift)
+  · [`AccessibilityModifiers.swift`](../../apps/ios/Finance/Accessibility/AccessibilityModifiers.swift)
+- Cross-platform: [Accessibility Patterns Library](./accessibility-patterns.md) — §5 Color & Contrast, §8 Touch Target Sizing
+  · [Cognitive Accessibility Mode](./cognitive-accessibility.md) · [Responsive Breakpoints](./responsive-breakpoints.md)
+- Standards: Apple HIG — Typography, Dynamic Type · WCAG 2.2 — 1.4.4 Resize Text, 1.4.10 Reflow

--- a/docs/design/ios-low-noise-accessibility-migration.md
+++ b/docs/design/ios-low-noise-accessibility-migration.md
@@ -1,0 +1,407 @@
+# Accessibility & Migration Plan for iOS Low-Noise Customization — Design
+
+> **Status:** PROPOSED — design only (no native build performed)
+> **Issue:** [#2581](https://github.com/jrmoulckers/finance/issues/2581) · Part of [#2122](https://github.com/jrmoulckers/finance/issues/2122)
+> **Platform:** iOS / iPadOS · WidgetKit · watchOS (SwiftUI, iOS 17+)
+> **Owner:** @ios-engineer
+> **Last updated:** 2026-06-22
+
+This document is the **accessibility and migration plan** that makes the
+already-designed module-visibility (low-noise) customization safe to ship:
+VoiceOver reading order, discoverability of the controls, how existing users are
+**migrated** to the new defaults, and the tests that prove **hiding a module
+never breaks navigation, deep links, Siri intents, widgets, or the watch**.
+
+It builds directly on — and does **not** re-specify — the foundational design in
+[ios-module-visibility-preferences.md](./ios-module-visibility-preferences.md)
+([#2577](https://github.com/jrmoulckers/finance/issues/2577)), which owns the
+preference store, the module catalog, the safe invariants, and the settings UI.
+**Read that first.** Where they overlap, that doc owns the model; this doc owns
+the migration rollout and the accessibility/navigation safety net. The named
+preset built on the same store is
+[ios-fire-minimalist-preset.md](./ios-fire-minimalist-preset.md), and the
+allocation surface that benefits from quieting is
+[ios-low-noise-etf-allocation.md](./ios-low-noise-etf-allocation.md).
+
+---
+
+## Table of Contents
+
+1. [Why this matters](#1-why-this-matters)
+2. [Scope & relationship to the visibility design](#2-scope--relationship-to-the-visibility-design)
+3. [The "hiding never breaks reachability" invariant](#3-the-hiding-never-breaks-reachability-invariant)
+4. [Navigation & deep-link survival](#4-navigation--deep-link-survival)
+5. [Siri intents, widgets, and the watch](#5-siri-intents-widgets-and-the-watch)
+6. [VoiceOver ordering & focus](#6-voiceover-ordering--focus)
+7. [Discoverability](#7-discoverability)
+8. [Default migration plan](#8-default-migration-plan)
+9. [Accessibility — Dynamic Type, Switch Control, Reduce Motion](#9-accessibility--dynamic-type-switch-control-reduce-motion)
+10. [Privacy](#10-privacy)
+11. [Empty, stale, error & reset states](#11-empty-stale-error--reset-states)
+12. [Smallest tests plan](#12-smallest-tests-plan)
+13. [Implementation readiness](#13-implementation-readiness)
+14. [Open questions](#14-open-questions)
+15. [References](#15-references)
+
+---
+
+## 1. Why this matters
+
+Letting people hide tabs, cards, and optional modules is a real
+cognitive-accessibility win — less noise, fewer numbers competing for attention
+(per [cognitive-accessibility.md](./cognitive-accessibility.md)). But hiding is
+**dangerous if it can strand a user**: a hidden tab must not break a deep link to
+that screen, a Siri "show my budget" must not dead-end, and VoiceOver must read
+the quieter layout in a sensible order. This plan specifies the guardrails and
+the migration so the feature quiets the UI **without ever removing access**.
+
+---
+
+## 2. Scope & relationship to the visibility design
+
+```mermaid
+flowchart LR
+    Base["ios-module-visibility-preferences.md (2577)<br/>store, catalog, invariants, settings UI"] --> This["THIS doc (2581)<br/>migration + a11y + navigation safety"]
+    This --> Nav["Deep links & navigation survival"]
+    This --> AX["VoiceOver order + discoverability"]
+    This --> Mig["Default migration of existing users"]
+    This --> Test["Tests: hidden != unreachable"]
+    Base --> Preset["ios-fire-minimalist-preset.md (2580)"]
+```
+
+**In scope here:** VoiceOver ordering and focus in the quieted UI;
+discoverability of the low-noise controls; the migration of existing installs to
+the new defaults; and the test matrix proving hidden modules stay reachable.
+
+**Out of scope (owned by [#2577](./ios-module-visibility-preferences.md)):** the
+`ModuleVisibilityStore` actor, the `ModuleVisibilityViewModel`, the catalog,
+non-hideable invariants, App-Group persistence, and the settings screen
+structure. **Also out of scope:** reordering modules, per-household preferences,
+and any shared backend schema.
+
+---
+
+## 3. The "hiding never breaks reachability" invariant
+
+The single rule that governs every section below:
+
+> **Hiding quiets _chrome_, never _capability_.** A hidden module's screens stay
+> in the navigation graph and remain reachable by deep link, Siri, search, and
+> Settings. Hiding changes what is _shown by default_, not what _exists_.
+
+This restates and operationalizes the
+[#2577 safe invariants](./ios-module-visibility-preferences.md#3-the-module-catalog--safe-invariants):
+Dashboard / Accounts / Transactions tabs always remain, Settings is always
+reachable, you cannot hide every dashboard card, and **hiding never deletes
+data**. This doc adds the navigation-layer corollaries (§4–§5) and the
+accessibility/migration work to uphold them.
+
+---
+
+## 4. Navigation & deep-link survival
+
+The deep-link surface is
+[`DeepLinkHandler.swift`](../../apps/ios/Finance/Navigation/DeepLinkHandler.swift),
+whose `AppDeepLink` enum already routes `account(id:)`, `transaction(id:)`,
+`budgetCategory(id:)`, `quickEntry`, `clipExpense`, and `invite`. A hidden module
+must not change resolution:
+
+| Link / entry                              | If the target module is hidden                                                                                  |
+| ----------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `…/budget/{id}` → `budgetCategory(id:)`   | Resolves and presents the budget detail **even if the Budgets tab is hidden** — push onto a present-able stack. |
+| `…/transaction/{id}` → `transaction(id:)` | Always resolves (Transactions is a non-hideable core tab).                                                      |
+| `…/account/{id}` → `account(id:)`         | Always resolves (Accounts is a non-hideable core tab).                                                          |
+| Quick-entry / clip-expense                | Resolves regardless of dashboard quick-action visibility — the action is a route, not a card.                   |
+| Spotlight / Handoff into a hidden module  | Resolves; the destination is presented even though its tab/card is hidden.                                      |
+
+**Mechanism:** because tabs are filtered from `Tab.allCases` at render time
+([#2577 §6](./ios-module-visibility-preferences.md#6-applying-visibility-across-surfaces)),
+the destination views still exist in the navigation graph. A deep link to a
+hidden tab resolves by **presenting the destination on the nearest visible
+stack** (e.g., push the budget detail onto the Dashboard's `NavigationStack`, or
+present it as a sheet) rather than selecting a non-existent tab.
+
+```mermaid
+flowchart TD
+    L["Deep link / Siri / Spotlight"] --> R["DeepLinkHandler.handle(url)"]
+    R --> Q{"Target module visible?"}
+    Q -->|Yes| T["Select its tab / scroll to its card"]
+    Q -->|No| P["Present destination on nearest visible stack<br/>(push or sheet) — never a dead end"]
+    P --> Opt["Optional gentle prompt:<br/>This module is hidden. Show it in Settings?"]
+```
+
+**Edge rule:** if a deep link is the _only_ way a user reached a hidden module,
+offer a non-blocking, dismissible prompt ("This area is hidden — show it again in
+Settings?") that links to the visibility screen. The content is **never** blocked
+behind that prompt.
+
+---
+
+## 5. Siri intents, widgets, and the watch
+
+Capability extends beyond on-screen chrome:
+
+- **App Intents / Siri** ([`Finance/Intents`](../../apps/ios/Finance/Intents/)):
+  `BudgetStatusIntent`, `ShowBalanceIntent`, `GoalProgressIntent`,
+  `SpendingSummaryIntent`, etc. continue to answer **even when their module is
+  hidden** — "what's my budget?" works with a hidden Budgets tab. Hiding affects
+  the app's visual surface, not the Shortcuts/Siri vocabulary. (If a future
+  preference should _also_ trim Siri suggestions, that is an explicit, separate
+  toggle — never an implicit side effect of hiding a tab.)
+- **Widgets** ([`apps/ios/FinanceWidget`](../../apps/ios/FinanceWidget/)): the
+  App-Group visibility flags are mirrored by
+  [`WidgetDataWriter`](../../apps/ios/Finance/Services/WidgetDataWriter.swift) so a
+  widget for a hidden module shows a neutral "Hidden in app" placeholder rather
+  than stale data, per
+  [#2577 §6](./ios-module-visibility-preferences.md#6-applying-visibility-across-surfaces).
+  A user who explicitly adds such a widget keeps it (their choice overrides the
+  quiet default).
+- **watchOS** ([`apps/ios/FinanceWatch`](../../apps/ios/FinanceWatch/)): the same
+  flags reach the watch via
+  [`WatchDataSender`](../../apps/ios/Finance/Services/WatchDataSender.swift);
+  complications for a hidden module degrade gracefully (placeholder), never crash
+  or show stale figures.
+
+---
+
+## 6. VoiceOver ordering & focus
+
+Quieting the UI changes the element tree, so reading order must stay coherent:
+
+- **Reading order matches visual order.** After cards/tabs are filtered, the
+  remaining elements must read top-to-bottom, left-to-right with no gaps or
+  phantom stops for hidden views. Hidden views are removed from the hierarchy
+  (`if visible { … }`), not merely `.opacity(0)` — so VoiceOver never lands on an
+  invisible element.
+- **No empty headers.** When a section's only content is hidden, its header is
+  removed too (e.g., an empty "More" grid hides its label), so VoiceOver does not
+  announce an empty group.
+- **Focus preservation on toggle.** Toggling visibility in Settings keeps focus
+  on the toggle just changed; returning to the Dashboard places focus on the
+  first visible heading, not on a now-removed card's old position.
+- **Section headers carry `.isHeader`** and the rotor's Headings list reflects
+  only visible sections, so rotor navigation stays useful in the quieted layout.
+- **Announce material change.** When a module is hidden/shown, post a concise
+  live-region announcement ("Reports hidden") via
+  [`announceForAccessibility`](../../apps/ios/Finance/Accessibility/AccessibilityModifiers.swift)
+  so a VoiceOver user knows the layout changed.
+- **The minimised-dashboard prompt is focusable.** If every optional card is
+  hidden, the "Your dashboard is minimised — adjust in Settings" prompt
+  ([#2577 §3](./ios-module-visibility-preferences.md#3-the-module-catalog--safe-invariants))
+  is a real, focusable control linking back to the visibility screen.
+
+---
+
+## 7. Discoverability
+
+A quieting feature is only safe if the user can always find their way back:
+
+- **One stable entry point.** A single "Low-Noise / Modules" `NavigationLink` in
+  [`SettingsView`](../../apps/ios/Finance/Screens/SettingsView.swift)'s
+  appearance/general area, mirroring the existing `@AppStorage`-backed
+  [`AppearanceSettingsView`](../../apps/ios/Finance/Screens/AppearanceSettingsView.swift)
+  pattern — no new top-level surface.
+- **Settings is non-hideable** (a §3 invariant), so the path back is always
+  present.
+- **Re-entry from the minimised state.** The minimised-dashboard prompt and the
+  optional deep-link prompt (§4) both link straight to the visibility screen.
+- **Calm, non-judgemental copy** per
+  [content-language-guidelines.md](./content-language-guidelines.md): "Show /
+  Hide", "Hidden", never "Disable / Removed".
+- **Searchable.** The Settings row label is localized so it surfaces in Settings
+  search, and (optionally) an App Shortcut phrase like "show hidden modules" can
+  route to it — a discoverability aid, not a requirement.
+
+---
+
+## 8. Default migration plan
+
+How existing installs move onto the feature without surprise:
+
+```mermaid
+flowchart TD
+    A["App update installed"] --> B{"Stored visibility prefs exist?"}
+    B -->|No (existing or new user)| C["Seed defaults = ALL VISIBLE<br/>(safe default, zero behaviour change)"]
+    B -->|Yes (re-launch)| D["Load stored flags"]
+    C --> E["No screen changes; feature is opt-in via Settings"]
+    D --> E
+    E --> F{"User opens Low-Noise settings?"}
+    F -->|Yes| G["They hide modules; choices persist + mirror to App Group"]
+    F -->|No| H["Nothing changes — silent, safe"]
+```
+
+Principles:
+
+- **Safe default = everything visible.** First launch after the update seeds the
+  store with all modules visible, so **no existing user sees anything disappear**.
+  The feature is strictly opt-in.
+- **Idempotent, versioned seed.** The seed runs once, keyed by a stored schema
+  version, so a re-launch never re-seeds over a user's choices. A future catalog
+  addition (a new hideable module) defaults the **new** key to visible while
+  preserving existing choices — additive, never destructive.
+- **Forward-compatible flags.** Unknown module ids in the persisted map are
+  ignored (per the
+  [#2577 bridge test](./ios-module-visibility-preferences.md#11-test-plan--smallest-tests-first)),
+  so a downgrade/upgrade never corrupts state.
+- **Fail safe = show.** Any read/write failure resolves to "visible" so a bug can
+  never make a module unreachable (mirrors
+  [#2577 §10](./ios-module-visibility-preferences.md#10-empty-stale-error--reset-states)).
+- **Reset is reversible.** "Reset to defaults" rewrites flags to all-visible and
+  touches **no data**.
+- **Cross-surface consistency.** On migration, the App-Group mirror is written so
+  widgets/watch agree with the app from first launch — no transient "hidden on
+  phone, shown on watch" mismatch.
+
+---
+
+## 9. Accessibility — Dynamic Type, Switch Control, Reduce Motion
+
+- **Dynamic Type:** the settings `Form` and all quieted surfaces scale through
+  AX1–AX5; toggle rows and module descriptions **wrap, never truncate**
+  ([#2577 §8](./ios-module-visibility-preferences.md#8-dynamic-type)). This reuses
+  the AX-size harness from
+  [ios-dynamic-type-layout-tests.md](./ios-dynamic-type-layout-tests.md) — the
+  minimised dashboard and the settings screen are added to that snapshot set.
+- **Switch Control / Full Keyboard Access:** every toggle, the reset button, the
+  Settings entry row, and the minimised-dashboard prompt are real focusable
+  controls — nothing is gesture-only.
+- **Reduce Motion:** hiding/showing a module cross-fades or swaps statically; no
+  card "slides away" sweep when `accessibilityReduceMotion` is on.
+- **No surprise removal:** hiding a module never silently removes an
+  accessibility-relied-upon control elsewhere without the user's explicit action
+  on the visibility screen.
+
+---
+
+## 10. Privacy
+
+- **Preferences are non-sensitive UI state** — module on/off flags only, no
+  balances, no PII. They live in App-Group `UserDefaults`, **never Keychain**
+  (Keychain is reserved for secrets), per
+  [#2577 §9](./ios-module-visibility-preferences.md#9-privacy).
+- **Privacy-aware logging:** log only `.public` events via `os.Logger` —
+  "module hidden", "module shown", "visibility reset", "migration seeded" — by
+  module id, never any financial value. Never `print()`.
+- **Hiding is not a privacy control.** Hiding a module does not redact its data
+  to onlookers; balance hiding remains the separate privacy-mode feature. The
+  visibility copy avoids implying otherwise.
+
+---
+
+## 11. Empty, stale, error & reset states
+
+| State                   | Trigger                                  | Behaviour                                                                                                              |
+| ----------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| **First run / migrate** | No stored prefs after update             | Seed all-visible; zero UI change; feature opt-in.                                                                      |
+| **All hidden**          | User hides every optional dashboard card | Net-worth hero stays, or the focusable "minimised — adjust in Settings" prompt; never a blank screen.                  |
+| **Deep link to hidden** | Link/Siri targets a hidden module        | Destination presented on nearest visible stack; optional non-blocking "show it again?" prompt; content never withheld. |
+| **Stale / widget**      | Widget reads cached flags                | Honours last-known visibility; hidden module's widget shows neutral "Hidden in app" placeholder, not stale data.       |
+| **Store error**         | App-Group read/write fails               | Fall back to **all visible** (fail safe); log `.public` error; everything stays reachable.                             |
+| **Reset**               | "Reset to defaults" confirmed            | All modules visible again; brief non-judgemental confirmation; **no data touched**.                                    |
+
+---
+
+## 12. Smallest tests plan
+
+Smallest/shared first; the navigation-survival tests are the heart of this doc.
+
+### 12.1 Shared (KMP) — verify parity, not re-implemented here
+
+- Reuse the `ModuleVisibilityRulesTest` parity tests from
+  [#2577 §11.1](./ios-module-visibility-preferences.md#11-test-plan--smallest-tests-first)
+  (catalog, invariants, default-visible). No new shared logic is introduced here;
+  any addition would go via **ADR to @kmp-engineer**.
+
+### 12.2 iOS unit (XCTest, `apps/ios/Tests/`)
+
+1. **`MigrationSeedTests`** — first run with no stored prefs seeds all-visible;
+   the seed is idempotent (a re-run does not overwrite user choices); a corrupt /
+   missing value falls back to defaults; a newly added catalog key defaults
+   visible while preserving existing flags.
+2. **`DeepLinkVisibilityTests`** — `DeepLinkHandler.handle` resolves
+   `budgetCategory(id:)`, `transaction(id:)`, `account(id:)`, and quick-entry to
+   the same destination **regardless of visibility flags**; a hidden-tab target
+   still yields a presentable route (never `.unknown`, never nil).
+3. **`IntentVisibilityTests`** — `BudgetStatusIntent` / `ShowBalanceIntent` /
+   `GoalProgressIntent` return their answer with the corresponding module hidden.
+4. **`VoiceOrderTests`** (pure where possible) — given a visibility map, the
+   computed ordered list of dashboard sections has no gaps and no empty headers;
+   the all-hidden case yields the net-worth hero / minimised prompt element.
+
+### 12.3 iOS UI / a11y (`apps/ios/Tests/UITests/`)
+
+5. **`HiddenModuleReachabilityUITests`** — hide "Budgets"; launch a
+   `…/budget/{id}` deep link; assert the budget detail is presented and
+   focusable; **VoiceOver** reads the quieted Dashboard in visual order with no
+   phantom stops; the optional "show again" prompt is reachable; **Reset**
+   restores all modules and the hidden module's data is intact.
+6. **AX-size snapshot** — the minimised Dashboard and the Low-Noise settings
+   screen render at `Large` and `AX5` without truncation, via the
+   [layout-test harness](./ios-dynamic-type-layout-tests.md#6-snapshot-harness-at-ax-sizes).
+
+### 12.4 Gate
+
+`node tools/agent-scripts/pre-push-check.js --fix` (lint + strict concurrency)
+plus the suites above. `SWIFT_STRICT_CONCURRENCY = complete`: the store is an
+`actor`, DTOs `Sendable`, UI state `@MainActor` (per the #2577 model). The
+minimum gate: `MigrationSeedTests` + `DeepLinkVisibilityTests` green (migration
+is safe **and** hidden modules stay reachable).
+
+---
+
+## 13. Implementation readiness
+
+See [`docs/ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md)
+(§2 — implementation vs. distribution decoupling).
+
+**Buildable now (no human gate):**
+
+- The migration seed, deep-link/intent survival, VoiceOver ordering, and all
+  unit/UI tests are implementable today on the iOS Simulator and a personal
+  device using **free Personal Team** signing. The feature is local preferences +
+  navigation routing — no paid enrollment, no entitlements required.
+
+**Gated by [#1239](https://github.com/jrmoulckers/finance/issues/1239):**
+
+- Only TestFlight / App Store distribution of the migrated build and any paid
+  physical-device matrix sit behind enrollment. Migration and accessibility work
+  need none of these. (Universal Links via Associated Domains is a separate
+  entitlement noted in the prerequisites runbook; in-app `AppDeepLink` routing —
+  what this plan tests — works locally without it.)
+
+No human-gated operation is required to implement or verify this plan.
+
+---
+
+## 14. Open questions
+
+- **Should hiding optionally trim Siri suggestions?** Default: **no** — hiding is
+  visual only. A separate explicit toggle could trim suggestions later; tracked,
+  not assumed.
+- **Preference sync across devices?** v1 is local + App Group; a "sync my layout"
+  capability is a separate shared-schema decision via ADR, not assumed here.
+- **Onboarding nudge?** Whether to surface the low-noise option during onboarding
+  vs. discovery-only in Settings — deferred to UX, default is discovery-only to
+  avoid adding onboarding noise.
+
+---
+
+## 15. References
+
+- Foundation: [iOS Module Visibility Preferences / Low-Noise Mode (#2577)](./ios-module-visibility-preferences.md)
+  — the store, catalog, invariants, and settings UI this plan migrates and hardens.
+- Built on the same store: [iOS FIRE Minimalist Preset (#2580)](./ios-fire-minimalist-preset.md)
+  · [iOS Low-Noise ETF Allocation Views](./ios-low-noise-etf-allocation.md)
+- Accessibility companions: [AX-Size Layout Tests (#2550)](./ios-dynamic-type-layout-tests.md)
+  · [Dynamic Type Reflow Audit (#2548)](./ios-dynamic-type-reflow-audit.md)
+- Cross-platform: [Accessibility Patterns Library](./accessibility-patterns.md)
+  · [Cognitive Accessibility Mode](./cognitive-accessibility.md)
+  · [Information Architecture](./information-architecture.md)
+  · [UX Principles](./ux-principles.md) · [Content & Language Guidelines](./content-language-guidelines.md)
+- Repo surfaces: [`DeepLinkHandler.swift`](../../apps/ios/Finance/Navigation/DeepLinkHandler.swift)
+  · [`MainTabView.swift`](../../apps/ios/Finance/Navigation/MainTabView.swift)
+  · [`SettingsView.swift`](../../apps/ios/Finance/Screens/SettingsView.swift)
+  · [`WidgetDataWriter.swift`](../../apps/ios/Finance/Services/WidgetDataWriter.swift)
+  · [`WatchDataSender.swift`](../../apps/ios/Finance/Services/WatchDataSender.swift)
+  · [`Finance/Intents`](../../apps/ios/Finance/Intents/)
+- Standards: Apple HIG — Navigation, Accessibility · WCAG 2.2 — 2.4.3 Focus Order, 3.2.3 Consistent Navigation

--- a/docs/design/ios-redundant-financial-state-cues.md
+++ b/docs/design/ios-redundant-financial-state-cues.md
@@ -1,0 +1,415 @@
+# Apply Redundant Financial State Cues Across iOS Screens — Design
+
+> **Status:** PROPOSED — design only (no native build performed)
+> **Issue:** [#2554](https://github.com/jrmoulckers/finance/issues/2554) · Part of [#2121](https://github.com/jrmoulckers/finance/issues/2121)
+> **Platform:** iOS · iPadOS · watchOS · WidgetKit · App Clip (SwiftUI, iOS 17+)
+> **Owner:** @ios-engineer
+> **Last updated:** 2026-06-22
+
+This document is the **rollout plan** for redundant, non-color financial state
+cues — the work of actually applying them to
+[`CurrencyLabel`](../../apps/ios/Finance/Components/CurrencyLabel.swift), the
+Dashboard, investment models/views, Analytics, and
+[`BudgetProgressChart`](../../apps/ios/Finance/Charts/BudgetProgressChart.swift)
+so every state is **visible and spoken without relying on color**.
+
+It does **not** redefine the cue vocabulary — the semantic model (states,
+text + symbol + shape + token channels, the grayscale acceptance bar) is fully
+specified in
+[ios-noncolor-financial-state-cues.md](./ios-noncolor-financial-state-cues.md)
+([#2552](https://github.com/jrmoulckers/finance/issues/2552)). **Read that first;
+this doc applies it.** Where the two could drift, the spec wins and this doc is
+the per-screen adoption checklist.
+
+---
+
+## Table of Contents
+
+1. [Why this matters](#1-why-this-matters)
+2. [Relationship to the cue spec](#2-relationship-to-the-cue-spec)
+3. [Current state — where color is the only signal](#3-current-state--where-color-is-the-only-signal)
+4. [The shared application pattern](#4-the-shared-application-pattern)
+5. [Per-screen rollout](#5-per-screen-rollout)
+   - [5.1 CurrencyLabel](#51-currencylabel)
+   - [5.2 Dashboard](#52-dashboard)
+   - [5.3 Investment models & views](#53-investment-models--views)
+   - [5.4 Analytics & Insights](#54-analytics--insights)
+   - [5.5 BudgetProgressChart](#55-budgetprogresschart)
+6. [Accessibility — VoiceOver, Dynamic Type, Reduce Motion](#6-accessibility--voiceover-dynamic-type-reduce-motion)
+7. [Privacy & balance hiding](#7-privacy--balance-hiding)
+8. [Stale, error, and empty states](#8-stale-error-and-empty-states)
+9. [Shared dependencies and the KMP boundary](#9-shared-dependencies-and-the-kmp-boundary)
+10. [Rollout sequencing](#10-rollout-sequencing)
+11. [Smallest tests plan](#11-smallest-tests-plan)
+12. [Implementation readiness](#12-implementation-readiness)
+13. [References](#13-references)
+
+---
+
+## 1. Why this matters
+
+The app today signals positive vs. negative money mostly by **color** — green
+gain, red loss, red over-budget. That fails
+[accessibility-patterns.md §5.3 — Never Convey Information by Color
+Alone](./accessibility-patterns.md#53-never-convey-information-by-color-alone)
+for the ~8% of users with a color-vision deficiency (red/green is the worst
+pairing), for grayscale / Always-On / e-ink rendering, and for high-glare
+outdoor use. The fix is to make **every** state recoverable from **text + icon +
+shape**, with color as a redundant reinforcement only. This doc carries that fix
+into the concrete screens called out in
+[#2554](https://github.com/jrmoulckers/finance/issues/2554).
+
+---
+
+## 2. Relationship to the cue spec
+
+```mermaid
+flowchart LR
+    Spec["ios-noncolor-financial-state-cues.md (2552)<br/>vocabulary: states, channels, tokens"] --> This["THIS doc (2554)<br/>apply to real screens"]
+    This --> CL["CurrencyLabel"]
+    This --> DB["Dashboard"]
+    This --> INV["Investment models / views"]
+    This --> AN["Analytics / Insights"]
+    This --> BP["BudgetProgressChart"]
+```
+
+The spec defines the **what**; this doc owns the **where and in what order**. The
+single new presentation type it proposes — a `FinancialStateCue` value plus a
+`stateCue(_:)` view modifier living under
+[`Finance/Components`](../../apps/ios/Finance/Components/) — is described in the
+spec ([§5](./ios-noncolor-financial-state-cues.md#5-affected-ios-surfaces)) and
+is **the** vehicle each screen below adopts. It is not re-specified here.
+
+---
+
+## 3. Current state — where color is the only signal
+
+Concrete, color-only signalling confirmed by reading the code today:
+
+| File                                                                                   | Color-only signal                                                                                        | Target state                                                            |
+| -------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| [`CurrencyLabel.swift`](../../apps/ios/Finance/Components/CurrencyLabel.swift)         | `amountColor` returns literal `.green` / `.red` by sign; no on-screen sign glyph or icon                 | sign glyph + direction symbol + semantic token; spoken "income/expense" |
+| [`BudgetProgressChart.swift`](../../apps/ios/Finance/Charts/BudgetProgressChart.swift) | over-budget ring uses literal `AnyShapeStyle(Color.red)`; safe uses a palette color — only color differs | shape-distinct status symbol + fill pattern + numeric % + token         |
+| [`InvestmentModels.swift`](../../apps/ios/Finance/Models/InvestmentModels.swift)       | `AssetClassUI.color` carries class identity by hue; gain/loss deltas rely on red/green                   | direction arrow + signed value; legend pairs swatch with label/symbol   |
+| `AnalyticsView` / `InsightsView`                                                       | trend up/down and over/under bands distinguished by color                                                | arrow direction + signed delta text + non-color band hatch              |
+| `DashboardView`                                                                        | net-worth and summary columns colored by sign; budget-health strip by color                              | sign glyph + status symbol on each summary value and the health strip   |
+
+> **The acceptance bar (from the spec):** print any of these screens in
+> grayscale. If gain still reads from loss, and safe from warning from
+> over-budget, the cue passes. Today, several of these collapse to one gray.
+
+The literal `.green` / `.red` / `Color.red` usages above are exactly the
+banned-token cases the spec's lint/unit check
+([spec §10](./ios-noncolor-financial-state-cues.md#10-test-plan)) is meant to
+catch; replacing them is the measurable goal of this rollout.
+
+---
+
+## 4. The shared application pattern
+
+Every screen adopts the same three moves, so the rollout is uniform and review
+is mechanical:
+
+1. **Replace literal colors with semantic tokens.** Swap `.green` / `.red` /
+   `Color.red` for
+   [`FinanceColors`](../../apps/ios/Finance/Theme/FinanceColors.swift) tokens
+   (`amountPositive`, `amountNegative`, `statusPositive`, `statusWarning`,
+   `statusNegative`). Tokens are light/dark + increased-contrast adaptive; literal
+   colors are not.
+2. **Add the non-color channels.** Pair each colored value with (a) a **text
+   label** or sign glyph (`+` / U+2212 `−`), (b) an **SF Symbol** whose
+   _silhouette_ encodes the state (`arrow.up.right` / `arrow.down.right`;
+   `checkmark.circle.fill` / `exclamationmark.circle.fill` /
+   `exclamationmark.triangle.fill`), and (c) where a bar/ring is involved, a
+   **fill pattern** that escalates with severity.
+3. **Speak the state.** Compose the VoiceOver label with the state word
+   ("income", "expense", "over budget", "on track") via
+   [`financeCurrencyLabel` / `financeLabel`](../../apps/ios/Finance/Accessibility/AccessibilityModifiers.swift)
+   — never a color word.
+
+The state itself is **consumed**, never computed, on iOS: budget health comes
+from the shared `BudgetHealth` enum and amount direction from the `Cents` sign /
+`TransactionType` (see [§9](#9-shared-dependencies-and-the-kmp-boundary)).
+
+---
+
+## 5. Per-screen rollout
+
+### 5.1 CurrencyLabel
+
+The most leveraged change — `CurrencyLabel` renders in transaction rows,
+account balances, dashboard summaries, and detail screens, so fixing it once
+propagates widely.
+
+- **Today:** `amountColor` returns `.green` for positive, `.red` for negative;
+  the displayed text has no on-screen sign or icon, only color.
+- **Apply:** route `amountColor` through `FinanceColors.amountPositive /
+amountNegative` (token, not literal). When `showSign` is true, prefix the
+  formatted string with `+` / `−` and place an optional leading direction symbol
+  (`arrow.up.right` / `arrow.down.right`) controlled by a `showDirectionGlyph`
+  parameter for compact rows. Keep the existing `.accessibilityLabel`
+  ("Income of …" / "Expense of …") — it already speaks the state, which is the
+  contract; do not regress it.
+- **Note:** `CurrencyLabel` already has the right VoiceOver phrasing in
+  `accessibilityDescription`; this change adds the **visible** non-color channel
+  to match the spoken one, and swaps literal colors for tokens.
+
+### 5.2 Dashboard
+
+[`DashboardView.swift`](../../apps/ios/Finance/Screens/DashboardView.swift)
+shows the net-worth hero, an Income/Expenses/Net summary, and a budget-health
+strip.
+
+- **Net-worth & summary:** each value carries a sign glyph + direction symbol
+  via the shared cue, not just color. At accessibility sizes the trio reflows
+  vertically (see [§6](#6-accessibility--voiceover-dynamic-type-reduce-motion)
+  and the
+  [reflow audit](./ios-dynamic-type-reflow-audit.md#5-surface-by-surface-audit)).
+- **Budget-health strip:** each segment shows the status **symbol**
+  (circle-check / circle-bang / triangle) and `% used` text, so safe/warning/over
+  is readable in grayscale, not by band color alone.
+- **Recent rows:** rendered through the consolidated `TransactionRowView`, which
+  already carries the income/expense cue per [#2544](./ios-transaction-row-voiceover-labels.md#7-redundant-non-color-cues).
+
+### 5.3 Investment models & views
+
+[`InvestmentModels.swift`](../../apps/ios/Finance/Models/InvestmentModels.swift),
+[`InvestmentDetailView.swift`](../../apps/ios/Finance/Screens/InvestmentDetailView.swift),
+[`InvestmentPortfolioView.swift`](../../apps/ios/Finance/Screens/InvestmentPortfolioView.swift).
+
+- **Gain/loss deltas** (day change, total return) get the direction arrow +
+  explicit signed value + token — never a bare red/green number.
+- **Allocation legend:** `AssetClassUI` already pairs each class with a
+  `systemImage` (`chart.line.uptrend.xyaxis`, `dollarsign.circle`, …) and a
+  CVD-safe `ChartColorPalette` color. The rollout ensures every legend entry
+  **shows the symbol + class name next to its swatch** so allocation is readable
+  without distinguishing hues — color stays a redundant layer.
+- **Holding rows:** value sign and direction cue accompany the amount; security
+  name wraps (no `lineLimit(1)`), consistent with the reflow audit.
+
+### 5.4 Analytics & Insights
+
+[`AnalyticsView.swift`](../../apps/ios/Finance/Screens/AnalyticsView.swift),
+[`InsightsView.swift`](../../apps/ios/Finance/Screens/InsightsView.swift), and
+their Swift Charts.
+
+- **Trend annotations** carry an arrow + signed delta, not a colored line alone,
+  per [data-visualization.md](./data-visualization.md) and the IBM CVD-safe
+  series palette in
+  [`ChartColorPalette`](../../apps/ios/Finance/Charts/ChartColorPalette.swift).
+- **Over/under-budget bands** use a non-color hatch in addition to the token
+  color; the band's role is also in its per-mark `.accessibilityLabel`.
+- **Metric cards** show the state symbol next to the value, and the insight
+  sentence states direction in words ("Spending up 12% vs. last month").
+- **Legends** wrap as whole chips via
+  [`FlowLayout`](../../apps/ios/Finance/Components/FlowLayout.swift); each entry
+  pairs the series name + symbol with its swatch.
+
+### 5.5 BudgetProgressChart
+
+[`BudgetProgressChart.swift`](../../apps/ios/Finance/Charts/BudgetProgressChart.swift)
+renders accessory-circular gauges per budget.
+
+- **Today:** `ringGradient` returns literal `Color.red` when `isOverBudget`,
+  otherwise a palette color — the _only_ difference between safe and over is hue.
+- **Apply:** drive the ring from the shared `BudgetHealth` (safe / warning /
+  over) and render, in addition to the token tint: a **status symbol** at the
+  ring center or label (circle-check / circle-bang / triangle), an **escalating
+  fill pattern** (solid → 45° hatch → cross-hatch) drawn as a `Shape`/`Canvas`
+  overlay so it scales with Dynamic Type, and an **over-budget end-cap flag** at
+  the 100% mark. The gauge's existing `.accessibilityValue` ("… % spent, $x of
+  $y") gains the state word ("over budget", "on track").
+- **Three shapes, not three reds:** the trio must be separable by silhouette in
+  grayscale, per the spec's
+  [§3.2](./ios-noncolor-financial-state-cues.md#3-cue-vocabulary-text--symbol--pattern--token).
+
+---
+
+## 6. Accessibility — VoiceOver, Dynamic Type, Reduce Motion
+
+Per [accessibility-patterns.md](./accessibility-patterns.md) and
+[cognitive-accessibility.md](./cognitive-accessibility.md):
+
+**VoiceOver**
+
+- Every cue speaks a **state word** — "income", "expense", "over budget", "on
+  track", "approaching limit" — and **never** a color word. Built via
+  [`financeCurrencyLabel` / `financeLabel`](../../apps/ios/Finance/Accessibility/AccessibilityModifiers.swift).
+- Negative amounts announce "expense" / "negative" explicitly (the minus glyph is
+  unreliable for AT) per
+  [accessibility-patterns.md §7.1](./accessibility-patterns.md#71-currency-formatting-for-screen-readers).
+- The status symbol and its value form **one** element
+  (`.accessibilityElement(children: .combine)`) so VoiceOver reads "over budget,
+  $35 over" as one coherent utterance.
+- A state crossing (e.g. into over-budget) announces via
+  [`financeLiveRegion` / `announceForAccessibility`](../../apps/ios/Finance/Accessibility/AccessibilityModifiers.swift)
+  without stealing focus.
+
+**Dynamic Type**
+
+- All labels use `FinanceTextStyle` / `.financeFont(...)`; status symbols scale
+  with `@ScaledMetric`. At AX1–AX5, inline `[symbol][amount][label]` rows reflow
+  vertically via
+  [`AdaptiveFinanceStack`](../../apps/ios/Finance/Accessibility/DynamicTypeSupport.swift).
+  Pattern fills keep ≥2pt stroke spacing at AX5 so hatching does not smear to
+  solid. This dovetails with the
+  [reflow audit](./ios-dynamic-type-reflow-audit.md) and the
+  [AX-size layout tests](./ios-dynamic-type-layout-tests.md).
+
+**Reduce Motion / Differentiate Without Color**
+
+- Honor `accessibilityReduceMotion`: a state transition cross-fades or swaps
+  statically, never sweeps.
+- Honor `accessibilityDifferentiateWithoutColor`: when **on**, increase pattern
+  prominence and always show the text label, even in compact widget/watch
+  layouts.
+
+---
+
+## 7. Privacy & balance hiding
+
+- State cues must not leak hidden values. When an amount is redacted (privacy
+  mode / `.privacySensitive()`), the **direction/state symbol may remain** (it
+  reveals no figure) but the **numeric** part stays hidden, and VoiceOver says
+  "Amount hidden" rather than reading a balance — consistent with
+  [#2544 §9](./ios-transaction-row-voiceover-labels.md#9-privacy--balance-hiding).
+- Widgets/complications inherit the same rule via the App Group privacy flag
+  ([`WidgetPrivacy.swift`](../../apps/ios/Shared/WidgetPrivacy.swift)): a cue's
+  color/symbol can show "over budget" without printing the over-amount on a Lock
+  Screen.
+- Logging stays `.public` metadata only — never a value — per the `os.Logger`
+  rules.
+
+---
+
+## 8. Stale, error, and empty states
+
+| State       | Cue behaviour                                                                                                                                                                                                                               |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Stale**   | When data is stale/offline, cues render from last-known state but are visibly marked stale (the [`OfflineBanner`](../../apps/ios/Finance/Components/OfflineBanner.swift) + a muted token); never imply a fresh "on track" on stale numbers. |
+| **Error**   | If state cannot be classified (load failed), show a **neutral** cue (no false gain/loss/over), surface the error via [`ErrorStateView`](../../apps/ios/Finance/Components/ErrorStateView.swift), and speak "status unavailable".            |
+| **Empty**   | No transactions/holdings ⇒ no state cue at all; [`EmptyStateView`](../../apps/ios/Finance/Components/EmptyStateView.swift) guidance instead — never a default green "all good".                                                             |
+| **Loading** | Skeleton placeholders carry no state color/symbol; cues appear only once real state resolves.                                                                                                                                               |
+
+Fail-safe principle: **absence of data is never rendered as a positive state.**
+
+---
+
+## 9. Shared dependencies and the KMP boundary
+
+The "what state is this?" / "how do we show it?" split (from the spec
+[§6](./ios-noncolor-financial-state-cues.md#6-shared-dependencies--the-classification-boundary))
+holds for every screen here:
+
+| Concern                                           | Owner                                                |
+| ------------------------------------------------- | ---------------------------------------------------- |
+| Budget health thresholds (75% / 100%)             | `packages/core` (`BudgetCalculator`, `BudgetHealth`) |
+| Over-budget flag, utilization                     | `packages/core` (`BudgetStatus`)                     |
+| Amount sign / income vs. expense                  | `packages/models` (`Cents`, `TransactionType`)       |
+| Currency formatting                               | `packages/core` (`MoneyFormatter`)                   |
+| State → (text / symbol / pattern / token) mapping | **`apps/ios`** (`FinancialStateCue`)                 |
+| VoiceOver phrasing, Dynamic Type                  | **`apps/ios`**                                       |
+
+- iOS **never** hard-codes the 75% / 100% thresholds or the income/expense
+  comparison; it consumes the pre-classified `BudgetHealth` and `Cents` sign.
+- If a unified shared `AmountDirection { GAIN, NEUTRAL, LOSS }` enum is wanted so
+  Android/Web/Windows share identical semantics, that addition belongs in
+  `packages/` via **ADR to @architect / @kmp-engineer** — the iOS engineer does
+  not edit `packages/` directly. Until then, iOS derives direction from the
+  existing `Cents` sign at the bridge.
+- The cue layer switches the Swift state enum **exhaustively** (no `default:`),
+  so a future state is a compile error until iOS handles it.
+
+---
+
+## 10. Rollout sequencing
+
+Ordered so the most-shared component lands first and each step is independently
+shippable:
+
+```mermaid
+flowchart LR
+    A["1. FinancialStateCue + stateCue() helper"] --> B["2. CurrencyLabel (widest reach)"]
+    B --> C["3. BudgetProgressChart (clear shape trio)"]
+    C --> D["4. Dashboard summary + health strip"]
+    D --> E["5. Analytics / Insights charts"]
+    E --> F["6. Investment models / views"]
+```
+
+1. Land the `FinancialStateCue` helper (spec-defined) with its unit tests.
+2. `CurrencyLabel` — biggest blast radius; token swap + sign/direction glyph.
+3. `BudgetProgressChart` — shape-distinct trio + pattern.
+4. Dashboard summary + budget-health strip.
+5. Analytics / Insights chart annotations, bands, legends.
+6. Investment deltas, legend, holding rows.
+
+Each step replaces literal colors with tokens, so the banned-color lint
+([§11](#11-smallest-tests-plan)) goes green incrementally.
+
+---
+
+## 11. Smallest tests plan
+
+Smallest/most-leveraged first:
+
+- **Unit — cue mapping (`FinancialStateCueTests`):** each shared state maps to
+  the expected (label, symbol, pattern, token); the switch is exhaustive.
+- **Unit — banned-color guard:** a source check (or unit test) asserts no
+  `Color.red` / `.green` / `.orange` / raw hex remains in the touched state-cue
+  paths (`CurrencyLabel`, `BudgetProgressChart`, investment deltas), enforcing the
+  spec's token-only rule.
+- **Unit — CurrencyLabel:** positive/negative/zero produce the correct sign
+  glyph, token, and the existing "Income/Expense of …" VoiceOver label
+  (regression-protect the spoken contract).
+- **Snapshot — grayscale acceptance:** render Dashboard, BudgetProgressChart,
+  and an investment delta in **grayscale** (and under Smart Invert / Increase
+  Contrast); assert each state is distinguishable — the spec's acceptance bar as
+  a test. Reuse the AX-size snapshot harness from
+  [ios-dynamic-type-layout-tests.md §6](./ios-dynamic-type-layout-tests.md#6-snapshot-harness-at-ax-sizes).
+- **XCUITest a11y audit:** `performAccessibilityAudit()` on Dashboard,
+  Budgets, Investments, Analytics reports zero `.contrast` / `.elementDetection`
+  issues; VoiceOver labels contain a state word and no color word.
+
+The minimum gate: cue-mapping unit tests + the banned-color guard pass, and the
+grayscale snapshot distinguishes safe/warning/over for `BudgetProgressChart`.
+
+---
+
+## 12. Implementation readiness
+
+See [`docs/ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md)
+(§2 — implementation vs. distribution decoupling).
+
+**Buildable now (no human gate):**
+
+- The `FinancialStateCue` helper, every per-screen adoption, the token swaps, and
+  all unit/snapshot/audit tests are implementable today on the iOS Simulator and
+  a personal device using **free Personal Team** signing. Adding non-color cues
+  and replacing literal colors with tokens needs no paid enrollment.
+
+**Gated by [#1239](https://github.com/jrmoulckers/finance/issues/1239):**
+
+- Only TestFlight / App Store distribution of the updated build and any paid
+  physical-device matrix sit behind enrollment. The cue work itself needs none.
+
+No human-gated operation is required to implement or verify this rollout.
+
+---
+
+## 13. References
+
+- Cue specification: [Semantic Non-Color Financial State Cues (#2552)](./ios-noncolor-financial-state-cues.md)
+  — the vocabulary this doc applies.
+- Layout companions: [Dynamic Type Reflow Audit (#2548)](./ios-dynamic-type-reflow-audit.md)
+  · [AX-Size Layout Tests (#2550)](./ios-dynamic-type-layout-tests.md)
+- VoiceOver: [Transaction Row VoiceOver Labels (#2544)](./ios-transaction-row-voiceover-labels.md)
+  · [Transaction Accessibility Regression (#2546)](./ios-transaction-accessibility-regression.md)
+- Cross-platform: [Accessibility Patterns Library](./accessibility-patterns.md) — §5 Color & Contrast, §7 Financial Data
+  · [Cognitive Accessibility Mode](./cognitive-accessibility.md)
+  · [Data Visualization](./data-visualization.md) · [iOS Icon System](./icon-system-ios.md)
+- Repo files touched: [`CurrencyLabel.swift`](../../apps/ios/Finance/Components/CurrencyLabel.swift)
+  · [`BudgetProgressChart.swift`](../../apps/ios/Finance/Charts/BudgetProgressChart.swift)
+  · [`InvestmentModels.swift`](../../apps/ios/Finance/Models/InvestmentModels.swift)
+  · [`FinanceColors.swift`](../../apps/ios/Finance/Theme/FinanceColors.swift)
+  · [`AccessibilityModifiers.swift`](../../apps/ios/Finance/Accessibility/AccessibilityModifiers.swift)
+- Standards: Apple HIG — Color, SF Symbols · WCAG 2.2 — 1.4.1 Use of Color, 1.4.11 Non-text Contrast


### PR DESCRIPTION
## Summary

Design-docs-only batch (iOS accessibility cluster, batch 2). Three **new**
`docs/design/` files — no code, no native build, no signing, no store actions.
Each grounds its guidance in real `apps/ios/` surfaces and cross-links the
existing accessibility/low-noise design docs rather than duplicating them.

- **#2550 — Accessibility-size layout tests for iOS Dynamic Type:** the
  AX1–AX5 snapshot + XCTest accessibility-audit harness that proves Dashboard,
  Transactions, Analytics/Insights, Reports, and Investment-detail surfaces stay
  uncut at the largest Dynamic Type sizes. Companion to the existing reflow audit.
- **#2554 — Apply redundant financial state cues across iOS screens:** the
  per-screen rollout plan that applies the existing non-color cue vocabulary to
  `CurrencyLabel`, Dashboard, investment models/views, Analytics, and
  `BudgetProgressChart` (icon + text + shape + token; spoken state). Applies the
  spec, does not redefine it.
- **#2581 — Accessibility & migration plan for iOS low-noise customization:**
  VoiceOver ordering, discoverability, default migration, and the deep-link /
  Siri / widget / watch survival tests so hidden modules never break
  reachability. Builds on the existing module-visibility design.

## Changes

- `docs/design/ios-dynamic-type-layout-tests.md` (new)
- `docs/design/ios-redundant-financial-state-cues.md` (new)
- `docs/design/ios-low-noise-accessibility-migration.md` (new)

Each doc: humans-first, ToC, Mermaid diagrams, relative links, deep a11y detail
(AX1–AX5 matrix, redundant non-color cues, VoiceOver, Reduce Motion), privacy /
balance-hiding, stale/error/empty states, a smallest-tests plan, and an
"Implementation readiness" section splitting buildable-now (free Personal Team
signing) from the distribution tail gated by #1239. Cross-links existing
`docs/design/` a11y files (no edits to them). Prettier `--check` passes.

No human-gated operations performed (no signing, no provisioning, no store
submission, no shared-package edits).

Closes #2550
Closes #2554
Closes #2581
