### PR TITLE
feat(web): FIRE/FI calculator with years-to-FI, Coast FI, and SWR (#2114)

### DIFF
--- a/apps/web/src/components/layout/navConfig.tsx
+++ b/apps/web/src/components/layout/navConfig.tsx
@@ -21,6 +21,7 @@ import type React from 'react';
 import { ensureStableNavOrder } from '../../lib/navigation/guardrails';
 import { Icon } from '../common/Icon';
 import { IconToken } from '../../icons/tokens';
+import { AppIcon } from '../icons';
 import { DebtIcon, InvoicesIcon, PrivacyIcon, ReportsIcon } from './navIcons';
 
 /** Named navigation groups, displayed in this order in the sidebar. */
@@ -188,6 +189,15 @@ export const NAV_CONFIG: readonly NavConfigItem[] = ensureStableNavOrder([
     group: 'plan',
     mobilePriority: 14,
     description: 'Long-range projections and what-ifs.',
+  },
+  {
+    id: 'fire',
+    label: 'FIRE Planner',
+    href: '/fire',
+    icon: <AppIcon name="flame" size={24} />,
+    group: 'plan',
+    mobilePriority: 18,
+    description: 'Financial independence: FI number, years-to-FI and Coast FI.',
   },
   {
     id: 'learning',

--- a/apps/web/src/lib/fire-types.ts
+++ b/apps/web/src/lib/fire-types.ts
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Types & constants for the FIRE (Financial Independence / Retire Early)
+ * planning engine (see `fire.ts`).
+ *
+ * All monetary values are **integer cents**; all rates are **decimals**.
+ * Returns are modelled as **real** (inflation-adjusted) — see `fire.ts` for the
+ * full set of documented assumptions.
+ *
+ * References: issue #2114
+ */
+
+/** Inputs for `yearsToFI`. */
+export interface YearsToFIInput {
+  /** Currently invested assets, in integer cents. */
+  readonly currentInvestedCents: number;
+  /** Annual contribution to investments, in integer cents. */
+  readonly annualContributionCents: number;
+  /** Expected annual **real** (inflation-adjusted) return, as a decimal. */
+  readonly realReturnRate: number;
+  /** The FI target (annual spending ÷ SWR), in integer cents. */
+  readonly fiNumberCents: number;
+}
+
+/** Result of `yearsToFI`. */
+export interface YearsToFIResult {
+  /** True when the FI number is reached within the search horizon. */
+  readonly reachedFI: boolean;
+  /** True when current assets already meet/exceed the FI number. */
+  readonly alreadyFI: boolean;
+  /** Whole months until FI (0 when already FI; capped when unreachable). */
+  readonly totalMonths: number;
+  /** Whole years portion of {@link totalMonths}. */
+  readonly years: number;
+  /** Remaining months portion (0–11) of {@link totalMonths}. */
+  readonly months: number;
+  /** Projected portfolio value at the point of reaching FI (or at the cap). */
+  readonly projectedCents: number;
+}
+
+/** Inputs for `coastFINumber`. */
+export interface CoastFIInput {
+  /** Annual spending in retirement, in integer cents. */
+  readonly annualSpendingCents: number;
+  /** Safe withdrawal rate, as a decimal (e.g. 0.04). */
+  readonly swrRate: number;
+  /** Expected annual **real** return, as a decimal. */
+  readonly realReturnRate: number;
+  /** Years from now until traditional retirement (when the FI number is needed). */
+  readonly yearsToTraditionalRetirement: number;
+}
+
+/** Inputs for `buildFIProjection`. */
+export interface FIProjectionInput {
+  /** Currently invested assets, in integer cents. */
+  readonly currentInvestedCents: number;
+  /** Annual contribution to investments, in integer cents. */
+  readonly annualContributionCents: number;
+  /** Expected annual **real** return, as a decimal. */
+  readonly realReturnRate: number;
+  /** The FI target, in integer cents. */
+  readonly fiNumberCents: number;
+  /** Maximum number of years to project (defaults to {@link DEFAULT_DISPLAY_HORIZON_YEARS}). */
+  readonly maxYears?: number;
+  /** Extra years to keep projecting after FI is reached (for chart context). */
+  readonly bufferYears?: number;
+}
+
+/** A single year in a FIRE projection series, suitable for charting. */
+export interface FIProjectionPoint {
+  /** Whole-year offset from today (0 === now). */
+  readonly year: number;
+  /** Projected portfolio value at the end of this year, in integer cents. */
+  readonly balanceCents: number;
+  /** Cumulative contributions made since today, in integer cents. */
+  readonly contributionsToDateCents: number;
+  /** Cumulative investment growth since today, in integer cents. */
+  readonly growthToDateCents: number;
+  /** The (constant) FI target, in integer cents, for drawing a target line. */
+  readonly fiNumberCents: number;
+  /** True once the balance meets/exceeds the FI number. */
+  readonly reachedFI: boolean;
+}
+
+/** Inputs for the high-level `calculateFIREPlan` orchestrator. */
+export interface FIREPlanInput {
+  /** Currently invested assets, in integer cents. */
+  readonly currentInvestedCents: number;
+  /** Annual spending in retirement (today's dollars), in integer cents. */
+  readonly annualSpendingCents: number;
+  /** Annual contribution to investments, in integer cents. */
+  readonly annualContributionCents: number;
+  /** Expected annual **real** return, as a decimal. */
+  readonly realReturnRate: number;
+  /** Safe withdrawal rate, as a decimal. */
+  readonly swrRate: number;
+  /** Current age in whole years (optional; enables Coast-FI age math). */
+  readonly currentAge?: number | null;
+  /** Traditional retirement age (defaults to {@link DEFAULT_RETIREMENT_AGE}). */
+  readonly traditionalRetirementAge?: number;
+  /**
+   * Explicit years-to-traditional-retirement override. Used when {@link currentAge}
+   * is not supplied. Defaults to {@link DEFAULT_YEARS_TO_RETIREMENT}.
+   */
+  readonly yearsToTraditionalRetirement?: number;
+  /** Injectable "today" for deterministic date math (defaults to `new Date()`). */
+  readonly now?: Date;
+}
+
+/** Full FIRE plan result returned by `calculateFIREPlan`. */
+export interface FIREPlanResult {
+  /** Annual spending ÷ SWR, in integer cents. */
+  readonly fiNumberCents: number;
+  /** Echoed safe withdrawal rate. */
+  readonly swrRate: number;
+  /** Years/months-to-FI detail. */
+  readonly yearsToFI: YearsToFIResult;
+  /** Calendar date (YYYY-MM-DD) FI is projected to be reached, or null. */
+  readonly fiDateIso: string | null;
+  /** Lump sum needed today to "coast" to the FI number, in integer cents. */
+  readonly coastFINumberCents: number;
+  /** True when current assets already meet the Coast-FI number. */
+  readonly isCoastFI: boolean;
+  /** Years from now until traditional retirement used for the Coast-FI math. */
+  readonly yearsToTraditionalRetirement: number;
+  /** Year-by-year projection series for charting. */
+  readonly projection: readonly FIProjectionPoint[];
+  /** Total contributions expected by the time FI is reached, in integer cents. */
+  readonly totalContributionsToFICents: number;
+  /** Total investment growth expected by the time FI is reached, in integer cents. */
+  readonly totalGrowthToFICents: number;
+}
+
+/** Default safe withdrawal rate (the "4% rule", Trinity Study). */
+export const DEFAULT_SWR = 0.04;
+
+/** Default expected annual real return (≈ historical equity-heavy portfolio). */
+export const DEFAULT_REAL_RETURN = 0.05;
+
+/** Default traditional retirement age. */
+export const DEFAULT_RETIREMENT_AGE = 65;
+
+/** Default years-to-retirement when age is not provided. */
+export const DEFAULT_YEARS_TO_RETIREMENT = 30;
+
+/**
+ * Hard cap on the FI search horizon. If FI is not reached within this many
+ * years the plan reports it as unreachable rather than looping forever.
+ */
+export const MAX_FI_SEARCH_YEARS = 100;
+
+/** Default number of years rendered in a projection chart. */
+export const DEFAULT_DISPLAY_HORIZON_YEARS = 50;
+
+/** Default buffer years kept in the projection after FI is reached. */
+export const DEFAULT_PROJECTION_BUFFER_YEARS = 3;

--- a/apps/web/src/lib/fire.test.ts
+++ b/apps/web/src/lib/fire.test.ts
@@ -1,0 +1,456 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Unit tests for the FIRE planning engine (`fire.ts`).
+ *
+ * Covers known-value cases, banker's rounding, boundary conditions (zero,
+ * negative, max-value), and the documented edge cases (already-FI, never-reaches,
+ * non-positive return, unreachable SWR). All amounts are integer cents.
+ *
+ * References: issue #2114
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  bankersRound,
+  buildFIProjection,
+  calculateFIREPlan,
+  coastFINumber,
+  fiNumber,
+  isCoastFI,
+  monthlyRateFromAnnual,
+  yearsToFI,
+  MAX_FI_SEARCH_YEARS,
+} from './fire';
+
+// Convenience: dollars → integer cents for readable fixtures.
+const $ = (dollars: number): number => Math.round(dollars * 100);
+
+describe('bankersRound (round half to even)', () => {
+  it('rounds halves to the nearest even integer', () => {
+    expect(bankersRound(0.5)).toBe(0);
+    expect(bankersRound(1.5)).toBe(2);
+    expect(bankersRound(2.5)).toBe(2);
+    expect(bankersRound(3.5)).toBe(4);
+  });
+
+  it('rounds non-halves normally', () => {
+    expect(bankersRound(2.4)).toBe(2);
+    expect(bankersRound(2.6)).toBe(3);
+    expect(bankersRound(-2.4)).toBe(-2);
+  });
+
+  it('rounds negative halves to even', () => {
+    expect(bankersRound(-2.5)).toBe(-2);
+    expect(bankersRound(-3.5)).toBe(-4);
+  });
+
+  it('returns 0 for non-finite input', () => {
+    expect(bankersRound(Number.POSITIVE_INFINITY)).toBe(0);
+    expect(bankersRound(Number.NaN)).toBe(0);
+  });
+});
+
+describe('monthlyRateFromAnnual', () => {
+  it('returns 0 for a 0% annual rate', () => {
+    expect(monthlyRateFromAnnual(0)).toBe(0);
+  });
+
+  it('compounds back to the annual rate over 12 months', () => {
+    const monthly = monthlyRateFromAnnual(0.05);
+    expect((1 + monthly) ** 12).toBeCloseTo(1.05, 10);
+  });
+
+  it('clamps a ≤ -100% annual return to a total monthly loss', () => {
+    expect(monthlyRateFromAnnual(-1)).toBe(-1);
+    expect(monthlyRateFromAnnual(-2)).toBe(-1);
+  });
+});
+
+describe('fiNumber (annual spending ÷ SWR)', () => {
+  it('computes the classic $40k @ 4% → $1,000,000 case', () => {
+    expect(fiNumber($(40_000), 0.04)).toBe($(1_000_000));
+  });
+
+  it('computes other known SWR cases', () => {
+    expect(fiNumber($(25_000), 0.04)).toBe($(625_000));
+    // $50k / 3.5% = $1,428,571.4285… → banker's rounded cents.
+    expect(fiNumber($(50_000), 0.035)).toBe(142_857_143);
+  });
+
+  it('handles very large spending without overflow (within safe integer range)', () => {
+    expect(fiNumber($(100_000_000), 0.04)).toBe($(2_500_000_000));
+  });
+
+  it('returns 0 for zero or negative spending', () => {
+    expect(fiNumber(0, 0.04)).toBe(0);
+    expect(fiNumber(-100, 0.04)).toBe(0);
+  });
+
+  it('returns Infinity for a non-positive SWR (unreachable target)', () => {
+    expect(fiNumber($(40_000), 0)).toBe(Number.POSITIVE_INFINITY);
+    expect(fiNumber($(40_000), -0.01)).toBe(Number.POSITIVE_INFINITY);
+  });
+});
+
+describe('yearsToFI', () => {
+  it('reports already-FI when current assets meet the target', () => {
+    const result = yearsToFI({
+      currentInvestedCents: $(1_000_000),
+      annualContributionCents: $(20_000),
+      realReturnRate: 0.05,
+      fiNumberCents: $(1_000_000),
+    });
+    expect(result.alreadyFI).toBe(true);
+    expect(result.reachedFI).toBe(true);
+    expect(result.totalMonths).toBe(0);
+    expect(result.years).toBe(0);
+    expect(result.months).toBe(0);
+    expect(result.projectedCents).toBe($(1_000_000));
+  });
+
+  it('computes an exact whole-year case at 0% return (linear accumulation)', () => {
+    // $1,000/mo, no growth, target $120,000 → exactly 120 months.
+    const result = yearsToFI({
+      currentInvestedCents: 0,
+      annualContributionCents: $(12_000),
+      realReturnRate: 0,
+      fiNumberCents: $(120_000),
+    });
+    expect(result.reachedFI).toBe(true);
+    expect(result.totalMonths).toBe(120);
+    expect(result.years).toBe(10);
+    expect(result.months).toBe(0);
+    expect(result.projectedCents).toBe($(120_000));
+  });
+
+  it('reports the remainder months at 0% return', () => {
+    // $1,000/mo, no growth, target $125,000 → 125 months = 10y 5m.
+    const result = yearsToFI({
+      currentInvestedCents: 0,
+      annualContributionCents: $(12_000),
+      realReturnRate: 0,
+      fiNumberCents: $(125_000),
+    });
+    expect(result.totalMonths).toBe(125);
+    expect(result.years).toBe(10);
+    expect(result.months).toBe(5);
+  });
+
+  it('reaches FI sooner with a positive return than with none', () => {
+    const base = {
+      currentInvestedCents: $(50_000),
+      annualContributionCents: $(20_000),
+      fiNumberCents: $(500_000),
+    };
+    const withGrowth = yearsToFI({ ...base, realReturnRate: 0.06 });
+    const noGrowth = yearsToFI({ ...base, realReturnRate: 0 });
+    expect(withGrowth.reachedFI).toBe(true);
+    expect(noGrowth.reachedFI).toBe(true);
+    expect(withGrowth.totalMonths).toBeLessThan(noGrowth.totalMonths);
+  });
+
+  it('reaches FI via compounding alone — a 10-year doubling', () => {
+    // Return chosen so the portfolio doubles every 10 years; $500k → $1M at ~120 months.
+    const tenYearDoubleReturn = 2 ** (1 / 10) - 1;
+    const result = yearsToFI({
+      currentInvestedCents: $(500_000),
+      annualContributionCents: 0,
+      realReturnRate: tenYearDoubleReturn,
+      fiNumberCents: $(1_000_000),
+    });
+    expect(result.reachedFI).toBe(true);
+    expect(result.totalMonths).toBeGreaterThanOrEqual(119);
+    expect(result.totalMonths).toBeLessThanOrEqual(121);
+  });
+
+  it('matches the closed-form future value of an ordinary annuity', () => {
+    const input = {
+      currentInvestedCents: $(100_000),
+      annualContributionCents: $(24_000),
+      realReturnRate: 0.05,
+      fiNumberCents: $(1_000_000),
+    };
+    const result = yearsToFI(input);
+    expect(result.reachedFI).toBe(true);
+    expect(result.projectedCents).toBeGreaterThanOrEqual(input.fiNumberCents);
+
+    const i = monthlyRateFromAnnual(input.realReturnRate);
+    const pmt = input.annualContributionCents / 12;
+    const n = result.totalMonths;
+    const growth = (1 + i) ** n;
+    const fv = input.currentInvestedCents * growth + pmt * ((growth - 1) / i);
+    expect(Math.abs(result.projectedCents - bankersRound(fv))).toBeLessThanOrEqual(10);
+  });
+
+  it('reports unreachable (capped) when nothing grows toward the target', () => {
+    const result = yearsToFI({
+      currentInvestedCents: $(50_000),
+      annualContributionCents: 0,
+      realReturnRate: 0,
+      fiNumberCents: $(120_000),
+    });
+    expect(result.reachedFI).toBe(false);
+    expect(result.alreadyFI).toBe(false);
+    expect(result.totalMonths).toBe(MAX_FI_SEARCH_YEARS * 12);
+    expect(result.years).toBe(MAX_FI_SEARCH_YEARS);
+    expect(result.projectedCents).toBe($(50_000));
+  });
+
+  it('reports unreachable when negative contributions (drawdown) drain the portfolio', () => {
+    const result = yearsToFI({
+      currentInvestedCents: $(50_000),
+      annualContributionCents: $(-12_000),
+      realReturnRate: 0,
+      fiNumberCents: $(120_000),
+    });
+    expect(result.reachedFI).toBe(false);
+  });
+
+  it('reports unreachable when the FI target is infinite', () => {
+    const result = yearsToFI({
+      currentInvestedCents: $(50_000),
+      annualContributionCents: $(20_000),
+      realReturnRate: 0.05,
+      fiNumberCents: Number.POSITIVE_INFINITY,
+    });
+    expect(result.reachedFI).toBe(false);
+  });
+
+  it('keeps totalMonths === years*12 + months', () => {
+    const result = yearsToFI({
+      currentInvestedCents: $(30_000),
+      annualContributionCents: $(18_000),
+      realReturnRate: 0.05,
+      fiNumberCents: $(750_000),
+    });
+    expect(result.years * 12 + result.months).toBe(result.totalMonths);
+  });
+});
+
+describe('coastFINumber', () => {
+  it('discounts the FI number back to today (exact 1-year, 100% return)', () => {
+    // FI = $1M; doubling in 1 year ⇒ need exactly half today.
+    expect(
+      coastFINumber({
+        annualSpendingCents: $(40_000),
+        swrRate: 0.04,
+        realReturnRate: 1.0,
+        yearsToTraditionalRetirement: 1,
+      }),
+    ).toBe($(500_000));
+  });
+
+  it('equals the FI number when there is no time to grow', () => {
+    expect(
+      coastFINumber({
+        annualSpendingCents: $(40_000),
+        swrRate: 0.04,
+        realReturnRate: 0.05,
+        yearsToTraditionalRetirement: 0,
+      }),
+    ).toBe($(1_000_000));
+  });
+
+  it('equals the FI number when the real return is 0%', () => {
+    expect(
+      coastFINumber({
+        annualSpendingCents: $(40_000),
+        swrRate: 0.04,
+        realReturnRate: 0,
+        yearsToTraditionalRetirement: 30,
+      }),
+    ).toBe($(1_000_000));
+  });
+
+  it('computes a realistic 30-year coast number (≈ $231,377)', () => {
+    const coast = coastFINumber({
+      annualSpendingCents: $(40_000),
+      swrRate: 0.04,
+      realReturnRate: 0.05,
+      yearsToTraditionalRetirement: 30,
+    });
+    // $1M / 1.05^30 ≈ $231,377.45.
+    expect(Math.abs(coast - 23_137_745)).toBeLessThanOrEqual(50);
+  });
+
+  it('exceeds the FI number when the real return is negative', () => {
+    const coast = coastFINumber({
+      annualSpendingCents: $(40_000),
+      swrRate: 0.04,
+      realReturnRate: -0.02,
+      yearsToTraditionalRetirement: 20,
+    });
+    expect(coast).toBeGreaterThan($(1_000_000));
+  });
+
+  it('is Infinity when the FI number is unreachable', () => {
+    expect(
+      coastFINumber({
+        annualSpendingCents: $(40_000),
+        swrRate: 0,
+        realReturnRate: 0.05,
+        yearsToTraditionalRetirement: 30,
+      }),
+    ).toBe(Number.POSITIVE_INFINITY);
+  });
+});
+
+describe('isCoastFI', () => {
+  it('is true when current assets meet/exceed the coast number', () => {
+    expect(isCoastFI($(600_000), $(500_000))).toBe(true);
+    expect(isCoastFI($(500_000), $(500_000))).toBe(true);
+  });
+
+  it('is false when current assets fall short', () => {
+    expect(isCoastFI($(400_000), $(500_000))).toBe(false);
+  });
+
+  it('is false when the coast number is infinite', () => {
+    expect(isCoastFI($(1_000_000), Number.POSITIVE_INFINITY)).toBe(false);
+  });
+});
+
+describe('buildFIProjection', () => {
+  it('starts at today with no contributions or growth', () => {
+    const series = buildFIProjection({
+      currentInvestedCents: $(100_000),
+      annualContributionCents: $(24_000),
+      realReturnRate: 0.05,
+      fiNumberCents: $(1_000_000),
+    });
+    expect(series[0].year).toBe(0);
+    expect(series[0].balanceCents).toBe($(100_000));
+    expect(series[0].contributionsToDateCents).toBe(0);
+    expect(series[0].growthToDateCents).toBe(0);
+    expect(series[0].reachedFI).toBe(false);
+  });
+
+  it('flips reachedFI at the correct year and keeps a buffer afterward', () => {
+    // $1,000/mo, 0% return, target $120,000 → FI at year 10; default 3-year buffer.
+    const series = buildFIProjection({
+      currentInvestedCents: 0,
+      annualContributionCents: $(12_000),
+      realReturnRate: 0,
+      fiNumberCents: $(120_000),
+    });
+    expect(series).toHaveLength(14); // years 0..13
+    expect(series[9].reachedFI).toBe(false);
+    expect(series[10].reachedFI).toBe(true);
+    expect(series.at(-1)?.year).toBe(13);
+  });
+
+  it('keeps the balance = current + contributions + growth identity at every point', () => {
+    const current = $(100_000);
+    const series = buildFIProjection({
+      currentInvestedCents: current,
+      annualContributionCents: $(24_000),
+      realReturnRate: 0.05,
+      fiNumberCents: $(1_000_000),
+    });
+    for (const point of series) {
+      expect(point.balanceCents).toBe(
+        current + point.contributionsToDateCents + point.growthToDateCents,
+      );
+    }
+  });
+
+  it('produces a monotonically increasing balance with positive contributions', () => {
+    const series = buildFIProjection({
+      currentInvestedCents: $(10_000),
+      annualContributionCents: $(12_000),
+      realReturnRate: 0.04,
+      fiNumberCents: $(1_000_000),
+    });
+    for (let i = 1; i < series.length; i += 1) {
+      expect(series[i].balanceCents).toBeGreaterThan(series[i - 1].balanceCents);
+    }
+  });
+
+  it('honours maxYears when the target is never reached', () => {
+    const series = buildFIProjection({
+      currentInvestedCents: 0,
+      annualContributionCents: 0,
+      realReturnRate: 0,
+      fiNumberCents: $(120_000),
+      maxYears: 5,
+    });
+    expect(series).toHaveLength(6); // years 0..5
+    expect(series.every((p) => !p.reachedFI)).toBe(true);
+  });
+});
+
+describe('calculateFIREPlan (integration)', () => {
+  const baseInput = {
+    currentInvestedCents: $(100_000),
+    annualSpendingCents: $(40_000),
+    annualContributionCents: $(36_000),
+    realReturnRate: 0.05,
+    swrRate: 0.04,
+    currentAge: 35,
+    traditionalRetirementAge: 65,
+    now: new Date('2020-06-15T12:00:00Z'),
+  };
+
+  it('produces a complete, internally-consistent plan', () => {
+    const plan = calculateFIREPlan(baseInput);
+
+    expect(plan.fiNumberCents).toBe($(1_000_000));
+    expect(plan.swrRate).toBe(0.04);
+    expect(plan.yearsToFI.reachedFI).toBe(true);
+    expect(plan.yearsToTraditionalRetirement).toBe(30);
+
+    // Coast number ≈ $231k; current $100k is below it.
+    expect(Math.abs(plan.coastFINumberCents - 23_137_745)).toBeLessThanOrEqual(50);
+    expect(plan.isCoastFI).toBe(false);
+
+    // Projection begins at today's balance.
+    expect(plan.projection.length).toBeGreaterThan(0);
+    expect(plan.projection[0].balanceCents).toBe($(100_000));
+
+    // FI date is a calendar date string.
+    expect(plan.fiDateIso).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+
+    // Contributions/growth split reconciles with the projected portfolio.
+    const monthlyContribution = baseInput.annualContributionCents / 12;
+    expect(plan.totalContributionsToFICents).toBe(
+      bankersRound(monthlyContribution * plan.yearsToFI.totalMonths),
+    );
+    expect(plan.totalGrowthToFICents).toBeGreaterThan(0);
+    expect(
+      baseInput.currentInvestedCents + plan.totalContributionsToFICents + plan.totalGrowthToFICents,
+    ).toBe(plan.yearsToFI.projectedCents);
+  });
+
+  it('flags an already-FI / already-Coast-FI saver', () => {
+    const plan = calculateFIREPlan({
+      ...baseInput,
+      currentInvestedCents: $(2_000_000),
+    });
+    expect(plan.yearsToFI.alreadyFI).toBe(true);
+    expect(plan.yearsToFI.totalMonths).toBe(0);
+    expect(plan.isCoastFI).toBe(true);
+    expect(plan.fiDateIso).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('reports an unreachable plan for a non-positive SWR', () => {
+    const plan = calculateFIREPlan({ ...baseInput, swrRate: 0 });
+    expect(plan.fiNumberCents).toBe(Number.POSITIVE_INFINITY);
+    expect(plan.yearsToFI.reachedFI).toBe(false);
+    expect(plan.fiDateIso).toBeNull();
+    expect(plan.coastFINumberCents).toBe(Number.POSITIVE_INFINITY);
+    expect(plan.isCoastFI).toBe(false);
+  });
+
+  it('falls back to a default horizon when age is omitted', () => {
+    const plan = calculateFIREPlan({
+      currentInvestedCents: $(100_000),
+      annualSpendingCents: $(40_000),
+      annualContributionCents: $(36_000),
+      realReturnRate: 0.05,
+      swrRate: 0.04,
+    });
+    expect(plan.yearsToTraditionalRetirement).toBe(30);
+  });
+});

--- a/apps/web/src/lib/fire.ts
+++ b/apps/web/src/lib/fire.ts
@@ -1,0 +1,409 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * FIRE (Financial Independence / Retire Early) planning engine.
+ *
+ * Pure, side-effect-free functions for modelling the journey to financial
+ * independence: the FI number, years/months-to-FI, the Coast-FI number, and a
+ * year-by-year projection series for charting.
+ *
+ * ── Money & rate conventions ───────────────────────────────────────────────
+ *   • All monetary values are **integer cents** (e.g. 100_000_00 === $1,000,000).
+ *   • All rates are **decimals** (e.g. 0.04 === 4%).
+ *   • Floating-point is only used for *rate math* (compounding/discounting); the
+ *     result is always rounded back to integer cents with banker's rounding
+ *     (round-half-to-even) before being returned.
+ *
+ * ── Modelling assumptions (documented, standard FIRE formulas) ──────────────
+ *   • Returns are **real** (inflation-adjusted). Because the FI number is
+ *     derived from *today's* annual spending, expressing growth in real terms
+ *     keeps the target and the projected balance in the same purchasing-power
+ *     units — the convention used by the Trinity Study and Mr. Money Mustache's
+ *     "The Shockingly Simple Math Behind Early Retirement".
+ *   • Accumulation uses the standard **future value of an ordinary annuity**:
+ *     each period the balance compounds and a contribution is added at period
+ *     end. We iterate **monthly** (so we can report whole months) and convert
+ *     the annual real return to a monthly rate **geometrically**
+ *     (`(1 + r)^(1/12) − 1`) so that twelve monthly steps compound to exactly
+ *     the annual return — avoiding the slight overstatement of a naive `r / 12`.
+ *   • FI number  = annual spending ÷ SWR  (the inverse of the 4% rule).
+ *   • Coast-FI   = FI number discounted back to today at the real return:
+ *                  `FI / (1 + r)^yearsToRetirement`. It is the lump sum that, with
+ *                  **no further contributions**, grows to the FI number by the
+ *                  traditional retirement date.
+ *
+ * References: issue #2114
+ */
+
+import type {
+  CoastFIInput,
+  FIProjectionInput,
+  FIProjectionPoint,
+  FIREPlanInput,
+  FIREPlanResult,
+  YearsToFIInput,
+  YearsToFIResult,
+} from './fire-types';
+
+import {
+  DEFAULT_DISPLAY_HORIZON_YEARS,
+  DEFAULT_PROJECTION_BUFFER_YEARS,
+  DEFAULT_RETIREMENT_AGE,
+  DEFAULT_YEARS_TO_RETIREMENT,
+  MAX_FI_SEARCH_YEARS,
+} from './fire-types';
+
+export * from './fire-types';
+
+// ---------------------------------------------------------------------------
+// Rounding & numeric helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Banker's rounding (round half to even, IEEE-754 / `RoundingMode.HALF_EVEN`).
+ *
+ * Examples: `0.5 → 0`, `1.5 → 2`, `2.5 → 2`, `3.5 → 4`.
+ *
+ * Non-finite input (NaN / ±Infinity) yields `0` — callers that can produce an
+ * unreachable (infinite) target guard for that case explicitly *before* calling
+ * this, so a stray Infinity never silently collapses to a misleading $0.
+ *
+ * @param value - The number to round.
+ * @returns The nearest integer, ties to even.
+ */
+export function bankersRound(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  const floored = Math.floor(value);
+  const diff = value - floored;
+  if (Math.abs(diff - 0.5) < Number.EPSILON) {
+    return floored % 2 === 0 ? floored : floored + 1;
+  }
+  return Math.round(value);
+}
+
+/** Clamp to a non-negative number (used to defend cents against bad input). */
+function nonNegative(value: number): number {
+  return value > 0 ? value : 0;
+}
+
+/**
+ * Convert an annual rate to its equivalent monthly rate **geometrically**, so
+ * that compounding twelve monthly steps reproduces the annual rate exactly.
+ *
+ * Guards the pathological case of a ≤ −100% annual return (a non-positive
+ * growth base) by treating it as a total monthly loss.
+ *
+ * @param annualRate - Annual rate as a decimal (e.g. 0.05).
+ * @returns The equivalent monthly rate as a decimal.
+ */
+export function monthlyRateFromAnnual(annualRate: number): number {
+  if (annualRate <= -1) return -1;
+  return Math.pow(1 + annualRate, 1 / 12) - 1;
+}
+
+// ---------------------------------------------------------------------------
+// Date helpers (calendar-date math — FI date is a LocalDate, not a timestamp)
+// ---------------------------------------------------------------------------
+
+/** Format a `Date` as a `YYYY-MM-DD` calendar date string. */
+function toIsoDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+/** Add whole months to a date, returning a new `Date` (no mutation). */
+function addMonths(date: Date, months: number): Date {
+  const next = new Date(date.getTime());
+  next.setMonth(next.getMonth() + months);
+  return next;
+}
+
+// ---------------------------------------------------------------------------
+// FI number
+// ---------------------------------------------------------------------------
+
+/**
+ * The FI number — the portfolio size at which the safe withdrawal rate covers
+ * annual spending: `annualSpending ÷ SWR`.
+ *
+ * Edge cases:
+ *   • `annualSpendingCents ≤ 0` → `0` (you need nothing if you spend nothing).
+ *   • `swrRate ≤ 0` → `Number.POSITIVE_INFINITY` (an unreachable target — a
+ *     non-positive withdrawal rate can never sustain any spending). Callers and
+ *     the downstream functions treat an infinite target as "never reached".
+ *
+ * @param annualSpendingCents - Annual spending in integer cents.
+ * @param swrRate - Safe withdrawal rate as a decimal (e.g. 0.04).
+ * @returns The FI number in integer cents, or `Infinity` when unreachable.
+ */
+export function fiNumber(annualSpendingCents: number, swrRate: number): number {
+  const spending = nonNegative(annualSpendingCents);
+  if (spending === 0) return 0;
+  if (swrRate <= 0) return Number.POSITIVE_INFINITY;
+  return bankersRound(spending / swrRate);
+}
+
+// ---------------------------------------------------------------------------
+// Years to FI
+// ---------------------------------------------------------------------------
+
+function notReached(projectedCents: number): YearsToFIResult {
+  return {
+    reachedFI: false,
+    alreadyFI: false,
+    totalMonths: MAX_FI_SEARCH_YEARS * 12,
+    years: MAX_FI_SEARCH_YEARS,
+    months: 0,
+    projectedCents: bankersRound(projectedCents),
+  };
+}
+
+/**
+ * Years (and months) until the FI number is reached, via monthly future-value-
+ * of-an-annuity iteration.
+ *
+ * The balance compounds at the geometric monthly rate and an evenly-split
+ * monthly contribution (`annualContribution / 12`) is added at the end of each
+ * month. Iteration stops the first month the balance meets/exceeds the FI
+ * number, or after {@link MAX_FI_SEARCH_YEARS} (reported as unreachable).
+ *
+ * Edge cases:
+ *   • Already FI (current ≥ target) → `{ reachedFI: true, alreadyFI: true, 0m }`.
+ *   • Infinite/zero-growth target that can never be met (e.g. no contributions
+ *     and a ≤ 0% return while below target) → `reachedFI: false`, capped.
+ *   • Negative contributions (modelling drawdown) are permitted; if they prevent
+ *     reaching the target the result is reported as unreachable.
+ *
+ * @param input - {@link YearsToFIInput}.
+ * @returns {@link YearsToFIResult}.
+ */
+export function yearsToFI(input: YearsToFIInput): YearsToFIResult {
+  const current = nonNegative(input.currentInvestedCents);
+  const target = input.fiNumberCents;
+
+  if (current >= target) {
+    return {
+      reachedFI: true,
+      alreadyFI: true,
+      totalMonths: 0,
+      years: 0,
+      months: 0,
+      projectedCents: bankersRound(current),
+    };
+  }
+
+  if (!Number.isFinite(target)) {
+    return notReached(current);
+  }
+
+  const monthlyRate = monthlyRateFromAnnual(input.realReturnRate);
+  const monthlyContribution = input.annualContributionCents / 12;
+  const maxMonths = MAX_FI_SEARCH_YEARS * 12;
+
+  let balance = current;
+  for (let month = 1; month <= maxMonths; month += 1) {
+    balance = balance * (1 + monthlyRate) + monthlyContribution;
+    if (balance >= target) {
+      return {
+        reachedFI: true,
+        alreadyFI: false,
+        totalMonths: month,
+        years: Math.floor(month / 12),
+        months: month % 12,
+        projectedCents: bankersRound(balance),
+      };
+    }
+  }
+
+  return notReached(balance);
+}
+
+// ---------------------------------------------------------------------------
+// Coast FI
+// ---------------------------------------------------------------------------
+
+/**
+ * The Coast-FI number — the lump sum needed **today** that, with no further
+ * contributions, compounds to the FI number by the traditional retirement date:
+ * `FI ÷ (1 + r)^yearsToRetirement`.
+ *
+ * Edge cases:
+ *   • `yearsToTraditionalRetirement ≤ 0` → equals the FI number (no time to grow).
+ *   • `realReturnRate === 0` → equals the FI number (no growth).
+ *   • `realReturnRate < 0` → greater than the FI number (you need more today
+ *     because the portfolio is expected to shrink in real terms).
+ *   • Unreachable FI number (Infinity) → `Infinity`.
+ *
+ * @param input - {@link CoastFIInput}.
+ * @returns The Coast-FI number in integer cents (or `Infinity`).
+ */
+export function coastFINumber(input: CoastFIInput): number {
+  const fi = fiNumber(input.annualSpendingCents, input.swrRate);
+  if (!Number.isFinite(fi)) return Number.POSITIVE_INFINITY;
+
+  const years = nonNegative(input.yearsToTraditionalRetirement);
+  if (years === 0) return fi;
+
+  const growthFactor = Math.pow(1 + input.realReturnRate, years);
+  if (!(growthFactor > 0)) return Number.POSITIVE_INFINITY;
+
+  return bankersRound(fi / growthFactor);
+}
+
+/**
+ * Whether current assets already meet/exceed the Coast-FI number — i.e. the
+ * portfolio can "coast" to the FI number with no further contributions.
+ *
+ * @param currentInvestedCents - Current invested assets in integer cents.
+ * @param coastFINumberCents - The Coast-FI number in integer cents.
+ * @returns `true` when already Coast-FI.
+ */
+export function isCoastFI(currentInvestedCents: number, coastFINumberCents: number): boolean {
+  if (!Number.isFinite(coastFINumberCents)) return false;
+  return currentInvestedCents >= coastFINumberCents;
+}
+
+// ---------------------------------------------------------------------------
+// Year-by-year projection (for charting)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a year-by-year projection of the portfolio against the FI target.
+ *
+ * Internally steps **monthly** (consistent with {@link yearsToFI}) and snapshots
+ * the balance at each year boundary. The series always starts at year 0 (today)
+ * and runs until either `maxYears`, or `bufferYears` past the year FI is reached.
+ *
+ * Each point exposes the running split of cumulative contributions vs investment
+ * growth so the chart can render a meaningful, non-colour-only breakdown.
+ *
+ * @param input - {@link FIProjectionInput}.
+ * @returns An array of {@link FIProjectionPoint}, one per whole year.
+ */
+export function buildFIProjection(input: FIProjectionInput): FIProjectionPoint[] {
+  const current = nonNegative(input.currentInvestedCents);
+  const target = input.fiNumberCents;
+  const targetIsFinite = Number.isFinite(target);
+
+  const monthlyRate = monthlyRateFromAnnual(input.realReturnRate);
+  const monthlyContribution = input.annualContributionCents / 12;
+  const maxYears = Math.max(1, Math.floor(input.maxYears ?? DEFAULT_DISPLAY_HORIZON_YEARS));
+  const bufferYears = Math.max(0, Math.floor(input.bufferYears ?? DEFAULT_PROJECTION_BUFFER_YEARS));
+
+  const currentCents = bankersRound(current);
+  const points: FIProjectionPoint[] = [];
+
+  let balance = current;
+  let contributions = 0;
+
+  const pushPoint = (year: number): void => {
+    const balanceCents = bankersRound(balance);
+    const contributionsToDateCents = bankersRound(contributions);
+    points.push({
+      year,
+      balanceCents,
+      contributionsToDateCents,
+      growthToDateCents: balanceCents - currentCents - contributionsToDateCents,
+      fiNumberCents: targetIsFinite ? target : 0,
+      reachedFI: targetIsFinite && balance >= target,
+    });
+  };
+
+  pushPoint(0);
+
+  let reachedYear: number | null = targetIsFinite && current >= target ? 0 : null;
+
+  for (let year = 1; year <= maxYears; year += 1) {
+    for (let month = 0; month < 12; month += 1) {
+      balance = balance * (1 + monthlyRate) + monthlyContribution;
+      contributions += monthlyContribution;
+    }
+    pushPoint(year);
+
+    if (reachedYear === null && targetIsFinite && balance >= target) {
+      reachedYear = year;
+    }
+    if (reachedYear !== null && year >= reachedYear + bufferYears) {
+      break;
+    }
+  }
+
+  return points;
+}
+
+// ---------------------------------------------------------------------------
+// High-level orchestrator
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve how many years separate "now" from traditional retirement.
+ * Prefers age math when an age is supplied, then an explicit override, then a
+ * sensible default.
+ */
+function resolveYearsToRetirement(input: FIREPlanInput): number {
+  if (input.currentAge != null && Number.isFinite(input.currentAge)) {
+    const retirementAge = input.traditionalRetirementAge ?? DEFAULT_RETIREMENT_AGE;
+    return nonNegative(retirementAge - input.currentAge);
+  }
+  if (input.yearsToTraditionalRetirement != null) {
+    return nonNegative(input.yearsToTraditionalRetirement);
+  }
+  return DEFAULT_YEARS_TO_RETIREMENT;
+}
+
+/**
+ * Compute a complete FIRE plan: FI number, years/months-to-FI, projected FI
+ * date, Coast-FI number and status, and a year-by-year projection series.
+ *
+ * This ties together the individual pure functions for convenience; each piece
+ * is also exported independently for fine-grained use and testing.
+ *
+ * @param input - {@link FIREPlanInput}.
+ * @returns {@link FIREPlanResult}.
+ */
+export function calculateFIREPlan(input: FIREPlanInput): FIREPlanResult {
+  const now = input.now ?? new Date();
+  const fiCents = fiNumber(input.annualSpendingCents, input.swrRate);
+
+  const ytf = yearsToFI({
+    currentInvestedCents: input.currentInvestedCents,
+    annualContributionCents: input.annualContributionCents,
+    realReturnRate: input.realReturnRate,
+    fiNumberCents: fiCents,
+  });
+
+  const yearsToTraditionalRetirement = resolveYearsToRetirement(input);
+  const coastCents = coastFINumber({
+    annualSpendingCents: input.annualSpendingCents,
+    swrRate: input.swrRate,
+    realReturnRate: input.realReturnRate,
+    yearsToTraditionalRetirement,
+  });
+
+  const projection = buildFIProjection({
+    currentInvestedCents: input.currentInvestedCents,
+    annualContributionCents: input.annualContributionCents,
+    realReturnRate: input.realReturnRate,
+    fiNumberCents: fiCents,
+  });
+
+  const fiDateIso = ytf.reachedFI ? toIsoDate(addMonths(now, ytf.totalMonths)) : null;
+
+  const totalContributionsToFICents = bankersRound(
+    (input.annualContributionCents / 12) * ytf.totalMonths,
+  );
+  const totalGrowthToFICents =
+    ytf.projectedCents - nonNegative(input.currentInvestedCents) - totalContributionsToFICents;
+
+  return {
+    fiNumberCents: fiCents,
+    swrRate: input.swrRate,
+    yearsToFI: ytf,
+    fiDateIso,
+    coastFINumberCents: coastCents,
+    isCoastFI: isCoastFI(nonNegative(input.currentInvestedCents), coastCents),
+    yearsToTraditionalRetirement,
+    projection,
+    totalContributionsToFICents,
+    totalGrowthToFICents,
+  };
+}

--- a/apps/web/src/pages/FirePlannerPage.css
+++ b/apps/web/src/pages/FirePlannerPage.css
@@ -1,0 +1,256 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+/**
+ * Styles for the FIRE Planner page (FirePlannerPage.tsx).
+ *
+ * All visual values come from design-token CSS custom properties. Layout is
+ * mobile-first; the inputs/results split becomes side-by-side on wide screens.
+ *
+ * References: issue #2114
+ */
+
+.fire-page {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.fire-page__header {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-3);
+  margin-bottom: var(--spacing-6);
+}
+
+.fire-page__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  flex: 0 0 auto;
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-secondary);
+  color: var(--semantic-status-warning);
+}
+
+.fire-page__title {
+  font-size: var(--type-scale-headline-font-size);
+  font-weight: var(--type-scale-headline-font-weight);
+  color: var(--semantic-text-primary);
+  margin: 0;
+}
+
+.fire-page__subtitle {
+  margin: var(--spacing-1) 0 0 0;
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-body-font-size);
+  max-width: 60ch;
+}
+
+/* ---------------------------------------------------------------------------
+ * Layout
+ * ------------------------------------------------------------------------- */
+
+.fire-layout {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--spacing-6);
+}
+
+@media (min-width: 960px) {
+  .fire-layout {
+    grid-template-columns: minmax(300px, 360px) 1fr;
+    align-items: start;
+  }
+}
+
+/* ---------------------------------------------------------------------------
+ * Inputs
+ * ------------------------------------------------------------------------- */
+
+.fire-form {
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-elevated);
+  padding: var(--spacing-4);
+}
+
+.fire-form__legend {
+  font-size: var(--type-scale-title-font-size);
+  font-weight: var(--type-scale-title-font-weight);
+  color: var(--semantic-text-primary);
+  margin: 0 0 var(--spacing-4) 0;
+}
+
+.fire-form__grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--spacing-4);
+}
+
+@media (min-width: 600px) and (max-width: 959px) {
+  .fire-form__grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.fire-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.fire-field__label {
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-medium);
+  color: var(--semantic-text-primary);
+}
+
+.fire-field__control {
+  display: flex;
+  align-items: center;
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-sm);
+  background: var(--semantic-background-primary);
+  overflow: hidden;
+}
+
+.fire-field__control:focus-within {
+  border-color: var(--semantic-interactive-default);
+  box-shadow: 0 0 0 2px var(--semantic-interactive-default);
+}
+
+.fire-field__affix {
+  padding: 0 var(--spacing-2);
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-body-font-size);
+  user-select: none;
+}
+
+.fire-field__affix--suffix {
+  order: 2;
+}
+
+.fire-field__input {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  color: var(--semantic-text-primary);
+  font-size: var(--type-scale-body-font-size);
+  padding: var(--spacing-2);
+}
+
+.fire-field__input:focus {
+  outline: none;
+}
+
+.fire-field__hint {
+  margin: 0;
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+/* ---------------------------------------------------------------------------
+ * Results
+ * ------------------------------------------------------------------------- */
+
+.fire-results {
+  min-width: 0;
+}
+
+.fire-results__summary {
+  margin: 0 0 var(--spacing-4) 0;
+  padding: var(--spacing-3) var(--spacing-4);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-secondary);
+  color: var(--semantic-text-primary);
+  font-size: var(--type-scale-body-font-size);
+}
+
+.fire-results__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--spacing-4);
+  margin-bottom: var(--spacing-6);
+}
+
+.fire-result-card {
+  padding: var(--spacing-4);
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-elevated);
+}
+
+.fire-result-card__label {
+  margin: 0 0 var(--spacing-1) 0;
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+.fire-result-card__value {
+  margin: 0;
+  font-size: var(--type-scale-title-font-size);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-text-primary);
+}
+
+.fire-result-card__detail {
+  margin-top: var(--spacing-2);
+}
+
+.fire-result-card__formula {
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+.fire-result-card__split {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+  font-size: var(--type-scale-caption-font-size);
+  color: var(--semantic-text-secondary);
+}
+
+/* Status row — icon + text (never colour alone). */
+.fire-status {
+  display: inline-flex;
+  align-items: flex-start;
+  gap: var(--spacing-1);
+  font-size: var(--type-scale-caption-font-size);
+  line-height: 1.4;
+}
+
+.fire-status__icon {
+  display: inline-flex;
+  flex: 0 0 auto;
+  margin-top: 0.1em;
+}
+
+.fire-status--positive {
+  color: var(--semantic-status-positive);
+}
+
+.fire-status--warning {
+  color: var(--semantic-status-warning);
+}
+
+.fire-status--neutral {
+  color: var(--semantic-text-secondary);
+}
+
+.fire-results__chart {
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--border-radius-md);
+  background: var(--semantic-background-elevated);
+  padding: var(--spacing-4);
+}
+
+@media (prefers-contrast: more) {
+  .fire-form,
+  .fire-result-card,
+  .fire-field__control,
+  .fire-results__chart {
+    border-width: 2px;
+  }
+}

--- a/apps/web/src/pages/FirePlannerPage.test.tsx
+++ b/apps/web/src/pages/FirePlannerPage.test.tsx
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for FirePlannerPage.
+ *
+ * The projection chart is mocked (it internally uses Recharts, which needs a
+ * real layout engine) so these tests focus on the calculator wiring: inputs
+ * drive the engine and the results render and update live.
+ *
+ * References: issue #2114
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+
+import { FirePlannerPage } from './FirePlannerPage';
+
+// Mock the chart barrel so we don't pull Recharts into jsdom.
+vi.mock('../components/charts', () => ({
+  TrendLineChart: () => <div data-testid="fire-projection-chart" />,
+}));
+
+describe('FirePlannerPage', () => {
+  it('renders the planner with labelled inputs', () => {
+    render(<FirePlannerPage />);
+
+    expect(screen.getByRole('heading', { name: 'FIRE Planner', level: 2 })).toBeInTheDocument();
+    expect(screen.getByLabelText('Current invested assets')).toBeInTheDocument();
+    expect(screen.getByLabelText('Annual spending in retirement')).toBeInTheDocument();
+    expect(screen.getByLabelText('Annual contributions')).toBeInTheDocument();
+    expect(screen.getByLabelText('Expected real return')).toBeInTheDocument();
+    expect(screen.getByLabelText('Safe withdrawal rate (SWR)')).toBeInTheDocument();
+  });
+
+  it('computes the FI number from the default inputs ($40k @ 4% → $1M)', () => {
+    render(<FirePlannerPage />);
+
+    const fiCard = screen.getByRole('article', { name: 'Financial independence number' });
+    expect(within(fiCard).getByText(/1,000,000/)).toBeInTheDocument();
+  });
+
+  it('recomputes the FI number live when annual spending changes', () => {
+    render(<FirePlannerPage />);
+
+    fireEvent.change(screen.getByLabelText('Annual spending in retirement'), {
+      target: { value: '50000' },
+    });
+
+    const fiCard = screen.getByRole('article', { name: 'Financial independence number' });
+    // $50,000 / 4% = $1,250,000.
+    expect(within(fiCard).getByText(/1,250,000/)).toBeInTheDocument();
+  });
+
+  it('shows a Coast-FI status conveyed with text (not colour alone)', () => {
+    render(<FirePlannerPage />);
+
+    const coastCard = screen.getByRole('article', {
+      name: 'Coast financial independence number',
+    });
+    // $100k today is below the ~$231k coast number at the default inputs.
+    expect(within(coastCard).getByText(/Not yet Coast FI/)).toBeInTheDocument();
+  });
+
+  it('renders the projection chart when FI is reachable', () => {
+    render(<FirePlannerPage />);
+    expect(screen.getByTestId('fire-projection-chart')).toBeInTheDocument();
+  });
+
+  it('announces results in a live status region', () => {
+    render(<FirePlannerPage />);
+    const status = screen.getByRole('status');
+    expect(status).toHaveTextContent(/FI number/i);
+  });
+
+  it('guards against a non-positive safe withdrawal rate', () => {
+    render(<FirePlannerPage />);
+
+    fireEvent.change(screen.getByLabelText('Safe withdrawal rate (SWR)'), {
+      target: { value: '0' },
+    });
+
+    const fiCard = screen.getByRole('article', { name: 'Financial independence number' });
+    expect(within(fiCard).getByText('—')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent(/withdrawal rate above 0%/i);
+  });
+});

--- a/apps/web/src/pages/FirePlannerPage.tsx
+++ b/apps/web/src/pages/FirePlannerPage.tsx
@@ -1,0 +1,452 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * FirePlannerPage — FIRE (Financial Independence / Retire Early) calculator.
+ *
+ * A fully client-side, edge-computed planner for the saver who cares about the
+ * *date* they can stop working. Inputs: current invested assets, annual
+ * spending, annual contributions, expected real return, and the safe withdrawal
+ * rate (SWR). Outputs: the FI number, years/months-to-FI (and projected FI
+ * date), the Coast-FI number (and whether already Coast-FI), and a year-by-year
+ * projection chart.
+ *
+ * All maths lives in the pure engine (`../lib/fire`); this page is presentation
+ * only. Money is handled in integer cents end-to-end and converted to major
+ * units (dollars) solely at the chart boundary, which expects display values.
+ *
+ * Accessibility (WCAG 2.2 AA):
+ * - Every control has an associated <label htmlFor> and an aria-describedby hint.
+ * - Results are announced via an aria-live status region.
+ * - The projection chart ships a text alternative + data table (TrendLineChart).
+ * - Status (Coast-FI / reachability) is conveyed with icon **and** text — never
+ *   colour alone.
+ *
+ * References: issue #2114
+ */
+
+import React, { useId, useMemo, useState } from 'react';
+
+import { AppIcon } from '../components/icons';
+import { TrendLineChart } from '../components/charts';
+import type { TrendDataPoint, TrendSeries } from '../components/charts/TrendLineChart';
+import { formatCurrency } from '../lib/currency';
+import {
+  calculateFIREPlan,
+  DEFAULT_RETIREMENT_AGE,
+  MAX_FI_SEARCH_YEARS,
+  type FIREPlanResult,
+} from '../lib/fire';
+
+import './FirePlannerPage.css';
+
+// ---------------------------------------------------------------------------
+// Parsing helpers (string inputs → cents / rates), defensive against junk input
+// ---------------------------------------------------------------------------
+
+/** Parse a dollar string into non-negative integer cents. */
+function parseDollarsToCents(value: string): number {
+  const dollars = Number.parseFloat(value);
+  if (!Number.isFinite(dollars)) return 0;
+  return Math.max(0, Math.round(dollars * 100));
+}
+
+/** Parse a percent string (e.g. "5") into a decimal rate (0.05). Allows negatives. */
+function parsePercentToRate(value: string): number {
+  const percent = Number.parseFloat(value);
+  if (!Number.isFinite(percent)) return 0;
+  return percent / 100;
+}
+
+/** Parse an age string into a whole number, or null when blank/invalid. */
+function parseAge(value: string): number | null {
+  const age = Number.parseInt(value, 10);
+  if (!Number.isFinite(age) || age < 0) return null;
+  return age;
+}
+
+/** Human-friendly "X years, Y months" (omitting zero parts). */
+function formatDuration(years: number, months: number): string {
+  const yearLabel = years === 1 ? '1 year' : `${years} years`;
+  const monthLabel = months === 1 ? '1 month' : `${months} months`;
+  if (years === 0) return monthLabel;
+  if (months === 0) return yearLabel;
+  return `${yearLabel}, ${monthLabel}`;
+}
+
+/** Format an ISO calendar date (YYYY-MM-DD) as e.g. "March 2041". */
+function formatFiDate(iso: string): string {
+  return new Date(`${iso}T00:00:00`).toLocaleDateString(undefined, {
+    month: 'long',
+    year: 'numeric',
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+interface NumberFieldProps {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  hint: string;
+  prefix?: string;
+  suffix?: string;
+  min?: number;
+  step?: number;
+}
+
+/** A labelled numeric input with a unit affix and a screen-reader hint. */
+const NumberField: React.FC<NumberFieldProps> = ({
+  id,
+  label,
+  value,
+  onChange,
+  hint,
+  prefix,
+  suffix,
+  min,
+  step,
+}) => (
+  <div className="fire-field">
+    <label className="fire-field__label" htmlFor={id}>
+      {label}
+    </label>
+    <div className="fire-field__control">
+      {prefix ? (
+        <span className="fire-field__affix" aria-hidden="true">
+          {prefix}
+        </span>
+      ) : null}
+      <input
+        id={id}
+        className="fire-field__input"
+        type="number"
+        inputMode="decimal"
+        value={value}
+        min={min}
+        step={step}
+        onChange={(event) => onChange(event.target.value)}
+        aria-describedby={`${id}-hint`}
+      />
+      {suffix ? (
+        <span className="fire-field__affix fire-field__affix--suffix" aria-hidden="true">
+          {suffix}
+        </span>
+      ) : null}
+    </div>
+    <p id={`${id}-hint`} className="fire-field__hint">
+      {hint}
+    </p>
+  </div>
+);
+
+interface ResultCardProps {
+  label: string;
+  value: string;
+  children?: React.ReactNode;
+  ariaLabel?: string;
+}
+
+/** A single headline result tile. */
+const ResultCard: React.FC<ResultCardProps> = ({ label, value, children, ariaLabel }) => (
+  <article className="fire-result-card" aria-label={ariaLabel ?? label}>
+    <p className="fire-result-card__label">{label}</p>
+    <p className="fire-result-card__value">{value}</p>
+    {children ? <div className="fire-result-card__detail">{children}</div> : null}
+  </article>
+);
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export const FirePlannerPage: React.FC = () => {
+  const fieldIdPrefix = useId();
+  const fid = (suffix: string): string => `${fieldIdPrefix}-${suffix}`;
+
+  const [currentInvested, setCurrentInvested] = useState('100000');
+  const [annualSpending, setAnnualSpending] = useState('40000');
+  const [annualContribution, setAnnualContribution] = useState('24000');
+  const [realReturnPercent, setRealReturnPercent] = useState('5');
+  const [swrPercent, setSwrPercent] = useState('4');
+  const [currentAge, setCurrentAge] = useState('35');
+  const [retirementAge, setRetirementAge] = useState('65');
+
+  const plan: FIREPlanResult = useMemo(
+    () =>
+      calculateFIREPlan({
+        currentInvestedCents: parseDollarsToCents(currentInvested),
+        annualSpendingCents: parseDollarsToCents(annualSpending),
+        annualContributionCents: parseDollarsToCents(annualContribution),
+        realReturnRate: parsePercentToRate(realReturnPercent),
+        swrRate: parsePercentToRate(swrPercent),
+        currentAge: parseAge(currentAge),
+        traditionalRetirementAge: parseAge(retirementAge) ?? DEFAULT_RETIREMENT_AGE,
+      }),
+    [
+      currentInvested,
+      annualSpending,
+      annualContribution,
+      realReturnPercent,
+      swrPercent,
+      currentAge,
+      retirementAge,
+    ],
+  );
+
+  const fiReachable = Number.isFinite(plan.fiNumberCents);
+  const ageNumber = parseAge(currentAge);
+  const retirementAgeNumber = parseAge(retirementAge) ?? DEFAULT_RETIREMENT_AGE;
+  const calendarYearNow = new Date().getFullYear();
+
+  // Chart series (dollars — TrendLineChart formats values as major units).
+  const chartSeries: TrendSeries[] = useMemo(
+    () => [
+      { dataKey: 'portfolio', name: 'Projected portfolio' },
+      { dataKey: 'fiTarget', name: 'FI number' },
+    ],
+    [],
+  );
+
+  const chartData: TrendDataPoint[] = useMemo(
+    () =>
+      plan.projection.map((point) => ({
+        label:
+          ageNumber != null
+            ? `Age ${ageNumber + point.year}`
+            : String(calendarYearNow + point.year),
+        portfolio: point.balanceCents / 100,
+        fiTarget: point.fiNumberCents / 100,
+      })),
+    [plan.projection, ageNumber, calendarYearNow],
+  );
+
+  // Concise live summary for assistive tech.
+  const summary = useMemo(() => {
+    if (!fiReachable) {
+      return 'Enter a safe withdrawal rate above 0% to calculate your FI number.';
+    }
+    const fiText = formatCurrency(plan.fiNumberCents);
+    if (plan.yearsToFI.alreadyFI) {
+      return `Your FI number is ${fiText}. Your current investments already meet it — you are financially independent.`;
+    }
+    if (!plan.yearsToFI.reachedFI) {
+      return `Your FI number is ${fiText}. At these inputs your portfolio does not reach it within ${MAX_FI_SEARCH_YEARS} years.`;
+    }
+    const duration = formatDuration(plan.yearsToFI.years, plan.yearsToFI.months);
+    const dateText = plan.fiDateIso ? ` (around ${formatFiDate(plan.fiDateIso)})` : '';
+    return `Your FI number is ${fiText}. At your current savings you reach financial independence in ${duration}${dateText}.`;
+  }, [fiReachable, plan]);
+
+  // Precomputed display strings (kept out of JSX to avoid nested ternaries).
+  const fiNumberDisplay = fiReachable ? formatCurrency(plan.fiNumberCents) : '—';
+  const coastNumberDisplay = Number.isFinite(plan.coastFINumberCents)
+    ? formatCurrency(plan.coastFINumberCents)
+    : '—';
+
+  let timeToFiValue = '—';
+  if (fiReachable) {
+    if (plan.yearsToFI.alreadyFI) {
+      timeToFiValue = 'Reached';
+    } else if (plan.yearsToFI.reachedFI) {
+      timeToFiValue = formatDuration(plan.yearsToFI.years, plan.yearsToFI.months);
+    } else {
+      timeToFiValue = 'Not reachable';
+    }
+  }
+
+  return (
+    <div className="fire-page">
+      <header className="fire-page__header">
+        <span className="fire-page__icon" aria-hidden="true">
+          <AppIcon name="flame" />
+        </span>
+        <div>
+          <h2 className="fire-page__title">FIRE Planner</h2>
+          <p className="fire-page__subtitle">
+            Model your path to financial independence — your FI number, when you can stop working,
+            and whether you have already hit Coast FI.
+          </p>
+        </div>
+      </header>
+
+      <div className="fire-layout">
+        {/* ---- Inputs ---- */}
+        <form
+          className="fire-form"
+          aria-label="Financial independence inputs"
+          onSubmit={(event) => event.preventDefault()}
+        >
+          <h3 className="fire-form__legend">Your numbers</h3>
+          <div className="fire-form__grid">
+            <NumberField
+              id={fid('current')}
+              label="Current invested assets"
+              value={currentInvested}
+              onChange={setCurrentInvested}
+              hint="Total of investment and retirement accounts, in US dollars."
+              prefix="$"
+              min={0}
+              step={1000}
+            />
+            <NumberField
+              id={fid('spending')}
+              label="Annual spending in retirement"
+              value={annualSpending}
+              onChange={setAnnualSpending}
+              hint="What you expect to spend each year, in today's dollars."
+              prefix="$"
+              min={0}
+              step={1000}
+            />
+            <NumberField
+              id={fid('contribution')}
+              label="Annual contributions"
+              value={annualContribution}
+              onChange={setAnnualContribution}
+              hint="How much you invest each year, spread evenly across the year."
+              prefix="$"
+              min={0}
+              step={1000}
+            />
+            <NumberField
+              id={fid('return')}
+              label="Expected real return"
+              value={realReturnPercent}
+              onChange={setRealReturnPercent}
+              hint="Annual return after inflation. A diversified portfolio is often modelled at 4–7%."
+              suffix="%"
+              step={0.1}
+            />
+            <NumberField
+              id={fid('swr')}
+              label="Safe withdrawal rate (SWR)"
+              value={swrPercent}
+              onChange={setSwrPercent}
+              hint="Share of the portfolio withdrawn each year. The Trinity Study popularised 4%."
+              suffix="%"
+              min={0.1}
+              step={0.1}
+            />
+            <NumberField
+              id={fid('age')}
+              label="Current age"
+              value={currentAge}
+              onChange={setCurrentAge}
+              hint="Used to label the timeline and the Coast-FI horizon. Optional."
+              min={0}
+              step={1}
+            />
+            <NumberField
+              id={fid('retirement-age')}
+              label="Traditional retirement age"
+              value={retirementAge}
+              onChange={setRetirementAge}
+              hint="When the Coast-FI calculation assumes you will tap your portfolio."
+              min={0}
+              step={1}
+            />
+          </div>
+        </form>
+
+        {/* ---- Results ---- */}
+        <section className="fire-results" aria-label="Results">
+          <p className="fire-results__summary" role="status" aria-live="polite">
+            {summary}
+          </p>
+
+          <div className="fire-results__grid">
+            <ResultCard
+              label="FI number"
+              value={fiNumberDisplay}
+              ariaLabel="Financial independence number"
+            >
+              <span className="fire-result-card__formula">annual spending ÷ SWR</span>
+            </ResultCard>
+
+            <ResultCard
+              label="Time to financial independence"
+              value={timeToFiValue}
+              ariaLabel="Time to financial independence"
+            >
+              {fiReachable && plan.yearsToFI.alreadyFI ? (
+                <span className="fire-status fire-status--positive">
+                  <span className="fire-status__icon" aria-hidden="true">
+                    <AppIcon name="check-circle" />
+                  </span>
+                  You have already reached your FI number.
+                </span>
+              ) : null}
+              {fiReachable && !plan.yearsToFI.alreadyFI && plan.yearsToFI.reachedFI ? (
+                <span className="fire-result-card__formula">
+                  {plan.fiDateIso ? `around ${formatFiDate(plan.fiDateIso)}` : null}
+                </span>
+              ) : null}
+              {fiReachable && !plan.yearsToFI.reachedFI ? (
+                <span className="fire-status fire-status--warning">
+                  <span className="fire-status__icon" aria-hidden="true">
+                    <AppIcon name="alert-triangle" />
+                  </span>
+                  Not reached within {MAX_FI_SEARCH_YEARS} years — try higher contributions or
+                  returns, or lower spending.
+                </span>
+              ) : null}
+            </ResultCard>
+
+            <ResultCard
+              label="Coast-FI number"
+              value={coastNumberDisplay}
+              ariaLabel="Coast financial independence number"
+            >
+              {plan.isCoastFI ? (
+                <span className="fire-status fire-status--positive">
+                  <span className="fire-status__icon" aria-hidden="true">
+                    <AppIcon name="check-circle" />
+                  </span>
+                  Coast FI reached — your investments can grow to your FI number by age{' '}
+                  {retirementAgeNumber} with no further contributions.
+                </span>
+              ) : (
+                <span className="fire-status fire-status--neutral">
+                  <span className="fire-status__icon" aria-hidden="true">
+                    <AppIcon name="circle" />
+                  </span>
+                  Not yet Coast FI — the amount you would need invested today to coast to FI by age{' '}
+                  {retirementAgeNumber}.
+                </span>
+              )}
+            </ResultCard>
+
+            {fiReachable && plan.yearsToFI.reachedFI && !plan.yearsToFI.alreadyFI ? (
+              <ResultCard
+                label="Contributions vs growth at FI"
+                value={formatCurrency(plan.yearsToFI.projectedCents)}
+                ariaLabel="Contributions versus growth at financial independence"
+              >
+                <span className="fire-result-card__split">
+                  <span>You invest {formatCurrency(plan.totalContributionsToFICents)}</span>
+                  <span>Growth adds {formatCurrency(plan.totalGrowthToFICents)}</span>
+                </span>
+              </ResultCard>
+            ) : null}
+          </div>
+
+          {fiReachable && chartData.length > 1 ? (
+            <div className="fire-results__chart">
+              <TrendLineChart
+                data={chartData}
+                series={chartSeries}
+                title="Projected portfolio vs FI number"
+                height={320}
+              />
+            </div>
+          ) : null}
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default FirePlannerPage;

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -69,6 +69,7 @@ const NetWorth = lazy(() => import('./pages/NetWorthPage'));
 const Subscriptions = lazy(() => import('./pages/SubscriptionsPage'));
 const BankConnections = lazy(() => import('./pages/BankConnectionsPage'));
 const Debt = lazy(() => import('./pages/DebtPage'));
+const FirePlanner = lazy(() => import('./pages/FirePlannerPage'));
 
 /**
  * Loading fallback shown while a lazy route chunk is being fetched.
@@ -575,6 +576,16 @@ export const AppRoutes: FC = () => (
         <AuthenticatedRoute>
           <RouteBoundary name="Planning">
             <Planning />
+          </RouteBoundary>
+        </AuthenticatedRoute>
+      }
+    />
+    <Route
+      path="/fire"
+      element={
+        <AuthenticatedRoute>
+          <RouteBoundary name="FIRE Planner">
+            <FirePlanner />
           </RouteBoundary>
         </AuthenticatedRoute>
       }


### PR DESCRIPTION
## Summary
Adds a FIRE / Financial-Independence calculator to the web app: FI number, years-to-FI, Coast-FI, and an SWR-driven projection — all client-side in integer cents.

## Changes
- New pure engine `lib/fire.ts` + `lib/fire-types.ts`: `fiNumber` (spending / SWR), `yearsToFI` (monthly ordinary-annuity future value, geometric annual to monthly rate), `coastFINumber` + `isCoastFI`, and a year-by-year projection series
- New accessible `/fire` FIRE Planner page (labeled inputs, `aria-live` results, status by icon+text, chart text alternative) + nav entry
- ~40 vitest unit tests (known values, banker's rounding, edge cases) + 7 page render tests

## Formulas / assumptions
Returns are treated as REAL (inflation-adjusted); FI number per the 4% rule (configurable SWR); integer cents with banker's rounding; edge cases handled (SWR<=0, return<=0, zero contributions, already-FI, never-reachable capped at 100y). Documented in the engine header.

## Follow-up
iOS-native FIRE surface remains a future enhancement (no shared/iOS FI support existed).

Closes #2114