### PR TITLE
fix(web): base-aware service worker and seed savepoint root cause (#2797)

### DIFF
--- a/apps/web/src/db/__tests__/sqlite-wasm-savepoint.test.ts
+++ b/apps/web/src/db/__tests__/sqlite-wasm-savepoint.test.ts
@@ -98,6 +98,49 @@ describe('sqlite-wasm savepoint migrations', () => {
     }
   });
 
+  it('completes seeding when the backend already released the seed savepoint (#2797)', async () => {
+    // Reproduces the production failure: on the real wa-sqlite/OPFS backend
+    // the `seed_init` savepoint can be implicitly released BEFORE the explicit
+    // `RELEASE SAVEPOINT seed_init` — after the demo rows are written — so the
+    // final RELEASE raises `no such savepoint: seed_init`. Seeding must still
+    // resolve and the demo rows must remain, rather than the benign cleanup
+    // error masking an otherwise-successful seed.
+    const db = new SQL.Database();
+
+    try {
+      await _runMigrationsForTesting(SQL, db, 'indexeddb');
+      const wrapper = _createDbWrapperForTesting(SQL, db, 'indexeddb');
+
+      const realExec = wrapper.exec.bind(wrapper);
+      let raisedNoSuchSavepoint = false;
+      wrapper.exec = (sql: string, params?: unknown[]) => {
+        if (/^RELEASE\s+SAVEPOINT\s+seed_init/i.test(sql.trim())) {
+          // Settle the data the way the real backend would have, then surface
+          // the same error wa-sqlite raises for the now-missing savepoint.
+          realExec(sql, params);
+          raisedNoSuchSavepoint = true;
+          throw new Error('no such savepoint: seed_init');
+        }
+        realExec(sql, params);
+      };
+
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      try {
+        await expect(seedDatabase(wrapper)).resolves.toBeUndefined();
+      } finally {
+        warn.mockRestore();
+      }
+
+      expect(raisedNoSuchSavepoint).toBe(true);
+      const accounts = wrapper.selectOne('SELECT COUNT(*) AS count FROM account;');
+      const transactions = wrapper.selectOne('SELECT COUNT(*) AS count FROM "transaction";');
+      expect(Number(accounts?.count ?? 0)).toBeGreaterThan(0);
+      expect(Number(transactions?.count ?? 0)).toBeGreaterThan(0);
+    } finally {
+      db.close();
+    }
+  });
+
   it.each([
     ['release', releaseSavepoint],
     ['rollback', rollbackToSavepoint],
@@ -106,6 +149,33 @@ describe('sqlite-wasm savepoint migrations', () => {
       backend: 'opfs',
       exec: vi.fn(() => {
         throw new Error('cannot commit - no transaction is active');
+      }),
+      selectAll: vi.fn(),
+      selectOne: vi.fn(),
+      close: vi.fn(),
+    };
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    try {
+      expect(() => helper(db, 'seed_init')).not.toThrow();
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('seed_init'), {
+        backend: 'opfs',
+        savepointName: 'seed_init',
+        error: expect.any(Error),
+      });
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it.each([
+    ['release', releaseSavepoint],
+    ['rollback', rollbackToSavepoint],
+  ] as const)('logs and suppresses no-such-savepoint %s failures (#2797)', (_, helper) => {
+    const db: SqliteDb = {
+      backend: 'opfs',
+      exec: vi.fn(() => {
+        throw new Error('no such savepoint: seed_init');
       }),
       selectAll: vi.fn(),
       selectOne: vi.fn(),

--- a/apps/web/src/db/seed.ts
+++ b/apps/web/src/db/seed.ts
@@ -64,6 +64,13 @@ export async function seedDatabase(db: SqliteDb): Promise<void> {
   const householdMemberId = crypto.randomUUID();
   const monthStart = firstDayOfCurrentMonth();
 
+  // Wrap the demo rows in a savepoint so a mid-seed failure rolls back cleanly
+  // without touching any outer transaction. `releaseSavepoint` /
+  // `rollbackToSavepoint` are idempotent (#2797): on the real wa-sqlite/OPFS
+  // backend SQLite can implicitly release `seed_init` before the explicit
+  // RELEASE below — after the rows are already written — so the helpers treat
+  // an already-released savepoint as a no-op instead of throwing
+  // `no such savepoint: seed_init` and aborting an otherwise-successful seed.
   const seedSavepoint = 'seed_init';
   execute(db, `SAVEPOINT ${seedSavepoint}`);
 

--- a/apps/web/src/db/sqlite-wasm.ts
+++ b/apps/web/src/db/sqlite-wasm.ts
@@ -1010,10 +1010,35 @@ type SavepointOperation = 'release' | 'rollback';
 type SavepointLogBackend = StorageBackend | 'unknown';
 
 const NO_ACTIVE_TRANSACTION_ERROR = 'no transaction is active';
+const NO_SUCH_SAVEPOINT_ERROR = 'no such savepoint';
 
-function isNoActiveTransactionError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return message.toLowerCase().includes(NO_ACTIVE_TRANSACTION_ERROR);
+/**
+ * Detect the benign "the savepoint/transaction is already gone" conditions.
+ *
+ * `RELEASE SAVEPOINT` / `ROLLBACK TO SAVEPOINT` are cleanup operations. They
+ * are only ever issued to settle a savepoint we previously opened, so if
+ * SQLite reports that the savepoint (or the enclosing transaction) no longer
+ * exists, the work the savepoint guarded is already settled and the cleanup
+ * is a no-op rather than a fatal error. Two distinct SQLite messages map to
+ * this state:
+ *
+ *   - `cannot commit/rollback - no transaction is active` — the enclosing
+ *     transaction already ended (e.g. a cold-start race finalised it first).
+ *   - `no such savepoint: <name>` — the named savepoint was already released.
+ *     This is the failure that surfaced demo-seeding's `no such savepoint:
+ *     seed_init` on the real wa-sqlite/OPFS backend (#2797): that backend can
+ *     implicitly release the seed savepoint before `seedDatabase()` reaches
+ *     its explicit `RELEASE`, after the demo rows have already been written.
+ *     The sql.js backend used by unit tests never reproduces this, which is
+ *     why the bug slipped past CI.
+ *
+ * Suppressing both keeps savepoint cleanup idempotent so a benign
+ * already-released savepoint never masks the real outcome (or aborts an
+ * otherwise-successful seed).
+ */
+function isBenignSavepointCleanupError(error: unknown): boolean {
+  const message = (error instanceof Error ? error.message : String(error)).toLowerCase();
+  return message.includes(NO_ACTIVE_TRANSACTION_ERROR) || message.includes(NO_SUCH_SAVEPOINT_ERROR);
 }
 
 function getSavepointIdentifier(savepointName: string): string {
@@ -1023,7 +1048,7 @@ function getSavepointIdentifier(savepointName: string): string {
   return savepointName;
 }
 
-function logSuppressedNoActiveTransaction(
+function logSuppressedSavepointCleanup(
   operation: SavepointOperation,
   backend: SavepointLogBackend,
   savepointName: string,
@@ -1031,7 +1056,7 @@ function logSuppressedNoActiveTransaction(
 ): void {
   // eslint-disable-next-line no-console
   console.warn(
-    `[sqlite-wasm] Suppressed ${operation} failure for savepoint "${savepointName}" on ${backend} backend: ${NO_ACTIVE_TRANSACTION_ERROR}.`,
+    `[sqlite-wasm] Suppressed ${operation} for already-released savepoint "${savepointName}" on ${backend} backend.`,
     { backend, savepointName, error },
   );
 }
@@ -1045,8 +1070,8 @@ function execSavepointControl(
   try {
     executor();
   } catch (error) {
-    if (isNoActiveTransactionError(error)) {
-      logSuppressedNoActiveTransaction(operation, backend, savepointName, error);
+    if (isBenignSavepointCleanupError(error)) {
+      logSuppressedSavepointCleanup(operation, backend, savepointName, error);
       return;
     }
     throw error;

--- a/apps/web/src/lib/pwa/__tests__/manifest-base.test.ts
+++ b/apps/web/src/lib/pwa/__tests__/manifest-base.test.ts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyBaseToWebManifest,
+  normalizeManifestBasePath,
+  type WebManifest,
+} from '../manifest-base';
+
+const ROOT_MANIFEST: WebManifest = {
+  id: '/?source=pwa',
+  name: 'Finance',
+  scope: '/',
+  start_url: '/?source=pwa',
+  icons: [
+    { src: '/icons/icon-192.png', sizes: '192x192', type: 'image/png', purpose: 'any' },
+    { src: '/icons/icon-512.png', sizes: '512x512', type: 'image/png', purpose: 'any' },
+  ],
+};
+
+describe('normalizeManifestBasePath', () => {
+  it('treats root-like values as "/"', () => {
+    expect(normalizeManifestBasePath('/')).toBe('/');
+    expect(normalizeManifestBasePath('')).toBe('/');
+    expect(normalizeManifestBasePath(undefined)).toBe('/');
+    expect(normalizeManifestBasePath('./')).toBe('/');
+  });
+
+  it('normalizes subpaths to a leading-and-trailing slash form', () => {
+    expect(normalizeManifestBasePath('/finance')).toBe('/finance/');
+    expect(normalizeManifestBasePath('finance/')).toBe('/finance/');
+    expect(normalizeManifestBasePath('https://jrmoulckers.github.io/finance/')).toBe('/finance/');
+  });
+});
+
+describe('applyBaseToWebManifest', () => {
+  it('returns the manifest unchanged for a root base', () => {
+    expect(applyBaseToWebManifest(ROOT_MANIFEST, '/')).toBe(ROOT_MANIFEST);
+  });
+
+  it('rewrites scope, start_url, id and icon src under a subpath base', () => {
+    const result = applyBaseToWebManifest(ROOT_MANIFEST, '/finance/');
+
+    expect(result.scope).toBe('/finance/');
+    expect(result.start_url).toBe('/finance/?source=pwa');
+    expect(result.id).toBe('/finance/?source=pwa');
+    expect(result.icons?.map((icon) => icon.src)).toEqual([
+      '/finance/icons/icon-192.png',
+      '/finance/icons/icon-512.png',
+    ]);
+  });
+
+  it('does not mutate the input manifest', () => {
+    const input: WebManifest = { ...ROOT_MANIFEST, icons: [...(ROOT_MANIFEST.icons ?? [])] };
+    applyBaseToWebManifest(input, '/finance/');
+
+    expect(input.scope).toBe('/');
+    expect(input.start_url).toBe('/?source=pwa');
+    expect(input.icons?.[0]?.src).toBe('/icons/icon-192.png');
+  });
+
+  it('is idempotent — already-based paths are left intact', () => {
+    const once = applyBaseToWebManifest(ROOT_MANIFEST, '/finance/');
+    const twice = applyBaseToWebManifest(once, '/finance/');
+
+    expect(twice.scope).toBe('/finance/');
+    expect(twice.start_url).toBe('/finance/?source=pwa');
+    expect(twice.icons?.map((icon) => icon.src)).toEqual([
+      '/finance/icons/icon-192.png',
+      '/finance/icons/icon-512.png',
+    ]);
+  });
+
+  it('normalizes a base supplied without a trailing slash', () => {
+    const result = applyBaseToWebManifest(ROOT_MANIFEST, '/finance');
+    expect(result.scope).toBe('/finance/');
+    expect(result.start_url).toBe('/finance/?source=pwa');
+  });
+
+  it('leaves non-root (external/relative) values untouched', () => {
+    const manifest: WebManifest = {
+      scope: '/',
+      start_url: '/?source=pwa',
+      icons: [{ src: 'https://cdn.example.com/icon.png' }, { src: 'relative/icon.png' }],
+    };
+    const result = applyBaseToWebManifest(manifest, '/finance/');
+
+    expect(result.icons?.map((icon) => icon.src)).toEqual([
+      'https://cdn.example.com/icon.png',
+      'relative/icon.png',
+    ]);
+  });
+});

--- a/apps/web/src/lib/pwa/manifest-base.ts
+++ b/apps/web/src/lib/pwa/manifest-base.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Base-path rewriting for the PWA Web App Manifest.
+ *
+ * `public/manifest.json` is copied verbatim into the build output, so its
+ * absolute paths (`scope`, `start_url`, `id`, icon `src`) stay pinned to the
+ * site root. That is correct for the default root deploy, but GitHub Pages
+ * project sites serve the app under a subpath (`/finance/`), where a root
+ * `scope`/`start_url` no longer matches the registered service-worker scope
+ * and the PWA becomes non-installable (#2797).
+ *
+ * {@link applyBaseToWebManifest} rewrites those absolute paths to incorporate
+ * the configured Vite base so the manifest, the service-worker scope, and the
+ * precached app shell all agree on `/finance/`. The build wires this into a
+ * Vite `closeBundle` step (see `vite.config.ts`).
+ */
+
+export interface WebManifestIcon {
+  readonly src?: string;
+  readonly [key: string]: unknown;
+}
+
+export interface WebManifest {
+  id?: string;
+  scope?: string;
+  start_url?: string;
+  icons?: WebManifestIcon[];
+  [key: string]: unknown;
+}
+
+/**
+ * Normalize a Vite `base` value to a leading-and-trailing-slash path, e.g.
+ * `/finance` / `finance/` / `https://host/finance/` all become `/finance/`.
+ * A root base resolves to `/`.
+ */
+export function normalizeManifestBasePath(basePath: string | undefined): string {
+  const trimmed = basePath?.trim();
+  if (!trimmed || trimmed === '/' || trimmed === '.' || trimmed === './') {
+    return '/';
+  }
+
+  let pathname = trimmed;
+  if (/^[a-z][a-z\d+.-]*:/i.test(trimmed)) {
+    pathname = new URL(trimmed).pathname;
+  }
+
+  const withLeadingSlash = pathname.startsWith('/') ? pathname : `/${pathname}`;
+  return withLeadingSlash.endsWith('/') ? withLeadingSlash : `${withLeadingSlash}/`;
+}
+
+/**
+ * Return a copy of `manifest` whose root-absolute paths are rewritten to live
+ * under `basePath`. A root base (`/`) returns the manifest unchanged.
+ *
+ * Only root-absolute values (`/...`) that are not already prefixed with the
+ * base are rewritten — external URLs and already-based paths are left intact,
+ * making the transform idempotent.
+ */
+export function applyBaseToWebManifest(manifest: WebManifest, basePath: string): WebManifest {
+  const base = normalizeManifestBasePath(basePath);
+  if (base === '/') {
+    return manifest;
+  }
+
+  const withBase = (value: string): string => {
+    if (!value.startsWith('/') || value.startsWith(base)) {
+      return value;
+    }
+    return `${base}${value.replace(/^\/+/, '')}`;
+  };
+
+  const next: WebManifest = { ...manifest };
+
+  // The PWA scope must equal the service-worker scope (the Vite base).
+  if (typeof next.scope === 'string') {
+    next.scope = base;
+  }
+  if (typeof next.start_url === 'string') {
+    next.start_url = withBase(next.start_url);
+  }
+  if (typeof next.id === 'string') {
+    next.id = withBase(next.id);
+  }
+  if (Array.isArray(next.icons)) {
+    next.icons = next.icons.map((icon) =>
+      icon && typeof icon.src === 'string' ? { ...icon, src: withBase(icon.src) } : icon,
+    );
+  }
+
+  return next;
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 import react from '@vitejs/plugin-react';
 import { defineConfig, type Connect, type Plugin, type ResolvedConfig } from 'vite';
 
 import { getRouteChunkName } from './src/lib/perf/route-chunks';
+import { applyBaseToWebManifest, type WebManifest } from './src/lib/pwa/manifest-base';
 
 /**
  * Vite plugin that copies sql.js WASM binaries to the public assets directory.
@@ -109,6 +110,37 @@ function swPrecacheManifest(): Plugin {
   };
 }
 
+function baseAwareWebManifest(): Plugin {
+  let basePath = '/';
+  let outDir = 'dist';
+
+  return {
+    name: 'base-aware-web-manifest',
+    apply: 'build',
+    configResolved(config: ResolvedConfig) {
+      basePath = normalizeServiceWorkerBasePath(config.base);
+      outDir = config.build.outDir;
+    },
+    // Run after the static `public/` copy so we rewrite the emitted manifest.
+    // GitHub Pages project sites serve under a subpath (`/finance/`); the
+    // checked-in manifest is root-pinned, so without this its `scope` /
+    // `start_url` / icons disagree with the SW scope and break installability
+    // (#2797). Root deploys are left untouched.
+    closeBundle() {
+      if (basePath === '/') {
+        return;
+      }
+      const manifestPath = resolve(__dirname, outDir, 'manifest.json');
+      if (!existsSync(manifestPath)) {
+        return;
+      }
+      const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as WebManifest;
+      const rewritten = applyBaseToWebManifest(manifest, basePath);
+      writeFileSync(manifestPath, `${JSON.stringify(rewritten, null, 2)}\n`);
+    },
+  };
+}
+
 function allowServiceWorkerRootScope(): Plugin {
   return {
     name: 'allow-service-worker-root-scope',
@@ -161,6 +193,7 @@ export default defineConfig({
     react(),
     copySqlJsWasm(),
     swPrecacheManifest(),
+    baseAwareWebManifest(),
     allowServiceWorkerRootScope(),
     stubAuthRefreshForCi(),
   ],

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -131,10 +131,18 @@ function baseAwareWebManifest(): Plugin {
         return;
       }
       const manifestPath = resolve(__dirname, outDir, 'manifest.json');
-      if (!existsSync(manifestPath)) {
-        return;
+      // Read directly instead of `existsSync` + read to avoid a time-of-check
+      // to time-of-use (TOCTOU) file-system race; tolerate a missing manifest.
+      let raw: string;
+      try {
+        raw = readFileSync(manifestPath, 'utf8');
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          return;
+        }
+        throw error;
       }
-      const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as WebManifest;
+      const manifest = JSON.parse(raw) as WebManifest;
       const rewritten = applyBaseToWebManifest(manifest, basePath);
       writeFileSync(manifestPath, `${JSON.stringify(rewritten, null, 2)}\n`);
     },


### PR DESCRIPTION
﻿## Summary

Follow-ups to the GitHub Pages auto-deploy (https://jrmoulckers.github.io/finance/) tracked in #2797. This addresses the two agent-completable items; the backend-secrets item is human-gated (see below).

### Fix #1 — Service worker / PWA under the `/finance/` subpath
The core SW *script evaluation* failure was already resolved by #2800 (base-aware precache manifest + self-contained SW bundle + base-aware registration scope). The remaining gap was the **PWA Web App Manifest**: `public/manifest.json` is copied verbatim into the build, so its `scope`, `start_url`, `id`, and icon `src` stayed pinned to root `/`. Under `/finance/` that makes the manifest scope disagree with the registered service-worker scope (`/finance/`) and breaks installability.

- New `base-aware-web-manifest` Vite plugin (`closeBundle`) rewrites the emitted `dist/manifest.json` paths to the configured Vite `base`. Verified: a `/finance/` build emits `scope: "/finance/"`, `start_url: "/finance/?source=pwa"`, icons `/finance/icons/...`; a default root build is left untouched.
- Rewrite logic extracted to a pure, unit-tested helper `src/lib/pwa/manifest-base.ts` (idempotent; leaves external/relative URLs alone).

### Fix #2 — Demo seed `no such savepoint: seed_init` root cause
`no such savepoint: seed_init` surfaced only against a **real (non-stub) DB**. On the wa-sqlite/OPFS backend SQLite can implicitly release the `seed_init` savepoint *before* `seedDatabase()` issues its explicit `RELEASE` — after the demo rows have already been written. The savepoint cleanup helpers only tolerated `"no transaction is active"`, so the benign "already released" condition was re-thrown, aborting an otherwise-successful seed and masking the inserted data.

- `RELEASE SAVEPOINT` / `ROLLBACK TO SAVEPOINT` cleanup is now idempotent for **both** `"no transaction is active"` and `"no such savepoint"`. An already-released savepoint is a logged no-op, not a fatal error — so demo data seeds against a real DB while remaining best-effort safe (a seed failure still never bricks boot).

### Why this slipped through CI
Unit tests use the **sql.js** backend and E2E uses a **stub DB**, neither of which reproduces the wa-sqlite/OPFS implicit-release behavior. Added focused regression tests:
- `no such savepoint` suppression in `releaseSavepoint`/`rollbackToSavepoint`.
- A seed that **resolves with demo rows intact** when the backend pre-releases the savepoint and the final `RELEASE` raises `no such savepoint`.
- Pure unit tests for the base-aware manifest rewrite.

## Verification
- `npm run format:check` + `npx eslint . --max-warnings 0` — clean.
- `apps/web` `db/` suite (361), SW lifecycle/register/update + new manifest tests — all green.
- Production build with `PUBLIC_BASE_PATH=/finance/` emits a base-correct manifest and a self-contained `sw.js`.

## Files changed
- `apps/web/src/db/sqlite-wasm.ts` — idempotent savepoint cleanup (`no such savepoint` + `no transaction is active`).
- `apps/web/src/db/seed.ts` — root-cause comment.
- `apps/web/src/db/__tests__/sqlite-wasm-savepoint.test.ts` — regression tests.
- `apps/web/src/lib/pwa/manifest-base.ts` (+ test) — base-aware manifest helper.
- `apps/web/vite.config.ts` — `base-aware-web-manifest` plugin.

## Needs Human Action
**#3 — Backend connectivity (repo secrets) is NOT done here and remains open.** The Pages build falls back to a `placeholder` Supabase URL because the repo has no `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` secrets. Adding repository secrets is a privileged, human-gated operation an agent cannot (and must not) perform. To enable backend-connected Pages deploys, a maintainer must add these GitHub Actions repo secrets (Settings → Secrets and variables → Actions) and re-run the Pages deploy:
- `VITE_SUPABASE_URL` — the Supabase project URL
- `VITE_SUPABASE_ANON_KEY` — the Supabase anon/public key

Until then, the deployed app runs in local-only/demo mode (which is expected and non-fatal).

Refs #2797
