### PR TITLE
docs(design): android debt comparison and learning curriculum design batch (#2658, #2669, #2678)

### DIFF
--- a/docs/design/android-avalanche-snowball-comparison.md
+++ b/docs/design/android-avalanche-snowball-comparison.md
@@ -1,0 +1,446 @@
+# Android Avalanche / Snowball Comparison & Goal Tradeoff UI
+
+> **Status:** PROPOSED — Pending human review
+> **Issue:** [#2658](https://github.com/jrmoulckers/finance/issues/2658) · Part of [#2153](https://github.com/jrmoulckers/finance/issues/2153)
+> **Platform:** Android (Jetpack Compose, Material 3)
+> **Last Updated:** 2026-06-22
+> **Design only:** Native implementation remains blocked by [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+
+---
+
+## Table of Contents
+
+1. [Purpose](#purpose)
+2. [Persona and Why This Matters](#persona-and-why-this-matters)
+3. [Goals and Non-Goals](#goals-and-non-goals)
+4. [Scope Boundaries With Sibling Work](#scope-boundaries-with-sibling-work)
+5. [Payoff Math Lives in KMP](#payoff-math-lives-in-kmp)
+6. [Comparison Surface and Entry Points](#comparison-surface-and-entry-points)
+7. [Strategy Cards: Time, Interest, and Cash Impact](#strategy-cards-time-interest-and-cash-impact)
+8. [Goal Tradeoff View](#goal-tradeoff-view)
+9. [Recommendation Mode](#recommendation-mode)
+10. [Plain-Language Copy](#plain-language-copy)
+11. [Accessibility Considerations](#accessibility-considerations)
+12. [Offline, Empty, and Error States](#offline-empty-and-error-states)
+13. [Test Plan](#test-plan)
+14. [Implementation Readiness](#implementation-readiness)
+15. [References](#references)
+
+---
+
+## Purpose
+
+A household that is paying down debt usually faces the same question: _should we
+attack the highest-interest balance first (avalanche), the smallest balance first
+(snowball), or add an extra payment — and what does each choice cost us against our
+**wedding** and **down-payment** goals?_ This document designs the Android Compose
+**payoff-strategy comparison surface** and the **goal tradeoff view**: how the three
+strategies sit side by side, how each reports **time-to-payoff, interest saved, and
+monthly cash impact**, how the tradeoff against funded goals is shown without guilt,
+and an optional **recommendation mode** for users who just want a nudge toward a
+sensible default.
+
+It is **design and breakdown only** while
+[#1242](https://github.com/jrmoulckers/finance/issues/1242) gates Google Play
+distribution. No Kotlin is written here, and **no payoff math is implemented in
+Compose** — that arithmetic is a shared KMP concern, with the web debt engines as
+the parity reference.
+
+> **Important framing:** every payoff date, interest-saved figure, and "months
+> sooner" number on this surface is an **estimate**, visibly labelled as such. The
+> comparison plans the household's _own_ payoff; it is not debt counseling,
+> consolidation advice, or a credit decision.
+
+---
+
+## Persona and Why This Matters
+
+The persona ([#2153](https://github.com/jrmoulckers/finance/issues/2153)): a couple
+balancing **debt payoff** against two near-term life goals — a **wedding** and a
+**house down payment**. They have heard the words "avalanche" and "snowball" but
+cannot feel the difference in their own numbers, and every dollar sent to debt is a
+dollar that does not go to the wedding fund. They need an honest, side-by-side
+comparison that makes the tradeoff legible **without shaming them** for choosing the
+emotionally easier path. This intersects with
+[Persona 3 (household / couples)](personas.md), the joint-debt foundation in
+[android-joint-debt-payoff-planner.md](android-joint-debt-payoff-planner.md), and the
+goal surfaces in
+[android-house-downpayment-planner.md](android-house-downpayment-planner.md) and
+[android-wedding-workspace-shell.md](android-wedding-workspace-shell.md).
+
+---
+
+## Goals and Non-Goals
+
+**Goals**
+
+- Show **avalanche, snowball, and extra-payment** strategies side by side, each with
+  **time-to-payoff**, **interest saved** (versus a minimum-only baseline), and
+  **monthly cash impact**.
+- Make the tradeoff against the **wedding** and **down-payment** goals visible — how
+  much a goal slips (or speeds up) under each strategy — in **neutral, non-guilt
+  language**.
+- Offer a **recommendation mode**: a single suggested strategy with a one-line
+  rationale, for users who want a simpler decision aid instead of a full comparison.
+- Render only **shared payoff state** from KMP; keep all math out of Compose.
+- Be fully accessible (TalkBack, Switch Access, 200% font, plain language) and define
+  offline/empty/error states.
+
+**Non-Goals**
+
+- Implementing the payoff engine, extra-payment simulation, or interest math — that is
+  KMP `packages/core`, with the web debt engines as parity (owned by @kmp-engineer /
+  @web-engineer).
+- Debt ownership, classification, and the planner shell — owned by
+  [android-joint-debt-payoff-planner.md](android-joint-debt-payoff-planner.md).
+- Editing the wedding or down-payment goal surfaces themselves — owned by
+  [android-wedding-workspace-shell.md](android-wedding-workspace-shell.md),
+  [android-wedding-actuals-cashflow.md](android-wedding-actuals-cashflow.md), and
+  [android-house-downpayment-planner.md](android-house-downpayment-planner.md).
+- Any debt counseling, refinancing, or consolidation recommendation.
+- Editing KMP `packages/*`, web, or any non-Android platform.
+
+---
+
+## Scope Boundaries With Sibling Work
+
+```mermaid
+flowchart TD
+    THIS[Issue 2658: Strategy comparison + goal tradeoff<br/>THIS DOC: strategy cards, tradeoff view, recommendation]
+    PLANNER[Issue 2656: Joint debt payoff shell<br/>inventory, ownership, entry points]
+    WED[Wedding workspace + actuals<br/>goal source for tradeoff]
+    HOUSE[House down-payment planner<br/>goal source for tradeoff]
+    KMP[KMP packages-core<br/>shared payoff + extra-payment engine]
+
+    THIS -->|renders shared strategy results from| KMP
+    THIS -->|launched from| PLANNER
+    THIS -->|reads goal targets from| WED
+    THIS -->|reads goal targets from| HOUSE
+```
+
+This doc owns the **comparison and tradeoff surfaces only**. The planner shell and
+debt ownership are the joint-debt doc; the wedding and house planners own their goal
+definitions; the strategy arithmetic is shared KMP. This surface is launched from the
+planner and **reads** goal targets to render the tradeoff — it never edits them.
+
+---
+
+## Payoff Math Lives in KMP
+
+Strategy ordering, projected payoff dates, interest-saved comparisons, and
+extra-payment simulation are **business logic** and must be shared, not duplicated in
+Compose. The web references already exist —
+[`debt-payoff-engine.ts`](../../apps/web/src/lib/debt-payoff-engine.ts),
+[`extra-payment-sim.ts`](../../apps/web/src/lib/expenses/extra-payment-sim.ts),
+[`debt-interest.ts`](../../apps/web/src/lib/expenses/debt-interest.ts), and
+[`debt-types.ts`](../../apps/web/src/lib/debt-types.ts) — and drive the web
+[`DebtPage.tsx`](../../apps/web/src/pages/DebtPage.tsx). The Android client consumes an
+**equivalent shared model from KMP `packages/core`** so both platforms agree on every
+strategy number.
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages-core (shared - do NOT edit here)"]
+        ENGINE[Strategy engine<br/>avalanche / snowball order<br/>payoff date + interest estimate]
+        EXTRA[Extra-payment simulation<br/>months-sooner + interest-saved]
+        TRADE[Goal tradeoff projection<br/>goal slip vs. payoff speed]
+        FMT[Currency / date / duration formatting]
+    end
+    subgraph Web["apps-web (parity reference)"]
+        WENG[debt-payoff-engine.ts<br/>extra-payment-sim.ts]
+        WPAGE[DebtPage.tsx]
+    end
+    subgraph Android["apps-android (this work)"]
+        VM[StrategyComparisonViewModel<br/>maps shared results to UI state]
+        UI[Compose strategy cards + tradeoff + recommendation]
+    end
+    WENG -.parity.-> ENGINE
+    WPAGE -.parity.-> UI
+    VM --> ENGINE
+    VM --> EXTRA
+    VM --> TRADE
+    VM --> FMT
+    UI --> VM
+```
+
+> This document **describes** the boundary. It does **not** implement KMP changes —
+> `packages/core` is owned by @kmp-engineer and the web engines by @web-engineer.
+> Compose is a pure renderer of shared state. The existing
+> [`Liability`](../../packages/models/src/commonMain/kotlin/com/finance/models/Liability.kt)
+> and
+> [`LiabilityInstallment`](../../packages/models/src/commonMain/kotlin/com/finance/models/LiabilityInstallment.kt)
+> models are the inputs the shared strategy and tradeoff model needs; goal targets
+> arrive from the shared goal models that the wedding and house planners already
+> consume. The ViewModel maps a shared `StrategyComparisonSummary` into immutable UI
+> state — it **never** re-derives a payoff date, interest figure, or goal slip in
+> Kotlin UI code.
+
+---
+
+## Comparison Surface and Entry Points
+
+The comparison is a focused surface reached **from the payoff planner shell**, not a
+new top-level destination. Entry points:
+
+- A **"Compare strategies"** action on the planner shell
+  ([android-joint-debt-payoff-planner.md](android-joint-debt-payoff-planner.md)).
+- A contextual link from a goal that is competing for cash (wedding / down payment),
+  framed as _"See how paying off debt affects this goal."_
+
+```mermaid
+flowchart LR
+    A[Payoff planner shell] -->|Compare strategies| B[Strategy comparison]
+    G[Wedding / house goal] -->|See debt tradeoff| B
+    B --> C[Strategy cards]
+    B --> D[Goal tradeoff view]
+    B --> E[Recommendation mode toggle]
+```
+
+The surface has three regions, each independently focusable: the **strategy cards**
+(default), the **goal tradeoff view**, and the **recommendation mode** toggle. A
+persistent, dismissible estimate banner sits at the top: _"These are estimates based on
+your current balances and payments."_
+
+---
+
+## Strategy Cards: Time, Interest, and Cash Impact
+
+Three cards (or a comparison table at ≥600dp width) present the strategies with
+identical metric rows so they are scannable:
+
+| Metric                  | What it shows                                                      | Tone                              |
+| ----------------------- | ------------------------------------------------------------------ | --------------------------------- |
+| **Time to payoff**      | Estimated debt-free date / months remaining                        | Neutral, "estimated" label inline |
+| **Interest saved**      | Versus a minimum-payment-only baseline (never a negative framing)  | Positive, factual                 |
+| **Monthly cash impact** | Dollars per month the plan asks for (and how it compares to today) | Neutral                           |
+
+- **Avalanche** — highest interest rate first; usually the largest interest saved.
+- **Snowball** — smallest balance first; usually the fastest first "win," labelled as
+  a **motivation** benefit, not a math benefit.
+- **Extra payment** — a what-if on top of either ordering; a small stepper/slider sets
+  the extra amount and the card recomputes (from the **shared** simulation) the
+  months-sooner and interest-saved deltas.
+
+Non-color cues are mandatory: each metric carries an **icon + text label**, and the
+"best on this metric" marker is a labelled badge ("Most interest saved"), never color
+alone — see [data-visualization.md](data-visualization.md) and
+[chart-component-specs.md](chart-component-specs.md).
+
+```mermaid
+flowchart TD
+    subgraph Cards["Strategy cards - same rows, scannable"]
+        AV[Avalanche<br/>time / interest / cash]
+        SN[Snowball<br/>time / interest / cash]
+        EX[Extra payment<br/>+ amount stepper]
+    end
+    AV --> PICK{Choose to apply?}
+    SN --> PICK
+    EX --> PICK
+    PICK -->|optional| APPLY[Hand back to planner shell]
+```
+
+Choosing a strategy does **not** mutate anything here; it hands the selected strategy
+id back to the planner shell, which owns any "make this my plan" action.
+
+---
+
+## Goal Tradeoff View
+
+The tradeoff view answers _"what does this cost my wedding / down payment?"_ For each
+funded goal it shows, per strategy, the **estimated change in the goal's funded date**
+(e.g. "wedding fund reaches target ~2 months later") alongside the debt benefit, so the
+user sees both sides of the same dollar.
+
+- Framing is **strictly neutral**: _"Sending more to debt moves your debt-free date up
+  and your wedding-fund date back by about the same effort."_ No "you're behind," no
+  "sacrifice," no urgency pressure — per
+  [content-language-guidelines.md](content-language-guidelines.md).
+- Both directions are shown: a strategy that frees cash _sooner_ can also _help_ a goal
+  later; the view never implies debt is the only virtuous choice.
+- Every number is an **estimate** and inherits the same inline labelling and a
+  short "How we estimate this" affordance.
+
+```mermaid
+flowchart LR
+    STRAT[Selected strategy] --> DEBT[Debt-free date estimate]
+    STRAT --> WED[Wedding-fund date estimate]
+    STRAT --> HOUSE[Down-payment date estimate]
+    DEBT --> BAL[Balanced, non-guilt summary line]
+    WED --> BAL
+    HOUSE --> BAL
+```
+
+If a household has no wedding or house goal configured, the tradeoff view shows a calm
+empty state (see [offline, empty, and error states](#offline-empty-and-error-states))
+rather than implying they _should_ have one.
+
+---
+
+## Recommendation Mode
+
+For users who do not want to weigh three cards, a **recommendation mode** toggle
+collapses the comparison to a **single suggested strategy** with a one-line rationale
+(e.g. _"Avalanche saves you the most interest based on your current rates — about
+[estimated amount]."_).
+
+- The recommendation is produced by the **shared** engine (a deterministic rule over
+  the same results), not a Compose-side heuristic.
+- It is a **decision aid, not advice**: copy says _"a common choice"_ / _"often saves
+  the most,"_ never _"you should."_ A persistent _"Compare all three"_ affordance keeps
+  the full view one tap away.
+- Snowball is surfaced honestly when its motivational "first win" is soon, with the
+  tradeoff (slightly more interest) stated plainly.
+
+The toggle state is a simple UI preference and is remembered across sessions via the
+existing learning/UX preference mechanism — it carries **no financial data**.
+
+---
+
+## Plain-Language Copy
+
+| Surface              | Plain-language copy                                                                   |
+| -------------------- | ------------------------------------------------------------------------------------- |
+| Estimate banner      | "These are estimates based on your current balances and payments. Real results vary." |
+| Avalanche card       | "Pay the highest-interest debt first. Usually saves the most on interest."            |
+| Snowball card        | "Pay the smallest balance first. You'll get your first win sooner."                   |
+| Extra payment        | "Add a little extra each month and see how much sooner you're debt-free."             |
+| Tradeoff line        | "More to debt now means debt-free sooner and your wedding fund a bit later."          |
+| Recommendation       | "A common choice for your numbers: avalanche. It often saves the most interest."      |
+| No goals empty state | "Add a wedding or down-payment goal to see how a payoff plan affects it."             |
+
+Copy avoids jargon, guilt, and urgency; numbers are always paired with the word
+"estimate" or "about." See [cognitive-accessibility.md](cognitive-accessibility.md) and
+[content-language-guidelines.md](content-language-guidelines.md).
+
+---
+
+## Accessibility Considerations
+
+- **TalkBack:** each strategy card is a single semantic group whose
+  `contentDescription` reads strategy name, then time/interest/cash as a sentence
+  ("Avalanche. Estimated debt-free in about 3 years. Saves about [amount] in interest.
+  Costs about [amount] a month."). The "best on metric" badge is announced as text. The
+  estimate banner is announced before the cards.
+- **Switch Access / keyboard:** linear focus order is banner → strategy cards →
+  extra-payment stepper → tradeoff view → recommendation toggle. Every control is
+  reachable and operable without gestures; the stepper exposes increment/decrement
+  actions, not only a drag.
+- **200% font / large text:** cards reflow from a 3-up row to a stacked single column;
+  the comparison table collapses to per-strategy stacked rows. No text is truncated and
+  no metric is hidden behind ellipsis at 200%.
+- **Touch targets:** all interactive elements ≥ 48dp; stepper buttons have generous
+  spacing to avoid mis-taps.
+- **Non-color encoding:** every comparative cue (best/most/fastest) uses icon + text;
+  charts follow [data-visualization.md](data-visualization.md) for non-color state.
+- **Cognitive load:** recommendation mode is the low-load path; the full comparison
+  never shows more than three metrics per card; one decision per screen.
+- See [accessibility-patterns.md](accessibility-patterns.md) and
+  [cognitive-accessibility.md](cognitive-accessibility.md).
+
+---
+
+## Offline, Empty, and Error States
+
+| State                | Behavior                                                                                                                                                    |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Offline**          | Comparison renders from the last shared payoff snapshot; a quiet "Showing your last figures" note appears. No metric is fabricated.                         |
+| **Empty (no debts)** | "No debts to compare yet" with a link back to the planner to add one — not an error.                                                                        |
+| **Empty (no goals)** | Tradeoff view shows "Add a goal to see the tradeoff"; strategy cards still work standalone.                                                                 |
+| **Single debt**      | Avalanche/snowball are identical; the surface says so plainly and leads with extra-payment.                                                                 |
+| **Stale estimate**   | If inputs changed since the last shared compute, show "Figures may be out of date" with a refresh affordance; never silently show stale numbers as current. |
+| **Compute error**    | Friendly retry ("We couldn't work out the comparison just now"); no raw error, no partial numbers presented as final.                                       |
+
+Errors and empties use plain language and never imply the user did something wrong. No
+balances, amounts, or payoff dates are written to Timber in any state (see
+[Test Plan](#test-plan)).
+
+---
+
+## Test Plan
+
+| Layer              | Tooling                         | What it verifies                                                                                      |
+| ------------------ | ------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Unit               | JUnit                           | ViewModel maps shared `StrategyComparisonSummary` → UI state for avalanche / snowball / extra.        |
+| Unit               | JUnit                           | Extra-payment slider value maps to the shared simulation request; no math is done in the ViewModel.   |
+| Unit               | JUnit                           | Recommendation mode reflects the shared engine's pick; UI never computes its own recommendation.      |
+| Unit (safety)      | JUnit                           | No Timber call logs balances, rates, amounts, payoff dates, or goal targets.                          |
+| Compose UI         | `createComposeRule` + semantics | Strategy cards, metric rows, tradeoff lines, and recommendation resolve `contentDescription`.         |
+| Compose UI         | `createComposeRule`             | Estimate banner is present and announced before metrics; "best on metric" badge is text, not color.   |
+| Compose UI         | `createComposeRule`             | Single-debt and no-goal states render their calm empties without fabricated numbers.                  |
+| Snapshot           | Paparazzi                       | Strategy cards (3-up + stacked), tradeoff view, recommendation mode, empties at {1x, 2x}, light/dark. |
+| Pseudolocalization | `en-XA` / `ar-XB`               | Copy expansion and RTL mirroring for metric labels, tradeoff lines, and the estimate banner.          |
+| Accessibility      | Espresso/Accessibility checks   | TalkBack order, Switch Access reachability, stepper actions, touch targets ≥ 48dp.                    |
+
+---
+
+## Implementation Readiness
+
+This is a design artifact. Execution splits into a **buildable-now** tier and a
+**Play-distribution tail** gated by
+[#1242](https://github.com/jrmoulckers/finance/issues/1242). See
+[../ops/human-gated-prerequisites.md](../ops/human-gated-prerequisites.md) and
+[../ops/launch-readiness-plan.md](../ops/launch-readiness-plan.md).
+
+**Buildable now — `assembleDebug` + sideload (no human gate):**
+
+- Build the comparison surface, strategy cards, extra-payment stepper, goal tradeoff
+  view, and recommendation mode as Compose surfaces rendering a shared
+  `StrategyComparisonSummary` (mock/in-memory results while KMP wiring lands).
+- Verify estimate labelling, non-guilt tradeoff copy, single-debt/no-goal empties,
+  accessibility, and pseudolocale/expansion snapshots on a debug build / emulator.
+- All of this runs on an emulator with **no signing, store credentials, or human-gated
+  operations**.
+
+**Play-distribution tail — human-gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242):**
+
+- Production signing + Play Console listing.
+- Any store-level data-safety declaration touching debt / household financial data.
+- Staged rollout / internal testing track.
+
+The shared strategy, extra-payment, and tradeoff models are delivered by KMP
+`packages/core` (the web `DebtPage` and debt engines are the parity reference); Compose
+stays render-only.
+
+---
+
+## References
+
+**Design docs**
+
+- [android-joint-debt-payoff-planner.md](android-joint-debt-payoff-planner.md) — payoff planner shell + debt ownership (#2656)
+- [android-house-downpayment-planner.md](android-house-downpayment-planner.md) — down-payment goal source
+- [android-wedding-workspace-shell.md](android-wedding-workspace-shell.md) — wedding workspace goal source
+- [android-wedding-actuals-cashflow.md](android-wedding-actuals-cashflow.md) — wedding cashflow context
+- [android-shared-goal-contributors.md](android-shared-goal-contributors.md) — household contribution flow
+- [android-credit-building-education.md](android-credit-building-education.md) — debt/credit education content
+- [content-language-guidelines.md](content-language-guidelines.md) — non-judgmental, plain copy
+- [cognitive-accessibility.md](cognitive-accessibility.md) — plain-language and load reduction
+- [accessibility-patterns.md](accessibility-patterns.md) — screen reader, focus, touch targets
+- [data-visualization.md](data-visualization.md) — non-color comparative cues
+- [chart-component-specs.md](chart-component-specs.md) — comparison visual specs
+- [component-library.md](component-library.md) — card, chip, stepper components
+- [information-architecture.md](information-architecture.md) — surface and navigation map
+- [ux-principles.md](ux-principles.md) — product UX principles
+- [personas.md](personas.md) — household / couples persona
+
+**Ops**
+
+- [../ops/human-gated-prerequisites.md](../ops/human-gated-prerequisites.md) — buildable-now vs. gated split
+- [../ops/launch-readiness-plan.md](../ops/launch-readiness-plan.md) — launch checklist
+
+**Android / web / KMP (read-only boundary)**
+
+- [`DebtPage.tsx`](../../apps/web/src/pages/DebtPage.tsx) — web payoff-planner parity reference (owned by @web-engineer)
+- [`debt-payoff-engine.ts`](../../apps/web/src/lib/debt-payoff-engine.ts) — strategy ordering + payoff math parity
+- [`extra-payment-sim.ts`](../../apps/web/src/lib/expenses/extra-payment-sim.ts) — extra-payment simulation parity
+- [`debt-interest.ts`](../../apps/web/src/lib/expenses/debt-interest.ts) — interest computation parity
+- [`debt-types.ts`](../../apps/web/src/lib/debt-types.ts) — debt classification types
+- [`Liability.kt`](../../packages/models/src/commonMain/kotlin/com/finance/models/Liability.kt) — shared liability model (owned by @kmp-engineer)
+- [`LiabilityInstallment.kt`](../../packages/models/src/commonMain/kotlin/com/finance/models/LiabilityInstallment.kt) — installment schedule model
+- [`PlanningScreen.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/screens/PlanningScreen.kt) — candidate entry-point host
+
+**Issues**
+
+- [#2658](https://github.com/jrmoulckers/finance/issues/2658) — this issue
+- [#2153](https://github.com/jrmoulckers/finance/issues/2153) — parent (joint debt cluster)
+- [#1242](https://github.com/jrmoulckers/finance/issues/1242) — Play Console + keystore (gate)

--- a/docs/design/android-learning-rewards-gamification.md
+++ b/docs/design/android-learning-rewards-gamification.md
@@ -1,0 +1,411 @@
+# Android Learning Rewards Integration with Gamification
+
+> **Status:** PROPOSED — Pending human review
+> **Issue:** [#2669](https://github.com/jrmoulckers/finance/issues/2669) · Part of [#2208](https://github.com/jrmoulckers/finance/issues/2208)
+> **Platform:** Android (Jetpack Compose, Material 3)
+> **Last Updated:** 2026-06-22
+> **Design only:** Native implementation remains blocked by [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+
+---
+
+## Table of Contents
+
+1. [Purpose](#purpose)
+2. [Persona and Why This Matters](#persona-and-why-this-matters)
+3. [Goals and Non-Goals](#goals-and-non-goals)
+4. [Scope Boundaries With Sibling Work](#scope-boundaries-with-sibling-work)
+5. [Reward Rules Live in KMP](#reward-rules-live-in-kmp)
+6. [Reward Entry Points](#reward-entry-points)
+7. ["Pick Up Where You Left Off"](#pick-up-where-you-left-off)
+8. [Earned-Reward Feedback](#earned-reward-feedback)
+9. [Healthy, Non-Manipulative Design](#healthy-non-manipulative-design)
+10. [Plain-Language Copy](#plain-language-copy)
+11. [Accessibility Considerations](#accessibility-considerations)
+12. [Offline, Empty, and Error States](#offline-empty-and-error-states)
+13. [Test Plan](#test-plan)
+14. [Implementation Readiness](#implementation-readiness)
+15. [References](#references)
+
+---
+
+## Purpose
+
+Learning sticks when finishing a lesson, passing a quiz, or returning for a short
+session **feels recognized** — without turning the app into a slot machine. This
+document designs the Android Compose UX that connects **lesson completion, quiz
+mastery, and short-session returns** to the existing gamification system: where reward
+**entry points** live on the learning and achievements surfaces, how
+**"pick up where you left off"** is shown, how **earned-reward feedback** is presented,
+and how all of it stays **healthy and non-manipulative**.
+
+It is **design and breakdown only** while
+[#1242](https://github.com/jrmoulckers/finance/issues/1242) gates Google Play
+distribution. No Kotlin is written here. The reward rules — what a lesson or quiz is
+worth, when an achievement unlocks, how a streak advances — are a **shared concern**
+that builds on the existing `GamificationEngine`; Compose only renders the resulting
+state.
+
+> **Important framing:** rewards here mark **effort and consistency**, not money. They
+> never imply a financial outcome, never pressure a return, and never expose any
+> financial data. Progress shown is the user's own learning activity.
+
+---
+
+## Persona and Why This Matters
+
+The persona ([#2208](https://github.com/jrmoulckers/finance/issues/2208)): someone
+building money confidence in **short sessions** between other commitments. They open
+the app, do one lesson or quiz, and want to feel they made progress — then leave and
+come back later. If the reward loop is manipulative (loss-framed streaks, FOMO timers,
+endless dings) it backfires into stress; if it is invisible, momentum dies. They need
+**gentle, honest recognition** and a frictionless way to resume. This intersects with
+[android-learning-progress-persistence.md](android-learning-progress-persistence.md)
+(the resume + progress source of truth),
+[android-streak-near-win-states.md](android-streak-near-win-states.md) (streak surface),
+and [android-sharesheet-wins-badges.md](android-sharesheet-wins-badges.md) (optional
+sharing of wins).
+
+---
+
+## Goals and Non-Goals
+
+**Goals**
+
+- Define **reward entry points** from the **learning screens** (lesson/quiz completion)
+  and the **achievements area**, so earning and viewing rewards are coherent.
+- Provide **"pick up where you left off"** — a resume affordance backed by the existing
+  learning progress state — plus clear **earned-reward feedback** when XP, an
+  achievement, or a streak advances.
+- Keep rewards **non-manipulative**: focused on healthy learning behavior, never
+  exploitative loops, never guilt, never dark patterns.
+- Build on the existing **`GamificationEngine` patterns** and future shared
+  learning-reward events; render only shared state in Compose.
+- Be fully accessible (TalkBack, Switch Access, 200% font, plain language) and define
+  offline/empty/error states.
+
+**Non-Goals**
+
+- Implementing the reward economy, achievement evaluation, or streak transitions — that
+  is the shared `GamificationEngine` / `packages/core` (owned by @kmp-engineer), with
+  the web gamification + wellness libraries as parity.
+- Owning **streak near-win visuals** — those belong to
+  [android-streak-near-win-states.md](android-streak-near-win-states.md); this doc
+  links to them and reuses their state.
+- Owning **learning progress persistence / resume storage** — owned by
+  [android-learning-progress-persistence.md](android-learning-progress-persistence.md);
+  this doc consumes its resume pointer.
+- Owning the **share-card** flow — owned by
+  [android-sharesheet-wins-badges.md](android-sharesheet-wins-badges.md).
+- Editing KMP `packages/*`, web, or any non-Android platform.
+
+---
+
+## Scope Boundaries With Sibling Work
+
+```mermaid
+flowchart TD
+    THIS[Issue 2669: Learning rewards integration<br/>THIS DOC: entry points, resume, earned feedback]
+    PROG[Learning progress persistence<br/>resume pointer + completion source]
+    STREAK[Streak near-win states<br/>streak surface + rules]
+    SHARE[Sharesheet wins and badges<br/>optional sharing]
+    KMP[KMP packages-core<br/>GamificationEngine + reward events]
+
+    THIS -->|reads resume + completion from| PROG
+    THIS -->|renders streak state from| STREAK
+    THIS -->|hands off a win to| SHARE
+    THIS -->|renders profile + rewards from| KMP
+```
+
+This doc owns the **integration UX** — connecting learning moments to reward feedback
+and resume. The progress persistence doc owns _where_ completion and the resume pointer
+live; the streak doc owns streak rules and near-win visuals; the sharesheet doc owns
+sharing. All reward math is the shared engine.
+
+---
+
+## Reward Rules Live in KMP
+
+What a lesson is worth, when an achievement unlocks, and how a streak advances are
+**business rules** that already live in the shared engine and must not be duplicated in
+Compose. The Kotlin source of truth is
+[`GamificationEngine`](../../packages/core/src/commonMain/kotlin/com/finance/core/gamification/GamificationEngine.kt)
+over the types in
+[`GamificationTypes.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/gamification/GamificationTypes.kt)
+(`AchievementDefinition`, `AchievementProgress`, `Streak`, `GamificationProfile`). The
+web parity for the _learning-reward_ mapping is
+[`learning-progress-rewards.ts`](../../apps/web/src/lib/wellness/learning-progress-rewards.ts)
+and
+[`achievements-engine.ts`](../../apps/web/src/components/gamification/achievements-engine.ts),
+driving [`AchievementsPage.tsx`](../../apps/web/src/pages/AchievementsPage.tsx) and
+[`LearningPage.tsx`](../../apps/web/src/pages/LearningPage.tsx).
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages-core (shared - do NOT edit here)"]
+        EVENT[Learning reward events<br/>lesson done / quiz mastered / session return]
+        ENGINE[GamificationEngine<br/>buildProfile / updateStreak]
+        PROFILE[GamificationProfile<br/>points / achievements / streaks]
+    end
+    subgraph Android["apps-android (this work)"]
+        VM[LearningRewardsViewModel<br/>maps profile + resume to UI state]
+        UI[Compose entry points + resume + earned feedback]
+    end
+    EVENT --> ENGINE
+    ENGINE --> PROFILE
+    PROFILE --> VM
+    VM --> UI
+```
+
+> This document **describes** the boundary. It does **not** implement KMP changes —
+> `GamificationEngine` and the reward events are owned by @kmp-engineer; the web
+> gamification/wellness libraries by @web-engineer. The Android
+> [`GamificationViewModel`](../../apps/android/src/main/kotlin/com/finance/android/ui/gamification/GamificationViewModel.kt)
+> and
+> [`LearningPathViewModel`](../../apps/android/src/main/kotlin/com/finance/android/ui/learning/LearningPathViewModel.kt)
+> already expose immutable state; this work maps a shared profile + resume pointer into
+> UI state. Compose **never** awards XP, evaluates an achievement, or advances a streak
+> on its own — it renders what the shared engine produced. Today
+> `GamificationViewModel` and the learning resume are wired through these seams, which
+> this design reuses rather than re-implements.
+
+---
+
+## Reward Entry Points
+
+Rewards appear at the **moments they are earned** and in **one place to review them**,
+so the loop is coherent and never nags:
+
+```mermaid
+flowchart LR
+    L1[Lesson complete] --> FB[Earned-reward feedback]
+    L2[Quiz mastered] --> FB
+    L3[Short-session return] --> FB
+    FB --> ACH[Achievements area: full reward history]
+    HOME[Learning home] --> RESUME[Pick up where you left off]
+    RESUME --> L1
+```
+
+- **From learning screens** — at the end of a lesson or quiz, an inline, dismissible
+  feedback surface (not a blocking modal) acknowledges the win and shows any XP /
+  achievement / streak change. It never auto-launches the next lesson.
+- **From the achievements area** — the durable home for reviewing earned rewards,
+  achievement progress, and active streaks (reusing the existing gamification screen),
+  reachable any time, with no pressure to act.
+- **From learning home** — the **resume** affordance (next section), so returning users
+  land directly on momentum.
+
+Entry points are **pull, not push**: the app does not interrupt unrelated screens with
+reward popovers, and there is no persistent badge nag count.
+
+---
+
+## "Pick Up Where You Left Off"
+
+The resume affordance is a single, calm card on the learning home that reads the
+**resume pointer** owned by
+[android-learning-progress-persistence.md](android-learning-progress-persistence.md) and
+offers a one-tap continue.
+
+- Shows the **lesson/path title** and a quiet progress indicator ("Lesson 3 of 6"),
+  derived from shared progress state — never a guilt line about time away.
+- If nothing is in progress, it becomes a gentle **"Start something new"** suggestion
+  (see [empty states](#offline-empty-and-error-states)), not an empty void.
+- Resume is **stateless to this surface**: it carries the pointer to the learning path
+  surface and does not itself mutate progress.
+
+```mermaid
+flowchart LR
+    PTR[Resume pointer<br/>from progress persistence] --> CARD[Pick up where you left off card]
+    CARD -->|tap continue| PATH[Learning path surface]
+    PTR -. none .-> NEW[Start something new suggestion]
+```
+
+---
+
+## Earned-Reward Feedback
+
+When the shared engine reports a change, the UI gives **proportional, honest**
+feedback:
+
+| Trigger              | Feedback                                                                   | Restraint                              |
+| -------------------- | -------------------------------------------------------------------------- | -------------------------------------- |
+| Lesson completed     | Inline "Lesson complete" with any XP delta                                 | One acknowledgement, dismissible       |
+| Quiz mastered        | "You've got this" with mastery + any achievement unlock                    | Celebrate mastery, not just attempts   |
+| Achievement unlocked | A labelled badge appears in feedback and persists in the achievements area | No confetti spam, single announcement  |
+| Streak advanced      | Reuses [streak near-win states](android-streak-near-win-states.md) visuals | No loss-framing, no countdown pressure |
+
+- Animations are **brief and reduced-motion aware** (honor the system setting via
+  [animation-library.md](animation-library.md)); a static, equivalent state always
+  exists.
+- Feedback is **announced once** to assistive tech (polite live region) — never a
+  repeating chime.
+- No numeric "you’ll lose your streak" threats and no time-pressure timers anywhere in
+  the feedback.
+
+---
+
+## Healthy, Non-Manipulative Design
+
+This is a guardrail section, not decoration:
+
+- **No dark patterns:** no FOMO countdowns, no loss-framed streak warnings, no
+  variable-ratio "surprise" reward gambling, no artificial scarcity, no nagging push to
+  return.
+- **Effort over addiction:** rewards recognize **completion and mastery**, not raw time
+  in app or session count for its own sake. Short, complete sessions are celebrated as
+  much as long ones.
+- **Always opt-out-able:** a setting can quiet reward animations/sounds entirely while
+  preserving the learning content and the resume affordance.
+- **Truthful:** XP and achievements are clearly **learning markers**, never implying a
+  monetary reward or a financial result.
+- **Privacy:** reward state is the user's own activity; nothing here logs or shares
+  financial data. If a minor uses learning content, the same minors-privacy posture as
+  the teen surfaces applies — no behavioral profiling, no external sharing by default
+  (see [android-teen-beginner-mode.md](android-teen-beginner-mode.md)).
+
+---
+
+## Plain-Language Copy
+
+| Surface               | Plain-language copy                                                 |
+| --------------------- | ------------------------------------------------------------------- |
+| Resume card           | "Pick up where you left off — Lesson 3 of 6."                       |
+| Resume (empty)        | "Ready to learn something new? Here's a good place to start."       |
+| Lesson complete       | "Lesson complete. Nice work."                                       |
+| Quiz mastered         | "You've got this — quiz mastered."                                  |
+| Achievement unlocked  | "New badge: [name]. You earned it by [how]."                        |
+| Streak advanced       | "That's [n] sessions in a row. No pressure to keep it going."       |
+| Quiet-rewards setting | "Turn off reward animations and sounds. Your progress still saves." |
+
+Copy avoids urgency, guilt, and money implications. See
+[cognitive-accessibility.md](cognitive-accessibility.md) and
+[content-language-guidelines.md](content-language-guidelines.md).
+
+---
+
+## Accessibility Considerations
+
+- **TalkBack:** the resume card announces title + progress as one phrase ("Pick up
+  where you left off. Lesson 3 of 6. Double-tap to continue."). Earned-reward feedback
+  is a **polite live region** announced exactly once; badges expose a text
+  `contentDescription` ("New badge: Consistent Learner").
+- **Switch Access / keyboard:** focus order is resume card → earned-reward feedback (if
+  present) → dismiss → achievements entry. Every reward control is reachable without
+  gestures; nothing is dismiss-by-timeout only — a visible control always exists.
+- **200% font / large text:** the resume card and feedback reflow and never truncate
+  titles or badge names; badge rows stack instead of clipping.
+- **Reduced motion:** all celebration animation respects the system reduced-motion
+  setting and degrades to a static state with identical information.
+- **Touch targets:** continue, dismiss, and achievement entry are ≥ 48dp.
+- **Cognitive load:** one acknowledgement per moment; no stacked popups; the durable
+  review lives in the achievements area so feedback can stay light.
+- See [accessibility-patterns.md](accessibility-patterns.md) and
+  [cognitive-accessibility.md](cognitive-accessibility.md).
+
+---
+
+## Offline, Empty, and Error States
+
+| State                      | Behavior                                                                                                                                                            |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Offline**                | Lessons, resume, and locally-computed reward feedback all work; the shared profile renders from the last snapshot. Nothing waits on a network.                      |
+| **Empty (new user)**       | No resume pointer → "Start something new" suggestion; achievements area shows "Your badges will appear here as you learn," not a barren grid.                       |
+| **Empty (no rewards yet)** | Feedback still acknowledges completion warmly even before any badge exists.                                                                                         |
+| **Reward compute lag**     | If the shared profile hasn't refreshed, show the completion acknowledgement immediately and reconcile the badge/streak when state arrives — never block the lesson. |
+| **Error**                  | If the profile can't load, the lesson and resume still work; the rewards strip shows a quiet "Rewards will update shortly," never a blocking error.                 |
+
+No reward state shows fabricated numbers, and **no financial data and no learning PII
+are written to Timber** in any state (see [Test Plan](#test-plan)).
+
+---
+
+## Test Plan
+
+| Layer              | Tooling                         | What it verifies                                                                                           |
+| ------------------ | ------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Unit               | JUnit                           | ViewModel maps shared `GamificationProfile` + resume pointer → UI state; no reward math in the VM.         |
+| Unit               | JUnit                           | A lesson/quiz completion event is forwarded to the shared engine; UI never awards XP itself.               |
+| Unit (healthy)     | JUnit                           | No loss-framed streak copy, countdown timer, or push-to-return is emitted by the reward state.             |
+| Unit (safety)      | JUnit                           | No Timber call logs financial data or learning PII; minors-privacy posture honored.                        |
+| Compose UI         | `createComposeRule` + semantics | Resume card, earned-reward feedback, and badges resolve `contentDescription`; live region announces once.  |
+| Compose UI         | `createComposeRule`             | Reduced-motion setting collapses celebration animation to a static, equivalent state.                      |
+| Compose UI         | `createComposeRule`             | Empty (new user) and no-rewards states render their warm copy without fabricated numbers.                  |
+| Snapshot           | Paparazzi                       | Resume card, completion feedback, achievement-unlock, streak-advance, and empties at {1x, 2x}, light/dark. |
+| Pseudolocalization | `en-XA` / `ar-XB`               | Copy expansion and RTL mirroring for resume, feedback, and badge names.                                    |
+| Accessibility      | Espresso/Accessibility checks   | TalkBack order, single-announcement live region, Switch Access reachability, touch targets ≥ 48dp.         |
+
+---
+
+## Implementation Readiness
+
+This is a design artifact. Execution splits into a **buildable-now** tier and a
+**Play-distribution tail** gated by
+[#1242](https://github.com/jrmoulckers/finance/issues/1242). See
+[../ops/human-gated-prerequisites.md](../ops/human-gated-prerequisites.md) and
+[../ops/launch-readiness-plan.md](../ops/launch-readiness-plan.md).
+
+**Buildable now — `assembleDebug` + sideload (no human gate):**
+
+- Build the reward entry points, "pick up where you left off" card, and earned-reward
+  feedback as Compose surfaces rendering a shared `GamificationProfile` + resume pointer
+  (mock/in-memory while shared reward events and KMP wiring land).
+- Verify healthy-design guardrails, reduced-motion fallback, empties, accessibility, and
+  pseudolocale/expansion snapshots on a debug build / emulator.
+- All of this runs on an emulator with **no signing, store credentials, or human-gated
+  operations**.
+
+**Play-distribution tail — human-gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242):**
+
+- Production signing + Play Console listing.
+- Any store-level data-safety / families-policy declaration if learning content is used
+  by minors.
+- Staged rollout / internal testing track.
+
+The reward rules and learning-reward events are delivered by the shared
+`GamificationEngine` in KMP `packages/core` (the web gamification + wellness libraries
+are the parity reference); Compose stays render-only.
+
+---
+
+## References
+
+**Design docs**
+
+- [android-learning-progress-persistence.md](android-learning-progress-persistence.md) — resume pointer + completion source
+- [android-streak-near-win-states.md](android-streak-near-win-states.md) — streak surface + near-win visuals (#2688)
+- [android-sharesheet-wins-badges.md](android-sharesheet-wins-badges.md) — optional win sharing
+- [android-teen-beginner-mode.md](android-teen-beginner-mode.md) — minors-privacy posture for learning
+- [android-credit-building-education.md](android-credit-building-education.md) — learning content context
+- [android-newcomer-us-finance-education.md](android-newcomer-us-finance-education.md) — adjacent learning content
+- [content-language-guidelines.md](content-language-guidelines.md) — non-manipulative, plain copy
+- [cognitive-accessibility.md](cognitive-accessibility.md) — plain-language and load reduction
+- [accessibility-patterns.md](accessibility-patterns.md) — screen reader, focus, live regions
+- [animation-library.md](animation-library.md) — reduced-motion and celebration motion
+- [component-library.md](component-library.md) — card, badge, chip components
+- [information-architecture.md](information-architecture.md) — surface and navigation map
+- [ux-principles.md](ux-principles.md) — product UX principles
+- [personas.md](personas.md) — learner persona
+
+**Ops**
+
+- [../ops/human-gated-prerequisites.md](../ops/human-gated-prerequisites.md) — buildable-now vs. gated split
+- [../ops/launch-readiness-plan.md](../ops/launch-readiness-plan.md) — launch checklist
+
+**Android / web / KMP (read-only boundary)**
+
+- [`GamificationEngine.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/gamification/GamificationEngine.kt) — shared reward rules (owned by @kmp-engineer)
+- [`GamificationTypes.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/gamification/GamificationTypes.kt) — achievement / streak / profile types
+- [`GamificationViewModel.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/gamification/GamificationViewModel.kt) — existing gamification state seam
+- [`GamificationScreen.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/gamification/GamificationScreen.kt) — achievements area host
+- [`LearningPathViewModel.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/learning/LearningPathViewModel.kt) — learning state seam
+- [`LearningPathContent.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/learning/LearningPathContent.kt) — lesson/path content model
+- [`learning-progress-rewards.ts`](../../apps/web/src/lib/wellness/learning-progress-rewards.ts) — learning-reward mapping parity (owned by @web-engineer)
+- [`achievements-engine.ts`](../../apps/web/src/components/gamification/achievements-engine.ts) — achievement evaluation parity
+- [`AchievementsPage.tsx`](../../apps/web/src/pages/AchievementsPage.tsx) — achievements surface parity
+- [`LearningPage.tsx`](../../apps/web/src/pages/LearningPage.tsx) — learning surface parity
+
+**Issues**
+
+- [#2669](https://github.com/jrmoulckers/finance/issues/2669) — this issue
+- [#2208](https://github.com/jrmoulckers/finance/issues/2208) — parent (learning rewards cluster)
+- [#1242](https://github.com/jrmoulckers/finance/issues/1242) — Play Console + keystore (gate)

--- a/docs/design/android-teen-curriculum-ordering.md
+++ b/docs/design/android-teen-curriculum-ordering.md
@@ -1,0 +1,400 @@
+# Android Teen Curriculum Ordering & Advanced-Topic Gating
+
+> **Status:** PROPOSED — Pending human review
+> **Issue:** [#2678](https://github.com/jrmoulckers/finance/issues/2678) · Part of [#2209](https://github.com/jrmoulckers/finance/issues/2209)
+> **Platform:** Android (Jetpack Compose, Material 3)
+> **Last Updated:** 2026-06-22
+> **Design only:** Native implementation remains blocked by [#1242](https://github.com/jrmoulckers/finance/issues/1242)
+
+---
+
+## Table of Contents
+
+1. [Purpose](#purpose)
+2. [Persona and Why This Matters](#persona-and-why-this-matters)
+3. [Goals and Non-Goals](#goals-and-non-goals)
+4. [Scope Boundaries With Sibling Work](#scope-boundaries-with-sibling-work)
+5. [Curriculum Ordering Lives in KMP](#curriculum-ordering-lives-in-kmp)
+6. [Teen-First Topic Order](#teen-first-topic-order)
+7. [Advanced-Topic Gating](#advanced-topic-gating)
+8. [Teen-Relevant Examples and Empty States](#teen-relevant-examples-and-empty-states)
+9. [Privacy-First for Minors](#privacy-first-for-minors)
+10. [Plain-Language Copy](#plain-language-copy)
+11. [Accessibility Considerations](#accessibility-considerations)
+12. [Offline, Empty, and Error States](#offline-empty-and-error-states)
+13. [Test Plan](#test-plan)
+14. [Implementation Readiness](#implementation-readiness)
+15. [References](#references)
+
+---
+
+## Purpose
+
+A teen with a **first job** does not need a retirement-account comparison on day one —
+they need to understand their **paycheck**, their **debit card**, why an **impulse buy**
+stings, how to **save for a car**, and the difference between **needs and wants**. This
+document designs how the Android learning catalog **orders** those teen-first topics and
+**gates** advanced paths (investing, retirement, tax) behind an explicit opt-in or tier
+advancement — so the experience feels like _their_ money, not adult homework.
+
+It is **design and breakdown only** while
+[#1242](https://github.com/jrmoulckers/finance/issues/1242) gates Google Play
+distribution. No Kotlin is written here. **Ordering and gating decisions are a shared
+curriculum concern** — Compose only renders the chosen path list it is handed; it never
+decides ordering or unlock rules itself.
+
+> **Important framing:** topic ordering and gating are **curriculum rules owned by the
+> shared layer**. The Android client is a renderer. Teen content uses **plain language**
+> and a **privacy-first posture for minors** throughout.
+
+---
+
+## Persona and Why This Matters
+
+The persona ([#2209](https://github.com/jrmoulckers/finance/issues/2209)): a teen
+earning their **first paycheck**, often with a parent nearby. Their money life is
+concrete and near-term — a paycheck, a debit card, a car they are saving for, the candy
+aisle. Investing, retirement, and taxes are real but **distant and abstract**, and
+leading with them reads as boring or intimidating. Showing the right topics in the right
+order, and quietly deferring the complex ones, is what keeps a teen engaged. This
+intersects with [android-teen-beginner-mode.md](android-teen-beginner-mode.md) (the
+plain-language beginner posture), [android-teen-goal-projections.md](android-teen-goal-projections.md)
+(saving for a car / "save X per week"), and the persistence/resume foundation in
+[android-learning-progress-persistence.md](android-learning-progress-persistence.md).
+
+---
+
+## Goals and Non-Goals
+
+**Goals**
+
+- **Prioritize** teen-first topics in the catalog: **paycheck, debit card, impulse
+  spending, saving for a car, and needs vs. wants**.
+- **Collapse or hide** investing, retirement, and tax paths until the user **opts in**
+  or **advances a tier** — never dead-ends, always a respectful "more when you're ready."
+- Add **teen-relevant examples** and **empty states** that read like a teen's life, not
+  adult homework.
+- Render only the **shared, chosen path list** from KMP curriculum gating; keep ordering
+  and unlock rules out of Compose.
+- Be fully accessible (TalkBack, Switch Access, 200% font, plain language) and define
+  offline/empty/error states.
+- Hold a **privacy-first posture for minors** across every surface.
+
+**Non-Goals**
+
+- Implementing the curriculum ordering/gating engine — that is shared `packages/`
+  curriculum logic (owned by @kmp-engineer), with the web learning libraries as parity.
+- Owning the **beginner-mode preference** or its copy transforms — owned by
+  [android-teen-beginner-mode.md](android-teen-beginner-mode.md); this doc consumes it.
+- Owning **goal projections** (save-for-a-car math) — owned by
+  [android-teen-goal-projections.md](android-teen-goal-projections.md).
+- Owning **progress persistence / resume** — owned by
+  [android-learning-progress-persistence.md](android-learning-progress-persistence.md).
+- Defining parental-control account mechanics or any KYC for minors.
+- Editing KMP `packages/*`, web, or any non-Android platform.
+
+---
+
+## Scope Boundaries With Sibling Work
+
+```mermaid
+flowchart TD
+    THIS[Issue 2678: Teen curriculum ordering + gating<br/>THIS DOC: renders chosen path list, gating UI]
+    BEGIN[Teen beginner mode<br/>plain-language preference + copy]
+    GOALS[Teen goal projections<br/>save-for-a-car math]
+    PROG[Learning progress persistence<br/>resume + completion]
+    KMP[KMP packages curriculum<br/>ordering + unlock decisions]
+
+    KMP -->|hands chosen path list to| THIS
+    THIS -->|inherits plain language from| BEGIN
+    THIS -->|links car goal to| GOALS
+    THIS -->|reads progress from| PROG
+```
+
+This doc owns **how the chosen catalog is presented and how gating reads** to a teen.
+The shared curriculum layer owns _which_ topics come in _what_ order and _when_ advanced
+paths unlock. Beginner mode owns language; goal projections own the car-saving math;
+persistence owns progress.
+
+---
+
+## Curriculum Ordering Lives in KMP
+
+Topic priority and advanced-topic unlock rules are **business logic** and must be
+shared, not hard-coded in Compose. The web parity already exists —
+[`curriculum.ts`](../../apps/web/src/lib/learning/curriculum.ts),
+[`adaptive.ts`](../../apps/web/src/lib/learning/adaptive.ts),
+[`types.ts`](../../apps/web/src/lib/learning/types.ts), and the teen-specific
+[`teen-learning-local.ts`](../../apps/web/src/lib/household/teen-learning-local.ts) —
+driving [`LearningPage.tsx`](../../apps/web/src/pages/LearningPage.tsx). The Android
+client consumes an **equivalent shared curriculum model** so both platforms agree on the
+ordered, gated path list.
+
+```mermaid
+flowchart LR
+    subgraph KMP["packages curriculum (shared - do NOT edit here)"]
+        ORDER[Topic ordering rules<br/>teen-first priority]
+        GATE[Advanced-topic gating<br/>opt-in / tier unlock]
+        ADAPT[Adaptive sequencing<br/>next recommended topic]
+    end
+    subgraph Web["apps-web (parity reference)"]
+        WCURR[curriculum.ts / adaptive.ts<br/>teen-learning-local.ts]
+        WPAGE[LearningPage.tsx]
+    end
+    subgraph Android["apps-android (this work)"]
+        VM[TeenCurriculumViewModel<br/>maps chosen path list to UI state]
+        UI[Compose ordered list + gating affordances]
+    end
+    WCURR -.parity.-> ORDER
+    WPAGE -.parity.-> UI
+    ORDER --> VM
+    GATE --> VM
+    ADAPT --> VM
+    VM --> UI
+```
+
+> This document **describes** the boundary. It does **not** implement curriculum
+> changes — ordering/gating logic is owned by @kmp-engineer and the web learning
+> libraries by @web-engineer. **Compose only renders the chosen path list**; it never
+> sorts topics, decides what is "advanced," or evaluates an unlock condition. The
+> existing
+> [`LearningPathViewModel`](../../apps/android/src/main/kotlin/com/finance/android/ui/learning/LearningPathViewModel.kt)
+> and
+> [`LearningPathContent`](../../apps/android/src/main/kotlin/com/finance/android/ui/learning/LearningPathContent.kt)
+> are the seams this design reuses; the ViewModel maps a shared
+> `TeenCurriculumPlan` (ordered topics + gating flags) into immutable UI state.
+
+---
+
+## Teen-First Topic Order
+
+The catalog leads with concrete, near-term topics. Ordering is **supplied by the shared
+layer**; the table below documents the _intended_ teen-first priority the renderer
+displays:
+
+| Order | Topic                | Why it leads                                             |
+| ----- | -------------------- | -------------------------------------------------------- |
+| 1     | **Your paycheck**    | The first real money event; gross vs. take-home.         |
+| 2     | **Your debit card**  | How spending actually happens day to day.                |
+| 3     | **Impulse spending** | The candy-aisle moment; pause-before-buy.                |
+| 4     | **Saving for a car** | A concrete, motivating goal (links to goal projections). |
+| 5     | **Needs vs. wants**  | The framework that ties the others together.             |
+
+- The list presents as a clear, **single-column** path with a visible "next" item, not a
+  sprawling grid.
+- Each item shows a short, plain title and a one-line "what you'll learn," never a wall
+  of text.
+- The **adaptive next topic** comes from the shared layer; the UI highlights it as a
+  gentle suggestion, never a forced sequence.
+
+---
+
+## Advanced-Topic Gating
+
+Investing, retirement, and tax paths are **collapsed or hidden** until the teen opts in
+or advances a tier. Gating is a **respectful door, not a wall**:
+
+```mermaid
+flowchart TD
+    BASE[Teen-first topics: visible, ordered] --> READY{Opt-in or tier advanced?}
+    READY -->|No| HINT[Collapsed: More topics when you're ready]
+    READY -->|Yes| ADV[Investing / Retirement / Taxes revealed]
+    HINT -->|tap to learn more| EXPLAIN[Plain explanation + opt-in]
+    EXPLAIN --> ADV
+```
+
+- **Default:** advanced paths are collapsed under a calm, optional affordance — e.g.
+  _"More topics, like investing and taxes, unlock as you go."_ Nothing flashes "locked"
+  in a punitive way; there are **no countdowns and no FOMO**.
+- **Opt-in:** a teen (or parent, per household setup) can choose to reveal an advanced
+  path early; the copy explains in one plain line what it covers before revealing it.
+- **Tier advancement:** completing the teen-first path can unlock advanced topics
+  automatically, surfaced as an encouraging _"You've unlocked more"_ — recognition, not
+  pressure.
+- The **decision of what is gated and when** is the shared layer's; the UI only renders
+  the resulting visible/collapsed/unlocked state. The renderer never hides or reveals a
+  topic on its own.
+
+---
+
+## Teen-Relevant Examples and Empty States
+
+Examples and empties are written for a teen's life, deliberately **not** adult homework:
+
+- **Examples:** a paycheck from a part-time shift, a $40 impulse buy, saving $15/week
+  toward a used car, choosing between a want (new game) and a need (phone bill). Dollar
+  amounts are small and realistic; no mortgages, no 401(k) match math.
+- **Empty states:** instead of "No data," surfaces say things like _"Nothing here yet —
+  start with your paycheck"_ or _"Add what you're saving for and we'll cheer you on."_
+- **Tone:** encouraging, curious, never schoolish; aligns with
+  [android-teen-beginner-mode.md](android-teen-beginner-mode.md) and
+  [content-language-guidelines.md](content-language-guidelines.md).
+
+---
+
+## Privacy-First for Minors
+
+Because the audience includes minors, privacy is a first-class constraint, not a
+footnote:
+
+- **No behavioral profiling or ad targeting** of teens; learning activity is used only to
+  sequence their own next topic.
+- **Local-first:** progress and any teen-relevant examples stay on-device through the
+  existing learning persistence; nothing about a minor's learning is shared externally by
+  default (mirrors [android-teen-beginner-mode.md](android-teen-beginner-mode.md) and the
+  household privacy posture).
+- **No data exhaust in logs:** Timber never records a minor's amounts, goal targets, or
+  topic-level behavior. Reward/streak hooks (if reused from
+  [android-learning-rewards-gamification.md](android-learning-rewards-gamification.md))
+  inherit the same minors posture.
+- **Plain consent:** revealing advanced paths early is an explicit, understandable choice
+  — never a silent toggle and never a default-on for minors.
+- Any store-level **families-policy / data-safety** declaration is part of the
+  Play-distribution tail, not buildable-now (see
+  [Implementation Readiness](#implementation-readiness)).
+
+---
+
+## Plain-Language Copy
+
+| Surface             | Plain-language copy                                        |
+| ------------------- | ---------------------------------------------------------- |
+| Path intro          | "Let's start with the money stuff you'll use right away."  |
+| Next-topic hint     | "Up next: your debit card."                                |
+| Advanced collapsed  | "More topics, like investing and taxes, unlock as you go." |
+| Advanced opt-in     | "Want to peek at investing? Here's what it covers."        |
+| Tier unlocked       | "Nice — you've unlocked more topics."                      |
+| Empty (no progress) | "Nothing here yet — start with your paycheck."             |
+| Empty (no car goal) | "Saving for something? Add it and we'll cheer you on."     |
+
+Copy is short, concrete, jargon-free, and never schoolish or guilt-laden. See
+[cognitive-accessibility.md](cognitive-accessibility.md),
+[android-spanish-education-formatting.md](android-spanish-education-formatting.md), and
+[content-language-guidelines.md](content-language-guidelines.md).
+
+---
+
+## Accessibility Considerations
+
+- **TalkBack:** the path reads as an ordered list with position ("Topic 1 of 5: Your
+  paycheck. What you'll learn: …"). The collapsed-advanced affordance announces its state
+  ("Collapsed. More topics unlock as you go. Double-tap to learn more."), never just
+  "locked."
+- **Switch Access / keyboard:** linear focus order follows the visible teen-first order,
+  then the advanced affordance; every reveal/opt-in control is operable without gestures.
+- **200% font / large text:** single-column list reflows cleanly; titles and "what you'll
+  learn" lines wrap without truncation; the advanced section expands without clipping.
+- **Touch targets:** topic rows, the next-topic hint, and the advanced affordance are
+  ≥ 48dp.
+- **Cognitive load:** one clear path, one highlighted next step, advanced complexity kept
+  out of sight until chosen — the lowest-load presentation by design.
+- **Non-color cues:** "unlocked" / "collapsed" use icon + text, never color alone.
+- See [accessibility-patterns.md](accessibility-patterns.md) and
+  [cognitive-accessibility.md](cognitive-accessibility.md).
+
+---
+
+## Offline, Empty, and Error States
+
+| State                     | Behavior                                                                                                                                          |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Offline**               | The full teen-first path and any unlocked advanced topics render from the last shared curriculum snapshot; learning works with no network.        |
+| **Empty (new teen)**      | No progress → "Start with your paycheck" suggestion; never a blank "No data" screen.                                                              |
+| **Empty (no car goal)**   | The save-for-a-car topic invites adding a goal (handing off to teen goal projections), not an error.                                              |
+| **Gating not yet loaded** | Until the shared plan arrives, show the teen-first topics and keep advanced collapsed — never reveal advanced topics by guessing.                 |
+| **Error**                 | If the curriculum plan can't load, show the teen-first defaults read-only with a quiet "More topics will appear shortly," never a blocking error. |
+
+Empties and errors use plain, encouraging language and never read as failure. **No
+minor's amounts, goals, or topic behavior are written to Timber** in any state (see
+[Test Plan](#test-plan)).
+
+---
+
+## Test Plan
+
+| Layer              | Tooling                         | What it verifies                                                                                        |
+| ------------------ | ------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Unit               | JUnit                           | ViewModel maps a shared `TeenCurriculumPlan` → ordered UI state; the UI never re-sorts topics.          |
+| Unit               | JUnit                           | Advanced topics stay collapsed until the shared plan flags opt-in / tier unlock; UI never gates itself. |
+| Unit (privacy)     | JUnit                           | No minor learning PII (amounts, goals, topic behavior) is logged or shared by default.                  |
+| Unit (safety)      | JUnit                           | No Timber call logs a minor's amounts, goal targets, or behavioral detail.                              |
+| Compose UI         | `createComposeRule` + semantics | Ordered path rows, next-topic hint, and collapsed/unlocked affordances resolve `contentDescription`.    |
+| Compose UI         | `createComposeRule`             | Collapsed-advanced affordance announces state (not just "locked") and reveals only on opt-in.           |
+| Compose UI         | `createComposeRule`             | Teen empty states render encouraging copy, not "No data."                                               |
+| Snapshot           | Paparazzi                       | Teen-first path, collapsed advanced, unlocked advanced, and empties at {1x, 2x}, light/dark.            |
+| Pseudolocalization | `en-XA` / `ar-XB`               | Copy expansion and RTL mirroring for topic titles, hints, and gating copy (with Spanish formatting).    |
+| Accessibility      | Espresso/Accessibility checks   | TalkBack list order/position, Switch Access reachability, touch targets ≥ 48dp.                         |
+
+---
+
+## Implementation Readiness
+
+This is a design artifact. Execution splits into a **buildable-now** tier and a
+**Play-distribution tail** gated by
+[#1242](https://github.com/jrmoulckers/finance/issues/1242). See
+[../ops/human-gated-prerequisites.md](../ops/human-gated-prerequisites.md) and
+[../ops/launch-readiness-plan.md](../ops/launch-readiness-plan.md).
+
+**Buildable now — `assembleDebug` + sideload (no human gate):**
+
+- Build the ordered teen-first path, the next-topic hint, the collapsed/opt-in/tier
+  advanced-topic affordances, and teen-relevant examples/empties as Compose surfaces
+  rendering a shared `TeenCurriculumPlan` (mock/in-memory while shared curriculum gating
+  and KMP wiring land).
+- Verify ordering display, gating presentation, minors-privacy posture, accessibility,
+  and pseudolocale/expansion snapshots on a debug build / emulator.
+- All of this runs on an emulator with **no signing, store credentials, or human-gated
+  operations**.
+
+**Play-distribution tail — human-gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242):**
+
+- Production signing + Play Console listing.
+- Any store-level **families-policy / data-safety** declaration for an experience used by
+  minors.
+- Staged rollout / internal testing track.
+
+Curriculum ordering and advanced-topic gating are delivered by the shared curriculum
+layer in KMP `packages/` (the web learning libraries are the parity reference); Compose
+only renders the chosen path list.
+
+---
+
+## References
+
+**Design docs**
+
+- [android-teen-beginner-mode.md](android-teen-beginner-mode.md) — plain-language beginner posture + copy
+- [android-teen-goal-projections.md](android-teen-goal-projections.md) — save-for-a-car projections (#2661)
+- [android-learning-progress-persistence.md](android-learning-progress-persistence.md) — progress + resume source
+- [android-learning-rewards-gamification.md](android-learning-rewards-gamification.md) — reward hooks (shared minors posture)
+- [android-credit-building-education.md](android-credit-building-education.md) — adjacent education content
+- [android-newcomer-us-finance-education.md](android-newcomer-us-finance-education.md) — adjacent learning catalog
+- [android-spanish-education-formatting.md](android-spanish-education-formatting.md) — localized education formatting
+- [content-language-guidelines.md](content-language-guidelines.md) — plain, non-schoolish copy
+- [cognitive-accessibility.md](cognitive-accessibility.md) — plain-language and load reduction
+- [accessibility-patterns.md](accessibility-patterns.md) — screen reader, focus, touch targets
+- [component-library.md](component-library.md) — list, card, disclosure components
+- [information-architecture.md](information-architecture.md) — surface and navigation map
+- [ux-principles.md](ux-principles.md) — product UX principles
+- [personas.md](personas.md) — teen / first-job persona
+
+**Ops**
+
+- [../ops/human-gated-prerequisites.md](../ops/human-gated-prerequisites.md) — buildable-now vs. gated split
+- [../ops/launch-readiness-plan.md](../ops/launch-readiness-plan.md) — launch checklist
+
+**Android / web / KMP (read-only boundary)**
+
+- [`curriculum.ts`](../../apps/web/src/lib/learning/curriculum.ts) — curriculum ordering parity (owned by @web-engineer)
+- [`adaptive.ts`](../../apps/web/src/lib/learning/adaptive.ts) — adaptive next-topic parity
+- [`types.ts`](../../apps/web/src/lib/learning/types.ts) — learning catalog types
+- [`teen-learning-local.ts`](../../apps/web/src/lib/household/teen-learning-local.ts) — teen learning local-first parity
+- [`LearningPage.tsx`](../../apps/web/src/pages/LearningPage.tsx) — web learning surface parity
+- [`LearningPathViewModel.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/learning/LearningPathViewModel.kt) — learning state seam
+- [`LearningPathContent.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/learning/LearningPathContent.kt) — lesson/path content model
+
+**Issues**
+
+- [#2678](https://github.com/jrmoulckers/finance/issues/2678) — this issue
+- [#2209](https://github.com/jrmoulckers/finance/issues/2209) — parent (teen curriculum cluster)
+- [#1242](https://github.com/jrmoulckers/finance/issues/1242) — Play Console + keystore (gate)


### PR DESCRIPTION
## Summary

Adds three **design-only** Android documents for the learning/debt cluster. No native
build, signing, or store action — these are design artifacts authored while Google Play
distribution remains human-gated by #1242. Each doc keeps business logic (payoff math,
reward rules, curriculum ordering) in shared KMP `packages/` and describes the
Compose-renders-shared-state boundary without implementing it. Projections are labelled
as estimates; teen content uses plain language and a privacy-first posture for minors.

## Changes

- **`docs/design/android-avalanche-snowball-comparison.md`** (#2658) — payoff-strategy
  comparison (avalanche / snowball / extra payment) with time-to-payoff, interest saved,
  and monthly cash impact; non-guilt goal tradeoff view against wedding / down-payment
  goals; optional recommendation mode. Math stays in KMP (web debt engines as parity).
- **`docs/design/android-learning-rewards-gamification.md`** (#2669) — learning reward
  entry points, "pick up where you left off" resume, and earned-reward feedback built on
  the existing shared `GamificationEngine`; explicit non-manipulative / healthy-design
  guardrails.
- **`docs/design/android-teen-curriculum-ordering.md`** (#2678) — teen-first topic
  ordering (paycheck, debit card, impulse spending, saving for a car, needs vs. wants)
  and respectful advanced-topic gating (investing / retirement / tax behind opt-in or
  tier advancement); shared curriculum layer owns ordering, Compose only renders the
  chosen path list.

Each doc includes: ToC, Mermaid diagrams, relative cross-links to existing docs,
accessibility (TalkBack, Switch Access, 200% font, cognitive/plain-language),
offline/empty/error states, a unit/Compose/Paparazzi test plan, and an Implementation
Readiness section splitting buildable-now (`assembleDebug` sideload) from the
Play-distribution tail gated by #1242 (links `../ops/human-gated-prerequisites.md`).

New files only — no existing files, shared config, code, or other platforms touched.
Prettier `--check` passes on all three.

Closes #2658
Closes #2669
Closes #2678
