### PR TITLE
docs(design): android vehicle logging and cash wallet design batch (#2521, #2522, #2541)

### DIFF
--- a/docs/design/android-cash-wallet-localized-widget.md
+++ b/docs/design/android-cash-wallet-localized-widget.md
@@ -1,0 +1,309 @@
+# Android — Cash Wallet Defaults & Localized Widget UX
+
+> **Status:** DRAFT — design only (pending human review)
+> **Owner:** @android-engineer
+> **Issue:** [#2541](https://github.com/jrmoulckers/finance/issues/2541) · **Part of** [#2180](https://github.com/jrmoulckers/finance/issues/2180)
+> **Platform:** Android phone (Jetpack Compose · Material 3 · Glance) · **minSdk 28 / compile-target 35**
+> **Last Updated:** 2026-06-22
+
+This document specifies the **design** for a cash-first Android user's **default cash wallet / category
+preferences**, **offline behavior** on budget devices, and a **localized Glance quick-entry widget**
+(Spanish first per [#2180](https://github.com/jrmoulckers/finance/issues/2180)). The widget today
+hardcodes English labels and just opens `MainActivity`; this design makes it default to a chosen cash
+wallet and speak the user's language.
+
+It is **design + breakdown only**. The defaults persistence and Glance widget plumbing are
+**buildable now** in a debug build (`assembleDebug` sideload); only **Play Store distribution** is
+human-gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242). See
+[§10 Implementation readiness](#10-implementation-readiness) and
+[`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md). All effort figures are
+**estimates**.
+
+---
+
+## Table of Contents
+
+- [1. Problem & Goals](#1-problem--goals)
+- [2. KMP / Compose / i18n Boundary](#2-kmp--compose--i18n-boundary)
+- [3. Affected Android Surfaces](#3-affected-android-surfaces)
+- [4. Shared Dependencies](#4-shared-dependencies)
+- [5. Default Cash Wallet & Category Preferences](#5-default-cash-wallet--category-preferences)
+- [6. Localized Glance Widget (Labels, Semantics, Text Expansion)](#6-localized-glance-widget-labels-semantics-text-expansion)
+- [7. Offline Behavior on Budget Devices](#7-offline-behavior-on-budget-devices)
+- [8. Accessibility (TalkBack, Switch Access, Font Scaling, Localization)](#8-accessibility-talkback-switch-access-font-scaling-localization)
+- [9. Test Plan](#9-test-plan)
+- [10. Implementation readiness](#10-implementation-readiness)
+- [11. Open Questions](#11-open-questions)
+
+---
+
+## 1. Problem & Goals
+
+From [#2180](https://github.com/jrmoulckers/finance/issues/2180): _"Allow quick entry to default to a
+chosen cash wallet/account… Localize widget labels and semantics for Spanish users… Support a very
+low-friction offline path for small cash expenses on budget Android devices."_
+
+Today the
+[`QuickEntryWidget`](../../apps/android/src/main/kotlin/com/finance/android/widget/QuickEntryWidget.kt)
+claims "Configurable default account and category" but **hardcodes English labels** and calls
+`actionStartActivity<MainActivity>()` (lands on the app home, not a prefilled draft).
+
+### Goals
+
+- Let the user pick a **default cash wallet/account** and **default category** for quick entry.
+- Persist those preferences locally and apply them across the **widget, App Shortcut, and FAB** paths.
+- **Localize** all widget labels and `contentDescription`s (Spanish first), with layouts that tolerate
+  **text expansion**.
+- Keep a **very low-friction offline path** that works on budget devices.
+
+### Non-Goals
+
+- The **deep-link destination / draft sheet** itself — owned by
+  [Cash quick-entry deep links](./android-cash-quick-entry-deep-links.md)
+  ([#2538](https://github.com/jrmoulckers/finance/issues/2538)). This doc decides **what defaults flow
+  into it** and **how the widget is localized**.
+- The generic **defaults persistence engine** — owned by
+  [Quick-add defaults & persistence](./android-quick-add-defaults-persistence.md)
+  ([#2525](https://github.com/jrmoulckers/finance/issues/2525)); here we specialize it for **cash**.
+- Owning the cash-account **selection rule** or any finance math (shared / repository).
+- Adding new translated strings to `packages/core` (that is `@kmp-engineer`'s catalog); this doc
+  defines the **boundary and the Android mirror**, not the canonical translations.
+
+---
+
+## 2. KMP / Compose / i18n Boundary
+
+**Terminology and value formatting are owned by KMP `packages/core/i18n`.** Compose and Glance render
+shared state; the cash-account selection rule and any money math stay shared/repository. The Android
+layer owns only the platform surfacing (Glance/RemoteViews, manifest-referenced shortcut labels) and
+text-expansion-tolerant layout.
+
+| Concern                                                     | Owner    | Symbol / location                                                                       |
+| ----------------------------------------------------------- | -------- | --------------------------------------------------------------------------------------- |
+| Locale resolution + fallback chain (es-MX → es → en)        | KMP      | `com.finance.core.i18n.Locale`, `StringProvider`                                        |
+| Canonical financial terminology (keys + bundles)            | KMP      | `com.finance.core.i18n.Strings`, `StringBundle` (e.g. `Strings.ACCOUNT_CASH`)           |
+| Currency / number / percent formatting                      | KMP      | `com.finance.core.i18n.NumberFormatting`, `com.finance.core.currency.CurrencyFormatter` |
+| Cash-account selection rule (which wallet when none chosen) | KMP/repo | shared rule per [defaults doc](./android-quick-add-defaults-persistence.md)             |
+| User's chosen default wallet/category (preference value)    | Android  | DataStore (Preferences) — see [§5](#5-default-cash-wallet--category-preferences)        |
+| Glance widget labels / semantics surfacing                  | Android  | `QuickEntryWidget` + Android string mirror (this doc)                                   |
+| Launcher-resolved App Shortcut labels                       | Android  | `res/values[-es]/strings.xml` (platform requires Android resources)                     |
+
+> **The boundary, precisely:**
+>
+> - **Financial _terminology_** ("Cash", "Groceries", "Gas") and **_value formatting_** (amounts,
+>   currency symbol, decimals) are **canonical in `packages/core/i18n`**. In-process Compose/Glance
+>   code resolves them via `StringProvider` / `NumberFormatting` for the active `Locale`.
+> - **Platform chrome that the OS resolves outside our process** — manifest-referenced **App Shortcut
+>   long/short labels** — must live in Android `res/values[-es]/strings.xml`. These are a **thin mirror**
+>   of the shared catalog and must stay in sync (audited by
+>   [String-resource migration audit](./android-string-resource-migration-audit.md)); they are **not**
+>   a second source of truth for terminology.
+> - **No hardcoded English** anywhere in `QuickEntryWidget`, the manifest shortcuts, or Compose —
+>   replacing the current hardcoded labels is the core #2180 i18n fix.
+
+```mermaid
+flowchart LR
+    Loc[Active Locale<br/>packages/core/i18n] --> SP[StringProvider / NumberFormatting]
+    SP -->|terms + formatted amounts| GW[QuickEntryWidget<br/>Glance, in-process]
+    SP --> UI[Compose quick-add surfaces]
+    Loc -.platform mirror.-> RES[res/values-es/strings.xml<br/>launcher shortcut labels]
+    RES --> SC[App Shortcut labels<br/>resolved by launcher]
+```
+
+---
+
+## 3. Affected Android Surfaces
+
+All new/modified surfaces are Compose or Glance — **no XML layouts**.
+
+| Surface                       | Type                          | Responsibility                                                                   |
+| ----------------------------- | ----------------------------- | -------------------------------------------------------------------------------- |
+| `QuickEntryWidget` (modify)   | Glance widget                 | Localized labels/semantics; cash chip defaults to chosen wallet; deep-links out. |
+| `CashDefaultsScreen`          | Composable (settings)         | Pick default cash wallet + default category; preview of widget result.           |
+| `CashDefaultsViewModel`       | `ViewModel` (`koinViewModel`) | Reads/writes preference; resolves display labels via `StringProvider`.           |
+| `CashDefaultsRepository`      | Repository / DataStore        | Persists chosen wallet id + category id (Preferences DataStore).                 |
+| `res/values[-es]/strings.xml` | Android resources             | Launcher-resolved App Shortcut labels (platform mirror only).                    |
+| `CashDefaultsModule`          | Koin module                   | `viewModelOf(::CashDefaultsViewModel)`, `singleOf(::CashDefaultsRepository)`.    |
+
+The widget/shortcut/FAB all funnel into the **existing** cash deep-link destination defined by
+[Cash quick-entry deep links](./android-cash-quick-entry-deep-links.md); this doc supplies the
+**default account/category args** and the **localized chrome**.
+
+---
+
+## 4. Shared Dependencies
+
+| Dependency                                       | Use                                                | Notes                                                |
+| ------------------------------------------------ | -------------------------------------------------- | ---------------------------------------------------- |
+| `StringProvider`, `Strings`, `Locale` (KMP i18n) | Localized terminology + fallback chain             | Canonical source; Compose/Glance resolve in-process. |
+| `NumberFormatting` / `CurrencyFormatter` (KMP)   | Locale-aware amount formatting                     | Compose/Glance never build money strings.            |
+| Cash-account selection rule (shared/repo)        | Resolve effective default when none chosen         | Owned by the defaults/persistence doc.               |
+| Preferences DataStore                            | Persist chosen wallet/category ids                 | Not secrets; never SharedPreferences for secrets.    |
+| Glance + GlanceAppWidget                         | Localized widget rendering & actions               | Debug-implementable plumbing.                        |
+| Koin 4.0.1 (`koin-compose-viewmodel`)            | DI for ViewModel + repository                      | `koinViewModel()` in Composables.                    |
+| Timber 5.0.1                                     | Structured logs (never `Log.*`, never log amounts) | See [§7](#7-offline-behavior-on-budget-devices).     |
+
+---
+
+## 5. Default Cash Wallet & Category Preferences
+
+- `CashDefaultsScreen` lets the user choose a **default cash wallet/account** and a **default
+  category** (e.g. "Cash" / "Groceries"). Labels are resolved via `StringProvider` for the active
+  `Locale`, so the picker reads in the user's language.
+- The **chosen ids** are persisted in **Preferences DataStore** (`cash_default_account_id`,
+  `cash_default_category_id`). These are non-secret preference values; secrets remain in Keystore.
+- **Effective default resolution** (when no explicit choice, or the chosen account was deleted) defers
+  to the **shared selection rule** (deep-link `account` hint → last-used cash account → household
+  primary cash account → first account), exactly as the
+  [cash quick-entry doc §7](./android-cash-quick-entry-deep-links.md#7-prefilled-cash-expense-draft)
+  defines. Android does not invent its own rule.
+- These defaults become the **deep-link args** appended by the widget / shortcut / FAB
+  (`?account=<id>&category=<id>`), landing the user in a prefilled cash draft.
+
+```mermaid
+flowchart TD
+    D[CashDefaultsScreen] -->|chosen ids| DS[Preferences DataStore]
+    DS --> WIRE[Widget / Shortcut / FAB args]
+    WIRE -->|account + category| DEST[Cash quick-add draft]
+    DS -. missing/deleted .-> RULE[Shared selection rule] --> DEST
+```
+
+---
+
+## 6. Localized Glance Widget (Labels, Semantics, Text Expansion)
+
+**Localized labels & semantics**
+
+- Replace every hardcoded string in `QuickEntryWidget` ("Quick Add", "Food", "Gas", …) with values
+  resolved from the shared catalog for the active `Locale`; every chip and the widget root carries a
+  **localized** `contentDescription` (Glance `semantics { contentDescription = … }`).
+- App Shortcut long/short labels come from `res/values[-es]/strings.xml` (launcher-resolved) — a thin
+  mirror of the shared terminology, never hardcoded English.
+- Amounts/preview values format through `NumberFormatting` / `CurrencyFormatter` (locale-aware), never
+  manual string concatenation.
+
+**Text-expansion tolerance (the key localization risk)**
+
+Spanish strings commonly run **~15–30% longer** than English ("Add" → "Añadir", "Cash" → "Efectivo");
+some locales expand further. Glance/RemoteViews layouts must not assume English width:
+
+| Risk                          | Design response                                                                                    |
+| ----------------------------- | -------------------------------------------------------------------------------------------------- |
+| Chip label overflow           | Chips size to content with wrap/`maxLines`; no fixed-width pills; min touch target ≥ 48 dp kept.   |
+| Truncated action label        | Prefer icon + short label; allow 2-line wrap on the smaller widget size before ellipsis.           |
+| Multi-cell widgets clipping   | Provide responsive size buckets (small/medium); hide secondary chips first, never the primary CTA. |
+| `contentDescription` mismatch | Descriptions resolve from the same locale source so TalkBack speaks the visible language.          |
+
+> Pseudo-locale (`en-XA`, accented + ~lengthened) and a real `es` pass are both used in snapshot tests
+> to catch expansion clipping early — see [§9](#9-test-plan).
+
+```mermaid
+flowchart LR
+    L[Active Locale] --> R[Resolve chip + CTA strings]
+    R --> SZ{Widget size bucket}
+    SZ -->|small| C1[Primary CTA + 1 chip, wrap]
+    SZ -->|medium| C2[Primary CTA + chips, wrap]
+    R --> CD[Localized contentDescription]
+```
+
+---
+
+## 7. Offline Behavior on Budget Devices
+
+| Scenario                                 | Behavior                                                                                                                                                              |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Offline (typical for cash-on-the-go)** | Tapping the widget/shortcut opens the prefilled draft and saves locally; "Saved offline" snackbar with localized `contentDescription`; `SyncWorker` reconciles later. |
+| **No default chosen yet**                | Widget uses the shared effective-default rule; `CashDefaultsScreen` prompts to pick a wallet; nothing crashes.                                                        |
+| **Chosen wallet deleted**                | Falls back to the shared selection rule; preference is cleared lazily; user sees the resolved account in the draft.                                                   |
+| **Budget device (low RAM / slow CPU)**   | Widget stays lightweight (no heavy images, minimal recompositions); cold deep-link routes after the auth/onboarding gate.                                             |
+| **Locale change at runtime**             | Widget re-renders labels via `StringProvider` on next update; launcher re-reads shortcut labels from resources.                                                       |
+| **Save failure**                         | Non-dismissing error snackbar + Retry; input preserved; `Timber.e(t, "Cash quick-add save failed")` — **never** log amount/account.                                   |
+
+> **Logging rule:** Timber only — never `Log.*`. Never log amounts, account numbers, balances, or
+> category values. Event names and non-sensitive identifiers only.
+
+See [Rugged Mode tokens](./android-rugged-mode-tokens.md) for budget/outdoor-device considerations and
+[Operating cash calendar](./android-operating-cash-calendar.md) for the broader cash context.
+
+---
+
+## 8. Accessibility (TalkBack, Switch Access, Font Scaling, Localization)
+
+- **`contentDescription` on every interactive/informational element** — widget root, each chip, the
+  FAB, and `CashDefaultsScreen` controls; all sourced from **localized** strings.
+- **TalkBack speaks the user's language** because descriptions and visible labels resolve from the
+  same shared locale source (no English description on a Spanish UI).
+- **Switch Access:** widget chips and the FAB are single focusable targets with clear labels; the deep
+  link lands focus on the amount field for immediate entry.
+- **Font scaling verified at 200%:** `CashDefaultsScreen` and the in-app surfaces reflow without
+  truncation; the widget degrades to a compact layout and wraps labels rather than clipping.
+- **Text expansion + font scale together:** snapshot the widget at `es` + 200% font to ensure the
+  primary CTA is never clipped (worst-case path).
+- **No color-only meaning:** default/selected chips use text + icon + container, not hue alone; AA
+  contrast across light / dark / OLED.
+
+See [Accessibility Patterns Library](./accessibility-patterns.md),
+[Cognitive Accessibility Mode](./cognitive-accessibility.md),
+[Content Language Guidelines](./content-language-guidelines.md), and
+[Spanish education & formatting coverage](./android-spanish-education-formatting.md).
+
+---
+
+## 9. Test Plan
+
+| Layer                  | Tool                                                                   | Coverage                                                                                                                   |
+| ---------------------- | ---------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| KMP i18n (reference)   | existing `StringProvider` / `NumberFormatting` tests (`packages/core`) | Fallback chain (es-MX → es → en), formatting — Android does not re-assert                                                  |
+| Preferences            | DataStore tests                                                        | Persist/read default wallet + category; clear on deletion; defaults survive process death                                  |
+| ViewModel              | JUnit + Turbine                                                        | `CashDefaultsUiState` emissions; label resolution via `StringProvider`; effective-default fallback                         |
+| Selection-rule wiring  | JUnit                                                                  | Missing/deleted chosen wallet → shared rule; Android adds no rule of its own                                               |
+| Glance widget          | Glance test + instrumented                                             | Localized labels render; chip → deep link with `account`/`category` args; `contentDescription` localized                   |
+| App Shortcut           | instrumented                                                           | Localized long/short labels from `res/values-es`; deep link resolves                                                       |
+| Localization snapshots | **Paparazzi**                                                          | Widget + `CashDefaultsScreen` in **en / es / pseudo-locale**, light / dark / OLED, **200% font**, RTL — assert no clipping |
+| Accessibility          | semantics assertions + Accessibility Scanner                           | `contentDescription` present + localized; spoken language matches UI; 200% font                                            |
+| Edge cases             | unit + UI                                                              | No default chosen, deleted wallet, runtime locale change, offline save, budget-device cold start                           |
+
+---
+
+## 10. Implementation readiness
+
+**Design + breakdown only** for this issue. Per the
+[Human-Gated Prerequisites runbook](../ops/human-gated-prerequisites.md), "blocked by #1242" gates
+**only distribution**, not implementation
+([decoupling §2](../ops/human-gated-prerequisites.md#2-implementation-vs-distribution--the-decoupling)).
+
+| Phase                                                                         | Status                                                                  | Notes                                                                                              |
+| ----------------------------------------------------------------------------- | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| **Design** (this doc)                                                         | ✅ Deliverable now                                                      | No accounts/secrets needed.                                                                        |
+| **Implementation** (defaults DataStore, localized `QuickEntryWidget`, screen) | ✅ Buildable now                                                        | `./gradlew :apps:android:assembleDebug` + sideload; Glance widget plumbing is debug-implementable. |
+| **Localization** (Spanish strings via shared catalog + Android mirror)        | ✅ Buildable now                                                        | Terminology canonical in `packages/core/i18n`; Android mirrors only launcher labels.               |
+| **Local tests** (unit / Compose / Glance / Paparazzi incl. es + 200% font)    | ✅ Runnable now                                                         | No enrollment.                                                                                     |
+| **Distribution** (Play Store, release signing)                                | 🔒 Gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242) | Google Play enrollment, keystore, CI secrets — **human-gated**.                                    |
+
+**Buildable-now scope (estimate):** default cash wallet/category preferences, the localized Glance
+widget (labels + semantics + text-expansion-tolerant layout), App Shortcut labels, and the offline
+save path all run on a debug build with on-device storage — no paid entitlement.
+
+**Distribution tail (human action required):** Play Store release and signing depend on the #1242
+prerequisites in
+[§3.1 of the runbook](../ops/human-gated-prerequisites.md#31-android-distribution--google-play-1242).
+No AI agent performs those steps.
+
+---
+
+## 11. Open Questions
+
+- Spanish variant priority — `es-MX` vs. generic `es` for first launch? Proposed: generic `es` with
+  the shared fallback chain handling regional variants; product confirms.
+- Should the widget offer **multiple** quick chips (cash + last-used category) on the medium size, or
+  stay single-CTA for speed? Proposed: single primary CTA + one default-category chip; hide extras on
+  small size first.
+- Do we add a one-time "Set your cash wallet" nudge after onboarding? Proposed: yes, soft and
+  dismissible; tracked separately.
+
+---
+
+_Part of [#2180](https://github.com/jrmoulckers/finance/issues/2180). Companion designs:
+[Cash quick-entry deep links](./android-cash-quick-entry-deep-links.md) ·
+[Quick-add defaults & persistence](./android-quick-add-defaults-persistence.md) ·
+[Spanish education & formatting coverage](./android-spanish-education-formatting.md)._

--- a/docs/design/android-vehicle-cost-per-mile.md
+++ b/docs/design/android-vehicle-cost-per-mile.md
@@ -1,0 +1,292 @@
+# Android — Vehicle Cost-Per-Mile Profitability Surfaces
+
+> **Status:** DRAFT — design only (pending human review)
+> **Owner:** @android-engineer
+> **Issue:** [#2522](https://github.com/jrmoulckers/finance/issues/2522) · **Part of** [#2139](https://github.com/jrmoulckers/finance/issues/2139)
+> **Platform:** Android phone (Jetpack Compose · Material 3 · Glance) · **minSdk 28 / compile-target 35**
+> **Last Updated:** 2026-06-22
+
+This document specifies the **design** for Android **cost-per-mile cards** and **shift / week
+profitability** surfaces that answer the [#2139](https://github.com/jrmoulckers/finance/issues/2139)
+question: _"was this shift profitable?"_ It reads earnings and miles already captured elsewhere,
+combines them with **shared vehicle-cost calculations**, and renders the result. Compose owns **no**
+finance math.
+
+It is **design + breakdown only**. The Compose cards and Glance plumbing are **buildable now** in a
+debug build (`assembleDebug` sideload); only **Play Store distribution** is human-gated by
+[#1242](https://github.com/jrmoulckers/finance/issues/1242). See
+[§10 Implementation readiness](#10-implementation-readiness) and
+[`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md). All effort figures are
+**estimates**.
+
+---
+
+## Table of Contents
+
+- [1. Goals & Non-Goals](#1-goals--non-goals)
+- [2. KMP / Compose Boundary](#2-kmp--compose-boundary)
+- [3. Surfaces — Cards & Integrations](#3-surfaces--cards--integrations)
+- [4. Shared Dependencies](#4-shared-dependencies)
+- [5. Cost-Per-Mile Card](#5-cost-per-mile-card)
+- [6. Shift & Week Profitability](#6-shift--week-profitability)
+- [7. State Model — Offline / Empty / Error](#7-state-model--offline--empty--error)
+- [8. Accessibility (TalkBack, Switch Access, Font Scaling)](#8-accessibility-talkback-switch-access-font-scaling)
+- [9. Test Plan](#9-test-plan)
+- [10. Implementation readiness](#10-implementation-readiness)
+- [11. Open Questions](#11-open-questions)
+
+---
+
+## 1. Goals & Non-Goals
+
+### Goals
+
+- Show a **cost-per-mile card**: total operating cost-per-mile and a **fixed vs. variable** breakdown,
+  sourced from the shared `VehicleCostSummary`.
+- Show **cost per active shift** and **profitability per shift / per week** by combining shared vehicle
+  cost with shift earnings and miles.
+- Integrate the profitability read-out into the **shift summary** and a **dashboard card**, and offer
+  an optional **Glance home-screen tile**.
+- Keep **all** cost-per-mile and profitability arithmetic in **KMP `packages/core`** — Compose renders.
+
+### Non-Goals
+
+- **Logging** vehicle costs, profiles, or maintenance reminders — owned by the companion doc
+  [Vehicle expense & maintenance logging](./android-vehicle-expense-maintenance-logging.md)
+  ([#2521](https://github.com/jrmoulckers/finance/issues/2521)).
+- **Capturing** miles / shifts — owned by [Shift mileage flow](./android-shift-mileage-flow.md) and
+  [Mileage presets & IRS export](./android-mileage-presets-irs-export.md); this doc consumes their
+  output (`WorkShiftSession`, miles).
+- **Computing** any new profitability number in Compose. The profitability combiner is shared
+  (see [§2](#2-kmp--compose-boundary)).
+- Tax-reserve and take-home calculations — see
+  [Gig take-home summary](./android-gig-take-home-summary.md); profitability here is pre-tax operating
+  profit and links out for the rest.
+
+---
+
+## 2. KMP / Compose Boundary
+
+Cost-per-mile already exists in **KMP `packages/core/vehicle`** via
+`VehicleCostCalculator.aggregate(...)` → `VehicleCostSummary` (which carries `costPerMileCents`,
+`fixedCostCents`, `variableCostCents`, business-allocated variants, and counts). The **profitability
+combiner** — vehicle cost ⊕ shift earnings ⊕ miles → "profitable?" — is **domain logic** and must also
+live in KMP. Compose only renders.
+
+| Concern                                                  | Owner   | Symbol / location                                                                          |
+| -------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------ |
+| Aggregated vehicle cost & cost-per-mile                  | KMP     | `VehicleCostCalculator.aggregate(...)` → `VehicleCostSummary` (`com.finance.core.vehicle`) |
+| Fixed vs. variable split, fuel/repair/maintenance totals | KMP     | fields on `VehicleCostSummary`                                                             |
+| Business-use allocation                                  | KMP     | `BusinessUseAllocation`, `VehicleCostCalculator.allocateBusinessCost(...)`                 |
+| Miles per shift / week                                   | KMP     | `WorkShiftSession`, `MileageCalculator.summarizeShift(...)` (`com.finance.core.mileage`)   |
+| **Shift / week profitability combiner**                  | KMP     | **proposed** shared projection (see note below) — **not** implemented in Android           |
+| Currency / number / percent formatting                   | KMP     | `com.finance.core.i18n.NumberFormatting`, `com.finance.core.currency.CurrencyFormatter`    |
+| Cards, integration points, Glance tile                   | Android | `apps/android/...` (this doc)                                                              |
+
+Source of truth:
+[`VehicleCostCalculator.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/vehicle/VehicleCostCalculator.kt),
+[`VehicleModels.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/vehicle/VehicleModels.kt).
+
+> **Proposed shared combiner (out of scope to implement here — flag `@kmp-engineer`):** a
+> `VehicleProfitabilityCalculator` in `packages/core/vehicle` that takes a `VehicleCostSummary` plus
+> shift/week earnings (cents) and miles, and returns a `ShiftProfitabilitySummary`
+> (`earningsCents`, `vehicleCostCents`, `operatingProfitCents`, `costPerMileCents`,
+> `profitPerMileCents`, `costPerShiftCents`, `breakEvenMiles`). Android **must not** add this math —
+> it renders the returned summary. This doc defines the **Android consumption contract** only.
+
+```mermaid
+flowchart LR
+    M[WorkShiftSession + miles<br/>packages/core/mileage] --> P[VehicleProfitabilityCalculator<br/>proposed, packages/core/vehicle]
+    C[VehicleCostSummary<br/>VehicleCostCalculator.aggregate] --> P
+    P -->|ShiftProfitabilitySummary| VM[ProfitabilityViewModel]
+    VM -->|UiState| UI[Compose cards + Glance tile]
+```
+
+> **Rule:** Compose never subtracts cost from earnings, never divides by miles, never rounds money.
+> If a number is not already on a shared summary, the fix is a **KMP** change, not Compose arithmetic.
+
+---
+
+## 3. Surfaces — Cards & Integrations
+
+All new, all Compose — **no XML layouts**.
+
+| Surface                      | Type                          | Responsibility                                                                |
+| ---------------------------- | ----------------------------- | ----------------------------------------------------------------------------- |
+| `CostPerMileCard`            | Composable                    | Cost-per-mile + fixed/variable breakdown from `VehicleCostSummary`.           |
+| `ShiftProfitabilityCard`     | Composable                    | Per-shift earnings vs. cost, operating profit, profit/mile, break-even miles. |
+| `WeekProfitabilityCard`      | Composable                    | Same read-out aggregated over a week; trend vs. prior week.                   |
+| Shift summary integration    | Composable (host) edit-point  | Embeds `ShiftProfitabilityCard` into the existing shift-end summary.          |
+| Dashboard integration        | Composable (host) edit-point  | Adds an at-a-glance profitability card to the home dashboard.                 |
+| `VehicleProfitabilityWidget` | Glance widget (optional)      | Home-screen cost-per-mile / week-profit tile; reads shared summary.           |
+| `ProfitabilityViewModel`     | `ViewModel` (`koinViewModel`) | Collects cost + mileage state; calls the shared combiner; exposes `UiState`.  |
+| `ProfitabilityModule`        | Koin module                   | `viewModelOf(::ProfitabilityViewModel)` and shared-calculator wiring.         |
+
+Integration points are **additive** — new cards slot into existing summary/dashboard hosts; this doc
+does not redesign those screens. Cross-links:
+[Shift mileage flow](./android-shift-mileage-flow.md) (shift summary host),
+[Gig take-home summary](./android-gig-take-home-summary.md) (earnings/take-home context),
+[Operating cash calendar](./android-operating-cash-calendar.md) (week framing),
+[Food-truck P&L report](./android-foodtruck-pnl-report.md) (small-business profitability sibling).
+
+---
+
+## 4. Shared Dependencies
+
+| Dependency                                          | Use                                                | Notes                                            |
+| --------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------ |
+| `VehicleCostCalculator`, `VehicleCostSummary` (KMP) | Cost-per-mile + fixed/variable + totals            | Already present in `packages/core`.              |
+| `MileageCalculator`, `WorkShiftSession` (KMP)       | Miles per shift / week                             | Read-only; owned by mileage docs.                |
+| Proposed `VehicleProfitabilityCalculator` (KMP)     | Combine cost + earnings + miles → profitability    | **@kmp-engineer**; not implemented here.         |
+| `NumberFormatting` / `CurrencyFormatter` (KMP)      | Locale-aware money / percent strings               | Compose never builds money strings.              |
+| Koin 4.0.1 (`koin-compose-viewmodel`)               | DI for ViewModel                                   | `koinViewModel()` in Composables.                |
+| Glance (optional widget)                            | Home-screen profitability tile                     | Debug-implementable plumbing.                    |
+| Timber 5.0.1                                        | Structured logs (never `Log.*`, never log amounts) | See [§7](#7-state-model--offline--empty--error). |
+
+---
+
+## 5. Cost-Per-Mile Card
+
+`CostPerMileCard` renders a single `VehicleCostSummary` for the chosen window/vehicle:
+
+- **Headline:** `costPerMileCents` formatted via shared formatter, e.g. "$0.51 / mile" (business-use
+  variant `businessAllocatedCostPerMileCents` shown when allocation < 100%).
+- **Breakdown:** **fixed vs. variable** using `fixedCostCents`, `variableCostCents`, `fuelCostCents`,
+  `repairCostCents`, `maintenanceReserveCents`. The split is **read** from the summary — Compose does
+  not re-sum.
+- **Miles + count chips:** `totalMiles`, plus `fillUpCount` / `repairCount` for context.
+- **Zero-miles guard:** when `totalMiles == 0`, the shared calculator returns `0` cost-per-mile; the
+  card shows "—" with a caption "Log miles to see cost per mile" rather than a misleading $0.00.
+
+```mermaid
+flowchart TD
+    S[VehicleCostSummary] --> H[Headline cost-per-mile]
+    S --> B[Fixed vs variable breakdown]
+    S --> M[Miles + count chips]
+```
+
+---
+
+## 6. Shift & Week Profitability
+
+The profitability cards render the **proposed shared** `ShiftProfitabilitySummary` (see
+[§2](#2-kmp--compose-boundary)):
+
+- **Cost per active shift** = vehicle cost attributed to the shift window, from the shared combiner.
+- **Operating profit** = earnings − vehicle cost (computed in KMP); shown with a clear
+  profitable / break-even / loss state.
+- **Profit per mile** and **break-even miles** give the driver a fast "was it worth it?" read.
+- **Week view** aggregates the same fields and shows a **trend vs. prior week** (delta computed in
+  KMP).
+
+**State cues (no color-only):** profitable / break-even / loss are conveyed by **text + icon +
+container shape**, never hue alone; AA contrast across light / dark / OLED. An "estimate" caption is
+shown whenever miles or costs are partial (e.g. a fill-up without odometer).
+
+> **Boundary reminder:** earnings come from the gig/earnings domain, miles from the mileage domain,
+> and cost from `VehicleCostSummary`; the **only** place they are combined is the shared combiner.
+> Android passes the three inputs and renders one summary.
+
+```mermaid
+flowchart LR
+    E[Shift earnings<br/>cents] --> K[Shared combiner]
+    MI[Shift miles] --> K
+    VC[VehicleCostSummary] --> K
+    K -->|ShiftProfitabilitySummary| UI[ShiftProfitabilityCard / WeekProfitabilityCard]
+```
+
+---
+
+## 7. State Model — Offline / Empty / Error
+
+| Scenario                    | Behavior                                                                                                                                     |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Offline**                 | Cards render from locally stored cost + shift data; no network needed; a small "Offline" chip with `contentDescription`.                     |
+| **No vehicle / no costs**   | Cards show a guidance empty state linking to [logging](./android-vehicle-expense-maintenance-logging.md) ("Add costs to see profitability"). |
+| **No shifts / zero miles**  | Profitability shows "—" with "Log a shift to see profit per mile"; cost-per-mile guarded to "—" (KMP returns 0).                             |
+| **Partial data (estimate)** | Cards render with an explicit **"Estimate"** caption when inputs are incomplete; never silently imply precision.                             |
+| **Stale Glance tile**       | Tile shows a "last updated" timestamp; refreshed via WorkManager/Glance update, never AlarmManager.                                          |
+| **Combiner / data error**   | Card shows a non-blocking error state + Retry; `Timber.e(t, "Profitability render failed")` — **never** log amounts/earnings.                |
+
+> **Logging rule:** Timber only — never `Log.*`. Never log earnings, costs, profit, or miles. Event
+> names and non-sensitive identifiers only.
+
+---
+
+## 8. Accessibility (TalkBack, Switch Access, Font Scaling)
+
+- **`contentDescription` on every card and chip** — e.g. "Cost per mile, about 51 cents", "Operating
+  profit this shift, 38 dollars, profitable".
+- **Merged semantics** so a profitability card reads as one coherent sentence, not glyph-by-glyph;
+  trend deltas read as "up 6 dollars versus last week".
+- **State announced**, not just shown: profitable / break-even / loss are part of the spoken label and
+  carry a non-color icon.
+- **Switch Access:** cards expose a single actionable focus (e.g. "View breakdown"); breakdown rows
+  are individually focusable with clear labels.
+- **Font scaling verified at 200%:** headline + breakdown reflow without truncation; numbers wrap
+  gracefully; the Glance tile degrades to a compact layout.
+- **Charts/visuals** (if any) provide a text alternative summarizing the same numbers (see
+  [Data visualization](./data-visualization.md)).
+
+See [Accessibility Patterns Library](./accessibility-patterns.md) and
+[Cognitive Accessibility Mode](./cognitive-accessibility.md).
+
+---
+
+## 9. Test Plan
+
+| Layer                | Tool                                                          | Coverage                                                                                                     |
+| -------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| KMP math (reference) | existing vehicle tests + new combiner tests (`packages/core`) | `aggregate`, cost-per-mile, and the proposed combiner — owned by `@kmp-engineer`, Android does not re-assert |
+| ViewModel            | JUnit + Turbine                                               | `ProfitabilityUiState` emissions; combiner called with correct inputs; no Compose-side math                  |
+| Card rendering       | `createComposeRule`                                           | Cost-per-mile, fixed/variable split, profit/break-even/loss states, "estimate" caption                       |
+| Empty / zero-miles   | Compose UI                                                    | "—" and guidance states; no misleading $0.00                                                                 |
+| Glance widget        | Glance test + instrumented                                    | Tile renders shared summary; "last updated"; WorkManager refresh                                             |
+| Accessibility        | semantics assertions + Accessibility Scanner                  | `contentDescription`, spoken state, 200% font scale                                                          |
+| Snapshot             | **Paparazzi**                                                 | Cost-per-mile, shift profit (profitable/break-even/loss), week trend — light / dark / OLED + 200% font + RTL |
+| Edge cases           | unit + UI                                                     | Zero miles, partial inputs (estimate), negative/loss profit, business-use < 100%, stale tile                 |
+
+---
+
+## 10. Implementation readiness
+
+**Design + breakdown only** for this issue. Per the
+[Human-Gated Prerequisites runbook](../ops/human-gated-prerequisites.md), "blocked by #1242" gates
+**only distribution**, not implementation
+([decoupling §2](../ops/human-gated-prerequisites.md#2-implementation-vs-distribution--the-decoupling)).
+
+| Phase                                                             | Status                                                                  | Notes                                                                             |
+| ----------------------------------------------------------------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| **Design** (this doc)                                             | ✅ Deliverable now                                                      | No accounts/secrets needed.                                                       |
+| **Shared combiner** (`VehicleProfitabilityCalculator`, KMP)       | ⏳ KMP prerequisite                                                     | `@kmp-engineer` adds it in `packages/core`; Android renders its output.           |
+| **Implementation** (Compose cards, integration points, ViewModel) | ✅ Buildable now                                                        | `./gradlew :apps:android:assembleDebug` + sideload; cost-per-mile already shared. |
+| **Glance profitability tile** (optional)                          | ✅ Buildable now                                                        | Glance widget plumbing is debug-implementable.                                    |
+| **Local tests** (unit / Compose / Paparazzi)                      | ✅ Runnable now                                                         | No enrollment.                                                                    |
+| **Distribution** (Play Store, release signing)                    | 🔒 Gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242) | Google Play enrollment, keystore, CI secrets — **human-gated**.                   |
+
+**Buildable-now scope (estimate):** the cost-per-mile card and fixed/variable breakdown render today
+against the existing shared `VehicleCostSummary`; profitability cards render as soon as the proposed
+KMP combiner lands. The optional Glance tile is debug-implementable. None require a paid entitlement.
+
+**Distribution tail (human action required):** Play Store release and signing depend on the #1242
+prerequisites in
+[§3.1 of the runbook](../ops/human-gated-prerequisites.md#31-android-distribution--google-play-1242).
+No AI agent performs those steps.
+
+---
+
+## 11. Open Questions
+
+- Which window defines "a shift's vehicle cost" — the trips' time window, or a daily/period
+  proration? Proposed: the shared combiner takes explicit miles + period earnings; the **proration
+  rule lives in KMP**, not Android.
+- Should break-even be expressed in **miles** or **dollars**? Proposed: surface both from the shared
+  summary; Compose chooses presentation only.
+- Does the week trend belong here or on the dashboard? Proposed: same card, embedded in both hosts.
+
+---
+
+_Part of [#2139](https://github.com/jrmoulckers/finance/issues/2139). Companion designs:
+[Vehicle expense & maintenance logging](./android-vehicle-expense-maintenance-logging.md) ·
+[Shift mileage flow](./android-shift-mileage-flow.md) ·
+[Gig take-home summary](./android-gig-take-home-summary.md)._

--- a/docs/design/android-vehicle-expense-maintenance-logging.md
+++ b/docs/design/android-vehicle-expense-maintenance-logging.md
@@ -1,0 +1,338 @@
+# Android — Vehicle Expense & Maintenance Logging
+
+> **Status:** DRAFT — design only (pending human review)
+> **Owner:** @android-engineer
+> **Issue:** [#2521](https://github.com/jrmoulckers/finance/issues/2521) · **Part of** [#2139](https://github.com/jrmoulckers/finance/issues/2139)
+> **Platform:** Android phone (Jetpack Compose · Material 3 · Glance) · **minSdk 28 / compile-target 35**
+> **Last Updated:** 2026-06-22
+
+This document specifies the **design** for logging a driver's true vehicle operating costs on Android:
+**vehicle profiles**, quick entry for **gas / repair / insurance / phone allocation**, and
+**odometer- and date-driven maintenance reminders**. "My car is the business" — gas, tires, oil
+changes, insurance, and phone usage all decide whether driving is profitable
+([#2139](https://github.com/jrmoulckers/finance/issues/2139)).
+
+It is **design + breakdown only**. The Compose surfaces, local persistence, and reminder plumbing are
+**buildable now** in a debug build (`assembleDebug` sideload); only **Play Store distribution** is
+human-gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242). See
+[§11 Implementation readiness](#11-implementation-readiness) and
+[`../ops/human-gated-prerequisites.md`](../ops/human-gated-prerequisites.md). All effort figures are
+**estimates**.
+
+---
+
+## Table of Contents
+
+- [1. Goals & Non-Goals](#1-goals--non-goals)
+- [2. KMP / Compose Boundary](#2-kmp--compose-boundary)
+- [3. Affected Android Surfaces](#3-affected-android-surfaces)
+- [4. Shared Dependencies](#4-shared-dependencies)
+- [5. Vehicle Profiles](#5-vehicle-profiles)
+- [6. Cost Entry — Gas, Repair, Insurance, Phone Allocation](#6-cost-entry--gas-repair-insurance-phone-allocation)
+- [7. Maintenance Reminders (Odometer + Recent Spend)](#7-maintenance-reminders-odometer--recent-spend)
+- [8. State Model — Offline / Empty / Error](#8-state-model--offline--empty--error)
+- [9. Accessibility (TalkBack, Switch Access, Font Scaling)](#9-accessibility-talkback-switch-access-font-scaling)
+- [10. Test Plan](#10-test-plan)
+- [11. Implementation readiness](#11-implementation-readiness)
+- [12. Open Questions](#12-open-questions)
+
+---
+
+## 1. Goals & Non-Goals
+
+### Goals
+
+- Create and edit **vehicle profiles** (display name, optional make/model/year) on Android.
+- Provide **low-friction logging** for the cost types that decide profitability:
+  - **Gas fill-ups** (cost, gallons, optional odometer/vendor).
+  - **Repairs** (mechanical, body, tires, diagnostic).
+  - **Fixed costs** (insurance, registration, loan/lease, depreciation, permits, parking subscriptions).
+  - **Variable costs** (tolls, parking, car washes, supplies).
+  - **Phone allocation** — the business-use share of a phone bill applied to vehicle operating cost.
+- Define **maintenance reminders** from odometer milestones (service intervals) and recent spend.
+- Persist everything **offline-first**; never block entry on connectivity.
+- Render all monetary math from **shared KMP state** — Compose never owns the finance math.
+
+### Non-Goals
+
+- **Cost-per-mile cards and shift/week profitability** surfaces — covered by the companion doc
+  [Vehicle cost-per-mile profitability surfaces](./android-vehicle-cost-per-mile.md)
+  ([#2522](https://github.com/jrmoulckers/finance/issues/2522)).
+- **Mileage capture** (start/pause/end shift, odometer vs. direct miles) — owned by
+  [Shift mileage flow](./android-shift-mileage-flow.md) and
+  [Mileage presets & IRS export](./android-mileage-presets-irs-export.md); this doc consumes miles, it
+  does not record trips.
+- GPS / live tracking, OCR of fuel receipts (receipt capture is covered by
+  [Receipt-to-expense draft](./android-receipt-to-expense-draft.md)), and Wear OS surfaces.
+- Owning any cents-per-mile or allocation arithmetic in Compose (see [§2](#2-kmp--compose-boundary)).
+
+---
+
+## 2. KMP / Compose Boundary
+
+All vehicle cost math already lives in **KMP `packages/core/vehicle`**. Compose only collects raw
+inputs (amounts in cents, gallons, odometer readings, dates) and renders shared state. This is the
+non-negotiable rule from [#2139](https://github.com/jrmoulckers/finance/issues/2139): "keep reusable
+business rules in KMP `packages/*`; Compose should render shared state rather than own finance math."
+
+| Concern                                                     | Owner   | Symbol / location                                                                           |
+| ----------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------- |
+| Vehicle profile model                                       | KMP     | `Vehicle` (`com.finance.core.vehicle`)                                                      |
+| Fixed cost (insurance, registration, loan/lease, …)         | KMP     | `VehicleFixedCost`, `VehicleFixedCostCategory`                                              |
+| Variable cost (tolls, parking, washes, supplies)            | KMP     | `VehicleVariableCost`, `VehicleVariableCostCategory`                                        |
+| Fuel fill-up                                                | KMP     | `VehicleFillUp`                                                                             |
+| Repair                                                      | KMP     | `VehicleRepair`, `VehicleRepairCategory`                                                    |
+| Maintenance interval / reserve                              | KMP     | `VehicleMaintenanceInterval`, `VehicleCostCalculator.calculateMaintenanceReserveCents(...)` |
+| Business-use allocation (incl. phone share)                 | KMP     | `BusinessUseAllocation`, `VehicleCostCalculator.allocateBusinessCost(...)`                  |
+| Aggregated cost summary (cost-per-mile cents, totals)       | KMP     | `VehicleCostCalculator.aggregate(...)` → `VehicleCostSummary`                               |
+| Currency / number formatting                                | KMP     | `com.finance.core.i18n.NumberFormatting`, `com.finance.core.currency.CurrencyFormatter`     |
+| Compose UI, entry forms, local persistence, reminder worker | Android | `apps/android/...` (this doc)                                                               |
+
+Source of truth:
+[`packages/core/.../vehicle/VehicleCostCalculator.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/vehicle/VehicleCostCalculator.kt)
+and
+[`VehicleModels.kt`](../../packages/core/src/commonMain/kotlin/com/finance/core/vehicle/VehicleModels.kt).
+
+> **Rule:** Compose never sums cents, never computes cost-per-mile, never prorates a maintenance
+> reserve, and never rounds money. It passes typed inputs to `VehicleCostCalculator` and renders the
+> returned `VehicleCostSummary`. All monetary values are **integer cents** end-to-end.
+
+```mermaid
+flowchart LR
+    A[VehicleLoggingScreen<br/>Compose] -->|raw inputs| B[VehicleLoggingViewModel]
+    B -->|typed entities| C[VehicleRepository<br/>SQLDelight + SQLCipher]
+    B -->|aggregate request| D[VehicleCostCalculator.aggregate]
+    D -->|VehicleCostSummary| B
+    B -->|UiState| A
+```
+
+### Phone allocation — where the math lives
+
+A driver's phone bill is only **partly** a business cost. The user enters the **full** bill once (a
+`VehicleFixedCost`, category `OTHER` until a dedicated phone category is added in KMP) plus a
+business-use percentage; the **allocated** share is computed by
+`VehicleCostCalculator.allocateBusinessCost(...)` / `BusinessUseAllocation`. Compose shows both the
+entered amount and the shared allocated result, but performs no percentage arithmetic itself.
+
+> **KMP follow-up (out of scope here, flag `@kmp-engineer`):** a first-class
+> `VehicleFixedCostCategory.PHONE` and a per-line allocation helper would make phone allocation
+> self-describing. Until then Android surfaces an "allocation %" field and defers the math to the
+> existing shared allocator. Android **must not** add a category or allocation rule of its own.
+
+---
+
+## 3. Affected Android Surfaces
+
+All new, all Compose — **no XML layouts**.
+
+| Surface                     | Type                          | Responsibility                                                             |
+| --------------------------- | ----------------------------- | -------------------------------------------------------------------------- |
+| `VehicleProfilesScreen`     | Composable (list)             | Lists vehicles; add/edit/select; empty state.                              |
+| `VehicleProfileEditor`      | Composable (form)             | Create/edit a `Vehicle`; validates via shared `init` requirements.         |
+| `VehicleCostLogScreen`      | Composable (hub)              | Per-vehicle log: fill-ups, repairs, fixed, variable, reminders.            |
+| `VehicleCostEntrySheet`     | `ModalBottomSheet`            | Quick-log a cost; type-specific fields; offline save.                      |
+| `MaintenanceReminderList`   | Composable                    | Upcoming/overdue reminders with due-by odometer/date.                      |
+| `VehicleLoggingViewModel`   | `ViewModel` (`koinViewModel`) | Holds `VehicleLoggingUiState`; calls repository + `VehicleCostCalculator`. |
+| `VehicleRepository`         | Repository                    | CRUD over local SQLDelight/SQLCipher; offline-first.                       |
+| `MaintenanceReminderWorker` | `CoroutineWorker`             | Periodic WorkManager check; posts due reminders (**never** AlarmManager).  |
+| `VehicleModule`             | Koin module                   | `viewModelOf(::VehicleLoggingViewModel)`, `singleOf(::VehicleRepository)`. |
+
+Navigation: a `Route.VehicleLog` entry is added to
+[`FinanceNavHost`](../../apps/android/src/main/kotlin/com/finance/android/ui/navigation/FinanceNavHost.kt);
+profile selection and entry sheets stay in-process (no deep-link URI round-trip needed for v1).
+
+---
+
+## 4. Shared Dependencies
+
+| Dependency                                     | Use                                                | Notes                                            |
+| ---------------------------------------------- | -------------------------------------------------- | ------------------------------------------------ |
+| `VehicleCostCalculator`, `VehicleModels` (KMP) | All cost math + entity models                      | Already present in `packages/core`.              |
+| `NumberFormatting` / `CurrencyFormatter` (KMP) | Locale-aware money + percent formatting            | Compose never builds money strings.              |
+| `MileageCalculator` / `WorkShiftSession` (KMP) | Miles-driven input for `aggregate(...)`            | Read-only here; owned by mileage docs.           |
+| SQLDelight Android driver + SQLCipher 4.6.1    | Encrypted local store                              | Per repo security rules.                         |
+| Koin 4.0.1 (`koin-compose-viewmodel`)          | DI for ViewModel + repository                      | `koinViewModel()` in Composables.                |
+| WorkManager                                    | `MaintenanceReminderWorker`                        | No AlarmManager / JobScheduler.                  |
+| Timber 5.0.1                                   | Structured logs (never `Log.*`, never log amounts) | See [§8](#8-state-model--offline--empty--error). |
+
+---
+
+## 5. Vehicle Profiles
+
+- A user can keep **multiple vehicles**; one is marked **active** for quick logging.
+- The editor maps 1:1 to the shared `Vehicle` model: `displayName` (required), optional
+  `make` / `model` / `year`. Validation messages mirror the shared `require(...)` rules so the UI and
+  KMP never disagree (e.g. "Year must be positive").
+- Empty state on `VehicleProfilesScreen`: an illustrated "Add your vehicle" CTA — see
+  [§8](#8-state-model--offline--empty--error).
+- Editing a profile **never** rewrites historical cost rows; it only changes display metadata.
+
+```mermaid
+flowchart TD
+    P[VehicleProfilesScreen] -->|Add| E[VehicleProfileEditor]
+    P -->|Select| L[VehicleCostLogScreen]
+    E -->|save Vehicle| R[VehicleRepository]
+    R --> P
+```
+
+---
+
+## 6. Cost Entry — Gas, Repair, Insurance, Phone Allocation
+
+`VehicleCostEntrySheet` opens from the log hub with a **type selector** that switches the field set.
+Every numeric money field is captured as **integer cents**; gallons/odometer as validated `Double`.
+
+| Type                 | Maps to (KMP)                                | Key fields                                                        |
+| -------------------- | -------------------------------------------- | ----------------------------------------------------------------- |
+| **Gas fill-up**      | `VehicleFillUp`                              | total cost, gallons (> 0), optional odometer, vendor, full-tank   |
+| **Repair**           | `VehicleRepair`                              | description, total cost, category, optional odometer              |
+| **Insurance**        | `VehicleFixedCost`                           | name, amount, category `INSURANCE`, optional due date             |
+| **Other fixed**      | `VehicleFixedCost`                           | registration / loan-lease / depreciation / permit / parking-sub   |
+| **Variable**         | `VehicleVariableCost`                        | tolls / parking / car-wash / supplies, amount, optional date      |
+| **Phone allocation** | `VehicleFixedCost` + `BusinessUseAllocation` | full bill, business-use %, shared-allocated share shown read-only |
+
+**Quick logging principles**
+
+- Default to the **active vehicle**; the type last used floats to the top of the selector.
+- Amount field is focused on open; keypad is numeric/decimal; currency symbol comes from
+  `NumberFormatting.currencySymbol(...)`, never hardcoded.
+- **Save writes locally first** (offline-first) and returns immediately; sync reconciles later.
+- After save, a confirmation snackbar with a localized `contentDescription` is shown; the running
+  cost summary on the hub re-renders from a fresh `VehicleCostSummary`.
+
+> Compose validates only **shape** (non-empty, parseable, > 0 where the model requires it) so it can
+> show inline errors before calling KMP; the **authoritative** invariants remain the shared model's
+> `require(...)` blocks. No duplicated business rules.
+
+---
+
+## 7. Maintenance Reminders (Odometer + Recent Spend)
+
+A `VehicleMaintenanceInterval` (e.g. "Oil change every 5,000 mi, expected $60") already lives in KMP
+and carries `intervalMiles`, `expectedCostCents`, and `lastServicedOdometerMiles`. Two reminder
+signals are surfaced:
+
+1. **Odometer milestone** — next-due odometer = `lastServicedOdometerMiles + intervalMiles`; a
+   reminder becomes **due soon** as the latest known odometer (from fill-ups / mileage) approaches it,
+   and **overdue** once passed.
+2. **Recent spend** — if repairs/fuel for a category spike, surface a soft nudge ("Tires trending
+   high this month") sourced from shared aggregates, not Compose math.
+
+> **KMP boundary:** the _due/overdue determination_ and the "miles remaining to service" derivation
+> are **finance/domain logic** and belong in `packages/core/vehicle` (a shared
+> `VehicleMaintenanceReminder` projection over `VehicleMaintenanceInterval` + latest odometer).
+> Proposing/implementing that shared helper is **out of scope for this Android doc** —
+> flag `@kmp-engineer`. Compose renders whatever the shared layer computes.
+
+**Scheduling**
+
+- A periodic `MaintenanceReminderWorker` (WorkManager, ~daily, constraints: battery-not-low) reads the
+  shared reminder projection and posts a notification for newly **due/overdue** items.
+- **No AlarmManager / JobScheduler** — WorkManager only, per repo rules.
+- Notifications are fully described for TalkBack with actionable "Mark serviced" / "Snooze" actions;
+  "Mark serviced" records a new `lastServicedOdometerMiles` via the repository.
+
+```mermaid
+flowchart LR
+    W[MaintenanceReminderWorker<br/>WorkManager periodic] --> S[Shared reminder projection<br/>packages/core/vehicle]
+    S -->|due / overdue| N[Notification + in-app list]
+    N -->|Mark serviced| R[VehicleRepository update]
+```
+
+---
+
+## 8. State Model — Offline / Empty / Error
+
+| Scenario                          | Behavior                                                                                                                             |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| **Offline (typical for drivers)** | Full create/edit/log works against the encrypted local store; "Saved offline" snackbar; `SyncWorker` reconciles later.               |
+| **No vehicles yet**               | `VehicleProfilesScreen` shows an illustrated empty state + "Add your vehicle" CTA; logging is disabled until a profile exists.       |
+| **No costs logged yet**           | Hub shows a friendly zero state ("No costs yet — log a fill-up to start") and a $0.00 summary from `aggregate(...)` with 0 miles.    |
+| **Invalid input**                 | Inline field error before any KMP call (empty name, gallons ≤ 0, negative amount); Save disabled; nothing persisted.                 |
+| **Save failure**                  | Non-dismissing error snackbar + Retry; inputs preserved; `Timber.e(t, "Vehicle cost save failed")` — **never** log amounts/odometer. |
+| **Reminder worker failure**       | Worker returns `Result.retry()`; no user-facing crash; next periodic run re-evaluates.                                               |
+| **Zero miles for cost-per-mile**  | Shared calculator returns `0` cost-per-mile (division-by-zero guarded in KMP); UI shows "—" with an explanatory caption.             |
+
+> **Logging rule:** Timber only — never `Log.*`. Never log account numbers, balances, amounts,
+> gallons, vendor, or odometer values. Log event names and non-sensitive identifiers only.
+
+---
+
+## 9. Accessibility (TalkBack, Switch Access, Font Scaling)
+
+- **`contentDescription` on every interactive/informational Composable** — type chips, amount fields,
+  Save, reminder rows, summary tiles.
+- **Summary tiles** use merged semantics, e.g. "Total operating cost this period, 412 dollars and 30
+  cents" rather than reading each glyph; cost-per-mile reads as "About 51 cents per mile."
+- **Form fields** are programmatically labelled; validation errors use `error` semantics and are
+  announced; focus moves to the first invalid field on a failed Save.
+- **Switch Access:** the linear type-selector → fields → Save flow maps cleanly to sequential
+  scanning; targets ≥ 48 dp (primary actions ≥ 56 dp).
+- **Font scaling verified at 200%:** the entry sheet and hub reflow without truncation; the Save bar
+  stays visible (content scrolls above a fixed action bar).
+- **No color-only meaning:** "overdue" reminders are conveyed by text + icon + container, not hue
+  alone; AA contrast across light / dark / OLED.
+- **Reminder notifications** are fully described and expose accessible actions.
+
+See [Accessibility Patterns Library](./accessibility-patterns.md) and
+[Cognitive Accessibility Mode](./cognitive-accessibility.md) for shared patterns.
+
+---
+
+## 10. Test Plan
+
+| Layer                | Tool                                         | Coverage                                                                                                      |
+| -------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| KMP math (reference) | existing vehicle tests (`packages/core`)     | `aggregate`, `calculateCostPerMile`, `allocateBusinessCost`, maintenance reserve — Android does not re-assert |
+| ViewModel            | JUnit + Turbine                              | `VehicleLoggingUiState` emissions; correct entity construction; KMP `aggregate` called, not re-implemented    |
+| Repository           | SQLDelight + SQLCipher tests                 | CRUD round-trips; offline insert; "mark serviced" updates `lastServicedOdometerMiles`                         |
+| Input validation     | JUnit                                        | Shape checks mirror shared `require(...)`; empty name, gallons ≤ 0, negative cents rejected pre-KMP           |
+| WorkManager          | `WorkManagerTestInitHelper`                  | Periodic reminder worker enqueues; idempotent; `Result.retry()` on failure                                    |
+| Compose UI           | `createComposeRule`                          | Type selector switches fields; offline save snackbar; reminder list renders due/overdue                       |
+| Accessibility        | semantics assertions + Accessibility Scanner | `contentDescription` present; error announcements; 200% font scale                                            |
+| Snapshot             | **Paparazzi**                                | Profiles empty, log hub, entry sheet, reminder list — light / dark / OLED + 200% font + RTL                   |
+| Edge cases           | unit + UI                                    | Zero miles (cost-per-mile "—"), missing odometer on fill-up, save failure retry, phone allocation share       |
+
+---
+
+## 11. Implementation readiness
+
+**Design + breakdown only** for this issue. Per the
+[Human-Gated Prerequisites runbook](../ops/human-gated-prerequisites.md), "blocked by #1242" gates
+**only distribution**, not implementation
+([decoupling §2](../ops/human-gated-prerequisites.md#2-implementation-vs-distribution--the-decoupling)).
+
+| Phase                                                                                | Status                                                                  | Notes                                                                             |
+| ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| **Design** (this doc)                                                                | ✅ Deliverable now                                                      | No accounts/secrets needed.                                                       |
+| **Implementation** (Compose, `VehicleRepository`, Koin, `MaintenanceReminderWorker`) | ✅ Buildable now                                                        | `./gradlew :apps:android:assembleDebug` + sideload; all deps local + KMP.         |
+| **Glance summary tile** (optional, if surfaced)                                      | ✅ Buildable now                                                        | Glance widget plumbing is debug-implementable; reads shared `VehicleCostSummary`. |
+| **Local tests** (unit / Robolectric / Compose / Paparazzi)                           | ✅ Runnable now                                                         | No enrollment.                                                                    |
+| **Distribution** (Play Store, release signing)                                       | 🔒 Gated by [#1242](https://github.com/jrmoulckers/finance/issues/1242) | Google Play enrollment, keystore, CI secrets — **human-gated**.                   |
+
+**Buildable-now scope (estimate):** vehicle profiles, all five cost-entry types, phone allocation
+display, the WorkManager reminder worker, offline persistence, and an optional Glance summary tile all
+run on a debug build with on-device encrypted storage — no paid entitlement.
+
+**Distribution tail (human action required):** Play Store release and signing depend on the #1242
+prerequisites in
+[§3.1 of the runbook](../ops/human-gated-prerequisites.md#31-android-distribution--google-play-1242).
+No AI agent performs those steps.
+
+---
+
+## 12. Open Questions
+
+- Should phone allocation get a first-class `VehicleFixedCostCategory.PHONE` in KMP, or stay `OTHER`
+  with an allocation field? (Flag `@kmp-engineer`; Android renders either way.)
+- Does the shared maintenance-reminder projection belong to #2521's KMP slice or #2522's? Proposed:
+  the **due/overdue projection** ships with the logging slice so reminders work without the
+  profitability surfaces.
+- Default reminder lead distance (miles) before "due soon" — product-tunable; placeholder 250 mi.
+
+---
+
+_Part of [#2139](https://github.com/jrmoulckers/finance/issues/2139). Companion designs:
+[Vehicle cost-per-mile profitability surfaces](./android-vehicle-cost-per-mile.md) ·
+[Shift mileage flow](./android-shift-mileage-flow.md) ·
+[Mileage presets & IRS export](./android-mileage-presets-irs-export.md)._


### PR DESCRIPTION
## Summary

Adds three **design-only** docs (no native builds, no signing, no store actions) for the Android
vehicle/cash cluster. Each keeps cost-per-mile/profitability math and localization
formatting/terminology conceptually in KMP `packages/core` and describes the
**Compose-renders-shared-state** boundary — no implementation.

- **#2521** — Vehicle expense & maintenance logging: Compose vehicle profiles; gas/repair/insurance/
  phone-allocation entry mapped to the existing `packages/core/vehicle` models; odometer/date
  maintenance reminders via WorkManager.
- **#2522** — Vehicle cost-per-mile profitability surfaces: cost-per-mile cards + shift/week
  profitability rendering shared `VehicleCostSummary` and a proposed shared profitability combiner
  (flagged to `@kmp-engineer`).
- **#2541** — Cash wallet defaults & localized Glance widget UX: default cash wallet/category
  preferences, offline budget-device path, localized widget labels/semantics with text-expansion
  tolerance; terminology/formatting boundary kept in `packages/core/i18n`.

## Changes

New files only (no existing files, code, or shared config touched):

- `docs/design/android-vehicle-expense-maintenance-logging.md`
- `docs/design/android-vehicle-cost-per-mile.md`
- `docs/design/android-cash-wallet-localized-widget.md`

Each doc follows `docs.instructions.md`: humans-first, ToC, Mermaid diagrams, relative links to
existing docs/source, accessibility (TalkBack, Switch Access, 200% font; localized widget
text-expansion for #2541), offline/empty/error states, a unit/Compose/Paparazzi test plan, and an
**Implementation readiness** section that splits buildable-now (`assembleDebug` sideload; Glance
plumbing debug-implementable) from the Play-distribution tail gated by #1242, linking
`../ops/human-gated-prerequisites.md`. Effort figures are labeled estimates. Prettier-clean.

Closes #2521
Closes #2522
Closes #2541
