### PR TITLE
docs(design): android field-mode and rugged design batch (#2559, #2561, #2565)

### DIFF
--- a/docs/design/android-field-mode-transaction-flow.md
+++ b/docs/design/android-field-mode-transaction-flow.md
@@ -1,0 +1,338 @@
+# Android Field-Mode Transaction & Receipt Flow — Design
+
+> **Status:** Design / breakdown only — native implementation gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+> **Issue:** [#2561](https://github.com/jrmoulckers/finance/issues/2561) · **Part of:** [#2186](https://github.com/jrmoulckers/finance/issues/2186)
+> **Platform:** Android (Jetpack Compose + Material 3 · Glance) · **minSdk 28 / target 35** · **Audience:** Android engineers, design, QA
+
+This document designs **Field mode** — a simplified, one-handed, glove-friendly
+flow for **adding an expense, picking a category, and (optionally) attaching a
+receipt** while working: wet hands, sunlight, cold fingers, a budget phone in one
+hand. It is the navigation/interaction companion to
+[Android Rugged Mode — Design Tokens & Preference](./android-rugged-mode-tokens.md)
+([#2559](https://github.com/jrmoulckers/finance/issues/2559)); rugged mode owns
+the _look and sizing_, this doc owns the _flow_.
+
+It is a **design / breakdown only** document and adds **no native code** while
+production signing and Play distribution remain blocked by
+[#1242](https://github.com/jrmoulckers/finance/issues/1242).
+
+The guiding rule, as everywhere in the Android client: **Compose renders shared
+state; it does not own finance math.** Draft assembly, category suggestion, and
+validation already live in Kotlin Multiplatform (KMP)
+[`packages/core`](../../packages/core/). Field mode is a thinner, larger-target
+_presentation_ of that same shared draft — never a second source of truth.
+
+---
+
+## Table of Contents
+
+1. [Goals & non-goals](#1-goals--non-goals)
+2. [Personas & jobs to be done](#2-personas--jobs-to-be-done)
+3. [The Compose-renders-shared-state boundary](#3-the-compose-renders-shared-state-boundary)
+4. [Field-mode navigation model](#4-field-mode-navigation-model)
+5. [Simplified add-expense flow](#5-simplified-add-expense-flow)
+6. [Category selection](#6-category-selection)
+7. [Receipt attachment entry point](#7-receipt-attachment-entry-point)
+8. [Offline-first, empty, and error states](#8-offline-first-empty-and-error-states)
+9. [Accessibility](#9-accessibility)
+10. [Test plan](#10-test-plan)
+11. [Implementation readiness](#11-implementation-readiness)
+12. [Cross-links](#12-cross-links)
+
+---
+
+## 1. Goals & non-goals
+
+### Goals
+
+- Provide a **two-tap-to-save** expense flow optimised for the field: amount →
+  category → save, with everything else deferred or pre-filled.
+- Make every primary action **bottom-reachable and large** (≥ 56 dp) so it works
+  one-handed with gloves on a budget device.
+- Offer an **optional** receipt attachment without making it a required step —
+  the user can save now and attach later.
+- Reuse the **existing shared draft and save path** so field mode produces a
+  normal [`Transaction`](../../packages/models/src/commonMain/kotlin/com/finance/models/Transaction.kt),
+  not a special-case record.
+- Be **offline-first**: every field-mode action works with no connectivity.
+
+### Non-goals
+
+- The visual token profile (contrast, sizing, motion) — owned by
+  [Android Rugged Mode — Design Tokens & Preference](./android-rugged-mode-tokens.md)
+  ([#2559](https://github.com/jrmoulckers/finance/issues/2559)).
+- Receipt _capture_ (CameraX, permissions, crop/retake) — designed in
+  [Android CameraX Receipt Capture & Fallback](./android-cameraX-receipt-capture.md)
+  ([#2563](https://github.com/jrmoulckers/finance/issues/2563)).
+- OCR review/correction → draft — designed in
+  [Android Receipt OCR Review → Transaction Draft](./android-receipt-ocr-review-draft.md)
+  ([#2565](https://github.com/jrmoulckers/finance/issues/2565)) and
+  [Android Receipt-to-Expense Draft Flow](./android-receipt-to-expense-draft.md).
+- Any change to KMP finance rules, money math, or category logic.
+
+---
+
+## 2. Personas & jobs to be done
+
+The driving persona from [#2186](https://github.com/jrmoulckers/finance/issues/2186)
+is a **mobile/field worker** — gig driver, food-truck operator, on-site trades —
+who must log a purchase _between tasks_, not at a desk. See
+[User Personas & MVP Scope](./personas.md).
+
+Jobs this flow must satisfy:
+
+- "Log a **cash or card expense in seconds** while I keep working."
+- "Pick the **right category without reading tiny rows** in the sun."
+- "**Snap a receipt if I have time**, otherwise just save and move on."
+
+Each job maps to a section: fast save (§4–§5), category (§6), receipt (§7).
+
+This flow reuses the canonical quick-entry destination from
+[Android Cash Quick-Entry Deep Links](./android-cash-quick-entry-deep-links.md)
+([#2538](https://github.com/jrmoulckers/finance/issues/2538)); field mode is the
+**enlarged, simplified rendering** of that same prefilled draft, not a new entry
+point.
+
+---
+
+## 3. The Compose-renders-shared-state boundary
+
+| Concern                               | Where it lives                                                                                                  | Notes                                                         |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| Draft assembly & validation           | KMP [`packages/core`](../../packages/core/)                                                                     | Amount (cents), category, payment hint, required-field rules. |
+| Category suggestion / recents ranking | KMP `packages/core`                                                                                             | Shared ranking; Compose only renders the ordered list.        |
+| Money formatting                      | [`CurrencyFormatter`](../../packages/core/src/commonMain/kotlin/com/finance/core/currency/CurrencyFormatter.kt) | Integer cents in, localized string out.                       |
+| Field-mode layout & navigation        | `apps/android` Compose                                                                                          | Larger targets, bottom-anchored actions, fewer steps.         |
+| Display sizing/contrast/motion        | Rugged tokens ([#2559](https://github.com/jrmoulckers/finance/issues/2559))                                     | Field mode consumes; does not define.                         |
+
+**Boundary rules**
+
+- The field-mode ViewModel calls shared draft/validation/suggestion functions and
+  exposes their results as immutable UI state. It never re-implements totals, tax,
+  or category rules in Kotlin/JVM code.
+- All money is integer **cents**; Compose only formats for display.
+- "Field mode" is a presentation flag — it changes step count, target size, and
+  reachability, never the underlying draft semantics or the saved record shape.
+
+```mermaid
+flowchart LR
+    subgraph Core["KMP packages/core (shared, no UI)"]
+        Draft["buildExpenseDraft()"]
+        Suggest["suggestCategories()"]
+        Valid["validateDraft()"]
+    end
+    subgraph Android["apps/android (Compose, renders only)"]
+        VM["FieldEntryViewModel"]
+        UI["FieldEntryScreen"]
+        Repo["TransactionRepository.insert()"]
+    end
+    Seed["Quick-entry deep link / FAB"] --> VM
+    VM --> Draft
+    VM --> Suggest
+    VM --> Valid
+    Draft --> UI
+    Suggest --> UI
+    UI -->|"Save"| Repo
+```
+
+---
+
+## 4. Field-mode navigation model
+
+Field mode collapses the standard multi-step create wizard into a **single
+bottom-sheet-style screen** where the most likely actions are within thumb reach.
+
+| Principle          | Implementation                                                           |
+| ------------------ | ------------------------------------------------------------------------ |
+| One-handed         | Primary actions pinned to the bottom; nothing critical in the top inset. |
+| Few steps          | Amount + category visible at once; save always reachable.                |
+| Forgiving touch    | ≥ 56 dp targets, generous spacing, no swipe-to-act, no long-press-only.  |
+| Defer the optional | Receipt, notes, account override are secondary, never blocking save.     |
+| Reuse, don't fork  | Saves through the same shared draft + repository as the standard flow.   |
+
+```mermaid
+flowchart TD
+    Start["Field entry (deep link / FAB)"] --> Amount["Big numeric keypad (amount)"]
+    Amount --> Cat["Category chips (recents first)"]
+    Cat --> Save{"Save now?"}
+    Save -->|"Save"| Done["Saved -> brief confirmation"]
+    Save -->|"Add receipt first"| Capture["Receipt capture (Issue 2563)"]
+    Capture --> Review["OCR review (Issue 2565)"]
+    Review --> Done
+    Done --> Next["Stay for next entry or exit"]
+```
+
+| Composable            | Type          | Responsibility                                                 |
+| --------------------- | ------------- | -------------------------------------------------------------- |
+| `FieldEntryScreen`    | `@Composable` | Hosts the keypad, category chips, and bottom action bar.       |
+| `FieldAmountKeypad`   | `@Composable` | Large numeric entry feeding shared cents.                      |
+| `FieldCategoryChips`  | `@Composable` | Horizontally scannable, recents-first category targets.        |
+| `FieldActionBar`      | `@Composable` | Bottom-anchored Save / Add receipt / Cancel.                   |
+| `FieldEntryViewModel` | `ViewModel`   | Owns the shared draft state; calls KMP draft/suggest/validate. |
+
+---
+
+## 5. Simplified add-expense flow
+
+- **Amount first.** A large numeric keypad with a prominent running total. The
+  value is held as integer **cents** in the shared draft; Compose formats it via
+  [`CurrencyFormatter`](../../packages/core/src/commonMain/kotlin/com/finance/core/currency/CurrencyFormatter.kt).
+- **Sensible defaults.** Payment method and account default to the user's
+  configured field defaults (see
+  [Quick-Add Defaults & Persistence](./android-quick-add-defaults-persistence.md)),
+  so a typical save needs only amount + category.
+- **Save is always reachable.** The bottom `FieldActionBar` keeps **Save** enabled
+  once the shared `validateDraft()` reports the required fields are present;
+  validation errors surface inline and via an assertive live region.
+- **Stay-to-continue.** After save, a brief confirmation offers "Add another" so a
+  user logging several field purchases in a row never leaves the flow.
+
+This flow reuses the proven save path rather than forking it — it produces a
+normal [`Transaction`](../../packages/models/src/commonMain/kotlin/com/finance/models/Transaction.kt)
+through the existing repository, queued locally and synced later when online.
+
+---
+
+## 6. Category selection
+
+Category selection is the highest-friction step in the sun, so field mode makes it
+**scan-fast and large**:
+
+- **Recents first.** The shared `suggestCategories()` ranking (recency +
+  frequency, computed in KMP) drives the chip order; Compose only renders it.
+- **Big chips, not tiny rows.** Each category is a ≥ 56 dp chip with an icon +
+  label (icon from the shared [icon system](./icon-system.md)), so it reads at a
+  glance and is glove-tappable.
+- **Search as escape hatch.** A single tap expands a searchable full list for the
+  rare uncommon category; the field default is the chip grid.
+- **Color is never the only signal.** Category is conveyed by icon + label, not
+  hue alone, satisfying the contrast guidance in the patterns library.
+
+No category math happens on the Android side — the chip order and the resulting
+category id come straight from shared state.
+
+---
+
+## 7. Receipt attachment entry point
+
+Receipt attachment in field mode is **optional and deferrable**. The
+`FieldActionBar` offers **Add receipt** as a secondary action that hands off to
+the existing receipt cluster and returns to the same draft:
+
+1. **Capture** — [Android CameraX Receipt Capture & Fallback](./android-cameraX-receipt-capture.md)
+   ([#2563](https://github.com/jrmoulckers/finance/issues/2563)) produces a
+   full-resolution image on-device.
+2. **OCR review** — [Android Receipt OCR Review → Transaction Draft](./android-receipt-ocr-review-draft.md)
+   ([#2565](https://github.com/jrmoulckers/finance/issues/2565)) lets the user
+   confirm/correct extracted fields, merging them into the **same** field-mode
+   draft.
+3. **Attachment** — persistence and COGS mapping are handled by
+   [Android Receipt Attachments & COGS Mapping](./android-receipt-attachments-cogs.md)
+   ([#2549](https://github.com/jrmoulckers/finance/issues/2549)).
+
+Crucially, **save never depends on the receipt**. The user can save the expense
+now and attach a receipt later; the attachment links to the already-saved
+transaction. All capture and OCR stay on-device (privacy-preserving — see §8).
+
+---
+
+## 8. Offline-first, empty, and error states
+
+| State                   | Trigger                                  | UX                                                                            |
+| ----------------------- | ---------------------------------------- | ----------------------------------------------------------------------------- |
+| Empty / first entry     | Screen opened with no amount             | Keypad focused; "Enter an amount to start" hint; Save disabled until valid.   |
+| No connectivity         | Airplane mode / dead zone                | Everything works; draft saved locally; optional "Saved — will sync later".    |
+| Validation error        | `validateDraft()` flags a required field | Inline error + assertive live region; focus moves to the first invalid field. |
+| Save failure            | Repository `insert` throws               | Non-destructive error card with **Retry**; the draft is preserved.            |
+| Receipt unavailable     | Camera/ML Kit unavailable                | Save still works; receipt step degrades to gallery/manual per #2563.          |
+| Process death mid-entry | App killed before save                   | `SavedStateHandle` restores amount/category so nothing is retyped.            |
+
+No financial data (amounts, totals, account numbers) is ever written to Timber.
+Structured logs capture flow milestones only (for example "field draft saved")
+via `Timber.d`/`Timber.w` with **no** sensitive values, per the client logging
+rules.
+
+---
+
+## 9. Accessibility
+
+This flow targets WCAG 2.2 AA and follows the shared
+[Accessibility Patterns Library](./accessibility-patterns.md). Because field mode
+is used in hostile conditions, accessibility _is_ the core requirement.
+
+- **TalkBack:** The amount announces its running value ("Amount, 12 dollars 50
+  cents"); each category chip exposes label + selected state; Save announces its
+  action and result. Headings use `semantics { heading() }`.
+- **Switch Access:** Logical top-to-bottom focus ending on the bottom action bar;
+  every action is a single, large, single-purpose target. No action depends on a
+  gesture, swipe, or long-press only.
+- **200% font scaling:** All text uses `sp` and wraps; the keypad and chips grow
+  in height rather than truncating. The action bar collapses to a vertical stack
+  at large scale without clipping Save.
+- **High contrast / sunlight / gloves:** When [rugged mode](./android-rugged-mode-tokens.md)
+  is on, targets grow to ≥ 56 dp, contrast rises, and motion reduces — field mode
+  consumes those tokens directly. State is shown by text + icon + shape, never
+  color alone.
+- **Wet-screen safety:** Generous hit slop; destructive actions (cancel/discard)
+  always confirm; no swipe-to-delete in the field path.
+- **Live regions:** Validation errors and save confirmation use an assertive live
+  region so non-visual users hear the outcome immediately.
+
+---
+
+## 10. Test plan
+
+| Layer                | Tooling                | Coverage                                                                                                                                                           |
+| -------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Unit (ViewModel)     | JUnit + coroutine test | Draft built from shared functions; amount held as cents; Save gates on shared `validateDraft()`; defaults applied; offline save queues locally.                    |
+| Unit (state machine) | JUnit                  | `Entering → Valid → Saving → Saved` transitions; error path preserves the draft; process-death restore from `SavedStateHandle`; "add another" resets cleanly.      |
+| Compose UI           | `compose-ui-test`      | Keypad/chip targets ≥ 56 dp; Save disabled until valid; category recents order matches shared ranking; semantics/`contentDescription` assertions; font-scale 2.0f. |
+| Snapshot             | Paparazzi              | `FieldEntryScreen` in: empty, valid, validation-error, saving, saved — at default and 200% font scale, standard vs. rugged theme, light/dark.                      |
+
+Shared business rules (`buildExpenseDraft`, `suggestCategories`, `validateDraft`)
+are covered by existing `packages/core` tests and are **not** re-tested here —
+only the Android rendering, navigation, and save wiring are.
+
+---
+
+## 11. Implementation readiness
+
+This is a design artifact. Implementation splits into a part that is fully
+buildable today and a tail that is gated by Play onboarding.
+
+See [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md) and the
+[Launch Readiness Plan](../ops/launch-readiness-plan.md) for the gating context.
+
+### Buildable now (debug, no human gate)
+
+- `FieldEntryScreen`, `FieldEntryViewModel`, the keypad/chips/action-bar
+  composables, state model, and Koin wiring are pure Compose + KMP consumption —
+  fully implementable and runnable via `./gradlew :apps:android:assembleDebug`
+  and sideload.
+- Save wiring reuses the existing local `TransactionRepository`; verifiable with
+  unit, Compose, and Paparazzi tests on CI and emulator/sideload.
+- The receipt entry point degrades gracefully (gallery/manual) so the flow is
+  testable without store presence.
+
+### Play-distribution tail (gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242))
+
+- Production signing keystore + Google Play Console onboarding.
+- Internal-testing-track upload, privacy declarations, and staged rollout.
+- Anything requiring a release-signed AAB (not `assembleDebug`).
+
+No part of the field-mode flow itself is blocked from being built and tested in
+debug; only its production distribution is.
+
+---
+
+## 12. Cross-links
+
+- Sibling: [Android Rugged Mode — Design Tokens & Preference](./android-rugged-mode-tokens.md) — [#2559](https://github.com/jrmoulckers/finance/issues/2559)
+- Sibling: [Android Receipt OCR Review → Transaction Draft](./android-receipt-ocr-review-draft.md) — [#2565](https://github.com/jrmoulckers/finance/issues/2565)
+- [Android CameraX Receipt Capture & Fallback](./android-cameraX-receipt-capture.md) — [#2563](https://github.com/jrmoulckers/finance/issues/2563)
+- [Android Receipt-to-Expense Draft Flow](./android-receipt-to-expense-draft.md) · [Android Receipt Attachments & COGS Mapping](./android-receipt-attachments-cogs.md)
+- [Android Cash Quick-Entry Deep Links](./android-cash-quick-entry-deep-links.md) · [Quick-Add Defaults & Persistence](./android-quick-add-defaults-persistence.md)
+- [Accessibility Patterns Library](./accessibility-patterns.md) · [Cognitive Accessibility Mode](./cognitive-accessibility.md) · [Icon System](./icon-system.md)
+- [Component Library](./component-library.md) · [UX Design Principles](./ux-principles.md) · [Content & Language Guidelines](./content-language-guidelines.md)
+- [Android Architecture](../architecture/android-architecture.md) · [Data Model](./data-model.md) · [Information Architecture](./information-architecture.md) · [User Personas](./personas.md)
+- Ops: [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md) · [Launch Readiness Plan](../ops/launch-readiness-plan.md)

--- a/docs/design/android-receipt-ocr-review-draft.md
+++ b/docs/design/android-receipt-ocr-review-draft.md
@@ -1,0 +1,361 @@
+# Android Receipt OCR Review → Transaction Draft — Design
+
+> **Status:** Design / breakdown only — native implementation gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+> **Issue:** [#2565](https://github.com/jrmoulckers/finance/issues/2565) · **Part of:** [#2388](https://github.com/jrmoulckers/finance/issues/2388)
+> **Platform:** Android (Jetpack Compose + Material 3) · **minSdk 28 / target 35** · **Audience:** Android engineers, design, QA
+
+This document designs the **on-device OCR review and correction surface** that
+turns **ML Kit text recognition** output into a **shared transaction draft** with
+an **optional receipt attachment**. It is the _review_ step of the receipt
+cluster: capture happens upstream, and the saved draft flows downstream through
+the existing draft/attachment designs.
+
+It is a **design / breakdown only** document and adds **no native code** while
+production signing and Play distribution remain blocked by
+[#1242](https://github.com/jrmoulckers/finance/issues/1242).
+
+The guiding rule, as everywhere in the Android client: **Compose renders shared
+state; it does not own finance math.** OCR text parsing, field extraction,
+confidence scoring, and draft assembly already live in Kotlin Multiplatform (KMP)
+[`packages/core`](../../packages/core/). ML Kit runs **on-device**; the Android
+layer collects recognized text, observes the shared analysis as state, and
+presents correction affordances. **No receipt text or image leaves the device.**
+
+> **Relationship to existing receipt docs.** This doc focuses on the **review /
+> correction interaction and confidence presentation** for the
+> [#2388](https://github.com/jrmoulckers/finance/issues/2388) capture cluster. It
+> deliberately **reuses** — and does not duplicate — the draft-building contract
+> in [Android Receipt-to-Expense Draft Flow](./android-receipt-to-expense-draft.md)
+> and the capture front-end in
+> [Android CameraX Receipt Capture & Fallback](./android-cameraX-receipt-capture.md).
+
+---
+
+## Table of Contents
+
+1. [Goals & non-goals](#1-goals--non-goals)
+2. [Personas & jobs to be done](#2-personas--jobs-to-be-done)
+3. [The Compose-renders-shared-state boundary](#3-the-compose-renders-shared-state-boundary)
+4. [OCR review pipeline](#4-ocr-review-pipeline)
+5. [Review & correction UI](#5-review--correction-ui)
+6. [Confidence presentation](#6-confidence-presentation)
+7. [Optional receipt attachment](#7-optional-receipt-attachment)
+8. [On-device privacy](#8-on-device-privacy)
+9. [Offline-first, empty, and error states](#9-offline-first-empty-and-error-states)
+10. [Accessibility](#10-accessibility)
+11. [Test plan](#11-test-plan)
+12. [Implementation readiness](#12-implementation-readiness)
+13. [Cross-links](#13-cross-links)
+
+---
+
+## 1. Goals & non-goals
+
+### Goals
+
+- Present **ML Kit on-device OCR** output as a **reviewable, correctable** set of
+  fields (merchant, date, total, tax hint, payment hint) that the user confirms
+  before saving.
+- Make **low-confidence fields obvious** and easy to fix without retyping the
+  whole receipt.
+- Produce a **shared transaction draft** (the same
+  `ReceiptTransactionDraft` shape used by the existing draft flow) that saves to a
+  normal [`Transaction`](../../packages/models/src/commonMain/kotlin/com/finance/models/Transaction.kt).
+- Offer the receipt image as an **optional attachment** on the resulting
+  transaction.
+- Keep everything **on-device and offline-first** — no receipt text or image
+  leaves the device during review (acceptance theme of
+  [#2388](https://github.com/jrmoulckers/finance/issues/2388)).
+
+### Non-goals
+
+- Camera capture, permissions, crop/retake — designed in
+  [Android CameraX Receipt Capture & Fallback](./android-cameraX-receipt-capture.md)
+  ([#2563](https://github.com/jrmoulckers/finance/issues/2563)).
+- The downstream save semantics and attachment/COGS persistence — designed in
+  [Android Receipt-to-Expense Draft Flow](./android-receipt-to-expense-draft.md)
+  ([#2547](https://github.com/jrmoulckers/finance/issues/2547)) and
+  [Android Receipt Attachments & COGS Mapping](./android-receipt-attachments-cogs.md)
+  ([#2549](https://github.com/jrmoulckers/finance/issues/2549)).
+- Any change to KMP business rules. The parser, draft builder, and confidence
+  model in `packages/core` are consumed **as-is**.
+- Server-side OCR or any cloud vision API — explicitly excluded for privacy.
+
+---
+
+## 2. Personas & jobs to be done
+
+The driving context from [#2388](https://github.com/jrmoulckers/finance/issues/2388)
+is a small-business / field user who snaps a receipt and wants a correct expense
+without manual data entry. See [User Personas & MVP Scope](./personas.md).
+
+Jobs this surface must satisfy:
+
+- "After I scan, **show me what it read** and let me fix the wrong bits."
+- "**Don't make me retype** the merchant and total when only the date is off."
+- "Prove to me the **scan stayed on my phone**."
+
+Each job maps to a section: review (§5), targeted correction (§5–§6), privacy (§8).
+
+This surface is the natural **review step** invoked from the field flow's receipt
+entry point (see [Android Field-Mode Transaction & Receipt Flow](./android-field-mode-transaction-flow.md),
+[#2561](https://github.com/jrmoulckers/finance/issues/2561)).
+
+---
+
+## 3. The Compose-renders-shared-state boundary
+
+All finance/business logic stays in KMP `packages/core`. The Android layer is a
+thin renderer over ML Kit text and shared analysis. The contract types and
+functions below already exist and are the single source of truth:
+
+| Shared type / function                                                    | Source                                                                                                                         | Role in this flow                                            |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
+| `ExtractedReceiptText`, `ExtractedReceiptLineItem`, `parseReceiptText(…)` | [`ReceiptTextParser.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/dataimport/ReceiptTextParser.kt)           | Normalises raw OCR text into merchant/date/total/line items. |
+| `ReceiptCogsExtensions.buildTransactionDraft(…)`                          | [`ReceiptCogsExtensions.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/receipt/cogs/ReceiptCogsExtensions.kt) | Assembles a `ReceiptTransactionDraft` from parsed output.    |
+| `ReceiptTransactionDraft`                                                 | `ReceiptCogsExtensions.kt`                                                                                                     | Category, amount (cents), tax, payment method, attachments.  |
+| `ReceiptConfidence` / `ReceiptConfidenceBand` / `ReceiptConfidenceFlag`   | `ReceiptCogsExtensions.kt`                                                                                                     | Decides which fields are auto-filled vs. flagged for review. |
+
+The on-device OCR adapter that feeds these shared functions already exists:
+[`AndroidMlKitReceiptOcrAdapter`](../../apps/android/src/main/kotlin/com/finance/android/receipt/AndroidMlKitReceiptOcrAdapter.kt).
+
+**Boundary rules**
+
+- The ViewModel calls shared functions and exposes their results as immutable UI
+  state. It never re-implements totals, tax math, or category rules in Kotlin/JVM
+  code.
+- All money is integer **cents** (`Cents`) across the boundary. Compose only
+  formats for display via the shared [`CurrencyFormatter`](../../packages/core/src/commonMain/kotlin/com/finance/core/currency/CurrencyFormatter.kt).
+- Confidence drives **presentation only**: a `LOW`/`UNUSABLE` band changes which
+  fields are highlighted, never the underlying values.
+
+```mermaid
+flowchart LR
+    subgraph Device["On-device, no network"]
+        MLKit["ML Kit text recognition"]
+        Adapter["AndroidMlKitReceiptOcrAdapter"]
+    end
+    subgraph Core["KMP packages/core (shared, no UI)"]
+        Parser["parseReceiptText()"]
+        Draft["buildTransactionDraft()"]
+        Conf["scoreConfidence() -> ReceiptConfidence"]
+    end
+    subgraph Android["apps/android (Compose, renders only)"]
+        VM["ReceiptOcrReviewViewModel"]
+        UI["ReceiptOcrReviewScreen"]
+        Repo["TransactionRepository.insert()"]
+    end
+    Image["Captured image (Issue 2563)"] --> MLKit
+    MLKit --> Adapter
+    Adapter --> Parser
+    Parser --> Draft
+    Draft --> Conf
+    Conf --> VM
+    VM --> UI
+    UI -->|"Confirm & save"| Repo
+```
+
+---
+
+## 4. OCR review pipeline
+
+The end-to-end path from a captured image to a saved draft:
+
+1. **Recognize** — the captured image (from [#2563](https://github.com/jrmoulckers/finance/issues/2563))
+   is passed to ML Kit text recognition on-device via
+   [`AndroidMlKitReceiptOcrAdapter`](../../apps/android/src/main/kotlin/com/finance/android/receipt/AndroidMlKitReceiptOcrAdapter.kt).
+2. **Parse** — recognized text is handed to the shared `parseReceiptText(…)`,
+   which yields merchant/date/total/line items as `ExtractedReceiptText`.
+3. **Assemble** — `buildTransactionDraft(…)` produces a `ReceiptTransactionDraft`.
+4. **Score** — `scoreConfidence(…)` yields a `ReceiptConfidence` per field/band.
+5. **Review** — Compose renders the draft with confidence cues and per-field
+   correction affordances.
+6. **Confirm & save** — on confirm, the (possibly corrected) draft saves to a
+   normal `Transaction` via the existing repository, with the receipt image
+   optionally attached.
+
+| Composable                  | Type          | Responsibility                                                |
+| --------------------------- | ------------- | ------------------------------------------------------------- |
+| `ReceiptOcrReviewScreen`    | `@Composable` | Hosts the parsed-field list, confidence cues, and action bar. |
+| `OcrFieldRow`               | `@Composable` | One reviewable field: label, value, confidence, edit control. |
+| `OcrLineItemsSection`       | `@Composable` | Optional expandable line-item list for itemised receipts.     |
+| `ReceiptThumbnailCard`      | `@Composable` | Shows the on-device image; opt-in attach toggle.              |
+| `ReviewActionBar`           | `@Composable` | Bottom-anchored Confirm & save / Retake / Discard.            |
+| `ReceiptOcrReviewViewModel` | `ViewModel`   | Calls KMP parse/assemble/score; holds the draft as UI state.  |
+
+---
+
+## 5. Review & correction UI
+
+The review surface shows **what OCR read** and makes **fixing it cheap**:
+
+- **Pre-filled fields.** Merchant, date, total, tax hint, and payment hint are
+  rendered from the shared draft, each in an `OcrFieldRow`.
+- **Targeted edits.** Tapping a field opens an inline editor scoped to _just_ that
+  field — correcting the date never disturbs the merchant or total. Edits update
+  UI state only; the shared math is re-derived where appropriate (for example,
+  total stays integer cents).
+- **Line items, deferred.** Itemised receipts expose an expandable
+  `OcrLineItemsSection`, collapsed by default so the common case (merchant +
+  total) stays simple.
+- **Save reuses the proven path.** Confirm maps the reviewed draft to a real
+  `Transaction` through the existing repository — the same save path used by the
+  [receipt-to-expense draft flow](./android-receipt-to-expense-draft.md).
+
+The user never has to clear and retype the whole receipt — the explicit design
+goal is **correct the few wrong fields, accept the rest**.
+
+---
+
+## 6. Confidence presentation
+
+Confidence comes entirely from the shared `ReceiptConfidence` model and drives
+**presentation only**:
+
+| Band       | Meaning                          | Presentation                                                        |
+| ---------- | -------------------------------- | ------------------------------------------------------------------- |
+| `HIGH`     | Trustworthy extraction           | Plain field; no nag; editable on tap.                               |
+| `LOW`      | Probably right, double-check     | Badge "double-check" + icon; field pre-focused for quick edit.      |
+| `UNUSABLE` | Missing/unreliable required data | Inline prompt to fill manually or **Retake**; Save gated as needed. |
+
+Rules:
+
+- A band **never changes a value** — it only changes highlighting and focus order.
+- Confidence is conveyed by **badge text + icon**, never color alone, satisfying
+  the contrast guidance in the [Accessibility Patterns Library](./accessibility-patterns.md).
+- `ReceiptConfidenceFlag`s map to specific field hints (for example,
+  `MISSING_TOTAL`) and to inline validation at save time.
+
+---
+
+## 7. Optional receipt attachment
+
+- The captured image is shown in a `ReceiptThumbnailCard` with an explicit
+  **Attach receipt** toggle — attachment is **optional**, never required to save.
+- When attachment is on, persistence and any COGS/supplies mapping are handled by
+  [Android Receipt Attachments & COGS Mapping](./android-receipt-attachments-cogs.md)
+  ([#2549](https://github.com/jrmoulckers/finance/issues/2549)); this surface only
+  passes the on-device image reference into the draft's `attachments`.
+- The attachment links to the saved transaction; the image stays in app-private,
+  encrypted storage and is never uploaded as part of review.
+
+---
+
+## 8. On-device privacy
+
+Privacy is a first-class requirement of [#2388](https://github.com/jrmoulckers/finance/issues/2388):
+
+- **On-device OCR only.** ML Kit text recognition runs locally; there is **no**
+  cloud vision call. The captured image and recognized text never leave the
+  device during capture or review.
+- **No-upload copy.** The review screen reiterates the capture-time assurance
+  ("Stays on your phone") so the user can trust the flow at the point of review.
+- **No sensitive logging.** No merchant, total, amount, or account value is ever
+  written to Timber. Structured logs record flow milestones only (for example
+  "draft built", "review confirmed") via `Timber.d`/`Timber.w` with **no**
+  sensitive values, per the client logging rules.
+- **Encrypted at rest.** If attached, the image lands in app-private storage on
+  the SQLCipher-encrypted data path; it is not written to shared/public media.
+
+---
+
+## 9. Offline-first, empty, and error states
+
+| State                    | Trigger                                          | UX                                                                                        |
+| ------------------------ | ------------------------------------------------ | ----------------------------------------------------------------------------------------- |
+| Empty / no recognition   | ML Kit returns no usable text                    | Friendly empty card: offer **Enter manually** and **Retake**.                             |
+| Unusable scan            | `band == UNUSABLE`, `merchant`/`total` both null | Manual-entry fallback (per #2563) + **Retake**; Save gated until required fields present. |
+| Partial extraction       | Some fields null                                 | Pre-fill what exists; flag the rest with `LOW`/`UNUSABLE` cues (see §6).                  |
+| Offline                  | No connectivity                                  | Fully functional — OCR and review are on-device; draft saved locally and synced later.    |
+| Save validation error    | `MISSING_TOTAL` etc. at confirm                  | Inline errors; assertive live region; focus first invalid field; draft preserved.         |
+| Repository/save failure  | `insert` throws                                  | Non-destructive error card with **Retry**; the reviewed draft is preserved.               |
+| Process death mid-review | App killed before save                           | `SavedStateHandle` restores the reviewed field values so no correction work is lost.      |
+
+---
+
+## 10. Accessibility
+
+This flow targets WCAG 2.2 AA and follows the shared
+[Accessibility Patterns Library](./accessibility-patterns.md).
+
+- **TalkBack:** Every `OcrFieldRow` exposes a `contentDescription` combining
+  label, value, and confidence ("Total, 24 dollars 80 cents, please
+  double-check"). Headings use `semantics { heading() }`. Confirm/Retake/Discard
+  announce their action and result. The thumbnail card is labelled and the attach
+  toggle announces its on/off state.
+- **Switch Access:** Logical top-to-bottom focus; the sticky `ReviewActionBar` is
+  reachable last with large, single-purpose targets (≥ 48 dp, ≥ 56 dp under
+  [rugged mode](./android-rugged-mode-tokens.md)). No action depends on a gesture
+  or long-press only.
+- **200% font scaling:** All text uses `sp` and wraps rather than truncates; the
+  action bar collapses Confirm/Retake/Discard into a vertical stack at large
+  scale; field rows grow in height and never clip the value.
+- **Live regions:** Validation errors and save confirmation use an assertive live
+  region so non-visual users hear the outcome immediately.
+- **Color independence:** Confidence is conveyed by badge text + icon, never color
+  alone.
+- **Field / rugged conditions:** When rugged mode is on, targets grow, contrast
+  rises, and motion reduces — this surface consumes those tokens, making review
+  usable in sunlight with gloves.
+
+---
+
+## 11. Test plan
+
+| Layer                | Tooling                | Coverage                                                                                                                                                                                          |
+| -------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Unit (ViewModel)     | JUnit + coroutine test | Draft seeded from shared parse/assemble/score; per-field edits do not mutate shared math; confirm maps to a valid `Transaction`; validation gates on `MISSING_TOTAL`/`MISSING_MERCHANT`.          |
+| Unit (state machine) | JUnit                  | `Recognizing → Reviewing → Saving → Saved` transitions; error path preserves the reviewed draft; process-death restore from `SavedStateHandle`.                                                   |
+| Compose UI           | `compose-ui-test`      | Low-confidence field shows the badge + correction control; Save disabled until required fields present; error card exposes **Retry**; attach toggle state; semantics assertions; font-scale 2.0f. |
+| Snapshot             | Paparazzi              | `ReceiptOcrReviewScreen` in: high-confidence, low-confidence, unusable, saving, error — at default and 200% font scale, standard vs. rugged theme, light/dark.                                    |
+
+Shared business rules (`parseReceiptText`, `buildTransactionDraft`,
+`scoreConfidence`) are covered by existing `packages/core` tests and are **not**
+re-tested here — only the Android rendering, correction, and save wiring are. ML
+Kit recognition is exercised through the adapter with fixture text so review logic
+is testable without a camera.
+
+---
+
+## 12. Implementation readiness
+
+This is a design artifact. Implementation splits into a part that is fully
+buildable today and a tail that is gated by Play onboarding.
+
+See [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md) and the
+[Launch Readiness Plan](../ops/launch-readiness-plan.md) for the gating context.
+
+### Buildable now (debug, no human gate)
+
+- `ReceiptOcrReviewScreen`, `ReceiptOcrReviewViewModel`, the field rows,
+  confidence cues, attachment card, state model, and Koin wiring are pure Compose
+  - KMP consumption over the existing on-device ML Kit adapter — fully
+    implementable and runnable via `./gradlew :apps:android:assembleDebug` and
+    sideload.
+- On-device OCR (ML Kit) and the shared parse/assemble/score functions need no
+  signing or store presence; review logic is testable with fixture text.
+- Save wiring reuses the existing local `TransactionRepository`; verifiable with
+  unit, Compose, and Paparazzi tests on CI and emulator/sideload.
+
+### Play-distribution tail (gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242))
+
+- Production signing keystore + Google Play Console onboarding.
+- Internal-testing-track upload, privacy declarations (camera + on-device OCR),
+  and staged rollout.
+- Anything requiring a release-signed AAB (not `assembleDebug`).
+
+No part of this review flow itself is blocked from being built and tested in debug;
+only its production distribution is.
+
+---
+
+## 13. Cross-links
+
+- Sibling: [Android CameraX Receipt Capture & Fallback](./android-cameraX-receipt-capture.md) — [#2563](https://github.com/jrmoulckers/finance/issues/2563)
+- Sibling: [Android Receipt-to-Expense Draft Flow](./android-receipt-to-expense-draft.md) — [#2547](https://github.com/jrmoulckers/finance/issues/2547)
+- Sibling: [Android Receipt Attachments & COGS Mapping](./android-receipt-attachments-cogs.md) — [#2549](https://github.com/jrmoulckers/finance/issues/2549)
+- Field cluster: [Android Field-Mode Transaction & Receipt Flow](./android-field-mode-transaction-flow.md) — [#2561](https://github.com/jrmoulckers/finance/issues/2561) · [Android Rugged Mode — Design Tokens & Preference](./android-rugged-mode-tokens.md) — [#2559](https://github.com/jrmoulckers/finance/issues/2559)
+- [Accessibility Patterns Library](./accessibility-patterns.md) · [Cognitive Accessibility Mode](./cognitive-accessibility.md)
+- [Component Library](./component-library.md) · [UX Design Principles](./ux-principles.md) · [Content & Language Guidelines](./content-language-guidelines.md)
+- [Android Architecture](../architecture/android-architecture.md) · [Data Model](./data-model.md) · [Information Architecture](./information-architecture.md) · [User Personas](./personas.md)
+- Ops: [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md) · [Launch Readiness Plan](../ops/launch-readiness-plan.md)

--- a/docs/design/android-rugged-mode-tokens.md
+++ b/docs/design/android-rugged-mode-tokens.md
@@ -1,0 +1,394 @@
+# Android Rugged Mode — Design Tokens & Preference
+
+> **Status:** Design / breakdown only — native implementation gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+> **Issue:** [#2559](https://github.com/jrmoulckers/finance/issues/2559) · **Part of:** [#2186](https://github.com/jrmoulckers/finance/issues/2186)
+> **Platform:** Android (Jetpack Compose + Material 3) · **minSdk 28 / target 35** · **Audience:** Android engineers, design, QA
+
+This document designs **Rugged mode** for the Android client: a user-selectable
+display profile tuned for **field conditions** — direct outdoor sunlight, gloved
+or wet hands, cold fingers, and one-handed use on a budget device. It defines the
+**preference model**, the **persistence expectations**, and — _conceptually_ —
+the **design-token additions** that a Rugged theme would consume.
+
+It is a **design / breakdown only** document. It does **not** add native code or
+edit any token source, while production signing and Play distribution remain
+blocked by [#1242](https://github.com/jrmoulckers/finance/issues/1242).
+
+> **Token ownership note.** This doc describes the Rugged-mode token set
+> _conceptually_. The actual token JSON under
+> [`packages/design-tokens/`](../../packages/design-tokens/) (and any generated
+> output) is owned by the design-engineer. **No token files are added or edited
+> here** — this is the Android-side intent and consumption contract that the
+> design-engineer can implement against.
+
+The guiding rule, as everywhere in the Android client: **Compose renders shared
+state; it does not own finance math.** Rugged mode changes _how_ surfaces look
+and _how big_ targets are; it never changes balances, totals, or category logic,
+which stay in Kotlin Multiplatform (KMP) [`packages/core`](../../packages/core/).
+
+---
+
+## Table of Contents
+
+1. [Goals & non-goals](#1-goals--non-goals)
+2. [Personas & field conditions](#2-personas--field-conditions)
+3. [The Compose-renders-shared-state boundary](#3-the-compose-renders-shared-state-boundary)
+4. [Rugged-mode preference & persistence](#4-rugged-mode-preference--persistence)
+5. [Token additions (conceptual)](#5-token-additions-conceptual)
+6. [Token → Compose theme mapping](#6-token--compose-theme-mapping)
+7. [Preference UI & quick toggle](#7-preference-ui--quick-toggle)
+8. [Offline-first, empty, and error states](#8-offline-first-empty-and-error-states)
+9. [Accessibility](#9-accessibility)
+10. [Test plan](#10-test-plan)
+11. [Implementation readiness](#11-implementation-readiness)
+12. [Cross-links](#12-cross-links)
+
+---
+
+## 1. Goals & non-goals
+
+### Goals
+
+- Add a **Rugged mode** preference the user can turn on/off, plus a fast
+  in-context toggle for the field.
+- Define a **token-driven** display profile that, when active, raises contrast,
+  enlarges touch targets and text, thickens borders/focus rings, and reduces
+  glare-prone surfaces — _without_ changing data.
+- Specify **persistence**: rugged mode survives process death, app restart, and
+  is restored on the next cold start, fully offline.
+- Keep all visual changes **token-mapped** so the design-engineer owns the values
+  and the Android theme simply consumes them.
+- Compose with existing accessibility surfaces (high-contrast, font scaling,
+  cognitive mode) rather than competing with them.
+
+### Non-goals
+
+- **Editing token source.** Token JSON/generation under
+  [`packages/design-tokens/`](../../packages/design-tokens/) is out of scope here
+  (see ownership note above).
+- The simplified field navigation and add-expense flow — designed separately in
+  [Android Field-Mode Transaction & Receipt Flow](./android-field-mode-transaction-flow.md)
+  ([#2561](https://github.com/jrmoulckers/finance/issues/2561)).
+- Any change to KMP finance rules, money math, or category logic.
+- Display-only hardware controls (screen brightness, torch) — Rugged mode hints
+  at them but the OS owns them.
+
+---
+
+## 2. Personas & field conditions
+
+The driving persona from [#2186](https://github.com/jrmoulckers/finance/issues/2186)
+is a **mobile/field worker** — gig driver, food-truck operator, trades or
+on-site worker — logging money _while working_, not at a desk. See
+[User Personas & MVP Scope](./personas.md) for the broader set.
+
+Rugged mode is designed against five concrete field conditions:
+
+| Condition           | Problem it causes                                 | Rugged-mode response                                            |
+| ------------------- | ------------------------------------------------- | --------------------------------------------------------------- |
+| Direct sunlight     | Low perceived contrast; washed-out color          | Max-contrast palette, darker text on lighter solids, less glare |
+| Gloved / cold hands | Reduced touch precision; capacitive misses        | Larger touch targets (≥ 56 dp), bigger spacing, fewer gestures  |
+| Wet screen          | Phantom touches; mis-taps; accidental destructive | Confirm-before-destructive, generous hit slop, no swipe-to-act  |
+| One-handed use      | Top of screen unreachable while holding cargo     | Bottom-anchored primary actions; reachable toggle               |
+| Budget device       | Slow GPU; dynamic-color/animation cost            | Reduced motion, simpler elevation, static high-contrast palette |
+
+Jobs this preference must satisfy:
+
+- "Make the screen **readable in the sun** without fighting brightness."
+- "Make the buttons **big enough to hit with gloves**."
+- "**Remember** I'm in the field — don't make me re-enable this every time."
+
+---
+
+## 3. The Compose-renders-shared-state boundary
+
+Rugged mode is a **presentation concern**. The split:
+
+| Concern                                 | Where it lives                              | Notes                                                        |
+| --------------------------------------- | ------------------------------------------- | ------------------------------------------------------------ |
+| Rugged on/off + restore                 | Android preference store (DataStore)        | A display preference; not finance data, not a secret.        |
+| Token values (color, size, motion)      | `packages/design-tokens/` (conceptual)      | Owned by design-engineer; Android consumes generated values. |
+| Balances, totals, category math         | KMP [`packages/core`](../../packages/core/) | Unchanged by rugged mode; Compose renders shared state.      |
+| Theme assembly from tokens + preference | `apps/android` Compose theme layer          | Picks the rugged token set when the preference is on.        |
+
+**Boundary rules**
+
+- Rugged mode never reaches into KMP business logic. It only selects a token set
+  and a few layout flags consumed by the Compose theme.
+- All money remains integer **cents** across the boundary and is formatted by the
+  shared [`CurrencyFormatter`](../../packages/core/src/commonMain/kotlin/com/finance/core/currency/CurrencyFormatter.kt);
+  rugged mode changes type size/contrast, never the value or its formatting.
+- The preference is a **plain display flag** — it carries no account, balance, or
+  PII — so it lives in standard DataStore, not the Keystore-backed secret store.
+
+```mermaid
+flowchart LR
+    subgraph Pref["apps/android preference (DataStore)"]
+        Flag["ruggedEnabled: Boolean"]
+    end
+    subgraph Tokens["packages/design-tokens (owned by design-engineer)"]
+        Std["semantic + component tokens"]
+        Rug["rugged token set (conceptual)"]
+    end
+    subgraph Theme["apps/android Compose theme"]
+        Sel["RuggedThemeSelector"]
+        MT["MaterialTheme(colorScheme, typography, shapes)"]
+    end
+    subgraph Core["KMP packages/core (unchanged)"]
+        Math["balances, totals, categories"]
+    end
+    Flag --> Sel
+    Std --> Sel
+    Rug --> Sel
+    Sel --> MT
+    Math --> MT
+```
+
+---
+
+## 4. Rugged-mode preference & persistence
+
+### Preference model
+
+Rugged mode is exposed as a small, render-only state object owned by a Compose
+`ViewModel` and backed by DataStore:
+
+| Field                   | Type      | Default | Meaning                                                        |
+| ----------------------- | --------- | ------- | -------------------------------------------------------------- |
+| `ruggedEnabled`         | `Boolean` | `false` | Master switch for the rugged display profile.                  |
+| `ruggedFollowsSunlight` | `Boolean` | `false` | Optional: auto-suggest rugged when ambient light is very high. |
+| `lastChangedAtEpochMs`  | `Long`    | `0`     | For diagnostics/telemetry only — never a financial value.      |
+
+> `ruggedFollowsSunlight` only ever _suggests_ via a dismissible hint; it never
+> silently flips the visual profile, so the screen never changes under the user's
+> hands unexpectedly.
+
+### Persistence expectations
+
+- **Store:** Jetpack **DataStore (Preferences)** — a display flag, not a secret.
+  Secrets stay in the Keystore-backed path; rugged mode does **not**.
+- **Survives:** process death (`SavedStateHandle` mirrors the in-flight value),
+  app restart, and device reboot. On cold start the theme reads the persisted
+  value _before first composition_ so there is **no flash** of the standard theme.
+- **Offline:** fully local; no network, no sync dependency. Setting it works in
+  airplane mode.
+- **Scope:** per-device display preference (a co-driver's phone shouldn't inherit
+  it via account sync). It is intentionally **not** synced through PowerSync.
+- **Migration safety:** absent key ⇒ `false`; unknown future keys ignored.
+
+```mermaid
+stateDiagram-v2
+    [*] --> StandardTheme
+    StandardTheme --> RuggedTheme: toggle on (persist)
+    RuggedTheme --> StandardTheme: toggle off (persist)
+    RuggedTheme --> RuggedTheme: process death then restore
+    StandardTheme --> StandardTheme: cold start reads persisted false
+```
+
+---
+
+## 5. Token additions (conceptual)
+
+This section describes the **intent** of the Rugged token set so the
+design-engineer can implement it under
+[`packages/design-tokens/`](../../packages/design-tokens/). It deliberately
+**mirrors the existing cognitive-mode precedent** (a semantic + component
+override layer) rather than inventing a new mechanism. **No files are added or
+edited here.**
+
+### Proposed semantic layer
+
+A high-contrast, low-glare semantic color set conceptually named
+`colors.rugged` (analogous to the existing `colors.high-contrast` /
+`colors.dark-oled` semantic sets):
+
+| Conceptual token   | Intent                                                        |
+| ------------------ | ------------------------------------------------------------- |
+| `rugged.surface`   | Lighter, matte solid; minimal translucency to cut glare.      |
+| `rugged.onSurface` | Near-black text for max sunlight legibility (target ≥ 7:1).   |
+| `rugged.primary`   | Saturated, high-contrast accent that survives bright ambient. |
+| `rugged.outline`   | Thicker, darker dividers/borders for shape definition.        |
+| `rugged.error`     | Distinct from `primary` by shape + icon, not hue alone.       |
+| `rugged.focusRing` | Extra-bold focus indicator for Switch Access in the field.    |
+
+### Proposed component / dimension layer
+
+Mirrors `component/cognitive.json` (`touchTargetMin`, increased padding):
+
+| Conceptual token        | Intent                                                       |
+| ----------------------- | ------------------------------------------------------------ |
+| `rugged.touchTargetMin` | ≥ 56 dp minimum hit target (above the 48 dp baseline).       |
+| `rugged.spacingScale`   | Larger inter-control spacing to reduce wet-screen mis-taps.  |
+| `rugged.borderWidth`    | Thicker control/borders (e.g. 2–3 dp) for definition.        |
+| `rugged.typeScaleBoost` | Additional type-scale step on top of the user's font scale.  |
+| `rugged.motionReduced`  | Disable non-essential animation on budget GPUs.              |
+| `rugged.elevationFlat`  | Flatter elevation to avoid glare-prone shadows/translucency. |
+
+### Relationship to existing accessibility settings
+
+Rugged mode **composes with**, and never silently overrides, existing settings:
+
+- It is a sibling to high-contrast and [cognitive mode](./cognitive-accessibility.md),
+  reusing the same override pattern.
+- It **respects the OS font scale** and adds `typeScaleBoost` on top — it never
+  caps or shrinks user-chosen text size.
+- If the user already runs system high-contrast, rugged mode layers field-specific
+  sizing/motion changes without double-darkening text.
+
+---
+
+## 6. Token → Compose theme mapping
+
+The Android theme layer reads the persisted preference and assembles
+`MaterialTheme` from the appropriate token set. The mapping is mechanical: tokens
+flow into `ColorScheme`, `Typography`, and `Shapes`; dimension tokens flow into a
+small `LocalRuggedMetrics` provider consumed by components.
+
+| Compose surface                    | Standard source                | Rugged source (conceptual)         |
+| ---------------------------------- | ------------------------------ | ---------------------------------- |
+| `ColorScheme`                      | dynamic-color / semantic light | `colors.rugged` semantic set       |
+| `Typography`                       | type tokens × OS font scale    | + `rugged.typeScaleBoost`          |
+| Min touch target (`LocalMinTouch`) | 48 dp baseline                 | `rugged.touchTargetMin` (≥ 56 dp)  |
+| Border / focus width               | 1 dp / default ring            | `rugged.borderWidth` / bold ring   |
+| Motion (`LocalAnimationSpec`)      | default specs                  | reduced per `rugged.motionReduced` |
+| Elevation / overlay                | tonal elevation                | `rugged.elevationFlat`             |
+
+Existing Android theming surfaces this plugs into (read-only references):
+[`FinanceTheme`](../../apps/android/src/main/kotlin/com/finance/android/ui/theme/FinanceTheme.kt),
+[`ThemeManager`](../../apps/android/src/main/kotlin/com/finance/android/ui/theme/ThemeManager.kt),
+[`ThemePreference`](../../apps/android/src/main/kotlin/com/finance/android/ui/theme/ThemePreference.kt),
+[`Color`](../../apps/android/src/main/kotlin/com/finance/android/ui/theme/Color.kt),
+[`Spacing`](../../apps/android/src/main/kotlin/com/finance/android/ui/theme/Spacing.kt),
+and the existing [`HighContrastTheme`](../../apps/android/src/main/kotlin/com/finance/android/ui/accessibility/HighContrastTheme.kt).
+A `RuggedThemeSelector` would slot alongside these and pick the rugged token set
+when `ruggedEnabled` is true.
+
+> **Dynamic color note.** Material You dynamic color can wash out under sunlight
+> and is GPU-costly on budget devices. When rugged mode is on, the theme prefers
+> the **static** `colors.rugged` set over wallpaper-derived dynamic color.
+
+---
+
+## 7. Preference UI & quick toggle
+
+Two entry points, both Compose:
+
+1. **Settings → Appearance** — a labelled switch row with a one-line explanation
+   and an inline preview chip showing the larger, higher-contrast button. This
+   joins the existing
+   [`AppearanceSettingsScreen`](../../apps/android/src/main/kotlin/com/finance/android/ui/screens/settings/AppearanceSettingsScreen.kt)
+   / [`AccessibilityPreferencesScreen`](../../apps/android/src/main/kotlin/com/finance/android/ui/screens/AccessibilityPreferencesScreen.kt)
+   surfaces.
+2. **In-context quick toggle** — a bottom-reachable affordance (e.g. a Quick
+   Settings tile or a long-press on the field FAB) so a user can switch to rugged
+   mode _without_ digging into settings while wearing gloves.
+
+| Composable             | Type          | Responsibility                                               |
+| ---------------------- | ------------- | ------------------------------------------------------------ |
+| `RuggedModeSettingRow` | `@Composable` | Labelled switch + explanation + live preview chip.           |
+| `RuggedQuickToggle`    | `@Composable` | Large, bottom-anchored toggle for in-field switching.        |
+| `RuggedModeViewModel`  | `ViewModel`   | Reads/writes the DataStore-backed preference; exposes state. |
+
+Every interactive element carries a `contentDescription` and a state description
+("Rugged mode, on" / "off") so TalkBack announces both the control and its value.
+
+---
+
+## 8. Offline-first, empty, and error states
+
+| State                    | Trigger                                 | UX                                                                                       |
+| ------------------------ | --------------------------------------- | ---------------------------------------------------------------------------------------- |
+| First run / never set    | No persisted key                        | Defaults to off; setting row shows a short "what this does" explanation.                 |
+| Toggle while offline     | Airplane mode / no network              | Works fully; no spinner, no network call — it is a local flag.                           |
+| Persist write fails      | DataStore I/O error                     | In-memory value still applies for the session; non-blocking retry; log a milestone only. |
+| Process death mid-toggle | App killed before write flushes         | `SavedStateHandle` restores the in-flight value; reconciled on next write.               |
+| Cold start               | App launches with rugged persisted true | Theme reads value before first composition — no flash of standard theme.                 |
+
+No financial data is ever written to Timber for this feature. Structured logs
+record flow milestones only (for example "rugged toggled") via `Timber.d`/`Timber.w`
+with **no** sensitive values, per the client logging rules.
+
+---
+
+## 9. Accessibility
+
+Rugged mode is itself an accessibility feature, and its own surfaces must meet
+WCAG 2.2 AA and the shared [Accessibility Patterns Library](./accessibility-patterns.md).
+
+- **TalkBack:** The switch row and quick toggle expose role, label, and on/off
+  state ("Rugged mode, switch, on"). The settings heading uses
+  `semantics { heading() }`. The preview chip is `contentDescription`-labelled
+  and not focus-trapping.
+- **Switch Access:** Logical top-to-bottom focus; the quick toggle is a single,
+  large, bottom-reachable target. Rugged mode bumps the focus-ring weight via
+  `rugged.focusRing` for outdoor visibility.
+- **200% font scaling:** All copy uses `sp` and wraps; rugged `typeScaleBoost`
+  adds to — never replaces — the user's OS font scale. No truncation of the
+  setting label or explanation at max scale.
+- **High contrast & sunlight:** Rugged palette targets ≥ 7:1 text contrast; state
+  is conveyed by text + icon + shape, never color alone, so it survives glare and
+  color-vision differences.
+- **Gloves / wet / outdoor:** Touch targets ≥ 56 dp with generous hit slop; no
+  swipe-to-act or long-press-only paths for the core toggle; destructive actions
+  always confirm to defend against phantom wet-screen touches.
+- **Large touch targets & reduced motion:** `rugged.touchTargetMin` and
+  `rugged.motionReduced` keep the field experience tappable and calm on budget
+  GPUs.
+
+---
+
+## 10. Test plan
+
+| Layer               | Tooling                | Coverage                                                                                                                                                   |
+| ------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Unit (ViewModel)    | JUnit + coroutine test | Default is off; toggle persists; restore after process death; absent-key migration ⇒ off; offline toggle applies without network.                          |
+| Unit (theme select) | JUnit                  | `RuggedThemeSelector` picks the rugged token set iff `ruggedEnabled`; respects OS font scale; composes with high-contrast without double-darkening.        |
+| Compose UI          | `compose-ui-test`      | Switch announces on/off state; quick toggle is reachable and ≥ 56 dp; semantics/`contentDescription` assertions; font-scale `2.0f` layout has no clipping. |
+| Snapshot            | Paparazzi              | A representative screen in standard vs. rugged, at default and 200% font scale, light/dark — asserting larger targets, thicker borders, flatter elevation. |
+
+Token _values_ themselves are validated in the design-tokens package by the
+design-engineer; this plan covers only the Android **preference, persistence, and
+theme consumption**.
+
+---
+
+## 11. Implementation readiness
+
+This is a design artifact. Implementation splits into a part that is fully
+buildable today and a tail that is gated by Play onboarding.
+
+See [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md) and the
+[Launch Readiness Plan](../ops/launch-readiness-plan.md) for the gating context.
+
+### Buildable now (debug, no human gate)
+
+- The `RuggedModeViewModel`, DataStore persistence, `RuggedThemeSelector`, setting
+  row, and quick toggle are pure Compose + Android plumbing — fully implementable
+  and runnable via `./gradlew :apps:android:assembleDebug` and sideload.
+- Theme consumption can be wired against the existing standard token set today and
+  swapped to the rugged set once the design-engineer lands the conceptual tokens.
+- Unit, Compose, and Paparazzi tests run on CI and emulator/sideload with no
+  signing or store presence.
+
+### Play-distribution tail (gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242))
+
+- Production signing keystore + Google Play Console onboarding.
+- Internal-testing-track upload, privacy declarations, and staged rollout.
+- Anything requiring a release-signed AAB (not `assembleDebug`).
+
+The rugged-mode preference and theme are not blocked from being built and tested
+in debug; only their production distribution is. The token _values_ are a parallel
+dependency owned by the design-engineer, not a build blocker for the Android
+plumbing.
+
+---
+
+## 12. Cross-links
+
+- Sibling: [Android Field-Mode Transaction & Receipt Flow](./android-field-mode-transaction-flow.md) — [#2561](https://github.com/jrmoulckers/finance/issues/2561)
+- Sibling: [Android Receipt OCR Review → Transaction Draft](./android-receipt-ocr-review-draft.md) — [#2565](https://github.com/jrmoulckers/finance/issues/2565)
+- [Cognitive Accessibility Mode](./cognitive-accessibility.md) · [Accessibility Patterns Library](./accessibility-patterns.md)
+- [OLED & Dark Mode](./oled-dark-mode.md) · [Token Preview](./token-preview.md) · [Component Library](./component-library.md)
+- [UX Design Principles](./ux-principles.md) · [Content & Language Guidelines](./content-language-guidelines.md) · [Responsive Breakpoints](./responsive-breakpoints.md)
+- [Android Architecture](../architecture/android-architecture.md) · [User Personas](./personas.md)
+- Ops: [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md) · [Launch Readiness Plan](../ops/launch-readiness-plan.md)


### PR DESCRIPTION
## Summary

Adds three **design / breakdown-only** docs under `docs/design/` for the Android field/rugged-mode cluster. No native code, no token-source edits, no build/sign/store actions — design artifacts only while native Android remains gated by #1242.

All three follow the house pattern: humans-first prose, Table of Contents, Mermaid diagrams, relative cross-links to existing docs, the **Compose-renders-shared-state** boundary (finance math stays in KMP `packages/core`), offline/empty/error states, accessibility (TalkBack, Switch Access, 200% font, high-contrast / gloves / outdoor-sunlight rugged considerations, ≥ 56 dp touch targets), a unit/Compose/Paparazzi test plan, and an **Implementation readiness** section that splits buildable-now (`assembleDebug` sideload) from the Play-distribution tail gated by #1242 via `../ops/human-gated-prerequisites.md`.

## Changes

- **`docs/design/android-rugged-mode-tokens.md`** — Rugged mode preference + persistence (DataStore display flag, survives process death / restart) and a **conceptual** design-token set (mirrors the cognitive-mode precedent). Token JSON under `packages/design-tokens/` is described conceptually only and is left untouched (owned by @design-engineer). _Part of #2186._
- **`docs/design/android-field-mode-transaction-flow.md`** — Simplified one-handed, glove/wet-friendly add-expense → category → optional-receipt flow that renders the shared draft; bottom-anchored large targets; reuses the existing save path. _Part of #2186._
- **`docs/design/android-receipt-ocr-review-draft.md`** — On-device ML Kit OCR review/correction surface producing the shared `ReceiptTransactionDraft` with an optional, encrypted-at-rest receipt attachment; privacy-preserving (no upload). _Part of #2388._

Conflict-free: three brand-new files only — no existing file, `packages/`, `apps/`, shared config, other platforms, or other docs touched. Prettier `--check` passes; all relative links and in-page ToC anchors verified.

Closes #2559
Closes #2561
Closes #2565
