### PR TITLE
docs(design): ios merchant matching, PassKit constraints, notification scheduling design batch (#2605, #2606, #2622)

### DIFF
--- a/docs/design/ios-merchant-matching-duplicate-detection.md
+++ b/docs/design/ios-merchant-matching-duplicate-detection.md
@@ -1,0 +1,407 @@
+# Merchant Matching & Duplicate Detection — iOS
+
+> Design for the **reconciliation rules** that stop a user-captured,
+> "Apple Pay–adjacent" draft from becoming a **duplicate** of the same purchase
+> once it arrives through connected-account bank/card sync. The business rules —
+> merchant normalization, amount/date matching, confidence scoring, and the
+> merge/keep/ask decision — are **deterministic** and conceptually shared in KMP
+> `packages/core`; the native layer owns prefill display, masking, the merge UI,
+> and accessibility. Everything runs **on-device**; no Apple Pay/Wallet
+> transaction stream is read (it is not exposed — see
+> [ios-passkit-wallet-constraints.md](./ios-passkit-wallet-constraints.md)).
+
+**Status:** PROPOSED — design only (native implementation buildable now; store distribution gated)
+**Issue:** [#2605](https://github.com/jrmoulckers/finance/issues/2605) — Part of [#2171](https://github.com/jrmoulckers/finance/issues/2171)
+**Platform:** iOS / iPadOS / macOS (SwiftUI, `@Observable`, iOS 17+)
+**Owner:** @ios-engineer
+**Related:** [ios-wallet-adjacent-capture-inbox.md](./ios-wallet-adjacent-capture-inbox.md) · [ios-passkit-wallet-constraints.md](./ios-passkit-wallet-constraints.md) · [ios-one-thumb-quick-add.md](./ios-one-thumb-quick-add.md) · [ios-noncolor-financial-state-cues.md](./ios-noncolor-financial-state-cues.md) · [accessibility-patterns.md](./accessibility-patterns.md) · [cognitive-accessibility.md](./cognitive-accessibility.md) · [content-language-guidelines.md](./content-language-guidelines.md) · [data-model.md](./data-model.md) · [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md)
+
+---
+
+## Table of Contents
+
+1. [Goal & Scope](#1-goal--scope)
+2. [The Duplicate Problem](#2-the-duplicate-problem)
+3. [Matching Rules](#3-matching-rules)
+4. [Merchant Normalization](#4-merchant-normalization)
+5. [Confidence Scoring & the Decision](#5-confidence-scoring--the-decision)
+6. [Reconciliation Flow](#6-reconciliation-flow)
+7. [Native ↔ KMP Boundary](#7-native--kmp-boundary)
+8. [Affected iOS Surfaces & Shared Dependencies](#8-affected-ios-surfaces--shared-dependencies)
+9. [Accessibility & Dynamic Type](#9-accessibility--dynamic-type)
+10. [Privacy & Security](#10-privacy--security)
+11. [Duplicate, Ambiguous, Stale, Error & Empty States](#11-duplicate-ambiguous-stale-error--empty-states)
+12. [Test Plan (Smallest Tests First)](#12-test-plan-smallest-tests-first)
+13. [Implementation Readiness](#13-implementation-readiness)
+14. [Open Questions](#14-open-questions)
+
+---
+
+## 1. Goal & Scope
+
+A user taps to pay for coffee, captures it manually (or via a receipt scan / the
+App Clip quick-add), and two days later the **same** charge lands through
+bank/card sync. Without reconciliation the user now sees **two** coffees and
+their budget is wrong. This design defines the rules that recognize the two
+records as the **same purchase** and resolve them into one, while never
+**silently** merging records that are merely similar.
+
+**In scope**
+
+- The **matching predicate**: when is candidate _C_ "the same purchase" as
+  synced transaction _S_ (or another draft)?
+- **Merchant normalization** so "SQ \*BLUE BOTTLE 0123" and "Blue Bottle Coffee"
+  compare as equal.
+- **Confidence scoring** and the **merge / link / keep-both / ask** decision.
+- The **ambiguous** case (one candidate, several plausible matches) and how it
+  surfaces to the user instead of guessing.
+
+**Out of scope (cross-referenced, not redefined here)**
+
+- The capture sources and the review-inbox surface that consumes these decisions
+  — [ios-wallet-adjacent-capture-inbox.md](./ios-wallet-adjacent-capture-inbox.md).
+- Why Apple Pay/Wallet history is unavailable and what we may use instead —
+  [ios-passkit-wallet-constraints.md](./ios-passkit-wallet-constraints.md).
+- Implementing the KMP rule engine (owned by `@kmp-engineer`; this is a design).
+
+---
+
+## 2. The Duplicate Problem
+
+Three record kinds can describe one real-world purchase, and any pair of them can
+collide:
+
+| Record kind                | Origin                                                      | Timing             | Fidelity                                       |
+| -------------------------- | ----------------------------------------------------------- | ------------------ | ---------------------------------------------- |
+| **User draft**             | Manual quick-add, receipt/share capture, App Clip queue     | At purchase time   | Exact amount, fuzzy merchant, user category    |
+| **Synced transaction**     | Bank/card aggregation via `packages/sync`                   | Hours to days late | Authoritative amount, processor-noisy merchant |
+| **Pending → posted shift** | A synced **pending** auth later **posts** (amount may tilt) | Days               | Amount can change by tax/tip; date can shift   |
+
+Reconciliation must handle: draft↔synced (the headline case), draft↔draft (two
+captures of one purchase), and synced-pending↔synced-posted (the same feed
+maturing). The same predicate serves all three.
+
+---
+
+## 3. Matching Rules
+
+A pair `(A, B)` is evaluated by independent, deterministic **dimensions**. Each
+yields a sub-score in `[0, 1]`; the engine combines them (§5). All thresholds are
+**configuration**, not magic numbers in code, so they can be tuned and tested.
+
+| Dimension     | Rule                                                                                                                    | Notes                                                                      |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| **Amount**    | Equal at minor-unit precision → full score. Within a tolerance band (absolute floor **or** small percentage) → partial. | Band covers tip/tax on a pending→posted shift; tolerance is per-currency.  |
+| **Date/time** | Within a primary window (hours) → full; within an extended window (a few days) → decaying partial; beyond → zero.       | Settlement lag means a wide-but-decaying window, not a hard equality.      |
+| **Merchant**  | Compare **normalized** names (§4) by token-set similarity; exact normalized equality → full.                            | Most signal but also most noise; never the sole basis for an auto-merge.   |
+| **Currency**  | Must be equal. Mismatch is a **hard veto** (score → 0 regardless of others).                                            | A 5.00 USD and 5.00 EUR draft are not the same purchase.                   |
+| **Account**   | Same account/card → boost; different known accounts → strong penalty; unknown (draft has no account) → neutral.         | Drafts often lack an account until accepted, so unknown must not penalize. |
+| **Direction** | Debit vs. credit must match.                                                                                            | A refund is not a duplicate of the purchase.                               |
+
+Two **hard vetoes** (currency mismatch, direction mismatch) short-circuit to "no
+match" before scoring — cheap and prevents nonsensical merges.
+
+---
+
+## 4. Merchant Normalization
+
+Raw descriptors are hostile: `"SQ *BLUE BOTTLE 0123 OAKLAND CA"`,
+`"TST* Blue Bottle"`, `"BLUEBOTTLE.COM 800-..."`. Normalization is a pure,
+ordered pipeline producing a stable **canonical token set**:
+
+1. **Upper-case + Unicode fold** (diacritics, full-width forms).
+2. **Strip processor prefixes/suffixes** — `SQ *`, `TST*`, `PAYPAL *`, `POS`,
+   trailing store numbers, phone numbers, URLs, city/state tails.
+3. **Drop noise tokens** — punctuation, standalone digit runs, common location
+   words, generic suffixes (`INC`, `LLC`, `COM`).
+4. **Tokenize + sort** into a set; similarity is token-set overlap (e.g.
+   Jaccard / weighted token ratio), which is robust to word order and trailing
+   junk.
+
+The pipeline is **deterministic and locale-aware** and lives with the matching
+rules in KMP so iOS, and later other platforms, normalize identically. It is
+**display-neutral**: normalization is only for comparison — the UI always shows
+the user-facing masked merchant, never the stripped token set.
+
+---
+
+## 5. Confidence Scoring & the Decision
+
+Sub-scores combine into one **confidence**, mapped to a four-way decision. The
+mapping is intentionally conservative: the system **auto-merges only when it is
+nearly certain**, and **asks** rather than guesses in the middle.
+
+```mermaid
+flowchart TD
+    A["Candidate A (draft)"] --> V{"Hard vetoes? currency / direction"}
+    B["Record B (synced or draft)"] --> V
+    V -->|"veto"| NM["No match - keep both"]
+    V -->|"pass"| SC["Score amount + date + merchant + account"]
+    SC --> CONF{"Confidence tier"}
+    CONF -->|"High - exact amount, in-window, merchant match"| MERGE["Auto-merge proposal (single undo)"]
+    CONF -->|"Medium - strong but imperfect"| ASK["Ask user: Merge or Keep both"]
+    CONF -->|"Low ambiguous - several plausible B"| PICK["Ask user to pick the match or keep separate"]
+    CONF -->|"None"| NM
+```
+
+| Tier                | Meaning                                                      | Default action                                 |
+| ------------------- | ------------------------------------------------------------ | ---------------------------------------------- |
+| **High**            | Exact amount + in primary window + normalized merchant match | Propose **merge** (still reversible, one undo) |
+| **Medium**          | One dimension imperfect (e.g. amount within tip band)        | **Ask**: Merge or Keep both                    |
+| **Low / ambiguous** | Multiple candidate matches, or merchant-only similarity      | **Ask** which match (or none)                  |
+| **None**            | Below floor or vetoed                                        | **Keep both** (no prompt)                      |
+
+**Merge semantics:** a merge keeps the **authoritative synced** record's amount,
+date, and account where they exist, and **preserves the user's draft category /
+note** (the human signal), recording a link so the pair never re-matches. The
+inbox ([ios-wallet-adjacent-capture-inbox.md](./ios-wallet-adjacent-capture-inbox.md))
+renders this as a single **Merge** affordance with a one-tap undo.
+
+---
+
+## 6. Reconciliation Flow
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant Sync as packages/sync feed
+    participant Bridge as Swift Export bridge
+    participant Eng as ReconciliationEngine (KMP, pure)
+    participant Inbox as Review Inbox (iOS)
+    U->>Inbox: Capture draft (manual / scan / clip)
+    Sync->>Bridge: New synced transactions
+    Bridge->>Eng: Match(draft, candidate set)
+    Eng-->>Bridge: Decision (tier + matched ids + reason)
+    Bridge-->>Inbox: MatchResult (masked, display-ready)
+    alt High confidence
+        Inbox->>U: Show single merged row + Undo
+    else Medium / ambiguous
+        Inbox->>U: Ask - Merge, Pick match, or Keep both
+        U->>Inbox: Choose
+    else None
+        Inbox->>U: Keep both (no prompt)
+    end
+    Inbox->>Eng: Record decision (suppress future re-match)
+```
+
+The engine is **stateless and pure** per call; the iOS side holds the candidate
+set, persists the user's decision, and feeds it back so an accepted "Keep both"
+is not re-proposed.
+
+---
+
+## 7. Native ↔ KMP Boundary
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages/core + packages/models (shared - DO NOT implement here)"]
+        K1["MerchantNormalizer (pure, locale-aware)"]
+        K2["MatchScorer: amount / date / merchant / account sub-scores"]
+        K3["DecisionPolicy: tier + action mapping (config-driven)"]
+    end
+    subgraph Bridge["Swift Export bridge (apps/ios/Finance/KMP)"]
+        B1["MatchResult: tier, matched ids, reason, masked fields"]
+    end
+    subgraph iOS["apps/ios (native - this design)"]
+        N1["ReconciliationViewModel (Observable)"]
+        N2["Merge / Pick-match / Keep-both UI + Undo"]
+        N3["Masking + prefill display (no PAN)"]
+        N4["Decision persistence (suppress re-match)"]
+    end
+    K1 --> K2 --> K3 --> B1 --> N1
+    N1 --> N2
+    N1 --> N3
+    N2 --> N4
+```
+
+- **Shared (KMP):** normalization, scoring, and the decision policy are
+  platform-neutral, deterministic business rules — they belong in
+  `packages/core` so every client reconciles identically. **This doc does not
+  implement them**; landing them is an ADR conversation with `@kmp-engineer` /
+  `@architect`.
+- **Native (iOS):** the `@Observable` view model, the merge/ask/undo SwiftUI,
+  masking and prefill display, accessibility semantics, and persistence of the
+  user's decision.
+- **Bridge:** Kotlin types map per the Swift Export contract (`Int` → `Int32`,
+  `String` → `String`, sealed `Decision` → enum). The bridge returns
+  **display-ready, masked** results; raw descriptors never cross into UI.
+
+---
+
+## 8. Affected iOS Surfaces & Shared Dependencies
+
+**New (native):**
+
+- `apps/ios/Finance/Features/Reconciliation/ReconciliationViewModel.swift` —
+  drives match proposals for the review inbox.
+- `apps/ios/Finance/Features/Reconciliation/MergeDecisionView.swift` — the
+  Merge / Pick-match / Keep-both affordance + undo.
+
+**Touched (additively):**
+
+- The **Review Inbox** rows gain a **Merge** action and an **ambiguous → pick**
+  sheet (UI owned by
+  [ios-wallet-adjacent-capture-inbox.md](./ios-wallet-adjacent-capture-inbox.md)).
+- The one-thumb quick-add flow
+  ([ios-one-thumb-quick-add.md](./ios-one-thumb-quick-add.md)) hands new drafts
+  to reconciliation before commit.
+
+**Reused unchanged:** `TransactionValidator`, `CategorizationEngine`, the App
+Group `ClipTransaction` pending queue, and the `packages/sync` feed.
+
+**Shared dependency:** the proposed `ReconciliationEngine` (normalizer + scorer +
+policy) in KMP `packages/core` via the Swift Export bridge ([§7](#7-native--kmp-boundary)).
+
+---
+
+## 9. Accessibility & Dynamic Type
+
+- **Decisions are non-color.** A proposed merge, an ambiguous prompt, and a
+  kept-separate pair each carry a **word + SF Symbol + shape** cue, reusing
+  [ios-noncolor-financial-state-cues.md](./ios-noncolor-financial-state-cues.md).
+  VoiceOver reads "Likely duplicate of Blue Bottle, 4 dollars 50, June 18" — not
+  "yellow badge".
+- **Plain-language reasons.** Each proposal states _why_ ("same amount and
+  merchant within two days") per
+  [content-language-guidelines.md](./content-language-guidelines.md) and
+  [cognitive-accessibility.md](./cognitive-accessibility.md) — no jargon, no
+  confidence percentages shouted at the user.
+- **Switch Control / keyboard.** Merge, Pick-match, and Keep-both are
+  `.accessibilityAction`s, not swipe-only; focus order is reason → matched record
+  → actions.
+- **Dynamic Type.** All reason text and the compare rows scale to AX5; the
+  side-by-side compare reflows to a stacked layout rather than truncating amount
+  or merchant. Targets stay ≥ 44×44 pt.
+- **Reduce Motion.** Merge collapses two rows with a cross-fade, not a slide;
+  undo restores without a cascade.
+
+---
+
+## 10. Privacy & Security
+
+- **On-device only.** Normalization, scoring, and the decision run locally; no
+  candidate, descriptor, or amount is sent anywhere for the purpose of matching.
+  This satisfies **data minimization** under GDPR/CCPA — reconciliation needs no
+  new collection.
+- **Apple Pay/Wallet is never read.** Restated from
+  [ios-passkit-wallet-constraints.md](./ios-passkit-wallet-constraints.md): there
+  is no public transaction stream and we will not use private APIs. Matching
+  operates only on user drafts and connected-account sync the user authorized.
+- **No PAN, ever.** Only last-4 display tokens and opaque account ids exist on
+  device; the normalizer strips, and never reconstructs, card data.
+- **`.private` logging.** Amounts, merchants, and account references are
+  `.private` in `os.Logger`; only structural events ("match: high, 1 candidate",
+  "user chose keep-both") are `.public`.
+- **Reversible & explainable.** Every auto-merge is undoable and every decision
+  records a human-readable reason, supporting a user's right to understand and
+  correct automated handling of their data.
+- **Decision data is minimal.** Suppression of a re-match stores a stable hash of
+  the pair, not the raw descriptors.
+
+---
+
+## 11. Duplicate, Ambiguous, Stale, Error & Empty States
+
+- **Duplicate detected (High).** Present one merged row with an inline "Likely
+  duplicate — merged" note and a single **Undo**; never double-count silently.
+- **Ambiguous (multiple candidates).** When one draft plausibly matches several
+  synced records, **do not pick** — show a short pick-list ("Which of these is
+  it?") with a **None of these** escape. This is the explicit ambiguous state the
+  acceptance criteria require.
+- **No match.** Keep both with no prompt; the draft proceeds through the normal
+  accept path.
+- **Stale feed.** If sync is older than a threshold, a draft may have **no**
+  counterpart yet; mark the row "No match yet — last synced <relative time>" and
+  offer **Refresh** rather than implying it is unique forever.
+- **Sync/normalization error.** A descriptor that fails to normalize falls back
+  to amount+date+currency matching and is flagged "merchant unreadable", never
+  dropped; a partial sync failure keeps already-fetched candidates with an inline
+  Retry.
+- **Empty.** No drafts to reconcile shows the inbox's positive empty state
+  (owned by the inbox doc), not a dead screen.
+
+---
+
+## 12. Test Plan (Smallest Tests First)
+
+Determinism is the contract, so every test uses **fixed fixtures** — no
+wall-clock reads, no network.
+
+### 12.1 Shared (Kotlin · `packages/core` · `commonTest`, owned by @kmp-engineer)
+
+1. **Normalizer golden tests:** `"SQ *BLUE BOTTLE 0123 OAKLAND CA"`,
+   `"TST* Blue Bottle"`, and `"BLUEBOTTLE.COM"` all normalize to the same token
+   set; unrelated merchants do not.
+2. **Amount tolerance:** equal amounts → full; within the tip/tax band → partial;
+   beyond → zero (per-currency floors asserted).
+3. **Date window:** in primary window → full; extended window → decayed partial;
+   beyond → zero, against a **fixed reference date**.
+4. **Hard vetoes:** currency mismatch and direction mismatch → "None" regardless
+   of other dimensions.
+5. **Decision mapping:** known sub-score combinations map to
+   High/Medium/Ambiguous/None deterministically (golden fixture).
+6. **Ambiguity:** one draft + two near-equal synced records → "ambiguous", not an
+   auto-merge.
+
+### 12.2 Native (Swift · iOS Simulator · XCTest)
+
+- `ReconciliationViewModelTests` (new):
+  - High confidence yields one merged row + working **Undo** (restores both).
+  - Ambiguous yields a pick-list including a **None** option; choosing None keeps
+    both and suppresses re-prompt.
+  - Merge preserves the user's draft **category/note** and the synced **amount**.
+  - Result exposes **only masked fields** (assert no PAN-shaped strings; account
+    token ≤ last-4).
+- `MergeDecisionView` snapshot/accessibility test: each state renders word +
+  symbol + shape, reads correctly to VoiceOver, and at AX5 Dynamic Type.
+
+### 12.3 Manual / QA gate (every UI PR)
+
+- Grayscale + Increase Contrast: merge / ambiguous / keep-both remain
+  distinguishable.
+- VoiceOver: reasons and action equivalents reachable; undo announced.
+- Ambiguous and stale-feed states render their intended copy and recovery action.
+
+---
+
+## 13. Implementation Readiness
+
+See [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md) §2 for the
+implementation-vs-distribution decoupling.
+
+### ✅ Buildable now — no enrollment required
+
+The reconciliation view model, the Merge / Pick-match / Keep-both UI, masking and
+prefill display, decision persistence, and **all native tests** build and run
+today under **free Personal Team signing**, driven by **fixtures** and a mock
+match provider. The normalization/scoring/policy can be prototyped behind a Swift
+protocol so the UI is verifiable before the shared engine lands. No `packages/`
+changes are required to demonstrate the iOS contract against mocks.
+
+### 🔒 Distribution & shared-engine tail — gated
+
+- **Distribution** (TestFlight/App Store, release signing, CI release) is gated by
+  [#1239](https://github.com/jrmoulckers/finance/issues/1239) — a **human** action
+  per the prerequisites runbook. Feature implementation is **not** blocked by it.
+- **Shared engine:** moving normalization/scoring/policy into `packages/core` is a
+  KMP change requiring an ADR with `@kmp-engineer` / `@architect`; until then iOS
+  builds against the protocol + fixtures.
+- **Live connected-account data** depends on the bank/market-data provider
+  credentials tracked separately (its own human-gated task) — not created here.
+
+No provisioning, certificates, secrets, or account registrations are performed as
+part of this design.
+
+---
+
+## 14. Open Questions
+
+1. Exact home for the engine — `packages/core` vs. `packages/sync` — and the
+   candidate-draft + `MatchResult` schema (ADR with `@kmp-engineer`).
+2. Default tolerance bands per currency (tip/tax %, absolute floor) and the
+   primary vs. extended date windows — start conservative, tune with fixtures.
+3. Should a confirmed pending→posted maturation auto-merge silently (same feed,
+   same auth id) while draft↔synced always at least notifies? Proposal: yes,
+   same-source maturation is a system fact, not a user-facing duplicate.
+4. Retention of suppression hashes for "Keep both" decisions — proposal: stable
+   pair hash, no raw descriptors, cleared on account disconnect.

--- a/docs/design/ios-notification-scheduling-telemetry.md
+++ b/docs/design/ios-notification-scheduling-telemetry.md
@@ -1,0 +1,446 @@
+# iOS Notification Scheduling, Fallback & Telemetry
+
+> Design for the **plumbing** beneath finance reminders: how `UNUserNotificationCenter`
+> and `BackgroundTasks` cooperate to **schedule and refresh** local notifications,
+> what happens when the on-device timing model is **unavailable** (deterministic
+> fallback), how a user **resets** learned behavior, and how we gather
+> **aggregate, privacy-preserving "no-content" metrics** to know the system is
+> healthy — without ever sending an amount, payee, or balance off the device. The
+> _what-to-say_ and _when-ideally_ live in their own docs; this is the **delivery
+> engine** that runs them. Everything is **on-device** and privacy-first.
+
+**Status:** PROPOSED — design only (native implementation buildable now; store distribution gated)
+**Issue:** [#2622](https://github.com/jrmoulckers/finance/issues/2622) — Part of [#2391](https://github.com/jrmoulckers/finance/issues/2391)
+**Platform:** iOS / iPadOS (SwiftUI, `UserNotifications`, `BackgroundTasks`, iOS 17+)
+**Owner:** @ios-engineer
+**Related:** [ios-smart-notification-timing.md](./ios-smart-notification-timing.md) · [ios-finance-alert-rules-deeplinks.md](./ios-finance-alert-rules-deeplinks.md) · [ios-notification-center-navigation.md](./ios-notification-center-navigation.md) · [content-language-guidelines.md](./content-language-guidelines.md) · [accessibility-patterns.md](./accessibility-patterns.md) · [cognitive-accessibility.md](./cognitive-accessibility.md) · [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md)
+
+---
+
+## Table of Contents
+
+1. [Goal & Scope](#1-goal--scope)
+2. [Current State](#2-current-state)
+3. [Scheduling Architecture](#3-scheduling-architecture)
+4. [BackgroundTasks Refresh & Rescheduling](#4-backgroundtasks-refresh--rescheduling)
+5. [Model-Unavailable Fallback](#5-model-unavailable-fallback)
+6. [Reset Controls](#6-reset-controls)
+7. [Aggregate No-Content Telemetry](#7-aggregate-no-content-telemetry)
+8. [Native ↔ KMP Boundary](#8-native--kmp-boundary)
+9. [Affected Surfaces & Shared Dependencies](#9-affected-surfaces--shared-dependencies)
+10. [Accessibility & Dynamic Type](#10-accessibility--dynamic-type)
+11. [Privacy & Security](#11-privacy--security)
+12. [Empty, Stale & Error States](#12-empty-stale--error-states)
+13. [Test Plan (Smallest Tests First)](#13-test-plan-smallest-tests-first)
+14. [Implementation Readiness](#14-implementation-readiness)
+15. [Open Questions](#15-open-questions)
+
+---
+
+## 1. Goal & Scope
+
+The smart-timing policy ([ios-smart-notification-timing.md](./ios-smart-notification-timing.md))
+decides _when_, and the alert-rules design
+([ios-finance-alert-rules-deeplinks.md](./ios-finance-alert-rules-deeplinks.md))
+decides _what_ and _where it lands_. Neither is useful without a robust engine to
+**enqueue, refresh, and recover** delivery. This design specifies that engine.
+
+**In scope**
+
+- `UNUserNotificationCenter` scheduling with calendar/time-interval triggers and
+  the pending-request budget.
+- `BackgroundTasks` (`BGAppRefreshTask` / `BGProcessingTask`) to refresh content
+  and re-schedule ahead of time.
+- **Fallback** when the timing model (or any on-device ML input) is unavailable:
+  a deterministic default schedule so reminders still fire.
+- **Reset controls** so a user can clear learned timing and re-baseline.
+- **Aggregate no-content metrics** — on-device counters that detect a sick
+  pipeline (scheduled-but-empty, suppressed, fired-no-open) without collecting any
+  financial content.
+
+**Out of scope (cross-referenced):** the timing math (timing doc), the alert
+families/actions/deep links (rules doc), and the alert-center UI
+([ios-notification-center-navigation.md](./ios-notification-center-navigation.md)).
+
+---
+
+## 2. Current State
+
+- The product uses **local notifications only** — there is **no remote push
+  server**, so scheduling is entirely on-device via `UNUserNotificationCenter`.
+- A `NotificationSchedulerService` already builds requests from
+  `BillReminderEngine` output; the timing doc adds a `DeliveryDecision` (chosen
+  time + interruption level) it consumes.
+- iOS caps **pending** notification requests (currently 64), and background
+  execution is **opportunistic** — the OS, not the app, decides when a
+  `BGAppRefreshTask` runs. The engine must be correct under both limits.
+- There is no formal **fallback** when an input model is missing, no **reset**
+  control, and no health signal when the pipeline silently produces nothing.
+
+---
+
+## 3. Scheduling Architecture
+
+```mermaid
+flowchart TD
+    R["Alert candidates (KMP rules: bill / budget / goal / review)"] --> SCH["NotificationSchedulerService"]
+    T["DeliveryDecision (time + interruption level, from timing policy)"] --> SCH
+    SCH --> BUD{"Within pending budget?"}
+    BUD -->|"yes"| ADD["Add UNNotificationRequest (calendar / time-interval trigger)"]
+    BUD -->|"no - over budget"| COAL["Coalesce / drop lowest-priority, keep soonest+highest"]
+    COAL --> ADD
+    ADD --> UNC["UNUserNotificationCenter (local delivery)"]
+    UNC --> DELIV["Delivered / opened / dismissed"]
+    DELIV --> MET["On-device aggregate counters"]
+```
+
+- **Trigger choice:** date-anchored reminders use `UNCalendarNotificationTrigger`;
+  short relative nudges use `UNTimeIntervalNotificationTrigger`. No repeating
+  triggers for content that can change — we re-schedule from fresh data instead.
+- **Pending budget:** the scheduler keeps a prioritized horizon (e.g. the next N
+  days) so it never exceeds the OS pending cap; when over budget it **coalesces**
+  and keeps the soonest, highest-`AlertPriority` items, deferring the rest to the
+  next refresh.
+- **Idempotent identifiers:** each request uses a **stable identifier** derived
+  from its source (e.g. bill id + due date) so re-scheduling **replaces** rather
+  than **duplicates** — critical because background refresh runs repeatedly.
+- **Content built late:** notification body/category/deep link come from the rules
+  doc; the scheduler only places them in time.
+
+---
+
+## 4. BackgroundTasks Refresh & Rescheduling
+
+Because content (balances, due dates, budget state) changes after a notification
+is scheduled, the engine refreshes opportunistically:
+
+```mermaid
+sequenceDiagram
+    participant OS as iOS scheduler
+    participant App as BGAppRefreshTask handler
+    participant KMP as Rules + timing (shared)
+    participant UNC as UNUserNotificationCenter
+    OS->>App: Launch task (opportunistic, time-boxed)
+    App->>KMP: Recompute candidates + DeliveryDecisions
+    KMP-->>App: Fresh candidate set
+    App->>UNC: Replace pending requests (stable ids)
+    App->>App: Update aggregate counters
+    App->>OS: setTaskCompleted + submit next BGAppRefreshTaskRequest
+    Note over App,OS: Always reschedule the next request before returning
+```
+
+- **Two task types:** a frequent, light **`BGAppRefreshTask`** to re-evaluate and
+  top up the pending horizon; an occasional **`BGProcessingTask`** for heavier
+  maintenance (pruning stale ids, recomputing histograms) when on power/idle.
+- **Always reschedule:** the handler **re-submits** the next
+  `BGAppRefreshTaskRequest` before completing, or background refresh silently
+  stops after one run.
+- **Time-boxed & safe:** each handler sets an expiration handler that flushes a
+  consistent state and calls `setTaskCompleted(success:)`; no partial writes.
+- **No background ≠ no reminders.** If the OS rarely grants background time (Low
+  Power Mode, user toggled Background App Refresh off), already-scheduled requests
+  still fire; we additionally **top up on foreground launch** so the horizon never
+  goes empty.
+
+---
+
+## 5. Model-Unavailable Fallback
+
+The timing model is a _preference_, not a _dependency_. Any of: cold start with no
+history, the on-device model/feature flag off, a decode error, or
+background-budget starvation must still produce reminders.
+
+```mermaid
+flowchart TD
+    C["Candidate needs a delivery time"] --> Q{"Timing model available & valid?"}
+    Q -->|"yes"| SMART["Use DeliveryDecision (likely-active hour)"]
+    Q -->|"no"| FB["Deterministic default schedule"]
+    FB --> D1["Per-family default hour (config)"]
+    FB --> D2["Respect quiet hours + min spacing"]
+    SMART --> OUT["Schedule request"]
+    D1 --> OUT
+    D2 --> OUT
+    OUT --> LOG["Increment fallback-used counter (aggregate)"]
+```
+
+- **Deterministic defaults:** each alert family has a sensible default hour (e.g.
+  bills in the morning, review prompts early evening) defined in **config**, not
+  code — so fallback is testable and tunable.
+- **Still bounded:** fallback honors **quiet hours**, **min spacing**, and the
+  **pending budget** — it degrades the _smartness_, never the _safety_.
+- **Observable, not silent:** every fallback increments an aggregate
+  `fallbackUsed` counter (§7) so we can see if the model is chronically
+  unavailable.
+- **No user-facing failure:** the user simply gets a reasonable reminder; the
+  "why this time" reason (owned by the alert center) reads "default schedule"
+  rather than "based on your activity".
+
+---
+
+## 6. Reset Controls
+
+Users must be able to start over without reinstalling:
+
+- **Reset learned timing.** Clears the local engagement buckets the timing policy
+  uses; the next schedule falls back to defaults (§5) and re-learns from scratch.
+- **Reset telemetry counters.** Clears the aggregate counters (§7) — they are
+  diagnostic, never identity, but the user owns them.
+- **Clear & reschedule.** Removes all pending requests and rebuilds the horizon
+  from current data — a clean recovery if scheduling ever looks wrong.
+- **Placement & confirmation.** These live in the alert center
+  ([ios-notification-center-navigation.md](./ios-notification-center-navigation.md));
+  each destructive reset uses a confirmation with plain-language consequences per
+  [content-language-guidelines.md](./content-language-guidelines.md). Resets are
+  **local and immediate** and need no network.
+
+---
+
+## 7. Aggregate No-Content Telemetry
+
+The goal: detect a **sick pipeline** (the app stops surfacing useful reminders)
+**without** collecting financial content. Telemetry is **aggregate counters
+only**, computed and (by default) **kept on-device**.
+
+| Counter            | Increments when                                                    | Why it matters                                  |
+| ------------------ | ------------------------------------------------------------------ | ----------------------------------------------- |
+| `scheduledTotal`   | A request is enqueued                                              | Baseline volume                                 |
+| `noContent`        | A refresh produced **zero** candidates when some were expected     | The "no-content" health signal the issue names  |
+| `suppressed`       | Timing policy suppressed a candidate (quiet hours / rate limit)    | Distinguishes "nothing to say" from "held back" |
+| `fallbackUsed`     | A default schedule was used because the model was unavailable (§5) | Detects chronic model unavailability            |
+| `delivered`        | The system delivered a request                                     | Delivery health                                 |
+| `openedNoAction`   | Delivered + opened but no follow-through                           | Relevance signal (no content captured)          |
+| `backgroundDenied` | A `BGAppRefreshTask` was not granted within the expected window    | Explains an empty horizon                       |
+
+**Privacy rules baked into the design:**
+
+- **No content, ever.** Counters carry **no** amounts, payees, merchants,
+  balances, categories, or notification text — only structural integers and the
+  alert **family** (bill/budget/goal/review) at most.
+- **On-device by default.** Counters live locally for in-app diagnostics. **No**
+  export happens unless the user has **opted in** to anonymous diagnostics; if so,
+  only **bucketed aggregate counts** (e.g. "noContent: 3 this week") leave the
+  device — never per-event records, never identifiers. This is **data
+  minimization** (GDPR Art. 5 / CCPA) by construction.
+- **`os.Logger` privacy.** Structural events are `.public`; anything derived from
+  user finance stays `.private`. Counters are intentionally content-free so they
+  are safe to read in diagnostics.
+- **User-clearable** via reset (§6).
+
+```mermaid
+flowchart LR
+    EVT["Pipeline events (schedule / deliver / suppress / fallback)"] --> CTR["On-device aggregate counters (content-free)"]
+    CTR --> DIAG["In-app diagnostics (always local)"]
+    CTR --> OPT{"User opted in to anonymous diagnostics?"}
+    OPT -->|"no (default)"| STAY["Stays on device"]
+    OPT -->|"yes"| EXP["Export bucketed aggregate counts only"]
+```
+
+---
+
+## 8. Native ↔ KMP Boundary
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages/core + packages/models (shared - DO NOT implement here)"]
+        K1["Rule evaluation: which candidates are worth surfacing (pure)"]
+        K2["Timing math: window selection (shareable, pure)"]
+        K3["Default-schedule config (per-family hours)"]
+    end
+    subgraph Bridge["Swift Export bridge (apps/ios/Finance/KMP)"]
+        B1["Candidate + DeliveryDecision (time or suppress + reason)"]
+    end
+    subgraph iOS["apps/ios (native - this design)"]
+        N1["NotificationSchedulerService (UNUserNotificationCenter)"]
+        N2["BackgroundTasks handlers (refresh + processing)"]
+        N3["Fallback selector + reset controls"]
+        N4["Aggregate counters (content-free)"]
+    end
+    K1 --> B1
+    K2 --> B1
+    K3 --> N3
+    B1 --> N1
+    N1 --> N2
+    N2 --> N4
+    N3 --> N1
+```
+
+- **Shared (KMP):** what is worth surfacing, the timing window math, and the
+  default-schedule config are platform-neutral rules in `packages/core`. **Not
+  implemented here** — ADR with `@kmp-engineer` / `@architect`.
+- **Native (iOS):** all Apple-framework plumbing — `UNUserNotificationCenter`,
+  `BackgroundTasks`, the fallback selector, reset controls, and the content-free
+  counters. These are inherently platform APIs and stay in `apps/ios`.
+- **Bridge:** returns `Candidate` + `DeliveryDecision`; the scheduler never sees
+  raw finance internals beyond what the rules already expose.
+
+---
+
+## 9. Affected Surfaces & Shared Dependencies
+
+**New (native):**
+
+- `apps/ios/Finance/Services/BackgroundRefreshCoordinator.swift` — registers and
+  handles the `BGAppRefreshTask` / `BGProcessingTask` identifiers.
+- `apps/ios/Finance/Services/NotificationTelemetryStore.swift` — content-free
+  aggregate counters with reset.
+- `apps/ios/Finance/Services/FallbackScheduleProvider.swift` — deterministic
+  default schedule when the model is unavailable.
+
+**Touched (additively):**
+
+- `NotificationSchedulerService` gains idempotent ids, budget-aware coalescing,
+  and a fallback path.
+- The alert center gains **reset controls** and a diagnostics row (UI owned by
+  [ios-notification-center-navigation.md](./ios-notification-center-navigation.md)).
+
+**Reused unchanged:** `UNCalendarNotificationTrigger` plumbing, `AlertPriority`,
+the timing policy's quiet-hours/spacing guards, the alert families/categories from
+the rules doc.
+
+**Shared dependency:** rule evaluation + timing math + default config in KMP
+`packages/core` via the Swift Export bridge ([§8](#8-native--kmp-boundary)).
+
+---
+
+## 10. Accessibility & Dynamic Type
+
+- **Reset controls** are standard, fully-labeled SwiftUI controls with confirming
+  alerts; VoiceOver reads the action and its consequence ("Reset learned timing —
+  reminders return to default times"), per
+  [accessibility-patterns.md](./accessibility-patterns.md).
+- **Plain language** for the diagnostics row and "why this time" reason follows
+  [content-language-guidelines.md](./content-language-guidelines.md) and
+  [cognitive-accessibility.md](./cognitive-accessibility.md) — "default schedule"
+  vs. "based on your activity", never opaque codes.
+- **Dynamic Type to AX5:** reset rows and any diagnostics counts reflow; no
+  truncation of consequence text.
+- **Switch Control / keyboard:** all controls reachable without gestures; the
+  destructive resets require explicit confirmation focus.
+- **Delivered notifications** inherit accessible titles/bodies and actions from
+  the rules doc; this engine does not alter their semantics.
+
+---
+
+## 11. Privacy & Security
+
+- **Local-only by default.** Scheduling, fallback, resets, and counters run on
+  device; nothing about a reminder's content leaves the phone.
+- **Content-free telemetry** (§7): counters never carry amounts, payees,
+  balances, categories, or notification text — only structural integers and at
+  most the alert family. Export is **opt-in, bucketed aggregate** only.
+- **No remote push.** There is no push token, no server delivery, so no payload
+  ever transits Apple's push infrastructure with finance data.
+- **`.private` logging.** Any finance-derived value is `.private` in `os.Logger`;
+  scheduling/telemetry structural events are `.public`.
+- **Keychain for secrets.** No tokens are introduced by this engine; any existing
+  secrets remain in the Keychain with
+  `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`.
+- **User control.** Reset controls (§6) let the user clear learned timing and
+  counters at any time — supporting correction/erasure expectations under
+  GDPR/CCPA.
+
+---
+
+## 12. Empty, Stale & Error States
+
+- **Notifications not authorized.** If the user denied permission, scheduling is a
+  no-op; the alert center explains and deep-links to Settings — never silently
+  failing.
+- **Nothing to schedule (good empty).** Zero candidates is normal ("You're all
+  caught up"); the `noContent` counter increments only when candidates were
+  **expected** but produced none, distinguishing health from quiet.
+- **Background refresh denied/unavailable.** Increment `backgroundDenied`; rely on
+  foreground top-up so the horizon recovers on next launch.
+- **Model unavailable.** Fall back to the default schedule (§5); surface "default
+  schedule" in the reason, not an error.
+- **Scheduling error / over budget.** Coalesce per §3 and log a `.public`
+  structural warning; never throw away the soonest, highest-priority reminder.
+- **Stale horizon.** If the last refresh is older than a threshold, top up on
+  foreground and mark the diagnostics row "last refreshed <relative time>".
+
+---
+
+## 13. Test Plan (Smallest Tests First)
+
+Determinism is the contract: every test uses **fixed fixtures and an injected
+clock** — no wall-clock reads, no real background scheduling.
+
+### 13.1 Native (Swift · iOS Simulator · XCTest)
+
+1. **Idempotent scheduling:** scheduling the same source twice yields **one**
+   pending request (stable id replaces, not duplicates).
+2. **Pending-budget coalescing:** with more candidates than the cap, assert the
+   soonest, highest-`AlertPriority` survive and the rest defer.
+3. **Fallback selection:** with the timing model marked unavailable, assert the
+   **per-family default hour** is used and quiet hours/min-spacing still apply
+   (assert exact time vs. a **fixed reference `Date`**).
+4. **Reschedule-on-complete:** the background handler **re-submits** the next
+   `BGAppRefreshTaskRequest` before completing (mock task scheduler).
+5. **Expiration safety:** an expiring task flushes consistent state and calls
+   `setTaskCompleted` without partial writes.
+6. **Reset controls:** reset-timing clears buckets (next schedule uses fallback);
+   clear-and-reschedule empties then rebuilds pending; reset-counters zeroes them.
+7. **Telemetry is content-free:** assert counter records contain **no** amount /
+   payee / merchant / text fields — only integers and family enum; `noContent`
+   increments only when candidates were expected.
+8. **Foreground top-up:** with background denied, a foreground launch refills an
+   empty horizon.
+
+### 13.2 Shared (Kotlin · `packages/core` · `commonTest`, owned by @kmp-engineer)
+
+- Rule evaluation and window-selection boundary cases (if the math lands in
+  `packages/core`) tested there with golden fixtures; default-schedule config
+  values asserted.
+
+### 13.3 Manual / QA gate (every UI PR)
+
+- VoiceOver on reset controls and confirmations; Dynamic Type AX5 on the
+  diagnostics row.
+- Simulate Background App Refresh off + Low Power Mode → reminders still fire from
+  the foreground top-up.
+- Toggle the model-unavailable flag → reminders arrive on the default schedule.
+
+---
+
+## 14. Implementation Readiness
+
+See [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md) §2 for the
+implementation-vs-distribution decoupling.
+
+### ✅ Buildable now — no enrollment required
+
+`UNUserNotificationCenter` scheduling, `BGAppRefreshTask` / `BGProcessingTask`
+registration and handling, the fallback selector, reset controls, and the
+content-free counters all build and run today under **free Personal Team
+signing** — local notifications and the BackgroundTasks framework need **no** paid
+entitlement for local testing. Every test in
+[§13](#13-test-plan-smallest-tests-first) — pure scheduling logic with fixtures
+and an injected clock/task-scheduler — runs without a device or enrollment.
+
+### 🔒 Distribution tail — gated
+
+- **Distribution** (TestFlight/App Store, release signing, CI release) is gated by
+  [#1239](https://github.com/jrmoulckers/finance/issues/1239) — a **human** action
+  per the prerequisites runbook. Feature implementation is **not** blocked.
+- **Remote push is explicitly not used**, so the Push Notifications paid
+  capability is **not** required by this design; if a future remote path is ever
+  added, that is a separate entitlement + design.
+- **Optional anonymous-diagnostics export** (§7), if ever enabled, would need a
+  privacy-reviewed backend endpoint and consent UX — a separate track, not built
+  here.
+
+No provisioning, certificates, secrets, or account registrations are performed as
+part of this design.
+
+---
+
+## 15. Open Questions
+
+1. Pending-horizon length and the exact pending-budget reserve per family —
+   start conservative, tune with the `noContent` / `scheduledTotal` ratio.
+2. `BGProcessingTask` cadence and what maintenance belongs there vs. the light
+   refresh — proposal: histogram recompute + stale-id pruning on power/idle only.
+3. Should anonymous-diagnostics export ever ship, what is the minimum bucketed
+   schema and consent flow? Default remains **on-device only**.
+4. Where do rule evaluation and timing math finally live — `packages/core` vs.
+   native — given the timing doc proposes shared math? ADR with `@kmp-engineer`.

--- a/docs/design/ios-passkit-wallet-constraints.md
+++ b/docs/design/ios-passkit-wallet-constraints.md
@@ -1,0 +1,388 @@
+# iOS PassKit & Wallet Capture Constraints
+
+> A **constraints reference**: what PassKit and Wallet do — and, more importantly,
+> do **not** — let a third-party finance app do, the entitlements involved, and
+> the **fallback capture UX** that works _within_ the platform rules. The headline
+> fact, stated plainly so no implementer "optimizes" past it: **Apple does not
+> expose Apple Pay / Wallet transaction data to third-party apps.** There is no
+> public API for a user's tap-to-pay history, the merchant of a payment, or a
+> card's transaction feed, and we will **not** use private APIs. Our
+> "wallet-adjacent" experience is therefore built from **user-initiated /
+> user-authorized** sources only. All capture is **on-device** and privacy-first.
+
+**Status:** PROPOSED — design / constraints reference (informs implementation; store distribution gated)
+**Issue:** [#2606](https://github.com/jrmoulckers/finance/issues/2606) — Part of [#2171](https://github.com/jrmoulckers/finance/issues/2171)
+**Platform:** iOS / iPadOS (PassKit, Wallet, VisionKit; SwiftUI, iOS 17+)
+**Owner:** @ios-engineer
+**Related:** [ios-wallet-adjacent-capture-inbox.md](./ios-wallet-adjacent-capture-inbox.md) · [ios-merchant-matching-duplicate-detection.md](./ios-merchant-matching-duplicate-detection.md) · [ios-one-thumb-quick-add.md](./ios-one-thumb-quick-add.md) · [accessibility-patterns.md](./accessibility-patterns.md) · [cognitive-accessibility.md](./cognitive-accessibility.md) · [content-language-guidelines.md](./content-language-guidelines.md) · [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md)
+
+---
+
+## Table of Contents
+
+1. [Purpose & Scope](#1-purpose--scope)
+2. [The Hard Constraint: No Apple Pay Transaction Access](#2-the-hard-constraint-no-apple-pay-transaction-access)
+3. [What PassKit Actually Exposes](#3-what-passkit-actually-exposes)
+4. [Entitlements & Capabilities](#4-entitlements--capabilities)
+5. [Legitimate Capture Sources (Design Within the Rules)](#5-legitimate-capture-sources-design-within-the-rules)
+6. [Fallback Capture UX](#6-fallback-capture-ux)
+7. [Native ↔ KMP Boundary](#7-native--kmp-boundary)
+8. [Affected iOS Surfaces & Shared Dependencies](#8-affected-ios-surfaces--shared-dependencies)
+9. [Accessibility & Dynamic Type](#9-accessibility--dynamic-type)
+10. [Privacy & Security](#10-privacy--security)
+11. [Stale, Error & Empty States](#11-stale-error--empty-states)
+12. [Test Plan (Smallest Tests First)](#12-test-plan-smallest-tests-first)
+13. [Implementation Readiness](#13-implementation-readiness)
+14. [Open Questions](#14-open-questions)
+
+---
+
+## 1. Purpose & Scope
+
+Before any "see what I tapped to pay" feature is built, the team needs one
+authoritative document that records the **platform limitations**, the
+**entitlement needs**, and the **fallback UX** so that design happens _within_
+the rules from day one. This doc is that reference; the capture experience it
+enables is specified in
+[ios-wallet-adjacent-capture-inbox.md](./ios-wallet-adjacent-capture-inbox.md)
+and the dedup that keeps it clean in
+[ios-merchant-matching-duplicate-detection.md](./ios-merchant-matching-duplicate-detection.md).
+
+**In scope**
+
+- The exact boundary of PassKit/Wallet access for a third-party app.
+- Which capabilities are free for local development vs. paid/entitlement-gated.
+- The fallback capture model (manual entry / user-initiated capture) and its UX
+  states.
+
+**Explicitly out of scope (and prohibited)**
+
+- Reading arbitrary Apple Pay/Wallet purchase history — **no public API exists.**
+- Any private/undocumented Wallet or PassKit call, UI scraping, or screenshot
+  parsing of system surfaces — an App Store rejection and a privacy violation.
+- Requesting, storing, logging, or reconstructing a full card number (PAN).
+
+---
+
+## 2. The Hard Constraint: No Apple Pay Transaction Access
+
+This is the load-bearing constraint of the entire wallet cluster:
+
+- **No third-party access to Apple Pay/Wallet transactions.** iOS does not
+  provide any API that returns the user's general Apple Pay purchases, the
+  merchant of a tap-to-pay, the amount, or a card's transaction feed. Transaction
+  history lives with the card issuer and the Secure Element, not in an app-visible
+  store.
+- **No private APIs.** We will not call undocumented Wallet/PassKit internals,
+  observe system notifications for payments, or scrape the system Wallet UI. This
+  is explicitly forbidden and out of scope.
+- **No PAN, ever.** The Primary Account Number is never available to the app and
+  must never be requested, stored, logged, or reconstructed. The system only ever
+  surfaces a **device-specific masked suffix** for passes the app itself
+  provisioned — not for arbitrary cards.
+- **The merchant case is different.** A PassKit access an app _does_ have is as a
+  **merchant accepting Apple Pay for its own charges** (`PKPaymentAuthorization…`)
+  — i.e. money the app itself collects. A personal-finance tracker is not the
+  merchant for the user's coffee, so this path does **not** yield third-party
+  spending data either.
+
+**Consequence:** the product cannot be "a window into Apple Pay." It is, by
+necessity, a **capture-and-reconcile** tool fed by sources we may legitimately
+use (§5), with honest UX that never implies it can see card taps it cannot.
+
+---
+
+## 3. What PassKit Actually Exposes
+
+| API surface                                             | What it gives a third-party app                                                      | What it does NOT give                                |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------ | ---------------------------------------------------- |
+| `PKPassLibrary`                                         | Passes (boarding/loyalty/coupons) this app added or is authorized for                | Any payment-card transaction history                 |
+| `PKPaymentPass` / `PKSecureElementPass`                 | Metadata for cards **this app provisioned** (e.g. issuer apps): masked suffix, state | Other cards, balances, or purchase history           |
+| `PKPaymentAuthorizationController` / `PKPaymentRequest` | The Apple Pay sheet for charges **the app itself** initiates as a merchant           | Visibility into purchases at _other_ merchants       |
+| `PKAddPaymentPassViewController`                        | Provisioning a card into Wallet (issuer-app flow), entitlement-gated                 | Reading existing third-party cards or their activity |
+| `PKPassLibraryDidChange` notifications                  | That the pass library changed (passes added/removed)                                 | Payment/transaction events                           |
+
+Net: PassKit is for **passes** and for being a **merchant** or a **card issuer**.
+None of these is a consumer-spending feed. A personal-finance app that is neither
+the issuer nor the merchant gets effectively **no transaction signal** from
+Wallet.
+
+---
+
+## 4. Entitlements & Capabilities
+
+The relevant capabilities and whether they require paid Apple Developer Program
+enrollment (human-gated, [#1239](https://github.com/jrmoulckers/finance/issues/1239)):
+
+| Capability                           | Needed for                                             | Free Personal Team?           | Notes                                                           |
+| ------------------------------------ | ------------------------------------------------------ | ----------------------------- | --------------------------------------------------------------- |
+| **Wallet (passes)**                  | Reading/adding passes the app owns                     | No (entitlement)              | Not needed for our capture model; we read no Apple Pay activity |
+| **In-App Provisioning / Apple Pay**  | Adding cards to Wallet as an issuer/merchant           | No (entitlement + agreements) | Out of scope — we are neither issuer nor merchant               |
+| **App Groups**                       | Sharing the pending-capture queue with App Clip/widget | **Yes**                       | Used today for `ClipTransaction`; works under free signing      |
+| **Camera (VisionKit / DataScanner)** | User-initiated receipt scan                            | **Yes**                       | `NSCameraUsageDescription`; no enrollment needed                |
+| **Photos (read, user-picked)**       | Scanning a saved receipt image                         | **Yes**                       | Prefer `PHPicker` (no full-library permission)                  |
+| **Share Extension target**           | "Share this receipt to Finance"                        | **Yes** to build              | Buildable locally; distributed under the enrollment gate        |
+
+**Takeaway:** every capability our capture model actually relies on (App Groups,
+Camera, Photos picker, Share Extension to build) is available under **free
+Personal Team signing**. The Wallet/Apple Pay entitlements we deliberately do
+**not** request, because they would not give us spending data anyway.
+
+---
+
+## 5. Legitimate Capture Sources (Design Within the Rules)
+
+Since Wallet is closed to us, capture is **user-initiated or user-authorized**.
+These mirror [ios-wallet-adjacent-capture-inbox.md](./ios-wallet-adjacent-capture-inbox.md)
+and are the only sources this design endorses:
+
+| Source                          | Mechanism (legitimate)                                                            | Produces                                   |
+| ------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------ |
+| **Connected-account activity**  | Bank/card aggregation via the sync backend (`packages/sync`) — explicit consent   | High/medium-confidence draft candidates    |
+| **Receipt / document scan**     | User-initiated `VisionKit` `DataScannerViewController` / `VNRecognizeTextRequest` | Medium/low-confidence drafts (amount/date) |
+| **Share-sheet / pasteboard**    | User shares an order email/SMS/receipt or pastes text; on-device parsing          | Medium/low-confidence drafts               |
+| **App Clip / widget quick-add** | Existing `ClipTransaction` pending queue (App Group), Lock Screen quick entry     | User-authored drafts to merge/dedup        |
+| **Manual quick-add**            | The one-thumb flow ([ios-one-thumb-quick-add.md](./ios-one-thumb-quick-add.md))   | User-authored, high confidence             |
+
+Every source is consent-based; **none reads Apple Pay state**. Each yields a
+**draft** that flows through dedup
+([ios-merchant-matching-duplicate-detection.md](./ios-merchant-matching-duplicate-detection.md))
+into the review inbox — never a silently-committed transaction.
+
+```mermaid
+flowchart LR
+    subgraph Closed["Closed to us (OS constraint)"]
+        AP["Apple Pay / Wallet transaction history"]
+    end
+    subgraph Open["Legitimate, user-authorized sources"]
+        S1["Connected-account sync"]
+        S2["Receipt / document scan"]
+        S3["Share sheet / paste"]
+        S4["App Clip / widget quick-add"]
+        S5["Manual quick-add"]
+    end
+    AP -. "no public API - not used" .-> X["(blocked)"]
+    S1 --> CAP["Draft capture"]
+    S2 --> CAP
+    S3 --> CAP
+    S4 --> CAP
+    S5 --> CAP
+    CAP --> INBOX["Review inbox + dedup"]
+```
+
+---
+
+## 6. Fallback Capture UX
+
+Because the "automatic" path is impossible, the UX must make the **available**
+paths feel fast and trustworthy, and must **set honest expectations**:
+
+- **Honest framing.** Onboarding and empty states say what the app _can_ do
+  ("Snap a receipt, paste an order, or connect your bank") and never imply it can
+  read Apple Pay. Copy follows
+  [content-language-guidelines.md](./content-language-guidelines.md).
+- **One-thumb manual entry** as the always-available floor
+  ([ios-one-thumb-quick-add.md](./ios-one-thumb-quick-add.md)) — no permissions,
+  no network.
+- **Receipt scan** front-and-center: a single tap to `DataScannerViewController`,
+  on-device text recognition, prefilled amount/date for confirmation.
+- **Share-to-Finance** so a confirmation email/SMS becomes a draft without
+  retyping.
+- **Connect an account** as the higher-fidelity option, clearly labeled as the
+  source of automatic candidates (subject to its own provider setup).
+- Every captured item lands as a **draft** in the review inbox; the user is always
+  the commit gate.
+
+---
+
+## 7. Native ↔ KMP Boundary
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages/core + packages/models (shared - DO NOT implement here)"]
+        K1["Draft/candidate model (platform-neutral)"]
+        K2["Field parsing rules (amount/date extraction helpers)"]
+        K3["Masking / minimization rules (no PAN)"]
+    end
+    subgraph Bridge["Swift Export bridge (apps/ios/Finance/KMP)"]
+        B1["CaptureDraft (masked, display-ready)"]
+    end
+    subgraph iOS["apps/ios (native - this design)"]
+        N1["PassKit boundary docs enforced in code review"]
+        N2["VisionKit scan + Share Extension + PHPicker"]
+        N3["Capture UI + honest framing (Observable)"]
+        N4["App Group pending queue"]
+    end
+    K1 --> B1 --> N3
+    K2 --> B1
+    K3 --> B1
+    N2 --> N3 --> N4
+```
+
+- **Native (iOS):** all Apple-framework integration — VisionKit, the Share
+  Extension, `PHPicker`, the App Group queue, and the SwiftUI capture surfaces —
+  plus the **review-gate discipline** that keeps any PassKit usage strictly within
+  §3. There is intentionally **no** PassKit transaction integration to build.
+- **Shared (KMP):** the platform-neutral draft/candidate model and field-parsing
+  and masking/minimization rules in `packages/core`. **Not implemented here** —
+  ADR with `@kmp-engineer` / `@architect`.
+- **Bridge:** returns **masked, display-ready** drafts; raw scanned text and any
+  card-like tokens never cross into persistent state.
+
+---
+
+## 8. Affected iOS Surfaces & Shared Dependencies
+
+**Documented constraints affecting (no new transaction-access code):**
+
+- The capture inbox and its sources
+  ([ios-wallet-adjacent-capture-inbox.md](./ios-wallet-adjacent-capture-inbox.md)).
+- Quick-add ([ios-one-thumb-quick-add.md](./ios-one-thumb-quick-add.md)).
+
+**Capabilities relied on (all free-signing buildable):** App Groups, Camera
+(VisionKit), Photos picker (`PHPicker`), a Share Extension target.
+
+**Reused unchanged:** the App Group `ClipTransaction` pending queue, the
+`packages/sync` feed, `TransactionValidator`.
+
+**Shared dependency:** the platform-neutral draft model + masking rules in KMP
+`packages/core` via the Swift Export bridge ([§7](#7-native--kmp-boundary)).
+
+---
+
+## 9. Accessibility & Dynamic Type
+
+- **Capture actions** (Scan, Paste, Connect, Add manually) each have a clear
+  `.accessibilityLabel` and hint; the scan camera surface exposes a labeled
+  capture control and an accessible "couldn't read" recovery, per
+  [accessibility-patterns.md](./accessibility-patterns.md).
+- **Honest, plain language.** The "we can't see Apple Pay automatically" framing
+  is written for clarity and reassurance, not apology, following
+  [cognitive-accessibility.md](./cognitive-accessibility.md).
+- **Dynamic Type to AX5:** capture cards and the scan-confirm sheet reflow rather
+  than truncate; masked amount/date never clip.
+- **Switch Control / keyboard:** every capture entry point is reachable without
+  gestures; the scan flow has a non-camera fallback (manual entry).
+- **Reduce Motion:** the scan-to-draft transition is a cross-fade, not a zoom.
+
+---
+
+## 10. Privacy & Security
+
+- **Apple Pay/Wallet data is never read** (the core constraint, §2). Design
+  correctness depends on this being explicit so no one drifts toward private APIs.
+- **No PAN/card data** is stored, logged, or transmitted; only user-visible last-4
+  display tokens and opaque account ids exist on device.
+- **On-device parsing only.** Raw receipt/email text is transient and discarded
+  after field extraction; it is never uploaded for parsing. This is **data
+  minimization** by construction (GDPR Art. 5(1)(c) / CCPA).
+- **Least-privilege permissions.** Prefer `PHPicker` (no full-library access);
+  request Camera only when the user taps Scan; no background access.
+- **Secrets in the Keychain.** Any connected-account session/refresh tokens live
+  in the Keychain with `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`, never
+  `UserDefaults`. The App Group queue holds only masked, non-secret draft fields.
+- **`.private` logging.** Amounts, merchants, and scanned text are `.private` in
+  `os.Logger`; only structural events ("scan started", "draft queued") are
+  `.public`.
+- **Biometric gate.** Viewing captured financial detail honors the app-lock /
+  `BiometricAuthManager` policy.
+
+---
+
+## 11. Stale, Error & Empty States
+
+- **Empty (no captures yet).** A positive, instructive empty state via
+  `ContentUnavailableView`: "Snap a receipt, paste an order, or connect an
+  account" — explicitly _not_ "we'll watch your Apple Pay".
+- **Permission denied (Camera/Photos).** Explain the value, offer the manual-entry
+  fallback, and deep-link to Settings; never dead-end.
+- **Scan/parse failure.** A receipt that can't be read marks its draft **low
+  confidence** with "couldn't read amount" and opens manual edit — never silently
+  dropped.
+- **No connected accounts.** Automatic candidates are unavailable; the inbox
+  points to manual capture so the feature still has offline value.
+- **Stale feed.** Show "last synced <relative time>"; if older than a threshold,
+  badge as stale and offer Refresh rather than presenting old data as fresh.
+- **Misconception guardrail.** If telemetry/support shows users expect Apple Pay
+  auto-import, surface a one-time explainer — an honesty state, not an error.
+
+---
+
+## 12. Test Plan (Smallest Tests First)
+
+This is a constraints/UX design, so tests guard the **boundary** and the
+**fallbacks** rather than a transaction integration that (correctly) does not
+exist.
+
+### 12.1 Shared (Kotlin · `packages/core` · `commonTest`, owned by @kmp-engineer)
+
+1. **Masking unit:** parsed output never contains more than last-4; PAN-shaped
+   inputs are rejected/redacted.
+2. **Field-parse unit:** representative receipt/email strings extract the expected
+   amount/date deterministically; unparseable input yields a low-confidence draft,
+   not a crash.
+
+### 12.2 Native (Swift · iOS Simulator · XCTest)
+
+- `CaptureBoundaryTests` (new): asserts the app exposes **no** PassKit
+  transaction-history call sites (a guard/lint-style test over the capture module)
+  and that the only PassKit imports, if any, are pass/merchant scoped.
+- `ReceiptScanViewModelTests`: a fixture image/text yields a prefilled draft; an
+  unreadable fixture yields the "couldn't read" recovery, not a committed record.
+- `CaptureEmptyStateTests`: empty/permission-denied/no-account states render their
+  intended honest copy and a working fallback action.
+- Accessibility snapshot of capture entry points at AX5 Dynamic Type; VoiceOver
+  labels present on Scan/Paste/Connect/Add.
+
+### 12.3 Manual / QA gate (every UI PR)
+
+- VoiceOver walkthrough of all capture entry points and the scan-confirm sheet.
+- Permission-denied and unreadable-receipt paths reach manual entry.
+- Copy review: no screen implies automatic Apple Pay/Wallet import.
+
+---
+
+## 13. Implementation Readiness
+
+See [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md) §2 for the
+implementation-vs-distribution decoupling.
+
+### ✅ Buildable now — no enrollment required
+
+The capture surfaces, VisionKit receipt scan, `PHPicker` import, the App Group
+pending queue, honest empty/permission states, the boundary guard test, and the
+fallback manual-entry flow all build and run today under **free Personal Team
+signing**. None of this needs the Wallet or Apple Pay entitlements — and
+deliberately so, since those would not yield spending data. A **Share Extension**
+target is buildable locally for verification.
+
+### 🔒 Distribution & entitlement tail — gated
+
+- **Distribution** (TestFlight/App Store, release signing, CI release) and
+  shipping the **Share Extension** to users are gated by
+  [#1239](https://github.com/jrmoulckers/finance/issues/1239) — a **human** action
+  per the prerequisites runbook. Feature implementation is **not** blocked.
+- **Wallet / Apple Pay / In-App Provisioning entitlements** are intentionally
+  **not** requested; if a future, genuinely issuer/merchant-scoped feature needs
+  them, that is a separate human-gated entitlement + agreements track and a new
+  design.
+- **Live connected-account data** depends on the bank/market-data provider
+  credentials tracked separately — its own human-gated task, not created here.
+
+No provisioning, certificates, secrets, account registrations, or entitlement
+requests are performed as part of this design.
+
+---
+
+## 14. Open Questions
+
+1. Should the app ship a short, persistent "How capture works" explainer to
+   pre-empt the Apple Pay misconception? Proposal: yes, one-time + a help link.
+2. Where do field-parsing helpers live — `packages/core` vs. a thin native
+   parser — given they touch locale and currency formatting? ADR with
+   `@kmp-engineer`.
+3. Do we add a **Share Extension** in the first native milestone or defer it
+   behind the distribution gate? Proposal: build it behind a flag for local QA,
+   ship post-enrollment.
+4. Retention of scanned-text intermediates — proposal: in-memory only, discarded
+   immediately after extraction, never persisted.


### PR DESCRIPTION
## Summary

Adds three **new** iOS design docs (design-only; no native builds, signing, or store actions) for the iOS wallet/activity + notification cluster. All work is on-device and privacy-first, with shared matching/scheduling business rules kept conceptually in KMP `packages/core` (described, not implemented) and Apple-framework integration in `apps/ios`.

These are **new files only** — no existing files, `packages/`, `apps/` code, shared config, or other platforms are edited. New docs cross-link (without editing) the existing wave-6 notification docs and the human-gated prerequisites runbook.

## Changes

- `docs/design/ios-merchant-matching-duplicate-detection.md` (#2605) — Merchant normalization, amount/date/currency/account matching rules, confidence scoring, and the merge / pick-match / keep-both decision (with the ambiguous state) so prefilled Wallet-adjacent drafts never duplicate synced bank imports. Native ↔ KMP boundary, accessibility, privacy, dedup/ambiguous/stale states, and a deterministic dedup test plan.
- `docs/design/ios-passkit-wallet-constraints.md` (#2606) — Authoritative constraints reference: **Apple does not expose Apple Pay/Wallet transaction data to third-party apps**; no public history API and no private-API misuse. Documents what PassKit actually exposes (passes/merchant/issuer only), entitlement/capability needs (and which are free under Personal Team signing), and the manual-entry / user-initiated capture fallback UX designed strictly within the rules.
- `docs/design/ios-notification-scheduling-telemetry.md` (#2622) — `UNUserNotificationCenter` + `BackgroundTasks` scheduling (idempotent ids, pending-budget coalescing, always-reschedule), deterministic model-unavailable fallback, reset controls, and content-free aggregate "no-content" telemetry (on-device by default; opt-in bucketed aggregate export only).

Each doc includes: ToC, Mermaid diagrams (native↔KMP boundary + matching/dedup or scheduling flows), relative cross-links to existing `docs/design` files only, accessibility (VoiceOver, Dynamic Type, Switch Control, Reduce Motion), privacy (on-device, data minimization, no PAN, no private APIs, GDPR/CCPA), stale/error/empty plus duplicate/ambiguous states, a smallest-tests-first plan (deterministic dedup + timing/scheduling fixtures), and an Implementation Readiness section splitting buildable-now (free Personal Team signing) from the distribution tail gated by #1239 via [`../ops/human-gated-prerequisites.md`](https://github.com/jrmoulckers/finance/blob/main/docs/ops/human-gated-prerequisites.md).

Prettier `--check` passes on all three files.

Closes #2605
Closes #2606
Closes #2622
