### PR TITLE
feat(web): chain-aware crypto cost basis and taxable-event tracking (#2168)

### DIFF
--- a/apps/web/src/components/investments/CryptoTaxableEventsReport.test.tsx
+++ b/apps/web/src/components/investments/CryptoTaxableEventsReport.test.tsx
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { CryptoTaxableEventsReport } from './CryptoTaxableEventsReport';
+import type {
+  CryptoAirdropEvent,
+  CryptoBridgeEvent,
+  CryptoSwapEvent,
+  CryptoTaxLot,
+} from '../../lib/assets';
+
+const ethLot: CryptoTaxLot = {
+  id: 'eth-1',
+  symbol: 'ETH',
+  quantity: 1,
+  acquisitionDate: '2021-01-01',
+  costBasisCents: 100000, // $1,000 basis
+  source: 'WALLET',
+  chain: 'ethereum',
+};
+
+describe('CryptoTaxableEventsReport', () => {
+  it('renders an empty state when there are no events', () => {
+    render(<CryptoTaxableEventsReport events={[]} />);
+    expect(screen.getByText(/no swaps, bridges, or airdrops recorded yet/i)).toBeInTheDocument();
+  });
+
+  it('shows a swap as a taxable event with a realized gain', () => {
+    const swap: CryptoSwapEvent = {
+      id: 'swap-1',
+      type: 'SWAP',
+      date: '2024-06-01',
+      chain: 'ethereum',
+      fromSymbol: 'ETH',
+      fromQuantity: 1,
+      toSymbol: 'USDC',
+      toQuantity: 2000,
+      fairMarketValueCents: 200000, // $2,000 proceeds → $1,000 gain
+    };
+
+    render(<CryptoTaxableEventsReport events={[swap]} openingLots={[ethLot]} />);
+
+    expect(screen.getByText('Crypto taxable events (FIFO)')).toBeInTheDocument();
+    expect(screen.getByText('Swap')).toBeInTheDocument();
+    expect(screen.getByText('Taxable')).toBeInTheDocument();
+    expect(screen.getByText('ethereum')).toBeInTheDocument();
+    // $1,000.00 gain appears in the summary and the event row.
+    expect(screen.getAllByText(/1,000\.00/).length).toBeGreaterThan(0);
+  });
+
+  it('labels a bridge as non-taxable', () => {
+    const bridge: CryptoBridgeEvent = {
+      id: 'bridge-1',
+      type: 'BRIDGE',
+      date: '2024-06-01',
+      symbol: 'ETH',
+      quantity: 1,
+      fromChain: 'ethereum',
+      toChain: 'arbitrum',
+    };
+
+    render(<CryptoTaxableEventsReport events={[bridge]} openingLots={[ethLot]} />);
+
+    expect(screen.getByText('Bridge')).toBeInTheDocument();
+    expect(screen.getByText('Non-taxable')).toBeInTheDocument();
+    expect(screen.getByText('arbitrum')).toBeInTheDocument();
+  });
+
+  it('shows airdrop ordinary income', () => {
+    const airdrop: CryptoAirdropEvent = {
+      id: 'air-1',
+      type: 'AIRDROP',
+      date: '2024-06-01',
+      chain: 'optimism',
+      symbol: 'OP',
+      quantity: 100,
+      fairMarketValueCents: 50000, // $500 FMV income
+    };
+
+    render(<CryptoTaxableEventsReport events={[airdrop]} />);
+
+    expect(screen.getByText('Airdrop')).toBeInTheDocument();
+    expect(screen.getByText('Taxable')).toBeInTheDocument();
+    expect(screen.getAllByText(/500\.00/).length).toBeGreaterThan(0);
+  });
+
+  it('reflects the lot-matching method in the heading', () => {
+    const swap: CryptoSwapEvent = {
+      id: 'swap-hifo',
+      type: 'SWAP',
+      date: '2024-06-01',
+      chain: 'ethereum',
+      fromSymbol: 'ETH',
+      fromQuantity: 1,
+      toSymbol: 'USDC',
+      toQuantity: 2000,
+      fairMarketValueCents: 200000,
+    };
+
+    render(<CryptoTaxableEventsReport events={[swap]} openingLots={[ethLot]} method="HIFO" />);
+    expect(screen.getByText('Crypto taxable events (HIFO)')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/investments/CryptoTaxableEventsReport.tsx
+++ b/apps/web/src/components/investments/CryptoTaxableEventsReport.tsx
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Presentational report for chain-aware crypto taxable events (DeFi).
+ *
+ * Given a set of swap/bridge/airdrop events and the opening tax-lot book, this
+ * component runs the pure {@link processCryptoEvents} engine and renders:
+ *   - headline totals (realized short/long-term gains and airdrop income),
+ *   - a per-event breakdown tagged with chain and tax treatment.
+ *
+ * The component is data-source agnostic — events and lots arrive via props, so
+ * it can later be wired to a hook/repository without changes here. It performs
+ * no data access and holds no state beyond a memoized derivation.
+ *
+ * References: issue #2168
+ */
+
+import React, { useMemo } from 'react';
+import {
+  processCryptoEvents,
+  type CryptoEventResult,
+  type CryptoLotMethod,
+  type CryptoTaxableEvent,
+  type CryptoTaxLot,
+} from '../../lib/assets';
+import { formatCurrency } from '../../lib/currency';
+
+/** Props for {@link CryptoTaxableEventsReport}. */
+export interface CryptoTaxableEventsReportProps {
+  /** Swap/bridge/airdrop events to summarize (any order; sorted by date). */
+  readonly events: readonly CryptoTaxableEvent[];
+  /** Opening tax-lot book the events are applied against. */
+  readonly openingLots?: readonly CryptoTaxLot[];
+  /** Lot-matching method for disposals (default FIFO). */
+  readonly method?: CryptoLotMethod;
+  /** ISO 4217 currency code for display formatting (default USD). */
+  readonly currency?: string;
+}
+
+const EVENT_TYPE_LABELS: Record<CryptoEventResult['eventType'], string> = {
+  SWAP: 'Swap',
+  BRIDGE: 'Bridge',
+  AIRDROP: 'Airdrop',
+};
+
+/**
+ * Render a chain-aware crypto taxable-events summary and per-event table.
+ */
+export const CryptoTaxableEventsReport: React.FC<CryptoTaxableEventsReportProps> = ({
+  events,
+  openingLots,
+  method = 'FIFO',
+  currency = 'USD',
+}) => {
+  const batch = useMemo(
+    () => processCryptoEvents(openingLots ?? [], events, method),
+    [openingLots, events, method],
+  );
+
+  const money = (cents: number): string =>
+    formatCurrency(cents, { currency, signDisplay: 'exceptZero' });
+
+  if (events.length === 0) {
+    return (
+      <section aria-labelledby="crypto-defi-events-heading">
+        <h3 id="crypto-defi-events-heading">Crypto taxable events</h3>
+        <p style={{ color: 'var(--semantic-text-secondary)' }}>
+          No swaps, bridges, or airdrops recorded yet.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section aria-labelledby="crypto-defi-events-heading">
+      <h3 id="crypto-defi-events-heading">Crypto taxable events ({method})</h3>
+
+      <dl style={summaryGridStyle}>
+        <SummaryStat
+          label="Short-term gain/loss"
+          value={money(batch.totalShortTermGainLossCents)}
+        />
+        <SummaryStat label="Long-term gain/loss" value={money(batch.totalLongTermGainLossCents)} />
+        <SummaryStat label="Realized gain/loss" value={money(batch.totalRealizedGainLossCents)} />
+        <SummaryStat label="Airdrop income" value={money(batch.totalOrdinaryIncomeCents)} />
+        <SummaryStat label="Taxable events" value={String(batch.taxableEventCount)} />
+      </dl>
+
+      <div style={{ overflowX: 'auto', marginTop: 'var(--spacing-4)' }}>
+        <table style={tableStyle} aria-label="Crypto taxable events">
+          <thead>
+            <tr>
+              <Th text="Date" />
+              <Th text="Type" />
+              <Th text="Chain" />
+              <Th text="Treatment" />
+              <Th text="Realized G/L" align="right" />
+              <Th text="Income" align="right" />
+            </tr>
+          </thead>
+          <tbody>
+            {batch.events.map((result) => (
+              <tr key={result.eventId}>
+                <Td>{result.date}</Td>
+                <Td>{EVENT_TYPE_LABELS[result.eventType]}</Td>
+                <Td>{result.chain}</Td>
+                <Td>
+                  <span style={result.taxable ? taxableBadgeStyle : nonTaxableBadgeStyle}>
+                    {result.taxable ? 'Taxable' : 'Non-taxable'}
+                  </span>
+                </Td>
+                <Td align="right">{money(result.realizedGainLossCents)}</Td>
+                <Td align="right">{money(result.ordinaryIncomeCents)}</Td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Presentational helpers
+// ---------------------------------------------------------------------------
+
+const SummaryStat: React.FC<{ readonly label: string; readonly value: string }> = ({
+  label,
+  value,
+}) => (
+  <div style={statCardStyle}>
+    <dt style={statLabelStyle}>{label}</dt>
+    <dd style={statValueStyle}>{value}</dd>
+  </div>
+);
+
+const Th: React.FC<{ readonly text: string; readonly align?: 'left' | 'right' }> = ({
+  text,
+  align = 'left',
+}) => (
+  <th scope="col" style={{ ...cellStyle, textAlign: align }}>
+    {text}
+  </th>
+);
+
+const Td: React.FC<{ readonly children: React.ReactNode; readonly align?: 'left' | 'right' }> = ({
+  children,
+  align = 'left',
+}) => <td style={{ ...cellStyle, textAlign: align }}>{children}</td>;
+
+// ---------------------------------------------------------------------------
+// Styles (design tokens with safe fallbacks)
+// ---------------------------------------------------------------------------
+
+const summaryGridStyle: React.CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))',
+  gap: 'var(--spacing-3)',
+  margin: 0,
+};
+
+const statCardStyle: React.CSSProperties = {
+  padding: 'var(--spacing-3)',
+  borderRadius: 'var(--radius-md, 8px)',
+  background: 'var(--semantic-background-secondary, #f9fafb)',
+};
+
+const statLabelStyle: React.CSSProperties = {
+  color: 'var(--semantic-text-secondary)',
+  fontSize: 'var(--font-size-sm, 0.875rem)',
+};
+
+const statValueStyle: React.CSSProperties = {
+  margin: 0,
+  fontWeight: 700,
+};
+
+const tableStyle: React.CSSProperties = {
+  width: '100%',
+  borderCollapse: 'collapse',
+  fontSize: 'var(--font-size-sm, 0.875rem)',
+};
+
+const cellStyle: React.CSSProperties = {
+  padding: 'var(--spacing-2)',
+  borderBottom: '1px solid var(--semantic-border, #e5e7eb)',
+};
+
+const taxableBadgeStyle: React.CSSProperties = {
+  color: 'var(--semantic-warning, #b45309)',
+  fontWeight: 600,
+};
+
+const nonTaxableBadgeStyle: React.CSSProperties = {
+  color: 'var(--semantic-text-secondary, #6b7280)',
+  fontWeight: 600,
+};

--- a/apps/web/src/lib/assets/crypto-defi.test.ts
+++ b/apps/web/src/lib/assets/crypto-defi.test.ts
@@ -1,0 +1,544 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+import {
+  processCryptoEvent,
+  processCryptoEvents,
+  summarizeCryptoEvents,
+  toAirdropIncome,
+} from './crypto-defi';
+import type { CryptoAirdropEvent, CryptoBridgeEvent, CryptoSwapEvent, CryptoTaxLot } from './types';
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+/** $1,000.00 of ETH acquired long ago on Ethereum (long-term when disposed). */
+const ethLotLongTerm: CryptoTaxLot = {
+  id: 'eth-1',
+  symbol: 'ETH',
+  quantity: 1,
+  acquisitionDate: '2021-01-01',
+  costBasisCents: 100000,
+  source: 'WALLET',
+  chain: 'ethereum',
+};
+
+// ---------------------------------------------------------------------------
+// Swaps — taxable disposal + acquisition
+// ---------------------------------------------------------------------------
+
+describe('processCryptoEvent — SWAP', () => {
+  it('treats a swap as a taxable disposal with a long-term gain', () => {
+    const swap: CryptoSwapEvent = {
+      id: 'swap-1',
+      type: 'SWAP',
+      date: '2024-06-01',
+      chain: 'ethereum',
+      fromSymbol: 'ETH',
+      fromQuantity: 1,
+      toSymbol: 'USDC',
+      toQuantity: 2000,
+      fairMarketValueCents: 200000, // $2,000 proceeds
+    };
+
+    const { eventResult, lots } = processCryptoEvent([ethLotLongTerm], swap, 'FIFO');
+
+    expect(eventResult.taxable).toBe(true);
+    expect(eventResult.disposal).not.toBeNull();
+    // gain = 200000 proceeds - 100000 basis = 100000, all long-term
+    expect(eventResult.realizedGainLossCents).toBe(100000);
+    expect(eventResult.longTermGainLossCents).toBe(100000);
+    expect(eventResult.shortTermGainLossCents).toBe(0);
+    expect(eventResult.disposal?.matchedLots[0].chain).toBe('ethereum');
+
+    // ETH lot consumed; new USDC lot acquired at FMV basis
+    expect(eventResult.consumedLotIds).toEqual(['eth-1']);
+    const usdc = lots.find((l) => l.symbol === 'USDC');
+    expect(usdc?.costBasisCents).toBe(200000);
+    expect(usdc?.quantity).toBe(2000);
+    expect(usdc?.chain).toBe('ethereum');
+    expect(lots.some((l) => l.symbol === 'ETH')).toBe(false);
+  });
+
+  it('records a realized loss when FMV is below basis', () => {
+    const swap: CryptoSwapEvent = {
+      id: 'swap-loss',
+      type: 'SWAP',
+      date: '2024-06-01',
+      chain: 'ethereum',
+      fromSymbol: 'ETH',
+      fromQuantity: 1,
+      toSymbol: 'DAI',
+      toQuantity: 600,
+      fairMarketValueCents: 60000, // $600 proceeds, below $1,000 basis
+    };
+
+    const { eventResult } = processCryptoEvent([ethLotLongTerm], swap, 'FIFO');
+    expect(eventResult.realizedGainLossCents).toBe(-40000);
+    expect(eventResult.longTermGainLossCents).toBe(-40000);
+  });
+
+  it('classifies a short-term gain when held one year or less', () => {
+    const shortLot: CryptoTaxLot = {
+      ...ethLotLongTerm,
+      id: 'eth-short',
+      acquisitionDate: '2024-01-01',
+    };
+    const swap: CryptoSwapEvent = {
+      id: 'swap-short',
+      type: 'SWAP',
+      date: '2024-06-01',
+      chain: 'ethereum',
+      fromSymbol: 'ETH',
+      fromQuantity: 1,
+      toSymbol: 'USDC',
+      toQuantity: 1500,
+      fairMarketValueCents: 150000,
+    };
+
+    const { eventResult } = processCryptoEvent([shortLot], swap, 'FIFO');
+    expect(eventResult.shortTermGainLossCents).toBe(50000);
+    expect(eventResult.longTermGainLossCents).toBe(0);
+    expect(eventResult.disposal?.matchedLots[0].isLongTerm).toBe(false);
+  });
+
+  it('capitalizes a network fee into the acquired asset basis', () => {
+    const swap: CryptoSwapEvent = {
+      id: 'swap-fee',
+      type: 'SWAP',
+      date: '2024-06-01',
+      chain: 'ethereum',
+      fromSymbol: 'ETH',
+      fromQuantity: 1,
+      toSymbol: 'USDC',
+      toQuantity: 2000,
+      fairMarketValueCents: 200000,
+      feeCents: 1500, // $15 gas
+    };
+
+    const { lots } = processCryptoEvent([ethLotLongTerm], swap, 'FIFO');
+    const usdc = lots.find((l) => l.symbol === 'USDC');
+    expect(usdc?.costBasisCents).toBe(201500);
+  });
+
+  it('consumes multiple lots (FIFO) on a partial-lot disposal', () => {
+    const lotA: CryptoTaxLot = {
+      id: 'a',
+      symbol: 'ETH',
+      quantity: 1,
+      acquisitionDate: '2021-01-01', // long-term
+      costBasisCents: 100000,
+      source: 'WALLET',
+      chain: 'ethereum',
+    };
+    const lotB: CryptoTaxLot = {
+      id: 'b',
+      symbol: 'ETH',
+      quantity: 1,
+      acquisitionDate: '2024-03-01', // short-term
+      costBasisCents: 100000,
+      source: 'WALLET',
+      chain: 'ethereum',
+    };
+
+    const swap: CryptoSwapEvent = {
+      id: 'swap-multi',
+      type: 'SWAP',
+      date: '2024-06-01',
+      chain: 'ethereum',
+      fromSymbol: 'ETH',
+      fromQuantity: 1.5,
+      toSymbol: 'USDC',
+      toQuantity: 3000,
+      fairMarketValueCents: 300000, // $2,000/ETH
+    };
+
+    const { eventResult, lots } = processCryptoEvent([lotA, lotB], swap, 'FIFO');
+
+    expect(eventResult.disposal?.matchedLots).toHaveLength(2);
+    // lotA fully used (long-term): proceeds 200000 - basis 100000 = 100000
+    expect(eventResult.longTermGainLossCents).toBe(100000);
+    // lotB 0.5 used (short-term): proceeds 100000 - basis 50000 = 50000
+    expect(eventResult.shortTermGainLossCents).toBe(50000);
+    expect(eventResult.realizedGainLossCents).toBe(150000);
+
+    // lotA gone, lotB reduced to 0.5 with halved basis
+    expect(eventResult.consumedLotIds).toEqual(['a']);
+    const leftover = lots.find((l) => l.id === 'b');
+    expect(leftover?.quantity).toBeCloseTo(0.5, 9);
+    expect(leftover?.costBasisCents).toBe(50000);
+  });
+
+  it('selects the highest-cost lot first under HIFO', () => {
+    const cheap: CryptoTaxLot = {
+      id: 'cheap',
+      symbol: 'ETH',
+      quantity: 1,
+      acquisitionDate: '2021-01-01',
+      costBasisCents: 50000,
+      source: 'WALLET',
+      chain: 'ethereum',
+    };
+    const pricey: CryptoTaxLot = {
+      id: 'pricey',
+      symbol: 'ETH',
+      quantity: 1,
+      acquisitionDate: '2022-01-01',
+      costBasisCents: 150000,
+      source: 'WALLET',
+      chain: 'ethereum',
+    };
+    const swap: CryptoSwapEvent = {
+      id: 'swap-hifo',
+      type: 'SWAP',
+      date: '2024-06-01',
+      chain: 'ethereum',
+      fromSymbol: 'ETH',
+      fromQuantity: 1,
+      toSymbol: 'USDC',
+      toQuantity: 1000,
+      fairMarketValueCents: 100000,
+    };
+
+    const { eventResult } = processCryptoEvent([cheap, pricey], swap, 'HIFO');
+    expect(eventResult.consumedLotIds).toEqual(['pricey']);
+    // 100000 proceeds - 150000 basis = -50000 (HIFO harvests the loss)
+    expect(eventResult.realizedGainLossCents).toBe(-50000);
+  });
+
+  it('only disposes lots on the swap chain (chain-aware basis)', () => {
+    const onEth: CryptoTaxLot = {
+      id: 'eth',
+      symbol: 'USDC',
+      quantity: 1000,
+      acquisitionDate: '2023-01-01',
+      costBasisCents: 100000,
+      source: 'WALLET',
+      chain: 'ethereum',
+    };
+    const onArb: CryptoTaxLot = {
+      id: 'arb',
+      symbol: 'USDC',
+      quantity: 1000,
+      acquisitionDate: '2023-01-01',
+      costBasisCents: 100000,
+      source: 'WALLET',
+      chain: 'arbitrum',
+    };
+    const swap: CryptoSwapEvent = {
+      id: 'swap-chain',
+      type: 'SWAP',
+      date: '2024-06-01',
+      chain: 'arbitrum',
+      fromSymbol: 'USDC',
+      fromQuantity: 1000,
+      toSymbol: 'ETH',
+      toQuantity: 0.4,
+      fairMarketValueCents: 110000,
+    };
+
+    const { eventResult, lots } = processCryptoEvent([onEth, onArb], swap, 'FIFO');
+
+    // Only the Arbitrum lot is consumed; the Ethereum lot is untouched.
+    expect(eventResult.consumedLotIds).toEqual(['arb']);
+    expect(lots.find((l) => l.id === 'eth')).toBeDefined();
+    expect(lots.some((l) => l.symbol === 'ETH' && l.chain === 'arbitrum')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bridges — non-taxable, basis & holding-period preserving
+// ---------------------------------------------------------------------------
+
+describe('processCryptoEvent — BRIDGE', () => {
+  it('moves an asset cross-chain without a taxable event, preserving basis and date', () => {
+    const bridge: CryptoBridgeEvent = {
+      id: 'bridge-1',
+      type: 'BRIDGE',
+      date: '2024-06-01',
+      symbol: 'ETH',
+      quantity: 1,
+      fromChain: 'ethereum',
+      toChain: 'arbitrum',
+    };
+
+    const { eventResult, lots } = processCryptoEvent([ethLotLongTerm], bridge, 'FIFO');
+
+    expect(eventResult.taxable).toBe(false);
+    expect(eventResult.disposal).toBeNull();
+    expect(eventResult.realizedGainLossCents).toBe(0);
+    expect(eventResult.ordinaryIncomeCents).toBe(0);
+
+    // Source lot removed; destination lot keeps the SAME basis and date.
+    expect(lots.some((l) => l.chain === 'ethereum')).toBe(false);
+    const moved = lots.find((l) => l.chain === 'arbitrum');
+    expect(moved?.costBasisCents).toBe(100000);
+    expect(moved?.acquisitionDate).toBe('2021-01-01');
+    expect(moved?.quantity).toBe(1);
+  });
+
+  it('preserves the holding period so a later swap stays long-term', () => {
+    const bridge: CryptoBridgeEvent = {
+      id: 'bridge-2',
+      type: 'BRIDGE',
+      date: '2024-05-01',
+      symbol: 'ETH',
+      quantity: 1,
+      fromChain: 'ethereum',
+      toChain: 'optimism',
+    };
+    const swap: CryptoSwapEvent = {
+      id: 'swap-after-bridge',
+      type: 'SWAP',
+      date: '2024-06-01',
+      chain: 'optimism',
+      fromSymbol: 'ETH',
+      fromQuantity: 1,
+      toSymbol: 'USDC',
+      toQuantity: 2500,
+      fairMarketValueCents: 250000,
+    };
+
+    const batch = processCryptoEvents([ethLotLongTerm], [bridge, swap], 'FIFO');
+    const swapResult = batch.events.find((e) => e.eventId === 'swap-after-bridge');
+    // Original acquisition was 2021 → still long-term despite the 2024 bridge.
+    expect(swapResult?.longTermGainLossCents).toBe(150000);
+    expect(swapResult?.shortTermGainLossCents).toBe(0);
+  });
+
+  it('splits across the bridged lots when multiple lots are consumed', () => {
+    const lotA: CryptoTaxLot = {
+      id: 'a',
+      symbol: 'ETH',
+      quantity: 1,
+      acquisitionDate: '2021-01-01',
+      costBasisCents: 100000,
+      source: 'WALLET',
+      chain: 'ethereum',
+    };
+    const lotB: CryptoTaxLot = {
+      id: 'b',
+      symbol: 'ETH',
+      quantity: 1,
+      acquisitionDate: '2022-01-01',
+      costBasisCents: 200000,
+      source: 'WALLET',
+      chain: 'ethereum',
+    };
+    const bridge: CryptoBridgeEvent = {
+      id: 'bridge-multi',
+      type: 'BRIDGE',
+      date: '2024-06-01',
+      symbol: 'ETH',
+      quantity: 2,
+      fromChain: 'ethereum',
+      toChain: 'base',
+    };
+
+    const { eventResult, lots } = processCryptoEvent([lotA, lotB], bridge, 'FIFO');
+    expect(eventResult.acquiredLots).toHaveLength(2);
+    const totalBasis = lots
+      .filter((l) => l.chain === 'base')
+      .reduce((sum, l) => sum + l.costBasisCents, 0);
+    expect(totalBasis).toBe(300000); // basis conserved across the move
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Airdrops — ordinary income at FMV that also establishes basis
+// ---------------------------------------------------------------------------
+
+describe('processCryptoEvent — AIRDROP', () => {
+  it('recognizes ordinary income at FMV and creates a lot at that basis', () => {
+    const airdrop: CryptoAirdropEvent = {
+      id: 'air-1',
+      type: 'AIRDROP',
+      date: '2024-06-01',
+      chain: 'optimism',
+      symbol: 'OP',
+      quantity: 100,
+      fairMarketValueCents: 50000, // $500 FMV
+    };
+
+    const { eventResult, lots } = processCryptoEvent([], airdrop, 'FIFO');
+
+    expect(eventResult.taxable).toBe(true);
+    expect(eventResult.ordinaryIncomeCents).toBe(50000);
+    expect(eventResult.realizedGainLossCents).toBe(0);
+
+    const lot = lots.find((l) => l.symbol === 'OP');
+    expect(lot?.costBasisCents).toBe(50000);
+    expect(lot?.acquisitionDate).toBe('2024-06-01');
+    expect(lot?.chain).toBe('optimism');
+  });
+
+  it('uses the airdrop basis when the tokens are later swapped', () => {
+    const airdrop: CryptoAirdropEvent = {
+      id: 'air-2',
+      type: 'AIRDROP',
+      date: '2024-01-01',
+      chain: 'optimism',
+      symbol: 'OP',
+      quantity: 100,
+      fairMarketValueCents: 50000,
+    };
+    const swap: CryptoSwapEvent = {
+      id: 'swap-air',
+      type: 'SWAP',
+      date: '2024-03-01',
+      chain: 'optimism',
+      fromSymbol: 'OP',
+      fromQuantity: 100,
+      toSymbol: 'USDC',
+      toQuantity: 800,
+      fairMarketValueCents: 80000, // $800 proceeds
+    };
+
+    const batch = processCryptoEvents([], [airdrop, swap], 'FIFO');
+    expect(batch.totalOrdinaryIncomeCents).toBe(50000);
+    // Capital gain on disposal = 80000 - 50000 basis = 30000 (short-term)
+    const swapResult = batch.events.find((e) => e.eventId === 'swap-air');
+    expect(swapResult?.shortTermGainLossCents).toBe(30000);
+  });
+
+  it('maps an airdrop event to an income record', () => {
+    const airdrop: CryptoAirdropEvent = {
+      id: 'air-3',
+      type: 'AIRDROP',
+      date: '2024-06-01',
+      chain: 'ethereum',
+      symbol: 'ARB',
+      quantity: 250,
+      fairMarketValueCents: 30000,
+    };
+    expect(toAirdropIncome(airdrop)).toEqual({
+      id: 'air-3',
+      symbol: 'ARB',
+      quantity: 250,
+      fairMarketValueCents: 30000,
+      dateReceived: '2024-06-01',
+      type: 'AIRDROP',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Batch processing & summary integration
+// ---------------------------------------------------------------------------
+
+describe('processCryptoEvents', () => {
+  it('applies events in chronological order regardless of input order', () => {
+    const airdrop: CryptoAirdropEvent = {
+      id: 'air',
+      type: 'AIRDROP',
+      date: '2024-01-01',
+      chain: 'optimism',
+      symbol: 'OP',
+      quantity: 100,
+      fairMarketValueCents: 50000,
+    };
+    const swap: CryptoSwapEvent = {
+      id: 'swap',
+      type: 'SWAP',
+      date: '2024-03-01',
+      chain: 'optimism',
+      fromSymbol: 'OP',
+      fromQuantity: 100,
+      toSymbol: 'USDC',
+      toQuantity: 700,
+      fairMarketValueCents: 70000,
+    };
+
+    // Pass out of order; the engine must sort the airdrop before the swap.
+    const batch = processCryptoEvents([], [swap, airdrop], 'FIFO');
+    expect(batch.events.map((e) => e.eventId)).toEqual(['air', 'swap']);
+    expect(batch.taxableEventCount).toBe(2);
+  });
+
+  it('aggregates totals across a mixed batch', () => {
+    const airdrop: CryptoAirdropEvent = {
+      id: 'air',
+      type: 'AIRDROP',
+      date: '2024-01-01',
+      chain: 'ethereum',
+      symbol: 'ENS',
+      quantity: 10,
+      fairMarketValueCents: 40000,
+    };
+    const bridge: CryptoBridgeEvent = {
+      id: 'bridge',
+      type: 'BRIDGE',
+      date: '2024-02-01',
+      symbol: 'ETH',
+      quantity: 1,
+      fromChain: 'ethereum',
+      toChain: 'arbitrum',
+    };
+    const swap: CryptoSwapEvent = {
+      id: 'swap',
+      type: 'SWAP',
+      date: '2024-03-01',
+      chain: 'arbitrum',
+      fromSymbol: 'ETH',
+      fromQuantity: 1,
+      toSymbol: 'USDC',
+      toQuantity: 3000,
+      fairMarketValueCents: 300000,
+    };
+
+    const batch = processCryptoEvents([ethLotLongTerm], [airdrop, bridge, swap], 'FIFO');
+
+    expect(batch.totalOrdinaryIncomeCents).toBe(40000);
+    // ETH basis 100000 bridged then sold for 300000 → 200000 long-term gain
+    expect(batch.totalLongTermGainLossCents).toBe(200000);
+    expect(batch.totalRealizedGainLossCents).toBe(200000);
+    expect(batch.disposals).toHaveLength(1);
+    expect(batch.incomeRecords).toHaveLength(1);
+    expect(batch.taxableEventCount).toBe(2); // airdrop + swap (bridge is not taxable)
+  });
+
+  it('returns an empty, zeroed result for no events', () => {
+    const batch = processCryptoEvents([ethLotLongTerm], [], 'FIFO');
+    expect(batch.events).toHaveLength(0);
+    expect(batch.finalLots).toHaveLength(1);
+    expect(batch.totalRealizedGainLossCents).toBe(0);
+    expect(batch.taxableEventCount).toBe(0);
+  });
+});
+
+describe('summarizeCryptoEvents', () => {
+  it('rolls swap gains and airdrop income into the annual summary', () => {
+    const airdrop: CryptoAirdropEvent = {
+      id: 'air',
+      type: 'AIRDROP',
+      date: '2024-01-01',
+      chain: 'optimism',
+      symbol: 'OP',
+      quantity: 100,
+      fairMarketValueCents: 50000,
+    };
+    const swap: CryptoSwapEvent = {
+      id: 'swap',
+      type: 'SWAP',
+      date: '2024-06-01',
+      chain: 'ethereum',
+      fromSymbol: 'ETH',
+      fromQuantity: 1,
+      toSymbol: 'USDC',
+      toQuantity: 2500,
+      fairMarketValueCents: 250000,
+    };
+
+    const batch = processCryptoEvents([ethLotLongTerm], [airdrop, swap], 'FIFO');
+    const summary = summarizeCryptoEvents(2024, batch);
+
+    expect(summary.taxYear).toBe(2024);
+    expect(summary.ordinaryIncomeCents).toBe(50000);
+    expect(summary.longTermGainLossCents).toBe(150000);
+    expect(summary.totalGainLossCents).toBe(
+      summary.shortTermGainLossCents + summary.longTermGainLossCents,
+    );
+    expect(summary.totalDisposals).toBe(1);
+  });
+});

--- a/apps/web/src/lib/assets/crypto-defi.ts
+++ b/apps/web/src/lib/assets/crypto-defi.ts
@@ -1,0 +1,507 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Chain-aware crypto taxable-event processing for DeFi activity.
+ *
+ * Extends the crypto tax-lot engine (see ./crypto-tax) to model the three most
+ * common DeFi event types with US tax treatment:
+ *
+ *   - SWAP    A crypto→crypto trade. A taxable disposal of the asset given up
+ *             (proceeds = fair market value of the trade) plus acquisition of
+ *             the asset received at a fresh cost basis equal to that FMV.
+ *   - BRIDGE  A same-asset cross-chain move. Generally NON-taxable: no disposal
+ *             occurs, cost basis and the original acquisition date are
+ *             preserved and re-tagged to the destination chain (the holding
+ *             period "tacks").
+ *   - AIRDROP Tokens received. Ordinary income at FMV on the date of receipt,
+ *             which also establishes the cost basis of the new lot.
+ *
+ * Cost basis is tracked PER CHAIN. Under IRS Rev. Proc. 2024-28 the IRS
+ * requires per-wallet/per-account basis tracking (universal "pooled" basis is
+ * no longer permitted from 2025), so disposals consume lots on the chain where
+ * the event occurs. Lots with no chain tag form a global fallback pool and are
+ * eligible on any chain.
+ *
+ * All monetary values are integer cents. Pure functions — no side effects.
+ *
+ * Assumptions / simplifications (documented for auditability):
+ *   - Swap FMV is supplied by the caller (price-oracle resolution is out of
+ *     scope here) and is used for BOTH the disposed-leg proceeds and the
+ *     acquired-leg cost basis.
+ *   - An optional swap network fee is capitalized into the acquired asset's
+ *     cost basis (treated as a transaction cost), not deducted from proceeds.
+ *   - Bridges are modeled as strictly non-taxable and basis-preserving; gas
+ *     paid to bridge is NOT modeled as a partial disposal here. The correct
+ *     treatment of self-transfer gas is genuinely unsettled — see the
+ *     "Needs Decision" note in the PR description.
+ *
+ * References: issue #2168
+ */
+
+import { bankersRound, safeDivide } from './crypto-portfolio';
+import { computeCryptoTaxSummary, sortLots } from './crypto-tax';
+import type {
+  ChainId,
+  CryptoAirdropEvent,
+  CryptoBridgeEvent,
+  CryptoDisposalResult,
+  CryptoEventBatchResult,
+  CryptoEventResult,
+  CryptoLotMethod,
+  CryptoSource,
+  CryptoSwapEvent,
+  CryptoTaxableEvent,
+  CryptoTaxLot,
+  CryptoTaxSummary,
+  LocalDate,
+  MatchedLot,
+  StakingIncome,
+} from './types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Tolerance for fractional-quantity comparisons (crypto allows many decimals). */
+const QUANTITY_EPSILON = 1e-9;
+
+/** Parse an ISO-8601 date string to a Date object (UTC midnight). */
+function parseDate(dateStr: string): Date {
+  return new Date(dateStr + 'T00:00:00Z');
+}
+
+/** Number of whole days between two ISO date strings. */
+function daysBetween(start: string, end: string): number {
+  const s = parseDate(start);
+  const e = parseDate(end);
+  return Math.floor((e.getTime() - s.getTime()) / (1000 * 60 * 60 * 24));
+}
+
+/**
+ * Whether a lot is eligible to be consumed by an event on the given chain.
+ *
+ * A tagged lot must match the event chain exactly. Untagged lots (no `chain`)
+ * act as a global fallback pool and are eligible on any chain.
+ */
+function lotMatchesChain(lot: CryptoTaxLot, chain: ChainId | undefined): boolean {
+  if (chain === undefined) return true;
+  return lot.chain === undefined || lot.chain === chain;
+}
+
+/** A portion of a lot consumed by a disposal or bridge. */
+interface ConsumedPortion {
+  readonly lotId: string;
+  readonly symbol: string;
+  readonly quantityUsed: number;
+  readonly costBasisCents: number;
+  readonly acquisitionDate: LocalDate;
+  readonly source: CryptoSource;
+  readonly chain?: ChainId;
+  /** Whether the entire originating lot was used (and thus removed). */
+  readonly fullyConsumed: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Lot-book consumption
+// ---------------------------------------------------------------------------
+
+/**
+ * Consume `quantity` units of `symbol` (optionally restricted to `chain`) from
+ * the lot book, returning the consumed portions plus the remaining lot book.
+ *
+ * Partially-used lots are reduced in place (quantity and cost basis scaled so
+ * total basis is conserved). Cost basis per consumed portion is computed with
+ * banker's rounding to stay in integer cents.
+ *
+ * @returns The consumed portions (in matching order) and the updated lot book.
+ */
+function consumeLots(
+  lots: readonly CryptoTaxLot[],
+  symbol: string,
+  chain: ChainId | undefined,
+  quantity: number,
+  method: CryptoLotMethod,
+): { consumed: ConsumedPortion[]; remaining: CryptoTaxLot[] } {
+  const eligible: CryptoTaxLot[] = [];
+  const remaining: CryptoTaxLot[] = [];
+
+  for (const lot of lots) {
+    if (lot.symbol === symbol && lotMatchesChain(lot, chain)) {
+      eligible.push(lot);
+    } else {
+      remaining.push(lot);
+    }
+  }
+
+  const sorted = sortLots(eligible, method);
+  const consumed: ConsumedPortion[] = [];
+  let need = quantity;
+
+  for (const lot of sorted) {
+    if (need <= QUANTITY_EPSILON) {
+      remaining.push(lot);
+      continue;
+    }
+
+    const use = Math.min(need, lot.quantity);
+    const costForUse = bankersRound(safeDivide(lot.costBasisCents, lot.quantity) * use);
+    const leftoverQty = lot.quantity - use;
+    const fullyConsumed = leftoverQty <= QUANTITY_EPSILON;
+
+    consumed.push({
+      lotId: lot.id,
+      symbol: lot.symbol,
+      quantityUsed: use,
+      costBasisCents: costForUse,
+      acquisitionDate: lot.acquisitionDate,
+      source: lot.source,
+      chain: lot.chain,
+      fullyConsumed,
+    });
+
+    if (!fullyConsumed) {
+      remaining.push({
+        ...lot,
+        quantity: leftoverQty,
+        costBasisCents: lot.costBasisCents - costForUse,
+      });
+    }
+
+    need -= use;
+  }
+
+  return { consumed, remaining };
+}
+
+/** Outcome of disposing of an asset from the lot book. */
+interface DisposalOutcome {
+  readonly result: CryptoDisposalResult;
+  readonly remaining: CryptoTaxLot[];
+  readonly consumedLotIds: string[];
+}
+
+/**
+ * Dispose of `quantity` units of `symbol` on `chain` for `proceedsCents`,
+ * computing the realized short/long-term gain or loss per matched lot.
+ *
+ * Proceeds are allocated to each consumed portion proportionally to the
+ * quantity used. Holdings of more than 365 days are long-term.
+ */
+function disposeFromLots(
+  lots: readonly CryptoTaxLot[],
+  symbol: string,
+  chain: ChainId | undefined,
+  quantity: number,
+  proceedsCents: number,
+  disposalDate: LocalDate,
+  method: CryptoLotMethod,
+): DisposalOutcome {
+  const { consumed, remaining } = consumeLots(lots, symbol, chain, quantity, method);
+
+  const matchedLots: MatchedLot[] = [];
+  let totalCostBasis = 0;
+  let shortTerm = 0;
+  let longTerm = 0;
+  const consumedLotIds: string[] = [];
+
+  for (const portion of consumed) {
+    const proceedsForUse = bankersRound(safeDivide(proceedsCents, quantity) * portion.quantityUsed);
+    const gainLoss = proceedsForUse - portion.costBasisCents;
+    const holdingDays = daysBetween(portion.acquisitionDate, disposalDate);
+    const isLongTerm = holdingDays > 365;
+
+    if (isLongTerm) {
+      longTerm += gainLoss;
+    } else {
+      shortTerm += gainLoss;
+    }
+
+    totalCostBasis += portion.costBasisCents;
+
+    matchedLots.push({
+      lotId: portion.lotId,
+      symbol: portion.symbol,
+      quantityUsed: portion.quantityUsed,
+      costBasisCents: portion.costBasisCents,
+      isLongTerm,
+      holdingDays,
+      gainLossCents: gainLoss,
+      chain: portion.chain,
+    });
+
+    if (portion.fullyConsumed) {
+      consumedLotIds.push(portion.lotId);
+    }
+  }
+
+  const result: CryptoDisposalResult = {
+    disposalDate,
+    proceedsCents,
+    totalCostBasisCents: totalCostBasis,
+    gainLossCents: proceedsCents - totalCostBasis,
+    shortTermGainLossCents: shortTerm,
+    longTermGainLossCents: longTerm,
+    matchedLots,
+  };
+
+  return { result, remaining, consumedLotIds };
+}
+
+// ---------------------------------------------------------------------------
+// Per-event processors
+// ---------------------------------------------------------------------------
+
+/** A single processed event plus the resulting lot book. */
+interface ProcessedEvent {
+  readonly eventResult: CryptoEventResult;
+  readonly lots: CryptoTaxLot[];
+}
+
+/** Process a swap: taxable disposal of one asset + acquisition of another. */
+function processSwap(
+  lots: readonly CryptoTaxLot[],
+  event: CryptoSwapEvent,
+  method: CryptoLotMethod,
+): ProcessedEvent {
+  const feeCents = event.feeCents ?? 0;
+  const { result, remaining, consumedLotIds } = disposeFromLots(
+    lots,
+    event.fromSymbol,
+    event.chain,
+    event.fromQuantity,
+    event.fairMarketValueCents,
+    event.date,
+    method,
+  );
+
+  const acquiredLot: CryptoTaxLot = {
+    id: `${event.id}-acq`,
+    symbol: event.toSymbol,
+    quantity: event.toQuantity,
+    acquisitionDate: event.date,
+    costBasisCents: event.fairMarketValueCents + feeCents,
+    source: 'DEFI',
+    chain: event.toChain ?? event.chain,
+  };
+
+  const realized = result.shortTermGainLossCents + result.longTermGainLossCents;
+
+  const eventResult: CryptoEventResult = {
+    eventId: event.id,
+    eventType: 'SWAP',
+    date: event.date,
+    chain: event.chain,
+    taxable: true,
+    disposal: result,
+    acquiredLots: [acquiredLot],
+    consumedLotIds,
+    ordinaryIncomeCents: 0,
+    realizedGainLossCents: realized,
+    shortTermGainLossCents: result.shortTermGainLossCents,
+    longTermGainLossCents: result.longTermGainLossCents,
+    note: `Taxable swap on ${event.chain}: disposed ${event.fromQuantity} ${event.fromSymbol}, acquired ${event.toQuantity} ${event.toSymbol} at fair market value.`,
+  };
+
+  return { eventResult, lots: [...remaining, acquiredLot] };
+}
+
+/** Process a bridge: non-taxable, basis- and holding-period-preserving move. */
+function processBridge(
+  lots: readonly CryptoTaxLot[],
+  event: CryptoBridgeEvent,
+  method: CryptoLotMethod,
+): ProcessedEvent {
+  const { consumed, remaining } = consumeLots(
+    lots,
+    event.symbol,
+    event.fromChain,
+    event.quantity,
+    method,
+  );
+
+  // One destination lot per consumed portion, preserving acquisition date and
+  // cost basis so the holding period "tacks" across the chain boundary.
+  const bridgedLots: CryptoTaxLot[] = consumed.map((portion, index) => ({
+    id: `${event.id}-${index}`,
+    symbol: portion.symbol,
+    quantity: portion.quantityUsed,
+    acquisitionDate: portion.acquisitionDate,
+    costBasisCents: portion.costBasisCents,
+    source: portion.source,
+    chain: event.toChain,
+  }));
+
+  const consumedLotIds = consumed.filter((p) => p.fullyConsumed).map((p) => p.lotId);
+
+  const eventResult: CryptoEventResult = {
+    eventId: event.id,
+    eventType: 'BRIDGE',
+    date: event.date,
+    chain: event.toChain,
+    taxable: false,
+    disposal: null,
+    acquiredLots: bridgedLots,
+    consumedLotIds,
+    ordinaryIncomeCents: 0,
+    realizedGainLossCents: 0,
+    shortTermGainLossCents: 0,
+    longTermGainLossCents: 0,
+    note: `Non-taxable bridge: moved ${event.quantity} ${event.symbol} from ${event.fromChain} to ${event.toChain}; cost basis and holding period preserved.`,
+  };
+
+  return { eventResult, lots: [...remaining, ...bridgedLots] };
+}
+
+/** Process an airdrop: ordinary income at FMV which establishes cost basis. */
+function processAirdrop(lots: readonly CryptoTaxLot[], event: CryptoAirdropEvent): ProcessedEvent {
+  const airdropLot: CryptoTaxLot = {
+    id: `${event.id}-acq`,
+    symbol: event.symbol,
+    quantity: event.quantity,
+    acquisitionDate: event.date,
+    costBasisCents: event.fairMarketValueCents,
+    source: 'DEFI',
+    chain: event.chain,
+  };
+
+  const eventResult: CryptoEventResult = {
+    eventId: event.id,
+    eventType: 'AIRDROP',
+    date: event.date,
+    chain: event.chain,
+    taxable: true,
+    disposal: null,
+    acquiredLots: [airdropLot],
+    consumedLotIds: [],
+    ordinaryIncomeCents: event.fairMarketValueCents,
+    realizedGainLossCents: 0,
+    shortTermGainLossCents: 0,
+    longTermGainLossCents: 0,
+    note: `Airdrop income on ${event.chain}: received ${event.quantity} ${event.symbol} at fair market value (ordinary income; establishes cost basis).`,
+  };
+
+  return { eventResult, lots: [...lots, airdropLot] };
+}
+
+/** Convert an airdrop event into a staking/DeFi income record (FMV at receipt). */
+export function toAirdropIncome(event: CryptoAirdropEvent): StakingIncome {
+  return {
+    id: event.id,
+    symbol: event.symbol,
+    quantity: event.quantity,
+    fairMarketValueCents: event.fairMarketValueCents,
+    dateReceived: event.date,
+    type: 'AIRDROP',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Process a single chain-aware crypto taxable event against a lot book.
+ *
+ * @param lots - The current lot book.
+ * @param event - The swap, bridge, or airdrop to apply.
+ * @param method - Lot-matching method for disposals (default FIFO).
+ * @returns The event result and the updated lot book.
+ */
+export function processCryptoEvent(
+  lots: readonly CryptoTaxLot[],
+  event: CryptoTaxableEvent,
+  method: CryptoLotMethod = 'FIFO',
+): ProcessedEvent {
+  switch (event.type) {
+    case 'SWAP':
+      return processSwap(lots, event, method);
+    case 'BRIDGE':
+      return processBridge(lots, event, method);
+    case 'AIRDROP':
+      return processAirdrop(lots, event);
+  }
+}
+
+/**
+ * Process a chronological batch of chain-aware crypto taxable events.
+ *
+ * Events are applied in date order (stable for same-day events) against a
+ * running lot book. Returns per-event results, the final lot book, taxable
+ * disposals, airdrop income records, and aggregate totals.
+ *
+ * @param initialLots - Opening lot book.
+ * @param events - Events to apply (any order; sorted internally by date).
+ * @param method - Lot-matching method for disposals (default FIFO).
+ * @returns Aggregate batch result.
+ */
+export function processCryptoEvents(
+  initialLots: readonly CryptoTaxLot[],
+  events: readonly CryptoTaxableEvent[],
+  method: CryptoLotMethod = 'FIFO',
+): CryptoEventBatchResult {
+  const ordered = [...events].sort(
+    (a, b) => parseDate(a.date).getTime() - parseDate(b.date).getTime(),
+  );
+
+  let lots: CryptoTaxLot[] = [...initialLots];
+  const results: CryptoEventResult[] = [];
+  const disposals: CryptoDisposalResult[] = [];
+  const incomeRecords: StakingIncome[] = [];
+
+  let totalRealized = 0;
+  let totalShort = 0;
+  let totalLong = 0;
+  let totalIncome = 0;
+  let taxableCount = 0;
+
+  for (const event of ordered) {
+    const processed = processCryptoEvent(lots, event, method);
+    lots = processed.lots;
+    results.push(processed.eventResult);
+
+    totalRealized += processed.eventResult.realizedGainLossCents;
+    totalShort += processed.eventResult.shortTermGainLossCents;
+    totalLong += processed.eventResult.longTermGainLossCents;
+    totalIncome += processed.eventResult.ordinaryIncomeCents;
+    if (processed.eventResult.taxable) taxableCount += 1;
+
+    if (processed.eventResult.disposal) {
+      disposals.push(processed.eventResult.disposal);
+    }
+    if (event.type === 'AIRDROP') {
+      incomeRecords.push(toAirdropIncome(event));
+    }
+  }
+
+  return {
+    events: results,
+    finalLots: lots,
+    disposals,
+    incomeRecords,
+    totalRealizedGainLossCents: totalRealized,
+    totalShortTermGainLossCents: totalShort,
+    totalLongTermGainLossCents: totalLong,
+    totalOrdinaryIncomeCents: totalIncome,
+    taxableEventCount: taxableCount,
+  };
+}
+
+/**
+ * Build an annual crypto tax summary that incorporates DeFi taxable events.
+ *
+ * Wires a processed event batch into the existing {@link computeCryptoTaxSummary}
+ * so swap disposals and airdrop income flow into the same annual rollup as
+ * ordinary sales and staking income.
+ *
+ * @param taxYear - The tax year to summarize.
+ * @param batch - A batch result from {@link processCryptoEvents}.
+ * @param allLots - All lots (for wash-sale detection); defaults to final lots.
+ * @returns Annual crypto tax summary.
+ */
+export function summarizeCryptoEvents(
+  taxYear: number,
+  batch: CryptoEventBatchResult,
+  allLots: readonly CryptoTaxLot[] = batch.finalLots,
+): CryptoTaxSummary {
+  return computeCryptoTaxSummary(taxYear, batch.disposals, batch.incomeRecords, allLots);
+}

--- a/apps/web/src/lib/assets/crypto-tax.ts
+++ b/apps/web/src/lib/assets/crypto-tax.ts
@@ -143,6 +143,7 @@ export function matchLots(
       isLongTerm,
       holdingDays,
       gainLossCents: gainLoss,
+      chain: lot.chain,
     });
 
     remaining -= quantityUsed;

--- a/apps/web/src/lib/assets/index.ts
+++ b/apps/web/src/lib/assets/index.ts
@@ -3,12 +3,13 @@
 /**
  * Barrel re-export for the assets module.
  *
- * References: issues #1667, #1672, #1696, #1704, #1710, #1712, #1717, #1739
+ * References: issues #1667, #1672, #1696, #1704, #1710, #1712, #1717, #1739, #2168
  */
 
 export * from './types';
 export * from './crypto-portfolio';
 export * from './crypto-tax';
+export * from './crypto-defi';
 export * from './alt-assets';
 export * from './private-investments';
 export * from './equity-comp';

--- a/apps/web/src/lib/assets/types.ts
+++ b/apps/web/src/lib/assets/types.ts
@@ -24,6 +24,16 @@ export type LocalDate = string;
 /** Source of a crypto holding. */
 export type CryptoSource = 'EXCHANGE' | 'WALLET' | 'DEFI' | 'STAKING';
 
+/**
+ * Blockchain network identifier used for chain-aware cost-basis tracking.
+ *
+ * A free-form lowercase slug such as `"ethereum"`, `"arbitrum"`, `"optimism"`,
+ * `"polygon"`, `"solana"`, or `"bitcoin"`. Per-chain identity matters because,
+ * under IRS Rev. Proc. 2024-28, cost basis must be tracked per wallet/account
+ * rather than universally pooled across all holdings (effective 2025).
+ */
+export type ChainId = string;
+
 /** A single crypto holding on an exchange or wallet. */
 export interface CryptoHolding {
   readonly id: string;
@@ -66,6 +76,8 @@ export interface CryptoTaxLot {
   readonly acquisitionDate: LocalDate;
   readonly costBasisCents: number;
   readonly source: CryptoSource;
+  /** Chain the lot lives on (optional; untagged lots are a global pool). */
+  readonly chain?: ChainId;
 }
 
 /** Result of matching lots against a disposal. */
@@ -88,6 +100,8 @@ export interface MatchedLot {
   readonly isLongTerm: boolean;
   readonly holdingDays: number;
   readonly gainLossCents: number;
+  /** Chain the consumed lot lived on (when chain-aware tracking is used). */
+  readonly chain?: ChainId;
 }
 
 /** Term classification. */
@@ -132,6 +146,117 @@ export interface CryptoTaxSummary {
   readonly ordinaryIncomeCents: number;
   readonly totalDisposals: number;
   readonly washSaleAlerts: readonly CryptoWashSaleAlert[];
+}
+
+// ---------------------------------------------------------------------------
+// Chain-aware DeFi taxable events (#2168)
+// ---------------------------------------------------------------------------
+
+/** Discriminator for chain-aware crypto taxable events. */
+export type CryptoEventType = 'SWAP' | 'BRIDGE' | 'AIRDROP';
+
+/**
+ * A crypto-to-crypto swap (e.g. ETH → USDC on a DEX).
+ *
+ * Treated as a taxable disposal of the asset given up at its fair market
+ * value, plus the acquisition of the asset received which takes a fresh cost
+ * basis equal to that same fair market value.
+ */
+export interface CryptoSwapEvent {
+  readonly id: string;
+  readonly type: 'SWAP';
+  readonly date: LocalDate;
+  /** Chain the swap executes on; disposed lots are drawn from this chain. */
+  readonly chain: ChainId;
+  readonly fromSymbol: string;
+  readonly fromQuantity: number;
+  readonly toSymbol: string;
+  readonly toQuantity: number;
+  /** Fair market value (cents) of the trade — proceeds of the disposed leg. */
+  readonly fairMarketValueCents: number;
+  /** Destination chain for the acquired asset (defaults to {@link chain}). */
+  readonly toChain?: ChainId;
+  /** Optional network fee (cents) capitalized into the acquired asset basis. */
+  readonly feeCents?: number;
+}
+
+/**
+ * A same-asset cross-chain bridge (e.g. USDC moved from Ethereum to Arbitrum).
+ *
+ * Generally NON-taxable: no disposal occurs because the taxpayer retains the
+ * same beneficial asset. Cost basis and the original acquisition date are
+ * preserved (the holding period "tacks") and re-tagged to the destination
+ * chain.
+ */
+export interface CryptoBridgeEvent {
+  readonly id: string;
+  readonly type: 'BRIDGE';
+  readonly date: LocalDate;
+  readonly symbol: string;
+  readonly quantity: number;
+  readonly fromChain: ChainId;
+  readonly toChain: ChainId;
+}
+
+/**
+ * An airdrop received into a wallet.
+ *
+ * Treated as ordinary income at the fair market value on the date of receipt
+ * (when the taxpayer gains dominion and control). That same FMV establishes
+ * the cost basis of the newly created lot.
+ */
+export interface CryptoAirdropEvent {
+  readonly id: string;
+  readonly type: 'AIRDROP';
+  readonly date: LocalDate;
+  readonly chain: ChainId;
+  readonly symbol: string;
+  readonly quantity: number;
+  readonly fairMarketValueCents: number;
+}
+
+/** Any chain-aware crypto taxable event. */
+export type CryptoTaxableEvent = CryptoSwapEvent | CryptoBridgeEvent | CryptoAirdropEvent;
+
+/** Result of processing a single chain-aware crypto taxable event. */
+export interface CryptoEventResult {
+  readonly eventId: string;
+  readonly eventType: CryptoEventType;
+  readonly date: LocalDate;
+  /** Primary chain associated with the event (destination for a bridge). */
+  readonly chain: ChainId;
+  /** Whether the event produced a taxable outcome (disposal or income). */
+  readonly taxable: boolean;
+  /** Capital-gain disposal detail (present for swaps), else null. */
+  readonly disposal: CryptoDisposalResult | null;
+  /** New tax lots created by the event (acquired/airdropped/bridged lots). */
+  readonly acquiredLots: readonly CryptoTaxLot[];
+  /** Ids of lots fully consumed (removed from the lot book) by the event. */
+  readonly consumedLotIds: readonly string[];
+  /** Ordinary income recognized (airdrops), in cents. */
+  readonly ordinaryIncomeCents: number;
+  /** Realized capital gain/loss (swaps), in cents. Equals short + long term. */
+  readonly realizedGainLossCents: number;
+  readonly shortTermGainLossCents: number;
+  readonly longTermGainLossCents: number;
+  /** Human-readable explanation of the tax treatment applied. */
+  readonly note: string;
+}
+
+/** Aggregate result of processing a chronological batch of events. */
+export interface CryptoEventBatchResult {
+  readonly events: readonly CryptoEventResult[];
+  /** The lot book after all events are applied. */
+  readonly finalLots: readonly CryptoTaxLot[];
+  /** Taxable disposals (from swaps), for feeding the annual tax summary. */
+  readonly disposals: readonly CryptoDisposalResult[];
+  /** Airdrop income records, for feeding the annual tax summary. */
+  readonly incomeRecords: readonly StakingIncome[];
+  readonly totalRealizedGainLossCents: number;
+  readonly totalShortTermGainLossCents: number;
+  readonly totalLongTermGainLossCents: number;
+  readonly totalOrdinaryIncomeCents: number;
+  readonly taxableEventCount: number;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Extends the existing crypto-tax engine with chain-aware taxable-event processing for SWAP, BRIDGE, and AIRDROP, reusing the integer-cents lot/cost-basis model (FIFO/LIFO/HIFO, banker's rounding, short/long-term split).

## Changes
- New `crypto-defi.ts` engine: `processCryptoEvent`/`processCryptoEvents` (chronological lot-book fold), `summarizeCryptoEvents`, `toAirdropIncome`
- Chain-aware lot isolation; bridges preserve basis + holding period across chains; airdrops = ordinary income at FMV establishing basis; swaps = taxable disposals
- New `CryptoTaxableEventsReport` accessible report component (+ tests); ~20 engine unit tests
- Integer cents throughout (no float money)

## Tax treatment (US)
Swaps = taxable disposals; airdrops = ordinary income at FMV on receipt; same-asset bridges = non-taxable, basis-preserving. Per-chain basis consistent with IRS Rev. Proc. 2024-28.

## Needs Decision
Bridge gas-fee treatment is modeled as strictly non-taxable/basis-preserving; whether self-transfer gas should be a small taxable disposal is unsettled and left for product/tax-counsel.

## Remaining Work
Canonical event models + schema in `packages/**` (kmp-engineer); a `useCryptoTaxableEvents` hook/repository to source events; navigation wiring; native multi-platform UI.

Refs #2168