### PR TITLE
feat(web): gig-driver take-home and vehicle cost-per-mile economics (#2135, #2139)

### DIFF
--- a/apps/web/src/components/mileage/TakeHomeSummary.tsx
+++ b/apps/web/src/components/mileage/TakeHomeSummary.tsx
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { formatCurrency } from '../../lib/currency';
+import type { GigTakeHomeResult, ProfitabilityPeriod } from '../../lib/gig-take-home';
+import './mileage.css';
+
+function formatPercent(rate: number): string {
+  return `${(rate * 100).toFixed(1)}%`;
+}
+
+function formatPerUnit(cents: number | null): string {
+  return cents === null ? '—' : formatCurrency(cents);
+}
+
+const DEDUCTION_METHOD_LABELS: Record<GigTakeHomeResult['deductionMethod'], string> = {
+  'standard-mileage': 'Standard mileage',
+  'actual-expenses': 'Actual expenses',
+};
+
+const GRANULARITY_HEADERS: Record<ProfitabilityPeriod['granularity'], string> = {
+  shift: 'Shift',
+  day: 'Day',
+  week: 'Week',
+};
+
+export interface TakeHomeSummaryProps {
+  result: GigTakeHomeResult;
+  periods?: ProfitabilityPeriod[];
+}
+
+/**
+ * Presentational card showing estimated gig-driver take-home pay after expenses
+ * and estimated taxes, plus optional day/week/shift profitability.
+ *
+ * All monetary values arrive as integer cents; this component only formats.
+ */
+export function TakeHomeSummary({ result, periods }: TakeHomeSummaryProps) {
+  const granularity = periods?.[0]?.granularity;
+
+  return (
+    <section className="mileage-card" aria-labelledby="take-home-summary-title">
+      <div className="mileage-card__header">
+        <div>
+          <h3 id="take-home-summary-title" className="mileage-card__title">
+            Take-home pay estimate
+          </h3>
+          <p className="mileage-card__description">
+            Gross payouts minus operating costs and estimated self-employment plus income taxes.
+            Estimate only — not tax advice.
+          </p>
+        </div>
+      </div>
+
+      <div className="mileage-stats">
+        <article className="mileage-stat">
+          <span className="mileage-stat__label">Gross payouts</span>
+          <p className="mileage-stat__value">{formatCurrency(result.grossPayoutsCents)}</p>
+        </article>
+        <article className="mileage-stat">
+          <span className="mileage-stat__label">Net cash profit</span>
+          <p className="mileage-stat__value">{formatCurrency(result.netCashProfitCents)}</p>
+        </article>
+        <article className="mileage-stat">
+          <span className="mileage-stat__label">Estimated tax set-aside</span>
+          <p className="mileage-stat__value">{formatCurrency(result.totalTaxSetAsideCents)}</p>
+        </article>
+        <article className="mileage-stat">
+          <span className="mileage-stat__label">Estimated take-home</span>
+          <p className="mileage-stat__value">{formatCurrency(result.estimatedTakeHomeCents)}</p>
+        </article>
+      </div>
+
+      <div className="deduction-summary__list" role="list" aria-label="Take-home breakdown">
+        <div className="deduction-summary__item" role="listitem">
+          <div className="deduction-summary__meta">
+            <span className="deduction-summary__label">Self-employment tax</span>
+            <span className="deduction-summary__caption">
+              15.3% on 92.35% of net SE earnings (SS capped at the wage base)
+            </span>
+          </div>
+          <strong>{formatCurrency(result.selfEmploymentTaxCents)}</strong>
+        </div>
+        <div className="deduction-summary__item" role="listitem">
+          <div className="deduction-summary__meta">
+            <span className="deduction-summary__label">Income-tax reserve</span>
+            <span className="deduction-summary__caption">
+              {formatPercent(result.incomeTaxReserveRate)} of taxable profit
+            </span>
+          </div>
+          <strong>{formatCurrency(result.incomeTaxReserveCents)}</strong>
+        </div>
+        <div className="deduction-summary__item" role="listitem">
+          <div className="deduction-summary__meta">
+            <span className="deduction-summary__label">Tax-deduction basis</span>
+            <span className="deduction-summary__caption">
+              {DEDUCTION_METHOD_LABELS[result.deductionMethod]} ·{' '}
+              {formatCurrency(result.taxDeductibleExpensesCents)} deducted
+            </span>
+          </div>
+          <strong>{formatPercent(result.effectiveTaxRate)}</strong>
+        </div>
+      </div>
+
+      {periods && periods.length > 0 && granularity ? (
+        <div className="mileage-report__table-wrapper">
+          <table className="mileage-report__table">
+            <caption className="mileage-card__description">
+              Profitability by {GRANULARITY_HEADERS[granularity].toLowerCase()}
+            </caption>
+            <thead>
+              <tr>
+                <th scope="col">{GRANULARITY_HEADERS[granularity]}</th>
+                <th scope="col">Take-home</th>
+                <th scope="col">Per mile</th>
+                <th scope="col">Per hour</th>
+              </tr>
+            </thead>
+            <tbody>
+              {periods.map((period) => (
+                <tr key={period.key}>
+                  <td>{period.label}</td>
+                  <td>{formatCurrency(period.estimatedTakeHomeCents)}</td>
+                  <td>{formatPerUnit(period.takeHomePerMileCents)}</td>
+                  <td>{formatPerUnit(period.takeHomePerHourCents)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/components/mileage/VehicleCostSummaryCard.tsx
+++ b/apps/web/src/components/mileage/VehicleCostSummaryCard.tsx
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { formatCurrency } from '../../lib/currency';
+import type { MaintenanceReminder, VehicleCostSummary } from '../../lib/vehicle-cost-per-mile';
+import './mileage.css';
+
+function formatPerUnit(cents: number | null): string {
+  return cents === null ? '—' : formatCurrency(cents);
+}
+
+const BEHAVIOR_LABELS: Record<'fixed' | 'variable', string> = {
+  fixed: 'Fixed',
+  variable: 'Variable',
+};
+
+const STATUS_LABELS: Record<MaintenanceReminder['status'], string> = {
+  ok: 'On track',
+  due_soon: 'Due soon',
+  overdue: 'Overdue',
+};
+
+export interface VehicleCostSummaryCardProps {
+  summary: VehicleCostSummary;
+  reminders?: MaintenanceReminder[];
+}
+
+/**
+ * Presentational card showing vehicle operating cost-per-mile, cost-per-shift,
+ * the fixed/variable split, and odometer-based maintenance reminders.
+ *
+ * Status is conveyed with text (not color alone) to meet WCAG 2.2 AA.
+ */
+export function VehicleCostSummaryCard({ summary, reminders }: VehicleCostSummaryCardProps) {
+  return (
+    <section className="mileage-card" aria-labelledby="vehicle-cost-summary-title">
+      <div className="mileage-card__header">
+        <div>
+          <h3 id="vehicle-cost-summary-title" className="mileage-card__title">
+            Vehicle cost per mile
+          </h3>
+          <p className="mileage-card__description">
+            Operating costs across {summary.milesDriven.toFixed(1)} business miles
+            {summary.activeShifts > 0 ? ` and ${summary.activeShifts} active shift(s)` : ''}.
+          </p>
+        </div>
+      </div>
+
+      <div className="mileage-stats">
+        <article className="mileage-stat">
+          <span className="mileage-stat__label">Cost per mile</span>
+          <p className="mileage-stat__value">{formatPerUnit(summary.costPerMileCents)}</p>
+        </article>
+        <article className="mileage-stat">
+          <span className="mileage-stat__label">Cost per shift</span>
+          <p className="mileage-stat__value">{formatPerUnit(summary.costPerShiftCents)}</p>
+        </article>
+        <article className="mileage-stat">
+          <span className="mileage-stat__label">Variable / mile</span>
+          <p className="mileage-stat__value">{formatPerUnit(summary.variableCostPerMileCents)}</p>
+        </article>
+        <article className="mileage-stat">
+          <span className="mileage-stat__label">Total operating cost</span>
+          <p className="mileage-stat__value">{formatCurrency(summary.totalCostCents)}</p>
+        </article>
+      </div>
+
+      <div className="mileage-stats">
+        <article className="mileage-stat">
+          <span className="mileage-stat__label">Fixed costs</span>
+          <p className="mileage-stat__value">{formatCurrency(summary.fixedCostCents)}</p>
+        </article>
+        <article className="mileage-stat">
+          <span className="mileage-stat__label">Variable costs</span>
+          <p className="mileage-stat__value">{formatCurrency(summary.variableCostCents)}</p>
+        </article>
+      </div>
+
+      {summary.byCategory.length > 0 ? (
+        <div className="deduction-summary__list" role="list" aria-label="Vehicle cost by category">
+          {summary.byCategory.map((entry) => (
+            <div key={entry.category} className="deduction-summary__item" role="listitem">
+              <div className="deduction-summary__meta">
+                <span className="deduction-summary__label">{entry.label}</span>
+                <span className="deduction-summary__caption">
+                  {BEHAVIOR_LABELS[entry.behavior]} · {formatPerUnit(entry.costPerMileCents)}/mi ·{' '}
+                  {entry.transactionCount} entr{entry.transactionCount === 1 ? 'y' : 'ies'}
+                </span>
+              </div>
+              <strong>{formatCurrency(entry.amountCents)}</strong>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="mileage-card__hint">
+          No vehicle expenses logged for this period. Tag transactions with “vehicle-expense” to
+          track operating costs.
+        </p>
+      )}
+
+      {reminders && reminders.length > 0 ? (
+        <div
+          className="deduction-summary__list"
+          role="list"
+          aria-label="Maintenance reminders by odometer milestone"
+        >
+          {reminders.map((reminder) => (
+            <div key={reminder.id} className="deduction-summary__item" role="listitem">
+              <div className="deduction-summary__meta">
+                <span className="deduction-summary__label">{reminder.label}</span>
+                <span className="deduction-summary__caption">
+                  Next service at {reminder.nextServiceOdometer.toLocaleString()} mi ·{' '}
+                  {reminder.status === 'overdue'
+                    ? `${reminder.milesOverdue.toLocaleString()} mi overdue`
+                    : `${reminder.milesRemaining.toLocaleString()} mi remaining`}
+                </span>
+              </div>
+              <span
+                className={`mileage-status mileage-status--${reminder.status}`}
+                data-status={reminder.status}
+              >
+                {STATUS_LABELS[reminder.status]}
+              </span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/components/mileage/mileage.css
+++ b/apps/web/src/components/mileage/mileage.css
@@ -226,3 +226,32 @@
     display: none;
   }
 }
+
+/* Maintenance reminder status badge.
+   Status is always conveyed by text; color and weight are supplementary
+   so meaning is never carried by color alone (WCAG 2.2 AA, 1.4.1). */
+.mileage-status {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.125rem 0.5rem;
+  border-radius: 999px;
+  border: 1px solid var(--semantic-border-default);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: var(--font-weight-semibold);
+  white-space: nowrap;
+}
+
+.mileage-status--ok {
+  color: var(--semantic-status-positive, var(--semantic-text-primary));
+  border-color: color-mix(in srgb, var(--semantic-status-positive) 40%, transparent);
+}
+
+.mileage-status--due_soon {
+  color: var(--semantic-status-warning, var(--semantic-text-primary));
+  border-color: color-mix(in srgb, var(--semantic-status-warning) 40%, transparent);
+}
+
+.mileage-status--overdue {
+  color: var(--semantic-status-negative, var(--semantic-text-primary));
+  border-color: color-mix(in srgb, var(--semantic-status-negative) 45%, transparent);
+}

--- a/apps/web/src/lib/gig-take-home.test.ts
+++ b/apps/web/src/lib/gig-take-home.test.ts
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_INCOME_TAX_RESERVE_RATE,
+  aggregateProfitability,
+  computeGigTakeHome,
+  weekStartKey,
+  type ShiftRecord,
+} from './gig-take-home';
+
+describe('computeGigTakeHome', () => {
+  it('estimates take-home with standard-mileage deductions and SE + income tax', () => {
+    const result = computeGigTakeHome({
+      grossPayoutsCents: 5_000_000, // $50,000 gross
+      operatingCostsCents: 800_000, // $8,000 actual vehicle cash costs
+      mileageDeductionCents: 1_000_000, // $10,000 standard mileage deduction
+      otherDeductionsCents: 100_000, // $1,000 phone/supplies
+      config: { incomeTaxReserveRate: 0.15 },
+    });
+
+    expect(result.deductionMethod).toBe('standard-mileage');
+    expect(result.netCashProfitCents).toBe(4_100_000); // 50k - 8k - 1k
+    expect(result.taxDeductibleExpensesCents).toBe(1_100_000); // mileage + other
+    expect(result.netSelfEmploymentEarningsCents).toBe(3_900_000); // 50k - 11k
+    expect(result.selfEmploymentTaxCents).toBe(551_053);
+    expect(result.selfEmploymentTaxDeductionCents).toBe(275_527);
+    expect(result.incomeTaxBaseCents).toBe(3_624_473);
+    expect(result.incomeTaxReserveCents).toBe(543_671);
+    expect(result.totalTaxSetAsideCents).toBe(1_094_724);
+    expect(result.estimatedTakeHomeCents).toBe(3_005_276);
+    expect(result.effectiveTaxRate).toBeCloseTo(0.218945, 5);
+  });
+
+  it('defaults the income-tax reserve rate when not provided', () => {
+    const result = computeGigTakeHome({ grossPayoutsCents: 100_000 });
+    expect(result.incomeTaxReserveRate).toBe(DEFAULT_INCOME_TAX_RESERVE_RATE);
+  });
+
+  it('returns all-zero output for zero income', () => {
+    const result = computeGigTakeHome({ grossPayoutsCents: 0 });
+
+    expect(result.netCashProfitCents).toBe(0);
+    expect(result.netSelfEmploymentEarningsCents).toBe(0);
+    expect(result.selfEmploymentTaxCents).toBe(0);
+    expect(result.incomeTaxReserveCents).toBe(0);
+    expect(result.totalTaxSetAsideCents).toBe(0);
+    expect(result.estimatedTakeHomeCents).toBe(0);
+    expect(result.effectiveTaxRate).toBe(0);
+  });
+
+  it('reports a loss (negative take-home) when costs exceed income with no taxable profit', () => {
+    const result = computeGigTakeHome({
+      grossPayoutsCents: 4_000,
+      operatingCostsCents: 6_000,
+      config: { deductionMethod: 'actual-expenses' },
+    });
+
+    // Actual-expense method deducts the operating costs, so there is no
+    // taxable SE profit and no tax is owed — just a cash loss.
+    expect(result.netSelfEmploymentEarningsCents).toBe(0);
+    expect(result.selfEmploymentTaxCents).toBe(0);
+    expect(result.totalTaxSetAsideCents).toBe(0);
+    expect(result.netCashProfitCents).toBe(-2_000);
+    expect(result.estimatedTakeHomeCents).toBe(-2_000);
+  });
+
+  it('applies the $400 annual SE-tax floor by default for a small single shift', () => {
+    const result = computeGigTakeHome({
+      grossPayoutsCents: 8_000, // $80 shift
+      operatingCostsCents: 5_000, // $50 gas + repairs
+      config: { incomeTaxReserveRate: 0.15 },
+    });
+
+    // Taxable base ($73.88) is under $400 → no SE tax with the floor on.
+    expect(result.selfEmploymentTaxCents).toBe(0);
+    expect(result.incomeTaxReserveCents).toBe(1_200); // 15% of $80 net SE
+    expect(result.totalTaxSetAsideCents).toBe(1_200);
+    expect(result.netCashProfitCents).toBe(3_000);
+    expect(result.estimatedTakeHomeCents).toBe(1_800);
+  });
+
+  it('disables the SE-tax floor for per-shift set-aside estimates', () => {
+    const result = computeGigTakeHome({
+      grossPayoutsCents: 8_000,
+      operatingCostsCents: 5_000,
+      config: { incomeTaxReserveRate: 0.15, applySelfEmploymentFloor: false },
+    });
+
+    expect(result.selfEmploymentTaxCents).toBe(1_130);
+    expect(result.selfEmploymentTaxDeductionCents).toBe(565);
+    expect(result.incomeTaxReserveCents).toBe(1_115); // 15% of ($80 - $5.65)
+    expect(result.totalTaxSetAsideCents).toBe(2_245);
+    expect(result.estimatedTakeHomeCents).toBe(755);
+  });
+
+  it('caps Social Security tax at the wage base for very high earners', () => {
+    const result = computeGigTakeHome({
+      grossPayoutsCents: 20_000_000, // $200,000 net SE
+      config: { applySelfEmploymentTax: true },
+    });
+
+    // SS capped at $168,600 wage base; Medicare on the full 92.35% base.
+    expect(result.selfEmploymentTaxCents).toBe(2_626_270);
+  });
+
+  it('can disable self-employment tax entirely', () => {
+    const withSe = computeGigTakeHome({ grossPayoutsCents: 5_000_000 });
+    const withoutSe = computeGigTakeHome({
+      grossPayoutsCents: 5_000_000,
+      config: { applySelfEmploymentTax: false },
+    });
+
+    expect(withSe.selfEmploymentTaxCents).toBeGreaterThan(0);
+    expect(withoutSe.selfEmploymentTaxCents).toBe(0);
+  });
+
+  it('clamps negative gross payouts to zero and ignores non-finite inputs', () => {
+    const result = computeGigTakeHome({
+      grossPayoutsCents: -1_000,
+      operatingCostsCents: Number.NaN,
+    });
+    expect(result.grossPayoutsCents).toBe(0);
+    expect(result.operatingCostsCents).toBe(0);
+    expect(result.estimatedTakeHomeCents).toBe(0);
+  });
+
+  it('clamps an out-of-range reserve rate into [0, 1]', () => {
+    const over = computeGigTakeHome({
+      grossPayoutsCents: 1_000_000,
+      config: { incomeTaxReserveRate: 5 },
+    });
+    const under = computeGigTakeHome({
+      grossPayoutsCents: 1_000_000,
+      config: { incomeTaxReserveRate: -1 },
+    });
+    expect(over.incomeTaxReserveRate).toBe(1);
+    expect(under.incomeTaxReserveRate).toBe(0);
+  });
+});
+
+describe('weekStartKey', () => {
+  it('maps any weekday to the preceding Monday', () => {
+    expect(weekStartKey('2024-02-14')).toBe('2024-02-12'); // Wed -> Mon
+    expect(weekStartKey('2024-02-12')).toBe('2024-02-12'); // Mon -> Mon
+    expect(weekStartKey('2024-02-18')).toBe('2024-02-12'); // Sun -> Mon
+  });
+});
+
+describe('aggregateProfitability', () => {
+  const shifts: ShiftRecord[] = [
+    {
+      id: 's1',
+      date: '2024-02-12',
+      grossCents: 8_000,
+      operatingCostsCents: 2_000,
+      mileageDeductionCents: 1_340,
+      miles: 20,
+      activeHours: 4,
+    },
+    {
+      id: 's2',
+      date: '2024-02-13',
+      grossCents: 12_000,
+      operatingCostsCents: 3_000,
+      mileageDeductionCents: 2_010,
+      miles: 30,
+      activeHours: 5,
+    },
+    {
+      id: 's3',
+      date: '2024-02-18',
+      grossCents: 10_000,
+      operatingCostsCents: 2_500,
+      mileageDeductionCents: 1_675,
+      miles: 25,
+      activeHours: 4,
+    },
+  ];
+
+  it('buckets each shift individually', () => {
+    const periods = aggregateProfitability(shifts, 'shift');
+    expect(periods.map((p) => p.key)).toEqual(['s1', 's2', 's3']);
+    expect(periods.every((p) => p.shiftCount === 1)).toBe(true);
+  });
+
+  it('buckets by calendar day', () => {
+    const periods = aggregateProfitability(shifts, 'day');
+    expect(periods.map((p) => p.key)).toEqual(['2024-02-12', '2024-02-13', '2024-02-18']);
+  });
+
+  it('buckets by Monday-based week and sums the period', () => {
+    const config = { applySelfEmploymentFloor: false, incomeTaxReserveRate: 0.15 };
+    const periods = aggregateProfitability(shifts, 'week', config);
+
+    expect(periods).toHaveLength(1);
+    const [week] = periods;
+    expect(week.key).toBe('2024-02-12');
+    expect(week.label).toBe('Week of 2024-02-12');
+    expect(week.shiftCount).toBe(3);
+    expect(week.grossCents).toBe(30_000);
+    expect(week.operatingCostsCents).toBe(7_500);
+    expect(week.miles).toBe(75);
+    expect(week.activeHours).toBe(13);
+
+    // The bucket math must equal a direct computation over the summed inputs.
+    const expected = computeGigTakeHome({
+      grossPayoutsCents: 30_000,
+      operatingCostsCents: 7_500,
+      mileageDeductionCents: 5_025,
+      otherDeductionsCents: 0,
+      config,
+    });
+    expect(week.netCashProfitCents).toBe(expected.netCashProfitCents);
+    expect(week.totalTaxSetAsideCents).toBe(expected.totalTaxSetAsideCents);
+    expect(week.estimatedTakeHomeCents).toBe(expected.estimatedTakeHomeCents);
+    expect(week.takeHomePerMileCents).toBe(Math.round(expected.estimatedTakeHomeCents / 75));
+    expect(week.takeHomePerHourCents).toBe(Math.round(expected.estimatedTakeHomeCents / 13));
+  });
+
+  it('returns null per-mile/per-hour metrics when miles or hours are zero', () => {
+    const periods = aggregateProfitability(
+      [{ id: 'x', date: '2024-02-12', grossCents: 5_000 }],
+      'shift',
+    );
+    expect(periods[0].takeHomePerMileCents).toBeNull();
+    expect(periods[0].takeHomePerHourCents).toBeNull();
+  });
+
+  it('returns an empty array for no shifts', () => {
+    expect(aggregateProfitability([], 'week')).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/gig-take-home.ts
+++ b/apps/web/src/lib/gig-take-home.ts
@@ -1,0 +1,386 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Gig-driver take-home pay calculator.
+ *
+ * Estimates the practical "money in pocket after taxes" for a self-employed
+ * gig driver (rideshare / delivery) by combining:
+ *
+ *   - gross payouts (fares, deliveries, tips),
+ *   - vehicle operating costs (gas, maintenance, repairs, ...),
+ *   - a tax-deduction basis (IRS standard mileage OR actual vehicle expenses),
+ *   - manual business deductions (phone allocation, supplies, ...),
+ *   - an estimated self-employment (SE) tax, and
+ *   - a configurable income-tax reserve.
+ *
+ * It also aggregates profitability at the day / week / shift level so a driver
+ * can see what a shift actually earns after costs and tax set-asides.
+ *
+ * ──────────────────────────────────────────────────────────────────────────
+ * IMPORTANT — this is an ESTIMATE, not tax advice. The income-tax reserve rate
+ * is a deliberately configurable default (see {@link DEFAULT_INCOME_TAX_RESERVE_RATE})
+ * because the true rate depends on filing status, other income, state, and
+ * deductions that this module does not model. SE tax is computed precisely via
+ * the shared {@link calculateSETax} engine (15.3% on 92.35% of net SE earnings,
+ * capped at the Social Security wage base).
+ * ──────────────────────────────────────────────────────────────────────────
+ *
+ * All monetary values are integer cents (never floats). Miles and hours are
+ * non-monetary quantities and may be fractional.
+ *
+ * References: issues #2135, #2139; IRC §1401, §6017.
+ */
+
+import { calculateSETax } from './tax/self-employment-tax';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Default income-tax reserve rate applied to taxable gig profit (after the
+ * deductible half of SE tax).
+ *
+ * This is a configurable estimate — NOT a statutory rate. ~15% is a common
+ * rough set-aside for a moderate-income sole proprietor blending federal and
+ * state income tax on Schedule C profit. Always allow the user to override it.
+ */
+export const DEFAULT_INCOME_TAX_RESERVE_RATE = 0.15;
+
+/**
+ * Minimum net SE earnings (the 92.35% taxable base) below which no SE tax is
+ * owed for the tax year (IRC §6017, the "$400 rule"), expressed in cents.
+ *
+ * This is an ANNUAL threshold. For per-shift "set aside as you go" estimates,
+ * disable the floor via {@link GigTakeHomeConfig.applySelfEmploymentFloor}.
+ */
+export const SE_TAX_MIN_NET_EARNINGS_CENTS = 400_00;
+
+/** Which expenses form the tax-deduction basis for net SE earnings. */
+export type DeductionMethod = 'standard-mileage' | 'actual-expenses';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface GigTakeHomeConfig {
+  /** Income-tax reserve rate as a decimal (0.15 = 15%). Default {@link DEFAULT_INCOME_TAX_RESERVE_RATE}. */
+  readonly incomeTaxReserveRate?: number;
+  /** Tax-deduction basis to use. Default `'standard-mileage'`. */
+  readonly deductionMethod?: DeductionMethod;
+  /** Whether to apply self-employment tax at all. Default `true`. */
+  readonly applySelfEmploymentTax?: boolean;
+  /**
+   * Whether to apply the annual $400 SE-tax floor. Default `true` (annual
+   * semantics). Set `false` for per-shift set-aside estimates where the driver
+   * will clearly exceed $400 across the year.
+   */
+  readonly applySelfEmploymentFloor?: boolean;
+}
+
+export interface GigTakeHomeInput {
+  /** Gross gig payouts including tips (cents). Negative inputs are clamped to 0. */
+  readonly grossPayoutsCents: number;
+  /** Actual vehicle operating cash costs in the period (cents). */
+  readonly operatingCostsCents?: number;
+  /** IRS standard-mileage deduction for the period (cents). */
+  readonly mileageDeductionCents?: number;
+  /** Other manual business deductions: phone allocation, supplies, etc. (cents). */
+  readonly otherDeductionsCents?: number;
+  /** Calculation configuration. */
+  readonly config?: GigTakeHomeConfig;
+}
+
+export interface GigTakeHomeResult {
+  /** Gross payouts used (cents, clamped ≥ 0). */
+  readonly grossPayoutsCents: number;
+  /** Actual operating costs used (cents). */
+  readonly operatingCostsCents: number;
+  /** Other deductions used (cents). */
+  readonly otherDeductionsCents: number;
+  /** Deduction method applied. */
+  readonly deductionMethod: DeductionMethod;
+  /** Expenses used as the tax-deduction basis (cents). */
+  readonly taxDeductibleExpensesCents: number;
+  /** Actual cash kept before taxes: gross − operating − other (cents, may be negative). */
+  readonly netCashProfitCents: number;
+  /** Net Schedule-C SE earnings used for tax: gross − deductible expenses, floored at 0 (cents). */
+  readonly netSelfEmploymentEarningsCents: number;
+  /** Estimated self-employment tax (cents). */
+  readonly selfEmploymentTaxCents: number;
+  /** Deductible half of the SE tax that reduces the income-tax base (cents). */
+  readonly selfEmploymentTaxDeductionCents: number;
+  /** Income-tax base: net SE earnings − half of SE tax, floored at 0 (cents). */
+  readonly incomeTaxBaseCents: number;
+  /** Income-tax reserve rate applied (decimal). */
+  readonly incomeTaxReserveRate: number;
+  /** Estimated income-tax reserve (cents). */
+  readonly incomeTaxReserveCents: number;
+  /** Total recommended tax set-aside: SE tax + income-tax reserve (cents). */
+  readonly totalTaxSetAsideCents: number;
+  /** Estimated take-home: net cash profit − total tax set-aside (cents, may be negative). */
+  readonly estimatedTakeHomeCents: number;
+  /** Effective tax set-aside rate on gross payouts (decimal; 0 when gross is 0). */
+  readonly effectiveTaxRate: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Clamp a value to an integer cent amount ≥ 0. */
+function clampCents(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.round(value));
+}
+
+/** Normalize a reserve rate to a finite decimal in [0, 1]. */
+function normalizeRate(rate: number | undefined): number {
+  if (rate === undefined || !Number.isFinite(rate)) {
+    return DEFAULT_INCOME_TAX_RESERVE_RATE;
+  }
+  return Math.min(1, Math.max(0, rate));
+}
+
+// ---------------------------------------------------------------------------
+// Core calculation
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute estimated take-home pay for a set of gig earnings and costs.
+ *
+ * @example
+ * ```ts
+ * computeGigTakeHome({
+ *   grossPayoutsCents: 5_000_000,      // $50,000 gross
+ *   operatingCostsCents: 800_000,      // $8,000 actual vehicle cash costs
+ *   mileageDeductionCents: 1_000_000,  // $10,000 standard mileage deduction
+ *   otherDeductionsCents: 100_000,     // $1,000 phone/supplies
+ *   config: { incomeTaxReserveRate: 0.15 },
+ * });
+ * ```
+ */
+export function computeGigTakeHome(input: GigTakeHomeInput): GigTakeHomeResult {
+  const config = input.config ?? {};
+  const grossPayoutsCents = clampCents(input.grossPayoutsCents);
+  const operatingCostsCents = clampCents(input.operatingCostsCents);
+  const mileageDeductionCents = clampCents(input.mileageDeductionCents);
+  const otherDeductionsCents = clampCents(input.otherDeductionsCents);
+
+  const deductionMethod: DeductionMethod = config.deductionMethod ?? 'standard-mileage';
+  const applySelfEmploymentTax = config.applySelfEmploymentTax ?? true;
+  const applySelfEmploymentFloor = config.applySelfEmploymentFloor ?? true;
+  const incomeTaxReserveRate = normalizeRate(config.incomeTaxReserveRate);
+
+  // Actual cash kept before tax (real money out of pocket). May be negative on
+  // a high-expense / low-earning shift — that is a genuine loss, not an error.
+  const netCashProfitCents = grossPayoutsCents - operatingCostsCents - otherDeductionsCents;
+
+  // Tax basis: a driver deducts EITHER standard mileage OR actual vehicle
+  // expenses (never both), plus other business deductions.
+  const vehicleDeductionCents =
+    deductionMethod === 'standard-mileage' ? mileageDeductionCents : operatingCostsCents;
+  const taxDeductibleExpensesCents = vehicleDeductionCents + otherDeductionsCents;
+
+  // Net Schedule-C profit cannot be negative for SE-tax purposes here.
+  const netSelfEmploymentEarningsCents = Math.max(
+    0,
+    grossPayoutsCents - taxDeductibleExpensesCents,
+  );
+
+  const seResult = calculateSETax(netSelfEmploymentEarningsCents);
+  const seFloorMet =
+    !applySelfEmploymentFloor || seResult.taxableBase >= SE_TAX_MIN_NET_EARNINGS_CENTS;
+  const selfEmploymentTaxCents = applySelfEmploymentTax && seFloorMet ? seResult.seTax : 0;
+  const selfEmploymentTaxDeductionCents = selfEmploymentTaxCents > 0 ? seResult.seDeduction : 0;
+
+  // Income tax is estimated on net SE earnings reduced by the deductible half
+  // of SE tax (an AGI adjustment), then floored at 0.
+  const incomeTaxBaseCents = Math.max(
+    0,
+    netSelfEmploymentEarningsCents - selfEmploymentTaxDeductionCents,
+  );
+  const incomeTaxReserveCents = Math.round(incomeTaxBaseCents * incomeTaxReserveRate);
+
+  const totalTaxSetAsideCents = selfEmploymentTaxCents + incomeTaxReserveCents;
+  const estimatedTakeHomeCents = netCashProfitCents - totalTaxSetAsideCents;
+  const effectiveTaxRate = grossPayoutsCents > 0 ? totalTaxSetAsideCents / grossPayoutsCents : 0;
+
+  return {
+    grossPayoutsCents,
+    operatingCostsCents,
+    otherDeductionsCents,
+    deductionMethod,
+    taxDeductibleExpensesCents,
+    netCashProfitCents,
+    netSelfEmploymentEarningsCents,
+    selfEmploymentTaxCents,
+    selfEmploymentTaxDeductionCents,
+    incomeTaxBaseCents,
+    incomeTaxReserveRate,
+    incomeTaxReserveCents,
+    totalTaxSetAsideCents,
+    estimatedTakeHomeCents,
+    effectiveTaxRate,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Day / week / shift profitability aggregation
+// ---------------------------------------------------------------------------
+
+/** A single logged gig shift / session. */
+export interface ShiftRecord {
+  readonly id: string;
+  /** Calendar date (YYYY-MM-DD). */
+  readonly date: string;
+  readonly grossCents: number;
+  readonly operatingCostsCents?: number;
+  readonly mileageDeductionCents?: number;
+  readonly otherDeductionsCents?: number;
+  /** Miles driven during the shift (non-monetary, may be fractional). */
+  readonly miles?: number;
+  /** Active (on-the-clock) hours during the shift. */
+  readonly activeHours?: number;
+}
+
+export type ProfitabilityGranularity = 'shift' | 'day' | 'week';
+
+export interface ProfitabilityPeriod {
+  /** Bucket key (shift id, `YYYY-MM-DD` day, or week-start `YYYY-MM-DD`). */
+  readonly key: string;
+  /** Human-readable label. */
+  readonly label: string;
+  readonly granularity: ProfitabilityGranularity;
+  readonly shiftCount: number;
+  readonly grossCents: number;
+  readonly operatingCostsCents: number;
+  readonly netCashProfitCents: number;
+  readonly totalTaxSetAsideCents: number;
+  readonly estimatedTakeHomeCents: number;
+  readonly miles: number;
+  readonly activeHours: number;
+  /** Estimated take-home per mile (cents); null when miles is 0. */
+  readonly takeHomePerMileCents: number | null;
+  /** Estimated take-home per active hour (cents); null when hours is 0. */
+  readonly takeHomePerHourCents: number | null;
+}
+
+/** Compute the Monday-based ISO week-start date key for a `YYYY-MM-DD` string. */
+export function weekStartKey(date: string): string {
+  const dt = new Date(`${date}T00:00:00Z`);
+  if (Number.isNaN(dt.getTime())) {
+    return date;
+  }
+  const day = dt.getUTCDay(); // 0 = Sunday … 6 = Saturday
+  const offsetToMonday = day === 0 ? -6 : 1 - day;
+  dt.setUTCDate(dt.getUTCDate() + offsetToMonday);
+  return dt.toISOString().slice(0, 10);
+}
+
+function bucketKeyFor(shift: ShiftRecord, granularity: ProfitabilityGranularity): string {
+  if (granularity === 'shift') {
+    return shift.id;
+  }
+  if (granularity === 'week') {
+    return weekStartKey(shift.date);
+  }
+  return shift.date;
+}
+
+function bucketLabelFor(key: string, granularity: ProfitabilityGranularity): string {
+  if (granularity === 'week') {
+    return `Week of ${key}`;
+  }
+  return key;
+}
+
+interface ShiftTotals {
+  grossCents: number;
+  operatingCostsCents: number;
+  mileageDeductionCents: number;
+  otherDeductionsCents: number;
+  miles: number;
+  activeHours: number;
+  shiftCount: number;
+}
+
+function emptyTotals(): ShiftTotals {
+  return {
+    grossCents: 0,
+    operatingCostsCents: 0,
+    mileageDeductionCents: 0,
+    otherDeductionsCents: 0,
+    miles: 0,
+    activeHours: 0,
+    shiftCount: 0,
+  };
+}
+
+function clampMiles(value: number | undefined): number {
+  return Number.isFinite(value) ? Math.max(0, value ?? 0) : 0;
+}
+
+/**
+ * Aggregate shift profitability into day / week / shift buckets.
+ *
+ * Taxes are estimated per bucket on that bucket's net earnings. The annual SE
+ * floor/cap are approximations at sub-annual granularity — pass
+ * `config.applySelfEmploymentFloor = false` for realistic per-shift set-asides.
+ *
+ * @returns Buckets sorted ascending by key.
+ */
+export function aggregateProfitability(
+  shifts: readonly ShiftRecord[],
+  granularity: ProfitabilityGranularity,
+  config?: GigTakeHomeConfig,
+): ProfitabilityPeriod[] {
+  const buckets = new Map<string, ShiftTotals>();
+
+  for (const shift of shifts) {
+    const key = bucketKeyFor(shift, granularity);
+    const totals = buckets.get(key) ?? emptyTotals();
+    totals.grossCents += clampCents(shift.grossCents);
+    totals.operatingCostsCents += clampCents(shift.operatingCostsCents);
+    totals.mileageDeductionCents += clampCents(shift.mileageDeductionCents);
+    totals.otherDeductionsCents += clampCents(shift.otherDeductionsCents);
+    totals.miles += clampMiles(shift.miles);
+    totals.activeHours += clampMiles(shift.activeHours);
+    totals.shiftCount += 1;
+    buckets.set(key, totals);
+  }
+
+  return [...buckets.entries()]
+    .map(([key, totals]) => {
+      const result = computeGigTakeHome({
+        grossPayoutsCents: totals.grossCents,
+        operatingCostsCents: totals.operatingCostsCents,
+        mileageDeductionCents: totals.mileageDeductionCents,
+        otherDeductionsCents: totals.otherDeductionsCents,
+        config,
+      });
+
+      const miles = Math.round(totals.miles * 10) / 10;
+      const activeHours = Math.round(totals.activeHours * 100) / 100;
+
+      return {
+        key,
+        label: bucketLabelFor(key, granularity),
+        granularity,
+        shiftCount: totals.shiftCount,
+        grossCents: result.grossPayoutsCents,
+        operatingCostsCents: result.operatingCostsCents,
+        netCashProfitCents: result.netCashProfitCents,
+        totalTaxSetAsideCents: result.totalTaxSetAsideCents,
+        estimatedTakeHomeCents: result.estimatedTakeHomeCents,
+        miles,
+        activeHours,
+        takeHomePerMileCents: miles > 0 ? Math.round(result.estimatedTakeHomeCents / miles) : null,
+        takeHomePerHourCents:
+          activeHours > 0 ? Math.round(result.estimatedTakeHomeCents / activeHours) : null,
+      } satisfies ProfitabilityPeriod;
+    })
+    .sort((left, right) => left.key.localeCompare(right.key));
+}

--- a/apps/web/src/lib/vehicle-cost-per-mile.test.ts
+++ b/apps/web/src/lib/vehicle-cost-per-mile.test.ts
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_MAINTENANCE_INTERVALS_MILES,
+  classifyVehicleExpense,
+  computeMaintenanceReminders,
+  getVehicleCostBehavior,
+  inferVehicleCategory,
+  summarizeVehicleCosts,
+  type MaintenanceInterval,
+  type VehicleExpenseEntry,
+  type VehicleTransactionInput,
+} from './vehicle-cost-per-mile';
+
+describe('getVehicleCostBehavior', () => {
+  it('classifies usage-based costs as variable and time-based costs as fixed', () => {
+    expect(getVehicleCostBehavior('fuel')).toBe('variable');
+    expect(getVehicleCostBehavior('maintenance')).toBe('variable');
+    expect(getVehicleCostBehavior('wash')).toBe('variable');
+    expect(getVehicleCostBehavior('insurance')).toBe('fixed');
+    expect(getVehicleCostBehavior('lease')).toBe('fixed');
+    expect(getVehicleCostBehavior('phone')).toBe('fixed');
+  });
+});
+
+describe('inferVehicleCategory', () => {
+  it('infers fuel from a gas-station payee', () => {
+    expect(
+      inferVehicleCategory({ payee: 'Chevron #123', note: null, tags: [], categoryName: null }),
+    ).toBe('fuel');
+  });
+
+  it('prefers the strongest keyword match', () => {
+    expect(
+      inferVehicleCategory({ payee: 'Discount Tire', note: null, tags: [], categoryName: null }),
+    ).toBe('tires');
+  });
+
+  it('returns null when nothing matches', () => {
+    expect(
+      inferVehicleCategory({ payee: 'Grocery Store', note: null, tags: [], categoryName: null }),
+    ).toBeNull();
+  });
+});
+
+describe('classifyVehicleExpense', () => {
+  const base: VehicleTransactionInput = {
+    id: 't1',
+    date: '2024-03-01',
+    payee: 'Shell',
+    note: 'Fill up',
+    amountCents: -4_500,
+    type: 'EXPENSE',
+    tags: ['vehicle-expense'],
+    customFields: null,
+  };
+
+  it('classifies a tagged expense and stores a positive amount', () => {
+    const entry = classifyVehicleExpense(base);
+    expect(entry).not.toBeNull();
+    expect(entry?.category).toBe('fuel');
+    expect(entry?.amountCents).toBe(4_500);
+  });
+
+  it('honors an explicit category and odometer in custom fields', () => {
+    const entry = classifyVehicleExpense({
+      ...base,
+      tags: [],
+      payee: 'Auto Shop',
+      note: 'New set',
+      customFields: { vehicleCostCategory: 'tires', vehicleOdometer: '62000' },
+    });
+    expect(entry?.category).toBe('tires');
+    expect(entry?.odometer).toBe(62_000);
+  });
+
+  it('ignores non-expense transactions', () => {
+    expect(classifyVehicleExpense({ ...base, type: 'INCOME' })).toBeNull();
+    expect(classifyVehicleExpense({ ...base, type: 'TRANSFER' })).toBeNull();
+  });
+
+  it('skips untagged transactions unless inferUntagged is enabled', () => {
+    const untagged: VehicleTransactionInput = { ...base, tags: [] };
+    expect(classifyVehicleExpense(untagged)).toBeNull();
+    expect(classifyVehicleExpense(untagged, { inferUntagged: true })?.category).toBe('fuel');
+  });
+
+  it('falls back to "other" for a flagged expense with no recognizable category', () => {
+    const entry = classifyVehicleExpense({
+      ...base,
+      payee: 'Misc Vendor',
+      note: 'unknown',
+    });
+    expect(entry?.category).toBe('other');
+  });
+});
+
+describe('summarizeVehicleCosts', () => {
+  const expenses: VehicleExpenseEntry[] = [
+    { id: 'e1', date: '2024-03-01', category: 'fuel', amountCents: 20_000 },
+    { id: 'e2', date: '2024-03-05', category: 'maintenance', amountCents: 5_000 },
+    { id: 'e3', date: '2024-03-10', category: 'insurance', amountCents: 12_000 },
+    { id: 'e4', date: '2024-03-12', category: 'wash', amountCents: 1_500 },
+    { id: 'e5', date: '2024-03-20', category: 'phone', amountCents: 3_000 },
+  ];
+
+  it('computes totals, fixed/variable split, and per-mile / per-shift metrics', () => {
+    const summary = summarizeVehicleCosts({ expenses, milesDriven: 500, activeShifts: 10 });
+
+    expect(summary.totalCostCents).toBe(41_500);
+    expect(summary.variableCostCents).toBe(26_500); // fuel + maintenance + wash
+    expect(summary.fixedCostCents).toBe(15_000); // insurance + phone
+    expect(summary.costPerMileCents).toBe(83);
+    expect(summary.variableCostPerMileCents).toBe(53);
+    expect(summary.costPerShiftCents).toBe(4_150);
+    expect(summary.fixedCostPerShiftCents).toBe(1_500);
+  });
+
+  it('summarizes by category in canonical order with per-mile values', () => {
+    const summary = summarizeVehicleCosts({ expenses, milesDriven: 500, activeShifts: 10 });
+    expect(summary.byCategory.map((c) => c.category)).toEqual([
+      'fuel',
+      'maintenance',
+      'wash',
+      'insurance',
+      'phone',
+    ]);
+    const fuel = summary.byCategory.find((c) => c.category === 'fuel');
+    expect(fuel?.costPerMileCents).toBe(40);
+    expect(fuel?.transactionCount).toBe(1);
+  });
+
+  it('returns null per-mile metrics when no miles are driven', () => {
+    const summary = summarizeVehicleCosts({ expenses, milesDriven: 0 });
+    expect(summary.costPerMileCents).toBeNull();
+    expect(summary.variableCostPerMileCents).toBeNull();
+    expect(summary.byCategory.every((c) => c.costPerMileCents === null)).toBe(true);
+  });
+
+  it('returns null per-shift metrics when there are no active shifts', () => {
+    const summary = summarizeVehicleCosts({ expenses, milesDriven: 500 });
+    expect(summary.costPerShiftCents).toBeNull();
+    expect(summary.fixedCostPerShiftCents).toBeNull();
+  });
+
+  it('filters expenses outside the reporting window', () => {
+    const summary = summarizeVehicleCosts({
+      expenses,
+      milesDriven: 500,
+      startDate: '2024-03-04',
+      endDate: '2024-03-15',
+    });
+    // Only maintenance, insurance, and wash fall in range.
+    expect(summary.totalCostCents).toBe(18_500);
+  });
+
+  it('handles an empty expense list', () => {
+    const summary = summarizeVehicleCosts({ expenses: [], milesDriven: 100, activeShifts: 2 });
+    expect(summary.totalCostCents).toBe(0);
+    expect(summary.costPerMileCents).toBe(0);
+    expect(summary.byCategory).toEqual([]);
+  });
+});
+
+describe('computeMaintenanceReminders', () => {
+  const intervals: MaintenanceInterval[] = [
+    {
+      id: 'oil',
+      label: 'Oil change',
+      intervalMiles: DEFAULT_MAINTENANCE_INTERVALS_MILES.oilChange,
+      lastServiceOdometer: 60_000,
+    },
+  ];
+
+  it('reports an upcoming service as ok', () => {
+    const [reminder] = computeMaintenanceReminders(intervals, 64_200);
+    expect(reminder.nextServiceOdometer).toBe(65_000);
+    expect(reminder.milesRemaining).toBe(800);
+    expect(reminder.milesOverdue).toBe(0);
+    expect(reminder.percentUsed).toBe(84);
+    expect(reminder.status).toBe('ok');
+  });
+
+  it('flags a service within the due-soon window', () => {
+    const [reminder] = computeMaintenanceReminders(intervals, 64_800);
+    expect(reminder.milesRemaining).toBe(200);
+    expect(reminder.status).toBe('due_soon');
+    expect(reminder.percentUsed).toBe(96);
+  });
+
+  it('flags an overdue service with positive overdue miles', () => {
+    const [reminder] = computeMaintenanceReminders(intervals, 65_500);
+    expect(reminder.milesRemaining).toBe(-500);
+    expect(reminder.milesOverdue).toBe(500);
+    expect(reminder.percentUsed).toBe(110);
+    expect(reminder.status).toBe('overdue');
+  });
+
+  it('respects a custom due-soon threshold', () => {
+    const [reminder] = computeMaintenanceReminders(intervals, 64_200, { dueSoonMiles: 1_000 });
+    expect(reminder.status).toBe('due_soon');
+  });
+});

--- a/apps/web/src/lib/vehicle-cost-per-mile.ts
+++ b/apps/web/src/lib/vehicle-cost-per-mile.ts
@@ -1,0 +1,510 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Vehicle operating cost-per-mile and maintenance tracking for gig drivers.
+ *
+ * Provides:
+ *   - quick categorization of vehicle expenses (gas, maintenance, repairs,
+ *     tires, washes, insurance, registration, lease/depreciation, phone
+ *     allocation, tolls, parking),
+ *   - fixed vs. variable cost classification,
+ *   - cost-per-mile and cost-per-active-shift metrics,
+ *   - odometer-milestone maintenance reminders.
+ *
+ * Cost data is derived from the locally-modeled transaction stream (tagged
+ * vehicle expenses) — no remote data sources. All monetary values are integer
+ * cents (never floats). Miles / odometer readings are non-monetary.
+ *
+ * Reference: issue #2139.
+ */
+
+// ---------------------------------------------------------------------------
+// Categories & behavior
+// ---------------------------------------------------------------------------
+
+export type VehicleCostCategory =
+  | 'fuel'
+  | 'maintenance'
+  | 'repairs'
+  | 'tires'
+  | 'wash'
+  | 'tolls'
+  | 'parking'
+  | 'insurance'
+  | 'registration'
+  | 'depreciation'
+  | 'lease'
+  | 'phone'
+  | 'other';
+
+/**
+ * Whether a cost varies with usage/mileage (`variable`) or is incurred per
+ * period regardless of how much you drive (`fixed`).
+ */
+export type VehicleCostBehavior = 'fixed' | 'variable';
+
+interface VehicleCategoryRule {
+  readonly label: string;
+  readonly behavior: VehicleCostBehavior;
+  readonly keywords: readonly string[];
+}
+
+export const VEHICLE_COST_RULES: Record<VehicleCostCategory, VehicleCategoryRule> = {
+  fuel: {
+    label: 'Fuel',
+    behavior: 'variable',
+    keywords: [
+      'gas',
+      'fuel',
+      'gasoline',
+      'petrol',
+      'shell',
+      'chevron',
+      'exxon',
+      'bp',
+      'arco',
+      'mobil',
+      'costco gas',
+    ],
+  },
+  maintenance: {
+    label: 'Maintenance',
+    behavior: 'variable',
+    keywords: [
+      'oil change',
+      'maintenance',
+      'service',
+      'tune-up',
+      'tune up',
+      'filter',
+      'fluids',
+      'jiffy lube',
+      'valvoline',
+    ],
+  },
+  repairs: {
+    label: 'Repairs',
+    behavior: 'variable',
+    keywords: ['repair', 'mechanic', 'brake', 'transmission', 'engine', 'body shop', 'alignment'],
+  },
+  tires: {
+    label: 'Tires',
+    behavior: 'variable',
+    keywords: ['tire', 'tires', 'wheel', 'discount tire', 'rotation'],
+  },
+  wash: {
+    label: 'Car wash',
+    behavior: 'variable',
+    keywords: ['car wash', 'wash', 'detail', 'detailing'],
+  },
+  tolls: {
+    label: 'Tolls',
+    behavior: 'variable',
+    keywords: ['toll', 'turnpike', 'ezpass', 'e-zpass', 'fastrak', 'sunpass'],
+  },
+  parking: {
+    label: 'Parking',
+    behavior: 'variable',
+    keywords: ['parking', 'garage', 'meter'],
+  },
+  insurance: {
+    label: 'Insurance',
+    behavior: 'fixed',
+    keywords: [
+      'insurance',
+      'geico',
+      'progressive',
+      'allstate',
+      'state farm',
+      'rideshare insurance',
+    ],
+  },
+  registration: {
+    label: 'Registration',
+    behavior: 'fixed',
+    keywords: ['registration', 'dmv', 'tags', 'license plate', 'smog', 'emissions'],
+  },
+  depreciation: {
+    label: 'Depreciation',
+    behavior: 'fixed',
+    keywords: ['depreciation'],
+  },
+  lease: {
+    label: 'Lease / payment',
+    behavior: 'fixed',
+    keywords: ['lease', 'car payment', 'auto loan', 'vehicle payment'],
+  },
+  phone: {
+    label: 'Phone allocation',
+    behavior: 'fixed',
+    keywords: ['phone', 'mobile', 'verizon', 'at&t', 't-mobile', 'cell', 'wireless'],
+  },
+  other: {
+    label: 'Other vehicle',
+    behavior: 'variable',
+    keywords: [],
+  },
+};
+
+const VEHICLE_CATEGORY_ORDER = Object.keys(VEHICLE_COST_RULES) as VehicleCostCategory[];
+
+/** Tag that flags a transaction as a vehicle operating expense. */
+export const VEHICLE_EXPENSE_TAG = 'vehicle-expense';
+
+/** Custom-field keys used to persist vehicle-expense metadata on a transaction. */
+export const VEHICLE_COST_FIELDS = {
+  category: 'vehicleCostCategory',
+  odometer: 'vehicleOdometer',
+} as const;
+
+export function getVehicleCostBehavior(category: VehicleCostCategory): VehicleCostBehavior {
+  return VEHICLE_COST_RULES[category].behavior;
+}
+
+export function getVehicleCategoryLabel(category: VehicleCostCategory): string {
+  return VEHICLE_COST_RULES[category].label;
+}
+
+export function getVehicleCategoryOptions(): Array<{
+  value: VehicleCostCategory;
+  label: string;
+  behavior: VehicleCostBehavior;
+}> {
+  return VEHICLE_CATEGORY_ORDER.map((category) => ({
+    value: category,
+    label: getVehicleCategoryLabel(category),
+    behavior: getVehicleCostBehavior(category),
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Expense entries
+// ---------------------------------------------------------------------------
+
+export interface VehicleExpenseEntry {
+  readonly id: string;
+  /** Calendar date (YYYY-MM-DD). */
+  readonly date: string;
+  readonly category: VehicleCostCategory;
+  /** Cost in cents (always stored as a positive magnitude). */
+  readonly amountCents: number;
+  /** Optional odometer reading captured with the expense. */
+  readonly odometer?: number | null;
+  readonly note?: string;
+}
+
+/** Minimal transaction shape needed to classify a vehicle expense. */
+export interface VehicleTransactionInput {
+  readonly id: string;
+  readonly date: string;
+  readonly payee: string | null;
+  readonly note: string | null;
+  readonly amountCents: number;
+  readonly type: 'EXPENSE' | 'INCOME' | 'TRANSFER';
+  readonly tags: readonly string[];
+  readonly customFields: Readonly<Record<string, string>> | null;
+  readonly categoryName?: string | null;
+}
+
+function parseVehicleCategory(raw: string | undefined): VehicleCostCategory | null {
+  if (!raw) {
+    return null;
+  }
+  return VEHICLE_CATEGORY_ORDER.includes(raw as VehicleCostCategory)
+    ? (raw as VehicleCostCategory)
+    : null;
+}
+
+function normalizeText(parts: Array<string | null | undefined>): string {
+  return parts
+    .filter((value): value is string => Boolean(value && value.trim()))
+    .join(' ')
+    .toLowerCase();
+}
+
+function parseOdometer(raw: string | undefined): number | null {
+  if (!raw) {
+    return null;
+  }
+  const parsed = Number.parseFloat(raw);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+}
+
+/**
+ * Infer a vehicle cost category from a transaction's payee / note / category /
+ * tags using keyword matching. Returns `null` when nothing matches.
+ */
+export function inferVehicleCategory(
+  transaction: Pick<VehicleTransactionInput, 'payee' | 'note' | 'tags' | 'categoryName'>,
+): VehicleCostCategory | null {
+  const text = normalizeText([
+    transaction.payee,
+    transaction.note,
+    transaction.categoryName,
+    transaction.tags.join(' '),
+  ]);
+
+  if (text.length === 0) {
+    return null;
+  }
+
+  let best: { category: VehicleCostCategory; score: number } | null = null;
+  for (const category of VEHICLE_CATEGORY_ORDER) {
+    const score = VEHICLE_COST_RULES[category].keywords.reduce(
+      (total, keyword) => total + (text.includes(keyword) ? 1 : 0),
+      0,
+    );
+    if (score > 0 && (best === null || score > best.score)) {
+      best = { category, score };
+    }
+  }
+
+  return best?.category ?? null;
+}
+
+/**
+ * Build a {@link VehicleExpenseEntry} from a transaction.
+ *
+ * Only `EXPENSE` transactions are considered. By default a transaction must be
+ * explicitly flagged as a vehicle expense (via {@link VEHICLE_EXPENSE_TAG} or a
+ * stored {@link VEHICLE_COST_FIELDS.category}) to avoid mis-counting personal
+ * spending. Pass `{ inferUntagged: true }` to also classify untagged
+ * transactions whose payee/note clearly match a vehicle category.
+ */
+export function classifyVehicleExpense(
+  transaction: VehicleTransactionInput,
+  options: { inferUntagged?: boolean } = {},
+): VehicleExpenseEntry | null {
+  if (transaction.type !== 'EXPENSE') {
+    return null;
+  }
+
+  const customFields = transaction.customFields ?? {};
+  const storedCategory = parseVehicleCategory(customFields[VEHICLE_COST_FIELDS.category]);
+  const isFlagged =
+    transaction.tags.includes(VEHICLE_EXPENSE_TAG) ||
+    customFields[VEHICLE_COST_FIELDS.category] !== undefined;
+
+  if (!isFlagged && !options.inferUntagged) {
+    return null;
+  }
+
+  const category =
+    storedCategory ?? inferVehicleCategory(transaction) ?? (isFlagged ? 'other' : null);
+  if (category === null) {
+    return null;
+  }
+
+  return {
+    id: transaction.id,
+    date: transaction.date,
+    category,
+    amountCents: Math.abs(Math.round(transaction.amountCents)),
+    odometer: parseOdometer(customFields[VEHICLE_COST_FIELDS.odometer]),
+    note: transaction.note?.trim() || transaction.payee?.trim() || '',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Cost-per-mile summary
+// ---------------------------------------------------------------------------
+
+export interface VehicleCategorySummary {
+  readonly category: VehicleCostCategory;
+  readonly label: string;
+  readonly behavior: VehicleCostBehavior;
+  readonly amountCents: number;
+  readonly transactionCount: number;
+  /** Cost per mile for this category (cents); null when miles is 0. */
+  readonly costPerMileCents: number | null;
+}
+
+export interface VehicleCostSummary {
+  readonly totalCostCents: number;
+  readonly fixedCostCents: number;
+  readonly variableCostCents: number;
+  readonly milesDriven: number;
+  readonly activeShifts: number;
+  /** Total cost per mile (cents); null when miles is 0. */
+  readonly costPerMileCents: number | null;
+  /** Variable cost per mile (cents); null when miles is 0. */
+  readonly variableCostPerMileCents: number | null;
+  /** Total cost per active shift (cents); null when shifts is 0. */
+  readonly costPerShiftCents: number | null;
+  /** Fixed cost per active shift (cents); null when shifts is 0. */
+  readonly fixedCostPerShiftCents: number | null;
+  readonly byCategory: readonly VehicleCategorySummary[];
+}
+
+export interface VehicleCostSummaryInput {
+  readonly expenses: readonly VehicleExpenseEntry[];
+  /** Total business miles driven for the period (non-monetary). */
+  readonly milesDriven: number;
+  /** Number of active shifts/sessions worked in the period. */
+  readonly activeShifts?: number;
+  readonly startDate?: string | null;
+  readonly endDate?: string | null;
+}
+
+function isWithinPeriod(date: string, startDate?: string | null, endDate?: string | null): boolean {
+  if (startDate && date < startDate) {
+    return false;
+  }
+  if (endDate && date > endDate) {
+    return false;
+  }
+  return true;
+}
+
+function perUnit(amountCents: number, units: number): number | null {
+  return units > 0 ? Math.round(amountCents / units) : null;
+}
+
+/**
+ * Summarize vehicle operating costs into total / fixed / variable buckets and
+ * derive cost-per-mile and cost-per-shift metrics.
+ */
+export function summarizeVehicleCosts(input: VehicleCostSummaryInput): VehicleCostSummary {
+  const milesDriven = Number.isFinite(input.milesDriven) ? Math.max(0, input.milesDriven) : 0;
+  const activeShifts =
+    Number.isFinite(input.activeShifts) && (input.activeShifts ?? 0) > 0
+      ? Math.floor(input.activeShifts as number)
+      : 0;
+
+  const inPeriod = input.expenses.filter((expense) =>
+    isWithinPeriod(expense.date, input.startDate, input.endDate),
+  );
+
+  const totalsByCategory = new Map<VehicleCostCategory, { amountCents: number; count: number }>();
+  let totalCostCents = 0;
+  let fixedCostCents = 0;
+  let variableCostCents = 0;
+
+  for (const expense of inPeriod) {
+    const amountCents = Math.abs(Math.round(expense.amountCents));
+    totalCostCents += amountCents;
+
+    if (getVehicleCostBehavior(expense.category) === 'fixed') {
+      fixedCostCents += amountCents;
+    } else {
+      variableCostCents += amountCents;
+    }
+
+    const existing = totalsByCategory.get(expense.category) ?? { amountCents: 0, count: 0 };
+    existing.amountCents += amountCents;
+    existing.count += 1;
+    totalsByCategory.set(expense.category, existing);
+  }
+
+  const byCategory: VehicleCategorySummary[] = VEHICLE_CATEGORY_ORDER.filter((category) =>
+    totalsByCategory.has(category),
+  ).map((category) => {
+    const entry = totalsByCategory.get(category) as { amountCents: number; count: number };
+    return {
+      category,
+      label: getVehicleCategoryLabel(category),
+      behavior: getVehicleCostBehavior(category),
+      amountCents: entry.amountCents,
+      transactionCount: entry.count,
+      costPerMileCents: perUnit(entry.amountCents, milesDriven),
+    };
+  });
+
+  return {
+    totalCostCents,
+    fixedCostCents,
+    variableCostCents,
+    milesDriven: Math.round(milesDriven * 10) / 10,
+    activeShifts,
+    costPerMileCents: perUnit(totalCostCents, milesDriven),
+    variableCostPerMileCents: perUnit(variableCostCents, milesDriven),
+    costPerShiftCents: perUnit(totalCostCents, activeShifts),
+    fixedCostPerShiftCents: perUnit(fixedCostCents, activeShifts),
+    byCategory,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Odometer-milestone maintenance reminders
+// ---------------------------------------------------------------------------
+
+/** Default service intervals a gig driver commonly tracks. */
+export const DEFAULT_MAINTENANCE_INTERVALS_MILES = {
+  oilChange: 5_000,
+  tireRotation: 7_500,
+  brakeInspection: 20_000,
+  tireReplacement: 50_000,
+} as const;
+
+export interface MaintenanceInterval {
+  readonly id: string;
+  readonly label: string;
+  /** Miles between services. */
+  readonly intervalMiles: number;
+  /** Odometer reading at the last completed service. */
+  readonly lastServiceOdometer: number;
+}
+
+export type MaintenanceStatus = 'ok' | 'due_soon' | 'overdue';
+
+export interface MaintenanceReminder {
+  readonly id: string;
+  readonly label: string;
+  readonly intervalMiles: number;
+  readonly lastServiceOdometer: number;
+  readonly nextServiceOdometer: number;
+  /** Miles until the next service (negative when overdue). */
+  readonly milesRemaining: number;
+  /** Miles past due (0 when not overdue). */
+  readonly milesOverdue: number;
+  /** Percent of the interval consumed (0–100+, clamped at 0 minimum). */
+  readonly percentUsed: number;
+  readonly status: MaintenanceStatus;
+}
+
+/**
+ * Compute odometer-based maintenance reminders given the current odometer.
+ *
+ * @param intervals - Tracked service intervals
+ * @param currentOdometer - Current odometer reading
+ * @param options.dueSoonMiles - Threshold for the `due_soon` status (default 500)
+ */
+export function computeMaintenanceReminders(
+  intervals: readonly MaintenanceInterval[],
+  currentOdometer: number,
+  options: { dueSoonMiles?: number } = {},
+): MaintenanceReminder[] {
+  const dueSoonMiles = Math.max(0, options.dueSoonMiles ?? 500);
+  const odometer = Number.isFinite(currentOdometer) ? Math.max(0, currentOdometer) : 0;
+
+  return intervals.map((interval) => {
+    const intervalMiles = Math.max(1, Math.round(interval.intervalMiles));
+    const lastServiceOdometer = Math.max(0, interval.lastServiceOdometer);
+    const nextServiceOdometer = lastServiceOdometer + intervalMiles;
+    const milesRemaining = Math.round(nextServiceOdometer - odometer);
+    const milesOverdue = Math.max(0, -milesRemaining);
+    const milesUsed = Math.max(0, odometer - lastServiceOdometer);
+    const percentUsed = Math.max(0, Math.round((milesUsed / intervalMiles) * 100));
+
+    let status: MaintenanceStatus;
+    if (milesRemaining <= 0) {
+      status = 'overdue';
+    } else if (milesRemaining <= dueSoonMiles) {
+      status = 'due_soon';
+    } else {
+      status = 'ok';
+    }
+
+    return {
+      id: interval.id,
+      label: interval.label,
+      intervalMiles,
+      lastServiceOdometer,
+      nextServiceOdometer,
+      milesRemaining,
+      milesOverdue,
+      percentUsed,
+      status,
+    };
+  });
+}

--- a/apps/web/src/pages/GigDriverPage.css
+++ b/apps/web/src/pages/GigDriverPage.css
@@ -1,0 +1,84 @@
+/* SPDX-License-Identifier: BUSL-1.1 */
+
+.gig-driver {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
+.gig-driver__header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.gig-driver__eyebrow {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.gig-driver__title {
+  font-size: var(--type-scale-display-font-size);
+  font-weight: var(--type-scale-display-font-weight);
+  margin: 0;
+}
+
+.gig-driver__description {
+  color: var(--semantic-text-secondary);
+  margin: 0;
+  max-width: 72ch;
+}
+
+.gig-driver__controls {
+  background: var(--semantic-surface-primary, var(--semantic-background-primary));
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--radius-lg, var(--border-radius-lg, var(--border-radius-md)));
+  box-shadow: var(--shadow-sm);
+  padding: var(--spacing-4);
+}
+
+.gig-driver__section-title {
+  font-size: var(--type-scale-title-font-size);
+  font-weight: var(--type-scale-title-font-weight);
+  margin: 0 0 var(--spacing-3);
+}
+
+.gig-driver__controls-grid {
+  display: grid;
+  gap: var(--spacing-3);
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.gig-driver__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.gig-driver__label {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+  font-weight: 600;
+}
+
+.gig-driver__input {
+  border: 1px solid var(--semantic-border-default);
+  border-radius: var(--radius-md, var(--border-radius-md));
+  font: inherit;
+  padding: var(--spacing-2) var(--spacing-3);
+}
+
+.gig-driver__hint {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+}
+
+.gig-driver__footnote {
+  color: var(--semantic-text-secondary);
+  font-size: var(--type-scale-caption-font-size);
+  margin: 0;
+}

--- a/apps/web/src/pages/GigDriverPage.tsx
+++ b/apps/web/src/pages/GigDriverPage.tsx
@@ -1,0 +1,424 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * GigDriverPage — gig-driver economics dashboard.
+ *
+ * Surfaces two beta features over local data only (no remote sources):
+ *   - #2135 take-home pay after expenses and estimated taxes
+ *   - #2139 vehicle cost-per-mile and odometer-milestone maintenance
+ *
+ * Income comes from local INCOME transactions, deductions from tagged business
+ * expenses, and miles from locally-logged mileage trips. Everything is computed
+ * client-side in integer cents.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { EmptyState, ErrorBanner, LoadingSpinner } from '../components/common';
+import { MileageDashboard } from '../components/mileage';
+import { TakeHomeSummary } from '../components/mileage/TakeHomeSummary';
+import { VehicleCostSummaryCard } from '../components/mileage/VehicleCostSummaryCard';
+import { useTransactions } from '../hooks/useTransactions';
+import { formatCurrency } from '../lib/currency';
+import {
+  MILEAGE_TRIPS_CHANGED_EVENT,
+  generateTaxReadyExpenseReport,
+  loadMileageTrips,
+  type ExpenseTransactionInput,
+  type TripEntry as MileageTrip,
+} from '../lib/mileage';
+import {
+  aggregateProfitability,
+  computeGigTakeHome,
+  DEFAULT_INCOME_TAX_RESERVE_RATE,
+  type DeductionMethod,
+  type ProfitabilityGranularity,
+  type ShiftRecord,
+} from '../lib/gig-take-home';
+import {
+  classifyVehicleExpense,
+  computeMaintenanceReminders,
+  DEFAULT_MAINTENANCE_INTERVALS_MILES,
+  summarizeVehicleCosts,
+  type MaintenanceInterval,
+  type VehicleExpenseEntry,
+} from '../lib/vehicle-cost-per-mile';
+
+import './GigDriverPage.css';
+
+function parsePercentToRate(value: string): number {
+  const parsed = Number.parseFloat(value);
+  if (!Number.isFinite(parsed)) {
+    return DEFAULT_INCOME_TAX_RESERVE_RATE;
+  }
+  return Math.min(1, Math.max(0, parsed / 100));
+}
+
+function parseOptionalNumber(value: string): number | null {
+  if (!value.trim()) {
+    return null;
+  }
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function milestoneIntervals(odometer: number): MaintenanceInterval[] {
+  if (odometer <= 0) {
+    return [];
+  }
+  const definitions: Array<{ id: string; label: string; intervalMiles: number }> = [
+    {
+      id: 'oil',
+      label: 'Oil change',
+      intervalMiles: DEFAULT_MAINTENANCE_INTERVALS_MILES.oilChange,
+    },
+    {
+      id: 'rotation',
+      label: 'Tire rotation',
+      intervalMiles: DEFAULT_MAINTENANCE_INTERVALS_MILES.tireRotation,
+    },
+    {
+      id: 'brakes',
+      label: 'Brake inspection',
+      intervalMiles: DEFAULT_MAINTENANCE_INTERVALS_MILES.brakeInspection,
+    },
+  ];
+
+  return definitions.map((definition) => ({
+    ...definition,
+    lastServiceOdometer: Math.floor(odometer / definition.intervalMiles) * definition.intervalMiles,
+  }));
+}
+
+export function GigDriverPage() {
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [reserveRatePercent, setReserveRatePercent] = useState('15');
+  const [deductionMethod, setDeductionMethod] = useState<DeductionMethod>('standard-mileage');
+  const [granularity, setGranularity] = useState<ProfitabilityGranularity>('week');
+  const [odometerInput, setOdometerInput] = useState('');
+  const [trips, setTrips] = useState<MileageTrip[]>(() => loadMileageTrips());
+
+  useEffect(() => {
+    const refreshTrips = () => setTrips(loadMileageTrips());
+    refreshTrips();
+    window.addEventListener(MILEAGE_TRIPS_CHANGED_EVENT, refreshTrips);
+    return () => window.removeEventListener(MILEAGE_TRIPS_CHANGED_EVENT, refreshTrips);
+  }, []);
+
+  const transactionFilters = useMemo(
+    () => ({ startDate: startDate || undefined, endDate: endDate || undefined }),
+    [endDate, startDate],
+  );
+  const { transactions, loading, error, refresh } = useTransactions(transactionFilters);
+
+  const txInputs = useMemo<ExpenseTransactionInput[]>(
+    () =>
+      transactions.map((tx) => ({
+        id: tx.id,
+        date: tx.date,
+        payee: tx.payee,
+        note: tx.note,
+        amountCents: tx.amount.amount,
+        type: tx.type,
+        tags: tx.tags,
+        customFields: tx.customFields,
+        categoryName: null,
+      })),
+    [transactions],
+  );
+
+  const report = useMemo(
+    () =>
+      generateTaxReadyExpenseReport({
+        trips,
+        transactions: txInputs,
+        startDate: startDate || null,
+        endDate: endDate || null,
+      }),
+    [endDate, startDate, trips, txInputs],
+  );
+
+  const reserveRate = useMemo(() => parsePercentToRate(reserveRatePercent), [reserveRatePercent]);
+
+  const grossPayoutsCents = useMemo(
+    () =>
+      transactions.reduce(
+        (sum, tx) => (tx.type === 'INCOME' ? sum + Math.abs(tx.amount.amount) : sum),
+        0,
+      ),
+    [transactions],
+  );
+
+  const vehicleExpenses = useMemo<VehicleExpenseEntry[]>(
+    () =>
+      txInputs
+        .map((input) => classifyVehicleExpense(input))
+        .filter((entry): entry is VehicleExpenseEntry => entry !== null),
+    [txInputs],
+  );
+
+  const businessMileageEntries = useMemo(
+    () => report.mileageEntries.filter((entry) => entry.purpose === 'business'),
+    [report.mileageEntries],
+  );
+
+  const businessMiles = useMemo(
+    () => Math.round(businessMileageEntries.reduce((sum, entry) => sum + entry.miles, 0) * 10) / 10,
+    [businessMileageEntries],
+  );
+
+  const activeShifts = useMemo(
+    () => new Set(businessMileageEntries.map((entry) => entry.date)).size,
+    [businessMileageEntries],
+  );
+
+  const vehicleSummary = useMemo(
+    () =>
+      summarizeVehicleCosts({
+        expenses: vehicleExpenses,
+        milesDriven: businessMiles,
+        activeShifts,
+        startDate: startDate || null,
+        endDate: endDate || null,
+      }),
+    [activeShifts, businessMiles, endDate, startDate, vehicleExpenses],
+  );
+
+  const takeHome = useMemo(
+    () =>
+      computeGigTakeHome({
+        grossPayoutsCents,
+        operatingCostsCents: vehicleSummary.totalCostCents,
+        mileageDeductionCents: report.totalMileageDeductionCents,
+        otherDeductionsCents: report.totalExpenseDeductionCents,
+        config: { incomeTaxReserveRate: reserveRate, deductionMethod },
+      }),
+    [
+      deductionMethod,
+      grossPayoutsCents,
+      report.totalExpenseDeductionCents,
+      report.totalMileageDeductionCents,
+      reserveRate,
+      vehicleSummary.totalCostCents,
+    ],
+  );
+
+  const shifts = useMemo<ShiftRecord[]>(() => {
+    interface MutableShift {
+      id: string;
+      date: string;
+      grossCents: number;
+      operatingCostsCents: number;
+      mileageDeductionCents: number;
+      otherDeductionsCents: number;
+      miles: number;
+    }
+
+    const byDate = new Map<string, MutableShift>();
+    const ensure = (date: string): MutableShift => {
+      const existing = byDate.get(date);
+      if (existing) {
+        return existing;
+      }
+      const created: MutableShift = {
+        id: date,
+        date,
+        grossCents: 0,
+        operatingCostsCents: 0,
+        mileageDeductionCents: 0,
+        otherDeductionsCents: 0,
+        miles: 0,
+      };
+      byDate.set(date, created);
+      return created;
+    };
+
+    for (const tx of transactions) {
+      if (tx.type === 'INCOME') {
+        const shift = ensure(tx.date);
+        shift.grossCents += Math.abs(tx.amount.amount);
+      }
+    }
+    for (const expense of vehicleExpenses) {
+      const shift = ensure(expense.date);
+      shift.operatingCostsCents += expense.amountCents;
+    }
+    for (const entry of businessMileageEntries) {
+      const shift = ensure(entry.date);
+      shift.mileageDeductionCents += entry.deductionCents;
+      shift.miles += entry.miles;
+    }
+
+    return [...byDate.values()];
+  }, [businessMileageEntries, transactions, vehicleExpenses]);
+
+  const profitability = useMemo(
+    () =>
+      aggregateProfitability(shifts, granularity, {
+        incomeTaxReserveRate: reserveRate,
+        deductionMethod,
+        applySelfEmploymentFloor: false,
+      }),
+    [deductionMethod, granularity, reserveRate, shifts],
+  );
+
+  const derivedOdometer = useMemo(() => {
+    const readings = trips
+      .map((trip) => trip.odometerEnd)
+      .filter((value): value is number => typeof value === 'number');
+    return readings.length > 0 ? Math.max(...readings) : 0;
+  }, [trips]);
+
+  const effectiveOdometer = parseOptionalNumber(odometerInput) ?? derivedOdometer;
+
+  const maintenanceReminders = useMemo(
+    () => computeMaintenanceReminders(milestoneIntervals(effectiveOdometer), effectiveOdometer),
+    [effectiveOdometer],
+  );
+
+  const handleRetry = useCallback(() => refresh(), [refresh]);
+
+  if (loading) {
+    return <LoadingSpinner label="Loading gig-driver economics" />;
+  }
+
+  if (error) {
+    return <ErrorBanner message={error} onRetry={handleRetry} />;
+  }
+
+  const hasData = transactions.length > 0 || trips.length > 0;
+
+  return (
+    <main className="gig-driver" aria-labelledby="gig-driver-title">
+      <header className="gig-driver__header">
+        <p className="gig-driver__eyebrow">Gig &amp; rideshare</p>
+        <h1 id="gig-driver-title" className="gig-driver__title">
+          Gig Driver Economics
+        </h1>
+        <p className="gig-driver__description">
+          Estimate take-home pay after operating costs and taxes, and track what your vehicle really
+          costs per mile. Figures are estimates for planning — not tax advice.
+        </p>
+      </header>
+
+      <section className="gig-driver__controls" aria-labelledby="gig-driver-controls-title">
+        <h2 id="gig-driver-controls-title" className="gig-driver__section-title">
+          Assumptions
+        </h2>
+        <div className="gig-driver__controls-grid">
+          <div className="gig-driver__field">
+            <label className="gig-driver__label" htmlFor="gig-start-date">
+              Start date
+            </label>
+            <input
+              id="gig-start-date"
+              className="gig-driver__input"
+              type="date"
+              value={startDate}
+              onChange={(event) => setStartDate(event.target.value)}
+            />
+          </div>
+          <div className="gig-driver__field">
+            <label className="gig-driver__label" htmlFor="gig-end-date">
+              End date
+            </label>
+            <input
+              id="gig-end-date"
+              className="gig-driver__input"
+              type="date"
+              value={endDate}
+              onChange={(event) => setEndDate(event.target.value)}
+            />
+          </div>
+          <div className="gig-driver__field">
+            <label className="gig-driver__label" htmlFor="gig-reserve-rate">
+              Income-tax reserve %
+            </label>
+            <input
+              id="gig-reserve-rate"
+              className="gig-driver__input"
+              type="number"
+              min="0"
+              max="100"
+              step="1"
+              inputMode="decimal"
+              value={reserveRatePercent}
+              onChange={(event) => setReserveRatePercent(event.target.value)}
+              aria-describedby="gig-reserve-rate-hint"
+            />
+            <span id="gig-reserve-rate-hint" className="gig-driver__hint">
+              Set-aside for income tax on top of self-employment tax.
+            </span>
+          </div>
+          <div className="gig-driver__field">
+            <label className="gig-driver__label" htmlFor="gig-deduction-method">
+              Deduction method
+            </label>
+            <select
+              id="gig-deduction-method"
+              className="gig-driver__input"
+              value={deductionMethod}
+              onChange={(event) => setDeductionMethod(event.target.value as DeductionMethod)}
+            >
+              <option value="standard-mileage">Standard mileage</option>
+              <option value="actual-expenses">Actual expenses</option>
+            </select>
+          </div>
+          <div className="gig-driver__field">
+            <label className="gig-driver__label" htmlFor="gig-granularity">
+              Profitability view
+            </label>
+            <select
+              id="gig-granularity"
+              className="gig-driver__input"
+              value={granularity}
+              onChange={(event) => setGranularity(event.target.value as ProfitabilityGranularity)}
+            >
+              <option value="day">By day</option>
+              <option value="week">By week</option>
+              <option value="shift">By shift</option>
+            </select>
+          </div>
+          <div className="gig-driver__field">
+            <label className="gig-driver__label" htmlFor="gig-odometer">
+              Current odometer
+            </label>
+            <input
+              id="gig-odometer"
+              className="gig-driver__input"
+              type="number"
+              min="0"
+              step="1"
+              inputMode="numeric"
+              placeholder={derivedOdometer > 0 ? String(derivedOdometer) : 'e.g. 64000'}
+              value={odometerInput}
+              onChange={(event) => setOdometerInput(event.target.value)}
+            />
+          </div>
+        </div>
+      </section>
+
+      {hasData ? (
+        <>
+          <TakeHomeSummary result={takeHome} periods={profitability} />
+          <VehicleCostSummaryCard summary={vehicleSummary} reminders={maintenanceReminders} />
+          <MileageDashboard report={report} />
+          <p className="gig-driver__footnote" role="note">
+            Gross payouts: {formatCurrency(grossPayoutsCents)} · Mileage deduction:{' '}
+            {formatCurrency(report.totalMileageDeductionCents)} · Operating costs:{' '}
+            {formatCurrency(vehicleSummary.totalCostCents)}. Tag vehicle expenses with
+            “vehicle-expense” and log trips to refine these estimates.
+          </p>
+        </>
+      ) : (
+        <EmptyState
+          title="No gig activity yet"
+          description="Add income transactions, tag vehicle expenses, and log mileage trips to see take-home pay and cost-per-mile estimates."
+        />
+      )}
+    </main>
+  );
+}
+
+export default GigDriverPage;

--- a/apps/web/src/pages/index.ts
+++ b/apps/web/src/pages/index.ts
@@ -28,6 +28,7 @@ export { BillDetailPage } from './BillDetailPage';
 export { CreateBillPage } from './CreateBillPage';
 export { ReportBuilderPage } from './ReportBuilderPage';
 export { ClientProfitabilityPage } from './ClientProfitabilityPage';
+export { GigDriverPage } from './GigDriverPage';
 export { PlanningPage } from './PlanningPage';
 export { HouseholdPage } from './HouseholdPage';
 export { CashFlowPage } from './CashFlowPage';

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -52,6 +52,7 @@ const Watchlists = lazy(() => import('./pages/WatchlistsPage'));
 const Household = lazy(() => import('./pages/HouseholdPage'));
 const ReportBuilder = lazy(() => import('./pages/ReportBuilderPage'));
 const ClientProfitability = lazy(() => import('./pages/ClientProfitabilityPage'));
+const GigDriver = lazy(() => import('./pages/GigDriverPage'));
 const Investments = lazy(() => import('./pages/InvestmentsPage'));
 const InvestmentDetail = lazy(() => import('./pages/InvestmentDetailPage'));
 const TaxCenter = lazy(() => import('./pages/TaxCenterPage'));
@@ -417,6 +418,16 @@ export const AppRoutes: FC = () => (
         <AuthenticatedRoute>
           <RouteBoundary name="Client Profitability">
             <ClientProfitability />
+          </RouteBoundary>
+        </AuthenticatedRoute>
+      }
+    />
+    <Route
+      path="/gig-driver"
+      element={
+        <AuthenticatedRoute>
+          <RouteBoundary name="Gig Driver Economics">
+            <GigDriver />
           </RouteBoundary>
         </AuthenticatedRoute>
       }


### PR DESCRIPTION
## Summary
Adds gig-driver economics to the web app: real take-home per hour/mile and true vehicle cost-per-mile — all client-side in integer cents.

## Changes
- `lib/gig-take-home.ts`: gross earnings - platform fees - mileage-based vehicle cost - estimated self-employment/income tax => net; net per hour and per mile
- `lib/vehicle-cost-per-mile.ts`: fuel + maintenance + depreciation + insurance per mile
- `/gig` Gig Driver page; `TakeHomeSummary` and `VehicleCostSummaryCard` surfaced in the mileage area (accessible: labeled inputs, aria-live results, no color-only signals)
- Full vitest unit tests (known values, banker's rounding, edge cases)

## Notes
Integer cents throughout with banker's rounding; tax is a configurable estimate (documented in engine header), not tax advice.

Closes #2135
Closes #2139