### PR TITLE
refactor(core): consume canonical mileage package in tax module (#2813)

### DIFF
--- a/packages/core/src/commonMain/kotlin/com/finance/core/tax/TaxCalculators.kt
+++ b/packages/core/src/commonMain/kotlin/com/finance/core/tax/TaxCalculators.kt
@@ -2,6 +2,7 @@
 
 package com.finance.core.tax
 
+import com.finance.core.mileage.MileageCalculation
 import com.finance.models.types.Cents
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.LocalDate
@@ -94,143 +95,6 @@ object SelfEmploymentTaxCalculator {
             medicareContribution = baseResult.medicareContribution,
             additionalMedicareTax = additionalMedicareTax,
         )
-    }
-}
-
-@Serializable
-enum class MileagePurpose { BUSINESS, MEDICAL, CHARITY }
-
-@Serializable
-data class MileageRate(
-    val purpose: MileagePurpose,
-    val centsPerMile: Long,
-    val taxYear: Int,
-)
-
-@Serializable
-data class TripEntry(
-    val tripId: String,
-    val date: LocalDate,
-    val miles: Double,
-    val purpose: MileagePurpose,
-    val startLocation: String,
-    val endLocation: String,
-    val vehicle: String? = null,
-    val isBusinessUse: Boolean? = null,
-    val supportReference: String? = null,
-    val notes: String? = null,
-)
-
-@Serializable
-data class TripDeduction(
-    val trip: TripEntry,
-    val rate: Long,
-    val deduction: Cents,
-)
-
-@Serializable
-data class MileagePurposeSummary(
-    val purpose: MileagePurpose,
-    val totalMiles: Double,
-    val rate: Long,
-    val totalDeduction: Cents,
-    val tripCount: Int,
-)
-
-@Serializable
-data class AnnualMileageSummary(
-    val year: Int,
-    val byPurpose: List<MileagePurposeSummary>,
-    val totalMiles: Double,
-    val totalDeduction: Cents,
-    val totalTrips: Int,
-)
-
-object MileageDeductionCalculator {
-    val MILEAGE_RATES_2024: List<MileageRate> = listOf(
-        MileageRate(MileagePurpose.BUSINESS, 67L, 2024),
-        MileageRate(MileagePurpose.MEDICAL, 21L, 2024),
-        MileageRate(MileagePurpose.CHARITY, 14L, 2024),
-    )
-    val MILEAGE_RATES_2025: List<MileageRate> = listOf(
-        MileageRate(MileagePurpose.BUSINESS, 70L, 2025),
-        MileageRate(MileagePurpose.MEDICAL, 21L, 2025),
-        MileageRate(MileagePurpose.CHARITY, 14L, 2025),
-    )
-    val STANDARD_MILEAGE_RATES_BY_YEAR: Map<Int, List<MileageRate>> = mapOf(
-        2024 to MILEAGE_RATES_2024,
-        2025 to MILEAGE_RATES_2025,
-    )
-
-    fun getMileageRate(purpose: MileagePurpose, taxYear: Int = 2024): Long? =
-        STANDARD_MILEAGE_RATES_BY_YEAR[taxYear]
-            ?.firstOrNull { it.purpose == purpose }
-            ?.centsPerMile
-
-    fun calculateTripDeduction(trip: TripEntry, taxYear: Int = 2024): TripDeduction {
-        val rate = getMileageRate(trip.purpose, taxYear)
-            ?: throw IllegalArgumentException("No mileage rate found for ${trip.purpose} in $taxYear.")
-        val deduction = if (trip.isBusinessUse == false) {
-            Cents.ZERO
-        } else {
-            roundCents(trip.miles * rate)
-        }
-
-        return TripDeduction(trip = trip, rate = rate, deduction = deduction)
-    }
-
-    fun calculateTripDeductions(trips: List<TripEntry>, taxYear: Int = 2024): List<TripDeduction> =
-        trips.map { calculateTripDeduction(it, taxYear) }
-
-    fun filterTripsByYear(trips: List<TripEntry>, year: Int): List<TripEntry> =
-        trips.filter { it.date.year == year }
-
-    fun filterTripsByPurpose(trips: List<TripEntry>, purpose: MileagePurpose): List<TripEntry> =
-        trips.filter { it.purpose == purpose }
-
-    fun summarizeByPurpose(
-        trips: List<TripEntry>,
-        purpose: MileagePurpose,
-        taxYear: Int = 2024,
-    ): MileagePurposeSummary {
-        val purposeTrips = filterTripsByPurpose(trips, purpose)
-        val rate = getMileageRate(purpose, taxYear) ?: 0L
-        val totalMiles = purposeTrips.sumOf { it.miles }
-        val totalDeduction = roundCents(totalMiles * rate)
-
-        return MileagePurposeSummary(
-            purpose = purpose,
-            totalMiles = totalMiles,
-            rate = rate,
-            totalDeduction = totalDeduction,
-            tripCount = purposeTrips.size,
-        )
-    }
-
-    fun generateAnnualMileageSummary(trips: List<TripEntry>, year: Int): AnnualMileageSummary {
-        val yearTrips = filterTripsByYear(trips, year)
-        val byPurpose = listOf(MileagePurpose.BUSINESS, MileagePurpose.MEDICAL, MileagePurpose.CHARITY)
-            .map { summarizeByPurpose(yearTrips, it, year) }
-        val totalMiles = byPurpose.sumOf { it.totalMiles }
-        val totalDeduction = Cents(byPurpose.sumOf { it.totalDeduction.amount })
-        val totalTrips = byPurpose.sumOf { it.tripCount }
-
-        return AnnualMileageSummary(
-            year = year,
-            byPurpose = byPurpose,
-            totalMiles = totalMiles,
-            totalDeduction = totalDeduction,
-            totalTrips = totalTrips,
-        )
-    }
-
-    fun validateTripEntry(trip: TripEntry): List<String> {
-        val errors = mutableListOf<String>()
-        if (trip.miles <= 0.0) errors += "Miles must be greater than zero."
-        if (trip.miles > 10_000.0) errors += "Miles exceeds 10,000 for a single trip — please verify."
-        if (trip.startLocation.isBlank()) errors += "Start location is required."
-        if (trip.endLocation.isBlank()) errors += "End location is required."
-        return errors
     }
 }
 
@@ -556,7 +420,13 @@ object TaxReserveCalculator {
 data class GigTakeHomeInput(
     val grossIncomeCents: Cents,
     val businessExpenseCents: Cents = Cents.ZERO,
-    val mileageDeductions: List<TripDeduction> = emptyList(),
+    /**
+     * Mileage deductions for the period, produced by the canonical mileage package
+     * (`com.finance.core.mileage.MileageCalculator`). The take-home math consumes only the
+     * per-trip [MileageCalculation.deductionCents]; the IRS standard-rate table and deduction
+     * math now live solely in `com.finance.core.mileage`.
+     */
+    val mileageDeductions: List<MileageCalculation> = emptyList(),
     val reserveRate: Double = TaxReserveCalculator.DEFAULT_TAX_RESERVE_RATE,
     val wagesCents: Cents = Cents.ZERO,
     val isMarriedFilingSeparately: Boolean = false,
@@ -575,7 +445,7 @@ data class GigTakeHomeResult(
 
 object GigTakeHomeCalculator {
     fun calculate(input: GigTakeHomeInput): GigTakeHomeResult {
-        val mileageDeductionCents = Cents(input.mileageDeductions.sumOf { it.deduction.amount })
+        val mileageDeductionCents = Cents(input.mileageDeductions.sumOf { it.deductionCents })
         val deductibleExpenses = input.businessExpenseCents.amount.coerceAtLeast(0L) +
             mileageDeductionCents.amount.coerceAtLeast(0L)
         val netSelfEmploymentIncomeCents = Cents(

--- a/packages/core/src/commonTest/kotlin/com/finance/core/tax/TaxCalculatorsTest.kt
+++ b/packages/core/src/commonTest/kotlin/com/finance/core/tax/TaxCalculatorsTest.kt
@@ -2,7 +2,13 @@
 
 package com.finance.core.tax
 
+import com.finance.core.mileage.MileageAuditMetadata
+import com.finance.core.mileage.MileageAuditSource
+import com.finance.core.mileage.MileageCalculator
+import com.finance.core.mileage.MileagePurpose
+import com.finance.core.mileage.MileageTripEntry
 import com.finance.models.types.Cents
+import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -108,25 +114,26 @@ class TaxCalculatorsTest {
     fun mileageDeduction_matchesWebTripFixtures() {
         val trips = webMileageTrips()
 
-        assertEquals(Cents(3_350), MileageDeductionCalculator.calculateTripDeduction(trips[0]).deduction)
-        assertEquals(Cents(8_040), MileageDeductionCalculator.calculateTripDeduction(trips[1]).deduction)
-        assertEquals(Cents(630), MileageDeductionCalculator.calculateTripDeduction(trips[2]).deduction)
-        assertEquals(Cents(210), MileageDeductionCalculator.calculateTripDeduction(trips[3]).deduction)
-        assertEquals(Cents(838), MileageDeductionCalculator.calculateTripDeduction(trips[5]).deduction)
+        assertEquals(3_350L, MileageCalculator.calculateTripDeduction(trips[0]).deductionCents)
+        assertEquals(8_040L, MileageCalculator.calculateTripDeduction(trips[1]).deductionCents)
+        assertEquals(630L, MileageCalculator.calculateTripDeduction(trips[2]).deductionCents)
+        assertEquals(210L, MileageCalculator.calculateTripDeduction(trips[3]).deductionCents)
+        assertEquals(838L, MileageCalculator.calculateTripDeduction(trips[5]).deductionCents)
     }
 
     @Test
     fun mileageSummary_matchesWebAnnualFixture() {
-        val summary = MileageDeductionCalculator.generateAnnualMileageSummary(webMileageTrips().take(5), 2024)
+        val summary = MileageCalculator.generateAnnualMileageSummary(webMileageTrips().take(5), 2024)
 
         assertEquals(2024, summary.year)
-        assertEquals(215.0, summary.totalMiles)
-        assertEquals(4, summary.totalTrips)
-        assertEquals(Cents(12_230), summary.totalDeduction)
+        assertEquals(215.0, summary.totalLoggedMiles)
+        assertEquals(215.0, summary.totalDeductibleMiles)
+        assertEquals(4, summary.totalTripCount)
+        assertEquals(12_230L, summary.totalDeductionCents)
         val business = summary.byPurpose.first { it.purpose == MileagePurpose.BUSINESS }
         assertEquals(170.0, business.totalMiles)
-        assertEquals(67L, business.rate)
-        assertEquals(Cents(11_390), business.totalDeduction)
+        assertEquals(67L, business.rateCentsPerMile)
+        assertEquals(11_390L, business.deductionCents)
         assertEquals(2, business.tripCount)
     }
 
@@ -134,12 +141,31 @@ class TaxCalculatorsTest {
     fun mileageDeduction_keepsPersonalTripsWithoutDeductionAndRejectsUnsupportedYears() {
         val businessTrip = webMileageTrips().first()
 
+        // A logged business trip with 0% business use deducts nothing but stays in the log.
         assertEquals(
-            Cents.ZERO,
-            MileageDeductionCalculator.calculateTripDeduction(businessTrip.copy(isBusinessUse = false)).deduction,
+            0L,
+            MileageCalculator.calculateMileageDeduction(
+                miles = businessTrip.miles,
+                purpose = MileagePurpose.BUSINESS,
+                taxYear = businessTrip.date.year,
+                businessUsePercent = 0,
+            ).deductionCents,
+        )
+        // Personal-purpose trips never produce a deduction.
+        assertEquals(
+            0L,
+            MileageCalculator.calculateMileageDeduction(
+                miles = businessTrip.miles,
+                purpose = MileagePurpose.PERSONAL,
+                taxYear = businessTrip.date.year,
+            ).deductionCents,
         )
         assertFailsWith<IllegalArgumentException> {
-            MileageDeductionCalculator.calculateTripDeduction(businessTrip, 2026)
+            MileageCalculator.calculateMileageDeduction(
+                miles = businessTrip.miles,
+                purpose = MileagePurpose.BUSINESS,
+                taxYear = 2026,
+            )
         }
     }
 
@@ -272,7 +298,7 @@ class TaxCalculatorsTest {
 
     @Test
     fun gigTakeHome_appliesMileageDeductionsToTaxableIncomeButNotCashTakeHome() {
-        val tripDeduction = MileageDeductionCalculator.calculateTripDeduction(webMileageTrips().first())
+        val tripDeduction = MileageCalculator.calculateTripDeduction(webMileageTrips().first())
         val result = GigTakeHomeCalculator.calculate(
             GigTakeHomeInput(
                 grossIncomeCents = Cents(500_000),
@@ -295,7 +321,7 @@ class TaxCalculatorsTest {
             GigTakeHomeInput(
                 grossIncomeCents = Cents(8_000_000),
                 businessExpenseCents = Cents(100_000),
-                mileageDeductions = listOf(MileageDeductionCalculator.calculateTripDeduction(webMileageTrips().first())),
+                mileageDeductions = listOf(MileageCalculator.calculateTripDeduction(webMileageTrips().first())),
                 reserveRate = 0.30,
             ),
         )
@@ -327,53 +353,31 @@ class TaxCalculatorsTest {
     )
 
     private fun webMileageTrips() = listOf(
-        TripEntry(
-            tripId = "trip-1",
-            date = LocalDate(2024, 3, 15),
-            miles = 50.0,
-            purpose = MileagePurpose.BUSINESS,
-            startLocation = "Home Office",
-            endLocation = "Client Site",
-        ),
-        TripEntry(
-            tripId = "trip-2",
-            date = LocalDate(2024, 4, 20),
-            miles = 120.0,
-            purpose = MileagePurpose.BUSINESS,
-            startLocation = "Office",
-            endLocation = "Conference Center",
-        ),
-        TripEntry(
-            tripId = "trip-3",
-            date = LocalDate(2024, 5, 10),
-            miles = 30.0,
-            purpose = MileagePurpose.MEDICAL,
-            startLocation = "Home",
-            endLocation = "Hospital",
-        ),
-        TripEntry(
-            tripId = "trip-4",
-            date = LocalDate(2024, 6, 1),
-            miles = 15.0,
-            purpose = MileagePurpose.CHARITY,
-            startLocation = "Home",
-            endLocation = "Food Bank",
-        ),
-        TripEntry(
-            tripId = "trip-5",
-            date = LocalDate(2023, 12, 15),
-            miles = 80.0,
-            purpose = MileagePurpose.BUSINESS,
-            startLocation = "Office",
-            endLocation = "Client",
-        ),
-        TripEntry(
-            tripId = "frac-1",
-            date = LocalDate(2024, 1, 15),
-            miles = 12.5,
-            purpose = MileagePurpose.BUSINESS,
-            startLocation = "A",
-            endLocation = "B",
+        mileageTrip("trip-1", LocalDate(2024, 3, 15), 50.0, MileagePurpose.BUSINESS, "Home Office", "Client Site"),
+        mileageTrip("trip-2", LocalDate(2024, 4, 20), 120.0, MileagePurpose.BUSINESS, "Office", "Conference Center"),
+        mileageTrip("trip-3", LocalDate(2024, 5, 10), 30.0, MileagePurpose.MEDICAL, "Home", "Hospital"),
+        mileageTrip("trip-4", LocalDate(2024, 6, 1), 15.0, MileagePurpose.CHARITY, "Home", "Food Bank"),
+        mileageTrip("trip-5", LocalDate(2023, 12, 15), 80.0, MileagePurpose.BUSINESS, "Office", "Client"),
+        mileageTrip("frac-1", LocalDate(2024, 1, 15), 12.5, MileagePurpose.BUSINESS, "A", "B"),
+    )
+
+    private fun mileageTrip(
+        id: String,
+        date: LocalDate,
+        miles: Double,
+        purpose: MileagePurpose,
+        startLocation: String,
+        endLocation: String,
+    ) = MileageTripEntry(
+        id = id,
+        date = date,
+        startLocation = startLocation,
+        endLocation = endLocation,
+        miles = miles,
+        purpose = purpose,
+        audit = MileageAuditMetadata(
+            source = MileageAuditSource.MANUAL,
+            createdAt = Instant.parse("2024-01-01T00:00:00Z"),
         ),
     )
 }


### PR DESCRIPTION
## Summary
Consolidates the two duplicate mileage representations in `packages/core`. The SE-tax take-home flow in `com.finance.core.tax` now consumes the **canonical** `com.finance.core.mileage` package for IRS rates and deduction calculation instead of its own copy.

### What changed
- **Removed** the duplicate mileage declarations from the tax module: `MileagePurpose`, `MileageRate`, `TripEntry`, `TripDeduction`, `MileagePurposeSummary`, `AnnualMileageSummary` and the entire `MileageDeductionCalculator` object (including its duplicate `MILEAGE_RATES_2024` / `MILEAGE_RATES_2025` tables).
- **`GigTakeHomeInput.mileageDeductions`** is now `List<MileageCalculation>` produced by `MileageCalculator`; `GigTakeHomeCalculator` reads `deductionCents` only. No tax-local adapter was needed because there are no other Kotlin consumers of the removed types (verified repo-wide) — keeping the change minimal.
- **One source of truth** for the IRS standard-mileage-rate tables: `com.finance.core.mileage.MileageCalculator`.
- **Tests** in `TaxCalculatorsTest` now reference the shared mileage types; coverage is preserved (and slightly strengthened — the personal/zero-deduction case now asserts both `businessUsePercent = 0` and `MileagePurpose.PERSONAL`).

### Rate-table reconciliation
The overlapping rates were **identical** in both sources, so there is no financial-math conflict:
| Year | BUSINESS | MEDICAL | CHARITY | MOVING |
|------|----------|---------|---------|--------|
| 2024 | 67c | 21c | 14c | 21c (canonical only) |
| 2025 | 70c | 21c | 14c | 21c (canonical only) |

The canonical table is a strict **superset** (it additionally models `MOVING` and `PERSONAL`). Per the issue guidance, the canonical values are kept as the single source of truth. No material discrepancy found.

### Parity preserved
Every web-parity fixture number is unchanged: per-trip deductions `3350 / 8040 / 630 / 210 / 838` cents, the annual summary (`215` deductible miles, `12230` total cents, `11390` business cents), and the gig take-home outputs (`mileageDeductionCents = 3350`, `netSelfEmploymentIncomeCents = 421650`, `takeHomeCents = 306938`). For the fixtures used (whole + `12.5` miles at 100% business use), the canonical calculator produces byte-identical cents to the old tax math.

### Verification note
- **Local Gradle/JDK was unavailable** in this environment, so `:packages:core` build + tests were not run locally; relying on CI (Gradle + detekt) to validate. Static verification done: brace balance, no dangling references to removed symbols (repo-wide grep), shared-type signatures matched against `MileageCalculator` / `MileageModels`.
- `prettier --check` passed. ESLint could not run locally due to a pre-existing `package-lock.json` mismatch unrelated to this change; only `.kt` files were modified (Kotlin is excluded from prettier via `.prettierignore` and linted by detekt in CI).

Closes #2813