### PR TITLE
docs(design): ios App Clip presets and savings-rate trend design batch (#2591, #2601, #2611)

### DIFF
--- a/docs/design/ios-appclip-widget-quickentry-presets.md
+++ b/docs/design/ios-appclip-widget-quickentry-presets.md
@@ -1,0 +1,402 @@
+# Reuse App Clip & Widget Quick-Entry Presets In-App — iOS
+
+> Three surfaces already capture a fast expense — the **Lock Screen quick-entry
+> widget**, the **App Clip**, and the in-app **quick-add** sheet — but each
+> carries its own private copy of the "coffee / lunch / transit / cash /
+> Apple Cash" presets. This design defines a **single shared preset catalog** so
+> the same named shortcuts power the widget, the App Clip, and a new row of
+> **in-app quick-add chips**, mapping to the same category/tender defaults and
+> the same shared validator.
+
+**Status:** PROPOSED — design only (native implementation buildable now; store distribution gated)
+**Issue:** [#2601](https://github.com/jrmoulckers/finance/issues/2601) — Part of [#2167](https://github.com/jrmoulckers/finance/issues/2167)
+**Platform:** iOS / iPadOS (SwiftUI + WidgetKit + App Clip, iOS 17+)
+**Owner:** @ios-engineer
+**Related:** [ios-one-thumb-quick-add.md](./ios-one-thumb-quick-add.md) · [ios-compact-transaction-stepper.md](./ios-compact-transaction-stepper.md) · [ios-wallet-adjacent-capture-inbox.md](./ios-wallet-adjacent-capture-inbox.md) · [ios-grocery-affordability-appclip.md](./ios-grocery-affordability-appclip.md) · [accessibility-patterns.md](./accessibility-patterns.md) · [cognitive-accessibility.md](./cognitive-accessibility.md) · [content-language-guidelines.md](./content-language-guidelines.md) · [information-architecture.md](./information-architecture.md) · [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md)
+
+---
+
+## Table of Contents
+
+1. [Goal & Scope](#1-goal--scope)
+2. [Current State (Three Copies of the Presets)](#2-current-state-three-copies-of-the-presets)
+3. [The Shared Preset Catalog](#3-the-shared-preset-catalog)
+4. [Preset-Reuse Flow](#4-preset-reuse-flow)
+5. [In-App Quick-Add Chips](#5-in-app-quick-add-chips)
+6. [Cash & Apple Cash (Tender, Not Category)](#6-cash--apple-cash-tender-not-category)
+7. [Accessibility & Dynamic Type](#7-accessibility--dynamic-type)
+8. [Privacy](#8-privacy)
+9. [States: Empty, Stale & Error](#9-states-empty-stale--error)
+10. [Native ↔ KMP Boundary](#10-native--kmp-boundary)
+11. [Affected Surfaces & Shared Dependencies](#11-affected-surfaces--shared-dependencies)
+12. [Test Plan (Smallest Tests First)](#12-test-plan-smallest-tests-first)
+13. [Implementation Readiness](#13-implementation-readiness)
+14. [Open Questions](#14-open-questions)
+
+---
+
+## 1. Goal & Scope
+
+A user who logs "coffee" from the Lock Screen widget, then "coffee" from the App
+Clip, then "coffee" inside the app should hit the **same** preset — same label,
+same default category, same icon. Today they hit three slightly different lists
+maintained in three files. This design collapses them to **one shared catalog**
+and adds the missing fourth consumer: a row of **quick-add chips** in the in-app
+sheet, so the express-lane capture from
+[ios-one-thumb-quick-add.md](./ios-one-thumb-quick-add.md) gains the same
+one-tap presets the widget and clip already have.
+
+**In scope:**
+
+- A **canonical preset catalog** (id, display label, default category mapping,
+  optional default tender, SF Symbol) owned conceptually in shared
+  `packages/core` / `packages/models`, consumed identically by all surfaces.
+- A new **quick-add chips** strip in the in-app quick-add sheet that pre-seeds
+  amount-keypad context from a preset — composing the existing
+  `applyQuickEntry(action:)` path, not a new entry flow.
+- Alignment of the widget enum, the App Clip category grid, and the in-app
+  `applyQuickEntry` mapping onto that single catalog.
+- Adding the **cash** and **Apple Cash** presets the issue names, modeled as
+  **tender defaults** distinct from spending categories ([§6](#6-cash--apple-cash-tender-not-category)).
+
+**Out of scope:**
+
+- The **quick-add sheet mechanics** (detents, keypad, save/undo) — owned by
+  [ios-one-thumb-quick-add.md](./ios-one-thumb-quick-add.md); this design only
+  adds the preset chips that feed it.
+- The **validation/save rules** — those stay in the shared validator the sheet
+  already calls; presets only pre-seed inputs.
+- New navigation/IA — chips live inside the existing sheet
+  ([information-architecture.md](./information-architecture.md)).
+
+> **Why one catalog:** divergent preset lists are a silent bug factory — a
+> "transit" preset on the widget that maps to a different category in-app erodes
+> trust in the totals. A single source removes that drift class entirely.
+
+---
+
+## 2. Current State (Three Copies of the Presets)
+
+The same idea is encoded three times, each subtly different:
+
+| Surface            | Where                                                                                                              | Preset set today                                                   |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------ |
+| Lock Screen widget | [`QuickEntryWidget.swift`](../../apps/ios/FinanceWidget/QuickEntryWidget.swift) `QuickEntryShortcut`               | `none / lunch / coffee / groceries / gas`                          |
+| In-app quick entry | [`TransactionCreateViewModel.applyQuickEntry`](../../apps/ios/Finance/ViewModels/TransactionCreateViewModel.swift) | `lunch → c2`, `coffee → c2`, `groceries → c1`, `gas → c3`          |
+| App Clip           | [`TransactionCategory.quickCategories`](../../apps/ios/Shared/SharedConstants.swift)                               | `food / transport / shopping / … / groceries / other` (categories) |
+
+- The widget and in-app paths agree on **named shortcuts** (lunch/coffee/…) and
+  route through the **same deep link**: `QuickEntryShortcut.deepLinkAction` →
+  [`FinanceWidgetDeepLinks.quickEntryURL`](../../apps/ios/Shared/WidgetPrivacy.swift)
+  → [`DeepLinkHandler.quickEntry(action:)`](../../apps/ios/Finance/Navigation/DeepLinkHandler.swift)
+  → `applyQuickEntry(action:)`. That string contract is the seam to standardize.
+- The App Clip uses **categories**, not named shortcuts — a different axis
+  ([`QuickTransactionView`](../../apps/ios/FinanceClip/QuickTransactionView.swift)
+  renders `quickCategories` as a grid). The catalog must reconcile "named
+  preset" and "category" cleanly.
+- The issue explicitly adds **transit / cash / Apple Cash**, none of which exist
+  in any current list — so the catalog both unifies and extends.
+
+---
+
+## 3. The Shared Preset Catalog
+
+A single ordered catalog of quick-entry presets, each a small value type
+(conceptually in `packages/core` / `packages/models`, **estimate** — final shape
+owned by `@kmp-engineer` / `@architect`):
+
+```text
+QuickEntryPreset
+  id            : String   // stable key, e.g. "coffee" (deep-link + telemetry)
+  label         : String   // localized display, e.g. "Coffee"
+  categoryId    : String?  // default spending category (nil for tender-only)
+  defaultTender : String?  // default account/tender, e.g. "cash" / "apple-cash"
+  symbolName    : String   // SF Symbol, resolved on iOS only
+  isEnabled     : Bool     // surface gating (e.g. hide tender presets in widget)
+```
+
+Proposed catalog (the issue's set, unified):
+
+| Preset id    | Label (en)   | Default category | Default tender | SF Symbol        |
+| ------------ | ------------ | ---------------- | -------------- | ---------------- |
+| `coffee`     | "Coffee"     | Dining           | —              | `cup.and.saucer` |
+| `lunch`      | "Lunch"      | Dining           | —              | `fork.knife`     |
+| `transit`    | "Transit"    | Transport        | —              | `tram.fill`      |
+| `cash`       | "Cash"       | (last used)      | Cash           | `banknote`       |
+| `apple-cash` | "Apple Cash" | (last used)      | Apple Cash     | `applelogo`      |
+
+- **iOS resolves presentation only:** the SF Symbol and the localized `label`
+  come from `String(localized:)` / SF Symbols on the Swift side; the catalog's
+  job is the **mapping**, not the rendering.
+- **id is the contract.** The existing `QuickEntryShortcut.rawValue` →
+  `deepLinkAction` → `applyQuickEntry(action:)` string already uses these ids;
+  standardizing on the catalog's `id` keeps the deep-link seam unchanged while
+  removing the per-surface copies.
+- **categoryId stays symbolic** (e.g. "dining"); the concrete category row id
+  (`c1`/`c2`/…) is resolved in-app after `loadData()`, exactly as
+  `applyQuickEntry` resolves today — so the catalog never hardcodes UI ids.
+
+---
+
+## 4. Preset-Reuse Flow
+
+```mermaid
+flowchart TD
+    CAT["Shared QuickEntryPreset catalog<br/>(packages/core + packages/models — DO NOT implement here)"]
+    CAT --> W["Lock Screen widget<br/>QuickEntryShortcut config"]
+    CAT --> CL["App Clip<br/>preset chips above category grid"]
+    CAT --> IN["In-app quick-add sheet<br/>NEW preset chips row"]
+    W -->|finance://quick-entry?action=ID| DL["DeepLinkHandler.quickEntry(action)"]
+    CL -->|/clip/expense?... handoff| DL
+    IN -->|direct call| AQ["applyQuickEntry(action: ID)"]
+    DL --> AQ
+    AQ --> VAL["Shared validator (KMP) + save"]
+```
+
+- Every surface resolves a preset to the **same `id`**, and every path converges
+  on `applyQuickEntry(action: id)` → the **same shared validator** the full
+  create flow uses. There is exactly one place where "coffee" becomes a category
+  default, regardless of where the user tapped.
+- The widget keeps emitting identifier-only deep links (no money in the URL,
+  per [`FinanceWidgetDeepLinks`](../../apps/ios/Shared/WidgetPrivacy.swift)); the
+  App Clip keeps its `/clip/expense` handoff; the in-app chips skip the URL and
+  call `applyQuickEntry` directly.
+
+---
+
+## 5. In-App Quick-Add Chips
+
+The new consumer: a horizontally scrollable **chips strip** at the top of the
+in-app quick-add sheet from [ios-one-thumb-quick-add.md](./ios-one-thumb-quick-add.md).
+
+```text
+┌──────────────────────────────────────────────┐
+│  [ ☕ Coffee ] [ 🍴 Lunch ] [ 🚊 Transit ] …   │  ← preset chips (this design)
+│                                                │
+│                 $ 4 . 50                       │  ← amount keypad (existing sheet)
+│            Dining · Checking ▾                 │  ← default chips (existing sheet)
+│                  [  Save  ]                    │
+└──────────────────────────────────────────────┘
+```
+
+- **Tapping a chip** calls `applyQuickEntry(action: preset.id)`, pre-seeding the
+  payee/category (and, for tender presets, the default account) while leaving
+  the amount keypad focused — so the flow stays **amount → save** in one thumb
+  arc.
+- **Selection is non-destructive:** a chip seeds defaults the user can still
+  override via the sheet's existing default chips; re-tapping a chip re-applies
+  its preset; tapping the selected chip again clears it back to "remembered
+  defaults."
+- **Order & overflow:** catalog order, horizontally scrollable; the strip never
+  pushes the keypad below the thumb arc. On the narrowest device the strip is one
+  scrollable row, not a wrap that steals vertical space.
+- **Reuse, don't fork:** the chips render from the **same catalog** as the
+  widget config picker and the App Clip grid — adding a preset once lights it up
+  everywhere.
+
+---
+
+## 6. Cash & Apple Cash (Tender, Not Category)
+
+`cash` and `apple-cash` are **not spending categories** — they describe **how you
+paid**. Modeling them as categories would corrupt category analytics.
+
+- They carry `defaultTender` (the account/tender) and **leave `categoryId` to the
+  user's last-used / suggested category** rather than forcing one.
+- In the in-app sheet, a tender preset pre-selects the **account** chip and opens
+  the keypad; the category remains the existing suggestion path
+  (`updateCategorySuggestion()` via the KMP categorization engine).
+- **Surface gating:** tender presets may be `isEnabled == false` on the **Lock
+  Screen widget** (where a single named shortcut is configured) and in the **App
+  Clip** (which has no signed-in account context), but **enabled** in-app where a
+  real account exists. The catalog's `isEnabled` flag expresses this without
+  forking the list.
+
+---
+
+## 7. Accessibility & Dynamic Type
+
+Per [accessibility-patterns.md](./accessibility-patterns.md) and
+[cognitive-accessibility.md](./cognitive-accessibility.md):
+
+- **Each chip is a button** with an explicit `.accessibilityLabel` (the preset
+  label, e.g. "Coffee"), an `.accessibilityHint` ("Pre-fills a coffee expense"),
+  the `.isButton` trait, and `.isSelected` when active. The leading SF Symbol is
+  `.accessibilityHidden(true)` — its meaning is already in the label.
+- **Selection is announced** (not color-only): the selected chip exposes
+  `.isSelected` and a subtle non-color affordance (filled background **and** a
+  checkmark / bold label), matching the App Clip's existing selected-category
+  treatment in [`QuickTransactionView`](../../apps/ios/FinanceClip/QuickTransactionView.swift).
+- **Dynamic Type:** chip labels use semantic fonts; at accessibility sizes the
+  strip stays a single scrollable row (labels grow, never truncate) and the
+  44 pt minimum target height is preserved.
+- **Reduce Motion:** the chip-apply transition collapses to an instant state
+  change when `accessibilityReduceMotion` is on.
+- **VoiceOver order:** chips precede the amount field in the swipe order, so a
+  VoiceOver user can pick a preset first, then land on the keypad.
+
+---
+
+## 8. Privacy
+
+- **Presets contain no money.** A preset is an id + category/tender mapping; deep
+  links remain identifier-only ([`FinanceWidgetDeepLinks`](../../apps/ios/Shared/WidgetPrivacy.swift)),
+  so nothing in the catalog or the widget/clip handoff can leak a balance.
+- **Cash / Apple Cash reveal nothing** — they name a tender, not an amount.
+- **Biometric gate preserved:** widget and deep-link entry into the in-app sheet
+  still pass through the existing biometric-gated create path
+  ([`DeepLinkHandler.quickEntry`](../../apps/ios/Finance/Navigation/DeepLinkHandler.swift));
+  presets do not bypass it.
+- **Logging:** preset selections may be logged by `id` as `.public` (non-sensitive
+  routing facts); the **amount** the user then enters stays `.private`. Never log
+  a preset together with its amount in a way that reconstructs a transaction.
+
+---
+
+## 9. States: Empty, Stale & Error
+
+| State                    | Trigger                                                       | Rendering                                                                                  |
+| ------------------------ | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| **Empty catalog**        | Catalog returns no enabled presets                            | Hide the chips strip entirely; the sheet still works as plain amount-first entry (no gap)  |
+| **Single preset**        | Only one enabled preset                                       | Show the one chip, left-aligned; no scroll affordance                                      |
+| **Disabled-here preset** | `isEnabled == false` for this surface (e.g. tender in widget) | Omit the chip on that surface only; it still appears where enabled                         |
+| **Unknown deep-link id** | `applyQuickEntry(action:)` gets an unmatched id               | Fall back to the default (no preset applied) exactly as the current `default:` branch does |
+| **Stale defaults**       | Remembered category/account no longer exists                  | Apply the preset's category; drop the missing account silently and let the user pick       |
+| **Save error**           | Shared validator/save fails after a preset seed               | The sheet's existing inline error + Retry handles it; the chip selection is preserved      |
+
+- The chips strip must **degrade to nothing** gracefully: an empty or failed
+  catalog never blocks plain expense entry.
+- Unknown ids are non-fatal — matching `applyQuickEntry`'s existing tolerant
+  `default:` behavior keeps old widget configs / stale links safe.
+
+---
+
+## 10. Native ↔ KMP Boundary
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages/core plus packages/models (KMP — DO NOT implement here)"]
+        K1["QuickEntryPreset catalog (id, categoryId, tender, isEnabled)"]
+        K2["Validation + categorization rules"]
+    end
+    subgraph Bridge["Swift Export bridge (apps/ios/Finance/KMP)"]
+        B1["Preset list exposed as Array"]
+    end
+    subgraph iOS["apps/ios (native — this design)"]
+        S1["Widget config / App Clip grid / in-app chips"]
+        S2["SF Symbol + localized label resolution"]
+        S3["applyQuickEntry(action: id) + sheet wiring"]
+    end
+    K1 --> B1 --> S1 --> S3
+    K2 --> S3
+    S1 --> S2
+```
+
+- The **catalog and its mappings** are shared business data (which category /
+  tender a named preset implies). iOS receives the list across the bridge and is
+  responsible only for **icon + label rendering** and for calling
+  `applyQuickEntry(action: id)`.
+- **Estimate (label):** exposing the catalog as a shared array (mapping
+  Kotlin `List` → Swift `Array`) is the proposed contract; its final shape and
+  whether tender lives in `packages/models` is decided by `@kmp-engineer` /
+  `@architect` via ADR — **not** implemented here. iOS must not hardcode a fourth
+  divergent copy of the presets.
+- Existing shared seams reused unchanged: the deep-link `action` string contract
+  and the shared validator the create flow already calls.
+
+---
+
+## 11. Affected Surfaces & Shared Dependencies
+
+**New (this design):**
+
+- `apps/ios/Finance/Components/QuickAddPresetChips.swift` (the in-app chips
+  strip), plus a small Swift view model that maps catalog presets → chip view
+  data and SF Symbols.
+
+**Touched (to consume the one catalog instead of a private list):**
+
+- [`QuickEntryWidget.swift`](../../apps/ios/FinanceWidget/QuickEntryWidget.swift) —
+  `QuickEntryShortcut` cases sourced from the catalog (ids unchanged).
+- [`QuickTransactionView.swift`](../../apps/ios/FinanceClip/QuickTransactionView.swift) —
+  add preset chips above the existing category grid (App Clip).
+- [`TransactionCreateViewModel.applyQuickEntry`](../../apps/ios/Finance/ViewModels/TransactionCreateViewModel.swift) —
+  resolve `categoryId`/`defaultTender` from the catalog instead of an inline
+  `switch`.
+- The in-app quick-add sheet from [ios-one-thumb-quick-add.md](./ios-one-thumb-quick-add.md) —
+  host the new chips strip.
+
+**Reused unchanged:**
+
+- [`FinanceWidgetDeepLinks.quickEntryURL`](../../apps/ios/Shared/WidgetPrivacy.swift),
+  [`DeepLinkHandler`](../../apps/ios/Finance/Navigation/DeepLinkHandler.swift), the
+  biometric-gated create path, and the shared validator.
+
+**Shared dependency:** the KMP preset catalog ([§10](#10-native--kmp-boundary)).
+
+---
+
+## 12. Test Plan (Smallest Tests First)
+
+1. **Catalog mapping (Swift unit):** each preset `id` resolves to the expected
+   `categoryId` / `defaultTender` / symbol; `apply` seeds the create view model
+   correctly and does **no** validation itself.
+2. **Parity (Swift unit):** the widget enum, App Clip chips, and in-app chips
+   derive from the **same** catalog — assert identical id sets per `isEnabled`
+   surface gating (this is the regression that prevents drift).
+3. **Tender preset (Swift unit):** `cash` / `apple-cash` set the account/tender
+   and leave category to the suggestion path, not a forced category.
+4. **Unknown id tolerance (Swift unit):** `applyQuickEntry("nope")` falls back to
+   defaults with no crash (matches current `default:`).
+5. **Deep-link round-trip (Swift unit):** `quickEntryURL(action: "coffee")` →
+   `DeepLinkHandler` → `applyQuickEntry("coffee")` seeds the coffee preset.
+6. **Chips accessibility (XCUITest, smallest):** chip exposes label/hint/button,
+   selection toggles `.isSelected`, and chips precede the keypad in swipe order.
+7. **Dynamic Type (snapshot):** chips strip at `.large` and `.accessibility5`
+   stays one scrollable row, ≥ 44 pt, no truncation.
+8. **Shared (KMP, owned by @kmp-engineer):** the catalog's category/tender
+   mappings and `isEnabled` gating are unit-tested in `packages/core`.
+
+---
+
+## 13. Implementation Readiness
+
+See [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md).
+
+**Buildable now (no paid enrollment) — free Personal Team signing:**
+
+- The in-app chips and the `applyQuickEntry` refactor are **pure SwiftUI + Swift**
+  — they build in the Simulator (no signing) and on a device under a **free Apple
+  ID (Personal Team)**.
+- The **App Clip** target and the **Lock Screen widget** both build and run under
+  a free Personal Team for development and on-device testing; App Group sharing
+  works locally. Only their public **distribution** is gated (below).
+- All tests in [§12](#12-test-plan-smallest-tests-first) run without enrollment;
+  the catalog tests run on cross-platform CI.
+
+**Distribution tail — gated by [#1239](https://github.com/jrmoulckers/finance/issues/1239):**
+
+- App Clip **distribution** (App Store, App Clip experiences / codes) and
+  TestFlight/App Store delivery of the app and widget are gated by Apple Developer
+  enrollment — **design and local build are not.** The PR should carry a
+  `## Needs Human Action` note pointing only at the
+  [§3.2 Apple Developer checklist](../ops/human-gated-prerequisites.md#32-ios-distribution--apple-developer-1239).
+  Agents must **not** perform enrollment, signing, App Clip experience
+  configuration, or secret setup, and must **not** modify shared `packages/`
+  without `@architect` / an ADR.
+
+---
+
+## 14. Open Questions
+
+1. **Preset set sign-off:** confirm the five-preset launch set (coffee, lunch,
+   transit, cash, Apple Cash) and their default categories with @content/design.
+2. **User-customizable presets:** is the catalog fixed for v1, or should users
+   reorder/add presets later? Default: fixed shared catalog for v1.
+3. **Tender model:** does `defaultTender` reference an account id, an account
+   _type_, or a payment-method enum? Owned by `@kmp-engineer` / `@architect`.
+4. **Widget single-shortcut vs. chips:** the Lock Screen widget shows one
+   configured shortcut; should a medium widget show a small chip set, or stay
+   single? Default: keep single on Lock Screen, chips in-app.
+5. **App Clip tender presets:** confirm tender presets stay disabled in the App
+   Clip (no signed-in account) and only category presets show there.

--- a/docs/design/ios-grocery-affordability-appclip.md
+++ b/docs/design/ios-grocery-affordability-appclip.md
@@ -1,0 +1,414 @@
+# Grocery Affordability Quick Check — Widget & App Clip — iOS
+
+> An in-store, one-glance answer to _"can I still afford this in my grocery
+> budget right now?"_ — surfaced as a **Home/Lock Screen widget** and a
+> lightweight **App Clip** entry point, with privacy masking on by default,
+> honest stale-data states, and **one-thumb category switching** so the same
+> check works for dining or transport without opening the full app.
+
+**Status:** PROPOSED — design only (native implementation buildable now; store distribution gated)
+**Issue:** [#2611](https://github.com/jrmoulckers/finance/issues/2611) — Part of [#2199](https://github.com/jrmoulckers/finance/issues/2199)
+**Platform:** iOS / iPadOS (WidgetKit + App Clip + SwiftUI, iOS 17+)
+**Owner:** @ios-engineer
+**Related:** [ios-grocery-safe-to-spend-card.md](./ios-grocery-safe-to-spend-card.md) · [ios-widget-freshness-pipeline.md](./ios-widget-freshness-pipeline.md) · [ios-today-spend-funmoney-widget.md](./ios-today-spend-funmoney-widget.md) · [ios-appclip-widget-quickentry-presets.md](./ios-appclip-widget-quickentry-presets.md) · [ios-noncolor-financial-state-cues.md](./ios-noncolor-financial-state-cues.md) · [data-visualization.md](./data-visualization.md) · [accessibility-patterns.md](./accessibility-patterns.md) · [cognitive-accessibility.md](./cognitive-accessibility.md) · [content-language-guidelines.md](./content-language-guidelines.md) · [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md)
+
+---
+
+## Table of Contents
+
+1. [Goal & Scope](#1-goal--scope)
+2. [Current State](#2-current-state)
+3. [The Widget (Home & Lock Screen)](#3-the-widget-home--lock-screen)
+4. [The App Clip Entry Point](#4-the-app-clip-entry-point)
+5. [One-Thumb Category Switching](#5-one-thumb-category-switching)
+6. [Privacy & Balance Masking](#6-privacy--balance-masking)
+7. [Accessibility & Dynamic Type](#7-accessibility--dynamic-type)
+8. [States: Empty, Stale & Error](#8-states-empty-stale--error)
+9. [Native ↔ KMP Boundary](#9-native--kmp-boundary)
+10. [Affected Surfaces & Shared Dependencies](#10-affected-surfaces--shared-dependencies)
+11. [Test Plan (Smallest Tests First)](#11-test-plan-smallest-tests-first)
+12. [Implementation Readiness](#12-implementation-readiness)
+13. [Open Questions](#13-open-questions)
+
+---
+
+## 1. Goal & Scope
+
+Standing in the grocery aisle, the question is small and urgent: _"do I have
+room left in groceries this period?"_ The in-app **safe-to-spend card**
+([ios-grocery-safe-to-spend-card.md](./ios-grocery-safe-to-spend-card.md),
+[#2610](https://github.com/jrmoulckers/finance/issues/2610)) answers it once the
+app is open. This design pushes the same answer **out to the glanceable layer** —
+a widget you can pin and an App Clip you can open from a code — so the check
+needs zero navigation and respects the same masking-by-default privacy posture.
+
+**In scope:**
+
+- A **Home Screen** (small/medium) and **Lock Screen** (accessory) **affordability
+  widget** showing grocery remaining / safe-to-spend, masked by default, reading
+  only the App Group cache.
+- A minimal **App Clip** affordability surface for in-store use, reusing the
+  existing App Clip shell and keeping to App Clip **minimal-data** rules.
+- **One-thumb category switching** (groceries ↔ dining ↔ transport) via the
+  widget's configuration intent and an interactive in-widget control where
+  supported.
+- Privacy masking, stale-data honesty, and full accessibility/state coverage.
+
+**Out of scope:**
+
+- The **safe-to-spend math** — it stays in KMP `packages/core`, exactly as
+  [ios-grocery-safe-to-spend-card.md](./ios-grocery-safe-to-spend-card.md)
+  specifies; this design **renders** a cached value, it does not compute it
+  ([§9](#9-native--kmp-boundary)).
+- The **freshness pipeline** that writes the cache — owned by
+  [ios-widget-freshness-pipeline.md](./ios-widget-freshness-pipeline.md); this
+  design consumes its output (`widget.budgets`) and adds a small affordability
+  payload, but does not change when/how the cache is rebuilt.
+- Quick **expense entry** itself — that is the quick-entry presets work
+  ([ios-appclip-widget-quickentry-presets.md](./ios-appclip-widget-quickentry-presets.md));
+  this widget/App Clip is a **read** check that can hand off to it.
+
+> **Read-first, by design:** the primary job is a trustworthy "how much room is
+> left" glance. Logging the purchase is a secondary, optional handoff — so the
+> surface stays calm and never blocks the affordability answer behind a form.
+
+---
+
+## 2. Current State
+
+- The widget data layer already models budgets for exactly this:
+  [`WidgetBudget`](../../apps/ios/FinanceWidget/WidgetDataProvider.swift) exposes
+  `spentMinorUnits`, `limitMinorUnits`, `remainingMinorUnits`, `progress`, and
+  `isOverBudget`; `WidgetDataProvider.readBudgets()` / `budgetRollup()` read them
+  from the App Group cache **only** (never the network).
+- Privacy masking is shared and **defaults to Bucketed**:
+  [`WidgetMoneyFormatter`](../../apps/ios/Shared/WidgetPrivacy.swift) +
+  `WidgetPrivacySettings.defaultMode = .bucketed`, with `.percent` and `.dots`
+  modes — the affordability surface reuses this verbatim.
+- A working **App Clip** already proves the amount-first, single-screen pattern
+  and App Store handoff: [`QuickTransactionView`](../../apps/ios/FinanceClip/QuickTransactionView.swift)
+  - [`FinanceClipApp`](../../apps/ios/FinanceClip/FinanceClipApp.swift) (URL
+    prefill via `/clip/expense`).
+- Deep links are **identifier-only**:
+  [`FinanceWidgetDeepLinks.budgetCategoryURL(categoryId:)`](../../apps/ios/Shared/WidgetPrivacy.swift)
+  → [`DeepLinkHandler.budgetCategory(id:)`](../../apps/ios/Finance/Navigation/DeepLinkHandler.swift)
+  → Budgets tab, so a tap can open the full grocery budget with no money in the
+  URL.
+- **Missing:** a dedicated affordability presentation (safe-to-spend framing, not
+  raw spent/limit), an App Clip affordability surface, and category switching.
+
+---
+
+## 3. The Widget (Home & Lock Screen)
+
+A configurable affordability widget reading the cached budget + safe-to-spend
+payload, masked by default.
+
+```text
+Home — small                         Home — medium
+┌──────────────────────┐             ┌──────────────────────────────────────┐
+│ 🛒 Groceries          │             │ 🛒 Groceries              On track ● │
+│ Safe to spend         │             │ Safe to spend     ▓▓▓▓▓▓░░░░  64%     │
+│   $50–$100  (bucket)  │             │   $50–$100 of $200 (bucketed)         │
+│ as of 2:14 PM         │             │ as of 2:14 PM · tap to open budget    │
+└──────────────────────┘             └──────────────────────────────────────┘
+```
+
+- **Families:** `.systemSmall` + `.systemMedium` on Home; `.accessoryRectangular`
+  - `.accessoryCircular` on the Lock Screen (circular shows progress + a state
+    glyph only, no figure). Follows the family structure of the existing
+    [`BudgetProgressWidget`](../../apps/ios/FinanceWidget/BudgetProgressWidget.swift)
+    and [today-spend widget](./ios-today-spend-funmoney-widget.md).
+- **Affordability framing, not raw spend:** lead with **safe-to-spend remaining**
+  (the supportive figure), with `progress` + "of {limit}" as context — reusing
+  the card's tone from
+  [ios-grocery-safe-to-spend-card.md](./ios-grocery-safe-to-spend-card.md).
+- **Masked by default:** all money renders through
+  [`WidgetMoneyFormatter`](../../apps/ios/Shared/WidgetPrivacy.swift) at the
+  instance's masking mode (Bucketed default), so a pinned widget shows a range or
+  percent, not an exact balance ([§6](#6-privacy--balance-masking)).
+- **Status is text + non-color:** "On track / Tight / Over" with a paired glyph,
+  per [ios-noncolor-financial-state-cues.md](./ios-noncolor-financial-state-cues.md)
+  — never hue alone.
+- **"As of" timestamp** is always shown, sourced from the cache write time, so a
+  stale glance is self-evident ([§8](#8-states-empty-stale--error)).
+- **Tap target:** the whole widget is a `Link` to
+  `budgetCategoryURL(categoryId:)` (identifier-only) opening the full grocery
+  budget — no money in the URL.
+
+---
+
+## 4. The App Clip Entry Point
+
+For an **in-store** check launched from an App Clip code / NFC tag / link, a
+minimal affordability surface — built on the existing
+[`FinanceClipApp`](../../apps/ios/FinanceClip/FinanceClipApp.swift) shell.
+
+- **Minimal-data by default.** App Clips are ephemeral and untrusted for personal
+  finance: a standalone App Clip (full app **not** installed) must **never** show
+  someone's real grocery balance. It presents a **neutral affordability helper** —
+  enter a price, see a generic "what fits a typical grocery run" guide and a
+  prompt to get the full app — and, optionally, an amount-first quick-expense
+  reusing [`QuickTransactionView`](../../apps/ios/FinanceClip/QuickTransactionView.swift).
+- **When the full app is installed**, the App Clip defers: it hands off to the
+  app's real affordability widget/card via the existing universal-link path
+  rather than duplicating sensitive data in the clip. The full, account-backed
+  number lives behind the app's biometric gate, not in the clip.
+- **No persisted secrets in the clip.** The App Clip keeps the existing pattern —
+  pending captures go to the shared App Group store
+  ([`ClipTransactionStore`](../../apps/ios/FinanceClip/ClipTransactionStore.swift));
+  no balances, tokens, or budget figures are cached in the clip container.
+- **Size budget:** the clip stays well under the 15 MB App Clip limit — it adds a
+  small affordability view, not new heavy dependencies.
+
+```mermaid
+flowchart TD
+    SCAN["App Clip code / NFC / link"] --> CLIP["FinanceClip affordability helper"]
+    CLIP -->|full app installed| HANDOFF["Universal link to app<br/>real masked safe-to-spend"]
+    CLIP -->|standalone| GENERIC["Neutral price-fits guide<br/>plus Get the App overlay"]
+    CLIP -.optional.-> QT["QuickTransactionView quick expense"]
+    HANDOFF --> APP["Finance app (biometric-gated)"]
+```
+
+---
+
+## 5. One-Thumb Category Switching
+
+The same affordability glance should work for **dining** or **transport**, not
+just groceries — switchable without two-handed navigation.
+
+- **Primary: configuration intent.** A `WidgetConfigurationIntent` parameter
+  selects the budget category (Groceries default), mirroring
+  [`QuickEntryWidgetIntent`](../../apps/ios/FinanceWidget/QuickEntryWidget.swift)'s
+  pattern. Long-press → Edit Widget swaps the category — the canonical,
+  always-available path.
+- **Secondary (Home medium): interactive switch.** Where supported, an in-widget
+  **interactive `AppIntent`** (iOS 17 `Button(intent:)`) cycles
+  Groceries → Dining → Transport in place, writing the chosen category to the App
+  Group so the next timeline reload reflects it. This is a **selection** action
+  (no money mutated), keeping it within WidgetKit's interactive constraints.
+- **Thumb reach:** the switch control sits bottom-trailing in the medium layout,
+  inside the one-thumb arc; the category label updates immediately and the figure
+  re-renders on the next entry.
+- **Category set** is sourced from the shared quick-entry / budget catalog
+  (see [ios-appclip-widget-quickentry-presets.md](./ios-appclip-widget-quickentry-presets.md))
+  so the switchable categories match the rest of the app.
+
+---
+
+## 6. Privacy & Balance Masking
+
+In-store glances are the **most** exposed context (someone may be looking over
+your shoulder), so masking is strict:
+
+- **Bucketed by default.** Money renders via
+  [`WidgetMoneyFormatter`](../../apps/ios/Shared/WidgetPrivacy.swift) at the
+  instance's mode; the default is **Bucketed** (`$50–$100`), with **Percent**
+  ("64% left") and **Dots** ("•••") as alternatives. An exact figure appears only
+  if the user explicitly opted that instance into `.visible`.
+- **First-add prompt respected:** reading a bucketed widget still flags
+  `markFirstAddPromptPending` exactly as `WidgetDataProvider.maskingMode(for:)`
+  does, so the app can later confirm whether exact amounts are acceptable.
+- **Lock Screen circular shows no figure** — progress arc + state glyph only.
+- **App Clip shows no real balance standalone** ([§4](#4-the-app-clip-entry-point)) —
+  minimal-data is the strongest masking.
+- **Deep links carry identifiers only** — `budgetCategoryURL` encodes a category
+  id, never an amount.
+- **Logging:** the widget/clip log routing and masking-mode facts as `.public`;
+  any minor-unit amount stays `.private`. Never log the safe-to-spend figure.
+
+> Consistent with the card: a widget surfaced on the Lock Screen renders the
+> **masked** form first, matching the bucketed-by-default widget policy.
+
+---
+
+## 7. Accessibility & Dynamic Type
+
+Per [accessibility-patterns.md](./accessibility-patterns.md) and
+[cognitive-accessibility.md](./cognitive-accessibility.md):
+
+- **Widget is one combined element.** Suggested VoiceOver reading (Bucketed):
+  _"Groceries, safe to spend, 50 to 100 dollars, on track, as of 2:14 PM. Opens
+  grocery budget."_ Built with `.accessibilityElement(children: .combine)`,
+  explicit label/value/hint, and the link trait. The spoken value uses the same
+  masking mode as the visual (via `WidgetCurrencyFormatter.formatForVoiceOver`).
+- **Status in words, not color:** "on track / tight / over" is spoken and shown
+  as text + glyph ([ios-noncolor-financial-state-cues.md](./ios-noncolor-financial-state-cues.md)).
+- **Dynamic Type:** widget text uses semantic fonts and respects the system size;
+  the medium layout prefers a **bar** over a ring at large sizes (ring labels
+  cramp), echoing the card's SE rules. No hardcoded sizes; figures never truncate
+  — the bucketed/percent forms are short by construction.
+- **Category switch control** (medium) is a ≥ 44 pt target with its own
+  `.accessibilityLabel` ("Switch category") and announces the new category.
+- **Reduce Motion:** progress-fill / value-change animation collapses to an
+  instant update when `accessibilityReduceMotion` is on.
+- **App Clip** inherits the existing clip's accessible patterns (headers,
+  hidden decorative glyphs, labeled inputs) from
+  [`QuickTransactionView`](../../apps/ios/FinanceClip/QuickTransactionView.swift).
+
+---
+
+## 8. States: Empty, Stale & Error
+
+| State                 | Trigger                                      | Rendering                                                                                      |
+| --------------------- | -------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| **Placeholder**       | WidgetKit placeholder / redacted             | Skeleton with a neutral grocery glyph; no real figure                                          |
+| **No grocery budget** | Cache has no matching category               | "Pin a grocery budget" prompt + tap-to-open; never a fabricated number                         |
+| **Empty cache**       | App Group cache not yet written              | Same as no-budget; the widget reads cache only and shows an empty state, never fetches network |
+| **Stale / offline**   | Cache write time older than freshness window | Show last-known **masked** value **with an explicit "as of {time}"**; visibly de-emphasize it  |
+| **Over budget**       | `remainingMinorUnits < 0`                    | Calm "Over by {bucket}" with constructive copy + drill-in; status text + glyph, no alarm color |
+| **Error**             | Decode/read failure                          | Fall back to placeholder + "Open app to refresh"; never crash a timeline entry                 |
+| **App Clip (no app)** | Standalone clip, full app absent             | Neutral price-fits helper + "Get the App"; **no** real balance shown                           |
+
+- **Stale honesty is mandatory:** the "as of" timestamp is always present so an
+  old glance is never mistaken for live data — the freshness pipeline
+  ([ios-widget-freshness-pipeline.md](./ios-widget-freshness-pipeline.md)) sets
+  the write time the widget displays.
+- States reflow at large Dynamic Type exactly like the happy path; the bucketed
+  figure and "as of" line wrap, never truncate.
+
+---
+
+## 9. Native ↔ KMP Boundary
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages/core plus packages/models (KMP — DO NOT implement here)"]
+        K1["safeToSpend(budget, pending, bills, payday)"]
+        K2["Budget remaining / state thresholds"]
+    end
+    subgraph Pipe["Freshness pipeline (writes App Group cache)"]
+        P1["widget.budgets + affordability payload"]
+    end
+    subgraph iOS["apps/ios (native — this design)"]
+        W1["WidgetDataProvider reads cache"]
+        W2["Affordability widget + App Clip render (masked)"]
+        W3["Config intent + interactive category switch (selection only)"]
+    end
+    K1 --> P1
+    K2 --> P1
+    P1 --> W1 --> W2
+    W3 --> W1
+```
+
+- The **safe-to-spend computation** is shared business logic in `packages/core`
+  (with shapes in `packages/models`), exactly as the card design specifies — the
+  widget/App Clip **render a precomputed value** read from the App Group cache;
+  they never compute or even fetch it (timeline providers read cache only).
+- **Estimate (label):** the affordability payload the cache needs (remaining,
+  limit, `state`, currency, and the write time) is an extension of the existing
+  `widget.budgets` cache or a small sibling key — its final shape is owned by
+  `@kmp-engineer` / `@architect` (math) and the freshness-pipeline doc (caching),
+  via ADR. iOS must **not** inline the safe-to-spend formula even temporarily.
+- The **interactive category switch** writes only a _selection_ (chosen category
+  id) to the App Group — no money mutation — staying within WidgetKit's
+  interactive-intent rules.
+- iOS owns layout, masking presentation, the config/interactive intents, and
+  accessibility only.
+
+---
+
+## 10. Affected Surfaces & Shared Dependencies
+
+**New (this design):**
+
+- `apps/ios/FinanceWidget/GroceryAffordabilityWidget.swift` — the widget,
+  configuration intent, timeline provider, and views.
+- An App Clip affordability view under `apps/ios/FinanceClip/` (e.g.
+  `AffordabilityCheckView.swift`) presented by the existing clip shell.
+- A small interactive `AppIntent` for in-widget category switching.
+
+**Touched / extended:**
+
+- [`WidgetDataProvider`](../../apps/ios/FinanceWidget/WidgetDataProvider.swift) —
+  add an affordability read (remaining + state + "as of") layered on the existing
+  budget cache.
+- [`FinanceWidgetBundle`](../../apps/ios/FinanceWidget/FinanceWidgetBundle.swift) —
+  register the new widget.
+
+**Reused unchanged:**
+
+- [`WidgetMoneyFormatter`](../../apps/ios/Shared/WidgetPrivacy.swift) /
+  `WidgetPrivacySettings` (masking, defaults, first-add prompt),
+  [`FinanceWidgetDeepLinks.budgetCategoryURL`](../../apps/ios/Shared/WidgetPrivacy.swift),
+  [`DeepLinkHandler`](../../apps/ios/Finance/Navigation/DeepLinkHandler.swift),
+  the App Clip shell/store, and the freshness pipeline cache.
+
+**Shared dependencies:** KMP `packages/core` safe-to-spend math
+([§9](#9-native--kmp-boundary)); the App Group write contract owned by
+[ios-widget-freshness-pipeline.md](./ios-widget-freshness-pipeline.md).
+
+---
+
+## 11. Test Plan (Smallest Tests First)
+
+1. **Masking render (Swift unit/snapshot):** the widget renders Bucketed by
+   default and Percent/Dots when configured — assert no exact figure leaks in the
+   default mode, including the VoiceOver value.
+2. **Affordability mapping (Swift unit):** given a cached payload, the view maps
+   remaining/limit/state correctly and computes **no** safe-to-spend math itself
+   (inject a stub provider).
+3. **Stale "as of" (Swift unit):** an old cache write time renders the
+   de-emphasized "as of {time}" treatment, never a "live" presentation.
+4. **Empty/no-budget (snapshot):** no matching category ⇒ "Pin a grocery budget"
+   prompt, no fabricated number; empty cache reads as empty (no network).
+5. **Over-budget (snapshot):** `remaining < 0` ⇒ calm "Over by {bucket}" with
+   text + glyph status, no alarm color.
+6. **Category switch (Swift unit):** the config intent and the interactive intent
+   change the rendered category by writing a selection to the App Group; assert
+   no money is mutated.
+7. **Deep-link drill-in (XCUITest, smallest):** tapping the widget opens the
+   Budgets tab on the selected category via `budgetCategory` (identifier-only URL).
+8. **App Clip minimal-data (Swift unit/snapshot):** standalone clip shows the
+   neutral helper and **no** real balance; with the app installed, it hands off.
+9. **Dynamic Type (snapshot):** small + medium + accessory families at `.large`
+   and `.accessibility5` — figures/"as of" wrap, nothing truncates.
+10. **Shared (KMP, owned by @kmp-engineer):** safe-to-spend correctness and state
+    thresholds are tested in `packages/core`, not iOS.
+
+---
+
+## 12. Implementation Readiness
+
+See [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md).
+
+**Buildable now (no paid enrollment) — free Personal Team signing:**
+
+- The widget and the App Clip affordability view are **SwiftUI + WidgetKit +
+  App Intents** reading the existing App Group cache — they build in the
+  Simulator (no signing) and on a device under a **free Apple ID (Personal
+  Team)**. App Group sharing, the configuration intent, and the interactive
+  category switch all work locally without enrollment.
+- All tests in [§11](#11-test-plan-smallest-tests-first) run locally; the shared
+  safe-to-spend math is tested on cross-platform CI.
+
+**Distribution tail — gated by [#1239](https://github.com/jrmoulckers/finance/issues/1239):**
+
+- **App Clip distribution** (App Store, App Clip experiences, App Clip codes / NFC
+  registration) and TestFlight/App Store delivery of the widget are gated by Apple
+  Developer enrollment — **design and local build are not.** The interactive
+  in-store experience (codes/NFC) specifically requires the paid program; the
+  affordability logic and UI do not. The PR should carry a `## Needs Human Action`
+  note pointing only at the
+  [§3.2 Apple Developer checklist](../ops/human-gated-prerequisites.md#32-ios-distribution--apple-developer-1239).
+  Agents must **not** perform enrollment, signing, App Clip experience
+  configuration, or secret setup, and must **not** modify shared `packages/`
+  without `@architect` / an ADR.
+
+---
+
+## 13. Open Questions
+
+1. **Payload home:** extend the existing `widget.budgets` cache with an
+   affordability shape, or add a dedicated `widget.affordability` key? Decision
+   shared with [ios-widget-freshness-pipeline.md](./ios-widget-freshness-pipeline.md).
+2. **Switchable category set:** fixed (Groceries/Dining/Transport) or
+   user-configurable? Default: the shared catalog's budgeted categories.
+3. **Interactive vs. config-only:** ship the in-widget interactive switch in v1,
+   or rely solely on the Edit-Widget configuration intent first? Default: config
+   intent first, interactive as a fast-follow where supported.
+4. **App Clip standalone value:** is a neutral "price-fits" helper worth shipping
+   standalone, or should the App Clip be installed-app-only (handoff)? Confirm
+   with privacy/design.
+5. **"As of" threshold:** how old is "stale" for the de-emphasis treatment —
+   match the freshness window from the pipeline doc.

--- a/docs/design/ios-savings-rate-trend-history.md
+++ b/docs/design/ios-savings-rate-trend-history.md
@@ -1,0 +1,401 @@
+# Savings-Rate Trend & History Detail — iOS
+
+> The Dashboard now shows a single headline savings-rate percentage and a
+> "vs last month" badge, but tapping it lands on a generic insights surface.
+> This design specifies the **detail destination** behind that tap: a trailing
+> multi-month **trend** (a sparse Swift Charts line), an explicit **prior-month
+> comparison**, and an optional **history list** for month-by-month context —
+> all rendering values the shared layer already computes.
+
+**Status:** PROPOSED — design only (native implementation buildable now; store distribution gated)
+**Issue:** [#2591](https://github.com/jrmoulckers/finance/issues/2591) — Part of [#2162](https://github.com/jrmoulckers/finance/issues/2162)
+**Platform:** iOS / iPadOS (SwiftUI + Swift Charts, iOS 17+)
+**Owner:** @ios-engineer
+**Related:** [ios-savings-rate-dashboard-card.md](./ios-savings-rate-dashboard-card.md) · [ios-net-worth-trend-chart.md](./ios-net-worth-trend-chart.md) · [ios-chart-voiceover-navigation.md](./ios-chart-voiceover-navigation.md) · [ios-chart-summaries-data-tables.md](./ios-chart-summaries-data-tables.md) · [ios-noncolor-financial-state-cues.md](./ios-noncolor-financial-state-cues.md) · [data-visualization.md](./data-visualization.md) · [chart-component-specs.md](./chart-component-specs.md) · [accessibility-patterns.md](./accessibility-patterns.md) · [content-language-guidelines.md](./content-language-guidelines.md) · [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md)
+
+---
+
+## Table of Contents
+
+1. [Goal & Scope](#1-goal--scope)
+2. [Current State](#2-current-state)
+3. [Where It Lives (Navigation)](#3-where-it-lives-navigation)
+4. [Trend Chart (Trailing Months)](#4-trend-chart-trailing-months)
+5. [Prior-Month Comparison](#5-prior-month-comparison)
+6. [History List](#6-history-list)
+7. [Accessibility](#7-accessibility)
+8. [Privacy & Balance Hiding](#8-privacy--balance-hiding)
+9. [States: Empty, Loading, Stale & Error](#9-states-empty-loading-stale--error)
+10. [Native ↔ KMP Boundary](#10-native--kmp-boundary)
+11. [Affected Surfaces & Shared Dependencies](#11-affected-surfaces--shared-dependencies)
+12. [Test Plan (Smallest Tests First)](#12-test-plan-smallest-tests-first)
+13. [Implementation Readiness](#13-implementation-readiness)
+14. [Open Questions](#14-open-questions)
+
+---
+
+## 1. Goal & Scope
+
+The savings-rate **card** ([ios-savings-rate-dashboard-card.md](./ios-savings-rate-dashboard-card.md),
+[#2589](https://github.com/jrmoulckers/finance/issues/2589)) deliberately keeps the
+Dashboard quiet: one headline percentage plus a non-color trend badge, with the
+"history over time" explicitly deferred to a follow-on under
+[#2162](https://github.com/jrmoulckers/finance/issues/2162). **This is that
+follow-on.** It specifies the detail surface the card deep-links into, so the
+single tap finally lands somewhere that answers "is my savings rate trending the
+right way, and what did it do the past few months?"
+
+**In scope:**
+
+- A **trailing trend** of month-end savings rates (default **3 months**, with a
+  6M / 1Y range control) drawn as a sparse Swift Charts line, mirroring the
+  shape and range pattern of [ios-net-worth-trend-chart.md](./ios-net-worth-trend-chart.md).
+- An explicit **prior-month comparison** (this month vs last month, in
+  percentage points) consistent with the card's badge so the two surfaces agree.
+- An optional **history list** — one row per month — for users who prefer the
+  numbers over the chart, and as the chart's text alternative anchor.
+- Full accessibility (chart text alternative + data table), privacy, and
+  empty/loading/stale/error coverage.
+
+**Out of scope:**
+
+- The **math.** Savings-rate computation (and the income/spending it derives
+  from) stays in KMP `packages/core`; iOS only renders values returned over the
+  Swift Export bridge ([§10](#10-native--kmp-boundary)). This design does **not**
+  implement or change that math.
+- A **new tab.** The detail is a pushed `NavigationStack` destination, not a new
+  IA node — consistent with "first-class without adding noise."
+- **Goal/target framing** (e.g. "you're below a 20% target"). Targets arrive
+  with goals under #2162; until then the surface stays descriptive.
+
+> **Why a pushed detail, not an expanded card:** the card's job is one glanceable
+> number. The trend, the per-month history, and the chart text alternatives need
+> vertical room and their own VoiceOver order, which belongs on a dedicated
+> screen one tap away — not inflated into the Dashboard scroll stack.
+
+---
+
+## 2. Current State
+
+- [`DashboardViewModel`](../../apps/ios/Finance/ViewModels/DashboardViewModel.swift)
+  exposes `savingsRate: Double` (a 0–100 percentage) for the **current month**,
+  computed via the bridge `aggregator.savingsRate(...)`. The card design adds a
+  `previousSavingsRate` for its badge. **Neither a multi-month series nor a
+  detail screen exists yet.**
+- The card deep-links to a generic destination (`InsightsView` / `AnalyticsView`)
+  that does **not** show savings-rate-over-time — the gap this doc closes.
+- The app already owns a **sparse trend pattern** worth reusing wholesale:
+  [ios-net-worth-trend-chart.md](./ios-net-worth-trend-chart.md) defines the
+  range control (3M / 6M / 1Y / All), the sparse Swift Charts presentation, and
+  the chart text-alternative contract — this design follows it rather than
+  inventing a parallel chart style.
+- Chart accessibility primitives already exist as patterns:
+  [ios-chart-voiceover-navigation.md](./ios-chart-voiceover-navigation.md)
+  (no-drag point inspection) and
+  [ios-chart-summaries-data-tables.md](./ios-chart-summaries-data-tables.md)
+  (spoken summary + table alternative). The detail reuses both.
+
+---
+
+## 3. Where It Lives (Navigation)
+
+The detail is a **pushed destination** reached from the savings-rate card's
+existing single tap target — no new tab, no new modal:
+
+```text
+Dashboard (Home tab)
+  └─ SavingsRateCard  ── tap ──▶  SavingsRateDetailView   ← NEW (this design)
+                                    ├─ Header: current % + prior-month delta
+                                    ├─ Trend chart (3M default, range control)
+                                    ├─ "Show data table" disclosure (a11y)
+                                    └─ History list (month-by-month)
+```
+
+- `SavingsRateDetailView` is appended to the Home tab's `NavigationStack`
+  (`NavigationPath`), replacing the card's current generic destination. The card
+  keeps its single 44 pt tap target and its `.accessibilityHint` ("Opens savings
+  trend").
+- The screen is driven by a dedicated `@Observable` `SavingsRateDetailViewModel`
+  so the Dashboard view model stays lean; it loads on `.task` and supports
+  pull-to-refresh, reusing the Dashboard's refresh/error plumbing.
+- Deep-link reachability: a future `finance://insights/savings` route can target
+  this screen, but the route is **out of scope** here (the card's in-app push is
+  the only entry point this design requires).
+
+---
+
+## 4. Trend Chart (Trailing Months)
+
+A **sparse** line of month-end savings rates, following
+[ios-net-worth-trend-chart.md §4](./ios-net-worth-trend-chart.md) and the
+[chart component specs](./chart-component-specs.md):
+
+- **Series:** one point per calendar month, value = that month's savings rate
+  (percentage). Y axis is a **percentage** scale (e.g. 0–60%, clamped sensibly),
+  not currency — reinforcing the privacy posture in [§8](#8-privacy--balance-hiding).
+- **Default range: trailing 3 months**, with a segmented control offering
+  **3M / 6M / 1Y**. The acceptance scope ("trailing 3-month and prior-month
+  comparisons") makes 3M the landing default; longer ranges are progressive.
+- **Sparse presentation:** thin line, single accent stroke, minimal gridlines,
+  endpoint label only — no point markers at every month unless the range is 3M
+  (where labeling all three is legible). Use the CVD-safe accent from
+  [data-visualization §2.1](./data-visualization.md#21-cvd-safe-palette).
+- **Direction is never color-only:** the header carries an arrow + sign + words
+  for the latest move (per [ios-noncolor-financial-state-cues.md](./ios-noncolor-financial-state-cues.md)),
+  so a glance at the chart is backed by a textual trend statement.
+- **Missing months** (no data / undefined rate) render as a **gap**, never as a
+  0% point — a fabricated zero would mislead the trend ([§9](#9-states-empty-loading-stale--error)).
+
+```mermaid
+flowchart LR
+    R["Range control 3M / 6M / 1Y"] --> S["Monthly savings-rate series"]
+    S --> C["Sparse Swift Charts line"]
+    S --> T["Data-table alternative"]
+    C --> H["Header trend statement arrow plus words"]
+```
+
+---
+
+## 5. Prior-Month Comparison
+
+The header restates, in full, the comparison the card shows compactly — so the
+two surfaces never disagree:
+
+- **This month vs last month**, in **percentage points** (`current − previous`),
+  rendered `+4 pts` / `−3 pts` / `Even with last month` (minus sign, not hyphen).
+  Points avoid the percent-of-a-percent ambiguity, matching the card's copy.
+- The same bridge call that powers the card's `previousSavingsRate` powers this
+  line — it is **presentation wiring**, not new arithmetic ([§10](#10-native--kmp-boundary)).
+- Copy is `String(localized:)` with translator comments, plain and
+  non-judgmental per [content-language-guidelines.md](./content-language-guidelines.md):
+
+| Element              | Copy (en)                                | Notes                               |
+| -------------------- | ---------------------------------------- | ----------------------------------- |
+| Current headline     | "{n}% saved this month"                  | Integer percent, `.monospacedDigit` |
+| Delta (up)           | "+{d} pts vs last month"                 | `d` = absolute point delta          |
+| Delta (down)         | "−{d} pts vs last month"                 | Minus sign, not hyphen              |
+| Delta (flat)         | "Even with last month"                   |                                     |
+| Trend statement (3M) | "Up over the last 3 months"              | Direction in words, not hue         |
+| Empty history        | "Not enough history yet to show a trend" | Neutral, no blame                   |
+
+---
+
+## 6. History List
+
+Below the chart, a compact month-by-month list gives the numbers directly and
+doubles as part of the chart's text alternative:
+
+- One row per month in range: **month label** (leading) + **savings rate**
+  (trailing, `.monospacedDigit`) + a **non-color delta chip** vs the prior month
+  (arrow + sign).
+- Rows are **read-only** here (this is context, not editing); tapping a row is an
+  optional future hook into that month's transactions — **out of scope** now.
+- The list is the natural home for the **"Show data table"** disclosure required
+  by [ios-chart-summaries-data-tables.md](./ios-chart-summaries-data-tables.md):
+  the same monthly data, in the same VoiceOver order as the chart.
+- Months with an **undefined rate** (zero income) render "—" with an
+  explanatory caption, never "0%" ([§9](#9-states-empty-loading-stale--error)).
+
+---
+
+## 7. Accessibility
+
+Per the [accessibility patterns library](./accessibility-patterns.md) and the
+chart accessibility docs:
+
+- **Chart text alternative (required):** the chart is paired with a spoken
+  summary and a data-table/list alternative per
+  [ios-chart-summaries-data-tables.md](./ios-chart-summaries-data-tables.md),
+  kept in the same swipe order as the chart. Example summary: _"Savings rate,
+  trailing 3 months: April 18 percent, May 22 percent, June 26 percent. Up 8
+  points over the period."_
+- **No-drag inspection:** point-by-point inspection uses adjustable actions /
+  a stepper, **not** a drag gesture, per
+  [ios-chart-voiceover-navigation.md](./ios-chart-voiceover-navigation.md).
+- **Header element:** current %, prior-month delta, and trend statement combine
+  into one VoiceOver element whose value speaks direction in **words**
+  ("up 4 points versus last month"), never relying on the arrow glyph or color.
+- **Dynamic Type:** semantic fonts only; the header percentage uses
+  `.minimumScaleFactor` only as a last resort and the delta wraps to a second
+  line at accessibility sizes rather than clipping — validate against
+  [ios-dynamic-type-reflow-audit.md](./ios-dynamic-type-reflow-audit.md). The
+  history rows reflow (label above value) at AX sizes.
+- **Reduce Motion:** any line-draw or count-up animation is gated on
+  `accessibilityReduceMotion` and falls back to an instant render
+  ([accessibility-patterns §6.1](./accessibility-patterns.md#61-reduced-motion-support)).
+- **Never color alone:** trend direction is carried by arrow + sign + words and
+  the chart is legible in grayscale
+  ([data-visualization §2.4](./data-visualization.md#24-never-color-alone)).
+- **Touch targets:** the range control segments and any disclosure controls are
+  ≥ 44 pt.
+
+---
+
+## 8. Privacy & Balance Hiding
+
+Savings rate is a **percentage**, not a balance — inherently privacy-friendlier
+than dollar figures — and this detail leans into that:
+
+- **The chart and history are percentage-only.** No absolute income or expense
+  dollars appear, so the surface stays fully informative even when amount-hiding
+  is active — mirroring the widget `.percent` masking mode
+  ([`WidgetMoneyFormatter`](../../apps/ios/Shared/WidgetPrivacy.swift)) which is
+  the privacy-safe representation.
+- If a future iteration surfaces the **underlying income/expense** behind a
+  month (e.g. on row tap), those amounts must route through the app's existing
+  masking; the default design avoids them so nothing needs unmasking.
+- **VoiceOver values speak percentages only** — never a dollar amount — so the
+  spoken trend leaks no balance.
+- **Logging:** `os.Logger` may record range changes and load timing as
+  `.public`, but any amount (should one ever be added) stays `.private`. Never
+  log a savings-rate-derived balance.
+
+> Rule of thumb, consistent with the card: **percentages pass; dollars get
+> masked.** This detail is percent-first by design.
+
+---
+
+## 9. States: Empty, Loading, Stale & Error
+
+| State                 | Trigger                                   | Rendering                                                                                       |
+| --------------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| **Loading**           | First `.task` before the series returns   | Skeleton chart + skeleton rows with `accessibilityLabel("Loading")`; no layout jump on arrival  |
+| **Empty (no data)**   | Fewer than 2 months of usable history     | Friendly "Not enough history yet to show a trend" + the single available month, no line         |
+| **Single month**      | Exactly 1 usable month                    | Show the headline % and that one history row; hide the line, show "Check back next month"       |
+| **Zero-income month** | A month where income = 0 (rate undefined) | That month renders "—" in the list and a **gap** in the chart, never "0%"                       |
+| **Stale / offline**   | Cache older than the app refresh window   | Render last-known series with the Dashboard's `OfflineBanner` + a "Last updated …" caption      |
+| **Error**             | Bridge/load failure sets `errorMessage`   | Inline recoverable message with Retry (reuse the Dashboard alert pattern); keep last-known data |
+
+- The surface must **distinguish "0% saved" from "no data"**: a real 0% month
+  (expenses ≥ income) renders an actual value with neutral copy; an undefined
+  month renders "—" and a gap.
+- Empty/stale/error states reflow at AX5 exactly like the happy path — wrap,
+  never truncate.
+
+---
+
+## 10. Native ↔ KMP Boundary
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages/core plus packages/models (KMP — DO NOT implement here)"]
+        K1["savingsRate(transactions, from, to)"]
+        K2["Per-month income / spending aggregation"]
+    end
+    subgraph Bridge["Swift Export bridge (apps/ios/Finance/KMP)"]
+        B1["SwiftExportAggregatorModule"]
+    end
+    subgraph iOS["apps/ios (native — this design)"]
+        V1["SavingsRateDetailViewModel<br/>monthly series + prior-month delta"]
+        V2["SavingsRateDetailView<br/>chart + history + a11y text alternative"]
+    end
+    K1 --> B1
+    K2 --> B1
+    B1 --> V1 --> V2
+```
+
+- The **savings-rate formula** lives in KMP `packages/core`, already surfaced via
+  [`SwiftExportAggregatorModule.savingsRate`](../../apps/ios/Finance/KMP/SwiftExportBridge.swift).
+  The detail builds its **monthly series** by invoking that same method once per
+  month window — wiring, not arithmetic.
+- **Estimate (label):** a thin shared convenience returning a ready-made
+  `[MonthlySavingsRate]` (month anchor + rate + an `isDefined` flag for the
+  zero-income case) would be cleaner than N per-month calls and keeps the
+  zero-income decision in shared code. Its exact shape is decided by
+  `@kmp-engineer` / `@architect` via the normal ADR path — **not** implemented
+  here, and iOS must not inline the per-month loop's business rules even
+  temporarily.
+- iOS owns layout, the chart, the range control, formatting, accessibility text
+  alternatives, and privacy rendering only.
+
+---
+
+## 11. Affected Surfaces & Shared Dependencies
+
+**New (this design):**
+
+- `apps/ios/Finance/Screens/SavingsRateDetailView.swift`
+- `apps/ios/Finance/ViewModels/SavingsRateDetailViewModel.swift`
+- A small `MonthlySavingsRate` view model type (presentation shape mapped from
+  the bridge value).
+
+**Touched:**
+
+- The savings-rate card's `NavigationLink` destination (defined by
+  [ios-savings-rate-dashboard-card.md](./ios-savings-rate-dashboard-card.md))
+  re-points from the generic insights screen to `SavingsRateDetailView`.
+
+**Reused unchanged:**
+
+- The bridge `SwiftExportAggregatorModule`, the net-worth trend's range-control
+  and sparse-chart patterns, the chart text-alternative components, the status
+  color tokens, and the Dashboard's error/refresh plumbing.
+
+**Shared dependency:** KMP `packages/core` savings-rate aggregation
+([§10](#10-native--kmp-boundary)).
+
+---
+
+## 12. Test Plan (Smallest Tests First)
+
+1. **Series mapping (Swift unit):** given a stub bridge returning per-month
+   rates, assert `SavingsRateDetailViewModel` builds the ordered series, the
+   prior-month delta, and the trend statement — and does **no** math itself.
+2. **Zero-income month (Swift unit):** a month with income = 0 maps to `isDefined
+== false` ⇒ "—" in the list and a chart **gap**, never "0%".
+3. **Empty / single-month (Swift unit):** < 2 usable months ⇒ empty/"check back"
+   copy and no line; exactly 1 month ⇒ headline + one row.
+4. **Range switching (Swift unit):** changing 3M → 6M → 1Y re-derives the series
+   window without refetching the math contract more than once per range.
+5. **Chart text alternative (XCUITest, smallest):** assert the spoken summary and
+   the data-table disclosure expose the same months/values in chart order, with
+   no dollar amounts in any accessibility value.
+6. **Dynamic Type reflow (snapshot):** render header + chart + 3 rows at
+   `.large` and `.accessibility5`; assert the delta wraps and nothing clips.
+7. **Privacy (snapshot/unit):** with amount-hiding on, assert the chart, header,
+   and rows remain visible (percent-only) and no masked dollar value appears.
+8. **Shared (KMP, owned by @kmp-engineer):** savings-rate correctness per month,
+   rounding, and the income = 0 boundary are tested in `packages/core`, not iOS.
+
+---
+
+## 13. Implementation Readiness
+
+See [Human-Gated Prerequisites](../ops/human-gated-prerequisites.md).
+
+**Buildable now (no paid enrollment) — free Personal Team signing:**
+
+- This is **pure SwiftUI + Swift Charts** on a pushed screen backed by an
+  existing bridge value computed over additional month windows — no
+  entitlements, App Groups, push, or Associated Domains. It builds and runs in
+  the Simulator (no signing) and on a device under a **free Apple ID (Personal
+  Team)** with no Apple Developer Program membership.
+- Every test in [§12](#12-test-plan-smallest-tests-first) runs locally without
+  enrollment; the shared math tests run on cross-platform CI.
+
+**Distribution tail — gated by [#1239](https://github.com/jrmoulckers/finance/issues/1239):**
+
+- Only App Store / TestFlight **distribution** of the build is gated; the feature
+  has **no** distribution-dependent capability. The PR should carry a
+  `## Needs Human Action` note pointing at the
+  [§3.2 Apple Developer checklist](../ops/human-gated-prerequisites.md#32-ios-distribution--apple-developer-1239)
+  for the distribution criterion only. Agents must **not** perform enrollment,
+  signing, or secret configuration, and must **not** modify shared `packages/`
+  without `@architect` / an ADR.
+
+---
+
+## 14. Open Questions
+
+1. **Range default:** the acceptance scope names 3M and prior-month; confirm 3M
+   is the landing default with 6M / 1Y as progressive (vs. defaulting to 6M).
+2. **Window definition:** "month" = calendar month vs. trailing 30-day windows —
+   must match the KMP-core window used by `savingsRate` so the chart and the
+   card's badge stay consistent.
+3. **Row tap target:** should a history row drill into that month's
+   transactions, or stay read-only context for now? Default: read-only.
+4. **Shared series surface:** adopt the estimated `[MonthlySavingsRate]` bridge
+   convenience ([§10](#10-native--kmp-boundary)) or keep N per-month calls on
+   iOS? Decision owned by `@kmp-engineer` / `@architect`.
+5. **Target framing:** once goals land (#2162), should the chart show a target
+   band (e.g. 20%)? Deferred until goals exist.


### PR DESCRIPTION
﻿## Summary

Adds three **design-only** docs under `docs/design/` for the iOS App Clip / savings cluster. No native build, signing, or store actions — these specify SwiftUI/WidgetKit/App Clip surfaces, the native↔KMP boundary (math stays conceptually in `packages/core`), accessibility, privacy/balance-hiding, stale/error/empty states, smallest-tests plans, and build-now vs. distribution-gated readiness.

## Changes

- `docs/design/ios-savings-rate-trend-history.md` — savings-rate **trend & history detail** behind the dashboard card's tap: trailing 3-month trend (sparse Swift Charts, range control), prior-month comparison, history list, chart text alternatives. (Closes #2591)
- `docs/design/ios-appclip-widget-quickentry-presets.md` — a **single shared quick-entry preset catalog** (coffee/lunch/transit/cash/Apple Cash) reused by the Lock Screen widget, App Clip, and new in-app quick-add chips; cash/Apple Cash modeled as tender, not category. (Closes #2601)
- `docs/design/ios-grocery-affordability-appclip.md` — **grocery affordability quick-check** Home/Lock Screen widget + minimal-data App Clip for in-store use, masked-by-default privacy, honest "as of" stale states, one-thumb category switching. (Closes #2611)

## Grounding & boundaries

- Grounded in real `apps/ios` surfaces (read-only): `QuickEntryWidget`, `QuickTransactionView`/`FinanceClipApp`, `WidgetDataProvider`, `WidgetPrivacy`/`WidgetMoneyFormatter`, `DeepLinkHandler`, `TransactionCreateViewModel.applyQuickEntry`.
- Cross-links existing design docs only (savings-rate card, grocery safe-to-spend card, one-thumb quick-add, widget freshness pipeline, today-spend widget, chart a11y docs) and `../ops/human-gated-prerequisites.md` (§3.2).
- Math kept conceptually in KMP `packages/core` (boundary described, not implemented); estimates labeled. App Clip distribution gated by #1239; design/build with a free Personal Team is unblocked.
- New files only — no edits to existing files, `packages/`, `apps/` code, or other platforms.

## Verification

- `npx prettier --check` passes on all three new files.

Closes #2591
Closes #2601
Closes #2611

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
