### PR TITLE
docs(design): android predictive shortcuts and celebration design batch (#2567, #2569, #2692)

### DIFF
--- a/docs/design/android-achievement-celebration-motion-haptics.md
+++ b/docs/design/android-achievement-celebration-motion-haptics.md
@@ -1,0 +1,415 @@
+# Android Achievement Celebration — Motion & Haptics — Design
+
+> **Status:** DESIGN — Implementation-ready (debug build/test unblocked; Play distribution gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242))
+> **Issue:** [#2692](https://github.com/jrmoulckers/finance/issues/2692) — _Part of [#2211](https://github.com/jrmoulckers/finance/issues/2211)_ (gamification depth)
+> **Platform:** Android (Jetpack Compose · Material 3 · Compose animation · Android haptics)
+> **Companion designs:** [Streak & Near-Win States](./android-streak-near-win-states.md) · [Sharesheet Wins & Badges](./android-sharesheet-wins-badges.md) · [Privacy-Safe Share Cards](./android-privacy-safe-share-cards.md)
+> **Last Updated:** 2026-06-22
+
+This document designs **achievement celebration moments** on Android — the **unlock
+banner**, the **detail sheet**, and the **milestone card** — using **tasteful
+motion** and **Android haptics**. It specifies celebration **surfaces**,
+**intensity tiers** (driven by the shared `AchievementRarity`), and the
+**reduced-motion** and **non-haptic** behaviors that keep celebrations inclusive.
+
+Crucially, haptics and motion are **enhancements, never the sole signal**: every
+celebration is fully legible with **no motion and no vibration**. Celebrations are
+also **guarded against manipulative patterns** — they reward _habits and
+milestones_, never _spending volume_. All achievement state comes from the shared
+KMP `GamificationEngine`; Compose only **renders** unlock state and plays the
+presentation layer. No Kotlin is written here — design + breakdown only.
+
+---
+
+## Table of Contents
+
+1. [Goals & Non-Goals](#1-goals--non-goals)
+2. [Architecture Boundary (Compose ↔ KMP)](#2-architecture-boundary-compose--kmp)
+3. [Grounding in Existing Code](#3-grounding-in-existing-code)
+4. [Celebration Surfaces](#4-celebration-surfaces)
+5. [Intensity Tiers by Rarity](#5-intensity-tiers-by-rarity)
+6. [Motion Spec](#6-motion-spec)
+7. [Haptics Spec](#7-haptics-spec)
+8. [Reduced-Motion & Non-Haptic Alternatives](#8-reduced-motion--non-haptic-alternatives)
+9. [Ethical Guardrails (No Manipulative Rewards)](#9-ethical-guardrails-no-manipulative-rewards)
+10. [Accessibility (TalkBack, Switch Access, Font Scaling)](#10-accessibility-talkback-switch-access-font-scaling)
+11. [Offline, Empty & Error States](#11-offline-empty--error-states)
+12. [Test Plan](#12-test-plan)
+13. [Implementation Readiness](#13-implementation-readiness)
+14. [Open Questions](#14-open-questions)
+15. [References](#15-references)
+
+---
+
+## 1. Goals & Non-Goals
+
+### Goals
+
+- Define **three celebration surfaces** — unlock banner, detail sheet, milestone
+  card — for unlocks, milestone hits, and healthy habit loops.
+- Specify **motion and haptic intensity** scaled by the shared
+  `AchievementRarity` (COMMON → LEGENDARY), with explicit ceilings.
+- Guarantee **reduced-motion** behavior and **non-haptic** alternatives so the
+  celebration is never dependent on motion or vibration.
+- Document **guardrails** against manipulative rewards tied to spending volume.
+- Reuse the existing shared haptics dispatcher and gamification models; **no new
+  finance/achievement rules in Compose**.
+
+### Non-Goals
+
+- **No achievement logic in Compose.** Unlock evaluation, rarity, points, and
+  milestone thresholds are the shared `GamificationEngine` / `Achievements` — the UI
+  renders results (see §2–§3).
+- **No new Kotlin in this issue.** Design-ready scoping; implementation follows once
+  agreed (#2211).
+- **No share/export design here.** Sharing wins lives in
+  [sharesheet wins & badges](./android-sharesheet-wins-badges.md) and
+  [privacy-safe share cards](./android-privacy-safe-share-cards.md); this doc is the
+  in-app moment only.
+- **No streak math.** Streak states are
+  [android-streak-near-win-states.md](./android-streak-near-win-states.md); a streak
+  milestone may _trigger_ a celebration but its rules stay shared.
+- **No financial amounts in celebration copy** (see §9). Counts, dates, and
+  milestone labels only.
+- **No Play distribution work** (gated by #1242 — see §13).
+
+---
+
+## 2. Architecture Boundary (Compose ↔ KMP)
+
+The celebration is a **presentation reaction to shared state**. The engine decides
+_what_ was unlocked and _how rare_ it is; Compose decides _how to present_ it
+(within accessibility and ethics constraints) and plays motion/haptics.
+
+```mermaid
+flowchart LR
+    subgraph Shared [packages/core gamification - source of truth]
+        ENG[GamificationEngine - evaluate unlocks]
+        DEF[AchievementDefinition - rarity, points]
+        PROG[AchievementProgress - isUnlocked, unlockedAt]
+        PROF[GamificationProfile - level, milestones]
+    end
+    subgraph SharedHaptics [packages/core haptics]
+        HDISP[HapticFeedbackDispatcher]
+        HSET[HapticFeedbackSettings - canPerformHaptics]
+    end
+    subgraph Android [apps/android - Compose presentation]
+        VM[GamificationViewModel]
+        CEL[Celebration surfaces - banner / sheet / card]
+        MOT[Compose animation - reduced-motion aware]
+        HAP[AndroidHapticFeedback - OS settings aware]
+    end
+    ENG --> PROG --> VM
+    DEF --> VM
+    PROF --> VM
+    VM -->|immutable celebration state| CEL
+    CEL --> MOT
+    CEL --> HAP
+    HSET --> HDISP --> HAP
+```
+
+- The ViewModel exposes an **immutable celebration UI state** (which achievement,
+  its rarity, its label) — Compose draws and animates it. The **decision to
+  celebrate** is shared; the **way to celebrate** is platform presentation.
+- Haptics route through the existing shared
+  [`HapticFeedbackDispatcher`](../../packages/core/src/commonMain/kotlin/com/finance/core/haptics/HapticFeedback.kt),
+  which only fires when `HapticFeedbackSettings.canPerformHaptics` is true — so OS
+  and app settings are honored centrally.
+
+---
+
+## 3. Grounding in Existing Code
+
+| Concern               | Source of truth (reuse — do **not** reimplement in Compose)                                                                                                                                                                       | Today's state                                                                |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Achievement model     | [`AchievementDefinition`](../../packages/core/src/commonMain/kotlin/com/finance/core/gamification/GamificationTypes.kt)                                                                                                           | Exists: `rarity`, `points`, `category`, `icon`                               |
+| Rarity tiers          | [`AchievementRarity`](../../packages/core/src/commonMain/kotlin/com/finance/core/gamification/GamificationTypes.kt)                                                                                                               | Exists: COMMON…LEGENDARY — _"affects display prominence and celebration UI"_ |
+| Unlock progress       | [`AchievementProgress`](../../packages/core/src/commonMain/kotlin/com/finance/core/gamification/GamificationTypes.kt)                                                                                                             | Exists: `isUnlocked`, `unlockedAt`, `progressFraction`                       |
+| Milestones            | [`SavingsMilestone`](../../packages/core/src/commonMain/kotlin/com/finance/core/gamification/GamificationTypes.kt) · `GamificationProfile`                                                                                        | Exists: milestone reached flags, level/points                                |
+| Unlock evaluation     | [`GamificationEngine`](../../packages/core/src/commonMain/kotlin/com/finance/core/gamification/GamificationEngine.kt) · [`Achievements`](../../packages/core/src/commonMain/kotlin/com/finance/core/gamification/Achievements.kt) | Exists: evaluates data → unlock state                                        |
+| Shared haptics        | [`HapticFeedbackDispatcher` / `HapticFeedbackSettings`](../../packages/core/src/commonMain/kotlin/com/finance/core/haptics/HapticFeedback.kt)                                                                                     | Exists: gated by `canPerformHaptics`; `NoOpHapticFeedback`                   |
+| Android haptic bridge | [`AndroidHapticFeedback`](../../apps/android/src/main/kotlin/com/finance/android/ui/feedback/HapticFeedbackManager.kt)                                                                                                            | Exists: `View.performHapticFeedback`, **reduce-motion guard**                |
+| Existing UI           | [`GamificationScreen` / `GamificationViewModel`](../../apps/android/src/main/kotlin/com/finance/android/ui/gamification/GamificationViewModel.kt)                                                                                 | Exists: renders profile; **no celebration moment yet**                       |
+| The gap to fill       | Celebration banner / sheet / card that reacts to a new unlock with rarity-scaled motion + haptics, reduced-motion safe                                                                                                            | **Not built** — this is the design target                                    |
+
+> Note the existing
+> [`AndroidHapticFeedback`](../../apps/android/src/main/kotlin/com/finance/android/ui/feedback/HapticFeedbackManager.kt)
+> already **no-ops when reduce-motion is on** (animator duration scale = 0). The
+> celebration layer must extend that same discipline to **motion**, not just haptics.
+
+---
+
+## 4. Celebration Surfaces
+
+Three surfaces, escalating in prominence, all built from shared unlock state:
+
+### 4.1 Unlock banner (lightweight)
+
+- A transient Material 3 banner / snackbar-style surface that slides in when a new
+  `AchievementProgress.isUnlocked` flips true.
+- Shows icon + title + "Unlocked" + a **View** action that opens the detail sheet.
+- Auto-dismisses after a short, accessibility-extended timeout; never blocks input.
+- This is the **default** moment for COMMON/UNCOMMON unlocks.
+
+### 4.2 Detail sheet (focused)
+
+- A Material 3 modal bottom sheet opened from the banner or the achievements list.
+- Shows the achievement art, title, description, **points** and **rarity** label,
+  and (for progressive ones) the `progressFraction` that completed it.
+- Houses the entry to **share** (handed off to
+  [sharesheet wins & badges](./android-sharesheet-wins-badges.md)).
+- Used for RARE+ unlocks and any "tap to view" from a banner.
+
+### 4.3 Milestone card (in-context)
+
+- An inline card on the dashboard / goal screen that marks a **healthy habit loop**
+  or **milestone hit** (e.g. a savings milestone reached, a streak milestone).
+- Persistent (not transient) — celebrates without nagging; dismissible.
+- Reuses milestone state from `GamificationProfile` / `SavingsMilestone` /
+  [streak states](./android-streak-near-win-states.md).
+
+```mermaid
+flowchart LR
+    UNLOCK[Shared unlock event] --> RAR{Rarity}
+    RAR -->|Common / Uncommon| BAN[Unlock banner]
+    RAR -->|Rare+| SHEET[Detail sheet]
+    BAN -->|View| SHEET
+    MILE[Milestone / habit-loop hit] --> CARD[Milestone card]
+```
+
+---
+
+## 5. Intensity Tiers by Rarity
+
+`AchievementRarity` already "affects display prominence and celebration UI". We map
+it to **explicit, capped** motion + haptic tiers. Higher rarity = slightly richer,
+**never** longer-than-tasteful or seizure-risky.
+
+| Rarity        | Surface (default) | Motion tier                                                   | Haptic tier (when allowed)         |
+| ------------- | ----------------- | ------------------------------------------------------------- | ---------------------------------- |
+| **COMMON**    | Banner            | Subtle fade + small scale-in                                  | Light confirm tick (or none)       |
+| **UNCOMMON**  | Banner            | Fade + scale-in + soft accent shimmer                         | Light confirm                      |
+| **RARE**      | Sheet             | Scale-in + brief accent sweep                                 | Confirm                            |
+| **EPIC**      | Sheet             | Scale-in + accent sweep + sparse particles                    | Confirm + a single soft emphasis   |
+| **LEGENDARY** | Sheet             | Richer (still brief) sweep + particles, single emphasis pulse | Emphasis confirm (single, bounded) |
+
+Hard ceilings (all tiers):
+
+- **Duration** ≤ ~1200ms total motion; particle effects ≤ ~800ms and **off** under
+  reduced motion.
+- **No flashing** faster than 3 Hz (photosensitivity safety) — never.
+- **Haptics** never repeat/loop; one bounded effect per celebration; always gated by
+  `canPerformHaptics`.
+- A higher tier must remain **fully legible** when reduced to the COMMON (text-only)
+  presentation.
+
+---
+
+## 6. Motion Spec
+
+- **Library:** Jetpack Compose animation (`AnimatedVisibility`, `animateFloatAsState`,
+  `updateTransition`) — no XML/View animators.
+- **Banner enter:** fade (`alpha 0→1`) + scale (`0.96→1.0`) over ~200–300ms with a
+  standard Material easing; exit symmetric.
+- **Sheet content:** staggered fade/scale of icon → title → meta; total ≤ ~600ms.
+- **Accent sweep / particles:** decorative, additive, and **strictly optional** —
+  rendered only when motion is allowed. They carry **no information**; removing them
+  loses nothing semantically.
+- **Determinism for tests:** drive animation from the immutable celebration state so
+  Paparazzi can snapshot the **settled** frame (post-animation) deterministically.
+- **Performance:** budget for low-end devices (minSdk 28) — particles capped, no
+  per-frame allocation; prefer `graphicsLayer` transforms.
+
+---
+
+## 7. Haptics Spec
+
+- Route **only** through the shared
+  [`HapticFeedbackDispatcher`](../../packages/core/src/commonMain/kotlin/com/finance/core/haptics/HapticFeedback.kt)
+  via the Android
+  [`AndroidHapticFeedback`](../../apps/android/src/main/kotlin/com/finance/android/ui/feedback/HapticFeedbackManager.kt)
+  bridge (which uses `View.performHapticFeedback` with API-aware constants).
+- A celebration emits **one** bounded effect — semantically a "success/confirm".
+  Today the shared `HapticFeedbackEffect` exposes `TRANSACTION_SAVE_SUCCESS` and
+  `TRANSACTION_VALIDATION_WARNING`; a celebration would reuse the success semantics
+  (a future shared `ACHIEVEMENT_UNLOCK` effect, if added, stays in `packages/core` —
+  not invented in Compose).
+- **Gating (all must pass):** OS haptics available (`hasVibrator`), app haptics
+  enabled (`HapticFeedbackSettings.appHapticsEnabled`), and reduce-motion **off**
+  (the bridge already returns early when animator duration scale = 0).
+- Requires the existing `android.permission.VIBRATE` (already in the manifest). No
+  custom waveform loops; no escalation that could feel coercive.
+
+```mermaid
+flowchart TD
+    EVT[Celebration triggered] --> G1{Device has vibrator?}
+    G1 -->|no| NOHAP[No haptic - visual + text only]
+    G1 -->|yes| G2{App haptics enabled?}
+    G2 -->|no| NOHAP
+    G2 -->|yes| G3{Reduce-motion off?}
+    G3 -->|no| NOHAP
+    G3 -->|yes| HAP[One bounded confirm haptic]
+```
+
+---
+
+## 8. Reduced-Motion & Non-Haptic Alternatives
+
+**Haptics and motion are enhancements, never the sole signal.** The celebration
+must be fully understandable with **zero motion and zero vibration**.
+
+| User setting / capability | Celebration behavior                                                                                                  |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| **Reduce motion ON**      | No particles/sweep/scale; instant, static reveal of banner/sheet/card. Haptics also suppressed (per existing bridge). |
+| **No haptic hardware**    | Visual + textual celebration only; identical information.                                                             |
+| **App haptics disabled**  | Visual + textual only.                                                                                                |
+| **Both disabled**         | Static, text-first celebration — title, "Unlocked", rarity, points; nothing lost.                                     |
+| **TalkBack on**           | Announce the unlock via live region regardless of motion/haptics (see §10).                                           |
+
+Principles:
+
+- **Information parity** — every fact conveyed by motion/haptics (something was
+  unlocked; how notable) is **also** conveyed in text and iconography.
+- **Detect reduced motion** the same way the existing bridge does
+  (`Settings.Global.ANIMATOR_DURATION_SCALE == 0`); honor it for **motion** too, not
+  only haptics.
+- **No "turn on animations" nagging.** Respect the choice silently.
+- **Settings** — celebrations honor a dedicated in-app "Celebrations" toggle
+  (and the existing haptics toggle); users can dial them down to text-only.
+
+---
+
+## 9. Ethical Guardrails (No Manipulative Rewards)
+
+Celebrations reinforce **healthy financial habits**, never spending. Guardrails:
+
+- **Never reward spending volume.** No celebration is triggered by _how much_ was
+  spent, by purchase count, or by hitting a higher spend tier. Triggers are habit /
+  milestone / savings / streak based (tracking consistency, budget adherence, goal
+  progress) — sourced from the shared engine's existing categories
+  (`TRACKING`, `BUDGETING`, `SAVING`, `STREAKS`, `ONBOARDING`).
+- **No amounts in celebration copy.** Show counts, dates, milestone labels, and
+  points — never balances or transaction amounts (consistent with
+  [privacy-safe share cards](./android-privacy-safe-share-cards.md)).
+- **No loss-aversion / FOMO pressure.** No countdowns that imply a reward "expires";
+  no "you're about to lose X" framing in celebrations (near-win _encouragement_ is
+  the separate, gentle [streak near-win](./android-streak-near-win-states.md) design).
+- **No artificial scarcity or variable-reward gambling loops.** Rarity reflects
+  genuine difficulty defined in `AchievementDefinition`, not a randomized payout.
+- **Frequency caps.** Coalesce multiple simultaneous unlocks into one moment; never
+  chain celebrations to maximize dopamine hits.
+- **Always dismissible & disableable.** Celebrations never block a task and can be
+  turned down to text-only or off.
+
+---
+
+## 10. Accessibility (TalkBack, Switch Access, Font Scaling)
+
+- **TalkBack** — the celebration announces via an `assertive`/polite **live region**
+  ("Achievement unlocked: Budget Keeper. Rare.") so it is conveyed independent of
+  motion/haptics. Banner/sheet/card all carry `contentDescription` (icon + title +
+  rarity + points). Decorative particles are marked **non-focusable / decorative**
+  and excluded from semantics.
+- **Switch Access** — the banner's **View** action and the sheet's **Share** /
+  **Dismiss** are standard focusable controls; nothing requires a gesture. Transient
+  banners give Switch/AT users **enough time** (extended timeout) or remain until
+  dismissed when an accessibility service is active.
+- **200% font scaling** — celebration text uses `sp` and wraps; the sheet scrolls;
+  the banner grows to fit rather than truncating. Layout verified at the largest
+  scale.
+- **Reduced motion** — see §8; static, instant reveal.
+- **Touch targets** — actions ≥ 48dp.
+- See [Accessibility Patterns Library](./accessibility-patterns.md) and
+  [Cognitive Accessibility Mode](./cognitive-accessibility.md) (cognitive mode may
+  prefer the calmest tier — text-only — for all rarities).
+
+---
+
+## 11. Offline, Empty & Error States
+
+| Condition                           | Behavior                                                                                                                        |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| **Offline**                         | Unlocks are evaluated locally by the shared engine; celebrations fire normally. No network needed.                              |
+| **No achievements yet (empty)**     | No celebration; the achievements screen shows its existing empty state. Never fabricate a moment.                               |
+| **Multiple simultaneous unlocks**   | Coalesce into one banner ("3 achievements unlocked") opening a sheet listing them — no chaining (§9).                           |
+| **Unlock state unreadable / error** | Skip the celebration silently; log via Timber (no sensitive data); the achievement still shows as unlocked once state recovers. |
+| **Haptics/motion unavailable**      | Degrade to text-only celebration (§8) — never an error.                                                                         |
+| **Celebration setting OFF**         | No motion/haptics/banner; achievement still recorded and visible in the list.                                                   |
+
+---
+
+## 12. Test Plan
+
+### Shared unit tests (reuse)
+
+- Unlock evaluation, rarity, points, milestones covered by the shared
+  `GamificationEngine` / `Achievements` tests in `packages/core`. **No** new shared
+  rules added here. Shared haptic gating covered by
+  [`HapticFeedbackDispatcherTest`](../../packages/core/src/commonTest/kotlin/com/finance/core/haptics/HapticFeedbackDispatcherTest.kt).
+
+### Android unit tests (`apps/android/src/test`)
+
+- ViewModel maps a new `AchievementProgress.isUnlocked` transition → celebration UI
+  state with the correct rarity tier.
+- Multiple unlocks coalesce into a single celebration state.
+- Haptic is requested only when `canPerformHaptics` and reduce-motion is off.
+- Celebration setting OFF suppresses banner/motion/haptics but not the unlock record.
+
+### Compose / instrumentation tests
+
+- Banner appears on unlock, exposes a **View** action, and is dismissible.
+- Live-region announcement is emitted (semantics) for TalkBack.
+- Reduce-motion: assert no particle/animation nodes; static reveal present.
+- Switch Access: actions are focusable; transient banner timeout extends under AT.
+
+### Paparazzi snapshot tests
+
+- Banner, detail sheet, and milestone card at each rarity tier (**settled** frame).
+- Reduced-motion variant (static) and full-motion settled variant.
+- 200% font scale variant; text-only (haptics+motion disabled) variant.
+
+---
+
+## 13. Implementation Readiness
+
+| Phase                                                                                                                                                     | Status               | Gate                                                                                                      |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- | --------------------------------------------------------------------------------------------------------- |
+| This design doc                                                                                                                                           | ✅ Done              | None                                                                                                      |
+| Shared gamification + haptics models (consumed, not modified)                                                                                             | ✅ Exists            | None — `packages/core`, owned by `@kmp-engineer`                                                          |
+| Celebration banner / sheet / milestone card, Compose motion (reduced-motion aware), haptic bridge reuse, unit/Compose/Paparazzi, `assembleDebug` sideload | 🟢 **Buildable now** | None — debug sideload per [`../ops/human-gated-prerequisites.md` §2](../ops/human-gated-prerequisites.md) |
+| Play Store release + production distribution of the celebration experience                                                                                | 🔒 **Gated**         | [#1242](https://github.com/jrmoulckers/finance/issues/1242) — keystore + Play Console                     |
+
+Celebration motion (Compose animation) and haptics (existing `AndroidHapticFeedback`
+bridge + shared dispatcher) are **standard local Android code** — fully
+implementable and testable today with `./gradlew :apps:android:assembleDebug`,
+Compose instrumentation, and Paparazzi snapshots of the settled frames. Achievement
+and rarity rules stay in `packages/core`. **Only Play distribution** (release
+signing, Play Console upload) is human-gated by #1242 — see
+[`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md) §§2–3.1.
+No build, signing, or store action is performed by this design.
+
+---
+
+## 14. Open Questions
+
+1. **Shared `ACHIEVEMENT_UNLOCK` effect.** Should `packages/core` add a dedicated
+   semantic haptic effect (vs. reusing `TRANSACTION_SAVE_SUCCESS`)? Owned by
+   `@kmp-engineer`; this doc only consumes it.
+2. **Celebration toggle granularity.** One "Celebrations" toggle vs. separate
+   "motion" and "haptics" sub-toggles (beyond the existing app haptics setting)?
+3. **Coalescing window.** How long to wait before grouping simultaneous unlocks into
+   one moment (e.g. 500ms) so we never chain dopamine hits (§9)?
+4. **Legendary art.** Particle/sweep assets per rarity from `@design-engineer` —
+   placeholders until provided; must stay within the photosensitivity ceiling.
+
+---
+
+## 15. References
+
+- Streak/near-win triggers: [Streak & Near-Win States](./android-streak-near-win-states.md)
+- Sharing wins: [Sharesheet Wins & Badges](./android-sharesheet-wins-badges.md) · [Privacy-Safe Share Cards](./android-privacy-safe-share-cards.md)
+- Shared models: [`GamificationTypes.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/gamification/GamificationTypes.kt) · [`GamificationEngine.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/gamification/GamificationEngine.kt) · [`Achievements.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/gamification/Achievements.kt)
+- Shared haptics: [`HapticFeedback.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/haptics/HapticFeedback.kt)
+- Android haptic bridge: [`HapticFeedbackManager.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/feedback/HapticFeedbackManager.kt)
+- Accessibility: [Accessibility Patterns Library](./accessibility-patterns.md) · [Cognitive Accessibility Mode](./cognitive-accessibility.md)
+- Gating: [`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md)

--- a/docs/design/android-predictive-shortcuts-widgets.md
+++ b/docs/design/android-predictive-shortcuts-widgets.md
@@ -1,0 +1,374 @@
+# Android Predictive Shortcuts & Widget Surfaces — Design
+
+> **Status:** DESIGN — Implementation-ready (debug build/test unblocked; Play distribution gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242))
+> **Issue:** [#2569](https://github.com/jrmoulckers/finance/issues/2569) — _Part of [#2396](https://github.com/jrmoulckers/finance/issues/2396)_ (predictive quick actions)
+> **Platform:** Android (Jetpack Compose · Material 3 · Glance · App Shortcuts · WorkManager) · **minSdk 28 / target 35**
+> **Companion designs:** [Quick-Action Ranking Contract](./android-quick-action-ranking-contract.md) · [Cash Quick-Entry Deep Links](./android-cash-quick-entry-deep-links.md) · [Goal Projection Widget](./android-goal-projection-widget.md)
+> **Last Updated:** 2026-06-22
+
+This document designs the **three Android surfaces** that render predictive quick
+actions — **App Shortcuts** (launcher long-press), a **Glance home-screen widget**,
+and an **in-app quick-action rail** — plus the **pin / dismiss / disable** controls
+users wield to take charge of what appears. All three surfaces draw from the **same
+ranked list** produced by the shared
+[ranking contract](./android-quick-action-ranking-contract.md); none of them invent
+ordering or finance math.
+
+Prediction is **on-device** and **privacy-preserving**: no behavioral data leaves
+the device. This is a **design + breakdown** only — the App Shortcut and Glance
+plumbing is **implementable now in debug** (`assembleDebug` sideload); only Play
+Store distribution is human-gated by
+[#1242](https://github.com/jrmoulckers/finance/issues/1242).
+
+---
+
+## Table of Contents
+
+1. [Goals & Non-Goals](#1-goals--non-goals)
+2. [Architecture Boundary (Compose ↔ KMP)](#2-architecture-boundary-compose--kmp)
+3. [Grounding in Existing Code](#3-grounding-in-existing-code)
+4. [Surface 1 — App Shortcuts](#4-surface-1--app-shortcuts)
+5. [Surface 2 — Glance Home-Screen Widget](#5-surface-2--glance-home-screen-widget)
+6. [Surface 3 — In-App Quick-Action Rail](#6-surface-3--in-app-quick-action-rail)
+7. [Pin / Dismiss / Disable Controls](#7-pin--dismiss--disable-controls)
+8. [Refresh: WorkManager & Glance](#8-refresh-workmanager--glance)
+9. [Privacy & On-Device Prediction](#9-privacy--on-device-prediction)
+10. [Accessibility (TalkBack, Switch Access, Font Scaling, Reduced Motion)](#10-accessibility-talkback-switch-access-font-scaling-reduced-motion)
+11. [Offline, Empty & Error States](#11-offline-empty--error-states)
+12. [Test Plan](#12-test-plan)
+13. [Implementation Readiness](#13-implementation-readiness)
+14. [Open Questions](#14-open-questions)
+15. [References](#15-references)
+
+---
+
+## 1. Goals & Non-Goals
+
+### Goals
+
+- Surface predictive quick actions on **App Shortcuts**, a **Glance widget**, and an
+  **in-app rail**, all bound to the same shared ranked list.
+- Give users **pin / dismiss / disable** controls with predictable, explained
+  outcomes (per the [ranking contract](./android-quick-action-ranking-contract.md)).
+- Deep-link each surface action to the **existing destination route** (reusing the
+  app's verified App Links host) — no new navigation math.
+- Keep prediction **on device** and **privacy-safe** — counts only, no behavioral
+  data off device.
+- Refresh surfaces efficiently with **WorkManager** + Glance state (never
+  AlarmManager/JobScheduler).
+
+### Non-Goals
+
+- **No ranking logic here.** Ordering, scoring, overrides precedence, and fallback
+  are the shared `QuickActionRanker` — this doc only **renders** its output
+  (see [ranking contract](./android-quick-action-ranking-contract.md)).
+- **No finance math in Glance/Compose.** Surfaces show labels and route to flows;
+  any amounts shown obey existing widget privacy formatting.
+- **No new deep-link infrastructure.** Reuse the verified `https://finance.app`
+  host and the route taxonomy from the
+  [cash quick-entry deep links](./android-cash-quick-entry-deep-links.md) design.
+- **No XML/View UI.** Glance + Compose only.
+- **No Play distribution work** (gated by #1242 — see §13).
+
+---
+
+## 2. Architecture Boundary (Compose ↔ KMP)
+
+The shared module ranks; Android renders the **same** ranked list to three
+surfaces. The Android layer owns only platform plumbing (ShortcutManager, Glance,
+deep-link routing) and privacy-safe persistence.
+
+```mermaid
+flowchart TD
+    subgraph Shared [packages/core quickaction - source of truth]
+        RANK[QuickActionRanker.rank limit N]
+        OUT[List of RankedQuickAction]
+    end
+    subgraph Android [apps/android - plumbing]
+        VM[QuickActionsViewModel - immutable StateFlow]
+        SC[ShortcutManagerCompat - dynamic shortcuts]
+        GL[Glance widget - QuickActions surface]
+        RAIL[In-app Compose rail]
+        WM[WorkManager refresh worker]
+        STORE[(Encrypted local store - counts + overrides)]
+    end
+    STORE --> RANK --> OUT --> VM
+    VM --> SC
+    VM --> GL
+    VM --> RAIL
+    WM --> VM
+    SC -->|deep link VIEW intent| ROUTE[Existing nav route]
+    GL -->|actionStartActivity + uri| ROUTE
+    RAIL -->|navigate| ROUTE
+```
+
+- One **source list**, three **renderers**. This guarantees parity: the App
+  Shortcut order, widget order, and rail order agree because they all call
+  `rank(...)` with the appropriate `limit`.
+- The **destination** strings on each `QuickActionCandidate` map to existing routes;
+  surfaces translate them into deep-link `Uri`s on the verified host.
+
+---
+
+## 3. Grounding in Existing Code
+
+| Concern                  | Existing source (reuse — do **not** fork)                                                                                           | Today's state                                                               |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| Ranked output            | [`QuickActionRanker`](../../packages/core/src/commonMain/kotlin/com/finance/core/quickaction/QuickActionRanking.kt)                 | Exists — see [ranking contract](./android-quick-action-ranking-contract.md) |
+| Existing widgets         | [`QuickEntryWidget`](../../apps/android/src/main/kotlin/com/finance/android/widget/QuickEntryWidget.kt), `QuickTransactionWidget`   | Exist (Glance) — quick-entry buttons launch the app                         |
+| Widget privacy formatter | [`WidgetPrivacyFormatter`](../../apps/android/src/main/kotlin/com/finance/android/widget/WidgetPrivacyFormatter.kt)                 | Exists — privacy-safe widget text                                           |
+| Widget refresh           | [`WidgetUpdater`](../../apps/android/src/main/kotlin/com/finance/android/widget/WidgetUpdater.kt)                                   | Exists — widget update plumbing                                             |
+| Deep-link host           | `AndroidManifest.xml` App Links (`https://finance.app`, `autoVerify`)                                                               | Exists — `/auth/callback`, `/invite`, `/transaction`                        |
+| Deep-link design         | [Cash Quick-Entry Deep Links](./android-cash-quick-entry-deep-links.md)                                                             | Exists — route taxonomy + App Shortcut wiring pattern                       |
+| Default candidates       | [`DefaultQuickActions`](../../packages/core/src/commonMain/kotlin/com/finance/core/quickaction/QuickActionRanking.kt)               | Exists — fallback ordered set                                               |
+| The gap to fill          | Dynamic App Shortcuts + a predictive Glance "Quick Actions" widget + in-app rail bound to the ranked list, with pin/dismiss/disable | **Not built** — this is the design target                                   |
+
+> No static `<shortcuts>` resource exists in the manifest yet — predictive shortcuts
+> are **dynamic** (`ShortcutManagerCompat.pushDynamicShortcut`), which is exactly
+> what a learned, reorderable set needs.
+
+---
+
+## 4. Surface 1 — App Shortcuts
+
+Long-pressing the launcher icon shows up to **four** dynamic shortcuts, drawn from
+`rank(..., limit = 4)`.
+
+- **Dynamic, not static.** Use `ShortcutManagerCompat.pushDynamicShortcut` /
+  `setDynamicShortcuts` so the set reflects the current ranking and overrides.
+- **Pinned-first.** Pinned actions always lead (the ranker guarantees this);
+  remaining slots fill by score / default order.
+- **Stable IDs.** Shortcut `id` = `QuickActionCandidate.id` (a product id, never a
+  user/entity id), so the launcher can de-dupe and the user can pin a shortcut to
+  the home screen.
+- **Deep link.** Each shortcut's intent is a `VIEW` intent to
+  `https://finance.app/<destination>` (verified host), landing in the existing flow.
+- **Labels.** `shortLabel`/`longLabel` come from the candidate's `titleKey` /
+  `descriptionKey` (localized; never hardcoded English).
+- **Rank-rate limiting.** Android throttles shortcut updates; refresh is coalesced
+  through WorkManager (§8) — never per-tap.
+
+```mermaid
+flowchart LR
+    LP[Launcher long-press] --> TOP4[Top 4 ranked actions]
+    TOP4 --> S1[Shortcut - pinned/first]
+    TOP4 --> S2[Shortcut]
+    TOP4 --> S3[Shortcut]
+    TOP4 --> S4[Shortcut]
+    S1 --> VIEW[VIEW intent to verified host route]
+```
+
+---
+
+## 5. Surface 2 — Glance Home-Screen Widget
+
+A small **Glance** "Quick Actions" widget shows the top **3–4** ranked actions as
+tappable tiles.
+
+- **Glance only** (no RemoteViews XML). Mirrors the existing
+  [`QuickEntryWidget`](../../apps/android/src/main/kotlin/com/finance/android/widget/QuickEntryWidget.kt)
+  pattern but renders the **ranked** set instead of fixed buttons.
+- **Each tile** = icon + localized label + `contentDescription`; tapping fires
+  `actionStartActivity` with the deep-link `Uri` to the existing route.
+- **No finance numbers** required for action tiles; if any future variant shows a
+  value, it must route through
+  [`WidgetPrivacyFormatter`](../../apps/android/src/main/kotlin/com/finance/android/widget/WidgetPrivacyFormatter.kt)
+  and respect lock-screen privacy (see [goal projection widget](./android-goal-projection-widget.md)).
+- **State** is provided via Glance state updated by the refresh worker (§8); the
+  widget never computes ranking — it reads a serialized ranked list snapshot.
+- **Resilient sizing** — tiles wrap/scale for 2×2 up to 4×1; degrade to fewer tiles
+  on small sizes rather than truncating labels.
+
+---
+
+## 6. Surface 3 — In-App Quick-Action Rail
+
+A horizontally scrollable **Compose** rail (e.g. atop the dashboard) renders the
+**full** ranked list (`limit = all`), and is the primary place users manage
+overrides.
+
+- **Material 3** assist/suggestion chips or cards; dynamic color (Material You).
+- **Each item** carries label + description + state; tap navigates via the existing
+  NavHost route (no deep link round-trip needed in-app).
+- **Overflow menu** per item exposes **Pin**, **Dismiss**, and **Disable** (§7).
+- **Fallback labeling** — when `fallbackApplied` is true, the rail header reads
+  "Suggested" (defaults) rather than "Recent"/"For you", so we never imply learning
+  that did not happen.
+
+---
+
+## 7. Pin / Dismiss / Disable Controls
+
+These map directly to `QuickActionOverrides` in the
+[ranking contract §5](./android-quick-action-ranking-contract.md#5-override-behavior-pin--dismiss--disable).
+The UI only **collects intent** and persists override sets; the shared ranker
+applies precedence.
+
+| Control     | Where exposed                          | Result (per shared ranker)                   | Reversible?                 |
+| ----------- | -------------------------------------- | -------------------------------------------- | --------------------------- |
+| **Pin**     | Rail overflow; launcher "pin shortcut" | Locked to top, in pin order                  | Yes — unpin                 |
+| **Dismiss** | Rail overflow; widget tile long-press  | Demoted below normal actions (still present) | Yes — reappears by score    |
+| **Disable** | Rail overflow → Settings list          | Removed from all surfaces                    | Yes — re-enable in Settings |
+
+- **Confirmation & undo.** Dismiss/disable show a Snackbar with **Undo** so an
+  accidental action is recoverable; disable is also always reversible in Settings.
+- **State announced.** Each control announces the outcome for TalkBack (§10).
+- **Persistence.** Override sets live in the encrypted local store and feed
+  `rank(...)`; a refresh (§8) re-pushes shortcuts/widget to reflect the change.
+- **No dark patterns.** Disable truly hides the action; we never re-surface a
+  disabled action through a "you might have missed this" nudge.
+
+---
+
+## 8. Refresh: WorkManager & Glance
+
+Surfaces are refreshed by a single coalesced path — **never** per interaction and
+**never** with AlarmManager/JobScheduler.
+
+```mermaid
+flowchart LR
+    TRIG[Triggers: app foreground, override change, daily window] --> WM[WorkManager QuickActionsRefreshWorker]
+    WM --> RANK[rank candidates + overrides + fresh counts]
+    RANK --> PUSH1[setDynamicShortcuts top 4]
+    RANK --> PUSH2[update Glance state + updateAll]
+    RANK --> PUSH3[emit StateFlow for in-app rail]
+```
+
+- **Worker** (extends the existing WorkManager setup; see
+  [`SyncWorker`](../../apps/android/src/main/kotlin/com/finance/android/sync/SyncWorker.kt)
+  for the established pattern) recomputes ranking and re-pushes shortcuts + widget.
+- **Triggers**: app foreground, any override change (immediate, debounced), and a
+  light daily/periodic window to roll the freshness window.
+- **Coalesced** to respect launcher shortcut rate limits and battery.
+- **In-app** the rail observes the `StateFlow` directly — no worker needed while the
+  screen is live.
+
+---
+
+## 9. Privacy & On-Device Prediction
+
+- **All prediction is local.** Counts and overrides live in the **encrypted**
+  local store; ranking runs in-process via the shared pure function. **No behavioral
+  data leaves the device.**
+- **No identifiers off device.** Only bounded aggregate **counts**
+  (`QuickActionUsefulnessEvent`) are eligible for **opt-in** telemetry, and only via
+  the allow-list guard — see
+  [ranking contract §8](./android-quick-action-ranking-contract.md#8-privacy-safe-aggregate-metrics).
+- **Widget/lock-screen** action tiles show **labels only**, no balances/amounts; any
+  future value uses `WidgetPrivacyFormatter` + lock-screen redaction.
+- **Logging** via Timber, debug builds only, aggregate event name only — never raw
+  per-action behavior, never financial data.
+
+---
+
+## 10. Accessibility (TalkBack, Switch Access, Font Scaling, Reduced Motion)
+
+- **TalkBack** — every shortcut, widget tile, and rail item has a localized
+  `contentDescription` ("Add transaction. Suggested action."). Override controls
+  announce **state and result**: "Pinned — kept at the top", "Dismissed — moved
+  down. Undo available.", "Disabled — hidden from suggestions. Re-enable in
+  Settings."
+- **Switch Access** — pin/dismiss/disable are reachable as focusable controls in the
+  rail overflow menu; no gesture-only paths. Widget tiles and shortcuts are standard
+  activatable targets.
+- **200% font scaling** — rail chips/cards and widget tiles use `sp` text and
+  wrap/scale; labels never truncate. The widget degrades to fewer tiles rather than
+  clipping text at large scales.
+- **Reduced motion** — rail reorder/enter animations respect the system
+  reduced-motion setting (animator duration scale = 0 → no animation); the new order
+  still applies instantly. Widget/shortcut updates are non-animated by nature.
+- **Order stability** — deterministic ranking yields a predictable traversal order;
+  it does not reshuffle mid-session. Cognitive mode may prefer the stable default
+  order — see [Cognitive Accessibility Mode](./cognitive-accessibility.md) and
+  [Accessibility Patterns Library](./accessibility-patterns.md).
+- **Touch targets** — all interactive targets ≥ 48dp; overflow affordances have
+  long-press alternatives surfaced as explicit menu items.
+
+---
+
+## 11. Offline, Empty & Error States
+
+| Condition                         | Behavior                                                                                                                                                                              |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Offline**                       | Fully local; surfaces work unchanged. No network needed.                                                                                                                              |
+| **First run / no signals**        | `fallbackApplied = true` → default ordered set; rail header reads "Suggested" (see ranking contract §7).                                                                              |
+| **All actions disabled**          | Rail shows a single "Turn suggestions back on in Settings" row; widget shows a quiet empty state, never blank; App Shortcuts fall back to a minimal default (e.g. "Add transaction"). |
+| **Glance state stale/unreadable** | Render last-known snapshot or `DefaultQuickActions`; schedule a refresh; log via Timber (no sensitive data).                                                                          |
+| **Shortcut push rate-limited**    | Skip this cycle; next coalesced refresh applies. No user-visible error.                                                                                                               |
+| **Deep-link route missing**       | Land on a safe default (dashboard) and log; never crash from a stale destination string.                                                                                              |
+
+---
+
+## 12. Test Plan
+
+### Shared unit tests (reuse)
+
+- Ordering / override / fallback covered by
+  [`QuickActionRankingTest`](../../packages/core/src/commonTest/kotlin/com/finance/core/quickaction/QuickActionRankingTest.kt).
+  This doc adds **no** new shared math.
+
+### Android unit tests (`apps/android/src/test`)
+
+- `QuickActionsRefreshWorker` recomputes and pushes top-N to shortcuts + Glance.
+- Destination → deep-link `Uri` mapping is correct for every `QuickActionType`.
+- Override change triggers a debounced refresh; disabled actions are absent from
+  pushed shortcuts.
+
+### Compose / instrumentation tests
+
+- Rail renders ranked order; overflow Pin/Dismiss/Disable mutate state and re-rank;
+  Snackbar Undo restores.
+- Deep-link instrumentation: launching each shortcut `Uri` (via `adb`) lands on the
+  correct route.
+- Semantics assertions for labels and announced override results.
+
+### Paparazzi snapshot tests
+
+- In-app rail: **learned order**, **fallback/Suggested**, **pinned-first**,
+  **all-disabled empty state**.
+- Glance widget preview at 2×2 and 4×1, normal + 200% font + reduced-motion (static).
+
+---
+
+## 13. Implementation Readiness
+
+| Phase                                                                                                                                                       | Status               | Gate                                                                                                      |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- | --------------------------------------------------------------------------------------------------------- |
+| This design doc                                                                                                                                             | ✅ Done              | None                                                                                                      |
+| Shared ranking contract (consumed, not modified)                                                                                                            | ✅ Exists            | None — `packages/core`, owned by `@kmp-engineer`                                                          |
+| Dynamic App Shortcuts, Glance "Quick Actions" widget, in-app rail, WorkManager refresh, deep-link routing, unit/Compose/Paparazzi, `assembleDebug` sideload | 🟢 **Buildable now** | None — debug sideload per [`../ops/human-gated-prerequisites.md` §2](../ops/human-gated-prerequisites.md) |
+| Play Store release + production widget / App Shortcut distribution on the live listing                                                                      | 🔒 **Gated**         | [#1242](https://github.com/jrmoulckers/finance/issues/1242) — keystore + Play Console                     |
+
+App Shortcuts (`ShortcutManagerCompat`) and Glance widget plumbing are **standard
+local Android code** — fully implementable and testable today with
+`./gradlew :apps:android:assembleDebug`, `adb`-driven deep-link instrumentation, and
+Paparazzi snapshots. The verified App Links host already exists in the manifest.
+Ranking math stays in `packages/core`. **Only Play distribution** (release signing,
+Play Console upload, production listing) is human-gated by #1242 — see
+[`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md) §§2–3.1.
+No build, signing, or store action is performed by this design.
+
+---
+
+## 14. Open Questions
+
+1. **Widget tile count by size.** Confirm 3 (2×2) vs 4 (4×1) tile counts and the
+   small-size degrade order.
+2. **Pin vs launcher pin.** Reconcile in-app "Pin" (override) with the launcher's
+   own "pin shortcut to home" — keep them independent but consistent in copy.
+3. **Shortcut icons.** Need per-action vector icons from `@design-engineer`'s icon
+   system; placeholders until provided.
+4. **Refresh cadence.** Final WorkManager periodic window (e.g. once daily) plus the
+   foreground/override triggers — tuned against launcher rate limits.
+
+---
+
+## 15. References
+
+- Ranking contract (companion): [Quick-Action Ranking Contract](./android-quick-action-ranking-contract.md)
+- Deep links / App Shortcuts pattern: [Cash Quick-Entry Deep Links](./android-cash-quick-entry-deep-links.md)
+- Widget privacy & states: [Goal Projection Widget](./android-goal-projection-widget.md)
+- Defaults persistence: [Quick-Add Defaults & Persistence](./android-quick-add-defaults-persistence.md)
+- Accessibility: [Accessibility Patterns Library](./accessibility-patterns.md) · [Cognitive Accessibility Mode](./cognitive-accessibility.md)
+- WorkManager pattern: [`SyncWorker`](../../apps/android/src/main/kotlin/com/finance/android/sync/SyncWorker.kt)
+- Gating: [`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md)

--- a/docs/design/android-quick-action-ranking-contract.md
+++ b/docs/design/android-quick-action-ranking-contract.md
@@ -1,0 +1,422 @@
+# Android Quick-Action Ranking Contract — Design
+
+> **Status:** DESIGN — Implementation-ready (debug build/test unblocked; Play distribution gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242))
+> **Issue:** [#2567](https://github.com/jrmoulckers/finance/issues/2567) — _Part of [#2396](https://github.com/jrmoulckers/finance/issues/2396)_ (predictive quick actions)
+> **Platform:** Android (Jetpack Compose · Material 3 · Glance · App Shortcuts) · **minSdk 28 / target 35**
+> **Companion designs:** [Predictive Shortcuts & Widget Surfaces](./android-predictive-shortcuts-widgets.md) · [Cash Quick-Entry Deep Links](./android-cash-quick-entry-deep-links.md) · [Quick-Add Defaults & Persistence](./android-quick-add-defaults-persistence.md)
+> **Last Updated:** 2026-06-22
+
+This document defines the **ranking contract** that decides _which_ quick actions
+the Android client surfaces, _in what order_, and _how the user can override_ that
+order. It specifies the **local candidate/scoring inputs**, **override behavior**
+(pin / dismiss / disable), the **stale fallback** used when there is no signal, and
+the **privacy-safe aggregate metrics** that let us measure usefulness **without any
+behavioral data leaving the device**.
+
+The ranking math already lives in shared KMP code at
+[`packages/core/.../quickaction/QuickActionRanking.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/quickaction/QuickActionRanking.kt).
+This doc treats that file as the **source of truth** and describes the
+**Compose-renders-shared-state boundary** — Android consumes a ranked list, never
+re-implements scoring. No Kotlin is written here; this is a design + breakdown only.
+
+---
+
+## Table of Contents
+
+1. [Goals & Non-Goals](#1-goals--non-goals)
+2. [Architecture Boundary (Compose ↔ KMP)](#2-architecture-boundary-compose--kmp)
+3. [Grounding in Existing Code](#3-grounding-in-existing-code)
+4. [Candidate & Scoring Inputs](#4-candidate--scoring-inputs)
+5. [Override Behavior (Pin / Dismiss / Disable)](#5-override-behavior-pin--dismiss--disable)
+6. [Deterministic Ranking & Tie-Breaks](#6-deterministic-ranking--tie-breaks)
+7. [Stale Fallback](#7-stale-fallback)
+8. [Privacy-Safe Aggregate Metrics](#8-privacy-safe-aggregate-metrics)
+9. [Android Adapter Responsibilities](#9-android-adapter-responsibilities)
+10. [Accessibility (TalkBack, Switch Access, Font Scaling, Reduced Motion)](#10-accessibility-talkback-switch-access-font-scaling-reduced-motion)
+11. [Offline, Empty & Error States](#11-offline-empty--error-states)
+12. [Test Plan](#12-test-plan)
+13. [Implementation Readiness](#13-implementation-readiness)
+14. [Open Questions](#14-open-questions)
+15. [References](#15-references)
+
+---
+
+## 1. Goals & Non-Goals
+
+### Goals
+
+- Define a **stable contract** for ranking quick actions that every Android surface
+  (App Shortcuts, Glance widget, in-app rail) consumes identically.
+- Describe the **local signal inputs** (impression / selection / completion /
+  dismissal counts) and how the shared scorer turns them into an ordered list.
+- Specify **override precedence** so a user can **pin**, **dismiss**, or **disable**
+  an action and get a predictable, explainable result.
+- Define the **stale fallback** ordering used on first run or when no fresh signal
+  exists, and the `fallbackApplied` flag the UI may surface.
+- Define **privacy-safe aggregate metrics** (counts only) that measure ranking
+  usefulness while keeping **all behavioral data on device**.
+
+### Non-Goals
+
+- **No scoring math in Compose.** Weights, caps, tie-breaks, and fallback logic are
+  the shared `QuickActionRanker` / `QuickActionLocalScorer` — the UI renders the
+  result (see §2).
+- **No new Kotlin in this issue.** The shared contract already exists; this doc
+  scopes the Android binding and states. Implementation follows once agreed.
+- **No surface layout here.** App Shortcut / widget / rail visuals and the
+  pin/dismiss/disable affordances live in the companion
+  [predictive shortcuts & widget surfaces](./android-predictive-shortcuts-widgets.md)
+  doc; this doc is the **contract** they both bind to.
+- **No off-device profiling.** No payees, amounts, account ids, or per-action ids
+  ever leave the device. Only bounded aggregate **counts** (see §8).
+- **No server-side ranking.** Prediction is **on-device** and deterministic.
+- **No Play distribution work** (gated by #1242 — see §13).
+
+---
+
+## 2. Architecture Boundary (Compose ↔ KMP)
+
+Ranking is **shared state rendered by Compose**. The shared module owns the
+candidate set, the scorer, the overrides model, and the deterministic ranker. The
+Android side supplies _local, privacy-safe signals_ and _user overrides_, then
+renders the returned `List<RankedQuickAction>`.
+
+```mermaid
+flowchart LR
+    subgraph Shared [packages/core quickaction - source of truth]
+        CAND[QuickActionCandidate + DefaultQuickActions]
+        SIG[QuickActionSignals - aggregate counts only]
+        OVR[QuickActionOverrides - pinned/dismissed/disabled]
+        SCORE[QuickActionLocalScorer]
+        RANK[QuickActionRanker.rank]
+        OUT[RankedQuickAction + fallbackApplied]
+    end
+    subgraph Android [apps/android - Compose + plumbing]
+        STORE[(Encrypted local store - counts + overrides)]
+        VM[QuickActionsViewModel]
+        UI[Shortcuts / Glance / in-app rail]
+    end
+    STORE -->|fresh counts| SIG
+    STORE -->|user choices| OVR
+    CAND --> RANK
+    SIG --> SCORE --> RANK
+    OVR --> RANK
+    RANK --> OUT
+    OUT -->|immutable UI state| VM --> UI
+    UI -->|aggregate count deltas only| STORE
+```
+
+- The **only** numbers Android feeds in are **bounded aggregate counts** and the
+  user's **override sets** — never raw events, timestamps of individual taps, or any
+  entity identifiers.
+- `QuickActionRanker.rank(candidates, overrides, limit)` is **pure and
+  deterministic**: same inputs → same order. This makes it trivially testable and
+  reproducible in Paparazzi snapshots.
+- The ViewModel maps the ranked list into an **immutable UI state**; Compose draws
+  it. No ranking decision is ever made in a Composable.
+
+---
+
+## 3. Grounding in Existing Code
+
+| Concern                   | Source of truth (do **not** reimplement in Compose)                                                                                                 | Today's state                                                          |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Action taxonomy           | [`QuickActionType`](../../packages/core/src/commonMain/kotlin/com/finance/core/quickaction/QuickActionRanking.kt)                                   | Exists: 7 platform-neutral types; enum order is a tie-break input      |
+| Candidate model           | [`QuickActionCandidate`](../../packages/core/src/commonMain/kotlin/com/finance/core/quickaction/QuickActionRanking.kt)                              | Exists: `id`, `titleKey`, `descriptionKey`, `destination`, `baseScore` |
+| Local signals             | [`QuickActionSignals`](../../packages/core/src/commonMain/kotlin/com/finance/core/quickaction/QuickActionRanking.kt)                                | Exists: counts only; `contributesToPrediction` requires `isFresh`      |
+| Scoring                   | [`QuickActionLocalScorer`](../../packages/core/src/commonMain/kotlin/com/finance/core/quickaction/QuickActionRanking.kt)                            | Exists: weighted + capped, clamped at 0                                |
+| Overrides                 | [`QuickActionOverrides` / `QuickActionOverrideState`](../../packages/core/src/commonMain/kotlin/com/finance/core/quickaction/QuickActionRanking.kt) | Exists: pinned / dismissed / disabled precedence                       |
+| Ranker                    | [`QuickActionRanker.rank`](../../packages/core/src/commonMain/kotlin/com/finance/core/quickaction/QuickActionRanking.kt)                            | Exists: deterministic ordering + `fallbackApplied`                     |
+| Stale fallback set        | [`DefaultQuickActions`](../../packages/core/src/commonMain/kotlin/com/finance/core/quickaction/QuickActionRanking.kt)                               | Exists: sensible default ordered candidates                            |
+| Aggregate metric          | [`QuickActionUsefulnessEvent`](../../packages/core/src/commonMain/kotlin/com/finance/core/quickaction/QuickActionRanking.kt)                        | Exists: counts only; `hasOnlyAggregateCountProperties()` guard         |
+| Contract tests            | [`QuickActionRankingTest`](../../packages/core/src/commonTest/kotlin/com/finance/core/quickaction/QuickActionRankingTest.kt)                        | Exists: shared deterministic ranking coverage                          |
+| The gap to fill (Android) | A `QuickActionsViewModel` + encrypted local store that supplies counts/overrides and renders `RankedQuickAction`                                    | **Not built** — this is the design target                              |
+
+> The shared layer is already complete. The Android work is **wiring + states +
+> persistence**: store counts/overrides encrypted, call `rank(...)`, render the
+> result, and emit aggregate metrics. No new finance/ranking math.
+
+---
+
+## 4. Candidate & Scoring Inputs
+
+### Candidate set
+
+Candidates come from the shared `DefaultQuickActions.candidates` (or a
+product-curated subset). Each `QuickActionCandidate` carries a **stable `id`**
+(never a user/account/entity id), localization keys (`titleKey`,
+`descriptionKey`), a `destination` route, a `defaultOrder`, and a `baseScore`.
+
+### Signals (counts only)
+
+`QuickActionSignals` carries four bounded aggregate counts plus an `isFresh` flag:
+
+| Signal            | Meaning                                 | Used by scorer when               |
+| ----------------- | --------------------------------------- | --------------------------------- |
+| `impressionCount` | times the action was shown              | `contributesToPrediction` is true |
+| `selectionCount`  | times the user tapped it                | `contributesToPrediction` is true |
+| `completionCount` | times the action's flow was completed   | `contributesToPrediction` is true |
+| `dismissalCount`  | times the user dismissed it             | `contributesToPrediction` is true |
+| `isFresh`         | recency gate — stale counts are ignored | gates _all_ of the above          |
+
+`contributesToPrediction = isFresh && hasUsefulnessCounts`. If a candidate is not
+fresh, its counts are ignored and the **base score** is used — this is how the
+contract avoids letting old behavior dominate forever.
+
+### Scoring (shared, capped)
+
+`QuickActionLocalScorer.score(candidate)` computes:
+
+```text
+score = baseScore
+      + min(impressionCount * 2, 20)
+      + min(selectionCount  * 8, 40)
+      + min(completionCount * 12, 48)
+      - min(dismissalCount  * 15, 45)
+      clamped to >= 0
+```
+
+- **Completion is weighted highest** (the user finished what they intended) and
+  **dismissal is the strongest negative** (they actively rejected it).
+- Each term is **capped** so no single signal can run away.
+- Android **never** computes this — it reads `RankedQuickAction.score` if it needs
+  to display or debug, but ordering already encodes it.
+
+> **Freshness is an Android responsibility to _supply_, not to _interpret_.** The
+> local store decides whether a count window is fresh (e.g. rolling N-day window)
+> and sets `isFresh`; the shared scorer decides what fresh means for scoring.
+
+---
+
+## 5. Override Behavior (Pin / Dismiss / Disable)
+
+User control beats prediction. `QuickActionOverrides` holds three disjoint
+intentions, resolved by `stateFor(actionId)`:
+
+| Override      | User intent                   | Effect on ranking                               |
+| ------------- | ----------------------------- | ----------------------------------------------- |
+| **Pinned**    | "Always keep this at the top" | Highest bucket; ordered by the user's pin order |
+| **Normal**    | (no override)                 | Ranked by score / defaults                      |
+| **Dismissed** | "Not now — push it down"      | Demoted below all normal actions, still present |
+| **Disabled**  | "Never show this"             | Removed entirely from the result                |
+
+```mermaid
+flowchart TD
+    A[Action id] --> P{Pinned?}
+    P -->|yes| PIN[Bucket 0 - keep pin order]
+    P -->|no| D{Disabled?}
+    D -->|yes| OUT[Removed from result]
+    D -->|no| M{Dismissed?}
+    M -->|yes| DEM[Bucket 2 - demoted]
+    M -->|no| NORM[Bucket 1 - normal ranking]
+```
+
+- **Precedence is deterministic**: pinned > disabled > dismissed (see
+  `QuickActionOverrides.stateFor`). Pinned wins even if also dismissed.
+- **Disable is reversible** and lives in settings (an "off" action is not lost — the
+  user can re-enable it). This is the safety valve for users who find prediction
+  noisy.
+- Android persists these three sets in the **encrypted local store** and feeds them
+  straight into `rank(...)`. The UI exposes pin/dismiss/disable affordances (see the
+  [surfaces doc](./android-predictive-shortcuts-widgets.md)).
+
+---
+
+## 6. Deterministic Ranking & Tie-Breaks
+
+`QuickActionRanker.rank` sorts by, in order:
+
+1. **Override bucket** — pinned (0), normal (1), dismissed (2); disabled is dropped.
+2. **Pinned list order** — within pinned, the user's explicit order.
+3. **Score descending** — _only when fresh signals exist_ (`fallbackApplied` false).
+4. **`defaultOrder`** — product-curated ordering.
+5. **`QuickActionType` enum ordinal** — stable taxonomy order.
+6. **`id`** — final lexicographic tie-break.
+
+Because every tie-break terminates in a unique `id`, the ranking is **total and
+reproducible** — essential for snapshot tests and for not "jittering" the App
+Shortcut list on every refresh. The `limit` parameter lets each surface ask for the
+top _N_ (e.g. 4 App Shortcuts, 3 widget slots) from the same ordered list.
+
+---
+
+## 7. Stale Fallback
+
+When **no candidate** has fresh, useful signals, `rank(...)` sets
+`fallbackApplied = true` and orders by `baseScore`/`defaultOrder` using
+`DefaultQuickActions`. This covers:
+
+- **First run** — no behavioral history yet.
+- **Post-reset / reinstall** — counts cleared.
+- **Stale window** — all counts aged out of the freshness window.
+
+Android behavior in fallback:
+
+- Render the **default ordered set** so the surface is never empty or random.
+- Optionally show a quiet **"Suggested"** label (vs. "Recent") so users understand
+  these are defaults, not learned. Never imply personalization that did not happen.
+- Continue collecting counts so the next refresh can transition out of fallback.
+
+---
+
+## 8. Privacy-Safe Aggregate Metrics
+
+We measure _whether ranking helps_ without learning _what any individual did_.
+`QuickActionUsefulnessEvent` carries **counts only** and self-validates via
+`hasOnlyAggregateCountProperties()` against a fixed allow-list of keys:
+
+| Property               | Meaning                        |
+| ---------------------- | ------------------------------ |
+| `shown_count`          | actions shown in the window    |
+| `selected_count`       | actions tapped (≤ shown)       |
+| `completed_count`      | flows completed (≤ selected)   |
+| `dismissed_count`      | actions dismissed (≤ shown)    |
+| `pinned_count`         | currently pinned actions       |
+| `disabled_count`       | currently disabled actions     |
+| `stale_fallback_count` | refreshes served from fallback |
+
+**Privacy invariants (must hold):**
+
+- **No identifiers** — no action ids, account ids, transaction ids, payees, amounts,
+  or timestamps of individual taps. The model's `init` enforces non-negativity and
+  the `selected ≤ shown`, `completed ≤ selected`, `dismissed ≤ shown` envelopes.
+- **On-device aggregation** — counts are accumulated locally over a window; only the
+  rolled-up event is eligible for telemetry, and only if the user has opted into
+  analytics. No behavioral data leaves the device by default.
+- **Allow-list enforced** — emit only if `hasOnlyAggregateCountProperties()` is true.
+- **Logging** — never log raw counts that could fingerprint; use Timber at debug only
+  with the aggregate event name (`quick_action_usefulness`), never per-action detail.
+  Never log financial data.
+
+---
+
+## 9. Android Adapter Responsibilities
+
+The Android layer is a thin, privacy-respecting adapter around the shared ranker:
+
+1. **Persist** counts and overrides in an **encrypted** store (SQLDelight +
+   SQLCipher; secrets/keys via Keystore — never SharedPreferences for sensitive
+   state). Counts are not "secrets" but stay in the encrypted DB for consistency.
+2. **Compute freshness** (rolling window) and set `isFresh` per candidate.
+3. **Call** `QuickActionRanker.rank(candidates, overrides, limit)` off the main
+   thread; expose the result as an immutable `StateFlow` UI state.
+4. **Render** to App Shortcuts (`ShortcutManagerCompat`), Glance widget, and the
+   in-app rail — all from the **same** ranked list (see surfaces doc).
+5. **Record** count deltas on impression / selection / completion / dismissal and
+   roll them into `QuickActionUsefulnessEvent` for opt-in telemetry only.
+6. **Background refresh** via **WorkManager** only (never AlarmManager/JobScheduler).
+
+---
+
+## 10. Accessibility (TalkBack, Switch Access, Font Scaling, Reduced Motion)
+
+The contract itself is invisible, but every surface that renders its output must be
+accessible. Requirements that the ranking contract makes easier:
+
+- **TalkBack** — each ranked action has a localized `titleKey` + `descriptionKey`,
+  so `contentDescription` is always available (e.g. "Add transaction. Suggested
+  action."). Pin/dismiss/disable controls announce **state and result** ("Pinned —
+  will stay at the top", "Dismissed — moved down", "Disabled — hidden from
+  suggestions").
+- **Order stability** — deterministic ranking means screen-reader and Switch Access
+  users get a **predictable traversal order** that does not reshuffle between
+  glances within a session.
+- **Switch Access** — pin/dismiss/disable are standard focusable controls with clear
+  labels; no gesture-only affordances (long-press alternatives required).
+- **200% font scaling** — action rows use `sp` text and wrap; never truncate the
+  action label. Surfaces must remain usable at the largest font scale.
+- **Reduced motion** — any reorder animation when ranking changes must respect the
+  system reduced-motion setting (animator duration scale = 0 → no motion); the new
+  order still applies instantly without animation.
+- See [Accessibility Patterns Library](./accessibility-patterns.md) and
+  [Cognitive Accessibility Mode](./cognitive-accessibility.md). Cognitive mode may
+  prefer the **stable default order** (fallback set) over learned reordering to
+  reduce surprise — expose that as a setting.
+
+---
+
+## 11. Offline, Empty & Error States
+
+| Condition                        | Behavior                                                                                              |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| **Offline**                      | Ranking is fully **local**; no network needed. No degraded state.                                     |
+| **No signals (first run)**       | `fallbackApplied = true` → default ordered set; quiet "Suggested" labeling (§7).                      |
+| **All actions disabled**         | Surface shows a minimal "Turn suggestions back on in Settings" affordance — never a blank widget.     |
+| **Store read failure**           | Fall back to `DefaultQuickActions` in-memory; log via Timber (no sensitive data); retry next refresh. |
+| **Limit larger than candidates** | Return all candidates; surfaces pad gracefully (no empty slots implying loss).                        |
+| **Corrupt overrides**            | Treat as empty overrides (all normal); never crash; rebuild on next user action.                      |
+
+---
+
+## 12. Test Plan
+
+### Shared unit tests (already present, extend as needed)
+
+- [`QuickActionRankingTest`](../../packages/core/src/commonTest/kotlin/com/finance/core/quickaction/QuickActionRankingTest.kt)
+  covers deterministic ordering, override precedence, scorer caps/clamp, and the
+  fallback flag. Extend with edge cases the Android adapter relies on (limit
+  boundaries, all-disabled, tie-break exhaustion).
+
+### Android unit tests (`apps/android/src/test`)
+
+- `QuickActionsViewModel` maps `List<RankedQuickAction>` → immutable UI state.
+- Freshness windowing sets `isFresh` correctly across boundary dates.
+- `QuickActionUsefulnessEvent` is only emitted when
+  `hasOnlyAggregateCountProperties()` is true and analytics is opted in.
+- Override persistence round-trips through the encrypted store.
+
+### Compose / instrumentation tests
+
+- Rail renders the ranked order; pin/dismiss/disable update state and re-rank.
+- Semantics: each action exposes label + state; controls announce results.
+- Disabled action disappears; re-enable restores it.
+
+### Paparazzi snapshot tests
+
+- In-app rail in: **fresh-learned order**, **fallback/default order**,
+  **pinned-on-top**, **all-disabled empty affordance**.
+- 200% font scale variant and reduced-motion (static) variant.
+
+---
+
+## 13. Implementation Readiness
+
+| Phase                                                                                                                             | Status               | Gate                                                                                                      |
+| --------------------------------------------------------------------------------------------------------------------------------- | -------------------- | --------------------------------------------------------------------------------------------------------- |
+| This design doc                                                                                                                   | ✅ Done              | None                                                                                                      |
+| Shared ranking contract (`QuickActionRanking.kt` + tests)                                                                         | ✅ Exists            | None — in `packages/core`, owned by `@kmp-engineer`                                                       |
+| Android adapter: encrypted store, `QuickActionsViewModel`, freshness, telemetry, unit/Compose/Paparazzi, `assembleDebug` sideload | 🟢 **Buildable now** | None — debug sideload per [`../ops/human-gated-prerequisites.md` §2](../ops/human-gated-prerequisites.md) |
+| App Shortcuts / Glance widget rendering of ranked output (debug)                                                                  | 🟢 **Buildable now** | None — see [surfaces doc](./android-predictive-shortcuts-widgets.md)                                      |
+| Play Store release + production App Shortcut / widget distribution                                                                | 🔒 **Gated**         | [#1242](https://github.com/jrmoulckers/finance/issues/1242) — keystore + Play Console                     |
+
+The ranking adapter is **standard local Android code** — fully implementable and
+testable today with `./gradlew :apps:android:assembleDebug` plus unit, Compose, and
+Paparazzi tests. Ranking math stays in `packages/core` (owned by `@kmp-engineer`).
+**Only Play distribution** (release signing, Play Console upload) is human-gated by
+#1242 — see [`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md)
+§§2–3.1. No build, signing, or store action is performed by this design.
+
+---
+
+## 14. Open Questions
+
+1. **Freshness window length.** What rolling window (e.g. 14 vs 30 days) best
+   balances responsiveness vs. stability before the shared `isFresh` gate kicks in?
+   Default proposal: 30-day rolling, decay handled by ignoring stale counts.
+2. **Per-surface limits.** Confirm slot counts: App Shortcuts (4 long-press), Glance
+   widget (3–4), in-app rail (all). All drawn from the same ranked list via `limit`.
+3. **"Suggested" vs "Recent" labeling.** Final copy for fallback vs learned states,
+   reviewed for honesty (never imply learning that did not happen).
+4. **Cognitive-mode default.** Should cognitive accessibility mode default to the
+   stable fallback order rather than learned reordering? Proposed: yes, opt-out.
+
+---
+
+## 15. References
+
+- Shared contract: [`QuickActionRanking.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/quickaction/QuickActionRanking.kt)
+- Surfaces (companion): [Predictive Shortcuts & Widget Surfaces](./android-predictive-shortcuts-widgets.md)
+- Deep links / App Shortcuts: [Cash Quick-Entry Deep Links](./android-cash-quick-entry-deep-links.md)
+- Defaults persistence: [Quick-Add Defaults & Persistence](./android-quick-add-defaults-persistence.md)
+- Accessibility: [Accessibility Patterns Library](./accessibility-patterns.md) · [Cognitive Accessibility Mode](./cognitive-accessibility.md)
+- Gating: [`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md)


### PR DESCRIPTION
## Summary

Adds three **new** Android design docs (design + breakdown only — no native builds,
signing, or store actions) for the predictive quick-action and celebration cluster
under `#2396` / `#2211`. Each doc keeps ranking/prediction/achievement logic in the
shared KMP `packages/core` and describes the **Compose-renders-shared-state**
boundary. Prediction stays **on-device** and **privacy-preserving** (no behavioral
data off device); celebrations **respect reduced-motion** and provide **non-haptic
alternatives**.

## Changes

- **`docs/design/android-quick-action-ranking-contract.md`** (#2567) — local
  candidate/scoring inputs, override behavior (pin/dismiss/disable), stale fallback,
  and privacy-safe aggregate metrics. Grounded in the existing shared
  `packages/core/.../quickaction/QuickActionRanking.kt`.
- **`docs/design/android-predictive-shortcuts-widgets.md`** (#2569) — App Shortcut,
  Glance widget, and in-app rail surfaces bound to the same ranked list, with
  pin/dismiss/disable controls and WorkManager refresh.
- **`docs/design/android-achievement-celebration-motion-haptics.md`** (#2692) —
  unlock banner, detail sheet, and milestone card celebration surfaces with
  rarity-scaled motion/haptics, reduced-motion + non-haptic parity, and ethical
  guardrails against rewards tied to spending volume.

Each doc follows `docs.instructions.md`: humans-first, ToC, Mermaid diagrams,
relative links to existing docs/source, accessibility (TalkBack, Switch Access, 200%
font, reduced motion, haptics-as-enhancement), offline/empty/error states, a test
plan (unit/Compose/Paparazzi), and an "Implementation readiness" section splitting
the **buildable-now** debug work (`assembleDebug` sideload; App Shortcuts / Glance
plumbing) from the Play-distribution tail gated by #1242, linking
`docs/ops/human-gated-prerequisites.md`.

New files only — no existing files, `packages/`, `apps/` code, shared config, or
other platforms were modified. Prettier passes on all three files.

Closes #2567
Closes #2569
Closes #2692
