### PR TITLE
docs(design): android gamification sharing and streak design batch (#2682, #2684, #2688)

### DIFF
--- a/docs/design/android-privacy-safe-share-cards.md
+++ b/docs/design/android-privacy-safe-share-cards.md
@@ -1,0 +1,362 @@
+# Android Privacy-Safe Goal & Achievement Share Cards — Design
+
+> **Status:** DESIGN — Implementation-ready (native build/test unblocked; store distribution gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242))
+> **Issue:** [#2682](https://github.com/jrmoulckers/finance/issues/2682) — _Part of [#2210](https://github.com/jrmoulckers/finance/issues/2210)_ (gamification sharing)
+> **Platform:** Android (Jetpack Compose · Material 3)
+> **Last Updated:** 2026-06-22
+
+This document specifies **privacy-safe share cards** for goal milestones, goal
+completions, badge unlocks, and streak milestones. A share card is a small,
+celebratory image the user can hand to the **Android Sharesheet** (designed in
+[android-sharesheet-wins-badges.md](./android-sharesheet-wins-badges.md)).
+
+The single most important rule: **a share card must never leak a real balance or
+dollar amount by default.** The default card shows **progress (percent) and
+badges only**. Revealing any amount is an **explicit, per-share opt-in** with a
+**redacted preview** the user must confirm before handoff.
+
+This is a **rendering and consent surface.** All achievement, streak, and goal
+math lives in the shared KMP layer (`packages/core`); Compose only renders the
+already-computed, already-masked state.
+
+---
+
+## Table of Contents
+
+1. [Goals & Non-Goals](#1-goals--non-goals)
+2. [Architecture Boundary (Compose ↔ KMP)](#2-architecture-boundary-compose--kmp)
+3. [Grounding in Existing Code](#3-grounding-in-existing-code)
+4. [Share-Card Catalog & Templates](#4-share-card-catalog--templates)
+5. [Privacy Model & Redaction](#5-privacy-model--redaction)
+6. [Preview & Edit States](#6-preview--edit-states)
+7. [Card Rendering (Compose → Bitmap)](#7-card-rendering-compose--bitmap)
+8. [Accessibility (TalkBack, Switch Access, Font Scaling, Reduced Motion)](#8-accessibility-talkback-switch-access-font-scaling-reduced-motion)
+9. [Offline, Empty & Error States](#9-offline-empty--error-states)
+10. [Test Plan](#10-test-plan)
+11. [Implementation Readiness](#11-implementation-readiness)
+12. [Open Questions](#12-open-questions)
+
+---
+
+## 1. Goals & Non-Goals
+
+### Goals
+
+- Define **card templates** for four moments: goal milestone (25/50/75%), goal
+  completion (100%), badge unlock, and streak milestone.
+- Make every template render in a **percent-only / badge-only** mode that
+  **hides dollar amounts** by default.
+- Specify the **preview and edit** states the user sees **before** the Android
+  Sharesheet handoff, including the **redaction toggle** and its confirmation.
+- Provide **TalkBack labels** for every card, control, and preview surface.
+- Define **safe defaults for parent-linked (teen / guardian-managed) accounts**
+  so amounts are never shareable without guardian-level consent.
+- Reuse the existing Android **ReferralScreen** share pattern and shared
+  gamification models instead of duplicating business rules in Compose.
+
+### Non-Goals
+
+- **No money math in Compose.** Progress fractions, milestone thresholds, and
+  unlock state come from `packages/core` (see §2–§3).
+- **No amount in the default card.** Showing an amount is opt-in only (§5); the
+  default never exposes `Goal.currentAmount` or any balance.
+- **No Sharesheet plumbing here.** Intent dispatch, chooser, cancel/retry, and
+  telemetry are specified in
+  [android-sharesheet-wins-badges.md](./android-sharesheet-wins-badges.md).
+- **No streak/near-win logic here.** Streak states are specified in
+  [android-streak-near-win-states.md](./android-streak-near-win-states.md); this
+  doc only renders a streak _milestone_ card from already-computed streak state.
+- **No new shared models.** If a privacy-safe field is missing, it is an
+  @kmp-engineer follow-up — not a Compose workaround that reaches for raw data.
+- **No store distribution work** (gated by #1242 — see §11).
+
+---
+
+## 2. Architecture Boundary (Compose ↔ KMP)
+
+The share card is a **pure projection** of shared state into pixels. Compose owns
+the visual template, the redaction toggle, and the bitmap render; KMP owns every
+number and unlock decision.
+
+```mermaid
+flowchart LR
+    subgraph Android [apps/android · Compose]
+        VM[ShareCardViewModel]
+        UI[ShareCardPreviewScreen]
+        REN[ShareCardRenderer - Compose to Bitmap]
+    end
+    subgraph Shared [packages/core · KMP - source of truth]
+        GP[GamificationProfile / AchievementUi]
+        ST[Streak milestone state]
+        GM[GamificationEngine.calculateSavingsMilestones]
+        MASK[Privacy-safe projection - percent only]
+    end
+    GP --> MASK
+    ST --> MASK
+    GM --> MASK
+    MASK -->|immutable ShareCardUiState| VM
+    VM --> UI
+    UI --> REN
+```
+
+- The ViewModel exposes **one immutable `StateFlow<ShareCardUiState>`**.
+- `ShareCardUiState` carries **only display-ready, already-masked fields**:
+  a percent (`Int 0..100`), a badge title/icon token, a streak count, and an
+  **optional** `revealableAmountLabel: String?` that is **null unless** the
+  shared layer says an amount is eligible to be revealed.
+- The **redaction toggle is a Compose UI state**, but the **amount string it can
+  reveal is supplied (or withheld) by the shared projection** — Compose can never
+  format a raw `Cents` value itself.
+- For **parent-linked accounts**, the shared projection returns
+  `revealableAmountLabel = null` regardless of the toggle, so the amount path is
+  structurally unreachable on those accounts.
+
+---
+
+## 3. Grounding in Existing Code
+
+| Concern                | Source of truth (do **not** reimplement in Compose)                                                                                                             | Today's state                                         |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| Achievement / badge    | [`AchievementDefinition` / `AchievementProgress`](../../packages/core/src/commonMain/kotlin/com/finance/core/gamification/GamificationTypes.kt)                 | Exists: title, icon token, rarity, `progressFraction` |
+| Achievement UI model   | [`AchievementUi`](../../apps/android/src/main/kotlin/com/finance/android/ui/gamification/GamificationViewModel.kt)                                              | Exists: `isUnlocked`, `progressFraction`, `points`    |
+| Goal progress          | [`GamificationEngine.calculateSavingsMilestones`](../../packages/core/src/commonMain/kotlin/com/finance/core/gamification/GamificationEngine.kt)                | Exists: 25/50/75/100% via milestone thresholds        |
+| Streak milestone       | [`Streak`](../../packages/core/src/commonMain/kotlin/com/finance/core/gamification/GamificationTypes.kt) + [streak design](./android-streak-near-win-states.md) | `currentCount` / `bestCount` already shared           |
+| Sensitive amount       | `Goal.currentAmount` (`Cents`) consumed by the engine — **never rendered by default**                                                                           | Exists; masked out of the default card                |
+| Share text pattern     | [`ReferralScreen` + `getShareText()`](../../apps/android/src/main/kotlin/com/finance/android/ui/screens/referral/ReferralScreen.kt)                             | Exists: `onShare: (String) -> Unit` callback          |
+| Privacy / masking      | Household privacy foundation — [android-household-privacy-dashboard.md](./android-household-privacy-dashboard.md)                                               | Exists: bucketed / percent summaries                  |
+| Parent-linked defaults | Teen / guardian mode — [android-teen-beginner-mode.md](./android-teen-beginner-mode.md)                                                                         | Exists: restricted teen surfaces                      |
+
+> The card **reuses** these models. It introduces **no new financial figures** and
+> renders **percent + badge** by default. The only amount a card can ever show is
+> one the **shared projection explicitly marks revealable** _and_ the user opts in
+> to per share.
+
+---
+
+## 4. Share-Card Catalog & Templates
+
+All templates share one layout skeleton (square + portrait variants) and differ
+only in the celebratory headline and the metric chip.
+
+```mermaid
+flowchart TB
+    A[ShareCard skeleton] --> B[Goal milestone 25/50/75 percent]
+    A --> C[Goal completion 100 percent]
+    A --> D[Badge unlock]
+    A --> E[Streak milestone]
+    B -.percent chip.-> M[Metric chip]
+    C -.percent chip.-> M
+    D -.badge icon + title.-> M
+    E -.streak count.-> M
+```
+
+| Template         | Default metric shown        | Never shown by default      | Headline copy (example)   |
+| ---------------- | --------------------------- | --------------------------- | ------------------------- |
+| Goal milestone   | Progress percent (e.g. 50%) | Saved amount, target amount | "Halfway to my goal!"     |
+| Goal completion  | "Goal reached" + 100%       | Final saved amount          | "Goal complete!"          |
+| Badge unlock     | Badge icon + title + rarity | Any financial figure        | "Unlocked: Budget Boss"   |
+| Streak milestone | Streak count + unit         | Any financial figure        | "30-day tracking streak!" |
+
+Design constraints for every template:
+
+- **No raw amount node** exists in the default composition tree — there is nothing
+  to accidentally un-hide.
+- The metric chip binds to `ShareCardUiState.percent` /
+  `badgeTitle` / `streakCount` — all non-financial.
+- App brand mark + first-name-or-handle only (never full name / email).
+- Square (1080×1080) for most apps; portrait (1080×1920) story variant.
+
+---
+
+## 5. Privacy Model & Redaction
+
+The privacy model is **deny-by-default**: amounts are off, and turning them on is
+a deliberate, visible, confirmable action.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Redacted
+    Redacted --> RevealRequested: tap "Show amount"
+    RevealRequested --> Redacted: not eligible (returns null)
+    RevealRequested --> ConfirmReveal: eligible amount available
+    ConfirmReveal --> Revealed: confirm in preview
+    ConfirmReveal --> Redacted: cancel
+    Revealed --> Redacted: toggle off
+```
+
+Rules:
+
+1. **Default = Redacted.** Every card opens with amounts hidden; the metric is a
+   **percent or badge**, never currency.
+2. **Reveal is per-share and non-sticky.** Opting in applies to the current share
+   only and resets to redacted next time (no "remember amount" default).
+3. **Eligibility is decided in shared code.** The toggle asks the shared
+   projection for `revealableAmountLabel`. If it returns `null` (parent-linked
+   account, household privacy rule, or unsupported template), the toggle is
+   **disabled with an explanatory caption** — Compose never formats the value.
+4. **Confirmation before reveal.** Turning amounts on shows a confirm step in the
+   preview ("This card will show $1,000. Show it?") so the user sees exactly what
+   would leave the device.
+5. **Parent-linked safe default.** Teen / guardian-managed accounts always get
+   `revealableAmountLabel = null`; sharing is **badge / percent only**, and a
+   caption states amounts are off for linked accounts (see
+   [android-teen-beginner-mode.md](./android-teen-beginner-mode.md)).
+6. **Redaction also covers metadata.** No account name, institution, full name,
+   or email is ever drawn — only an opt-in first name / handle.
+
+---
+
+## 6. Preview & Edit States
+
+Before any Sharesheet handoff the user lands on a **preview** they can edit.
+
+| State              | What the user sees                                                         | Primary action        |
+| ------------------ | -------------------------------------------------------------------------- | --------------------- |
+| Preview (default)  | Redacted card, template picker, "Show amount" toggle (off), "Share" button | Share                 |
+| Editing            | Template swap (square ↔ portrait), light/dark, toggle accent color         | Apply                 |
+| Reveal confirm     | Inline confirm sheet naming the exact amount that would appear             | Confirm / Cancel      |
+| Amount disabled    | Toggle greyed with caption ("Amounts are off for linked accounts")         | (Share badge/percent) |
+| Render in progress | Skeleton + "Preparing your card…" with progress semantics                  | (Cancelable)          |
+
+- **Edits never touch numbers.** Only template, orientation, theme, and the
+  redaction toggle are editable — the metric value is read-only shared state.
+- The **"Share" button is disabled until the preview bitmap is ready**, so the
+  handoff always carries a fully rendered, fully redacted image.
+- Handoff itself (intent + chooser) is delegated to
+  [android-sharesheet-wins-badges.md](./android-sharesheet-wins-badges.md) via an
+  `onShare(card: ShareableCard)` callback, mirroring `ReferralScreen.onShare`.
+
+---
+
+## 7. Card Rendering (Compose → Bitmap)
+
+The card is a normal `@Composable` rendered off-screen to a bitmap so the exact
+preview pixels are what get shared.
+
+- Use a Compose **`GraphicsLayer` capture** (`rememberGraphicsLayer()` +
+  `drawWithContent { ... record }` → `toImageBitmap()`) on the same composable the
+  user previews — preview and exported image cannot diverge.
+- The bitmap is written to **app-internal cache** and shared via **FileProvider**
+  content URI (no `WRITE_EXTERNAL_STORAGE`, no secrets on disk). File plumbing and
+  grant flags are specified in the Sharesheet doc.
+- Rendering is **deterministic and side-effect free** so Paparazzi snapshots match
+  the exported image (§10).
+- The exported image is a **picture, not data**: it contains only the redacted
+  visuals — there is no embedded metadata, EXIF amount, or hidden payload.
+
+---
+
+## 8. Accessibility (TalkBack, Switch Access, Font Scaling, Reduced Motion)
+
+- **TalkBack:** every card exposes one summarizing `contentDescription`, e.g.
+  _"Share card: Halfway to my goal, fifty percent. Amounts hidden."_ When reveal
+  is on it becomes _"…shows one thousand dollars."_ so the spoken description
+  always matches the redaction state. The toggle, template chips, confirm, and
+  share controls each have their own `contentDescription`.
+- **Switch Access:** preview → template chips → reveal toggle → share form a
+  logical, fully operable traversal order; the reveal-confirm sheet traps focus
+  until confirmed or cancelled.
+- **Font scaling (200%):** the card image renders at a **fixed internal density**
+  (so shared images are legible everywhere), while the **surrounding preview UI**
+  reflows with system font scale and never truncates the toggle caption.
+- **Reduced motion:** the unlock/celebration shimmer respects
+  `Settings.Global.ANIMATOR_DURATION_SCALE == 0` (and the app reduced-motion
+  preference) by rendering a **static** celebratory card — no looping particles.
+  See [animation-library.md](./animation-library.md) and
+  [accessibility-patterns.md](./accessibility-patterns.md).
+- **Color independence:** rarity / progress are conveyed by **text + icon**, not
+  color alone, per [accessibility-patterns.md](./accessibility-patterns.md).
+- **Plain language:** headline and caption copy follows
+  [content-language-guidelines.md](./content-language-guidelines.md) — celebratory,
+  never boastful about money.
+
+---
+
+## 9. Offline, Empty & Error States
+
+| Condition                    | Behavior                                                                                  |
+| ---------------------------- | ----------------------------------------------------------------------------------------- |
+| Offline                      | Card generation is **fully local** — rendering and preview work with no network.          |
+| No unlock / no milestone yet | Empty state: "No wins to share yet — reach a milestone to unlock a card" (no card shown). |
+| Amount eligibility unknown   | Treat as **not eligible**: toggle disabled, fail closed to redacted.                      |
+| Bitmap render failure        | Show retry with an apologetic message; **never** hand off a partial/blank image.          |
+| Profile still loading        | Skeleton card with `contentDescription = "Loading your achievement"`.                     |
+| Reveal requested but null    | Toggle stays off with caption; share proceeds with the redacted card.                     |
+
+Fail-closed is the rule: any uncertainty about whether an amount may be shown
+resolves to **hidden**.
+
+---
+
+## 10. Test Plan
+
+- **Unit (ViewModel):** `ShareCardUiState` exposes percent/badge/streak and
+  `revealableAmountLabel`; assert it is `null` for parent-linked accounts and for
+  templates that never reveal amounts; assert reveal is non-sticky (resets each
+  open).
+- **Privacy parity (critical):** a semantics + render test asserts the **default**
+  card contains **no currency glyph and no digit string matching an amount**, and
+  that no `Goal.currentAmount` value reaches the composition unless the shared
+  projection marked it revealable _and_ the toggle is confirmed.
+- **Redaction state machine:** Redacted → RevealRequested → (null ⇒ Redacted) and
+  (eligible ⇒ ConfirmReveal ⇒ Revealed/Redacted) all transition correctly.
+- **Compose UI / semantics:** `contentDescription` present on card, toggle,
+  template chips, confirm sheet, and share button; spoken description flips with
+  redaction state; reveal-confirm traps Switch-Access focus.
+- **Paparazzi snapshots:** each of the four templates, square + portrait, redacted
+  vs revealed, light/dark + dynamic color, at default and 200% font scale, and a
+  reduced-motion static variant.
+- **Renderer determinism:** the captured bitmap equals the previewed composable
+  (golden-image compare) so preview ≡ exported image.
+- **Parent-linked:** snapshot + unit test that the reveal toggle is disabled and
+  captioned on teen / guardian-managed accounts.
+
+---
+
+## 11. Implementation Readiness
+
+Per [`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md)
+§2 (Implementation vs. Distribution), this feature is **decoupled**: design and
+native implementation are buildable and testable now; only store distribution
+waits on #1242. Card images are generated and previewed entirely on-device.
+
+### ✅ Buildable now (debug / free signing — no enrollment, no secrets)
+
+- This design doc and the privacy/redaction contract.
+- All Compose UI, `ShareCardViewModel`, the `ShareCardRenderer` (Compose → bitmap),
+  FileProvider cache wiring, and Koin registration.
+- Unit tests, the privacy-parity tests, Compose semantics/UI tests, and Paparazzi
+  snapshots.
+- Local verification via `./gradlew :apps:android:assembleDebug` + sideload, per
+  [`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md)
+  §2 "Free local build/test paths."
+- Any missing privacy-safe projection field is a `packages/core` change (owned by
+  @kmp-engineer) — also unblocked; not store-gated.
+
+### 🔒 Distribution tail — gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+
+- Release signing with the production keystore.
+- Google Play Console upload / release-track promotion.
+- The signed-AAB release workflow and its CI secrets.
+- Any Play data-safety declaration covering shared imagery.
+
+These are **human-gated** and out of scope for SME agents — see the
+[Human-Gated Prerequisites Runbook](../ops/human-gated-prerequisites.md) §3.1.
+Until then the cards are fully exercisable via debug sideload (the Sharesheet
+chooser opens locally; see the Sharesheet doc).
+
+---
+
+## 12. Open Questions
+
+1. **Revealable eligibility owner** — should the "amount is revealable" decision be
+   a new field on the shared gamification projection, or derived from the existing
+   household privacy rule set? (@kmp-engineer)
+2. **Handle vs first name** — is the opt-in identity on a card a profile handle, a
+   first name, or fully anonymous by default?
+3. **Story variant scope** — do we ship the portrait/story template in v1, or
+   start with the square card only?
+4. **Brand mark policy** — confirm the brand mark/wordmark usage on user-generated
+   share imagery with @design-engineer.
+5. **Locale formatting** — when an amount _is_ revealed, confirm currency/locale
+   formatting comes from the shared formatter (never a Compose `String.format`).

--- a/docs/design/android-sharesheet-wins-badges.md
+++ b/docs/design/android-sharesheet-wins-badges.md
@@ -1,0 +1,371 @@
+# Android Sharesheet Entry Points for Wins & Badges — Design
+
+> **Status:** DESIGN — Implementation-ready (native build/test unblocked; store distribution gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242))
+> **Issue:** [#2684](https://github.com/jrmoulckers/finance/issues/2684) — _Part of [#2210](https://github.com/jrmoulckers/finance/issues/2210)_ (gamification sharing)
+> **Platform:** Android (Jetpack Compose · Material 3)
+> **Last Updated:** 2026-06-22
+
+This document specifies the **entry points and flows** for sharing savings wins
+and badges from goals and gamification screens, and the **Android Sharesheet
+handoff** (`Intent.ACTION_SEND` via the system chooser). It covers **25/50/75/100%
+goal milestones, goal completion, badge unlocks, and streak milestones**, plus
+**cancellation, retry, and unsupported-app** handling and **privacy-safe
+telemetry**.
+
+The card _artwork_ and its **redaction rules** are owned by
+[android-privacy-safe-share-cards.md](./android-privacy-safe-share-cards.md). This
+doc is about **where the "Share" affordance appears and what happens after the
+user taps it** — it never re-derives financial figures and never shares an
+un-redacted card.
+
+---
+
+## Table of Contents
+
+1. [Goals & Non-Goals](#1-goals--non-goals)
+2. [Architecture Boundary (Compose ↔ KMP)](#2-architecture-boundary-compose--kmp)
+3. [Grounding in Existing Code](#3-grounding-in-existing-code)
+4. [Entry Points](#4-entry-points)
+5. [Flow Overview](#5-flow-overview)
+6. [Sharesheet Plumbing](#6-sharesheet-plumbing)
+7. [Cancellation, Retry & Unsupported-App Handling](#7-cancellation-retry--unsupported-app-handling)
+8. [Telemetry](#8-telemetry)
+9. [Accessibility (TalkBack, Switch Access, Font Scaling, Reduced Motion)](#9-accessibility-talkback-switch-access-font-scaling-reduced-motion)
+10. [Offline, Empty & Error States](#10-offline-empty--error-states)
+11. [Test Plan](#11-test-plan)
+12. [Implementation Readiness](#12-implementation-readiness)
+13. [Open Questions](#13-open-questions)
+
+---
+
+## 1. Goals & Non-Goals
+
+### Goals
+
+- Define **share entry points** for 25/50/75/100% goal milestones, goal
+  completion, badge unlocks, and streak milestones.
+- Specify the **Android-native Sharesheet handoff** built on `Intent.ACTION_SEND`
+  - `Intent.createChooser`, reusing the existing **ReferralScreen** pattern.
+- Define **cancellation, retry, and unsupported-app** handling so a failed or
+  abandoned share is graceful and never blocks the user.
+- Document **privacy-safe telemetry** for share **preview, send, cancel, and
+  redaction choice** — counts and enums only, never amounts.
+- Keep the affordance **opt-in and unobtrusive** — celebrate, don't nag.
+
+### Non-Goals
+
+- **No card artwork or redaction rules.** Templates and the amount-hiding contract
+  live in [android-privacy-safe-share-cards.md](./android-privacy-safe-share-cards.md).
+- **No streak math or near-win copy.** That is
+  [android-streak-near-win-states.md](./android-streak-near-win-states.md); this
+  doc only triggers a share from an already-computed streak milestone.
+- **No new shared business rules in Compose.** Milestone detection comes from
+  `packages/core` (see §3); the UI only reacts to it.
+- **No background or auto-sharing.** A share is always an explicit user tap; no
+  WorkManager job ever opens a chooser.
+- **No custom in-app share targets.** We hand off to the **system** Sharesheet —
+  no bespoke contact picker or social SDK.
+- **No store distribution work** (gated by #1242 — see §12).
+
+---
+
+## 2. Architecture Boundary (Compose ↔ KMP)
+
+The Sharesheet handoff is **platform glue**. The decision _that_ a win occurred is
+shared state; the decision _to share_ is a user tap; the act of sharing is an
+Android `Intent`.
+
+```mermaid
+flowchart LR
+    subgraph Shared [packages/core · KMP - source of truth]
+        EVT[Milestone / unlock / streak event]
+        AT[AnalyticsTracker - consent gated]
+    end
+    subgraph Android [apps/android · Compose + Activity]
+        TRIG[Share entry point composable]
+        VM[ShareCardViewModel]
+        REN[ShareCardRenderer to bitmap]
+        NAV[FinanceNavHost onShare callback]
+        ACT[Activity: ACTION_SEND + createChooser]
+    end
+    EVT -->|win available| TRIG
+    TRIG --> VM
+    VM --> REN
+    REN -->|ShareableCard| NAV
+    NAV --> ACT
+    ACT -.send / cancel result.-> VM
+    VM -->|share_* events| AT
+```
+
+- The screen exposes an **`onShare(card: ShareableCard)` callback** — identical in
+  spirit to `ReferralScreen.onShare: (String) -> Unit`, extended to carry a
+  rendered image URI plus a redaction-safe text fallback.
+- `FinanceNavHost` is the **only** place that touches an `Activity` `Intent`,
+  replacing the existing `TODO(#1296): Wire to Android Sharesheet via Activity
+intent` stubs.
+- **Telemetry goes through the shared `AnalyticsTracker`**, which is consent-gated
+  and contractually forbidden from transmitting PII or financial amounts.
+
+---
+
+## 3. Grounding in Existing Code
+
+| Concern               | Source of truth / reference                                                                                                                                                                                                 | Today's state                                                  |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| Share callback shape  | [`ReferralScreen.onShare` + `getShareText()`](../../apps/android/src/main/kotlin/com/finance/android/ui/screens/referral/ReferralScreen.kt)                                                                                 | Exists: `onShare: (String) -> Unit` from a `FilledTonalButton` |
+| Intent dispatch point | [`FinanceNavHost`](../../apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceNavHost.kt) (`onShare` / `onShareInvite` lambdas)                                                                            | Exists with `TODO(#1296)` to wire `ACTION_SEND`                |
+| Existing ACTION_SEND  | `PrivacySettingsScreen` / `SettingsScreen` (`Intent.createChooser`)                                                                                                                                                         | Exists: the app already uses the system chooser elsewhere      |
+| Win detection         | [`GamificationEngine` / `AchievementUi`](../../apps/android/src/main/kotlin/com/finance/android/ui/gamification/GamificationViewModel.kt)                                                                                   | Exists: unlock + milestone + streak state                      |
+| Milestone thresholds  | [`GamificationEngine.calculateSavingsMilestones`](../../packages/core/src/commonMain/kotlin/com/finance/core/gamification/GamificationEngine.kt)                                                                            | Exists: 25/50/75/100% buckets                                  |
+| Telemetry transport   | [`AnalyticsTracker`](../../packages/core/src/commonMain/kotlin/com/finance/core/analytics/AnalyticsTracker.kt) + [`AnalyticsEvent`](../../packages/core/src/commonMain/kotlin/com/finance/core/analytics/AnalyticsEvent.kt) | Exists: consent-gated, "never transmit PII / amounts"          |
+| Card artwork          | [android-privacy-safe-share-cards.md](./android-privacy-safe-share-cards.md)                                                                                                                                                | Designed under #2682                                           |
+
+> The handoff **reuses** the proven ReferralScreen callback shape and the existing
+> `ACTION_SEND` usage; it only adds **gamification entry points** and an image
+> payload. No new financial computation is introduced.
+
+---
+
+## 4. Entry Points
+
+Each entry point is a small, optional **"Share" affordance** placed next to a win.
+None of them is modal or blocking.
+
+| Entry point       | Where it lives                             | Trigger                               | Card template    |
+| ----------------- | ------------------------------------------ | ------------------------------------- | ---------------- |
+| 25% milestone     | Goal detail / goal projection surfaces     | Crosses 25% (debounced)               | Goal milestone   |
+| 50% milestone     | Goal detail / goal projection surfaces     | Crosses 50%                           | Goal milestone   |
+| 75% milestone     | Goal detail / goal projection surfaces     | Crosses 75%                           | Goal milestone   |
+| 100% / completion | Goal detail + completion celebration       | Goal status COMPLETED                 | Goal completion  |
+| Badge unlock      | Gamification screen + unlock toast/overlay | `AchievementUi.isUnlocked` flips true | Badge unlock     |
+| Streak milestone  | Gamification streak card                   | Streak hits a milestone count         | Streak milestone |
+
+Placement rules:
+
+- The affordance appears as a **secondary `FilledTonalButton` / icon button** with
+  an explicit `contentDescription` (mirroring the Referral "Share" button), never a
+  primary CTA that competes with the financial action.
+- **Milestone shares are de-duplicated**: each threshold offers a share **once**
+  (the "already celebrated" flag is shared/persisted state, not a Compose
+  heuristic) so re-opening a goal does not re-nag.
+- See goal surfaces in
+  [android-goal-projection-widget.md](./android-goal-projection-widget.md) and
+  [android-shared-goal-contributors.md](./android-shared-goal-contributors.md)
+  for where the goal-side buttons sit.
+
+---
+
+## 5. Flow Overview
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Preview: tap Share
+    Preview --> Rendering: confirm card
+    Preview --> Idle: dismiss
+    Rendering --> Chooser: bitmap ready
+    Rendering --> RenderError: render failed
+    RenderError --> Rendering: retry
+    RenderError --> Idle: give up
+    Chooser --> Sent: target chosen
+    Chooser --> Cancelled: back / outside tap
+    Chooser --> NoTargets: no app can handle
+    Sent --> Idle
+    Cancelled --> Idle
+    NoTargets --> Idle
+```
+
+- **Preview** is owned by the share-card doc (redaction toggle lives there); this
+  flow begins when the user confirms the card.
+- Android does **not** report which app was chosen or whether the user completed
+  the send; we therefore treat reaching the chooser as `share_send_initiated` and
+  record `Cancelled` only when we detect dismissal without a chooser result (§8).
+
+---
+
+## 6. Sharesheet Plumbing
+
+The handoff is centralized in `FinanceNavHost` (the one place allowed to touch an
+`Activity`/`Intent`), replacing the `TODO(#1296)` stubs:
+
+- Build an `Intent(Intent.ACTION_SEND)` with `type = "image/png"`, set
+  `EXTRA_STREAM` to the **FileProvider content URI** of the rendered card, and add
+  a **redaction-safe `EXTRA_TEXT`** caption fallback.
+- Grant read access with `FLAG_GRANT_READ_URI_PERMISSION` and attach the URI via
+  **`ClipData`** so target apps inherit the grant.
+- Wrap in **`Intent.createChooser(...)`** so the user always gets the system
+  Sharesheet (consistent with `SettingsScreen` / `PrivacySettingsScreen`).
+- Prefer **`androidx.core.app.ShareCompat.IntentBuilder`** to construct the intent
+  (sets MIME, stream, and clip data correctly) over hand-rolled extras.
+- The image lives in **app-internal cache** behind a configured `FileProvider`
+  (no external-storage permission, no secrets on disk).
+- Text-only fallback (e.g. a target that rejects images) sends the
+  **redaction-safe caption** only — never an amount.
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant S as Share entry point
+    participant V as ShareCardViewModel
+    participant N as FinanceNavHost
+    participant A as Android Sharesheet
+    U->>S: Tap Share
+    S->>V: request card
+    V->>V: render bitmap to cache (FileProvider URI)
+    V->>N: onShare(ShareableCard)
+    N->>A: ACTION_SEND + createChooser
+    A-->>U: system chooser
+    U-->>A: pick target or dismiss
+    A-->>V: result (initiated / cancelled / no targets)
+```
+
+---
+
+## 7. Cancellation, Retry & Unsupported-App Handling
+
+| Situation                    | Detection                                 | UX response                                                           |
+| ---------------------------- | ----------------------------------------- | --------------------------------------------------------------------- |
+| User dismisses chooser       | Returns to app with no chooser selection  | Silently return to preview; record `share_cancelled`; no error toast  |
+| No app can handle the intent | `resolveActivity == null` / empty targets | Inline message "No apps available to share" + "Copy caption" fallback |
+| Bitmap render failed         | Renderer throws / returns null            | Retry affordance; never open the chooser with a missing/blank image   |
+| FileProvider grant failed    | `SecurityException` on URI grant          | Fall back to **text-only** `ACTION_SEND`; log via Timber (no amounts) |
+| Target rejects image MIME    | Chosen app cannot accept `image/png`      | System falls back to `EXTRA_TEXT` caption (already redaction-safe)    |
+| Offline                      | n/a (handoff is local)                    | Works fully offline; the _target_ app handles its own connectivity    |
+
+- **Retry** re-renders and re-dispatches; it never reuses a stale bitmap.
+- **Give up** returns to Idle with no penalty — sharing is always optional.
+- Errors are logged with **Timber** (`Timber.e` / `Timber.w`) and **never include
+  amounts, account IDs, or the chosen target package**.
+
+---
+
+## 8. Telemetry
+
+Telemetry flows through the shared **`AnalyticsTracker`**, which is consent-gated
+and forbidden from transmitting PII or financial amounts. Events use the existing
+`FeatureAdopted`-style shape (`feature_key` + anonymous enums), so no new
+amount-bearing event is introduced.
+
+| Event                    | When                                  | Properties (anonymous only)                              |
+| ------------------------ | ------------------------------------- | -------------------------------------------------------- |
+| `share_preview_opened`   | Preview shown                         | `surface` (goal/badge/streak), `milestone` (25/50/…)     |
+| `share_send_initiated`   | Chooser launched                      | `surface`, `milestone`, `template`                       |
+| `share_cancelled`        | Chooser dismissed without a target    | `surface`, `milestone`                                   |
+| `share_redaction_choice` | User toggled amount reveal in preview | `revealed` (true/false) — **the choice, not the amount** |
+| `share_no_targets`       | No app could handle the intent        | `surface`                                                |
+| `share_render_error`     | Bitmap render failed                  | `surface`, `reason_code`                                 |
+
+Rules:
+
+- **No amounts, no balances, no account identifiers, no chosen-app package name.**
+- `share_redaction_choice` records **whether** the user opted to show an amount —
+  never the value — to measure how often redaction is bypassed.
+- All events are **no-ops without analytics consent** (`AnalyticsTracker.isEnabled`)
+  and buffer offline like every other event.
+
+---
+
+## 9. Accessibility (TalkBack, Switch Access, Font Scaling, Reduced Motion)
+
+- **TalkBack:** every share entry point has a descriptive `contentDescription`
+  (e.g. _"Share your 50 percent goal milestone"_), mirroring the Referral "Share
+  referral code" label. The system Sharesheet provides its own accessibility.
+- **Switch Access:** the share button is reachable in the screen's normal
+  traversal order and is not a hidden long-press-only action.
+- **Font scaling (200%):** the entry-point button and any inline error
+  ("No apps available to share") reflow and never truncate at large font scales.
+- **Reduced motion:** a badge-unlock that auto-surfaces a share affordance must not
+  rely on a looping celebration; with reduced motion the affordance appears
+  statically (see [animation-library.md](./animation-library.md) and
+  [accessibility-patterns.md](./accessibility-patterns.md)).
+- **Non-blocking:** the share affordance is never a focus trap; dismissing the
+  chooser always returns focus to the originating control.
+- **Plain language** per
+  [content-language-guidelines.md](./content-language-guidelines.md) and
+  [cognitive-accessibility.md](./cognitive-accessibility.md).
+
+---
+
+## 10. Offline, Empty & Error States
+
+| Condition              | Behavior                                                                             |
+| ---------------------- | ------------------------------------------------------------------------------------ |
+| Offline                | Entry points and the handoff are **fully local**; the chooser opens without network. |
+| No wins yet            | No share affordance is shown (nothing to celebrate).                                 |
+| Win already shared     | The one-time milestone affordance is hidden (de-dup flag is shared state).           |
+| No share-capable apps  | Inline "No apps available to share" + "Copy caption" fallback (§7).                  |
+| Render/handoff failure | Graceful retry/give-up; never a blank or partial image leaves the app.               |
+| Analytics consent off  | Sharing still works; telemetry events are silently dropped.                          |
+
+---
+
+## 11. Test Plan
+
+- **Unit (ViewModel):** entry-point visibility per surface; one-time milestone
+  de-dup; `share_cancelled` vs `share_send_initiated` resolution; redaction-choice
+  event carries a boolean, never a value.
+- **Telemetry parity (critical):** assert no `share_*` event property contains a
+  currency string, digit-amount, account ID, or target package name; assert all
+  events no-op when consent is off.
+- **Intent construction:** verify `ACTION_SEND` has `image/png`, a FileProvider
+  `EXTRA_STREAM`, `FLAG_GRANT_READ_URI_PERMISSION`, `ClipData`, and a
+  redaction-safe `EXTRA_TEXT`; verify `createChooser` is used.
+- **Cancellation / no-targets:** simulate empty resolver → inline fallback;
+  simulate dismissal → `share_cancelled`, no error toast.
+- **Compose UI / semantics:** `contentDescription` on every entry point; share
+  button is in Switch-Access traversal order; large-font reflow has no truncation.
+- **Paparazzi snapshots:** each entry point (goal milestone button on goal detail,
+  badge-unlock share affordance, streak-milestone share) light/dark + dynamic
+  color, default and 200% font, plus the "no apps available" inline state.
+- **NavHost wiring:** the `onShare` lambda dispatches a chooser and replaces the
+  `TODO(#1296)` stub (instrumented or Robolectric).
+
+---
+
+## 12. Implementation Readiness
+
+Per [`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md)
+§2 (Implementation vs. Distribution), this feature is **decoupled**: the Sharesheet
+plumbing is **fully debug-implementable** — `ACTION_SEND` + `createChooser` works
+on a sideloaded debug build today; only store distribution waits on #1242.
+
+### ✅ Buildable now (debug / free signing — no enrollment, no secrets)
+
+- This design doc and the entry-point/telemetry contract.
+- All share entry-point composables, the `onShare` NavHost wiring (replacing the
+  `TODO(#1296)` stubs), FileProvider config, and Koin registration.
+- The consent-gated `share_*` telemetry on the shared `AnalyticsTracker`.
+- Unit tests, telemetry-parity tests, intent-construction tests, Compose
+  semantics/UI tests, and Paparazzi snapshots.
+- Local verification via `./gradlew :apps:android:assembleDebug` + sideload, per
+  [`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md)
+  §2 "Free local build/test paths." The chooser opens locally end-to-end.
+
+### 🔒 Distribution tail — gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+
+- Release signing with the production keystore.
+- Google Play Console upload / release-track promotion.
+- The signed-AAB release workflow and its CI secrets.
+- Play data-safety declaration covering shared content and analytics.
+
+These are **human-gated** and out of scope for SME agents — see the
+[Human-Gated Prerequisites Runbook](../ops/human-gated-prerequisites.md) §3.1.
+Until then, sharing is fully exercisable via debug sideload.
+
+---
+
+## 13. Open Questions
+
+1. **One-time de-dup storage** — confirm the "already celebrated this milestone"
+   flag is a shared/persisted record (synced) rather than a device-local flag, so
+   it does not re-prompt across devices. (@kmp-engineer)
+2. **Completed-send signal** — Android hides which app was chosen and whether the
+   send completed; do we accept `share_send_initiated` as our success proxy, or add
+   a returning-foreground heuristic?
+3. **Caption text source** — confirm the redaction-safe `EXTRA_TEXT` caption is
+   produced alongside the card (share-card doc) and localized via the shared
+   formatter.
+4. **Auto-surface vs manual** — should a fresh badge unlock auto-offer a share
+   affordance, or only ever show it on the gamification screen?
+5. **Per-surface opt-out** — do users get a setting to disable share affordances on
+   goal screens independently of the gamification screen?

--- a/docs/design/android-streak-near-win-states.md
+++ b/docs/design/android-streak-near-win-states.md
@@ -1,0 +1,380 @@
+# Android Real Streak Integration & Near-Win States — Design
+
+> **Status:** DESIGN — Implementation-ready (native build/test unblocked; store distribution gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242))
+> **Issue:** [#2688](https://github.com/jrmoulckers/finance/issues/2688) — _Part of [#2211](https://github.com/jrmoulckers/finance/issues/2211)_ (gamification depth)
+> **Platform:** Android (Jetpack Compose · Material 3)
+> **Last Updated:** 2026-06-22
+
+This document designs the Android gamification surface for **real streak data**
+and **near-win feedback**, replacing today's static, always-empty streak list. It
+defines the **streak data contract**, the **near-win messaging** ("2 more
+check-ins", "keep your streak alive today"), and the **empty, paused, recovered,
+and broken** streak states.
+
+Today `GamificationViewModel` builds its profile with `streaks = emptyList()` and a
+comment that streaks are _"tracked separately via `StreakRepository`."_ This doc
+specifies that repository contract and the Compose states it feeds — **without
+writing Kotlin yet**. All streak math stays in the shared KMP
+`GamificationEngine`; Compose only renders the resulting state.
+
+---
+
+## Table of Contents
+
+1. [Goals & Non-Goals](#1-goals--non-goals)
+2. [Architecture Boundary (Compose ↔ KMP)](#2-architecture-boundary-compose--kmp)
+3. [Grounding in Existing Code](#3-grounding-in-existing-code)
+4. [Streak Data Contract](#4-streak-data-contract)
+5. [Streak States](#5-streak-states)
+6. [Near-Win Messaging](#6-near-win-messaging)
+7. [State Derivation (Today vs. Last Activity)](#7-state-derivation-today-vs-last-activity)
+8. [UI Composition](#8-ui-composition)
+9. [Accessibility (TalkBack, Switch Access, Font Scaling, Reduced Motion)](#9-accessibility-talkback-switch-access-font-scaling-reduced-motion)
+10. [Offline, Empty & Error States](#10-offline-empty--error-states)
+11. [Test Plan](#11-test-plan)
+12. [Implementation Readiness](#12-implementation-readiness)
+13. [Open Questions](#13-open-questions)
+
+---
+
+## 1. Goals & Non-Goals
+
+### Goals
+
+- Define a **streak data contract** (`StreakRepository`) that supplies real active
+  streaks to `GamificationViewModel` instead of `emptyList()`.
+- Specify **near-win messages** such as _"2 more check-ins"_ and _"keep your streak
+  alive today"_ driven by shared state, not Compose guesswork.
+- Define **empty, paused, recovered, and broken** streak states plus the **active**
+  and **near-win** states, each with copy and accessibility.
+- Keep all **streak rules in `packages/core`** (`GamificationEngine.updateStreak`)
+  and have Compose render the shared result.
+- Reuse the existing `Streak` model and `StreakCard` composable rather than
+  inventing parallel structures.
+
+### Non-Goals
+
+- **No streak math in Compose.** Extend/reset/grace logic belongs to the shared
+  engine (see §2–§3). The UI never computes day deltas itself for business logic.
+- **No new Kotlin in this issue.** This is design-ready scoping; implementation
+  follows once the contract is agreed (#2211).
+- **No achievement/badge changes.** Badge unlocks are
+  [android-sharesheet-wins-badges.md](./android-sharesheet-wins-badges.md) /
+  existing achievements; this doc is streaks only.
+- **No notifications design here.** "Keep your streak alive today" _reminders_ (if
+  any) ride the existing WorkManager + push path and are a separate follow-up — no
+  AlarmManager / JobScheduler.
+- **No financial amounts.** Streak surfaces show **counts and dates only** — never
+  balances (and any future streak share card obeys
+  [android-privacy-safe-share-cards.md](./android-privacy-safe-share-cards.md)).
+- **No store distribution work** (gated by #1242 — see §12).
+
+---
+
+## 2. Architecture Boundary (Compose ↔ KMP)
+
+Streaks are **shared state rendered by Compose**. The repository persists/serves
+streaks; the engine decides how they evolve; the ViewModel maps them to an
+immutable UI state; the screen draws them.
+
+```mermaid
+flowchart LR
+    subgraph Shared [packages/core · KMP - source of truth]
+        ENG[GamificationEngine.updateStreak / buildProfile]
+        REPO[StreakRepository contract]
+        TYPE[Streak: currentCount, bestCount, lastActivityDate]
+    end
+    subgraph Android [apps/android · Compose]
+        VM[GamificationViewModel]
+        UI[GamificationScreen / StreakCard]
+    end
+    REPO --> ENG
+    ENG --> TYPE
+    TYPE -->|active streaks| VM
+    VM -->|immutable GamificationUiState| UI
+```
+
+- `GamificationViewModel` already exposes one immutable
+  `StateFlow<GamificationUiState>` carrying `activeStreaks: List<Streak>`; today it
+  is fed `emptyList()`. This design **fills that list from `StreakRepository`**.
+- **All transitions** (extend on consecutive day, no-op same day, reset on gap) are
+  the shared `GamificationEngine.updateStreak` rules — Compose never re-implements
+  them.
+- The ViewModel may compute **presentation-only** derivations (e.g. "is this a
+  near-win banner") from shared `currentCount`/`lastActivityDate` plus the shared
+  "today" — but the **near-win threshold and grace policy are shared inputs**, not
+  Compose magic numbers.
+
+---
+
+## 3. Grounding in Existing Code
+
+| Concern            | Source of truth (do **not** reimplement in Compose)                                                                                                   | Today's state                                                        |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| Streak model       | [`Streak`](../../packages/core/src/commonMain/kotlin/com/finance/core/gamification/GamificationTypes.kt)                                              | Exists: `type`, `currentCount`, `bestCount`, `lastActivityDate`      |
+| Streak transitions | [`GamificationEngine.updateStreak`](../../packages/core/src/commonMain/kotlin/com/finance/core/gamification/GamificationEngine.kt)                    | Exists: +1 consecutive, no-op same day, reset on gap                 |
+| Profile assembly   | [`GamificationEngine.buildProfile(progress, streaks)`](../../packages/core/src/commonMain/kotlin/com/finance/core/gamification/GamificationEngine.kt) | Exists: filters `currentCount > 0` into `activeStreaks`              |
+| The gap to fill    | [`GamificationViewModel`](../../apps/android/src/main/kotlin/com/finance/android/ui/gamification/GamificationViewModel.kt) (`streaks = emptyList()`)  | **Empty today** — comment: "tracked separately via StreakRepository" |
+| Streak UI          | `StreakCard` in [`GamificationScreen`](../../apps/android/src/main/kotlin/com/finance/android/ui/gamification/GamificationScreen.kt)                  | Exists: renders count + best, hidden when list is empty              |
+| Streak category    | `AchievementCategory.STREAKS`                                                                                                                         | Exists: streak achievements already categorized                      |
+
+> The work is **wiring + states**, not new math: feed real `Streak`s into the
+> existing `buildProfile`/`activeStreaks` path and render the states below. The
+> `updateStreak` engine already encodes the extend/reset rules.
+
+---
+
+## 4. Streak Data Contract
+
+`StreakRepository` is a **shared (`packages/core`) contract** that the Android repo
+layer observes; the ViewModel consumes it the same way it observes transactions,
+accounts, budgets, and goals today.
+
+Conceptual shape (design only — owned by @kmp-engineer, **not** implemented here):
+
+- `observeActiveStreaks(householdId): Flow<List<Streak>>` — emits the current
+  streaks (already `currentCount`-filtered by `buildProfile`).
+- `recordActivity(type, date): Streak` — delegates to
+  `GamificationEngine.updateStreak(existing, type, date)` and persists the result;
+  it is the **only** writer of streak state.
+- Streak persistence reuses the encrypted SQLDelight store (SQLCipher) like other
+  finance data; **no streak state in SharedPreferences**.
+
+```mermaid
+flowchart TB
+    ACT[User activity e.g. daily check-in] --> RA[StreakRepository.recordActivity]
+    RA --> US[GamificationEngine.updateStreak]
+    US --> DB[(Encrypted SQLDelight store)]
+    DB --> OBS[observeActiveStreaks Flow]
+    OBS --> VM[GamificationViewModel]
+```
+
+Notes:
+
+- The repository never recomputes day math — it **delegates to `updateStreak`** so
+  the "consecutive vs gap" rule has exactly one home.
+- `recordActivity` is **idempotent per day** because `updateStreak` returns the
+  existing streak unchanged when `daysSinceLast == 0`.
+- The `type` string (e.g. `"daily-tracking"`, `"budget-adherence"`) is the existing
+  `Streak.type`; UI titles humanize it (today `StreakCard` already does
+  `type.replaceFirstChar { … }.replace("-", " ")`).
+
+---
+
+## 5. Streak States
+
+The engine's primitive transitions (`updateStreak`) plus the shared "today" yield
+the following **presentation states**. Note the engine **resets to 1 on any gap**
+(it has no built-in pause); "paused" and "recovered" are therefore states that
+require a **shared grace-period policy** — see §7 and the open questions.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Empty
+    Empty --> Active: first activity
+    Active --> NearWin: close to a milestone or due today
+    NearWin --> Active: activity recorded
+    Active --> AtRisk: no activity yet today
+    AtRisk --> Active: check in today
+    AtRisk --> Broken: day passed with a gap
+    Broken --> Active: restart (count = 1)
+    Active --> Paused: grace policy applies (shared)
+    Paused --> Recovered: activity within grace window
+    Recovered --> Active: streak continues
+    Paused --> Broken: grace window elapsed
+```
+
+| State     | Meaning                                                   | Source signal                                           |
+| --------- | --------------------------------------------------------- | ------------------------------------------------------- |
+| Empty     | No streak of this type yet                                | `activeStreaks` has no entry for `type`                 |
+| Active    | Ongoing streak, not due/at-risk right now                 | `currentCount > 0`, last activity recent                |
+| Near-win  | One/two activities from a milestone, or due today         | shared near-win threshold + `lastActivityDate` vs today |
+| At-risk   | Streak alive but no activity **yet today**                | `lastActivityDate < today` within the keep-alive window |
+| Broken    | A gap elapsed; `updateStreak` reset `currentCount` to 1   | engine reset on `daysSinceLast > 1`                     |
+| Paused    | Grace policy is holding the streak (shared follow-up)     | shared grace policy (not yet in engine — §13)           |
+| Recovered | Activity landed inside the grace window; streak continues | shared grace policy resolves to continue                |
+
+---
+
+## 6. Near-Win Messaging
+
+Near-win copy turns a number into momentum. It is **derived from shared state**
+(`currentCount`, milestone thresholds, and `lastActivityDate` vs today) and chosen
+in the ViewModel as a **presentation string**, with thresholds supplied by shared
+config — never hardcoded business rules in Compose.
+
+| State / trigger                       | Message (example)                         | Tone                 |
+| ------------------------------------- | ----------------------------------------- | -------------------- |
+| 2 from a milestone                    | "2 more check-ins to hit 30 days"         | Encouraging          |
+| 1 from a milestone                    | "1 more check-in for your 30-day badge"   | Encouraging          |
+| Alive but no activity today (at-risk) | "Keep your streak alive today"            | Gentle nudge         |
+| Just hit a milestone                  | "30-day streak! Nice work."               | Celebratory          |
+| Recovered within grace                | "Welcome back — your streak continues"    | Reassuring           |
+| Broken / restarted                    | "Fresh start — day 1 of a new streak"     | Kind, non-judgmental |
+| Empty                                 | "Start a streak with your first check-in" | Inviting             |
+
+Copy rules (per [content-language-guidelines.md](./content-language-guidelines.md)
+and [cognitive-accessibility.md](./cognitive-accessibility.md)):
+
+- **No shame on broken streaks** — never "you lost your streak" / "you failed".
+- **No financial figures** — streaks are about consistency, not amounts.
+- Numbers are **localized via the shared formatter**; plurals handled by Android
+  plural string resources, not string concatenation.
+
+---
+
+## 7. State Derivation (Today vs. Last Activity)
+
+The only time-sensitive input is **"today"**. To keep it testable and consistent
+with the engine (which already takes `now`/`activityDate`):
+
+- "Today" is a **shared, injected clock value** (kotlinx-datetime `LocalDate`),
+  passed in like `updateStreak(existing, type, activityDate)` already accepts a
+  date — never `LocalDate.now()` read ad hoc in a composable.
+- **At-risk** = streak active **and** `lastActivityDate < today` within the
+  keep-alive window. This is a presentation flag computed from shared inputs.
+- **Near-win threshold** (how close counts as "near") is a **shared constant/config
+  value**, so product can tune it once for all platforms.
+- **Paused / recovered** depend on a **grace-period policy that does not yet exist
+  in `GamificationEngine`** (the engine resets on any gap). Until that shared policy
+  lands, the UI treats a gap as **Broken/restart** and the Paused/Recovered states
+  are specified-but-dormant (flagged in §13 as an @kmp-engineer follow-up).
+
+```mermaid
+flowchart TB
+    S[Streak from repository] --> T{lastActivityDate vs today}
+    T -- same day --> ACT[Active or Near-win]
+    T -- within keep-alive window --> RISK[At-risk: keep alive today]
+    T -- gap, no grace --> BRK[Broken: restart at 1]
+    T -- gap, within grace policy --> PAU[Paused then Recovered - shared follow-up]
+```
+
+---
+
+## 8. UI Composition
+
+The existing `StreakCard` is extended (not replaced) to carry state + near-win
+copy. Today it renders `currentCount` and `bestCount`; the evolution adds a state
+badge and an optional near-win line.
+
+- **Streak list** stays a section in `GamificationScreen` (`activeStreaks`),
+  rendered with `LazyColumn` items keyed by `Streak.type` (as today).
+- **`StreakCard` additions:** a state chip (Active / Near-win / At-risk /
+  Recovered / restarted) using **text + icon, not color alone**, and an optional
+  near-win caption from §6.
+- **Empty state:** when `activeStreaks` is empty, show an inviting empty card
+  ("Start a streak…") instead of hiding the section silently, so the surface is no
+  longer a dead, always-empty list.
+- **Celebration on milestone:** reuse the reduced-motion-aware celebration pattern
+  (see the Referral `CelebrationOverlay` and
+  [animation-library.md](./animation-library.md)); static fallback when reduced
+  motion is on.
+- A **streak milestone** may offer a share affordance, which defers entirely to
+  [android-sharesheet-wins-badges.md](./android-sharesheet-wins-badges.md) and
+  [android-privacy-safe-share-cards.md](./android-privacy-safe-share-cards.md).
+
+---
+
+## 9. Accessibility (TalkBack, Switch Access, Font Scaling, Reduced Motion)
+
+- **TalkBack:** each `StreakCard` keeps a single summarizing `contentDescription`
+  that now includes **state and near-win** info, e.g. _"Daily tracking streak: 28
+  days. Best: 40 days. 2 more check-ins to hit 30 days."_ — extending the existing
+  card description rather than adding chatty child nodes.
+- **At-risk** is announced as actionable, e.g. _"Daily tracking streak, 28 days.
+  Keep your streak alive today."_
+- **Switch Access:** the streak section and any per-card action (share, check-in)
+  are in the normal traversal order; the empty-state CTA is operable.
+- **Font scaling (200%):** count, best, state chip, and near-win caption reflow
+  and wrap; the big streak number scales without clipping the card.
+- **Reduced motion:** milestone celebration honors the system animator scale and
+  the app reduced-motion preference — static celebratory card, no looping
+  particles (see [accessibility-patterns.md](./accessibility-patterns.md)).
+- **Color independence:** state is never color-only — Active/At-risk/Broken each
+  carry text + icon per [accessibility-patterns.md](./accessibility-patterns.md).
+
+---
+
+## 10. Offline, Empty & Error States
+
+| Condition                    | Behavior                                                                                   |
+| ---------------------------- | ------------------------------------------------------------------------------------------ |
+| Offline                      | Streaks read from the local encrypted store; fully usable offline.                         |
+| No streaks yet               | Inviting empty card ("Start a streak with your first check-in"), not a blank section.      |
+| Repository load error        | Section shows a non-blocking retry; the rest of the gamification screen still renders.     |
+| Clock/timezone edge          | Day boundaries use the shared injected date; at-risk/broken are computed from it.          |
+| Grace policy absent          | Gaps render as **Broken/restart**; Paused/Recovered remain dormant until shared follow-up. |
+| Streak with `currentCount` 0 | Already filtered out by `buildProfile`; never rendered as active.                          |
+
+---
+
+## 11. Test Plan
+
+- **Unit (ViewModel):** with a fake `StreakRepository`, `activeStreaks` is
+  populated (not empty); state derivation yields Active / Near-win / At-risk /
+  Broken correctly from `lastActivityDate` vs an injected "today"; near-win copy
+  selection matches thresholds.
+- **Engine parity:** assert the UI never recomputes streak transitions — extend /
+  same-day no-op / gap-reset are asserted against `GamificationEngine.updateStreak`
+  directly (shared tests already exist) and the ViewModel only reads results.
+- **Copy / tone tests:** broken-streak and near-win strings contain **no blame**
+  language and **no financial amounts** (string-resource assertions).
+- **Compose UI / semantics:** `contentDescription` on every `StreakCard` includes
+  state + near-win; empty-state CTA present and operable; state chips are not
+  color-only.
+- **Paparazzi snapshots:** Empty, Active, Near-win (1-from and 2-from), At-risk,
+  Broken/restart, and Recovered cards — light/dark + dynamic color, default and
+  200% font, plus a reduced-motion static milestone celebration.
+- **Idempotency:** `recordActivity` twice on the same day does not advance the
+  count (mirrors `updateStreak` same-day no-op).
+
+---
+
+## 12. Implementation Readiness
+
+Per [`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md)
+§2 (Implementation vs. Distribution), this feature is **decoupled**: wiring real
+streaks and rendering the states is fully buildable/testable now; only store
+distribution waits on #1242. This issue intentionally **writes no Kotlin yet** — it
+locks the contract so implementation under #2211 is unambiguous.
+
+### ✅ Buildable now (debug / free signing — no enrollment, no secrets)
+
+- This design doc, the `StreakRepository` contract, and the state/near-win spec.
+- Once approved: the Android `StreakRepository` observer wiring,
+  `GamificationViewModel` change (real streaks instead of `emptyList()`), the
+  `StreakCard` state/near-win additions, and Koin registration.
+- The shared `StreakRepository` + any grace-period policy are `packages/core`
+  changes (owned by @kmp-engineer) — also unblocked; not store-gated.
+- Unit tests, copy/tone tests, Compose semantics/UI tests, and Paparazzi snapshots.
+- Local verification via `./gradlew :apps:android:assembleDebug` + sideload, per
+  [`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md)
+  §2 "Free local build/test paths."
+
+### 🔒 Distribution tail — gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+
+- Release signing with the production keystore.
+- Google Play Console upload / release-track promotion.
+- The signed-AAB release workflow and its CI secrets.
+- Push delivery configuration for any "keep your streak alive" production reminder.
+
+These are **human-gated** and out of scope for SME agents — see the
+[Human-Gated Prerequisites Runbook](../ops/human-gated-prerequisites.md) §3.1.
+Until then the streak surface is fully exercisable via debug sideload.
+
+---
+
+## 13. Open Questions
+
+1. **Grace-period policy** — should `GamificationEngine` gain an explicit
+   pause/recover/grace concept (so Paused/Recovered are real), or do we ship
+   Broken/restart only in v1? This is the key @kmp-engineer decision for #2211.
+2. **Near-win threshold source** — confirm "near" (1 vs 2 activities, or a percent
+   of the next milestone) is a single shared config value across platforms.
+3. **Streak types in v1** — which `Streak.type` values do we surface first
+   (daily-tracking, budget-adherence, …) and where does each `recordActivity` fire?
+4. **Reminder ownership** — is the "keep your streak alive today" reminder a
+   WorkManager/push concern designed in a separate notifications issue rather than
+   here?
+5. **Timezone / day boundary** — confirm the shared "today" uses the user's local
+   timezone consistently with how `updateStreak` callers pass `activityDate`.


### PR DESCRIPTION
## Summary

Adds three **design-only** docs (no Kotlin, no native build, no store actions) for
the Android gamification sharing & streak cluster. All streak/achievement logic
stays conceptually in KMP `packages/core`; Compose only renders already-computed,
already-masked shared state.

The defining privacy rule across this batch: **share cards never leak real
balances or amounts by default** — they show progress (percent) and badges only,
with an explicit per-share opt-in and a redacted preview the user must confirm.
Parent-linked (teen/guardian) accounts can never reveal amounts.

## Changes

- `docs/design/android-privacy-safe-share-cards.md` (#2682) — privacy-safe share
  card templates (goal milestone, completion, badge unlock, streak milestone),
  deny-by-default redaction model, preview/edit states before the Sharesheet
  handoff, Compose→bitmap rendering, and safe defaults for parent-linked accounts.
- `docs/design/android-sharesheet-wins-badges.md` (#2684) — Sharesheet entry points
  for 25/50/75/100% milestones, goal completion, badge unlocks, and streak
  milestones; `ACTION_SEND` + `createChooser` plumbing (replacing the `TODO(#1296)`
  NavHost stubs); cancellation/retry/unsupported-app handling; and privacy-safe
  telemetry (preview/send/cancel/redaction-choice — counts and enums only).
- `docs/design/android-streak-near-win-states.md` (#2688) — real streak data
  contract (`StreakRepository` feeding `GamificationViewModel` instead of
  `emptyList()`), near-win messaging ("2 more check-ins", "keep your streak alive
  today"), and empty/paused/recovered/broken states — no Kotlin written yet.

Each doc follows `docs.instructions.md`: humans-first, ToC, Mermaid diagrams,
relative links to existing docs/source, accessibility (TalkBack, Switch Access,
200% font, reduced motion for celebrations), offline/empty/error states, a
unit/Compose/Paparazzi test plan, and an **Implementation Readiness** section that
links `../ops/human-gated-prerequisites.md` and splits buildable-now
(`assembleDebug` sideload; Sharesheet plumbing is debug-implementable) from the
Play-distribution tail gated by #1242.

## Verification

- `npx prettier --check` passes on all three new files.
- Only three new files added; no existing files, code, or shared config touched.
- All relative cross-links verified to resolve.

Closes #2682
Closes #2684
Closes #2688
